### PR TITLE
Harden IPInt dispatch

### DIFF
--- a/Source/JavaScriptCore/llint/InPlaceInterpreter.asm
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter.asm
@@ -49,17 +49,11 @@
 # - PC: (Program Counter) IPInt's program counter. This records the interpreter's position in Wasm bytecode.
 # - MC: (Metadata Counter) IPInt's metadata pointer. This records the corresponding position in generated metadata.
 # - WI: (Wasm Instance) pointer to the current JSWebAssemblyInstance object. This is used for accessing
-#       function-specific data.
+#       function-specific data (callee-save).
 # - PL: (Pointer to Locals) pointer to the address of local 0 in the current function. This is used for accessing
 #       locals quickly.
-# - MB: (Memory Base) pointer to the current Wasm memory base address.
-# - BC: (Bounds Check) the size of the current Wasm memory region, for bounds checking.
-#
-# Additionally, there are a few registers that are optionally supported for optimization:
-# - IB: (Instruction Base) pointer to the address of the `unreachable` (0x00) label, removing the need to reload
-#       this address at every dispatch.
-# - HR: (Hoist Register) used for hoisting the load of the next opcode in Wasm instructions with low register
-#       pressure, helping reduce the impact of load misses.
+# - MB: (Memory Base) pointer to the current Wasm memory base address (callee-save).
+# - BC: (Bounds Check) the size of the current Wasm memory region, for bounds checking (callee-save).
 #
 # Finally, we provide four "sc" (safe for call) registers which are guaranteed to not overlap with argument
 # registers (sc0, sc1, sc2, sc3)
@@ -71,9 +65,6 @@ if ARM64 or ARM64E
     const PL = t6
     const MB = csr3
     const BC = csr4
-
-    const IB = t7
-    const HR = t3
 
     const sc0 = ws0
     const sc1 = ws1
@@ -87,9 +78,6 @@ elsif X86_64
     const MB = csr3
     const BC = csr4
 
-    const IB = t7
-    const HR = t3
-
     const sc0 = ws0
     const sc1 = ws1
     const sc2 = csr3
@@ -101,9 +89,6 @@ elsif RISCV64
     const PL = csr10
     const MB = csr3
     const BC = csr4
-
-    const IB = invalidGPR
-    const HR = invalidGPR
 
     const sc0 = ws0
     const sc1 = ws1
@@ -117,9 +102,6 @@ elsif ARMv7
     const MB = invalidGPR
     const BC = invalidGPR
 
-    const IB = invalidGPR
-    const HR = invalidGPR
-
     const sc0 = t4
     const sc1 = t5
     const sc2 = csr0
@@ -131,9 +113,6 @@ else
     const PL = invalidGPR
     const MB = invalidGPR
     const BC = invalidGPR
-
-    const IB = invalidGPR
-    const HR = invalidGPR
 
     const sc0 = invalidGPR
     const sc1 = invalidGPR
@@ -172,30 +151,6 @@ const UnboxedWasmCalleeStackSlot = CallerFrame - constexpr Wasm::numberOfIPIntCa
 const IPIntCalleeSaveSpaceAsVirtualRegisters = constexpr Wasm::numberOfIPIntCalleeSaveRegisters + constexpr Wasm::numberOfIPIntInternalRegisters
 const IPIntCalleeSaveSpaceStackAligned = (IPIntCalleeSaveSpaceAsVirtualRegisters * SlotSize + StackAlignment - 1) & ~StackAlignmentMask
 const IPIntCalleeSaveSpaceStackAligned = 2*IPIntCalleeSaveSpaceStackAligned
-
-# ---------------------------
-# 1.2: Optional optimizations
-# ---------------------------
-
-macro IfIPIntUsesIB(m)
-    if ARM64 or ARM64E or X86_64
-        m()
-    end
-end
-
-macro IfIPIntUsesHR(m, m2)
-    if ARM64 or ARM64E
-        m()
-    else
-        m2()
-    end
-end
-
-macro HoistNextOpcode(offset)
-    IfIPIntUsesHR(macro()
-        loadb offset[PC], HR
-    end, macro() end)
-end
 
 ##############################
 # 2. Core interpreter macros #
@@ -349,18 +304,18 @@ macro operationCall(fn)
     if ARM64 or ARM64E
         push PL, ws0
     elsif X86_64
-        push PL, IB
+        push PL
+        # preserve 16 byte alignment.
+        subq MachineRegisterSize, sp
     end
     fn()
     if ARM64 or ARM64E
         pop ws0, PL
     elsif X86_64
-        pop IB, PL
+        addq MachineRegisterSize, sp
+        pop PL
     end
     pop MC, PC
-    if ARM64 or ARM64E
-        pcrtoaddr _ipint_unreachable, IB
-    end
 end
 
 macro operationCallMayThrow(fn)
@@ -371,7 +326,9 @@ macro operationCallMayThrow(fn)
     if ARM64 or ARM64E
         push PL, ws0
     elsif X86_64
-        push PL, IB
+        push PL
+        # preserve 16 byte alignment.
+        subq MachineRegisterSize, sp
     end
     fn()
     bpneq r1, (constexpr JSC::IPInt::SlowPathExceptionTag), .continuation
@@ -381,12 +338,10 @@ macro operationCallMayThrow(fn)
     if ARM64 or ARM64E
         pop ws0, PL
     elsif X86_64
