### PR TITLE
Remove PlatformMediaSessionManager::singleton

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2069,6 +2069,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/audio/PlatformMediaSession.h
     platform/audio/PlatformMediaSessionInterface.h
     platform/audio/PlatformMediaSessionManager.h
+    platform/audio/PlatformMediaSessionTypes.h
     platform/audio/PlatformRawAudioData.h
     platform/audio/PushPullFIFO.h
     platform/audio/RealtimeAudioThread.h

--- a/Source/WebCore/Modules/audiosession/DOMAudioSession.cpp
+++ b/Source/WebCore/Modules/audiosession/DOMAudioSession.cpp
@@ -104,7 +104,7 @@ ExceptionOr<void> DOMAudioSession::setType(Type type)
     AudioSession::singleton().setCategoryOverride(categoryOverride);
 
     if (categoryOverride == AudioSessionCategory::None)
-        PlatformMediaSessionManager::updateAudioSessionCategoryIfNecessary();
+        Ref { page->mediaSessionManager() }->updateAudioSessionCategoryIfNecessary();
 
     return { };
 }

--- a/Source/WebCore/Modules/mediacapabilities/MediaCapabilities.cpp
+++ b/Source/WebCore/Modules/mediacapabilities/MediaCapabilities.cpp
@@ -183,10 +183,14 @@ static void gatherDecodingInfo(Document& document, MediaDecodingConfiguration&& 
     configuration.canExposeVP9 = document.settings().vp9DecoderEnabled();
 #endif
 
+    RefPtr protectedPage = document.page();
+    if (protectedPage)
+        configuration.pageIdentifier = protectedPage->identifier();
+
 #if ENABLE(WEB_RTC)
     if (configuration.type == MediaDecodingType::WebRTC) {
-        if (auto* page = document.page())
-            page->webRTCProvider().createDecodingConfiguration(WTFMove(configuration), WTFMove(decodingCallback));
+        if (protectedPage)
+            protectedPage->webRTCProvider().createDecodingConfiguration(WTFMove(configuration), WTFMove(decodingCallback));
         return;
     }
 #endif

--- a/Source/WebCore/Modules/mediasession/MediaSession.h
+++ b/Source/WebCore/Modules/mediasession/MediaSession.h
@@ -58,6 +58,7 @@ class HTMLMediaElement;
 class MediaMetadata;
 class MediaSessionCoordinator;
 class MediaSessionCoordinatorPrivate;
+class MediaSessionManagerInterface;
 class Navigator;
 struct NowPlayingInfo;
 template<typename> class DOMPromiseDeferred;
@@ -107,7 +108,8 @@ public:
     void willPausePlayback();
 
     Document* document() const;
-    
+    RefPtr<Document> protectedDocument() const;
+
 #if ENABLE(MEDIA_SESSION_COORDINATOR)
     MediaSessionReadyState readyState() const { return m_readyState; };
     void setReadyState(MediaSessionReadyState);
@@ -170,6 +172,8 @@ private:
     void suspend(ReasonForSuspension) final;
     void stop() final;
     bool virtualHasPendingActivity() const final;
+
+    RefPtr<MediaSessionManagerInterface> sessionManager() const;
 
     WeakPtr<Navigator> m_navigator;
     RefPtr<MediaMetadata> m_metadata;

--- a/Source/WebCore/Modules/mediastream/MediaStream.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaStream.cpp
@@ -36,6 +36,7 @@
 #include "EventNames.h"
 #include "EventTargetInlines.h"
 #include "Logging.h"
+#include "MediaSessionManagerInterface.h"
 #include "MediaStreamTrackEvent.h"
 #include "Page.h"
 #include "RealtimeMediaSource.h"
@@ -304,6 +305,11 @@ void MediaStream::startProducingData()
         return;
     m_isProducingData = true;
     m_private->startProducingData();
+
+    if (!getAudioTracks().isEmpty()) {
+        if (RefPtr manager = mediaSessionManager())
+            manager->sessionCanProduceAudioChanged();
+    }
 }
 
 void MediaStream::stopProducingData()
@@ -401,7 +407,20 @@ WTFLogChannel& MediaStream::logChannel() const
     return LogWebRTC;
 }
 #endif
-    
+
+RefPtr<MediaSessionManagerInterface> MediaStream::mediaSessionManager() const
+{
+    RefPtr document = dynamicDowncast<Document>(scriptExecutionContext());
+    if (!document)
+        return nullptr;
+
+    RefPtr page = document->page();
+    if (!page)
+        return nullptr;
+
+    return &page->mediaSessionManager();
+}
+
 } // namespace WebCore
 
 #endif // ENABLE(MEDIA_STREAM)

