### PR TITLE
Tools/Scripts/bisect-builds broken because host fails to resolve

### DIFF
--- a/Tools/Scripts/bisect-builds
+++ b/Tools/Scripts/bisect-builds
@@ -45,7 +45,7 @@ import tempfile
 import urllib
 
 
-REST_API_URL = 'https://q1tzqfy48e.execute-api.us-west-2.amazonaws.com/v2_2/'
+REST_API_URL = 'https://archives.webkit.org/'
 REST_API_ARCHIVE_ENDPOINT = 'archives/'
 REST_API_MINIFIED_ARCHIVE_ENDPOINT = 'minified-archives/'
 REST_API_PLATFORM_ENDPOINT = 'platforms'
@@ -192,17 +192,17 @@ def get_indices_from_revisions(revision_list, start_revision, end_revision):
 
 
 def get_sorted_revisions(revisions_dict):
-    revisions = [int(item['revision']['N']) for item in revisions_dict['revisions']['Items']]
+    revisions = [item['identifier']['S'] for item in revisions_dict['revisions']['Items']]
     return sorted(revisions)
 
 
 def get_s3_location_for_revision(url, revision):
-    url = '/'.join([url, str(revision)])
+    url = '?'.join([url, f'identifier={str(revision)}'])
     r = urllib.request.urlopen(url)
     data = json.load(r)
 
-    for archive in data['archive']:
-        s3_url = archive['s3_url']
+    for archive in data['revisions']['Items']:
+        s3_url = archive['s3_url']['S']
     return s3_url
 
 
@@ -344,7 +344,7 @@ def print_list_and_exit(revision_list, options):
     print_platforms(minified_platforms())
     print('Supported unminified platforms:')
     print_platforms(unminified_platforms())
-    print('{} revisions available for {}:'.format(len(revision_list), options.queue))
+    print('{} identifiers available for {}:'.format(len(revision_list), options.queue))
     print(revision_list)
     exit(0)
 
@@ -355,8 +355,8 @@ def fetch_revision_list(options, last_evaluated_key=None):
     data = json.load(r)
     revision_list = get_sorted_revisions(data)
 
-    if 'LastEvaluatedKey' in data['revisions']:
-        last_evaluated_key = data['revisions']['LastEvaluatedKey']
+    if 'LastEvaluatedKey' in data:
+        last_evaluated_key = data['LastEvaluatedKey']
         revision_list += fetch_revision_list(options, last_evaluated_key)
 
     return revision_list


### PR DESCRIPTION
#### 90505809a9bc57eaea29c3f27b1e8a08b444ac4c
<pre>
Tools/Scripts/bisect-builds broken because host fails to resolve
<a href="https://bugs.webkit.org/show_bug.cgi?id=291389">https://bugs.webkit.org/show_bug.cgi?id=291389</a>
<a href="https://rdar.apple.com/problem/149025878">rdar://problem/149025878</a>

Reviewed by Alexey Proskuryakov

This commit changes the Rest API URL and switches from working with Subversion numeric revisions to identifiers used to represent Git commits.

Several changes were also needed at the backend to replace API Gateway endpoints which can no longer be deployed without authentication.

(get_sorted_revisions):
(get_s3_location_for_revision):
(print_list_and_exit):
(fetch_revision_list):

Canonical link: <a href="https://commits.webkit.org/295006@main">https://commits.webkit.org/295006@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8272f933752e20efbe8d06c2773aa20576d333c5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/103745 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/23447 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/13767 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/108936 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/54397 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/105785 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/23794 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/31993 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78822 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/106751 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/18460 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/93587 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59156 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/18271 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/11635 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/53773 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/88048 "Found 1 new API test failure: TestWebKitAPI.CARingBufferTest.FetchTimeBoundsConsistent (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/11693 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/111325 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/30901 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/22783 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/87822 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/31262 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/89788 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87472 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22281 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32354 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10084 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/25258 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/30829 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/30623 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/33958 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/32184 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->