-        pop IB, PL
+        addq MachineRegisterSize, sp
+        pop PL
     end
     pop MC, PC
-    if ARM64 or ARM64E
-        pcrtoaddr _ipint_unreachable, IB
-    end
 end
 
 # Exception handling
@@ -573,13 +528,6 @@ if WEBASSEMBLY and (ARM64 or ARM64E or X86_64 or ARMv7)
     # OSR Check
     ipintPrologueOSR(5)
 
-    IfIPIntUsesIB(macro ()
-if ARM64 or ARM64E
-        pcrtoaddr _ipint_unreachable, IB
-elsif X86_64
-        leap (_ipint_unreachable - _ipint_entry_relativePCBase)[PL], IB
-end
-    end)
     move sp, PL
 
     loadp Wasm::IPIntCallee::m_bytecode[ws0], PC
@@ -621,9 +569,6 @@ if ARMv7
 end
 
     loadp CodeBlock[cfr], wasmInstance
-    if ARM64 or ARM64E
-        pcrtoaddr _ipint_unreachable, IB
-    end
     loadp Wasm::IPIntCallee::m_bytecode[ws0], t1
     addp t1, PC
     loadp Wasm::IPIntCallee::m_metadata[ws0], t1
@@ -661,10 +606,6 @@ global _ipint_catch_entry
 _ipint_catch_entry:
 if WEBASSEMBLY and (ARM64 or ARM64E or X86_64)
     ipintCatchCommon()
-if X86_64
-    initPCRelative(ipint_catch_entry, IB)
-    leap (_ipint_unreachable - _ipint_catch_entry_relativePCBase)[IB], IB
-end
 
     move cfr, a1
     move sp, a2
@@ -682,10 +623,6 @@ global _ipint_catch_all_entry
 _ipint_catch_all_entry:
 if WEBASSEMBLY and (ARM64 or ARM64E or X86_64)
     ipintCatchCommon()
-if X86_64
-    initPCRelative(ipint_catch_all_entry, IB)
-    leap (_ipint_unreachable - _ipint_catch_all_entry_relativePCBase)[IB], IB
-end
 
     move cfr, a1
     move 0, a2
@@ -703,10 +640,6 @@ global _ipint_table_catch_entry
 _ipint_table_catch_entry:
 if WEBASSEMBLY and (ARM64 or ARM64E or X86_64 or ARMv7)
     ipintCatchCommon()
-if X86_64
-    initPCRelative(ipint_table_catch_entry, IB)
-    leap (_ipint_unreachable - _ipint_table_catch_entry_relativePCBase)[IB], IB
-end
 
     # push arguments but no ref: sp in a2, call normal operation
 
@@ -726,10 +659,6 @@ global _ipint_table_catch_ref_entry
 _ipint_table_catch_ref_entry:
 if WEBASSEMBLY and (ARM64 or ARM64E or X86_64 or ARMv7)
     ipintCatchCommon()
-if X86_64
-    initPCRelative(ipint_table_catch_ref_entry, IB)
-    leap (_ipint_unreachable - _ipint_table_catch_ref_entry_relativePCBase)[IB], IB
-end
 
     # push both arguments and ref
 
@@ -749,10 +678,6 @@ global _ipint_table_catch_all_entry
 _ipint_table_catch_all_entry:
 if WEBASSEMBLY and (ARM64 or ARM64E or X86_64 or ARMv7)
     ipintCatchCommon()
-if X86_64
-    initPCRelative(ipint_table_catch_all_entry, IB)
-    leap (_ipint_unreachable - _ipint_table_catch_all_entry_relativePCBase)[IB], IB
-end
 
     # do nothing: 0 in sp for no arguments, call normal operation
 
@@ -772,10 +697,6 @@ global _ipint_table_catch_allref_entry
 _ipint_table_catch_allref_entry:
 if WEBASSEMBLY and (ARM64 or ARM64E or X86_64 or ARMv7)
     ipintCatchCommon()
-if X86_64
-    initPCRelative(ipint_table_catch_allref_entry, IB)
-    leap (_ipint_unreachable - _ipint_table_catch_allref_entry_relativePCBase)[IB], IB
-end
 
     # push only the ref
 

