### PR TITLE
[JSC] Use std::numbers Constants for Static Properties of `Math` Object

### DIFF
--- a/JSTests/microbenchmarks/math-e.js
+++ b/JSTests/microbenchmarks/math-e.js
@@ -1,0 +1,7 @@
+(function () {
+  var result = 0;
+  for (var i = 0; i < testLoopCount; ++i) {
+    result += Math.E;
+  }
+  if (Math.abs(result - testLoopCount * Math.E) < Number.EPSILON) throw 'Error: bad: ' + result;
+})();

--- a/JSTests/microbenchmarks/math-ln10.js
+++ b/JSTests/microbenchmarks/math-ln10.js
@@ -1,0 +1,7 @@
+(function () {
+  var result = 0;
+  for (var i = 0; i < testLoopCount; ++i) {
+    result += Math.LN10;
+  }
+  if (Math.abs(result - testLoopCount * Math.LN10) < Number.EPSILON) throw 'Error: bad: ' + result;
+})();

--- a/JSTests/microbenchmarks/math-ln2.js
+++ b/JSTests/microbenchmarks/math-ln2.js
@@ -1,0 +1,7 @@
+(function () {
+  var result = 0;
+  for (var i = 0; i < testLoopCount; ++i) {
+    result += Math.LN2;
+  }
+  if (Math.abs(result - testLoopCount * Math.LN2) < Number.EPSILON) throw 'Error: bad: ' + result;
+})();

--- a/JSTests/microbenchmarks/math-log10e.js
+++ b/JSTests/microbenchmarks/math-log10e.js
@@ -1,0 +1,7 @@
+(function () {
+  var result = 0;
+  for (var i = 0; i < testLoopCount; ++i) {
+    result += Math.LOG10E;
+  }
+  if (Math.abs(result - testLoopCount * Math.LOG10E) < Number.EPSILON) throw 'Error: bad: ' + result;
+})();

--- a/JSTests/microbenchmarks/math-log2e.js
+++ b/JSTests/microbenchmarks/math-log2e.js
@@ -1,0 +1,7 @@
+(function () {
+  var result = 0;
+  for (var i = 0; i < testLoopCount; ++i) {
+    result += Math.LOG2E;
+  }
+  if (Math.abs(result - testLoopCount * Math.LOG2E) < Number.EPSILON) throw 'Error: bad: ' + result;
+})();

--- a/JSTests/microbenchmarks/math-sqrt1_2.js
+++ b/JSTests/microbenchmarks/math-sqrt1_2.js
@@ -1,0 +1,7 @@
+(function () {
+  var result = 0;
+  for (var i = 0; i < testLoopCount; ++i) {
+    result += Math.SQRT1_2;
+  }
+  if (Math.abs(result - testLoopCount * Math.SQRT1_2) < Number.EPSILON) throw 'Error: bad: ' + result;
+})();

--- a/JSTests/microbenchmarks/math-sqrt2.js
+++ b/JSTests/microbenchmarks/math-sqrt2.js
@@ -1,0 +1,7 @@
+(function () {
+  var result = 0;
+  for (var i = 0; i < testLoopCount; ++i) {
+    result += Math.SQRT2;
+  }
+  if (Math.abs(result - testLoopCount * Math.SQRT2) < Number.EPSILON) throw 'Error: bad: ' + result;
+})();

--- a/Source/JavaScriptCore/runtime/MathObject.cpp
+++ b/Source/JavaScriptCore/runtime/MathObject.cpp
@@ -81,14 +81,14 @@ void MathObject::finishCreation(VM& vm, JSGlobalObject* globalObject)
     Base::finishCreation(vm);
     ASSERT(inherits(info()));
 
