### PR TITLE
[JSC] Add `DisposableStack` constructor from Explicit Resource Management Proposal

### DIFF
--- a/JSTests/stress/disposable-stack-constructor.js
+++ b/JSTests/stress/disposable-stack-constructor.js
@@ -1,0 +1,25 @@
+//@ requireOptions("--useExplicitResourceManagement=1")
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`expected ${expected} but got ${actual}`);
+}
+
+function shouldThrow(func, errorType, message) {
+    let error;
+    try {
+        func();
+    } catch (e) {
+        error = e;
+    }
+    if (!(error instanceof errorType))
+        throw new Error(`Expected ${errorType.name}!`);
+    if (message !== undefined)
+        shouldBe(String(error), message);
+}
+
+shouldBe(typeof DisposableStack, "function");
+shouldBe(Object.getPrototypeOf(DisposableStack.prototype), Object.prototype);
+shouldBe(new DisposableStack() instanceof Object, true);
+shouldBe(new DisposableStack() instanceof DisposableStack, true);
+shouldThrow(() => { DisposableStack(); }, TypeError);

--- a/JSTests/test262/config.yaml
+++ b/JSTests/test262/config.yaml
@@ -47,7 +47,7 @@ skip:
     - test/staging/sm/Temporal
     # Explicit Resource Management
     - test/staging/explicit-resource-management
-    - test/built-ins/DisposableStack
+    - test/built-ins/DisposableStack/prototype
     - test/built-ins/AsyncDisposableStack
     - test/language/statements/using
     - test/language/statements/await-using

--- a/Source/JavaScriptCore/CMakeLists.txt
+++ b/Source/JavaScriptCore/CMakeLists.txt
@@ -990,6 +990,9 @@ set(JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS
     runtime/DirectEvalExecutable.h
     runtime/DisallowScope.h
     runtime/DisallowVMEntry.h
+    runtime/DisposableStackConstructor.h
+    runtime/DisposableStackPrototype.h
+    runtime/DisposableStackPrototypeInlines.h
     runtime/DumpContext.h
     runtime/ECMAMode.h
     runtime/EnsureStillAliveHere.h
@@ -1072,6 +1075,8 @@ set(JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS
     runtime/JSDateMath.h
     runtime/JSDestructibleObject.h
     runtime/JSDestructibleObjectHeapCellType.h
+    runtime/JSDisposableStack.h
+    runtime/JSDisposableStackInlines.h
     runtime/JSExportMacros.h
     runtime/JSFunction.h
     runtime/JSFunctionInlines.h

--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -1432,6 +1432,11 @@
 		8BC0648B1E1ABA9400B2B8CA /* AsyncGeneratorFunctionConstructor.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BC064841E1A4FD100B2B8CA /* AsyncGeneratorFunctionConstructor.h */; };
 		8BC064921E1ADCC400B2B8CA /* AsyncGeneratorPrototype.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BC064901E1AD6AC00B2B8CA /* AsyncGeneratorPrototype.h */; };
 		8BC064961E1D845C00B2B8CA /* AsyncIteratorPrototype.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BC064941E1D828B00B2B8CA /* AsyncIteratorPrototype.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		8C9F78DA2DCF65F400868239 /* DisposableStackConstructor.h in Headers */ = {isa = PBXBuildFile; fileRef = 8C9F78D92DCF65F400868239 /* DisposableStackConstructor.h */; };
