### PR TITLE
Remove iOS specific header includes in LocalFrame.h

### DIFF
--- a/Source/WebCore/editing/VisibleSelection.h
+++ b/Source/WebCore/editing/VisibleSelection.h
@@ -38,6 +38,7 @@ enum class Directionality : uint8_t { None, Strong };
 enum class SelectionDirection : uint8_t { Forward, Backward, Right, Left };
 
 class VisibleSelection {
+    WTF_MAKE_FAST_ALLOCATED;
 public:
     WEBCORE_EXPORT VisibleSelection();
     static const VisibleSelection& emptySelection();

--- a/Source/WebCore/page/LocalFrame.cpp
+++ b/Source/WebCore/page/LocalFrame.cpp
@@ -181,6 +181,11 @@ LocalFrame::LocalFrame(Page& page, ClientCreator&& clientCreator, FrameIdentifie
     : Frame(page, identifier, FrameType::Local, ownerElement, parent, opener, WTFMove(frameTreeSyncData))
     , m_loader(makeUniqueRefWithoutRefCountedCheck<FrameLoader>(*this, WTFMove(clientCreator)))
     , m_script(makeUniqueRef<ScriptController>(*this))
+#if PLATFORM(IOS_FAMILY)
+    , m_viewportArguments(makeUniqueRef<ViewportArguments>())
+    , m_rangedSelectionBase(makeUniqueRef<VisibleSelection>())
+    , m_rangedSelectionInitialExtent(makeUniqueRef<VisibleSelection>())
+#endif
     , m_pageZoomFactor(parentPageZoomFactor(this))
     , m_textZoomFactor(parentTextZoomFactor(this))
     , m_rootFrame(WebCore::rootFrame(*this))

--- a/Source/WebCore/page/LocalFrame.h
+++ b/Source/WebCore/page/LocalFrame.h
@@ -35,12 +35,6 @@
 #include <wtf/UniqueRef.h>
 #include <wtf/WeakRef.h>
 
-#if PLATFORM(IOS_FAMILY)
-#include "Timer.h"
-#include "ViewportArguments.h"
-#include "VisibleSelection.h"
-#endif
-
 #if PLATFORM(WIN)
 #include "FrameWin.h"
 #endif
@@ -74,6 +68,7 @@ class Document;
 class Editor;
 class Element;
 class EventHandler;
+class FloatPoint;
 class FloatSize;
 class FrameDestructionObserver;
 class FrameLoader;
@@ -101,6 +96,12 @@ class VisiblePosition;
 class Widget;
 
 enum class AdjustViewSize : bool;
+
+#if PLATFORM(IOS_FAMILY)
+class VisibleSelection;
+struct ViewportArguments;
+#endif
+
 enum class SandboxFlag : uint16_t;
 enum class UserScriptInjectionTime : bool;
 enum class WindowProxyProperty : uint8_t;
@@ -282,8 +283,8 @@ public:
 #if PLATFORM(IOS_FAMILY)
     WEBCORE_EXPORT int preferredHeight() const;
     WEBCORE_EXPORT void updateLayout() const;
-    WEBCORE_EXPORT NSRect caretRect();
-    WEBCORE_EXPORT NSRect rectForScrollToVisible();
+    WEBCORE_EXPORT IntRect caretRect();
+    WEBCORE_EXPORT IntRect rectForScrollToVisible();
 
     // This function is used by Legacy WebKit.
     WEBCORE_EXPORT void setTimersPaused(bool);
@@ -389,10 +390,10 @@ private:
 
     void setTimersPausedInternal(bool);
 
-    ViewportArguments m_viewportArguments;
+    UniqueRef<ViewportArguments> m_viewportArguments;
+    UniqueRef<VisibleSelection> m_rangedSelectionBase;
+    UniqueRef<VisibleSelection> m_rangedSelectionInitialExtent;
     bool m_selectionChangeCallbacksDisabled { false };
-    VisibleSelection m_rangedSelectionBase;
-    VisibleSelection m_rangedSelectionInitialExtent;
 #endif
 
     float m_pageZoomFactor;

--- a/Source/WebCore/page/ios/FrameIOS.mm
+++ b/Source/WebCore/page/ios/FrameIOS.mm
@@ -112,7 +112,7 @@ const ViewportArguments& LocalFrame::viewportArguments() const
 
 void LocalFrame::setViewportArguments(const ViewportArguments& arguments)
 {
-    m_viewportArguments = arguments;
+    m_viewportArguments.get() = arguments;
 }
 
 NSArray *LocalFrame::wordsInCurrentParagraph() const
@@ -611,20 +611,20 @@ void LocalFrame::updateLayout() const
         view->adjustViewSize();
 }
 
-NSRect LocalFrame::caretRect()
+IntRect LocalFrame::caretRect()
 {
     VisibleSelection visibleSelection = selection().selection();
     if (visibleSelection.isNone())
-        return CGRectZero;
+        return { };
     return visibleSelection.isCaret() ? selection().absoluteCaretBounds() : VisiblePosition(visibleSelection.end()).absoluteCaretBounds();
 }
 
-NSRect LocalFrame::rectForScrollToVisible()
+IntRect LocalFrame::rectForScrollToVisible()
 {
     VisibleSelection selection(this->selection().selection());
 
     if (selection.isNone())
-        return CGRectZero;
+        return { };
 
     if (selection.isCaret())
         return caretRect();
@@ -668,46 +668,46 @@ void LocalFrame::dispatchPageShowEventBeforeResume()
 
 void LocalFrame::setRangedSelectionBaseToCurrentSelection()
 {
-    m_rangedSelectionBase = selection().selection();
+    m_rangedSelectionBase.get() = selection().selection();
 }
 
 void LocalFrame::setRangedSelectionBaseToCurrentSelectionStart()
 {
     const VisibleSelection& visibleSelection = selection().selection();
-    m_rangedSelectionBase = VisibleSelection(visibleSelection.start(), visibleSelection.affinity());
+    m_rangedSelectionBase.get() = VisibleSelection(visibleSelection.start(), visibleSelection.affinity());
 }
 
 void LocalFrame::setRangedSelectionBaseToCurrentSelectionEnd()
 {
     const VisibleSelection& visibleSelection = selection().selection();
-    m_rangedSelectionBase = VisibleSelection(visibleSelection.end(), visibleSelection.affinity());
+    m_rangedSelectionBase.get() = VisibleSelection(visibleSelection.end(), visibleSelection.affinity());
 }
 
 VisibleSelection LocalFrame::rangedSelectionBase() const
 {
-    return m_rangedSelectionBase;
+    return m_rangedSelectionBase.get();
 }
 
 void LocalFrame::clearRangedSelectionInitialExtent()
 {
-    m_rangedSelectionInitialExtent = VisibleSelection();
+    m_rangedSelectionInitialExtent.get() = VisibleSelection();
 }
 
 void LocalFrame::setRangedSelectionInitialExtentToCurrentSelectionStart()
 {
     const VisibleSelection& visibleSelection = selection().selection();
-    m_rangedSelectionInitialExtent = VisibleSelection(visibleSelection.start(), visibleSelection.affinity());
+    m_rangedSelectionInitialExtent.get() = VisibleSelection(visibleSelection.start(), visibleSelection.affinity());
 }
 
 void LocalFrame::setRangedSelectionInitialExtentToCurrentSelectionEnd()
 {
     const VisibleSelection& visibleSelection = selection().selection();
-    m_rangedSelectionInitialExtent = VisibleSelection(visibleSelection.end(), visibleSelection.affinity());
+    m_rangedSelectionInitialExtent.get() = VisibleSelection(visibleSelection.end(), visibleSelection.affinity());
 }
 
 VisibleSelection LocalFrame::rangedSelectionInitialExtent() const
 {
-    return m_rangedSelectionInitialExtent;
+    return m_rangedSelectionInitialExtent.get();
 }
 
 void LocalFrame::recursiveSetUpdateAppearanceEnabled(bool enabled)


### PR DESCRIPTION
#### d224a98f33b350738dcd8f21ac03eec68441a271
<pre>
Remove iOS specific header includes in LocalFrame.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=292710">https://bugs.webkit.org/show_bug.cgi?id=292710</a>

Reviewed by Anne van Kesteren.

Moved m_viewportArguments, m_rangedSelectionBase, and m_rangedSelectionInitialExtent to UniqueRef
so that we can avoid header includes in LocalFrame.h.

Also made caretRect() and rectForScrollToVisible() to return IntRect instead of NSRect to avoid
having to include IntRect.h.

* Source/WebCore/editing/VisibleSelection.h:
* Source/WebCore/page/LocalFrame.cpp:
(WebCore::LocalFrame::LocalFrame):
* Source/WebCore/page/LocalFrame.h:
* Source/WebCore/page/ios/FrameIOS.mm:
(WebCore::LocalFrame::setViewportArguments):
(WebCore::LocalFrame::caretRect):
(WebCore::LocalFrame::rectForScrollToVisible):
(WebCore::LocalFrame::setRangedSelectionBaseToCurrentSelection):
(WebCore::LocalFrame::setRangedSelectionBaseToCurrentSelectionStart):
(WebCore::LocalFrame::setRangedSelectionBaseToCurrentSelectionEnd):
(WebCore::LocalFrame::rangedSelectionBase const):
(WebCore::LocalFrame::clearRangedSelectionInitialExtent):
(WebCore::LocalFrame::setRangedSelectionInitialExtentToCurrentSelectionStart):
(WebCore::LocalFrame::setRangedSelectionInitialExtentToCurrentSelectionEnd):
(WebCore::LocalFrame::rangedSelectionInitialExtent const):

Canonical link: <a href="https://commits.webkit.org/294682@main">https://commits.webkit.org/294682@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/465ff29663fdf0e25604146c6a4827709ad382ca

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/102660 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/22333 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/12651 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/107825 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/53301 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/104699 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/22641 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/30835 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78085 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/35060 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/105666 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17541 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/92656 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58417 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/17389 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/10686 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/52658 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/87202 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10757 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/110201 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/29797 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21973 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/87064 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/30161 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88847 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86669 "Found 102 new API test failures: /WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/sequence, /TestWebKit:WebKit.InjectedBundleInitializationUserDataCallbackWins, /TestWebKit:WebKit.GeolocationBasicWithHighAccuracy, /WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/cancel-sequence, /TestWebKit:WebKit.ForceRepaint, /TestWebKit:WebKit.PendingAPIRequestURL, /WebKitGTK/TestUIClient:/webkit/WebKitWebView/mediaKeySystem-permission-requests, /TestWebKit:WebKit.PreventEmptyUserAgent, /TestWebKit:WebKit2.ProvisionalURLAfterWillSendRequestCallback, /WebKitGTK/TestDownloads:/webkit/Downloads/contex-menu-download-actions ... (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31498 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/9234 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/24050 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16670 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/29724 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/35040 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/29532 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/32858 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/31094 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->