### PR TITLE
EventTarget.h and TreeScope.h don't need to include ExceptionOr.h

### DIFF
--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.cpp
@@ -30,6 +30,7 @@
 
 #include "ContextDestructionObserverInlines.h"
 #include "DOMException.h"
+#include "ExceptionOr.h"
 #include "JSDOMPromiseDeferred.h"
 #include "JSWebCodecsVideoEncoderSupport.h"
 #include "Logging.h"

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.h
@@ -36,6 +36,7 @@
 
 namespace WebCore {
 
+class Exception;
 class WebCodecsEncodedVideoChunk;
 class WebCodecsErrorCallback;
 class WebCodecsEncodedVideoChunkOutputCallback;

--- a/Source/WebCore/dom/EventTarget.h
+++ b/Source/WebCore/dom/EventTarget.h
@@ -32,7 +32,6 @@
 
 #include "EventListenerMap.h"
 #include "EventListenerOptions.h"
-#include "ExceptionOr.h"
 #include "ScriptWrappable.h"
 #include <memory>
 #include <wtf/CheckedPtr.h>
@@ -48,10 +47,11 @@ class JSObject;
 namespace WebCore {
 
 enum class EventTargetInterfaceType : uint8_t;
-struct AddEventListenerOptions;
 class DOMWrapperWorld;
 class EventTarget;
 class JSEventListener;
+struct AddEventListenerOptions;
+template<typename> class ExceptionOr;
 
 struct EventTargetData {
     WTF_MAKE_TZONE_ALLOCATED(EventTargetData);

--- a/Source/WebCore/dom/TreeScope.h
+++ b/Source/WebCore/dom/TreeScope.h
@@ -26,7 +26,6 @@
 
 #pragma once
 
-#include "ExceptionOr.h"
 #include "HitTestSource.h"
 #include <memory>
 #include <wtf/Forward.h>
@@ -64,6 +63,7 @@ class ShadowRoot;
 class TreeScopeOrderedMap;
 class WeakPtrImplWithEventTargetData;
 struct SVGResourcesMap;
+template<typename> class ExceptionOr;
 
 class TreeScope : public NoVirtualDestructorBase {
     friend class Document;

--- a/Source/WebCore/html/DOMTokenList.cpp
+++ b/Source/WebCore/html/DOMTokenList.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "DOMTokenList.h"
 
+#include "ExceptionOr.h"
 #include "SpaceSplitString.h"
 #include <wtf/HashSet.h>
 #include <wtf/SetForScope.h>

--- a/Source/WebCore/html/HTMLInputElement.cpp
+++ b/Source/WebCore/html/HTMLInputElement.cpp
@@ -1213,6 +1213,11 @@ ExceptionOr<void> HTMLInputElement::setValue(const String& value, TextFieldEvent
     return { };
 }
 
+void HTMLInputElement::setValueForUser(const String& value)
+{
+    setValue(value, DispatchInputAndChangeEvent);
+}
+
 void HTMLInputElement::setValueInternal(const String& sanitizedValue, TextFieldEventBehavior eventBehavior)
 {
     m_valueIfDirty = sanitizedValue;

--- a/Source/WebCore/html/HTMLInputElement.h
+++ b/Source/WebCore/html/HTMLInputElement.h
@@ -87,7 +87,7 @@ public:
     WEBCORE_EXPORT void setType(const AtomString&);
     WEBCORE_EXPORT ValueOrReference<String> value() const final;
     WEBCORE_EXPORT ExceptionOr<void> setValue(const String&, TextFieldEventBehavior = DispatchNoEvent, TextControlSetValueSelection = TextControlSetValueSelection::SetSelectionToEnd) final;
-    void setValueForUser(const String& value) { setValue(value, DispatchInputAndChangeEvent); }
+    WEBCORE_EXPORT void setValueForUser(const String&);
     WEBCORE_EXPORT WallTime valueAsDate() const;
     WEBCORE_EXPORT ExceptionOr<void> setValueAsDate(WallTime);
     WallTime accessibilityValueAsDate() const;

--- a/Source/WebCore/html/track/InbandWebVTTTextTrack.cpp
+++ b/Source/WebCore/html/track/InbandWebVTTTextTrack.cpp
@@ -28,6 +28,7 @@
 
 #if ENABLE(VIDEO)
 
+#include "ExceptionOr.h"
 #include "InbandTextTrackPrivate.h"
 #include "Logging.h"
 #include "ScriptExecutionContext.h"

--- a/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKDOMElement.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKDOMElement.mm
@@ -28,6 +28,7 @@
 
 #import "WKDOMInternals.h"
 #import <WebCore/Element.h>
+#import <WebCore/ExceptionOr.h>
 
 @implementation WKDOMElement
 


### PR DESCRIPTION
#### f6c083332052ac3ea29b134b511839159b6c1d19
<pre>
EventTarget.h and TreeScope.h don&apos;t need to include ExceptionOr.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=292812">https://bugs.webkit.org/show_bug.cgi?id=292812</a>

Reviewed by Eric Carlson.

Replaced #include&lt;ExceptionOr.h&gt; with a forward declaration of ExceptionOr.

* Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.cpp:
* Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.h:
* Source/WebCore/dom/EventTarget.h:
* Source/WebCore/dom/TreeScope.h:
* Source/WebCore/html/DOMTokenList.cpp:
* Source/WebCore/html/HTMLInputElement.cpp:
(WebCore::HTMLInputElement::setValueForUser):
* Source/WebCore/html/HTMLInputElement.h:
* Source/WebCore/html/track/InbandWebVTTTextTrack.cpp:
* Source/WebKit/WebProcess/InjectedBundle/API/mac/WKDOMElement.mm:

Canonical link: <a href="https://commits.webkit.org/294744@main">https://commits.webkit.org/294744@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2570a3712e984d1fcf86f776b3d06a2c4e3c953f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/102933 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/22607 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/12927 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/108101 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/53574 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/104972 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/22930 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/31108 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78251 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/35202 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/105939 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17755 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/92876 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58586 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/17594 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/10922 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/52931 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/87399 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10989 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/110474 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/30070 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/22143 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/87240 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/30434 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/89082 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86863 "Found 102 new API test failures: /WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/sequence, /TestWebKit:WebKit.InjectedBundleInitializationUserDataCallbackWins, /TestWebKit:WebKit.GeolocationBasicWithHighAccuracy, /WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/cancel-sequence, /TestWebKit:WebKit.ForceRepaint, /TestWebKit:WebKit.PendingAPIRequestURL, /WebKitGTK/TestUIClient:/webkit/WebKitWebView/mediaKeySystem-permission-requests, /TestWebKit:WebKit.PreventEmptyUserAgent, /TestWebKit:WebKit2.ProvisionalURLAfterWillSendRequestCallback, /WebKitGTK/TestDownloads:/webkit/Downloads/contex-menu-download-actions ... (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31711 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/9421 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/24332 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16699 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/29997 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/35319 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/29805 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/33132 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/31367 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->