### PR TITLE
Cache gradients with the destination colorspace

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7609,6 +7609,9 @@ webkit.org/b/271428 fast/text/bidi-text-and-partial-layout-crash.html [ Skip ]
 # At the time of writing this test consumes all available IOSurfaces. If the next test is image-buffer-backend-variants.html, that will fail.
 fast/canvas/2d.context.many.small.html [ Slow Skip ]
 
+# Requires Display-P3 support
+fast/canvas/gradient-into-p3-canvas.html [ Failure ]
+
 webkit.org/b/268995 [ Debug ] fast/misc/out-of-flow-position-inside-mathml-crash.html [ Skip ]
 
 webkit.org/b/261557 media/video-remove-insert-repaints.html [ Pass Crash ]

--- a/LayoutTests/fast/canvas/gradient-into-p3-canvas-expected.txt
+++ b/LayoutTests/fast/canvas/gradient-into-p3-canvas-expected.txt
@@ -1,0 +1,5 @@
+PASS false is false
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/canvas/gradient-into-p3-canvas.html
+++ b/LayoutTests/fast/canvas/gradient-into-p3-canvas.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <script src="../../resources/js-test.js"></script>
+    <script>
+
+        function assertPixelApprox(ctx, x,y, r,g,b,a, tolerance)
+        {
+            var imgdata = ctx.getImageData(x, y, 1, 1);
+            var diff = Math.max(Math.abs(r-imgdata.data[0]), Math.abs(g-imgdata.data[1]), Math.abs(b-imgdata.data[2]), Math.abs(a-imgdata.data[3]));
+            shouldBeFalse((diff > tolerance).toString());
+        }
+
+        window.addEventListener('load', () => {
+            
+            const canvas = document.getElementsByTagName('canvas')[0];
+            const ctx = canvas.getContext('2d', { colorSpace: "display-p3" });
+            
+            const gradient = ctx.createLinearGradient(0, 0, 50, 50);
+
+            gradient.addColorStop(0, "blue");
+            gradient.addColorStop(0.25, "green");
+            gradient.addColorStop(0.5, "blue");
+            gradient.addColorStop(1, "blue");
+
+            ctx.fillStyle = gradient;
+            ctx.fillRect(0, 0, 50, 50);
+
+            assertPixelApprox(ctx, 48, 48, 0, 0, 244, 255, 2);
+        }, false);
+    </script>
+</head>
+<body>
+    <canvas height=50 width=50></canvas>
+</body>
+</html>

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -74,6 +74,8 @@ media/media-source/remoteplayback-from-source-element.html [ Pass ]
 # Individually failing tests should be marked in separate expectations.
 [ Sonoma+ ] imported/w3c/web-platform-tests/css/css-text/word-break/auto-phrase [ Pass ]
 
+fast/canvas/gradient-into-p3-canvas.html [ Pass ]
+
 #//////////////////////////////////////////////////////////////////////////////////////////
 # End platform-specific directories.
 #//////////////////////////////////////////////////////////////////////////////////////////

--- a/Source/WebCore/platform/graphics/Gradient.h
+++ b/Source/WebCore/platform/graphics/Gradient.h
@@ -106,7 +106,9 @@ public:
 
 #if USE(CG)
     void paint(GraphicsContext&);
-    void paint(CGContextRef);
+    // If the DestinationColorSpace is present, the gradient may cache a platform renderer using colors converted into this colorspace,
+    // which can be more efficient to render since it avoids colorspace conversions when lower level frameworks render the gradient.
+    void paint(CGContextRef, std::optional<DestinationColorSpace> = { });
 #endif
 
 #if USE(SKIA)

--- a/Source/WebCore/platform/graphics/cg/ColorCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/ColorCG.cpp
@@ -227,8 +227,8 @@ ColorComponents<float, 4> platformConvertColorComponents(ColorSpace inputColorSp
     auto transform = adoptCF(CGColorTransformCreate(outputColorSpace.platformColorSpace(), nullptr));
     auto result = CGColorTransformConvertColorComponents(transform.get(), cgInputColorSpace, kCGRenderingIntentDefault, sourceComponents.data(), destinationComponents.data());
     ASSERT_UNUSED(result, result);
-    // FIXME: CGColorTransformConvertColorComponents doesn't copy over any alpha component.
-    return { static_cast<float>(destinationComponents[0]), static_cast<float>(destinationComponents[1]), static_cast<float>(destinationComponents[2]), static_cast<float>(destinationComponents[3]) };
+    // CGColorTransformConvertColorComponents doesn't copy over any alpha component.
+    return { static_cast<float>(destinationComponents[0]), static_cast<float>(destinationComponents[1]), static_cast<float>(destinationComponents[2]), static_cast<float>(sourceComponents[3]) };
 }
 
 }

