### PR TITLE
Fix ODR violation in ListDataController

### DIFF
--- a/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.h
+++ b/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.h
@@ -89,9 +89,7 @@ protected:
     virtual bool hasCachedListData() const = 0;
     virtual void didUpdateCachedListData() { }
     virtual void updateList(CompletionHandler<void()>&&) = 0;
-#ifdef __OBJC__
-    virtual WPResourceType resourceType() const = 0;
-#endif
+    virtual unsigned resourceTypeValue() const = 0;
 
     RetainPtr<WKWebPrivacyNotificationListener> m_notificationListener;
     WeakHashSet<ListDataObserver> m_observers;
@@ -138,34 +136,30 @@ public:
 
 private:
     void didUpdateCachedListData() final { m_cachedListData.shrinkToFit(); }
-#ifdef __OBJC__
-    WPResourceType resourceType() const final;
-#endif
+    unsigned resourceTypeValue() const final;
 };
 
 class StorageAccessPromptQuirkController : public ListDataController<StorageAccessPromptQuirkController, Vector<WebCore::OrganizationStorageAccessPromptQuirk>> {
 private:
     void updateList(CompletionHandler<void()>&&) final;
     void didUpdateCachedListData() final;
-#ifdef __OBJC__
-    WPResourceType resourceType() const final;
-#endif
+    unsigned resourceTypeValue() const final;
 };
 
 class StorageAccessUserAgentStringQuirkController : public ListDataController<StorageAccessUserAgentStringQuirkController, HashMap<WebCore::RegistrableDomain, String>> {
 private:
     void updateList(CompletionHandler<void()>&&) final;
-#ifdef __OBJC__
-    WPResourceType resourceType() const final;
-#endif
+    unsigned resourceTypeValue() const final;
 };
 
 class ScriptTelemetryController : public ListDataController<ScriptTelemetryController, ScriptTelemetryRules> {
 private:
     void updateList(CompletionHandler<void()>&&) final;
     void didUpdateCachedListData() final;
+    unsigned resourceTypeValue() const final;
 #ifdef __OBJC__
-    WPResourceType resourceType() const final;
+    // FIXME: Remove when WebPrivacyHelpersAdditions.mm no longer depends on it.
+    WPResourceType resourceType() const;
 #endif
 };
 

--- a/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.mm
+++ b/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.mm
@@ -102,7 +102,7 @@ Ref<ListDataObserver> ListDataControllerBase::observeUpdates(Function<void()>&& 
 {
     ASSERT(RunLoop::isMain());
     if (!m_notificationListener) {
-        m_notificationListener = adoptNS([[WKWebPrivacyNotificationListener alloc] initWithType:resourceType() callback:^{
+        m_notificationListener = adoptNS([[WKWebPrivacyNotificationListener alloc] initWithType:static_cast<WPResourceType>(resourceTypeValue()) callback:^{
             updateList([weakThis = WeakPtr { *this }] {
                 RefPtr protectedThis = weakThis.get();
                 if (!protectedThis)
@@ -136,7 +136,7 @@ void ListDataControllerBase::initializeIfNeeded()
     });
 }
 
-WPResourceType LinkDecorationFilteringController::resourceType() const
+unsigned LinkDecorationFilteringController::resourceTypeValue() const
 {
     return WPResourceTypeLinkFilteringData;
 }
@@ -224,9 +224,9 @@ void requestLinkDecorationFilteringData(LinkFilteringRulesCallback&& callback)
     }];
 }
 
-WPResourceType StorageAccessPromptQuirkController::resourceType() const
+unsigned StorageAccessPromptQuirkController::resourceTypeValue() const
 {
-    return static_cast<WPResourceType>(WPResourceTypeStorageAccessPromptQuirksData);
+    return WPResourceTypeStorageAccessPromptQuirksData;
 }
 
 void StorageAccessPromptQuirkController::didUpdateCachedListData()
@@ -295,9 +295,9 @@ void StorageAccessPromptQuirkController::updateList(CompletionHandler<void()>&& 
     }];
 }
 
-WPResourceType StorageAccessUserAgentStringQuirkController::resourceType() const
+unsigned StorageAccessUserAgentStringQuirkController::resourceTypeValue() const
 {
-    return static_cast<WPResourceType>(WPResourceTypeStorageAccessUserAgentStringQuirksData);
+    return WPResourceTypeStorageAccessUserAgentStringQuirksData;
 }
 
 void StorageAccessUserAgentStringQuirkController::updateList(CompletionHandler<void()>&& completionHandler)
@@ -758,12 +758,12 @@ void ScriptTelemetryController::updateList(CompletionHandler<void()>&& completio
 {
     RunLoop::protectedMain()->dispatch(WTFMove(completion));
 }
-
-WPResourceType ScriptTelemetryController::resourceType() const
-{
-    return static_cast<WPResourceType>(9);
-}
 #endif
+
+unsigned ScriptTelemetryController::resourceTypeValue() const
+{
+    return 9;
+}
 
 void ScriptTelemetryController::didUpdateCachedListData()
 {


### PR DESCRIPTION
#### be75d50ff3e3df5adff146a63c4756299f31a331
<pre>
Fix ODR violation in ListDataController
<a href="https://bugs.webkit.org/show_bug.cgi?id=292761">https://bugs.webkit.org/show_bug.cgi?id=292761</a>
<a href="https://rdar.apple.com/150981612">rdar://150981612</a>

Reviewed by Wenson Hsieh.

The class ListDataController can have multiple definitions across different translation units, because its virtual
function only exist when OBJC is true. This is against ODR rule and can lead to undefined behavior at runtime, like
crash due to failing to find a function in vtable.

* Source/WebKit/Platform/cocoa/WebPrivacyHelpers.h:
* Source/WebKit/Platform/cocoa/WebPrivacyHelpers.mm:
(WebKit::ListDataControllerBase::observeUpdates):
(WebKit::LinkDecorationFilteringController::resourceTypeValue const):
(WebKit::StorageAccessPromptQuirkController::resourceTypeValue const):
(WebKit::StorageAccessUserAgentStringQuirkController::resourceTypeValue const):
(WebKit::ScriptTelemetryController::resourceTypeValue const):
(WebKit::LinkDecorationFilteringController::resourceType const): Deleted.
(WebKit::StorageAccessPromptQuirkController::resourceType const): Deleted.
(WebKit::StorageAccessUserAgentStringQuirkController::resourceType const): Deleted.
(WebKit::ScriptTelemetryController::resourceType const): Deleted.

Canonical link: <a href="https://commits.webkit.org/294716@main">https://commits.webkit.org/294716@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/18b4b9ecc0a69b9a859abf2e4489c05d9e3ad858

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/102770 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/22443 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/12763 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/107935 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/53411 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/22760 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/30945 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78148 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/35115 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/105776 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17625 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/92748 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58480 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/17470 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/52768 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/87282 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10851 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/110311 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/29907 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/22038 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/87133 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/30271 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88944 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86744 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22090 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31578 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/9304 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/24163 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/29834 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/35155 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/29642 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/32969 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/31204 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->