+		8C9F78E12DCF660E00868239 /* DisposableStackPrototype.h in Headers */ = {isa = PBXBuildFile; fileRef = 8C9F78E02DCF660E00868239 /* DisposableStackPrototype.h */; };
+		8C9F78E32DCF661700868239 /* DisposableStackPrototypeInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = 8C9F78E22DCF661700868239 /* DisposableStackPrototypeInlines.h */; };
+		8C9F78F62DD0ED9E00868239 /* JSDisposableStack.h in Headers */ = {isa = PBXBuildFile; fileRef = 8C9F78F52DD0ED9E00868239 /* JSDisposableStack.h */; };
+		8C9F78F82DD0EDA400868239 /* JSDisposableStackInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = 8C9F78F72DD0EDA400868239 /* JSDisposableStackInlines.h */; };
 		8CB955CB2C8AF8E100282DA2 /* JSAsyncFromSyncIterator.h in Headers */ = {isa = PBXBuildFile; fileRef = 8CB955CA2C8AF8E100282DA2 /* JSAsyncFromSyncIterator.h */; };
 		8CB955CD2C8AF8F500282DA2 /* JSAsyncFromSyncIteratorInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = 8CB955CC2C8AF8F500282DA2 /* JSAsyncFromSyncIteratorInlines.h */; };
 		8CB955D12C8E9A0C00282DA2 /* JSRegExpStringIterator.h in Headers */ = {isa = PBXBuildFile; fileRef = 8CB955D02C8E9A0C00282DA2 /* JSRegExpStringIterator.h */; };
@@ -4799,6 +4804,14 @@
 		8BC064941E1D828B00B2B8CA /* AsyncIteratorPrototype.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AsyncIteratorPrototype.h; sourceTree = "<group>"; };
 		8C469C292D8EBC8A008C6403 /* StringReplaceCache.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = StringReplaceCache.cpp; sourceTree = "<group>"; };
 		8C9F78BF2DC8836D00868239 /* AsyncIteratorPrototype.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = AsyncIteratorPrototype.js; sourceTree = "<group>"; };
+		8C9F78D82DCF65EB00868239 /* DisposableStackConstructor.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = DisposableStackConstructor.cpp; sourceTree = "<group>"; };
+		8C9F78D92DCF65F400868239 /* DisposableStackConstructor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DisposableStackConstructor.h; sourceTree = "<group>"; };
+		8C9F78DF2DCF660700868239 /* DisposableStackPrototype.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = DisposableStackPrototype.cpp; sourceTree = "<group>"; };
+		8C9F78E02DCF660E00868239 /* DisposableStackPrototype.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DisposableStackPrototype.h; sourceTree = "<group>"; };
+		8C9F78E22DCF661700868239 /* DisposableStackPrototypeInlines.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DisposableStackPrototypeInlines.h; sourceTree = "<group>"; };
+		8C9F78F42DD0ED9700868239 /* JSDisposableStack.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = JSDisposableStack.cpp; sourceTree = "<group>"; };
+		8C9F78F52DD0ED9E00868239 /* JSDisposableStack.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = JSDisposableStack.h; sourceTree = "<group>"; };
+		8C9F78F72DD0EDA400868239 /* JSDisposableStackInlines.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = JSDisposableStackInlines.h; sourceTree = "<group>"; };
 		8CB955C92C8AF8D000282DA2 /* JSAsyncFromSyncIterator.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = JSAsyncFromSyncIterator.cpp; sourceTree = "<group>"; };
 		8CB955CA2C8AF8E100282DA2 /* JSAsyncFromSyncIterator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSAsyncFromSyncIterator.h; sourceTree = "<group>"; };
 		8CB955CC2C8AF8F500282DA2 /* JSAsyncFromSyncIteratorInlines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSAsyncFromSyncIteratorInlines.h; sourceTree = "<group>"; };
@@ -8124,6 +8137,11 @@
 				14386A731DD69895008652C4 /* DirectEvalExecutable.h */,
 				FE54DEFE1E8D742800A892C5 /* DisallowScope.h */,
 				FE54DEFA1E8C6D7200A892C5 /* DisallowVMEntry.h */,
+				8C9F78D82DCF65EB00868239 /* DisposableStackConstructor.cpp */,
+				8C9F78D92DCF65F400868239 /* DisposableStackConstructor.h */,
+				8C9F78DF2DCF660700868239 /* DisposableStackPrototype.cpp */,
+				8C9F78E02DCF660E00868239 /* DisposableStackPrototype.h */,
+				8C9F78E22DCF661700868239 /* DisposableStackPrototypeInlines.h */,
 				E31618101EC5FE080006A218 /* DOMAnnotation.h */,
 				E31618111EC5FE080006A218 /* DOMAttributeGetterSetter.cpp */,
 				E31618121EC5FE080006A218 /* DOMAttributeGetterSetter.h */,
