### PR TITLE
Rename dynamic_objc_cast to dynamicObjCDowncast

### DIFF
--- a/Source/JavaScriptCore/API/JSValue.mm
+++ b/Source/JavaScriptCore/API/JSValue.mm
@@ -409,7 +409,7 @@ inline Expected<Result, JSValueRef> performPropertyOperation(NSStringFunction st
 
     Result result;
     // If it's a NSString already, reduce indirection and just pass the NSString.
-    if (auto *propertyKeyString = dynamic_objc_cast<NSString>(propertyKey)) {
+    if (auto *propertyKeyString = dynamicObjCDowncast<NSString>(propertyKey)) {
         auto name = OpaqueJSString::tryCreate(propertyKeyString);
         result = stringFunction([context JSGlobalContextRef], object, name.get(), arguments..., &exception);
     } else
@@ -1149,7 +1149,7 @@ static ObjcContainerConvertor::Task objectToValueWithoutCopy(JSContext *context,
         if ([object isKindOfClass:[JSValue class]])
             return { object, ((JSValue *)object)->m_value, ContainerNone };
 
-        if (auto *nsString = dynamic_objc_cast<NSString>(object)) {
+        if (auto *nsString = dynamicObjCDowncast<NSString>(object)) {
             auto string = OpaqueJSString::tryCreate(nsString);
             return { object, JSValueMakeString(contextRef, string.get()), ContainerNone };
         }
@@ -1206,7 +1206,7 @@ JSValueRef objectToValue(JSContext *context, id object)
             ASSERT([current.objc isKindOfClass:[NSDictionary class]]);
             NSDictionary *dictionary = (NSDictionary *)current.objc;
             for (id key in [dictionary keyEnumerator]) {
-                if (auto *keyString = dynamic_objc_cast<NSString>(key)) {
+                if (auto *keyString = dynamicObjCDowncast<NSString>(key)) {
                     auto propertyName = OpaqueJSString::tryCreate(keyString);
                     JSObjectSetProperty(contextRef, js, propertyName.get(), convertor.convert([dictionary objectForKey:key]), 0, 0);
                 }

--- a/Source/WTF/wtf/cocoa/TypeCastsCocoa.h
+++ b/Source/WTF/wtf/cocoa/TypeCastsCocoa.h
@@ -76,7 +76,7 @@ inline RetainPtr<id> bridge_id_cast(RetainPtr<CFTypeRef>&& object)
 #undef WTF_NS_TO_CF_BRIDGE_TRANSFER
 #undef WTF_CF_TO_NS_BRIDGE_TRANSFER
 
-// Use checked_objc_cast<> instead of dynamic_objc_cast<> when a specific NS type is required.
+// Use checked_objc_cast<> instead of dynamicObjCDowncast<> when a specific NS type is required.
 
 // Because ARC enablement is a compile-time choice, and we compile this header
 // both ways, we need a separate copy of our code when ARC is enabled.
@@ -130,12 +130,12 @@ template<typename T, typename U> inline T *checked_objc_cast(U *object)
     return static_cast<T*>(object);
 }
 
-// Use dynamic_objc_cast<> instead of checked_objc_cast<> when actively checking NS types,
+// Use dynamicObjCDowncast<> instead of checked_objc_cast<> when actively checking NS types,
 // similar to dynamic_cast<> in C++.
 
-// See RetainPtr.h for: template<typename T> T* dynamic_objc_cast(id object).
+// See RetainPtr.h for: template<typename T> T* dynamicObjCDowncast(id object).
 
-template<typename T, typename U, typename = std::enable_if_t<std::is_base_of_v<U, T>>> RetainPtr<T> dynamic_objc_cast(RetainPtr<U>&& object)
+template<typename T, typename U, typename = std::enable_if_t<std::is_base_of_v<U, T>>> RetainPtr<T> dynamicObjCDowncast(RetainPtr<U>&& object)
 {
     static_assert(std::is_base_of_v<U, T>);
     static_assert(!std::is_same_v<U, T>);
@@ -144,14 +144,14 @@ template<typename T, typename U, typename = std::enable_if_t<std::is_base_of_v<U
     return adoptNS(static_cast<T*>(object.leakRef()));
 }
 
-template<typename T> RetainPtr<T> dynamic_objc_cast(RetainPtr<id>&& object)
+template<typename T> RetainPtr<T> dynamicObjCDowncast(RetainPtr<id>&& object)
 {
     if (!is_objc<T>(object.get()))
         return nullptr;
     return adoptNS(reinterpret_cast<T*>(object.leakRef()));
 }
 
-template<typename T, typename U, typename = std::enable_if_t<std::is_base_of_v<U, T>>> RetainPtr<T> dynamic_objc_cast(const RetainPtr<U>& object)
+template<typename T, typename U, typename = std::enable_if_t<std::is_base_of_v<U, T>>> RetainPtr<T> dynamicObjCDowncast(const RetainPtr<U>& object)
 {
     static_assert(std::is_base_of_v<U, T>);
     static_assert(!std::is_same_v<U, T>);
@@ -160,21 +160,21 @@ template<typename T, typename U, typename = std::enable_if_t<std::is_base_of_v<U
     return static_cast<T*>(object.get());
 }
 
-template<typename T> RetainPtr<T> dynamic_objc_cast(const RetainPtr<id>& object)
+template<typename T> RetainPtr<T> dynamicObjCDowncast(const RetainPtr<id>& object)
 {
     if (!is_objc<T>(object.get()))
         return nullptr;
     return reinterpret_cast<T*>(object.get());
 }
 
-template<typename T> T *dynamic_objc_cast(NSObject *object)
+template<typename T> T *dynamicObjCDowncast(NSObject *object)
 {
     if (!is_objc<T>(object))
         return nullptr;
     return static_cast<T*>(object);
 }
 
-template<typename T> T *dynamic_objc_cast(id object)
+template<typename T> T *dynamicObjCDowncast(id object)
 {
     if (!is_objc<T>(object))
         return nullptr;
@@ -186,5 +186,5 @@ template<typename T> T *dynamic_objc_cast(id object)
 using WTF::bridge_cast;
 using WTF::bridge_id_cast;
 using WTF::checked_objc_cast;
-using WTF::dynamic_objc_cast;
+using WTF::dynamicObjCDowncast;
 using WTF::is_objc;

--- a/Source/WTF/wtf/text/cocoa/StringCocoa.mm
+++ b/Source/WTF/wtf/text/cocoa/StringCocoa.mm
@@ -33,7 +33,7 @@ RetainPtr<id> makeNSArrayElement(const String& vectorElement)
 
 std::optional<String> makeVectorElement(const String*, id arrayElement)
 {
-    NSString *nsString = dynamic_objc_cast<NSString>(arrayElement);
+    NSString *nsString = dynamicObjCDowncast<NSString>(arrayElement);
     if (!nsString)
         return std::nullopt;
     return { { nsString } };

--- a/Source/WebCore/Modules/applepay/PaymentInstallmentConfiguration.mm
+++ b/Source/WebCore/Modules/applepay/PaymentInstallmentConfiguration.mm
@@ -167,7 +167,7 @@ static std::optional<ApplePayInstallmentItem> makeVectorElement(const ApplePayIn
 static RetainPtr<NSDictionary> applicationMetadataDictionary(const ApplePayInstallmentConfiguration& configuration)
 {
     if (RetainPtr applicationMetadata = [configuration.applicationMetadata.createNSString() dataUsingEncoding:NSUTF8StringEncoding])
-        return dynamic_objc_cast<NSDictionary>([NSJSONSerialization JSONObjectWithData:applicationMetadata.get() options:0 error:nil]);
+        return dynamicObjCDowncast<NSDictionary>([NSJSONSerialization JSONObjectWithData:applicationMetadata.get() options:0 error:nil]);
     return { };
 }
 

--- a/Source/WebCore/Modules/applepay/cocoa/PaymentMerchantSessionCocoa.mm
+++ b/Source/WebCore/Modules/applepay/cocoa/PaymentMerchantSessionCocoa.mm
@@ -42,7 +42,7 @@ std::optional<PaymentMerchantSession> PaymentMerchantSession::fromJS(JSC::JSGlob
     if (!jsonString)
         return std::nullopt;
 
-    auto dictionary = dynamic_objc_cast<NSDictionary>([NSJSONSerialization JSONObjectWithData:[jsonString.createNSString().get() dataUsingEncoding:NSUTF8StringEncoding] options:0 error:nil]);
+    auto dictionary = dynamicObjCDowncast<NSDictionary>([NSJSONSerialization JSONObjectWithData:[jsonString.createNSString().get() dataUsingEncoding:NSUTF8StringEncoding] options:0 error:nil]);
     if (!dictionary || ![dictionary isKindOfClass:[NSDictionary class]])
         return std::nullopt;
 

--- a/Source/WebCore/bridge/objc/objc_utility.mm
+++ b/Source/WebCore/bridge/objc/objc_utility.mm
@@ -194,7 +194,7 @@ JSValue convertObjcValueToValue(JSGlobalObject* lexicalGlobalObject, void* buffe
     switch (type) {
         case ObjcObjectType: {
             id obj = *(const id*)buffer;
-            if (auto *str = dynamic_objc_cast<NSString>(obj))
+            if (auto *str = dynamicObjCDowncast<NSString>(obj))
                 return convertNSStringToString(lexicalGlobalObject, str);
             if ([obj isKindOfClass:webUndefinedClass()])
                 return jsUndefined();

--- a/Source/WebCore/editing/cocoa/AttributedString.mm
+++ b/Source/WebCore/editing/cocoa/AttributedString.mm
@@ -443,7 +443,7 @@ static std::optional<AttributedString::AttributeValue> extractArray(NSArray *arr
         Vector<String> result;
         result.reserveInitialCapacity(arrayLength);
         for (id element in array) {
-            if (auto *string = dynamic_objc_cast<NSString>(element))
+            if (auto *string = dynamicObjCDowncast<NSString>(element))
                 result.append(string);
             else
                 RELEASE_LOG_ERROR(Editing, "NSAttributedString extraction failed with array containing <%@>", NSStringFromClass([element class]));
@@ -694,15 +694,15 @@ static std::optional<AttributedString::AttributeValue> extractValue(id value, Ta
 {
     if (CFGetTypeID((CFTypeRef)value) == CGColorGetTypeID())
         return { { AttributedString::ColorFromCGColor  { Color::createAndPreserveColorSpace((CGColorRef) value) } } };
-    if (auto* number = dynamic_objc_cast<NSNumber>(value))
+    if (auto* number = dynamicObjCDowncast<NSNumber>(value))
         return { { { number.doubleValue } } };
-    if (auto* string = dynamic_objc_cast<NSString>(value))
+    if (auto* string = dynamicObjCDowncast<NSString>(value))
         return { { { String { string } } } };
-    if (auto* url = dynamic_objc_cast<NSURL>(value))
+    if (auto* url = dynamicObjCDowncast<NSURL>(value))
         return { { { URL { url } } } };
-    if (auto* array = dynamic_objc_cast<NSArray>(value))
+    if (auto* array = dynamicObjCDowncast<NSArray>(value))
         return extractArray(array);
-    if (auto* date = dynamic_objc_cast<NSDate>(value))
+    if (auto* date = dynamicObjCDowncast<NSDate>(value))
         return { { { RetainPtr { date } } } };
     if ([value isKindOfClass:PlatformNSShadow])
         return { { { RetainPtr { (NSShadow *)value } } } };
@@ -751,7 +751,7 @@ static HashMap<String, AttributedString::AttributeValue> extractDictionary(NSDic
 {
     HashMap<String, AttributedString::AttributeValue> result;
     [dictionary enumerateKeysAndObjectsUsingBlock:[&](id key, id value, BOOL *) {
-        RetainPtr keyString = dynamic_objc_cast<NSString>(key);
+        RetainPtr keyString = dynamicObjCDowncast<NSString>(key);
         if (!keyString) {
             ASSERT_NOT_REACHED();
             return;

--- a/Source/WebCore/editing/cocoa/DataDetection.mm
+++ b/Source/WebCore/editing/cocoa/DataDetection.mm
@@ -456,7 +456,7 @@ void DataDetection::removeDataDetectedLinksInDocument(Document& document)
 
 std::optional<double> DataDetection::extractReferenceDate(NSDictionary *context)
 {
-    if (auto date = dynamic_objc_cast<NSDate>([context objectForKey:PAL::get_DataDetectorsUI_kDataDetectorsReferenceDateKey()]))
+    if (auto date = dynamicObjCDowncast<NSDate>([context objectForKey:PAL::get_DataDetectorsUI_kDataDetectorsReferenceDateKey()]))
         return [date timeIntervalSince1970];
     return std::nullopt;
 }

--- a/Source/WebCore/editing/mac/EditorMac.mm
+++ b/Source/WebCore/editing/mac/EditorMac.mm
@@ -117,13 +117,13 @@ void Editor::platformPasteFont()
     auto style = MutableStyleProperties::create();
 
     Color backgroundColor;
-    if (NSColor *nsBackgroundColor = dynamic_objc_cast<NSColor>([fontAttributes objectForKey:NSBackgroundColorAttributeName]))
+    if (NSColor *nsBackgroundColor = dynamicObjCDowncast<NSColor>([fontAttributes objectForKey:NSBackgroundColorAttributeName]))
         backgroundColor = colorFromCocoaColor(nsBackgroundColor);
     if (!backgroundColor.isValid())
         backgroundColor = Color::transparentBlack;
     style->setProperty(CSSPropertyBackgroundColor, CSSValuePool::singleton().createColorValue(backgroundColor));
 
-    if (NSFont *font = dynamic_objc_cast<NSFont>([fontAttributes objectForKey:NSFontAttributeName])) {
+    if (NSFont *font = dynamicObjCDowncast<NSFont>([fontAttributes objectForKey:NSFontAttributeName])) {
         // FIXME: Need more sophisticated escaping code if we want to handle family names
         // with characters like single quote or backslash in their names.
         style->setProperty(CSSPropertyFontFamily, [NSString stringWithFormat:@"'%@'", [font familyName]]);
@@ -139,7 +139,7 @@ void Editor::platformPasteFont()
     }
 
     Color foregroundColor;
-    if (NSColor *nsForegroundColor = dynamic_objc_cast<NSColor>([fontAttributes objectForKey:NSForegroundColorAttributeName])) {
+    if (NSColor *nsForegroundColor = dynamicObjCDowncast<NSColor>([fontAttributes objectForKey:NSForegroundColorAttributeName])) {
         foregroundColor = colorFromCocoaColor(nsForegroundColor);
         if (!foregroundColor.isValid())
             foregroundColor = Color::transparentBlack;
@@ -148,7 +148,7 @@ void Editor::platformPasteFont()
     style->setProperty(CSSPropertyColor, CSSValuePool::singleton().createColorValue(foregroundColor));
 
     FontShadow fontShadow;
-    if (NSShadow *nsFontShadow = dynamic_objc_cast<NSShadow>([fontAttributes objectForKey:NSShadowAttributeName]))
+    if (NSShadow *nsFontShadow = dynamicObjCDowncast<NSShadow>([fontAttributes objectForKey:NSShadowAttributeName]))
         fontShadow = fontShadowFromNSShadow(nsFontShadow);
     style->setProperty(CSSPropertyTextShadow, serializationForCSS(fontShadow));
 

--- a/Source/WebCore/page/cocoa/CaptionUserPreferencesMediaAFCocoa.mm
+++ b/Source/WebCore/page/cocoa/CaptionUserPreferencesMediaAFCocoa.mm
@@ -63,7 +63,7 @@ RetainPtr<WebCaptionUserPreferencesMediaAFWeakObserver> CaptionUserPreferencesMe
 
 RefPtr<CaptionUserPreferencesMediaAF> CaptionUserPreferencesMediaAF::extractCaptionUserPreferencesMediaAF(void* observer)
 {
-    RetainPtr strongObserver { dynamic_objc_cast<WebCaptionUserPreferencesMediaAFWeakObserver>(reinterpret_cast<id>(observer)) };
+    RetainPtr strongObserver { dynamicObjCDowncast<WebCaptionUserPreferencesMediaAFWeakObserver>(reinterpret_cast<id>(observer)) };
     if (!strongObserver)
         return nullptr;
     return [strongObserver userPreferences];

--- a/Source/WebCore/platform/audio/cocoa/SpatialAudioExperienceHelper.mm
+++ b/Source/WebCore/platform/audio/cocoa/SpatialAudioExperienceHelper.mm
@@ -84,15 +84,15 @@ String spatialAudioExperienceDescription(CASpatialAudioExperience *experience)
     StringBuilder builder;
     builder.append('{', NSStringFromClass(experience.class));
 
-    if (auto *headTrackedExperience = dynamic_objc_cast<CAHeadTrackedSpatialAudio>(experience)) {
+    if (auto *headTrackedExperience = dynamicObjCDowncast<CAHeadTrackedSpatialAudio>(experience)) {
         builder.append(": soundStageSize("_s, headTrackedExperience.soundStageSize, "), "_s);
 
         auto *anchoringStrategy = headTrackedExperience.anchoringStrategy;
         builder.append("anchoringStrategy: {"_s, NSStringFromClass(anchoringStrategy.class));
 
-        if (auto *sceneAnchoringStrategy = dynamic_objc_cast<CASceneAnchoringStrategy>(anchoringStrategy))
+        if (auto *sceneAnchoringStrategy = dynamicObjCDowncast<CASceneAnchoringStrategy>(anchoringStrategy))
             builder.append(": sceneId: "_s, sceneAnchoringStrategy.sceneIdentifier);
-        else if (auto *tetherAnchoringStrategy = dynamic_objc_cast<CAAudioTetherAnchoringStrategy>(anchoringStrategy))
+        else if (auto *tetherAnchoringStrategy = dynamicObjCDowncast<CAAudioTetherAnchoringStrategy>(anchoringStrategy))
             builder.append(": identifier: "_s, tetherAnchoringStrategy.audioTether.identifier.UUIDString);
 
         builder.append('}');

--- a/Source/WebCore/platform/cocoa/EffectiveRateChangedListener.mm
+++ b/Source/WebCore/platform/cocoa/EffectiveRateChangedListener.mm
@@ -63,7 +63,7 @@ namespace WebCore {
 
 static void timebaseEffectiveRateChangedCallback(CFNotificationCenterRef, void* observer, CFNotificationName, const void*, CFDictionaryRef)
 {
-    RetainPtr adapter { dynamic_objc_cast<WebEffectiveRateChangedListenerObjCAdapter>(reinterpret_cast<id>(observer)) };
+    RetainPtr adapter { dynamicObjCDowncast<WebEffectiveRateChangedListenerObjCAdapter>(reinterpret_cast<id>(observer)) };
     if (RefPtr protectedListener = [adapter protectedListener])
         protectedListener->effectiveRateChanged();
 }

--- a/Source/WebCore/platform/cocoa/SerializedPlatformDataCueValue.mm
+++ b/Source/WebCore/platform/cocoa/SerializedPlatformDataCueValue.mm
@@ -71,19 +71,19 @@ SerializedPlatformDataCueValue::SerializedPlatformDataCueValue(AVMetadataItem *i
             m_data->otherAttributes.add(keyString, value);
     }
 
-    if (auto *keyString = dynamic_objc_cast<NSString>(item.key))
+    if (auto *keyString = dynamicObjCDowncast<NSString>(item.key))
         m_data->key = keyString;
 
     if (item.locale)
         m_data->locale = item.locale;
 
-    if (auto *str = dynamic_objc_cast<NSString>(item.value))
+    if (auto *str = dynamicObjCDowncast<NSString>(item.value))
         m_data->value = str;
-    else if (auto *data = dynamic_objc_cast<NSData>(item.value))
+    else if (auto *data = dynamicObjCDowncast<NSData>(item.value))
         m_data->value = data;
-    else if (auto *date = dynamic_objc_cast<NSDate>(item.value))
+    else if (auto *date = dynamicObjCDowncast<NSDate>(item.value))
         m_data->value = date;
-    else if (auto *number = dynamic_objc_cast<NSNumber>(item.value))
+    else if (auto *number = dynamicObjCDowncast<NSNumber>(item.value))
         m_data->value = number;
 }
 

--- a/Source/WebCore/platform/graphics/avfoundation/WebAVSampleBufferListener.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/WebAVSampleBufferListener.mm
@@ -180,7 +180,7 @@ static bool isSampleBufferVideoRenderer(id object)
 - (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void*)context
 {
     if (context == errorContext) {
-        RetainPtr error = dynamic_objc_cast<NSError>([change valueForKey:NSKeyValueChangeNewKey]);
+        RetainPtr error = dynamicObjCDowncast<NSError>([change valueForKey:NSKeyValueChangeNewKey]);
         if (!error)
             return;
 
@@ -228,7 +228,7 @@ static bool isSampleBufferVideoRenderer(id object)
 - (void)layerFailedToDecode:(NSNotification *)notification
 {
     RetainPtr renderer = WebCore::isSampleBufferVideoRenderer(notification.object) ? (WebSampleBufferVideoRendering *)notification.object : nil;
-    RetainPtr error = dynamic_objc_cast<NSError>([notification.userInfo valueForKey:AVSampleBufferDisplayLayerFailedToDecodeNotificationErrorKey]);
+    RetainPtr error = dynamicObjCDowncast<NSError>([notification.userInfo valueForKey:AVSampleBufferDisplayLayerFailedToDecodeNotificationErrorKey]);
 
     ensureOnMainThread([self, protectedSelf = RetainPtr { self }, renderer = WTFMove(renderer), error = WTFMove(error)] {
         if (!_videoRenderers.contains(renderer.get()))
@@ -254,7 +254,7 @@ static bool isSampleBufferVideoRenderer(id object)
 #if HAVE(AVSAMPLEBUFFERDISPLAYLAYER_READYFORDISPLAY)
 - (void)layerReadyForDisplayChanged:(NSNotification *)notification
 {
-    RetainPtr layer = dynamic_objc_cast<AVSampleBufferDisplayLayer>(notification.object);
+    RetainPtr layer = dynamicObjCDowncast<AVSampleBufferDisplayLayer>(notification.object);
     if (!layer)
         return;
 
@@ -271,7 +271,7 @@ static bool isSampleBufferVideoRenderer(id object)
 
 - (void)audioRendererWasAutomaticallyFlushed:(NSNotification *)notification
 {
-    RetainPtr renderer = dynamic_objc_cast<AVSampleBufferAudioRenderer>(notification.object);
+    RetainPtr renderer = dynamicObjCDowncast<AVSampleBufferAudioRenderer>(notification.object);
     CMTime flushTime = [[notification.userInfo valueForKey:AVSampleBufferAudioRendererFlushTimeKey] CMTimeValue];
 
     ensureOnMainThread([self, protectedSelf = RetainPtr { self }, renderer = WTFMove(renderer), flushTime] {

--- a/Source/WebCore/platform/graphics/avfoundation/objc/CDMFairPlayStreamingAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/CDMFairPlayStreamingAVFObjC.mm
@@ -38,9 +38,9 @@ namespace WebCore {
 
 Vector<Ref<SharedBuffer>> CDMPrivateFairPlayStreaming::keyIDsForRequest(AVContentKeyRequest *request)
 {
-    if (auto *identiferStr = dynamic_objc_cast<NSString>(request.identifier))
+    if (auto *identiferStr = dynamicObjCDowncast<NSString>(request.identifier))
         return { SharedBuffer::create([identiferStr dataUsingEncoding:NSUTF8StringEncoding]) };
-    if (auto *identifierData = dynamic_objc_cast<NSData>(request.identifier))
+    if (auto *identifierData = dynamicObjCDowncast<NSData>(request.identifier))
         return { SharedBuffer::create(identifierData) };
     if (request.initializationData) {
         if (auto sinfKeyIDs = CDMPrivateFairPlayStreaming::extractKeyIDsSinf(SharedBuffer::create(request.initializationData)))

--- a/Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm
@@ -1030,7 +1030,7 @@ void CDMInstanceSessionFairPlayStreamingAVFObjC::loadSession(LicenseType license
         for (NSData* expiredSessionData in [PAL::getAVContentKeySessionClass() pendingExpiredSessionReportsWithAppIdentifier:appIdentifier.get() storageDirectoryAtURL:storageURL]) {
             static const NSString *PlaybackSessionIdKey = @"PlaybackSessionID";
             NSDictionary *expiredSession = [NSPropertyListSerialization propertyListWithData:expiredSessionData options:kCFPropertyListImmutable format:nullptr error:nullptr];
-            RetainPtr playbackSessionIdValue = dynamic_objc_cast<NSString>([expiredSession objectForKey:PlaybackSessionIdKey]);
+            RetainPtr playbackSessionIdValue = dynamicObjCDowncast<NSString>([expiredSession objectForKey:PlaybackSessionIdKey]);
             if (!playbackSessionIdValue)
                 continue;
 
@@ -1096,7 +1096,7 @@ void CDMInstanceSessionFairPlayStreamingAVFObjC::removeSessionData(const String&
         for (NSData* expiredSessionData in [PAL::getAVContentKeySessionClass() pendingExpiredSessionReportsWithAppIdentifier:appIdentifier.get() storageDirectoryAtURL:storageURL]) {
             NSDictionary *expiredSession = [NSPropertyListSerialization propertyListWithData:expiredSessionData options:kCFPropertyListImmutable format:nullptr error:nullptr];
             static const NSString *PlaybackSessionIdKey = @"PlaybackSessionID";
-            RetainPtr playbackSessionIdValue = dynamic_objc_cast<NSString>([expiredSession objectForKey:PlaybackSessionIdKey]);
+            RetainPtr playbackSessionIdValue = dynamicObjCDowncast<NSString>([expiredSession objectForKey:PlaybackSessionIdKey]);
             if (!playbackSessionIdValue)
                 continue;
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.mm
@@ -214,7 +214,7 @@ void CDMSessionAVContentKeySession::releaseKeys()
         for (NSData* expiredSessionData in expiredSessions) {
             static const NSString *PlaybackSessionIdKey = @"PlaybackSessionID";
             NSDictionary *expiredSession = [NSPropertyListSerialization propertyListWithData:expiredSessionData options:kCFPropertyListImmutable format:nullptr error:nullptr];
-            RetainPtr playbackSessionIdValue = dynamic_objc_cast<NSString>([expiredSession objectForKey:PlaybackSessionIdKey]);
+            RetainPtr playbackSessionIdValue = dynamicObjCDowncast<NSString>([expiredSession objectForKey:PlaybackSessionIdKey]);
             if (!playbackSessionIdValue)
                 continue;
 

--- a/Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerCocoa.mm
+++ b/Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerCocoa.mm
@@ -1372,7 +1372,7 @@ AVPlayerLayer *PlatformCALayerCocoa::avPlayerLayer() const
     if ([platformLayer() isKindOfClass:PAL::getAVPlayerLayerClass()])
         return static_cast<AVPlayerLayer *>(platformLayer());
 
-    if (auto *layer = dynamic_objc_cast<WebVideoContainerLayer>(platformLayer()))
+    if (auto *layer = dynamicObjCDowncast<WebVideoContainerLayer>(platformLayer()))
         return layer.playerLayer;
 
     ASSERT_NOT_REACHED();

--- a/Source/WebCore/platform/graphics/cocoa/HEVCUtilitiesCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/HEVCUtilitiesCocoa.mm
@@ -143,7 +143,7 @@ static std::optional<Vector<uint16_t>> parseStringArrayFromDictionaryToUInt16Vec
         return std::nullopt;
     bool parseFailed = false;
     auto result = makeVector(bridge_cast(array), [&] (id value) {
-        auto parseResult = parseInteger<uint16_t>(String(dynamic_objc_cast<NSString>(value)));
+        auto parseResult = parseInteger<uint16_t>(String(dynamicObjCDowncast<NSString>(value)));
         parseFailed |= !parseResult;
         return parseResult;
     });

--- a/Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.mm
+++ b/Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.mm
@@ -150,7 +150,7 @@ VideoMediaSampleRenderer::VideoMediaSampleRenderer(WebSampleBufferVideoRendering
     if (!renderer)
         return;
 
-    if (auto *displayLayer = dynamic_objc_cast<AVSampleBufferDisplayLayer>(renderer)) {
+    if (auto *displayLayer = dynamicObjCDowncast<AVSampleBufferDisplayLayer>(renderer)) {
 #if HAVE(AVSAMPLEBUFFERVIDEORENDERER)
         m_renderer = [displayLayer sampleBufferRenderer];
 #endif
@@ -158,8 +158,8 @@ VideoMediaSampleRenderer::VideoMediaSampleRenderer(WebSampleBufferVideoRendering
         return;
     }
 #if HAVE(AVSAMPLEBUFFERVIDEORENDERER)
-    ASSERT(dynamic_objc_cast<AVSampleBufferVideoRenderer>(renderer));
-    m_renderer = dynamic_objc_cast<AVSampleBufferVideoRenderer>(renderer);
+    ASSERT(dynamicObjCDowncast<AVSampleBufferVideoRenderer>(renderer));
+    m_renderer = dynamicObjCDowncast<AVSampleBufferVideoRenderer>(renderer);
 #endif
 }
 

--- a/Source/WebCore/platform/graphics/cocoa/WebCoreCALayerExtras.mm
+++ b/Source/WebCore/platform/graphics/cocoa/WebCoreCALayerExtras.mm
@@ -98,7 +98,7 @@
         return NO;
 
     CGPoint pointInMask = [self.mask convertPoint:point fromLayer:self];
-    if (auto *shapeMask = dynamic_objc_cast<CAShapeLayer>(self.mask)) {
+    if (auto *shapeMask = dynamicObjCDowncast<CAShapeLayer>(self.mask)) {
         bool isEvenOddFill = [shapeMask.fillRule isEqualToString:kCAFillRuleEvenOdd];
         return CGPathContainsPoint(shapeMask.path, nullptr, pointInMask, isEvenOddFill);
     }
@@ -112,7 +112,7 @@
         return NO;
 
     CGRect rectInMask = [self.mask convertRect:rect fromLayer:self];
-    if (auto *shapeMask = dynamic_objc_cast<CAShapeLayer>(self.mask)) {
+    if (auto *shapeMask = dynamicObjCDowncast<CAShapeLayer>(self.mask)) {
         CGRect pathBounds = CGPathGetPathBoundingBox(shapeMask.path);
         return CGRectIntersectsRect(pathBounds, rectInMask);
     }

--- a/Source/WebCore/platform/ios/PlatformPasteboardIOS.mm
+++ b/Source/WebCore/platform/ios/PlatformPasteboardIOS.mm
@@ -596,7 +596,7 @@ Vector<String> PlatformPasteboard::typesSafeForDOMToReadAndWrite(const String& o
         if (![teamDataObject isKindOfClass:NSDictionary.class])
             continue;
 
-        RetainPtr originInTeamData = dynamic_objc_cast<NSString>([teamDataObject objectForKey:@(originKeyForTeamData)]);
+        RetainPtr originInTeamData = dynamicObjCDowncast<NSString>([teamDataObject objectForKey:@(originKeyForTeamData)]);
         if (!originInTeamData)
             continue;
         if (String(originInTeamData.get()) != origin)
@@ -822,9 +822,9 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     if (!value)
         return { };
 
-    RetainPtr url = dynamic_objc_cast<NSURL>(value);
+    RetainPtr url = dynamicObjCDowncast<NSURL>(value);
     if (!url) {
-        if (auto *urlData = dynamic_objc_cast<NSData>(value))
+        if (auto *urlData = dynamicObjCDowncast<NSData>(value))
             url = adoptNS([[NSURL alloc] initWithDataRepresentation:urlData relativeToURL:nil]);
     }
 

--- a/Source/WebCore/platform/mac/PlatformPasteboardMac.mm
+++ b/Source/WebCore/platform/mac/PlatformPasteboardMac.mm
@@ -159,7 +159,7 @@ void PlatformPasteboard::getPathnamesForType(Vector<String>& pathnames, const St
     if (!isFilePasteboardType(pasteboardType))
         return;
     id paths = [m_pasteboard propertyListForType:pasteboardType.createNSString().get()];
-    if (auto *pathsString = dynamic_objc_cast<NSString>(paths)) {
+    if (auto *pathsString = dynamicObjCDowncast<NSString>(paths)) {
         pathnames.append(pathsString);
         return;
     }

--- a/Source/WebCore/platform/mac/WidgetMac.mm
+++ b/Source/WebCore/platform/mac/WidgetMac.mm
@@ -66,7 +66,7 @@ static void safeRemoveFromSuperview(NSView *view)
     // If the view is the first responder, then set the window's first responder to nil so
     // we don't leave the window pointing to a view that's no longer in it.
     NSWindow *window = [view window];
-    auto *firstResponderView = dynamic_objc_cast<NSView>([window firstResponder]);
+    auto *firstResponderView = dynamicObjCDowncast<NSView>([window firstResponder]);
     if ([firstResponderView isDescendantOf:view])
         [window makeFirstResponder:nil];
 

--- a/Source/WebCore/platform/mediastream/mac/ScreenCaptureKitCaptureSource.mm
+++ b/Source/WebCore/platform/mediastream/mac/ScreenCaptureKitCaptureSource.mm
@@ -113,7 +113,7 @@ using namespace WebCore;
     RetainPtr attachments = (__bridge NSArray *)PAL::CMSampleBufferGetSampleAttachmentsArray(sampleBuffer, false);
     SCFrameStatus status = SCFrameStatusStopped;
     [attachments enumerateObjectsUsingBlock:makeBlockPtr([&] (NSDictionary *attachment, NSUInteger, BOOL *stop) {
-        RetainPtr statusNumber = dynamic_objc_cast<NSNumber>(attachment[SCStreamFrameInfoStatus]);
+        RetainPtr statusNumber = dynamicObjCDowncast<NSNumber>(attachment[SCStreamFrameInfoStatus]);
         if (!statusNumber)
             return;
 
@@ -560,10 +560,10 @@ void ScreenCaptureKitCaptureSource::streamDidOutputVideoSampleBuffer(RetainPtr<C
         if (!protectedThis)
             return;
 
-        if (RetainPtr scaleFactorNumber = dynamic_objc_cast<NSNumber>(attachment[SCStreamFrameInfoScaleFactor]))
+        if (RetainPtr scaleFactorNumber = dynamicObjCDowncast<NSNumber>(attachment[SCStreamFrameInfoScaleFactor]))
             scaleFactor = [scaleFactorNumber floatValue];
 
-        if (RetainPtr contentScaleNumber = dynamic_objc_cast<NSNumber>(attachment[SCStreamFrameInfoContentScale]))
+        if (RetainPtr contentScaleNumber = dynamicObjCDowncast<NSNumber>(attachment[SCStreamFrameInfoContentScale]))
             contentScale = [contentScaleNumber floatValue];
 
         if (RetainPtr contentRectDictionary = dynamic_cf_cast<CFDictionaryRef>(attachment[SCStreamFrameInfoContentRect])) {
@@ -581,7 +581,7 @@ void ScreenCaptureKitCaptureSource::streamDidOutputVideoSampleBuffer(RetainPtr<C
             }
         }
 #endif
-        RetainPtr statusNumber = dynamic_objc_cast<NSNumber>(attachment[SCStreamFrameInfoStatus]);
+        RetainPtr statusNumber = dynamicObjCDowncast<NSNumber>(attachment[SCStreamFrameInfoStatus]);
         if (!statusNumber)
             return;
 

--- a/Source/WebCore/platform/network/cocoa/CookieCocoa.mm
+++ b/Source/WebCore/platform/network/cocoa/CookieCocoa.mm
@@ -63,10 +63,10 @@ static double cookieCreated(NSHTTPCookie *cookie)
         return 1000.0 * (referenceFormat + NSTimeIntervalSince1970);
     };
 
-    if (RetainPtr number = dynamic_objc_cast<NSNumber>(value.get()))
+    if (RetainPtr number = dynamicObjCDowncast<NSNumber>(value.get()))
         return toCanonicalFormat(number.get().doubleValue);
 
-    if (RetainPtr string = dynamic_objc_cast<NSString>(value.get()))
+    if (RetainPtr string = dynamicObjCDowncast<NSString>(value.get()))
         return toCanonicalFormat(string.get().doubleValue);
 
     return 0;

--- a/Source/WebCore/platform/network/cocoa/ResourceResponseCocoa.mm
+++ b/Source/WebCore/platform/network/cocoa/ResourceResponseCocoa.mm
@@ -165,7 +165,7 @@ void ResourceResponse::platformLazyInit(InitLevel initLevel)
     
     @autoreleasepool {
 
-        RetainPtr urlResponse = dynamic_objc_cast<NSHTTPURLResponse>(m_nsResponse.get());
+        RetainPtr urlResponse = dynamicObjCDowncast<NSHTTPURLResponse>(m_nsResponse.get());
         RetainPtr messageRef = urlResponse ? CFURLResponseGetHTTPResponse([urlResponse _CFURLResponse]) : nullptr;
 
         if (m_initLevel < CommonFieldsOnly) {

--- a/Source/WebCore/platform/network/mac/ResourceErrorMac.mm
+++ b/Source/WebCore/platform/network/mac/ResourceErrorMac.mm
@@ -227,9 +227,9 @@ void ResourceError::platformLazyInit()
     m_errorCode = [m_platformError code];
 
     RetainPtr userInfo = [m_platformError userInfo];
-    if (auto *failingURLString = dynamic_objc_cast<NSString>([userInfo valueForKey:@"NSErrorFailingURLStringKey"]))
+    if (auto *failingURLString = dynamicObjCDowncast<NSString>([userInfo valueForKey:@"NSErrorFailingURLStringKey"]))
         m_failingURL = URL { failingURLString };
-    else if (auto *failingURL = dynamic_objc_cast<NSURL>([userInfo valueForKey:@"NSErrorFailingURLKey"]))
+    else if (auto *failingURL = dynamicObjCDowncast<NSURL>([userInfo valueForKey:@"NSErrorFailingURLKey"]))
         m_failingURL = URL { failingURL };
     // Workaround for <rdar://problem/6554067>
     m_localizedDescription = m_failingURL.string();
@@ -317,11 +317,11 @@ String ResourceError::blockedTrackerHostName() const
 bool ResourceError::hasMatchingFailingURLKeys() const
 {
     if (RetainPtr<id> nsErrorFailingURL = [nsError().userInfo objectForKey:@"NSErrorFailingURLKey"]) {
-        RetainPtr failingURL = dynamic_objc_cast<NSURL>(nsErrorFailingURL.get());
+        RetainPtr failingURL = dynamicObjCDowncast<NSURL>(nsErrorFailingURL.get());
         if (!failingURL)
             return false;
         if (RetainPtr<id> nsErrorFailingURLString = [nsError().userInfo objectForKey:@"NSErrorFailingURLStringKey"]) {
-            RetainPtr failingURLString = dynamic_objc_cast<NSString>(nsErrorFailingURLString.get());
+            RetainPtr failingURLString = dynamicObjCDowncast<NSString>(nsErrorFailingURLString.get());
             if (!failingURLString)
                 return false;
             if (![failingURL isEqual:URL(failingURLString.get()).createNSURL().get()])

--- a/Source/WebCore/rendering/AttachmentLayout.mm
+++ b/Source/WebCore/rendering/AttachmentLayout.mm
@@ -252,7 +252,7 @@ static CGFloat shortCaptionPointSizeWithContentSizeCategory(CFStringRef contentS
 {
     auto descriptor = adoptCF(CTFontDescriptorCreateWithTextStyle(kCTUIFontTextStyleShortCaption1, contentSizeCategory, 0));
     auto pointSize = adoptCF(CTFontDescriptorCopyAttribute(descriptor.get(), kCTFontSizeAttribute));
-    return [dynamic_objc_cast<NSNumber>((__bridge id)pointSize.get()) floatValue];
+    return [dynamicObjCDowncast<NSNumber>((__bridge id)pointSize.get()) floatValue];
 }
 
 static CGFloat attachmentDynamicTypeScaleFactor()

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
@@ -958,7 +958,7 @@ static NSDictionary<NSString *, id> *extractResolutionReport(NSError *error)
             return;
 
         RetainPtr<NSData> resumeData;
-        if (RetainPtr userInfo = dynamic_objc_cast<NSDictionary>(updatedError.get().userInfo)) {
+        if (RetainPtr userInfo = dynamicObjCDowncast<NSDictionary>(updatedError.get().userInfo)) {
             resumeData = userInfo.get()[@"NSURLSessionDownloadTaskResumeData"];
             if (resumeData && ![resumeData isKindOfClass:[NSData class]]) {
                 RELEASE_LOG(NetworkSession, "Download task %llu finished with resume data of wrong class: %s", (unsigned long long)task.taskIdentifier, NSStringFromClass([resumeData class]).UTF8String);
@@ -1097,7 +1097,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 // FIXME: Remove when rdar://108002223 can be resolved.
 - (void)URLSession:(NSURLSession *)session task:(NSURLSessionTask *)task _didReceiveInformationalResponse:(NSURLResponse *)response
 {
-    if (RetainPtr httpResponse = dynamic_objc_cast<NSHTTPURLResponse>(response))
+    if (RetainPtr httpResponse = dynamicObjCDowncast<NSHTTPURLResponse>(response))
         [self URLSession:session task:task didReceiveInformationalResponse:httpResponse.get()];
 }
 
@@ -1130,7 +1130,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         negotiatedLegacyTLS = checkForLegacyTLS(metrics.get());
 
         // Avoid MIME type sniffing if the response comes back as 304 Not Modified.
-        RetainPtr httpResponse = dynamic_objc_cast<NSHTTPURLResponse>(response);
+        RetainPtr httpResponse = dynamicObjCDowncast<NSHTTPURLResponse>(response);
         int statusCode = httpResponse ? [httpResponse statusCode] : 0;
         RetainPtr xContentTypeOptions = httpResponse ? [httpResponse valueForHTTPHeaderField:@"X-Content-Type-Options"] : nil;
         bool isNoSniff = xContentTypeOptions && [xContentTypeOptions caseInsensitiveCompare:@"nosniff"] == NSOrderedSame;

--- a/Source/WebKit/NetworkProcess/cocoa/WebSocketTaskCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/WebSocketTaskCocoa.mm
@@ -128,7 +128,7 @@ void WebSocketTask::didConnect(const String& protocol)
 {
     String extensionsValue;
     RetainPtr response = [m_task response];
-    if (RetainPtr httpResponse  = dynamic_objc_cast<NSHTTPURLResponse>(response.get()))
+    if (RetainPtr httpResponse  = dynamicObjCDowncast<NSHTTPURLResponse>(response.get()))
         extensionsValue = [httpResponse valueForHTTPHeaderField:@"Sec-WebSocket-Extensions"];
 
     m_receivedDidConnect = true;

--- a/Source/WebKit/Platform/cocoa/CocoaHelpers.h
+++ b/Source/WebKit/Platform/cocoa/CocoaHelpers.h
@@ -82,7 +82,7 @@ T *objectForKey(NSDictionary *dictionary, id key, bool returningNilIfEmpty = tru
     ASSERT(returningNilIfEmpty);
     ASSERT(!containingObjectsOfClass);
     // Specialized implementations in CocoaHelpers.mm handle returningNilIfEmpty and containingObjectsOfClass for different Foundation types.
-    return dynamic_objc_cast<T>(dictionary[key]);
+    return dynamicObjCDowncast<T>(dictionary[key]);
 }
 
 template<typename T>
@@ -93,7 +93,7 @@ T *objectForKey(const RetainPtr<NSDictionary>& dictionary, id key, bool returnin
 
 inline bool boolForKey(NSDictionary *dictionary, id key, bool defaultValue)
 {
-    NSNumber *value = dynamic_objc_cast<NSNumber>(dictionary[key]);
+    NSNumber *value = dynamicObjCDowncast<NSNumber>(dictionary[key]);
     return value ? value.boolValue : defaultValue;
 }
 

--- a/Source/WebKit/Platform/cocoa/CocoaHelpers.mm
+++ b/Source/WebKit/Platform/cocoa/CocoaHelpers.mm
@@ -180,14 +180,14 @@ template<>
 NSString *objectForKey<NSString>(NSDictionary *dictionary, id key, bool nilIfEmpty, Class requiredClass)
 {
     ASSERT(!requiredClass);
-    NSString *result = dynamic_objc_cast<NSString>(dictionary[key]);
+    NSString *result = dynamicObjCDowncast<NSString>(dictionary[key]);
     return !nilIfEmpty || result.length ? result : nil;
 }
 
 template<>
 NSArray *objectForKey<NSArray>(NSDictionary *dictionary, id key, bool nilIfEmpty, Class requiredClass)
 {
-    NSArray *result = dynamic_objc_cast<NSArray>(dictionary[key]);
+    NSArray *result = dynamicObjCDowncast<NSArray>(dictionary[key]);
     result = !nilIfEmpty || result.count ? result : nil;
     if (!result || !requiredClass)
         return result;
@@ -199,7 +199,7 @@ NSArray *objectForKey<NSArray>(NSDictionary *dictionary, id key, bool nilIfEmpty
 template<>
 NSDictionary *objectForKey<NSDictionary>(NSDictionary *dictionary, id key, bool nilIfEmpty, Class requiredClass)
 {
-    NSDictionary *result = dynamic_objc_cast<NSDictionary>(dictionary[key]);
+    NSDictionary *result = dynamicObjCDowncast<NSDictionary>(dictionary[key]);
     result = !nilIfEmpty || result.count ? result : nil;
     if (!result || !requiredClass)
         return result;
@@ -211,7 +211,7 @@ NSDictionary *objectForKey<NSDictionary>(NSDictionary *dictionary, id key, bool 
 template<>
 NSSet *objectForKey<NSSet>(NSDictionary *dictionary, id key, bool nilIfEmpty, Class requiredClass)
 {
-    NSSet *result = dynamic_objc_cast<NSSet>(dictionary[key]);
+    NSSet *result = dynamicObjCDowncast<NSSet>(dictionary[key]);
     result = !nilIfEmpty || result.count ? result : nil;
     if (!result || !requiredClass)
         return result;
@@ -259,7 +259,7 @@ id parseJSON(NSData *json, JSONOptionSet options, NSError **error)
     if (options.contains(JSONOptions::FragmentsAllowed))
         return result;
 
-    return dynamic_objc_cast<NSDictionary>(result);
+    return dynamicObjCDowncast<NSDictionary>(result);
 }
 
 id parseJSON(NSString *json, JSONOptionSet options, NSError **error)
@@ -278,7 +278,7 @@ id parseJSON(API::Data& json, JSONOptionSet options, NSError **error)
 NSString *encodeJSONString(id object, JSONOptionSet options, NSError **error)
 {
 #if JSC_OBJC_API_ENABLED
-    if (JSValue *value = dynamic_objc_cast<JSValue>(object)) {
+    if (JSValue *value = dynamicObjCDowncast<JSValue>(object)) {
         if (!options.contains(JSONOptions::FragmentsAllowed) && !value._isDictionary)
             return nil;
 
@@ -298,7 +298,7 @@ NSData *encodeJSONData(id object, JSONOptionSet options, NSError **error)
         return nil;
 
 #if JSC_OBJC_API_ENABLED
-    if (JSValue *value = dynamic_objc_cast<JSValue>(object)) {
+    if (JSValue *value = dynamicObjCDowncast<JSValue>(object)) {
         if (!options.contains(JSONOptions::FragmentsAllowed) && !value._isDictionary)
             return nil;
 
@@ -498,7 +498,7 @@ HashSet<String> toImpl(NSSet *set)
     result.reserveInitialCapacity(set.count);
 
     for (id element in set) {
-        if (auto *string = dynamic_objc_cast<NSString>(element))
+        if (auto *string = dynamicObjCDowncast<NSString>(element))
             result.addVoid(string);
     }
 
@@ -511,19 +511,19 @@ DataMap toDataMap(NSDictionary *dictionary)
     result.reserveInitialCapacity(dictionary.count);
 
     for (id key in dictionary) {
-        String keyString = dynamic_objc_cast<NSString>(key);
+        String keyString = dynamicObjCDowncast<NSString>(key);
         if (keyString.isEmpty()) {
             ASSERT_NOT_REACHED();
             continue;
         }
 
         id value = dictionary[key];
-        if (auto *valueString = dynamic_objc_cast<NSString>(value)) {
+        if (auto *valueString = dynamicObjCDowncast<NSString>(value)) {
             result.add(keyString, valueString);
             continue;
         }
 
-        if (auto *valueData = dynamic_objc_cast<NSData>(value)) {
+        if (auto *valueData = dynamicObjCDowncast<NSData>(value)) {
             result.add(keyString, API::Data::createWithoutCopying(valueData));
             continue;
         }

--- a/Source/WebKit/Platform/cocoa/MediaPlaybackTargetContextSerialized.mm
+++ b/Source/WebKit/Platform/cocoa/MediaPlaybackTargetContextSerialized.mm
@@ -104,7 +104,7 @@ Variant<MediaPlaybackTargetContextCocoa, MediaPlaybackTargetContextMock> MediaPl
     ASSERT(m_targetType == MediaPlaybackTargetContextType::AVOutputContext);
 
 #if HAVE(WK_SECURE_CODING_AVOUTPUTCONTEXT)
-    return MediaPlaybackTargetContextCocoa(dynamic_objc_cast<AVOutputContext>(m_context.toID()));
+    return MediaPlaybackTargetContextCocoa(dynamicObjCDowncast<AVOutputContext>(m_context.toID()));
 #else
     auto propertyList = [NSMutableDictionary dictionaryWithCapacity:2];
     propertyList[@"AVOutputContextSerializationKeyContextID"] = m_contextID.createNSString().get();

--- a/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.mm
+++ b/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.mm
@@ -86,7 +86,7 @@ SOFT_LINK_OPTIONAL(libnetwork, nw_context_set_tracker_lookup_callback, void, __c
 - (void)didUpdate:(NSNotification *)notification
 {
     ASSERT(PAL::isWebPrivacyFrameworkAvailable());
-    auto type = dynamic_objc_cast<NSNumber>([notification.userInfo objectForKey:PAL::get_WebPrivacy_WPNotificationUserInfoResourceTypeKey()]);
+    auto type = dynamicObjCDowncast<NSNumber>([notification.userInfo objectForKey:PAL::get_WebPrivacy_WPNotificationUserInfoResourceTypeKey()]);
     if (!type)
         return;
 

--- a/Source/WebKit/Platform/mac/MenuUtilities.mm
+++ b/Source/WebKit/Platform/mac/MenuUtilities.mm
@@ -98,7 +98,7 @@ static DDMacAction *actionForMenuItem(NSMenuItem *item)
 static DDAction *actionForMenuItem(NSMenuItem *item)
 #endif
 {
-    auto *representedObject = dynamic_objc_cast<NSDictionary>(item.representedObject);
+    auto *representedObject = dynamicObjCDowncast<NSDictionary>(item.representedObject);
     if (!representedObject)
         return nil;
 

--- a/Source/WebKit/Shared/API/Cocoa/_WKFrameHandle.mm
+++ b/Source/WebKit/Shared/API/Cocoa/_WKFrameHandle.mm
@@ -47,7 +47,7 @@
     if (object == self)
         return YES;
 
-    auto *handle = dynamic_objc_cast<_WKFrameHandle>(object);
+    auto *handle = dynamicObjCDowncast<_WKFrameHandle>(object);
     if (!handle)
         return NO;
 
@@ -83,7 +83,7 @@
     if (!(self = [super init]))
         return nil;
 
-    RetainPtr frameID = dynamic_objc_cast<NSNumber>([decoder decodeObjectOfClass:[NSNumber class] forKey:@"frameID"]);
+    RetainPtr frameID = dynamicObjCDowncast<NSNumber>([decoder decodeObjectOfClass:[NSNumber class] forKey:@"frameID"]);
     if (!frameID) {
         [self release];
         return nil;

--- a/Source/WebKit/Shared/Cocoa/APIObject.mm
+++ b/Source/WebKit/Shared/Cocoa/APIObject.mm
@@ -583,13 +583,13 @@ RetainPtr<NSObject<NSSecureCoding>> Object::toNSObject()
 
 RefPtr<API::Object> Object::fromNSObject(NSObject<NSSecureCoding> *object)
 {
-    if (auto *str = dynamic_objc_cast<NSString>(object))
+    if (auto *str = dynamicObjCDowncast<NSString>(object))
         return API::String::create(str);
-    if (auto *data = dynamic_objc_cast<NSData>(object))
+    if (auto *data = dynamicObjCDowncast<NSData>(object))
         return API::Data::createWithoutCopying(data);
-    if (auto *number = dynamic_objc_cast<NSNumber>(object))
+    if (auto *number = dynamicObjCDowncast<NSNumber>(object))
         return API::Double::create([number doubleValue]);
-    if (auto *array = dynamic_objc_cast<NSArray>(object)) {
+    if (auto *array = dynamicObjCDowncast<NSArray>(object)) {
         Vector<RefPtr<API::Object>> result;
         result.reserveInitialCapacity(array.count);
         for (id member in array) {
@@ -598,7 +598,7 @@ RefPtr<API::Object> Object::fromNSObject(NSObject<NSSecureCoding> *object)
         }
         return API::Array::create(WTFMove(result));
     }
-    if (auto *dictionary = dynamic_objc_cast<NSDictionary>(object)) {
+    if (auto *dictionary = dynamicObjCDowncast<NSDictionary>(object)) {
         __block HashMap<WTF::String, RefPtr<API::Object>> result;
         [dictionary enumerateKeysAndObjectsUsingBlock:^(NSString *key, id value, BOOL *stop) {
             if (auto valueObject = fromNSObject(value); valueObject && [key isKindOfClass:NSString.class])

--- a/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm
@@ -110,26 +110,26 @@
 
 - (id)archiver:(NSKeyedArchiver *)archiver willEncodeObject:(id)object
 {
-    if (auto unwrappedURL = dynamic_objc_cast<NSURL>(object); unwrappedURL && transformURLs)
+    if (auto unwrappedURL = dynamicObjCDowncast<NSURL>(object); unwrappedURL && transformURLs)
         return adoptNS([[WKSecureCodingURLWrapper alloc] initWithURL:unwrappedURL]).autorelease();
 
     if (rewriteMutableArray) {
-        if (auto mutableArray = dynamic_objc_cast<NSMutableArray>(object))
+        if (auto mutableArray = dynamicObjCDowncast<NSMutableArray>(object))
             return adoptNS([mutableArray copy]).autorelease();
     }
 
     if (rewriteMutableData) {
-        if (auto mutableData = dynamic_objc_cast<NSMutableData>(object))
+        if (auto mutableData = dynamicObjCDowncast<NSMutableData>(object))
             return adoptNS([mutableData copy]).autorelease();
     }
 
     if (rewriteMutableDictionary) {
-        if (auto mutableDict = dynamic_objc_cast<NSMutableDictionary>(object))
+        if (auto mutableDict = dynamicObjCDowncast<NSMutableDictionary>(object))
             return adoptNS([mutableDict copy]).autorelease();
     }
 
     if (rewriteMutableString) {
-        if (auto mutableString = dynamic_objc_cast<NSMutableString>(object))
+        if (auto mutableString = dynamicObjCDowncast<NSMutableString>(object))
             return adoptNS([mutableString copy]).autorelease();
     }
 
@@ -145,10 +145,10 @@
 - (id)unarchiver:(NSKeyedUnarchiver *)unarchiver didDecodeObject:(id) NS_RELEASES_ARGUMENT object NS_RETURNS_RETAINED
 {
     auto adoptedObject = adoptNS(object);
-    if (auto wrapper = dynamic_objc_cast<WKSecureCodingURLWrapper>(adoptedObject.get()))
+    if (auto wrapper = dynamicObjCDowncast<WKSecureCodingURLWrapper>(adoptedObject.get()))
         return retainPtr(wrapper.wrappedURL).leakRef();
 
-    if (auto wrapper = dynamic_objc_cast<WKSecureCodingCGColorWrapper>(adoptedObject.get()))
+    if (auto wrapper = dynamicObjCDowncast<WKSecureCodingCGColorWrapper>(adoptedObject.get()))
         return static_cast<id>(retainPtr(wrapper.wrappedColor).leakRef());
 
     return adoptedObject.leakRef();

--- a/Source/WebKit/Shared/Cocoa/CoreIPCError.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCError.mm
@@ -86,7 +86,7 @@ bool CoreIPCError::isSafeToEncodeUserInfo(id value)
     if ([value isKindOfClass:NSString.class] || [value isKindOfClass:NSURL.class] || [value isKindOfClass:NSNumber.class])
         return true;
 
-    if (auto array = dynamic_objc_cast<NSArray>(value)) {
+    if (auto array = dynamicObjCDowncast<NSArray>(value)) {
         for (id object in array) {
             if (!isSafeToEncodeUserInfo(object))
                 return false;
@@ -94,7 +94,7 @@ bool CoreIPCError::isSafeToEncodeUserInfo(id value)
         return true;
     }
 
-    if (auto dictionary = dynamic_objc_cast<NSDictionary>(value)) {
+    if (auto dictionary = dynamicObjCDowncast<NSDictionary>(value)) {
         for (id innerValue in dictionary.objectEnumerator) {
             if (!isSafeToEncodeUserInfo(innerValue))
                 return false;

--- a/Source/WebKit/Shared/Cocoa/CoreIPCNSURLRequest.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCNSURLRequest.mm
@@ -126,16 +126,16 @@ CoreIPCNSURLRequest::CoreIPCNSURLRequest(NSURLRequest *request)
         vector.reserveInitialCapacity(headerFields.get().count);
         for (id key in headerFields.get()) {
             RetainPtr<id> value = [headerFields objectForKey:key];
-            if (RetainPtr valueArray = dynamic_objc_cast<NSArray>(value.get())) {
+            if (RetainPtr valueArray = dynamicObjCDowncast<NSArray>(value.get())) {
                 Vector<String> valueVector;
                 valueVector.reserveInitialCapacity(valueArray.get().count);
                 for (id item in valueArray.get()) {
-                    if (RetainPtr nsString = dynamic_objc_cast<NSString>(item))
+                    if (RetainPtr nsString = dynamicObjCDowncast<NSString>(item))
                         valueVector.append(nsString.get());
                 }
                 vector.append({ key, valueVector });
             }
-            if (RetainPtr nsString = dynamic_objc_cast<NSString>(value.get()))
+            if (RetainPtr nsString = dynamicObjCDowncast<NSString>(value.get()))
                 vector.append({ key, nsString.get() });
         }
         vector.shrinkToFit();

--- a/Source/WebKit/Shared/Cocoa/CoreIPCSecureCoding.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCSecureCoding.mm
@@ -56,7 +56,7 @@ static std::unique_ptr<HashSet<String>>& internalClassNamesExemptFromSecureCodin
         exemptClassNames.get() = WTF::makeUnique<HashSet<String>>();
 
         for (id value in array.get()) {
-            if (RetainPtr string = dynamic_objc_cast<NSString>(value))
+            if (RetainPtr string = dynamicObjCDowncast<NSString>(value))
                 exemptClassNames.get()->add(string.get());
         }
     });

--- a/Source/WebKit/Shared/Cocoa/WKNSDictionary.mm
+++ b/Source/WebKit/Shared/Cocoa/WKNSDictionary.mm
@@ -67,7 +67,7 @@ using namespace WebKit;
 
 - (id)objectForKey:(id)key
 {
-    RetainPtr str = dynamic_objc_cast<NSString>(key);
+    RetainPtr str = dynamicObjCDowncast<NSString>(key);
     if (!str)
         return nil;
 

--- a/Source/WebKit/Shared/Extensions/WebExtensionUtilities.mm
+++ b/Source/WebKit/Shared/Extensions/WebExtensionUtilities.mm
@@ -90,13 +90,13 @@ static NSString *classToClassString(Class classType, bool plural = false)
 
 static NSString *valueToTypeString(NSObject *value, bool plural = false)
 {
-    if (auto *number = dynamic_objc_cast<NSNumber>(value)) {
+    if (auto *number = dynamicObjCDowncast<NSNumber>(value)) {
         if (std::isnan(number.doubleValue))
             return plural ? @"NaN values" : @"NaN";
 
         if (std::isinf(number.doubleValue))
             return plural ? @"Infinity values" : @"Infinity";
-    } else if (auto *scriptValue = dynamic_objc_cast<JSValue>(value)) {
+    } else if (auto *scriptValue = dynamicObjCDowncast<JSValue>(value)) {
         if (scriptValue.isUndefined)
             return plural ? @"undefined values" : @"undefined";
 
@@ -132,7 +132,7 @@ static bool validateSingleObject(NSString *key, NSObject *value, Class expectedV
 {
     ASSERT([expectedValueType respondsToSelector:@selector(isSubclassOfClass:)]);
 
-    auto *number = dynamic_objc_cast<NSNumber>(value);
+    auto *number = dynamicObjCDowncast<NSNumber>(value);
 
     if (number && std::isnan(number.doubleValue)) {
         if (outExceptionString)
@@ -166,7 +166,7 @@ static bool validateArray(NSString *key, NSObject *value, NSArray<Class> *validC
     ASSERT(validClassesArray.count == 1);
 
     Class expectedElementType = validClassesArray.firstObject;
-    NSArray *arrayValue = dynamic_objc_cast<NSArray>(value);
+    NSArray *arrayValue = dynamicObjCDowncast<NSArray>(value);
     if (!arrayValue) {
         if (outExceptionString)
             *outExceptionString = constructExpectedMessage(key, [[NSString alloc] initWithFormat:@"an array of %@", classToClassString(expectedElementType, true)], valueToTypeString(value));
@@ -235,10 +235,10 @@ static bool validateSet(NSString *key, NSObject *value, NSOrderedSet *validClass
 
 static bool validate(NSString *key, NSObject *value, id expectedValueType, NSString **outExceptionString)
 {
-    if (NSArray<Class> *validClassesArray = dynamic_objc_cast<NSArray>(expectedValueType))
+    if (NSArray<Class> *validClassesArray = dynamicObjCDowncast<NSArray>(expectedValueType))
         return validateArray(key, value, validClassesArray, outExceptionString);
 
-    if (NSOrderedSet *validClassesSet = dynamic_objc_cast<NSOrderedSet>(expectedValueType))
+    if (NSOrderedSet *validClassesSet = dynamicObjCDowncast<NSOrderedSet>(expectedValueType))
         return validateSet(key, value, validClassesSet, outExceptionString);
 
     return validateSingleObject(key, value, expectedValueType, outExceptionString);

--- a/Source/WebKit/Shared/JavaScriptEvaluationResult.mm
+++ b/Source/WebKit/Shared/JavaScriptEvaluationResult.mm
@@ -153,7 +153,7 @@ auto JavaScriptEvaluationResult::toVariant(id object) -> Variant
     if (!object)
         return NullType::NullPointer;
 
-    if (auto* jsValue = dynamic_objc_cast<JSValue>(object))
+    if (auto* jsValue = dynamicObjCDowncast<JSValue>(object))
         return jsValueToVariant(jsValue);
 
     if ([object isKindOfClass:NSNull.class])
@@ -169,7 +169,7 @@ auto JavaScriptEvaluationResult::toVariant(id object) -> Variant
         return CoreIPCNumber((NSNumber *)object);
     }
 
-    if (auto* nsString = dynamic_objc_cast<NSString>(object))
+    if (auto* nsString = dynamicObjCDowncast<NSString>(object))
         return String(nsString);
 
     if ([object isKindOfClass:NSDate.class])
@@ -205,7 +205,7 @@ JSObjectID JavaScriptEvaluationResult::addObjectToMap(id object)
         return *m_nullObjectID;
     }
 
-    if (auto* jsValue = dynamic_objc_cast<JSValue>(object)) {
+    if (auto* jsValue = dynamicObjCDowncast<JSValue>(object)) {
         if (jsValue.isArray)
             return addObjectToMap([jsValue toArray]);
     }

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm
@@ -323,7 +323,7 @@ static void applyVisualStylingToLayer(CALayer *layer, const AppleVisualEffectDat
 
 static void updateAppleVisualEffect(CALayer *layer, RemoteLayerTreeNode* layerTreeNode, AppleVisualEffectData effectData)
 {
-    if (RetainPtr materialLayer = dynamic_objc_cast<MTMaterialLayer>(layer)) {
+    if (RetainPtr materialLayer = dynamicObjCDowncast<MTMaterialLayer>(layer)) {
         if (RetainPtr recipe = materialRecipeForAppleVisualEffect(effectData.effect, effectData.colorScheme)) {
             [materialLayer setRecipe:recipe.get()];
             return;
@@ -350,7 +350,7 @@ static void updateAppleVisualEffect(CALayer *layer, RemoteLayerTreeNode* layerTr
 
 #if PLATFORM(IOS_FAMILY)
         if (layerTreeNode) {
-            if (RetainPtr materialHostingView = dynamic_objc_cast<WKMaterialHostingView>(layerTreeNode->uiView()))
+            if (RetainPtr materialHostingView = dynamicObjCDowncast<WKMaterialHostingView>(layerTreeNode->uiView()))
                 [materialHostingView updateMaterialEffectType:hostedMaterialEffectTypeForAppleVisualEffect(effectData.effect) colorScheme:hostedMaterialColorSchemeForAppleVisualEffectData(effectData) cornerRadius:cornerRadius];
         }
 #endif
@@ -447,11 +447,11 @@ void RemoteLayerTreePropertyApplier::applyPropertiesToLayer(CALayer *layer, Remo
         Path path;
         if (properties.shapeRoundedRect)
             path.addRoundedRect(*properties.shapeRoundedRect);
-        dynamic_objc_cast<CAShapeLayer>(layer).path = path.platformPath();
+        dynamicObjCDowncast<CAShapeLayer>(layer).path = path.platformPath();
     }
 
     if (properties.changedProperties & LayerChange::ShapePathChanged)
-        dynamic_objc_cast<CAShapeLayer>(layer).path = properties.shapePath.platformPath();
+        dynamicObjCDowncast<CAShapeLayer>(layer).path = properties.shapePath.platformPath();
 
     if (properties.changedProperties & LayerChange::MinificationFilterChanged)
         layer.minificationFilter = toCAFilterType(properties.minificationFilter);
@@ -463,7 +463,7 @@ void RemoteLayerTreePropertyApplier::applyPropertiesToLayer(CALayer *layer, Remo
         PlatformCAFilters::setBlendingFiltersOnLayer(layer, properties.blendMode);
 
     if (properties.changedProperties & LayerChange::WindRuleChanged) {
-        if (auto *shapeLayer = dynamic_objc_cast<CAShapeLayer>(layer)) {
+        if (auto *shapeLayer = dynamicObjCDowncast<CAShapeLayer>(layer)) {
             switch (properties.windRule) {
             case WindRule::NonZero:
                 shapeLayer.fillRule = kCAFillRuleNonZero;
@@ -544,7 +544,7 @@ void RemoteLayerTreePropertyApplier::applyPropertiesToLayer(CALayer *layer, Remo
             playerLayer = [(WKVideoView*)layerTreeNode->uiView() playerLayer];
 #endif
         ASSERT([playerLayer respondsToSelector:@selector(setVideoGravity:)]);
-        if (RetainPtr webAVPlayerLayer = dynamic_objc_cast<WebAVPlayerLayer>(playerLayer))
+        if (RetainPtr webAVPlayerLayer = dynamicObjCDowncast<WebAVPlayerLayer>(playerLayer))
             [webAVPlayerLayer setVideoGravity:convertMediaPlayerToAVLayerVideoGravity(properties.videoGravity)];
     }
 #endif
@@ -636,7 +636,7 @@ void RemoteLayerTreePropertyApplier::applyHierarchyUpdates(RemoteLayerTreeNode& 
 
         RetainPtr view = node.uiView();
 #if HAVE(MATERIAL_HOSTING)
-        if (RetainPtr materialHostingView = dynamic_objc_cast<WKMaterialHostingView>(view.get()))
+        if (RetainPtr materialHostingView = dynamicObjCDowncast<WKMaterialHostingView>(view.get()))
             view = [materialHostingView contentView];
 #endif
 
@@ -706,7 +706,7 @@ void RemoteLayerTreePropertyApplier::applyPropertiesToUIView(UIView *view, const
 
 #if HAVE(MATERIAL_HOSTING)
     if (properties.changedProperties & LayerChange::BoundsChanged) {
-        if (RetainPtr materialHostingView = dynamic_objc_cast<WKMaterialHostingView>(view))
+        if (RetainPtr materialHostingView = dynamicObjCDowncast<WKMaterialHostingView>(view))
             [materialHostingView updateHostingSize:properties.bounds.size()];
     }
 #endif

--- a/Source/WebKit/UIProcess/API/Cocoa/NSAttributedString.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/NSAttributedString.mm
@@ -231,7 +231,7 @@ static NSMutableArray<NSURL *> *readOnlyAccessPaths()
 + (void)validateEntry:(id)maybeFileURL
 {
     NSString *errorMessage = nil;
-    auto* url = dynamic_objc_cast<NSURL>(maybeFileURL);
+    auto* url = dynamicObjCDowncast<NSURL>(maybeFileURL);
     if (!url)
         errorMessage = @"The NSArray associated with _WKReadAccessFileURLsOption may only contain NSURL objects.";
     else if (!url.isFileURL)
@@ -250,7 +250,7 @@ static NSMutableArray<NSURL *> *readOnlyAccessPaths()
         return;
     }
 
-    auto *allowNetworkLoadsAsNumber = dynamic_objc_cast<NSNumber>(allowNetworkLoadsValue);
+    auto *allowNetworkLoadsAsNumber = dynamicObjCDowncast<NSNumber>(allowNetworkLoadsValue);
     if (!allowNetworkLoadsAsNumber)
         [self clearConfigurationAndRaiseExceptionIfNecessary:@"The value associated with _WKAllowNetworkLoadsOption must be an NSNumber."];
 
@@ -271,7 +271,7 @@ static NSMutableArray<NSURL *> *readOnlyAccessPaths()
         return;
     }
 
-    auto identifier = dynamic_objc_cast<NSString>(identifierValue);
+    auto identifier = dynamicObjCDowncast<NSString>(identifierValue);
     if (!identifier)
         [self clearConfigurationAndRaiseExceptionIfNecessary:@"The value associated with _WKSourceApplicationBundleIdentifierOption must be an NSString."];
 
@@ -285,7 +285,7 @@ static NSMutableArray<NSURL *> *readOnlyAccessPaths()
 + (void)maybeConsumeBundlePaths:(id)maybeReadAccessFileURLs
 {
     NSString *errorMessage = nil;
-    auto* readAccessFileURLs = dynamic_objc_cast<NSArray<NSURL *>>(maybeReadAccessFileURLs);
+    auto* readAccessFileURLs = dynamicObjCDowncast<NSArray<NSURL *>>(maybeReadAccessFileURLs);
     if (!readAccessFileURLs)
         errorMessage = @"The value associated with _WKReadAccessFileURLsOption must be an NSArray of NSURL objects.";
     else if (readAccessFileURLs.count > maximumReadOnlyAccessPaths)
@@ -408,7 +408,7 @@ static NSMutableArray<NSURL *> *readOnlyAccessPaths()
 
         webView.get().navigationDelegate = navigationDelegate.get();
 
-        if (auto* textZoomFactor = dynamic_objc_cast<NSNumber>(options[NSTextSizeMultiplierDocumentOption]))
+        if (auto* textZoomFactor = dynamicObjCDowncast<NSNumber>(options[NSTextSizeMultiplierDocumentOption]))
             webView.get()._textZoomFactor = textZoomFactor.doubleValue;
         else
             webView.get()._textZoomFactor = 1;
@@ -482,7 +482,7 @@ static NSMutableArray<NSURL *> *readOnlyAccessPaths()
         };
 
         auto timeoutInterval = defaultTimeoutInterval;
-        if (auto* timeoutOption = dynamic_objc_cast<NSNumber>(options[NSTimeoutDocumentOption])) {
+        if (auto* timeoutOption = dynamicObjCDowncast<NSNumber>(options[NSTimeoutDocumentOption])) {
             if (timeoutOption.doubleValue >= 0)
                 timeoutInterval = timeoutOption.doubleValue;
         }
@@ -521,7 +521,7 @@ static NSMutableArray<NSURL *> *readOnlyAccessPaths()
 + (void)loadFromHTMLWithFileURL:(NSURL *)fileURL options:(NSDictionary<NSAttributedStringDocumentReadingOptionKey, id> *)options completionHandler:(NSAttributedStringCompletionHandler)completionHandler
 {
     [self _loadFromHTMLWithOptions:options contentLoader:^WKNavigation *(WKWebView *webView) {
-        auto* readAccessURL = dynamic_objc_cast<NSURL>(options[NSReadAccessURLDocumentOption]);
+        auto* readAccessURL = dynamicObjCDowncast<NSURL>(options[NSReadAccessURLDocumentOption]);
         return [webView loadFileURL:fileURL allowingReadAccessToURL:readAccessURL];
     } completionHandler:completionHandler];
 }
@@ -529,7 +529,7 @@ static NSMutableArray<NSURL *> *readOnlyAccessPaths()
 + (void)loadFromHTMLWithString:(NSString *)string options:(NSDictionary<NSAttributedStringDocumentReadingOptionKey, id> *)options completionHandler:(NSAttributedStringCompletionHandler)completionHandler
 {
     [self _loadFromHTMLWithOptions:options contentLoader:^WKNavigation *(WKWebView *webView) {
-        auto* baseURL = dynamic_objc_cast<NSURL>(options[NSBaseURLDocumentOption]);
+        auto* baseURL = dynamicObjCDowncast<NSURL>(options[NSBaseURLDocumentOption]);
         return [webView loadHTMLString:string baseURL:baseURL];
     } completionHandler:completionHandler];
 }
@@ -537,9 +537,9 @@ static NSMutableArray<NSURL *> *readOnlyAccessPaths()
 + (void)loadFromHTMLWithData:(NSData *)data options:(NSDictionary<NSAttributedStringDocumentReadingOptionKey, id> *)options completionHandler:(NSAttributedStringCompletionHandler)completionHandler
 {
     [self _loadFromHTMLWithOptions:options contentLoader:^WKNavigation *(WKWebView *webView) {
-        RetainPtr textEncodingName = dynamic_objc_cast<NSString>(options[NSTextEncodingNameDocumentOption]);
-        auto characterEncoding = static_cast<NSStringEncoding>(dynamic_objc_cast<NSNumber>(options[NSCharacterEncodingDocumentOption]).unsignedIntegerValue);
-        auto* baseURL = dynamic_objc_cast<NSURL>(options[NSBaseURLDocumentOption]);
+        RetainPtr textEncodingName = dynamicObjCDowncast<NSString>(options[NSTextEncodingNameDocumentOption]);
+        auto characterEncoding = static_cast<NSStringEncoding>(dynamicObjCDowncast<NSNumber>(options[NSCharacterEncodingDocumentOption]).unsignedIntegerValue);
+        auto* baseURL = dynamicObjCDowncast<NSURL>(options[NSBaseURLDocumentOption]);
 
         if (characterEncoding && !textEncodingName) {
             auto stringEncoding = CFStringConvertNSStringEncodingToEncoding(characterEncoding);

--- a/Source/WebKit/UIProcess/API/Cocoa/WKHTTPCookieStore.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKHTTPCookieStore.mm
@@ -209,7 +209,7 @@ static WKCookiePolicy toWKCookiePolicy(WebCore::HTTPCookieAcceptPolicy policy)
 
 static std::optional<WebCore::Cookie> makeVectorElement(const WebCore::Cookie*, id arrayElement)
 {
-    if (NSHTTPCookie *nsCookie = dynamic_objc_cast<NSHTTPCookie>(arrayElement))
+    if (NSHTTPCookie *nsCookie = dynamicObjCDowncast<NSHTTPCookie>(arrayElement))
         return WebCore::Cookie { nsCookie };
 
     return std::nullopt;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKScrollGeometry.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKScrollGeometry.mm
@@ -54,7 +54,7 @@
     if (other == self)
         return YES;
 
-    RetainPtr otherGeometry = dynamic_objc_cast<WKScrollGeometry>(other);
+    RetainPtr otherGeometry = dynamicObjCDowncast<WKScrollGeometry>(other);
     if (!otherGeometry)
         return NO;
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionAction.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionAction.mm
@@ -55,7 +55,7 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(WKWebExtensionAction, WebExtensionAction, 
     if (self == object)
         return YES;
 
-    auto *other = dynamic_objc_cast<WKWebExtensionAction>(object);
+    auto *other = dynamicObjCDowncast<WKWebExtensionAction>(object);
     if (!other)
         return NO;
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionCommand.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionCommand.mm
@@ -57,7 +57,7 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(WKWebExtensionCommand, WebExtensionCommand
     if (self == object)
         return YES;
 
-    auto *other = dynamic_objc_cast<WKWebExtensionCommand>(object);
+    auto *other = dynamicObjCDowncast<WKWebExtensionCommand>(object);
     if (!other)
         return NO;
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionControllerConfiguration.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionControllerConfiguration.mm
@@ -145,7 +145,7 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(WKWebExtensionControllerConfiguration, Web
     if (self == object)
         return YES;
 
-    auto *other = dynamic_objc_cast<WKWebExtensionControllerConfiguration>(object);
+    auto *other = dynamicObjCDowncast<WKWebExtensionControllerConfiguration>(object);
     if (!other)
         return NO;
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionDataRecord.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionDataRecord.mm
@@ -45,7 +45,7 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(WKWebExtensionDataRecord, WebExtensionData
     if (self == object)
         return YES;
 
-    auto *other = dynamic_objc_cast<WKWebExtensionDataRecord>(object);
+    auto *other = dynamicObjCDowncast<WKWebExtensionDataRecord>(object);
     if (!other)
         return NO;
 
@@ -141,7 +141,7 @@ namespace WebKit {
 
 static std::optional<Ref<WebExtensionDataRecord>> makeVectorElement(const Ref<WebExtensionDataRecord>*, id arrayElement)
 {
-    if (auto *record = dynamic_objc_cast<WKWebExtensionDataRecord>(arrayElement))
+    if (auto *record = dynamicObjCDowncast<WKWebExtensionDataRecord>(arrayElement))
         return Ref { record._webExtensionDataRecord };
     return std::nullopt;
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionMatchPattern.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionMatchPattern.mm
@@ -159,7 +159,7 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(WKWebExtensionMatchPattern, WebExtensionMa
     if (self == object)
         return YES;
 
-    WKWebExtensionMatchPattern *other = dynamic_objc_cast<WKWebExtensionMatchPattern>(object);
+    WKWebExtensionMatchPattern *other = dynamicObjCDowncast<WKWebExtensionMatchPattern>(object);
     if (!other)
         return NO;
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionMessagePort.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionMessagePort.mm
@@ -47,7 +47,7 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(WKWebExtensionMessagePort, WebExtensionMes
     if (self == object)
         return YES;
 
-    auto *other = dynamic_objc_cast<WKWebExtensionMessagePort>(object);
+    auto *other = dynamicObjCDowncast<WKWebExtensionMessagePort>(object);
     if (!other)
         return NO;
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -513,8 +513,8 @@ static uint32_t convertSystemLayoutDirection(NSUserInterfaceLayoutDirection dire
 {
 #if ENABLE(SCREEN_TIME)
     if (context == &screenTimeWebpageControllerBlockedKVOContext) {
-        BOOL urlWasBlocked = dynamic_objc_cast<NSNumber>(change[NSKeyValueChangeOldKey]).boolValue;
-        BOOL urlIsBlocked = dynamic_objc_cast<NSNumber>(change[NSKeyValueChangeNewKey]).boolValue;
+        BOOL urlWasBlocked = dynamicObjCDowncast<NSNumber>(change[NSKeyValueChangeOldKey]).boolValue;
+        BOOL urlIsBlocked = dynamicObjCDowncast<NSNumber>(change[NSKeyValueChangeNewKey]).boolValue;
         BOOL wasBlockedByScreenTime = _isBlockedByScreenTime;
 
         if (urlWasBlocked != urlIsBlocked) {
@@ -1426,7 +1426,7 @@ static WKMediaPlaybackState toWKMediaPlaybackState(WebKit::MediaPlaybackState me
     NSString *errorMessage = nil;
 
     for (id key in arguments) {
-        RetainPtr keyString = dynamic_objc_cast<NSString>(key);
+        RetainPtr keyString = dynamicObjCDowncast<NSString>(key);
         if (!keyString) {
             errorMessage = @"Key value must be NSString";
             break;

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKApplicationManifest.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKApplicationManifest.mm
@@ -63,7 +63,7 @@ static RetainPtr<NSArray<NSNumber *>> fromPurposes(OptionSet<WebCore::Applicatio
 
 static std::optional<WebCore::ApplicationManifest::Icon> makeVectorElement(const WebCore::ApplicationManifest::Icon*, id arrayElement)
 {
-    auto icon = dynamic_objc_cast<_WKApplicationManifestIcon>(arrayElement);
+    auto icon = dynamicObjCDowncast<_WKApplicationManifestIcon>(arrayElement);
     if (!icon)
         return std::nullopt;
 
@@ -77,7 +77,7 @@ static std::optional<WebCore::ApplicationManifest::Icon> makeVectorElement(const
 
 static std::optional<WebCore::ApplicationManifest::Shortcut> makeVectorElement(const WebCore::ApplicationManifest::Shortcut*, id arrayElement)
 {
-    auto shortcut = dynamic_objc_cast<_WKApplicationManifestShortcut>(arrayElement);
+    auto shortcut = dynamicObjCDowncast<_WKApplicationManifestShortcut>(arrayElement);
     if (!shortcut)
         return std::nullopt;
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTextInputContext.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTextInputContext.mm
@@ -64,7 +64,7 @@
     if (self == otherObject)
         return YES;
 
-    auto *other = dynamic_objc_cast<_WKTextInputContext>(otherObject);
+    auto *other = dynamicObjCDowncast<_WKTextInputContext>(otherObject);
     if (!other)
         return NO;
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanel.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanel.mm
@@ -785,7 +785,7 @@ static void createNSErrorFromWKErrorIfNecessary(NSError **error, WKErrorCode err
     credentialMap[cbor::CBORValue(WebCore::privateKeyKey)] = cbor::CBORValue(WebCore::toBufferSource(bridge_id_cast(privateKeyRep.get())));
     credentialMap[cbor::CBORValue(WebCore::keyTypeKey)] = cbor::CBORValue(keyType);
     credentialMap[cbor::CBORValue(WebCore::keySizeKey)] = cbor::CBORValue(keySize);
-    credentialMap[cbor::CBORValue(WebCore::relyingPartyKey)] = cbor::CBORValue(String(dynamic_objc_cast<NSString>(attributes.get()[bridge_id_cast(kSecAttrLabel)])));
+    credentialMap[cbor::CBORValue(WebCore::relyingPartyKey)] = cbor::CBORValue(String(dynamicObjCDowncast<NSString>(attributes.get()[bridge_id_cast(kSecAttrLabel)])));
     auto decodedResponse = cbor::CBORReader::read(makeVector(attributes.get()[bridge_id_cast(kSecAttrApplicationTag)]));
     if (!decodedResponse || !decodedResponse->isMap()) {
         createNSErrorFromWKErrorIfNecessary(error, WKErrorMalformedCredential);

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -883,7 +883,7 @@ static WebCore::Color scrollViewBackgroundColor(WKWebView *webView, AllowPageBac
     if (_findInteractionEnabled) {
         [_findInteraction dismissFindNavigator];
 
-        if (auto *findSession = dynamic_objc_cast<UITextSearchingFindSession>([_findInteraction activeFindSession]))
+        if (auto *findSession = dynamicObjCDowncast<UITextSearchingFindSession>([_findInteraction activeFindSession]))
             findSession.searchableObject = [self _searchableObject];
     }
 #endif
@@ -1256,7 +1256,7 @@ static void configureScrollViewWithOverlayRegionsIDs(WKBaseScrollView* scrollVie
         HashSet<UIView *> overlayAncestorsChain;
         for (UIView *overlayAncestor = (UIView *)overlayView; overlayAncestor; overlayAncestor = [overlayAncestor superview]) {
             overlayAncestorsChain.add(overlayAncestor);
-            if (auto *layer = dynamic_objc_cast<WKBaseScrollView>(overlayAncestor)) {
+            if (auto *layer = dynamicObjCDowncast<WKBaseScrollView>(overlayAncestor)) {
                 enclosingScrollView = layer;
                 break;
             }
@@ -2176,7 +2176,7 @@ static WebCore::FloatPoint constrainContentOffset(WebCore::FloatPoint contentOff
     if ([scrollView isZooming])
         *targetContentOffset = [scrollView contentOffset];
     else {
-        auto axesToPreventMomentumScrolling = dynamic_objc_cast<WKBaseScrollView>(scrollView).axesToPreventMomentumScrolling;
+        auto axesToPreventMomentumScrolling = dynamicObjCDowncast<WKBaseScrollView>(scrollView).axesToPreventMomentumScrolling;
         if ([_contentView preventsPanningInXAxis] || (axesToPreventMomentumScrolling & UIAxisHorizontal))
             targetContentOffset->x = scrollView.contentOffset.x;
         if ([_contentView preventsPanningInYAxis] || (axesToPreventMomentumScrolling & UIAxisVertical))
@@ -3670,7 +3670,7 @@ static WebCore::UserInterfaceLayoutDirection toUserInterfaceLayoutDirection(UISe
 
 - (void)_enhancedWindowingToggled:(NSNotification *)notification
 {
-    if (dynamic_objc_cast<UIWindowScene>(notification.object) != self.window.windowScene)
+    if (dynamicObjCDowncast<UIWindowScene>(notification.object) != self.window.windowScene)
         return;
 
     if (!_page || !_page->hasRunningProcess())

--- a/Source/WebKit/UIProcess/Cocoa/CoreTelephonyUtilities.mm
+++ b/Source/WebKit/UIProcess/Cocoa/CoreTelephonyUtilities.mm
@@ -59,7 +59,7 @@ bool shouldAllowAutoFillForCellularIdentifiers(const URL& topURL)
         auto entitlementValue = adoptCF(SecTaskCopyValueForEntitlement(task.get(), CFSTR("com.apple.CommCenter.fine-grained"), nullptr));
         auto entitlementValueAsArray = (__bridge NSArray *)dynamic_cf_cast<CFArrayRef>(entitlementValue.get());
         for (id value in entitlementValueAsArray) {
-            if (auto string = dynamic_objc_cast<NSString>(value); [string isEqualToString:@"public-cellular-plan"])
+            if (auto string = dynamicObjCDowncast<NSString>(value); [string isEqualToString:@"public-cellular-plan"])
                 return true;
         }
         return false;

--- a/Source/WebKit/UIProcess/Cocoa/MediaPermissionUtilities.mm
+++ b/Source/WebKit/UIProcess/Cocoa/MediaPermissionUtilities.mm
@@ -91,7 +91,7 @@ bool checkUsageDescriptionStringForType(MediaPermissionType type)
         if (audioAccess == kTCCAccessPreflightGranted)
             return true;
         std::call_once(audioDescriptionFlag, [] {
-            hasMicrophoneDescriptionString = dynamic_objc_cast<NSString>(NSBundle.mainBundle.infoDictionary[@"NSMicrophoneUsageDescription"]).length > 0;
+            hasMicrophoneDescriptionString = dynamicObjCDowncast<NSString>(NSBundle.mainBundle.infoDictionary[@"NSMicrophoneUsageDescription"]).length > 0;
         });
         return hasMicrophoneDescriptionString;
     case MediaPermissionType::Video:
@@ -99,7 +99,7 @@ bool checkUsageDescriptionStringForType(MediaPermissionType type)
         if (videoAccess == kTCCAccessPreflightGranted)
             return true;
         std::call_once(videoDescriptionFlag, [] {
-            hasCameraDescriptionString = dynamic_objc_cast<NSString>(NSBundle.mainBundle.infoDictionary[@"NSCameraUsageDescription"]).length > 0;
+            hasCameraDescriptionString = dynamicObjCDowncast<NSString>(NSBundle.mainBundle.infoDictionary[@"NSCameraUsageDescription"]).length > 0;
         });
         return hasCameraDescriptionString;
     }
@@ -107,7 +107,7 @@ bool checkUsageDescriptionStringForType(MediaPermissionType type)
 
 bool checkUsageDescriptionStringForSpeechRecognition()
 {
-    return dynamic_objc_cast<NSString>(NSBundle.mainBundle.infoDictionary[@"NSSpeechRecognitionUsageDescription"]).length > 0;
+    return dynamicObjCDowncast<NSString>(NSBundle.mainBundle.infoDictionary[@"NSSpeechRecognitionUsageDescription"]).length > 0;
 }
 
 static RetainPtr<NSString> visibleDomain(const String& host)

--- a/Source/WebKit/UIProcess/Cocoa/ModelElementControllerCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/ModelElementControllerCocoa.mm
@@ -76,7 +76,7 @@ WKModelView * ModelElementController::modelViewForModelIdentifier(ModelIdentifie
     if (!node)
         return nil;
 
-    return dynamic_objc_cast<WKModelView>(node->uiView());
+    return dynamicObjCDowncast<WKModelView>(node->uiView());
 }
 
 ASVInlinePreview * ModelElementController::previewForModelIdentifier(ModelIdentifier modelIdentifier)

--- a/Source/WebKit/UIProcess/Cocoa/SystemPreviewControllerCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/SystemPreviewControllerCocoa.mm
@@ -306,7 +306,7 @@ static NSString * const _WKARQLWebsiteURLParameterKey = @"ARQLWebsiteURLParamete
 
 - (void)dataTask:(_WKDataTask *)dataTask didReceiveResponse:(NSURLResponse *)response decisionHandler:(void (^)(_WKDataTaskResponsePolicy))decisionHandler
 {
-    if (auto *HTTPResponse = dynamic_objc_cast<NSHTTPURLResponse>(response)) {
+    if (auto *HTTPResponse = dynamicObjCDowncast<NSHTTPURLResponse>(response)) {
         if ([NSHTTPURLResponse isErrorStatusCode:HTTPResponse.statusCode]) {
             RELEASE_LOG(SystemPreview, "cancelling subresource load due to error status code: %ld", (long)HTTPResponse.statusCode);
             decisionHandler(_WKDataTaskResponsePolicyCancel);

--- a/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm
+++ b/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm
@@ -972,7 +972,7 @@ RetainPtr<WKVideoView> VideoPresentationManagerProxy::createViewWithID(PlaybackS
     if (RefPtr page = m_page.get())
         page->protectedLegacyMainFrameProcess()->send(Messages::VideoPresentationManager::EnsureUpdatedVideoDimensions(contextId, nativeSize), page->webPageIDInMainFrameProcess());
 
-    return dynamic_objc_cast<WKVideoView>(interface->videoView());
+    return dynamicObjCDowncast<WKVideoView>(interface->videoView());
 }
 #endif
 
@@ -1457,7 +1457,7 @@ void VideoPresentationManagerProxy::didCleanupFullscreen(PlaybackSessionContextI
     auto [model, interface] = ensureModelAndInterface(contextId);
 
 #if USE(EXTENSIONKIT)
-    if (auto layerHostView = dynamic_objc_cast<WKLayerHostView>(interface->layerHostView()))
+    if (auto layerHostView = dynamicObjCDowncast<WKLayerHostView>(interface->layerHostView()))
         [layerHostView setVisibilityPropagationView:nil];
 #endif
 
@@ -1495,7 +1495,7 @@ void VideoPresentationManagerProxy::setVideoLayerFrame(PlaybackSessionContextIde
     MachSendRight fenceSendRight;
 #if PLATFORM(IOS_FAMILY)
 #if USE(EXTENSIONKIT)
-    auto view = dynamic_objc_cast<WKLayerHostView>(interface->layerHostView());
+    auto view = dynamicObjCDowncast<WKLayerHostView>(interface->layerHostView());
     if (view && view->_hostingView) {
         auto hostingUpdateCoordinator = [BELayerHierarchyHostingTransactionCoordinator coordinatorWithError:nil];
         [hostingUpdateCoordinator addLayerHierarchyHostingView:view->_hostingView.get()];

--- a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
@@ -910,7 +910,7 @@ void WebPageProxy::startApplePayAMSUISession(URL&& originatingURL, ApplePayAMSUI
         return;
     }
 
-    RetainPtr amsRequest = adoptNS([allocAMSEngagementRequestInstance() initWithRequestDictionary:dynamic_objc_cast<NSDictionary>([NSJSONSerialization JSONObjectWithData:[request.engagementRequest.createNSString() dataUsingEncoding:NSUTF8StringEncoding] options:0 error:nil])]);
+    RetainPtr amsRequest = adoptNS([allocAMSEngagementRequestInstance() initWithRequestDictionary:dynamicObjCDowncast<NSDictionary>([NSJSONSerialization JSONObjectWithData:[request.engagementRequest.createNSString() dataUsingEncoding:NSUTF8StringEncoding] options:0 error:nil])]);
     [amsRequest setOriginatingURL:originatingURL.createNSURL().get()];
 
     auto amsBag = retainPtr([getAMSUIEngagementTaskClass() createBagForSubProfile]);

--- a/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
@@ -583,7 +583,7 @@ bool WebProcessPool::processSuppressionEnabled() const
 
 static inline RefPtr<WebProcessPool> extractWebProcessPool(void* observer)
 {
-    RetainPtr strongObserver { dynamic_objc_cast<WKProcessPoolWeakObserver>(reinterpret_cast<id>(observer)) };
+    RetainPtr strongObserver { dynamicObjCDowncast<WKProcessPoolWeakObserver>(reinterpret_cast<id>(observer)) };
     if (!strongObserver)
         return nullptr;
     return [strongObserver pool];
@@ -911,7 +911,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 #endif
 
     m_finishedMobileAssetFontDownloadObserver = [[NSNotificationCenter defaultCenter] addObserverForName:@"FontActivateNotification" object:nil queue:[NSOperationQueue currentQueue] usingBlock:^(NSNotification *notification) {
-        RetainPtr fontFamily = dynamic_objc_cast<NSString>(notification.userInfo[@"FontActivateNotificationFontFamilyKey"]);
+        RetainPtr fontFamily = dynamicObjCDowncast<NSString>(notification.userInfo[@"FontActivateNotificationFontFamilyKey"]);
         if (fontFamily) {
             RetainPtr ctFont = adoptCF(CTFontCreateWithName(bridge_cast(fontFamily.get()), 0.0, nullptr));
             RetainPtr downloaded = adoptCF(static_cast<CFBooleanRef>(CTFontCopyAttribute(ctFont.get(), kCTFontDownloadedAttribute)));

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIDeclarativeNetRequestCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIDeclarativeNetRequestCocoa.mm
@@ -376,7 +376,7 @@ void WebExtensionContext::declarativeNetRequestUpdateDynamicRules(String&& rules
         return @(ruleID);
     }).get();
 
-    auto *rulesToAdd = dynamic_objc_cast<NSArray>(parseJSON(rulesToAddJSON.createNSString().get(), JSONOptions::FragmentsAllowed)) ?: @[ ];
+    auto *rulesToAdd = dynamicObjCDowncast<NSArray>(parseJSON(rulesToAddJSON.createNSString().get(), JSONOptions::FragmentsAllowed)) ?: @[ ];
 
     if (!ruleIDsToDelete.count && !rulesToAdd.count) {
         completionHandler({ });
@@ -418,7 +418,7 @@ void WebExtensionContext::declarativeNetRequestUpdateSessionRules(String&& rules
         return @(ruleID);
     }).get();
 
-    auto *rulesToAdd = dynamic_objc_cast<NSArray>(parseJSON(rulesToAddJSON.createNSString().get(), JSONOptions::FragmentsAllowed)) ?: @[ ];
+    auto *rulesToAdd = dynamicObjCDowncast<NSArray>(parseJSON(rulesToAddJSON.createNSString().get(), JSONOptions::FragmentsAllowed)) ?: @[ ];
 
     if (!ruleIDsToDelete.count && !rulesToAdd.count) {
         completionHandler({ });

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionActionCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionActionCocoa.mm
@@ -387,7 +387,7 @@ static void* kvoContext = &kvoContext;
         return nil;
 
     _webExtensionAction = action;
-    _popupWebView = dynamic_objc_cast<_WKWebExtensionActionWebView>(action.popupWebView());
+    _popupWebView = dynamicObjCDowncast<_WKWebExtensionActionWebView>(action.popupWebView());
 
     self.view = _popupWebView;
     self.modalPresentationStyle = UIModalPresentationPopover;
@@ -414,7 +414,7 @@ static void* kvoContext = &kvoContext;
 
 - (void)presentationController:(UIPresentationController *)presentationController prepareAdaptivePresentationController:(UIPresentationController *)adaptivePresentationController
 {
-    if (auto *sheetPresentationController = dynamic_objc_cast<UISheetPresentationController>(adaptivePresentationController))
+    if (auto *sheetPresentationController = dynamicObjCDowncast<UISheetPresentationController>(adaptivePresentationController))
         [self _updateDetentForSheetPresentationController:sheetPresentationController];
 }
 
@@ -437,7 +437,7 @@ static void* kvoContext = &kvoContext;
     if (!webExtensionAction || !objectForKey<NSNumber>(notification.userInfo, UIPresentationControllerDismissalTransitionDidEndCompletedKey).boolValue)
         return;
 
-    auto *dismissedViewController = dynamic_objc_cast<UIViewController>(notification.object);
+    auto *dismissedViewController = dynamicObjCDowncast<UIViewController>(notification.object);
     if (dismissedViewController != self && dismissedViewController != self.navigationController)
         return;
 
@@ -469,7 +469,7 @@ static void* kvoContext = &kvoContext;
             self.preferredContentSize = contentSize;
         }
 
-        [self _updateDetentForSheetPresentationController:dynamic_objc_cast<UISheetPresentationController>(presentationController)];
+        [self _updateDetentForSheetPresentationController:dynamicObjCDowncast<UISheetPresentationController>(presentationController)];
     } else {
         CGSize contentSize = _popupWebView.scrollView.contentSize;
         CGSize desiredSize = CGSizeMake(std::min(contentSize.width, maximumPopoverWidth), std::min(contentSize.height, maximumPopoverHeight));
@@ -522,7 +522,7 @@ static void* kvoContext = &kvoContext;
         return nil;
 
     _webExtensionAction = action;
-    _popupWebView = dynamic_objc_cast<_WKWebExtensionActionWebView>(action.popupWebView());
+    _popupWebView = dynamicObjCDowncast<_WKWebExtensionActionWebView>(action.popupWebView());
 
     _popupWebView.accessibilityRole = NSAccessibilityPopoverRole;
 
@@ -572,7 +572,7 @@ static void* kvoContext = &kvoContext;
         return;
 
     // Close if another popover is about to show in the same window.
-    auto *incomingPopover = dynamic_objc_cast<NSPopover>(notification.object);
+    auto *incomingPopover = dynamicObjCDowncast<NSPopover>(notification.object);
     auto *incomingPopoverWindow = incomingPopover.positioningView.window;
     if (![incomingPopoverWindow isEqual:self.positioningView.window])
         return;
@@ -948,7 +948,7 @@ void WebExtensionAction::detectPopoverColorScheme()
         bool forceLightPopoverAppearance = false;
         bool forceDarkPopoverAppearance = false;
 
-        if (auto *colorSchemesArray = dynamic_objc_cast<NSArray>(result)) {
+        if (auto *colorSchemesArray = dynamicObjCDowncast<NSArray>(result)) {
             auto *supportedColorSchemes = [NSSet setWithArray:colorSchemesArray];
             if (([supportedColorSchemes containsObject:@"light"] || [supportedColorSchemes containsObject:@"only"]) && ![supportedColorSchemes containsObject:@"dark"])
                 forceLightPopoverAppearance = true;

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
@@ -3111,7 +3111,7 @@ CocoaMenuItem *WebExtensionContext::singleMenuItemOrExtensionItemWithSubmenu(con
 
     if (menuItems.count == 1) {
         if (!allowTopLevelImages)
-            dynamic_objc_cast<NSMenuItem>(menuItems.firstObject).image = nil;
+            dynamicObjCDowncast<NSMenuItem>(menuItems.firstObject).image = nil;
         return menuItems.firstObject;
     }
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionMatchPatternCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionMatchPatternCocoa.mm
@@ -45,7 +45,7 @@ WebExtensionMatchPattern::MatchPatternSet toPatterns(NSSet *set)
     matchPatterns.reserveInitialCapacity(set.count);
 
     for (id object in set) {
-        if (auto *pattern = dynamic_objc_cast<WKWebExtensionMatchPattern>(object))
+        if (auto *pattern = dynamicObjCDowncast<WKWebExtensionMatchPattern>(object))
             matchPatterns.addVoid(pattern._webExtensionMatchPattern);
     }
 

--- a/Source/WebKit/UIProcess/Gamepad/ios/UIGamepadProviderIOS.mm
+++ b/Source/WebKit/UIProcess/Gamepad/ios/UIGamepadProviderIOS.mm
@@ -41,7 +41,7 @@ ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     auto firstResponder = [[[UIApplication sharedApplication] keyWindow] firstResponder];
 ALLOW_DEPRECATED_DECLARATIONS_END
 
-    if (auto *view = dynamic_objc_cast<WKContentView>(firstResponder))
+    if (auto *view = dynamicObjCDowncast<WKContentView>(firstResponder))
         return view.page;
 
 #if ENABLE(WEBXR) && !USE(OPENXR)

--- a/Source/WebKit/UIProcess/Gamepad/mac/UIGamepadProviderMac.mm
+++ b/Source/WebKit/UIProcess/Gamepad/mac/UIGamepadProviderMac.mm
@@ -41,11 +41,11 @@ WebPageProxy* UIGamepadProvider::platformWebPageProxyForGamepadInput()
     ASSERT(hasProcessPrivilege(ProcessPrivilege::CanCommunicateWithWindowServer));
     auto responder = [[NSApp keyWindow] firstResponder];
 
-    if (RetainPtr view = dynamic_objc_cast<WKWebView>(responder))
+    if (RetainPtr view = dynamicObjCDowncast<WKWebView>(responder))
         return view->_page.get();
 
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    if (RetainPtr view = dynamic_objc_cast<WKView>(responder))
+    if (RetainPtr view = dynamicObjCDowncast<WKView>(responder))
         return toImpl(view.get().pageRef);
 ALLOW_DEPRECATED_DECLARATIONS_END
 

--- a/Source/WebKit/UIProcess/PDF/WKPDFPageNumberIndicator.mm
+++ b/Source/WebKit/UIProcess/PDF/WKPDFPageNumberIndicator.mm
@@ -98,7 +98,7 @@ static constexpr Seconds indicatorMoveDuration { 0.3_s };
     [_label setAdjustsFontSizeToFitWidth:YES];
     [_label setAutoresizingMask:UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight];
     WebCore::PlatformCAFilters::setBlendingFiltersOnLayer([_label layer], WebCore::BlendMode::PlusDarker);
-    if (RetainPtr visualEffectBackdropView = dynamic_objc_cast<UIVisualEffectView>(_backdropView))
+    if (RetainPtr visualEffectBackdropView = dynamicObjCDowncast<UIVisualEffectView>(_backdropView))
         [[visualEffectBackdropView contentView] addSubview:_label.get()];
     else
         [_backdropView addSubview:_label.get()];

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeViews.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeViews.mm
@@ -268,7 +268,7 @@ UIScrollView *findActingScrollParent(UIScrollView *scrollView, const RemoteLayer
         }
         if (auto* node = RemoteLayerTreeNode::forCALayer(view.layer)) {
             if (auto* actingParent = host.nodeForID(node->actingScrollContainerID())) {
-                if (auto scrollView = dynamic_objc_cast<UIScrollView>(actingParent->uiView()))
+                if (auto scrollView = dynamicObjCDowncast<UIScrollView>(actingParent->uiView()))
                     return scrollView;
             }
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.mm
@@ -77,7 +77,7 @@
     if (!scrollingTreeNodeDelegate) [[unlikely]]
         return;
 
-    if (RetainPtr baseScrollView = dynamic_objc_cast<WKBaseScrollView>(scrollView))
+    if (RetainPtr baseScrollView = dynamicObjCDowncast<WKBaseScrollView>(scrollView))
         [baseScrollView updateInteractiveScrollVelocity];
 
     scrollingTreeNodeDelegate->scrollViewDidScroll(scrollView.contentOffset, _inUserInteraction);
@@ -107,7 +107,7 @@
         scrollingTreeNodeDelegate->clearActiveTouchActions();
         
         if (touchActions && !touchActions.containsAny({ WebCore::TouchAction::Auto, WebCore::TouchAction::Manipulation })) {
-            auto axesToPreventMomentumScrolling = dynamic_objc_cast<WKBaseScrollView>(scrollView).axesToPreventMomentumScrolling;
+            auto axesToPreventMomentumScrolling = dynamicObjCDowncast<WKBaseScrollView>(scrollView).axesToPreventMomentumScrolling;
             if (!touchActions.contains(WebCore::TouchAction::PanX) || (axesToPreventMomentumScrolling & UIAxisHorizontal))
                 targetContentOffset->x = scrollView.contentOffset.x;
             if (!touchActions.contains(WebCore::TouchAction::PanY) || (axesToPreventMomentumScrolling & UIAxisVertical))
@@ -241,7 +241,7 @@
         return nil;
 
     // An "acting parent" is a non-ancestor scrolling parent. We tell this to UIKit so it can propagate scrolls correctly.
-    return dynamic_objc_cast<WKBEScrollView>(scrollingTreeNodeDelegate->findActingScrollParent(scrollView));
+    return dynamicObjCDowncast<WKBEScrollView>(scrollingTreeNodeDelegate->findActingScrollParent(scrollView));
 }
 
 #if HAVE(UISCROLLVIEW_ASYNCHRONOUS_SCROLL_EVENT_HANDLING)
@@ -483,7 +483,7 @@ void ScrollingTreeScrollingNodeDelegateIOS::currentSnapPointIndicesDidChange(std
 WKBaseScrollView *ScrollingTreeScrollingNodeDelegateIOS::scrollView() const
 {
     if (auto* delegate = scrollLayer().delegate) {
-        auto scrollView = dynamic_objc_cast<WKBaseScrollView>(delegate);
+        auto scrollView = dynamicObjCDowncast<WKBaseScrollView>(delegate);
         ASSERT(scrollView);
         return scrollView;
     }

--- a/Source/WebKit/UIProcess/ios/UIKitUtilities.mm
+++ b/Source/WebKit/UIProcess/ios/UIKitUtilities.mm
@@ -226,7 +226,7 @@ static UIAxis axesForDelta(WebCore::FloatSize delta)
 - (UIScrollView *)_wk_parentScrollView
 {
     for (RetainPtr parent = [self superview]; parent; parent = [parent superview]) {
-        if (RetainPtr scrollView = dynamic_objc_cast<UIScrollView>(parent.get()))
+        if (RetainPtr scrollView = dynamicObjCDowncast<UIScrollView>(parent.get()))
             return scrollView.get();
     }
     return nil;
@@ -362,7 +362,7 @@ RetainPtr<UIAlertController> createUIAlertController(NSString *title, NSString *
 UIScrollView *scrollViewForTouches(NSSet<UITouch *> *touches)
 {
     for (UITouch *touch in touches) {
-        if (auto scrollView = dynamic_objc_cast<UIScrollView>(touch.view))
+        if (auto scrollView = dynamicObjCDowncast<UIScrollView>(touch.view))
             return scrollView;
     }
     return nil;

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -628,10 +628,10 @@ inline static UITextPosition *positionWithOffsetFrom(UITextPosition *position, N
     if (!offset)
         return position;
 
-    if (auto concretePosition = dynamic_objc_cast<WKTextPosition>(position); !concretePosition.anchors.isEmpty())
+    if (auto concretePosition = dynamicObjCDowncast<WKTextPosition>(position); !concretePosition.anchors.isEmpty())
         return adoptNS([[WKRelativeTextPosition alloc] initWithAnchors:concretePosition.anchors offset:offset]).autorelease();
 
-    if (auto relativePosition = dynamic_objc_cast<WKRelativeTextPosition>(position))
+    if (auto relativePosition = dynamicObjCDowncast<WKRelativeTextPosition>(position))
         return adoptNS([[WKRelativeTextPosition alloc] initWithAnchors:[relativePosition anchors] offset:offset + [relativePosition offset]]).autorelease();
 
     return nil;
@@ -639,10 +639,10 @@ inline static UITextPosition *positionWithOffsetFrom(UITextPosition *position, N
 
 inline static std::pair<OptionSet<WebKit::TextPositionAnchor>, NSInteger> anchorsAndOffset(UITextPosition *position)
 {
-    if (auto concretePosition = dynamic_objc_cast<WKTextPosition>(position); concretePosition.anchors)
+    if (auto concretePosition = dynamicObjCDowncast<WKTextPosition>(position); concretePosition.anchors)
         return { concretePosition.anchors, 0 };
 
-    if (auto relativePosition = dynamic_objc_cast<WKRelativeTextPosition>(position))
+    if (auto relativePosition = dynamicObjCDowncast<WKRelativeTextPosition>(position))
         return { relativePosition.anchors, relativePosition.offset };
 
     return { { }, 0 };
@@ -1065,7 +1065,7 @@ inline static RetainPtr<NSString> textRelativeToSelectionStart(WKRelativeTextRan
 
 static WKDragSessionContext *existingLocalDragSessionContext(id <UIDragSession> session)
 {
-    return dynamic_objc_cast<WKDragSessionContext>(session.localContext);
+    return dynamicObjCDowncast<WKDragSessionContext>(session.localContext);
 }
 
 static WKDragSessionContext *ensureLocalDragSessionContext(id <UIDragSession> session)
@@ -3358,7 +3358,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     if (!hitView)
         return NO;
 
-    RetainPtr hitScroller = dynamic_objc_cast<UIScrollView>(hitView.get()) ?: [hitView _wk_parentScrollView];
+    RetainPtr hitScroller = dynamicObjCDowncast<UIScrollView>(hitView.get()) ?: [hitView _wk_parentScrollView];
     return hitScroller && hitScroller == self._selectionContainerViewInternal._wk_parentScrollView;
 }
 
@@ -3384,7 +3384,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 {
     UIView *view = firstView ?: self.webView.scrollView;
     for (; view; view = view.superview) {
-        if (auto scrollView = dynamic_objc_cast<UIScrollView>(view); scrollView && matchFunction(scrollView))
+        if (auto scrollView = dynamicObjCDowncast<UIScrollView>(view); scrollView && matchFunction(scrollView))
             return YES;
     }
     return NO;
@@ -5678,7 +5678,7 @@ static void selectionChangedWithTouch(WKTextInteractionWrapper *interaction, con
 
 - (BOOL)_handleTapOverInteractiveControl:(CGPoint)position
 {
-    auto *hitButton = dynamic_objc_cast<UIControl>([self hitTest:position withEvent:nil]);
+    auto *hitButton = dynamicObjCDowncast<UIControl>([self hitTest:position withEvent:nil]);
     if (!hitButton)
         return NO;
 
@@ -6384,14 +6384,14 @@ static void logTextInteraction(const char* methodName, UIGestureRecognizer *loup
 {
     _autocorrectionContextNeedsUpdate = YES;
 
-    if (RetainPtr autoFillSuggestion = dynamic_objc_cast<UITextAutofillSuggestion>(textSuggestion)) {
+    if (RetainPtr autoFillSuggestion = dynamicObjCDowncast<UITextAutofillSuggestion>(textSuggestion)) {
         // Maintain binary compatibility with UITextAutofillSuggestion, even when using the ServiceExtensions text input.
         _page->autofillLoginCredentials([autoFillSuggestion username], [autoFillSuggestion password]);
         return;
     }
 
 #if USE(BROWSERENGINEKIT)
-    if (RetainPtr autoFillSuggestion = dynamic_objc_cast<BEAutoFillTextSuggestion>(textSuggestion)) {
+    if (RetainPtr autoFillSuggestion = dynamicObjCDowncast<BEAutoFillTextSuggestion>(textSuggestion)) {
         RetainPtr contents = [autoFillSuggestion contents];
         _page->autofillLoginCredentials([contents objectForKey:UITextContentTypeUsername], [contents objectForKey:UITextContentTypePassword]);
         return;
@@ -6412,7 +6412,7 @@ static void logTextInteraction(const char* methodName, UIGestureRecognizer *loup
     if ([inputDelegate respondsToSelector:@selector(_webView:insertTextSuggestion:inInputSession:)]) {
         auto uiTextSuggestion = [&]() -> RetainPtr<UITextSuggestion> {
 #if USE(BROWSERENGINEKIT)
-            if (auto beTextSuggestion = dynamic_objc_cast<BETextSuggestion>(textSuggestion))
+            if (auto beTextSuggestion = dynamicObjCDowncast<BETextSuggestion>(textSuggestion))
                 return beTextSuggestion._uikitTextSuggestion;
 #endif
             return textSuggestion;
@@ -6433,7 +6433,7 @@ static void logTextInteraction(const char* methodName, UIGestureRecognizer *loup
     if (self.selectedTextRange == range && editorState.selectionIsRange)
         return editorState.postLayoutData->wordAtSelection.createNSString().autorelease();
 
-    if (auto relativeRange = dynamic_objc_cast<WKRelativeTextRange>(range))
+    if (auto relativeRange = dynamicObjCDowncast<WKRelativeTextRange>(range))
         return textRelativeToSelectionStart(relativeRange, *editorState.postLayoutData, _lastInsertedCharacterToOverrideCharacterBeforeSelection).autorelease();
 
     return nil;
@@ -6518,12 +6518,12 @@ static void logTextInteraction(const char* methodName, UIGestureRecognizer *loup
 
 - (CGRect)caretRectForPosition:(UITextPosition *)position
 {
-    return dynamic_objc_cast<WKTextPosition>(position).positionRect;
+    return dynamicObjCDowncast<WKTextPosition>(position).positionRect;
 }
 
 - (NSArray *)selectionRectsForRange:(UITextRange *)range
 {
-    return dynamic_objc_cast<WKTextRange>(range).selectionRects;
+    return dynamicObjCDowncast<WKTextRange>(range).selectionRects;
 }
 
 - (void)setSelectedTextRange:(UITextRange *)range
@@ -6988,11 +6988,11 @@ static WebKit::WritingDirection coreWritingDirection(NSWritingDirection directio
 // Accepts either NSTextAlternatives, or an equivalent type that's currently defined as PlatformTextAlternatives.
 - (void)addTextAlternatives:(NSObject *)alternatives
 {
-    RetainPtr platformAlternatives = dynamic_objc_cast<PlatformTextAlternatives>(alternatives);
+    RetainPtr platformAlternatives = dynamicObjCDowncast<PlatformTextAlternatives>(alternatives);
 
 #if USE(BROWSERENGINEKIT)
     if (!platformAlternatives) {
-        if (RetainPtr nsAlternatives = dynamic_objc_cast<NSTextAlternatives>(alternatives))
+        if (RetainPtr nsAlternatives = dynamicObjCDowncast<NSTextAlternatives>(alternatives))
             platformAlternatives = adoptNS([[PlatformTextAlternatives alloc] _initWithNSTextAlternatives:nsAlternatives.get()]);
     }
 #endif
@@ -7318,7 +7318,7 @@ static UITextAutocapitalizationType toUITextAutocapitalize(WebCore::Autocapitali
     traits.textContentType = [self contentTypeFromFieldName:_focusedElementInformation.autofillFieldName];
 #endif
 
-    auto extendedTraits = dynamic_objc_cast<WKExtendedTextInputTraits>(traits);
+    auto extendedTraits = dynamicObjCDowncast<WKExtendedTextInputTraits>(traits);
     auto privateTraits = (id <UITextInputTraits_Private>)traits;
 
     BOOL isSingleLineDocument = ^{
@@ -9889,7 +9889,7 @@ static String fallbackLabelTextForUnlabeledInputFieldInZoomedFormControls(WebCor
 {
     NSSet<UITouch *> *touches = [event touchesForGestureRecognizer:gestureRecognizer];
     for (UITouch *touch in touches) {
-        if (dynamic_objc_cast<UIScrollView>(touch.view)._wk_isInterruptingDeceleration)
+        if (dynamicObjCDowncast<UIScrollView>(touch.view)._wk_isInterruptingDeceleration)
             return YES;
     }
     return self._scroller._wk_isInterruptingDeceleration;
@@ -10428,7 +10428,7 @@ static WebCore::DataOwnerType coreDataOwnerType(_UIDataOwner platformType)
         if (gestureRecognizer == _highlightLongPressGestureRecognizer)
             return YES;
 
-        if (auto *tapGesture = dynamic_objc_cast<UITapGestureRecognizer>(gestureRecognizer))
+        if (auto *tapGesture = dynamicObjCDowncast<UITapGestureRecognizer>(gestureRecognizer))
             return tapGesture.numberOfTapsRequired > 1 && tapGesture.numberOfTouchesRequired < 2;
 
         return NO;
@@ -10977,7 +10977,7 @@ static NSArray<NSItemProvider *> *extractItemProvidersFromDropSession(id <UIDrop
 - (void)removeTextPlaceholder:(UITextPlaceholder *)placeholder willInsertText:(BOOL)willInsertText completionHandler:(void (^)(void))completionHandler
 {
     // FIXME: Implement support for willInsertText. See <https://bugs.webkit.org/show_bug.cgi?id=208747>.
-    if (RetainPtr wkTextPlaceholder = dynamic_objc_cast<WKTextPlaceholder>(placeholder))
+    if (RetainPtr wkTextPlaceholder = dynamicObjCDowncast<WKTextPlaceholder>(placeholder))
         _page->removeTextPlaceholder([wkTextPlaceholder elementContext], makeBlockPtr(completionHandler));
     else
         completionHandler();
@@ -11790,12 +11790,12 @@ static WebKit::DocumentEditingContextRequest toWebRequest(id request)
     WKBETextDocumentRequestOptions options = WKBETextDocumentRequestOptionNone;
     CGRect documentRect;
 
-    if (auto uiRequest = dynamic_objc_cast<UIWKDocumentRequest>(request)) {
+    if (auto uiRequest = dynamicObjCDowncast<UIWKDocumentRequest>(request)) {
         documentRect = uiRequest.documentRect;
         options = static_cast<WKBETextDocumentRequestOptions>(uiRequest.flags);
     }
 #if USE(BROWSERENGINEKIT)
-    else if (auto seRequest = dynamic_objc_cast<WKBETextDocumentRequest>(request)) {
+    else if (auto seRequest = dynamicObjCDowncast<WKBETextDocumentRequest>(request)) {
         documentRect = seRequest._documentRect;
         options = seRequest.options;
     }
@@ -11806,7 +11806,7 @@ static WebKit::DocumentEditingContextRequest toWebRequest(id request)
         .granularityCount = [request granularityCount],
         .rect = documentRect
     };
-    if (auto textInputContext = dynamic_objc_cast<_WKTextInputContext>([request inputElementIdentifier]))
+    if (auto textInputContext = dynamicObjCDowncast<_WKTextInputContext>([request inputElementIdentifier]))
         webRequest.textInputContext = [textInputContext _textInputContext];
 
     return webRequest;
@@ -12633,7 +12633,7 @@ static RetainPtr<NSItemProvider> createItemProvider(const WebKit::WebPageProxy& 
     if (!self.supportsTextReplacement)
         return;
 
-    auto foundTextRange = dynamic_objc_cast<WKFoundTextRange>(range);
+    auto foundTextRange = dynamicObjCDowncast<WKFoundTextRange>(range);
     if (!foundTextRange)
         return;
 
@@ -12642,7 +12642,7 @@ static RetainPtr<NSItemProvider> createItemProvider(const WebKit::WebPageProxy& 
 
 - (void)decorateFoundTextRange:(UITextRange *)range inDocument:(UITextSearchDocumentIdentifier)document usingStyle:(UITextSearchFoundTextStyle)style
 {
-    auto foundTextRange = dynamic_objc_cast<WKFoundTextRange>(range);
+    auto foundTextRange = dynamicObjCDowncast<WKFoundTextRange>(range);
     if (!foundTextRange)
         return;
 
@@ -12657,7 +12657,7 @@ static RetainPtr<NSItemProvider> createItemProvider(const WebKit::WebPageProxy& 
 
 - (void)scrollRangeToVisible:(UITextRange *)range inDocument:(UITextSearchDocumentIdentifier)document
 {
-    if (auto foundTextRange = dynamic_objc_cast<WKFoundTextRange>(range))
+    if (auto foundTextRange = dynamicObjCDowncast<WKFoundTextRange>(range))
         _page->scrollTextRangeToVisible([foundTextRange webFoundTextRange]);
 }
 
@@ -12707,7 +12707,7 @@ static RetainPtr<NSItemProvider> createItemProvider(const WebKit::WebPageProxy& 
 
 - (void)requestRectForFoundTextRange:(UITextRange *)range completionHandler:(void (^)(CGRect))completionHandler
 {
-    if (auto* foundTextRange = dynamic_objc_cast<WKFoundTextRange>(range)) {
+    if (auto* foundTextRange = dynamicObjCDowncast<WKFoundTextRange>(range)) {
         _page->requestRectForFoundTextRange([foundTextRange webFoundTextRange], [completionHandler = makeBlockPtr(completionHandler)] (WebCore::FloatRect rect) {
             completionHandler(rect);
         });
@@ -13172,7 +13172,7 @@ static BOOL shouldUseMachineReadableCodeMenuFromImageAnalysisResult(CocoaImageAn
         auto revealImageIdentifier = elementActionTypeToUIActionIdentifier(_WKElementActionTypeRevealImage);
         auto showTextIdentifier = elementActionTypeToUIActionIdentifier(_WKElementActionTypeImageExtraction);
         [menu.children enumerateObjectsUsingBlock:^(UIMenuElement *child, NSUInteger index, BOOL* stop) {
-            auto *action = dynamic_objc_cast<UIAction>(child);
+            auto *action = dynamicObjCDowncast<UIAction>(child);
             if ([action.identifier isEqualToString:revealImageIdentifier])
                 foundRevealImageItem = YES;
             else if ([action.identifier isEqualToString:showTextIdentifier])
@@ -13183,7 +13183,7 @@ static BOOL shouldUseMachineReadableCodeMenuFromImageAnalysisResult(CocoaImageAn
         auto newItems = adoptNS([NSMutableArray<UIMenuElement *> new]);
 
         for (UIMenuElement *child in adjustedChildren.get()) {
-            UIAction *action = dynamic_objc_cast<UIAction>(child);
+            UIAction *action = dynamicObjCDowncast<UIAction>(child);
             if (!action)
                 continue;
 
@@ -14239,7 +14239,7 @@ static inline WKTextAnimationType toWKTextAnimationType(WebCore::TextAnimationTy
         return YES;
 
     RetainPtr mainScroller = [_webView scrollView];
-    RetainPtr innerScroller = dynamic_objc_cast<UIScrollView>(lastHitView.get()) ?: [lastHitView _wk_parentScrollView];
+    RetainPtr innerScroller = dynamicObjCDowncast<UIScrollView>(lastHitView.get()) ?: [lastHitView _wk_parentScrollView];
     for (RetainPtr scroller = innerScroller; scroller; scroller = [scroller _wk_parentScrollView]) {
         if ([scroller isDragging])
             return NO;

--- a/Source/WebKit/UIProcess/ios/WKPDFView.mm
+++ b/Source/WebKit/UIProcess/ios/WKPDFView.mm
@@ -797,11 +797,11 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 - (NSComparisonResult)compareFoundRange:(UITextRange *)fromRange toRange:(UITextRange *)toRange inDocument:(UITextSearchDocumentIdentifier)document
 {
-    auto from = dynamic_objc_cast<WKPDFFoundTextPosition>(fromRange.start);
+    auto from = dynamicObjCDowncast<WKPDFFoundTextPosition>(fromRange.start);
     if (!from)
         return NSOrderedSame;
 
-    auto to = dynamic_objc_cast<WKPDFFoundTextPosition>(toRange.start);
+    auto to = dynamicObjCDowncast<WKPDFFoundTextPosition>(toRange.start);
     if (!to)
         return NSOrderedSame;
 
@@ -827,7 +827,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     if (style != UITextSearchFoundTextStyleHighlighted)
         return;
 
-    auto foundTextRange = dynamic_objc_cast<WKPDFFoundTextRange>(range);
+    auto foundTextRange = dynamicObjCDowncast<WKPDFFoundTextRange>(range);
     if (!foundTextRange)
         return;
 

--- a/Source/WebKit/UIProcess/ios/WKTextInteractionWrapper.mm
+++ b/Source/WebKit/UIProcess/ios/WKTextInteractionWrapper.mm
@@ -166,7 +166,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(HideEditMenuScope);
 #endif
 
     for (id<UIInteraction> interaction in _view.interactions) {
-        if (RetainPtr selectionInteraction = dynamic_objc_cast<UITextSelectionDisplayInteraction>(interaction))
+        if (RetainPtr selectionInteraction = dynamicObjCDowncast<UITextSelectionDisplayInteraction>(interaction))
             return selectionInteraction.get();
     }
 

--- a/Source/WebKit/UIProcess/ios/WKTouchEventsGestureRecognizer.mm
+++ b/Source/WebKit/UIProcess/ios/WKTouchEventsGestureRecognizer.mm
@@ -304,7 +304,7 @@ static CGPoint mapRootViewToViewport(CGPoint pointInRootView, WKContentView *con
 
     for (UITouch *touch in touches) {
         // Get the identifier of this touch. Or create one if one did not exist.
-        auto associatedIdentifier = dynamic_objc_cast<NSNumber>(objc_getAssociatedObject(touch, &associatedTouchIdentifierKey));
+        auto associatedIdentifier = dynamicObjCDowncast<NSNumber>(objc_getAssociatedObject(touch, &associatedTouchIdentifierKey));
 
         // Create a new identifier for trackpad events in the Begin phase regardless, because the UITouch
         // instance persists between trackpad clicks, and there is existing web content that does not expect subsequent

--- a/Source/WebKit/UIProcess/ios/forms/WKDateTimeInputControl.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKDateTimeInputControl.mm
@@ -423,34 +423,34 @@ static constexpr auto yearAndMonthDatePickerMode = static_cast<UIDatePickerMode>
 
 - (void)setTimePickerHour:(NSInteger)hour minute:(NSInteger)minute
 {
-    if (auto picker = dynamic_objc_cast<WKDateTimePicker>(self.control))
+    if (auto picker = dynamicObjCDowncast<WKDateTimePicker>(self.control))
         [picker setHour:hour minute:minute];
 }
 
 - (NSString *)dateTimePickerCalendarType
 {
-    if (auto picker = dynamic_objc_cast<WKDateTimePicker>(self.control))
+    if (auto picker = dynamicObjCDowncast<WKDateTimePicker>(self.control))
         return picker.calendarType;
     return nil;
 }
 
 - (double)timePickerValueHour
 {
-    if (auto picker = dynamic_objc_cast<WKDateTimePicker>(self.control))
+    if (auto picker = dynamicObjCDowncast<WKDateTimePicker>(self.control))
         return picker.hour;
     return -1;
 }
 
 - (double)timePickerValueMinute
 {
-    if (auto picker = dynamic_objc_cast<WKDateTimePicker>(self.control))
+    if (auto picker = dynamicObjCDowncast<WKDateTimePicker>(self.control))
         return picker.minute;
     return -1;
 }
 
 - (BOOL)dismissWithAnimationForTesting
 {
-    if (auto picker = dynamic_objc_cast<WKDateTimePicker>(self.control)) {
+    if (auto picker = dynamicObjCDowncast<WKDateTimePicker>(self.control)) {
         [picker.datePickerController assertAccessoryViewCanBeHitTestedForTesting];
         [picker.datePickerController dismissDatePicker];
         return YES;

--- a/Source/WebKit/UIProcess/ios/forms/WKFormAccessoryView.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKFormAccessoryView.mm
@@ -303,7 +303,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 
 - (UIButton *)_autoFillButton
 {
-    return dynamic_objc_cast<UIButton>([_autoFillButtonItem customView]);
+    return dynamicObjCDowncast<UIButton>([_autoFillButtonItem customView]);
 }
 
 - (void)_refreshAutofillPresentation

--- a/Source/WebKit/UIProcess/ios/forms/WKFormColorControl.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKFormColorControl.mm
@@ -171,7 +171,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 
 - (void)selectColor:(UIColor *)color
 {
-    if (auto *picker = dynamic_objc_cast<WKColorPicker>(self.control))
+    if (auto *picker = dynamicObjCDowncast<WKColorPicker>(self.control))
         [picker selectColor:color];
 }
 

--- a/Source/WebKit/UIProcess/ios/forms/WKFormSelectControl.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKFormSelectControl.mm
@@ -108,7 +108,7 @@ CGFloat adjustedFontSize(CGFloat textWidth, UIFont *font, CGFloat initialFontSiz
 
 - (NSString *)selectFormPopoverTitle
 {
-    if (auto *popover = dynamic_objc_cast<WKSelectPopover>(self.control))
+    if (auto *popover = dynamicObjCDowncast<WKSelectPopover>(self.control))
         return [popover tableViewController].title;
     return nil;
 }

--- a/Source/WebKit/UIProcess/ios/forms/WKFormSelectPicker.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKFormSelectPicker.mm
@@ -757,12 +757,12 @@ static constexpr auto removeLineLimitForChildrenMenuOption = static_cast<UIMenuO
 #if USE(UICONTEXTMENU)
     NSMutableArray<NSString *> *itemTitles = [NSMutableArray array];
     for (UIMenuElement *menuElement in [_selectMenu children]) {
-        if (auto *action = dynamic_objc_cast<UIAction>(menuElement)) {
+        if (auto *action = dynamicObjCDowncast<UIAction>(menuElement)) {
             [itemTitles addObject:action.title];
             continue;
         }
 
-        if (auto *menu = dynamic_objc_cast<UIMenu>(menuElement)) {
+        if (auto *menu = dynamicObjCDowncast<UIMenu>(menuElement)) {
             for (UIMenuElement *groupedMenuElement in [menu children])
                 [itemTitles addObject:groupedMenuElement.title];
         }
@@ -1260,7 +1260,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         UIPresentationController *presentationController = [_navigationController presentationController];
         presentationController.delegate = self;
 
-        if (auto sheetPresentationController = dynamic_objc_cast<UISheetPresentationController>(presentationController)) {
+        if (auto sheetPresentationController = dynamicObjCDowncast<UISheetPresentationController>(presentationController)) {
             sheetPresentationController.detents = @[UISheetPresentationControllerDetent.mediumDetent, UISheetPresentationControllerDetent.largeDetent];
             sheetPresentationController.widthFollowsPreferredContentSizeWhenEdgeAttached = YES;
             sheetPresentationController.prefersEdgeAttachedInCompactHeight = YES;

--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
@@ -1984,7 +1984,7 @@ static constexpr NSString *kPrefersFullScreenDimmingKey = @"WebKitPrefersFullScr
             } else {
                 scene.sizeRestrictions.minimumSize = [originalState sceneMinimumSize];
                 scene.mrui_placement.preferredResizingBehavior = [originalState sceneResizingBehavior];
-                if (auto delegate = dynamic_objc_cast<WKFullscreenWindowSceneDelegate>(scene.delegate))
+                if (auto delegate = dynamicObjCDowncast<WKFullscreenWindowSceneDelegate>(scene.delegate))
                     scene.delegate = [delegate originalDelegate];
 
                 for (MRUIPlatterOrnament *ornament in [originalState ornamentProperties])

--- a/Source/WebKit/UIProcess/mac/WKFullScreenWindowController.mm
+++ b/Source/WebKit/UIProcess/mac/WKFullScreenWindowController.mm
@@ -84,7 +84,7 @@ static NSRect convertRectToScreen(NSWindow *window, NSRect rect)
 
 static void makeResponderFirstResponderIfDescendantOfView(NSWindow *window, NSResponder *responder, NSView *view)
 {
-    if (auto *responderView = dynamic_objc_cast<NSView>(responder); responderView && [responderView isDescendantOf:view])
+    if (auto *responderView = dynamicObjCDowncast<NSView>(responder); responderView && [responderView isDescendantOf:view])
         [window makeFirstResponder:responder];
 }
 

--- a/Source/WebKit/UIProcess/mac/WKSharingServicePickerDelegate.mm
+++ b/Source/WebKit/UIProcess/mac/WKSharingServicePickerDelegate.mm
@@ -130,13 +130,13 @@
 
     RetainPtr<id> item = [items objectAtIndex:0];
 
-    if (RetainPtr attributedString = dynamic_objc_cast<NSAttributedString>(item.get())) {
+    if (RetainPtr attributedString = dynamicObjCDowncast<NSAttributedString>(item.get())) {
         RetainPtr data = [attributedString RTFDFromRange:NSMakeRange(0, [attributedString length]) documentAttributes:@{ }];
         dataReference = span(data.get());
 
         types.append(NSPasteboardTypeRTFD);
         types.append(WebCore::legacyRTFDPasteboardType());
-    } else if (RetainPtr data = dynamic_objc_cast<NSData>(item.get())) {
+    } else if (RetainPtr data = dynamicObjCDowncast<NSData>(item.get())) {
         RetainPtr<CGImageSourceRef> source = adoptCF(CGImageSourceCreateWithData(bridge_cast(data.get()), NULL));
         RetainPtr<CGImageRef> image = adoptCF(CGImageSourceCreateImageAtIndex(source.get(), 0, NULL));
 
@@ -145,7 +145,7 @@
 
         dataReference = span(data.get());
         types.append(NSPasteboardTypeTIFF);
-    } else if (RetainPtr itemProvider = dynamic_objc_cast<NSItemProvider>(item.get())) {
+    } else if (RetainPtr itemProvider = dynamicObjCDowncast<NSItemProvider>(item.get())) {
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
         RefPtr menuProxy = _menuProxy.get();
         WeakPtr weakPage = menuProxy ? menuProxy->page() : nullptr;

--- a/Source/WebKit/UIProcess/mac/WebColorPickerMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebColorPickerMac.mm
@@ -165,7 +165,7 @@ void WebColorPickerMac::showColorPicker(const WebCore::Color& color)
     [self deactivate];
 
     // Deactivate previous NSPopoverColorWell
-    if (RetainPtr owner = dynamic_objc_cast<NSPopoverColorWell>([NSColorWell _exclusiveColorPanelOwner]))
+    if (RetainPtr owner = dynamicObjCDowncast<NSPopoverColorWell>([NSColorWell _exclusiveColorPanelOwner]))
         [owner deactivate];
 
     RetainPtr controller = checked_objc_cast<NSColorPopoverController>([popover.get() contentViewController]);

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -816,7 +816,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     if (!_webViewImpl)
         return;
 
-    RetainPtr insertListControl = dynamic_objc_cast<NSSegmentedControl>(self.view);
+    RetainPtr insertListControl = dynamicObjCDowncast<NSSegmentedControl>(self.view);
     switch (insertListControl.get().selectedSegment) {
     case noListSegment:
         // There is no "remove list" edit command, but InsertOrderedList and InsertUnorderedList both
@@ -840,7 +840,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 - (void)setCurrentListType:(WebKit::ListType)listType
 {
-    RetainPtr insertListControl = dynamic_objc_cast<NSSegmentedControl>(self.view);
+    RetainPtr insertListControl = dynamicObjCDowncast<NSSegmentedControl>(self.view);
     switch (listType) {
     case WebKit::ListType::None:
         [insertListControl setSelected:YES forSegment:noListSegment];
@@ -924,7 +924,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
     RetainPtr<NSColorPickerTouchBarItem> colorPickerItem;
     if ([identifier isEqualToString:NSTouchBarItemIdentifierTextColorPicker])
-        colorPickerItem = dynamic_objc_cast<NSColorPickerTouchBarItem>(item.get());
+        colorPickerItem = dynamicObjCDowncast<NSColorPickerTouchBarItem>(item.get());
     if (isTextFormatItem)
         colorPickerItem = self.colorPickerItem;
     if (colorPickerItem) {
@@ -1186,7 +1186,7 @@ static void* imageOverlayObservationContext = &imageOverlayObservationContext;
     if (!_impl)
         return NO;
 
-    for (RetainPtr view = dynamic_objc_cast<NSView>(_impl->view().window.firstResponder); view; view = view.get().superview) {
+    for (RetainPtr view = dynamicObjCDowncast<NSView>(_impl->view().window.firstResponder); view; view = view.get().superview) {
         if (view == _overlayView)
             return YES;
     }
@@ -1322,7 +1322,7 @@ WebViewImpl::WebViewImpl(WKWebView *view, WebProcessPool& processPool, Ref<API::
     [view addTrackingArea:m_flagsChangedEventMonitorTrackingArea.get()];
 
     for (NSView *subview in view.subviews) {
-        if (RetainPtr layerHostingView = dynamic_objc_cast<WKFlippedView>(subview)) {
+        if (RetainPtr layerHostingView = dynamicObjCDowncast<WKFlippedView>(subview)) {
             // A layer hosting view may have already been created and added to the view hierarchy
             // in the process of initializing the WKWebView from an NSCoder.
             m_layerHostingView = layerHostingView.get();
@@ -1574,8 +1574,8 @@ bool WebViewImpl::resignFirstResponder()
         if (m_page->maintainsInactiveSelection())
             return false;
 
-        RetainPtr<NSWindow> nextResponderWindow = dynamic_objc_cast<NSView>(nextResponder.get()).window;
-        return !dynamic_objc_cast<NSPanel>(nextResponderWindow.get());
+        RetainPtr<NSWindow> nextResponderWindow = dynamicObjCDowncast<NSView>(nextResponder.get()).window;
+        return !dynamicObjCDowncast<NSPanel>(nextResponderWindow.get());
     }();
 
     if (shouldClearSelection)
@@ -2936,7 +2936,7 @@ void WebViewImpl::changeFontColorFromSender(id sender)
     if (![sender respondsToSelector:@selector(color)])
         return;
 
-    RetainPtr color = dynamic_objc_cast<NSColor>([sender color]);
+    RetainPtr color = dynamicObjCDowncast<NSColor>([sender color]);
     if (!color)
         return;
 
@@ -4213,7 +4213,7 @@ static bool handleLegacyFilesPromisePasteboard(id<NSDraggingInfo> draggingInfo, 
     // FIXME: legacyFilesPromisePasteboardType() contains UTIs, not path names. Also, it's not
     // guaranteed that the count of UTIs equals the count of files, since some clients only write
     // unique UTIs.
-    RetainPtr files = dynamic_objc_cast<NSArray>([draggingInfo.draggingPasteboard propertyListForType:WebCore::legacyFilesPromisePasteboardType()]);
+    RetainPtr files = dynamicObjCDowncast<NSArray>([draggingInfo.draggingPasteboard propertyListForType:WebCore::legacyFilesPromisePasteboardType()]);
     if (!files)
         return false;
 
@@ -4246,7 +4246,7 @@ static bool handleLegacyFilesPromisePasteboard(id<NSDraggingInfo> draggingInfo, 
 
 static bool handleLegacyFilesPasteboard(id<NSDraggingInfo> draggingInfo, Box<WebCore::DragData>&& dragData, WebPageProxy& page)
 {
-    RetainPtr files = dynamic_objc_cast<NSArray>([draggingInfo.draggingPasteboard propertyListForType:WebCore::legacyFilenamesPasteboardType()]);
+    RetainPtr files = dynamicObjCDowncast<NSArray>([draggingInfo.draggingPasteboard propertyListForType:WebCore::legacyFilenamesPasteboardType()]);
     if (!files)
         return false;
 
@@ -4329,7 +4329,7 @@ void WebViewImpl::registerDraggedTypes()
 
 NSString *WebViewImpl::fileNameForFilePromiseProvider(NSFilePromiseProvider *provider, NSString *)
 {
-    RetainPtr userInfo = dynamic_objc_cast<WKPromisedAttachmentContext>(provider.userInfo);
+    RetainPtr userInfo = dynamicObjCDowncast<WKPromisedAttachmentContext>(provider.userInfo);
     if (!userInfo)
         return nil;
 
@@ -4348,7 +4348,7 @@ void WebViewImpl::didPerformDragOperation(bool handled)
 
 void WebViewImpl::writeToURLForFilePromiseProvider(NSFilePromiseProvider *provider, NSURL *fileURL, void(^completionHandler)(NSError *))
 {
-    RetainPtr userInfo = dynamic_objc_cast<WKPromisedAttachmentContext>(provider.userInfo);
+    RetainPtr userInfo = dynamicObjCDowncast<WKPromisedAttachmentContext>(provider.userInfo);
     if (!userInfo) {
         completionHandler(webKitUnknownError());
         return;
@@ -4777,7 +4777,7 @@ void WebViewImpl::insertTextPlaceholderWithSize(CGSize size, void(^completionHan
 void WebViewImpl::removeTextPlaceholder(NSTextPlaceholder *placeholder, bool willInsertText, void(^completionHandler)())
 {
     // FIXME: Implement support for willInsertText. See <https://bugs.webkit.org/show_bug.cgi?id=208747>.
-    if (RetainPtr wkTextPlaceholder = dynamic_objc_cast<WKTextPlaceholder>(placeholder))
+    if (RetainPtr wkTextPlaceholder = dynamicObjCDowncast<WKTextPlaceholder>(placeholder))
         m_page->removeTextPlaceholder([wkTextPlaceholder elementContext], makeBlockPtr(completionHandler));
     else
         completionHandler();
@@ -5490,7 +5490,7 @@ void WebViewImpl::setMarkedText(id string, NSRange selectedRange, NSRange replac
     LOG(TextInput, "setMarkedText:\"%@\" selectedRange:(%u, %u) replacementRange:(%u, %u)", string, selectedRange.location, selectedRange.length, replacementRange.location, replacementRange.length);
 
 #if HAVE(INLINE_PREDICTIONS)
-    if (RetainPtr attributedString = dynamic_objc_cast<NSAttributedString>(string)) {
+    if (RetainPtr attributedString = dynamicObjCDowncast<NSAttributedString>(string)) {
         BOOL hasTextCompletion = [&] {
             __block BOOL result = NO;
 
@@ -6250,7 +6250,7 @@ void WebViewImpl::dismissTextTouchBarPopoverItemWithIdentifier(NSString *identif
         }
     }
 
-    if (RetainPtr touchBarItem = dynamic_objc_cast<NSPopoverTouchBarItem>(foundItem))
+    if (RetainPtr touchBarItem = dynamicObjCDowncast<NSPopoverTouchBarItem>(foundItem))
         [touchBarItem dismissPopover:nil];
 }
 

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPICookiesCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPICookiesCocoa.mm
@@ -264,7 +264,7 @@ void WebExtensionAPICookies::getAll(NSDictionary *details, Ref<WebExtensionCallb
         filterParameters.domain = normalizeDomain(details[domainKey]);
 
     if (details[pathKey])
-        filterParameters.path = dynamic_objc_cast<NSString>(details[pathKey]);
+        filterParameters.path = dynamicObjCDowncast<NSString>(details[pathKey]);
 
     if (details[secureKey])
         filterParameters.secure = objectForKey<NSNumber>(details, secureKey).boolValue;
@@ -311,9 +311,9 @@ void WebExtensionAPICookies::set(NSDictionary *details, Ref<WebExtensionCallback
     cookie.name = details[nameKey] ?: @"";
     cookie.value = details[valueKey] ?: @"";
     cookie.secure = details[secureKey] ? objectForKey<NSNumber>(details, secureKey).boolValue : false;
-    auto *domain = dynamic_objc_cast<NSString>(details[domainKey]);
+    auto *domain = dynamicObjCDowncast<NSString>(details[domainKey]);
     cookie.domain = domain ? String(domain) : normalizeDomain(url.host().toString());
-    auto *path = dynamic_objc_cast<NSString>(details[pathKey]);
+    auto *path = dynamicObjCDowncast<NSString>(details[pathKey]);
     cookie.path = path ? String(path) : url.path().toString();
     cookie.httpOnly = objectForKey<NSNumber>(details, httpOnlyKey).boolValue;
     cookie.created = WallTime::now().secondsSinceEpoch().milliseconds();

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIMenusCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIMenusCocoa.mm
@@ -362,10 +362,10 @@ void WebExtensionAPIMenus::update(WebPage& page, WebFrame& frame, id identifier,
         return;
 
     NSString *identifierString;
-    if (NSNumber *identifierNumber = dynamic_objc_cast<NSNumber>(identifier))
+    if (NSNumber *identifierNumber = dynamicObjCDowncast<NSNumber>(identifier))
         identifierString = identifierNumber.stringValue;
     else
-        identifierString = dynamic_objc_cast<NSString>(identifier);
+        identifierString = dynamicObjCDowncast<NSString>(identifier);
 
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::MenusUpdate(identifierString, parameters.value()), [this, protectedThis = Ref { *this }, callback = WTFMove(callback), clickCallback = WTFMove(clickCallback), newIdentifier = parameters.value().identifier, oldIdentifier = String(identifierString)](Expected<void, WebExtensionError>&& result) mutable {
         if (!result) {
@@ -402,10 +402,10 @@ void WebExtensionAPIMenus::remove(id identifier, Ref<WebExtensionCallbackHandler
         return;
 
     NSString *identifierString;
-    if (NSNumber *identifierNumber = dynamic_objc_cast<NSNumber>(identifier))
+    if (NSNumber *identifierNumber = dynamicObjCDowncast<NSNumber>(identifier))
         identifierString = identifierNumber.stringValue;
     else
-        identifierString = dynamic_objc_cast<NSString>(identifier);
+        identifierString = dynamicObjCDowncast<NSString>(identifier);
 
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::MenusRemove(identifierString), [this, protectedThis = Ref { *this }, callback = WTFMove(callback), identifier = String(identifierString)](Expected<void, WebExtensionError>&& result) {
         if (!result) {

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIRuntimeCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIRuntimeCocoa.mm
@@ -676,12 +676,12 @@ void WebExtensionContextProxy::internalDispatchRuntimeMessageEvent(WebExtensionC
                 callbackAggregatorWrapper.get().aggregator(replyMessage, IsDefaultReply::No);
             });
 
-            if (dynamic_objc_cast<NSNumber>(returnValue).boolValue) {
+            if (dynamicObjCDowncast<NSNumber>(returnValue).boolValue) {
                 anyListenerHandledMessage = true;
                 continue;
             }
 
-            JSValue *value = dynamic_objc_cast<JSValue>(returnValue);
+            JSValue *value = dynamicObjCDowncast<JSValue>(returnValue);
             if (!value._isThenable)
                 continue;
 

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPISidebarActionCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPISidebarActionCocoa.mm
@@ -85,7 +85,7 @@ static Variant<std::monostate, String, SidebarError> parseDetailsStringFromKey(N
         return std::monostate();
     }
 
-    RetainPtr nsStringValue = dynamic_objc_cast<NSString>(maybeValue.get());
+    RetainPtr nsStringValue = dynamicObjCDowncast<NSString>(maybeValue.get());
     if (!nsStringValue]) {
         if (required)
             return SidebarError { toErrorString(nullString(), @"details", adoptNS([[NSString alloc] initWithFormat:@"'%@' must be of type 'string'", key]).get()) };

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIStorageAreaCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIStorageAreaCocoa.mm
@@ -78,7 +78,7 @@ void WebExtensionAPIStorageArea::get(WebPageProxyIdentifier webPageProxyIdentifi
         return;
 
     Vector<String> keysVector;
-    NSDictionary *keysWithDefaultValues = dynamic_objc_cast<NSDictionary>(items);
+    NSDictionary *keysWithDefaultValues = dynamicObjCDowncast<NSDictionary>(items);
 
     if (keysWithDefaultValues) {
         if (!keysWithDefaultValues.count) {
@@ -89,7 +89,7 @@ void WebExtensionAPIStorageArea::get(WebPageProxyIdentifier webPageProxyIdentifi
         keysVector = makeVector<String>(keysWithDefaultValues.allKeys);
     }
 
-    if (NSArray *keys = dynamic_objc_cast<NSArray>(items)) {
+    if (NSArray *keys = dynamicObjCDowncast<NSArray>(items)) {
         if (!keys.count) {
             callback->call(@{ });
             return;
@@ -98,7 +98,7 @@ void WebExtensionAPIStorageArea::get(WebPageProxyIdentifier webPageProxyIdentifi
         keysVector = makeVector<String>(keys);
     }
 
-    if (NSString *key = dynamic_objc_cast<NSString>(items))
+    if (NSString *key = dynamicObjCDowncast<NSString>(items))
         keysVector = { key };
 
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::StorageGet(webPageProxyIdentifier, m_type, keysVector), [keysWithDefaultValues, protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<String, WebExtensionError>&& result) {
@@ -140,9 +140,9 @@ void WebExtensionAPIStorageArea::getBytesInUse(WebPageProxyIdentifier webPagePro
         return;
 
     Vector<String> keysVector;
-    if (NSArray *keysArray = dynamic_objc_cast<NSArray>(keys))
+    if (NSArray *keysArray = dynamicObjCDowncast<NSArray>(keys))
         keysVector = makeVector<String>(keysArray);
-    else if (NSString *key = dynamic_objc_cast<NSString>(keys))
+    else if (NSString *key = dynamicObjCDowncast<NSString>(keys))
         keysVector = { key };
 
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::StorageGetBytesInUse(webPageProxyIdentifier, m_type, keysVector), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<size_t, WebExtensionError>&& result) {

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITabsCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITabsCocoa.mm
@@ -763,7 +763,7 @@ void WebExtensionAPITabs::remove(NSObject *tabIDs, Ref<WebExtensionCallbackHandl
 
     Vector<WebExtensionTabIdentifier> identifiers;
 
-    if (NSNumber *tabID = dynamic_objc_cast<NSNumber>(tabIDs)) {
+    if (NSNumber *tabID = dynamicObjCDowncast<NSNumber>(tabIDs)) {
         auto tabIdentifer = toWebExtensionTabIdentifier(tabID.doubleValue);
         if (!isValid(tabIdentifer)) {
             *outExceptionString = toErrorString(nullString(), @"tabIDs", @"'%@' is not a tab identifier", tabID).createNSString().autorelease();
@@ -771,7 +771,7 @@ void WebExtensionAPITabs::remove(NSObject *tabIDs, Ref<WebExtensionCallbackHandl
         }
 
         identifiers.append(tabIdentifer.value());
-    } else if (NSArray *tabIDArray = dynamic_objc_cast<NSArray>(tabIDs)) {
+    } else if (NSArray *tabIDArray = dynamicObjCDowncast<NSArray>(tabIDs)) {
         identifiers.reserveInitialCapacity(tabIDArray.count);
 
         for (NSNumber *tabID in tabIDArray) {

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebRequestCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebRequestCocoa.mm
@@ -386,7 +386,7 @@ void WebExtensionContextProxy::resourceLoadDidPerformHTTPRedirection(WebExtensio
 void WebExtensionContextProxy::resourceLoadDidReceiveChallenge(WebExtensionTabIdentifier tabID, WebExtensionWindowIdentifier windowID, const WebCore::AuthenticationChallenge& webCoreChallenge, const ResourceLoadInfo& resourceLoad)
 {
     auto *challenge = webCoreChallenge.nsURLAuthenticationChallenge();
-    auto *httpResponse = dynamic_objc_cast<NSHTTPURLResponse>(challenge.failureResponse);
+    auto *httpResponse = dynamicObjCDowncast<NSHTTPURLResponse>(challenge.failureResponse);
     if (!httpResponse)
         return;
 

--- a/Source/WebKit/WebProcess/Extensions/Bindings/Cocoa/JSWebExtensionWrapperCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/Bindings/Cocoa/JSWebExtensionWrapperCocoa.mm
@@ -368,7 +368,7 @@ JSValueRef toJSValueRefOrJSNull(JSContextRef context, id object)
 NSArray *toNSArray(JSContextRef context, JSValueRef value, Class containingObjectsOfClass)
 {
     ASSERT(containingObjectsOfClass);
-    return dynamic_objc_cast<NSArray>(toNSObject(context, value, containingObjectsOfClass));
+    return dynamicObjCDowncast<NSArray>(toNSObject(context, value, containingObjectsOfClass));
 }
 
 JSContext *toJSContext(JSContextRef context)
@@ -412,7 +412,7 @@ JSValueRef toJSValueRef(JSContextRef context, id object)
     if (!object)
         return JSValueMakeUndefined(context);
 
-    if (JSValue *value = dynamic_objc_cast<JSValue>(object))
+    if (JSValue *value = dynamicObjCDowncast<JSValue>(object))
         return value.JSValueRef;
 
     return [JSValue valueWithObject:object inContext:toJSContext(context)].JSValueRef;
@@ -475,7 +475,7 @@ using namespace WebKit;
 
 - (BOOL)_isThenable
 {
-    return self.isObject && dynamic_objc_cast<JSValue>(self[@"then"])._isFunction;
+    return self.isObject && dynamicObjCDowncast<JSValue>(self[@"then"])._isFunction;
 }
 
 - (void)_awaitThenableResolutionWithCompletionHandler:(void (^)(JSValue *result, JSValue *error))completionHandler

--- a/Source/WebKit/WebProcess/Extensions/Cocoa/_WKWebExtensionWebNavigationURLFilter.mm
+++ b/Source/WebKit/WebProcess/Extensions/Cocoa/_WKWebExtensionWebNavigationURLFilter.mm
@@ -172,13 +172,13 @@ static NSString * const portsKey = @"ports";
         constexpr NSInteger maximumPortNumber = 65535;
         static NSOrderedSet *expectedPortOrRangeTypes = [NSOrderedSet orderedSetWithObjects:NSNumber.class, @[ NSNumber.class ], nil];
 
-        NSUInteger count = dynamic_objc_cast<NSArray>(rawValue).count;
+        NSUInteger count = dynamicObjCDowncast<NSArray>(rawValue).count;
         for (NSUInteger i = 0; i < count; ++i) {
             id portOrRange = rawValue[i];
             if (!validateObject(portOrRange, adoptNS([[NSString alloc] initWithFormat:@"%@[%lu]", portsKey, i]).get(), expectedPortOrRangeTypes, outErrorMessage))
                 return nil;
 
-            if (NSNumber *number = dynamic_objc_cast<NSNumber>(portOrRange)) {
+            if (NSNumber *number = dynamicObjCDowncast<NSNumber>(portOrRange)) {
                 NSInteger integerValue = number.integerValue;
                 if (integerValue < 0 || integerValue > maximumPortNumber) {
                     *outErrorMessage = toErrorString(nullString(), portsKey, @"'%zd' is not a valid port", integerValue).createNSString().autorelease();
@@ -186,7 +186,7 @@ static NSString * const portsKey = @"ports";
                 }
 
                 [ports addIndex:(NSUInteger)integerValue];
-            } else if (NSArray<NSNumber *> *rangeArray = dynamic_objc_cast<NSArray>(portOrRange)) {
+            } else if (NSArray<NSNumber *> *rangeArray = dynamicObjCDowncast<NSArray>(portOrRange)) {
                 if (rangeArray.count != 2) {
                     *outErrorMessage = toErrorString(nullString(), portsKey, @"a port range must specify 2 numbers").createNSString().autorelease();
                     return nil;

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -4023,7 +4023,7 @@ void UnifiedPDFPlugin::handlePDFActionForAnnotation(PDFAnnotation *annotation, P
             return;
 
 #if HAVE(PDFDOCUMENT_RESET_FORM_FIELDS)
-        if (RetainPtr resetAction = dynamic_objc_cast<PDFActionResetForm>(action))
+        if (RetainPtr resetAction = dynamicObjCDowncast<PDFActionResetForm>(action))
             [m_pdfDocument resetFormFields:resetAction.get()];
 #endif
 

--- a/Source/WebKitLegacy/mac/Storage/WebDatabaseProvider.mm
+++ b/Source/WebKitLegacy/mac/Storage/WebDatabaseProvider.mm
@@ -32,7 +32,7 @@
 String WebDatabaseProvider::indexedDatabaseDirectoryPath()
 {
     RetainPtr defaults = [NSUserDefaults standardUserDefaults];
-    RetainPtr databasesDirectory = dynamic_objc_cast<NSString>([defaults objectForKey:WebDatabaseDirectoryDefaultsKey]);
+    RetainPtr databasesDirectory = dynamicObjCDowncast<NSString>([defaults objectForKey:WebDatabaseDirectoryDefaultsKey]);
     if (!databasesDirectory)
         databasesDirectory = FileSystem::pathByAppendingComponent("~/Library/WebKit/Databases/___IndexedDB"_s, String([[NSBundle mainBundle] bundleIdentifier])).createNSString();
     else

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebDragClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebDragClient.mm
@@ -185,7 +185,7 @@ void WebDragClient::beginDrag(DragItem dragItem, LocalFrame& frame, const IntPoi
 {
     ASSERT(!dataTransfer.pasteboard().hasData());
 
-    RetainPtr<WebHTMLView> topWebHTMLView = dynamic_objc_cast<WebHTMLView>(m_webView.mainFrame.frameView.documentView);
+    RetainPtr<WebHTMLView> topWebHTMLView = dynamicObjCDowncast<WebHTMLView>(m_webView.mainFrame.frameView.documentView);
     ASSERT(topWebHTMLView);
 
     [topWebHTMLView _stopAutoscrollTimer];

--- a/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
@@ -1913,7 +1913,7 @@ static bool mouseEventIsPartOfClickOrDrag(NSEvent *event)
     NSView *hitView = [contentView hitTest:locationForHitTest];
     forceWebHTMLViewHitTest = NO;
     
-    auto view = retainPtr(dynamic_objc_cast<WebHTMLView>(hitView));
+    auto view = retainPtr(dynamicObjCDowncast<WebHTMLView>(hitView));
     if (lastHitView != view && lastHitView && [lastHitView _frame]) {
         // If we are moving out of a view (or frame), let's pretend the mouse moved
         // all the way out of that view. But we have to account for scrolling, because

--- a/Source/WebKitLegacy/mac/WebView/WebView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebView.mm
@@ -9232,7 +9232,7 @@ FORWARD(toggleUnderline)
         }
     }
 
-    if (auto* touchBarItem = dynamic_objc_cast<NSPopoverTouchBarItem>(foundItem))
+    if (auto* touchBarItem = dynamicObjCDowncast<NSPopoverTouchBarItem>(foundItem))
         [touchBarItem dismissPopover:nil];
 }
 

--- a/Tools/DumpRenderTree/mac/TestRunnerMac.mm
+++ b/Tools/DumpRenderTree/mac/TestRunnerMac.mm
@@ -1204,7 +1204,7 @@ void TestRunner::generateTestReport(JSStringRef message, JSStringRef group)
 
 bool TestRunner::isSecureEventInputEnabled() const
 {
-    return dynamic_objc_cast<WebHTMLView>(mainFrame.frameView.documentView)._secureEventInputEnabledForTesting;
+    return dynamicObjCDowncast<WebHTMLView>(mainFrame.frameView.documentView)._secureEventInputEnabledForTesting;
 }
 
 #endif // PLATFORM(MAC)

--- a/Tools/DumpRenderTree/mac/UIScriptControllerMac.mm
+++ b/Tools/DumpRenderTree/mac/UIScriptControllerMac.mm
@@ -245,7 +245,7 @@ void UIScriptControllerMac::sendEventStream(JSStringRef eventsJSON, JSValueRef c
     unsigned callbackID = m_context->prepareForAsyncTask(callback, CallbackTypeNonPersistent);
 
     auto jsonString = eventsJSON->string();
-    auto eventInfo = dynamic_objc_cast<NSDictionary>([NSJSONSerialization JSONObjectWithData:[jsonString.createNSString() dataUsingEncoding:NSUTF8StringEncoding] options:NSJSONReadingMutableContainers | NSJSONReadingMutableLeaves error:nil]);
+    auto eventInfo = dynamicObjCDowncast<NSDictionary>([NSJSONSerialization JSONObjectWithData:[jsonString.createNSString() dataUsingEncoding:NSUTF8StringEncoding] options:NSJSONReadingMutableContainers | NSJSONReadingMutableLeaves error:nil]);
     if (!eventInfo || ![eventInfo isKindOfClass:[NSDictionary class]]) {
         WTFLogAlways("JSON is not convertible to a dictionary");
         return;

--- a/Tools/TestWebKitAPI/Tests/WTF/cocoa/TypeCastsCocoa.mm
+++ b/Tools/TestWebKitAPI/Tests/WTF/cocoa/TypeCastsCocoa.mm
@@ -175,19 +175,19 @@ TEST(TypeCastsCocoa, checked_objc_cast)
     }
 }
 
-TEST(TypeCastsCocoa, dynamic_objc_cast)
+TEST(TypeCastsCocoa, dynamicObjCDowncast)
 {
     NSObject *obj = nil;
-    EXPECT_EQ(nil, dynamic_objc_cast<NSString>(obj));
+    EXPECT_EQ(nil, dynamicObjCDowncast<NSString>(obj));
 
     @autoreleasepool {
         auto objectNS = adoptNS<id>([[NSString alloc] initWithFormat:@"%s", helloWorldCString]);
         uintptr_t objectNSPtr;
         AUTORELEASEPOOL_FOR_ARC_DEBUG {
             objectNSPtr = reinterpret_cast<uintptr_t>(objectNS.get());
-            EXPECT_EQ(objectNS.get(), dynamic_objc_cast<NSString>(objectNS.get()));
-            EXPECT_EQ(objectNS.get(), dynamic_objc_cast<NSObject>(objectNS.get()));
-            EXPECT_EQ(nil, dynamic_objc_cast<NSArray>(objectNS.get()));
+            EXPECT_EQ(objectNS.get(), dynamicObjCDowncast<NSString>(objectNS.get()));
+            EXPECT_EQ(objectNS.get(), dynamicObjCDowncast<NSObject>(objectNS.get()));
+            EXPECT_EQ(nil, dynamicObjCDowncast<NSArray>(objectNS.get()));
         }
         EXPECT_EQ(1L, CFGetRetainCount((CFTypeRef)objectNSPtr));
     }
@@ -197,8 +197,8 @@ TEST(TypeCastsCocoa, dynamic_objc_cast)
         uintptr_t objectNSPtr;
         AUTORELEASEPOOL_FOR_ARC_DEBUG {
             objectNSPtr = reinterpret_cast<uintptr_t>(objectNS.get());
-            EXPECT_EQ(objectNS.get(), dynamic_objc_cast<NSString>(objectNS.get()));
-            EXPECT_EQ(nil, dynamic_objc_cast<NSArray>(objectNS.get()));
+            EXPECT_EQ(objectNS.get(), dynamicObjCDowncast<NSString>(objectNS.get()));
+            EXPECT_EQ(nil, dynamicObjCDowncast<NSArray>(objectNS.get()));
         }
         EXPECT_EQ(1L, CFGetRetainCount((CFTypeRef)objectNSPtr));
     }
@@ -208,8 +208,8 @@ TEST(TypeCastsCocoa, dynamic_objc_cast)
         uintptr_t objectNSPtr;
         AUTORELEASEPOOL_FOR_ARC_DEBUG {
             objectNSPtr = reinterpret_cast<uintptr_t>(objectNS.get());
-            EXPECT_EQ(objectNS.get(), dynamic_objc_cast<NSObject>(objectNS.get()));
-            EXPECT_EQ(nil, dynamic_objc_cast<NSArray>(objectNS.get()));
+            EXPECT_EQ(objectNS.get(), dynamicObjCDowncast<NSObject>(objectNS.get()));
+            EXPECT_EQ(nil, dynamicObjCDowncast<NSArray>(objectNS.get()));
         }
         EXPECT_EQ(1L, CFGetRetainCount((CFTypeRef)objectNSPtr));
     }
@@ -219,8 +219,8 @@ TEST(TypeCastsCocoa, dynamic_objc_cast)
         uintptr_t objectIDPtr;
         AUTORELEASEPOOL_FOR_ARC_DEBUG {
             objectIDPtr = reinterpret_cast<uintptr_t>(objectID.get());
-            EXPECT_EQ(objectID.get(), dynamic_objc_cast<NSObject>(objectID.get()));
-            EXPECT_EQ(nil, dynamic_objc_cast<MyObjectSubtype>(objectID.get()));
+            EXPECT_EQ(objectID.get(), dynamicObjCDowncast<NSObject>(objectID.get()));
+            EXPECT_EQ(nil, dynamicObjCDowncast<MyObjectSubtype>(objectID.get()));
         }
         EXPECT_EQ(1L, CFGetRetainCount((CFTypeRef)objectIDPtr));
     }
@@ -230,17 +230,17 @@ TEST(TypeCastsCocoa, dynamic_objc_cast)
         uintptr_t objectNSPtr;
         AUTORELEASEPOOL_FOR_ARC_DEBUG {
             objectNSPtr = reinterpret_cast<uintptr_t>(objectNS.get());
-            EXPECT_EQ(nil, dynamic_objc_cast<MyObjectSubtype>(objectNS.get()));
+            EXPECT_EQ(nil, dynamicObjCDowncast<MyObjectSubtype>(objectNS.get()));
         }
         EXPECT_EQ(1L, CFGetRetainCount((CFTypeRef)objectNSPtr));
     }
 }
 
-TEST(TypeCastsCocoa, dynamic_objc_cast_RetainPtr)
+TEST(TypeCastsCocoa, dynamicObjCDowncast_RetainPtr)
 {
     @autoreleasepool {
         RetainPtr<NSObject> object;
-        auto objectCast = dynamic_objc_cast<NSString>(WTFMove(object));
+        auto objectCast = dynamicObjCDowncast<NSString>(WTFMove(object));
         SUPPRESS_USE_AFTER_MOVE EXPECT_EQ(nil, object.get());
         EXPECT_EQ(nil, objectCast.get());
     }
@@ -256,7 +256,7 @@ TEST(TypeCastsCocoa, dynamic_objc_cast_RetainPtr)
         RetainPtr<NSString> objectCast;
         uintptr_t objectCastPtr;
         AUTORELEASEPOOL_FOR_ARC_DEBUG {
-            objectCast = dynamic_objc_cast<NSString>(WTFMove(object));
+            objectCast = dynamicObjCDowncast<NSString>(WTFMove(object));
             objectCastPtr = reinterpret_cast<uintptr_t>(objectCast.get());
         }
         SUPPRESS_USE_AFTER_MOVE EXPECT_EQ(nil, object.get());
@@ -272,7 +272,7 @@ TEST(TypeCastsCocoa, dynamic_objc_cast_RetainPtr)
         RetainPtr<NSObject> objectCast2;
         uintptr_t objectCastPtr2;
         AUTORELEASEPOOL_FOR_ARC_DEBUG {
-            objectCast2 = dynamic_objc_cast<NSObject>(WTFMove(object));
+            objectCast2 = dynamicObjCDowncast<NSObject>(WTFMove(object));
             objectCastPtr2 = reinterpret_cast<uintptr_t>(objectCast2.get());
         }
         SUPPRESS_USE_AFTER_MOVE EXPECT_EQ(nil, object.get());
@@ -288,7 +288,7 @@ TEST(TypeCastsCocoa, dynamic_objc_cast_RetainPtr)
         RetainPtr<NSArray> objectCastBad;
         uintptr_t objectPtr2;
         AUTORELEASEPOOL_FOR_ARC_DEBUG {
-            objectCastBad = dynamic_objc_cast<NSArray>(WTFMove(object));
+            objectCastBad = dynamicObjCDowncast<NSArray>(WTFMove(object));
             objectPtr2 = reinterpret_cast<uintptr_t>(object.get());
         }
         EXPECT_EQ(objectPtr, objectPtr2);
@@ -326,7 +326,7 @@ TEST(TypeCastsCocoa, dynamic_objc_cast_RetainPtr)
         RetainPtr<NSObject> objectCast;
         uintptr_t objectCastPtr;
         AUTORELEASEPOOL_FOR_ARC_DEBUG {
-            objectCast = dynamic_objc_cast<NSObject>(WTFMove(object));
+            objectCast = dynamicObjCDowncast<NSObject>(WTFMove(object));
             objectCastPtr = reinterpret_cast<uintptr_t>(objectCast.get());
         }
         SUPPRESS_USE_AFTER_MOVE EXPECT_EQ(nil, object.get());
@@ -341,7 +341,7 @@ TEST(TypeCastsCocoa, dynamic_objc_cast_RetainPtr)
 
         RetainPtr<MyObjectSubtype> objectCastBad;
         AUTORELEASEPOOL_FOR_ARC_DEBUG {
-            objectCastBad = dynamic_objc_cast<MyObjectSubtype>(WTFMove(object));
+            objectCastBad = dynamicObjCDowncast<MyObjectSubtype>(WTFMove(object));
         }
         EXPECT_EQ(nil, objectCastBad.get());
         EXPECT_EQ(1L, CFGetRetainCount((CFTypeRef)objectPtr));

--- a/Tools/TestWebKitAPI/Tests/WebKit/AdvancedPrivacyProtections.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/AdvancedPrivacyProtections.mm
@@ -333,7 +333,7 @@ TEST(AdvancedPrivacyProtections, RemoveTrackingQueryParametersWhenCopyingURL)
 #if PLATFORM(MAC)
     auto copiedString = [pasteboard stringForType:NSPasteboardTypeString];
 #else
-    auto copiedString = dynamic_objc_cast<NSString>([pasteboard valueForPasteboardType:UTTypeUTF8PlainText.identifier]);
+    auto copiedString = dynamicObjCDowncast<NSString>([pasteboard valueForPasteboardType:UTTypeUTF8PlainText.identifier]);
 #endif
     EXPECT_WK_STREQ("http://example.com/?hello=world", copiedString);
 }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/AdaptiveImageGlyph.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/AdaptiveImageGlyph.mm
@@ -928,9 +928,9 @@ TEST(AdaptiveImageGlyph, AttributedStringDocumentEditingContext)
     [request setGranularityCount:1];
 
     RetainPtr context = [webView synchronouslyRequestDocumentContext:request.get()];
-    RetainPtr contextBefore = dynamic_objc_cast<NSAttributedString>([context contextBefore]);
-    RetainPtr selectedText = dynamic_objc_cast<NSAttributedString>([context selectedText]);
-    RetainPtr contextAfter = dynamic_objc_cast<NSAttributedString>([context contextAfter]);
+    RetainPtr contextBefore = dynamicObjCDowncast<NSAttributedString>([context contextBefore]);
+    RetainPtr selectedText = dynamicObjCDowncast<NSAttributedString>([context selectedText]);
+    RetainPtr contextAfter = dynamicObjCDowncast<NSAttributedString>([context contextAfter]);
 
     EXPECT_WK_STREQ(@"Hello ", [contextBefore string]);
     EXPECT_WK_STREQ(@"\uFFFC", [selectedText string]);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/CopyHTML.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/CopyHTML.mm
@@ -289,7 +289,7 @@ TEST(CopyHTML, CopySelectedTextInTextDocument)
 
 #if PLATFORM(MAC)
     RetainPtr pastedObjects = [[NSPasteboard generalPasteboard] readObjectsForClasses:@[ NSAttributedString.class ] options:nil];
-    RetainPtr copiedText = dynamic_objc_cast<NSAttributedString>([pastedObjects firstObject]);
+    RetainPtr copiedText = dynamicObjCDowncast<NSAttributedString>([pastedObjects firstObject]);
 #elif !PLATFORM(WATCHOS) && !PLATFORM(APPLETV)
     RetainPtr itemProvider = [[[UIPasteboard generalPasteboard] itemProviders] firstObject];
     __block bool doneLoading = false;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/DocumentEditingContext.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/DocumentEditingContext.mm
@@ -938,9 +938,9 @@ TEST(DocumentEditingContext, SpatialAndCurrentSelectionRequest_LimitContextToVis
     };
 
     RetainPtr context = [webView synchronouslyRequestDocumentContext:makeRequest(UIWKDocumentRequestText | UIWKDocumentRequestSpatialAndCurrentSelection, UITextGranularityCharacter, 0, CGRectMake(1, 1, 978, 598))];
-    String selectedText = dynamic_objc_cast<NSString>([context selectedText]);
-    auto contextBeforeParts = trimmedComponentsSeparatedByNewlines(dynamic_objc_cast<NSString>([context contextBefore]));
-    auto contextAfterParts = trimmedComponentsSeparatedByNewlines(dynamic_objc_cast<NSString>([context contextAfter]));
+    String selectedText = dynamicObjCDowncast<NSString>([context selectedText]);
+    auto contextBeforeParts = trimmedComponentsSeparatedByNewlines(dynamicObjCDowncast<NSString>([context contextBefore]));
+    auto contextAfterParts = trimmedComponentsSeparatedByNewlines(dynamicObjCDowncast<NSString>([context contextAfter]));
 
     EXPECT_EQ(contextBeforeParts.size(), 1U);
     EXPECT_WK_STREQ("Here's to the crazy ones.", contextBeforeParts[0]);
@@ -1578,7 +1578,7 @@ TEST(DocumentEditingContext, CharacterRectsInEditableWebView)
     [webView waitForNextPresentationUpdate];
 
     RetainPtr context = [webView synchronouslyRequestDocumentContext:makeRequest(UIWKDocumentRequestText | UIWKDocumentRequestRects, UITextGranularitySentence, 15)];
-    auto contextAfter = dynamic_objc_cast<NSString>([context contextAfter]);
+    auto contextAfter = dynamicObjCDowncast<NSString>([context contextAfter]);
     EXPECT_GT(contextAfter.length, 0U);
 
     for (auto range : contextAfter.composedCharacterRanges) {
@@ -1673,11 +1673,11 @@ TEST(DocumentEditingContext, RequestAnnotationsForTextChecking)
             "})()"];
         [webView waitForNextPresentationUpdate];
         auto *context = [webView synchronouslyRequestDocumentContext:makeRequest(UIWKDocumentRequestText | UIWKDocumentRequestAnnotation, UITextGranularitySentence, 3)];
-        auto annotatedText = String { dynamic_objc_cast<NSAttributedString>(context.annotatedText).string };
+        auto annotatedText = String { dynamicObjCDowncast<NSAttributedString>(context.annotatedText).string };
         auto combinedContext = makeString(
-            String { dynamic_objc_cast<NSString>(context.contextBefore) },
-            String { dynamic_objc_cast<NSString>(context.selectedText) },
-            String { dynamic_objc_cast<NSString>(context.contextAfter) }
+            String { dynamicObjCDowncast<NSString>(context.contextBefore) },
+            String { dynamicObjCDowncast<NSString>(context.selectedText) },
+            String { dynamicObjCDowncast<NSString>(context.contextAfter) }
         );
         return std::pair { WTFMove(combinedContext), WTFMove(annotatedText) };
     };
@@ -1714,10 +1714,10 @@ TEST(DocumentEditingContext, ContextWithWritingSuggestions)
     [[webView textInputContentView] setAttributedMarkedText:attributedText.get() selectedRange:NSMakeRange(0, 0)];
 
     RetainPtr context = [webView synchronouslyRequestDocumentContext:makeRequest(UIWKDocumentRequestText, UITextGranularityWord, 2)];
-    RetainPtr contextBefore = dynamic_objc_cast<NSString>([context contextBefore]) ?: @"";
-    RetainPtr selectedText = dynamic_objc_cast<NSString>([context selectedText]) ?: @"";
-    RetainPtr contextAfter = dynamic_objc_cast<NSString>([context contextAfter]) ?: @"";
-    RetainPtr markedText = dynamic_objc_cast<NSString>([context markedText]) ?: @"";
+    RetainPtr contextBefore = dynamicObjCDowncast<NSString>([context contextBefore]) ?: @"";
+    RetainPtr selectedText = dynamicObjCDowncast<NSString>([context selectedText]) ?: @"";
+    RetainPtr contextAfter = dynamicObjCDowncast<NSString>([context contextAfter]) ?: @"";
+    RetainPtr markedText = dynamicObjCDowncast<NSString>([context markedText]) ?: @"";
     NSRange selectedRangeInMarkedText = [context selectedRangeInMarkedText];
 
     EXPECT_WK_STREQ("Hel", contextBefore.get());

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/UnifiedPDFTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/UnifiedPDFTests.mm
@@ -405,7 +405,7 @@ UNIFIED_PDF_TEST(LookUpSelectedText)
     [request setFlags:UIWKDocumentRequestText];
 
     RetainPtr context = [webView synchronouslyRequestDocumentContext:request.get()];
-    EXPECT_WK_STREQ(@"PDF", dynamic_objc_cast<NSString>([context selectedText]));
+    EXPECT_WK_STREQ(@"PDF", dynamicObjCDowncast<NSString>([context selectedText]));
 #endif
 
     bool done = false;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPICommands.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPICommands.mm
@@ -330,7 +330,7 @@ TEST(WKWebExtensionAPICommands, PerformMenuItem)
 #if USE(APPKIT)
     [menuItem.target performSelector:menuItem.action withObject:nil];
 #else
-    [dynamic_objc_cast<UIAction>(menuItem) performWithSender:nil target:nil];
+    [dynamicObjCDowncast<UIAction>(menuItem) performWithSender:nil target:nil];
 #endif
 
     [manager run];

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIMenus.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIMenus.mm
@@ -134,7 +134,7 @@ static inline void performMenuItemAction(auto *menuItem)
 #if USE(APPKIT)
     [menuItem.target performSelector:menuItem.action withObject:nil];
 #else
-    [dynamic_objc_cast<CocoaMenuAction>(menuItem) performWithSender:nil target:nil];
+    [dynamicObjCDowncast<CocoaMenuAction>(menuItem) performWithSender:nil target:nil];
 #endif
 }
 
@@ -397,7 +397,7 @@ TEST(WKWebExtensionAPIMenus, ActionSubmenus)
 
     auto *submenuItem = topLevelMenuItem.submenu.itemArray.firstObject;
 #else
-    auto *parentMenu = dynamic_objc_cast<UIMenu>(topLevelMenuItem);
+    auto *parentMenu = dynamicObjCDowncast<UIMenu>(topLevelMenuItem);
 
     EXPECT_EQ(parentMenu.children.count, expectedSubmenuTitles.count);
     [parentMenu.children enumerateObjectsUsingBlock:^(CocoaMenuItem *action, NSUInteger index, BOOL *stop) {
@@ -499,7 +499,7 @@ TEST(WKWebExtensionAPIMenus, ActionSubmenusUpdate)
 
     auto *submenuItem = topLevelMenuItem.submenu.itemArray.firstObject;
 #else
-    auto *parentMenu = dynamic_objc_cast<UIMenu>(topLevelMenuItem);
+    auto *parentMenu = dynamicObjCDowncast<UIMenu>(topLevelMenuItem);
 
     EXPECT_EQ(parentMenu.children.count, expectedSubmenuTitles.count);
     [parentMenu.children enumerateObjectsUsingBlock:^(CocoaMenuItem *action, NSUInteger index, BOOL *stop) {
@@ -567,7 +567,7 @@ TEST(WKWebExtensionAPIMenus, TabMenus)
 #if USE(APPKIT)
     menuItems = menuItems.firstObject.submenu.itemArray;
 #else
-    auto *parentMenu = dynamic_objc_cast<UIMenu>(menuItems.firstObject);
+    auto *parentMenu = dynamicObjCDowncast<UIMenu>(menuItems.firstObject);
     menuItems = parentMenu.children;
 #endif
 
@@ -635,13 +635,13 @@ TEST(WKWebExtensionAPIMenus, MenuItemProperties)
 #if USE(APPKIT)
     menuItems = menuItems.firstObject.submenu.itemArray;
 #else
-    auto *parentMenu = dynamic_objc_cast<UIMenu>(menuItems.firstObject);
+    auto *parentMenu = dynamicObjCDowncast<UIMenu>(menuItems.firstObject);
     menuItems = parentMenu.children;
 #endif
 
     EXPECT_EQ(menuItems.count, 2lu);
 
-    auto *firstMenuItem = dynamic_objc_cast<CocoaMenuAction>(menuItems.firstObject);
+    auto *firstMenuItem = dynamicObjCDowncast<CocoaMenuAction>(menuItems.firstObject);
     EXPECT_TRUE([firstMenuItem isKindOfClass:[CocoaMenuItem class]]);
     EXPECT_EQ(firstMenuItem.state, CocoaMenuItemStateOn);
     EXPECT_NS_EQUAL(firstMenuItem.title, @"Menu Item with Ampersand & More");
@@ -656,7 +656,7 @@ TEST(WKWebExtensionAPIMenus, MenuItemProperties)
     EXPECT_TRUE(CGSizeEqualToSize(firstMenuItem.image.size, CGSizeMake(20, 20)));
 #endif
 
-    auto *secondMenuItem = dynamic_objc_cast<CocoaMenuAction>(menuItems.lastObject);
+    auto *secondMenuItem = dynamicObjCDowncast<CocoaMenuAction>(menuItems.lastObject);
     EXPECT_TRUE([secondMenuItem isKindOfClass:[CocoaMenuItem class]]);
     EXPECT_NS_EQUAL(secondMenuItem.title, @"Menu Item with Command");
 
@@ -724,13 +724,13 @@ TEST(WKWebExtensionAPIMenus, MenuItemPropertiesUpdate)
 #if USE(APPKIT)
     menuItems = menuItems.firstObject.submenu.itemArray;
 #else
-    auto *parentMenu = dynamic_objc_cast<UIMenu>(menuItems.firstObject);
+    auto *parentMenu = dynamicObjCDowncast<UIMenu>(menuItems.firstObject);
     menuItems = parentMenu.children;
 #endif
 
     EXPECT_EQ(menuItems.count, 2lu);
 
-    auto *firstMenuItem = dynamic_objc_cast<CocoaMenuAction>(menuItems.firstObject);
+    auto *firstMenuItem = dynamicObjCDowncast<CocoaMenuAction>(menuItems.firstObject);
     EXPECT_TRUE([firstMenuItem isKindOfClass:[CocoaMenuItem class]]);
     EXPECT_EQ(firstMenuItem.state, CocoaMenuItemStateOn);
     EXPECT_NS_EQUAL(firstMenuItem.title, @"Menu Item with Ampersand & More");
@@ -745,7 +745,7 @@ TEST(WKWebExtensionAPIMenus, MenuItemPropertiesUpdate)
     EXPECT_TRUE(CGSizeEqualToSize(firstMenuItem.image.size, CGSizeMake(20, 20)));
 #endif
 
-    auto *secondMenuItem = dynamic_objc_cast<CocoaMenuAction>(menuItems.lastObject);
+    auto *secondMenuItem = dynamicObjCDowncast<CocoaMenuAction>(menuItems.lastObject);
     EXPECT_TRUE([secondMenuItem isKindOfClass:[CocoaMenuItem class]]);
     EXPECT_NS_EQUAL(secondMenuItem.title, @"Menu Item with Command");
 
@@ -789,7 +789,7 @@ TEST(WKWebExtensionAPIMenus, MenuItemWithIconVariants)
 
     EXPECT_EQ(menuItems.count, 1lu);
 
-    auto *menuItem = dynamic_objc_cast<CocoaMenuAction>(menuItems.firstObject);
+    auto *menuItem = dynamicObjCDowncast<CocoaMenuAction>(menuItems.firstObject);
     EXPECT_TRUE([menuItem isKindOfClass:[CocoaMenuItem class]]);
     EXPECT_NS_EQUAL(menuItem.title, @"Menu Item with Icon Variants");
 
@@ -848,7 +848,7 @@ TEST(WKWebExtensionAPIMenus, MenuItemWithImageDataVariants)
 
     EXPECT_EQ(menuItems.count, 1lu);
 
-    auto *menuItem = dynamic_objc_cast<CocoaMenuAction>(menuItems.firstObject);
+    auto *menuItem = dynamicObjCDowncast<CocoaMenuAction>(menuItems.firstObject);
     EXPECT_TRUE([menuItem isKindOfClass:[CocoaMenuItem class]]);
     EXPECT_NS_EQUAL(menuItem.title, @"Menu Item with ImageData Variants");
 
@@ -950,7 +950,7 @@ TEST(WKWebExtensionAPIMenus, MenuItemWithMixedValidAndInvalidIconVariants)
 
     EXPECT_EQ(menuItems.count, 1lu);
 
-    auto *menuItem = dynamic_objc_cast<CocoaMenuAction>(menuItems.firstObject);
+    auto *menuItem = dynamicObjCDowncast<CocoaMenuAction>(menuItems.firstObject);
     EXPECT_TRUE([menuItem isKindOfClass:[CocoaMenuItem class]]);
     EXPECT_NS_EQUAL(menuItem.title, @"Menu Item with Mixed Variants");
 
@@ -1009,7 +1009,7 @@ TEST(WKWebExtensionAPIMenus, MenuItemWithAnySizeVariantAndSVGDataURL)
 
     EXPECT_EQ(menuItems.count, 1lu);
 
-    auto *menuItem = dynamic_objc_cast<CocoaMenuAction>(menuItems.firstObject);
+    auto *menuItem = dynamicObjCDowncast<CocoaMenuAction>(menuItems.firstObject);
     EXPECT_TRUE([menuItem isKindOfClass:[CocoaMenuItem class]]);
     EXPECT_NS_EQUAL(menuItem.title, @"Menu Item with SVG Icon Variants");
 
@@ -1066,7 +1066,7 @@ TEST(WKWebExtensionAPIMenus, UpdateMenuItemWithIconVariants)
 
     EXPECT_EQ(menuItems.count, 1lu);
 
-    auto *menuItem = dynamic_objc_cast<CocoaMenuAction>(menuItems.firstObject);
+    auto *menuItem = dynamicObjCDowncast<CocoaMenuAction>(menuItems.firstObject);
     EXPECT_TRUE([menuItem isKindOfClass:[CocoaMenuItem class]]);
     EXPECT_NS_EQUAL(menuItem.title, @"Menu Item with Icon Variants");
 
@@ -1124,7 +1124,7 @@ TEST(WKWebExtensionAPIMenus, ClearMenuItemIconVariantsWithNull)
 
     EXPECT_EQ(menuItems.count, 1lu);
 
-    auto *menuItem = dynamic_objc_cast<CocoaMenuAction>(menuItems.firstObject);
+    auto *menuItem = dynamicObjCDowncast<CocoaMenuAction>(menuItems.firstObject);
     EXPECT_TRUE([menuItem isKindOfClass:[CocoaMenuItem class]]);
     EXPECT_NS_EQUAL(menuItem.title, @"Menu Item without Icon Variants");
 
@@ -1171,7 +1171,7 @@ TEST(WKWebExtensionAPIMenus, ClearMenuItemIconVariantsWithEmpty)
 
     EXPECT_EQ(menuItems.count, 1lu);
 
-    auto *menuItem = dynamic_objc_cast<CocoaMenuAction>(menuItems.firstObject);
+    auto *menuItem = dynamicObjCDowncast<CocoaMenuAction>(menuItems.firstObject);
     EXPECT_TRUE([menuItem isKindOfClass:[CocoaMenuItem class]]);
     EXPECT_NS_EQUAL(menuItem.title, @"Menu Item without Icon Variants");
 
@@ -1226,14 +1226,14 @@ TEST(WKWebExtensionAPIMenus, ToggleCheckboxMenuItems)
 #if USE(APPKIT)
     menuItems = menuItems.firstObject.submenu.itemArray;
 #else
-    auto *parentMenu = dynamic_objc_cast<UIMenu>(menuItems.firstObject);
+    auto *parentMenu = dynamicObjCDowncast<UIMenu>(menuItems.firstObject);
     menuItems = parentMenu.children;
 #endif
 
     EXPECT_EQ(menuItems.count, 2lu);
 
-    auto *checkbox1 = dynamic_objc_cast<CocoaMenuAction>(menuItems.firstObject);
-    auto *checkbox2 = dynamic_objc_cast<CocoaMenuAction>(menuItems.lastObject);
+    auto *checkbox1 = dynamicObjCDowncast<CocoaMenuAction>(menuItems.firstObject);
+    auto *checkbox2 = dynamicObjCDowncast<CocoaMenuAction>(menuItems.lastObject);
 
     EXPECT_TRUE([checkbox1 isKindOfClass:[CocoaMenuItem class]]);
     EXPECT_TRUE([checkbox2 isKindOfClass:[CocoaMenuItem class]]);
@@ -1251,14 +1251,14 @@ TEST(WKWebExtensionAPIMenus, ToggleCheckboxMenuItems)
 #if USE(APPKIT)
     updatedMenuItems = updatedMenuItems.firstObject.submenu.itemArray;
 #else
-    parentMenu = dynamic_objc_cast<UIMenu>(updatedMenuItems.firstObject);
+    parentMenu = dynamicObjCDowncast<UIMenu>(updatedMenuItems.firstObject);
     updatedMenuItems = parentMenu.children;
 #endif
 
     EXPECT_EQ(updatedMenuItems.count, 2lu);
 
-    checkbox1 = dynamic_objc_cast<CocoaMenuAction>(updatedMenuItems.firstObject);
-    checkbox2 = dynamic_objc_cast<CocoaMenuAction>(updatedMenuItems.lastObject);
+    checkbox1 = dynamicObjCDowncast<CocoaMenuAction>(updatedMenuItems.firstObject);
+    checkbox2 = dynamicObjCDowncast<CocoaMenuAction>(updatedMenuItems.lastObject);
 
     EXPECT_EQ(checkbox1.state, CocoaMenuItemStateOff);
     EXPECT_EQ(checkbox2.state, CocoaMenuItemStateOn);
@@ -1338,17 +1338,17 @@ TEST(WKWebExtensionAPIMenus, RadioItemGrouping)
 #if USE(APPKIT)
     menuItems = menuItems.firstObject.submenu.itemArray;
 #else
-    auto *parentMenu = dynamic_objc_cast<UIMenu>(menuItems.firstObject);
+    auto *parentMenu = dynamicObjCDowncast<UIMenu>(menuItems.firstObject);
     menuItems = parentMenu.children;
 #endif
 
     EXPECT_EQ(menuItems.count, 6lu);
 
-    auto *radio1Group1 = dynamic_objc_cast<CocoaMenuAction>(menuItems[0]);
-    auto *radio2Group1 = dynamic_objc_cast<CocoaMenuAction>(menuItems[1]);
-    auto *radio1Group2 = dynamic_objc_cast<CocoaMenuAction>(menuItems[3]);
-    auto *radio2Group2 = dynamic_objc_cast<CocoaMenuAction>(menuItems[4]);
-    auto *radio3Group2 = dynamic_objc_cast<CocoaMenuAction>(menuItems[5]);
+    auto *radio1Group1 = dynamicObjCDowncast<CocoaMenuAction>(menuItems[0]);
+    auto *radio2Group1 = dynamicObjCDowncast<CocoaMenuAction>(menuItems[1]);
+    auto *radio1Group2 = dynamicObjCDowncast<CocoaMenuAction>(menuItems[3]);
+    auto *radio2Group2 = dynamicObjCDowncast<CocoaMenuAction>(menuItems[4]);
+    auto *radio3Group2 = dynamicObjCDowncast<CocoaMenuAction>(menuItems[5]);
 
     EXPECT_EQ(radio1Group1.state, CocoaMenuItemStateOn);
     EXPECT_EQ(radio2Group1.state, CocoaMenuItemStateOff);
@@ -1368,17 +1368,17 @@ TEST(WKWebExtensionAPIMenus, RadioItemGrouping)
 #if USE(APPKIT)
     updatedMenuItems = updatedMenuItems.firstObject.submenu.itemArray;
 #else
-    parentMenu = dynamic_objc_cast<UIMenu>(updatedMenuItems.firstObject);
+    parentMenu = dynamicObjCDowncast<UIMenu>(updatedMenuItems.firstObject);
     updatedMenuItems = parentMenu.children;
 #endif
 
     EXPECT_EQ(updatedMenuItems.count, 6lu);
 
-    radio1Group1 = dynamic_objc_cast<CocoaMenuAction>(updatedMenuItems[0]);
-    radio2Group1 = dynamic_objc_cast<CocoaMenuAction>(updatedMenuItems[1]);
-    radio1Group2 = dynamic_objc_cast<CocoaMenuAction>(updatedMenuItems[3]);
-    radio2Group2 = dynamic_objc_cast<CocoaMenuAction>(updatedMenuItems[4]);
-    radio3Group2 = dynamic_objc_cast<CocoaMenuAction>(updatedMenuItems[5]);
+    radio1Group1 = dynamicObjCDowncast<CocoaMenuAction>(updatedMenuItems[0]);
+    radio2Group1 = dynamicObjCDowncast<CocoaMenuAction>(updatedMenuItems[1]);
+    radio1Group2 = dynamicObjCDowncast<CocoaMenuAction>(updatedMenuItems[3]);
+    radio2Group2 = dynamicObjCDowncast<CocoaMenuAction>(updatedMenuItems[4]);
+    radio3Group2 = dynamicObjCDowncast<CocoaMenuAction>(updatedMenuItems[5]);
 
     // The checked item as clicked again, so it does not change.
     EXPECT_EQ(radio1Group1.state, CocoaMenuItemStateOn);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionContext.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionContext.mm
@@ -959,7 +959,7 @@ TEST(WKWebExtensionContext, LoadNonExistentImage)
     EXPECT_NS_EQUAL(manager.get().context.errors, @[ ]);
 
     [NSNotificationCenter.defaultCenter addObserverForName:WKWebExtensionContextErrorsDidUpdateNotification object:nil queue:nil usingBlock:^(NSNotification *notification) {
-        auto *extensionContext = dynamic_objc_cast<WKWebExtensionContext>(notification.object);
+        auto *extensionContext = dynamicObjCDowncast<WKWebExtensionContext>(notification.object);
 
         EXPECT_EQ(extensionContext.errors.count, 1ul);
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewGetContents.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewGetContents.mm
@@ -143,16 +143,16 @@ TEST(WKWebView, GetContentsShouldReturnAttributedString)
             if (!i) {
                 EXPECT_WK_STREQ(@"Hello ", substring.string);
 #if USE(APPKIT)
-                EXPECT_WK_STREQ(@"Times-Roman", dynamic_objc_cast<NSFont>(attributes[NSFontAttributeName]).fontName);
+                EXPECT_WK_STREQ(@"Times-Roman", dynamicObjCDowncast<NSFont>(attributes[NSFontAttributeName]).fontName);
 #else
-                EXPECT_WK_STREQ(@"TimesNewRomanPSMT", dynamic_objc_cast<UIFont>(attributes[NSFontAttributeName]).fontName);
+                EXPECT_WK_STREQ(@"TimesNewRomanPSMT", dynamicObjCDowncast<UIFont>(attributes[NSFontAttributeName]).fontName);
 #endif
             } else if (i == 1) {
                 EXPECT_WK_STREQ(@"World!", substring.string);
 #if USE(APPKIT)
-                EXPECT_WK_STREQ(@"Times-Bold", dynamic_objc_cast<NSFont>(attributes[NSFontAttributeName]).fontName);
+                EXPECT_WK_STREQ(@"Times-Bold", dynamicObjCDowncast<NSFont>(attributes[NSFontAttributeName]).fontName);
 #else
-                EXPECT_WK_STREQ(@"TimesNewRomanPS-BoldMT", dynamic_objc_cast<UIFont>(attributes[NSFontAttributeName]).fontName);
+                EXPECT_WK_STREQ(@"TimesNewRomanPS-BoldMT", dynamicObjCDowncast<UIFont>(attributes[NSFontAttributeName]).fontName);
 #endif
             } else
                 ASSERT_NOT_REACHED();
@@ -161,9 +161,9 @@ TEST(WKWebView, GetContentsShouldReturnAttributedString)
         }];
 
 #if USE(APPKIT)
-        EXPECT_WK_STREQ(@"sRGB IEC61966-2.1 colorspace 1 0 0 1", dynamic_objc_cast<NSColor>(documentAttributes[NSBackgroundColorDocumentAttribute]).description);
+        EXPECT_WK_STREQ(@"sRGB IEC61966-2.1 colorspace 1 0 0 1", dynamicObjCDowncast<NSColor>(documentAttributes[NSBackgroundColorDocumentAttribute]).description);
 #else
-        EXPECT_WK_STREQ(@"kCGColorSpaceModelRGB 1 0 0 1 ", dynamic_objc_cast<UIColor>(documentAttributes[NSBackgroundColorDocumentAttribute]).description);
+        EXPECT_WK_STREQ(@"kCGColorSpaceModelRGB 1 0 0 1 ", dynamicObjCDowncast<UIColor>(documentAttributes[NSBackgroundColorDocumentAttribute]).description);
 #endif
 
         finished = true;
@@ -193,9 +193,9 @@ TEST(WKWebView, GetContentsWithOpticallySizedFontShouldReturnAttributedString)
                 EXPECT_WK_STREQ(@"Hello", substring.string);
 
 #if USE(APPKIT)
-                EXPECT_EQ([dynamic_objc_cast<NSFont>(attributes[NSFontAttributeName]) pointSize], 16);
+                EXPECT_EQ([dynamicObjCDowncast<NSFont>(attributes[NSFontAttributeName]) pointSize], 16);
 #else
-                EXPECT_EQ([dynamic_objc_cast<UIFont>(attributes[NSFontAttributeName]) pointSize], 16);
+                EXPECT_EQ([dynamicObjCDowncast<UIFont>(attributes[NSFontAttributeName]) pointSize], 16);
 #endif
             } else
                 ASSERT_NOT_REACHED();
@@ -553,7 +553,7 @@ TEST(WKWebView, TextWithWebFontAsAttributedString)
     [result enumerateAttributesInRange:NSMakeRange(0, [result length]) options:0 usingBlock:^(NSDictionary<NSAttributedStringKey, id> *attributes, NSRange range, BOOL *) {
         substringsAndFonts.append({
             { [[[result string] substringWithRange:range] stringByTrimmingCharactersInSet:whitespaceSet] },
-            dynamic_objc_cast<WebCore::CocoaFont>(attributes[NSFontAttributeName])
+            dynamicObjCDowncast<WebCore::CocoaFont>(attributes[NSFontAttributeName])
         });
     }];
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WritingTools.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WritingTools.mm
@@ -879,7 +879,7 @@ TEST(WritingTools, ProofreadingWithLinks)
     [attributedText enumerateAttributesInRange:NSMakeRange(0, [attributedText length]) options:0 usingBlock:^(NSDictionary<NSAttributedStringKey, id> *attributes, NSRange range, BOOL *) {
         substringsAndURLs.append({
             [[[attributedText string] substringWithRange:range] stringByTrimmingCharactersInSet:whitespaceSet],
-            dynamic_objc_cast<NSURL>(attributes[NSLinkAttributeName])
+            dynamicObjCDowncast<NSURL>(attributes[NSLinkAttributeName])
         });
     }];
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/iOSMouseSupport.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/iOSMouseSupport.mm
@@ -102,7 +102,7 @@ struct PointerInfo {
 - (UIPointerInteraction *)pointerInteraction
 {
     for (id<UIInteraction> interaction in self.textInputContentView.interactions) {
-        if (auto result = dynamic_objc_cast<UIPointerInteraction>(interaction))
+        if (auto result = dynamicObjCDowncast<UIPointerInteraction>(interaction))
             return result;
     }
     return nil;

--- a/Tools/TestWebKitAPI/Tests/mac/MouseEventTests.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/MouseEventTests.mm
@@ -113,7 +113,7 @@ TEST(MouseEventTests, CoalesceMouseMoveEvents)
     NSArray<NSDictionary *> *mouseEvents = [webView objectByEvaluatingJavaScript:@"allMouseEvents"];
     auto checkEventAtIndex = [&](NSString *type, NSPoint location, NSUInteger index) {
         auto info = mouseEvents[index];
-        EXPECT_WK_STREQ(type, dynamic_objc_cast<NSString>(info[@"type"]));
+        EXPECT_WK_STREQ(type, dynamicObjCDowncast<NSString>(info[@"type"]));
         EXPECT_EQ([info[@"x"] floatValue], location.x);
         EXPECT_EQ([info[@"y"] floatValue], location.y);
     };

--- a/Tools/TestWebKitAPI/Tests/mac/WKWebViewForTestingImmediateActions.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/WKWebViewForTestingImmediateActions.mm
@@ -63,7 +63,7 @@ static NSPoint swizzledImmediateActionLocationInView(id, SEL, NSView *)
 - (NSImmediateActionGestureRecognizer *)immediateActionGesture
 {
     for (NSGestureRecognizer *gesture in [self gestureRecognizers]) {
-        if (RetainPtr immediateActionGesture = dynamic_objc_cast<NSImmediateActionGestureRecognizer>(gesture))
+        if (RetainPtr immediateActionGesture = dynamicObjCDowncast<NSImmediateActionGestureRecognizer>(gesture))
             return immediateActionGesture.get();
     }
     return nil;

--- a/Tools/TestWebKitAPI/cocoa/TestWKWebView.mm
+++ b/Tools/TestWebKitAPI/cocoa/TestWKWebView.mm
@@ -300,11 +300,11 @@ static NSString *overrideBundleIdentifier(id, SEL)
     TestWebKitAPI::Util::run(&finished);
 
 #if USE(BROWSERENGINEKIT)
-    if (RetainPtr context = dynamic_objc_cast<BETextDocumentContext>(result.get()))
+    if (RetainPtr context = dynamicObjCDowncast<BETextDocumentContext>(result.get()))
         return [context _uikitDocumentContext];
 #endif
 
-    if (RetainPtr context = dynamic_objc_cast<UIWKDocumentContext>(result.get()))
+    if (RetainPtr context = dynamicObjCDowncast<UIWKDocumentContext>(result.get()))
         return context.autorelease();
 
     return nil;
@@ -359,14 +359,14 @@ static NSString *overrideBundleIdentifier(id, SEL)
 #if USE(BROWSERENGINEKIT)
     if (auto asyncTextInput = self.asyncTextInput) {
         [asyncTextInput requestTextContextForAutocorrectionWithCompletionHandler:[&](WKBETextDocumentContext *context) {
-            auto uiContext = dynamic_objc_cast<UIWKDocumentContext>(context);
-            if (auto seContext = dynamic_objc_cast<WKBETextDocumentContext>(context))
+            auto uiContext = dynamicObjCDowncast<UIWKDocumentContext>(context);
+            if (auto seContext = dynamicObjCDowncast<WKBETextDocumentContext>(context))
                 uiContext = seContext._uikitDocumentContext;
             result = {
-                dynamic_objc_cast<NSString>(uiContext.contextBefore),
-                dynamic_objc_cast<NSString>(uiContext.selectedText),
-                dynamic_objc_cast<NSString>(uiContext.contextAfter),
-                dynamic_objc_cast<NSString>(uiContext.markedText),
+                dynamicObjCDowncast<NSString>(uiContext.contextBefore),
+                dynamicObjCDowncast<NSString>(uiContext.selectedText),
+                dynamicObjCDowncast<NSString>(uiContext.contextAfter),
+                dynamicObjCDowncast<NSString>(uiContext.markedText),
                 uiContext.selectedRangeInMarkedText,
             };
             done = true;
@@ -1328,7 +1328,7 @@ static UIWindowScene *windowScene()
 
 - (UITextSelectionDisplayInteraction *)textSelectionDisplayInteraction
 {
-    return dynamic_objc_cast<UITextSelectionDisplayInteraction>([self.textInputContentView valueForKeyPath:@"interactionAssistant._selectionViewManager"]);
+    return dynamicObjCDowncast<UITextSelectionDisplayInteraction>([self.textInputContentView valueForKeyPath:@"interactionAssistant._selectionViewManager"]);
 }
 
 #endif
@@ -1524,8 +1524,8 @@ static WKContentView *recursiveFindWKContentView(UIView *view)
 
     auto rawData = [pipe fileHandleForReading].availableData;
     auto messages = [NSMutableArray<NSString *> array];
-    for (id messageData in dynamic_objc_cast<NSArray>([NSJSONSerialization JSONObjectWithData:rawData options:0 error:nil]))
-        [messages addObject:dynamic_objc_cast<NSString>([messageData objectForKey:@"eventMessage"])];
+    for (id messageData in dynamicObjCDowncast<NSArray>([NSJSONSerialization JSONObjectWithData:rawData options:0 error:nil]))
+        [messages addObject:dynamicObjCDowncast<NSString>([messageData objectForKey:@"eventMessage"])];
     return messages;
 }
 

--- a/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm
+++ b/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm
@@ -140,7 +140,7 @@ static constexpr BOOL shouldEnableSiteIsolation = NO;
 #endif // PLATFORM(MAC)
 
     _internalDelegate.openNewTab = ^(WKWebExtensionTabConfiguration *configuration, WKWebExtensionContext *context, void (^completionHandler)(id<WKWebExtensionTab>, NSError *)) {
-        auto *desiredWindow = dynamic_objc_cast<TestWebExtensionWindow>(configuration.window) ?: window;
+        auto *desiredWindow = dynamicObjCDowncast<TestWebExtensionWindow>(configuration.window) ?: window;
         auto *newTab = [desiredWindow openNewTabAtIndex:configuration.index];
 
         if (configuration.url) {
@@ -595,7 +595,7 @@ static WKUserContentController *userContentController(BOOL usingPrivateBrowsing)
 - (void)setParentTab:(id<WKWebExtensionTab>)parentTab forWebExtensionContext:(WKWebExtensionContext *)context completionHandler:(void (^)(NSError *))completionHandler
 {
     dispatch_async(dispatch_get_main_queue(), ^{
-        self->_parentTab = dynamic_objc_cast<TestWebExtensionTab>(parentTab);
+        self->_parentTab = dynamicObjCDowncast<TestWebExtensionTab>(parentTab);
 
         completionHandler(nil);
     });
@@ -793,7 +793,7 @@ static WKUserContentController *userContentController(BOOL usingPrivateBrowsing)
     __weak TestWebExtensionTab *weakTab = newTab;
 
     newTab.duplicate = ^(WKWebExtensionTabConfiguration *configuration, void (^completionHandler)(TestWebExtensionTab *, NSError *)) {
-        auto *desiredWindow = dynamic_objc_cast<TestWebExtensionWindow>(configuration.window) ?: weakTab.window;
+        auto *desiredWindow = dynamicObjCDowncast<TestWebExtensionWindow>(configuration.window) ?: weakTab.window;
         auto *duplicatedTab = [desiredWindow openNewTabAtIndex:configuration.index];
 
         [duplicatedTab.webView loadRequest:[NSURLRequest requestWithURL:weakTab.webView.URL]];

--- a/Tools/TestWebKitAPI/ios/DragAndDropSimulatorIOS.mm
+++ b/Tools/TestWebKitAPI/ios/DragAndDropSimulatorIOS.mm
@@ -71,7 +71,7 @@ template<typename InteractionType>
 InteractionType *findInteractionOfType(UIView *view)
 {
     for (id<UIInteraction> interaction in view.interactions) {
-        if (auto foundInteraction = dynamic_objc_cast<InteractionType>(interaction))
+        if (auto foundInteraction = dynamicObjCDowncast<InteractionType>(interaction))
             return foundInteraction;
     }
     return nil;

--- a/Tools/TestWebKitAPI/ios/IOSMouseEventTestHarness.mm
+++ b/Tools/TestWebKitAPI/ios/IOSMouseEventTestHarness.mm
@@ -94,7 +94,7 @@ MouseEventTestHarness::MouseEventTestHarness(TestWKWebView *webView)
 
     for (UIGestureRecognizer *gestureRecognizer in contentView.gestureRecognizers) {
         if ([gestureRecognizer.name isEqualToString:@"WKMouseHover"])
-            m_hoverGestureRecognizer = dynamic_objc_cast<UIHoverGestureRecognizer>(gestureRecognizer);
+            m_hoverGestureRecognizer = dynamicObjCDowncast<UIHoverGestureRecognizer>(gestureRecognizer);
         else if ([gestureRecognizer.name isEqualToString:@"WKMouseTouch"])
             m_mouseTouchGestureRecognizer = gestureRecognizer;
     }

--- a/Tools/TestWebKitAPI/ios/TestUIMenuBuilder.mm
+++ b/Tools/TestWebKitAPI/ios/TestUIMenuBuilder.mm
@@ -71,7 +71,7 @@
 - (UIAction *)actionWithTitle:(NSString *)title
 {
     return (UIAction *)[self findMatching:^BOOL(UIMenuElement *element) {
-        return [dynamic_objc_cast<UIAction>(element).title isEqual:title];
+        return [dynamicObjCDowncast<UIAction>(element).title isEqual:title];
     }];
 }
 
@@ -83,14 +83,14 @@
 - (UIAction *)actionForIdentifier:(UIActionIdentifier)identifier
 {
     return (UIAction *)[self findMatching:^BOOL(UIMenuElement *element) {
-        return [dynamic_objc_cast<UIAction>(element).identifier isEqual:identifier];
+        return [dynamicObjCDowncast<UIAction>(element).identifier isEqual:identifier];
     }];
 }
 
 - (UICommand *)commandForAction:(SEL)action propertyList:(id)propertyList
 {
     return (UICommand *)[self findMatching:^BOOL(UIMenuElement *element) {
-        auto command = dynamic_objc_cast<UICommand>(element);
+        auto command = dynamicObjCDowncast<UICommand>(element);
         return command.action == action && (command.propertyList == propertyList || [command.propertyList isEqual:propertyList]);
     }];
 }

--- a/Tools/TestWebKitAPI/mac/TestDraggingInfo.mm
+++ b/Tools/TestWebKitAPI/mac/TestDraggingInfo.mm
@@ -101,7 +101,7 @@
         if (classObject != NSFilePromiseReceiver.class)
             continue;
 
-        RetainPtr promisedTypeIdentifiers = dynamic_objc_cast<NSArray>([_pasteboard propertyListForType:NSFilesPromisePboardType]);
+        RetainPtr promisedTypeIdentifiers = dynamicObjCDowncast<NSArray>([_pasteboard propertyListForType:NSFilesPromisePboardType]);
         RetainPtr externalPromisedFiles = [_dragAndDropSimulator externalPromisedFiles];
         RELEASE_ASSERT([promisedTypeIdentifiers count] == [externalPromisedFiles count]);
 

--- a/Tools/WebKitTestRunner/cocoa/TestRunnerWKWebView.mm
+++ b/Tools/WebKitTestRunner/cocoa/TestRunnerWKWebView.mm
@@ -278,7 +278,7 @@ IGNORE_WARNINGS_END
 #if USE(UICONTEXTMENU)
     auto dismissContextMenuInteractionsForView = ^(UIView *view) {
         for (id<UIInteraction> interaction in view.interactions) {
-            if (auto contextMenuInteraction = dynamic_objc_cast<UIContextMenuInteraction>(interaction)) {
+            if (auto contextMenuInteraction = dynamicObjCDowncast<UIContextMenuInteraction>(interaction)) {
                 [UIView performWithoutAnimation:^{
                     [contextMenuInteraction dismissMenu];
                 }];
@@ -344,7 +344,7 @@ IGNORE_WARNINGS_END
     if (self.showingPopover)
         return;
 
-    auto controller = dynamic_objc_cast<UIPopoverPresentationController>(notification.object);
+    auto controller = dynamicObjCDowncast<UIPopoverPresentationController>(notification.object);
     static Class validationBubbleDelegateClass = [&] {
         return NSClassFromString(@"WebValidationBubbleDelegate");
     }();

--- a/Tools/WebKitTestRunner/ios/UIPasteboardConsistencyEnforcer.mm
+++ b/Tools/WebKitTestRunner/ios/UIPasteboardConsistencyEnforcer.mm
@@ -57,12 +57,12 @@
     if (_pasteboardToReset)
         return;
 
-    auto pasteboard = dynamic_objc_cast<UIPasteboard>(notification.object);
+    auto pasteboard = dynamicObjCDowncast<UIPasteboard>(notification.object);
     if (![_pasteboardName isEqualToString:pasteboard.name])
         return;
 
-    auto userInfoDictionary = dynamic_objc_cast<NSDictionary>(notification.userInfo);
-    if ([dynamic_objc_cast<NSArray>([userInfoDictionary objectForKey:UIPasteboardChangedTypesAddedKey]) count])
+    auto userInfoDictionary = dynamicObjCDowncast<NSDictionary>(notification.userInfo);
+    if ([dynamicObjCDowncast<NSArray>([userInfoDictionary objectForKey:UIPasteboardChangedTypesAddedKey]) count])
         _pasteboardToReset = pasteboard;
 }
 

--- a/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.mm
+++ b/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.mm
@@ -532,7 +532,7 @@ void UIScriptControllerIOS::sendEventStream(JSStringRef eventsJSON, JSValueRef c
     unsigned callbackID = m_context->prepareForAsyncTask(callback, CallbackTypeNonPersistent);
 
     String jsonString = eventsJSON->string();
-    auto eventInfo = dynamic_objc_cast<NSDictionary>([NSJSONSerialization JSONObjectWithData:[jsonString.createNSString() dataUsingEncoding:NSUTF8StringEncoding] options:NSJSONReadingMutableContainers | NSJSONReadingMutableLeaves error:nil]);
+    auto eventInfo = dynamicObjCDowncast<NSDictionary>([NSJSONSerialization JSONObjectWithData:[jsonString.createNSString() dataUsingEncoding:NSUTF8StringEncoding] options:NSJSONReadingMutableContainers | NSJSONReadingMutableLeaves error:nil]);
 
     auto *webView = this->webView();
     
@@ -951,7 +951,7 @@ CGRect UIScriptControllerIOS::selectionViewBoundsClippedToContentView(UIView *vi
     rect = CGRectIntersection(contentView.bounds, rect);
 
     for (RetainPtr parent = [view superview]; parent; parent = [parent superview]) {
-        RetainPtr scroller = dynamic_objc_cast<UIScrollView>(parent.get());
+        RetainPtr scroller = dynamicObjCDowncast<UIScrollView>(parent.get());
         if (!scroller)
             continue;
 
@@ -1679,7 +1679,7 @@ id<BETextInput> UIScriptControllerIOS::asyncTextInput() const
 
 UITextSelectionDisplayInteraction *UIScriptControllerIOS::textSelectionDisplayInteraction() const
 {
-    return dynamic_objc_cast<UITextSelectionDisplayInteraction>([platformContentView() valueForKeyPath:@"interactionAssistant._selectionViewManager"]);
+    return dynamicObjCDowncast<UITextSelectionDisplayInteraction>([platformContentView() valueForKeyPath:@"interactionAssistant._selectionViewManager"]);
 }
 
 #endif

--- a/Tools/WebKitTestRunner/mac/UIScriptControllerMac.mm
+++ b/Tools/WebKitTestRunner/mac/UIScriptControllerMac.mm
@@ -388,7 +388,7 @@ void UIScriptControllerMac::sendEventStream(JSStringRef eventsJSON, JSValueRef c
     unsigned callbackID = m_context->prepareForAsyncTask(callback, CallbackTypeNonPersistent);
 
     auto jsonString = eventsJSON->string();
-    auto eventInfo = dynamic_objc_cast<NSDictionary>([NSJSONSerialization JSONObjectWithData:[jsonString.createNSString() dataUsingEncoding:NSUTF8StringEncoding] options:NSJSONReadingMutableContainers | NSJSONReadingMutableLeaves error:nil]);
+    auto eventInfo = dynamicObjCDowncast<NSDictionary>([NSJSONSerialization JSONObjectWithData:[jsonString.createNSString() dataUsingEncoding:NSUTF8StringEncoding] options:NSJSONReadingMutableContainers | NSJSONReadingMutableLeaves error:nil]);
     if (!eventInfo || ![eventInfo isKindOfClass:[NSDictionary class]]) {
         WTFLogAlways("JSON is not convertible to a dictionary");
         return;


### PR DESCRIPTION
#### 4be5dbbe156f06a7cb1592b48f4cad52284fea8e
<pre>
Rename dynamic_objc_cast to dynamicObjCDowncast
<a href="https://bugs.webkit.org/show_bug.cgi?id=292699">https://bugs.webkit.org/show_bug.cgi?id=292699</a>

Reviewed by NOBODY (OOPS!).

Renamed the function for consistency.

* Source/JavaScriptCore/API/JSValue.mm:
(performPropertyOperation):
(objectToValueWithoutCopy):
(objectToValue):
* Source/WTF/wtf/cocoa/TypeCastsCocoa.h:
(WTF::dynamicObjCDowncast):
(WTF::dynamic_objc_cast): Deleted.
* Source/WTF/wtf/text/cocoa/StringCocoa.mm:
(WTF::makeVectorElement):
* Source/WebCore/Modules/applepay/PaymentInstallmentConfiguration.mm:
(WebCore::applicationMetadataDictionary):
* Source/WebCore/Modules/applepay/cocoa/PaymentMerchantSessionCocoa.mm:
(WebCore::PaymentMerchantSession::fromJS):
* Source/WebCore/bridge/objc/objc_utility.mm:
(JSC::Bindings::convertObjcValueToValue):
* Source/WebCore/editing/cocoa/AttributedString.mm:
(WebCore::extractArray):
(WebCore::extractValue):
(WebCore::extractDictionary):
* Source/WebCore/editing/cocoa/DataDetection.mm:
(WebCore::DataDetection::extractReferenceDate):
* Source/WebCore/editing/mac/EditorMac.mm:
(WebCore::Editor::platformPasteFont):
* Source/WebCore/page/cocoa/CaptionUserPreferencesMediaAFCocoa.mm:
(WebCore::CaptionUserPreferencesMediaAF::extractCaptionUserPreferencesMediaAF):
* Source/WebCore/platform/audio/cocoa/SpatialAudioExperienceHelper.mm:
(WebCore::spatialAudioExperienceDescription):
* Source/WebCore/platform/cocoa/EffectiveRateChangedListener.mm:
(WebCore::timebaseEffectiveRateChangedCallback):
* Source/WebCore/platform/cocoa/SerializedPlatformDataCueValue.mm:
(WebCore::SerializedPlatformDataCueValue::SerializedPlatformDataCueValue):
* Source/WebCore/platform/graphics/avfoundation/WebAVSampleBufferListener.mm:
(-[WebAVSampleBufferListenerPrivate observeValueForKeyPath:ofObject:change:context:]):
(-[WebAVSampleBufferListenerPrivate layerFailedToDecode:]):
(-[WebAVSampleBufferListenerPrivate layerReadyForDisplayChanged:]):
(-[WebAVSampleBufferListenerPrivate audioRendererWasAutomaticallyFlushed:]):
* Source/WebCore/platform/graphics/avfoundation/objc/CDMFairPlayStreamingAVFObjC.mm:
(WebCore::CDMPrivateFairPlayStreaming::keyIDsForRequest):
* Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm:
(WebCore::CDMInstanceSessionFairPlayStreamingAVFObjC::loadSession):
(WebCore::CDMInstanceSessionFairPlayStreamingAVFObjC::removeSessionData):
* Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.mm:
(WebCore::CDMSessionAVContentKeySession::releaseKeys):
* Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerCocoa.mm:
(WebCore::PlatformCALayerCocoa::avPlayerLayer const):
* Source/WebCore/platform/graphics/cocoa/HEVCUtilitiesCocoa.mm:
(WebCore::parseStringArrayFromDictionaryToUInt16Vector):
* Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.mm:
* Source/WebCore/platform/graphics/cocoa/WebCoreCALayerExtras.mm:
(-[CALayer _web_maskContainsPoint:]):
(-[CALayer _web_maskMayIntersectRect:]):
* Source/WebCore/platform/ios/PlatformPasteboardIOS.mm:
(WebCore::PlatformPasteboard::typesSafeForDOMToReadAndWrite const):
(WebCore::PlatformPasteboard::readURL const):
* Source/WebCore/platform/mac/PlatformPasteboardMac.mm:
(WebCore::PlatformPasteboard::getPathnamesForType const):
* Source/WebCore/platform/mac/WidgetMac.mm:
(WebCore::safeRemoveFromSuperview):
* Source/WebCore/platform/mediastream/mac/ScreenCaptureKitCaptureSource.mm:
(-[WebCoreScreenCaptureKitHelper stream:didOutputSampleBuffer:ofType:]):
(WebCore::ScreenCaptureKitCaptureSource::streamDidOutputVideoSampleBuffer):
* Source/WebCore/platform/network/cocoa/CookieCocoa.mm:
(WebCore::cookieCreated):
* Source/WebCore/platform/network/cocoa/ResourceResponseCocoa.mm:
(WebCore::ResourceResponse::platformLazyInit):
* Source/WebCore/platform/network/mac/ResourceErrorMac.mm:
(WebCore::ResourceError::platformLazyInit):
(WebCore::ResourceError::hasMatchingFailingURLKeys const):
* Source/WebCore/rendering/AttachmentLayout.mm:
(WebCore::shortCaptionPointSizeWithContentSizeCategory):
* Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm:
(-[WKNetworkSessionDelegate URLSession:task:didCompleteWithError:]):
(-[WKNetworkSessionDelegate URLSession:task:_didReceiveInformationalResponse:]):
(-[WKNetworkSessionDelegate URLSession:dataTask:didReceiveResponse:completionHandler:]):
* Source/WebKit/NetworkProcess/cocoa/WebSocketTaskCocoa.mm:
(WebKit::WebSocketTask::didConnect):
* Source/WebKit/Platform/cocoa/CocoaHelpers.h:
(WebKit::objectForKey):
(WebKit::boolForKey):
* Source/WebKit/Platform/cocoa/CocoaHelpers.mm:
(WebKit::objectForKey&lt;NSString&gt;):
(WebKit::objectForKey&lt;NSArray&gt;):
(WebKit::objectForKey&lt;NSDictionary&gt;):
(WebKit::objectForKey&lt;NSSet&gt;):
(WebKit::parseJSON):
(WebKit::encodeJSONString):
(WebKit::encodeJSONData):
(WebKit::toImpl):
(WebKit::toDataMap):
* Source/WebKit/Platform/cocoa/MediaPlaybackTargetContextSerialized.mm:
(WebKit::MediaPlaybackTargetContextSerialized::platformContext const):
* Source/WebKit/Platform/cocoa/WebPrivacyHelpers.mm:
(-[WKWebPrivacyNotificationListener didUpdate:]):
* Source/WebKit/Platform/mac/MenuUtilities.mm:
(WebKit::actionForMenuItem):
* Source/WebKit/Shared/API/Cocoa/_WKFrameHandle.mm:
(-[_WKFrameHandle isEqual:]):
(-[_WKFrameHandle initWithCoder:]):
* Source/WebKit/Shared/Cocoa/APIObject.mm:
(API::Object::fromNSObject):
* Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm:
(-[WKSecureCodingArchivingDelegate archiver:willEncodeObject:]):
(-[WKSecureCodingArchivingDelegate unarchiver:didDecodeObject:]):
* Source/WebKit/Shared/Cocoa/CoreIPCError.mm:
(WebKit::CoreIPCError::isSafeToEncodeUserInfo):
* Source/WebKit/Shared/Cocoa/CoreIPCNSURLRequest.mm:
(WebKit::CoreIPCNSURLRequest::CoreIPCNSURLRequest):
* Source/WebKit/Shared/Cocoa/CoreIPCSecureCoding.mm:
(WebKit::SecureCoding::internalClassNamesExemptFromSecureCodingCrash):
* Source/WebKit/Shared/Cocoa/WKNSDictionary.mm:
(-[WKNSDictionary objectForKey:]):
* Source/WebKit/Shared/Extensions/WebExtensionUtilities.mm:
(WebKit::valueToTypeString):
(WebKit::validateSingleObject):
(WebKit::validateArray):
(WebKit::validate):
* Source/WebKit/Shared/JavaScriptEvaluationResult.mm:
(WebKit::JavaScriptEvaluationResult::toVariant):
(WebKit::JavaScriptEvaluationResult::addObjectToMap):
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm:
(WebKit::updateAppleVisualEffect):
(WebKit::RemoteLayerTreePropertyApplier::applyPropertiesToLayer):
(WebKit::RemoteLayerTreePropertyApplier::applyHierarchyUpdates):
(WebKit::RemoteLayerTreePropertyApplier::applyPropertiesToUIView):
* Source/WebKit/UIProcess/API/Cocoa/NSAttributedString.mm:
(+[_WKAttributedStringWebViewCache validateEntry:]):
(+[_WKAttributedStringWebViewCache maybeUpdateShouldAllowNetworkLoads:]):
(+[_WKAttributedStringWebViewCache maybeUpdateSourceApplicationBundleIdentifier:]):
(+[_WKAttributedStringWebViewCache maybeConsumeBundlePaths:]):
(+[NSAttributedString _loadFromHTMLWithOptions:contentLoader:completionHandler:]):
(+[NSAttributedString loadFromHTMLWithFileURL:options:completionHandler:]):
(+[NSAttributedString loadFromHTMLWithString:options:completionHandler:]):
(+[NSAttributedString loadFromHTMLWithData:options:completionHandler:]):
* Source/WebKit/UIProcess/API/Cocoa/WKHTTPCookieStore.mm:
(makeVectorElement):
* Source/WebKit/UIProcess/API/Cocoa/WKScrollGeometry.mm:
(-[WKScrollGeometry isEqual:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionAction.mm:
(-[WKWebExtensionAction isEqual:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionCommand.mm:
(-[WKWebExtensionCommand isEqual:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionControllerConfiguration.mm:
(-[WKWebExtensionControllerConfiguration isEqual:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionDataRecord.mm:
(-[WKWebExtensionDataRecord isEqual:]):
(WebKit::makeVectorElement):
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionMatchPattern.mm:
(-[WKWebExtensionMatchPattern isEqual:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionMessagePort.mm:
(-[WKWebExtensionMessagePort isEqual:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView observeValueForKeyPath:ofObject:change:context:]):
(-[WKWebView _evaluateJavaScript:asAsyncFunction:withSourceURL:withArguments:forceUserGesture:inFrame:inWorld:completionHandler:]):
* Source/WebKit/UIProcess/API/Cocoa/_WKApplicationManifest.mm:
(makeVectorElement):
* Source/WebKit/UIProcess/API/Cocoa/_WKTextInputContext.mm:
(-[_WKTextInputContext isEqual:]):
* Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanel.mm:
(+[_WKWebAuthenticationPanel exportLocalAuthenticatorCredentialWithGroupAndID:credential:error:]):
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _didCommitLoadForMainFrame]):
(configureScrollViewWithOverlayRegionsIDs):
(-[WKWebView scrollViewWillEndDragging:withVelocity:targetContentOffset:]):
(-[WKWebView _enhancedWindowingToggled:]):
* Source/WebKit/UIProcess/Cocoa/CoreTelephonyUtilities.mm:
(WebKit::shouldAllowAutoFillForCellularIdentifiers):
* Source/WebKit/UIProcess/Cocoa/MediaPermissionUtilities.mm:
(WebKit::checkUsageDescriptionStringForType):
(WebKit::checkUsageDescriptionStringForSpeechRecognition):
* Source/WebKit/UIProcess/Cocoa/ModelElementControllerCocoa.mm:
(WebKit::ModelElementController::modelViewForModelIdentifier):
* Source/WebKit/UIProcess/Cocoa/SystemPreviewControllerCocoa.mm:
* Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm:
(WebKit::VideoPresentationManagerProxy::createViewWithID):
(WebKit::VideoPresentationManagerProxy::didCleanupFullscreen):
(WebKit::VideoPresentationManagerProxy::setVideoLayerFrame):
* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
(WebKit::WebPageProxy::startApplePayAMSUISession):
* Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm:
(WebKit::extractWebProcessPool):
(WebKit::WebProcessPool::registerNotificationObservers):
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIDeclarativeNetRequestCocoa.mm:
(WebKit::WebExtensionContext::declarativeNetRequestUpdateDynamicRules):
(WebKit::WebExtensionContext::declarativeNetRequestUpdateSessionRules):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionActionCocoa.mm:
(-[_WKWebExtensionActionViewController initWithWebExtensionAction:]):
(-[_WKWebExtensionActionViewController presentationController:prepareAdaptivePresentationController:]):
(-[_WKWebExtensionActionViewController _viewControllerDismissalTransitionDidEnd:]):
(-[_WKWebExtensionActionViewController _updatePopoverContentSize]):
(-[_WKWebExtensionActionPopover initWithWebExtensionAction:]):
(-[_WKWebExtensionActionPopover _otherPopoverWillShow:]):
(WebKit::WebExtensionAction::detectPopoverColorScheme):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::singleMenuItemOrExtensionItemWithSubmenu const):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionMatchPatternCocoa.mm:
(WebKit::toPatterns):
* Source/WebKit/UIProcess/Gamepad/ios/UIGamepadProviderIOS.mm:
(WebKit::UIGamepadProvider::platformWebPageProxyForGamepadInput):
* Source/WebKit/UIProcess/Gamepad/mac/UIGamepadProviderMac.mm:
(WebKit::UIGamepadProvider::platformWebPageProxyForGamepadInput):
* Source/WebKit/UIProcess/PDF/WKPDFPageNumberIndicator.mm:
(-[WKPDFPageNumberIndicator initWithFrame:view:pageCount:]):
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeViews.mm:
(WebKit::findActingScrollParent):
* Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.mm:
(-[WKScrollingNodeScrollViewDelegate scrollViewDidScroll:]):
(-[WKScrollingNodeScrollViewDelegate scrollViewWillEndDragging:withVelocity:targetContentOffset:]):
(-[WKScrollingNodeScrollViewDelegate parentScrollViewForScrollView:]):
(WebKit::ScrollingTreeScrollingNodeDelegateIOS::scrollView const):
* Source/WebKit/UIProcess/ios/UIKitUtilities.mm:
(-[UIView _wk_parentScrollView]):
(WebKit::scrollViewForTouches):
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(positionWithOffsetFrom):
(anchorsAndOffset):
(existingLocalDragSessionContext):
(-[WKContentView _pointIsInsideSelectionRect:outBoundingRect:]):
(-[WKContentView _hasEnclosingScrollView:matchingCriteria:]):
(-[WKContentView _handleTapOverInteractiveControl:]):
(-[WKContentView insertTextSuggestion:]):
(-[WKContentView textInRange:]):
(-[WKContentView caretRectForPosition:]):
(-[WKContentView selectionRectsForRange:]):
(-[WKContentView addTextAlternatives:]):
(-[WKContentView _updateTextInputTraits:]):
(-[WKContentView gestureRecognizer:isInterruptingMomentumScrollingWithEvent:]):
(-[WKContentView deferringGestureRecognizer:shouldDeferOtherGestureRecognizer:]):
(-[WKContentView removeTextPlaceholder:willInsertText:completionHandler:]):
(toWebRequest):
(-[WKContentView replaceFoundTextInRange:inDocument:withText:]):
(-[WKContentView decorateFoundTextRange:inDocument:usingStyle:]):
(-[WKContentView scrollRangeToVisible:inDocument:]):
(-[WKContentView requestRectForFoundTextRange:completionHandler:]):
(-[WKContentView _insertDynamicImageAnalysisContextMenuItemsIfPossible]):
(-[WKContentView _canStartNavigationSwipeAtLastInteractionLocation]):
* Source/WebKit/UIProcess/ios/WKPDFView.mm:
(-[WKPDFView compareFoundRange:toRange:inDocument:]):
(-[WKPDFView decorateFoundTextRange:inDocument:usingStyle:]):
* Source/WebKit/UIProcess/ios/WKTextInteractionWrapper.mm:
(-[WKTextInteractionWrapper textSelectionDisplayInteraction]):
* Source/WebKit/UIProcess/ios/WKTouchEventsGestureRecognizer.mm:
(-[WKTouchEventsGestureRecognizer _recordTouches:ofType:forEvent:]):
* Source/WebKit/UIProcess/ios/forms/WKDateTimeInputControl.mm:
(-[WKDateTimeInputControl setTimePickerHour:minute:]):
(-[WKDateTimeInputControl dateTimePickerCalendarType]):
(-[WKDateTimeInputControl timePickerValueHour]):
(-[WKDateTimeInputControl timePickerValueMinute]):
(-[WKDateTimeInputControl dismissWithAnimationForTesting]):
* Source/WebKit/UIProcess/ios/forms/WKFormAccessoryView.mm:
(-[WKFormAccessoryView _autoFillButton]):
* Source/WebKit/UIProcess/ios/forms/WKFormColorControl.mm:
(-[WKFormColorControl selectColor:]):
* Source/WebKit/UIProcess/ios/forms/WKFormSelectControl.mm:
(-[WKFormSelectControl selectFormPopoverTitle]):
* Source/WebKit/UIProcess/ios/forms/WKFormSelectPicker.mm:
(-[WKSelectPicker menuItemTitles]):
(-[WKSelectMultiplePicker configurePresentation]):
* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm:
(-[WKFullScreenWindowController _performSpatialFullScreenTransition:completionHandler:]):
* Source/WebKit/UIProcess/mac/WKFullScreenWindowController.mm:
(makeResponderFirstResponderIfDescendantOfView):
* Source/WebKit/UIProcess/mac/WKSharingServicePickerDelegate.mm:
(-[WKSharingServicePickerDelegate sharingService:didShareItems:]):
* Source/WebKit/UIProcess/mac/WebColorPickerMac.mm:
(-[WKPopoverColorWell _showPopover]):
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(-[WKTextListTouchBarViewController _selectList:]):
(-[WKTextListTouchBarViewController setCurrentListType:]):
(-[WKTextTouchBarItemController itemForIdentifier:]):
(-[WKImageAnalysisOverlayViewDelegate firstResponderIsInsideImageOverlay]):
(WebKit::m_flagsChangedEventMonitorTrackingArea):
(WebKit::WebViewImpl::resignFirstResponder):
(WebKit::WebViewImpl::changeFontColorFromSender):
(WebKit::handleLegacyFilesPromisePasteboard):
(WebKit::handleLegacyFilesPasteboard):
(WebKit::WebViewImpl::fileNameForFilePromiseProvider):
(WebKit::WebViewImpl::writeToURLForFilePromiseProvider):
(WebKit::WebViewImpl::removeTextPlaceholder):
(WebKit::WebViewImpl::setMarkedText):
(WebKit::WebViewImpl::dismissTextTouchBarPopoverItemWithIdentifier):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPICookiesCocoa.mm:
(WebKit::WebExtensionAPICookies::getAll):
(WebKit::WebExtensionAPICookies::set):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIMenusCocoa.mm:
(WebKit::WebExtensionAPIMenus::update):
(WebKit::WebExtensionAPIMenus::remove):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIRuntimeCocoa.mm:
(WebKit::WebExtensionContextProxy::internalDispatchRuntimeMessageEvent):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPISidebarActionCocoa.mm:
(WebKit::parseDetailsStringFromKey):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIStorageAreaCocoa.mm:
(WebKit::WebExtensionAPIStorageArea::get):
(WebKit::WebExtensionAPIStorageArea::getBytesInUse):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITabsCocoa.mm:
(WebKit::WebExtensionAPITabs::remove):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebRequestCocoa.mm:
(WebKit::WebExtensionContextProxy::resourceLoadDidReceiveChallenge):
* Source/WebKit/WebProcess/Extensions/Bindings/Cocoa/JSWebExtensionWrapperCocoa.mm:
(WebKit::toNSArray):
(WebKit::toJSValueRef):
(-[JSValue _isThenable]):
* Source/WebKit/WebProcess/Extensions/Cocoa/_WKWebExtensionWebNavigationURLFilter.mm:
(-[_WKWebExtensionWebNavigationURLPredicate initWithTypeString:value:outErrorMessage:]):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::handlePDFActionForAnnotation):
* Source/WebKitLegacy/mac/Storage/WebDatabaseProvider.mm:
(WebDatabaseProvider::indexedDatabaseDirectoryPath):
* Source/WebKitLegacy/mac/WebCoreSupport/WebDragClient.mm:
(WebDragClient::beginDrag):
* Source/WebKitLegacy/mac/WebView/WebHTMLView.mm:
(-[WebHTMLView _updateMouseoverWithEvent:]):
* Source/WebKitLegacy/mac/WebView/WebView.mm:
(-[WebView _dismissTextTouchBarPopoverItemWithIdentifier:]):
* Tools/DumpRenderTree/mac/TestRunnerMac.mm:
(TestRunner::isSecureEventInputEnabled const):
* Tools/DumpRenderTree/mac/UIScriptControllerMac.mm:
(WTR::UIScriptControllerMac::sendEventStream):
* Tools/TestWebKitAPI/Tests/WTF/cocoa/TypeCastsCocoa.mm:
(TestWebKitAPI::TEST(TypeCastsCocoa, dynamicObjCDowncast)):
(TestWebKitAPI::TEST(TypeCastsCocoa, dynamicObjCDowncast_RetainPtr)):
(TestWebKitAPI::TEST(TypeCastsCocoa, dynamic_objc_cast)): Deleted.
(TestWebKitAPI::TEST(TypeCastsCocoa, dynamic_objc_cast_RetainPtr)): Deleted.
* Tools/TestWebKitAPI/Tests/WebKit/AdvancedPrivacyProtections.mm:
(TestWebKitAPI::TEST(AdvancedPrivacyProtections, RemoveTrackingQueryParametersWhenCopyingURL)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/AdaptiveImageGlyph.mm:
(TestWebKitAPI::TEST(AdaptiveImageGlyph, AttributedStringDocumentEditingContext)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/CopyHTML.mm:
(TEST(CopyHTML, CopySelectedTextInTextDocument)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/DocumentEditingContext.mm:
(TEST(DocumentEditingContext, SpatialAndCurrentSelectionRequest_LimitContextToVisibleText)):
(TEST(DocumentEditingContext, CharacterRectsInEditableWebView)):
(TEST(DocumentEditingContext, RequestAnnotationsForTextChecking)):
(TEST(DocumentEditingContext, ContextWithWritingSuggestions)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/UnifiedPDFTests.mm:
(TestWebKitAPI::UNIFIED_PDF_TEST):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPICommands.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPICommands, PerformMenuItem)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIMenus.mm:
(TestWebKitAPI::performMenuItemAction):
(TestWebKitAPI::TEST(WKWebExtensionAPIMenus, ActionSubmenus)):
(TestWebKitAPI::TEST(WKWebExtensionAPIMenus, ActionSubmenusUpdate)):
(TestWebKitAPI::TEST(WKWebExtensionAPIMenus, TabMenus)):
(TestWebKitAPI::TEST(WKWebExtensionAPIMenus, MenuItemProperties)):
(TestWebKitAPI::TEST(WKWebExtensionAPIMenus, MenuItemPropertiesUpdate)):
(TestWebKitAPI::TEST(WKWebExtensionAPIMenus, MenuItemWithIconVariants)):
(TestWebKitAPI::TEST(WKWebExtensionAPIMenus, MenuItemWithImageDataVariants)):
(TestWebKitAPI::TEST(WKWebExtensionAPIMenus, MenuItemWithMixedValidAndInvalidIconVariants)):
(TestWebKitAPI::TEST(WKWebExtensionAPIMenus, MenuItemWithAnySizeVariantAndSVGDataURL)):
(TestWebKitAPI::TEST(WKWebExtensionAPIMenus, UpdateMenuItemWithIconVariants)):
(TestWebKitAPI::TEST(WKWebExtensionAPIMenus, ClearMenuItemIconVariantsWithNull)):
(TestWebKitAPI::TEST(WKWebExtensionAPIMenus, ClearMenuItemIconVariantsWithEmpty)):
(TestWebKitAPI::TEST(WKWebExtensionAPIMenus, ToggleCheckboxMenuItems)):
(TestWebKitAPI::TEST(WKWebExtensionAPIMenus, RadioItemGrouping)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionContext.mm:
(TestWebKitAPI::TEST(WKWebExtensionContext, LoadNonExistentImage)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewGetContents.mm:
(TestWebKitAPI::TEST(WKWebView, GetContentsShouldReturnAttributedString)):
(TestWebKitAPI::TEST(WKWebView, GetContentsWithOpticallySizedFontShouldReturnAttributedString)):
(TestWebKitAPI::TEST(WKWebView, TextWithWebFontAsAttributedString)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WritingTools.mm:
(TEST(WritingTools, ProofreadingWithLinks)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/iOSMouseSupport.mm:
(-[TestWKWebView pointerInteraction]):
* Tools/TestWebKitAPI/Tests/mac/MouseEventTests.mm:
(TestWebKitAPI::TEST(MouseEventTests, CoalesceMouseMoveEvents)):
* Tools/TestWebKitAPI/Tests/mac/WKWebViewForTestingImmediateActions.mm:
(-[WKWebViewForTestingImmediateActions immediateActionGesture]):
* Tools/TestWebKitAPI/cocoa/TestWKWebView.mm:
(-[WKWebView synchronouslyRequestDocumentContext:]):
(-[WKWebView autocorrectionContext]):
(-[TestWKWebView textSelectionDisplayInteraction]):
(-[TestWKWebView collectLogsForNewConnections]):
* Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm:
(-[TestWebExtensionManager initForExtension:extensionControllerConfiguration:]):
(-[TestWebExtensionTab setParentTab:forWebExtensionContext:completionHandler:]):
(-[TestWebExtensionWindow openNewTabAtIndex:]):
* Tools/TestWebKitAPI/ios/DragAndDropSimulatorIOS.mm:
(findInteractionOfType):
* Tools/TestWebKitAPI/ios/IOSMouseEventTestHarness.mm:
(TestWebKitAPI::MouseEventTestHarness::MouseEventTestHarness):
* Tools/TestWebKitAPI/ios/TestUIMenuBuilder.mm:
(-[TestUIMenuBuilder actionWithTitle:]):
(-[TestUIMenuBuilder actionForIdentifier:]):
(-[TestUIMenuBuilder commandForAction:propertyList:]):
* Tools/TestWebKitAPI/mac/TestDraggingInfo.mm:
(-[TestDraggingInfo enumerateDraggingItemsWithOptions:forView:classes:searchOptions:usingBlock:]):
* Tools/WebKitTestRunner/cocoa/TestRunnerWKWebView.mm:
(-[TestRunnerWKWebView _dismissAllContextMenuInteractions]):
(-[TestRunnerWKWebView _willPresentPopover:]):
* Tools/WebKitTestRunner/ios/UIPasteboardConsistencyEnforcer.mm:
(-[UIPasteboardConsistencyEnforcer pasteboardChanged:]):
* Tools/WebKitTestRunner/ios/UIScriptControllerIOS.mm:
(WTR::UIScriptControllerIOS::sendEventStream):
(WTR::UIScriptControllerIOS::selectionViewBoundsClippedToContentView const):
(WTR::UIScriptControllerIOS::textSelectionDisplayInteraction const):
* Tools/WebKitTestRunner/mac/UIScriptControllerMac.mm:
(WTR::UIScriptControllerMac::sendEventStream):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4be5dbbe156f06a7cb1592b48f4cad52284fea8e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/102578 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/22247 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/12561 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/107739 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/53215 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/104617 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/22555 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/30753 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78029 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/35010 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/105584 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17472 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/92584 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58364 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/17311 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/10613 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/52572 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/95249 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/87121 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10682 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/110114 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/101187 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/29710 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21906 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/87005 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/30074 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88779 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86610 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31436 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/9165 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/23960 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/29638 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/34950 "Found 38 new failures in UIProcess/API/Cocoa/WKHTTPCookieStore.mm, UIProcess/API/Cocoa/_WKTextInputContext.mm, platform/graphics/avfoundation/objc/CDMFairPlayStreamingAVFObjC.mm, Shared/API/Cocoa/_WKFrameHandle.mm, Shared/Cocoa/APIObject.mm, platform/graphics/cocoa/WebCoreCALayerExtras.mm, UIProcess/mac/WKFullScreenWindowController.mm, UIProcess/API/Cocoa/NSAttributedString.mm, Platform/cocoa/WebPrivacyHelpers.mm, editing/mac/EditorMac.mm ...") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/124821 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/29449 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34626 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/32772 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/31008 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->