### PR TITLE
[JSC] Implement `SuppressedError` from Explicit Resource Management Proposal

### DIFF
--- a/JSTests/stress/suppressed-error-basic.js
+++ b/JSTests/stress/suppressed-error-basic.js
@@ -1,0 +1,55 @@
+//@ requireOptions("--useExplicitResourceManagement=1")
+
+function shouldBe(a, b) {
+    if (a !== b)
+        throw new Error(`Expected ${b} but got ${a}`);
+}
+
+shouldBe(SuppressedError.prototype.constructor, SuppressedError);
+shouldBe(SuppressedError.prototype.message, "");
+shouldBe(SuppressedError.prototype.name, "SuppressedError");
+
+{
+    class OurSuppressedError extends SuppressedError {
+        constructor(...args) {
+            super(...args);
+        }
+    }
+    const e1 = new OurSuppressedError();
+    shouldBe(e1 instanceof Error, true);
+    shouldBe(e1 instanceof SuppressedError, true);
+}
+
+{
+    let toStringCallCount = 0;
+    const obj = {
+        toString() {
+            toStringCallCount++;
+            return "this is error message";
+        }
+    };
+    const e1 = new SuppressedError(undefined, undefined, obj);
+    shouldBe(toStringCallCount, 1);
+    shouldBe(e1.message, "this is error message");
+
+    const e2 = SuppressedError(undefined, undefined, obj);
+    shouldBe(toStringCallCount, 2);
+    shouldBe(e2.message, "this is error message");
+
+}
+
+{
+    const error = {};
+    const suppressed = {};
+    const message = "message";
+
+    const e1 = new SuppressedError(error, suppressed, message);
+    shouldBe(e1.error, error);
+    shouldBe(e1.suppressed, suppressed);
+    shouldBe(e1.message, message);
+
+    const e2 = SuppressedError(error, suppressed, message);
+    shouldBe(e2.error, error);
+    shouldBe(e2.suppressed, suppressed);
+    shouldBe(e2.message, message);
+}

--- a/JSTests/test262/config.yaml
+++ b/JSTests/test262/config.yaml
@@ -49,7 +49,6 @@ skip:
     - test/staging/explicit-resource-management
     - test/built-ins/DisposableStack
     - test/built-ins/AsyncDisposableStack
-    - test/built-ins/NativeErrors/SuppressedError
     - test/language/statements/using
     - test/language/statements/await-using
   files:

--- a/Source/JavaScriptCore/Sources.txt
+++ b/Source/JavaScriptCore/Sources.txt
@@ -1064,6 +1064,9 @@ runtime/Structure.cpp
 runtime/StructureCache.cpp
 runtime/StructureChain.cpp
 runtime/StructureRareData.cpp
+runtime/SuppressedError.cpp
+runtime/SuppressedErrorConstructor.cpp
+runtime/SuppressedErrorPrototype.cpp
 runtime/Symbol.cpp
 runtime/SymbolConstructor.cpp
 runtime/SymbolObject.cpp

--- a/Source/JavaScriptCore/runtime/CommonIdentifiers.h
+++ b/Source/JavaScriptCore/runtime/CommonIdentifiers.h
@@ -315,7 +315,10 @@
     macro(written) \
     macro(year) \
     macro(years) \
-    macro(yearsDisplay)
+    macro(yearsDisplay) \
+    macro(error) \
+    macro(suppressed) \
+    macro(SuppressedError)
 
 #define JSC_COMMON_IDENTIFIERS_EACH_PRIVATE_FIELD(macro) \
     macro(constructor)

--- a/Source/JavaScriptCore/runtime/Error.cpp
+++ b/Source/JavaScriptCore/runtime/Error.cpp
@@ -105,6 +105,8 @@ JSObject* createError(JSGlobalObject* globalObject, ErrorTypeWithExtension error
         return createURIError(globalObject, message);
     case ErrorTypeWithExtension::AggregateError:
         break;
+    case ErrorTypeWithExtension::SuppressedError:
+        break;
     case ErrorTypeWithExtension::OutOfMemoryError:
         return createOutOfMemoryError(globalObject, message);
     }

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.h
@@ -239,6 +239,7 @@ public:
     LazyClassStructure m_typeErrorStructure;
     LazyClassStructure m_URIErrorStructure;
     LazyClassStructure m_aggregateErrorStructure;
