### PR TITLE
Use C++20's CTAD with aliases in Tests/WTF/WeakPtr

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WTF/WeakPtr.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/WeakPtr.cpp
@@ -91,32 +91,6 @@ template<typename T> using WeakListHashSet = WTF::WeakListHashSet<T, WeakPtrImpl
 template<typename T> using WeakPtr = WTF::WeakPtr<T, WeakPtrImplWithCounter>;
 template<typename T> using WeakPtrFactory = WTF::WeakPtrFactory<T, WeakPtrImplWithCounter>;
 
-// FIXME: Drop when we support C++20. C++17 does not support template parameter deduction for aliases and WeakPtr is an alias in this file.
-template<typename T, typename = std::enable_if_t<!WTF::IsSmartPtr<T>::value>> inline auto makeWeakPtr(T& object, EnableWeakPtrThreadingAssertions enableWeakPtrThreadingAssertions = EnableWeakPtrThreadingAssertions::Yes)
-{
-    return WeakPtr<T>(object, enableWeakPtrThreadingAssertions);
-}
-
-// FIXME: Drop when we support C++20. C++17 does not support template parameter deduction for aliases and WeakPtr is an alias in this file.
-template<typename T, typename = std::enable_if_t<!WTF::IsSmartPtr<T>::value>> inline auto makeWeakPtr(T* ptr, EnableWeakPtrThreadingAssertions enableWeakPtrThreadingAssertions = EnableWeakPtrThreadingAssertions::Yes) -> decltype(makeWeakPtr(*ptr))
-{
-    if (!ptr)
-        return { };
-    return makeWeakPtr(*ptr, enableWeakPtrThreadingAssertions);
-}
-
-// FIXME: Drop when we support C++20. C++17 does not support template parameter deduction for aliases and WeakPtr is an alias in this file.
-template<typename T, typename = std::enable_if_t<!WTF::IsSmartPtr<T>::value>> inline auto makeWeakPtr(const Ref<T>& object, EnableWeakPtrThreadingAssertions enableWeakPtrThreadingAssertions = EnableWeakPtrThreadingAssertions::Yes)
-{
-    return makeWeakPtr(object.get(), enableWeakPtrThreadingAssertions);
-}
-
-// FIXME: Drop when we support C++20. C++17 does not support template parameter deduction for aliases and WeakPtr is an alias in this file.
-template<typename T, typename = std::enable_if_t<!WTF::IsSmartPtr<T>::value>> inline auto makeWeakPtr(const RefPtr<T>& object, EnableWeakPtrThreadingAssertions enableWeakPtrThreadingAssertions = EnableWeakPtrThreadingAssertions::Yes)
-{
-    return makeWeakPtr(object.get(), enableWeakPtrThreadingAssertions);
-}
-
 struct Int : public CanMakeWeakPtr<Int> {
     Int(int i) : m_i(i) { }
     operator int() const { return m_i; }
@@ -338,49 +312,49 @@ TEST(WTF_WeakPtr, Downcasting)
         EXPECT_EQ(baseWeakPtr->foo(), basePtr->foo());
         EXPECT_EQ(baseWeakPtr.get()->foo(), basePtr->foo());
 
-        derivedWeakPtr = makeWeakPtr(object);
+        derivedWeakPtr = object;
         EXPECT_EQ(derivedWeakPtr->foo(), dummy1);
         EXPECT_EQ(derivedWeakPtr->foo(), derivedPtr->foo());
-        EXPECT_EQ(derivedWeakPtr.get()->foo(), derivedPtr->foo());
+        EXPECT_EQ(derivedWeakPtr->foo(), derivedPtr->foo());
 
-        EXPECT_EQ(baseWeakPtr.get(), derivedWeakPtr.get());
+        EXPECT_EQ(baseWeakPtr.get(), derivedWeakPtr);
     }
 
     EXPECT_NULL(baseWeakPtr.get());