--- a/Source/WebCore/platform/graphics/cg/GradientRendererCG.h
+++ b/Source/WebCore/platform/graphics/cg/GradientRendererCG.h
@@ -43,15 +43,18 @@ struct ColorConvertedToInterpolationColorSpaceStop {
 
 class GradientRendererCG {
 public:
-    GradientRendererCG(ColorInterpolationMethod, const GradientColorStops&);
+    GradientRendererCG(ColorInterpolationMethod, const GradientColorStops&, std::optional<DestinationColorSpace>);
 
     void drawLinearGradient(CGContextRef, CGPoint startPoint, CGPoint endPoint, CGGradientDrawingOptions);
     void drawRadialGradient(CGContextRef, CGPoint startCenter, CGFloat startRadius, CGPoint endCenter, CGFloat endRadius, CGGradientDrawingOptions);
     void drawConicGradient(CGContextRef, CGPoint center, CGFloat angle);
 
+    std::optional<DestinationColorSpace> colorSpace() const;
+
 private:
     struct Gradient {
         RetainPtr<CGGradientRef> gradient;
+        std::optional<DestinationColorSpace> colorSpace;
     };
 
     struct Shading {
@@ -85,8 +88,8 @@ private:
 
     using Strategy = Variant<Gradient, Shading>;
 
-    Strategy pickStrategy(ColorInterpolationMethod, const GradientColorStops&) const;
-    Strategy makeGradient(ColorInterpolationMethod, const GradientColorStops&) const;
+    Strategy pickStrategy(ColorInterpolationMethod, const GradientColorStops&, std::optional<DestinationColorSpace>) const;
+    Strategy makeGradient(ColorInterpolationMethod, const GradientColorStops&, std::optional<DestinationColorSpace>) const;
     Strategy makeShading(ColorInterpolationMethod, const GradientColorStops&) const;
 
     Strategy m_strategy;


### PR DESCRIPTION
#### 47195378027dfc79782682ef15e877bb87cb96b9
<pre>
Cache gradients with the destination colorspace
<a href="https://bugs.webkit.org/show_bug.cgi?id=292808">https://bugs.webkit.org/show_bug.cgi?id=292808</a>
<a href="https://rdar.apple.com/151043882">rdar://151043882</a>

Reviewed by Sam Weinig.

When a gradient is painted by the underlying frameworks, its colors (usually sRGB) are converted
to the display colorspace, which has some cost. Gradients are usually fairly long-lived and painted
many times, so we can avoid that repeated colorspace conversion by having the gradient store colors
in the destination colorspace.

The test fails on iOS because of <a href="https://rdar.apple.com/151188818">rdar://151188818</a>.

* LayoutTests/TestExpectations:
* LayoutTests/platform/mac/TestExpectations:
* LayoutTests/fast/canvas/gradient-into-p3-canvas-expected.txt: Added.
* LayoutTests/fast/canvas/gradient-into-p3-canvas.html: Added. Tests the change in `platformConvertColorComponents()`.
* Source/WebCore/platform/graphics/Gradient.h: Pass an optional DestinationColorSpace to paint().
* Source/WebCore/platform/graphics/cg/ColorCG.cpp:
(WebCore::platformConvertColorComponents): We need to copy over the alpha, which is the fourth component.
* Source/WebCore/platform/graphics/cg/GradientCG.cpp:
(WebCore::Gradient::paint): The cached platform gradient can be reused if its colorspace matches the
destination colorspace.
* Source/WebCore/platform/graphics/cg/GradientRendererCG.cpp:
(WebCore::GradientRendererCG::GradientRendererCG):
(WebCore::GradientRendererCG::colorSpace const):
(WebCore::GradientRendererCG::pickStrategy const):
(WebCore::GradientRendererCG::makeGradient const): Convert the colors to the destination colorspace.
* Source/WebCore/platform/graphics/cg/GradientRendererCG.h:

Canonical link: <a href="https://commits.webkit.org/294844@main">https://commits.webkit.org/294844@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dd5a97b44ab61667449b3629739661411e1f3ddc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/103229 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/22905 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/13225 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/108398 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/53872 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/105268 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/23241 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/31511 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78461 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/35390 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/106235 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/18018 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/93131 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58794 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/17860 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/11174 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/53227 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/87667 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/11236 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/110775 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/30367 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/22463 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/87457 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/30732 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/89330 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87090 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22168 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31947 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/9662 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/24690 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/30296 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/35615 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/30102 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/33429 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/31664 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->