### PR TITLE
CRASH in WebCore::RenderVTTCue::layout()

### DIFF
--- a/Source/WebCore/rendering/RenderVTTCue.cpp
+++ b/Source/WebCore/rendering/RenderVTTCue.cpp
@@ -92,6 +92,10 @@ bool RenderVTTCue::initializeLayoutParameters(LayoutUnit& step, LayoutUnit& posi
     if (!firstInlineBox)
         return false;
 
+    auto* backdropBox = this->backdropBox();
+    if (!backdropBox)
+        return false;
+
     // 1. Horizontal: Let step be the height of the first line box in boxes.
     //    Vertical: Let step be the width of the first line box in boxes.
     auto firstInlineBoxSize = firstInlineBox->visualRectIgnoringBlockDirection().size();
@@ -108,7 +112,7 @@ bool RenderVTTCue::initializeLayoutParameters(LayoutUnit& step, LayoutUnit& posi
     auto inlineBoxHeights = LayoutUnit { };
     for (auto inlineBox = firstInlineBox; inlineBox; inlineBox = inlineBox->nextInlineBoxLineRightward())
         inlineBoxHeights += inlineBox->logicalHeight();
-    auto logicalHeightDelta = backdropBox().logicalHeight() - inlineBoxHeights;
+    auto logicalHeightDelta = backdropBox->logicalHeight() - inlineBoxHeights;
     if (logicalHeightDelta > 0)
         step += logicalHeightDelta;
 
@@ -174,7 +178,9 @@ bool RenderVTTCue::isOutside() const
     if (!firstChild())
         return false;
 
-    return !rectIsWithinContainer(backdropBox().absoluteBoundingBoxRect());
+    if (auto* backdropBox = this->backdropBox())
+        return !rectIsWithinContainer(backdropBox->absoluteBoundingBoxRect());
+    return false;
 }
 
 bool RenderVTTCue::rectIsWithinContainer(const IntRect& rect) const
@@ -195,7 +201,9 @@ RenderVTTCue* RenderVTTCue::overlappingObject() const
 {
     ASSERT(firstChild());
 
-    return overlappingObjectForRect(backdropBox().absoluteBoundingBoxRect());
+    if (auto* backdropBox = this->backdropBox())
+        return overlappingObjectForRect(backdropBox->absoluteBoundingBoxRect());
+    return nullptr;
 }
 
 RenderVTTCue* RenderVTTCue::overlappingObjectForRect(const IntRect& rect) const
@@ -205,7 +213,8 @@ RenderVTTCue* RenderVTTCue::overlappingObjectForRect(const IntRect& rect) const
         if (!previousCue || !previousCue->firstChild())
             continue;
 
-        if (rect.intersects(previousCue->backdropBox().absoluteBoundingBoxRect()))
+        auto* previousCueBackdropBox = previousCue->backdropBox();
+        if (previousCueBackdropBox && rect.intersects(previousCueBackdropBox->absoluteBoundingBoxRect()))
             return previousCue;
     }
 
@@ -281,8 +290,12 @@ void RenderVTTCue::moveIfNecessaryToKeepWithinContainer()
     if (!firstChild())
         return;
 
+    auto* backdropBox = this->backdropBox();
+    if (!backdropBox)
+        return;
+
     IntRect containerRect = containingBlock()->absoluteBoundingBoxRect();
-    IntRect cueRect = backdropBox().absoluteBoundingBoxRect();
+    IntRect cueRect = backdropBox->absoluteBoundingBoxRect();
 
     int topOverflow = cueRect.y() - containerRect.y();
     int bottomOverflow = containerRect.maxY() - cueRect.maxY();
@@ -314,17 +327,24 @@ bool RenderVTTCue::findNonOverlappingPosition(int& newX, int& newY) const
     if (!firstChild())
         return false;
 
+    auto* backdropBox = this->backdropBox();
+    if (!backdropBox)
+        return false;
+
     newX = x();
     newY = y();