@@ -8398,6 +8416,9 @@
 				C2A7F687160432D400F76B98 /* JSDestructibleObject.h */,
 				0F7DF1391E29710E0095951B /* JSDestructibleObjectHeapCellType.cpp */,
 				0F7DF13A1E29710E0095951B /* JSDestructibleObjectHeapCellType.h */,
+				8C9F78F42DD0ED9700868239 /* JSDisposableStack.cpp */,
+				8C9F78F52DD0ED9E00868239 /* JSDisposableStack.h */,
+				8C9F78F72DD0EDA400868239 /* JSDisposableStackInlines.h */,
 				A7B4ACAE1484C9CE00B38A36 /* JSExportMacros.h */,
 				5300740C22DD6F6600B9ACB3 /* JSFinalizationRegistry.cpp */,
 				533D074622C2D9D1004D2FE2 /* JSFinalizationRegistry.h */,
@@ -10817,6 +10838,9 @@
 				FE54DEFF1E8D76FA00A892C5 /* DisallowScope.h in Headers */,
 				FE54DEFB1E8C6D8800A892C5 /* DisallowVMEntry.h in Headers */,
 				0FF42731158EBD54004CB9FF /* Disassembler.h in Headers */,
+				8C9F78DA2DCF65F400868239 /* DisposableStackConstructor.h in Headers */,
+				8C9F78E12DCF660E00868239 /* DisposableStackPrototype.h in Headers */,
+				8C9F78E32DCF661700868239 /* DisposableStackPrototypeInlines.h in Headers */,
 				E31618131EC5FE170006A218 /* DOMAnnotation.h in Headers */,
 				E31618151EC5FE270006A218 /* DOMAttributeGetterSetter.h in Headers */,
 				278D26072A70CF21007F5BC3 /* DOMAttributeGetterSetterInlines.h in Headers */,
@@ -11257,6 +11281,8 @@
 				978801411471AD920041B016 /* JSDateMath.h in Headers */,
 				C2A7F688160432D400F76B98 /* JSDestructibleObject.h in Headers */,
 				0F7DF13C1E2971130095951B /* JSDestructibleObjectHeapCellType.h in Headers */,
+				8C9F78F62DD0ED9E00868239 /* JSDisposableStack.h in Headers */,
+				8C9F78F82DD0EDA400868239 /* JSDisposableStackInlines.h in Headers */,
 				FE384EE61ADDB7AD0055DE2C /* JSDollarVM.h in Headers */,
 				86E3C614167BABD7006D760A /* JSExport.h in Headers */,
 				A7B4ACAF1484C9CE00B38A36 /* JSExportMacros.h in Headers */,

--- a/Source/JavaScriptCore/Sources.txt
+++ b/Source/JavaScriptCore/Sources.txt
@@ -788,6 +788,8 @@ runtime/DeferredWorkTimer.cpp
 runtime/DirectArguments.cpp
 runtime/DirectArgumentsOffset.cpp
 runtime/DirectEvalExecutable.cpp
+runtime/DisposableStackConstructor.cpp
+runtime/DisposableStackPrototype.cpp
 runtime/DoublePredictionFuzzerAgent.cpp
 runtime/DumpContext.cpp
 runtime/ECMAMode.cpp
@@ -893,6 +895,7 @@ runtime/JSDataView.cpp
 runtime/JSDataViewPrototype.cpp
 runtime/JSDateMath.cpp @no-unify // Confine U_SHOW_CPLUSPLUS_API's effect to this file.
 runtime/JSDestructibleObjectHeapCellType.cpp
+runtime/JSDisposableStack.cpp
 runtime/JSFinalizationRegistry.cpp
 runtime/JSFunction.cpp
 runtime/JSGenerator.cpp

--- a/Source/JavaScriptCore/assembler/AssemblerCommon.h
+++ b/Source/JavaScriptCore/assembler/AssemblerCommon.h
@@ -28,6 +28,7 @@
 #include "OSCheck.h"
 #include <optional>
 #include <wtf/Atomics.h>
