### PR TITLE
[css-anchor-position-1] Style resolution should visit children of anchor-positioned elements after it's resolved

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7672,7 +7672,6 @@ webkit.org/b/282024 fast/text/text-box-edge-with-margin-padding-border-simple.ht
 # -- Anchor Positioning -- #
 
 # general failures
-webkit.org/b/291260 imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-visibility-change.html [ ImageOnlyFailure ]
 webkit.org/b/289743 imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-multicol-007.html [ ImageOnlyFailure ]
 webkit.org/b/289743 imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-multicol-008.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-top-layer-001.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-visibility-change-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-visibility-change-expected.html
@@ -17,16 +17,43 @@
   background: lime;
 }
 
-.target {
-  position: fixed;
-  background: cyan;
-  left: 111px;
+.target-inner {
+  width: 30px;
+  height: 20px;
 }
+
+.target {
+  position: absolute;
+}
+
+#target-1 {
+  background: cyan;
+  left: 50px;
+}
+
+#target-2 {
+  top: 20px;
+  left: 0;
+  background: blue;
+}
+
+#target-3 {
+  top: 20px;
+  left: 50px;
+  background: magenta;
+}
+
 </style>
 
 <div class="container">
   <div class="anchor"></div>
-  <div class="target">
-    <div style="width:30px;height:20px;"></div>
+  <div id="target-1" class="target">
+    <div class="target-inner"></div>
+  </div>
+  <div id="target-2" class="target">
+    <div class="target-inner"></div>
+  </div>
+  <div id="target-3" class="target">
+    <div class="target-inner"></div>
   </div>
 </div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-visibility-change-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-visibility-change-ref.html
@@ -17,16 +17,43 @@
   background: lime;
 }
 
-.target {
-  position: fixed;
-  background: cyan;
-  left: 111px;
+.target-inner {
+  width: 30px;
+  height: 20px;
 }
+
+.target {
+  position: absolute;
+}
+
+#target-1 {
+  background: cyan;
+  left: 50px;
+}
+
+#target-2 {
+  top: 20px;
+  left: 0;
+  background: blue;
+}
+
+#target-3 {
+  top: 20px;
+  left: 50px;
+  background: magenta;
+}
+
 </style>
 
 <div class="container">
   <div class="anchor"></div>
-  <div class="target">
-    <div style="width:30px;height:20px;"></div>
+  <div id="target-1" class="target">
+    <div class="target-inner"></div>
+  </div>
+  <div id="target-2" class="target">
+    <div class="target-inner"></div>
+  </div>
+  <div id="target-3" class="target">
+    <div class="target-inner"></div>
   </div>
 </div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-visibility-change.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-visibility-change.html
@@ -1,8 +1,9 @@
 <!DOCTYPE html>
 <html class=reftest-wait>
-<title>Tests 'anchor-center' value when target visibility changes</title>
+<title>Tests 'anchor-center' value when target visibility changes (by changing 'display', 'visibility', or popover trigger)</title>
 <link rel="help" href="https://drafts.csswg.org/css-anchor-position-1/#valdef-justify-self-anchor-center">
 <link rel="author" href="mailto:plampe@igalia.com">
+<link rel="author" href="mailto:kiet.ho@apple.com">
 <link rel="match" href="anchor-center-visibility-change-ref.html">
 <script src="/common/reftest-wait.js"></script>
 <script src="/common/rendering-utils.js"></script>
@@ -27,27 +28,61 @@
 
 .target {
   position-anchor: --anchor;
-  position: fixed;
-  background: cyan;
+  position: absolute;
+}
+
+.target-inner {
+  width: 30px;
+  height: 20px;
+}
+
+#target-1 {
   justify-self: anchor-center;
+  background: cyan;
   display: none;
+}
+
+#target-2 {
+  align-self: anchor-center;
+  background: blue;
+  visibility: hidden;
+}
+
+#target-3 {
+  align-self: anchor-center;
+  justify-self: anchor-center;
+  background: magenta;
+
+  /* Override default popover style */
+  margin: 0;
+  padding: 0;
+  border: none;
 }
 </style>
 
 <div class="container">
   <div class="anchor"></div>
-  <div id="target" class="target">
-    <div style="width:30px;height:20px;"></div>
+  <div id="target-1" class="target">
+    <div class="target-inner"></div>
+  </div>
+  <div id="target-2" class="target">
+    <div class="target-inner"></div>
+  </div>
+  <div id="target-3" class="target" popover>
+    <div class="target-inner"></div>
   </div>
 </div>
 
 <script>