--- a/Source/WebCore/Modules/mediastream/MediaStream.h
+++ b/Source/WebCore/Modules/mediastream/MediaStream.h
@@ -47,6 +47,7 @@
 namespace WebCore {
 
 class Document;
+class MediaSessionManagerInterface;
 
 class MediaStream final
     : public EventTarget
@@ -152,6 +153,7 @@ private:
     MediaStreamTrackVector filteredTracks(NOESCAPE const Function<bool(const MediaStreamTrack&)>&) const;
 
     Document* document() const;
+    RefPtr<MediaSessionManagerInterface> mediaSessionManager() const;
 
     const Ref<MediaStreamPrivate> m_private;
 

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrack.h
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrack.h
@@ -49,6 +49,7 @@ namespace WebCore {
 
 class AudioSourceProvider;
 class Document;
+class MediaSessionManagerInterface;
 
 struct MediaTrackConstraints;
 
@@ -217,6 +218,8 @@ private:
     // AudioCaptureSource
     bool isCapturingAudio() const final;
     bool wantsToCaptureAudio() const final;
+
+    RefPtr<MediaSessionManagerInterface> mediaSessionManager() const;
 
 #if !RELEASE_LOG_DISABLED
     ASCIILiteral logClassName() const final { return "MediaStreamTrack"_s; }

--- a/Source/WebCore/Modules/mediastream/UserMediaRequest.cpp
+++ b/Source/WebCore/Modules/mediastream/UserMediaRequest.cpp
@@ -145,7 +145,7 @@ void UserMediaRequest::start()
 
     ASSERT(document.page());
     if (RefPtr page = document.page())
-        PlatformMediaSessionManager::singleton().prepareToSendUserMediaPermissionRequestForPage(*page);
+        page->mediaSessionManager().prepareToSendUserMediaPermissionRequestForPage(*page);
     controller->requestUserMediaAccess(*this);
 }
 

--- a/Source/WebCore/Modules/webaudio/AudioContext.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioContext.cpp
@@ -699,8 +699,9 @@ bool AudioContext::shouldOverrideBackgroundPlaybackRestriction(PlatformMediaSess
 void AudioContext::defaultDestinationWillBecomeConnected()
 {
     // We might need to interrupt if we previously overrode a background interruption.
-    if (!PlatformMediaSessionManager::singleton().isApplicationInBackground() || m_mediaSession->state() == PlatformMediaSession::State::Interrupted) {
-        PlatformMediaSessionManager::updateNowPlayingInfoIfNecessary();
+    RefPtr manager = sessionManager();
+    if (manager && (!manager->isApplicationInBackground() || m_mediaSession->state() == PlatformMediaSession::State::Interrupted)) {
+        manager->updateNowPlayingInfoIfNecessary();
         return;
     }
 
@@ -778,6 +779,11 @@ ExceptionOr<Ref<MediaStreamAudioDestinationNode>> AudioContext::createMediaStrea
 bool AudioContext::virtualHasPendingActivity() const
 {
     return !isClosed();
+}
+
+RefPtr<MediaSessionManagerInterface> AudioContext::sessionManager() const
+{
+    return BaseAudioContext::mediaSessionManager();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/webaudio/AudioContext.h
+++ b/Source/WebCore/Modules/webaudio/AudioContext.h
@@ -134,6 +134,7 @@ private:
 #endif
 
     // PlatformMediaSessionClient
+    RefPtr<MediaSessionManagerInterface> sessionManager() const final;
     PlatformMediaSession::MediaType mediaType() const final { return isSuspended() || isStopped() ? PlatformMediaSession::MediaType::None : PlatformMediaSession::MediaType::WebAudio; }
     PlatformMediaSession::MediaType presentationType() const final { return PlatformMediaSession::MediaType::WebAudio; }
     void mayResumePlayback(bool shouldResume) final;

--- a/Source/WebCore/Modules/webaudio/BaseAudioContext.cpp
+++ b/Source/WebCore/Modules/webaudio/BaseAudioContext.cpp
@@ -67,6 +67,7 @@
 #include "JSDOMPromiseDeferred.h"
 #include "LocalFrame.h"
 #include "Logging.h"
+#include "MediaSessionManagerInterface.h"
 #include "NetworkingContext.h"
 #include "OriginAccessPatterns.h"
 #include "OscillatorNode.h"
@@ -244,7 +245,8 @@ void BaseAudioContext::setState(State state)
     if (m_state != state) {
         m_state = state;
         queueTaskToDispatchEvent(*this, TaskSource::MediaElement, Event::create(eventNames().statechangeEvent, Event::CanBubble::Yes, Event::IsCancelable::No));
-        PlatformMediaSessionManager::updateNowPlayingInfoIfNecessary();
+        if (RefPtr manager = mediaSessionManager())
+            manager->updateNowPlayingInfoIfNecessary();
     }
 
     size_t stateIndex = static_cast<size_t>(state);
@@ -982,6 +984,20 @@ WTFLogChannel& BaseAudioContext::logChannel() const
     return LogMedia;
 }
 #endif
+
+RefPtr<MediaSessionManagerInterface> BaseAudioContext::mediaSessionManager() const
+{
+    RefPtr document = this->document();
+    if (!document)
+        return nullptr;
+
+    RefPtr page = document->page();
+    if (!page)
+        return nullptr;
+
+    return &page->mediaSessionManager();
+}
+
 
 } // namespace WebCore
 

--- a/Source/WebCore/Modules/webaudio/BaseAudioContext.h
+++ b/Source/WebCore/Modules/webaudio/BaseAudioContext.h
@@ -72,6 +72,7 @@ class DynamicsCompressorNode;
 class GainNode;
 class IIRFilterNode;
 class MediaElementAudioSourceNode;
+class MediaSessionManagerInterface;
 class OscillatorNode;
 class PannerNode;
 class PeriodicWave;
@@ -256,6 +257,8 @@ protected:
     void setState(State);
 
     void clear();
+
+    RefPtr<MediaSessionManagerInterface> mediaSessionManager() const;
 
 protected:
     // Only accessed when the graph lock is held.

--- a/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -14,7 +14,6 @@ Modules/indexeddb/server/UniqueIDBDatabase.cpp
 Modules/mediacontrols/MediaControlsHost.cpp
 Modules/mediarecorder/MediaRecorder.cpp
 Modules/mediasession/MediaMetadata.cpp
-Modules/mediasession/MediaSession.cpp
 Modules/mediastream/RTCController.cpp
 Modules/mediastream/RTCPeerConnection.cpp
 Modules/mediastream/RTCRtpScriptTransformer.cpp

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -2625,9 +2625,11 @@ void Document::visibilityStateChanged()
     });
 
 #if ENABLE(MEDIA_STREAM) && PLATFORM(IOS_FAMILY)
-    if (auto mediaSessionManager = PlatformMediaSessionManager::singletonIfExists()) {
-        if (!mediaSessionManager->isInterrupted())
-            updateCaptureAccordingToMutedState();
+    if (RefPtr page = this->page()) {
+        if (RefPtr mediaSessionManager = page->mediaSessionManagerIfExists()) {
+            if (!mediaSessionManager->isInterrupted())
+                updateCaptureAccordingToMutedState();
+        }
     }
 #endif
 

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -218,8 +218,6 @@ public:
 
     WEBCORE_EXPORT static HashSet<WeakRef<HTMLMediaElement>>& allMediaElements();
 
-    WEBCORE_EXPORT static RefPtr<HTMLMediaElement> bestMediaElementForRemoteControls(MediaElementSession::PlaybackControlsPurpose, const Document* = nullptr);
-
     WEBCORE_EXPORT void rewind(double timeDelta);
     WEBCORE_EXPORT void returnToRealtime() override;
 
@@ -1055,6 +1053,7 @@ private:
 
     DOMWrapperWorld& ensureIsolatedWorld();
 
+    RefPtr<MediaSessionManagerInterface> sessionManager() const final;
     PlatformMediaSession::MediaType mediaType() const override;
     PlatformMediaSession::MediaType presentationType() const override;
     PlatformMediaSession::DisplayType displayType() const override;
@@ -1097,6 +1096,7 @@ private:
     void unregisterWithDocument(Document&);
 
     void initializeMediaSession();
+    void invalidateMediaSession();
 
     void updateCaptionContainer();
     bool ensureMediaControls();

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -149,6 +149,7 @@ class LowPowerModeNotifier;
 class MediaCanStartListener;
 class MediaPlaybackTarget;
 class MediaSessionCoordinatorPrivate;
+class MediaSessionManagerInterface;
 class ModelPlayerProvider;
 class PageConfiguration;
 class PageConsoleClient;
@@ -252,6 +253,7 @@ enum class FindOption : uint16_t;
 enum class FilterRenderingMode : uint8_t;
 enum class LayoutMilestone : uint16_t;
 enum class LoginStatusAuthenticationType : uint8_t;
+enum class PlatformMediaSessionPlaybackControlsPurpose : uint8_t;
 enum class MediaPlaybackTargetContextMockState : uint8_t;
 enum class MediaProducerMediaState : uint32_t;
 enum class MediaProducerMediaCaptureKind : uint8_t;
@@ -1347,6 +1349,12 @@ public:
     WEBCORE_EXPORT void setPresentingApplicationBundleIdentifier(String&&);
 #endif
 
+    WEBCORE_EXPORT RefPtr<HTMLMediaElement> bestMediaElementForRemoteControls(PlatformMediaSessionPlaybackControlsPurpose, Document*);
+
+    WEBCORE_EXPORT MediaSessionManagerInterface& mediaSessionManager();
+    WEBCORE_EXPORT MediaSessionManagerInterface* mediaSessionManagerIfExists() const;
+    WEBCORE_EXPORT static MediaSessionManagerInterface* mediaSessionManagerForPageIdentifier(PageIdentifier);
+
 #if ENABLE(MODEL_ELEMENT)
     bool shouldDisableModelLoadDelaysForTesting() const { return m_modelLoadDelaysDisabledForTesting; }
     void disableModelLoadDelaysForTesting() { m_modelLoadDelaysDisabledForTesting = true; }
@@ -1819,6 +1827,10 @@ private:
 #if PLATFORM(COCOA)
     String m_presentingApplicationBundleIdentifier;
 #endif
+
+    using MediaSessionManagerFactory = Function<RefPtr<MediaSessionManagerInterface> (std::optional<PageIdentifier>)>;
+    std::optional<MediaSessionManagerFactory> m_mediaSessionManagerFactory;
+    RefPtr<MediaSessionManagerInterface> m_mediaSessionManager;
 
 #if ENABLE(MODEL_ELEMENT)
     bool m_modelLoadDelaysDisabledForTesting { false };

--- a/Source/WebCore/page/PageConfiguration.h
+++ b/Source/WebCore/page/PageConfiguration.h
@@ -76,6 +76,7 @@ class FrameLoader;
 class HistoryItemClient;
 class InspectorBackendClient;
 class LocalFrameLoaderClient;
+class MediaSessionManagerInterface;
 class ModelPlayerProvider;
 class PaymentCoordinatorClient;
 class PerformanceLoggingClient;
@@ -98,6 +99,7 @@ class WebRTCProvider;
 
 enum class SandboxFlag : uint16_t;
 using SandboxFlags = OptionSet<SandboxFlag>;
+using MediaSessionManagerFactory = Function<RefPtr<MediaSessionManagerInterface> (std::optional<PageIdentifier>)>;
 
 class PageConfiguration {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(PageConfiguration, WEBCORE_EXPORT);
@@ -244,6 +246,8 @@ public:
 #if HAVE(DIGITAL_CREDENTIALS_UI)
     Ref<CredentialRequestCoordinatorClient> credentialRequestCoordinatorClient;
 #endif
+
+    std::optional<MediaSessionManagerFactory> mediaSessionManagerFactory;
 };
 
 }

--- a/Source/WebCore/page/SettingsBase.h
+++ b/Source/WebCore/page/SettingsBase.h
@@ -132,6 +132,9 @@ public:
 
     WEBCORE_EXPORT void resetToConsistentState();
 
+    WEBCORE_EXPORT RefPtr<Page> protectedPage() const;
+    WeakPtr<Page> page() const { return m_page; }
+
 protected:
     explicit SettingsBase(Page*);
     virtual ~SettingsBase();
@@ -168,7 +171,6 @@ protected:
     void useSystemAppearanceChanged();
     void fontFallbackPrefersPictographsChanged();
     void updateDisplayEDRHeadroom();
-    RefPtr<Page> protectedPage() const;
 
     WeakPtr<Page> m_page;
 

--- a/Source/WebCore/page/cocoa/PageCocoa.mm
+++ b/Source/WebCore/page/cocoa/PageCocoa.mm
@@ -136,7 +136,7 @@ const String& Page::presentingApplicationBundleIdentifier() const
 void Page::setPresentingApplicationBundleIdentifier(String&& bundleIdentifier)
 {
     m_presentingApplicationBundleIdentifier = WTFMove(bundleIdentifier);
-    PlatformMediaSessionManager::updateNowPlayingInfoIfNecessary();
+    mediaSessionManager().updateNowPlayingInfoIfNecessary();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/RemoteCommandListener.h
+++ b/Source/WebCore/platform/RemoteCommandListener.h
@@ -34,7 +34,7 @@ namespace WebCore {
 class RemoteCommandListenerClient {
 public:
     virtual ~RemoteCommandListenerClient() = default;
-    virtual void didReceiveRemoteControlCommand(PlatformMediaSession::RemoteControlCommandType, const PlatformMediaSession::RemoteCommandArgument&) = 0;
+    virtual void didReceiveRemoteControlCommand(PlatformMediaSessionRemoteControlCommandType, const PlatformMediaSessionRemoteCommandArgument&) = 0;
 };
 
 class WEBCORE_EXPORT RemoteCommandListener : public AbstractRefCounted {
@@ -47,10 +47,10 @@ public:
     static void setCreationFunction(CreationFunction&&);
     static void resetCreationFunction();
 
-    void addSupportedCommand(PlatformMediaSession::RemoteControlCommandType);
-    void removeSupportedCommand(PlatformMediaSession::RemoteControlCommandType);
+    void addSupportedCommand(PlatformMediaSessionRemoteControlCommandType);
+    void removeSupportedCommand(PlatformMediaSessionRemoteControlCommandType);
 
-    using RemoteCommandsSet = HashSet<PlatformMediaSession::RemoteControlCommandType, IntHash<PlatformMediaSession::RemoteControlCommandType>, WTF::StrongEnumHashTraits<PlatformMediaSession::RemoteControlCommandType>>;
+    using RemoteCommandsSet = PlatformMediaSessionRemoteCommandsSet;
     void setSupportedCommands(const RemoteCommandsSet&);
     const RemoteCommandsSet& supportedCommands() const;
 

--- a/Source/WebCore/platform/audio/PlatformMediaSession.h
+++ b/Source/WebCore/platform/audio/PlatformMediaSession.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2014-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,11 +29,8 @@
 
 namespace WebCore {
 
-class PlatformMediaSession
-    : public PlatformMediaSessionInterface
-{
+class PlatformMediaSession : public PlatformMediaSessionInterface {
     WTF_MAKE_TZONE_ALLOCATED(PlatformMediaSession);
-
 public:
     static Ref<PlatformMediaSession> create(PlatformMediaSessionClient& client)
     {

--- a/Source/WebCore/platform/audio/PlatformMediaSessionInterface.cpp
+++ b/Source/WebCore/platform/audio/PlatformMediaSessionInterface.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "PlatformMediaSessionInterface.h"
 
+#include "MediaSessionManagerInterface.h"
 #include <wtf/NeverDestroyed.h>
 
 namespace WebCore {
@@ -33,6 +34,7 @@ namespace WebCore {
 class EmptyPlatformMediaSessionClient final : public PlatformMediaSessionClient {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(EmptyPlatformMediaSessionClient);
 public:
+    RefPtr<MediaSessionManagerInterface> sessionManager() const final { return nullptr; }
     PlatformMediaSessionMediaType mediaType() const final { return PlatformMediaSessionMediaType::None; }
     PlatformMediaSessionMediaType presentationType() const final { return PlatformMediaSessionMediaType::None; }
     void mayResumePlayback(bool) final { }
@@ -56,5 +58,7 @@ PlatformMediaSessionClient& emptyPlatformMediaSessionClient()
     static NeverDestroyed<EmptyPlatformMediaSessionClient> client { };
     return client;
 }
+
+PlatformMediaSessionClient::~PlatformMediaSessionClient() = default;
 
 }

--- a/Source/WebCore/platform/audio/PlatformMediaSessionTypes.h
+++ b/Source/WebCore/platform/audio/PlatformMediaSessionTypes.h
@@ -1,0 +1,117 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+namespace WebCore {
+
+enum class AudioSessionCategory : uint8_t;
+enum class AudioSessionMode : uint8_t;
+enum class RouteSharingPolicy : uint8_t;
+
+enum class PlatformMediaSessionMediaType : uint8_t {
+    None,
+    Video,
+    VideoAudio,
+    Audio,
+    WebAudio,
+};
+
+enum class PlatformMediaSessionState : uint8_t {
+    Idle,
+    Autoplaying,
+    Playing,
+    Paused,
+    Interrupted,
+};
+
+enum class PlatformMediaSessionInterruptionType : uint8_t {
+    NoInterruption,
+    SystemSleep,
+    EnteringBackground,
+    SystemInterruption,
+    SuspendedUnderLock,
+    InvisibleAutoplay,
+    ProcessInactive,
+    PlaybackSuspended,
+    PageNotVisible,
+};
+
+enum class PlatformMediaSessionPlaybackControlsPurpose : uint8_t {
+    ControlsManager,
+    NowPlaying,
+    MediaSession
+};
+
+enum class PlatformMediaSessionDisplayType : uint8_t {
+    Normal,
+    Fullscreen,
+    Optimized,
+};
+
+enum class PlatformMediaSessionEndInterruptionFlags : uint8_t {
+    NoFlags = 0,
+    MayResumePlaying = 1 << 0,
+};
+
+enum class DelayCallingUpdateNowPlaying : bool {
+    No,
+    Yes
+};
+
+enum class PlatformMediaSessionRemoteControlCommandType : uint8_t {
+    NoCommand,
+    PlayCommand,
+    PauseCommand,
+    StopCommand,
+    TogglePlayPauseCommand,
+    BeginSeekingBackwardCommand,
+    EndSeekingBackwardCommand,
+    BeginSeekingForwardCommand,
+    EndSeekingForwardCommand,
+    SeekToPlaybackPositionCommand,
+    SkipForwardCommand,
+    SkipBackwardCommand,
+    NextTrackCommand,
+    PreviousTrackCommand,
+    BeginScrubbingCommand,
+    EndScrubbingCommand,
+};
+
+struct PlatformMediaSessionRemoteCommandArgument {
+    std::optional<double> time;
+    std::optional<bool> fastSeek;
+};
+
+using PlatformMediaSessionRemoteCommandsSet = HashSet<PlatformMediaSessionRemoteControlCommandType, IntHash<PlatformMediaSessionRemoteControlCommandType>, WTF::StrongEnumHashTraits<PlatformMediaSessionRemoteControlCommandType>>;
+
+class AudioCaptureSource : public CanMakeWeakPtr<AudioCaptureSource> {
+public:
+    virtual ~AudioCaptureSource() = default;
+    virtual bool isCapturingAudio() const = 0;
+    virtual bool wantsToCaptureAudio() const = 0;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.h
+++ b/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.h
@@ -133,7 +133,7 @@ private:
     RefPtr<AudioHardwareListener> m_audioHardwareListener;
 
     AudioHardwareListener::BufferSizeRange m_supportedAudioHardwareBufferSizes;
-    size_t m_defaultBufferSize;
+    std::optional<size_t> m_defaultBufferSize;
 
     RunLoop::Timer m_delayCategoryChangeTimer;
     AudioSession::CategoryType m_previousCategory { AudioSession::CategoryType::None };

--- a/Source/WebCore/platform/audio/glib/MediaSessionManagerGLib.cpp
+++ b/Source/WebCore/platform/audio/glib/MediaSessionManagerGLib.cpp
@@ -115,7 +115,7 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(MediaSessionManagerGLib);
 
-const std::unique_ptr<PlatformMediaSessionManager> PlatformMediaSessionManager::create()
+RefPtr<PlatformMediaSessionManager> PlatformMediaSessionManager::create(std::optional<PageIdentifier>)
 {
     GUniqueOutPtr<GError> error;
     auto mprisInterface = adoptGRef(g_dbus_node_info_new_for_xml(s_mprisInterface, &error.outPtr()));
@@ -123,7 +123,7 @@ const std::unique_ptr<PlatformMediaSessionManager> PlatformMediaSessionManager::
         g_warning("Failed at parsing XML Interface definition: %s", error->message);
         return nullptr;
     }
-    return makeUniqueWithoutRefCountedCheck<MediaSessionManagerGLib, PlatformMediaSessionManager>(WTFMove(mprisInterface));
+    return adoptRef(new MediaSessionManagerGLib(WTFMove(mprisInterface)));
 }
 
 MediaSessionManagerGLib::MediaSessionManagerGLib(GRefPtr<GDBusNodeInfo>&& mprisInterface)

--- a/Source/WebCore/platform/audio/ios/MediaSessionHelperIOS.h
+++ b/Source/WebCore/platform/audio/ios/MediaSessionHelperIOS.h
@@ -27,6 +27,7 @@
 
 #if PLATFORM(IOS_FAMILY)
 
+#include "MediaPlaybackTarget.h"
 #include <wtf/WeakHashSet.h>
 
 namespace WebCore {
@@ -39,8 +40,6 @@ template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::MediaSession
 }
 
 namespace WebCore {
-
-class MediaPlaybackTarget;
 
 enum class SuspendedUnderLock : bool { No, Yes };
 enum class HasAvailableTargets : bool { No, Yes };

--- a/Source/WebCore/platform/audio/ios/MediaSessionManagerIOS.mm
+++ b/Source/WebCore/platform/audio/ios/MediaSessionManagerIOS.mm
@@ -45,9 +45,9 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(MediaSessionManageriOS);
 
-const std::unique_ptr<PlatformMediaSessionManager> PlatformMediaSessionManager::create()
+RefPtr<PlatformMediaSessionManager> PlatformMediaSessionManager::create(std::optional<PageIdentifier>)
 {
-    auto manager = std::unique_ptr<MediaSessionManageriOS>(new MediaSessionManageriOS);
+    auto manager = adoptRef(new MediaSessionManageriOS);
     MediaSessionHelper::sharedHelper().addClient(*manager);
     return manager;
 }

--- a/Source/WebCore/platform/graphics/MediaPlaybackTarget.h
+++ b/Source/WebCore/platform/graphics/MediaPlaybackTarget.h
@@ -29,11 +29,11 @@
 
 #include "MediaPlaybackTargetContext.h"
 #include <wtf/Forward.h>
-#include <wtf/RefCounted.h>
+#include <wtf/ThreadSafeRefCounted.h>
 
 namespace WebCore {
 
-class MediaPlaybackTarget : public RefCounted<MediaPlaybackTarget> {
+class MediaPlaybackTarget : public ThreadSafeRefCounted<MediaPlaybackTarget> {
 public:
     virtual ~MediaPlaybackTarget() = default;
 

--- a/Source/WebCore/platform/graphics/cocoa/MediaEngineConfigurationFactoryCocoa.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/MediaEngineConfigurationFactoryCocoa.cpp
@@ -33,6 +33,7 @@
 #include "HEVCUtilitiesCocoa.h"
 #include "MediaCapabilitiesDecodingInfo.h"
 #include "MediaDecodingConfiguration.h"
+#include "MediaEngineConfigurationFactory.h"
 #include "MediaPlayer.h"
 #include "MediaSessionHelperIOS.h"
 #include "PlatformMediaSessionManager.h"
@@ -163,7 +164,11 @@ static std::optional<MediaCapabilitiesInfo> computeMediaCapabilitiesInfo(const M
     if (!configuration.audio->spatialRendering.value_or(false))
         return info;
 
-    auto supportsSpatialPlayback = PlatformMediaSessionManager::singleton().supportsSpatialAudioPlaybackForConfiguration(configuration);
+    RefPtr manager = configuration.pageIdentifier ? MediaEngineConfigurationFactory::mediaSessionManagerForPageIdentifier(configuration.pageIdentifier.value()) : nullptr;
+    if (!manager)
+        return std::nullopt;
+
+    auto supportsSpatialPlayback = manager->supportsSpatialAudioPlaybackForConfiguration(configuration);
     if (!supportsSpatialPlayback.has_value())
         return std::nullopt;
 

--- a/Source/WebCore/platform/mediacapabilities/MediaDecodingConfiguration.h
+++ b/Source/WebCore/platform/mediacapabilities/MediaDecodingConfiguration.h
@@ -27,11 +27,14 @@
 
 #include "MediaConfiguration.h"
 #include "MediaDecodingType.h"
+#include "PageIdentifier.h"
 
 namespace WebCore {
 
 struct MediaDecodingConfiguration : MediaConfiguration {
     MediaDecodingType type;
+
+    std::optional<PageIdentifier> pageIdentifier;
 
     bool canExposeVP9 { true };
 
@@ -40,7 +43,7 @@ struct MediaDecodingConfiguration : MediaConfiguration {
 
 inline MediaDecodingConfiguration MediaDecodingConfiguration::isolatedCopy() const
 {
-    return { MediaConfiguration::isolatedCopy(), type, canExposeVP9 };
+    return { MediaConfiguration::isolatedCopy(), type, pageIdentifier, canExposeVP9 };
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/mediacapabilities/MediaEngineConfigurationFactory.cpp
+++ b/Source/WebCore/platform/mediacapabilities/MediaEngineConfigurationFactory.cpp
@@ -33,6 +33,7 @@
 #include "MediaDecodingConfiguration.h"
 #include "MediaEncodingConfiguration.h"
 #include "MediaEngineConfigurationFactoryMock.h"
+#include "MediaSessionManagerInterface.h"
 #include <algorithm>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/Vector.h>
@@ -167,6 +168,25 @@ void MediaEngineConfigurationFactory::enableMock()
 void MediaEngineConfigurationFactory::disableMock()
 {
     mockEnabled() = false;
+}
+
+static MediaEngineConfigurationFactory::MediaSessionManagerProvider& mediaSessionManagerProvider()
+{
+    static NeverDestroyed<MediaEngineConfigurationFactory::MediaSessionManagerProvider> provider;
+    return provider.get();
+}
+
+void MediaEngineConfigurationFactory::setMediaSessionManagerProvider(MediaSessionManagerProvider&& provider)
+{
+    mediaSessionManagerProvider() = WTFMove(provider);
+}
+
+RefPtr<MediaSessionManagerInterface> MediaEngineConfigurationFactory::mediaSessionManagerForPageIdentifier(PageIdentifier pageIdentifier)
+{
+    if (mediaSessionManagerProvider())
+        return mediaSessionManagerProvider()(pageIdentifier);
+
+    return nullptr;
 }
 
 }

--- a/Source/WebCore/platform/mediacapabilities/MediaEngineConfigurationFactory.h
+++ b/Source/WebCore/platform/mediacapabilities/MediaEngineConfigurationFactory.h
@@ -27,10 +27,12 @@
 
 #pragma once
 
+#include "PageIdentifier.h"
 #include <wtf/Function.h>
 
 namespace WebCore {
 
+class MediaSessionManagerInterface;
 struct MediaCapabilitiesDecodingInfo;
 struct MediaCapabilitiesEncodingInfo;
 struct MediaDecodingConfiguration;
@@ -46,7 +48,7 @@ public:
 
     WEBCORE_EXPORT static void createDecodingConfiguration(MediaDecodingConfiguration&&, DecodingConfigurationCallback&&);
     WEBCORE_EXPORT static void createEncodingConfiguration(MediaEncodingConfiguration&&, EncodingConfigurationCallback&&);
-    
+
     using CreateDecodingConfiguration = Function<void(MediaDecodingConfiguration&&, DecodingConfigurationCallback&&)>;
     using CreateEncodingConfiguration = Function<void(MediaEncodingConfiguration&&, EncodingConfigurationCallback&&)>;
 
@@ -54,13 +56,19 @@ public:
         CreateDecodingConfiguration createDecodingConfiguration;
         CreateEncodingConfiguration createEncodingConfiguration;
     };
-    
+
     WEBCORE_EXPORT static void clearFactories();
     WEBCORE_EXPORT static void resetFactories();
     WEBCORE_EXPORT static void installFactory(MediaEngineFactory&&);
-    
+
     WEBCORE_EXPORT static void enableMock();
     WEBCORE_EXPORT static void disableMock();
+
+    using MediaSessionManagerProvider = Function<RefPtr<MediaSessionManagerInterface> (PageIdentifier)>;
+    WEBCORE_EXPORT static void setMediaSessionManagerProvider(MediaSessionManagerProvider&&);
+
+    WEBCORE_EXPORT static RefPtr<MediaSessionManagerInterface> mediaSessionManagerForPageIdentifier(PageIdentifier);
+
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/mock/MockRealtimeAudioSource.cpp
+++ b/Source/WebCore/platform/mock/MockRealtimeAudioSource.cpp
@@ -147,12 +147,6 @@ void MockRealtimeAudioSource::settingsDidChange(OptionSet<RealtimeMediaSourceSet
 
 void MockRealtimeAudioSource::startProducingData()
 {
-#if PLATFORM(IOS_FAMILY)
-    PlatformMediaSessionManager::singleton().sessionCanProduceAudioChanged();
-    ASSERT(AudioSession::singleton().category() == AudioSession::CategoryType::PlayAndRecord);
-    ASSERT(AudioSession::singleton().mode() == AudioSession::Mode::VideoChat);
-#endif
-
     if (!sampleRate())
         setSampleRate(std::get<MockMicrophoneProperties>(m_device.properties).defaultSampleRate);
 

--- a/Source/WebCore/testing/InternalSettings.cpp
+++ b/Source/WebCore/testing/InternalSettings.cpp
@@ -65,10 +65,11 @@ InternalSettings::Backup::Backup(Settings& settings)
 #if USE(AUDIO_SESSION)
     , m_shouldManageAudioSessionCategory(DeprecatedGlobalSettings::shouldManageAudioSessionCategory())
 #endif
-#if ENABLE(VIDEO) || ENABLE(WEB_AUDIO)
-    , m_shouldDeactivateAudioSession(PlatformMediaSessionManager::shouldDeactivateAudioSession())
-#endif
 {
+#if ENABLE(VIDEO) || ENABLE(WEB_AUDIO)
+    if (RefPtr page = settings.page().get())
+        m_shouldDeactivateAudioSession = page->mediaSessionManager().shouldDeactivateAudioSession();
+#endif
 }
 
 void InternalSettings::Backup::restoreTo(Settings& settings)
@@ -120,7 +121,8 @@ void InternalSettings::Backup::restoreTo(Settings& settings)
 #endif
 
 #if ENABLE(VIDEO) || ENABLE(WEB_AUDIO)
-    PlatformMediaSessionManager::setShouldDeactivateAudioSession(m_shouldDeactivateAudioSession);
+    if (RefPtr page = settings.page().get())
+        page->mediaSessionManager().setShouldDeactivateAudioSession(m_shouldDeactivateAudioSession);
 #endif
 
 #if ENABLE(WEB_AUDIO)
@@ -535,8 +537,9 @@ ExceptionOr<void>  InternalSettings::setShouldDeactivateAudioSession(bool should
 {
     if (!m_page)
         return Exception { ExceptionCode::InvalidAccessError };
+
 #if ENABLE(VIDEO) || ENABLE(WEB_AUDIO)
-    PlatformMediaSessionManager::setShouldDeactivateAudioSession(should);
+    m_page->mediaSessionManager().setShouldDeactivateAudioSession(should);
 #else
     UNUSED_PARAM(should);
 #endif

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -110,6 +110,7 @@ class InternalsSetLike;
 class LocalFrame;
 class Location;
 class MallocStatistics;
+class MediaSessionManagerInterface;
 class MediaStream;
 class MediaStreamTrack;
 class MemoryInfo;
@@ -1618,6 +1619,8 @@ private:
     CachedResource* resourceFromMemoryCache(const String& url);
 
     bool hasMarkerFor(DocumentMarkerType, int from, int length);
+
+    RefPtr<MediaSessionManagerInterface> sessionManager() const;
 
 #if ENABLE(MEDIA_STREAM)
     // RealtimeMediaSourceObserver API

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -3569,6 +3569,7 @@ struct WebCore::MediaEncodingConfiguration : WebCore::MediaConfiguration {
 
 struct WebCore::MediaDecodingConfiguration : WebCore::MediaConfiguration {
     WebCore::MediaDecodingType type;
+    std::optional<WebCore::PageIdentifier> pageIdentifier;
     bool canExposeVP9;
 };
 

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -9484,6 +9484,16 @@ void WebPageProxy::resumeAllMediaPlayback(CompletionHandler<void()>&& completion
     sendWithAsyncReply(Messages::WebPage::ResumeAllMediaPlayback(), WTFMove(completionHandler));
 }
 
+void WebPageProxy::processWillSuspend()
+{
+    Ref { m_legacyMainFrameProcess }->send(Messages::WebPage::ProcessWillSuspend(), webPageIDInMainFrameProcess());
+}
+
+void WebPageProxy::processDidResume()
+{
+    Ref { m_legacyMainFrameProcess }->send(Messages::WebPage::ProcessDidResume(), webPageIDInMainFrameProcess());
+}
+
 void WebPageProxy::setMayStartMediaWhenInWindow(bool mayStartMedia)
 {
     if (mayStartMedia == m_mayStartMediaWhenInWindow)

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1086,6 +1086,9 @@ public:
     WebCore::FloatRect selectionBoundingRectInRootViewCoordinates() const;
 #endif
 
+    void processWillSuspend();
+    void processDidResume();
+
 #if PLATFORM(IOS_FAMILY)
     void textInputContextsInRect(WebCore::FloatRect, CompletionHandler<void(const Vector<WebCore::ElementContext>&)>&&);
     void focusTextInputContextAndPlaceCaret(const WebCore::ElementContext&, const WebCore::IntPoint&, CompletionHandler<void(bool)>&&);

--- a/Source/WebKit/WebProcess/GPU/GPUProcessConnection.cpp
+++ b/Source/WebKit/WebProcess/GPU/GPUProcessConnection.cpp
@@ -54,7 +54,7 @@
 #include "WebPageMessages.h"
 #include "WebProcess.h"
 #include "WebProcessProxyMessages.h"
-#include <WebCore/PlatformMediaSessionManager.h>
+#include <WebCore/PlatformMediaSession.h>
 #include <WebCore/RenderingMode.h>
 #include <WebCore/SharedBuffer.h>
 
@@ -345,7 +345,7 @@ bool GPUProcessConnection::waitForDidInitialize()
 void GPUProcessConnection::didReceiveRemoteCommand(PlatformMediaSession::RemoteControlCommandType type, const PlatformMediaSession::RemoteCommandArgument& argument)
 {
 #if ENABLE(VIDEO) || ENABLE(WEB_AUDIO)
-    PlatformMediaSessionManager::singleton().processDidReceiveRemoteControlCommand(type, argument);
+    WebProcess::singleton().didReceiveRemoteCommand(type, argument);
 #endif
 }
 

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -193,9 +193,9 @@ void WebPage::platformDidReceiveLoadParameters(const LoadParameters& parameters)
 
 void WebPage::requestActiveNowPlayingSessionInfo(CompletionHandler<void(bool, WebCore::NowPlayingInfo&&)>&& completionHandler)
 {
-    if (RefPtr sharedManager = WebCore::PlatformMediaSessionManager::singletonIfExists()) {
-        if (auto nowPlayingInfo = sharedManager->nowPlayingInfo()) {
-            bool registeredAsNowPlayingApplication = sharedManager->registeredAsNowPlayingApplication();
+    if (RefPtr manager = mediaSessionManagerIfExists()) {
+        if (auto nowPlayingInfo = manager->nowPlayingInfo()) {
+            bool registeredAsNowPlayingApplication = manager->registeredAsNowPlayingApplication();
             completionHandler(registeredAsNowPlayingApplication, WTFMove(*nowPlayingInfo));
             return;
         }
@@ -1442,6 +1442,18 @@ void WebPage::getWebArchives(CompletionHandler<void(HashMap<WebCore::FrameIdenti
             result.add(localFrame->frameID(), archive.releaseNonNull());
     }
     completionHandler(WTFMove(result));
+}
+
+void WebPage::processSystemWillSleep() const
+{
+    if (RefPtr manager = mediaSessionManagerIfExists())
+        manager->processSystemWillSleep();
+}
+
+void WebPage::processSystemDidWake() const
+{
+    if (RefPtr manager = mediaSessionManagerIfExists())
+        manager->processSystemDidWake();
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -201,6 +201,7 @@ class LocalFrame;
 class LocalFrameView;
 class MediaPlaybackTargetContext;
 class MediaSessionCoordinator;
+class MediaSessionManagerInterface;
 class Page;
 class PolicyDecision;
 class PrintContext;
@@ -248,6 +249,7 @@ enum class MediaProducerMediaCaptureKind : uint8_t;
 enum class MediaProducerMediaState : uint32_t;
 enum class MediaProducerMutedState : uint8_t;
 enum class PlatformEventModifier : uint8_t;
+enum class PlatformMediaSessionRemoteControlCommandType : uint8_t;
 enum class RenderAsTextFlag : uint16_t;
 enum class ScheduleLocationChangeResult : uint8_t;
 enum class SelectionDirection : uint8_t;
@@ -305,6 +307,7 @@ struct MediaUsageInfo;
 struct MessageWithMessagePorts;
 struct NavigationIdentifierType;
 struct NowPlayingInfo;
+struct PlatformMediaSessionRemoteCommandArgument;
 struct ProcessSyncData;
 struct PromisedAttachmentInfo;
 struct RemoteUserInputEventData;
@@ -1441,6 +1444,15 @@ public:
     void shouldDismissKeyboardAfterTapAtPoint(WebCore::FloatPoint, CompletionHandler<void(bool)>&&);
 #endif
 
+    void processWillSuspend();
+    void processDidResume();
+    void didReceiveRemoteCommand(WebCore::PlatformMediaSessionRemoteControlCommandType, const WebCore::PlatformMediaSessionRemoteCommandArgument&);
+
+#if PLATFORM(COCOA)
+    void processSystemWillSleep() const;
+    void processSystemDidWake() const;
+#endif
+
 #if ENABLE(META_VIEWPORT)
     void setViewportConfigurationViewLayoutSize(const WebCore::FloatSize&, double layoutSizeScaleFactorFromClient, double minimumEffectiveDeviceWidth);
     void setOverrideViewportArguments(const std::optional<WebCore::ViewportArguments>&);
@@ -2022,6 +2034,9 @@ public:
     bool shouldSendConsoleLogsToUIProcessForTesting() const { return m_shouldSendConsoleLogsToUIProcessForTesting; }
 
     void setNeedsFixedContainerEdgesUpdate() { m_needsFixedContainerEdgesUpdate = true; }
+
+    RefPtr<WebCore::MediaSessionManagerInterface> mediaSessionManager() const;
+    WebCore::MediaSessionManagerInterface* mediaSessionManagerIfExists() const;
 
 #if ENABLE(MODEL_ELEMENT)
     bool shouldDisableModelLoadDelaysForTesting() const;

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -148,6 +148,9 @@ messages -> WebPage WantsAsyncDispatchMessage {
     ClearServiceWorkerEntitlementOverride() -> ()
 #endif
 
+    ProcessWillSuspend()
+    ProcessDidResume()
+
     RequestImageBitmap(struct WebCore::ElementContext elementContext) -> (std::optional<WebCore::ShareableBitmapHandle> image, String sourceMIMEType)
 
     SetControlledByAutomation(bool controlled)

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -4934,7 +4934,7 @@ void WebPage::applicationWillResignActive()
     [[NSNotificationCenter defaultCenter] postNotificationName:WebUIApplicationWillResignActiveNotification object:nil];
 
     // FIXME(224775): Move to WebProcess
-    if (auto* manager = PlatformMediaSessionManager::singletonIfExists())
+    if (RefPtr manager = mediaSessionManagerIfExists())
         manager->applicationWillBecomeInactive();
 
     if (m_page)
@@ -4949,7 +4949,7 @@ void WebPage::applicationDidEnterBackground(bool isSuspendedUnderLock)
     freezeLayerTree(LayerTreeFreezeReason::BackgroundApplication);
 
     // FIXME(224775): Move to WebProcess
-    if (auto* manager = PlatformMediaSessionManager::singletonIfExists())
+    if (RefPtr manager = mediaSessionManagerIfExists())
         manager->applicationDidEnterBackground(isSuspendedUnderLock);
 
     if (m_page)
@@ -4971,7 +4971,7 @@ void WebPage::applicationWillEnterForeground(bool isSuspendedUnderLock)
     [[NSNotificationCenter defaultCenter] postNotificationName:WebUIApplicationWillEnterForegroundNotification object:nil userInfo:@{@"isSuspendedUnderLock": @(isSuspendedUnderLock)}];
 
     // FIXME(224775): Move to WebProcess
-    if (auto* manager = PlatformMediaSessionManager::singletonIfExists())
+    if (RefPtr manager = mediaSessionManagerIfExists())
         manager->applicationWillEnterForeground(isSuspendedUnderLock);
 
     if (m_page)
@@ -4983,7 +4983,7 @@ void WebPage::applicationDidBecomeActive()
     [[NSNotificationCenter defaultCenter] postNotificationName:WebUIApplicationDidBecomeActiveNotification object:nil];
 
     // FIXME(224775): Move to WebProcess
-    if (auto* manager = PlatformMediaSessionManager::singletonIfExists())
+    if (RefPtr manager = mediaSessionManagerIfExists())
         manager->applicationDidBecomeActive();
 
     if (m_page)
@@ -4992,13 +4992,13 @@ void WebPage::applicationDidBecomeActive()
 
 void WebPage::applicationDidEnterBackgroundForMedia(bool isSuspendedUnderLock)
 {
-    if (auto* manager = PlatformMediaSessionManager::singletonIfExists())
+    if (RefPtr manager = mediaSessionManagerIfExists())
         manager->applicationDidEnterBackground(isSuspendedUnderLock);
 }
 
 void WebPage::applicationWillEnterForegroundForMedia(bool isSuspendedUnderLock)
 {
-    if (auto* manager = PlatformMediaSessionManager::singletonIfExists())
+    if (RefPtr manager = mediaSessionManagerIfExists())
         manager->applicationWillEnterForeground(isSuspendedUnderLock);
 }
 

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -128,7 +128,7 @@
 #include <WebCore/PageGroup.h>
 #include <WebCore/PermissionController.h>
 #include <WebCore/PlatformKeyboardEvent.h>
-#include <WebCore/PlatformMediaSessionManager.h>
+#include <WebCore/PlatformMediaSession.h>
 #include <WebCore/ProcessIdentifier.h>
 #include <WebCore/ProcessWarming.h>
 #include <WebCore/Quirks.h>
@@ -1746,8 +1746,9 @@ void WebProcess::prepareToSuspend(bool isSuspensionImminent, MonotonicTime estim
 
 #if ENABLE(VIDEO)
     suspendAllMediaBuffering();
-    if (RefPtr platformMediaSessionManager = PlatformMediaSessionManager::singletonIfExists())
-        platformMediaSessionManager->processWillSuspend();
+
+    for (auto& page : m_pageMap.values())
+        page->processWillSuspend();
 #endif
 
     // Ask the process to slim down before it suspends, in case it suspends for a very long time.
@@ -1844,8 +1845,8 @@ void WebProcess::processDidResume()
 #endif
 
 #if ENABLE(VIDEO)
-    if (RefPtr platformMediaSessionManager = PlatformMediaSessionManager::singletonIfExists())
-        platformMediaSessionManager->processDidResume();
+    for (auto& page : m_pageMap.values())
+        page->processDidResume();
     resumeAllMediaBuffering();
 #endif
 }
@@ -2618,6 +2619,12 @@ void WebProcess::setResourceMonitorContentRuleListAsync(WebCompiledContentRuleLi
     completionHandler();
 }
 #endif
+
+void WebProcess::didReceiveRemoteCommand(PlatformMediaSession::RemoteControlCommandType type, const PlatformMediaSession::RemoteCommandArgument& argument)
+{
+    for (auto& page : m_pageMap.values())
+        page->didReceiveRemoteCommand(type, argument);
+}
 
 } // namespace WebKit
 

--- a/Source/WebKit/WebProcess/WebProcess.h
+++ b/Source/WebKit/WebProcess/WebProcess.h
@@ -109,6 +109,7 @@ class Site;
 class UserGestureToken;
 
 enum class EventMakesGamepadsVisible : bool;
+enum class PlatformMediaSessionRemoteControlCommandType : uint8_t;
 enum class RenderAsTextFlag : uint16_t;
 enum class RenderingPurpose : uint8_t;
 enum class ScriptTrackingPrivacyCategory : uint8_t;
@@ -119,6 +120,7 @@ struct MessagePortIdentifier;
 struct MessageWithMessagePorts;
 struct MockMediaDevice;
 struct PrewarmInformation;
+struct PlatformMediaSessionRemoteCommandArgument;
 struct ScreenProperties;
 struct ServiceWorkerContextData;
 }
@@ -511,6 +513,8 @@ public:
     void registerAdditionalFonts(AdditionalFonts&&);
     void registerFontMap(HashMap<String, URL>&&, HashMap<String, Vector<String>>&&, Vector<SandboxExtension::Handle>&& sandboxExtensions);
 #endif
+
+    void didReceiveRemoteCommand(WebCore::PlatformMediaSessionRemoteControlCommandType, const WebCore::PlatformMediaSessionRemoteCommandArgument&);
 
 #if ENABLE(INITIALIZE_ACCESSIBILITY_ON_DEMAND)
     void initializeAccessibility(Vector<SandboxExtension::Handle>&&);

--- a/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
+++ b/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
@@ -1541,14 +1541,14 @@ void WebProcess::systemWillPowerOn()
 
 void WebProcess::systemWillSleep()
 {
-    if (PlatformMediaSessionManager::singletonIfExists())
-        PlatformMediaSessionManager::singleton().processSystemWillSleep();
+    for (auto& page : m_pageMap.values())
+        page->processSystemWillSleep();
 }
 
 void WebProcess::systemDidWake()
 {
-    if (PlatformMediaSessionManager::singletonIfExists())
-        PlatformMediaSessionManager::singleton().processSystemDidWake();
+    for (auto& page : m_pageMap.values())
+        page->processSystemDidWake();
 }
 #endif
 


### PR DESCRIPTION
#### 17897423938e86e276fab1d57b6ef0d99944e41d
<pre>
Remove PlatformMediaSessionManager::singleton
<a href="https://bugs.webkit.org/show_bug.cgi?id=292687">https://bugs.webkit.org/show_bug.cgi?id=292687</a>
<a href="https://rdar.apple.com/150885431">rdar://150885431</a>

Reviewed by Andy Estes.

For site-isolation we will need to move MediaSessionManager and related classes to the
GPU process and have a different MediaSessionManagerInterface proxy for every Page. As a
step in this direction, get rid of PlatformMediaSessionManager::singleton and add
Page::mediaSessionManager and remove all PlatformMediaSessionManager static methods.

Add a factory function to PageConfiguration that WebProcess will use to create a
RemoveMediaSessionManager once it exists.

* Source/WebCore/Headers.cmake:
* Source/WebCore/Modules/audiosession/DOMAudioSession.cpp:
(WebCore::DOMAudioSession::setType): Use Page::mediaSessionManager instead of
PlatformMediaSessionManager::singleton.

* Source/WebCore/Modules/mediacapabilities/MediaCapabilities.cpp:
(WebCore::gatherDecodingInfo): Ditto.

* Source/WebCore/Modules/mediasession/MediaSession.cpp:
(WebCore::MediaSession::setActionHandler): Ditto.
(WebCore::MediaSession::protectedDocument const): Add Document RefPtr
(WebCore::MediaSession::sessionManager const): Add accessor.
(WebCore::MediaSession::activeMediaElement const):
(WebCore::MediaSession::updateNowPlayingInfo):
(WebCore::MediaSession::updateCaptureState):
(WebCore::MediaSession::document const): Deleted.
* Source/WebCore/Modules/mediasession/MediaSession.h:

* Source/WebCore/Modules/mediastream/MediaStream.cpp:
(WebCore::MediaStream::startProducingData): Call `sessionCanProduceAudioChanged` if the
stream has an audio track so we don&apos;t need to do call it from the Mock audio source.
(WebCore::MediaStream::mediaSessionManager const):
* Source/WebCore/Modules/mediastream/MediaStream.h:

* Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp:
(WebCore::MediaStreamTrack::MediaStreamTrack): Use Page::mediaSessionManager instead of
PlatformMediaSessionManager::singleton.
(WebCore::MediaStreamTrack::~MediaStreamTrack): Ditto.
(WebCore::MediaStreamTrack::stopTrack): Ditto.
(WebCore::MediaStreamTrack::trackEnded): Ditto.
(WebCore::MediaStreamTrack::trackMutedChanged): Ditto.
(WebCore::MediaStreamTrack::mediaSessionManager const):
* Source/WebCore/Modules/mediastream/MediaStreamTrack.h:

* Source/WebCore/Modules/mediastream/UserMediaRequest.cpp:
(WebCore::UserMediaRequest::start): Ditto.

* Source/WebCore/Modules/webaudio/AudioContext.cpp:
(WebCore::AudioContext::defaultDestinationWillBecomeConnected): Ditto.
(WebCore::AudioContext::sessionManager const): Ditto.
* Source/WebCore/Modules/webaudio/AudioContext.h:

* Source/WebCore/Modules/webaudio/BaseAudioContext.cpp:
(WebCore::BaseAudioContext::setState): Ditto.
(WebCore::BaseAudioContext::mediaSessionManager const):
* Source/WebCore/Modules/webaudio/BaseAudioContext.h:

* Source/WebCore/WebCore.xcodeproj/project.pbxproj:

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::visibilityStateChanged): Ditto.

* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::bestMediaElementForRemoteControls): Deleted.
(WebCore::HTMLMediaElement::seekToPlaybackPositionEndedTimerFired): Use
Page::mediaSessionManager instead of PlatformMediaSessionManager::singleton.
(WebCore::HTMLMediaElement::couldPlayIfEnoughData const): Ditto.
(WebCore::HTMLMediaElement::shouldDisableSleep const): Ditto.
(WebCore::HTMLMediaElement::shouldOverrideBackgroundPlaybackRestriction const): Ditto.
(WebCore::HTMLMediaElement::sessionManager const):
* Source/WebCore/html/HTMLMediaElement.h:

* Source/WebCore/html/MediaElementSession.cpp:
(WebCore::MediaElementSession::isVisibleInViewportChanged): Use
PlatformMediaSessionClient::sessionManager instead of PlatformMediaSessionManager::singleton.
(WebCore::MediaElementSession::clientDataBufferingTimerFired): Ditto.
(WebCore::MediaElementSession::updateClientDataBuffering): Ditto.
(WebCore::MediaElementSession::canShowControlsManager const): Ditto.
(WebCore::MediaElementSession::setHasPlaybackTargetAvailabilityListeners): Ditto.

* Source/WebCore/page/Page.cpp:
(WebCore::Page::bestMediaElementForRemoteControls): Move from HTMLMediaElement.
(WebCore::Page::mediaPlaybackExists): Use mediaSessionManager instance variable instead of
PlatformMediaSessionManager::singletonIfExists.
(WebCore::Page::mediaPlaybackIsPaused): Ditto.
(WebCore::Page::pauseAllMediaPlayback): Ditto.
(WebCore::Page::suspendAllMediaPlayback): Ditto.
(WebCore::Page::resumeAllMediaPlayback): Ditto.
(WebCore::Page::suspendAllMediaBuffering): Ditto.
(WebCore::Page::resumeAllMediaBuffering): Ditto.
(WebCore::Page::setActivityState): Ditto.
(WebCore::Page::activeNowPlayingSessionUpdateTimerFired): Ditto.
(WebCore::Page::setPresentingApplicationAuditToken): Ditto.
(WebCore::Page::mediaSessionManager): Allocate `m_mediaSessionManager` with the factory
function if it doesn&apos;t exist. If m_mediaSessionManagerFactory is null, true for WK1 and
WK2 until we move the session manager to the GPU process, create a factory that allocates
and instance of PlatformMediaSessionManager.
(WebCore::Page::mediaSessionManagerIfExists const):
(WebCore::Page::mediaSessionManagerForPageIdentifier):
* Source/WebCore/page/Page.h:

* Source/WebCore/page/PageConfiguration.h: Add MediaSessionManagerFactory.

* Source/WebCore/page/cocoa/PageCocoa.mm:
(WebCore::Page::setPresentingApplicationBundleIdentifier): Use mediaSessionManager() instead
of PlatformMediaSessionManager directly.

* Source/WebCore/platform/RemoteCommandListener.h:
* Source/WebCore/platform/audio/MediaSessionManagerInterface.h: Inherit from
ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr.
(WebCore::MediaSessionManagerInterface::addSupportedCommand):
(WebCore::MediaSessionManagerInterface::removeSupportedCommand):
(WebCore::MediaSessionManagerInterface::supportedCommands const):

* Source/WebCore/platform/audio/PlatformMediaSession.cpp:
(WebCore::PlatformMediaSession::setActive): Use the client&apos;s mediaSessionManager instead of
PlatformMediaSessionManager::singleton.
(WebCore::PlatformMediaSession::setState): Ditto.
(WebCore::PlatformMediaSession::clientWillBeginPlayback): Ditto.
(WebCore::PlatformMediaSession::processClientWillPausePlayback): Ditto.
(WebCore::PlatformMediaSession::stopSession): Ditto.
(WebCore::PlatformMediaSession::isPlayingToWirelessPlaybackTargetChanged): Ditto.
(WebCore::PlatformMediaSession::canProduceAudioChanged): Ditto.
(WebCore::PlatformMediaSession::clientCharacteristicsChanged): Ditto.

* Source/WebCore/platform/audio/PlatformMediaSessionInterface.cpp:
* Source/WebCore/platform/audio/PlatformMediaSessionInterface.h: Move structs, classes,
and enums used by both PlatformMediaSessionInterface andn MediaSessionManagerInterface to
PlatformMediaSessionTypes.h to avoid recursive includes.
(WebCore::PlatformMediaSessionInterface::sessionManager const):

* Source/WebCore/platform/audio/PlatformMediaSessionManager.cpp:
(WebCore::PlatformMediaSessionManager::create): Add optional PageIdentifier parameter.
(WebCore::PlatformMediaSessionManager::updateNowPlayingInfoIfNecessary): Make not static.
(WebCore::PlatformMediaSessionManager::updateAudioSessionCategoryIfNecessary): Ditto.
(WebCore::sharedPlatformMediaSessionManager): Deleted.
(WebCore::PlatformMediaSessionManager::singleton): Deleted.
(WebCore::PlatformMediaSessionManager::singletonIfExists): Deleted.
(WebCore::PlatformMediaSessionManager::setAlternateWebMPlayerEnabled): Deleted.
(WebCore::PlatformMediaSessionManager::alternateWebMPlayerEnabled): Deleted.
* Source/WebCore/platform/audio/PlatformMediaSessionManager.h:
(WebCore::PlatformMediaSessionManager::ref const): Deleted.
(WebCore::PlatformMediaSessionManager::deref const): Deleted.

* Source/WebCore/platform/audio/PlatformMediaSessionTypes.h: Added.

* Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.h:
* Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm:
(WebCore::MediaSessionManagerCocoa::MediaSessionManagerCocoa): Don&apos;t initialize m_defaultBufferSize
as it requires a sync call to the GPU process.
(WebCore::MediaSessionManagerCocoa::updateSessionState): Initialize m_defaultBufferSize if
necessary.
(WebCore::PlatformMediaSessionManager::create): Add optional PageIdentifier parameter.

* Source/WebCore/platform/audio/ios/MediaSessionManagerIOS.mm:
(WebCore::PlatformMediaSessionManager::create): Ditto.

* Source/WebCore/platform/graphics/MediaPlayer.cpp:
(WebCore::cocoaWebMPlayerEnabled):
(WebCore::MediaPlayer::setCocoaWebMPlayerEnabled):
* Source/WebCore/platform/graphics/MediaPlayer.h:

* Source/WebCore/platform/graphics/cocoa/MediaEngineConfigurationFactoryCocoa.cpp:
(WebCore::computeMediaCapabilitiesInfo): Use the factory function to look up the correct
media session for the configuration page identifier.
* Source/WebCore/platform/mediacapabilities/MediaDecodingConfiguration.h: Add optional
page identifier.

* Source/WebCore/platform/mediacapabilities/MediaEngineConfigurationFactory.cpp:
(WebCore::mediaSessionManagerProvider):
(WebCore::MediaEngineConfigurationFactory::setMediaSessionManagerProvider):
(WebCore::MediaEngineConfigurationFactory::mediaSessionManagerForPageIdentifier):
* Source/WebCore/platform/mediacapabilities/MediaEngineConfigurationFactory.h:

* Source/WebCore/platform/mock/MockRealtimeAudioSource.cpp:
(WebCore::MockRealtimeAudioSource::startProducingData): Remove the call to
PlatformMediaSessionManager::singleton().sessionCanProduceAudioChanged, it is done in
MediaStream::startProducingData. Remove the asserts about audio session category and mode
because they will be changed asynchronously.

* Source/WebCore/testing/InternalSettings.cpp:
(WebCore::InternalSettings::Backup::Backup):
(WebCore::InternalSettings::Backup::restoreTo):
(WebCore::InternalSettingsWrapper::InternalSettingsWrapper): Deleted.
(WebCore::InternalSettingsWrapper::~InternalSettingsWrapper): Deleted.
(): Deleted.
(WebCore::InternalSettingsWrapper::internalSettings const): Deleted.
(WebCore::InternalSettings::supplementName): Deleted.
(WebCore::InternalSettings::from): Deleted.
(WebCore::InternalSettings::hostDestroyed): Deleted.
(WebCore::InternalSettings::InternalSettings): Deleted.
(WebCore::InternalSettings::create): Deleted.
(WebCore::InternalSettings::resetToConsistentState): Deleted.
(WebCore::InternalSettings::settings const): Deleted.
(WebCore::InternalSettings::setStandardFontFamily): Deleted.
(WebCore::InternalSettings::setSerifFontFamily): Deleted.
(WebCore::InternalSettings::setSansSerifFontFamily): Deleted.
(WebCore::InternalSettings::setFixedFontFamily): Deleted.
(WebCore::InternalSettings::setCursiveFontFamily): Deleted.
(WebCore::InternalSettings::setFantasyFontFamily): Deleted.
(WebCore::InternalSettings::setPictographFontFamily): Deleted.
(WebCore::InternalSettings::setTextAutosizingWindowSizeOverride): Deleted.
(WebCore::InternalSettings::setEditingBehavior): Deleted.
(WebCore::InternalSettings::setStorageBlockingPolicy): Deleted.
(WebCore::InternalSettings::setMinimumTimerInterval): Deleted.
(WebCore::InternalSettings::setTimeWithoutMouseMovementBeforeHidingControls): Deleted.
(WebCore::InternalSettings::setFontLoadTimingOverride): Deleted.
(WebCore::InternalSettings::setAllowAnimationControlsOverride): Deleted.
(WebCore::InternalSettings::setUserInterfaceDirectionPolicy): Deleted.
(WebCore::InternalSettings::setSystemLayoutDirection): Deleted.
(WebCore::InternalSettings::forcedColorsAreInvertedAccessibilityValue const): Deleted.
(WebCore::InternalSettings::setForcedColorsAreInvertedAccessibilityValue): Deleted.
(WebCore::InternalSettings::forcedDisplayIsMonochromeAccessibilityValue const): Deleted.
(WebCore::InternalSettings::setForcedDisplayIsMonochromeAccessibilityValue): Deleted.
(WebCore::InternalSettings::forcedPrefersContrastAccessibilityValue const): Deleted.
(WebCore::InternalSettings::setForcedPrefersContrastAccessibilityValue): Deleted.
(WebCore::InternalSettings::forcedPrefersReducedMotionAccessibilityValue const): Deleted.
(WebCore::InternalSettings::setForcedPrefersReducedMotionAccessibilityValue): Deleted.
(WebCore::InternalSettings::forcedSupportsHighDynamicRangeValue const): Deleted.
(WebCore::InternalSettings::setForcedSupportsHighDynamicRangeValue): Deleted.
(WebCore::InternalSettings::vp9DecoderEnabled const): Deleted.
(WebCore::InternalSettings::setCustomPasteboardDataEnabled): Deleted.
(WebCore::InternalSettings::setShouldManageAudioSessionCategory): Deleted.
(WebCore::InternalSettings::setShouldDisplayTrackKind): Deleted.
(WebCore::InternalSettings::shouldDisplayTrackKind): Deleted.
(WebCore::InternalSettings::setEditableRegionEnabled): Deleted.
(WebCore::InternalSettings::setCanStartMedia): Deleted.
(WebCore::InternalSettings::setUseDarkAppearance): Deleted.
(WebCore::InternalSettings::setUseElevatedUserInterfaceLevel): Deleted.
(WebCore::InternalSettings::setAllowUnclampedScrollPosition): Deleted.
(WebCore::InternalSettings::setShouldDeactivateAudioSession): Deleted.
(WebCore::InternalSettings::setShouldMockBoldSystemFontForAccessibility): Deleted.
(WebCore::InternalSettings::setDefaultAudioContextSampleRate): Deleted.
(WebCore::InternalSettings::setAllowedMediaContainerTypes): Deleted.
(WebCore::InternalSettings::setAllowedMediaCodecTypes): Deleted.
(WebCore::InternalSettings::setAllowedMediaVideoCodecIDs): Deleted.
(WebCore::InternalSettings::setAllowedMediaAudioCodecIDs): Deleted.
(WebCore::InternalSettings::setAllowedMediaCaptionFormatTypes): Deleted.
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::resetToConsistentState):
(WebCore::Internals::beginMediaSessionInterruption):
(WebCore::Internals::endMediaSessionInterruption):
(WebCore::Internals::applicationWillBecomeInactive):
(WebCore::Internals::applicationDidBecomeActive):
(WebCore::Internals::applicationWillEnterForeground const):
(WebCore::Internals::applicationDidEnterBackground const):
(WebCore::Internals::setMediaSessionRestrictions):
(WebCore::Internals::mediaSessionRestrictions const):
(WebCore::Internals::postRemoteControlCommand):
(WebCore::Internals::simulateSystemSleep const):
(WebCore::Internals::simulateSystemWake const):
(WebCore::Internals::nowPlayingMetadata const):
(WebCore::Internals::nowPlayingState const):
(WebCore::Internals::isMonitoringWirelessRoutes const):
(WebCore::Internals::audioCaptureSourceCount const):
(WebCore::Internals::processWillSuspend):
(WebCore::Internals::processDidResume):
(WebCore::Internals::setIsPlayingToAutomotiveHeadUnit):
(WebCore::Internals::platformSupportedCommands const):
(WebCore::Internals::sessionManager const):
* Source/WebCore/testing/Internals.h:

* Source/WebKit/GPUProcess/GPUProcess.cpp:
(WebKit::GPUProcess::updateGPUProcessPreferences): setAlternateWebMPlayerEnabled moved from
PlatformMediaSessionManager to MediaPlayer.

* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::processWillSuspend): Added, used to
(WebKit::WebPageProxy::processDidResume):
* Source/WebKit/UIProcess/WebPageProxy.h:

* Source/WebKit/WebProcess/GPU/GPUProcessConnection.cpp:
(WebKit::GPUProcessConnection::didReceiveRemoteCommand): Pass the remote command to the
WebProcess, which will pass it to the each WebPage, which will pass it to the Page, which
will pass it to the media session manager.

* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::requestActiveNowPlayingSessionInfo):
(WebKit::WebPage::processSystemWillSleep const):
(WebKit::WebPage::processSystemDidWake const):

* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::m_textAnimationController):
(WebKit::WebPage::updatePreferences):
(WebKit::WebPage::processWillSuspend):
(WebKit::WebPage::processDidResume):
(WebKit::WebPage::didReceiveRemoteCommand):
(WebKit::WebPage::startObservingNowPlayingMetadata):
(WebKit::WebPage::stopObservingNowPlayingMetadata):
(WebKit::WebPage::mediaSessionManager const):
(WebKit::WebPage::mediaSessionManagerIfExists const):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:

* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::applicationWillResignActive):
(WebKit::WebPage::applicationDidEnterBackground):
(WebKit::WebPage::applicationWillEnterForeground):
(WebKit::WebPage::applicationDidBecomeActive):
(WebKit::WebPage::applicationDidEnterBackgroundForMedia):
(WebKit::WebPage::applicationWillEnterForegroundForMedia):

* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::prepareToSuspend):
(WebKit::WebProcess::processDidResume):
(WebKit::WebProcess::didReceiveRemoteCommand):
* Source/WebKit/WebProcess/WebProcess.h:

* Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm:
(WebKit::WebProcess::systemWillSleep):
(WebKit::WebProcess::systemDidWake):

Canonical link: <a href="https://commits.webkit.org/297837@main">https://commits.webkit.org/297837@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/12cca9be7231bccce6ba58df93de6ed0e934203f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/113058 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/32793 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/23271 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/119262 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/63650 "Built successfully") | ✅ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/115020 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/33445 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/41356 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/86052 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/36712 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ✅ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/116005 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26706 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101699 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66362 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/25984 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/19829 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/63020 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/96093 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/19903 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/122483 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/40136 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/29931 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/94899 "Found 2 new test failures: imported/w3c/web-platform-tests/html/semantics/forms/constraints/infinite_backtracking.html inspector/dom-debugger/event-animation-frame-breakpoints.html (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40520 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97918 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94641 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24154 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39782 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17588 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/36261 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/40022 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/45521 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39663 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/42996 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/41400 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->