+#include <wtf/MathExtras.h>
 
 namespace JSC {
 

--- a/Source/JavaScriptCore/heap/Heap.h
+++ b/Source/JavaScriptCore/heap/Heap.h
@@ -299,6 +299,7 @@ class Heap;
     v(wrapForValidIteratorSpace, cellHeapCellType, JSWrapForValidIterator) \
     v(asyncFromSyncIteratorSpace, cellHeapCellType, JSAsyncFromSyncIterator) \
     v(regExpStringIteratorSpace, cellHeapCellType, JSRegExpStringIterator) \
+    v(disposableStackSpace, cellHeapCellType, JSDisposableStack) \
     \
     FOR_EACH_JSC_WEBASSEMBLY_DYNAMIC_ISO_SUBSPACE(v)
 

--- a/Source/JavaScriptCore/heap/HeapSubspaceTypes.h
+++ b/Source/JavaScriptCore/heap/HeapSubspaceTypes.h
@@ -66,6 +66,7 @@
 #include "JSCustomGetterFunction.h"
 #include "JSCustomSetterFunction.h"
 #include "JSDataView.h"
+#include "JSDisposableStack.h"
 #include "JSFunction.h"
 #include "JSGlobalLexicalEnvironment.h"
 #include "JSGlobalObject.h"

--- a/Source/JavaScriptCore/runtime/CommonIdentifiers.h
+++ b/Source/JavaScriptCore/runtime/CommonIdentifiers.h
@@ -318,7 +318,8 @@
     macro(yearsDisplay) \
     macro(error) \
     macro(suppressed) \
-    macro(SuppressedError)
+    macro(SuppressedError) \
+    macro(DisposableStack)
 
 #define JSC_COMMON_IDENTIFIERS_EACH_PRIVATE_FIELD(macro) \
     macro(constructor)

--- a/Source/JavaScriptCore/runtime/DisposableStackConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/DisposableStackConstructor.cpp
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2025 Sosuke Suzuki <aosukeke@gmail.com>.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "DisposableStackConstructor.h"
+
+#include "AbstractSlotVisitor.h"
+#include "BuiltinNames.h"
+#include "GetterSetter.h"
+#include "JSDisposableStack.h"
+#include "JSCInlines.h"
+#include "DisposableStackPrototype.h"
+#include "SlotVisitor.h"
+
+namespace JSC {
+
+const ClassInfo DisposableStackConstructor::s_info = { "Function"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(DisposableStackConstructor) };
+
+Structure* DisposableStackConstructor::createStructure(VM& vm, JSGlobalObject* globalObject, JSValue prototype)
+{
+    return Structure::create(vm, globalObject, prototype, TypeInfo(InternalFunctionType, StructureFlags), info());
+}
+
+DisposableStackConstructor* DisposableStackConstructor::create(VM& vm, JSGlobalObject* globalObject, Structure* structure, DisposableStackPrototype* disposableStackPrototype)
+{
+    DisposableStackConstructor* constructor = new (NotNull, allocateCell<DisposableStackConstructor>(vm)) DisposableStackConstructor(vm, structure);
+    constructor->finishCreation(vm, globalObject, disposableStackPrototype);
+    return constructor;
+}
+
+void DisposableStackConstructor::finishCreation(VM& vm, JSGlobalObject*, DisposableStackPrototype* prototype)
+{
+    Base::finishCreation(vm, 0, vm.propertyNames->DisposableStack.string(), PropertyAdditionMode::WithoutStructureTransition);
+    putDirectWithoutTransition(vm, vm.propertyNames->prototype, prototype, static_cast<unsigned>(PropertyAttribute::DontEnum | PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly));
+}
+
+template<typename Visitor>
+void DisposableStackConstructor::visitChildrenImpl(JSCell* cell, Visitor& visitor)
+{
+    auto* thisObject = jsCast<DisposableStackConstructor*>(cell);
+    ASSERT_GC_OBJECT_INHERITS(thisObject, info());
+    Base::visitChildren(thisObject, visitor);
+}
+
+DEFINE_VISIT_CHILDREN(DisposableStackConstructor);
+
+static JSC_DECLARE_HOST_FUNCTION(callDisposableStack);
+static JSC_DECLARE_HOST_FUNCTION(constructDisposableStack);
+
+DisposableStackConstructor::DisposableStackConstructor(VM& vm, Structure* structure)
+    : Base(vm, structure, callDisposableStack, constructDisposableStack)
+{
+}
+
+JSC_DEFINE_HOST_FUNCTION(callDisposableStack, (JSGlobalObject* globalObject, CallFrame*))
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    return JSValue::encode(throwConstructorCannotBeCalledAsFunctionTypeError(globalObject, scope, "DisposableStack"_s));
+}
+
+JSC_DEFINE_HOST_FUNCTION(constructDisposableStack, (JSGlobalObject* globalObject, CallFrame* callFrame))
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    JSObject* newTarget = asObject(callFrame->newTarget());
+    Structure* disposableStackStructure = JSC_GET_DERIVED_STRUCTURE(vm, disposableStackStructure, newTarget, callFrame->jsCallee());
+    RETURN_IF_EXCEPTION(scope, { });
+
+    auto* disposableStack = JSDisposableStack::create(vm, disposableStackStructure);
+    auto* capabilityArray = constructEmptyArray(globalObject, nullptr);
+    if (!capabilityArray) [[unlikely]]
+        RETURN_IF_EXCEPTION(scope, { });
+    disposableStack->internalField(JSDisposableStack::Field::Capability).set(vm, disposableStack, capabilityArray);
+
+    RELEASE_AND_RETURN(scope, JSValue::encode(disposableStack));
+}
+
+} // namespace JSC

