### PR TITLE
[Cocoa] Remove MediaSourceCanFallbackToDecompressionSession preference

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -5011,22 +5011,6 @@ MediaSessionPlaylistEnabled:
     WebCore:
       default: true
 
-MediaSourceCanFallbackToDecompressionSession:
-  type: bool
-  status: stable
-  category: media
-  humanReadableName: "MediaSource automatically falls back to DecompressionSession"
-  humanReadableDescription: "MediaSource automatically falls back to DecompressionSession"
-  condition: ENABLE(MEDIA_SOURCE) && USE(AVFOUNDATION)
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: true
-    WebCore:
-      default: true
-  sharedPreferenceForWebProcess: true
-
 MediaSourceEnabled:
   type: bool
   status: embedder

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -8035,7 +8035,7 @@ void HTMLMediaElement::createMediaPlayer() WTF_IGNORES_THREAD_SAFETY_ANALYSIS
     player->setInFullscreenOrPictureInPicture(isFullscreen());
 
 #if USE(AVFOUNDATION) && ENABLE(MEDIA_SOURCE)
-    player->setDecompressionSessionPreferences(document().settings().mediaSourcePrefersDecompressionSession(), document().settings().mediaSourceCanFallbackToDecompressionSession(), document().settings().videoRendererProtectedFallbackDisabled());
+    player->setDecompressionSessionPreferences(document().settings().mediaSourcePrefersDecompressionSession(), document().settings().videoRendererProtectedFallbackDisabled());
 #endif
     schedulePlaybackControlsManagerUpdate();
 #if ENABLE(LEGACY_ENCRYPTED_MEDIA) && ENABLE(ENCRYPTED_MEDIA)

--- a/Source/WebCore/platform/graphics/MediaPlayer.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlayer.cpp
@@ -546,12 +546,11 @@ bool MediaPlayer::load(const URL& url, const LoadOptions& options, MediaSourcePr
 }
 
 #if USE(AVFOUNDATION)
-void MediaPlayer::setDecompressionSessionPreferences(bool preferDecompressionSession, bool canFallbackToDecompressionSession, bool videoRendererProtectedFallbackDisabled)
+void MediaPlayer::setDecompressionSessionPreferences(bool preferDecompressionSession, bool videoRendererProtectedFallbackDisabled)
 {
     m_preferDecompressionSession = preferDecompressionSession;
-    m_canFallbackToDecompressionSession = canFallbackToDecompressionSession;
     m_videoRendererProtectedFallbackDisabled = videoRendererProtectedFallbackDisabled;
-    m_private->setDecompressionSessionPreferences(preferDecompressionSession, canFallbackToDecompressionSession, videoRendererProtectedFallbackDisabled);
+    m_private->setDecompressionSessionPreferences(preferDecompressionSession, videoRendererProtectedFallbackDisabled);
 }
 #endif
 