-    putDirectWithoutTransition(vm, Identifier::fromString(vm, "E"_s), jsNumber(Math::exp(1.0)), PropertyAttribute::DontDelete | PropertyAttribute::DontEnum | PropertyAttribute::ReadOnly);
-    putDirectWithoutTransition(vm, Identifier::fromString(vm, "LN2"_s), jsNumber(Math::log(2.0)), PropertyAttribute::DontDelete | PropertyAttribute::DontEnum | PropertyAttribute::ReadOnly);
-    putDirectWithoutTransition(vm, Identifier::fromString(vm, "LN10"_s), jsNumber(Math::log(10.0)), PropertyAttribute::DontDelete | PropertyAttribute::DontEnum | PropertyAttribute::ReadOnly);
-    putDirectWithoutTransition(vm, Identifier::fromString(vm, "LOG2E"_s), jsNumber(1.0 / Math::log(2.0)), PropertyAttribute::DontDelete | PropertyAttribute::DontEnum | PropertyAttribute::ReadOnly);
-    putDirectWithoutTransition(vm, Identifier::fromString(vm, "LOG10E"_s), jsNumber(0.4342944819032518), PropertyAttribute::DontDelete | PropertyAttribute::DontEnum | PropertyAttribute::ReadOnly);
+    putDirectWithoutTransition(vm, Identifier::fromString(vm, "E"_s), jsNumber(std::numbers::e), PropertyAttribute::DontDelete | PropertyAttribute::DontEnum | PropertyAttribute::ReadOnly);
+    putDirectWithoutTransition(vm, Identifier::fromString(vm, "LN2"_s), jsNumber(std::numbers::ln2), PropertyAttribute::DontDelete | PropertyAttribute::DontEnum | PropertyAttribute::ReadOnly);
+    putDirectWithoutTransition(vm, Identifier::fromString(vm, "LN10"_s), jsNumber(std::numbers::ln10), PropertyAttribute::DontDelete | PropertyAttribute::DontEnum | PropertyAttribute::ReadOnly);
+    putDirectWithoutTransition(vm, Identifier::fromString(vm, "LOG2E"_s), jsNumber(std::numbers::log2e), PropertyAttribute::DontDelete | PropertyAttribute::DontEnum | PropertyAttribute::ReadOnly);
+    putDirectWithoutTransition(vm, Identifier::fromString(vm, "LOG10E"_s), jsNumber(std::numbers::log10e), PropertyAttribute::DontDelete | PropertyAttribute::DontEnum | PropertyAttribute::ReadOnly);
     putDirectWithoutTransition(vm, Identifier::fromString(vm, "PI"_s), jsNumber(std::numbers::pi), PropertyAttribute::DontDelete | PropertyAttribute::DontEnum | PropertyAttribute::ReadOnly);
-    putDirectWithoutTransition(vm, Identifier::fromString(vm, "SQRT1_2"_s), jsNumber(sqrt(0.5)), PropertyAttribute::DontDelete | PropertyAttribute::DontEnum | PropertyAttribute::ReadOnly);
-    putDirectWithoutTransition(vm, Identifier::fromString(vm, "SQRT2"_s), jsNumber(sqrt(2.0)), PropertyAttribute::DontDelete | PropertyAttribute::DontEnum | PropertyAttribute::ReadOnly);
+    putDirectWithoutTransition(vm, Identifier::fromString(vm, "SQRT1_2"_s), jsNumber(std::numbers::sqrt2 / 2), PropertyAttribute::DontDelete | PropertyAttribute::DontEnum | PropertyAttribute::ReadOnly);
+    putDirectWithoutTransition(vm, Identifier::fromString(vm, "SQRT2"_s), jsNumber(std::numbers::sqrt2), PropertyAttribute::DontDelete | PropertyAttribute::DontEnum | PropertyAttribute::ReadOnly);
     JSC_TO_STRING_TAG_WITHOUT_TRANSITION();
 
     putDirectNativeFunctionWithoutTransition(vm, globalObject, Identifier::fromString(vm, "abs"_s), 1, mathProtoFuncAbs, ImplementationVisibility::Public, AbsIntrinsic, static_cast<unsigned>(PropertyAttribute::DontEnum));


### PR DESCRIPTION
#### c92215d439eff338cf67fd8233632129f3b30ad9
<pre>
[JSC] Use std::numbers Constants for Static Properties of `Math` Object
<a href="https://bugs.webkit.org/show_bug.cgi?id=292817">https://bugs.webkit.org/show_bug.cgi?id=292817</a>

Reviewed by NOBODY (OOPS!).

Use std::numbers constants for static properties of Math object

* JSTests/microbenchmarks/math-e.js: Added.
* JSTests/microbenchmarks/math-ln10.js: Added.
* JSTests/microbenchmarks/math-ln2.js: Added.
* JSTests/microbenchmarks/math-log10e.js: Added.
* JSTests/microbenchmarks/math-log2e.js: Added.
* JSTests/microbenchmarks/math-sqrt1_2.js: Added.
* JSTests/microbenchmarks/math-sqrt2.js: Added.
* Source/JavaScriptCore/runtime/MathObject.cpp:
(JSC::MathObject::finishCreation):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c92215d439eff338cf67fd8233632129f3b30ad9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/102945 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/22619 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/12939 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/108113 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/53586 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/22944 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/31120 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78259 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/35209 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/105951 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17766 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/92886 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58595 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/17601 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/10931 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/52943 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/95620 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/87410 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10998 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/110486 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/101555 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/30082 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/22153 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/87247 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/30446 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/89091 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86870 "Found 102 new API test failures: /WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/sequence, /TestWebKit:WebKit.InjectedBundleInitializationUserDataCallbackWins, /TestWebKit:WebKit.GeolocationBasicWithHighAccuracy, /WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/cancel-sequence, /TestWebKit:WebKit.ForceRepaint, /TestWebKit:WebKit.PendingAPIRequestURL, /WebKitGTK/TestUIClient:/webkit/WebKitWebView/mediaKeySystem-permission-requests, /TestWebKit:WebKit.PreventEmptyUserAgent, /TestWebKit:WebKit2.ProvisionalURLAfterWillSendRequestCallback, /WebKitGTK/TestDownloads:/webkit/Downloads/contex-menu-download-actions ... (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31720 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/9430 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/24346 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/30009 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/35331 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/125188 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/29817 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34730 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/33144 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/31379 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->