### PR TITLE
[WebDriver][BiDi] Driver segfault waiting for relay response when browser abruptly closes

### DIFF
--- a/Source/WebDriver/Session.cpp
+++ b/Source/WebDriver/Session.cpp
@@ -3306,9 +3306,9 @@ void Session::relayBidiCommand(const String& message, unsigned commandId, Functi
     m_host->sendCommandToBackend("processBidiMessage"_s, WTFMove(parameters), [protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler), commandId](SessionHost::CommandResponse&& response) {
         if (response.isError) {
             auto errorCode = CommandResult::ErrorCode::UnknownError;
-            auto errorMessage = response.responseObject->getString("message"_s);
-            if (errorMessage.isNull())
-                errorMessage = "Unknown error"_s;
+            std::optional<String> errorMessage;
+            if (response.responseObject)
+                errorMessage = response.responseObject->getString("message"_s);
             completionHandler(WebSocketMessageHandler::Message::fail(errorCode, std::nullopt, errorMessage, { commandId }));
         }
     });

--- a/Source/WebDriver/SessionHost.cpp
+++ b/Source/WebDriver/SessionHost.cpp
@@ -46,9 +46,11 @@ void SessionHost::inspectorDisconnected()
 {
     Ref<SessionHost> protectedThis(*this);
     // Browser closed or crashed, finish all pending commands with error.
+    RefPtr<JSON::Object> errorResponse = JSON::Object::create();
+    errorResponse->setString("message"_s, "Session terminated without a reply"_s);
     for (auto messageID : copyToVector(m_commandRequests.keys())) {
         auto responseHandler = m_commandRequests.take(messageID);
-        responseHandler({ nullptr, true });
+        responseHandler({ errorResponse , true });
     }
 
 #if ENABLE(WEBDRIVER_BIDI)


### PR DESCRIPTION
#### c89929f28371a2215edddfdba37139aea5432d05
<pre>
[WebDriver][BiDi] Driver segfault waiting for relay response when browser abruptly closes
<a href="https://bugs.webkit.org/show_bug.cgi?id=292738">https://bugs.webkit.org/show_bug.cgi?id=292738</a>

Reviewed by Carlos Garcia Campos.

Originally, SessionHost::inspectorDisconnected reported just empty error
messages, while Session::relayBidiCommand expected a string error if the
initial dispatch failed. This combination could lead to segfaults when
the browser closed prematurely.

This commit makes Session::relayBidiCommand check the response message
contents to avoid such segfauls, and also add an error message to
SessionHost::inspectorDisconnected, making it easier for the clients to
know why the command failed.

* Source/WebDriver/Session.cpp:
(WebDriver::Session::relayBidiCommand): Check if we have a response
object before accessing it.
* Source/WebDriver/SessionHost.cpp:
(WebDriver::SessionHost::inspectorDisconnected): Instead of an empty
error, give a message telling the command is failing because the browser
closed.

Canonical link: <a href="https://commits.webkit.org/294769@main">https://commits.webkit.org/294769@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4978f7dc2807004d4cc2beeb0716f9150895bd6e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/102771 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/22444 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/12764 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/107936 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/53412 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/22761 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/30946 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78149 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/35117 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/105777 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17629 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/92749 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58481 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/17480 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/10784 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/52769 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/87286 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10852 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/110312 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/29908 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/22039 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/87134 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/30272 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88945 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86745 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22124 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31582 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/9305 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/24164 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/29835 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/35156 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/29643 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/32970 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/31205 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->