--- a/Source/JavaScriptCore/runtime/DisposableStackConstructor.h
+++ b/Source/JavaScriptCore/runtime/DisposableStackConstructor.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2025 Sosuke Suzuki <aosukeke@gmail.com>.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "InternalFunction.h"
+
+namespace JSC {
+
+class DisposableStackPrototype;
+
+class DisposableStackConstructor final : public InternalFunction {
+public:
+    typedef InternalFunction Base;
+
+    static Structure* createStructure(VM&, JSGlobalObject*, JSValue);
+    static DisposableStackConstructor* create(VM&, JSGlobalObject*, Structure*, DisposableStackPrototype*);
+
+    DECLARE_INFO;
+    DECLARE_VISIT_CHILDREN;
+private:
+    DisposableStackConstructor(VM&, Structure*);
+
+    void finishCreation(VM&, JSGlobalObject*, DisposableStackPrototype*);
+};
+STATIC_ASSERT_ISO_SUBSPACE_SHARABLE(DisposableStackConstructor, InternalFunction);
+
+} // namespace JSC

--- a/Source/JavaScriptCore/runtime/DisposableStackPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/DisposableStackPrototype.cpp
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2025 Sosuke Suzuki <aosukeke@gmail.com>.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "DisposableStackPrototype.h"
+
+#include "BuiltinNames.h"
+#include "InterpreterInlines.h"
+#include "JSCBuiltins.h"
+#include "JSCInlines.h"
+#include "VMEntryScopeInlines.h"
+
+namespace JSC {
+
+const ClassInfo DisposableStackPrototype::s_info = { "DisposableStack"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(DisposableStackPrototype) };
+
+void DisposableStackPrototype::finishCreation(VM& vm, JSGlobalObject*)
+{
+    Base::finishCreation(vm);
+    ASSERT(inherits(info()));
+}
+
+} // namespace JSC

