### PR TITLE
Add a layout test to test resuming HTMLModelElement after exiting the back/forward cache

### DIFF
--- a/LayoutTests/model-element/model-element-suspend-resume-expected.txt
+++ b/LayoutTests/model-element/model-element-suspend-resume-expected.txt
@@ -1,0 +1,1 @@
+PASSED: model is resumed after being suspended

--- a/LayoutTests/model-element/model-element-suspend-resume.html
+++ b/LayoutTests/model-element/model-element-suspend-resume.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ UsesBackForwardCache=true ModelElementEnabled=true ModelProcessEnabled=true ] -->
+<html>
+<head>
+<title>&lt;model> state after suspend and resume</title>
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src="resources/model-utils.js"></script>
+<script>
+    if (window.testRunner)
+        testRunner.waitUntilDone();
+
+    internals.disableModelLoadDelaysForTesting();
+
+    var lastRecordedCurrentTime;
+
+    window.addEventListener("pageshow", async () => {
+        assert_equals(document.visibilityState, "visible");
+
+        if (!event.persisted)
+            return;
+
+        // This page was restored from the page cache.
+        assert_true(document.getElementById("test-model").currentTime < lastRecordedCurrentTime + 0.2, "Model's animation current time shouldn't have progressed much since navigating away (it takes 0.5 seconds for go-back-on-load.html to navigate back)");
+        lastRecordedCurrentTime = document.getElementById("test-model").currentTime;
+
+        // Wait a little bit since the reload of suspended model
+        // is not synchronous.
+        await sleepForSeconds(0.5);
+
+        // This page was restored from the page cache. Make sure
+        // the animation is still running and progressing.
+        assert_false(document.getElementById("test-model").paused, "Model's animation should be running after resume");
+        assert_true(document.getElementById("test-model").currentTime > lastRecordedCurrentTime, "Model's animation current time should progress after resume");
+
+        document.getElementById("result").innerText = "PASSED: model is resumed after being suspended";
+        testRunner.dumpAsText();
+        testRunner.notifyDone();
+    }, false);
+
+    window.addEventListener("pagehide", function(event) {
+        assert_true(event.persisted, "Page should have entered the page cache");
+    }, false);
+
+    window.addEventListener('load', async () => {
+        const model = document.getElementById("test-model");
+        assert_true(!!model, "Model element should exist");
+        await model.ready;
+        model.playbackRate = 2;
+
+        await sleepForSeconds(0.5);
+        assert_false(model.paused, "Model animation should autoplay");
+
+        lastRecordedCurrentTime = model.currentTime;
+        assert_true(lastRecordedCurrentTime > 0, "Model animation's current time should have progressed");
+
+        window.location.href = "resources/go-back-on-load.html";
+    }, false);
+</script>
+<body>
+    <model id='test-model' autoplay loop>
+        <source src='resources/stopwatch-60s.usdz'/>
+    </model>
+    <div id="result"></div>
+</body>
+</html>

--- a/LayoutTests/model-element/resources/go-back-on-load.html
+++ b/LayoutTests/model-element/resources/go-back-on-load.html
@@ -1,0 +1,18 @@
+This page should go back after 0.5 seconds. If a test outputs the contents of this
+page, then the test page failed to enter the page cache.
+<script>
+  function triggerBackNavigation() {
+      setTimeout(function() {
+          history.back();
+      }, 500);
+  }
+
+  window.addEventListener("pageshow", (event) => {
+      if (event.persisted)
+          triggerBackNavigation();
+  });
+
+  window.addEventListener("load", function() {
+      triggerBackNavigation();
+  });
+</script>


### PR DESCRIPTION
#### 1455290287a1ccf7945e077d1526319ed606d70a
<pre>
Add a layout test to test resuming HTMLModelElement after exiting the back/forward cache
<a href="https://bugs.webkit.org/show_bug.cgi?id=292813">https://bugs.webkit.org/show_bug.cgi?id=292813</a>
<a href="https://rdar.apple.com/151048734">rdar://151048734</a>

Reviewed by Mike Wyrzykowski.

This test page has an autoplay &lt;model&gt; element that should start
playing on load. After navigating to a different page, it would
temporarily pause the animation while suspended, and resume playing
after the element is resumed when the page is navigated back to.

* LayoutTests/model-element/model-element-suspend-resume-expected.txt: Added.
* LayoutTests/model-element/model-element-suspend-resume.html: Added.
* LayoutTests/model-element/resources/go-back-on-load.html: Added.

Canonical link: <a href="https://commits.webkit.org/294751@main">https://commits.webkit.org/294751@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4291a1262627c979285fb21546ff2565aa194dc1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/102929 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/22603 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/12923 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/108097 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/53570 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/22925 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/31104 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78248 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/35197 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/105935 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17751 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/92874 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58582 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/17589 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/10920 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/52927 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/87396 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10987 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/110470 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/30066 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/22140 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/87236 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/30430 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/89080 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86859 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22113 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31704 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/9419 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/24328 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/29993 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/29801 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/33128 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/31363 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->