### PR TITLE
AX: AXCoreObject::{nextSiblingIncludingIgnored, previousSiblingIncludingIgnored} are O(n), causing poor performance on sites with big accessibility trees

### DIFF
--- a/Source/WebCore/accessibility/AccessibilityListBox.cpp
+++ b/Source/WebCore/accessibility/AccessibilityListBox.cpp
@@ -67,6 +67,10 @@ void AccessibilityListBox::addChildren()
 
     for (const auto& listItem : selectElement->listItems())
         addChild(listBoxOptionAccessibilityObject(listItem.get()), DescendIfIgnored::No);
+
+#ifndef NDEBUG
+    verifyChildrenIndexInParent();
+#endif
 }
 
 void AccessibilityListBox::setSelectedChildren(const AccessibilityChildrenVector& children)

--- a/Source/WebCore/accessibility/AccessibilityMathMLElement.cpp
+++ b/Source/WebCore/accessibility/AccessibilityMathMLElement.cpp
@@ -84,6 +84,10 @@ void AccessibilityMathMLElement::addChildren()
         addChild(object);
 
     m_subtreeDirty = false;
+
+#ifndef NDEBUG
+    verifyChildrenIndexInParent();
+#endif
 }
 
 String AccessibilityMathMLElement::textUnderElement(TextUnderElementMode mode) const

--- a/Source/WebCore/accessibility/AccessibilityMenuListPopup.cpp
+++ b/Source/WebCore/accessibility/AccessibilityMenuListPopup.cpp
@@ -103,6 +103,10 @@ void AccessibilityMenuListPopup::addChildren()
             addChild(*menuListOptionObject, DescendIfIgnored::No);
         }
     }
+
+#ifndef NDEBUG
+    verifyChildrenIndexInParent();
+#endif
 }
 
 void AccessibilityMenuListPopup::handleChildrenChanged()

--- a/Source/WebCore/accessibility/AccessibilityObject.h
+++ b/Source/WebCore/accessibility/AccessibilityObject.h
@@ -906,6 +906,11 @@ protected:
     bool allowsTextRanges() const;
     unsigned getLengthForTextRange() const;
 
+#ifndef NDEBUG
+    void verifyChildrenIndexInParent() const final { return AXCoreObject::verifyChildrenIndexInParent(m_children); }
+#endif
+    void resetChildrenIndexInParent() const;
+
 private:
     ProcessID processID() const final { return legacyPresentingApplicationPID(); }
     bool hasAncestorFlag(AXAncestorFlag flag) const { return ancestorFlagsAreInitialized() && m_ancestorFlags.contains(flag); }

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.h
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.h
@@ -186,7 +186,6 @@ private:
     void addImageMapChildren();
     void addAttachmentChildren();
     void addRemoteSVGChildren();
-    void addListItemMarker();
 #if PLATFORM(COCOA)
     void updateAttachmentViewParents();
 #endif

--- a/Source/WebCore/accessibility/AccessibilityScrollView.cpp
+++ b/Source/WebCore/accessibility/AccessibilityScrollView.cpp
@@ -183,6 +183,7 @@ void AccessibilityScrollView::removeChildScrollbar(AccessibilityObject* scrollba
     if (position != notFound) {
         m_children[position]->detachFromParent();
         m_children.remove(position);
+        resetChildrenIndexInParent();
 
         if (CheckedPtr cache = axObjectCache())
             cache->remove(scrollbar->objectID());
@@ -268,6 +269,10 @@ void AccessibilityScrollView::addChildren()
     addRemoteFrameChild();
     addChild(webAreaObject());
     updateScrollbars();
+
+#ifndef NDEBUG
+    verifyChildrenIndexInParent();
+#endif
 }
 
 AccessibilityObject* AccessibilityScrollView::webAreaObject() const

--- a/Source/WebCore/accessibility/AccessibilitySlider.cpp
+++ b/Source/WebCore/accessibility/AccessibilitySlider.cpp
@@ -98,6 +98,10 @@ void AccessibilitySlider::addChildren()
         cache->remove(thumb->objectID());
     else
         addChild(thumb.get());
+
+#ifndef NDEBUG
+    verifyChildrenIndexInParent();
+#endif
 }
 
 AccessibilityObject* AccessibilitySlider::elementAccessibilityHitTest(const IntPoint& point) const