--- a/Source/JavaScriptCore/runtime/DisposableStackPrototype.h
+++ b/Source/JavaScriptCore/runtime/DisposableStackPrototype.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2025 Sosuke Suzuki <aosukeke@gmail.com>.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "JSObject.h"
+
+namespace JSC {
+
+class DisposableStackPrototype final : public JSNonFinalObject {
+public:
+    using Base = JSNonFinalObject;
+
+    static constexpr unsigned StructureFlags = Base::StructureFlags;
+
+    template<typename CellType, SubspaceAccess>
+    static GCClient::IsoSubspace* subspaceFor(VM& vm)
+    {
+        STATIC_ASSERT_ISO_SUBSPACE_SHARABLE(DisposableStackPrototype, Base);
+        return &vm.plainObjectSpace();
+    }
+
+    static DisposableStackPrototype* create(VM& vm, JSGlobalObject* globalObject, Structure* structure)
+    {
+        DisposableStackPrototype* prototype = new (NotNull, allocateCell<DisposableStackPrototype>(vm)) DisposableStackPrototype(vm, structure);
+        prototype->finishCreation(vm, globalObject);
+        return prototype;
+    }
+
+    DECLARE_INFO;
+
+    inline static Structure* createStructure(VM&, JSGlobalObject*, JSValue);
+
+private:
+    DisposableStackPrototype(VM& vm, Structure* structure)
+        : Base(vm, structure)
+    {
+    }
+    void finishCreation(VM&, JSGlobalObject*);
+};
+
+} // namespace JSC

--- a/Source/JavaScriptCore/runtime/DisposableStackPrototypeInlines.h
+++ b/Source/JavaScriptCore/runtime/DisposableStackPrototypeInlines.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2025 Sosuke Suzuki <aosukeke@gmail.com>.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "DisposableStackPrototype.h"
+
+namespace JSC {
+
+inline Structure* DisposableStackPrototype::createStructure(VM& vm, JSGlobalObject* globalObject, JSValue prototype)
+{
+    return Structure::create(vm, globalObject, prototype, TypeInfo(ObjectType, StructureFlags), info());
+}
+
+} // namespace JSC

--- a/Source/JavaScriptCore/runtime/JSDisposableStack.cpp
+++ b/Source/JavaScriptCore/runtime/JSDisposableStack.cpp
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2025 Sosuke Suzuki <aosukeke@gmail.com>.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "JSDisposableStack.h"
+
+#include "JSCInlines.h"
+#include "JSInternalFieldObjectImplInlines.h"
+
+namespace JSC {
+
+const ClassInfo JSDisposableStack::s_info = { "DisposableStack"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSDisposableStack) };
+
+JSDisposableStack* JSDisposableStack::create(VM& vm, Structure* structure)
+{
+    JSDisposableStack* disposableStack = new (NotNull, allocateCell<JSDisposableStack>(vm)) JSDisposableStack(vm, structure);
+    disposableStack->finishCreation(vm);
+    return disposableStack;
+}
+
+void JSDisposableStack::finishCreation(VM& vm)
+{
+    Base::finishCreation(vm);
+    auto values = initialValues();
+    ASSERT(values.size() == numberOfInternalFields);
+    internalField(Field::State).set(vm, this, values[0]);
+    internalField(Field::Capability).set(vm, this, values[1]);
+}
+
+template<typename Visitor>
+void JSDisposableStack::visitChildrenImpl(JSCell* cell, Visitor& visitor)
+{
+    auto* thisObject = jsCast<JSDisposableStack*>(cell);
+    ASSERT_GC_OBJECT_INHERITS(thisObject, info());
+    Base::visitChildren(thisObject, visitor);
+}
+
+DEFINE_VISIT_CHILDREN(JSDisposableStack);
+
+} // namespace JSC

