### PR TITLE
[WPE] WPEPlatform: implement EventSenderProxy touch methods

### DIFF
--- a/Source/WebKit/UIProcess/API/wpe/WPEWebViewPlatform.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/WPEWebViewPlatform.cpp
@@ -308,7 +308,7 @@ Vector<WebKit::WebPlatformTouchPoint> ViewPlatform::touchPointsForEvent(WPEEvent
         double x, y;
         wpe_event_get_position(currentEvent, &x, &y);
         WebCore::IntPoint position(x, y);
-        points.append(WebPlatformTouchPoint(it.key, stateForEvent(it.key, currentEvent), position, position));
+        points.append(WebPlatformTouchPoint(it.key, stateForEvent(it.key, event), position, position));
     }
     return points;
 }

--- a/Tools/WebKitTestRunner/wpe/EventSenderProxyClientWPE.h
+++ b/Tools/WebKitTestRunner/wpe/EventSenderProxyClientWPE.h
@@ -26,8 +26,8 @@
 #pragma once
 
 #if ENABLE(WPE_PLATFORM)
-
 #include "EventSenderProxyClient.h"
+#include <wtf/Vector.h>
 
 namespace WTR {
 
@@ -45,6 +45,31 @@ private:
     void mouseScrollBy(int, int, double, double, double) override;
 
     void keyDown(WKStringRef, double, WKEventModifiers, unsigned) override;
+
+#if ENABLE(TOUCH_EVENTS)
+    void addTouchPoint(int, int, double) override;
+    void updateTouchPoint(int, int, int, double) override;
+    void releaseTouchPoint(int, double) override;
+    void cancelTouchPoint(int, double) override;
+    void clearTouchPoints() override;
+    void touchStart(double) override;
+    void touchMove(double) override;
+    void touchEnd(double) override;
+    void touchCancel(double) override;
+    void setTouchModifier(WKEventModifiers, bool);
+
+    struct TouchPoint {
+        enum class State { Down, Up, Move, Cancel, Stationary };
+
+        uint32_t id { 0 };
+        State state { State::Stationary };
+        int x { 0 };
+        int y { 0 };
+    };
+
+    Vector<TouchPoint> m_touchPoints;
+    unsigned m_touchModifiers { 0 };
+#endif // ENABLE(TOUCH_EVENTS)
 };
 
 } // namespace WTR


### PR DESCRIPTION
#### 14f5637a0139d0acb53a8a1bd2845eb10ecb8ea1
<pre>
[WPE] WPEPlatform: implement EventSenderProxy touch methods
<a href="https://bugs.webkit.org/show_bug.cgi?id=292766">https://bugs.webkit.org/show_bug.cgi?id=292766</a>

Reviewed by Alejandro G. Castro.

Also fix a bug I found while running tests in touchPointsForEvent() that
we were passing the wrong WPEEvent.

* Source/WebKit/UIProcess/API/wpe/WPEWebViewPlatform.cpp:
(WKWPE::ViewPlatform::touchPointsForEvent):
* Tools/WebKitTestRunner/wpe/EventSenderProxyClientWPE.cpp:
(WTR::EventSenderProxyClientWPE::addTouchPoint):
(WTR::EventSenderProxyClientWPE::updateTouchPoint):
(WTR::EventSenderProxyClientWPE::releaseTouchPoint):
(WTR::EventSenderProxyClientWPE::cancelTouchPoint):
(WTR::EventSenderProxyClientWPE::clearTouchPoints):
(WTR::EventSenderProxyClientWPE::touchStart):
(WTR::EventSenderProxyClientWPE::touchMove):
(WTR::EventSenderProxyClientWPE::touchEnd):
(WTR::EventSenderProxyClientWPE::touchCancel):
(WTR::EventSenderProxyClientWPE::setTouchModifier):
* Tools/WebKitTestRunner/wpe/EventSenderProxyClientWPE.h:

Canonical link: <a href="https://commits.webkit.org/294892@main">https://commits.webkit.org/294892@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d858807994bb72db1ba7908f350eeb793c3a20e4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/103290 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/22966 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/13287 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/108463 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/53933 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/105329 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/23305 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/31517 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78495 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/35422 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/106296 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/18063 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/93182 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58828 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/17899 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/11224 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/53289 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/87704 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/11286 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/110837 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/30428 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/22468 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/87492 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-on-non-root.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/30793 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/89380 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87128 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31990 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/9708 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/24751 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16772 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/30357 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/35676 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/30163 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/33490 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/31725 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->