### PR TITLE
MacOS WebKit performance benchmarks should upload screenshot on every run

### DIFF
--- a/Tools/Scripts/webkitpy/benchmark_runner/webdriver_benchmark_runner.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/webdriver_benchmark_runner.py
@@ -1,5 +1,7 @@
 import json
 import logging
+import time
+import os
 
 from webkitpy.benchmark_runner.benchmark_runner import BenchmarkRunner
 
@@ -25,6 +27,8 @@ class WebDriverBenchmarkRunner(BenchmarkRunner):
             self._browser_driver.diagnose_test_failure(self._diagnose_dir, error)
             raise error
         else:
+            if not any(file.startswith('test-successful-screenshot-') for file in os.listdir(self._diagnose_dir)):
+                self._browser_driver._save_screenshot_to_path(self._diagnose_dir, f'test-successful-screenshot-{int(time.time())}.jpg')
             self._browser_driver.close_browsers()
 
         return json.loads(result)

--- a/Tools/Scripts/webkitpy/benchmark_runner/webserver_benchmark_runner.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/webserver_benchmark_runner.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os
+import time
 
 from webkitcorepy import NullContext, Timeout
 
@@ -47,6 +48,8 @@ class WebServerBenchmarkRunner(BenchmarkRunner):
             self._browser_driver.diagnose_test_failure(self._diagnose_dir, error)
             raise error
         else:
+            if not any(file.startswith('test-successful-screenshot-') for file in os.listdir(self._diagnose_dir)):
+                self._browser_driver._save_screenshot_to_path(self._diagnose_dir, f'test-successful-screenshot-{int(time.time())}.jpg')
             self._browser_driver.close_browsers()
         finally:
             self._http_server_driver.kill_server()


### PR DESCRIPTION
#### 85f74665fde1cedc472093a5221563da74b1f191
<pre>
MacOS WebKit performance benchmarks should upload screenshot on every run
<a href="https://bugs.webkit.org/show_bug.cgi?id=292793">https://bugs.webkit.org/show_bug.cgi?id=292793</a>

Reviewed by Dewei Zhu.

This commit makes macOS benchmarks initiated from run_benchmark upload a screenshot after every test run.

Canonical link: <a href="https://commits.webkit.org/294856@main">https://commits.webkit.org/294856@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4785ddb3fe3f2067956cb899ed40f45f31cd95a0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/102917 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/22591 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/12911 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/108084 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/53558 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/104956 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/22942 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/31092 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78241 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/35196 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/105923 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17765 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/92866 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58575 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/102393 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/17600 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/10909 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/52915 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/87409 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10976 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/110458 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/30054 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/22133 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/87229 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/30418 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/89069 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86849 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22179 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31697 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/9410 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/24316 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/29981 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/29789 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/33116 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/31351 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->