+    LazyClassStructure m_suppressedErrorStructure;
 
     WriteBarrier<ObjectConstructor> m_objectConstructor;
     WriteBarrier<ArrayConstructor> m_arrayConstructor;
@@ -1202,6 +1203,8 @@ private:
     void initializeErrorConstructor(LazyClassStructure::Initializer&);
 
     void initializeAggregateErrorConstructor(LazyClassStructure::Initializer&);
+
+    void initializeSuppressedErrorConstructor(LazyClassStructure::Initializer&);
 
     JS_EXPORT_PRIVATE void init(VM&);
     void initStaticGlobals(VM&);

--- a/Source/JavaScriptCore/runtime/JSGlobalObjectInlines.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObjectInlines.h
@@ -531,6 +531,8 @@ inline Structure* JSGlobalObject::errorStructure(ErrorType errorType) const
         return m_URIErrorStructure.get(this);
     case ErrorType::AggregateError:
         return m_aggregateErrorStructure.get(this);
+    case ErrorType::SuppressedError:
+        return m_suppressedErrorStructure.get(this);
     }
     ASSERT_NOT_REACHED();
     return nullptr;

--- a/Source/JavaScriptCore/runtime/SuppressedError.h
+++ b/Source/JavaScriptCore/runtime/SuppressedError.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Apple Inc. All Rights Reserved.
+ * Copyright (C) 2025 Sosuke Suzuki <aosukeke@gmail.com>.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,53 +25,10 @@
 
 #pragma once
 
-#include <wtf/text/ASCIILiteral.h>
+#include "ErrorInstance.h"
 
 namespace JSC {
 
-#define JSC_ERROR_TYPES(macro) \
-    macro(Error) \
-    macro(EvalError) \
-    macro(RangeError) \
-    macro(ReferenceError) \
-    macro(SyntaxError) \
-    macro(TypeError) \
-    macro(URIError) \
-    macro(AggregateError) \
-    macro(SuppressedError) \
-
-#define JSC_ERROR_TYPES_WITH_EXTENSION(macro) \
-    JSC_ERROR_TYPES(macro) \
-    macro(OutOfMemoryError) \
-
-enum class ErrorType : uint8_t {
-#define DECLARE_ERROR_TYPES_ENUM(name) name,
-    JSC_ERROR_TYPES(DECLARE_ERROR_TYPES_ENUM)
-#undef DECLARE_ERROR_TYPES_ENUM
-};
-
-#define COUNT_ERROR_TYPES(name) 1 +
-static constexpr unsigned NumberOfErrorType {
-    JSC_ERROR_TYPES(COUNT_ERROR_TYPES) 0
-};
-#undef COUNT_ERROR_TYPES
-
-enum class ErrorTypeWithExtension : uint8_t {
-#define DECLARE_ERROR_TYPES_ENUM(name) name,
-    JSC_ERROR_TYPES_WITH_EXTENSION(DECLARE_ERROR_TYPES_ENUM)
-#undef DECLARE_ERROR_TYPES_ENUM
-};
-
-ASCIILiteral errorTypeName(ErrorType);
-ASCIILiteral errorTypeName(ErrorTypeWithExtension);
+ErrorInstance* createSuppressedError(JSGlobalObject*, VM&, Structure*, JSValue error, JSValue suppressed, JSValue message, ErrorInstance::SourceAppender = nullptr, RuntimeType = TypeNothing, bool useCurrentFrame = true);
 
 } // namespace JSC
-
-namespace WTF {
-
-class PrintStream;
-
-void printInternal(PrintStream&, JSC::ErrorType);
-void printInternal(PrintStream&, JSC::ErrorTypeWithExtension);
-
-} // namespace WTF

