### PR TITLE
Web Inspector: sourcemap parsing should not block rendering

### DIFF
--- a/LayoutTests/inspector/debugger/resources/log-pause-location.js
+++ b/LayoutTests/inspector/debugger/resources/log-pause-location.js
@@ -18,7 +18,7 @@ TestPage.registerInitializer(() => {
 
     function getLineContent(sourceCode, lineNumber) {
         if (sourceCode instanceof WI.SourceMapResource)
-            return sourceCode.sourceMap.sourceContent(sourceCode.url).split("\n")[lineNumber];
+            return sourceCode.inlineContent.split("\n")[lineNumber];
 
         return lines[lineNumber];
     }

--- a/LayoutTests/inspector/model/source-map-spec-expected.txt
+++ b/LayoutTests/inspector/model/source-map-spec-expected.txt
@@ -3,550 +3,390 @@ Run source map specification consumer test cases.
 
 == Running test suite: SourceMapSpec
 -- Running test case: versionValid
-expecting VALID source map
-PASS: Script resource and source map event should have triggered
 PASS: Resource should have loaded 1 SourceMap.
 PASS: SourceMap should be a WI.SourceMap instance.
 
 -- Running test case: versionMissing
-expecting INVALID source map
 WARN: Source Map "version-missing.js.map" has invalid "version"
-PASS: Script resource should have loaded
 PASS: Expected that there is an associated failed source map URL
 PASS: Expected no source map resource loaded
 
 -- Running test case: versionNotANumber
-expecting INVALID source map
 WARN: Source Map "version-not-a-number.js.map" has invalid "version"
-PASS: Script resource should have loaded
 PASS: Expected that there is an associated failed source map URL
 PASS: Expected no source map resource loaded
 
 -- Running test case: versionNumericString
-expecting INVALID source map
 WARN: Source Map "version-numeric-string.js.map" has invalid "version"
-PASS: Script resource should have loaded
 PASS: Expected that there is an associated failed source map URL
 PASS: Expected no source map resource loaded
 
 -- Running test case: versionTooHigh
-expecting INVALID source map
 WARN: Source Map "version-too-high.js.map" has invalid "version"
-PASS: Script resource should have loaded
 PASS: Expected that there is an associated failed source map URL
 PASS: Expected no source map resource loaded
 
 -- Running test case: versionTooLow
-expecting INVALID source map
 WARN: Source Map "version-too-low.js.map" has invalid "version"
-PASS: Script resource should have loaded
 PASS: Expected that there is an associated failed source map URL
 PASS: Expected no source map resource loaded
 
 -- Running test case: mappingsMissing
-expecting INVALID source map
 WARN: Source Map "mappings-missing.js.map" has invalid "mappings"
-PASS: Script resource should have loaded
 PASS: Expected that there is an associated failed source map URL
 PASS: Expected no source map resource loaded
 
 -- Running test case: sourcesMissing
-expecting INVALID source map
 WARN: Source Map "sources-missing.js.map" has invalid "sources"
-PASS: Script resource should have loaded
 PASS: Expected that there is an associated failed source map URL
 PASS: Expected no source map resource loaded
 
 -- Running test case: sourcesNotAList1
-expecting INVALID source map
 WARN: Source Map "sources-not-a-list-1.js.map" has invalid "sources"
-PASS: Script resource should have loaded
 PASS: Expected that there is an associated failed source map URL
 PASS: Expected no source map resource loaded
 
 -- Running test case: sourcesNotAList2
-expecting INVALID source map
 WARN: Source Map "sources-not-a-list-2.js.map" has invalid "sources"
-PASS: Script resource should have loaded
 PASS: Expected that there is an associated failed source map URL
 PASS: Expected no source map resource loaded
 
 -- Running test case: sourcesNotStringOrNull
-expecting INVALID source map
 WARN: Source Map "sources-not-string-or-null.js.map" has invalid "sources"
-PASS: Script resource should have loaded
 PASS: Expected that there is an associated failed source map URL
 PASS: Expected no source map resource loaded
 
 -- Running test case: sourcesContentMissing
-expecting VALID source map
-PASS: Script resource and source map event should have triggered
 PASS: Resource should have loaded 1 SourceMap.
 PASS: SourceMap should be a WI.SourceMap instance.
 
 -- Running test case: sourcesContentNotAList1
-expecting INVALID source map
 WARN: Source Map "sources-content-not-a-list-1.js.map" has invalid "sourcesContent"
-PASS: Script resource should have loaded
 PASS: Expected that there is an associated failed source map URL
 PASS: Expected no source map resource loaded
 
 -- Running test case: sourcesContentNotAList2
-expecting INVALID source map
 WARN: Source Map "sources-content-not-a-list-2.js.map" has invalid "sourcesContent"
-PASS: Script resource should have loaded
 PASS: Expected that there is an associated failed source map URL
 PASS: Expected no source map resource loaded
 
 -- Running test case: sourcesContentNotStringOrNull
-expecting INVALID source map
 WARN: Source Map "sources-content-not-string-or-null.js.map" has invalid "sourcesContent"
-PASS: Script resource should have loaded
 PASS: Expected that there is an associated failed source map URL
 PASS: Expected no source map resource loaded
 
 -- Running test case: sourcesAndSourcesContentBothNull
-expecting VALID source map
-PASS: Script resource and source map event should have triggered
 PASS: Resource should have loaded 1 SourceMap.
 PASS: SourceMap should be a WI.SourceMap instance.
 
 -- Running test case: fileNotAString1
-expecting INVALID source map
 WARN: Source Map "file-not-a-string-1.js.map" has invalid "file"
-PASS: Script resource should have loaded
 PASS: Expected that there is an associated failed source map URL
 PASS: Expected no source map resource loaded
 
 -- Running test case: fileNotAString2
-expecting INVALID source map
 WARN: Source Map "file-not-a-string-2.js.map" has invalid "file"
-PASS: Script resource should have loaded
 PASS: Expected that there is an associated failed source map URL
 PASS: Expected no source map resource loaded
 
 -- Running test case: sourceRootNotAString1
-expecting INVALID source map
 WARN: Source Map "source-root-not-a-string-1.js.map" has invalid "sourceRoot"
-PASS: Script resource should have loaded
 PASS: Expected that there is an associated failed source map URL
 PASS: Expected no source map resource loaded
 
 -- Running test case: sourceRootNotAString2
-expecting INVALID source map
 WARN: Source Map "source-root-not-a-string-2.js.map" has invalid "sourceRoot"
-PASS: Script resource should have loaded
 PASS: Expected that there is an associated failed source map URL
 PASS: Expected no source map resource loaded
 
 -- Running test case: namesMissing
-expecting VALID source map
-PASS: Script resource and source map event should have triggered
 PASS: Resource should have loaded 1 SourceMap.
 PASS: SourceMap should be a WI.SourceMap instance.
 
 -- Running test case: namesNotAList1
-expecting INVALID source map
 WARN: Source Map "names-not-a-list-1.js.map" has invalid "names"
-PASS: Script resource should have loaded
 PASS: Expected that there is an associated failed source map URL
 PASS: Expected no source map resource loaded
 
 -- Running test case: namesNotAList2
-expecting INVALID source map
 WARN: Source Map "names-not-a-list-2.js.map" has invalid "names"
-PASS: Script resource should have loaded
 PASS: Expected that there is an associated failed source map URL
 PASS: Expected no source map resource loaded
 
 -- Running test case: namesNotString
-expecting INVALID source map
 WARN: Source Map "names-not-string.js.map" has invalid "names"
-PASS: Script resource should have loaded
 PASS: Expected that there is an associated failed source map URL
 PASS: Expected no source map resource loaded
 
 -- Running test case: ignoreListEmpty
-expecting VALID source map
-PASS: Script resource and source map event should have triggered
 PASS: Resource should have loaded 1 SourceMap.
 PASS: SourceMap should be a WI.SourceMap instance.
 
 -- Running test case: ignoreListValid1
-expecting VALID source map
-PASS: Script resource and source map event should have triggered
 PASS: Resource should have loaded 1 SourceMap.
 PASS: SourceMap should be a WI.SourceMap instance.
 PASS: Should have resource 'empty-original.js'.
 
 -- Running test case: ignoreListWrongType1
-expecting INVALID source map
 WARN: Source Map "ignore-list-wrong-type-1.js.map" has invalid "ignoreList"
-PASS: Script resource should have loaded
 PASS: Expected that there is an associated failed source map URL
 PASS: Expected no source map resource loaded
 
 -- Running test case: ignoreListWrongType2
-expecting INVALID source map
 WARN: Source Map "ignore-list-wrong-type-2.js.map" has invalid "ignoreList"
-PASS: Script resource should have loaded
 PASS: Expected that there is an associated failed source map URL
 PASS: Expected no source map resource loaded
 
 -- Running test case: ignoreListWrongType3
-expecting INVALID source map
 WARN: Source Map "ignore-list-wrong-type-3.js.map" has invalid "ignoreList"
-PASS: Script resource should have loaded
 PASS: Expected that there is an associated failed source map URL
 PASS: Expected no source map resource loaded
 
 -- Running test case: ignoreListWrongType4
-expecting INVALID source map
 WARN: Source Map "ignore-list-wrong-type-4.js.map" has invalid "ignoreList"
-PASS: Script resource should have loaded
 PASS: Expected that there is an associated failed source map URL
 PASS: Expected no source map resource loaded
 
 -- Running test case: ignoreListOutOfBounds1
-expecting INVALID source map
 WARN: Source Map "ignore-list-out-of-bounds-1.js.map" has invalid "ignoreList"
-PASS: Script resource should have loaded
 PASS: Expected that there is an associated failed source map URL
 PASS: Expected no source map resource loaded
 
 -- Running test case: ignoreListOutOfBounds2
-expecting INVALID source map
 WARN: Source Map "ignore-list-out-of-bounds-2.js.map" has invalid "ignoreList"
-PASS: Script resource should have loaded
 PASS: Expected that there is an associated failed source map URL
 PASS: Expected no source map resource loaded
 
 -- Running test case: unrecognizedProperty
-expecting VALID source map
-PASS: Script resource and source map event should have triggered
 PASS: Resource should have loaded 1 SourceMap.
 PASS: SourceMap should be a WI.SourceMap instance.
 
 -- Running test case: invalidVLQDueToNonBase64Character
-expecting INVALID source map
 WARN: Source Map "invalid-vlq-non-base64-char.js.map" has invalid "mappings"
-PASS: Script resource should have loaded
 PASS: Expected that there is an associated failed source map URL
 PASS: Expected no source map resource loaded
 
 -- Running test case: invalidVLQDueToNonBase64CharacterPadding
-expecting INVALID source map
 WARN: Source Map "invalid-vlq-non-base64-char-padding.js.map" has invalid "mappings"
-PASS: Script resource should have loaded
 PASS: Expected that there is an associated failed source map URL
 PASS: Expected no source map resource loaded
 
 -- Running test case: invalidVLQDueToMissingContinuationDigits
-expecting INVALID source map
 WARN: Source Map "invalid-vlq-missing-continuation.js.map" has invalid "mappings"
-PASS: Script resource should have loaded
 PASS: Expected that there is an associated failed source map URL
 PASS: Expected no source map resource loaded
 
 -- Running test case: invalidMappingNotAString1
-expecting INVALID source map
 WARN: Source Map "invalid-mapping-not-a-string-1.js.map" has invalid "mappings"
-PASS: Script resource should have loaded
 PASS: Expected that there is an associated failed source map URL
 PASS: Expected no source map resource loaded
 
 -- Running test case: invalidMappingNotAString2
-expecting INVALID source map
 WARN: Source Map "invalid-mapping-not-a-string-2.js.map" has invalid "mappings"
-PASS: Script resource should have loaded
 PASS: Expected that there is an associated failed source map URL
 PASS: Expected no source map resource loaded
 
 -- Running test case: invalidMappingSegmentBadSeparator
-expecting INVALID source map
 WARN: Source Map "invalid-mapping-bad-separator.js.map" has invalid "mappings"
-PASS: Script resource should have loaded
 PASS: Expected that there is an associated failed source map URL
 PASS: Expected no source map resource loaded
 
 -- Running test case: invalidMappingSegmentWithZeroFields
-expecting INVALID source map
 WARN: Source Map "invalid-mapping-segment-with-zero-fields.js.map" has invalid "mappings"
-PASS: Script resource should have loaded
 PASS: Expected that there is an associated failed source map URL
 PASS: Expected no source map resource loaded
 
 -- Running test case: invalidMappingSegmentWithTwoFields
-expecting INVALID source map
 WARN: Source Map "invalid-mapping-segment-with-two-fields.js.map" has invalid "mappings"
-PASS: Script resource should have loaded
 PASS: Expected that there is an associated failed source map URL
 PASS: Expected no source map resource loaded
 
 -- Running test case: invalidMappingSegmentWithThreeFields
-expecting INVALID source map
 WARN: Source Map "invalid-mapping-segment-with-three-fields.js.map" has invalid "mappings"
-PASS: Script resource should have loaded
 PASS: Expected that there is an associated failed source map URL
 PASS: Expected no source map resource loaded
 
 -- Running test case: invalidMappingSegmentWithSourceIndexOutOfBounds
-expecting INVALID source map
 WARN: Source Map "invalid-mapping-segment-source-index-out-of-bounds.js.map" has invalid "mappings"
-PASS: Script resource should have loaded
 PASS: Expected that there is an associated failed source map URL
 PASS: Expected no source map resource loaded
 
 -- Running test case: invalidMappingSegmentWithNameIndexOutOfBounds
-expecting INVALID source map
 WARN: Source Map "invalid-mapping-segment-name-index-out-of-bounds.js.map" has invalid "mappings"
-PASS: Script resource should have loaded
 PASS: Expected that there is an associated failed source map URL
 PASS: Expected no source map resource loaded
 
 -- Running test case: invalidMappingSegmentWithNegativeColumn
-expecting INVALID source map
 WARN: Source Map "invalid-mapping-segment-negative-column.js.map" has invalid "mappings"
-PASS: Script resource should have loaded
 PASS: Expected that there is an associated failed source map URL
 PASS: Expected no source map resource loaded
 
 -- Running test case: invalidMappingSegmentWithNegativeSourceIndex
-expecting INVALID source map
 WARN: Source Map "invalid-mapping-segment-negative-source-index.js.map" has invalid "mappings"
-PASS: Script resource should have loaded
 PASS: Expected that there is an associated failed source map URL
 PASS: Expected no source map resource loaded
 
 -- Running test case: invalidMappingSegmentWithNegativeOriginalLine
-expecting INVALID source map
 WARN: Source Map "invalid-mapping-segment-negative-original-line.js.map" has invalid "mappings"
-PASS: Script resource should have loaded
 PASS: Expected that there is an associated failed source map URL
 PASS: Expected no source map resource loaded
 
 -- Running test case: invalidMappingSegmentWithNegativeOriginalColumn
-expecting INVALID source map
 WARN: Source Map "invalid-mapping-segment-negative-original-column.js.map" has invalid "mappings"
-PASS: Script resource should have loaded
 PASS: Expected that there is an associated failed source map URL
 PASS: Expected no source map resource loaded
 
 -- Running test case: invalidMappingSegmentWithNegativeNameIndex
-expecting INVALID source map
 WARN: Source Map "invalid-mapping-segment-negative-name-index.js.map" has invalid "mappings"
-PASS: Script resource should have loaded
 PASS: Expected that there is an associated failed source map URL
 PASS: Expected no source map resource loaded
 
 -- Running test case: invalidMappingSegmentWithNegativeRelativeColumn
-expecting INVALID source map
 WARN: Source Map "invalid-mapping-segment-negative-relative-column.js.map" has invalid "mappings"
-PASS: Script resource should have loaded
 PASS: Expected that there is an associated failed source map URL
 PASS: Expected no source map resource loaded
 
 -- Running test case: invalidMappingSegmentWithNegativeRelativeSourceIndex
-expecting INVALID source map
 WARN: Source Map "invalid-mapping-segment-negative-relative-source-index.js.map" has invalid "mappings"
-PASS: Script resource should have loaded
 PASS: Expected that there is an associated failed source map URL
 PASS: Expected no source map resource loaded
 
 -- Running test case: invalidMappingSegmentWithNegativeRelativeOriginalLine
-expecting INVALID source map
 WARN: Source Map "invalid-mapping-segment-negative-relative-original-line.js.map" has invalid "mappings"
-PASS: Script resource should have loaded
 PASS: Expected that there is an associated failed source map URL
 PASS: Expected no source map resource loaded
 
 -- Running test case: invalidMappingSegmentWithNegativeRelativeOriginalColumn
-expecting INVALID source map
 WARN: Source Map "invalid-mapping-segment-negative-relative-original-column.js.map" has invalid "mappings"
-PASS: Script resource should have loaded
 PASS: Expected that there is an associated failed source map URL
 PASS: Expected no source map resource loaded
 
 -- Running test case: invalidMappingSegmentWithNegativeRelativeNameIndex
-expecting INVALID source map
 WARN: Source Map "invalid-mapping-segment-negative-relative-name-index.js.map" has invalid "mappings"
-PASS: Script resource should have loaded
 PASS: Expected that there is an associated failed source map URL
 PASS: Expected no source map resource loaded
 
 -- Running test case: invalidMappingSegmentWithColumnExceeding32Bits
-expecting INVALID source map
 WARN: Source Map "invalid-mapping-segment-column-too-large.js.map" has invalid "mappings"
-PASS: Script resource should have loaded
 PASS: Expected that there is an associated failed source map URL
 PASS: Expected no source map resource loaded
 
 -- Running test case: invalidMappingSegmentWithSourceIndexExceeding32Bits
-expecting INVALID source map
 WARN: Source Map "invalid-mapping-segment-source-index-too-large.js.map" has invalid "mappings"
-PASS: Script resource should have loaded
 PASS: Expected that there is an associated failed source map URL
 PASS: Expected no source map resource loaded
 
 -- Running test case: invalidMappingSegmentWithOriginalLineExceeding32Bits
-expecting INVALID source map
 WARN: Source Map "invalid-mapping-segment-original-line-too-large.js.map" has invalid "mappings"
-PASS: Script resource should have loaded
 PASS: Expected that there is an associated failed source map URL
 PASS: Expected no source map resource loaded
 
 -- Running test case: invalidMappingSegmentWithOriginalColumnExceeding32Bits
-expecting INVALID source map
 WARN: Source Map "invalid-mapping-segment-original-column-too-large.js.map" has invalid "mappings"
-PASS: Script resource should have loaded
 PASS: Expected that there is an associated failed source map URL
 PASS: Expected no source map resource loaded
 
 -- Running test case: invalidMappingSegmentWithNameIndexExceeding32Bits
-expecting INVALID source map
 WARN: Source Map "invalid-mapping-segment-name-index-too-large.js.map" has invalid "mappings"
-PASS: Script resource should have loaded
 PASS: Expected that there is an associated failed source map URL
 PASS: Expected no source map resource loaded
 
 -- Running test case: validMappingFieldsWith32BitMaxValues
-expecting VALID source map
-PASS: Script resource and source map event should have triggered
 PASS: Resource should have loaded 1 SourceMap.
 PASS: SourceMap should be a WI.SourceMap instance.
 
 -- Running test case: validMappingLargeVLQ
-expecting VALID source map
-PASS: Script resource and source map event should have triggered
 PASS: Resource should have loaded 1 SourceMap.
 PASS: SourceMap should be a WI.SourceMap instance.
 
 -- Running test case: validMappingEmptyGroups
-expecting VALID source map
-PASS: Script resource and source map event should have triggered
 PASS: Resource should have loaded 1 SourceMap.
 PASS: SourceMap should be a WI.SourceMap instance.
 
 -- Running test case: validMappingEmptyString
-expecting VALID source map
-PASS: Script resource and source map event should have triggered
 PASS: Resource should have loaded 1 SourceMap.
 PASS: SourceMap should be a WI.SourceMap instance.
 
 -- Running test case: indexMapWrongTypeSections
-expecting INVALID source map
 WARN: Source Map "index-map-wrong-type-sections.js.map" has invalid "mappings"
-PASS: Script resource should have loaded
 PASS: Expected that there is an associated failed source map URL
 PASS: Expected no source map resource loaded
 
 -- Running test case: indexMapWrongTypeOffset
-expecting INVALID source map
 WARN: Source Map "index-map-wrong-type-offset.js.map" has invalid "offset"
-PASS: Script resource should have loaded
 PASS: Expected that there is an associated failed source map URL
 PASS: Expected no source map resource loaded
 
 -- Running test case: indexMapWrongTypeMap
-expecting INVALID source map
 WARN: Source Map "index-map-wrong-type-map.js.map" has invalid "map"
-PASS: Script resource should have loaded
 PASS: Expected that there is an associated failed source map URL
 PASS: Expected no source map resource loaded
 
 -- Running test case: indexMapInvalidBaseMappings
-expecting INVALID source map
 WARN: Source Map "index-map-invalid-base-mappings.js.map" has invalid "mappings"
-PASS: Script resource should have loaded
 PASS: Expected that there is an associated failed source map URL
 PASS: Expected no source map resource loaded
 
 -- Running test case: indexMapInvalidOverlap
-expecting INVALID source map
 WARN: Source Map "index-map-invalid-overlap.js.map" has invalid "offset.column"
-PASS: Script resource should have loaded
 PASS: Expected that there is an associated failed source map URL
 PASS: Expected no source map resource loaded
 
 -- Running test case: indexMapInvalidOrder
-expecting INVALID source map
 WARN: Source Map "index-map-invalid-order.js.map" has invalid "offset.line"
-PASS: Script resource should have loaded
 PASS: Expected that there is an associated failed source map URL
 PASS: Expected no source map resource loaded
 
 -- Running test case: indexMapMissingMap
-expecting INVALID source map
 WARN: Source Map "index-map-missing-map.js.map" has invalid "map"
-PASS: Script resource should have loaded
 PASS: Expected that there is an associated failed source map URL
 PASS: Expected no source map resource loaded
 
 -- Running test case: indexMapInvalidSubMap
-expecting INVALID source map
 WARN: Source Map "index-map-invalid-sub-map.js.map" has invalid "mappings"
-PASS: Script resource should have loaded
 PASS: Expected that there is an associated failed source map URL
 PASS: Expected no source map resource loaded
 
 -- Running test case: indexMapMissingOffset
-expecting INVALID source map
 WARN: Source Map "index-map-missing-offset.js.map" has invalid "offset"
-PASS: Script resource should have loaded
 PASS: Expected that there is an associated failed source map URL
 PASS: Expected no source map resource loaded
 
 -- Running test case: indexMapMissingOffsetLine
-expecting INVALID source map
 WARN: Source Map "index-map-missing-offset-line.js.map" has invalid "offset.line"
-PASS: Script resource should have loaded
 PASS: Expected that there is an associated failed source map URL
 PASS: Expected no source map resource loaded
 
 -- Running test case: indexMapMissingOffsetColumn
-expecting INVALID source map
 WARN: Source Map "index-map-missing-offset-column.js.map" has invalid "offset.column"
-PASS: Script resource should have loaded
 PASS: Expected that there is an associated failed source map URL
 PASS: Expected no source map resource loaded
 
 -- Running test case: indexMapOffsetLineWrongType
-expecting INVALID source map
 WARN: Source Map "index-map-offset-line-wrong-type.js.map" has invalid "offset.line"
-PASS: Script resource should have loaded
 PASS: Expected that there is an associated failed source map URL
 PASS: Expected no source map resource loaded
 
 -- Running test case: indexMapOffsetColumnWrongType
-expecting INVALID source map
 WARN: Source Map "index-map-offset-column-wrong-type.js.map" has invalid "offset.column"
-PASS: Script resource should have loaded
 PASS: Expected that there is an associated failed source map URL
 PASS: Expected no source map resource loaded
 
 -- Running test case: indexMapEmptySections
-expecting VALID source map
-PASS: Script resource and source map event should have triggered
 PASS: Resource should have loaded 1 SourceMap.
 PASS: SourceMap should be a WI.SourceMap instance.
 
 -- Running test case: indexMapFileWrongType1
-expecting INVALID source map
 WARN: Source Map "index-map-file-wrong-type-1.js.map" has invalid "file"
-PASS: Script resource should have loaded
 PASS: Expected that there is an associated failed source map URL
 PASS: Expected no source map resource loaded
 
 -- Running test case: indexMapFileWrongType2
-expecting INVALID source map
 WARN: Source Map "index-map-file-wrong-type-2.js.map" has invalid "file"
-PASS: Script resource should have loaded
 PASS: Expected that there is an associated failed source map URL
 PASS: Expected no source map resource loaded
 
 -- Running test case: basicMapping
-expecting VALID source map
-PASS: Script resource and source map event should have triggered
 PASS: Resource should have loaded 1 SourceMap.
 PASS: SourceMap should be a WI.SourceMap instance.
 PASS: Test location (0, 0) should be mapped.
@@ -599,8 +439,6 @@ PASS: Mapped column should be 0.
 PASS: Mapped source should be 'basic-mapping-original.js'.
 
 -- Running test case: sourceRootResolution
-expecting VALID source map
-PASS: Script resource and source map event should have triggered
 PASS: Resource should have loaded 1 SourceMap.
 PASS: SourceMap should be a WI.SourceMap instance.
 PASS: Test location (0, 0) should be mapped.
@@ -613,8 +451,6 @@ PASS: Mapped column should be 9.
 PASS: Mapped source should be 'theroot/basic-mapping-original.js'.
 
 -- Running test case: sourceResolutionAbsoluteURL
-expecting VALID source map
-PASS: Script resource and source map event should have triggered
 PASS: Resource should have loaded 1 SourceMap.
 PASS: SourceMap should be a WI.SourceMap instance.
 PASS: Test location (0, 0) should be mapped.
@@ -627,8 +463,6 @@ PASS: Mapped column should be 9.
 PASS: Mapped source should be '/baz/quux/basic-mapping-original.js'.
 
 -- Running test case: basicMappingWithIndexMap
-expecting VALID source map
-PASS: Script resource and source map event should have triggered
 PASS: Resource should have loaded 1 SourceMap.
 PASS: SourceMap should be a WI.SourceMap instance.
 PASS: Test location (0, 0) should be mapped.
@@ -681,8 +515,6 @@ PASS: Mapped column should be 0.
 PASS: Mapped source should be 'basic-mapping-original.js'.
 
 -- Running test case: indexMapWithMissingFile
-expecting VALID source map
-PASS: Script resource and source map event should have triggered
 PASS: Resource should have loaded 1 SourceMap.
 PASS: SourceMap should be a WI.SourceMap instance.
 PASS: Test location (0, 0) should be mapped.
@@ -735,8 +567,6 @@ PASS: Mapped column should be 0.
 PASS: Mapped source should be 'basic-mapping-original.js'.
 
 -- Running test case: indexMapWithTwoConcatenatedSources
-expecting VALID source map
-PASS: Script resource and source map event should have triggered
 PASS: Resource should have loaded 1 SourceMap.
 PASS: SourceMap should be a WI.SourceMap instance.
 PASS: Test location (0, 0) should be mapped.
@@ -813,8 +643,6 @@ PASS: Mapped column should be 0.
 PASS: Mapped source should be 'second-source-original.js'.
 
 -- Running test case: sourcesNullSourcesContentNonNull
-expecting VALID source map
-PASS: Script resource and source map event should have triggered
 PASS: Resource should have loaded 1 SourceMap.
 PASS: SourceMap should be a WI.SourceMap instance.
 PASS: Test location (0, 0) should be mapped.
@@ -827,8 +655,6 @@ PASS: Mapped column should be 9.
 PASS: Mapped source should be 'null'.
 
 -- Running test case: sourcesNonNullSourcesContentNull
-expecting VALID source map
-PASS: Script resource and source map event should have triggered
 PASS: Resource should have loaded 1 SourceMap.
 PASS: SourceMap should be a WI.SourceMap instance.
 PASS: Test location (0, 0) should be mapped.
@@ -841,8 +667,6 @@ PASS: Mapped column should be 9.
 PASS: Mapped source should be 'basic-mapping-original.js'.
 
 -- Running test case: transitiveMapping
-expecting VALID source map
-PASS: Script resource and source map event should have triggered
 PASS: Resource should have loaded 1 SourceMap.
 PASS: SourceMap should be a WI.SourceMap instance.
 Transitive mapping test ignored
@@ -855,8 +679,6 @@ Transitive mapping test ignored
 Transitive mapping test ignored
 
 -- Running test case: transitiveMappingWithThreeSteps
-expecting VALID source map
-PASS: Script resource and source map event should have triggered
 PASS: Resource should have loaded 1 SourceMap.
 PASS: SourceMap should be a WI.SourceMap instance.
 Transitive mapping test ignored
@@ -869,8 +691,6 @@ Transitive mapping test ignored
 Transitive mapping test ignored
 
 -- Running test case: vlqValidSingleDigit
-expecting VALID source map
-PASS: Script resource and source map event should have triggered
 PASS: Resource should have loaded 1 SourceMap.
 PASS: SourceMap should be a WI.SourceMap instance.
 PASS: Test location (0, 15) should be mapped.
@@ -879,8 +699,6 @@ PASS: Mapped column should be 0.
 PASS: Mapped source should be 'vlq-valid-single-digit-original.js'.
 
 -- Running test case: vlqValidNegativeDigit
-expecting VALID source map
-PASS: Script resource and source map event should have triggered
 PASS: Resource should have loaded 1 SourceMap.
 PASS: SourceMap should be a WI.SourceMap instance.
 PASS: Test location (2, 15) should be mapped.
@@ -893,8 +711,6 @@ PASS: Mapped column should be 1.
 PASS: Mapped source should be 'vlq-valid-negative-digit-original.js'.
 
 -- Running test case: vlqValidContinuationBitPresent1
-expecting VALID source map
-PASS: Script resource and source map event should have triggered
 PASS: Resource should have loaded 1 SourceMap.
 PASS: SourceMap should be a WI.SourceMap instance.
 PASS: Test location (0, 15) should be mapped.
@@ -903,8 +719,6 @@ PASS: Mapped column should be 1.
 PASS: Mapped source should be 'vlq-valid-continuation-bit-present-1-original.js'.
 
 -- Running test case: vlqValidContinuationBitPresent2
-expecting VALID source map
-PASS: Script resource and source map event should have triggered
 PASS: Resource should have loaded 1 SourceMap.
 PASS: SourceMap should be a WI.SourceMap instance.
 PASS: Test location (2, 16) should be mapped.
@@ -913,8 +727,6 @@ PASS: Mapped column should be 1.
 PASS: Mapped source should be 'vlq-valid-continuation-bit-present-2-original.js'.
 
 -- Running test case: mappingSemanticsSingleFieldSegment
-expecting VALID source map
-PASS: Script resource and source map event should have triggered
 PASS: Resource should have loaded 1 SourceMap.
 PASS: SourceMap should be a WI.SourceMap instance.
 PASS: Test location (0, 0) should be mapped.
@@ -927,8 +739,6 @@ PASS: Generated column should be 2.
 PASS: Generated path should be 'mapping-semantics-single-field-segment.js'.
 
 -- Running test case: mappingSemanticsFourFieldSegment
-expecting VALID source map
-PASS: Script resource and source map event should have triggered
 PASS: Resource should have loaded 1 SourceMap.
 PASS: SourceMap should be a WI.SourceMap instance.
 PASS: Test location (0, 1) should be mapped.
@@ -937,8 +747,6 @@ PASS: Mapped column should be 2.
 PASS: Mapped source should be 'mapping-semantics-four-field-segment-original.js'.
 
 -- Running test case: mappingSemanticsFiveFieldSegment
-expecting VALID source map
-PASS: Script resource and source map event should have triggered
 PASS: Resource should have loaded 1 SourceMap.
 PASS: SourceMap should be a WI.SourceMap instance.
 PASS: Test location (0, 1) should be mapped.
@@ -947,8 +755,6 @@ PASS: Mapped column should be 2.
 PASS: Mapped source should be 'mapping-semantics-five-field-segment-original.js'.
 
 -- Running test case: mappingSemanticsColumnReset
-expecting VALID source map
-PASS: Script resource and source map event should have triggered
 PASS: Resource should have loaded 1 SourceMap.
 PASS: SourceMap should be a WI.SourceMap instance.
 PASS: Test location (0, 1) should be mapped.
@@ -961,8 +767,6 @@ PASS: Mapped column should be 0.
 PASS: Mapped source should be 'mapping-semantics-column-reset-original.js'.
 
 -- Running test case: mappingSemanticsRelative1
-expecting VALID source map
-PASS: Script resource and source map event should have triggered
 PASS: Resource should have loaded 1 SourceMap.
 PASS: SourceMap should be a WI.SourceMap instance.
 PASS: Test location (0, 1) should be mapped.
@@ -975,8 +779,6 @@ PASS: Mapped column should be 4.
 PASS: Mapped source should be 'mapping-semantics-relative-1-original.js'.
 
 -- Running test case: mappingSemanticsRelative2
-expecting VALID source map
-PASS: Script resource and source map event should have triggered
 PASS: Resource should have loaded 1 SourceMap.
 PASS: SourceMap should be a WI.SourceMap instance.
 PASS: Test location (0, 1) should be mapped.

--- a/LayoutTests/inspector/model/source-map-spec.html
+++ b/LayoutTests/inspector/model/source-map-spec.html
@@ -45,13 +45,6 @@ function test()
             InspectorTest.expectThat(sourceMap.resources.some((resource) => resource.urlComponents.path.endsWith(sourceName)), `Should have resource '${sourceName}'.`);
     }
 
-    function withTimeout(promise, seconds)
-    {
-        return Promise.race([promise, new Promise((resolve, reject) => {
-            setTimeout(resolve, seconds);
-        })]);
-    }
-
     let suite = InspectorTest.createAsyncSuite("SourceMapSpec");
 
     // Construct tests in this callback after the test JSON is fetched.
@@ -61,30 +54,20 @@ function test()
                 name: testCase.name,
                 description: testCase.description,
                 async test() {
-                    InspectorTest.log("expecting " + (testCase.sourceMapIsValid ? "VALID" : "INVALID") + " source map");
-                    const [resourceEvent] = await Promise.all([
-                        withTimeout(WI.Frame.awaitEvent(WI.Frame.Event.ResourceWasAdded), 300),
+                    let [resourceWasAdded] = await Promise.all([
+                        WI.Frame.awaitEvent(WI.Frame.Event.ResourceWasAdded),
                         InspectorTest.evaluateInPage(`triggerScriptResource('${testCase.baseFile}');`)
                     ]);
-                    let resource;
-                    let sourceMapEvent;
-                    if (resourceEvent !== undefined) {
-                        resource = resourceEvent.data.resource;
-                        sourceMapEvent = await withTimeout(resource.awaitEvent(WI.SourceCode.Event.SourceMapAdded), 75);
-                    }
+                    let {resource} = resourceWasAdded.data;
 
                     if (testCase.sourceMapIsValid) {
-                        InspectorTest.expectThat(resource && sourceMapEvent, "Script resource and source map event should have triggered");
-                        if (!resource)
-                            return;
+                        await resource.awaitEvent(WI.SourceCode.Event.SourceMapAdded);
                         InspectorTest.expectEqual(resource.sourceMaps.length, 1, "Resource should have loaded 1 SourceMap.");
                         InspectorTest.expectThat(resource.sourceMaps[0] instanceof WI.SourceMap, "SourceMap should be a WI.SourceMap instance.");
                         if (!(resource.sourceMaps[0] instanceof WI.SourceMap))
                             return;
                     } else {
-                        InspectorTest.expectThat(resource, "Script resource should have loaded");
-                        if (!resource)
-                            return;
+                        await WI.networkManager.awaitEvent(WI.NetworkManager.Event.SourceMapParseFailed);
                         const hasFailedSourceMap = WI.networkManager.isSourceMapURL(absoluteURL(testCase.sourceMapFile, resource.displayURL));
                         InspectorTest.expectThat(hasFailedSourceMap, "Expected that there is an associated failed source map URL");
                         InspectorTest.expectEqual(resource.sourceMaps.length, 0, "Expected no source map resource loaded");

--- a/LayoutTests/inspector/unit-tests/map-utilities-expected.txt
+++ b/LayoutTests/inspector/unit-tests/map-utilities-expected.txt
@@ -36,3 +36,19 @@ PASS: Map should have same first key after changing its value.
 PASS: Map should have different first key after deleting previous first key.
 PASS: Map should not have first key after deleting all entries.
 
+-- Running test case: Map.prototype.firstValue
+PASS: Map should not start with a first value.
+PASS: Map should have first value.
+PASS: Map should have same first value after adding another entry.
+PASS: Map should have different first value after changing its value.
+PASS: Map should have different first value after deleting previous first key.
+PASS: Map should not have first value after deleting all entries.
+
+-- Running test case: Map.prototype.lastKey
+PASS: Map should not start with a last key.
+PASS: Map should have last key.
+PASS: Map should have different last key after adding another entry.
+PASS: Map should have same last key after changing first value.
+PASS: Map should have different last key after deleting previous last key.
+PASS: Map should not have last key after deleting all entries.
+

--- a/LayoutTests/inspector/unit-tests/map-utilities.html
+++ b/LayoutTests/inspector/unit-tests/map-utilities.html
@@ -106,6 +106,63 @@ function test()
         }
     });
 
+    suite.addTestCase({
+        name: "Map.prototype.firstValue",
+        test() {
+            const key1 = "key1";
+            const key2 = "key2";
+            const value1 = "value1";
+            const value2 = "value2";
+            const value3 = "value3";
+
+            let map = new Map;
+            InspectorTest.expectEqual(map.firstValue, undefined, "Map should not start with a first value.");
+
+            map.set(key1, value1);
+            InspectorTest.expectEqual(map.firstValue, value1, "Map should have first value.");
+
+            map.set(key2, value2);
+            InspectorTest.expectEqual(map.firstValue, value1, "Map should have same first value after adding another entry.");
+
+            map.set(key1, value3);
+            InspectorTest.expectEqual(map.firstValue, value3, "Map should have different first value after changing its value.");
+
+            map.delete(key1);
+            InspectorTest.expectEqual(map.firstValue, value2, "Map should have different first value after deleting previous first key.");
+
+            map.delete(key2);
+            InspectorTest.expectEqual(map.firstValue, undefined, "Map should not have first value after deleting all entries.");
+        }
+    });
+
+    suite.addTestCase({
+        name: "Map.prototype.lastKey",
+        test() {
+            const key1 = "key1";
+            const key2 = "key2";
+            const value1 = "value1";
+            const value2 = 200;
+
+            let map = new Map;
+            InspectorTest.expectEqual(map.lastKey, undefined, "Map should not start with a last key.");
+
+            map.set(key1, value1);
+            InspectorTest.expectEqual(map.lastKey, key1, "Map should have last key.");
+
+            map.set(key2, value2);
+            InspectorTest.expectEqual(map.lastKey, key2, "Map should have different last key after adding another entry.");
+
+            map.set(key1, value2);
+            InspectorTest.expectEqual(map.lastKey, key2, "Map should have same last key after changing first value.");
+
+            map.delete(key2);
+            InspectorTest.expectEqual(map.lastKey, key1, "Map should have different last key after deleting previous last key.");
+
+            map.delete(key1);
+            InspectorTest.expectEqual(map.lastKey, undefined, "Map should not have last key after deleting all entries.");
+        }
+    });
+
     suite.runTestCasesAndFinish();
 }
 </script>

--- a/Source/WebInspectorUI/UserInterface/Base/Utilities.js
+++ b/Source/WebInspectorUI/UserInterface/Base/Utilities.js
@@ -158,6 +158,22 @@ Object.defineProperty(Map.prototype, "firstKey",
     }
 });
 
