### PR TITLE
[GTK] Color chooser opens in a dialog outside the window

### DIFF
--- a/Source/WebCore/platform/gtk/GUniquePtrGtk.h
+++ b/Source/WebCore/platform/gtk/GUniquePtrGtk.h
@@ -20,6 +20,7 @@
 #ifndef GUniquePtrGtk_h
 #define GUniquePtrGtk_h
 
+#include <gdk/gdk.h>
 #include <gtk/gtk.h>
 #include <wtf/glib/GUniquePtr.h>
 
@@ -28,6 +29,8 @@ namespace WTF {
 #if !USE(GTK4)
 WTF_DEFINE_GPTR_DELETER(GdkEvent, gdk_event_free)
 #endif
+
+WTF_DEFINE_GPTR_DELETER(GdkRGBA, gdk_rgba_free)
 
 WTF_DEFINE_GPTR_DELETER(GtkTreePath, gtk_tree_path_free)
 

--- a/Source/WebKit/UIProcess/gtk/WebColorPickerGtk.h
+++ b/Source/WebKit/UIProcess/gtk/WebColorPickerGtk.h
@@ -27,6 +27,8 @@
 
 #include "WebColorPicker.h"
 #include <gdk/gdk.h>
+#include <gtk/gtk.h>
+#include <wtf/glib/GRefPtr.h>
 
 typedef struct _GtkColorChooser GtkColorChooser;
 
@@ -58,10 +60,19 @@ protected:
     GtkWidget* m_webView;
 
 private:
+#if GTK_CHECK_VERSION(4, 10, 0)
+    static void colorDialogChooseCallback(GtkColorDialog*, GAsyncResult*, WebColorPickerGtk*);
+#else
     static void colorChooserDialogRGBAChangedCallback(GtkColorChooser*, GParamSpec*, WebColorPickerGtk*);
     static void colorChooserDialogResponseCallback(GtkColorChooser*, int /*responseID*/, WebColorPickerGtk*);
+#endif
 
+#if GTK_CHECK_VERSION(4, 10, 0)
+    GRefPtr<GtkColorDialog> m_colorDialog;
+    GRefPtr<GCancellable> m_cancellable;
+#else
     GtkWidget* m_colorChooser;
+#endif
 };
 
 } // namespace WebKit


### PR DESCRIPTION
#### b782b51cdda94223c3b51c072b6ea9db0e3a89a2
<pre>
[GTK] Color chooser opens in a dialog outside the window
<a href="https://bugs.webkit.org/show_bug.cgi?id=259613">https://bugs.webkit.org/show_bug.cgi?id=259613</a>

Reviewed by NOBODY (OOPS!).

GtkColorChooserDialog is deprecated, so use GtkColorDialog instead if it
is available. GtkColorDialog is notably a modal window, so this fixes
the color dialog opening in an entirely separate window from the rest of
the application.

The downside is that it is modal for the window rather than modal for
the web view, so you cannot interact with other tabs if any tab is
displaying a color picker. Perhaps this is not ideal. I think the nicest
approach would be to embed the dialog inside the WebKitWebViewBase, but
I&apos;m not sure how we would possibly do that since it&apos;s no longer a
GtkWidget.

* Source/WebCore/platform/gtk/GUniquePtrGtk.h:
* Source/WebKit/UIProcess/gtk/WebColorPickerGtk.cpp:
(WebKit::WebColorPickerGtk::WebColorPickerGtk):
(WebKit::WebColorPickerGtk::~WebColorPickerGtk):
(WebKit::WebColorPickerGtk::endPicker):
(WebKit::WebColorPickerGtk::colorDialogChooseCallback):
(WebKit::WebColorPickerGtk::showColorPicker):
* Source/WebKit/UIProcess/gtk/WebColorPickerGtk.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b782b51cdda94223c3b51c072b6ea9db0e3a89a2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/103399 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/23081 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/13399 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/108573 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/54042 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/105438 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/23427 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/31632 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78575 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/106405 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/18155 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/93275 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58909 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/17996 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/11319 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/53399 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/87790 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/11381 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/110949 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/30546 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/22540 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/87571 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/30907 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/89473 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87212 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32075 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/9795 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/24873 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/30474 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/35786 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/125643 "Build is in progress. Recent messages:") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/30274 "Built successfully") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/35/builds/125643 "Build is in progress. Recent messages:") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/33605 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/31835 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->