### PR TITLE
AX: Move HeadingLevel and HierarchicalLevel to AXCoreObject

### DIFF
--- a/Source/WebCore/accessibility/AXCoreObject.cpp
+++ b/Source/WebCore/accessibility/AXCoreObject.cpp
@@ -1156,6 +1156,45 @@ unsigned AXCoreObject::blockquoteLevel() const
     return level;
 }
 
+unsigned AXCoreObject::headingLevel() const
+{
+    if (isHeading()) {
+        unsigned level = ariaLevel();
+        if (level > 0)
+            return level;
+    }
+
+    unsigned tagLevel = headingTagLevel();
+    if (tagLevel > 0)
+        return tagLevel;
+
+    return 0;
+}
+
+unsigned AXCoreObject::hierarchicalLevel() const
+{
+    unsigned level = ariaLevel();
+    if (level > 0)
+        return level;
+
+    // Only tree item will calculate its level through the DOM currently.
+    if (roleValue() != AccessibilityRole::TreeItem)
+        return 0;
+
+    // Hierarchy leveling starts at 1, to match the aria-level spec.
+    // We measure tree hierarchy by the number of groups that the item is within.
+    level = 1;
+    for (RefPtr ancestor = parentObject(); ancestor; ancestor = ancestor->parentObject()) {
+        auto ancestorRole = ancestor->roleValue();
+        if (ancestorRole == AccessibilityRole::Group)
+            level++;
+        else if (ancestorRole == AccessibilityRole::Tree)
+            break;
+    }
+
+    return level;
+}
+
 bool AXCoreObject::supportsPressAction() const
 {
     if (roleValue() == AccessibilityRole::Presentational)

--- a/Source/WebCore/accessibility/AXCoreObject.h
+++ b/Source/WebCore/accessibility/AXCoreObject.h
@@ -1023,7 +1023,8 @@ public:
     virtual bool isIgnored() const = 0;
 
     unsigned blockquoteLevel() const;
-    virtual unsigned headingLevel() const = 0;
+    unsigned headingLevel() const;
+    virtual unsigned headingTagLevel() const = 0;
     virtual AccessibilityButtonState checkboxOrRadioValue() const = 0;
     virtual String valueDescription() const = 0;
     virtual float valueForRange() const = 0;
@@ -1259,8 +1260,9 @@ public:
 
     virtual String language() const = 0;
     String languageIncludingAncestors() const;
+    virtual unsigned ariaLevel() const = 0;
     // 1-based, to match the aria-level spec.
-    virtual unsigned hierarchicalLevel() const = 0;
+    unsigned hierarchicalLevel() const;
     virtual bool isInlineText() const = 0;
 
     virtual void setFocused(bool) = 0;

--- a/Source/WebCore/accessibility/AXLogger.cpp
+++ b/Source/WebCore/accessibility/AXLogger.cpp
@@ -656,6 +656,9 @@ TextStream& operator<<(WTF::TextStream& stream, AXProperty property)
     case AXProperty::ARIARoleDescription:
         stream << "ARIARoleDescription";
         break;
+    case AXProperty::ARIALevel:
+        stream << "ARIALevel";
+        break;
     case AXProperty::BackgroundColor:
         stream << "BackgroundColor";
         break;
@@ -812,12 +815,6 @@ TextStream& operator<<(WTF::TextStream& stream, AXProperty property)
         break;
     case AXProperty::HasUnderline:
         stream << "HasUnderline";
-        break;
-    case AXProperty::HeadingLevel:
-        stream << "HeadingLevel";
-        break;
-    case AXProperty::HierarchicalLevel:
-        stream << "HierarchicalLevel";
         break;
     case AXProperty::HorizontalScrollBar:
         stream << "HorizontalScrollBar";

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -4927,6 +4927,9 @@ void AXObjectCache::updateIsolatedTree(const Vector<std::pair<Ref<AccessibilityO
         case AXNotification::InputTypeChanged:
             tree->queueNodeUpdate(notification.first->objectID(), { AXProperty::InputType });
             break;
+        case AXNotification::LevelChanged:
+            tree->queueNodeUpdate(notification.first->objectID(), { AXProperty::ARIALevel });
+            break;
         case AXNotification::MaximumValueChanged:
             tree->queueNodeUpdate(notification.first->objectID(), { { AXProperty::MaxValueForRange, AXProperty::ValueForRange } });
             break;
@@ -5021,7 +5024,6 @@ void AXObjectCache::updateIsolatedTree(const Vector<std::pair<Ref<AccessibilityO
         case AXNotification::HasPopupChanged:
         case AXNotification::InvalidStatusChanged:
         case AXNotification::IsAtomicChanged:
-        case AXNotification::LevelChanged:
         case AXNotification::LiveRegionStatusChanged:
         case AXNotification::LiveRegionRelevantChanged:
         case AXNotification::PlaceholderChanged:

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
@@ -983,15 +983,8 @@ AXCoreObject::AccessibilityChildrenVector AccessibilityNodeObject::radioButtonGr
     return result;
 }
 
-unsigned AccessibilityNodeObject::headingLevel() const
+unsigned AccessibilityNodeObject::headingTagLevel() const
 {
-    // headings can be in block flow and non-block flow
-    if (isHeading()) {
-        int level = getIntegralAttribute(aria_levelAttr);
-        if (level > 0)
-            return level;
-    }
-
     const auto& tag = tagName();
     if (tag == h1Tag)
         return 1;
@@ -2102,33 +2095,6 @@ URL AccessibilityNodeObject::url() const
 #endif
 
     return URL();
-}
-
-unsigned AccessibilityNodeObject::hierarchicalLevel() const
-{
-    RefPtr element = dynamicDowncast<Element>(node());
-    if (!element)
-        return 0;
-
-    if (!element->attributeWithoutSynchronization(aria_levelAttr).isEmpty())
-        return element->getIntegralAttribute(aria_levelAttr);
-
-    // Only tree item will calculate its level through the DOM currently.
-    if (roleValue() != AccessibilityRole::TreeItem)
-        return 0;
-
-    // Hierarchy leveling starts at 1, to match the aria-level spec.
-    // We measure tree hierarchy by the number of groups that the item is within.
-    unsigned level = 1;
-    for (AccessibilityObject* parent = parentObject(); parent; parent = parent->parentObject()) {
-        AccessibilityRole parentRole = parent->ariaRoleAttribute();
-        if (parentRole == AccessibilityRole::Group)
-            level++;
-        else if (parentRole == AccessibilityRole::Tree)
-            break;
-    }
-
-    return level;
 }
 
 void AccessibilityNodeObject::setIsExpanded(bool expand)

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.h
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.h
@@ -78,7 +78,6 @@ public:
     void setFocused(bool) override;
     bool isFocused() const final;
     bool canSetFocusAttribute() const override;
-    unsigned headingLevel() const final;
 
     bool canSetValueAttribute() const override;
 
@@ -91,10 +90,11 @@ public:
     std::optional<AccessibilityOrientation> orientationFromARIA() const;
     std::optional<AccessibilityOrientation> explicitOrientation() const override { return orientationFromARIA(); }
 
+    unsigned headingTagLevel() const final;
+
     AccessibilityButtonState checkboxOrRadioValue() const final;
 
     URL url() const override;
-    unsigned hierarchicalLevel() const final;
     String textUnderElement(TextUnderElementMode = TextUnderElementMode()) const override;
     String accessibilityDescriptionForChildren() const;
     String description() const override;

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -1448,6 +1448,12 @@ RenderView* AccessibilityObject::topRenderer() const
     return nullptr;
 }
 
+unsigned AccessibilityObject::ariaLevel() const
+{
+    int level = getIntegralAttribute(aria_levelAttr);
+    return level > 0 ? level : 0;
+}
+
 String AccessibilityObject::language() const
 {
     const auto& lang = getAttribute(langAttr);

--- a/Source/WebCore/accessibility/AccessibilityObject.h
+++ b/Source/WebCore/accessibility/AccessibilityObject.h
@@ -257,7 +257,7 @@ public:
     bool isShowingValidationMessage() const;
     String validationMessage() const;
 
-    unsigned headingLevel() const override { return 0; }
+    unsigned headingTagLevel() const override { return 0; }
     AccessibilityButtonState checkboxOrRadioValue() const override;
     String valueDescription() const override { return String(); }
     float valueForRange() const override { return 0.0f; }
@@ -490,9 +490,9 @@ public:
     Document* topDocument() const;
     RenderView* topRenderer() const;
     ScrollView* scrollView() const override { return nullptr; }
+    unsigned ariaLevel() const final;
     String language() const final;
     // 1-based, to match the aria-level spec.
-    unsigned hierarchicalLevel() const override { return 0; }
     bool isInlineText() const final;
 
     // Ensures that the view is focused and active before attempting to set focus to an AccessibilityObject.

--- a/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
+++ b/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
@@ -664,7 +664,7 @@ static AccessibilityObjectWrapper *ancestorWithRole(const AXCoreObject& descenda
     // Trait information also needs to be gathered from the parents above the object.
     // The parentObject is needed instead of the unignoredParentObject, because a table might be ignored, but information still needs to be gathered from it.
     for (auto* parent = backingObject->parentObject(); parent; parent = parent->parentObject()) {
-        AccessibilityRole parentRole = parent->roleValue();
+        auto parentRole = parent->roleValue();
         if (parentRole == AccessibilityRole::WebArea)
             break;
 

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
@@ -274,7 +274,7 @@ private:
     String datetimeAttributeValue() const final { return stringAttributeValue(AXProperty::DatetimeAttributeValue); }
     bool canSetValueAttribute() const final { return boolAttributeValue(AXProperty::CanSetValueAttribute); }
     bool canSetSelectedAttribute() const final { return boolAttributeValue(AXProperty::CanSetSelectedAttribute); }
-    unsigned headingLevel() const final { return unsignedAttributeValue(AXProperty::HeadingLevel); }
+    unsigned headingTagLevel() const final;
     AccessibilityButtonState checkboxOrRadioValue() const final { return propertyValue<AccessibilityButtonState>(AXProperty::ButtonState); }
     String valueDescription() const final { return stringAttributeValue(AXProperty::ValueDescription); }
     float valueForRange() const final { return floatAttributeValue(AXProperty::ValueForRange); }
@@ -373,7 +373,7 @@ private:
     {
         return propertyValue<std::optional<AccessibilityOrientation>>(AXProperty::ExplicitOrientation);
     }
-    unsigned hierarchicalLevel() const final { return unsignedAttributeValue(AXProperty::HierarchicalLevel); }
+    unsigned ariaLevel() const final { return unsignedAttributeValue(AXProperty::ARIALevel); }
     String language() const final { return stringAttributeValue(AXProperty::Language); }
     void setSelectedChildren(const AccessibilityChildrenVector&) final;
     AccessibilityChildrenVector visibleChildren() final { return tree()->objectsForIDs(vectorAttributeValue<AXID>(AXProperty::VisibleChildren)); }

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
@@ -616,6 +616,9 @@ void AXIsolatedTree::updateNodeProperties(AccessibilityObject& axObject, const A
         case AXProperty::ARIARoleDescription:
             properties.append({ AXProperty::ARIARoleDescription, axObject.ariaRoleDescription().isolatedCopy() });
             break;
+        case AXProperty::ARIALevel:
+            properties.append({ AXProperty::ARIALevel, axObject.ariaLevel() });
+            break;
         case AXProperty::ValueAutofillButtonType:
             properties.append({ AXProperty::ValueAutofillButtonType, static_cast<int>(axObject.valueAutofillButtonType()) });
             properties.append({ AXProperty::IsValueAutofillAvailable, axObject.isValueAutofillAvailable() });

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
@@ -84,6 +84,7 @@ enum class AXPropertyFlag : uint32_t {
 };
 
 enum class AXProperty : uint16_t {
+    ARIALevel,
     ARIARoleDescription,
 #if !ENABLE(AX_THREAD_TEXT_APIS)
     // Rather than caching text content as property when ENABLE(AX_THREAD_TEXT_APIS), we should
@@ -152,8 +153,6 @@ enum class AXProperty : uint16_t {
     IsSuperscript,
     HasTextShadow,
     HasUnderline,
-    HeadingLevel,
-    HierarchicalLevel,
     HorizontalScrollBar,
     IdentifierAttribute,
     IncrementButton,


### PR DESCRIPTION
#### bc34242b2e93638f8a33dfdb7e28a5dd97e96d31
<pre>
AX: Move HeadingLevel and HierarchicalLevel to AXCoreObject
<a href="https://bugs.webkit.org/show_bug.cgi?id=292746">https://bugs.webkit.org/show_bug.cgi?id=292746</a>
<a href="https://rdar.apple.com/150967922">rdar://150967922</a>

Reviewed by Tyler Wilcock.

By caching aria-level, we are able to move the implementations of
headingLevel and hierarchicalLevel to a shared AXCoreObject
implementation. This also requires that the tags h1-h6 are cached
on the isolated tree.

As a follow up to this PR, I would like to share the way we use
tags on the live and isolated trees, to prevent methods like
`headingTagLevel` from also having separate implementations.

* Source/WebCore/accessibility/AXCoreObject.cpp:
(WebCore::AXCoreObject::headingLevel const):
(WebCore::AXCoreObject::hierarchicalLevel const):
* Source/WebCore/accessibility/AXCoreObject.h:
* Source/WebCore/accessibility/AXLogger.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::updateIsolatedTree):
* Source/WebCore/accessibility/AccessibilityNodeObject.cpp:
(WebCore::AccessibilityNodeObject::headingTagLevel const):
(WebCore::AccessibilityNodeObject::headingLevel const): Deleted.
(WebCore::AccessibilityNodeObject::hierarchicalLevel const): Deleted.
* Source/WebCore/accessibility/AccessibilityNodeObject.h:
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::ariaLevel const):
* Source/WebCore/accessibility/AccessibilityObject.h:
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp:
(WebCore::AXIsolatedObject::initializeProperties):
(WebCore::AXIsolatedObject::headingTagLevel const):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h:
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp:
(WebCore::AXIsolatedTree::updateNodeProperties):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h:

Canonical link: <a href="https://commits.webkit.org/294788@main">https://commits.webkit.org/294788@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7f91a0abdc99aade02a797b952448ea97fd484dc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/102847 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/22521 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/12841 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/108013 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/53488 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/104886 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/22840 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/31022 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78205 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/35167 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/105853 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17687 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/92815 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58539 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/17531 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/10850 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/52845 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/87341 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10917 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/110388 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/29984 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/22090 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/87189 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/30348 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/89010 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86806 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22134 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31646 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/9362 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/24246 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/29911 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/35233 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/29719 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/33046 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/31281 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->