### PR TITLE
[visionOS] Spatial HLS playback not staying in spatial mode while seeking

### DIFF
--- a/Source/WebCore/platform/graphics/avfoundation/objc/AudioTrackPrivateAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/AudioTrackPrivateAVFObjC.mm
@@ -71,7 +71,18 @@ void AudioTrackPrivateAVFObjC::resetPropertiesFromTrack()
     setId(m_impl->id());
     setLabel(m_impl->label());
     setLanguage(m_impl->language());
-    setConfiguration(m_impl->audioTrackConfiguration());
+
+    // Occasionally, when tearing down an AVAssetTrack in a HLS stream, the track
+    // will go from having a formatDescription (and therefore having valid values
+    // for properties that are derived from the format description, like codec() or
+    // sampleRate()) to not having a format description. AVAssetTrack is ostensibly an
+    // invariant, and properties like formatDescription should never move from
+    // non-null to null. When this happens, ignore the configuration change.
+    auto newConfiguration = m_impl->audioTrackConfiguration();
+    if (!configuration().codec.isEmpty() && newConfiguration.codec.isEmpty())
+        return;
+
+    setConfiguration(WTFMove(newConfiguration));
 }
 
 void AudioTrackPrivateAVFObjC::audioTrackConfigurationChanged()

--- a/Source/WebCore/platform/graphics/avfoundation/objc/VideoTrackPrivateAVFObjC.cpp
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/VideoTrackPrivateAVFObjC.cpp
@@ -71,7 +71,18 @@ void VideoTrackPrivateAVFObjC::resetPropertiesFromTrack()
     setId(m_impl->id());
     setLabel(m_impl->label());
     setLanguage(m_impl->language());
-    setConfiguration(m_impl->videoTrackConfiguration());
+
+    // Occasionally, when tearing down an AVAssetTrack in a HLS stream, the track
+    // will go from having a formatDescription (and therefore having valid values
+    // for properties that are derived from the format description, like codec() or
+    // sampleRate()) to not having a format description. AVAssetTrack is ostensibly an
+    // invariant, and properties like formatDescription should never move from
+    // non-null to null. When this happens, ignore the configuration change.
+    auto newConfiguration = m_impl->videoTrackConfiguration();
+    if (!configuration().codec.isEmpty() && newConfiguration.codec.isEmpty())
+        return;
+
+    setConfiguration(WTFMove(newConfiguration));
 }
 
 void VideoTrackPrivateAVFObjC::videoTrackConfigurationChanged()


### PR DESCRIPTION
#### 9a0cbe308d311966582b5bc3333637b3b007e642
<pre>
[visionOS] Spatial HLS playback not staying in spatial mode while seeking
<a href="https://rdar.apple.com/146978728">rdar://146978728</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=292737">https://bugs.webkit.org/show_bug.cgi?id=292737</a>

Reviewed by Eric Carlson.

During a seek operation, an AVURLAsset backed by a HLS stream will tear down all
its AVPlayerItemTracks/AVAssetTracks and re-create those tracks once the seek
completes. During this tear-down, the old AVAssetTracks will sometimes &quot;lose&quot;
their CMFormatDescriptions as reported by AVAssetTrack.formatDescriptions. When
this happens, WebKit will report that the AVAssetTrack is no longer spatial.
(In addition, the track will no longer have a codec, nor a width or height.)

To work around this behavior, inside both AudioTrackPrivateAVFObjC and
VideoTrackPrivateAVFObjC, change the behavior of resetPropertiesFromTrack() to
skip updating the VideoTrackPrivate&apos;s configuration in the case where the old
configuration had a codec, but the new configuration does not. This prevents
the behavior where the track&apos;s internal objects are torn down from affecting
the clients of VideoTrackPrivateAVFObjC.

* Source/WebCore/platform/graphics/avfoundation/objc/AudioTrackPrivateAVFObjC.mm:
(WebCore::AudioTrackPrivateAVFObjC::resetPropertiesFromTrack):
* Source/WebCore/platform/graphics/avfoundation/objc/VideoTrackPrivateAVFObjC.cpp:
(WebCore::VideoTrackPrivateAVFObjC::resetPropertiesFromTrack):

Canonical link: <a href="https://commits.webkit.org/294687@main">https://commits.webkit.org/294687@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9a1d7e3648b0adfa1afc7cd4572098c7301fba11

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/102688 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/22361 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/12679 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/107853 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/53329 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/104727 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/22670 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/30863 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78098 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/35071 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/105694 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17570 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/92674 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58430 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/17411 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/10706 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/52686 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/87226 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10776 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/110229 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/29825 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/21992 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/87082 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/30189 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88866 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86687 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22072 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31524 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/9247 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/24078 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/29752 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/35072 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/29560 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/32887 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/31122 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->