### PR TITLE
Visible (single-pixel) corner joint when two border sides have the same resolved color, but only one is a system color

### DIFF
--- a/LayoutTests/fast/borders/border-left-system-color-border-bottom-same-resolved-color-expected.html
+++ b/LayoutTests/fast/borders/border-left-system-color-border-bottom-same-resolved-color-expected.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<style>
+
+body {
+    background: red;
+}
+
+span {
+    border-left: 1px solid Canvas;
+    border-bottom: 1px solid Canvas;
+}
+
+</style>
+<span>Test</span>

--- a/LayoutTests/fast/borders/border-left-system-color-border-bottom-same-resolved-color.html
+++ b/LayoutTests/fast/borders/border-left-system-color-border-bottom-same-resolved-color.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<style>
+
+body {
+    background: red;
+}
+
+span {
+    border-left: 1px solid Canvas;
+}
+
+</style>
+<span>Test</span>
+<script>
+
+const element = document.querySelector("span");
+element.style.borderBottom = getComputedStyle(element).borderLeft;
+
+</script>

--- a/Source/WebCore/rendering/BorderEdge.h
+++ b/Source/WebCore/rendering/BorderEdge.h
@@ -73,7 +73,7 @@ using BorderEdges = RectEdges<BorderEdge>;
 BorderEdges borderEdges(const RenderStyle&, float deviceScaleFactor, RectEdges<bool> closedEdges = { true }, LayoutSize inflation = { }, bool setColorsToBlack = false);
 BorderEdges borderEdgesForOutline(const RenderStyle&, float deviceScaleFactor);
 
-inline bool edgesShareColor(const BorderEdge& firstEdge, const BorderEdge& secondEdge) { return firstEdge.color() == secondEdge.color(); }
+inline bool edgesShareColor(const BorderEdge& firstEdge, const BorderEdge& secondEdge) { return equalIgnoringSemanticColor(firstEdge.color(), secondEdge.color()); }
 inline BoxSideFlag edgeFlagForSide(BoxSide side) { return static_cast<BoxSideFlag>(1 << static_cast<unsigned>(side)); }
 inline bool includesEdge(OptionSet<BoxSideFlag> flags, BoxSide side) { return flags.contains(edgeFlagForSide(side)); }
 


### PR DESCRIPTION
#### 4a5c967fabbe3a3872d3bad460b5f7d527180fd4
<pre>
Visible (single-pixel) corner joint when two border sides have the same resolved color, but only one is a system color
<a href="https://bugs.webkit.org/show_bug.cgi?id=292795">https://bugs.webkit.org/show_bug.cgi?id=292795</a>
<a href="https://rdar.apple.com/151025313">rdar://151025313</a>

Reviewed by Simon Fraser and Richard Robinson.

If adjacent border sides have a different color, `BorderPainter` takes a slightly
more complex painting path to mitre (join at an angle) the sides. In that scenario,
`BorderPainter` builds and draws a path, as opposed to a simple rect. Even when
used for the same resolved color, the two painting codepaths can therefore result
in small pixel differences.

When using a system color on one side and an explicitly specified color equal to
the same resolved color on the other, the mitre path is used since `edgesShareColor`
performs strict `Color` equality. System colors have the &quot;semantic&quot; bit set, which
means they will never be strictly equal to a non-system color.

Fix by updating `edgesShareColor` to perform color comparison ignoring the semantic
bit. This ensures the simple painting path is always used when two border sides
have the same resolved color.

* LayoutTests/fast/borders/border-left-system-color-border-bottom-same-resolved-color-expected.html: Added.
* LayoutTests/fast/borders/border-left-system-color-border-bottom-same-resolved-color.html: Added.
* Source/WebCore/rendering/BorderEdge.h:
(WebCore::edgesShareColor):

Canonical link: <a href="https://commits.webkit.org/294741@main">https://commits.webkit.org/294741@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1ad2086a8ed3a600da3174a30f1f8f8b1cc3c9db

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/102872 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/22546 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/12866 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/108038 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/53513 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/104911 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/22866 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/31047 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78219 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/35177 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/105878 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17706 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/92834 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58553 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/17549 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/10870 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/52870 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/87359 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10937 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/110413 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/30009 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/22108 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/87202 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/30373 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/89030 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86820 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31663 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/9380 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/24271 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16696 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/29936 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/35258 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/29744 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/33071 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/31306 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->