-  // #target should be invisible initially.
+  // Targets should be invisible initially.
   waitForAtLeastOneFrame().then(() => {
-    // Change #target to be visible.
-    document.getElementById('target').style.display = 'flow';
+    // Change targets to be visible.
+    document.getElementById('target-1').style.display = 'flow';
+    document.getElementById('target-2').style.visibility = 'visible';
+    document.getElementById('target-3').showPopover();
+
     waitForAtLeastOneFrame().then(() => {
-      // #target should be visible and anchor-centered now.
+      // Targets should be visible now.
       takeScreenshot();
     });
   });

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-visibility-change-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-visibility-change-expected.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+
+<style>
+  .containing-block {
+    position: relative;
+    width: 150px;
+    height: 150px;
+    outline: 2px black solid;
+  }
+
+  .cell {
+    width: 50px;
+    height: 50px;
+  }
+
+  #anchor-cell {
+    position: absolute;
+    top: 50px;
+    left: 50px;
+
+    background: green;
+  }
+
+  .anchor-positioned-cell {
+    position: absolute;
+  }
+
+  #target-1 {
+    top: 0;
+    right: 0;
+  }
+
+  #target-2 {
+    bottom: 0;
+    left: 0;
+  }
+
+  #target-3 {
+    bottom: 0;
+    right: 0;
+  }
+
+  .blue-background {
+    background: blue;
+  }
+
+  .magenta-background {
+    background: magenta;
+  }
+
+  .cyan-background {
+    background: cyan;
+  }
+</style>
+
+<body>
+  <div class="containing-block">
+    <div class="cell" id="anchor-cell"></div>
+
+    <div class="cell anchor-positioned-cell" id="target-1">
+      <div class="cell blue-background"></div>
+    </div>
+
+    <div class="cell anchor-positioned-cell" id="target-2">
+      <div class="cell magenta-background"></div>
+    </div>
+
+    <div class="cell anchor-positioned-cell" id="target-3">
+      <div class="cell cyan-background"></div>
+    </div>
+  </div>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-visibility-change.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-visibility-change.html
@@ -1,0 +1,113 @@
+<!DOCTYPE html>
+
+<html class="reftest-wait">
+
+<head>
+  <title>Tests that an element positioned using position-area renders when it's initially hidden, then shown</title>
+
+  <link rel="help" href="https://drafts.csswg.org/css-anchor-position-1/#position-area">
+  <link rel="author" href="mailto:kiet.ho@apple.com">
+  <link rel="match" href="reference/position-area-visibility-change-ref.html">
+
+  <script src="/common/reftest-wait.js"></script>
+  <script src="/common/rendering-utils.js"></script>
+
+  <style>
+    .containing-block {
+      position: relative;
+      width: 150px;
+      height: 150px;
+      outline: 2px black solid;
+    }
+
+    .cell {
+      width: 50px;
+      height: 50px;
+    }
+
+    #anchor-cell {
+      position: absolute;
+      top: 50px;
+      left: 50px;
+
+      anchor-name: --anchor;
+
+      background: green;
+    }
+
+    .anchor-positioned-cell {
+      position: absolute;
+      position-anchor: --anchor;
+    }
+
+    #target-1 {
+      position-area: top right;
+
+      /* Will be changed to 'block' */
+      display: none;
+    }
+
+    #target-2 {
+      position-area: bottom left;
+
+      /* Will be changed to 'visible' */
+      visibility: hidden;
+    }
+
+    #target-3 {
+      position-area: bottom right;
+
+      /* Override default popover style */
+      margin: 0;
+      padding: 0;
+      border: none;
+    }
+
+    .blue-background {
+      background: blue;
+    }
+
+    .magenta-background {
+      background: magenta;
+    }
+
+    .cyan-background {
+      background: cyan;
+    }
+  </style>
+</head>
+
+<body>
+  <div class="containing-block">
+    <div class="cell" id="anchor-cell"></div>
+
+    <div class="cell anchor-positioned-cell" id="target-1">
+      <div class="cell blue-background"></div>
+    </div>
+
+    <div class="cell anchor-positioned-cell" id="target-2">
+      <div class="cell magenta-background"></div>
+    </div>
+
+    <div class="cell anchor-positioned-cell" id="target-3" popover>
+      <div class="cell cyan-background"></div>
+    </div>
+  </div>
+
+  <script>
+    // All targets should initially be hidden.
+    waitForAtLeastOneFrame().then(() => {
+      // Change targets to be visible.
+      document.getElementById('target-1').style.display = 'block';
+      document.getElementById('target-2').style.visibility = 'visible';
+      document.getElementById('target-3').showPopover();
+
+      waitForAtLeastOneFrame().then(() => {
+        // All targets should be visible now.
+        takeScreenshot();
+      });
+    });
+  </script>
+</body>
+
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/reference/position-area-visibility-change-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/reference/position-area-visibility-change-ref.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+
+<style>
+  .containing-block {
+    position: relative;
+    width: 150px;
+    height: 150px;
+    outline: 2px black solid;
+  }
+
+  .cell {
+    width: 50px;
+    height: 50px;
+  }
+
+  #anchor-cell {
+    position: absolute;
+    top: 50px;
+    left: 50px;
+
+    background: green;
+  }
+
+  .anchor-positioned-cell {
+    position: absolute;
+  }
+
+  #target-1 {
+    top: 0;
+    right: 0;
+  }
+
+  #target-2 {
+    bottom: 0;
+    left: 0;
+  }
+
+  #target-3 {
+    bottom: 0;
+    right: 0;
+  }
+
+  .blue-background {
+    background: blue;
+  }
+
+  .magenta-background {
+    background: magenta;
+  }
+
+  .cyan-background {
+    background: cyan;
+  }
+</style>
+
+<body>
+  <div class="containing-block">
+    <div class="cell" id="anchor-cell"></div>
+
+    <div class="cell anchor-positioned-cell" id="target-1">
+      <div class="cell blue-background"></div>
+    </div>
+
+    <div class="cell anchor-positioned-cell" id="target-2">
+      <div class="cell magenta-background"></div>
+    </div>
+
+    <div class="cell anchor-positioned-cell" id="target-3">
+      <div class="cell cyan-background"></div>
+    </div>
+  </div>
+</body>