--- a/Source/WebCore/accessibility/AccessibilityTable.cpp
+++ b/Source/WebCore/accessibility/AccessibilityTable.cpp
@@ -486,6 +486,10 @@ void AccessibilityTable::addChildren()
     // update their roles now that the table knows its status.
     // see bug: https://bugs.webkit.org/show_bug.cgi?id=147001
     updateChildrenRoles();
+
+#ifndef NDEBUG
+    verifyChildrenIndexInParent();
+#endif
 }
 
 // Returns the number of columns the table should have.

--- a/Source/WebCore/accessibility/AccessibilityTableColumn.cpp
+++ b/Source/WebCore/accessibility/AccessibilityTableColumn.cpp
@@ -106,6 +106,10 @@ void AccessibilityTableColumn::addChildren()
 
         addChild(*cell);
     }
+
+#ifndef NDEBUG
+    verifyChildrenIndexInParent();
+#endif
 }
     
 } // namespace WebCore

--- a/Source/WebCore/accessibility/AccessibilityTableHeaderContainer.cpp
+++ b/Source/WebCore/accessibility/AccessibilityTableHeaderContainer.cpp
@@ -74,6 +74,10 @@ void AccessibilityTableHeaderContainer::addChildren()
 
     for (const auto& child : m_children)
         m_headerRect.unite(child->elementRect());
+
+#ifndef NDEBUG
+    verifyChildrenIndexInParent();
+#endif
 }
 
 } // namespace WebCore

--- a/Source/WebCore/accessibility/AccessibilityTableRow.cpp
+++ b/Source/WebCore/accessibility/AccessibilityTableRow.cpp
@@ -174,6 +174,10 @@ void AccessibilityTableRow::addChildren()
             tableCell->setAXColIndexFromRow(*colIndex + index);
         index++;
     }
