### PR TITLE
[WPE][GTK] WebKitNetworkProxySettings documentation references removed function webkit_web_context_set_network_proxy_settings()

### DIFF
--- a/Source/WebKit/UIProcess/API/glib/WebKitNetworkProxySettings.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitNetworkProxySettings.cpp
@@ -28,18 +28,6 @@
 
 using namespace WebCore;
 
-/**
- * WebKitNetworkProxySettings:
- * @See_also: #WebKitWebContext
- *
- * Configures network proxies.
- *
- * WebKitNetworkProxySettings can be used to provide a custom proxy configuration
- * to a #WebKitWebContext. You need to call webkit_web_context_set_network_proxy_settings()
- * with %WEBKIT_NETWORK_PROXY_MODE_CUSTOM and a WebKitNetworkProxySettings.
- *
- * Since: 2.16
- */
 struct _WebKitNetworkProxySettings {
     _WebKitNetworkProxySettings()
         : settings(SoupNetworkProxySettings::Mode::Custom)

--- a/Source/WebKit/UIProcess/API/glib/WebKitNetworkProxySettings.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitNetworkProxySettings.h.in
@@ -67,4 +67,32 @@ webkit_network_proxy_settings_add_proxy_for_scheme (WebKitNetworkProxySettings *
 
 G_END_DECLS
 
+#if ENABLE(2022_GLIB_API)
+/**
+ * WebKitNetworkProxySettings:
+ * @See_also: #WebKitWebsiteDataManager
+ *
+ * Configures network proxies.
+ *
+ * WebKitNetworkProxySettings can be used to provide a custom proxy configuration
+ * to a #WebKitWebsiteDataManager. You need to call webkit_website_data_manager_set_network_proxy_settings()
+ * with %WEBKIT_NETWORK_PROXY_MODE_CUSTOM and a WebKitNetworkProxySettings.
+ *
+ * Since: 2.16
+ */
+#else
+/**
+ * WebKitNetworkProxySettings:
+ * @See_also: #WebKitWebContext
+ *
+ * Configures network proxies.
+ *
+ * WebKitNetworkProxySettings can be used to provide a custom proxy configuration
+ * to a #WebKitWebContext. You need to call webkit_web_context_set_network_proxy_settings()
+ * with %WEBKIT_NETWORK_PROXY_MODE_CUSTOM and a WebKitNetworkProxySettings.
+ *
+ * Since: 2.16
+ */
+#endif
+
 #endif /* WebKitNetworkProxySettings_h */


### PR DESCRIPTION
#### 99bdc2f8f1fcb13a0c92a79675ca7b4ed72ab457
<pre>
[WPE][GTK] WebKitNetworkProxySettings documentation references removed function webkit_web_context_set_network_proxy_settings()
<a href="https://bugs.webkit.org/show_bug.cgi?id=292733">https://bugs.webkit.org/show_bug.cgi?id=292733</a>

Reviewed by Adrian Perez de Castro.

This function was removed in the 2022 APIs, so we need to conditionally
compile it.

* Source/WebKit/UIProcess/API/glib/WebKitNetworkProxySettings.cpp:
* Source/WebKit/UIProcess/API/glib/WebKitNetworkProxySettings.h.in:

Canonical link: <a href="https://commits.webkit.org/294680@main">https://commits.webkit.org/294680@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7a089711a9c34866c1b2ed2200ab6d3b6c7d48fe

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/102678 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/22351 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/12669 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/107843 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/53319 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/22659 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/30853 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/78093 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/53319 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/105684 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17556 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/92670 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58425 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/17397 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/52676 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/87214 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10772 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/110219 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/29815 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/21983 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/87073 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/30179 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88862 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86678 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22064 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31511 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/9243 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/24068 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/29742 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/35062 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/29550 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/32877 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/31112 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->