### PR TITLE
 Resize cursor doesn't show if there's text under the resize control

### DIFF
--- a/LayoutTests/fast/events/cursors/mouse-cursor-resizer-expected.txt
+++ b/LayoutTests/fast/events/cursors/mouse-cursor-resizer-expected.txt
@@ -1,0 +1,12 @@
+Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+Tests that the mouse cursor change to corret type when text-align is set to right
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS internals.getCurrentCursorInfo() is "type=Pointer hotSpot=0,0"
+PASS internals.getCurrentCursorInfo() is "type=SouthEastResize hotSpot=0,0"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/events/cursors/mouse-cursor-resizer.html
+++ b/LayoutTests/fast/events/cursors/mouse-cursor-resizer.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        .target {
+            margin: 10px;
+            overflow: hidden;
+            width: 200px;
+            height: 100px;
+            resize: both;
+            text-align: right;
+            border: 12px solid silver;
+        }
+    </style>
+    <script src="../../../resources/js-test.js"></script>
+    <script src="../../../resources/ui-helper.js"></script>
+    <script>
+        window.jsTestIsAsync = true;
+
+        const borderWidth = 12;
+
+        window.addEventListener('load', async () => {
+            description("Tests that the mouse cursor change to corret type when text-align is set to right");
+            
+            await UIHelper.moveMouseAndWaitForFrame(2, 2);
+            shouldBeEqualToString('internals.getCurrentCursorInfo()', 'type=Pointer hotSpot=0,0');
+            let target = document.getElementById('target');
+            let targetBounds = target.getBoundingClientRect();
+            await UIHelper.moveMouseAndWaitForFrame(targetBounds.right - borderWidth - 4, targetBounds.bottom - borderWidth - 4);
+            shouldBeEqualToString('internals.getCurrentCursorInfo()', 'type=SouthEastResize hotSpot=0,0');
+            finishJSTest();
+        }, false);
+    </script>
+</head>
+<body>
+    <div id="test-container">
+        <div id="target" class="target">
+            Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+        </div>
+    </div>
+    <div id="console"></div>
+</body>
+</html>

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -1711,9 +1711,13 @@ std::optional<Cursor> EventHandler::selectCursor(const HitTestResult& result, bo
             return handCursor();
 
         bool inResizer = false;
-        if (renderer && renderer->hasLayer()) {
-            // FIXME: With right-aligned text in a box, the renderer here is usually a RenderText, which prevents showing the resize cursor: webkit.org/b/210935.
-            auto& layerRenderer = downcast<RenderLayerModelObject>(*renderer);
+        auto resizerRenderer = renderer;
+
+        if (is<RenderText>(resizerRenderer))
+            resizerRenderer = resizerRenderer->parent();
+
+        if (resizerRenderer && resizerRenderer->hasLayer()) {
+            auto& layerRenderer = downcast<RenderLayerModelObject>(*resizerRenderer);
             inResizer = layerRenderer.layer()->isPointInResizeControl(roundedIntPoint(result.localPoint()));
             if (inResizer)
                 return layerRenderer.shouldPlaceVerticalScrollbarOnLeft() ? southWestResizeCursor() : southEastResizeCursor();


### PR DESCRIPTION
#### 342a27a71e7c14e7d5ea23a29dd3c1f2ec2c8585
<pre>
 Resize cursor doesn&apos;t show if there&apos;s text under the resize control
<a href="https://bugs.webkit.org/show_bug.cgi?id=210935">https://bugs.webkit.org/show_bug.cgi?id=210935</a>

Reviewed by Simon Fraser.

The resizer cursor was not appearing over the resize control when the text
was aligned to the right because it was overlapping with control resizer coordinates.
This was happening because the hit test detected the Text element when in resize control coordinates,
causing RenderText to be used for determining the cursor type.

The fix ensures that when RenderText is the hit-tested object, we use its
parent renderer instead to check if the cursor is over the resizer control.

* LayoutTests/fast/events/cursors/mouse-cursor-resizer-expected.txt: Added.
* LayoutTests/fast/events/cursors/mouse-cursor-resizer.html: Added.
* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::selectCursor):
(WebCore::EventHandler::updateMouseEventTargetNode):

Canonical link: <a href="https://commits.webkit.org/294907@main">https://commits.webkit.org/294907@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/004687ebe6e1726fd72d57086dbebf0e064cb4c6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/103379 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/23061 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/13377 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/108553 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/54022 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/105418 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/23404 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/31612 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78558 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/35498 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/106385 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/18135 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/93259 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58892 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/17969 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/11302 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/53379 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/87770 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/11364 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/110929 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/30526 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/22525 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/87554 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/30887 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/89457 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87203 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32066 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/9781 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/24852 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16781 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/30454 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/35765 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/30254 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/33585 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/31815 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->