### PR TITLE
Import wpt/webidl/ecmascript-binding/es-exceptions

### DIFF
--- a/LayoutTests/imported/w3c/resources/import-expectations.json
+++ b/LayoutTests/imported/w3c/resources/import-expectations.json
@@ -348,6 +348,7 @@
     "web-platform-tests/webgl": "skip",
     "web-platform-tests/webgpu": "skip",
     "web-platform-tests/webhid": "skip",
+    "web-platform-tests/webidl/ecmascript-binding/es-exceptions": "import",
     "web-platform-tests/webmessaging": "import",
     "web-platform-tests/webmidi": "skip",
     "web-platform-tests/webnn": "skip",

--- a/LayoutTests/imported/w3c/web-platform-tests/WebIDL/ecmascript-binding/es-exceptions/DOMException-constants.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/WebIDL/ecmascript-binding/es-exceptions/DOMException-constants.any.js
@@ -1,3 +1,5 @@
+// META: global=window,dedicatedworker,shadowrealm
+
 'use strict';
 
 test(function() {

--- a/LayoutTests/imported/w3c/web-platform-tests/WebIDL/ecmascript-binding/es-exceptions/DOMException-constructor-and-prototype.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/WebIDL/ecmascript-binding/es-exceptions/DOMException-constructor-and-prototype.any.js
@@ -1,3 +1,5 @@
+// META: global=window,dedicatedworker,shadowrealm
+
 test(function() {
     assert_own_property(self, "DOMException", "property of global");
 

--- a/LayoutTests/imported/w3c/web-platform-tests/WebIDL/ecmascript-binding/es-exceptions/DOMException-constructor-behavior.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/WebIDL/ecmascript-binding/es-exceptions/DOMException-constructor-behavior.any.js
@@ -1,3 +1,5 @@
+// META: global=window,dedicatedworker,shadowrealm
+
 'use strict';
 
 test(function() {

--- a/LayoutTests/imported/w3c/web-platform-tests/WebIDL/ecmascript-binding/es-exceptions/DOMException-custom-bindings.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/WebIDL/ecmascript-binding/es-exceptions/DOMException-custom-bindings.any.js
@@ -1,3 +1,5 @@
+// META: global=window,dedicatedworker,shadowrealm
+
 "use strict";
 
 test(() => {

--- a/LayoutTests/imported/w3c/web-platform-tests/WebIDL/ecmascript-binding/es-exceptions/DOMException-is-error.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/WebIDL/ecmascript-binding/es-exceptions/DOMException-is-error.any-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL DOMException-is-error assert_true: expected true got false
+

--- a/LayoutTests/imported/w3c/web-platform-tests/WebIDL/ecmascript-binding/es-exceptions/DOMException-is-error.any.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/WebIDL/ecmascript-binding/es-exceptions/DOMException-is-error.any.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/WebIDL/ecmascript-binding/es-exceptions/DOMException-is-error.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/WebIDL/ecmascript-binding/es-exceptions/DOMException-is-error.any.js
@@ -1,0 +1,9 @@
+// META: global=window,dedicatedworker,shadowrealm
+
+'use strict';
+
+test(function() {
+  // https://github.com/tc39/proposal-is-error/issues/9
+  // https://github.com/whatwg/webidl/pull/1421
+  assert_true(Error.isError(new DOMException()));
+});

--- a/LayoutTests/imported/w3c/web-platform-tests/WebIDL/ecmascript-binding/es-exceptions/DOMException-is-error.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/WebIDL/ecmascript-binding/es-exceptions/DOMException-is-error.any.worker-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL DOMException-is-error assert_true: expected true got false
+

--- a/LayoutTests/imported/w3c/web-platform-tests/WebIDL/ecmascript-binding/es-exceptions/DOMException-is-error.any.worker.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/WebIDL/ecmascript-binding/es-exceptions/DOMException-is-error.any.worker.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/WebIDL/ecmascript-binding/es-exceptions/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/WebIDL/ecmascript-binding/es-exceptions/w3c-import.log
@@ -18,4 +18,5 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/webidl/ecmascript-binding/es-exceptions/DOMException-constructor-and-prototype.any.js
 /LayoutTests/imported/w3c/web-platform-tests/webidl/ecmascript-binding/es-exceptions/DOMException-constructor-behavior.any.js
 /LayoutTests/imported/w3c/web-platform-tests/webidl/ecmascript-binding/es-exceptions/DOMException-custom-bindings.any.js
+/LayoutTests/imported/w3c/web-platform-tests/webidl/ecmascript-binding/es-exceptions/DOMException-is-error.any.js
 /LayoutTests/imported/w3c/web-platform-tests/webidl/ecmascript-binding/es-exceptions/exceptions.html


### PR DESCRIPTION
#### 9cd47327b764d709167008118dbada1f92fcfd7b
<pre>
Import wpt/webidl/ecmascript-binding/es-exceptions
<a href="https://bugs.webkit.org/show_bug.cgi?id=292728">https://bugs.webkit.org/show_bug.cgi?id=292728</a>

Reviewed by Anne van Kesteren.

The latest revision contains the test for `Error.isError(new DOMException)`.
It&apos;s required for bug 292727.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/efbafc67856c5fc2f711d37a108b27ca94d2c8f6">https://github.com/web-platform-tests/wpt/commit/efbafc67856c5fc2f711d37a108b27ca94d2c8f6</a>

This change is generated by `./Tools/Scripts/import-w3c-tests web-platform-tests/webidl/ecmascript-binding/es-exceptions`.

* LayoutTests/imported/w3c/resources/import-expectations.json:
* LayoutTests/imported/w3c/web-platform-tests/WebIDL/ecmascript-binding/es-exceptions/DOMException-constants.any.js:
* LayoutTests/imported/w3c/web-platform-tests/WebIDL/ecmascript-binding/es-exceptions/DOMException-constructor-and-prototype.any.js:
* LayoutTests/imported/w3c/web-platform-tests/WebIDL/ecmascript-binding/es-exceptions/DOMException-constructor-behavior.any.js:
* LayoutTests/imported/w3c/web-platform-tests/WebIDL/ecmascript-binding/es-exceptions/DOMException-custom-bindings.any.js:
* LayoutTests/imported/w3c/web-platform-tests/WebIDL/ecmascript-binding/es-exceptions/DOMException-is-error.any-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/WebIDL/ecmascript-binding/es-exceptions/DOMException-is-error.any.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/WebIDL/ecmascript-binding/es-exceptions/DOMException-is-error.any.js: Added.
(test):
* LayoutTests/imported/w3c/web-platform-tests/WebIDL/ecmascript-binding/es-exceptions/DOMException-is-error.any.worker-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/WebIDL/ecmascript-binding/es-exceptions/DOMException-is-error.any.worker.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/WebIDL/ecmascript-binding/es-exceptions/w3c-import.log:

Canonical link: <a href="https://commits.webkit.org/294702@main">https://commits.webkit.org/294702@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bcb70c72b58ab8906b65b244ac8ef15ec13f70fc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/102756 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/22429 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/12749 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/107921 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/53397 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/22744 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/30931 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78140 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/35105 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/105762 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17619 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/92735 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58472 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/17463 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/10770 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/52754 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/87275 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10838 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/110297 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/29893 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/22027 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/87124 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/30257 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88931 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86734 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31565 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/9296 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/24147 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16676 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/29820 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/29628 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/32955 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/31190 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->