-    IntRect srcRect = backdropBox().absoluteBoundingBoxRect();
+    IntRect srcRect = backdropBox->absoluteBoundingBoxRect();
     IntRect destRect = srcRect;
 
     // Move the box up, looking for a non-overlapping position:
     while (RenderVTTCue* cue = overlappingObjectForRect(destRect)) {
+        auto* cueBackdropBox = cue->backdropBox();
+        if (!cueBackdropBox)
+            continue;
         if (m_cue->vertical() == VTTCue::DirectionSetting::Horizontal)
-            destRect.setY(cue->backdropBox().absoluteBoundingBoxRect().y() - destRect.height());
+            destRect.setY(cueBackdropBox->absoluteBoundingBoxRect().y() - destRect.height());
         else
-            destRect.setX(cue->backdropBox().absoluteBoundingBoxRect().x() - destRect.width());
+            destRect.setX(cueBackdropBox->absoluteBoundingBoxRect().x() - destRect.width());
     }
 
     if (rectIsWithinContainer(destRect)) {
@@ -337,10 +357,13 @@ bool RenderVTTCue::findNonOverlappingPosition(int& newX, int& newY) const
 
     // Move the box down, looking for a non-overlapping position:
     while (RenderVTTCue* cue = overlappingObjectForRect(destRect)) {
+        auto* cueBackdropBox = cue->backdropBox();
+        if (!cueBackdropBox)
+            continue;
         if (m_cue->vertical() == VTTCue::DirectionSetting::Horizontal)
-            destRect.setY(cue->backdropBox().absoluteBoundingBoxRect().maxY());
+            destRect.setY(cueBackdropBox->absoluteBoundingBoxRect().maxY());
         else
-            destRect.setX(cue->backdropBox().absoluteBoundingBoxRect().maxX());
+            destRect.setX(cueBackdropBox->absoluteBoundingBoxRect().maxX());
     }
 
     if (rectIsWithinContainer(destRect)) {
@@ -415,12 +438,16 @@ void RenderVTTCue::repositionCueSnapToLinesNotSet()
     if (!firstChild())
         return;
 
+    auto* backdropBox = this->backdropBox();
+    if (!backdropBox)
+        return;
+
     // https://w3c.github.io/webvtt/#processing-cue-settings
     // 7.2.28 Adjust the positions of boxes according to the appropriate steps from the following list:
 
     // ↳ If cue’s WebVTT cue snap-to-lines flag is false
     // 1. Let bounding box be the bounding box of the boxes in boxes.
-    auto boundingBox = backdropBox().absoluteBoundingBoxRect();
+    auto boundingBox = backdropBox->absoluteBoundingBoxRect();
 
     // 2. Run the appropriate steps from the following list:
     switch (m_cue->vertical()) {
@@ -478,19 +505,23 @@ void RenderVTTCue::repositionCueSnapToLinesNotSet()
     // boxes will unfortunately overlap.)
 }
 
-RenderBlockFlow& RenderVTTCue::backdropBox() const
+RenderBlockFlow* RenderVTTCue::backdropBox() const
 {
-    ASSERT(firstChild());
-
     // firstChild() returns the wrapping (backdrop) <div>. The cue object is
     // the <div>'s first child.
-    RenderObject& firstChild = *this->firstChild();
-    return downcast<RenderBlockFlow>(firstChild);
+    auto* firstChild = this->firstChild();
+    ASSERT(firstChild);
+    ASSERT(is<RenderBlockFlow>(firstChild));
+    return dynamicDowncast<RenderBlockFlow>(firstChild);
 }
 
 RenderInline* RenderVTTCue::cueBox() const
 {
-    auto* firstChild = backdropBox().firstChild();
+    auto* backdropBox = this->backdropBox();
+    if (!backdropBox)
+        return nullptr;
+
+    auto* firstChild = backdropBox->firstChild();
     ASSERT(firstChild);
     ASSERT(is<RenderInline>(firstChild));
     return dynamicDowncast<RenderInline>(firstChild);

--- a/Source/WebCore/rendering/RenderVTTCue.h
+++ b/Source/WebCore/rendering/RenderVTTCue.h
@@ -66,7 +66,7 @@ private:
     void repositionCueSnapToLinesNotSet();
     void repositionGenericCue();
 
-    RenderBlockFlow& backdropBox() const;
+    RenderBlockFlow* backdropBox() const;
     RenderInline* cueBox() const;
 
     WeakPtr<VTTCue, WeakPtrImplWithEventTargetData> m_cue;


### PR DESCRIPTION
#### c0baf2f4e80bb22cad3c4f8d643c531e1e131ed9
<pre>
CRASH in WebCore::RenderVTTCue::layout()
<a href="https://rdar.apple.com/150635350">rdar://150635350</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=292735">https://bugs.webkit.org/show_bug.cgi?id=292735</a>

Reviewed by Eric Carlson.

Crash reports show a release assert crash in RenderVTTCue::backdropBox(), where
the firstChild() of the render is downcast unconditionally to a RenderBlockFlow.
Either firstChild() is null, or it&apos;s a renderer of a different type. Without removing
the debug assertions, refactor RenderVTTCue::backdropBox() to return a pointer
rather than a reference, and update all its callers to handle the possibility of
a null backdropBox().

* Source/WebCore/rendering/RenderVTTCue.cpp:
(WebCore::RenderVTTCue::initializeLayoutParameters):
(WebCore::RenderVTTCue::isOutside const):
(WebCore::RenderVTTCue::overlappingObject const):
(WebCore::RenderVTTCue::overlappingObjectForRect const):
(WebCore::RenderVTTCue::moveIfNecessaryToKeepWithinContainer):
(WebCore::RenderVTTCue::findNonOverlappingPosition const):
(WebCore::RenderVTTCue::repositionCueSnapToLinesNotSet):
(WebCore::RenderVTTCue::backdropBox const):
(WebCore::RenderVTTCue::cueBox const):
* Source/WebCore/rendering/RenderVTTCue.h:

Canonical link: <a href="https://commits.webkit.org/294692@main">https://commits.webkit.org/294692@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/003087f59a82c3050aa920bbce0a885c390ad706

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/102689 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/22362 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/12680 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/107854 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/53330 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/104728 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/22671 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/30864 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78099 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/35072 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/105695 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17566 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/92675 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58431 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/17415 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/10707 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/52687 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/87222 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10777 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/110230 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/29826 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21987 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/87080 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/30190 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88867 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86685 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22075 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31525 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/9248 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/24079 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/29753 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/35073 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/29561 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/32888 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/31123 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->