### PR TITLE
xkcd.com: Back navigation doesn't work after using the "random" button

### DIFF
--- a/LayoutTests/http/tests/history/redirect-302-twice-expected.txt
+++ b/LayoutTests/http/tests/history/redirect-302-twice-expected.txt
@@ -1,0 +1,10 @@
+This page is the target of a redirect.
+
+PASS: History item count should be 3 and is.
+
+
+============== Back Forward List ==============
+        http://127.0.0.1:8000/history/redirect-302-twice.html
+        http://127.0.0.1:8000/history/resources/redirect-target.html#2
+curr->  http://127.0.0.1:8000/history/resources/redirect-target.html#3
+===============================================

--- a/LayoutTests/http/tests/history/redirect-302-twice.html
+++ b/LayoutTests/http/tests/history/redirect-302-twice.html
@@ -1,0 +1,16 @@
+<html>
+<head>
+<title>302 Redirect</title>
+<script>
+  function runTest() {
+    if (window.testRunner) {
+        testRunner.clearBackForwardList();
+        testRunner.waitUntilDone();
+    }
+    sessionStorage.navigateTwice = true;
+    window.setTimeout(function() {window.location = 'resources/redirect-helper.pl?302';}, 0);
+  }
+</script>
+
+<body onload="runTest()">This page is a 302 redirect.</body>
+</html>

--- a/LayoutTests/http/tests/history/resources/redirect-helper.pl
+++ b/LayoutTests/http/tests/history/resources/redirect-helper.pl
@@ -11,8 +11,10 @@ $STATUS_TEXTS = {
   '307' => 'Moved Temporarily'
 };
 
+$fragment = (($ENV{'HTTP_COOKIE'} || '') =~ /secondNavigation=true/) ? '#3' : '#2';
+
 print "Status: $REDIRECT_CODE $STATUS_TEXTS{$REDIRECT_CODE}\r\n";
-print "Location: redirect-target.html#2\r\n";
+print "Location: redirect-target.html$fragment\r\n";
 print "Content-type: text/html\r\n";
 print "\r\n";
 

--- a/LayoutTests/http/tests/history/resources/redirect-target.html
+++ b/LayoutTests/http/tests/history/resources/redirect-target.html
@@ -22,6 +22,14 @@ function testHistoryItemCount()
 }
 
 window.addEventListener("load", function () {
+    if (sessionStorage.navigateTwice) {
+        delete sessionStorage.navigateTwice;
+        document.cookie = "secondNavigation=true";
+        window.setTimeout(() => {
+            window.location = 'redirect-helper.pl?302';
+        }, 0);
+        return;
+    }
     if (window.testRunner) {
         testRunner.dumpAsText();
         testHistoryItemCount();

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -4270,7 +4270,7 @@ bool FrameLoader::shouldTreatURLAsSameAsCurrent(const SecurityOrigin* requesterO
         return false;
     if (requesterOrigin && (!m_frame->document() || !requesterOrigin->isSameOriginAs(m_frame->protectedDocument()->protectedSecurityOrigin())))
         return false;
-    return url == currentHistoryItem->url() || url == currentHistoryItem->originalURL();
+    return url == currentHistoryItem->url();
 }
 
 bool FrameLoader::shouldTreatURLAsSrcdocDocument(const URL& url) const


### PR DESCRIPTION
#### ac5860080b7db9ca627ac8b2f17d67214c40c865
<pre>
xkcd.com: Back navigation doesn&apos;t work after using the &quot;random&quot; button
<a href="https://bugs.webkit.org/show_bug.cgi?id=292739">https://bugs.webkit.org/show_bug.cgi?id=292739</a>
<a href="https://rdar.apple.com/90175606">rdar://90175606</a>

Reviewed by Alex Christensen.

This condition was added 22 years ago in 2796@main and I’m not sure why. It’s causing an issue where,
if subsequent navigations to the same URL result in a 302 redirect to a new URL, the new URL is not added
to the back/forward list. This change aligns Safari’s behavior with Chrome and Firefox.

* LayoutTests/http/tests/history/redirect-302-twice-expected.txt: Added.
* LayoutTests/http/tests/history/redirect-302-twice.html: Added.
* LayoutTests/http/tests/history/resources/redirect-helper.pl:
* LayoutTests/http/tests/history/resources/redirect-target.html:
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::shouldTreatURLAsSameAsCurrent const):

Canonical link: <a href="https://commits.webkit.org/294798@main">https://commits.webkit.org/294798@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2454982e8604f38af19b20e6a0486524ab5cf20c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/103152 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/22827 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/13146 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/108320 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/53795 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/105191 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/23162 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/31327 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/108320 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/53795 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/106158 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17955 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/93073 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/108320 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/17800 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/11114 "Passed tests") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/53150 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/87608 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/11177 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/110697 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/30289 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/22334 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/87407 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/30654 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/89271 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87037 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31888 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/9608 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/24613 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16726 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/30216 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/35538 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/30024 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/33351 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/31586 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->