--- a/Source/JavaScriptCore/runtime/JSDisposableStack.h
+++ b/Source/JavaScriptCore/runtime/JSDisposableStack.h
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2025 Sosuke Suzuki <aosukeke@gmail.com>.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "JSInternalFieldObjectImpl.h"
+
+namespace JSC {
+
+const static uint8_t JSDisposableStackNumberOfInternalFields = 2;
+
+class JSDisposableStack final : public JSInternalFieldObjectImpl<JSDisposableStackNumberOfInternalFields> {
+
+public:
+    using Base = JSInternalFieldObjectImpl<JSDisposableStackNumberOfInternalFields>;
+
+    DECLARE_EXPORT_INFO;
+
+    enum class State : int32_t {
+        Pending = 0,
+        Disposed
+    };
+
+    enum class Field : uint8_t {
+        State = 0,
+        Capability,
+    };
+    static_assert(numberOfInternalFields == JSDisposableStackNumberOfInternalFields);
+
+    static std::array<JSValue, numberOfInternalFields> initialValues()
+    {
+        return { {
+            jsNumber(static_cast<int32_t>(State::Pending)),
+            jsNull(),
+        } };
+    }
+
+    const WriteBarrier<Unknown>& internalField(Field field) const { return Base::internalField(static_cast<uint32_t>(field)); }
+    WriteBarrier<Unknown>& internalField(Field field) { return Base::internalField(static_cast<uint32_t>(field)); }
+
+    template<typename CellType, SubspaceAccess mode>
+    static GCClient::IsoSubspace* subspaceFor(VM& vm)
+    {
+        return vm.disposableStackSpace<mode>();
+    }
+
+    inline static Structure* createStructure(VM&, JSGlobalObject*, JSValue);
+
+    static JSDisposableStack* createWithInitialValues(VM&);
+    static JSDisposableStack* create(VM&, Structure*);
+
+private:
+    JSDisposableStack(VM& vm, Structure* structure)
+        : Base(vm, structure)
+    {
+    }
+
+    void finishCreation(VM&);
+    DECLARE_VISIT_CHILDREN;
+};
+
+STATIC_ASSERT_IS_TRIVIALLY_DESTRUCTIBLE(JSDisposableStack);
+
+} // namespace JSC

--- a/Source/JavaScriptCore/runtime/JSDisposableStackInlines.h
+++ b/Source/JavaScriptCore/runtime/JSDisposableStackInlines.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2025 Sosuke Suzuki <aosukeke@gmail.com>.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "JSDisposableStack.h"
+
+namespace JSC {
+
+inline Structure* JSDisposableStack::createStructure(VM& vm, JSGlobalObject* globalObject, JSValue prototype)
+{
+    return Structure::create(vm, globalObject, prototype, TypeInfo(DisposableStackType, StructureFlags), info());
+}
+
+} // namespace JSC

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.h
@@ -397,6 +397,7 @@ public:
     LazyProperty<JSGlobalObject, Structure> m_callableProxyObjectStructure;
     LazyProperty<JSGlobalObject, Structure> m_proxyRevokeStructure;
     LazyClassStructure m_sharedArrayBufferStructure;
+    LazyClassStructure m_disposableStackStructure;
 
 #define DEFINE_STORAGE_FOR_SIMPLE_TYPE_PROTOTYPE(capitalName, lowerName, properName, instanceType, jsName, prototypeBase, featureFlag) \
     WriteBarrier<capitalName ## Prototype> m_ ## lowerName ## Prototype;
@@ -915,6 +916,7 @@ public:
     Structure* proxyObjectStructure() const { return m_proxyObjectStructure.get(this); }
     Structure* callableProxyObjectStructure() const { return m_callableProxyObjectStructure.get(this); }
     Structure* proxyRevokeStructure() const { return m_proxyRevokeStructure.get(this); }
+    Structure* disposableStackStructure() const { return m_disposableStackStructure.get(this); }
     Structure* restParameterStructure() const { return arrayStructureForIndexingTypeDuringAllocation(ArrayWithContiguous); }
     Structure* originalRestParameterStructure() const { return originalArrayStructureForIndexingType(ArrayWithContiguous); }
 #if ENABLE(WEBASSEMBLY)

--- a/Source/JavaScriptCore/runtime/JSType.cpp
+++ b/Source/JavaScriptCore/runtime/JSType.cpp
@@ -125,6 +125,7 @@ void printInternal(PrintStream& out, JSC::JSType type)
     CASE(JSWrapForValidIteratorType)
     CASE(JSRegExpStringIteratorType)
     CASE(JSAsyncFromSyncIteratorType)
+    CASE(DisposableStackType)
     }
 }
 

