### PR TITLE
[macOS] webkit.org doesn't render completely after showing/hiding the sidebar

### DIFF
--- a/LayoutTests/fast/css/viewport-units-after-changing-obscured-content-insets-expected.html
+++ b/LayoutTests/fast/css/viewport-units-after-changing-obscured-content-insets-expected.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="../../resources/ui-helper.js"></script>
+<style>
+html {
+    width: 100%;
+    height: 100%;
+    scrollbar-width: none;
+}
+
+body {
+    margin: 0;
+}
+
+.container {
+    width: 100vw;
+    height: 100vh;
+    background-color: tomato;
+}
+</style>
+</head>
+<body>
+    <div class="container"></div>
+</body>
+</html>

--- a/LayoutTests/fast/css/viewport-units-after-changing-obscured-content-insets.html
+++ b/LayoutTests/fast/css/viewport-units-after-changing-obscured-content-insets.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="../../resources/ui-helper.js"></script>
+<style>
+html {
+    width: 100%;
+    height: 100%;
+    scrollbar-width: none;
+}
+
+body {
+    margin: 0;
+}
+
+.container {
+    width: 100vw;
+    height: 100vh;
+    background-color: tomato;
+}
+</style>
+<script>
+jsTestIsAsync = true;
+
+addEventListener("load", async () => {
+    window.testRunner?.waitUntilDone();
+    await UIHelper.setObscuredInsets(100, 100, 0, 0);
+    await UIHelper.ensureStablePresentationUpdate();
+    await UIHelper.setObscuredInsets(0, 0, 0, 0);
+    window.testRunner?.notifyDone();
+});
+</script>
+</head>
+<body>
+    <div class="container"></div>
+</body>
+</html>

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -1054,6 +1054,9 @@ void LocalFrameView::obscuredContentInsetsDidChange(const FloatBoxExtent& newObs
 
     if (platformWidget())
         platformSetContentInsets(newObscuredContentInsets);
+
+    if (RefPtr document = m_frame->document())
+        document->updateViewportUnitsOnResize();
     
     renderView->setNeedsLayout();
     layoutContext().layout();


### PR DESCRIPTION
#### 2f1d182fbf18f5b0685a5d19c979b56ca8f9a950
<pre>
[macOS] webkit.org doesn&apos;t render completely after showing/hiding the sidebar
<a href="https://bugs.webkit.org/show_bug.cgi?id=292744">https://bugs.webkit.org/show_bug.cgi?id=292744</a>
<a href="https://rdar.apple.com/149499441">rdar://149499441</a>

Reviewed by Megan Gardner and Aditya Keerthi.

Changing obscured content insets on macOS (e.g. changing sidebar width, or navigation bar height by
toggling the favorites bar) causes the viewport size for CSS viewport units to change, but currently
doesn&apos;t invalidate any element styles that are dependent on viewport units. As a result, `vw` and
`vh` may become stale when changing obscured content insets, until the user resizes the window (or
otherwise forces style to be recalculated for elements that use viewport units). On webkit.org, this
ends up being the width of the main content, which has `width: 100vw;`.

To fix this, we call `updateViewportUnitsOnResize()` when obscured content insets change.

* LayoutTests/fast/css/viewport-units-after-changing-obscured-content-insets-expected.html: Added.
* LayoutTests/fast/css/viewport-units-after-changing-obscured-content-insets.html: Added.

Add a layout test to verify that adding and then removing top/left content insets leaves viewport
units in its original state. The test ends up being flaky without this fix.

* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::obscuredContentInsetsDidChange):

See above.

Canonical link: <a href="https://commits.webkit.org/294711@main">https://commits.webkit.org/294711@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7e57b6298dc33d286d2b1f1b504d9966b21dd062

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/102744 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/22417 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/12736 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/107909 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/53385 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/104783 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/22731 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/30919 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78134 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/35100 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/105750 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17605 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/92721 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58466 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/17448 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/10756 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/52742 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/87262 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10824 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/110285 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/29881 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/22022 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/87119 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/30245 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88917 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86728 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22087 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31561 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/9287 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/24134 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/29808 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/35128 "Failed to build and analyze WebKit") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/29616 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/32943 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/31178 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->