--- a/Source/JavaScriptCore/runtime/SuppressedErrorConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/SuppressedErrorConstructor.cpp
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2025 Sosuke Suzuki <aosukeke@gmail.com>.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "SuppressedErrorConstructor.h"
+
+#include "ClassInfo.h"
+#include "ExceptionScope.h"
+#include "GCAssertions.h"
+#include "JSCInlines.h"
+#include "RuntimeType.h"
+#include "SuppressedError.h"
+#include "SuppressedErrorPrototype.h"
+
+namespace JSC {
+
+STATIC_ASSERT_IS_TRIVIALLY_DESTRUCTIBLE(SuppressedErrorConstructor);
+
+const ClassInfo SuppressedErrorConstructor::s_info = { "Function"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(SuppressedErrorConstructor) };
+
+static JSC_DECLARE_HOST_FUNCTION(callSuppressedErrorConstructor);
+static JSC_DECLARE_HOST_FUNCTION(constructSuppressedErrorConstructor);
+
+SuppressedErrorConstructor::SuppressedErrorConstructor(VM& vm, Structure* structure)
+    : Base(vm, structure, callSuppressedErrorConstructor, constructSuppressedErrorConstructor)
+{
+}
+
+void SuppressedErrorConstructor::finishCreation(VM& vm, SuppressedErrorPrototype* prototype)
+{
+    Base::finishCreation(vm, 3, errorTypeName(ErrorType::SuppressedError), PropertyAdditionMode::WithoutStructureTransition);
+    ASSERT(inherits(info()));
+
+    putDirectWithoutTransition(vm, vm.propertyNames->prototype, prototype, PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly | PropertyAttribute::DontEnum);
+}
+
+JSC_DEFINE_HOST_FUNCTION(callSuppressedErrorConstructor, (JSGlobalObject* globalObject, CallFrame* callFrame))
+{
+    VM& vm = globalObject->vm();
+    JSValue error = callFrame->argument(0);
+    JSValue suppressed = callFrame->argument(1);
+    JSValue message = callFrame->argument(2);
+    Structure* errorStructure = globalObject->errorStructure(ErrorType::SuppressedError);
+    return JSValue::encode(createSuppressedError(globalObject, vm, errorStructure, error, suppressed, message, nullptr, TypeNothing, false));
+}
+
+JSC_DEFINE_HOST_FUNCTION(constructSuppressedErrorConstructor, (JSGlobalObject* globalObject, CallFrame* callFrame))
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    JSValue error = callFrame->argument(0);
+    JSValue suppressed = callFrame->argument(1);
+    JSValue message = callFrame->argument(2);
+
+    JSObject* newTarget = asObject(callFrame->newTarget());
+    Structure* errorStructure = JSC_GET_DERIVED_STRUCTURE(vm, errorStructureWithErrorType<ErrorType::SuppressedError>, newTarget, callFrame->jsCallee());
+    RETURN_IF_EXCEPTION(scope, { });
+    ASSERT(errorStructure);
+
+    RELEASE_AND_RETURN(scope, JSValue::encode(createSuppressedError(globalObject, vm, errorStructure, error, suppressed, message, nullptr, TypeNothing, false)));
+}
+
+}

--- a/Source/JavaScriptCore/runtime/SuppressedErrorConstructor.h
+++ b/Source/JavaScriptCore/runtime/SuppressedErrorConstructor.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Apple Inc. All Rights Reserved.
+ * Copyright (C) 2025 Sosuke Suzuki <aosukeke@gmail.com>.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,53 +25,31 @@
 
 #pragma once
 
-#include <wtf/text/ASCIILiteral.h>
+#include "InternalFunction.h"
 
 namespace JSC {
 
-#define JSC_ERROR_TYPES(macro) \
-    macro(Error) \
-    macro(EvalError) \
-    macro(RangeError) \
-    macro(ReferenceError) \
-    macro(SyntaxError) \
-    macro(TypeError) \
-    macro(URIError) \
-    macro(AggregateError) \
-    macro(SuppressedError) \
+class SuppressedErrorPrototype;
 
-#define JSC_ERROR_TYPES_WITH_EXTENSION(macro) \
-    JSC_ERROR_TYPES(macro) \
-    macro(OutOfMemoryError) \
+class SuppressedErrorConstructor final : public InternalFunction {
+public:
+    using Base = InternalFunction;
 
-enum class ErrorType : uint8_t {
-#define DECLARE_ERROR_TYPES_ENUM(name) name,
-    JSC_ERROR_TYPES(DECLARE_ERROR_TYPES_ENUM)
-#undef DECLARE_ERROR_TYPES_ENUM
+    DECLARE_INFO;
+
+    inline static Structure* createStructure(VM&, JSGlobalObject*, JSValue);
+
+    static SuppressedErrorConstructor* create(VM& vm, Structure* structure, SuppressedErrorPrototype* prototype)
+    {
+        SuppressedErrorConstructor* constructor = new (NotNull, allocateCell<SuppressedErrorConstructor>(vm)) SuppressedErrorConstructor(vm, structure);
+        constructor->finishCreation(vm, prototype);
+        return constructor;
+    }
+
+private:
+    explicit SuppressedErrorConstructor(VM&, Structure*);
+
+    void finishCreation(VM&, SuppressedErrorPrototype*);
 };
 
-#define COUNT_ERROR_TYPES(name) 1 +
-static constexpr unsigned NumberOfErrorType {
-    JSC_ERROR_TYPES(COUNT_ERROR_TYPES) 0
-};
-#undef COUNT_ERROR_TYPES
-
-enum class ErrorTypeWithExtension : uint8_t {
-#define DECLARE_ERROR_TYPES_ENUM(name) name,
-    JSC_ERROR_TYPES_WITH_EXTENSION(DECLARE_ERROR_TYPES_ENUM)
-#undef DECLARE_ERROR_TYPES_ENUM
-};
-
-ASCIILiteral errorTypeName(ErrorType);
-ASCIILiteral errorTypeName(ErrorTypeWithExtension);
-
-} // namespace JSC
-
-namespace WTF {
-
-class PrintStream;
-
-void printInternal(PrintStream&, JSC::ErrorType);
-void printInternal(PrintStream&, JSC::ErrorTypeWithExtension);
-
-} // namespace WTF
+}