@@ -647,7 +646,7 @@ void MediaPlayer::loadWithNextMediaEngine(const MediaPlayerFactory* current)
         if (playerPrivate) {
             client().mediaPlayerEngineUpdated();
 #if USE(AVFOUNDATION)
-            playerPrivate->setDecompressionSessionPreferences(m_preferDecompressionSession, m_canFallbackToDecompressionSession, m_videoRendererProtectedFallbackDisabled);
+            playerPrivate->setDecompressionSessionPreferences(m_preferDecompressionSession, m_videoRendererProtectedFallbackDisabled);
 #endif
             if (m_pageIsVisible)
                 playerPrivate->setPageIsVisible(m_pageIsVisible);

--- a/Source/WebCore/platform/graphics/MediaPlayer.h
+++ b/Source/WebCore/platform/graphics/MediaPlayer.h
@@ -719,7 +719,7 @@ public:
 
 #if USE(AVFOUNDATION)
     AVPlayer *objCAVFoundationAVPlayer() const;
-    void setDecompressionSessionPreferences(bool, bool, bool);
+    void setDecompressionSessionPreferences(bool, bool);
 #endif
 
     bool performTaskAtTime(Function<void()>&&, const MediaTime&);
@@ -876,7 +876,6 @@ private:
     ProcessIdentity m_processIdentity;
 #if USE(AVFOUNDATION)
     bool m_preferDecompressionSession { false };
-    bool m_canFallbackToDecompressionSession { false };
     bool m_videoRendererProtectedFallbackDisabled { true };
 #endif
 

--- a/Source/WebCore/platform/graphics/MediaPlayerPrivate.h
+++ b/Source/WebCore/platform/graphics/MediaPlayerPrivate.h
@@ -315,7 +315,7 @@ public:
 
 #if USE(AVFOUNDATION)
     virtual AVPlayer *objCAVFoundationAVPlayer() const { return nullptr; }
-    virtual void setDecompressionSessionPreferences(bool, bool, bool) { }
+    virtual void setDecompressionSessionPreferences(bool, bool) { }
 #endif
 
     virtual bool performTaskAtTime(Function<void()>&&, const MediaTime&) { return false; }

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
@@ -341,10 +341,9 @@ private:
 
     void isInFullscreenOrPictureInPictureChanged(bool) final;
 
-    void setDecompressionSessionPreferences(bool preferDecompressionSession, bool canFallbackToDecompressionSession, bool videoRendererProtectedFallbackDisabled) final
+    void setDecompressionSessionPreferences(bool preferDecompressionSession, bool videoRendererProtectedFallbackDisabled) final
     {
         m_preferDecompressionSession = preferDecompressionSession;
-        m_canFallbackToDecompressionSession = canFallbackToDecompressionSession;
         m_videoRendererProtectedFallbackDisabled = videoRendererProtectedFallbackDisabled;
     }
 
@@ -430,7 +429,6 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
     bool m_shouldMaintainAspectRatio { true };
     bool m_needsPlaceholderImage { false };
     bool m_preferDecompressionSession { false };
-    bool m_canFallbackToDecompressionSession { false };
     bool m_videoRendererProtectedFallbackDisabled { true };
     LoadOptions m_loadOptions;
 #if HAVE(SPATIAL_TRACKING_LABEL)

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
@@ -801,6 +801,7 @@ void MediaPlayerPrivateMediaSourceAVFObjC::acceleratedRenderingStateChanged()
     RefPtr renderer = layerOrVideoRenderer();
     if (willUseDecompressionSessionIfNeeded()) {
         if (renderer && !renderer->isUsingDecompressionSession()) {
+            // Gathering video frame metadata changed.
             if (RefPtr mediaSourcePrivate = m_mediaSourcePrivate)
                 mediaSourcePrivate->videoRendererWillReconfigure(*renderer);
             renderer->setPrefersDecompressionSession(true);
@@ -1143,7 +1144,7 @@ bool MediaPlayerPrivateMediaSourceAVFObjC::willUseDecompressionSessionIfNeeded()
     if (!canUseDecompressionSession())
         return false;
 
-    return m_preferDecompressionSession || (m_canFallbackToDecompressionSession && m_isGatheringVideoFrameMetadata);
+    return m_preferDecompressionSession || m_isGatheringVideoFrameMetadata;
 }
 
 bool MediaPlayerPrivateMediaSourceAVFObjC::shouldBePlaying() const

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp
@@ -204,7 +204,7 @@ void RemoteMediaPlayerProxy::loadMediaSource(URL&& url, const MediaPlayer::LoadO
     RefPtr player = m_player;
 #if USE(AVFOUNDATION) && ENABLE(MEDIA_SOURCE)
     if (auto preferences = sharedPreferencesForWebProcess())
-        player->setDecompressionSessionPreferences(preferences->mediaSourcePrefersDecompressionSession, preferences->mediaSourceCanFallbackToDecompressionSession, preferences->videoRendererProtectedFallbackDisabled);
+        player->setDecompressionSessionPreferences(preferences->mediaSourcePrefersDecompressionSession, preferences->videoRendererProtectedFallbackDisabled);
 #endif
     player->load(url, options, *protectedMediaSourceProxy());
 


### PR DESCRIPTION
#### 66e4071387a60bf704f552b39092a18037792c13
<pre>
[Cocoa] Remove MediaSourceCanFallbackToDecompressionSession preference
<a href="https://bugs.webkit.org/show_bug.cgi?id=292706">https://bugs.webkit.org/show_bug.cgi?id=292706</a>
<a href="https://rdar.apple.com/150911179">rdar://150911179</a>

Reviewed by Eric Carlson.

MediaSourceCanFallbackToDecompressionSession was designed to only enable the
DecompressionSession in the VideoMediaSampleRenderer should requestVideoFrameCallback
JS API was used.
This option had always been enabled by default and has been for several months now.
Additionally, this option was always overridden by the MediaSourcePrefersDecompressionSession
one which too is alwyays enabled, so even if MediaSourceCanFallbackToDecompressionSession
had been turned off, it would have had no effect.

Code can be considered mature and preference can be removed.

Canonical link: <a href="https://commits.webkit.org/294743@main">https://commits.webkit.org/294743@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2e7612b958af38df7f9a7bc914b173039a8d1707

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/102788 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/22461 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/12781 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/107953 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/53429 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/104827 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/22780 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/30963 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78168 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/35134 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/105794 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17641 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/92765 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58500 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/17490 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/10800 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/52786 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/95463 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/87297 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10868 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/110329 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/101398 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/29925 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/22050 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/87153 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/30289 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88961 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86767 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22108 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31595 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/9317 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/24181 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/29852 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/35174 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/125031 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/29660 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34694 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/32987 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/31222 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->