### PR TITLE
Remove BroadcastChannelOriginPartitioningEnabled preference

### DIFF
--- a/LayoutTests/http/tests/local/blob/navigate-blob.html
+++ b/LayoutTests/http/tests/local/blob/navigate-blob.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN"><!-- webkit-test-runner [ BroadcastChannelOriginPartitioningEnabled=true ] -->
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
 <script src="../../../../resources/testharness.js"></script>

--- a/LayoutTests/http/tests/messaging/broadcastchannel-partitioning.html
+++ b/LayoutTests/http/tests/messaging/broadcastchannel-partitioning.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ BroadcastChannelOriginPartitioningEnabled=true ] -->
+<!DOCTYPE html>
 <html>
 <body>
 <script src="/js-test-resources/js-test.js"></script>

--- a/LayoutTests/http/wpt/shared-workers/third-party-shared-worker-broadcast-channel.html
+++ b/LayoutTests/http/wpt/shared-workers/third-party-shared-worker-broadcast-channel.html
@@ -1,4 +1,4 @@
-<html><!-- webkit-test-runner [ BroadcastChannelOriginPartitioningEnabled=true ] -->
+<html>
 <head>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-opener-policy/blob-popup.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-opener-policy/blob-popup.https.html
@@ -3,38 +3,44 @@
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
 <script src=/common/get-host-info.sub.js></script>
-<script src="/common/utils.js"></script>
+<script src=/common/utils.js></script>
+<script src=/common/dispatcher/dispatcher.js></script>
 <script>