--- a/Source/JavaScriptCore/runtime/SuppressedErrorConstructorInlines.h
+++ b/Source/JavaScriptCore/runtime/SuppressedErrorConstructorInlines.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Apple Inc. All Rights Reserved.
+ * Copyright (C) 2025 Sosuke Suzuki <aosukeke@gmail.com>.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,53 +25,13 @@
 
 #pragma once
 
-#include <wtf/text/ASCIILiteral.h>
+#include "SuppressedErrorConstructor.h"
 
 namespace JSC {
 
-#define JSC_ERROR_TYPES(macro) \
-    macro(Error) \
-    macro(EvalError) \
-    macro(RangeError) \
-    macro(ReferenceError) \
-    macro(SyntaxError) \
-    macro(TypeError) \
-    macro(URIError) \
-    macro(AggregateError) \
-    macro(SuppressedError) \
-
-#define JSC_ERROR_TYPES_WITH_EXTENSION(macro) \
-    JSC_ERROR_TYPES(macro) \
-    macro(OutOfMemoryError) \
-
-enum class ErrorType : uint8_t {
-#define DECLARE_ERROR_TYPES_ENUM(name) name,
-    JSC_ERROR_TYPES(DECLARE_ERROR_TYPES_ENUM)
-#undef DECLARE_ERROR_TYPES_ENUM
-};
-
-#define COUNT_ERROR_TYPES(name) 1 +
-static constexpr unsigned NumberOfErrorType {
-    JSC_ERROR_TYPES(COUNT_ERROR_TYPES) 0
-};
-#undef COUNT_ERROR_TYPES
-
-enum class ErrorTypeWithExtension : uint8_t {
-#define DECLARE_ERROR_TYPES_ENUM(name) name,
-    JSC_ERROR_TYPES_WITH_EXTENSION(DECLARE_ERROR_TYPES_ENUM)
-#undef DECLARE_ERROR_TYPES_ENUM
-};
-
-ASCIILiteral errorTypeName(ErrorType);
-ASCIILiteral errorTypeName(ErrorTypeWithExtension);
+inline Structure* SuppressedErrorConstructor::createStructure(VM& vm, JSGlobalObject* globalObject, JSValue prototype)
+{
+    return Structure::create(vm, globalObject, prototype, TypeInfo(InternalFunctionType, StructureFlags), info());
+}
 
 } // namespace JSC
-
-namespace WTF {
-
-class PrintStream;
-
-void printInternal(PrintStream&, JSC::ErrorType);
-void printInternal(PrintStream&, JSC::ErrorTypeWithExtension);
-
-} // namespace WTF

--- a/Source/JavaScriptCore/runtime/SuppressedErrorPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/SuppressedErrorPrototype.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Apple Inc. All Rights Reserved.
+ * Copyright (C) 2025 Sosuke Suzuki <aosukeke@gmail.com>.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,55 +23,24 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
+#include "config.h"
+#include "SuppressedErrorPrototype.h"
 