+
+#ifndef NDEBUG
+    verifyChildrenIndexInParent();
+#endif
 }
 
 std::optional<unsigned> AccessibilityTableRow::axColumnIndex() const

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
@@ -720,13 +720,21 @@ const AXCoreObject::AccessibilityChildrenVector& AXIsolatedObject::children(bool
     ASSERT(!isMainThread());
 #endif
     if (updateChildrenIfNeeded && m_childrenDirty) {
-        m_children = WTF::compactMap(m_childrenIDs, [&](auto& childID) -> std::optional<Ref<AXCoreObject>> {
-            if (RefPtr child = tree()->objectForID(childID))
+        unsigned index = 0;
+        m_children = WTF::compactMap(m_childrenIDs, [&] (auto& childID) -> std::optional<Ref<AXCoreObject>> {
+            if (RefPtr child = tree()->objectForID(childID)) {
+                if (setChildIndexInParent(*child, index))
+                    ++index;
                 return child.releaseNonNull();
+            }
             return std::nullopt;
         });
         m_childrenDirty = false;
         ASSERT(m_children.size() == m_childrenIDs.size());
+
+#ifndef NDEBUG
+        verifyChildrenIndexInParent();
+#endif
     }
     return m_children;
 }

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
@@ -574,6 +574,10 @@ private:
     String innerHTML() const final;
     String outerHTML() const final;
 
+#ifndef NDEBUG
+    void verifyChildrenIndexInParent() const final { return AXCoreObject::verifyChildrenIndexInParent(m_children); }
+#endif
+
     Vector<AXID> m_childrenIDs;
     Vector<Ref<AXCoreObject>> m_children;
     AXPropertyVector m_properties;


### PR DESCRIPTION
#### 202b4702d12b320ab03a6c2b9e4be7918023ab78
<pre>
AX: AXCoreObject::{nextSiblingIncludingIgnored, previousSiblingIncludingIgnored} are O(n), causing poor performance on sites with big accessibility trees
<a href="https://bugs.webkit.org/show_bug.cgi?id=292799">https://bugs.webkit.org/show_bug.cgi?id=292799</a>
<a href="https://rdar.apple.com/151029465">rdar://151029465</a>

Reviewed by Joshua Hoffman.

Prior to this commit, AXCoreObject::{nextSiblingIncludingIgnored, previousSiblingIncludingIgnored} were O(n) because
it iterated over siblings to find |this|, then used that index to return the next or previous sibling.

With this commit, each object now has an m_indexInParent member variable that is assigned by its parent when added as
a child. This new member variable does not increase the size of AXCoreObject, AXIsolatedObject, or AccessibilityObject
at all, as it was placed into a place that used to be occupied by padding between existing member variables.

This commit adds ASSERTs that verifies the cached indices are correct (contiguous, starting from zero, no gaps). When
debugging one of these ASSERTs, I discovered another performance optimization that also prevents said ASSERT. Prior to
this commit, we used to add all DOM children, then add our list marker child at index 0. This requires shifting the
entire vector over, which is O(n). Now, we move the addListItemMarker() call to the right place, obviating the need
for this O(n) work.

This eliminates 23782 samples of 49643 accessibility thread samples on <a href="http://html.spec.whatwg.org">http://html.spec.whatwg.org</a>, taken while holding
the VO-Right keys.

* Source/WebCore/accessibility/AXCoreObject.cpp:
(WebCore::AXCoreObject::verifyChildrenIndexInParent const):
(WebCore::AXCoreObject::indexInSiblings const):
(WebCore::AXCoreObject::nextSiblingIncludingIgnored const):
(WebCore::AXCoreObject::previousSiblingIncludingIgnored):
* Source/WebCore/accessibility/AXCoreObject.h:
(WebCore::AXCoreObject::setIndexInParent):
(WebCore::AXCoreObject::shouldSetChildIndexInParent const):
(WebCore::AXCoreObject::setChildIndexInParent const):
(WebCore::AXCoreObject::indexInParent const):
* Source/WebCore/accessibility/AccessibilityListBox.cpp:
(WebCore::AccessibilityListBox::addChildren):
* Source/WebCore/accessibility/AccessibilityMathMLElement.cpp:
(WebCore::AccessibilityMathMLElement::addChildren):
* Source/WebCore/accessibility/AccessibilityMenuListPopup.cpp:
(WebCore::AccessibilityMenuListPopup::addChildren):
* Source/WebCore/accessibility/AccessibilityNodeObject.cpp:
(WebCore::AccessibilityNodeObject::updateOwnedChildren):
(WebCore::AccessibilityNodeObject::addChildren):
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::insertChild):
(WebCore::AccessibilityObject::resetChildrenIndexInParent const):
* Source/WebCore/accessibility/AccessibilityObject.h:
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::AccessibilityRenderObject::addChildren):
(WebCore::AccessibilityRenderObject::addListItemMarker): Deleted.
* Source/WebCore/accessibility/AccessibilityRenderObject.h:
* Source/WebCore/accessibility/AccessibilityScrollView.cpp:
(WebCore::AccessibilityScrollView::removeChildScrollbar):
(WebCore::AccessibilityScrollView::addChildren):
* Source/WebCore/accessibility/AccessibilitySlider.cpp:
(WebCore::AccessibilitySlider::addChildren):
* Source/WebCore/accessibility/AccessibilityTable.cpp:
(WebCore::AccessibilityTable::addChildren):
* Source/WebCore/accessibility/AccessibilityTableColumn.cpp:
(WebCore::AccessibilityTableColumn::addChildren):
* Source/WebCore/accessibility/AccessibilityTableHeaderContainer.cpp:
(WebCore::AccessibilityTableHeaderContainer::addChildren):
* Source/WebCore/accessibility/AccessibilityTableRow.cpp:
(WebCore::AccessibilityTableRow::addChildren):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp:
(WebCore::AXIsolatedObject::children):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h:

Canonical link: <a href="https://commits.webkit.org/294747@main">https://commits.webkit.org/294747@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3fbfc8dcad204d30a9750dd7e2e930a8e1560c92

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/102888 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/22562 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/12882 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/108054 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/53529 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/104927 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/22882 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/31063 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78223 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/35178 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/105894 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17719 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/92850 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58557 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/17559 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/10885 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/52886 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/87368 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10952 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/110429 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/30025 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/22118 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/87209 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/30389 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/89045 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86828 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22111 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31678 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/9393 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/24287 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/29952 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/35274 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/29760 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/33087 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/31322 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->