--- a/Source/JavaScriptCore/runtime/JSType.h
+++ b/Source/JavaScriptCore/runtime/JSType.h
@@ -112,6 +112,7 @@ namespace JSC {
     macro(WithScopeType, SpecObjectOther) \
     /* End JSScope types. */ \
     \
+    macro(DisposableStackType, SpecObjectOther) \
     macro(ModuleNamespaceObjectType, SpecObjectOther) \
     macro(ShadowRealmType, SpecObjectOther) \
     macro(RegExpObjectType, SpecRegExpObject) \


### PR DESCRIPTION
#### 6bf4c5606ebc30f7dc8e8537fbc18dd357bd9a2a
<pre>
[JSC] Add `DisposableStack` constructor from Explicit Resource Management Proposal
<a href="https://bugs.webkit.org/show_bug.cgi?id=292818">https://bugs.webkit.org/show_bug.cgi?id=292818</a>

Reviewed by Yusuke Suzuki.

This patch implements `DisposableStack` constructor[1] from Explicit
Resource Management Proposal[2].

I will implement the prototype methods in a subsequent PR.

[1]: <a href="https://tc39.es/proposal-explicit-resource-management/#sec-disposablestack">https://tc39.es/proposal-explicit-resource-management/#sec-disposablestack</a>
[2]: <a href="https://github.com/tc39/proposal-explicit-resource-management">https://github.com/tc39/proposal-explicit-resource-management</a>

* JSTests/test262/config.yaml:
* Source/JavaScriptCore/CMakeLists.txt:
* Source/JavaScriptCore/Sources.txt:
* Source/JavaScriptCore/heap/Heap.h:
* Source/JavaScriptCore/heap/HeapSubspaceTypes.h:
* Source/JavaScriptCore/runtime/CommonIdentifiers.h:
* Source/JavaScriptCore/runtime/DisposableStack.cpp: Added.
(JSC::DisposableStack::create):
(JSC::DisposableStack::finishCreation):
(JSC::DisposableStack::visitChildrenImpl):
* Source/JavaScriptCore/runtime/DisposableStack.h: Added.
* Source/JavaScriptCore/runtime/DisposableStackConstructor.cpp: Added.
(JSC::DisposableStackConstructor::createStructure):
(JSC::DisposableStackConstructor::create):
(JSC::DisposableStackConstructor::finishCreation):
(JSC::DisposableStackConstructor::visitChildrenImpl):
(JSC::DisposableStackConstructor::DisposableStackConstructor):
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/DisposableStackConstructor.h: Added.
* Source/JavaScriptCore/runtime/DisposableStackConstructorInlines.h: Added.
* Source/JavaScriptCore/runtime/DisposableStackInlines.h: Added.
(JSC::DisposableStack::createStructure):
* Source/JavaScriptCore/runtime/DisposableStackPrototype.cpp: Added.
(JSC::DisposableStackPrototype::finishCreation):
* Source/JavaScriptCore/runtime/DisposableStackPrototype.h: Added.
* Source/JavaScriptCore/runtime/DisposableStackPrototypeInlines.h: Added.
(JSC::DisposableStackPrototype::createStructure):
* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
(JSC::JSGlobalObject::init):
(JSC::JSGlobalObject::visitChildrenImpl):
* Source/JavaScriptCore/runtime/JSGlobalObject.h:
(JSC::JSGlobalObject::disposableStackStructure const):
* Source/JavaScriptCore/runtime/JSType.cpp:
(WTF::printInternal):
* Source/JavaScriptCore/runtime/JSType.h:

Canonical link: <a href="https://commits.webkit.org/294880@main">https://commits.webkit.org/294880@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/215bf3a15af3473b2ddc8e483f1e1524940d9fb8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/103407 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/23089 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/13407 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/108581 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/54051 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/23435 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/31640 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/78582 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/106413 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/18163 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/93282 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58917 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/18000 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/11327 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/53407 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/96082 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/87797 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/11388 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/110957 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/102018 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/30554 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/22547 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/87579 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/30915 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/89481 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87220 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22199 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32086 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/9801 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/24881 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/30482 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/35794 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/125651 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/30282 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34832 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/33613 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/31843 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->