-#include <wtf/text/ASCIILiteral.h>
+#include "CallFrame.h"
+#include "JSCInlines.h"
+#include "ThrowScope.h"
 
 namespace JSC {
 
-#define JSC_ERROR_TYPES(macro) \
-    macro(Error) \
-    macro(EvalError) \
-    macro(RangeError) \
-    macro(ReferenceError) \
-    macro(SyntaxError) \
-    macro(TypeError) \
-    macro(URIError) \
-    macro(AggregateError) \
-    macro(SuppressedError) \
+SuppressedErrorPrototype::SuppressedErrorPrototype(VM& vm, Structure* structure)
+    : Base(vm, structure)
+{
+}
 
-#define JSC_ERROR_TYPES_WITH_EXTENSION(macro) \
-    JSC_ERROR_TYPES(macro) \
-    macro(OutOfMemoryError) \
-
-enum class ErrorType : uint8_t {
-#define DECLARE_ERROR_TYPES_ENUM(name) name,
-    JSC_ERROR_TYPES(DECLARE_ERROR_TYPES_ENUM)
-#undef DECLARE_ERROR_TYPES_ENUM
-};
-
-#define COUNT_ERROR_TYPES(name) 1 +
-static constexpr unsigned NumberOfErrorType {
-    JSC_ERROR_TYPES(COUNT_ERROR_TYPES) 0
-};
-#undef COUNT_ERROR_TYPES
-
-enum class ErrorTypeWithExtension : uint8_t {
-#define DECLARE_ERROR_TYPES_ENUM(name) name,
-    JSC_ERROR_TYPES_WITH_EXTENSION(DECLARE_ERROR_TYPES_ENUM)
-#undef DECLARE_ERROR_TYPES_ENUM
-};
-
-ASCIILiteral errorTypeName(ErrorType);
-ASCIILiteral errorTypeName(ErrorTypeWithExtension);
+void SuppressedErrorPrototype::finishCreation(VM& vm)
+{
+    Base::finishCreation(vm, errorTypeName(ErrorType::SuppressedError));
+    ASSERT(inherits(info()));
+}
 
 } // namespace JSC
-
-namespace WTF {
-
-class PrintStream;
-
-void printInternal(PrintStream&, JSC::ErrorType);
-void printInternal(PrintStream&, JSC::ErrorTypeWithExtension);
-
-} // namespace WTF

--- a/Source/JavaScriptCore/runtime/SuppressedErrorPrototypeInlines.h
+++ b/Source/JavaScriptCore/runtime/SuppressedErrorPrototypeInlines.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Apple Inc. All Rights Reserved.
+ * Copyright (C) 2025 Sosuke Suzuki <aosukeke@gmail.com>.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,53 +25,13 @@
 
 #pragma once
 
-#include <wtf/text/ASCIILiteral.h>
+#include "SuppressedErrorPrototype.h"
 
 namespace JSC {
 
-#define JSC_ERROR_TYPES(macro) \
-    macro(Error) \
-    macro(EvalError) \
-    macro(RangeError) \
-    macro(ReferenceError) \
-    macro(SyntaxError) \
-    macro(TypeError) \
-    macro(URIError) \
-    macro(AggregateError) \
-    macro(SuppressedError) \
-
-#define JSC_ERROR_TYPES_WITH_EXTENSION(macro) \
-    JSC_ERROR_TYPES(macro) \
-    macro(OutOfMemoryError) \
-
-enum class ErrorType : uint8_t {
-#define DECLARE_ERROR_TYPES_ENUM(name) name,
-    JSC_ERROR_TYPES(DECLARE_ERROR_TYPES_ENUM)
-#undef DECLARE_ERROR_TYPES_ENUM
-};
-
-#define COUNT_ERROR_TYPES(name) 1 +
-static constexpr unsigned NumberOfErrorType {
-    JSC_ERROR_TYPES(COUNT_ERROR_TYPES) 0
-};
-#undef COUNT_ERROR_TYPES
-
-enum class ErrorTypeWithExtension : uint8_t {
-#define DECLARE_ERROR_TYPES_ENUM(name) name,
-    JSC_ERROR_TYPES_WITH_EXTENSION(DECLARE_ERROR_TYPES_ENUM)
-#undef DECLARE_ERROR_TYPES_ENUM
-};
-
-ASCIILiteral errorTypeName(ErrorType);
-ASCIILiteral errorTypeName(ErrorTypeWithExtension);
+inline Structure* SuppressedErrorPrototype::createStructure(VM& vm, JSGlobalObject* globalObject, JSValue prototype)
+{
+    return Structure::create(vm, globalObject, prototype, TypeInfo(ObjectType, StructureFlags), info());
+}
 
 } // namespace JSC
