### PR TITLE
Allow use of ::before/::after pseudo-elements with <progress>

### DIFF
--- a/LayoutTests/fast/css/progress-before-after-expected.html
+++ b/LayoutTests/fast/css/progress-before-after-expected.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<style>
+div {
+  width: 100px;
+  height: 100px;
+  position: relative;
+  background: green;
+}
+</style>
+<div></div>
+

--- a/LayoutTests/fast/css/progress-before-after.html
+++ b/LayoutTests/fast/css/progress-before-after.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<style>
+progress {
+  width: 100px;
+  height: 100px;
+  appearance: none;
+  position: relative;
+}
+progress::before {
+  position: absolute;
+  content: "";
+  width: 50%;
+  height: 100%;
+  background: green;
+}
+progress::after {
+  position: absolute;
+  content: "";
+  top: 0;
+  right: 0;
+  width: 50%;
+  height: 100%;
+  background: green;
+}
+</style>
+<progress></progress>

--- a/Source/WebCore/html/HTMLProgressElement.cpp
+++ b/Source/WebCore/html/HTMLProgressElement.cpp
@@ -63,11 +63,6 @@ RenderPtr<RenderElement> HTMLProgressElement::createElementRenderer(RenderStyle&
     return createRenderer<RenderProgress>(*this, WTFMove(style));
 }
 
-bool HTMLProgressElement::childShouldCreateRenderer(const Node& child) const
-{
-    return hasShadowRootParent(child) && HTMLElement::childShouldCreateRenderer(child);
-}
-
 RenderProgress* HTMLProgressElement::renderProgress() const
 {
     if (auto* renderProgress = dynamicDowncast<RenderProgress>(renderer()))

--- a/Source/WebCore/html/HTMLProgressElement.h
+++ b/Source/WebCore/html/HTMLProgressElement.h
@@ -54,7 +54,6 @@ private:
     bool isLabelable() const final { return true; }
 
     RenderPtr<RenderElement> createElementRenderer(RenderStyle&&, const RenderTreePosition&) final;
-    bool childShouldCreateRenderer(const Node&) const final;
     RenderProgress* renderProgress() const;
 
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;


### PR DESCRIPTION
#### d793d6d497f04c25f5edf5b6b33d9b3367c3a9eb
<pre>
Allow use of ::before/::after pseudo-elements with &lt;progress&gt;
<a href="https://bugs.webkit.org/show_bug.cgi?id=287948">https://bugs.webkit.org/show_bug.cgi?id=287948</a>
<a href="https://rdar.apple.com/145125372">rdar://145125372</a>

Reviewed by Alan Baradlay.

The specs are unclear but Chrome allows this and we already allow it for &lt;meter&gt;.

* LayoutTests/fast/css/progress-before-after-expected.html: Added.
* LayoutTests/fast/css/progress-before-after.html: Added.
* Source/WebCore/html/HTMLProgressElement.cpp:
(WebCore::HTMLProgressElement::childShouldCreateRenderer const): Deleted.
* Source/WebCore/html/HTMLProgressElement.h:

Canonical link: <a href="https://commits.webkit.org/294663@main">https://commits.webkit.org/294663@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/606b4e7c73c8dea761c72eabc4afcd19a0d4f4b0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/102608 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/22277 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/12591 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/107769 "Hash 606b4e7c for PR 45102 does not build (failure)") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/53245 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/104647 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/22585 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/30783 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/107769 "Hash 606b4e7c for PR 45102 does not build (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/35027 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/105614 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17496 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/92606 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/107769 "Hash 606b4e7c for PR 45102 does not build (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/17335 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/10638 "Passed tests") | [❌ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/52602 "Hash 606b4e7c for PR 45102 does not build (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/87146 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10706 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/110144 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/29740 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21924 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/87027 "Passed tests") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/30104 "Build is in progress. Recent messages:OS: Sequoia (15.2), Xcode: 16.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88803 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86634 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22049 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31459 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/9188 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/23990 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/29668 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/34980 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/29479 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/32802 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/31038 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->