--- a/Source/JavaScriptCore/llint/InPlaceInterpreter.cpp
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2023-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -39,102 +39,32 @@
 
 namespace JSC { namespace IPInt {
 
-#define VALIDATE_IPINT_OPCODE(opcode, name) \
+#define VALIDATE_IPINT_OPCODE_FROM_BASE(dispatchBase, width, opcode, name) \
 do { \
-    void* base = reinterpret_cast<void*>(ipint_unreachable_validate); \
+    void* base = reinterpret_cast<void*>(dispatchBase); \
     void* ptr = reinterpret_cast<void*>(ipint_ ## name ## _validate); \
     void* untaggedBase = CodePtr<CFunctionPtrTag>::fromTaggedPtr(base).template untaggedPtr<>(); \
     void* untaggedPtr = CodePtr<CFunctionPtrTag>::fromTaggedPtr(ptr).template untaggedPtr<>(); \
-    RELEASE_ASSERT_WITH_MESSAGE((char*)(untaggedPtr) - (char*)(untaggedBase) == opcode * 256, #name); \
+    RELEASE_ASSERT_WITH_MESSAGE((char*)(untaggedPtr) - (char*)(untaggedBase) == opcode * width, #name); \
 } while (false);
 
-#define VALIDATE_IPINT_0xFB_OPCODE(opcode, name) \
-do { \
-    void* base = reinterpret_cast<void*>(ipint_struct_new_validate); \
-    void* ptr = reinterpret_cast<void*>(ipint_ ## name ## _validate); \
-    void* untaggedBase = CodePtr<CFunctionPtrTag>::fromTaggedPtr(base).template untaggedPtr<>(); \
-    void* untaggedPtr = CodePtr<CFunctionPtrTag>::fromTaggedPtr(ptr).template untaggedPtr<>(); \
-    RELEASE_ASSERT_WITH_MESSAGE((char*)(untaggedPtr) - (char*)(untaggedBase) == opcode * 256, #name); \
-} while (false);
-
-#define VALIDATE_IPINT_0xFC_OPCODE(opcode, name) \
-do { \
-    void* base = reinterpret_cast<void*>(ipint_i32_trunc_sat_f32_s_validate); \
-    void* ptr = reinterpret_cast<void*>(ipint_ ## name ## _validate); \
-    void* untaggedBase = CodePtr<CFunctionPtrTag>::fromTaggedPtr(base).template untaggedPtr<>(); \
-    void* untaggedPtr = CodePtr<CFunctionPtrTag>::fromTaggedPtr(ptr).template untaggedPtr<>(); \
-    RELEASE_ASSERT_WITH_MESSAGE((char*)(untaggedPtr) - (char*)(untaggedBase) == opcode * 256, #name); \
-} while (false);
-
-#define VALIDATE_IPINT_SIMD_OPCODE(opcode, name) \
-do { \
-    void* base = reinterpret_cast<void*>(ipint_simd_v128_load_mem_validate); \
-    void* ptr = reinterpret_cast<void*>(ipint_ ## name ## _validate); \
-    void* untaggedBase = CodePtr<CFunctionPtrTag>::fromTaggedPtr(base).template untaggedPtr<>(); \
-    void* untaggedPtr = CodePtr<CFunctionPtrTag>::fromTaggedPtr(ptr).template untaggedPtr<>(); \
-    RELEASE_ASSERT_WITH_MESSAGE((char*)(untaggedPtr) - (char*)(untaggedBase) == opcode * 256, #name); \
-} while (false);
-
-#define VALIDATE_IPINT_ATOMIC_OPCODE(opcode, name) \
-do { \
-    void* base = reinterpret_cast<void*>(ipint_memory_atomic_notify_validate); \
-    void* ptr = reinterpret_cast<void*>(ipint_ ## name ## _validate); \
-    void* untaggedBase = CodePtr<CFunctionPtrTag>::fromTaggedPtr(base).template untaggedPtr<>(); \
-    void* untaggedPtr = CodePtr<CFunctionPtrTag>::fromTaggedPtr(ptr).template untaggedPtr<>(); \
-    RELEASE_ASSERT_WITH_MESSAGE((char*)(untaggedPtr) - (char*)(untaggedBase) == opcode * 256, #name); \
-} while (false);
-
-#define VALIDATE_IPINT_ARGUMINT_OPCODE(opcode, name) \
-do { \
-    void* base = reinterpret_cast<void*>(ipint_argumINT_a0_validate); \
-    void* ptr = reinterpret_cast<void*>(ipint_ ## name ## _validate); \
-    void* untaggedBase = CodePtr<CFunctionPtrTag>::fromTaggedPtr(base).template untaggedPtr<>(); \
-    void* untaggedPtr = CodePtr<CFunctionPtrTag>::fromTaggedPtr(ptr).template untaggedPtr<>(); \
-    RELEASE_ASSERT_WITH_MESSAGE((char*)(untaggedPtr) - (char*)(untaggedBase) == opcode * 64, #name); \
-} while (false);
-
-#define VALIDATE_IPINT_SLOW_PATH(opcode, name) \
-do { \
-    void* base = reinterpret_cast<void*>(ipint_local_get_slow_path_validate); \
-    void* ptr = reinterpret_cast<void*>(ipint_ ## name ## _validate); \
-    void* untaggedBase = CodePtr<CFunctionPtrTag>::fromTaggedPtr(base).template untaggedPtr<>(); \
-    void* untaggedPtr = CodePtr<CFunctionPtrTag>::fromTaggedPtr(ptr).template untaggedPtr<>(); \
-    RELEASE_ASSERT_WITH_MESSAGE((char*)(untaggedPtr) - (char*)(untaggedBase) == opcode * 256, #name); \
-} while (false);
-
-#define VALIDATE_IPINT_MINT_CALL_OPCODE(opcode, name) \
-do { \
-    void* base = reinterpret_cast<void*>(ipint_mint_a0_validate); \
-    void* ptr = reinterpret_cast<void*>(ipint_ ## name ## _validate); \
-    void* untaggedBase = CodePtr<CFunctionPtrTag>::fromTaggedPtr(base).template untaggedPtr<>(); \
-    void* untaggedPtr = CodePtr<CFunctionPtrTag>::fromTaggedPtr(ptr).template untaggedPtr<>(); \
-    RELEASE_ASSERT_WITH_MESSAGE((char*)(untaggedPtr) - (char*)(untaggedBase) == opcode * 64, #name); \
-} while (false);
-
-#define VALIDATE_IPINT_MINT_RETURN_OPCODE(opcode, name) \
-do { \
-    void* base = reinterpret_cast<void*>(ipint_mint_r0_validate); \
-    void* ptr = reinterpret_cast<void*>(ipint_ ## name ## _validate); \
-    void* untaggedBase = CodePtr<CFunctionPtrTag>::fromTaggedPtr(base).template untaggedPtr<>(); \
-    void* untaggedPtr = CodePtr<CFunctionPtrTag>::fromTaggedPtr(ptr).template untaggedPtr<>(); \
-    RELEASE_ASSERT_WITH_MESSAGE((char*)(untaggedPtr) - (char*)(untaggedBase) == opcode * 64, #name); \
-} while (false);
-
-#define VALIDATE_IPINT_UINT_OPCODE(opcode, name) \
-do { \
-    void* base = reinterpret_cast<void*>(ipint_uint_r0_validate); \
-    void* ptr = reinterpret_cast<void*>(ipint_ ## name ## _validate); \
-    void* untaggedBase = CodePtr<CFunctionPtrTag>::fromTaggedPtr(base).template untaggedPtr<>(); \
-    void* untaggedPtr = CodePtr<CFunctionPtrTag>::fromTaggedPtr(ptr).template untaggedPtr<>(); \
-    RELEASE_ASSERT_WITH_MESSAGE((char*)(untaggedPtr) - (char*)(untaggedBase) == opcode * 64, #name); \
-} while (false);
+#define VALIDATE_IPINT_OPCODE(opcode, name) VALIDATE_IPINT_OPCODE_FROM_BASE(ipint_unreachable_validate, 256, opcode, name)
+#define VALIDATE_IPINT_GC_OPCODE(opcode, name) VALIDATE_IPINT_OPCODE_FROM_BASE(ipint_struct_new_validate, 256, opcode, name)
+#define VALIDATE_IPINT_CONVERSION_OPCODE(opcode, name) VALIDATE_IPINT_OPCODE_FROM_BASE(ipint_i32_trunc_sat_f32_s_validate, 256, opcode, name)
+#define VALIDATE_IPINT_SIMD_OPCODE(opcode, name) VALIDATE_IPINT_OPCODE_FROM_BASE(ipint_simd_v128_load_mem_validate, 256, opcode, name)
+#define VALIDATE_IPINT_ATOMIC_OPCODE(opcode, name) VALIDATE_IPINT_OPCODE_FROM_BASE(ipint_memory_atomic_notify_validate, 256, opcode, name)
+#define VALIDATE_IPINT_ARGUMINT_OPCODE(opcode, name) VALIDATE_IPINT_OPCODE_FROM_BASE(ipint_argumINT_a0_validate, 64, opcode, name)
+#define VALIDATE_IPINT_SLOW_PATH(opcode, name) VALIDATE_IPINT_OPCODE_FROM_BASE(ipint_local_get_slow_path_validate, 256, opcode, name)
+#define VALIDATE_IPINT_MINT_CALL_OPCODE(opcode, name) VALIDATE_IPINT_OPCODE_FROM_BASE(ipint_mint_a0_validate, 64, opcode, name)
+#define VALIDATE_IPINT_MINT_RETURN_OPCODE(opcode, name) VALIDATE_IPINT_OPCODE_FROM_BASE(ipint_mint_r0_validate, 64, opcode, name)
+#define VALIDATE_IPINT_UINT_OPCODE(opcode, name) VALIDATE_IPINT_OPCODE_FROM_BASE(ipint_uint_r0_validate, 64, opcode, name)
 
 void initialize()
 {
 #if !ENABLE(C_LOOP) && ((CPU(ADDRESS64) && (CPU(ARM64) || CPU(X86_64))) || (CPU(ADDRESS32) && CPU(ARM_THUMB2)))
     FOR_EACH_IPINT_OPCODE(VALIDATE_IPINT_OPCODE);
-    FOR_EACH_IPINT_0xFB_OPCODE(VALIDATE_IPINT_0xFB_OPCODE);
-    FOR_EACH_IPINT_0xFC_TRUNC_OPCODE(VALIDATE_IPINT_0xFC_OPCODE);
+    FOR_EACH_IPINT_GC_OPCODE(VALIDATE_IPINT_GC_OPCODE);
+    FOR_EACH_IPINT_CONVERSION_OPCODE(VALIDATE_IPINT_CONVERSION_OPCODE);
     FOR_EACH_IPINT_SIMD_OPCODE(VALIDATE_IPINT_SIMD_OPCODE);
     FOR_EACH_IPINT_ATOMIC_OPCODE(VALIDATE_IPINT_ATOMIC_OPCODE);
 

--- a/Source/JavaScriptCore/llint/InPlaceInterpreter.h
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2023-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -38,6 +38,12 @@ extern "C" void SYSV_ABI ipint_table_catch_entry();
 extern "C" void SYSV_ABI ipint_table_catch_ref_entry();
 extern "C" void SYSV_ABI ipint_table_catch_all_entry();
 extern "C" void SYSV_ABI ipint_table_catch_allref_entry();
+
+extern "C" void SYSV_ABI ipint_dispatch_base() REFERENCED_FROM_ASM WTF_INTERNAL NO_REORDER;
+extern "C" void SYSV_ABI ipint_gc_dispatch_base() REFERENCED_FROM_ASM WTF_INTERNAL NO_REORDER;
+extern "C" void SYSV_ABI ipint_conversion_dispatch_base() REFERENCED_FROM_ASM WTF_INTERNAL NO_REORDER;
+extern "C" void SYSV_ABI ipint_simd_dispatch_base() REFERENCED_FROM_ASM WTF_INTERNAL NO_REORDER;
+extern "C" void SYSV_ABI ipint_atomic_dispatch_base() REFERENCED_FROM_ASM WTF_INTERNAL NO_REORDER;
 
 #define IPINT_VALIDATE_DEFINE_FUNCTION(opcode, name) \
     extern "C" void SYSV_ABI ipint_ ## name ## _validate() REFERENCED_FROM_ASM WTF_INTERNAL NO_REORDER;
@@ -294,13 +300,13 @@ extern "C" void SYSV_ABI ipint_table_catch_allref_entry();
     m(0xf8, reserved_0xf8) \
     m(0xf9, reserved_0xf9) \
     m(0xfa, reserved_0xfa) \
-    m(0xfb, fb_block) \
-    m(0xfc, fc_block) \
-    m(0xfd, simd) \
-    m(0xfe, atomic) \
+    m(0xfb, gc_prefix) \
+    m(0xfc, conversion_prefix) \
+    m(0xfd, simd_prefix) \
+    m(0xfe, atomic_prefix) \
     m(0xff, reserved_0xff)
 
-#define FOR_EACH_IPINT_0xFB_OPCODE(m) \
+#define FOR_EACH_IPINT_GC_OPCODE(m) \
     m(0x00, struct_new) \
     m(0x01, struct_new_default) \
     m(0x02, struct_get) \
@@ -333,7 +339,7 @@ extern "C" void SYSV_ABI ipint_table_catch_allref_entry();
     m(0x1d, i31_get_s) \
     m(0x1e, i31_get_u)
 
-#define FOR_EACH_IPINT_0xFC_TRUNC_OPCODE(m) \
+#define FOR_EACH_IPINT_CONVERSION_OPCODE(m) \
     m(0x00, i32_trunc_sat_f32_s) \
     m(0x01, i32_trunc_sat_f32_u) \
     m(0x02, i32_trunc_sat_f64_s) \
@@ -786,8 +792,8 @@ extern "C" void SYSV_ABI ipint_table_catch_allref_entry();
 
 #if !ENABLE(C_LOOP) && (CPU(ADDRESS64) && (CPU(ARM64) || CPU(X86_64)) || (CPU(ADDRESS32) && CPU(ARM_THUMB2)))
 FOR_EACH_IPINT_OPCODE(IPINT_VALIDATE_DEFINE_FUNCTION);
-FOR_EACH_IPINT_0xFB_OPCODE(IPINT_VALIDATE_DEFINE_FUNCTION);
-FOR_EACH_IPINT_0xFC_TRUNC_OPCODE(IPINT_VALIDATE_DEFINE_FUNCTION);
+FOR_EACH_IPINT_GC_OPCODE(IPINT_VALIDATE_DEFINE_FUNCTION);
+FOR_EACH_IPINT_CONVERSION_OPCODE(IPINT_VALIDATE_DEFINE_FUNCTION);
 FOR_EACH_IPINT_SIMD_OPCODE(IPINT_VALIDATE_DEFINE_FUNCTION);
 FOR_EACH_IPINT_ATOMIC_OPCODE(IPINT_VALIDATE_DEFINE_FUNCTION);
 FOR_EACH_IPINT_ARGUMINT_OPCODE(IPINT_VALIDATE_DEFINE_FUNCTION);

--- a/Source/JavaScriptCore/llint/InPlaceInterpreter32_64.asm
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter32_64.asm
@@ -19,6 +19,14 @@ macro restoreIPIntRegisters()
     addp IPIntCalleeSaveSpaceStackAligned, sp
 end
 
+# Dispatch target bases
+
+const ipint_dispatch_base = _ipint_unreachable
+const ipint_gc_dispatch_base = _ipint_struct_new
+const ipint_conversion_dispatch_base = _ipint_i32_trunc_sat_f32_s
+const ipint_simd_dispatch_base = _ipint_simd_v128_load_mem
+const ipint_atomic_dispatch_base = _ipint_memory_atomic_notify
+
 # Tail-call dispatch
 
 macro nextIPIntInstruction()
@@ -3163,23 +3171,23 @@ reservedOpcode(0xf7)
 reservedOpcode(0xf8)
 reservedOpcode(0xf9)
 reservedOpcode(0xfa)
-unimplementedInstruction(_fb_block)
+unimplementedInstruction(_gc_prefix)
 
-ipintOp(_fc_block, macro()
+ipintOp(_conversion_prefix, macro()
     decodeLEBVarUInt32(1, t0, t1, t2, t3, t4)
     # Security guarantee: always less than 18 (0x00 -> 0x11)
-    biaeq t0, 0x12, .ipint_fc_nonexistent
+    biaeq t0, 0x12, .ipint_conversion_nonexistent
     lshiftp 8, t0
-    leap (_ipint_i32_trunc_sat_f32_s + 1), t1
+    leap (ipint_conversion_dispatch_base + 1), t1
     addp t1, t0
     emit "bx r0"
 
-.ipint_fc_nonexistent:
+.ipint_conversion_nonexistent:
     break
 end)
 
-unimplementedInstruction(_simd)
-unimplementedInstruction(_atomic)
+unimplementedInstruction(_simd_prefix)
+unimplementedInstruction(_atomic_prefix)
 reservedOpcode(0xff)
 
     #######################
@@ -3607,6 +3615,7 @@ end)
     #######################
 
 # 0xFD 0x00 - 0xFD 0x0B: memory
+
 unimplementedInstruction(_simd_v128_load_mem)
 unimplementedInstruction(_simd_v128_load_8x8s_mem)
 unimplementedInstruction(_simd_v128_load_8x8u_mem)
@@ -4500,10 +4509,6 @@ mintAlign(_end)
     getIPIntCallee()
     pop MC
 
-    # Restore IB
-    IfIPIntUsesIB(macro()
-        pcrtoaddr _ipint_unreachable, IB
-    end)
     nextIPIntInstruction()
 
 .ipint_perform_tail_call:

--- a/Source/JavaScriptCore/llint/InPlaceInterpreter64.asm
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter64.asm
@@ -1,4 +1,4 @@
-# Copyright (C) 2023-2024 Apple Inc. All rights reserved.
+# Copyright (C) 2023-2025 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -20,7 +20,6 @@
 # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 # THE POSSIBILITY OF SUCH DAMAGE.
-
 
 # Callee save
 
@@ -54,51 +53,31 @@ macro restoreIPIntRegisters()
     addp IPIntCalleeSaveSpaceStackAligned, sp
 end
 
-# Tail-call dispatch
+# Dispatch target bases
 
-macro IPIntDispatch()
+const ipint_dispatch_base = _ipint_unreachable
+const ipint_gc_dispatch_base = _ipint_struct_new
+const ipint_conversion_dispatch_base = _ipint_i32_trunc_sat_f32_s
+const ipint_simd_dispatch_base = _ipint_simd_v128_load_mem
+const ipint_atomic_dispatch_base = _ipint_memory_atomic_notify
+
+# Tail-call bytecode dispatch
+
+macro nextIPIntInstruction()
+    loadb [PC], t0
 if ARM64 or ARM64E
-    # x7 = IB
     # x0 = opcode
+    pcrtoaddr ipint_dispatch_base, t7
     emit "add x0, x7, x0, lsl #8"
     emit "br x0"
 elsif X86_64
     lshiftq 8, t0
-    leap [t0, IB], t0
-    jmp t0
+    leap ipint_dispatch_base, t1
+    addp t0, t1
+    jmp t1
 else
-    break
+    error
 end
-end
-
-macro IPIntDispatchFromHR()
-if ARM64 or ARM64E
-    # x7 = IB
-    # x3 = opcode
-    emit "add x0, x7, x3, lsl #8"
-    emit "br x0"
-elsif X86_64
-    lshiftq 8, t3
-    leap (_ipint_unreachable), t1
-    addq t1, t3
-    jmp t3
-else
-    break
-end
-end
-
-macro nextIPIntInstruction()
-    loadb [PC], t0
-    IPIntDispatch()
-end
-
-macro hoistedDispatch()
-    IfIPIntUsesHR(macro()
-        IPIntDispatchFromHR()
-    end, macro()
-        loadb [PC], t0
-        IPIntDispatch()
-    end)
 end
 
 # Stack operations
@@ -432,8 +411,6 @@ end
     loadi Wasm::IPIntCallee::m_highestReturnStackOffset[ws0], sc0
     addp cfr, sc0
 
-    # since IB is an argument register, we swap back to PC (which is unused afterwards)
-    # for x86 PC base
     initPCRelative(mint_entry, PC)
     uintDispatch()
 
@@ -632,7 +609,7 @@ ipintOp(_call_ref, macro()
     loadq [sp], IPIntCallCallee
     loadq 8[sp], IPIntCallFunctionSlot
     addq 16, sp
-    
+
     loadb IPInt::CallRefMetadata::length[MC], t3
     advanceMC(IPInt::CallRefMetadata::signature)
     advancePCByReg(t3)
@@ -1775,8 +1752,6 @@ ipintOp(_i32_popcnt, macro()
 end)
 
 ipintOp(_i32_add, macro()
-    HoistNextOpcode(1)
-
     # i32.add
     popInt32(t1, t2)
     popInt32(t0, t2)
@@ -1784,7 +1759,7 @@ ipintOp(_i32_add, macro()
     pushInt32(t0)
 
     advancePC(1)
-    hoistedDispatch()
+    nextIPIntInstruction()
 end)
 
 ipintOp(_i32_sub, macro()
@@ -3165,71 +3140,74 @@ reservedOpcode(0xf8)
 reservedOpcode(0xf9)
 reservedOpcode(0xfa)
 
-ipintOp(_fb_block, macro()
+ipintOp(_gc_prefix, macro()
     decodeLEBVarUInt32(1, t0, t1, t2, t3, t4)
     # Security guarantee: always less than 30 (0x00 -> 0x1e)
-    biaeq t0, 0x1f, .ipint_fb_nonexistent
+    biaeq t0, 0x1f, .ipint_gc_nonexistent
     if ARM64 or ARM64E
-        pcrtoaddr _ipint_struct_new, t1
+        pcrtoaddr ipint_gc_dispatch_base, t1
         emit "add x0, x1, x0, lsl 8"
         emit "br x0"
     elsif X86_64
         lshifti 8, t0
-        leap (_ipint_struct_new - _ipint_unreachable)[IB], t1
+        leap ipint_gc_dispatch_base, t1
         addq t1, t0
         jmp t0
     end
 
-.ipint_fb_nonexistent:
+.ipint_gc_nonexistent:
     break
 end)
 
-ipintOp(_fc_block, macro()
+ipintOp(_conversion_prefix, macro()
     decodeLEBVarUInt32(1, t0, t1, t2, t3, t4)
     # Security guarantee: always less than 18 (0x00 -> 0x11)
-    biaeq t0, 0x12, .ipint_fc_nonexistent
+    biaeq t0, 0x12, .ipint_conversion_nonexistent
     if ARM64 or ARM64E
-        pcrtoaddr _ipint_i32_trunc_sat_f32_s, t1
+        pcrtoaddr ipint_conversion_dispatch_base, t1
         emit "add x0, x1, x0, lsl 8"
         emit "br x0"
     elsif X86_64
         lshifti 8, t0
-        leap (_ipint_i32_trunc_sat_f32_s - _ipint_unreachable)[IB], t1
+        leap ipint_conversion_dispatch_base, t1
         addq t1, t0
         jmp t0
     end
 
-.ipint_fc_nonexistent:
+.ipint_conversion_nonexistent:
     break
 end)
 
-ipintOp(_simd, macro()
-    # TODO: for relaxed SIMD, handle parsing the value.
-    # Metadata? Could just hardcode loading two bytes though
+ipintOp(_simd_prefix, macro()
     decodeLEBVarUInt32(1, t0, t1, t2, t3, t4)
+    # Securty guarantee: always less than 269 (0x00 -> 0x10c)
+    biaeq t0, 0x10d, .ipint_simd_nonexistent
     if ARM64 or ARM64E
-        pcrtoaddr _ipint_simd_v128_load_mem, t1
+        pcrtoaddr ipint_simd_dispatch_base, t1
         emit "add x0, x1, x0, lsl 8"
         emit "br x0"
     elsif X86_64
         lshifti 8, t0
-        leap (_ipint_simd_v128_load_mem - _ipint_unreachable)[IB], t1
+        leap ipint_simd_dispatch_base, t1
         addq t1, t0
         jmp t0
     end
+
+.ipint_simd_nonexistent:
+    break
 end)
 
-ipintOp(_atomic, macro()
+ipintOp(_atomic_prefix, macro()
     decodeLEBVarUInt32(1, t0, t1, t2, t3, t4)
     # Security guarantee: always less than 78 (0x00 -> 0x4e)
     biaeq t0, 0x4f, .ipint_atomic_nonexistent
     if ARM64 or ARM64E
-        pcrtoaddr _ipint_memory_atomic_notify, t1
+        pcrtoaddr ipint_atomic_dispatch_base, t1
         emit "add x0, x1, x0, lsl 8"
         emit "br x0"
     elsif X86_64
         lshifti 8, t0
-        leap (_ipint_memory_atomic_notify - _ipint_unreachable)[IB], t1
+        leap ipint_atomic_dispatch_base, t1
         addq t1, t0
         jmp t0
     end
@@ -3241,11 +3219,12 @@ end)
 reservedOpcode(0xff)
     break
 
-    #######################
-    ## 0xFB instructions ##
-    #######################
+    #####################
+    ## GC instructions ##
+    #####################
 
 ipintOp(_struct_new, macro()
+_ipint_gc_dispatch_base:
     loadp IPInt::StructNewMetadata::typeIndex[MC], a1  # type index
     move sp, a2
     operationCallMayThrow(macro() cCall3(_ipint_extern_struct_new) end)
@@ -3574,7 +3553,7 @@ ipintOp(_br_on_cast, macro()
     operationCall(macro() cCall3(_ipint_extern_ref_test) end)
 
     advanceMC(constexpr (sizeof(IPInt::RefTestCastMetadata)))
-    
+
     bineq r0, 0, _ipint_br
     loadb IPInt::BranchMetadata::instructionLength[MC], t0
     advanceMC(constexpr (sizeof(IPInt::BranchMetadata)))
@@ -3591,7 +3570,7 @@ ipintOp(_br_on_cast_fail, macro()
     operationCall(macro() cCall3(_ipint_extern_ref_test) end)
 
     advanceMC(constexpr (sizeof(IPInt::RefTestCastMetadata)))
-    
+
     bieq r0, 0, _ipint_br
     loadb IPInt::BranchMetadata::instructionLength[MC], t0
     advanceMC(constexpr (sizeof(IPInt::BranchMetadata)))
@@ -3648,9 +3627,9 @@ ipintOp(_i31_get_u, macro()
     throwException(NullI31Get)
 end)
 
-    #######################
-    ## 0xFC instructions ##
-    #######################
+    #############################
+    ## Conversion instructions ##
+    #############################
 
 ipintOp(_i32_trunc_sat_f32_s, macro()
     popFloat32(ft0)
@@ -4118,6 +4097,7 @@ end)
     #######################
 
 # 0xFD 0x00 - 0xFD 0x0B: memory
+
 unimplementedInstruction(_simd_v128_load_mem)
 unimplementedInstruction(_simd_v128_load_8x8s_mem)
 unimplementedInstruction(_simd_v128_load_8x8u_mem)
@@ -4161,10 +4141,12 @@ unimplementedInstruction(_simd_i16x8_replace_lane)
 ipintOp(_simd_i32x4_extract_lane, macro()
     # i32x4.extract_lane (lane)
     loadb 2[PC], t0  # lane index
+    andi 0x3, t0
     popv v0
     if ARM64 or ARM64E
         pcrtoaddr _simd_i32x4_extract_lane_0, t1
         leap [t1, t0, 8], t0
+        emit "br x0"
         _simd_i32x4_extract_lane_0:
         umovi t0, v0_i, 0
         jmp _simd_i32x4_extract_lane_end
@@ -6551,15 +6533,6 @@ if X86_64
     loadp 2*SlotSize[sc3], PC
 end
 
-    # Restore IB
-    IfIPIntUsesIB(macro()
-if ARM64 or ARM64E
-        pcrtoaddr _ipint_unreachable, IB
-elsif X86_64
-        initPCRelative(mint_end, IB)
-        leap (_ipint_unreachable - _mint_end_relativePCBase)[IB], IB
-end
-    end)
     # Restore memory
     ipintReloadMemory()
     nextIPIntInstruction()

--- a/Source/JavaScriptCore/llint/LowLevelInterpreter.asm
+++ b/Source/JavaScriptCore/llint/LowLevelInterpreter.asm
@@ -1,4 +1,4 @@
-# Copyright (C) 2011-2024 Apple Inc. All rights reserved.
+# Copyright (C) 2011-2025 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/Source/JavaScriptCore/llint/LowLevelInterpreter.cpp
+++ b/Source/JavaScriptCore/llint/LowLevelInterpreter.cpp
@@ -111,7 +111,7 @@ using WebConfig::g_config;
 
 #define OFFLINE_ASM_OPCODE_LABEL(opcode) DEFINE_OPCODE(opcode) USE_LABEL(opcode); TRACE_OPCODE(opcode);
 
-#define OFFLINE_ASM_GLOBAL_LABEL(label)  label: USE_LABEL(label);
+#define OFFLINE_ASM_GLOBAL_LABEL(label)  .global label label: USE_LABEL(label);
 
 #if ENABLE(LABEL_TRACING)
 #define TRACE_LABEL(prefix, label) dataLog(#prefix, ": ", #label, "\n")


### PR DESCRIPTION
#### ac36e134cce1c97cde1de68a9479d3b73bf39a3c
<pre>
Harden IPInt dispatch
<a href="https://bugs.webkit.org/show_bug.cgi?id=292725">https://bugs.webkit.org/show_bug.cgi?id=292725</a>
<a href="https://rdar.apple.com/150797746">rdar://150797746</a>

Reviewed by Justin Michaud and Daniel Liu.

This patch hardens how IPInt dispatches opcodes for better CFI protection. Since IPInt does an offset based
dispatch the previous dispatch was something like:

```
macro dispatchToNextIPIntInstruction()
    // x7 is set to _ipInt_instruction_base on entry to IPInt entry/call return.
    loadb [PC], x0
    emit &quot;add x0, x7, x0, lsl #8&quot;
    emit &quot;br x0&quot;
end

align 256
_ipint_dispatch_base:
.first_wasm_bytecode:
// stuff
dispatchToNextIPIntInstruction()

align 256
.second_wasm_bytecode:
// stuff
dispatchToNextIPIntInstruction()
...
align 256
.255_wasm_bytecode:
// stuff
dispatchToNextIPIntInstruction()
```
In the old system no matter what value [PC] points to there are 256 offsets reachable, all of which are
either a valid opcode or a slab of `brk`s.

However, this still means if an attacker is able to return to the IPInt interpreter on some path that
doesn&apos;t reset x7 then they&apos;ll be able to implement a JOP attack. One example would be to build a fake
object with a vtable pointing to one of the &quot;C function&quot; labels (e.g. _first_wasm_bytecode_validate,
which is used for offset validation).

After this change dispatch is now:

```
macro dispatchToNextIPIntInstruction()
    loadb something, x0
    pcrtoaddr _ipint_dispatch_base, x7
    emit &quot;add x0, x7, x0, lsl #8&quot;
    emit &quot;br x0&quot;
end
```

which makes it clearly impossible to get a PAC bypass in IPInt dispatch. Since there&apos;s no longer
a semi-pinned register with the base pointer this patch removes all that associated code.

Additionally, this change adds a names for all the dispatch starts to make the
code a bit easier to read.

Lastly, the SIMD prefix opcode was missing a security guard so this patch adds that too.

Canonical link: <a href="https://commits.webkit.org/294973@main">https://commits.webkit.org/294973@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/47f7bd410a7e3f3113ce2d5af109d3a2128f391c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/103674 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/131/builds/23376 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/13696 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/108864 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/54326 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/23718 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/123/builds/31922 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/108864 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/54326 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/106680 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/130/builds/23718 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/93523 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/108864 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/130/builds/23718 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/11571 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/53702 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/96349 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/130/builds/23718 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/11630 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/111253 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/102285 "Built successfully and passed tests") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/30830 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/123/builds/31922 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/111253 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/31191 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/89724 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/111253 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/10025 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/25187 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16827 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/30758 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/36061 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/125918 "Built successfully") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/30552 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/34872 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/33887 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/32113 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->