+Object.defineProperty(Map.prototype, "firstValue",
+{
+    get()
+    {
+        return this.values().next().value;
+    }
+});
+
+Object.defineProperty(Map.prototype, "lastKey",
+{
+    get()
+    {
+        return Array.from(this.keys()).lastValue;
+    }
+});
+
 Object.defineProperty(WeakMap.prototype, "getOrInitialize",
 {
     value(key, initialValue)

--- a/Source/WebInspectorUI/UserInterface/Controllers/NetworkManager.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/NetworkManager.js
@@ -1516,7 +1516,7 @@ WI.NetworkManager = class NetworkManager extends WI.Object
     {
         this._downloadingSourceMaps.add(sourceMapURL);
 
-        let sourceMapLoaded = (error, content, mimeType, statusCode) => {
+        let sourceMapLoaded = async (error, content, mimeType, statusCode) => {
             if (error || statusCode >= 400) {
                 this._sourceMapLoadFailed(sourceMapURL);
                 return;
@@ -1535,7 +1535,7 @@ WI.NetworkManager = class NetworkManager extends WI.Object
             try {
                 let payload = JSON.parse(content);
                 let baseURL = sourceMapURL.startsWith("data:") ? originalSourceCode.url : sourceMapURL;
-                let sourceMap = new WI.SourceMap(baseURL, originalSourceCode, payload);
+                let sourceMap = await WI.SourceMap.fromJSON(originalSourceCode, baseURL, payload);
                 this._sourceMapLoadAndParseSucceeded(sourceMapURL, sourceMap);
             } catch (error) {
                 this._sourceMapParseFailed(sourceMapURL, error);
@@ -1580,6 +1580,8 @@ WI.NetworkManager = class NetworkManager extends WI.Object
             sourceMapURL = parseURL(sourceMapURL).lastPathComponent;
 
         let message = WI.UIString("Source Map \u0022%s\u0022 has %s").format(sourceMapURL, error);
+
+        this.dispatchEventToListeners(WI.NetworkManager.Event.SourceMapParseFailed, {sourceMapURL});
 
         if (window.InspectorTest) {
             console.warn(message);
@@ -1754,4 +1756,5 @@ WI.NetworkManager.Event = {
     LocalResourceOverrideAdded: "network-manager-local-resource-override-added",
     LocalResourceOverrideRemoved: "network-manager-local-resource-override-removed",
     EmulatedConditionChanged: "network-manager-emulated-condition-changed",
+    SourceMapParseFailed: "network-manager-source-map-parse-failed",
 };

--- a/Source/WebInspectorUI/UserInterface/Models/SourceCodeLocation.js
+++ b/Source/WebInspectorUI/UserInterface/Models/SourceCodeLocation.js
@@ -310,24 +310,12 @@ WI.SourceCodeLocation = class SourceCodeLocation extends WI.Object
         if (!this._sourceCode)
             return;
 
-        var sourceMaps = this._sourceCode.sourceMaps;
-        if (!sourceMaps.length)
-            return;
-
-        for (var i = 0; i < sourceMaps.length; ++i) {
-            var sourceMap = sourceMaps[i];
-            var entry = sourceMap.findEntry(this._lineNumber, this._columnNumber);
-            if (!entry || entry.length === 2)
-                continue;
-            console.assert(entry.length === 5);
-            var url = entry[2];
-            var sourceMapResource = sourceMap.resourceForURL(url);
-            if (!sourceMapResource)
-                return;
-            this._mappedResource = sourceMapResource;
-            this._mappedLineNumber = entry[3];
-            this._mappedColumnNumber = entry[4];
-            return;
+        for (let sourceMap of this._sourceCode.sourceMaps) {
+            let originalPosition = sourceMap.findOriginalPosition(this._lineNumber, this._columnNumber);
+            if (originalPosition) {
+                [this._mappedResource, this._mappedLineNumber, this._mappedColumnNumber] = originalPosition;
+                break;
+            }
         }
     }
 

--- a/Source/WebInspectorUI/UserInterface/Views/FrameTreeElement.js
+++ b/Source/WebInspectorUI/UserInterface/Views/FrameTreeElement.js
@@ -106,7 +106,7 @@ WI.FrameTreeElement = class FrameTreeElement extends WI.ResourceTreeElement
 
         this.updateParentStatus();
 
-        if (this.resource && this.resource.sourceMaps.length)
+        if (this.resource.sourceMaps.length)
             this.shouldRefreshChildren = true;
     }
 
@@ -168,11 +168,9 @@ WI.FrameTreeElement = class FrameTreeElement extends WI.ResourceTreeElement
         for (let resource of this._frame.resourceCollection)
             this.addChildForRepresentedObject(resource);
 
-        var sourceMaps = this.resource && this.resource.sourceMaps;
-        for (var i = 0; i < sourceMaps.length; ++i) {
-            var sourceMap = sourceMaps[i];
-            for (var j = 0; j < sourceMap.resources.length; ++j)
-                this.addChildForRepresentedObject(sourceMap.resources[j]);
+        for (let sourceMap of this.resource.sourceMaps) {
+            for (let sourceMapResource of sourceMap.resources)
+                this.addChildForRepresentedObject(sourceMapResource);
         }
 
         for (let extraScript of this._frame.extraScriptCollection) {

--- a/Source/WebInspectorUI/UserInterface/Views/OpenResourceDialog.js
+++ b/Source/WebInspectorUI/UserInterface/Views/OpenResourceDialog.js
@@ -342,7 +342,6 @@ WI.OpenResourceDialog = class OpenResourceDialog extends WI.Dialog
         if (!this.representedObjectIsValid(resource))
             return;
 
-        // Recurse on source maps if any exist.
         for (let sourceMap of resource.sourceMaps) {
             for (let sourceMapResource of sourceMap.resources)
                 this._addResource(sourceMapResource, suppressFilterUpdate);

--- a/Source/WebInspectorUI/UserInterface/Views/SourceCodeTreeElement.js
+++ b/Source/WebInspectorUI/UserInterface/Views/SourceCodeTreeElement.js
@@ -112,11 +112,8 @@ WI.SourceCodeTreeElement = class SourceCodeTreeElement extends WI.FolderizedTree
                 findAndCombineFolderChains(treeElement.children[i], previousSingleTreeElement);
         }
 
-        var sourceMaps = this._sourceCode.sourceMaps;
-        for (var i = 0; i < sourceMaps.length; ++i) {
-            var sourceMap = sourceMaps[i];
-            for (var j = 0; j < sourceMap.resources.length; ++j) {
-                var sourceMapResource = sourceMap.resources[j];
+        for (let sourceMap of this.resource.sourceMaps) {
+            for (let sourceMapResource of sourceMap.resources) {
                 var relativeSubpath = sourceMapResource.sourceMapDisplaySubpath;
                 var folderTreeElement = this.createFoldersAsNeededForSubpath(relativeSubpath);
                 var sourceMapTreeElement = new WI.SourceMapResourceTreeElement(sourceMapResource);

--- a/Source/WebInspectorUI/UserInterface/Views/WorkerTreeElement.js
+++ b/Source/WebInspectorUI/UserInterface/Views/WorkerTreeElement.js
@@ -97,8 +97,7 @@ WI.WorkerTreeElement = class WorkerTreeElement extends WI.ScriptTreeElement
         for (let script of this._target.extraScriptCollection)
             this.addChildForRepresentedObject(script);
 
-        let sourceMaps = this._target.mainResource.sourceMaps;
-        for (let sourceMap of sourceMaps) {
+        for (let sourceMap of this._target.mainResource.sourceMaps) {
             for (let resource of sourceMap.resources)
                 this.addChildForRepresentedObject(resource);
         }


### PR DESCRIPTION
#### 87cce29e4be749a0b851263fdca88aac03535b75
<pre>
Web Inspector: sourcemap parsing should not block rendering
<a href="https://bugs.webkit.org/show_bug.cgi?id=292712">https://bugs.webkit.org/show_bug.cgi?id=292712</a>

Reviewed by BJ Burg.

Currently all of the sourcemap parsing logic is synchronous, so if a sourcemap is extremely large it can potentially block rendering.
As such, having the parsing logic periodically yield (similar to `WI.Recording.prototype._process`).

* Source/WebInspectorUI/UserInterface/Models/SourceMap.js:
(WI.SourceMap):
(WI.SourceMap.async fromJSON): Added.
(WI.SourceMap._invalidPropertyError): Renamed from `WI.SourceMap.prototype._invalidPropertyError`.
(WI.SourceMap.prototype.get resources):
(WI.SourceMap.prototype.calculateBlackboxSourceRangesForProtocol):
(WI.SourceMap.prototype.findOriginalPosition): Renamed from `findEntry`.
(WI.SourceMap.prototype.findGeneratedPosition): Renamed from `findEntryReversed`.
(WI.SourceMap._VLQ): Renamed from `WI.SourceMap.StringCharIterator`.
(WI.SourceMap._VLQ.prototype.hasNextCharacter): Renamed from `WI.SourceMap.StringCharIterator.prototype.hasNext`.
(WI.SourceMap._VLQ.prototype.peekNextCharacter): Renamed from `WI.SourceMap.StringCharIterator.prototype.peekNext`.
(WI.SourceMap._VLQ.prototype.takeNextCharacter): Renamed from `WI.SourceMap.StringCharIterator.prototype.next`.
(WI.SourceMap._VLQ.prototype.atSeparator): Renamed from `WI.SourceMap.prototype._isSeparator`.
(WI.SourceMap._VLQ.prototype.decode): Renamed from `WI.SourceMap.prototype._decodeVLQ`.
(WI.SourceMap.prototype.resourceForURL): Deleted.
(WI.SourceMap.prototype.sourceContent): Deleted.
(WI.SourceMap.prototype._parseMappingPayload): Deleted.
(WI.SourceMap.prototype._parseMap): Deleted.
* Source/WebInspectorUI/UserInterface/Models/SourceMapResource.js:
(WI.SourceMapResource.prototype.get inlineContent): Added.
(WI.SourceMapResource.prototype.createSourceCodeLocation):
* Source/WebInspectorUI/UserInterface/Controllers/NetworkManager.js:
(WI.NetworkManager.prototype._loadAndParseSourceMap):
(WI.NetworkManager.prototype._sourceMapParseFailed):
Create a new `static` import/parsing method to massage the JSON before creating the `WI.SourceMap`.
This also ensures exceptions (which are currently used to immediately bail out of parsing) are not thrown in the constructor, which is a bit of a code smell.

* Source/WebInspectorUI/UserInterface/Models/SourceCodeLocation.js:
(WI.SourceCodeLocation.prototype.resolveMappedLocation):
Drive-by: callers shouldn&apos;t have to know about the structure of `mappings` or partial segments.

* Source/WebInspectorUI/UserInterface/Views/FrameTreeElement.js:
(WI.FrameTreeElement.prototype.onpopulate):
* Source/WebInspectorUI/UserInterface/Views/OpenResourceDialog.js:
(WI.OpenResourceDialog.prototype._addResource):
* Source/WebInspectorUI/UserInterface/Views/SourceCodeTreeElement.js:
(WI.SourceCodeTreeElement.prototype.onpopulate):
* Source/WebInspectorUI/UserInterface/Views/WorkerTreeElement.js:
(WI.WorkerTreeElement.prototype.onpopulate):
Drive-by: use iterators for `WI.SourceMap.prototype.get resources` since it `Array.from` on a `Map` (i.e. a temporary array that&apos;s recalculated each time).

* LayoutTests/inspector/model/source-map-spec.html:
* LayoutTests/inspector/model/source-map-spec-expected.txt:
Simplify some of the test output to focus more on the actual content being tested (e.g. the resource should always load so there&apos;s no need to have output for when it does).

* LayoutTests/inspector/debugger/resources/log-pause-location.js:
(TestPage.registerInitializer.getLineContent):
The `inlineContent` is now owned by the `WI.SourceMapResource` instead of being fetched from the `WI.SourceMap`.
This is slightly better as now there&apos;s no chance of the same URL having different content based on the JSON `sources` and `sourcesContent`.

* Source/WebInspectorUI/UserInterface/Base/Utilities.js:
(Map.prototype.get firstValue): Added.
(Map.prototype.get lastKey): Added.
* LayoutTests/inspector/unit-tests/map-utilities.html:
* LayoutTests/inspector/unit-tests/map-utilities-expected.txt:
Add some helper methods that let `Map` be treated more like an array.

Canonical link: <a href="https://commits.webkit.org/294875@main">https://commits.webkit.org/294875@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4bb769b533bdcdd78167567439e5eebcdb63ac4c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/103393 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/23075 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/13393 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/108567 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/54036 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/23420 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/31626 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78568 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/35518 "Build is being retried. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Skipped layout-tests; layout-tests (retry)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/106399 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/18150 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/93270 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58902 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/17985 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/11314 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/53393 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/87785 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/11376 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/110943 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/30540 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/22535 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/87565 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/30901 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/89468 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87205 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22195 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32077 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/9790 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/24867 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/30468 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/35779 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/30268 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/33599 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/31829 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->