-    EXPECT_NULL(derivedWeakPtr.get());
+    EXPECT_NULL(derivedWeakPtr);
 }
 
 TEST(WTF_WeakPtr, DerivedConstructAndAssign)
 {
     Derived derived;
     {
-        WeakPtr<Derived> derivedWeakPtr = makeWeakPtr(derived);
+        WeakPtr<Derived> derivedWeakPtr = derived;
         WeakPtr<Base> baseWeakPtr { WTFMove(derivedWeakPtr) };
         EXPECT_EQ(baseWeakPtr.get(), &derived);
-        SUPPRESS_USE_AFTER_MOVE EXPECT_NULL(derivedWeakPtr.get());
+        SUPPRESS_USE_AFTER_MOVE EXPECT_NULL(derivedWeakPtr);
     }
 
     {
-        WeakPtr<Derived> derivedWeakPtr = makeWeakPtr(derived);
+        WeakPtr<Derived> derivedWeakPtr = derived;
         WeakPtr<Base> baseWeakPtr { derivedWeakPtr };
         EXPECT_EQ(baseWeakPtr.get(), &derived);
-        EXPECT_EQ(derivedWeakPtr.get(), &derived);
+        EXPECT_EQ(derivedWeakPtr, &derived);
     }
 
     {
-        WeakPtr<Derived> derivedWeakPtr = makeWeakPtr(derived);
+        WeakPtr<Derived> derivedWeakPtr = derived;
         WeakPtr<Base> baseWeakPtr;
         baseWeakPtr = WTFMove(derivedWeakPtr);
         EXPECT_EQ(baseWeakPtr.get(), &derived);
-        SUPPRESS_USE_AFTER_MOVE EXPECT_NULL(derivedWeakPtr.get());
+        SUPPRESS_USE_AFTER_MOVE EXPECT_NULL(derivedWeakPtr);
     }
 
     {
-        WeakPtr<Derived> derivedWeakPtr = makeWeakPtr(derived);
+        WeakPtr<Derived> derivedWeakPtr = derived;
         WeakPtr<Base> baseWeakPtr;
         baseWeakPtr = derivedWeakPtr;
         EXPECT_EQ(baseWeakPtr.get(), &derived);
-        EXPECT_EQ(derivedWeakPtr.get(), &derived);
+        EXPECT_EQ(derivedWeakPtr, &derived);
     }
 }
 
