### PR TITLE
Fix start offset adjustment in rangeForParagraphSplittingTextNodesIfNeeded

### DIFF
--- a/LayoutTests/fast/editing/indent-split-paragraph-at-line-preserving-and-non-whitespace-collapsing-start-expected.txt
+++ b/LayoutTests/fast/editing/indent-split-paragraph-at-line-preserving-and-non-whitespace-collapsing-start-expected.txt
@@ -1,0 +1,1 @@
+PASS if no crash.

--- a/LayoutTests/fast/editing/indent-split-paragraph-at-line-preserving-and-non-whitespace-collapsing-start.html
+++ b/LayoutTests/fast/editing/indent-split-paragraph-at-line-preserving-and-non-whitespace-collapsing-start.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<style>
+blockquote,br { -webkit-user-modify: read-only; }
+img { float: right; }
+.pre { white-space: pre; }
+</style>
+<div style="contain: strict">
+  <div contenteditable="true">
+    <span class="pre">&#x0A;A&#x0A;<div><span id="container"></span>&#x0A;</div>
+  </div>
+</div>
+<script>
+  window.testRunner?.dumpAsText();
+  document.designMode = "on";
+  window.getSelection().selectAllChildren(container);
+  document.execCommand("indent",false,null);
+  document.execCommand("insertImage",false,"x");
+  document.execCommand("delete",false,null);
+  document.execCommand("insertImage",false,"x");
+  document.execCommand("delete",false,null);
+  window.getSelection().selectAllChildren(container);
+  document.execCommand("indent",false,null);
+  document.execCommand("indent",false,null);
+  document.body.innerHTML = "PASS if no crash.";
+</script>

--- a/Source/WebCore/editing/ApplyBlockElementCommand.cpp
+++ b/Source/WebCore/editing/ApplyBlockElementCommand.cpp
@@ -217,7 +217,7 @@ void ApplyBlockElementCommand::rangeForParagraphSplittingTextNodesIfNeeded(const
 
         // Avoid obtanining the start of next paragraph for start
         if (preservesNewLine && isNewLineAtPosition(start) && !isNewLineAtPosition(start.previous()) && start.offsetInContainerNode() > 0)
-            start = startOfParagraph(end.previous()).deepEquivalent();
+            start = startOfParagraph(start.previous()).deepEquivalent();
 
         // If start is in the middle of a text node, split.
         if (!collapsesWhiteSpace && start.offsetInContainerNode() > 0) {


### PR DESCRIPTION
#### 983e776f3ae9860a43e123b86aaecce97335f109
<pre>
Fix start offset adjustment in rangeForParagraphSplittingTextNodesIfNeeded
<a href="https://bugs.webkit.org/show_bug.cgi?id=289375">https://bugs.webkit.org/show_bug.cgi?id=289375</a>

Reviewed by Ryosuke Niwa.

Currently if the start is a text node preserving new lines, we can do

start = startOfParagraph(end.previous()).deepEquivalent();

which may move to a different node. In particular, if start was not
collapsing whitespace then we may try to split at the start position
which is no longer guaranteed to be a text node.

Comparing with what we do for the end position, it seems this is just
a mistake from <a href="https://commits.webkit.org/59955@main">https://commits.webkit.org/59955@main</a> and we mean to
consider the position before the start instead.

* LayoutTests/fast/editing/indent-split-paragraph-at-line-preserving-and-non-whitespace-collapsing-start-expected.txt: Added.
* LayoutTests/fast/editing/indent-split-paragraph-at-line-preserving-and-non-whitespace-collapsing-start.html: Added.
* Source/WebCore/editing/ApplyBlockElementCommand.cpp:
(WebCore::ApplyBlockElementCommand::rangeForParagraphSplittingTextNodesIfNeeded): Use the position before the start instead.

Canonical link: <a href="https://commits.webkit.org/294949@main">https://commits.webkit.org/294949@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b485c8ca5712b91f1ba1f88687f8b887da7ef852

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/102789 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/22462 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/12782 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/107954 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/53430 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/104828 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/22781 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/30964 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78165 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/35130 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/105795 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17640 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/92764 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58497 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/17489 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/10799 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/52787 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/87296 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10867 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/110330 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/29926 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/22049 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/87152 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/30290 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88960 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86766 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22238 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31596 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/9316 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/24182 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/29853 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/35175 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/29661 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/32988 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/31223 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->