-
-namespace WTF {
-
-class PrintStream;
-
-void printInternal(PrintStream&, JSC::ErrorType);
-void printInternal(PrintStream&, JSC::ErrorTypeWithExtension);
-
-} // namespace WTF


### PR DESCRIPTION
#### 17f3c1124307771e573d3f11e36284c03e9b4e6d
<pre>
[JSC] Implement `SuppressedError` from Explicit Resource Management Proposal
<a href="https://bugs.webkit.org/show_bug.cgi?id=292747">https://bugs.webkit.org/show_bug.cgi?id=292747</a>

Reviewed by Yusuke Suzuki.

This patch implements new `SuppressedError`[1] built-in from Explicit
Resource Management Proposal[2].

[1]: <a href="https://tc39.es/proposal-explicit-resource-management/#sec-suppressederror-objects">https://tc39.es/proposal-explicit-resource-management/#sec-suppressederror-objects</a>
[2]: <a href="https://github.com/tc39/proposal-explicit-resource-management">https://github.com/tc39/proposal-explicit-resource-management</a>

* JSTests/stress/suppressed-error-basic.js: Added.
(shouldBe):
(shouldBe.OurSuppressedError):
* JSTests/test262/config.yaml:
* Source/JavaScriptCore/Sources.txt:
* Source/JavaScriptCore/runtime/CommonIdentifiers.h:
* Source/JavaScriptCore/runtime/Error.cpp:
(JSC::createError):
* Source/JavaScriptCore/runtime/ErrorType.h:
* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
(JSC::JSGlobalObject::initializeSuppressedErrorConstructor):
(JSC::JSGlobalObject::init):
* Source/JavaScriptCore/runtime/JSGlobalObject.h:
* Source/JavaScriptCore/runtime/JSGlobalObjectInlines.h:
(JSC::JSGlobalObject::errorStructure const):
* Source/JavaScriptCore/runtime/SuppressedError.cpp: Copied from Source/JavaScriptCore/runtime/ErrorType.h.
(JSC::createSuppressedError):
* Source/JavaScriptCore/runtime/SuppressedError.h: Copied from Source/JavaScriptCore/runtime/ErrorType.h.
* Source/JavaScriptCore/runtime/SuppressedErrorConstructor.cpp: Added.
(JSC::SuppressedErrorConstructor::SuppressedErrorConstructor):
(JSC::SuppressedErrorConstructor::finishCreation):
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/SuppressedErrorConstructor.h: Copied from Source/JavaScriptCore/runtime/ErrorType.h.
* Source/JavaScriptCore/runtime/SuppressedErrorConstructorInlines.h: Copied from Source/JavaScriptCore/runtime/ErrorType.h.
(JSC::SuppressedErrorConstructor::createStructure):
* Source/JavaScriptCore/runtime/SuppressedErrorPrototype.cpp: Copied from Source/JavaScriptCore/runtime/ErrorType.h.
(JSC::SuppressedErrorPrototype::SuppressedErrorPrototype):
(JSC::SuppressedErrorPrototype::finishCreation):
* Source/JavaScriptCore/runtime/SuppressedErrorPrototype.h: Copied from Source/JavaScriptCore/runtime/ErrorType.h.
* Source/JavaScriptCore/runtime/SuppressedErrorPrototypeInlines.h: Copied from Source/JavaScriptCore/runtime/ErrorType.h.
(JSC::SuppressedErrorPrototype::createStructure):

Canonical link: <a href="https://commits.webkit.org/294774@main">https://commits.webkit.org/294774@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4d5d421a38e4054e7d1641ee9ef3f528abbf45f9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/102782 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/22455 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/12775 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/107961 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/53423 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/22823 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/30957 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78169 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/35127 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/105788 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17680 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/92762 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58501 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/17550 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/10797 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/52780 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/95457 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/87334 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10865 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/110323 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/101392 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/29919 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/22045 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/87151 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/30283 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88958 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86778 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22126 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31591 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/9314 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/24175 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/29846 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/35167 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/125025 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/29654 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34693 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/32981 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/31216 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->