### PR TITLE
Introduce WTF::unsignedCast() to cast a signed type variable into an unsigned type one

### DIFF
--- a/Source/JavaScriptCore/b3/B3Common.h
+++ b/Source/JavaScriptCore/b3/B3Common.h
@@ -31,6 +31,7 @@
 #include "GPRInfo.h"
 #include "JSExportMacros.h"
 #include "Options.h"
+#include <wtf/StdLibExtras.h>
 
 namespace JSC { namespace B3 {
 
@@ -72,9 +73,8 @@ static IntType chillMod(IntType numerator, IntType denominator)
 template<typename IntType>
 static IntType chillUDiv(IntType numerator, IntType denominator)
 {
-    typedef typename std::make_unsigned<IntType>::type UnsignedIntType;
-    UnsignedIntType unsignedNumerator = static_cast<UnsignedIntType>(numerator);
-    UnsignedIntType unsignedDenominator = static_cast<UnsignedIntType>(denominator);
+    auto unsignedNumerator = unsignedCast(numerator);
+    auto unsignedDenominator = unsignedCast(denominator);
     if (!unsignedDenominator)
         return 0;
     return unsignedNumerator / unsignedDenominator;
@@ -83,9 +83,8 @@ static IntType chillUDiv(IntType numerator, IntType denominator)
 template<typename IntType>
 static IntType chillUMod(IntType numerator, IntType denominator)
 {
-    typedef typename std::make_unsigned<IntType>::type UnsignedIntType;
-    UnsignedIntType unsignedNumerator = static_cast<UnsignedIntType>(numerator);
-    UnsignedIntType unsignedDenominator = static_cast<UnsignedIntType>(denominator);
+    auto unsignedNumerator = unsignedCast(numerator);
+    auto unsignedDenominator = unsignedCast(denominator);
     if (!unsignedDenominator)
         return 0;
     return unsignedNumerator % unsignedDenominator;
@@ -94,8 +93,7 @@ static IntType chillUMod(IntType numerator, IntType denominator)
 template<typename IntType>
 static IntType rotateRight(IntType value, int32_t shift)
 {
-    typedef typename std::make_unsigned<IntType>::type UnsignedIntType;
-    UnsignedIntType uValue = static_cast<UnsignedIntType>(value);
+    auto uValue = unsignedCast(value);
     int32_t bits = sizeof(IntType) * 8;
     int32_t mask = bits - 1;
     shift &= mask;
@@ -105,8 +103,7 @@ static IntType rotateRight(IntType value, int32_t shift)
 template<typename IntType>
 static IntType rotateLeft(IntType value, int32_t shift)
 {
-    typedef typename std::make_unsigned<IntType>::type UnsignedIntType;
-    UnsignedIntType uValue = static_cast<UnsignedIntType>(value);
+    auto uValue = unsignedCast(value);
     int32_t bits = sizeof(IntType) * 8;
     int32_t mask = bits - 1;
     shift &= mask;

--- a/Source/JavaScriptCore/b3/B3ComputeDivisionMagic.h
+++ b/Source/JavaScriptCore/b3/B3ComputeDivisionMagic.h
@@ -75,6 +75,8 @@
 
 #if ENABLE(B3_JIT)
 
+#include <wtf/StdLibExtras.h>
+
 namespace JSC { namespace B3 {
 
 template<typename T>
@@ -88,11 +90,10 @@ struct DivisionMagic {
 template<typename T>
 DivisionMagic<T> computeDivisionMagic(T divisor)
 {
-    typedef typename std::make_unsigned<T>::type UnsignedT;
-    UnsignedT d = divisor;
+    auto d = unsignedCast(divisor);
     unsigned p;
-    UnsignedT ad, anc, delta, q1, r1, q2, r2, t;
-    UnsignedT signedMin = static_cast<UnsignedT>(std::numeric_limits<T>::min());
+    std::make_unsigned_t<T> ad, anc, delta, q1, r1, q2, r2, t;
+    auto signedMin = unsignedCast(std::numeric_limits<T>::min());
     DivisionMagic<T> mag;
     unsigned bitWidth = sizeof(divisor) * 8;
 

--- a/Source/JavaScriptCore/b3/B3ReduceStrength.cpp
+++ b/Source/JavaScriptCore/b3/B3ReduceStrength.cpp
@@ -160,7 +160,7 @@ public:
     template<typename T>
     static IntRange rangeForZShr(int32_t shiftAmount)
     {
-        typename std::make_unsigned<T>::type mask = 0;
+        std::make_unsigned_t<T> mask = 0;
         mask--;
         mask >>= shiftAmount;
         return rangeForMask<T>(static_cast<T>(mask));
@@ -313,7 +313,7 @@ public:
             return rangeForZShr<T>(shiftAmount);
 
         // If the input range is non-negative, then this just brings the range closer to zero.
-        typedef typename std::make_unsigned<T>::type UnsignedT;
+        using UnsignedT = std::make_unsigned_t<T>;
         UnsignedT newMin = static_cast<UnsignedT>(m_min) >> static_cast<UnsignedT>(shiftAmount);
         UnsignedT newMax = static_cast<UnsignedT>(m_max) >> static_cast<UnsignedT>(shiftAmount);
         

--- a/Source/JavaScriptCore/b3/testb3.h
+++ b/Source/JavaScriptCore/b3/testb3.h
@@ -553,9 +553,7 @@ EffectiveType modelLoad(EffectiveType value)
     } u;
     
     u.original = value;
-    if (std::is_signed<LoadedType>::value)
-        return static_cast<EffectiveType>(u.loaded);
-    return static_cast<EffectiveType>(static_cast<typename std::make_unsigned<EffectiveType>::type>(u.loaded));
+    return static_cast<EffectiveType>(static_cast<std::make_unsigned_t<EffectiveType>>(u.loaded));
 }
 
 template<>

--- a/Source/JavaScriptCore/b3/testb3_5.cpp
+++ b/Source/JavaScriptCore/b3/testb3_5.cpp
@@ -26,6 +26,8 @@
 #include "config.h"
 #include "testb3.h"
 
+#include <wtf/StdLibExtras.h>
+
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 #if ENABLE(B3_JIT)
@@ -1779,17 +1781,13 @@ InputType modelCompare(B3::Opcode opcode, InputType left, InputType right)
     case GreaterEqual:
         return left >= right;
     case Above:
-        return static_cast<typename std::make_unsigned<InputType>::type>(left) >
-            static_cast<typename std::make_unsigned<InputType>::type>(right);
+        return unsignedCast(left) > unsignedCast(right);
     case Below:
-        return static_cast<typename std::make_unsigned<InputType>::type>(left) <
-            static_cast<typename std::make_unsigned<InputType>::type>(right);
+        return unsignedCast(left) < unsignedCast(right);
     case AboveEqual:
-        return static_cast<typename std::make_unsigned<InputType>::type>(left) >=
-            static_cast<typename std::make_unsigned<InputType>::type>(right);
+        return unsignedCast(left) >= unsignedCast(right);
     case BelowEqual:
-        return static_cast<typename std::make_unsigned<InputType>::type>(left) <=
-            static_cast<typename std::make_unsigned<InputType>::type>(right);
+        return unsignedCast(left) <= unsignedCast(right);
     case BitAnd:
         return !!(left & right);
     default:

--- a/Source/WTF/wtf/CheckedArithmetic.h
+++ b/Source/WTF/wtf/CheckedArithmetic.h
@@ -30,6 +30,7 @@
 #include <limits>
 #include <stdint.h>
 #include <type_traits>
+#include <wtf/StdLibExtras.h>
 
 /* On Linux with clang, libgcc is usually used instead of compiler-rt, and it does
  * not provide the __mulodi4 symbol used by clang for __builtin_mul_overflow
@@ -163,7 +164,7 @@ template <typename Target, typename Source> struct BoundsChecker<Target, Source,
     {
         // When converting value to unsigned Source, value will become a big value if value is negative.
         // Casted value will become bigger than Target::max as Source is bigger than Target.
-        return static_cast<std::make_unsigned_t<Source>>(value) <= std::numeric_limits<Target>::max();
+        return unsignedCast(value) <= std::numeric_limits<Target>::max();
     }
 };
 
@@ -1002,6 +1003,13 @@ template<typename T> bool isSumSmallerThanOrEqual(T a, T b, T bound)
     return !sum.hasOverflowed() && sum.value() <= bound;
 }
 
+template<typename ToType, typename FromType>
+inline ToType safeCast(FromType value)
+{
+    RELEASE_ASSERT(isInBounds<ToType>(value));
+    return static_cast<ToType>(value);
+}
+
 }
 
 using WTF::AssertNoOverflow;
@@ -1024,5 +1032,6 @@ using WTF::checkedProduct;
 using WTF::differenceOverflows;
 using WTF::isInBounds;
 using WTF::productOverflows;
+using WTF::safeCast;
 using WTF::sumOverflows;
 using WTF::isSumSmallerThanOrEqual;

--- a/Source/WTF/wtf/EnumTraits.h
+++ b/Source/WTF/wtf/EnumTraits.h
@@ -269,13 +269,10 @@ constexpr std::underlying_type_t<E> enumNamesMax()
 template<typename E>
 constexpr size_t enumNamesSize()
 {
-    using Underlying = std::underlying_type_t<E>;
-    using Unsigned = std::make_unsigned_t<Underlying>;
-
-    constexpr Underlying min = enumNamesMin<E>();
-    constexpr Underlying max = enumNamesMax<E>();
+    constexpr auto min = enumNamesMin<E>();
+    constexpr auto max = enumNamesMax<E>();
     static_assert(min <= max, "Invalid enum range: min must be <= max.");
-    return static_cast<size_t>(static_cast<Unsigned>(max - min)) + 1;
+    return static_cast<size_t>(max - min) + 1;
 }
 
 template<typename E, size_t... Is>

--- a/Source/WTF/wtf/Hasher.h
+++ b/Source/WTF/wtf/Hasher.h
@@ -86,10 +86,11 @@ inline void add(Hasher& hasher, UInt128 value)
     add(hasher, low);
 }
 
-template<typename SignedArithmetic> std::enable_if_t<std::is_signed<SignedArithmetic>::value, void> add(Hasher& hasher, SignedArithmetic number)
+template<typename SignedArithmetic>
+void add(Hasher& hasher, SignedArithmetic number) requires (std::is_signed_v<SignedArithmetic>)
 {
     // We overloaded for double and float below, just deal with integers here.
-    add(hasher, static_cast<std::make_unsigned_t<SignedArithmetic>>(number));
+    add(hasher, unsignedCast(number));
 }
 
 inline void add(Hasher& hasher, bool boolean)

--- a/Source/WTF/wtf/HexNumber.h
+++ b/Source/WTF/wtf/HexNumber.h
@@ -21,6 +21,7 @@
 #pragma once
 
 #include <array>
+#include <wtf/StdLibExtras.h>
 #include <wtf/text/StringImpl.h>
 
 namespace WTF {
@@ -41,7 +42,7 @@ WTF_EXPORT_PRIVATE std::span<LChar> appendHex(std::span<LChar> buffer, std::uint
 template<size_t arraySize, typename NumberType>
 inline std::span<LChar> appendHex(std::array<LChar, arraySize>& buffer, NumberType number, unsigned minimumDigits, HexConversionMode mode)
 {
-    return appendHex(std::span<LChar> { buffer }, static_cast<typename std::make_unsigned<NumberType>::type>(number), minimumDigits, mode);
+    return appendHex(std::span<LChar> { buffer }, unsignedCast(number), minimumDigits, mode);
 }
 
 } // namespace Internal

--- a/Source/WTF/wtf/LEBDecoder.h
+++ b/Source/WTF/wtf/LEBDecoder.h
@@ -78,7 +78,7 @@ inline bool WARN_UNUSED_RETURN decodeInt(std::span<const uint8_t> bytes, size_t&
     static_assert(std::is_signed_v<T>);
     if (bytes.size() <= offset)
         return false;
-    using UnsignedT = typename std::make_unsigned<T>::type;
+    using UnsignedT = std::make_unsigned_t<T>;
     result = 0;
     unsigned shift = 0;
     size_t last = std::min(maxByteLength<T>(), bytes.size() - offset) - 1;

--- a/Source/WTF/wtf/MathExtras.h
+++ b/Source/WTF/wtf/MathExtras.h
@@ -34,6 +34,7 @@
 #include <numbers>
 #include <stdint.h>
 #include <stdlib.h>
+#include <wtf/CheckedArithmetic.h>
 #include <wtf/StdLibExtras.h>
 
 #if OS(OPENBSD)
@@ -555,8 +556,7 @@ constexpr unsigned clzConstexpr(T value)
 {
     constexpr unsigned bitSize = sizeof(T) * CHAR_BIT;
 
-    using UT = typename std::make_unsigned<T>::type;
-    UT uValue = value;
+    auto uValue = unsignedCast(value);
 
     unsigned zeroCount = 0;
     for (int i = bitSize - 1; i >= 0; i--) {
@@ -572,8 +572,7 @@ inline unsigned clz(T value)
 {
     constexpr unsigned bitSize = sizeof(T) * CHAR_BIT;
 
-    using UT = typename std::make_unsigned<T>::type;
-    UT uValue = value;
+    auto uValue = unsignedCast(value);
 
     constexpr unsigned bitSize64 = sizeof(uint64_t) * CHAR_BIT;
     if (uValue)
@@ -586,8 +585,7 @@ constexpr unsigned ctzConstexpr(T value)
 {
     constexpr unsigned bitSize = sizeof(T) * CHAR_BIT;
 
-    using UT = typename std::make_unsigned<T>::type;
-    UT uValue = value;
+    auto uValue = unsignedCast(value);
 
     unsigned zeroCount = 0;
     for (unsigned i = 0; i < bitSize; i++) {
@@ -605,8 +603,7 @@ inline unsigned ctz(T value)
 {
     constexpr unsigned bitSize = sizeof(T) * CHAR_BIT;
 
-    using UT = typename std::make_unsigned<T>::type;
-    UT uValue = value;
+    auto uValue = unsignedCast(value);
 
     if (uValue)
         return __builtin_ctzll(uValue);
@@ -693,7 +690,7 @@ template<typename T>
 requires std::is_integral_v<T>
 constexpr T negate(T v)
 {
-    return static_cast<T>(~static_cast<std::make_unsigned_t<T>>(v) + 1U);
+    return static_cast<T>(~unsignedCast(v) + 1U);
 }
 
 template<typename BitsType, typename InputType>

--- a/Source/WTF/wtf/StdLibExtras.h
+++ b/Source/WTF/wtf/StdLibExtras.h
@@ -41,7 +41,6 @@
 #include <utility>
 #include <wtf/Assertions.h>
 #include <wtf/Brigand.h>
-#include <wtf/CheckedArithmetic.h>
 #include <wtf/Compiler.h>
 #include <wtf/GetPtr.h>
 #include <wtf/IterationStatus.h>
@@ -188,13 +187,6 @@ inline std::span<std::byte> alignedBytes(std::span<std::byte> buffer, size_t ali
 inline std::span<const std::byte> alignedBytes(std::span<const std::byte> buffer, size_t alignment)
 {
     return buffer.subspan(alignedBytesCorrection(buffer, alignment));
-}
-
-template<typename ToType, typename FromType>
-inline ToType safeCast(FromType value)
-{
-    RELEASE_ASSERT(isInBounds<ToType>(value));
-    return static_cast<ToType>(value);
 }
 
 // Returns a count of the number of bits set in 'bits'.
@@ -1250,6 +1242,11 @@ template<ByteType T, typename U> constexpr auto byteCast(const U& value)
     return ByteCastTraits<U>::template cast<T>(value);
 }
 
+template<typename T> constexpr auto unsignedCast(T value) requires (std::is_integral_v<T> || std::is_enum_v<T>)
+{
+    return static_cast<std::make_unsigned_t<T>>(value);
+}
+
 // This is like std::invocable but it takes the expected signature rather than just the arguments.
 template<typename Functor, typename Signature> concept Invocable = requires(std::decay_t<Functor>&& f, std::function<Signature> expected) {
     { expected = std::move(f) };
@@ -1550,7 +1547,6 @@ using WTF::memmoveSpan;
 using WTF::memsetSpan;
 using WTF::mergeDeduplicatedSorted;
 using WTF::reinterpretCastSpanStartTo;
-using WTF::safeCast;
 using WTF::secureMemsetSpan;
 using WTF::singleElementSpan;
 using WTF::skip;
@@ -1563,6 +1559,7 @@ using WTF::stringToDouble;
 using WTF::toTwosComplement;
 using WTF::tryBinarySearch;
 using WTF::unsafeMakeSpan;
+using WTF::unsignedCast;
 using WTF::valueOrCompute;
 using WTF::valueOrDefault;
 using WTF::weakOrderingCast;

--- a/Source/WTF/wtf/text/IntegerToStringConversion.h
+++ b/Source/WTF/wtf/text/IntegerToStringConversion.h
@@ -27,6 +27,7 @@
 #include <string>
 #include <wtf/Forward.h>
 #include <wtf/MathExtras.h>
+#include <wtf/StdLibExtras.h>
 #include <wtf/text/LChar.h>
 
 namespace WTF {
@@ -55,7 +56,7 @@ template<typename T, typename SignedIntegerType>
 inline typename IntegerToStringConversionTrait<T>::ReturnType numberToStringSigned(SignedIntegerType number, typename IntegerToStringConversionTrait<T>::AdditionalArgumentType* additionalArgument = nullptr)
 {
     if (number < 0)
-        return numberToStringImpl<T, typename std::make_unsigned_t<SignedIntegerType>, NegativeNumber>(-static_cast<typename std::make_unsigned_t<SignedIntegerType>>(number), additionalArgument);
+        return numberToStringImpl<T, typename std::make_unsigned_t<SignedIntegerType>, NegativeNumber>(-unsignedCast(number), additionalArgument);
     return numberToStringImpl<T, typename std::make_unsigned_t<SignedIntegerType>, PositiveNumber>(number, additionalArgument);
 }
 
@@ -92,7 +93,7 @@ inline void writeIntegerToBuffer(IntegerType integer, std::span<CharacterType> d
     else if constexpr (std::is_signed_v<IntegerType>) {
         if (integer < 0)
             return writeIntegerToBufferImpl<CharacterType, typename std::make_unsigned_t<IntegerType>, NegativeNumber>(WTF::negate(integer), destination);
-        return writeIntegerToBufferImpl<CharacterType, typename std::make_unsigned_t<IntegerType>, PositiveNumber>(std::make_unsigned_t<IntegerType>(integer), destination);
+        return writeIntegerToBufferImpl<CharacterType, typename std::make_unsigned_t<IntegerType>, PositiveNumber>(unsignedCast(integer), destination);
     } else
         return writeIntegerToBufferImpl<CharacterType, IntegerType, PositiveNumber>(integer, destination);
 }
@@ -124,7 +125,7 @@ constexpr unsigned lengthOfIntegerAsString(IntegerType integer)
     else if constexpr (std::is_signed_v<IntegerType>) {
         if (integer < 0)
             return lengthOfIntegerAsStringImpl<typename std::make_unsigned_t<IntegerType>, NegativeNumber>(WTF::negate(integer));
-        return lengthOfIntegerAsStringImpl<typename std::make_unsigned_t<IntegerType>, PositiveNumber>(std::make_unsigned_t<IntegerType>(integer));
+        return lengthOfIntegerAsStringImpl<typename std::make_unsigned_t<IntegerType>, PositiveNumber>(unsignedCast(integer));
     } else
         return lengthOfIntegerAsStringImpl<IntegerType, PositiveNumber>(integer);
 }

--- a/Source/WTF/wtf/text/StringBuffer.h
+++ b/Source/WTF/wtf/text/StringBuffer.h
@@ -31,6 +31,7 @@
 #include <limits>
 #include <unicode/utypes.h>
 #include <wtf/Assertions.h>
+#include <wtf/CheckedArithmetic.h>
 #include <wtf/DebugHeap.h>
 #include <wtf/MallocSpan.h>
 #include <wtf/Noncopyable.h>

--- a/Source/WTF/wtf/text/StringCommon.h
+++ b/Source/WTF/wtf/text/StringCommon.h
@@ -117,8 +117,7 @@ size_t strlenSpan(std::span<T, Extent> span) requires(sizeof(T) == 1)
 
 template<typename CharacterType> inline constexpr bool isLatin1(CharacterType character)
 {
-    using UnsignedCharacterType = typename std::make_unsigned<CharacterType>::type;
-    return static_cast<UnsignedCharacterType>(character) <= static_cast<UnsignedCharacterType>(0xFF);
+    return unsignedCast(character) <= 0xFFu;
 }
 
 template<> ALWAYS_INLINE constexpr bool isLatin1(LChar)

--- a/Source/WTF/wtf/text/StringHasher.h
+++ b/Source/WTF/wtf/text/StringHasher.h
@@ -24,6 +24,7 @@
 #include <array>
 #include <unicode/utypes.h>
 #include <wtf/FastMalloc.h>
+#include <wtf/StdLibExtras.h>
 #include <wtf/text/LChar.h>
 
 namespace WTF {
@@ -51,7 +52,7 @@ public:
         template<typename CharType>
         static constexpr UChar convert(CharType character)
         {
-            return static_cast<std::make_unsigned_t<CharType>>((character));
+            return unsignedCast(character);
         }
     };
 

--- a/Source/WebCore/css/parser/CSSParser.cpp
+++ b/Source/WebCore/css/parser/CSSParser.cpp
@@ -78,6 +78,7 @@
 #include <bitset>
 #include <memory>
 #include <optional>
+#include <wtf/StdLibExtras.h>
 
 namespace WebCore {
 
@@ -821,7 +822,7 @@ RefPtr<StyleRuleFontFeatureValuesBlock> CSSParser::consumeFontFeatureValuesRuleB
             ASSERT(value->isInteger());
             auto tagInteger = value->resolveAsIntegerDeprecated();
             ASSERT(tagInteger >= 0);
-            values.append(std::make_unsigned_t<int>(tagInteger));
+            values.append(unsignedCast(tagInteger));
             if (maxValues && values.size() > *maxValues)
                 return { };
         }

--- a/Source/WebCore/platform/graphics/GlyphBuffer.h
+++ b/Source/WebCore/platform/graphics/GlyphBuffer.h
@@ -36,6 +36,7 @@
 #include <climits>
 #include <limits>
 #include <wtf/CheckedRef.h>
+#include <wtf/StdLibExtras.h>
 #include <wtf/Vector.h>
 
 namespace WebCore {
@@ -85,7 +86,7 @@ public:
     std::optional<GlyphBufferStringOffset> checkedStringOffsetAt(size_t index, unsigned stringLength) const
     {
         auto result = uncheckedStringOffsetAt(index);
-        if (static_cast<std::make_unsigned_t<GlyphBufferStringOffset>>(result) >= stringLength)
+        if (unsignedCast(result) >= stringLength)
             return std::nullopt;
         return result;
     }

--- a/Source/WebGPU/WGSL/AttributeValidator.cpp
+++ b/Source/WebGPU/WGSL/AttributeValidator.cpp
@@ -454,7 +454,7 @@ void AttributeValidator::visit(AST::StructureMember& member)
             auto alignmentValue = constantValue->integerValue();
             if (alignmentValue < 1)
                 error(attribute.span(), "@align value must be positive"_s);
-            else if (!isPowerOfTwo<std::make_unsigned_t<decltype(alignmentValue)>>(alignmentValue))
+            else if (!isPowerOfTwo(unsignedCast(alignmentValue)))
                 error(attribute.span(), "@align value must be a power of two"_s);
 
             if (!m_errors.isEmpty()) [[unlikely]] {

--- a/Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp
@@ -71,14 +71,18 @@
 #include <WebCore/ScrollingStateFrameHostingNode.h>
 #include <WebCore/ScrollingStateFrameHostingNodeWithStuffAfterTuple.h>
 #include <WebCore/TimingFunction.h>
+#include <wtf/CreateUsingClass.h>
+#include <wtf/EnumTraits.h>
+#include <wtf/Seconds.h>
+#include <wtf/StdLibExtras.h>
+
 #if USE(AVFOUNDATION)
 #include <pal/cocoa/AVFoundationSoftLink.h>
 #endif
+
 #if ENABLE(DATA_DETECTION)
 #include <pal/cocoa/DataDetectorsCoreSoftLink.h>
 #endif
-#include <wtf/CreateUsingClass.h>
-#include <wtf/Seconds.h>
 
 static_assert(std::is_same_v<WebCore::SharedStringHash,
     uint32_t
@@ -115,7 +119,7 @@ namespace WebKit {
 
 template<typename E> uint64_t enumValueForIPCTestAPI(E e)
 {
-    return static_cast<std::make_unsigned_t<std::underlying_type_t<E>>>(e);
+    return unsignedCast(e);
 }
 
 Vector<SerializedTypeInfo> allSerializedTypes()


### PR DESCRIPTION
#### 71d38ea602290ddb3bf462074ab971898083a14c
<pre>
Introduce WTF::unsignedCast() to cast a signed type variable into an unsigned type one
<a href="https://bugs.webkit.org/show_bug.cgi?id=292702">https://bugs.webkit.org/show_bug.cgi?id=292702</a>

Reviewed by Darin Adler.

Introduce WTF::unsignedCast() to cast a signed type variable into an unsigned type one.
It relies on std::make_unsigned_t internally to figure out the unsigned type to cast to.

Do some adoption in the codebase.

* Source/JavaScriptCore/b3/B3Common.h:
(JSC::B3::chillUDiv):
(JSC::B3::chillUMod):
(JSC::B3::rotateRight):
(JSC::B3::rotateLeft):
* Source/JavaScriptCore/b3/B3ComputeDivisionMagic.h:
(JSC::B3::computeDivisionMagic):
* Source/JavaScriptCore/b3/B3ReduceStrength.cpp:
* Source/JavaScriptCore/b3/testb3.h:
(modelLoad):
* Source/JavaScriptCore/b3/testb3_5.cpp:
(modelCompare):
* Source/WTF/wtf/CheckedArithmetic.h:
(WTF::safeCast):
* Source/WTF/wtf/EnumTraits.h:
(WTF::enumNamesSize):
* Source/WTF/wtf/Hasher.h:
(WTF::requires):
* Source/WTF/wtf/HexNumber.h:
(WTF::Internal::appendHex):
* Source/WTF/wtf/LEBDecoder.h:
(WTF::LEBDecoder::decodeInt):
* Source/WTF/wtf/MathExtras.h:
(WTF::clzConstexpr):
(WTF::clz):
(WTF::ctzConstexpr):
(WTF::ctz):
(WTF::negate):
* Source/WTF/wtf/StdLibExtras.h:
(WTF::requires):
(WTF::safeCast): Deleted.
* Source/WTF/wtf/text/IntegerToStringConversion.h:
(WTF::numberToStringSigned):
(WTF::writeIntegerToBuffer):
(WTF::lengthOfIntegerAsString):
* Source/WTF/wtf/text/StringBuffer.h:
* Source/WTF/wtf/text/StringCommon.h:
(WTF::isLatin1):
* Source/WTF/wtf/text/StringHasher.h:
(WTF::StringHasher::DefaultConverter::convert):
* Source/WebCore/css/parser/CSSParser.cpp:
(WebCore::CSSParser::consumeFontFeatureValuesRuleBlock):
* Source/WebCore/platform/graphics/GlyphBuffer.h:
(WebCore::GlyphBuffer::checkedStringOffsetAt const):
* Source/WebGPU/WGSL/AttributeValidator.cpp:
(WGSL::AttributeValidator::visit):
* Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp:
(WebKit::enumValueForIPCTestAPI):

Canonical link: <a href="https://commits.webkit.org/294691@main">https://commits.webkit.org/294691@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/524723b5d6412b004b443029b0949bc865a17995

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/102657 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/22331 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/12648 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/107822 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/53298 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/104696 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/22638 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/30832 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78086 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/35059 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/105663 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17544 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/92655 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58418 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/102185 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/17384 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/10685 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/52655 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/95332 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/87205 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10756 "Found 1 new test failure: http/tests/workers/service/registerServiceWorkerClient-after-network-process-crash.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/110198 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/101268 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/29794 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21971 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/87076 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/30158 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88846 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86681 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22074 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31497 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/9233 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/24047 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/29721 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/35038 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/124900 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/29529 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34671 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/32855 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/31091 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->