### PR TITLE
Style property `nativeAppearanceDisabled` should be inherited

### DIFF
--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -98,37 +98,11 @@ RenderTheme::RenderTheme()
 
 RenderTheme::~RenderTheme() = default;
 
-static bool parentOfElementUsesPrimitiveAppearance(const Element& element)
-{
-    if (RefPtr parent = element.parentOrShadowHostElement()) {
-        if (CheckedPtr computedStyle = parent->computedStyle())
-            return computedStyle->usedAppearance() == StyleAppearance::None;
-    }
-
-    return false;
-}
-
 StyleAppearance RenderTheme::adjustAppearanceForElement(RenderStyle& style, const Element* element, StyleAppearance autoAppearance) const
 {
     if (!element) {
         style.setUsedAppearance(StyleAppearance::None);
         return StyleAppearance::None;
-    }
-
-    // Each user agent part for input type='color' controls
-    // should use StyleAppearance::None if their parent is
-    // using primitive appearance.
-
-    // FIXME: (rdar://148625484) If the parent devolves
-    // after the initial styles are applied, the children
-    // are not immediately updated to match.
-
-    if ((autoAppearance == StyleAppearance::ColorWellSwatch
-        || autoAppearance == StyleAppearance::ColorWellSwatchOverlay
-        || autoAppearance == StyleAppearance::ColorWellSwatchWrapper)
-        && parentOfElementUsesPrimitiveAppearance(*element)) {
-            style.setUsedAppearance(StyleAppearance::None);
-            return StyleAppearance::None;
     }
 
     auto appearance = style.usedAppearance();
@@ -269,7 +243,7 @@ void RenderTheme::adjustStyle(RenderStyle& style, const Element* element)
         style.setEffectiveDisplay(DisplayType::Block);
 
     bool widgetMayDevolve = devolvableWidgetsEnabledAndSupported(element);
-    bool widgetHasNativeAppearanceDisabled = widgetMayDevolve && element->isDevolvableWidget() && style.nativeAppearanceDisabled() && !isAppearanceAllowedForAllElements(appearance);
+    bool widgetHasNativeAppearanceDisabled = widgetMayDevolve && style.nativeAppearanceDisabled() && !isAppearanceAllowedForAllElements(appearance);
     bool hasAppearanceFromUAStyle = element && hasAppearanceForElementTypeFromUAStyle(*element);
 
     if (!widgetMayDevolve || shouldCheckLegacyStylesForNativeAppearance(element))

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -1283,6 +1283,7 @@ static bool rareInheritedDataChangeRequiresRepaint(const StyleRareInheritedData&
 #if ENABLE(DARK_MODE_CSS)
         || first.colorScheme != second.colorScheme
 #endif
+        || first.nativeAppearanceDisabled != second.nativeAppearanceDisabled
     ;
 }
 
@@ -2216,6 +2217,7 @@ void RenderStyle::conservativelyCollectChangedAnimatableProperties(const RenderS
         // cursorData
         // textEmphasisCustomMark
         // insideDefaultButton
+        // nativeAppearanceDisabled
     };
 
     if (m_inheritedFlags != other.m_inheritedFlags)

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -1134,7 +1134,6 @@ public:
 #endif
 
     inline bool useSmoothScrolling() const;
-    inline bool nativeAppearanceDisabled() const;
 
 #if ENABLE(TEXT_AUTOSIZING)
     inline TextSizeAdjustment textSizeAdjust() const;
@@ -1691,7 +1690,6 @@ public:
 #endif
 
     inline void setUseSmoothScrolling(bool);
-    inline void setNativeAppearanceDisabled(bool);
 
 #if ENABLE(TEXT_AUTOSIZING)
     inline void setTextSizeAdjust(TextSizeAdjustment);
@@ -2219,8 +2217,6 @@ public:
 
     static bool initialUseSmoothScrolling() { return false; }
 
-    static bool initialNativeAppearanceDisabled() { return false; }
-
     static inline FilterOperations initialFilter();
     static inline FilterOperations initialAppleColorFilter();
 
@@ -2364,6 +2360,9 @@ public:
 
     inline bool insideDefaultButton() const;
     inline void setInsideDefaultButton(bool);
+
+    inline bool nativeAppearanceDisabled() const;
+    inline void setNativeAppearanceDisabled(bool);
 
 private:
     struct NonInheritedFlags {

--- a/Source/WebCore/rendering/style/RenderStyleInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleInlines.h
@@ -827,8 +827,6 @@ inline float RenderStyle::wordSpacing() const { return m_inheritedData->fontData
 constexpr LengthType RenderStyle::zeroLength() { return LengthType::Fixed; }
 inline float RenderStyle::zoom() const { return m_nonInheritedData->rareData->zoom; }
 
-inline bool RenderStyle::nativeAppearanceDisabled() const { return m_nonInheritedData->rareData->nativeAppearanceDisabled; }
-
 inline const Style::CornerShapeValue& RenderStyle::cornerBottomLeftShape() const { return border().bottomLeftCornerShape(); }
 inline const Style::CornerShapeValue& RenderStyle::cornerBottomRightShape() const { return border().bottomRightCornerShape(); }
 inline const Style::CornerShapeValue& RenderStyle::cornerTopLeftShape() const { return border().topLeftCornerShape(); }
@@ -901,6 +899,8 @@ inline Style::Color RenderStyle::tapHighlightColor() const { return m_rareInheri
 #endif
 
 inline bool RenderStyle::insideDefaultButton() const { return m_rareInheritedData->insideDefaultButton; }
+
+inline bool RenderStyle::nativeAppearanceDisabled() const { return m_rareInheritedData->nativeAppearanceDisabled; }
 
 inline bool RenderStyle::NonInheritedFlags::hasPseudoStyle(PseudoId pseudo) const
 {

--- a/Source/WebCore/rendering/style/RenderStyleSetters.h
+++ b/Source/WebCore/rendering/style/RenderStyleSetters.h
@@ -371,8 +371,6 @@ inline void RenderStyle::setCornerBottomRightShape(Style::CornerShapeValue&& sha
 inline void RenderStyle::setCornerTopLeftShape(Style::CornerShapeValue&& shape) { SET_NESTED(m_nonInheritedData, surroundData, border.m_cornerShapes.topLeft(), WTFMove(shape)); }
 inline void RenderStyle::setCornerTopRightShape(Style::CornerShapeValue&& shape) { SET_NESTED(m_nonInheritedData, surroundData, border.m_cornerShapes.topRight(), WTFMove(shape)); }
 
-inline void RenderStyle::setNativeAppearanceDisabled(bool value) { SET_NESTED(m_nonInheritedData, rareData, nativeAppearanceDisabled, value); }
-
 #if ENABLE(APPLE_PAY)
 inline void RenderStyle::setApplePayButtonStyle(ApplePayButtonStyle style) { SET_NESTED(m_nonInheritedData, rareData, applePayButtonStyle, static_cast<unsigned>(style)); }
 inline void RenderStyle::setApplePayButtonType(ApplePayButtonType type) { SET_NESTED(m_nonInheritedData, rareData, applePayButtonType, static_cast<unsigned>(type)); }
@@ -406,6 +404,8 @@ inline void RenderStyle::setTapHighlightColor(const Style::Color& color) { SET(m
 #endif
 
 inline void RenderStyle::setInsideDefaultButton(bool value) { SET(m_rareInheritedData, insideDefaultButton, value); }
+
+inline void RenderStyle::setNativeAppearanceDisabled(bool value) { SET(m_rareInheritedData, nativeAppearanceDisabled, value); }
 
 inline void RenderStyle::NonInheritedFlags::setHasPseudoStyles(PseudoIdSet pseudoIdSet)
 {

--- a/Source/WebCore/rendering/style/StyleRareInheritedData.cpp
+++ b/Source/WebCore/rendering/style/StyleRareInheritedData.cpp
@@ -146,6 +146,7 @@ StyleRareInheritedData::StyleRareInheritedData()
     , isInVisibilityAdjustmentSubtree(false)
     , usedContentVisibility(static_cast<unsigned>(ContentVisibility::Visible))
     , insideDefaultButton(false)
+    , nativeAppearanceDisabled(false)
 #if HAVE(CORE_MATERIAL)
     , usedAppleVisualEffectForSubtree(static_cast<unsigned>(AppleVisualEffect::None))
 #endif
@@ -247,6 +248,7 @@ inline StyleRareInheritedData::StyleRareInheritedData(const StyleRareInheritedDa
     , isInVisibilityAdjustmentSubtree(o.isInVisibilityAdjustmentSubtree)
     , usedContentVisibility(o.usedContentVisibility)
     , insideDefaultButton(o.insideDefaultButton)
+    , nativeAppearanceDisabled(o.nativeAppearanceDisabled)
 #if HAVE(CORE_MATERIAL)
     , usedAppleVisualEffectForSubtree(o.usedAppleVisualEffectForSubtree)
 #endif
@@ -382,6 +384,7 @@ bool StyleRareInheritedData::operator==(const StyleRareInheritedData& o) const
         && effectiveInert == o.effectiveInert
         && usedContentVisibility == o.usedContentVisibility
         && insideDefaultButton == o.insideDefaultButton
+        && nativeAppearanceDisabled == o.nativeAppearanceDisabled
 #if HAVE(CORE_MATERIAL)
         && usedAppleVisualEffectForSubtree == o.usedAppleVisualEffectForSubtree
 #endif
@@ -508,6 +511,7 @@ void StyleRareInheritedData::dumpDifferences(TextStream& ts, const StyleRareInhe
     LOG_IF_DIFFERENT_WITH_CAST(ContentVisibility, usedContentVisibility);
 
     LOG_IF_DIFFERENT_WITH_CAST(bool, insideDefaultButton);
+    LOG_IF_DIFFERENT_WITH_CAST(bool, nativeAppearanceDisabled);
 
 #if HAVE(CORE_MATERIAL)
     LOG_IF_DIFFERENT_WITH_CAST(AppleVisualEffect, usedAppleVisualEffectForSubtree);

--- a/Source/WebCore/rendering/style/StyleRareInheritedData.h
+++ b/Source/WebCore/rendering/style/StyleRareInheritedData.h
@@ -184,6 +184,8 @@ public:
 
     unsigned insideDefaultButton : 1;
 
+    unsigned nativeAppearanceDisabled : 1;
+
 #if HAVE(CORE_MATERIAL)
     unsigned usedAppleVisualEffectForSubtree : 4; // AppleVisualEffect
 #endif

--- a/Source/WebCore/rendering/style/StyleRareNonInheritedData.cpp
+++ b/Source/WebCore/rendering/style/StyleRareNonInheritedData.cpp
@@ -135,7 +135,6 @@ StyleRareNonInheritedData::StyleRareNonInheritedData()
     , positionTryOrder(static_cast<unsigned>(RenderStyle::initialPositionTryOrder()))
     , positionVisibility(RenderStyle::initialPositionVisibility().toRaw())
     , fieldSizing(static_cast<unsigned>(RenderStyle::initialFieldSizing()))
-    , nativeAppearanceDisabled(static_cast<unsigned>(RenderStyle::initialNativeAppearanceDisabled()))
 #if HAVE(CORE_MATERIAL)
     , appleVisualEffect(static_cast<unsigned>(RenderStyle::initialAppleVisualEffect()))
 #endif
@@ -243,7 +242,6 @@ inline StyleRareNonInheritedData::StyleRareNonInheritedData(const StyleRareNonIn
     , positionTryOrder(o.positionTryOrder)
     , positionVisibility(o.positionVisibility)
     , fieldSizing(o.fieldSizing)
-    , nativeAppearanceDisabled(o.nativeAppearanceDisabled)
 #if HAVE(CORE_MATERIAL)
     , appleVisualEffect(o.appleVisualEffect)
 #endif
@@ -358,7 +356,6 @@ bool StyleRareNonInheritedData::operator==(const StyleRareNonInheritedData& o) c
         && positionTryOrder == o.positionTryOrder
         && positionVisibility == o.positionVisibility
         && fieldSizing == o.fieldSizing
-        && nativeAppearanceDisabled == o.nativeAppearanceDisabled
 #if HAVE(CORE_MATERIAL)
         && appleVisualEffect == o.appleVisualEffect
 #endif
@@ -531,8 +528,6 @@ void StyleRareNonInheritedData::dumpDifferences(TextStream& ts, const StyleRareN
     LOG_IF_DIFFERENT_WITH_CAST(bool, hasClip);
     LOG_IF_DIFFERENT_WITH_CAST(Style::PositionTryOrder, positionTryOrder);
     LOG_IF_DIFFERENT(fieldSizing);
-
-    LOG_IF_DIFFERENT(nativeAppearanceDisabled);
 
 #if HAVE(CORE_MATERIAL)
     LOG_IF_DIFFERENT(appleVisualEffect);

--- a/Source/WebCore/rendering/style/StyleRareNonInheritedData.h
+++ b/Source/WebCore/rendering/style/StyleRareNonInheritedData.h
@@ -275,8 +275,6 @@ public:
 
     unsigned fieldSizing : 1; // FieldSizing
 
-    unsigned nativeAppearanceDisabled : 1;
-
 #if HAVE(CORE_MATERIAL)
     unsigned appleVisualEffect : 5; // AppleVisualEffect
 #endif


### PR DESCRIPTION
#### e9dfe40088fc6421629ed54088490758490a2c05
<pre>
Style property `nativeAppearanceDisabled` should be inherited
<a href="https://bugs.webkit.org/show_bug.cgi?id=292763">https://bugs.webkit.org/show_bug.cgi?id=292763</a>
<a href="https://rdar.apple.com/148625484">rdar://148625484</a>

Reviewed by NOBODY (OOPS!).

If native appearance is disabled for an element, it should also be
disabled for its children in order to prevent widgets in the devolved
state from retaining native components.

* Source/WebCore/rendering/RenderTheme.cpp:
(WebCore::RenderTheme::adjustAppearanceForElement const):
(WebCore::RenderTheme::adjustStyle):
(WebCore::parentOfElementUsesPrimitiveAppearance): Deleted.
* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::rareInheritedDataChangeRequiresRepaint):
(WebCore::RenderStyle::conservativelyCollectChangedAnimatableProperties const):
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/style/RenderStyleInlines.h:
(WebCore::RenderStyle::nativeAppearanceDisabled const):
* Source/WebCore/rendering/style/RenderStyleSetters.h:
(WebCore::RenderStyle::setNativeAppearanceDisabled):
* Source/WebCore/rendering/style/StyleRareInheritedData.cpp:
(WebCore::StyleRareInheritedData::StyleRareInheritedData):
(WebCore::StyleRareInheritedData::operator== const):
(WebCore::StyleRareInheritedData::dumpDifferences const):
* Source/WebCore/rendering/style/StyleRareInheritedData.h:
* Source/WebCore/rendering/style/StyleRareNonInheritedData.cpp:
(WebCore::StyleRareNonInheritedData::StyleRareNonInheritedData):
(WebCore::StyleRareNonInheritedData::operator== const):
(WebCore::StyleRareNonInheritedData::dumpDifferences const):
* Source/WebCore/rendering/style/StyleRareNonInheritedData.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e9dfe40088fc6421629ed54088490758490a2c05

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/102785 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/22458 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/12778 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/107950 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/53426 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/104824 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/22776 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/30960 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78166 "Found 136 new test failures: imported/w3c/web-platform-tests/css/css-ui/compute-kind-widget-generated/grouped-kind-of-widget-fallback-background-attachment-001.html imported/w3c/web-platform-tests/css/css-ui/compute-kind-widget-generated/grouped-kind-of-widget-fallback-background-color-001.html imported/w3c/web-platform-tests/css/css-ui/compute-kind-widget-generated/grouped-kind-of-widget-fallback-border-image-source-001.html imported/w3c/web-platform-tests/css/css-ui/compute-kind-widget-generated/kind-of-widget-fallback-checkbox-input-background-attachment-001.html imported/w3c/web-platform-tests/css/css-ui/compute-kind-widget-generated/kind-of-widget-fallback-checkbox-input-background-clip-001.html imported/w3c/web-platform-tests/css/css-ui/compute-kind-widget-generated/kind-of-widget-fallback-checkbox-input-background-color-001.html imported/w3c/web-platform-tests/css/css-ui/compute-kind-widget-generated/kind-of-widget-fallback-checkbox-input-background-image-001.html imported/w3c/web-platform-tests/css/css-ui/compute-kind-widget-generated/kind-of-widget-fallback-checkbox-input-background-origin-001.html imported/w3c/web-platform-tests/css/css-ui/compute-kind-widget-generated/kind-of-widget-fallback-checkbox-input-background-position-001.html imported/w3c/web-platform-tests/css/css-ui/compute-kind-widget-generated/kind-of-widget-fallback-checkbox-input-background-size-001.html ... (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/35131 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/105791 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17639 "Found 4 new test failures: fast/forms/ios/form-control-refresh/checkbox/ignored-properties.html fast/forms/ios/form-control-refresh/radio/ignored-properties.html fast/forms/ios/form-control-refresh/range/border.html fast/forms/search-styled.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/92763 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58498 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/17496 "Found 60 new test failures: imported/w3c/web-platform-tests/css/css-position/position-fixed-scroll-overlap.html imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-fixed-ancestor-iframe.html imported/w3c/web-platform-tests/css/css-sizing/range-percent-intrinsic-size-2.html imported/w3c/web-platform-tests/css/css-sizing/range-percent-intrinsic-size-2a.html imported/w3c/web-platform-tests/css/css-ui/compute-kind-widget-generated/kind-of-widget-fallback-checkbox-input-background-attachment-001.html imported/w3c/web-platform-tests/css/css-ui/compute-kind-widget-generated/kind-of-widget-fallback-checkbox-input-background-clip-001.html imported/w3c/web-platform-tests/css/css-ui/compute-kind-widget-generated/kind-of-widget-fallback-checkbox-input-background-color-001.html imported/w3c/web-platform-tests/css/css-ui/compute-kind-widget-generated/kind-of-widget-fallback-checkbox-input-background-image-001.html imported/w3c/web-platform-tests/css/css-ui/compute-kind-widget-generated/kind-of-widget-fallback-checkbox-input-background-origin-001.html imported/w3c/web-platform-tests/css/css-ui/compute-kind-widget-generated/kind-of-widget-fallback-checkbox-input-background-position-001.html ... (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/10798 "Found 60 new test failures: fast/css/text-input-with-webkit-border-radius.html fast/forms/001.html fast/forms/number/number-dark-appearance.html fast/forms/search-styled.html fast/workers/worker-page-cache.html fonts/monospace.html fonts/sans-serif.html fonts/serif.html fonts/unicode-character-font-crash.html fonts/use-typo-metrics-1.html ... (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/52783 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/87295 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10866 "Found 60 new test failures: compositing/transforms/transformed-replaced-with-shadow-children.html fast/css/attribute-selector-null-crash.html fast/css/text-input-with-webkit-border-radius.html fast/forms/001.html fast/forms/number/number-dark-appearance.html fast/forms/search-styled.html http/tests/contentextensions/make-https.html http/tests/security/contentSecurityPolicy/user-style-sheet-font-crasher.py http/tests/xmlhttprequest/state-after-network-error.html imported/w3c/web-platform-tests/css/css-sizing/range-percent-intrinsic-size-2.html ... (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/110326 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/29922 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/22048 "Found 60 new test failures: fast/css/text-input-with-webkit-border-radius.html fast/forms/001.html fast/forms/number/number-dark-appearance.html fast/forms/search-styled.html fast/text/zero-width-characters-complex-script.html fullscreen/full-screen-enter-while-exiting-multiple-elements.html http/tests/contentextensions/make-https.html http/tests/images/gif-progressive-load.html http/tests/resourceLoadStatistics/website-data-removal-for-site-navigated-to-with-filtered-link-decoration-after-long-deletion.html http/tests/security/contentSecurityPolicy/script-redirect-blocked.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/87148 "Found 137 new test failures: fast/forms/001.html imported/w3c/web-platform-tests/css/css-ui/compute-kind-widget-generated/grouped-kind-of-widget-fallback-background-attachment-001.html imported/w3c/web-platform-tests/css/css-ui/compute-kind-widget-generated/grouped-kind-of-widget-fallback-background-color-001.html imported/w3c/web-platform-tests/css/css-ui/compute-kind-widget-generated/grouped-kind-of-widget-fallback-border-image-source-001.html imported/w3c/web-platform-tests/css/css-ui/compute-kind-widget-generated/kind-of-widget-fallback-checkbox-input-background-attachment-001.html imported/w3c/web-platform-tests/css/css-ui/compute-kind-widget-generated/kind-of-widget-fallback-checkbox-input-background-clip-001.html imported/w3c/web-platform-tests/css/css-ui/compute-kind-widget-generated/kind-of-widget-fallback-checkbox-input-background-color-001.html imported/w3c/web-platform-tests/css/css-ui/compute-kind-widget-generated/kind-of-widget-fallback-checkbox-input-background-image-001.html imported/w3c/web-platform-tests/css/css-ui/compute-kind-widget-generated/kind-of-widget-fallback-checkbox-input-background-origin-001.html imported/w3c/web-platform-tests/css/css-ui/compute-kind-widget-generated/kind-of-widget-fallback-checkbox-input-background-position-001.html ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/30286 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88959 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86762 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31594 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/9315 "Found 60 new test failures: css3/masking/clip-path-inset-corners.html css3/viewport-percentage-lengths/vh-resize.html fast/css/duplicated-after-pseudo-element.html fast/css/text-input-with-webkit-border-radius.html fast/forms/001.html fast/forms/number/number-dark-appearance.html fast/forms/search-styled.html http/tests/multipart/multipart-async-image.html http/tests/security/cached-cross-origin-preloaded-css-stylesheet.html imported/w3c/web-platform-tests/css/css-sizing/range-percent-intrinsic-size-2.html ... (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/24178 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/29849 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/35171 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/29657 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/32984 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/31219 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->