### PR DESCRIPTION
#### 8c48c1a274e9c031298fce6c195974f85c056c9d
<pre>
[css-anchor-position-1] Style resolution should visit children of anchor-positioned elements after it&apos;s resolved
<a href="https://rdar.apple.com/148608785">rdar://148608785</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=291065">https://bugs.webkit.org/show_bug.cgi?id=291065</a>

Reviewed by Antti Koivisto.

There&apos;s an optimization in Style::TreeResolver::resolveComposedTree that
defers visiting children of a query container or anchor-positioned element
until it can be resolved (e.g an anchor-positioned element waiting for its
anchor dependencies to be laid out):
* On initial style resolution, save the element change and which descendants
  to resolve (the &quot;state&quot;), and skip visiting the children
* On subsequent style resolutions, restore the state and continue as usual.
  The code gets &quot;tricked&quot; into resuming visiting into its children, where
  the previous resolution left off.

This is implemented for query containers, but not for anchor-positioned
elements. This leads to a subtle bug: if an anchor-positioned element is
initially hidden (`display: none`, `visibility: hidden` or hidden popover),
and then shown (`display` other than none, `visibility: visible`, or shown
popover), style resolution will **not** visit its children:
* On initial style resolution after the visibility change, the code indicates all
  descendents must be visited. Since the parent can&apos;t be resolved until subsequent
  resolutions, we skip visiting the children but **doesn&apos;t** save the state.
* On subsequent style resolutions, the parent can be resolved, so we can resume
  visiting the children. But we don&apos;t restore the state to &quot;trick&quot; the code into
  thinking it has to do so, so it skips visiting the children.

The results is the style resolution/layout/render code never sees the children,
and therefore won&apos;t layout/render them.

The solution is to implement the state save and restore for anchor-positioned
elements. However, this logic is currently tightly coupled with query
containers, so make it generic so it can be use for both purposes.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-visibility-change-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-visibility-change-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-visibility-change.html:
    - Add cases where the anchor-center element is hidden using
      `visibility: hidden` or popover, then shown.

* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-visibility-change-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-visibility-change.html: Added.
    - Add test that checks that an initially hidden anchor-positioned element
      using `position-area` properly renders when shown.

* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/reference/position-area-visibility-change-ref.html: Added.
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::resolveComposedTree):
    - Before checking whether to visit children or not, call
      resumeDescendantResolutionIfNeeded.
    - If deferring descendant resolution because of query containers or
      anchor-positioned elements, call deferDescendantResolution.

(WebCore::Style::TreeResolver::deferDescendantResolution):
    - New function that saves the state necessary to defer descendant resolution.

(WebCore::Style::TreeResolver::resumeDescendantResolutionIfNeeded):
    - New function that restores the state necessary to resume descendant resolution.

(WebCore::Style::TreeResolver::updateStateForQueryContainer):
    - Move the state saving and restore logic into separate methods
      (deferDescendantResolution, resumeDescendantResolutionIfNeeded)

(WebCore::Style::TreeResolver::resolve):
* Source/WebCore/style/StyleTreeResolver.h:
    - Move states relevant to descendant resolution deferral in QueryContainerState
      into DeferredDescendantResolutionState.

Canonical link: <a href="https://commits.webkit.org/294924@main">https://commits.webkit.org/294924@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c9b20fcc5040f43fe12707918e5510a96ca98117

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/103348 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/23024 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/13345 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/108521 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/53991 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/105387 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/23364 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/31575 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78540 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/35490 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/106354 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/18114 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/93233 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58873 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/18001 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/11274 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/53348 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/87752 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/11336 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/110898 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/30486 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/22509 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/87537 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/30851 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/89430 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87174 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22224 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32037 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/9757 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/24820 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/30415 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/35780 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/30223 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/33548 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/31784 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->