@@ -388,21 +362,21 @@ TEST(WTF_WeakPtr, DerivedConstructAndAssignConst)
 {
     const Derived derived;
     {
-        auto derivedWeakPtr = makeWeakPtr(derived);
+        auto derivedWeakPtr = WeakPtr { derived };
         WeakPtr<const Base> baseWeakPtr { WTFMove(derivedWeakPtr) };
         EXPECT_EQ(baseWeakPtr.get(), &derived);
         SUPPRESS_USE_AFTER_MOVE EXPECT_NULL(derivedWeakPtr.get());
     }
 
     {
-        auto derivedWeakPtr = makeWeakPtr(derived);
+        auto derivedWeakPtr = WeakPtr<const Derived> { derived };
         WeakPtr<const Base> baseWeakPtr { derivedWeakPtr };
         EXPECT_EQ(baseWeakPtr.get(), &derived);
         EXPECT_EQ(derivedWeakPtr.get(), &derived);
     }
 
     {
-        auto derivedWeakPtr = makeWeakPtr(derived);
+        auto derivedWeakPtr = WeakPtr<const Derived> { derived };
         WeakPtr<const Base> baseWeakPtr;
         baseWeakPtr = WTFMove(derivedWeakPtr);
         EXPECT_EQ(baseWeakPtr.get(), &derived);
@@ -410,7 +384,7 @@ TEST(WTF_WeakPtr, DerivedConstructAndAssignConst)
     }
 
     {
-        auto derivedWeakPtr = makeWeakPtr(derived);
+        auto derivedWeakPtr = WeakPtr<const Derived> { derived };
         WeakPtr<const Base> baseWeakPtr;
         baseWeakPtr = derivedWeakPtr;
         EXPECT_EQ(baseWeakPtr.get(), &derived);
@@ -444,7 +418,7 @@ TEST(WTF_WeakPtr, MakeWeakPtrTakesRef)
     EXPECT_EQ(baseObject->refCount(), 1U);
     EXPECT_EQ(baseObject->weakCount(), 0U);
     {
-        auto baseObjectWeakPtr = makeWeakPtr(baseObject);
+        auto baseObjectWeakPtr = WeakPtr<BaseObjectWithRefAndWeakPtr> { baseObject };
         EXPECT_EQ(baseObject->refCount(), 1U);
         EXPECT_EQ(baseObject->weakCount(), 1U);
         EXPECT_EQ(baseObjectWeakPtr.get(), baseObject.ptr());
@@ -458,7 +432,7 @@ TEST(WTF_WeakPtr, MakeWeakPtrTakesRef)
         EXPECT_EQ(derivedObject->refCount(), 1U);
         EXPECT_EQ(derivedObject->weakCount(), 0U);
         {
-            WeakPtr<DerivedObjectWithRefAndWeakPtr> derivedObjectWeakPtr = makeWeakPtr(derivedObject);
+            WeakPtr<DerivedObjectWithRefAndWeakPtr> derivedObjectWeakPtr = derivedObject;
             EXPECT_EQ(derivedObject->refCount(), 1U);
             EXPECT_EQ(derivedObject->weakCount(), 1U);
             EXPECT_EQ(derivedObjectWeakPtr.get(), derivedObject.ptr());
@@ -469,7 +443,7 @@ TEST(WTF_WeakPtr, MakeWeakPtrTakesRef)
             Ref<BaseObjectWithRefAndWeakPtr> baseRefPtr = derivedObject;
             EXPECT_EQ(derivedObject->refCount(), 2U);
             EXPECT_EQ(derivedObject->weakCount(), 0U);
-            baseWeakPtr = makeWeakPtr(baseRefPtr);
+            baseWeakPtr = baseRefPtr;
             EXPECT_EQ(derivedObject->refCount(), 2U);
             EXPECT_EQ(derivedObject->weakCount(), 1U);
             EXPECT_EQ(baseWeakPtr.get(), derivedObject.ptr());
@@ -487,7 +461,7 @@ TEST(WTF_WeakPtr, MakeWeakPtrTakesRefPtr)
     EXPECT_EQ(baseObject->refCount(), 1U);
     EXPECT_EQ(baseObject->weakCount(), 0U);
     {
-        auto baseObjectWeakPtr = makeWeakPtr(baseObject);
+        auto baseObjectWeakPtr = baseObject;
         EXPECT_EQ(baseObject->refCount(), 1U);
         EXPECT_EQ(baseObject->weakCount(), 1U);
         EXPECT_EQ(baseObjectWeakPtr.get(), baseObject.get());
@@ -499,12 +473,12 @@ TEST(WTF_WeakPtr, MakeWeakPtrTakesRefPtr)
     EXPECT_EQ(derivedObject->refCount(), 1U);
     EXPECT_EQ(derivedObject->weakCount(), 0U);
     {
-        WeakPtr<DerivedObjectWithRefAndWeakPtr> derivedObjectWeakPtr = makeWeakPtr(derivedObject);
+        WeakPtr<DerivedObjectWithRefAndWeakPtr> derivedObjectWeakPtr = derivedObject;
         EXPECT_EQ(derivedObject->refCount(), 1U);
         EXPECT_EQ(derivedObject->weakCount(), 1U);
         EXPECT_EQ(derivedObjectWeakPtr.get(), derivedObject.get());
 
-        WeakPtr<BaseObjectWithRefAndWeakPtr> baseObjectWeakPtr = makeWeakPtr<BaseObjectWithRefAndWeakPtr>(derivedObject);
+        WeakPtr<BaseObjectWithRefAndWeakPtr> baseObjectWeakPtr = WeakPtr<BaseObjectWithRefAndWeakPtr>(derivedObject);
         EXPECT_EQ(derivedObject->refCount(), 1U);
         EXPECT_EQ(derivedObject->weakCount(), 2U);
         EXPECT_EQ(baseObjectWeakPtr.get(), derivedObject.get());


### PR DESCRIPTION
#### 56ec61801813ab746c26ef551d9294f7ae4345a7
<pre>
Use C++20&apos;s CTAD with aliases in Tests/WTF/WeakPtr
<a href="https://bugs.webkit.org/show_bug.cgi?id=292755">https://bugs.webkit.org/show_bug.cgi?id=292755</a>
<a href="https://rdar.apple.com/problem/150980099">rdar://problem/150980099</a>

Reviewed by NOBODY (OOPS!).

Drop makeWeakPtr() helper functions in favor of direct WeakPtr construction
by using C++20 class template argument deduction with aliases core language feature.

* Tools/TestWebKitAPI/Tests/WTF/WeakPtr.cpp:
(TestWebKitAPI::TEST(WTF_WeakPtr, Downcasting)):
(TestWebKitAPI::TEST(WTF_WeakPtr, DerivedConstructAndAssign)):
(TestWebKitAPI::TEST(WTF_WeakPtr, DerivedConstructAndAssignConst)):
(TestWebKitAPI::TEST(WTF_WeakPtr, MakeWeakPtrTakesRef)):
(TestWebKitAPI::TEST(WTF_WeakPtr, MakeWeakPtrTakesRefPtr)):
(TestWebKitAPI::makeWeakPtr): Deleted.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/56ec61801813ab746c26ef551d9294f7ae4345a7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/102841 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/22515 "Hash 56ec6180 for PR 45146 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/12834 "Hash 56ec6180 for PR 45146 does not build (failure)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/108007 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/53482 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/104880 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/22834 "Hash 56ec6180 for PR 45146 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/31016 "Hash 56ec6180 for PR 45146 does not build (failure)") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78198 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/35160 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/105847 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/130/builds/22834 "Hash 56ec6180 for PR 45146 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/138/builds/12834 "Hash 56ec6180 for PR 45146 does not build (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58532 "Found 1 new API test failure: /TestWTF:WTF_WeakPtr.MakeWeakPtrTakesRefPtr (failure)") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/130/builds/22834 "Hash 56ec6180 for PR 45146 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/138/builds/12834 "Hash 56ec6180 for PR 45146 does not build (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/52839 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/130/builds/22834 "Hash 56ec6180 for PR 45146 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/138/builds/12834 "Hash 56ec6180 for PR 45146 does not build (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/110382 "Built successfully") | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/29978 "Hash 56ec6180 for PR 45146 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/123/builds/31016 "Hash 56ec6180 for PR 45146 does not build (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/87183 "Passed tests") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/30342 "Hash 56ec6180 for PR 45146 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/138/builds/12834 "Hash 56ec6180 for PR 45146 does not build (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86800 "Found 1 new API test failure: /TestWTF:WTF_WeakPtr.MakeWeakPtrTakesRefPtr (failure)") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/138/builds/12834 "Hash 56ec6180 for PR 45146 does not build (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/24240 "Built successfully") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/29905 "Hash 56ec6180 for PR 45146 does not build (failure)") | | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/29713 "Hash 56ec6180 for PR 45146 does not build (failure)") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/33040 "Hash 56ec6180 for PR 45146 does not build (failure)") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/31275 "Hash 56ec6180 for PR 45146 does not build (failure)") | | | 
<!--EWS-Status-Bubble-End-->