### PR TITLE
[TESTING] Verifying libpas Structure Heap calls pas_page_malloc commit

### DIFF
--- a/Source/JavaScriptCore/heap/StructureAlignedMemoryAllocator.cpp
+++ b/Source/JavaScriptCore/heap/StructureAlignedMemoryAllocator.cpp
@@ -109,6 +109,8 @@ public:
 #if !USE(SYSTEM_MALLOC)
         m_useDebugHeap = !bmalloc::api::isEnabled();
         if (!m_useDebugHeap) [[likely]] {
+            // Protect the structure heap region; pas_page_malloc commit will mark the region as readable / writeable
+            OSAllocator::protect((void *) g_jscConfig.startOfStructureHeap, g_jscConfig.sizeOfStructureHeap, false, false);
             bmalloc_force_auxiliary_heap_into_reserved_memory(&structureHeap, reinterpret_cast<uintptr_t>(g_jscConfig.startOfStructureHeap) + MarkedBlock::blockSize, reinterpret_cast<uintptr_t>(g_jscConfig.startOfStructureHeap) + g_jscConfig.sizeOfStructureHeap);
             return;
         }

--- a/Source/bmalloc/libpas/src/libpas/pas_page_malloc.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_page_malloc.c
@@ -221,6 +221,8 @@ static void commit_impl(void* ptr, size_t size, bool do_mprotect, pas_mmap_capab
     if (end_as_int == base_as_int)
         return;
 
+    PAS_SYSCALL(mprotect((void*)base_as_int, end_as_int - base_as_int, PROT_READ | PROT_WRITE));
+
     if (PAS_MPROTECT_DECOMMITTED && do_mprotect && mmap_capability)
         PAS_SYSCALL(mprotect((void*)base_as_int, end_as_int - base_as_int, PROT_READ | PROT_WRITE));
 


### PR DESCRIPTION
Not seeing pas_page_malloc commit called by the structure heap when enabling libpas on Windows; Windows requires commit is called unlike other platforms.

Kicking off EWS to verify if commit is called on this codepath.<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b2ef0059ba580f651e3307eb2d69a9862682e17a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/102807 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/22480 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/12800 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/107973 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/53448 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/22799 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/30982 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78179 "Failure limit exceed. At least found 495 new test failures: accessibility/ARIA-reflection.html accessibility/accessibility-crash-focused-element-change.html accessibility/accessibility-crash-setattribute.html accessibility/accessibility-crash-with-dynamic-inline-content.html accessibility/accessibility-node-memory-management.html accessibility/accessibility-node-reparent.html accessibility/accessibility-object-detached.html accessibility/accessibility-object-update-during-style-resolution-crash.html accessibility/activation-of-input-field-inside-other-element.html accessibility/active-descendant-changes-result-in-focus-changes.html ... (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/35144 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/105813 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17657 "Found 60 new test failures: accessibility/accessibility-node-reparent.html accessibility/announcement-notification.html accessibility/aria-braillelabel.html accessibility/aria-brailleroledescription.html accessibility/aria-checked-mixed-value.html accessibility/aria-controlled-table-row-visibility.html accessibility/aria-current-state-changed-notification.html accessibility/aria-current.html accessibility/aria-describedby-on-input.html accessibility/aria-description.html ... (failure)") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/93192 "Build was cancelled. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Running apply-patch; Checked out pull request; run-api-tests (failure); re-run-api-tests (cancelled)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58511 "Found 245 new API test failures: /TestJSC:/jsc/array-buffer, /WPE/TestWebProcessExtensions:/webkit/WebKitWebProcessExtension/window-object-cleared, /TestWebKit:WebKit.GeolocationBasicWithHighAccuracy, /TestWebKit:WebKit.ForceRepaint, /TestWebKit:WebKit.GeolocationWatchMultiprocess, /WPE/TestLoaderClient:/webkit/WebKitWebView/user-agent, /WPE/TestWebKitFindController:/webkit/WebKitFindController/text-not-found, /WPE/TestInputMethodContext:/webkit/WebKitInputMethodContext/cancel-sequence, /WPE/TestCookieManager:/webkit/WebKitCookieManager/delete-cookie, /TestWebKit:WebKit.PendingAPIRequestURL ... (failure)") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/17540 "Found 60 new test failures: imported/w3c/web-platform-tests/FileAPI/Blob-methods-from-detached-frame.html imported/w3c/web-platform-tests/FileAPI/FileReader/Progress_event_bubbles_cancelable.html imported/w3c/web-platform-tests/FileAPI/FileReader/workers.html imported/w3c/web-platform-tests/FileAPI/FileReaderSync.worker.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-array-buffer.any.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-array-buffer.any.worker.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-bytes.any.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-bytes.any.worker.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-constructor-dom.window.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-constructor-endings.html ... (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/10815 "Found 60 new test failures: accessibility/ARIA-reflection.html accessibility/accessibility-crash-focused-element-change.html accessibility/accessibility-crash-setattribute.html accessibility/display-contents/aria-grid.html accessibility/display-contents/aria-hidden.html accessibility/display-contents/element-roles.html accessibility/mac/abbr-acronym-tags.html accessibility/mac/accesskey.html accessibility/mac/active-descendant-after-visibility-change.html accessibility/mac/attributed-string/attributed-string-does-not-includes-misspelled-for-non-editable.html ... (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/52805 "Built successfully") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/95482 "Found 3 new JSC binary failures: testair, testapi, testb3, Found 124287 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Array/ArrayBtreeBadCodeGen.js.default, ChakraCore.yaml/ChakraCore/test/Array/ArrayElementMissingValueSetToZero.js.default, ChakraCore.yaml/ChakraCore/test/Array/InlineArrayPopWithIntConstSrc.js.default, ChakraCore.yaml/ChakraCore/test/Array/LastUsedSegmentHasNULLElement.js.default, ChakraCore.yaml/ChakraCore/test/Array/SegmentMapFlagResetInJSArrayConstructor.js.default, ChakraCore.yaml/ChakraCore/test/Array/TryGrowHeadSegmentBug.js.default, ChakraCore.yaml/ChakraCore/test/Array/arr_bailout.js.default, ChakraCore.yaml/ChakraCore/test/Array/array_apply.js.default, ChakraCore.yaml/ChakraCore/test/Array/array_ctr.js.default, ChakraCore.yaml/ChakraCore/test/Array/array_fastinit.js.default ... (failure)") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/87709 "Build was cancelled. Recent messages:OS: Sequoia (15.2), Xcode: 16.2; Running apply-patch; Checked out pull request; run-api-tests (failure); re-run-api-tests (cancelled)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10882 "Found 60 new test failures: accessibility/ARIA-reflection.html accessibility/accessibility-crash-focused-element-change.html accessibility/combobox/aria-combobox-control-owns-elements.html accessibility/combobox/aria-combobox-hierarchy.html accessibility/combobox/aria-combobox-no-owns.html accessibility/combobox/mac/aria-combobox-activedescendant.html accessibility/combobox/mac/combobox-activedescendant-notifications.html accessibility/combobox/mac/combobox-inherited-role.html accessibility/custom-elements/autocomplete.html accessibility/custom-elements/controls-shadow.html ... (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/110348 "Built successfully") | 
| [❌ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/101417 "Found 1 new JSC binary failure: testapi, Found 124280 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Array/ArrayBtreeBadCodeGen.js.default, ChakraCore.yaml/ChakraCore/test/Array/ArrayElementMissingValueSetToZero.js.default, ChakraCore.yaml/ChakraCore/test/Array/InlineArrayPopWithIntConstSrc.js.default, ChakraCore.yaml/ChakraCore/test/Array/LastUsedSegmentHasNULLElement.js.default, ChakraCore.yaml/ChakraCore/test/Array/SegmentMapFlagResetInJSArrayConstructor.js.default, ChakraCore.yaml/ChakraCore/test/Array/TryGrowHeadSegmentBug.js.default, ChakraCore.yaml/ChakraCore/test/Array/arr_bailout.js.default, ChakraCore.yaml/ChakraCore/test/Array/array_apply.js.default, ChakraCore.yaml/ChakraCore/test/Array/array_ctr.js.default, ChakraCore.yaml/ChakraCore/test/Array/array_fastinit.js.default ... (failure)") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/29944 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/22062 "Exiting early after 60 failures. 60 tests run. 60 failures") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/87166 "Failure limit exceed. At least found 495 new test failures: accessibility/ARIA-reflection.html accessibility/accessibility-crash-focused-element-change.html accessibility/accessibility-crash-setattribute.html accessibility/accessibility-crash-with-dynamic-inline-content.html accessibility/accessibility-node-memory-management.html accessibility/accessibility-node-reparent.html accessibility/accessibility-object-detached.html accessibility/accessibility-object-update-during-style-resolution-crash.html accessibility/activation-of-input-field-inside-other-element.html accessibility/active-descendant-changes-result-in-focus-changes.html ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/30308 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/88975 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86781 "Found 282 new API test failures: /WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/sequence, /TestJSC:/jsc/array-buffer, /TestWebKit:WebKit.InjectedBundleInitializationUserDataCallbackWins, /WebKitGTK/TestDownloads:/webkit/Downloads/policy-decision-download-cancel, /TestWebKit:WebKit.GeolocationBasicWithHighAccuracy, /TestWebKit:WebKit.PendingAPIRequestURL, /WebKitGTK/TestAuthentication:/webkit/Authentication/authentication-failure, /WebKitGTK/TestDownloads:/webkit/Downloads/contex-menu-download-actions, /WebKitGTK/TestPrinting:/webkit/WebKitWebView/print, /WebKitGTK/TestFrame:/webkit/WebKitFrame/javascript-context ... (failure)") | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31611 "Found 60 new test failures: cookies/cookie-store-register-eventlistener-from-file-protocol.html cookies/cookie-store-start-listening-for-change-with-null-url-crash.html http/wpt/webxr/events_transient_pointer_input_source.https.html http/wpt/webxr/xrDevice_requestSession_hand_tracking_feature.https.html http/wpt/webxr/xrDevice_requestSession_previously_enabled_feature_not_requested.https.html http/wpt/webxr/xrFrame_fillJointRadii.html http/wpt/webxr/xrFrame_fillJointRadii_missing_joint_pose.html http/wpt/webxr/xrFrame_fillPoses.html http/wpt/webxr/xrFrame_fillPoses_missing_joint_pose.html http/wpt/webxr/xrFrame_getJointPose.html ... (failure)") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/9329 "Found 60 new test failures: accessibility/ARIA-reflection.html accessibility/accessibility-crash-focused-element-change.html accessibility/accessibility-crash-setattribute.html accessibility/combobox/aria-combobox-control-owns-elements.html accessibility/combobox/aria-combobox-hierarchy.html accessibility/combobox/mac/aria-combobox-activedescendant.html accessibility/combobox/mac/combobox-activedescendant-notifications.html accessibility/custom-elements/autocomplete.html accessibility/custom-elements/controls-shadow.html accessibility/custom-elements/controls.html ... (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/24206 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/29871 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/35193 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/125050 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/29679 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34701 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/33006 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/31241 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->