-async_test(t => {
-  window.test = t; // Make the test available globally so the blob URL can use it
+promise_test(async t => {
   window.furtherPopup = null;
 
-  const bc = new BroadcastChannel(token());
-  bc.onmessage = t.step_func_done(({ data }) => {
-    assert_equals(data.name.length, 0);
-    assert_false(data.opener);
-    assert_true(furtherPopup.closed);
-  });
+  const responseToken = token();
+  const iframeToken = token();
 
   const blobContents = `<script>
-const w = window.open("${get_host_info().HTTPS_REMOTE_ORIGIN}/html/cross-origin-opener-policy/resources/coop-coep.py?coop=x&coep=x&channel=${bc.name}", "${bc.name}");
+const w = window.open("${get_host_info().HTTPS_REMOTE_ORIGIN}/html/cross-origin-opener-policy/resources/coop-coep.py?coop=x&coep=x&responseToken=${responseToken}&iframeToken=${iframeToken}", "${responseToken}");
 window.opener.furtherPopup = w;
 <\/script>`;
   const blob = new Blob([blobContents], { type: "text/html" });
   const blobURL = URL.createObjectURL(blob);
   const popup = window.open(blobURL);
-  t.add_cleanup(() => {
+  t.add_cleanup(async () => {
     // Close the popups once the test is complete.
     // The browsing context of the second popup is closed hence use the
     //  broadcast channel to trigger the closure.
-    bc.postMessage("close");
+    await send(iframeToken, "close");
     popup.close();
   });
+
+  let popupOnloadHappened = false;
   popup.onload = t.step_func(() => {
     assert_equals(popup.opener, window);
     assert_equals(popup.location.href, blobURL);
     assert_equals(popup.document.URL, blobURL);
     assert_equals(popup.origin, window.origin);
+    popupOnloadHappened = true;
   });
+
+  const data = JSON.parse(await receive(responseToken));
+
+  assert_true(popupOnloadHappened);
+  assert_equals(data.name.length, 0);
+  assert_false(data.opener);
+  assert_true(furtherPopup.closed);
 });
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-opener-policy/coep-navigate-popup.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-opener-policy/coep-navigate-popup.https.html
@@ -6,9 +6,11 @@
 <meta name=variant content=?4-last>
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
-<script src="/common/subset-tests.js"></script>
-<script src="/common/get-host-info.sub.js"></script>
-<script src="resources/common.js"></script>
+<script src=/common/subset-tests.js></script>
+<script src=/common/get-host-info.sub.js></script>
+<script src=/common/utils.js></script>
+<script src=resources/common.js></script>
+<script src=/common/dispatcher/dispatcher.js></script>
 <script>
 [
   {
@@ -55,17 +57,18 @@
 
   ["same-origin", "same-site"].forEach(site => {
     const title = `Popup navigating to ${site} with ${variant.title}`;
-    const channel = title.replace(/ /g,"-");
+    const responseToken = token();
+    const iframeToken = token();
     const navigateHost = site === "same-origin" ? SAME_ORIGIN : SAME_SITE;
-    const navigateURL = `${navigateHost.origin}/html/cross-origin-opener-policy/resources/coop-coep.py?coop=${variant.coop}&coep=${variant.coep}&channel=${channel}`;
+    const navigateURL = `${navigateHost.origin}/html/cross-origin-opener-policy/resources/coop-coep.py?coop=${variant.coop}&coep=${variant.coep}&responseToken=${responseToken}&iframeToken=${iframeToken}`;
     const opener = site === "same-origin" ? variant.opener : false;
 
-    async_test(t => {
+    promise_test(t => {
       // For each test we open a COOP: same-origin/COEP: require-corp document in a popup and then
       // navigate that to either a same-origin (site=="same-origin") or same-site (site=="same-site")
       // document whose COOP and COEP are set as per the top-most array. We then verify that this
       // document has the correct opener for its specific setup.
-      url_test(t, `${SAME_ORIGIN.origin}/html/cross-origin-opener-policy/resources/coop-coep.py?coop=same-origin&coep=require-corp&navigate=${encodeURIComponent(navigateURL)}`, channel, opener);
+      return dispatcher_url_test(t, `${SAME_ORIGIN.origin}/html/cross-origin-opener-policy/resources/coop-coep.py?coop=same-origin&coep=require-corp&navigate=${encodeURIComponent(navigateURL)}`, responseToken, iframeToken, opener, undefined, () => t.done());
     }, title);
   });
 });

--- a/LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-opener-policy/historical/coep-navigate-popup-unsafe-inherit.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-opener-policy/historical/coep-navigate-popup-unsafe-inherit.https.html
@@ -3,9 +3,11 @@
 <meta name=timeout content=long>
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
-<script src="/common/get-host-info.sub.js"></script>
-<script src="../resources/common.js"></script>
-<script src="/common/subset-tests.js"></script>
+<script src=/common/subset-tests.js></script>
+<script src=/common/get-host-info.sub.js></script>
+<script src=/common/utils.js></script>
+<script src=../resources/common.js></script>
+<script src=/common/dispatcher/dispatcher.js></script>
 <script>
 [
   {
@@ -23,17 +25,18 @@
 ].forEach((variant) => {
   ["same-origin", "same-site"].forEach((site) => {
     const title = `Popup navigating to ${site} with ${variant.title}`;
-    const channel = title.replace(/ /g,"-");
+    const responseToken = token();
+    const iframeToken = token();
     const navigateHost = site === "same-origin" ? SAME_ORIGIN : SAME_SITE;
-    const navigateURL = `${navigateHost.origin}/html/cross-origin-opener-policy/resources/coop-coep.py?coop=${variant.coop}&coep=${variant.coep}&channel=${channel}`;
+    const navigateURL = `${navigateHost.origin}/html/cross-origin-opener-policy/resources/coop-coep.py?coop=${variant.coop}&coep=${variant.coep}&responseToken=${responseToken}&iframeToken=${iframeToken}`;
     const opener = site === "same-origin" ? variant.opener : false;
 
-    async_test(t => {
+    promise_test(t => {
       // For each test we open a COOP: same-origin/COEP: require-corp document in a popup and then
       // navigate that to either a document with same origin (site=="same-origin") or
       // not-same-origin (site=="same-site") whose COOP and COEP are set as per the top-most array.
       // We then verify that this document has the correct opener for its specific setup.
-      url_test(t, `${SAME_ORIGIN.origin}/html/cross-origin-opener-policy/resources/coop-coep.py?coop=same-origin&coep=require-corp&navigate=${encodeURIComponent(navigateURL)}`, channel, opener);
+      return dispatcher_url_test(t, `${SAME_ORIGIN.origin}/html/cross-origin-opener-policy/resources/coop-coep.py?coop=same-origin&coep=require-corp&navigate=${encodeURIComponent(navigateURL)}`, responseToken, iframeToken, opener, undefined, () => t.done());
     }, title);
   });
 });

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -992,20 +992,6 @@ BroadcastChannelEnabled:
     WebCore:
       default: true
 
-BroadcastChannelOriginPartitioningEnabled:
-  type: bool
-  status: stable
-  category: dom
-  humanReadableName: "BroadcastChannel Origin Partitioning"
-  humanReadableDescription: "BroadcastChannel Origin Partitioning"
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
-
 BuiltInNotificationsEnabled:
   type: bool
   status: unstable

--- a/Source/WebCore/dom/BroadcastChannel.cpp
+++ b/Source/WebCore/dom/BroadcastChannel.cpp
@@ -65,9 +65,7 @@ static HashMap<BroadcastChannelIdentifier, ScriptExecutionContextIdentifier>& ch
 
 static PartitionedSecurityOrigin partitionedSecurityOriginFromContext(ScriptExecutionContext& context)
 {
-    Ref securityOrigin { *context.securityOrigin() };
-    Ref topOrigin { context.settingsValues().broadcastChannelOriginPartitioningEnabled ? context.topOrigin() : securityOrigin.get() };
-    return { WTFMove(topOrigin), WTFMove(securityOrigin) };
+    return { context.topOrigin(), context.protectedSecurityOrigin().releaseNonNull() };
 }
 
 class BroadcastChannel::MainThreadBridge : public ThreadSafeRefCounted<MainThreadBridge, WTF::DestructionThread::Main>, public Identified<BroadcastChannelIdentifier> {

--- a/Tools/WebKitTestRunner/TestOptions.cpp
+++ b/Tools/WebKitTestRunner/TestOptions.cpp
@@ -86,7 +86,6 @@ const TestFeatures& TestOptions::defaults()
             { "AppBadgeEnabled", true },
             { "AsyncFrameScrollingEnabled", false },
             { "AsyncOverflowScrollingEnabled", false },
-            { "BroadcastChannelOriginPartitioningEnabled", false },
             { "BuiltInNotificationsEnabled", false },
             { "CSSOMViewScrollingAPIEnabled", true },
             { "CSSUnprefixedBackdropFilterEnabled", true },


### PR DESCRIPTION
#### af02d9c410b3f99db1666790e7faf958dc2783a1
<pre>
Remove BroadcastChannelOriginPartitioningEnabled preference
<a href="https://bugs.webkit.org/show_bug.cgi?id=292720">https://bugs.webkit.org/show_bug.cgi?id=292720</a>

Reviewed by Youenn Fablet.

This has been enabled by default for a long time now.

This incorporates <a href="https://github.com/web-platform-tests/wpt/pull/52494">https://github.com/web-platform-tests/wpt/pull/52494</a>
to ensure a couple of web-platform-tests that relied on
BroadcastChannel not being partitioned no longer do so.

Canonical link: <a href="https://commits.webkit.org/295154@main">https://commits.webkit.org/295154@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7a136c1f3ce9935bddddf06da27c9bca558dd10c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/103631 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/23314 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/13634 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/108807 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/54278 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/105671 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/23669 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/31864 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78751 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/106637 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/18365 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/93489 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59086 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/18182 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/11536 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/53632 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/96306 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/87958 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/11595 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/111185 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/102242 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/30779 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/22700 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/87744 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/31139 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/89689 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87392 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32270 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/9993 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/25133 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16924 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/30706 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/36018 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/125875 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/30506 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34861 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/33837 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/32067 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->