### PR TITLE
Avoid including ExceptionOr.h in many header files

### DIFF
--- a/Source/WebCore/Modules/ShapeDetection/BarcodeDetector.h
+++ b/Source/WebCore/Modules/ShapeDetection/BarcodeDetector.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include "BarcodeDetectorInterface.h"
-#include "ExceptionOr.h"
 #include "ImageBitmap.h"
 #include "JSDOMPromiseDeferredForward.h"
 #include <wtf/Ref.h>
@@ -34,10 +33,12 @@
 
 namespace WebCore {
 
-struct BarcodeDetectorOptions;
-enum class BarcodeFormat : uint8_t;
-struct DetectedBarcode;
 class ScriptExecutionContext;
+struct BarcodeDetectorOptions;
+struct DetectedBarcode;
+template<typename> class ExceptionOr;
+
+enum class BarcodeFormat : uint8_t;
 
 class BarcodeDetector : public RefCounted<BarcodeDetector> {
 public:

--- a/Source/WebCore/Modules/ShapeDetection/FaceDetector.h
+++ b/Source/WebCore/Modules/ShapeDetection/FaceDetector.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include "ExceptionOr.h"
+
 #include "FaceDetectorInterface.h"
 #include "ImageBitmap.h"
 #include "JSDOMPromiseDeferredForward.h"
@@ -34,9 +34,10 @@
 
 namespace WebCore {
 
+class ScriptExecutionContext;
 struct FaceDetectorOptions;
 struct DetectedFace;
-class ScriptExecutionContext;
+template<typename> class ExceptionOr;
 
 class FaceDetector : public RefCounted<FaceDetector> {
 public:

--- a/Source/WebCore/Modules/ShapeDetection/TextDetector.h
+++ b/Source/WebCore/Modules/ShapeDetection/TextDetector.h
@@ -34,8 +34,9 @@
 
 namespace WebCore {
 
-struct DetectedText;
 class ScriptExecutionContext;
+struct DetectedText;
+template<typename> class ExceptionOr;
 
 class TextDetector : public RefCounted<TextDetector> {
 public:

--- a/Source/WebCore/Modules/WebGPU/GPUBuffer.h
+++ b/Source/WebCore/Modules/WebGPU/GPUBuffer.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include "ExceptionOr.h"
 #include "GPUBufferMapState.h"
 #include "GPUIntegralTypes.h"
 #include "GPUMapMode.h"
@@ -46,6 +45,7 @@
 namespace WebCore {
 
 class GPUDevice;
+template<typename> class ExceptionOr;
 
 class GPUBuffer : public RefCountedAndCanMakeWeakPtr<GPUBuffer> {
 public:

--- a/Source/WebCore/Modules/WebGPU/GPUComputePassEncoder.h
+++ b/Source/WebCore/Modules/WebGPU/GPUComputePassEncoder.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include "ExceptionOr.h"
 #include "GPUIntegralTypes.h"
 #include "WebGPUComputePassEncoder.h"
 #include <JavaScriptCore/Uint32Array.h>
@@ -41,6 +40,7 @@ class GPUBindGroup;
 class GPUBuffer;
 class GPUComputePipeline;
 class GPUQuerySet;
+template<typename> class ExceptionOr;
 
 namespace WebGPU {
 class Device;

--- a/Source/WebCore/Modules/WebGPU/GPURenderBundleEncoder.h
+++ b/Source/WebCore/Modules/WebGPU/GPURenderBundleEncoder.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include "ExceptionOr.h"
 #include "GPUIndexFormat.h"
 #include "GPUIntegralTypes.h"
 #include "GPURenderBundleDescriptor.h"
@@ -43,6 +42,7 @@ class GPUBindGroup;
 class GPUBuffer;
 class GPURenderBundle;
 class GPURenderPipeline;
+template<typename> class ExceptionOr;
 
 class GPURenderBundleEncoder : public RefCounted<GPURenderBundleEncoder> {
 public:

--- a/Source/WebCore/Modules/WebGPU/GPURenderPassEncoder.h
+++ b/Source/WebCore/Modules/WebGPU/GPURenderPassEncoder.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include "ExceptionOr.h"
 #include "GPUColorDict.h"
 #include "GPUIndexFormat.h"
 #include "GPUIntegralTypes.h"
@@ -45,6 +44,7 @@ class GPUBuffer;
 class GPUQuerySet;
 class GPURenderBundle;
 class GPURenderPipeline;
+template<typename> class ExceptionOr;
 
 namespace WebGPU {
 class Device;

--- a/Source/WebCore/Modules/WebGPU/GPUTexture.h
+++ b/Source/WebCore/Modules/WebGPU/GPUTexture.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include "ExceptionOr.h"
 #include "GPUIntegralTypes.h"
 #include "GPUTextureAspect.h"
 #include "GPUTextureDimension.h"
@@ -44,6 +43,8 @@ class GPUTextureView;
 
 struct GPUTextureDescriptor;
 struct GPUTextureViewDescriptor;
+
+template<typename> class ExceptionOr;
 
 class GPUTexture : public RefCountedAndCanMakeWeakPtr<GPUTexture> {
 public:

--- a/Source/WebCore/Modules/applepay-ams-ui/ApplePayAMSUIPaymentHandler.h
+++ b/Source/WebCore/Modules/applepay-ams-ui/ApplePayAMSUIPaymentHandler.h
@@ -29,7 +29,6 @@
 
 #include "ApplePayAMSUIRequest.h"
 #include "ContextDestructionObserver.h"
-#include "ExceptionOr.h"
 #include "PaymentHandler.h"
 #include "PaymentRequest.h"
 #include <wtf/Function.h>
@@ -49,6 +48,8 @@ class Page;
 
 struct AddressErrors;
 struct PayerErrorFields;
+
+template<typename> class ExceptionOr;
 
 enum class PaymentComplete;
 

--- a/Source/WebCore/Modules/applepay/ApplePayContactField.cpp
+++ b/Source/WebCore/Modules/applepay/ApplePayContactField.cpp
@@ -25,7 +25,9 @@
 
 #include "config.h"
 #include "ApplePayContactField.h"
+
 #include "ApplePaySessionPaymentRequest.h"
+#include "ExceptionOr.h"
 
 #if ENABLE(APPLE_PAY)
 

--- a/Source/WebCore/Modules/applepay/ApplePayContactField.h
+++ b/Source/WebCore/Modules/applepay/ApplePayContactField.h
@@ -27,11 +27,10 @@
 
 #if ENABLE(APPLE_PAY)
 
-#include "ExceptionOr.h"
-
 namespace WebCore {
 
 struct ApplePaySessionPaymentRequestContactFields;
+template<typename> class ExceptionOr;
 
 enum class ApplePayContactField : uint8_t {
     Email,

--- a/Source/WebCore/Modules/applepay/ApplePayDeferredPaymentRequest.h
+++ b/Source/WebCore/Modules/applepay/ApplePayDeferredPaymentRequest.h
@@ -27,12 +27,13 @@
 
 #if ENABLE(APPLE_PAY_DEFERRED_PAYMENTS)
 
-#include "ExceptionOr.h"
 #include <WebCore/ApplePayLineItem.h>
 #include <wtf/WallTime.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
+
+template<typename> class ExceptionOr;
 
 struct ApplePayDeferredPaymentRequest final {
     String billingAgreement;

--- a/Source/WebCore/Modules/applepay/ApplePayMerchantCapability.cpp
+++ b/Source/WebCore/Modules/applepay/ApplePayMerchantCapability.cpp
@@ -26,6 +26,8 @@
 #include "config.h"
 #include "ApplePayMerchantCapability.h"
 
+#include "ExceptionOr.h"
+
 #if ENABLE(APPLE_PAY)
 
 namespace WebCore {

--- a/Source/WebCore/Modules/applepay/ApplePayMerchantCapability.h
+++ b/Source/WebCore/Modules/applepay/ApplePayMerchantCapability.h
@@ -28,9 +28,10 @@
 #if ENABLE(APPLE_PAY)
 
 #include "ApplePaySessionPaymentRequest.h"
-#include "ExceptionOr.h"
 
 namespace WebCore {
+
+template<typename> class ExceptionOr;
 
 enum class ApplePayMerchantCapability {
     Supports3DS,

--- a/Source/WebCore/Modules/applepay/ApplePaySession.h
+++ b/Source/WebCore/Modules/applepay/ApplePaySession.h
@@ -32,7 +32,6 @@
 #include "ApplePayPaymentRequest.h"
 #include "EventTarget.h"
 #include "EventTargetInterfaces.h"
-#include "ExceptionOr.h"
 #include "PaymentSession.h"
 #include <wtf/Ref.h>
 #include <wtf/RefCounted.h>
@@ -58,6 +57,7 @@ struct ApplePayShippingMethod;
 struct ApplePayPaymentMethodUpdate;
 struct ApplePayShippingContactUpdate;
 struct ApplePayShippingMethodUpdate;
+template<typename> class ExceptionOr;
 
 class ApplePaySession final : public PaymentSession, public ActiveDOMObject, public EventTarget {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(ApplePaySession);

--- a/Source/WebCore/Modules/applepay/PaymentRequestValidator.h
+++ b/Source/WebCore/Modules/applepay/PaymentRequestValidator.h
@@ -28,10 +28,11 @@
 #if ENABLE(APPLE_PAY)
 
 #include "ApplePaySessionPaymentRequest.h"
-#include "ExceptionOr.h"
 #include <wtf/OptionSet.h>
 
 namespace WebCore {
+
+template<typename> class ExceptionOr;
 
 class PaymentRequestValidator {
 public:

--- a/Source/WebCore/Modules/applepay/PaymentSession.h
+++ b/Source/WebCore/Modules/applepay/PaymentSession.h
@@ -27,7 +27,6 @@
 
 #if ENABLE(APPLE_PAY)
 
-#include "ExceptionOr.h"
 #include "PaymentSessionBase.h"
 
 namespace WebCore {
@@ -41,6 +40,7 @@ class PaymentMethod;
 class PaymentSessionError;
 class ScriptExecutionContext;
 struct ApplePayShippingMethod;
+template<typename> class ExceptionOr;
 
 class PaymentSession : public virtual PaymentSessionBase {
 public:

--- a/Source/WebCore/Modules/async-clipboard/ClipboardItem.cpp
+++ b/Source/WebCore/Modules/async-clipboard/ClipboardItem.cpp
@@ -31,6 +31,7 @@
 #include "ClipboardItemBindingsDataSource.h"
 #include "ClipboardItemPasteboardDataSource.h"
 #include "CommonAtomStrings.h"
+#include "ExceptionOr.h"
 #include "Navigator.h"
 #include "PasteboardCustomData.h"
 #include "PasteboardItemInfo.h"

--- a/Source/WebCore/Modules/async-clipboard/ClipboardItem.h
+++ b/Source/WebCore/Modules/async-clipboard/ClipboardItem.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include "ExceptionOr.h"
 #include <wtf/KeyValuePair.h>
 #include <wtf/Ref.h>
 #include <wtf/RefCountedAndCanMakeWeakPtr.h>
@@ -45,6 +44,7 @@ class Navigator;
 class PasteboardCustomData;
 class ScriptExecutionContext;
 struct PasteboardItemInfo;
+template<typename> class ExceptionOr;
 
 class ClipboardItem : public RefCountedAndCanMakeWeakPtr<ClipboardItem> {
 public:

--- a/Source/WebCore/Modules/audiosession/DOMAudioSession.cpp
+++ b/Source/WebCore/Modules/audiosession/DOMAudioSession.cpp
@@ -32,6 +32,7 @@
 #include "Document.h"
 #include "EventNames.h"
 #include "EventTargetInlines.h"
+#include "ExceptionOr.h"
 #include "Page.h"
 #include "PermissionsPolicy.h"
 #include "PlatformMediaSessionManager.h"

--- a/Source/WebCore/Modules/audiosession/DOMAudioSession.h
+++ b/Source/WebCore/Modules/audiosession/DOMAudioSession.h
@@ -31,11 +31,12 @@
 #include "AudioSession.h"
 #include "EventTarget.h"
 #include "EventTargetInterfaces.h"
-#include "ExceptionOr.h"
 #include <wtf/RefCounted.h>
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+template<typename> class ExceptionOr;
 
 enum class DOMAudioSessionType : uint8_t { Auto, Playback, Transient, TransientSolo, Ambient, PlayAndRecord };
 enum class DOMAudioSessionState : uint8_t { Inactive, Active, Interrupted };

--- a/Source/WebCore/Modules/beacon/NavigatorBeacon.h
+++ b/Source/WebCore/Modules/beacon/NavigatorBeacon.h
@@ -27,7 +27,6 @@
 
 #include "CachedRawResourceClient.h"
 #include "CachedResourceHandle.h"
-#include "ExceptionOr.h"
 #include "FetchBody.h"
 #include "Supplementable.h"
 #include <wtf/CheckedRef.h>
@@ -40,6 +39,7 @@ class CachedRawResource;
 class Document;
 class Navigator;
 class ResourceError;
+template<typename> class ExceptionOr;
 
 class NavigatorBeacon final : public Supplement<Navigator>, private CachedRawResourceClient {
     WTF_MAKE_TZONE_ALLOCATED(NavigatorBeacon);

--- a/Source/WebCore/Modules/cache/DOMCacheEngine.h
+++ b/Source/WebCore/Modules/cache/DOMCacheEngine.h
@@ -33,9 +33,11 @@
 #include "ResourceResponse.h"
 #include "SharedBuffer.h"
 #include <wtf/CompletionHandler.h>
+#include <wtf/CrossThreadCopier.h>
 
 namespace WebCore {
 
+class Exception;
 class ScriptExecutionContext;
 
 struct CacheQueryOptions;

--- a/Source/WebCore/Modules/compression/DecompressionStreamDecoder.h
+++ b/Source/WebCore/Modules/compression/DecompressionStreamDecoder.h
@@ -26,7 +26,6 @@
 
 #include "BufferSource.h"
 #include "CompressionStream.h"
-#include "ExceptionOr.h"
 #include "Formats.h"
 #include "SharedBuffer.h"
 #include "ZStream.h"
@@ -38,6 +37,8 @@
 #include <zlib.h>
 
 namespace WebCore {
+
+template<typename> class ExceptionOr;
 
 class DecompressionStreamDecoder : public RefCounted<DecompressionStreamDecoder> {
 public:

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeys.h
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeys.h
@@ -31,7 +31,6 @@
 #if ENABLE(ENCRYPTED_MEDIA)
 
 #include "CDMInstance.h"
-#include "ExceptionOr.h"
 #include "MediaKeySessionType.h"
 #include <wtf/Ref.h>
 #include <wtf/RefCounted.h>
@@ -51,6 +50,7 @@ class BufferSource;
 class DeferredPromise;
 class Document;
 class MediaKeySession;
+template<typename> class ExceptionOr;
 
 class MediaKeys final
     : public RefCounted<MediaKeys>

--- a/Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeySession.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeySession.cpp
@@ -32,6 +32,7 @@
 #include "EventLoop.h"
 #include "EventNames.h"
 #include "EventTargetInlines.h"
+#include "ExceptionOr.h"
 #include "Logging.h"
 #include "Page.h"
 #include "SecurityOriginData.h"

--- a/Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeySession.h
+++ b/Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeySession.h
@@ -31,7 +31,6 @@
 #include "ContextDestructionObserverInlines.h"
 #include "EventTarget.h"
 #include "EventTargetInterfaces.h"
-#include "ExceptionOr.h"
 #include "LegacyCDMSession.h"
 #include "Timer.h"
 #include <JavaScriptCore/Forward.h>
@@ -41,6 +40,7 @@ namespace WebCore {
 
 class WebKitMediaKeyError;
 class WebKitMediaKeys;
+template<typename> class ExceptionOr;
 
 class WebKitMediaKeySession final : public RefCounted<WebKitMediaKeySession>, public EventTarget, public ActiveDOMObject, private LegacyCDMSessionClient {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(WebKitMediaKeySession);

--- a/Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeys.h
+++ b/Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeys.h
@@ -27,7 +27,6 @@
 
 #if ENABLE(LEGACY_ENCRYPTED_MEDIA)
 
-#include "ExceptionOr.h"
 #include "LegacyCDM.h"
 #include <JavaScriptCore/Forward.h>
 #include <wtf/Vector.h>
@@ -39,6 +38,7 @@ class Document;
 class WeakPtrImplWithEventTargetData;
 class HTMLMediaElement;
 class WebKitMediaKeySession;
+template<typename> class ExceptionOr;
 
 class WebKitMediaKeys final : public RefCounted<WebKitMediaKeys>, private LegacyCDMClient {
     WTF_MAKE_FAST_ALLOCATED;

--- a/Source/WebCore/Modules/entriesapi/DOMFileSystem.cpp
+++ b/Source/WebCore/Modules/entriesapi/DOMFileSystem.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "DOMFileSystem.h"
 
+#include "ExceptionOr.h"
 #include "File.h"
 #include "FileSystemDirectoryEntry.h"
 #include "FileSystemFileEntry.h"

--- a/Source/WebCore/Modules/entriesapi/DOMFileSystem.h
+++ b/Source/WebCore/Modules/entriesapi/DOMFileSystem.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include "ExceptionOr.h"
 #include "FileSystemDirectoryEntry.h"
 #include "ScriptWrappable.h"
 #include <wtf/RefCounted.h>
@@ -38,6 +37,7 @@ class File;
 class FileSystemFileEntry;
 class FileSystemEntry;
 class ScriptExecutionContext;
+template<typename> class ExceptionOr;
 
 class DOMFileSystem final : public ScriptWrappable, public RefCounted<DOMFileSystem> {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(DOMFileSystem);

--- a/Source/WebCore/Modules/entriesapi/FileSystemDirectoryReader.cpp
+++ b/Source/WebCore/Modules/entriesapi/FileSystemDirectoryReader.cpp
@@ -30,6 +30,7 @@
 #include "DOMFileSystem.h"
 #include "Document.h"
 #include "ErrorCallback.h"
+#include "ExceptionOr.h"
 #include "FileSystemDirectoryEntry.h"
 #include "FileSystemEntriesCallback.h"
 #include "ScriptExecutionContext.h"

--- a/Source/WebCore/Modules/fetch/FetchBody.h
+++ b/Source/WebCore/Modules/fetch/FetchBody.h
@@ -30,7 +30,6 @@
 #pragma once
 
 #include "DOMFormData.h"
-#include "ExceptionOr.h"
 #include "FetchBodyConsumer.h"
 #include "FormData.h"
 #include "ReadableStream.h"
@@ -42,6 +41,8 @@ class DeferredPromise;
 class FetchBodyOwner;
 class FetchBodySource;
 class ScriptExecutionContext;
+
+template<typename> class ExceptionOr;
 
 class FetchBody {
 public:

--- a/Source/WebCore/Modules/fetch/FetchBodyOwner.h
+++ b/Source/WebCore/Modules/fetch/FetchBodyOwner.h
@@ -30,7 +30,6 @@
 #pragma once
 
 #include "ActiveDOMObject.h"
-#include "ExceptionOr.h"
 #include "FetchBody.h"
 #include "FetchBodySource.h"
 #include "FetchHeaders.h"
@@ -42,6 +41,8 @@
 #include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
+
+template<typename> class ExceptionOr;
 
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(FetchBodyOwner);
 

--- a/Source/WebCore/Modules/fetch/FetchHeaders.h
+++ b/Source/WebCore/Modules/fetch/FetchHeaders.h
@@ -28,7 +28,6 @@
 
 #pragma once
 
-#include "ExceptionOr.h"
 #include "FetchHeadersGuard.h"
 #include "HTTPHeaderMap.h"
 #include <wtf/HashTraits.h>
@@ -37,6 +36,7 @@
 namespace WebCore {
 
 class ScriptExecutionContext;
+template<typename> class ExceptionOr;
 
 class FetchHeaders : public RefCounted<FetchHeaders> {
 public:

--- a/Source/WebCore/Modules/fetch/FetchRequest.h
+++ b/Source/WebCore/Modules/fetch/FetchRequest.h
@@ -29,7 +29,6 @@
 #pragma once
 
 #include "AbortSignal.h"
-#include "ExceptionOr.h"
 #include "FetchBodyOwner.h"
 #include "FetchIdentifier.h"
 #include "FetchOptions.h"
@@ -44,6 +43,7 @@ class Blob;
 class ScriptExecutionContext;
 class URLSearchParams;
 class WebCoreOpaqueRoot;
+template<typename> class ExceptionOr;
 
 class FetchRequest final : public FetchBodyOwner {
 public:

--- a/Source/WebCore/Modules/fetch/FormDataConsumer.h
+++ b/Source/WebCore/Modules/fetch/FormDataConsumer.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include "ExceptionOr.h"
 #include "ScriptExecutionContextIdentifier.h"
 #include <span>
 #include <wtf/Function.h>
@@ -39,6 +38,7 @@ namespace WebCore {
 class BlobLoader;
 class FormData;
 class ScriptExecutionContext;
+template<typename> class ExceptionOr;
 
 class FormDataConsumer : public RefCountedAndCanMakeWeakPtr<FormDataConsumer> {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(FormDataConsumer, WEBCORE_EXPORT);

--- a/Source/WebCore/Modules/filesystemaccess/FileSystemSyncAccessHandle.h
+++ b/Source/WebCore/Modules/filesystemaccess/FileSystemSyncAccessHandle.h
@@ -27,7 +27,6 @@
 
 #include "ActiveDOMObject.h"
 #include "BufferSource.h"
-#include "ExceptionOr.h"
 #include "FileSystemSyncAccessHandleIdentifier.h"
 #include "IDLTypes.h"
 #include <wtf/Deque.h>
@@ -40,6 +39,7 @@ namespace WebCore {
 
 class FileSystemFileHandle;
 template<typename> class DOMPromiseDeferred;
+template<typename> class ExceptionOr;
 
 class FileSystemSyncAccessHandle : public RefCountedAndCanMakeWeakPtr<FileSystemSyncAccessHandle>, public ActiveDOMObject {
 public:

--- a/Source/WebCore/Modules/highlight/Highlight.h
+++ b/Source/WebCore/Modules/highlight/Highlight.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include "ExceptionOr.h"
 #include "Position.h"
 #include "Range.h"
 #include "StaticRange.h"

--- a/Source/WebCore/Modules/indexeddb/IDBCursor.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBCursor.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "IDBCursor.h"
 
+#include "ExceptionOr.h"
 #include "IDBBindingUtilities.h"
 #include "IDBDatabase.h"
 #include "IDBGetResult.h"

--- a/Source/WebCore/Modules/indexeddb/IDBCursor.h
+++ b/Source/WebCore/Modules/indexeddb/IDBCursor.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include "ExceptionOr.h"
 #include "IDBCursorDirection.h"
 #include "IDBCursorInfo.h"
 #include "IDBKeyPath.h"
@@ -41,6 +40,7 @@ class IDBGetResult;
 class IDBIndex;
 class IDBObjectStore;
 class IDBTransaction;
+template<typename> class ExceptionOr;
 
 class IDBCursor : public ScriptWrappable, public RefCounted<IDBCursor> {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(IDBCursor);

--- a/Source/WebCore/Modules/indexeddb/IDBFactory.h
+++ b/Source/WebCore/Modules/indexeddb/IDBFactory.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include "ExceptionOr.h"
 #include "JSDOMPromiseDeferredForward.h"
 #include <wtf/Function.h>
 #include <wtf/Forward.h>
@@ -44,6 +43,7 @@ namespace WebCore {
 class IDBOpenDBRequest;
 class ScriptExecutionContext;
 class SecurityOrigin;
+template<typename> class ExceptionOr;
 
 namespace IDBClient {
 class IDBConnectionProxy;

--- a/Source/WebCore/Modules/indexeddb/IDBIndex.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBIndex.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "IDBIndex.h"
 
+#include "ExceptionOr.h"
 #include "IDBBindingUtilities.h"
 #include "IDBCursor.h"
 #include "IDBDatabase.h"

--- a/Source/WebCore/Modules/indexeddb/IDBKeyRange.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBKeyRange.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "IDBKeyRange.h"
 
+#include "ExceptionOr.h"
 #include "IDBBindingUtilities.h"
 #include "IDBKey.h"
 #include "IDBKeyData.h"

--- a/Source/WebCore/Modules/indexeddb/IDBKeyRange.h
+++ b/Source/WebCore/Modules/indexeddb/IDBKeyRange.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include "ExceptionOr.h"
 #include "ScriptWrappable.h"
 #include <wtf/RefCounted.h>
 #include <wtf/RefPtr.h>
@@ -40,6 +39,7 @@ namespace WebCore {
 
 class IDBKey;
 class ScriptExecutionContext;
+template<typename> class ExceptionOr;
 
 class IDBKeyRange final : public ScriptWrappable, public RefCounted<IDBKeyRange> {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(IDBKeyRange);

--- a/Source/WebCore/Modules/indexeddb/IDBObjectStore.h
+++ b/Source/WebCore/Modules/indexeddb/IDBObjectStore.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include "ActiveDOMObject.h"
-#include "ExceptionOr.h"
 #include "IDBCursorDirection.h"
 #include "IDBIndexIdentifier.h"
 #include "IDBKeyPath.h"
@@ -57,6 +56,8 @@ class WeakPtrImplWithEventTargetData;
 class WebCoreOpaqueRoot;
 
 struct IDBKeyRangeData;
+
+template<typename> class ExceptionOr;
 
 namespace IndexedDB {
 enum class ObjectStoreOverwriteMode : uint8_t;

--- a/Source/WebCore/Modules/indexeddb/IDBRequest.h
+++ b/Source/WebCore/Modules/indexeddb/IDBRequest.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include "EventTarget.h"
-#include "ExceptionOr.h"
 #include "IDBActiveDOMObject.h"
 #include "IDBError.h"
 #include "IDBGetAllResult.h"
@@ -58,6 +57,7 @@ class IDBResultData;
 class IDBTransaction;
 class ThreadSafeDataBuffer;
 class WebCoreOpaqueRoot;
+template<typename> class ExceptionOr;
 
 namespace IDBClient {
 class IDBConnectionProxy;

--- a/Source/WebCore/Modules/mediarecorder/MediaRecorder.h
+++ b/Source/WebCore/Modules/mediarecorder/MediaRecorder.h
@@ -29,7 +29,6 @@
 #include "ActiveDOMObject.h"
 #include "EventTarget.h"
 #include "EventTargetInterfaces.h"
-#include "ExceptionOr.h"
 #include "MediaRecorderPrivateOptions.h"
 #include "MediaStream.h"
 #include "MediaStreamTrackPrivate.h"
@@ -42,6 +41,7 @@ namespace WebCore {
 class Blob;
 class Document;
 class MediaRecorderPrivate;
+template<typename> class ExceptionOr;
 
 class MediaRecorder final
     : public ActiveDOMObject

--- a/Source/WebCore/Modules/mediarecorder/MediaRecorderErrorEvent.h
+++ b/Source/WebCore/Modules/mediarecorder/MediaRecorderErrorEvent.h
@@ -30,6 +30,7 @@
 namespace WebCore {
 
 class DOMException;
+class Exception;
 
 class MediaRecorderErrorEvent final : public Event {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(MediaRecorderErrorEvent);

--- a/Source/WebCore/Modules/mediasession/MediaSession.h
+++ b/Source/WebCore/Modules/mediasession/MediaSession.h
@@ -28,7 +28,6 @@
 #if ENABLE(MEDIA_SESSION)
 
 #include "ActiveDOMObject.h"
-#include "ExceptionOr.h"
 #include "MediaPositionState.h"
 #include "MediaProducer.h"
 #include "MediaSessionAction.h"
@@ -60,8 +59,9 @@ class MediaMetadata;
 class MediaSessionCoordinator;
 class MediaSessionCoordinatorPrivate;
 class Navigator;
-template<typename> class DOMPromiseDeferred;
 struct NowPlayingInfo;
+template<typename> class DOMPromiseDeferred;
+template<typename> class ExceptionOr;
 
 class MediaSessionObserver : public CanMakeWeakPtr<MediaSessionObserver> {
 public:

--- a/Source/WebCore/Modules/mediasource/ManagedMediaSource.cpp
+++ b/Source/WebCore/Modules/mediasource/ManagedMediaSource.cpp
@@ -30,6 +30,7 @@
 
 #include "Event.h"
 #include "EventNames.h"
+#include "ExceptionOr.h"
 #include "MediaSourcePrivate.h"
 #include "SourceBufferList.h"
 #include <wtf/TZoneMallocInlines.h>

--- a/Source/WebCore/Modules/mediasource/MediaSource.h
+++ b/Source/WebCore/Modules/mediasource/MediaSource.h
@@ -34,7 +34,6 @@
 
 #include "ActiveDOMObject.h"
 #include "EventTarget.h"
-#include "ExceptionOr.h"
 #include "HTMLMediaElement.h"
 #include "MediaPlayer.h"
 #include "MediaPromiseTypes.h"
@@ -63,6 +62,7 @@ class TextTrack;
 class TimeRanges;
 class VideoTrack;
 class VideoTrackPrivate;
+template<typename> class ExceptionOr;
 
 enum class MediaSourceReadyState { Closed, Open, Ended };
 

--- a/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
+++ b/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
@@ -43,6 +43,7 @@
 #include "Document.h"
 #include "Event.h"
 #include "EventNames.h"
+#include "ExceptionOr.h"
 #include "HTMLMediaElement.h"
 #include "InbandTextTrack.h"
 #include "InbandTextTrackPrivate.h"

--- a/Source/WebCore/Modules/mediasource/SourceBuffer.h
+++ b/Source/WebCore/Modules/mediasource/SourceBuffer.h
@@ -37,7 +37,6 @@
 #include "AudioTrackClient.h"
 #include "EventTarget.h"
 #include "EventTargetInterfaces.h"
-#include "ExceptionOr.h"
 #include "SourceBufferPrivate.h"
 #include "SourceBufferPrivateClient.h"
 #include "TextTrackClient.h"
@@ -59,6 +58,7 @@ class TextTrackList;
 class TimeRanges;
 class VideoTrackList;
 class WebCoreOpaqueRoot;
+template<typename> class ExceptionOr;
 
 class SourceBuffer
     : public RefCounted<SourceBuffer>

--- a/Source/WebCore/Modules/mediastream/MediaDevices.h
+++ b/Source/WebCore/Modules/mediastream/MediaDevices.h
@@ -37,7 +37,6 @@
 #include "EventNames.h"
 #include "EventTarget.h"
 #include "EventTargetInterfaces.h"
-#include "ExceptionOr.h"
 #include "IDLTypes.h"
 #include "MediaTrackConstraints.h"
 #include "RealtimeMediaSourceCenter.h"

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrackProcessor.h
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrackProcessor.h
@@ -26,7 +26,6 @@
 
 #if ENABLE(MEDIA_STREAM) && ENABLE(WEB_CODECS)
 
-#include "ExceptionOr.h"
 #include "MediaStreamTrack.h"
 #include "ReadableStreamSource.h"
 #include "RealtimeMediaSource.h"
@@ -42,6 +41,7 @@ namespace WebCore {
 class ReadableStream;
 class ScriptExecutionContext;
 class WebCodecsVideoFrame;
+template<typename> class ExceptionOr;
 
 class MediaStreamTrackProcessor
     : public RefCounted<MediaStreamTrackProcessor>

--- a/Source/WebCore/Modules/mediastream/PeerConnectionBackend.h
+++ b/Source/WebCore/Modules/mediastream/PeerConnectionBackend.h
@@ -52,6 +52,7 @@ namespace WebCore {
 
 class DeferredPromise;
 class Document;
+class Exception;
 class MediaStream;
 class MediaStreamTrack;
 class PeerConnectionBackend;
@@ -77,6 +78,7 @@ struct RTCOfferOptions;
 struct RTCRtpTransceiverInit;
 
 template<typename IDLType> class DOMPromiseDeferred;
+template<typename> class ExceptionOr;
 
 namespace PeerConnection {
 using SessionDescriptionPromise = DOMPromiseDeferred<IDLDictionary<RTCSessionDescriptionInit>>;

--- a/Source/WebCore/Modules/mediastream/RTCDTMFSender.h
+++ b/Source/WebCore/Modules/mediastream/RTCDTMFSender.h
@@ -30,7 +30,6 @@
 #include "ActiveDOMObject.h"
 #include "EventTarget.h"
 #include "EventTargetInterfaces.h"
-#include "ExceptionOr.h"
 #include "ScriptWrappable.h"
 #include "Timer.h"
 
@@ -39,6 +38,7 @@ namespace WebCore {
 class MediaStreamTrack;
 class RTCDTMFSenderBackend;
 class RTCRtpSender;
+template<typename> class ExceptionOr;
 
 class RTCDTMFSender final : public RefCounted<RTCDTMFSender>, public EventTarget, public ActiveDOMObject {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(RTCDTMFSender);

--- a/Source/WebCore/Modules/mediastream/RTCDataChannel.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCDataChannel.cpp
@@ -31,6 +31,7 @@
 #include "Blob.h"
 #include "EventNames.h"
 #include "ExceptionCode.h"
+#include "ExceptionOr.h"
 #include "Logging.h"
 #include "MessageEvent.h"
 #include "RTCDataChannelRemoteHandler.h"

--- a/Source/WebCore/Modules/mediastream/RTCDataChannel.h
+++ b/Source/WebCore/Modules/mediastream/RTCDataChannel.h
@@ -32,7 +32,6 @@
 #include "Event.h"
 #include "EventTarget.h"
 #include "EventTargetInterfaces.h"
-#include "ExceptionOr.h"
 #include "NetworkSendQueue.h"
 #include "RTCDataChannelHandler.h"
 #include "RTCDataChannelHandlerClient.h"
@@ -50,6 +49,7 @@ namespace WebCore {
 
 class Blob;
 class RTCPeerConnectionHandler;
+template<typename> class ExceptionOr;
 
 class RTCDataChannel final : public RefCounted<RTCDataChannel>, public ActiveDOMObject, public RTCDataChannelHandlerClient, public EventTarget {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(RTCDataChannel);

--- a/Source/WebCore/Modules/mediastream/RTCIceCandidate.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCIceCandidate.cpp
@@ -35,6 +35,7 @@
 
 #if ENABLE(WEB_RTC)
 
+#include "ExceptionOr.h"
 #include "RTCIceCandidateInit.h"
 #include <wtf/TZoneMallocInlines.h>
 

--- a/Source/WebCore/Modules/mediastream/RTCIceCandidate.h
+++ b/Source/WebCore/Modules/mediastream/RTCIceCandidate.h
@@ -32,13 +32,13 @@
 
 #if ENABLE(WEB_RTC)
 
-#include "ExceptionOr.h"
 #include "RTCIceCandidateFields.h"
 #include "ScriptWrappable.h"
 
 namespace WebCore {
 
 struct RTCIceCandidateInit;
+template<typename> class ExceptionOr;
 
 class RTCIceCandidate final : public RefCounted<RTCIceCandidate>, public ScriptWrappable {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(RTCIceCandidate);

--- a/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransformer.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransformer.cpp
@@ -28,6 +28,7 @@
 
 #if ENABLE(WEB_RTC)
 
+#include "ExceptionOr.h"
 #include "SFrameUtils.h"
 #include <algorithm>
 #include <wtf/StdLibExtras.h>

--- a/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransformer.h
+++ b/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransformer.h
@@ -27,14 +27,17 @@
 
 #if ENABLE(WEB_RTC)
 
-#include "ExceptionOr.h"
 #include "RTCRtpTransformBackend.h"
 #include <wtf/Lock.h>
 #include <wtf/ThreadSafeRefCounted.h>
+#include <wtf/Vector.h>
+#include <wtf/text/WTFString.h>
 
 namespace WebCore {
 
 class CryptoKey;
+
+template<typename> class ExceptionOr;
 
 class RTCRtpSFrameTransformer : public ThreadSafeRefCounted<RTCRtpSFrameTransformer, WTF::DestructionThread::Main> {
 public:

--- a/Source/WebCore/Modules/mediastream/RTCRtpScriptTransform.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCRtpScriptTransform.cpp
@@ -30,6 +30,7 @@
 
 #include "ErrorEvent.h"
 #include "EventNames.h"
+#include "ExceptionOr.h"
 #include "JSDOMGlobalObject.h"
 #include "MessageChannel.h"
 #include "RTCRtpScriptTransformer.h"

--- a/Source/WebCore/Modules/mediastream/RTCRtpScriptTransformer.h
+++ b/Source/WebCore/Modules/mediastream/RTCRtpScriptTransformer.h
@@ -28,7 +28,6 @@
 #if ENABLE(WEB_RTC)
 
 #include "ActiveDOMObject.h"
-#include "ExceptionOr.h"
 #include "JSDOMPromiseDeferredForward.h"
 #include "RTCRtpTransformBackend.h"
 #include <JavaScriptCore/JSCJSValue.h>
@@ -49,6 +48,8 @@ class SimpleReadableStreamSource;
 class WritableStream;
 
 struct MessageWithMessagePorts;
+
+template<typename> class ExceptionOr;
 
 enum class RTCRtpScriptTransformerIdentifierType { };
 using RTCRtpScriptTransformerIdentifier = AtomicObjectIdentifier<RTCRtpScriptTransformerIdentifierType>;

--- a/Source/WebCore/Modules/mediastream/RTCRtpTransceiverBackend.h
+++ b/Source/WebCore/Modules/mediastream/RTCRtpTransceiverBackend.h
@@ -26,12 +26,13 @@
 
 #if ENABLE(WEB_RTC)
 
-#include "ExceptionOr.h"
 #include "RTCRtpTransceiverDirection.h"
 #include <wtf/Forward.h>
 
 namespace WebCore {
+
 struct RTCRtpCodecCapability;
+template<typename> class ExceptionOr;
 
 class RTCRtpTransceiverBackend {
 public:

--- a/Source/WebCore/Modules/mediastream/RTCSessionDescription.h
+++ b/Source/WebCore/Modules/mediastream/RTCSessionDescription.h
@@ -33,7 +33,6 @@
 
 #if ENABLE(WEB_RTC)
 
-#include "ExceptionOr.h"
 #include "RTCSdpType.h"
 #include "ScriptWrappable.h"
 

--- a/Source/WebCore/Modules/mediastream/VideoTrackGenerator.h
+++ b/Source/WebCore/Modules/mediastream/VideoTrackGenerator.h
@@ -26,7 +26,6 @@
 
 #if ENABLE(MEDIA_STREAM) && ENABLE(WEB_CODECS)
 
-#include "ExceptionOr.h"
 #include "RealtimeMediaSource.h"
 #include "WritableStreamSink.h"
 #include <wtf/RefCounted.h>
@@ -36,6 +35,7 @@ namespace WebCore {
 class MediaStreamTrack;
 class ScriptExecutionContext;
 class WritableStream;
+template<typename> class ExceptionOr;
 
 class VideoTrackGenerator : public RefCounted<VideoTrackGenerator> {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(VideoTrackGenerator);

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp
@@ -23,6 +23,7 @@
 #if USE(GSTREAMER_WEBRTC)
 
 #include "Document.h"
+#include "ExceptionOr.h"
 #include "GStreamerCommon.h"
 #include "GStreamerDataChannelHandler.h"
 #include "GStreamerIncomingTrackProcessor.h"

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.cpp
@@ -23,6 +23,7 @@
 #if USE(GSTREAMER_WEBRTC)
 
 #include "Document.h"
+#include "ExceptionOr.h"
 #include "GStreamerCommon.h"
 #include "GStreamerMediaEndpoint.h"
 #include "GStreamerRtpReceiverBackend.h"

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpTransceiverBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpTransceiverBackend.cpp
@@ -22,6 +22,7 @@
 
 #if ENABLE(WEB_RTC) && USE(GSTREAMER_WEBRTC)
 
+#include "ExceptionOr.h"
 #include "GStreamerRtpReceiverBackend.h"
 #include "GStreamerRtpSenderBackend.h"
 #include "GStreamerWebRTCUtils.h"

--- a/Source/WebCore/Modules/model-element/HTMLModelElement.h
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.h
@@ -32,7 +32,6 @@
 #include "CachedRawResourceClient.h"
 #include "CachedResourceHandle.h"
 #include "EventLoop.h"
-#include "ExceptionOr.h"
 #include "HTMLElement.h"
 #include "HTMLModelElementCamera.h"
 #include "IDLTypes.h"
@@ -62,6 +61,7 @@ class MouseEvent;
 
 template<typename IDLType> class DOMPromiseDeferred;
 template<typename IDLType> class DOMPromiseProxyWithResolveCallback;
+template<typename> class ExceptionOr;
 
 #if ENABLE(MODEL_PROCESS)
 template<typename IDLType> class DOMPromiseProxy;

--- a/Source/WebCore/Modules/notifications/NotificationJSONParser.h
+++ b/Source/WebCore/Modules/notifications/NotificationJSONParser.h
@@ -27,7 +27,6 @@
 
 #if ENABLE(DECLARATIVE_WEB_PUSH)
 
-#include "ExceptionOr.h"
 #include "NotificationOptionsPayload.h"
 #include "NotificationPayload.h"
 #include <wtf/JSONValues.h>
@@ -35,6 +34,8 @@
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
+
+template<typename> class ExceptionOr;
 
 class NotificationJSONParser {
 public:

--- a/Source/WebCore/Modules/notifications/NotificationOptionsPayload.h
+++ b/Source/WebCore/Modules/notifications/NotificationOptionsPayload.h
@@ -25,6 +25,7 @@
 #pragma once
 
 #include "NotificationDirection.h"
+#include <wtf/text/WTFString.h>
 
 OBJC_CLASS NSDictionary;
 

--- a/Source/WebCore/Modules/notifications/NotificationPayload.h
+++ b/Source/WebCore/Modules/notifications/NotificationPayload.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include "ExceptionOr.h"
 #include "NotificationOptionsPayload.h"
 #include <wtf/CrossThreadCopier.h>
 #include <wtf/URL.h>
@@ -36,6 +35,7 @@ OBJC_CLASS NSDictionary;
 namespace WebCore {
 
 struct NotificationData;
+template<typename> class ExceptionOr;
 
 struct NotificationPayload {
     URL defaultActionURL;

--- a/Source/WebCore/Modules/paymentrequest/PaymentRequest.h
+++ b/Source/WebCore/Modules/paymentrequest/PaymentRequest.h
@@ -30,7 +30,6 @@
 #include "ActiveDOMObject.h"
 #include "EventTarget.h"
 #include "EventTargetInterfaces.h"
-#include "ExceptionOr.h"
 #include "IDLTypes.h"
 #include "PaymentDetailsInit.h"
 #include "PaymentMethodChangeEvent.h"
@@ -51,6 +50,7 @@ enum class PaymentShippingType;
 struct PaymentDetailsUpdate;
 struct PaymentMethodData;
 template<typename IDLType> class DOMPromiseDeferred;
+template<typename> class ExceptionOr;
 
 class PaymentRequest final : public ActiveDOMObject, public EventTarget, public RefCounted<PaymentRequest> {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(PaymentRequest);

--- a/Source/WebCore/Modules/paymentrequest/PaymentRequestUpdateEvent.h
+++ b/Source/WebCore/Modules/paymentrequest/PaymentRequestUpdateEvent.h
@@ -34,6 +34,7 @@ namespace WebCore {
 
 class DOMPromise;
 struct PaymentRequestUpdateEventInit;
+template<typename> class ExceptionOr;
 
 class PaymentRequestUpdateEvent : public Event {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(PaymentRequestUpdateEvent);

--- a/Source/WebCore/Modules/paymentrequest/PaymentResponse.h
+++ b/Source/WebCore/Modules/paymentrequest/PaymentResponse.h
@@ -31,6 +31,7 @@
 #include "ContextDestructionObserver.h"
 #include "EventTarget.h"
 #include "EventTargetInterfaces.h"
+#include "ExceptionOr.h"
 #include "JSValueInWrappedObject.h"
 #include "PaymentAddress.h"
 #include <wtf/WeakPtr.h>

--- a/Source/WebCore/Modules/plugins/YouTubePluginReplacement.cpp
+++ b/Source/WebCore/Modules/plugins/YouTubePluginReplacement.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "YouTubePluginReplacement.h"
 
+#include "ExceptionOr.h"
 #include "HTMLIFrameElement.h"
 #include "HTMLNames.h"
 #include "HTMLPlugInElement.h"

--- a/Source/WebCore/Modules/push-api/PushMessageData.h
+++ b/Source/WebCore/Modules/push-api/PushMessageData.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include "ExceptionOr.h"
 #include <JavaScriptCore/ArrayBuffer.h>
 #include <JavaScriptCore/JSCJSValue.h>
 #include <JavaScriptCore/Uint8Array.h>
@@ -37,6 +36,7 @@ namespace WebCore {
 class Blob;
 class JSDOMGlobalObject;
 class ScriptExecutionContext;
+template<typename> class ExceptionOr;
 
 class PushMessageData final : public RefCounted<PushMessageData> {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(PushMessageData);

--- a/Source/WebCore/Modules/push-api/PushStrategy.h
+++ b/Source/WebCore/Modules/push-api/PushStrategy.h
@@ -26,12 +26,13 @@
 #pragma once
 #if ENABLE(DECLARATIVE_WEB_PUSH)
 
-#include "ExceptionOr.h"
 #include "PushPermissionState.h"
 #include "PushSubscriptionData.h"
 #include "PushSubscriptionIdentifier.h"
 
 namespace WebCore {
+
+template<typename> class ExceptionOr;
 
 class WEBCORE_EXPORT PushStrategy {
 public:

--- a/Source/WebCore/Modules/push-api/PushSubscription.h
+++ b/Source/WebCore/Modules/push-api/PushSubscription.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include "EpochTimeStamp.h"
-#include "ExceptionOr.h"
 #include "JSDOMPromiseDeferredForward.h"
 #include "PushEncryptionKeyName.h"
 #include "PushSubscriptionData.h"
@@ -46,6 +45,7 @@ class PushSubscriptionOptions;
 class PushSubscriptionOwner;
 class ScriptExecutionContext;
 class ServiceWorkerContainer;
+template<typename> class ExceptionOr;
 
 class PushSubscription : public RefCounted<PushSubscription> {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED_EXPORT(PushSubscription, WEBCORE_EXPORT);

--- a/Source/WebCore/Modules/push-api/PushSubscriptionOptions.cpp
+++ b/Source/WebCore/Modules/push-api/PushSubscriptionOptions.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "PushSubscriptionOptions.h"
 
+#include "ExceptionOr.h"
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {

--- a/Source/WebCore/Modules/push-api/PushSubscriptionOptions.h
+++ b/Source/WebCore/Modules/push-api/PushSubscriptionOptions.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include "EpochTimeStamp.h"
-#include "ExceptionOr.h"
 
 #include <JavaScriptCore/ArrayBuffer.h>
 #include <optional>
@@ -34,6 +33,8 @@
 #include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
+
+template<typename> class ExceptionOr;
 
 class PushSubscriptionOptions : public RefCounted<PushSubscriptionOptions> {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(PushSubscriptionOptions);

--- a/Source/WebCore/Modules/storage/WorkerStorageConnection.cpp
+++ b/Source/WebCore/Modules/storage/WorkerStorageConnection.cpp
@@ -28,6 +28,7 @@
 
 #include "ClientOrigin.h"
 #include "Document.h"
+#include "ExceptionOr.h"
 #include "StorageEstimate.h"
 #include "WorkerFileSystemStorageConnection.h"
 #include "WorkerGlobalScope.h"

--- a/Source/WebCore/Modules/streams/ReadableStreamSink.h
+++ b/Source/WebCore/Modules/streams/ReadableStreamSink.h
@@ -26,7 +26,6 @@
 
 #pragma once
 
-#include "ExceptionOr.h"
 #include <JavaScriptCore/Forward.h>
 #include <span>
 #include <wtf/Function.h>
@@ -36,6 +35,7 @@ namespace WebCore {
 
 class BufferSource;
 class ReadableStream;
+template<typename> class ExceptionOr;
 
 class ReadableStreamSink : public RefCounted<ReadableStreamSink> {
 public:

--- a/Source/WebCore/Modules/streams/TransformStream.h
+++ b/Source/WebCore/Modules/streams/TransformStream.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include "ExceptionOr.h"
 #include "JSDOMGlobalObject.h"
 #include "JSValueInWrappedObject.h"
 #include <JavaScriptCore/Strong.h>
@@ -39,6 +38,7 @@ class InternalWritableStream;
 class JSDOMGlobalObject;
 class ReadableStream;
 class WritableStream;
+template<typename> class ExceptionOr;
 
 class TransformStream : public RefCounted<TransformStream> {
 public:

--- a/Source/WebCore/Modules/streams/WritableStream.h
+++ b/Source/WebCore/Modules/streams/WritableStream.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include "ExceptionOr.h"
 #include "JSDOMGlobalObject.h"
 #include <JavaScriptCore/Strong.h>
 #include <wtf/RefCountedAndCanMakeWeakPtr.h>
@@ -36,6 +35,7 @@ namespace WebCore {
 class InternalWritableStream;
 class JSDOMGlobalObject;
 class WritableStreamSink;
+template<typename> class ExceptionOr;
 
 class WritableStream : public RefCountedAndCanMakeWeakPtr<WritableStream> {
 public:

--- a/Source/WebCore/Modules/streams/WritableStreamSink.h
+++ b/Source/WebCore/Modules/streams/WritableStreamSink.h
@@ -26,7 +26,6 @@
 
 #pragma once
 
-#include "ExceptionOr.h"
 #include "JSDOMPromiseDeferred.h"
 #include "ScriptExecutionContext.h"
 #include <wtf/RefCounted.h>
@@ -37,6 +36,8 @@ class JSValue;
 }
 
 namespace WebCore {
+
+template<typename> class ExceptionOr;
 
 class WritableStreamSink : public RefCounted<WritableStreamSink> {
 public:

--- a/Source/WebCore/Modules/url-pattern/URLPattern.h
+++ b/Source/WebCore/Modules/url-pattern/URLPattern.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include "ExceptionOr.h"
 #include "URLPatternComponent.h"
 #include "URLPatternInit.h"
 #include <wtf/Forward.h>
@@ -39,6 +38,8 @@ namespace WebCore {
 class ScriptExecutionContext;
 struct URLPatternOptions;
 struct URLPatternResult;
+template<typename> class ExceptionOr;
+
 enum class BaseURLStringType : bool { Pattern, URL };
 
 namespace URLPatternUtilities {

--- a/Source/WebCore/Modules/url-pattern/URLPatternCanonical.cpp
+++ b/Source/WebCore/Modules/url-pattern/URLPatternCanonical.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "URLPatternCanonical.h"
 
+#include "ExceptionOr.h"
 #include "URLDecomposition.h"
 #include "URLPattern.h"
 #include <wtf/URL.h>

--- a/Source/WebCore/Modules/url-pattern/URLPatternCanonical.h
+++ b/Source/WebCore/Modules/url-pattern/URLPatternCanonical.h
@@ -25,9 +25,12 @@
 
 #pragma once
 
-#include "ExceptionOr.h"
+#include <wtf/text/StringView.h>
+#include <wtf/text/WTFString.h>
 
 namespace WebCore {
+
+template<typename> class ExceptionOr;
 
 enum class BaseURLStringType : bool;
 enum class EncodingCallbackType : uint8_t { Protocol, Username, Password, Host, IPv6Host, Port, Path, OpaquePath, Search, Hash };

--- a/Source/WebCore/Modules/url-pattern/URLPatternComponent.cpp
+++ b/Source/WebCore/Modules/url-pattern/URLPatternComponent.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "URLPatternComponent.h"
 
+#include "ExceptionOr.h"
 #include "ScriptExecutionContext.h"
 #include "URLPatternCanonical.h"
 #include "URLPatternParser.h"

--- a/Source/WebCore/Modules/url-pattern/URLPatternConstructorStringParser.h
+++ b/Source/WebCore/Modules/url-pattern/URLPatternConstructorStringParser.h
@@ -25,11 +25,12 @@
 
 #pragma once
 
-#include "ExceptionOr.h"
 #include "ScriptExecutionContext.h"
 #include "URLPatternInit.h"
 
 namespace WebCore {
+
+template<typename> class ExceptionOr;
 
 enum class EncodingCallbackType : uint8_t;
 

--- a/Source/WebCore/Modules/url-pattern/URLPatternTokenizer.h
+++ b/Source/WebCore/Modules/url-pattern/URLPatternTokenizer.h
@@ -25,10 +25,12 @@
 
 #pragma once
 
-#include "ExceptionOr.h"
 #include <wtf/text/StringView.h>
 
 namespace WebCore {
+
+template<typename> class ExceptionOr;
+
 namespace URLPatternUtilities {
 
 enum class TokenType : uint8_t { Open, Close, Regexp, Name, Char, EscapedChar, OtherModifier, Asterisk, End, InvalidChar };

--- a/Source/WebCore/Modules/webaudio/AudioBuffer.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioBuffer.cpp
@@ -36,6 +36,7 @@
 #include "AudioContext.h"
 #include "AudioFileReader.h"
 #include "AudioUtilities.h"
+#include "ExceptionOr.h"
 #include "ScriptWrappableInlines.h"
 #include "WebCoreOpaqueRoot.h"
 #include <JavaScriptCore/JSCInlines.h>

--- a/Source/WebCore/Modules/webaudio/AudioBuffer.h
+++ b/Source/WebCore/Modules/webaudio/AudioBuffer.h
@@ -30,7 +30,6 @@
 #pragma once
 
 #include "AudioBufferOptions.h"
-#include "ExceptionOr.h"
 #include "JSValueInWrappedObject.h"
 #include "ScriptWrappable.h"
 #include <JavaScriptCore/Forward.h>
@@ -42,6 +41,7 @@ namespace WebCore {
 
 class AudioBus;
 class WebCoreOpaqueRoot;
+template<typename> class ExceptionOr;
 
 class AudioBuffer : public ScriptWrappable, public RefCounted<AudioBuffer> {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(AudioBuffer);

--- a/Source/WebCore/Modules/webaudio/AudioDestinationNode.h
+++ b/Source/WebCore/Modules/webaudio/AudioDestinationNode.h
@@ -31,6 +31,7 @@
 namespace WebCore {
 
 class AudioBus;
+class Exception;
 struct AudioIOPosition;
 
 class AudioDestinationNode : public AudioNode {

--- a/Source/WebCore/Modules/webaudio/AudioListener.h
+++ b/Source/WebCore/Modules/webaudio/AudioListener.h
@@ -30,7 +30,6 @@
 #pragma once
 
 #include "AudioArray.h"
-#include "ExceptionOr.h"
 #include "FloatPoint3D.h"
 #include <wtf/Ref.h>
 #include <wtf/RefCounted.h>
@@ -39,6 +38,7 @@ namespace WebCore {
 
 class AudioParam;
 class BaseAudioContext;
+template<typename> class ExceptionOr;
 
 // AudioListener maintains the state of the listener in the audio scene as defined in the OpenAL specification.
 

--- a/Source/WebCore/Modules/webaudio/AudioNode.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioNode.cpp
@@ -36,6 +36,7 @@
 #include "AudioParam.h"
 #include "ContextDestructionObserverInlines.h"
 #include "EventTargetInterfaces.h"
+#include "ExceptionOr.h"
 #include "Logging.h"
 #include <wtf/Atomics.h>
 #include <wtf/MainThread.h>

--- a/Source/WebCore/Modules/webaudio/AudioNode.h
+++ b/Source/WebCore/Modules/webaudio/AudioNode.h
@@ -28,7 +28,6 @@
 #include "ChannelCountMode.h"
 #include "ChannelInterpretation.h"
 #include "EventTarget.h"
-#include "ExceptionOr.h"
 #include <wtf/Forward.h>
 #include <wtf/LoggerHelper.h>
 
@@ -37,10 +36,11 @@
 namespace WebCore {
 
 class AudioNodeInput;
-struct AudioNodeOptions;
 class AudioNodeOutput;
 class AudioParam;
 class BaseAudioContext;
+struct AudioNodeOptions;
+template<typename> class ExceptionOr;
 
 enum class NoiseInjectionPolicy : uint8_t;
 

--- a/Source/WebCore/Modules/webaudio/AudioWorkletProcessor.h
+++ b/Source/WebCore/Modules/webaudio/AudioWorkletProcessor.h
@@ -30,7 +30,6 @@
 
 #if ENABLE(WEB_AUDIO)
 #include "AudioArray.h"
-#include "ExceptionOr.h"
 #include "JSValueInWrappedObject.h"
 #include "ScriptWrappable.h"
 #include <wtf/Forward.h>
@@ -54,6 +53,7 @@ class JSCallbackDataStrong;
 class MessagePort;
 class ScriptExecutionContext;
 class WebCoreOpaqueRoot;
+template<typename> class ExceptionOr;
 
 class AudioWorkletProcessor : public ScriptWrappable, public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<AudioWorkletProcessor> {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(AudioWorkletProcessor);

--- a/Source/WebCore/Modules/webaudio/BiquadFilterNode.cpp
+++ b/Source/WebCore/Modules/webaudio/BiquadFilterNode.cpp
@@ -28,6 +28,7 @@
 #if ENABLE(WEB_AUDIO)
 
 #include "BiquadFilterNode.h"
+#include "ExceptionOr.h"
 #include <JavaScriptCore/Float32Array.h>
 #include <wtf/TZoneMallocInlines.h>
 

--- a/Source/WebCore/Modules/webaudio/DelayNode.cpp
+++ b/Source/WebCore/Modules/webaudio/DelayNode.cpp
@@ -30,6 +30,7 @@
 
 #include "DelayOptions.h"
 #include "DelayProcessor.h"
+#include "ExceptionOr.h"
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
 

--- a/Source/WebCore/Modules/webaudio/MediaElementAudioSourceNode.cpp
+++ b/Source/WebCore/Modules/webaudio/MediaElementAudioSourceNode.cpp
@@ -33,6 +33,7 @@
 #include "AudioNodeOutput.h"
 #include "AudioSourceProvider.h"
 #include "AudioUtilities.h"
+#include "ExceptionOr.h"
 #include "Logging.h"
 #include "MediaElementAudioSourceOptions.h"
 #include "MediaPlayer.h"

--- a/Source/WebCore/Modules/webaudio/PannerNode.cpp
+++ b/Source/WebCore/Modules/webaudio/PannerNode.cpp
@@ -34,6 +34,7 @@
 #include "AudioNodeOutput.h"
 #include "AudioUtilities.h"
 #include "ChannelCountMode.h"
+#include "ExceptionOr.h"
 #include "HRTFDatabaseLoader.h"
 #include "HRTFPanner.h"
 #include "ScriptExecutionContext.h"

--- a/Source/WebCore/Modules/webaudio/PeriodicWave.h
+++ b/Source/WebCore/Modules/webaudio/PeriodicWave.h
@@ -29,7 +29,6 @@
 #pragma once
 
 #include "AudioArray.h"
-#include "ExceptionOr.h"
 #include "PeriodicWaveOptions.h"
 #include <JavaScriptCore/Forward.h>
 #include <memory>
@@ -39,6 +38,7 @@
 namespace WebCore {
 
 class BaseAudioContext;
+template<typename> class ExceptionOr;
 
 enum class ShouldDisableNormalization : bool { No, Yes };
 

--- a/Source/WebCore/Modules/webauthn/AuthenticatorAttestationResponse.cpp
+++ b/Source/WebCore/Modules/webauthn/AuthenticatorAttestationResponse.cpp
@@ -32,6 +32,7 @@
 #include "CBORReader.h"
 #include "CryptoAlgorithmECDH.h"
 #include "CryptoKeyEC.h"
+#include "ExceptionOr.h"
 #include "WebAuthenticationUtils.h"
 #include <wtf/text/Base64.h>
 

--- a/Source/WebCore/Modules/webauthn/PublicKeyCredential.h
+++ b/Source/WebCore/Modules/webauthn/PublicKeyCredential.h
@@ -29,7 +29,6 @@
 
 #include "AuthenticationResponseJSON.h"
 #include "BasicCredential.h"
-#include "ExceptionOr.h"
 #include "IDLTypes.h"
 #include "RegistrationResponseJSON.h"
 #include <wtf/Forward.h>
@@ -39,6 +38,7 @@ namespace WebCore {
 enum class AuthenticatorAttachment : uint8_t;
 class AuthenticatorResponse;
 class Document;
+
 typedef IDLRecord<IDLDOMString, IDLBoolean> PublicKeyCredentialClientCapabilities;
 typedef Variant<RegistrationResponseJSON, AuthenticationResponseJSON> PublicKeyCredentialJSON;
 
@@ -52,6 +52,7 @@ struct AllAcceptedCredentialsOptions;
 struct CurrentUserDetailsOptions;
 
 template<typename IDLType> class DOMPromiseDeferred;
+template<typename> class ExceptionOr;
 
 class PublicKeyCredential final : public BasicCredential {
 public:

--- a/Source/WebCore/Modules/webauthn/fido/Pin.cpp
+++ b/Source/WebCore/Modules/webauthn/fido/Pin.cpp
@@ -42,6 +42,7 @@
 #include "CryptoKeyEC.h"
 #include "CryptoKeyHMAC.h"
 #include "DeviceResponseConverter.h"
+#include "ExceptionOr.h"
 #include "WebAuthenticationConstants.h"
 #include "WebAuthenticationUtils.h"
 #if HAVE(SWIFT_CPP_INTEROP)

--- a/Source/WebCore/Modules/webcodecs/WebCodecsAudioDataAlgorithms.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsAudioDataAlgorithms.h
@@ -30,10 +30,11 @@
 
 #if ENABLE(WEB_CODECS)
 
-#include <ExceptionOr.h>
 #include <span>
 
 namespace WebCore {
+
+template<typename> class ExceptionOr;
 
 bool isValidAudioDataInit(const WebCodecsAudioData::Init&);
 

--- a/Source/WebCore/Modules/webcodecs/WebCodecsEncodedAudioChunk.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsEncodedAudioChunk.h
@@ -29,11 +29,12 @@
 #if ENABLE(WEB_CODECS)
 
 #include "BufferSource.h"
-#include "ExceptionOr.h"
 #include "WebCodecsEncodedAudioChunkData.h"
 #include <wtf/ThreadSafeRefCounted.h>
 
 namespace WebCore {
+
+template<typename> class ExceptionOr;
 
 class WebCodecsEncodedAudioChunkStorage : public ThreadSafeRefCounted<WebCodecsEncodedAudioChunkStorage> {
 public:

--- a/Source/WebCore/Modules/webcodecs/WebCodecsEncodedVideoChunk.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsEncodedVideoChunk.h
@@ -28,11 +28,12 @@
 #if ENABLE(WEB_CODECS)
 
 #include "BufferSource.h"
-#include "ExceptionOr.h"
 #include "WebCodecsEncodedVideoChunkData.h"
 #include <wtf/ThreadSafeRefCounted.h>
 
 namespace WebCore {
+
+template<typename> class ExceptionOr;
 
 class WebCodecsEncodedVideoChunkStorage : public ThreadSafeRefCounted<WebCodecsEncodedVideoChunkStorage> {
 public:

--- a/Source/WebCore/Modules/webdatabase/Database.cpp
+++ b/Source/WebCore/Modules/webdatabase/Database.cpp
@@ -39,6 +39,7 @@
 #include "DatabaseThread.h"
 #include "DatabaseTracker.h"
 #include "Document.h"
+#include "ExceptionOr.h"
 #include "LocalDOMWindow.h"
 #include "Logging.h"
 #include "SQLError.h"

--- a/Source/WebCore/Modules/webdatabase/Database.h
+++ b/Source/WebCore/Modules/webdatabase/Database.h
@@ -28,7 +28,6 @@
 
 #pragma once
 
-#include "ExceptionOr.h"
 #include "SQLiteDatabase.h"
 #include <wtf/Deque.h>
 #include <wtf/Lock.h>
@@ -49,6 +48,7 @@ class SQLTransactionErrorCallback;
 class SQLTransactionWrapper;
 class VoidCallback;
 class SecurityOriginData;
+template<typename> class ExceptionOr;
 
 using DatabaseGUID = int;
 

--- a/Source/WebCore/Modules/webdatabase/DatabaseManager.h
+++ b/Source/WebCore/Modules/webdatabase/DatabaseManager.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include "DatabaseDetails.h"
-#include "ExceptionOr.h"
 #include <wtf/Assertions.h>
 #include <wtf/HashSet.h>
 #include <wtf/Lock.h>
@@ -42,6 +41,7 @@ class Document;
 class Exception;
 class SecurityOrigin;
 class SecurityOriginData;
+template<typename> class ExceptionOr;
 
 class DatabaseManager {
     WTF_MAKE_NONCOPYABLE(DatabaseManager);

--- a/Source/WebCore/Modules/webdatabase/DatabaseTask.cpp
+++ b/Source/WebCore/Modules/webdatabase/DatabaseTask.cpp
@@ -30,6 +30,7 @@
 #include "DatabaseTask.h"
 
 #include "Database.h"
+#include "ExceptionOr.h"
 #include "Logging.h"
 #include "SQLTransaction.h"
 #include <wtf/TZoneMallocInlines.h>

--- a/Source/WebCore/Modules/webdatabase/DatabaseTask.h
+++ b/Source/WebCore/Modules/webdatabase/DatabaseTask.h
@@ -28,16 +28,17 @@
 
 #pragma once
 
-#include "ExceptionOr.h"
 #include <wtf/Condition.h>
 #include <wtf/Forward.h>
 #include <wtf/Lock.h>
+#include <wtf/RefPtr.h>
 #include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
 class Database;
 class SQLTransaction;
+template<typename> class ExceptionOr;
 
 // Can be used to wait until DatabaseTask is completed.
 // Has to be passed into DatabaseTask::create to be associated with the task.

--- a/Source/WebCore/Modules/webdatabase/DatabaseTracker.cpp
+++ b/Source/WebCore/Modules/webdatabase/DatabaseTracker.cpp
@@ -34,6 +34,7 @@
 #include "DatabaseManager.h"
 #include "DatabaseManagerClient.h"
 #include "DatabaseThread.h"
+#include "ExceptionOr.h"
 #include "Logging.h"
 #include "OriginLock.h"
 #include "SecurityOrigin.h"

--- a/Source/WebCore/Modules/webdatabase/DatabaseTracker.h
+++ b/Source/WebCore/Modules/webdatabase/DatabaseTracker.h
@@ -30,7 +30,6 @@
 
 #include "DatabaseDetails.h"
 #include "DatabaseManagerClient.h"
-#include "ExceptionOr.h"
 #include "SQLiteDatabase.h"
 #include "SecurityOriginData.h"
 #include "SecurityOriginHash.h"
@@ -50,6 +49,7 @@ class DatabaseManagerClient;
 class OriginLock;
 class SecurityOrigin;
 class SecurityOriginData;
+template<typename> class ExceptionOr;
 
 enum class CurrentQueryBehavior { Interrupt, RunToCompletion };
 

--- a/Source/WebCore/Modules/webdatabase/LocalDOMWindowWebDatabase.h
+++ b/Source/WebCore/Modules/webdatabase/LocalDOMWindowWebDatabase.h
@@ -26,13 +26,20 @@
 
 #pragma once
 
-#include "ExceptionOr.h"
+#include <wtf/RefPtr.h>
+
+namespace WTF {
+
+class String;
+
+} // namespace WTF
 
 namespace WebCore {
 
 class Database;
 class DatabaseCallback;
 class LocalDOMWindow;
+template<typename> class ExceptionOr;
 
 class LocalDOMWindowWebDatabase {
 public:

--- a/Source/WebCore/Modules/webdatabase/SQLResultSet.h
+++ b/Source/WebCore/Modules/webdatabase/SQLResultSet.h
@@ -28,11 +28,12 @@
 
 #pragma once
 
-#include "ExceptionOr.h"
 #include "SQLResultSetRowList.h"
 #include <wtf/ThreadSafeRefCounted.h>
 
 namespace WebCore {
+
+template<typename> class ExceptionOr;
 
 class SQLResultSet : public ThreadSafeRefCounted<SQLResultSet> {
 public:

--- a/Source/WebCore/Modules/webdatabase/SQLResultSetRowList.h
+++ b/Source/WebCore/Modules/webdatabase/SQLResultSetRowList.h
@@ -28,10 +28,11 @@
 
 #pragma once
 
-#include "ExceptionOr.h"
 #include "SQLValue.h"
 
 namespace WebCore {
+
+template<typename> class ExceptionOr;
 
 class SQLResultSetRowList : public RefCounted<SQLResultSetRowList> {
 public:

--- a/Source/WebCore/Modules/webdatabase/SQLTransaction.cpp
+++ b/Source/WebCore/Modules/webdatabase/SQLTransaction.cpp
@@ -35,6 +35,7 @@
 #include "DatabaseThread.h"
 #include "DatabaseTracker.h"
 #include "Document.h"
+#include "ExceptionOr.h"
 #include "Logging.h"
 #include "OriginLock.h"
 #include "SQLError.h"

--- a/Source/WebCore/Modules/webdatabase/SQLTransaction.h
+++ b/Source/WebCore/Modules/webdatabase/SQLTransaction.h
@@ -28,7 +28,6 @@
 
 #pragma once
 
-#include "ExceptionOr.h"
 #include "SQLCallbackWrapper.h"
 #include "SQLTransactionBackend.h"
 #include "SQLTransactionStateMachine.h"
@@ -46,6 +45,7 @@ class SQLTransactionBackend;
 class SQLTransactionCallback;
 class SQLTransactionErrorCallback;
 class VoidCallback;
+template<typename> class ExceptionOr;
 
 class SQLTransactionWrapper : public ThreadSafeRefCounted<SQLTransactionWrapper> {
 public:

--- a/Source/WebCore/Modules/websockets/WebSocket.h
+++ b/Source/WebCore/Modules/websockets/WebSocket.h
@@ -32,11 +32,10 @@
 
 #include "ActiveDOMObject.h"
 #include "EventTarget.h"
-#include "ExceptionOr.h"
-#include <wtf/URL.h>
 #include "WebSocketChannelClient.h"
 #include <wtf/HashSet.h>
 #include <wtf/Lock.h>
+#include <wtf/URL.h>
 
 namespace JSC {
 class ArrayBuffer;
@@ -47,6 +46,7 @@ namespace WebCore {
 
 class Blob;
 class ThreadableWebSocketChannel;
+template<typename> class ExceptionOr;
 
 class WebSocket final : public RefCounted<WebSocket>, public EventTarget, public ActiveDOMObject, private WebSocketChannelClient {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(WebSocket);

--- a/Source/WebCore/Modules/webtransport/WebTransport.h
+++ b/Source/WebCore/Modules/webtransport/WebTransport.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include "ActiveDOMObject.h"
-#include "ExceptionOr.h"
 #include "WebTransportOptions.h"
 #include "WebTransportReliabilityMode.h"
 #include "WebTransportSessionClient.h"
@@ -63,6 +62,8 @@ struct WebTransportBidirectionalStreamConstructionParameters;
 struct WebTransportCloseInfo;
 struct WebTransportSendStreamOptions;
 struct WebTransportHash;
+
+template<typename> class ExceptionOr;
 
 class WebTransport : public WebTransportSessionClient, public ActiveDOMObject {
 public:

--- a/Source/WebCore/Modules/webtransport/WebTransportBidirectionalStream.h
+++ b/Source/WebCore/Modules/webtransport/WebTransportBidirectionalStream.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include "ExceptionOr.h"
 #include <wtf/RefCounted.h>
 
 namespace WebCore {
@@ -40,6 +39,7 @@ public:
 
     WebTransportReceiveStream& readable() { return m_readable.get(); }
     WebTransportSendStream& writable() { return m_writable.get(); }
+
 private:
     WebTransportBidirectionalStream(Ref<WebTransportReceiveStream>&&, Ref<WebTransportSendStream>&&);
 

--- a/Source/WebCore/Modules/webtransport/WebTransportDatagramDuplexStream.h
+++ b/Source/WebCore/Modules/webtransport/WebTransportDatagramDuplexStream.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include "ExceptionOr.h"
 #include <wtf/Deque.h>
 #include <wtf/RefCounted.h>
 
@@ -38,6 +37,7 @@ namespace WebCore {
 class DOMPromise;
 class ReadableStream;
 class WritableStream;
+template<typename> class ExceptionOr;
 
 class WebTransportDatagramDuplexStream : public RefCounted<WebTransportDatagramDuplexStream> {
 public:

--- a/Source/WebCore/Modules/webxr/WebXRFrame.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRFrame.cpp
@@ -28,6 +28,7 @@
 
 #if ENABLE(WEBXR)
 
+#include "ExceptionOr.h"
 #include "WebXRBoundedReferenceSpace.h"
 #include "WebXRJointPose.h"
 #include "WebXRJointSpace.h"

--- a/Source/WebCore/Modules/webxr/WebXRFrame.h
+++ b/Source/WebCore/Modules/webxr/WebXRFrame.h
@@ -28,7 +28,6 @@
 #if ENABLE(WEBXR)
 
 #include "DOMHighResTimeStamp.h"
-#include "ExceptionOr.h"
 #include "PlatformXR.h"
 #include <JavaScriptCore/Float32Array.h>
 #include <wtf/Ref.h>
@@ -46,6 +45,7 @@ class WebXRReferenceSpace;
 class WebXRSession;
 class WebXRSpace;
 class WebXRViewerPose;
+template<typename> class ExceptionOr;
 
 class WebXRFrame : public RefCounted<WebXRFrame> {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(WebXRFrame);

--- a/Source/WebCore/Modules/webxr/WebXRReferenceSpace.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRReferenceSpace.cpp
@@ -29,6 +29,7 @@
 #if ENABLE(WEBXR)
 
 #include "Document.h"
+#include "ExceptionOr.h"
 #include "WebXRFrame.h"
 #include "WebXRRigidTransform.h"
 #include "WebXRSession.h"

--- a/Source/WebCore/Modules/webxr/WebXRRigidTransform.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRRigidTransform.cpp
@@ -29,6 +29,7 @@
 #if ENABLE(WEBXR)
 
 #include "DOMPointReadOnly.h"
+#include "ExceptionOr.h"
 #include "TransformationMatrix.h"
 #include <JavaScriptCore/TypedArrayInlines.h>
 #include <wtf/TZoneMallocInlines.h>

--- a/Source/WebCore/Modules/webxr/WebXRRigidTransform.h
+++ b/Source/WebCore/Modules/webxr/WebXRRigidTransform.h
@@ -27,7 +27,6 @@
 
 #if ENABLE(WEBXR)
 
-#include "ExceptionOr.h"
 #include "JSValueInWrappedObject.h"
 #include "TransformationMatrix.h"
 #include <JavaScriptCore/Forward.h>
@@ -37,8 +36,9 @@
 
 namespace WebCore {
 
-struct DOMPointInit;
 class DOMPointReadOnly;
+struct DOMPointInit;
+template<typename> class ExceptionOr;
 
 class WebXRRigidTransform : public RefCountedAndCanMakeWeakPtr<WebXRRigidTransform> {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED_EXPORT(WebXRRigidTransform, WEBCORE_EXPORT);

--- a/Source/WebCore/Modules/webxr/WebXRWebGLLayer.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRWebGLLayer.cpp
@@ -29,6 +29,7 @@
 
 #if ENABLE(WEBXR)
 
+#include "ExceptionOr.h"
 #include "HTMLCanvasElement.h"
 #include "IntSize.h"
 #include "OffscreenCanvas.h"

--- a/Source/WebCore/Modules/webxr/WebXRWebGLLayer.h
+++ b/Source/WebCore/Modules/webxr/WebXRWebGLLayer.h
@@ -29,7 +29,6 @@
 #if ENABLE(WEBXR)
 
 #include "CanvasObserver.h"
-#include "ExceptionOr.h"
 #include "FloatRect.h"
 #include "GraphicsTypesGL.h"
 #include "PlatformXR.h"
@@ -51,6 +50,7 @@ class WebXRSession;
 class WebXRView;
 class WebXRViewport;
 struct XRWebGLLayerInit;
+template<typename> class ExceptionOr;
 
 class WebXRWebGLLayer : public WebXRLayer, private CanvasObserver {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(WebXRWebGLLayer);

--- a/Source/WebCore/Modules/webxr/XRGPUBinding.h
+++ b/Source/WebCore/Modules/webxr/XRGPUBinding.h
@@ -33,7 +33,6 @@
 #include "XREye.h"
 #include "XRGPUProjectionLayerInit.h"
 
-#include <ExceptionOr.h>
 #include <wtf/Ref.h>
 #include <wtf/RefPtr.h>
 #include <wtf/TZoneMalloc.h>
@@ -64,6 +63,8 @@ struct XREquirectLayerInit;
 struct XRGPUProjectionLayerInit;
 struct XRProjectionLayerInit;
 struct XRQuadLayerInit;
+
+template<typename> class ExceptionOr;
 
 // https://github.com/immersive-web/WebXR-WebGPU-Binding/blob/main/explainer.md
 class XRGPUBinding : public RefCounted<XRGPUBinding> {

--- a/Source/WebCore/Modules/webxr/XRWebGLBinding.cpp
+++ b/Source/WebCore/Modules/webxr/XRWebGLBinding.cpp
@@ -28,6 +28,7 @@
 
 #if ENABLE(WEBXR_LAYERS)
 
+#include "ExceptionOr.h"
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {

--- a/Source/WebCore/Modules/webxr/XRWebGLBinding.h
+++ b/Source/WebCore/Modules/webxr/XRWebGLBinding.h
@@ -27,9 +27,9 @@
 
 #if ENABLE(WEBXR_LAYERS)
 
+#include "ExceptionOr.h"
 #include "XREye.h"
 
-#include <ExceptionOr.h>
 #include <wtf/Ref.h>
 #include <wtf/RefPtr.h>
 #include <wtf/TZoneMalloc.h>

--- a/Source/WebCore/animation/AnimationEffect.h
+++ b/Source/WebCore/animation/AnimationEffect.h
@@ -29,7 +29,6 @@
 #include "AnimationEffectTiming.h"
 #include "BasicEffectTiming.h"
 #include "ComputedEffectTiming.h"
-#include "ExceptionOr.h"
 #include "FillMode.h"
 #include "KeyframeEffectOptions.h"
 #include "OptionalEffectTiming.h"

--- a/Source/WebCore/animation/DocumentTimeline.h
+++ b/Source/WebCore/animation/DocumentTimeline.h
@@ -28,7 +28,6 @@
 #include "AnimationFrameRate.h"
 #include "AnimationTimeline.h"
 #include "DocumentTimelineOptions.h"
-#include "ExceptionOr.h"
 #include "Timer.h"
 #include <wtf/Ref.h>
 #include <wtf/WeakPtr.h>

--- a/Source/WebCore/animation/WebAnimationUtilities.h
+++ b/Source/WebCore/animation/WebAnimationUtilities.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include "ExceptionOr.h"
 #include "RenderStyleConstants.h"
 #include "WebAnimationTypes.h"
 #include <wtf/Forward.h>

--- a/Source/WebCore/bindings/js/InternalReadableStream.h
+++ b/Source/WebCore/bindings/js/InternalReadableStream.h
@@ -25,12 +25,14 @@
 
 #pragma once
 
-#include "ExceptionOr.h"
 #include "JSDOMGuardedObject.h"
 #include <JavaScriptCore/JSObject.h>
 
 namespace WebCore {
+
+class Exception;
 class ReadableStreamSink;
+template<typename> class ExceptionOr;
 
 class InternalReadableStream final : public DOMGuarded<JSC::JSObject> {
 public:

--- a/Source/WebCore/bindings/js/InternalWritableStream.h
+++ b/Source/WebCore/bindings/js/InternalWritableStream.h
@@ -25,11 +25,13 @@
 
 #pragma once
 
-#include "ExceptionOr.h"
 #include "JSDOMGuardedObject.h"
 #include <JavaScriptCore/JSObject.h>
 
 namespace WebCore {
+
+template<typename> class ExceptionOr;
+
 class InternalWritableStream final : public DOMGuarded<JSC::JSObject> {
 public:
     static ExceptionOr<Ref<InternalWritableStream>> createFromUnderlyingSink(JSDOMGlobalObject&, JSC::JSValue underlyingSink, JSC::JSValue strategy);

--- a/Source/WebCore/bindings/js/SerializedScriptValue.h
+++ b/Source/WebCore/bindings/js/SerializedScriptValue.h
@@ -28,7 +28,6 @@
 
 #include "Blob.h"
 #include "DetachedRTCDataChannel.h"
-#include "ExceptionOr.h"
 #include <JavaScriptCore/ArrayBuffer.h>
 #include <JavaScriptCore/JSCJSValue.h>
 #include <JavaScriptCore/Strong.h>
@@ -82,6 +81,8 @@ class IDBValue;
 class MessagePort;
 class DetachedImageBitmap;
 class FragmentedSharedBuffer;
+template<typename> class ExceptionOr;
+
 enum class SerializationReturnCode;
 
 enum class SerializationErrorMode { NonThrowing, Throwing };

--- a/Source/WebCore/crypto/CryptoAlgorithm.cpp
+++ b/Source/WebCore/crypto/CryptoAlgorithm.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "CryptoAlgorithm.h"
 
+#include "ExceptionOr.h"
 #include "ScriptExecutionContext.h"
 
 namespace WebCore {

--- a/Source/WebCore/crypto/CryptoAlgorithm.h
+++ b/Source/WebCore/crypto/CryptoAlgorithm.h
@@ -30,7 +30,6 @@
 #include "CryptoKeyFormat.h"
 #include "CryptoKeyPair.h"
 #include "CryptoKeyUsage.h"
-#include "ExceptionOr.h"
 #include "JsonWebKey.h"
 #include <pal/crypto/CryptoDigest.h>
 #include <wtf/Function.h>
@@ -42,6 +41,9 @@ namespace WebCore {
 
 class CryptoAlgorithmParameters;
 class ScriptExecutionContext;
+template<typename> class ExceptionOr;
+
+enum class ExceptionCode : uint8_t;
 
 using KeyData = Variant<Vector<uint8_t>, JsonWebKey>;
 using KeyOrKeyPair = Variant<RefPtr<CryptoKey>, CryptoKeyPair>;

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmAESCTR.cpp
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmAESCTR.cpp
@@ -30,6 +30,7 @@
 #include "CryptoAlgorithmAesCtrParams.h"
 #include "CryptoAlgorithmAesKeyParams.h"
 #include "CryptoKeyAES.h"
+#include "ExceptionOr.h"
 #include <wtf/CrossThreadCopier.h>
 #include <wtf/FlipBytes.h>
 #include <wtf/StdLibExtras.h>

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmAESGCM.cpp
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmAESGCM.cpp
@@ -29,6 +29,7 @@
 #include "CryptoAlgorithmAesGcmParams.h"
 #include "CryptoAlgorithmAesKeyParams.h"
 #include "CryptoKeyAES.h"
+#include "ExceptionOr.h"
 #include "ScriptExecutionContext.h"
 #include <algorithm>
 #include <ranges>

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmAESKW.cpp
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmAESKW.cpp
@@ -28,6 +28,7 @@
 
 #include "CryptoAlgorithmAesKeyParams.h"
 #include "CryptoKeyAES.h"
+#include "ExceptionOr.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmPBKDF2.cpp
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmPBKDF2.cpp
@@ -28,6 +28,7 @@
 
 #include "CryptoAlgorithmPbkdf2Params.h"
 #include "CryptoKeyRaw.h"
+#include "ExceptionOr.h"
 #include <JavaScriptCore/JSCJSValueInlines.h>
 #include <wtf/CrossThreadCopier.h>
 

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmRSASSA_PKCS1_v1_5.cpp
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmRSASSA_PKCS1_v1_5.cpp
@@ -30,6 +30,7 @@
 #include "CryptoAlgorithmRsaHashedKeyGenParams.h"
 #include "CryptoKeyPair.h"
 #include "CryptoKeyRSA.h"
+#include "ExceptionOr.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmX25519.cpp
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmX25519.cpp
@@ -23,6 +23,7 @@
 #include "CryptoAlgorithmEcKeyParams.h"
 #include "CryptoAlgorithmX25519Params.h"
 #include "CryptoKeyOKP.h"
+#include "ExceptionOr.h"
 #include "ScriptExecutionContext.h"
 #include <wtf/CryptographicUtilities.h>
 

--- a/Source/WebCore/crypto/cocoa/CryptoAlgorithmECDSAMac.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoAlgorithmECDSAMac.cpp
@@ -31,6 +31,7 @@
 #include "CryptoAlgorithmEcdsaParams.h"
 #include "CryptoDigestAlgorithm.h"
 #include "CryptoKeyEC.h"
+#include "ExceptionOr.h"
 #include <wtf/StdLibExtras.h>
 
 #if HAVE(SWIFT_CPP_INTEROP)

--- a/Source/WebCore/crypto/cocoa/CryptoAlgorithmEd25519Cocoa.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoAlgorithmEd25519Cocoa.cpp
@@ -27,6 +27,7 @@
 #include "CryptoAlgorithmEd25519.h"
 
 #include "CryptoKeyOKP.h"
+#include "ExceptionOr.h"
 #if HAVE(SWIFT_CPP_INTEROP)
 #include <pal/PALSwift.h>
 #endif

--- a/Source/WebCore/crypto/cocoa/CryptoKeyOKPCocoa.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoKeyOKPCocoa.cpp
@@ -27,6 +27,7 @@
 #include "CryptoKeyOKP.h"
 
 #include "CommonCryptoDERUtilities.h"
+#include "ExceptionOr.h"
 #include "JsonWebKey.h"
 #include "Logging.h"
 #include <wtf/StdLibExtras.h>

--- a/Source/WebCore/crypto/cocoa/CryptoUtilitiesCocoa.h
+++ b/Source/WebCore/crypto/cocoa/CryptoUtilitiesCocoa.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include "ExceptionOr.h"
 #include <CommonCrypto/CommonCryptoError.h>
 #include <wtf/Vector.h>
 
@@ -34,6 +33,8 @@ typedef uint32_t CCHmacAlgorithm;
 typedef uint32_t CCOperation;
 
 namespace WebCore {
+
+template<typename> class ExceptionOr;
 
 ExceptionOr<Vector<uint8_t>> transformAESCTR(CCOperation, const Vector<uint8_t>& counter, size_t counterLength, const Vector<uint8_t>& key, std::span<const uint8_t> data);
 CCStatus keyDerivationHMAC(CCDigestAlgorithm, std::span<const uint8_t> keyDerivationKey, std::span<const uint8_t> context, std::span<const uint8_t> salt, Vector<uint8_t>& derivedKey);

--- a/Source/WebCore/crypto/gcrypt/CryptoAlgorithmAESCBCGCrypt.cpp
+++ b/Source/WebCore/crypto/gcrypt/CryptoAlgorithmAESCBCGCrypt.cpp
@@ -28,6 +28,7 @@
 
 #include "CryptoAlgorithmAesCbcCfbParams.h"
 #include "CryptoKeyAES.h"
+#include "ExceptionOr.h"
 #include "NotImplemented.h"
 #include <pal/crypto/gcrypt/Handle.h>
 #include <pal/crypto/gcrypt/Utilities.h>

--- a/Source/WebCore/crypto/gcrypt/CryptoAlgorithmHKDFGCrypt.cpp
+++ b/Source/WebCore/crypto/gcrypt/CryptoAlgorithmHKDFGCrypt.cpp
@@ -30,6 +30,7 @@
 
 #include "CryptoAlgorithmHkdfParams.h"
 #include "CryptoKeyRaw.h"
+#include "ExceptionOr.h"
 #include "GCryptUtilities.h"
 
 namespace WebCore {

--- a/Source/WebCore/crypto/gcrypt/CryptoAlgorithmHMACGCrypt.cpp
+++ b/Source/WebCore/crypto/gcrypt/CryptoAlgorithmHMACGCrypt.cpp
@@ -30,6 +30,7 @@
 #include "CryptoAlgorithmHMAC.h"
 
 #include "CryptoKeyHMAC.h"
+#include "ExceptionOr.h"
 #include <pal/crypto/gcrypt/Handle.h>
 #include <wtf/CryptographicUtilities.h>
 

--- a/Source/WebCore/crypto/gcrypt/CryptoKeyOKPGCrypt.cpp
+++ b/Source/WebCore/crypto/gcrypt/CryptoKeyOKPGCrypt.cpp
@@ -21,6 +21,7 @@
 #include "CryptoKeyOKP.h"
 
 #include "CryptoKeyPair.h"
+#include "ExceptionOr.h"
 #include "GCryptRFC7748.h"
 #include "GCryptRFC8032.h"
 #include "GCryptUtilities.h"

--- a/Source/WebCore/crypto/keys/CryptoKeyAES.h
+++ b/Source/WebCore/crypto/keys/CryptoKeyAES.h
@@ -27,13 +27,13 @@
 
 #include "CryptoAlgorithmIdentifier.h"
 #include "CryptoKey.h"
-#include "ExceptionOr.h"
 #include <wtf/Function.h>
 #include <wtf/Vector.h>
 
 namespace WebCore {
 
 class CryptoAlgorithmParameters;
+template<typename> class ExceptionOr;
 
 struct JsonWebKey;
 

--- a/Source/WebCore/crypto/keys/CryptoKeyEC.cpp
+++ b/Source/WebCore/crypto/keys/CryptoKeyEC.cpp
@@ -27,6 +27,7 @@
 #include "CryptoKeyEC.h"
 
 #include "CryptoAlgorithmRegistry.h"
+#include "ExceptionOr.h"
 #include "JsonWebKey.h"
 #if HAVE(SWIFT_CPP_INTEROP)
 #include <pal/PALSwift.h>

--- a/Source/WebCore/crypto/keys/CryptoKeyEC.h
+++ b/Source/WebCore/crypto/keys/CryptoKeyEC.h
@@ -27,7 +27,6 @@
 
 #include "CryptoKey.h"
 #include "CryptoKeyPair.h"
-#include "ExceptionOr.h"
 
 #if OS(DARWIN) && !PLATFORM(GTK)
 #include "CommonCryptoUtilities.h"
@@ -66,6 +65,7 @@ using PlatformECKeyContainer = WebCore::EvpPKeyPtr;
 namespace WebCore {
 
 struct JsonWebKey;
+template<typename> class ExceptionOr;
 
 class CryptoKeyEC final : public CryptoKey {
 public:

--- a/Source/WebCore/crypto/keys/CryptoKeyHMAC.h
+++ b/Source/WebCore/crypto/keys/CryptoKeyHMAC.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include "CryptoKey.h"
-#include "ExceptionOr.h"
 #include <wtf/Function.h>
 #include <wtf/Vector.h>
 
@@ -34,6 +33,7 @@ namespace WebCore {
 
 class CryptoAlgorithmParameters;
 struct JsonWebKey;
+template<typename> class ExceptionOr;
 
 class CryptoKeyHMAC final : public CryptoKey {
 public:

--- a/Source/WebCore/crypto/keys/CryptoKeyOKP.h
+++ b/Source/WebCore/crypto/keys/CryptoKeyOKP.h
@@ -27,11 +27,11 @@
 
 #include "CryptoKey.h"
 #include "CryptoKeyPair.h"
-#include "ExceptionOr.h"
 
 namespace WebCore {
 
 struct JsonWebKey;
+template<typename> class ExceptionOr;
 
 class CryptoKeyOKP final : public CryptoKey {
 public:

--- a/Source/WebCore/crypto/keys/CryptoKeyRSA.h
+++ b/Source/WebCore/crypto/keys/CryptoKeyRSA.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include "CryptoKey.h"
-#include "ExceptionOr.h"
 #include <wtf/Function.h>
 
 #if OS(DARWIN) && !PLATFORM(GTK)
@@ -62,6 +61,8 @@ class ScriptExecutionContext;
 
 struct CryptoKeyPair;
 struct JsonWebKey;
+
+template<typename> class ExceptionOr;
 
 class CryptoKeyRSA final : public CryptoKey {
 public:

--- a/Source/WebCore/crypto/openssl/CryptoAlgorithmAESCBCOpenSSL.cpp
+++ b/Source/WebCore/crypto/openssl/CryptoAlgorithmAESCBCOpenSSL.cpp
@@ -28,6 +28,7 @@
 
 #include "CryptoAlgorithmAesCbcCfbParams.h"
 #include "CryptoKeyAES.h"
+#include "ExceptionOr.h"
 #include "OpenSSLCryptoUniquePtr.h"
 #include <openssl/evp.h>
 

--- a/Source/WebCore/crypto/openssl/CryptoAlgorithmAESCFBOpenSSL.cpp
+++ b/Source/WebCore/crypto/openssl/CryptoAlgorithmAESCFBOpenSSL.cpp
@@ -28,6 +28,7 @@
 
 #include "CryptoAlgorithmAesCbcCfbParams.h"
 #include "CryptoKeyAES.h"
+#include "ExceptionOr.h"
 #include "OpenSSLUtilities.h"
 #include <wtf/StdLibExtras.h>
 

--- a/Source/WebCore/crypto/openssl/CryptoAlgorithmAESCTROpenSSL.cpp
+++ b/Source/WebCore/crypto/openssl/CryptoAlgorithmAESCTROpenSSL.cpp
@@ -28,6 +28,7 @@
 
 #include "CryptoAlgorithmAesCtrParams.h"
 #include "CryptoKeyAES.h"
+#include "ExceptionOr.h"
 #include "OpenSSLCryptoUniquePtr.h"
 #include <openssl/evp.h>
 

--- a/Source/WebCore/crypto/openssl/CryptoAlgorithmAESGCMOpenSSL.cpp
+++ b/Source/WebCore/crypto/openssl/CryptoAlgorithmAESGCMOpenSSL.cpp
@@ -28,6 +28,7 @@
 
 #include "CryptoAlgorithmAesGcmParams.h"
 #include "CryptoKeyAES.h"
+#include "ExceptionOr.h"
 #include "OpenSSLCryptoUniquePtr.h"
 #include <openssl/evp.h>
 

--- a/Source/WebCore/crypto/openssl/CryptoAlgorithmAESKWOpenSSL.cpp
+++ b/Source/WebCore/crypto/openssl/CryptoAlgorithmAESKWOpenSSL.cpp
@@ -27,6 +27,7 @@
 #include "CryptoAlgorithmAESKW.h"
 
 #include "CryptoKeyAES.h"
+#include "ExceptionOr.h"
 #include "OpenSSLUtilities.h"
 
 namespace WebCore {

--- a/Source/WebCore/crypto/openssl/CryptoAlgorithmECDSAOpenSSL.cpp
+++ b/Source/WebCore/crypto/openssl/CryptoAlgorithmECDSAOpenSSL.cpp
@@ -28,6 +28,7 @@
 
 #include "CryptoAlgorithmEcdsaParams.h"
 #include "CryptoKeyEC.h"
+#include "ExceptionOr.h"
 #include "OpenSSLUtilities.h"
 
 namespace WebCore {

--- a/Source/WebCore/crypto/openssl/CryptoAlgorithmHKDFOpenSSL.cpp
+++ b/Source/WebCore/crypto/openssl/CryptoAlgorithmHKDFOpenSSL.cpp
@@ -28,6 +28,7 @@
 
 #include "CryptoAlgorithmHkdfParams.h"
 #include "CryptoKeyRaw.h"
+#include "ExceptionOr.h"
 #include "OpenSSLUtilities.h"
 #include <openssl/hkdf.h>
 

--- a/Source/WebCore/crypto/openssl/CryptoAlgorithmHMACOpenSSL.cpp
+++ b/Source/WebCore/crypto/openssl/CryptoAlgorithmHMACOpenSSL.cpp
@@ -27,6 +27,7 @@
 #include "CryptoAlgorithmHMAC.h"
 
 #include "CryptoKeyHMAC.h"
+#include "ExceptionOr.h"
 #include "OpenSSLCryptoUniquePtr.h"
 #include "OpenSSLUtilities.h"
 #include <openssl/evp.h>

--- a/Source/WebCore/crypto/openssl/CryptoAlgorithmPBKDF2OpenSSL.cpp
+++ b/Source/WebCore/crypto/openssl/CryptoAlgorithmPBKDF2OpenSSL.cpp
@@ -28,6 +28,7 @@
 
 #include "CryptoAlgorithmPbkdf2Params.h"
 #include "CryptoKeyRaw.h"
+#include "ExceptionOr.h"
 #include "OpenSSLUtilities.h"
 #include <openssl/evp.h>
 

--- a/Source/WebCore/crypto/openssl/CryptoAlgorithmRSASSA_PKCS1_v1_5OpenSSL.cpp
+++ b/Source/WebCore/crypto/openssl/CryptoAlgorithmRSASSA_PKCS1_v1_5OpenSSL.cpp
@@ -27,6 +27,7 @@
 #include "CryptoAlgorithmRSASSA_PKCS1_v1_5.h"
 
 #include "CryptoKeyRSA.h"
+#include "ExceptionOr.h"
 #include "OpenSSLUtilities.h"
 
 namespace WebCore {

--- a/Source/WebCore/crypto/openssl/CryptoAlgorithmRSA_OAEPOpenSSL.cpp
+++ b/Source/WebCore/crypto/openssl/CryptoAlgorithmRSA_OAEPOpenSSL.cpp
@@ -28,6 +28,7 @@
 
 #include "CryptoAlgorithmRsaOaepParams.h"
 #include "CryptoKeyRSA.h"
+#include "ExceptionOr.h"
 #include "OpenSSLUtilities.h"
 #include <wtf/StdLibExtras.h>
 

--- a/Source/WebCore/crypto/openssl/CryptoAlgorithmRSA_PSSOpenSSL.cpp
+++ b/Source/WebCore/crypto/openssl/CryptoAlgorithmRSA_PSSOpenSSL.cpp
@@ -30,6 +30,7 @@
 
 #include "CryptoAlgorithmRsaPssParams.h"
 #include "CryptoKeyRSA.h"
+#include "ExceptionOr.h"
 #include "OpenSSLUtilities.h"
 
 namespace WebCore {

--- a/Source/WebCore/crypto/openssl/CryptoKeyRSAOpenSSL.cpp
+++ b/Source/WebCore/crypto/openssl/CryptoKeyRSAOpenSSL.cpp
@@ -29,6 +29,7 @@
 #include "CryptoAlgorithmRegistry.h"
 #include "CryptoKeyPair.h"
 #include "CryptoKeyRSAComponents.h"
+#include "ExceptionOr.h"
 #include "OpenSSLUtilities.h"
 #include <JavaScriptCore/TypedArrayInlines.h>
 #include <openssl/X509.h>

--- a/Source/WebCore/css/CSSPrimitiveValue.h
+++ b/Source/WebCore/css/CSSPrimitiveValue.h
@@ -27,7 +27,6 @@
 #include "CSSPropertyNames.h"
 #include "CSSValue.h"
 #include "CSSValueKeywords.h"
-#include "ExceptionOr.h"
 #include "LayoutUnit.h"
 #include <utility>
 #include <wtf/Forward.h>
@@ -41,6 +40,8 @@ class RenderStyle;
 class RenderView;
 
 struct Length;
+
+template<typename> class ExceptionOr;
 
 // Max/min values for CSS, needs to slightly smaller/larger than the true max/min values to allow for rounding without overflowing.
 // Subtract two (rather than one) to allow for values to be converted to float and back without exceeding the LayoutUnit::max.

--- a/Source/WebCore/css/CSSRule.h
+++ b/Source/WebCore/css/CSSRule.h
@@ -23,7 +23,6 @@
 #pragma once
 
 #include "CSSParserEnum.h"
-#include "ExceptionOr.h"
 #include "StyleRuleType.h"
 #include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/TypeCasts.h>
@@ -36,6 +35,8 @@ class StyleRule;
 class StyleRuleWithNesting;
 
 struct CSSParserContext;
+
+template<typename> class ExceptionOr;
 
 namespace CSS {
 struct SerializationContext;

--- a/Source/WebCore/css/CSSStyleDeclaration.h
+++ b/Source/WebCore/css/CSSStyleDeclaration.h
@@ -22,7 +22,6 @@
 
 #include "CSSProperty.h"
 #include "CSSPropertyNames.h"
-#include "ExceptionOr.h"
 #include "ScriptWrappable.h"
 #include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
 #include <wtf/CheckedRef.h>
@@ -36,6 +35,8 @@ class DeprecatedCSSOMValue;
 class MutableStyleProperties;
 class StyleProperties;
 class StyledElement;
+
+template<typename> class ExceptionOr;
 
 enum class StyleDeclarationType : uint8_t {
     Style,

--- a/Source/WebCore/css/CSSStyleSheetObservableArray.h
+++ b/Source/WebCore/css/CSSStyleSheetObservableArray.h
@@ -26,12 +26,12 @@
 #pragma once
 
 #include "CSSStyleSheet.h"
-#include "ExceptionOr.h"
 #include "JSObservableArray.h"
 
 namespace WebCore {
 
 class ContainerNode;
+template<typename> class ExceptionOr;
 
 class CSSStyleSheetObservableArray : public JSC::ObservableArray {
 public:

--- a/Source/WebCore/css/DOMCSSRegisterCustomProperty.h
+++ b/Source/WebCore/css/DOMCSSRegisterCustomProperty.h
@@ -26,13 +26,13 @@
 #pragma once
 
 #include "DOMCSSCustomPropertyDescriptor.h"
-#include "ExceptionOr.h"
 #include "Supplementable.h"
 
 namespace WebCore {
 
 class Document;
 class DOMCSSNamespace;
+template<typename> class ExceptionOr;
 
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(DOMCSSRegisterCustomProperty);
 class DOMCSSRegisterCustomProperty final : public Supplement<DOMCSSNamespace> {

--- a/Source/WebCore/css/FontFace.h
+++ b/Source/WebCore/css/FontFace.h
@@ -28,7 +28,6 @@
 #include "ActiveDOMObject.h"
 #include "CSSFontFace.h"
 #include "CSSPropertyNames.h"
-#include "ExceptionOr.h"
 #include "IDLTypes.h"
 #include <wtf/UniqueRef.h>
 #include <wtf/WeakPtr.h>
@@ -41,6 +40,7 @@ class ArrayBufferView;
 namespace WebCore {
 
 template<typename IDLType> class DOMPromiseProxyWithResolveCallback;
+template<typename> class ExceptionOr;
 
 class FontFace final : public RefCounted<FontFace>, public ActiveDOMObject, public CSSFontFaceClient {
 public:

--- a/Source/WebCore/css/MediaList.h
+++ b/Source/WebCore/css/MediaList.h
@@ -20,7 +20,6 @@
 
 #pragma once
 
-#include "ExceptionOr.h"
 #include "MediaQuery.h"
 #include "MediaQueryParserContext.h"
 #include <memory>
@@ -35,6 +34,7 @@ namespace WebCore {
 
 class CSSRule;
 class CSSStyleSheet;
+template<typename> class ExceptionOr;
 
 class MediaList final : public RefCounted<MediaList> {
 public:

--- a/Source/WebCore/css/typedom/CSSStyleValueFactory.cpp
+++ b/Source/WebCore/css/typedom/CSSStyleValueFactory.cpp
@@ -55,6 +55,7 @@
 #include "CSSValuePool.h"
 #include "CSSVariableData.h"
 #include "CSSVariableReferenceValue.h"
+#include "ExceptionOr.h"
 #include "RenderStyle.h"
 #include "StylePropertiesInlines.h"
 #include "StylePropertyShorthand.h"

--- a/Source/WebCore/css/typedom/StylePropertyMap.cpp
+++ b/Source/WebCore/css/typedom/StylePropertyMap.cpp
@@ -36,6 +36,7 @@
 #include "CSSValuePair.h"
 #include "CSSVariableReferenceValue.h"
 #include "Document.h"
+#include "ExceptionOr.h"
 #include "StylePropertyShorthand.h"
 #include <wtf/FixedVector.h>
 #include <wtf/text/MakeString.h>

--- a/Source/WebCore/css/typedom/color/CSSRGB.h
+++ b/Source/WebCore/css/typedom/color/CSSRGB.h
@@ -26,9 +26,10 @@
 #pragma once
 
 #include "CSSOMColorValue.h"
-#include "ExceptionOr.h"
 
 namespace WebCore {
+
+template<typename> class ExceptionOr;
 
 using CSSColorRGBComp = Variant<double, RefPtr<CSSNumericValue>, String, RefPtr<CSSKeywordValue>>;
 using RectifiedCSSColorRGBComp = Variant<RefPtr<CSSNumericValue>, RefPtr<CSSKeywordValue>>;

--- a/Source/WebCore/dom/BroadcastChannel.cpp
+++ b/Source/WebCore/dom/BroadcastChannel.cpp
@@ -29,6 +29,7 @@
 #include "BroadcastChannelRegistry.h"
 #include "EventNames.h"
 #include "EventTargetInlines.h"
+#include "ExceptionOr.h"
 #include "MessageEvent.h"
 #include "Page.h"
 #include "PartitionedSecurityOrigin.h"

--- a/Source/WebCore/dom/BroadcastChannel.h
+++ b/Source/WebCore/dom/BroadcastChannel.h
@@ -30,7 +30,6 @@
 #include "ClientOrigin.h"
 #include "EventTarget.h"
 #include "EventTargetInterfaces.h"
-#include "ExceptionOr.h"
 #include <wtf/Forward.h>
 #include <wtf/RefCounted.h>
 
@@ -42,6 +41,7 @@ class JSValue;
 namespace WebCore {
 
 class SerializedScriptValue;
+template<typename> class ExceptionOr;
 
 class BroadcastChannel : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<BroadcastChannel>, public EventTarget, public ActiveDOMObject {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(BroadcastChannel);

--- a/Source/WebCore/dom/DOMImplementation.h
+++ b/Source/WebCore/dom/DOMImplementation.h
@@ -23,7 +23,6 @@
 
 #pragma once
 
-#include "ExceptionOr.h"
 #include "ScriptExecutionContextIdentifier.h"
 #include "XMLDocument.h"
 #include <wtf/WeakRef.h>

--- a/Source/WebCore/dom/DOMPointReadOnly.h
+++ b/Source/WebCore/dom/DOMPointReadOnly.h
@@ -31,7 +31,6 @@
 #pragma once
 
 #include "DOMPointInit.h"
-#include "ExceptionOr.h"
 #include "FloatPoint3D.h"
 #include "ScriptWrappable.h"
 #include <wtf/NoVirtualDestructorBase.h>
@@ -40,9 +39,10 @@
 
 namespace WebCore {
 
-struct DOMMatrixInit;
 class DOMPoint;
 class WebCoreOpaqueRoot;
+struct DOMMatrixInit;
+template<typename> class ExceptionOr;
 
 class DOMPointReadOnly : public ScriptWrappable, public RefCounted<DOMPointReadOnly>, public NoVirtualDestructorBase {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED_EXPORT(DOMPointReadOnly, WEBCORE_EXPORT);

--- a/Source/WebCore/dom/DataTransferItemList.h
+++ b/Source/WebCore/dom/DataTransferItemList.h
@@ -33,7 +33,6 @@
 
 #include "ContextDestructionObserver.h"
 #include "DataTransfer.h"
-#include "ExceptionOr.h"
 #include "ScriptWrappable.h"
 #include <wtf/CheckedRef.h>
 #include <wtf/Forward.h>
@@ -46,6 +45,7 @@ namespace WebCore {
 class DataTransferItem;
 class Document;
 class File;
+template<typename> class ExceptionOr;
 
 class DataTransferItemList final : public ScriptWrappable, public ContextDestructionObserver, public CanMakeWeakPtr<DataTransferItemList> {
     WTF_MAKE_NONCOPYABLE(DataTransferItemList);

--- a/Source/WebCore/dom/DatasetDOMStringMap.h
+++ b/Source/WebCore/dom/DatasetDOMStringMap.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include "ExceptionOr.h"
 #include "ScriptWrappable.h"
 #include <wtf/WeakRef.h>
 
@@ -33,6 +32,7 @@ namespace WebCore {
 
 class Element;
 class WeakPtrImplWithEventTargetData;
+template<typename> class ExceptionOr;
 
 class DatasetDOMStringMap final : public ScriptWrappable {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(DatasetDOMStringMap);

--- a/Source/WebCore/dom/DeviceOrientationAndMotionAccessController.h
+++ b/Source/WebCore/dom/DeviceOrientationAndMotionAccessController.h
@@ -29,7 +29,6 @@
 
 #include "DeviceOrientationOrMotionPermissionState.h"
 #include "EventTarget.h"
-#include "ExceptionOr.h"
 #include "SecurityOriginData.h"
 #include <wtf/Function.h>
 #include <wtf/TZoneMalloc.h>

--- a/Source/WebCore/dom/Event.h
+++ b/Source/WebCore/dom/Event.h
@@ -27,7 +27,6 @@
 #include "EventInit.h"
 #include "EventInterfaces.h"
 #include "EventOptions.h"
-#include "ExceptionOr.h"
 #include "ScriptWrappable.h"
 #include <wtf/MonotonicTime.h>
 #include <wtf/RefCountedAndCanMakeWeakPtr.h>

--- a/Source/WebCore/dom/MessagePort.h
+++ b/Source/WebCore/dom/MessagePort.h
@@ -30,7 +30,6 @@
 #include "ContextDestructionObserverInlines.h"
 #include "EventTarget.h"
 #include "EventTargetInterfaces.h"
-#include "ExceptionOr.h"
 #include "MessagePortChannel.h"
 #include "MessagePortIdentifier.h"
 #include "MessageWithMessagePorts.h"
@@ -48,6 +47,8 @@ class LocalFrame;
 class WebCoreOpaqueRoot;
 
 struct StructuredSerializeOptions;
+
+template<typename> class ExceptionOr;
 
 class MessagePort final : public ActiveDOMObject, public EventTarget, public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<MessagePort> {
     WTF_MAKE_NONCOPYABLE(MessagePort);

--- a/Source/WebCore/dom/MutationObserver.h
+++ b/Source/WebCore/dom/MutationObserver.h
@@ -31,7 +31,6 @@
 
 #pragma once
 
-#include "ExceptionOr.h"
 #include "GCReachableRef.h"
 #include <wtf/Forward.h>
 #include <wtf/HashSet.h>
@@ -53,6 +52,7 @@ class MutationObserverRegistration;
 class MutationRecord;
 class Node;
 class WindowEventLoop;
+template<typename> class ExceptionOr;
 
 enum class MutationObserverOptionType : uint8_t {
     // MutationType

--- a/Source/WebCore/dom/NamedNodeMap.h
+++ b/Source/WebCore/dom/NamedNodeMap.h
@@ -25,13 +25,13 @@
 #pragma once
 
 #include "Element.h"
-#include "ExceptionOr.h"
 #include "ScriptWrappable.h"
 #include <wtf/WeakRef.h>
 
 namespace WebCore {
 
 class Attr;
+template<typename> class ExceptionOr;
 
 class NamedNodeMap final : public ScriptWrappable {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(NamedNodeMap);

--- a/Source/WebCore/dom/NodeIterator.h
+++ b/Source/WebCore/dom/NodeIterator.h
@@ -24,7 +24,6 @@
 
 #pragma once
 
-#include "ExceptionOr.h"
 #include "NodeFilter.h"
 #include "ScriptWrappable.h"
 #include "Traversal.h"
@@ -32,6 +31,8 @@
 #include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
+
+template<typename> class ExceptionOr;
 
 class NodeIterator final : public ScriptWrappable, public RefCountedAndCanMakeWeakPtr<NodeIterator>, public NodeIteratorBase {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED_EXPORT(NodeIterator, WEBCORE_EXPORT);

--- a/Source/WebCore/dom/Observable.h
+++ b/Source/WebCore/dom/Observable.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include "ExceptionOr.h"
 #include "ScriptWrappable.h"
 #include "SubscriberCallback.h"
 #include "VoidCallback.h"

--- a/Source/WebCore/dom/TextDecoder.h
+++ b/Source/WebCore/dom/TextDecoder.h
@@ -25,7 +25,6 @@
 #pragma once
 
 #include "BufferSource.h"
-#include "ExceptionOr.h"
 #include <pal/text/TextEncoding.h>
 #include <wtf/RefCounted.h>
 
@@ -34,6 +33,8 @@ class TextCodec;
 }
 
 namespace WebCore {
+
+template<typename> class ExceptionOr;
 
 class TextDecoder final : public RefCounted<TextDecoder> {
 public:

--- a/Source/WebCore/dom/TreeWalker.h
+++ b/Source/WebCore/dom/TreeWalker.h
@@ -24,7 +24,6 @@
 
 #pragma once
 
-#include "ExceptionOr.h"
 #include "NodeFilter.h"
 #include "ScriptWrappable.h"
 #include "Traversal.h"
@@ -32,6 +31,8 @@
 #include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
+
+template<typename> class ExceptionOr;
 
 class TreeWalker final : public ScriptWrappable, public RefCounted<TreeWalker>, public NodeIteratorBase {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED_EXPORT(TreeWalker, WEBCORE_EXPORT);

--- a/Source/WebCore/dom/TrustedType.h
+++ b/Source/WebCore/dom/TrustedType.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include "ExceptionOr.h"
 #include "TrustedHTML.h"
 #include "TrustedScript.h"
 #include "TrustedScriptURL.h"
@@ -43,6 +42,7 @@ namespace WebCore {
 class Exception;
 class ScriptExecutionContext;
 class QualifiedName;
+template<typename> class ExceptionOr;
 
 enum class TrustedType : int8_t {
     TrustedHTML,

--- a/Source/WebCore/dom/TrustedTypePolicy.h
+++ b/Source/WebCore/dom/TrustedTypePolicy.h
@@ -28,7 +28,6 @@
 #include "CreateHTMLCallback.h"
 #include "CreateScriptCallback.h"
 #include "CreateScriptURLCallback.h"
-#include "ExceptionOr.h"
 #include "ScriptWrappable.h"
 #include "TrustedTypePolicyOptions.h"
 #include <JavaScriptCore/Strong.h>
@@ -40,9 +39,11 @@ namespace WebCore {
 class TrustedHTML;
 class TrustedScript;
 class TrustedScriptURL;
-enum class TrustedType : int8_t;
-struct TrustedTypePolicyOptions;
 class WebCoreOpaqueRoot;
+struct TrustedTypePolicyOptions;
+template<typename> class ExceptionOr;
+
+enum class TrustedType : int8_t;
 
 enum class IfMissing : bool { Throw, ReturnNull };
 

--- a/Source/WebCore/dom/ViewTransition.h
+++ b/Source/WebCore/dom/ViewTransition.h
@@ -28,7 +28,6 @@
 #include "ActiveDOMObject.h"
 #include "Document.h"
 #include "Element.h"
-#include "ExceptionOr.h"
 #include "ImageBuffer.h"
 #include "MutableStyleProperties.h"
 #include "Styleable.h"
@@ -55,6 +54,7 @@ class RenderLayerModelObject;
 class RenderViewTransitionCapture;
 class RenderLayerModelObject;
 class ViewTransitionTypeSet;
+template<typename> class ExceptionOr;
 
 enum class ViewTransitionPhase : uint8_t {
     PendingCapture,

--- a/Source/WebCore/editing/TextCheckingHelper.h
+++ b/Source/WebCore/editing/TextCheckingHelper.h
@@ -20,7 +20,6 @@
 
 #pragma once
 
-#include "ExceptionOr.h"
 #include "SimpleRange.h"
 #include "TextChecking.h"
 
@@ -33,6 +32,8 @@ class TextCheckerClient;
 class VisibleSelection;
 
 struct TextCheckingResult;
+
+template<typename> class ExceptionOr;
 
 // FIXME: Should move this class to its own header.
 class TextCheckingParagraph {

--- a/Source/WebCore/editing/markup.h
+++ b/Source/WebCore/editing/markup.h
@@ -27,7 +27,6 @@
 
 #include "CSSStyleSheet.h"
 #include "Element.h"
-#include "ExceptionOr.h"
 #include "FloatSize.h"
 #include "HTMLInterchange.h"
 #include "MarkupExclusionRule.h"
@@ -54,6 +53,8 @@ class VisibleSelection;
 
 struct PresentationSize;
 struct SimpleRange;
+
+template<typename> class ExceptionOr;
 
 void replaceSubresourceURLs(Ref<DocumentFragment>&&, UncheckedKeyHashMap<AtomString, AtomString>&&);
 void removeSubresourceURLAttributes(Ref<DocumentFragment>&&, Function<bool(const URL&)> shouldRemoveURL);

--- a/Source/WebCore/fileapi/FileReader.h
+++ b/Source/WebCore/fileapi/FileReader.h
@@ -35,7 +35,6 @@
 #include "EventTarget.h"
 #include "EventTargetInterfaces.h"
 #include "ExceptionCode.h"
-#include "ExceptionOr.h"
 #include "FileReaderLoader.h"
 #include "FileReaderLoaderClient.h"
 #include "FileReaderSync.h"
@@ -49,6 +48,7 @@ class ArrayBuffer;
 namespace WebCore {
 
 class Blob;
+template<typename> class ExceptionOr;
 
 class FileReader final : public RefCounted<FileReader>, public ActiveDOMObject, public EventTarget, private FileReaderLoaderClient {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(FileReader);

--- a/Source/WebCore/fileapi/FileReaderSync.cpp
+++ b/Source/WebCore/fileapi/FileReaderSync.cpp
@@ -34,6 +34,7 @@
 
 #include "Blob.h"
 #include "BlobURL.h"
+#include "ExceptionOr.h"
 #include "FileReaderLoader.h"
 #include <JavaScriptCore/ArrayBuffer.h>
 

--- a/Source/WebCore/fileapi/FileReaderSync.h
+++ b/Source/WebCore/fileapi/FileReaderSync.h
@@ -30,7 +30,8 @@
 
 #pragma once
 
-#include "ExceptionOr.h"
+#include <wtf/Ref.h>
+#include <wtf/RefCounted.h>
 
 namespace JSC {
 class ArrayBuffer;
@@ -41,6 +42,7 @@ namespace WebCore {
 class Blob;
 class FileReaderLoader;
 class ScriptExecutionContext;
+template<typename> class ExceptionOr;
 
 class FileReaderSync : public RefCounted<FileReaderSync> {
 public:

--- a/Source/WebCore/html/CustomPaintCanvas.h
+++ b/Source/WebCore/html/CustomPaintCanvas.h
@@ -29,7 +29,6 @@
 #include "CanvasBase.h"
 #include "ContextDestructionObserver.h"
 #include "EventTarget.h"
-#include "ExceptionOr.h"
 #include "ImageBuffer.h"
 #include "IntSize.h"
 #include "PaintRenderingContext2D.h"

--- a/Source/WebCore/html/ImageBitmap.h
+++ b/Source/WebCore/html/ImageBitmap.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include "ExceptionOr.h"
 #include "IDLTypes.h"
 #include "ScriptWrappable.h"
 #include <atomic>
@@ -71,6 +70,7 @@ enum class RenderingMode : uint8_t;
 struct ImageBitmapOptions;
 
 template<typename IDLType> class DOMPromiseDeferred;
+template<typename> class ExceptionOr;
 
 class DetachedImageBitmap {
 public:

--- a/Source/WebCore/html/ImageData.h
+++ b/Source/WebCore/html/ImageData.h
@@ -29,7 +29,6 @@
 #pragma once
 
 #include "ByteArrayPixelBuffer.h"
-#include "ExceptionOr.h"
 #include "ImageDataArray.h"
 #include "ImageDataSettings.h"
 #include "IntSize.h"
@@ -38,6 +37,8 @@
 #include <wtf/Forward.h>
 
 namespace WebCore {
+
+template<typename> class ExceptionOr;
 
 class ImageData : public RefCounted<ImageData> {
 public:

--- a/Source/WebCore/html/MediaController.cpp
+++ b/Source/WebCore/html/MediaController.cpp
@@ -30,6 +30,7 @@
 #if ENABLE(VIDEO)
 
 #include "EventNames.h"
+#include "ExceptionOr.h"
 #include "HTMLMediaElement.h"
 #include "TimeRanges.h"
 #include <pal/system/Clock.h>

--- a/Source/WebCore/html/MediaControllerInterface.h
+++ b/Source/WebCore/html/MediaControllerInterface.h
@@ -27,12 +27,13 @@
 
 #if ENABLE(VIDEO)
 
-#include "ExceptionOr.h"
 #include "HTMLMediaElementEnums.h"
 
 namespace WebCore {
 
 class TimeRanges;
+
+template<typename> class ExceptionOr;
 
 class MediaControllerInterface : public HTMLMediaElementEnums {
 public:

--- a/Source/WebCore/html/OffscreenCanvas.h
+++ b/Source/WebCore/html/OffscreenCanvas.h
@@ -33,7 +33,6 @@
 #include "ContextDestructionObserver.h"
 #include "EventTarget.h"
 #include "EventTargetInterfaces.h"
-#include "ExceptionOr.h"
 #include "IDLTypes.h"
 #include "ImageBuffer.h"
 #include "IntSize.h"
@@ -64,6 +63,8 @@ class OffscreenCanvasRenderingContext2D;
 class WebGL2RenderingContext;
 class WebGLRenderingContext;
 class WebGLRenderingContextBase;
+
+template<typename> class ExceptionOr;
 
 using OffscreenRenderingContext = Variant<
 #if ENABLE(WEBGL)

--- a/Source/WebCore/html/TimeRanges.h
+++ b/Source/WebCore/html/TimeRanges.h
@@ -25,10 +25,11 @@
 
 #pragma once
 
-#include "ExceptionOr.h"
 #include "PlatformTimeRanges.h"
 
 namespace WebCore {
+
+template<typename> class ExceptionOr;
 
 class TimeRanges : public RefCounted<TimeRanges> {
 public:

--- a/Source/WebCore/html/URLSearchParams.h
+++ b/Source/WebCore/html/URLSearchParams.h
@@ -24,7 +24,6 @@
 
 #pragma once
 
-#include "ExceptionOr.h"
 #include "ScriptExecutionContext.h"
 #include <wtf/Vector.h>
 #include <wtf/WeakPtr.h>
@@ -34,6 +33,7 @@ namespace WebCore {
 
 class DOMURL;
 class ScriptExecutionContext;
+template<typename> class ExceptionOr;
 
 class URLSearchParams : public RefCounted<URLSearchParams> {
 public:

--- a/Source/WebCore/html/canvas/CanvasGradient.h
+++ b/Source/WebCore/html/canvas/CanvasGradient.h
@@ -26,13 +26,13 @@
 
 #pragma once
 
-#include "ExceptionOr.h"
 #include "FloatPoint.h"
 
 namespace WebCore {
 
 class Gradient;
 class ScriptExecutionContext;
+template<typename> class ExceptionOr;
 
 class CanvasGradient : public RefCounted<CanvasGradient> {
 public:

--- a/Source/WebCore/html/canvas/CanvasPath.cpp
+++ b/Source/WebCore/html/canvas/CanvasPath.cpp
@@ -37,6 +37,7 @@
 
 #include "AffineTransform.h"
 #include "DOMPointInit.h"
+#include "ExceptionOr.h"
 #include "FloatRect.h"
 #include "FloatRoundedRect.h"
 #include "FloatSize.h"

--- a/Source/WebCore/html/canvas/CanvasPath.h
+++ b/Source/WebCore/html/canvas/CanvasPath.h
@@ -28,13 +28,13 @@
 
 #pragma once
 
-#include "ExceptionOr.h"
 #include "Path.h"
 #include <wtf/Forward.h>
 
 namespace WebCore {
 
 struct DOMPointInit;
+template<typename> class ExceptionOr;
 
 class CanvasPath {
 public:

--- a/Source/WebCore/html/canvas/CanvasPattern.h
+++ b/Source/WebCore/html/canvas/CanvasPattern.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include "ExceptionOr.h"
 #include <wtf/Forward.h>
 #include <wtf/Ref.h>
 #include <wtf/RefCounted.h>
@@ -35,6 +34,7 @@ namespace WebCore {
 class Pattern;
 class SourceImage;
 struct DOMMatrix2DInit;
+template<typename> class ExceptionOr;
 
 class CanvasPattern : public RefCounted<CanvasPattern> {
 public:

--- a/Source/WebCore/html/canvas/GPUCanvasContext.h
+++ b/Source/WebCore/html/canvas/GPUCanvasContext.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include "ExceptionOr.h"
 #include "GPUBasedCanvasRenderingContext.h"
 #include <wtf/Ref.h>
 #include <wtf/RefCounted.h>
@@ -40,9 +39,10 @@ namespace WebCore {
 
 class CanvasBase;
 class GPU;
-struct GPUCanvasConfiguration;
 class GPUTexture;
 class ImageBitmap;
+struct GPUCanvasConfiguration;
+template<typename> class ExceptionOr;
 
 class GPUCanvasContext : public GPUBasedCanvasRenderingContext {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(GPUCanvasContext);

--- a/Source/WebCore/html/canvas/ImageBitmapRenderingContext.h
+++ b/Source/WebCore/html/canvas/ImageBitmapRenderingContext.h
@@ -27,7 +27,6 @@
 
 #include "CanvasRenderingContext.h"
 
-#include "ExceptionOr.h"
 #include "ImageBitmapRenderingContextSettings.h"
 #include <memory>
 #include <wtf/RefPtr.h>
@@ -37,6 +36,7 @@ namespace WebCore {
 class ImageBitmap;
 class ImageBuffer;
 class OffscreenCanvas;
+template<typename> class ExceptionOr;
 
 #if ENABLE(OFFSCREEN_CANVAS)
 using ImageBitmapCanvas = Variant<RefPtr<HTMLCanvasElement>, RefPtr<OffscreenCanvas>>;

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
@@ -28,7 +28,6 @@
 #if ENABLE(WEBGL)
 
 #include "EventLoop.h"
-#include "ExceptionOr.h"
 #include "GPUBasedCanvasRenderingContext.h"
 #include "GraphicsContextGL.h"
 #include "ImageBuffer.h"
@@ -167,6 +166,8 @@ using WebGLCanvas = Variant<RefPtr<HTMLCanvasElement>>;
 #if ENABLE(MEDIA_STREAM)
 class VideoFrame;
 #endif
+
+template<typename> class ExceptionOr;
 
 class WebGLRenderingContextBase : public GraphicsContextGL::Client, public GPUBasedCanvasRenderingContext {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(WebGLRenderingContextBase);

--- a/Source/WebCore/inspector/DOMEditor.h
+++ b/Source/WebCore/inspector/DOMEditor.h
@@ -30,8 +30,6 @@
 
 #pragma once
 
-#include "ExceptionOr.h"
-
 #include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
@@ -41,6 +39,8 @@ class Element;
 class InspectorHistory;
 class Node;
 class Text;
+
+template<typename> class ExceptionOr;
 
 typedef String ErrorString;
 

--- a/Source/WebCore/inspector/DOMPatchSupport.h
+++ b/Source/WebCore/inspector/DOMPatchSupport.h
@@ -30,7 +30,6 @@
 
 #pragma once
 
-#include "ExceptionOr.h"
 #include <wtf/HashMap.h>
 #include <wtf/Vector.h>
 
@@ -41,6 +40,7 @@ class DOMEditor;
 class Document;
 class Node;
 class WeakPtrImplWithEventTargetData;
+template<typename> class ExceptionOr;
 
 class DOMPatchSupport final {
 public:

--- a/Source/WebCore/inspector/InspectorAuditAccessibilityObject.h
+++ b/Source/WebCore/inspector/InspectorAuditAccessibilityObject.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include "ExceptionOr.h"
 #include <JavaScriptCore/InspectorAuditAgent.h>
 #include <wtf/Forward.h>
 #include <wtf/Ref.h>
@@ -35,6 +34,7 @@ namespace WebCore {
 
 class Document;
 class Node;
+template<typename> class ExceptionOr;
 
 class InspectorAuditAccessibilityObject : public RefCounted<InspectorAuditAccessibilityObject> {
 public:

--- a/Source/WebCore/inspector/InspectorAuditDOMObject.h
+++ b/Source/WebCore/inspector/InspectorAuditDOMObject.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include "ExceptionOr.h"
 #include "PageAuditAgent.h"
 #include <wtf/Ref.h>
 #include <wtf/RefCounted.h>
@@ -35,6 +34,7 @@ namespace WebCore {
 class Document;
 class Node;
 class VoidCallback;
+template<typename> class ExceptionOr;
 
 class InspectorAuditDOMObject : public RefCounted<InspectorAuditDOMObject> {
 public:

--- a/Source/WebCore/inspector/InspectorAuditResourcesObject.h
+++ b/Source/WebCore/inspector/InspectorAuditResourcesObject.h
@@ -31,7 +31,6 @@
 #include "CachedResourceClient.h"
 #include "CachedSVGDocumentClient.h"
 #include "CachedStyleSheetClient.h"
-#include "ExceptionOr.h"
 #include <JavaScriptCore/InspectorAuditAgent.h>
 #include <wtf/Forward.h>
 #include <wtf/Ref.h>
@@ -42,6 +41,7 @@ namespace WebCore {
 
 class CachedResource;
 class Document;
+template<typename> class ExceptionOr;
 
 class InspectorAuditResourcesObject : public RefCounted<InspectorAuditResourcesObject> {
 public:

--- a/Source/WebCore/inspector/InspectorFrontendHost.h
+++ b/Source/WebCore/inspector/InspectorFrontendHost.h
@@ -30,7 +30,6 @@
 
 #include "ContextMenu.h"
 #include "ContextMenuProvider.h"
-#include "ExceptionOr.h"
 #include "InspectorFrontendClient.h"
 #include <JavaScriptCore/JSCJSValue.h>
 #include <wtf/RefCounted.h>
@@ -50,6 +49,7 @@ class HTMLIFrameElement;
 class OffscreenCanvasRenderingContext2D;
 class Page;
 class Path2D;
+template<typename> class ExceptionOr;
 
 class InspectorFrontendHost : public RefCounted<InspectorFrontendHost> {
 public:

--- a/Source/WebCore/inspector/InspectorHistory.h
+++ b/Source/WebCore/inspector/InspectorHistory.h
@@ -30,11 +30,12 @@
 
 #pragma once
 
-#include "ExceptionOr.h"
 #include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 
 namespace WebCore {
+
+template<typename> class ExceptionOr;
 
 class InspectorHistory final {
     WTF_MAKE_TZONE_ALLOCATED(InspectorHistory);

--- a/Source/WebCore/page/ChromeClient.h
+++ b/Source/WebCore/page/ChromeClient.h
@@ -28,6 +28,7 @@
 #include "DisabledAdaptations.h"
 #include "DocumentStorageAccess.h"
 #include "ExceptionData.h"
+#include "ExceptionOr.h"
 #include "FocusDirection.h"
 #include "HTMLMediaElementEnums.h"
 #include "HighlightVisibility.h"
@@ -172,8 +173,6 @@ enum class TextAnimationRunMode : uint8_t;
 
 enum class MediaProducerMediaState : uint32_t;
 using MediaProducerMediaStateFlags = OptionSet<MediaProducerMediaState>;
-
-template<typename> class ExceptionOr;
 
 namespace ShapeDetection {
 class BarcodeDetector;

--- a/Source/WebCore/page/Crypto.cpp
+++ b/Source/WebCore/page/Crypto.cpp
@@ -32,6 +32,7 @@
 #include "Crypto.h"
 
 #include "Document.h"
+#include "ExceptionOr.h"
 #include "SubtleCrypto.h"
 #include <JavaScriptCore/ArrayBufferView.h>
 #include <wtf/CryptographicallyRandomNumber.h>

--- a/Source/WebCore/page/Crypto.h
+++ b/Source/WebCore/page/Crypto.h
@@ -30,7 +30,6 @@
 #pragma once
 
 #include "ContextDestructionObserver.h"
-#include "ExceptionOr.h"
 
 namespace JSC {
 class ArrayBufferView;
@@ -39,6 +38,7 @@ class ArrayBufferView;
 namespace WebCore {
 
 class SubtleCrypto;
+template<typename> class ExceptionOr;
 
 class Crypto : public ContextDestructionObserver, public RefCounted<Crypto> {
 public:

--- a/Source/WebCore/page/DOMSelection.h
+++ b/Source/WebCore/page/DOMSelection.h
@@ -29,7 +29,6 @@
 
 #pragma once
 
-#include "ExceptionOr.h"
 #include "GetComposedRangesOptions.h"
 #include "LocalDOMWindowProperty.h"
 #include <wtf/Forward.h>
@@ -46,6 +45,8 @@ class StaticRange;
 class VisibleSelection;
 
 struct SimpleRange;
+
+template<typename> class ExceptionOr;
 
 class DOMSelection : public RefCounted<DOMSelection>, public LocalDOMWindowProperty {
 public:

--- a/Source/WebCore/page/EventSource.h
+++ b/Source/WebCore/page/EventSource.h
@@ -35,7 +35,6 @@
 #include "EventLoop.h"
 #include "EventTarget.h"
 #include "EventTargetInterfaces.h"
-#include "ExceptionOr.h"
 #include "ThreadableLoaderClient.h"
 #include "Timer.h"
 #include <wtf/URL.h>
@@ -46,6 +45,7 @@ namespace WebCore {
 class MessageEvent;
 class TextResourceDecoder;
 class ThreadableLoader;
+template<typename> class ExceptionOr;
 
 class EventSource final : public RefCounted<EventSource>, public EventTarget, private ThreadableLoaderClient, public ActiveDOMObject {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(EventSource);

--- a/Source/WebCore/page/Location.h
+++ b/Source/WebCore/page/Location.h
@@ -30,7 +30,6 @@
 
 #include "DOMStringList.h"
 #include "EventTarget.h"
-#include "ExceptionOr.h"
 #include "ScriptWrappable.h"
 #include <wtf/WeakPtr.h>
 
@@ -39,6 +38,7 @@ namespace WebCore {
 class DOMWindow;
 class Frame;
 class LocalDOMWindow;
+template<typename> class ExceptionOr;
 
 class Location final : public ScriptWrappable, public RefCounted<Location> {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(Location);

--- a/Source/WebCore/page/LoginStatus.h
+++ b/Source/WebCore/page/LoginStatus.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include "ExceptionOr.h"
 #include "RegistrableDomain.h"
 #include <wtf/TZoneMalloc.h>
 #include <wtf/UniqueRef.h>
@@ -33,6 +32,8 @@
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
+
+template<typename> class ExceptionOr;
 
 enum class LoginStatusAuthenticationType : uint8_t { WebAuthn, PasswordManager, Unmanaged };
 

--- a/Source/WebCore/page/NavigationTransition.h
+++ b/Source/WebCore/page/NavigationTransition.h
@@ -32,6 +32,7 @@
 namespace WebCore {
 
 class DOMPromise;
+class Exception;
 
 class NavigationTransition final : public RefCounted<NavigationTransition> {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(NavigationTransition);

--- a/Source/WebCore/page/NavigatorBase.h
+++ b/Source/WebCore/page/NavigatorBase.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include "ContextDestructionObserver.h"
-#include "ExceptionOr.h"
 #include <wtf/CheckedPtr.h>
 #include <wtf/Forward.h>
 #include <wtf/RefCountedAndCanMakeWeakPtr.h>
@@ -43,6 +42,7 @@ class ServiceWorkerContainer;
 class StorageManager;
 class WebCoreOpaqueRoot;
 class WebLockManager;
+template<typename> class ExceptionOr;
 
 class NavigatorBase : public RefCountedAndCanMakeWeakPtr<NavigatorBase>, public ContextDestructionObserver, public CanMakeCheckedPtr<NavigatorBase> {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(NavigatorBase);

--- a/Source/WebCore/page/Performance.h
+++ b/Source/WebCore/page/Performance.h
@@ -36,7 +36,6 @@
 #include "DOMHighResTimeStamp.h"
 #include "EventTarget.h"
 #include "EventTargetInterfaces.h"
-#include "ExceptionOr.h"
 #include "ReducedResolutionSeconds.h"
 #include "ScriptExecutionContext.h"
 #include "Timer.h"
@@ -67,6 +66,7 @@ class ResourceTiming;
 class ScriptExecutionContext;
 struct PerformanceMarkOptions;
 struct PerformanceMeasureOptions;
+template<typename> class ExceptionOr;
 
 class Performance final : public RefCounted<Performance>, public ContextDestructionObserver, public EventTarget {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(Performance);

--- a/Source/WebCore/page/PerformanceMark.cpp
+++ b/Source/WebCore/page/PerformanceMark.cpp
@@ -28,6 +28,7 @@
 
 #include "DOMWrapperWorld.h"
 #include "Document.h"
+#include "ExceptionOr.h"
 #include "LocalDOMWindow.h"
 #include "MessagePort.h"
 #include "Performance.h"

--- a/Source/WebCore/page/PerformanceObserver.h
+++ b/Source/WebCore/page/PerformanceObserver.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include "ExceptionOr.h"
 #include "PerformanceEntry.h"
 #include "PerformanceObserverCallback.h"
 #include <wtf/OptionSet.h>
@@ -37,6 +36,7 @@ namespace WebCore {
 
 class Performance;
 class ScriptExecutionContext;
+template<typename> class ExceptionOr;
 
 class PerformanceObserver : public RefCounted<PerformanceObserver> {
 public:

--- a/Source/WebCore/page/PerformanceUserTiming.h
+++ b/Source/WebCore/page/PerformanceUserTiming.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include "ExceptionOr.h"
 #include "PerformanceMark.h"
 #include "PerformanceMeasure.h"
 #include <wtf/HashMap.h>
@@ -39,6 +38,7 @@ class JSGlobalObject;
 namespace WebCore {
 
 class Performance;
+template<typename> class ExceptionOr;
 
 using PerformanceEntryMap = UncheckedKeyHashMap<String, Vector<Ref<PerformanceEntry>>>;
 

--- a/Source/WebCore/page/PointerCaptureController.h
+++ b/Source/WebCore/page/PointerCaptureController.h
@@ -25,7 +25,6 @@
 #pragma once
 
 #include "EventTarget.h"
-#include "ExceptionOr.h"
 #include "MouseEventTypes.h"
 #include "PointerID.h"
 #include <wtf/HashMap.h>
@@ -42,6 +41,7 @@ class Page;
 class PlatformTouchEvent;
 class PointerEvent;
 class WindowProxy;
+template<typename> class ExceptionOr;
 
 class PointerCaptureController {
     WTF_MAKE_NONCOPYABLE(PointerCaptureController);

--- a/Source/WebCore/page/ShareDataReader.h
+++ b/Source/WebCore/page/ShareDataReader.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include "ExceptionOr.h"
 #include "ShareData.h"
 #include <wtf/CompletionHandler.h>
 
@@ -35,6 +34,7 @@ class Blob;
 class BlobLoader;
 class Document;
 class ScriptExecutionContext;
+template<typename> class ExceptionOr;
 
 class ShareDataReader : public RefCounted<ShareDataReader> {
 public:

--- a/Source/WebCore/page/UndoManager.h
+++ b/Source/WebCore/page/UndoManager.h
@@ -25,8 +25,6 @@
 
 #pragma once
 
-#include "Document.h"
-#include "ExceptionOr.h"
 #include <wtf/Ref.h>
 #include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/RefPtr.h>
@@ -35,7 +33,9 @@
 
 namespace WebCore {
 
+class Document;
 class UndoItem;
+template<typename> class ExceptionOr;
 
 class UndoManager : public RefCountedAndCanMakeWeakPtr<UndoManager> {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(UndoManager);

--- a/Source/WebCore/page/UserMessageHandler.h
+++ b/Source/WebCore/page/UserMessageHandler.h
@@ -27,7 +27,6 @@
 
 #if ENABLE(USER_MESSAGE_HANDLERS)
 
-#include "ExceptionOr.h"
 #include "FrameDestructionObserver.h"
 #include "UserMessageHandlerDescriptor.h"
 
@@ -39,6 +38,7 @@ class JSValue;
 namespace WebCore {
 
 class DeferredPromise;
+template<typename> class ExceptionOr;
 
 class UserMessageHandler : public RefCounted<UserMessageHandler>, public FrameDestructionObserver {
 public:

--- a/Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm
@@ -32,6 +32,7 @@
 #import "CDMKeySystemConfiguration.h"
 #import "CDMMediaCapability.h"
 #import "ContentKeyGroupFactoryAVFObjC.h"
+#import "ExceptionOr.h"
 #import "InitDataRegistry.h"
 #import "Logging.h"
 #import "MediaSampleAVFObjC.h"

--- a/Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.cpp
@@ -31,6 +31,7 @@
 #include "AudioTrackPrivateWebM.h"
 #include "CMUtilities.h"
 #include "ContentType.h"
+#include "ExceptionOr.h"
 #include "H264UtilitiesCocoa.h"
 #include "InbandTextTrackPrivate.h"
 #include "LibWebRTCMacros.h"

--- a/Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.h
+++ b/Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.h
@@ -27,7 +27,6 @@
 
 #if ENABLE(MEDIA_SOURCE)
 
-#include "ExceptionOr.h"
 #include "LibWebRTCMacros.h"
 #include "MediaSample.h"
 #include "SharedBuffer.h"
@@ -54,6 +53,7 @@ namespace WebCore {
 
 class PacketDurationParser;
 struct TrackInfo;
+template<typename> class ExceptionOr;
 
 class WebMParser
     : private webm::Callback

--- a/Source/WebCore/platform/mediastream/RTCDTMFSenderBackend.h
+++ b/Source/WebCore/platform/mediastream/RTCDTMFSenderBackend.h
@@ -26,7 +26,6 @@
 
 #if ENABLE(WEB_RTC)
 
-#include "ExceptionOr.h"
 #include <wtf/Function.h>
 #include <wtf/text/WTFString.h>
 

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSourceCenter.h
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSourceCenter.h
@@ -34,7 +34,6 @@
 
 #if ENABLE(MEDIA_STREAM)
 
-#include "ExceptionOr.h"
 #include "MediaStreamRequest.h"
 #include "RealtimeMediaSource.h"
 #include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>

--- a/Source/WebCore/storage/Storage.cpp
+++ b/Source/WebCore/storage/Storage.cpp
@@ -27,6 +27,7 @@
 #include "Storage.h"
 
 #include "Document.h"
+#include "ExceptionOr.h"
 #include "LegacySchemeRegistry.h"
 #include "LocalFrame.h"
 #include "Page.h"

--- a/Source/WebCore/storage/Storage.h
+++ b/Source/WebCore/storage/Storage.h
@@ -25,13 +25,13 @@
 
 #pragma once
 
-#include "ExceptionOr.h"
 #include "LocalDOMWindowProperty.h"
 #include "ScriptWrappable.h"
 
 namespace WebCore {
 
 class StorageArea;
+template<typename> class ExceptionOr;
 
 class Storage final : public ScriptWrappable, public RefCounted<Storage>, public LocalDOMWindowProperty {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(Storage);

--- a/Source/WebCore/svg/SVGAngle.h
+++ b/Source/WebCore/svg/SVGAngle.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "ExceptionOr.h"
 #include "SVGAngleValue.h"
 #include "SVGValueProperty.h"
 

--- a/Source/WebCore/svg/SVGAngleValue.h
+++ b/Source/WebCore/svg/SVGAngleValue.h
@@ -21,11 +21,12 @@
 
 #pragma once
 
-#include "ExceptionOr.h"
 #include "SVGPropertyTraits.h"
 #include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
+
+template<typename> class ExceptionOr;
 
 class SVGAngleValue {
     WTF_MAKE_TZONE_ALLOCATED(SVGAngleValue);

--- a/Source/WebCore/svg/SVGLengthContext.h
+++ b/Source/WebCore/svg/SVGLengthContext.h
@@ -20,7 +20,6 @@
 
 #pragma once
 
-#include "ExceptionOr.h"
 #include "FloatRect.h"
 #include "SVGLengthValue.h"
 #include "SVGUnitTypes.h"
@@ -31,6 +30,8 @@ class SVGElement;
 class WeakPtrImplWithEventTargetData;
 
 struct Length;
+
+template<typename> class ExceptionOr;
 
 class SVGLengthContext {
 public:

--- a/Source/WebCore/svg/SVGLengthValue.h
+++ b/Source/WebCore/svg/SVGLengthValue.h
@@ -21,7 +21,6 @@
 
 #pragma once
 
-#include "ExceptionOr.h"
 #include "SVGParsingError.h"
 #include "SVGPropertyTraits.h"
 #include <wtf/TZoneMalloc.h>
@@ -32,6 +31,7 @@ class CSSPrimitiveValue;
 class CSSToLengthConversionData;
 class Element;
 class SVGLengthContext;
+template<typename> class ExceptionOr;
 
 enum class SVGLengthType : uint8_t {
     Unknown = 0,

--- a/Source/WebCore/svg/SVGLocatable.h
+++ b/Source/WebCore/svg/SVGLocatable.h
@@ -22,13 +22,13 @@
 #pragma once
 
 #include "AffineTransform.h"
-#include "ExceptionOr.h"
 
 namespace WebCore {
 
 class FloatRect;
 class SVGElement;
 class SVGMatrix;
+template<typename> class ExceptionOr;
 
 enum class CTMScope : bool {
     NearestViewportScope, // Used for getCTM()

--- a/Source/WebCore/svg/SVGPreserveAspectRatioValue.h
+++ b/Source/WebCore/svg/SVGPreserveAspectRatioValue.h
@@ -20,7 +20,6 @@
 
 #pragma once
 
-#include "ExceptionOr.h"
 #include "SVGPropertyTraits.h"
 #include <wtf/TZoneMalloc.h>
 
@@ -32,6 +31,7 @@ namespace WebCore {
 
 class AffineTransform;
 class FloatRect;
+template<typename> class ExceptionOr;
 
 class SVGPreserveAspectRatioValue {
     WTF_MAKE_TZONE_ALLOCATED(SVGPreserveAspectRatioValue);

--- a/Source/WebCore/testing/InternalSettings.h
+++ b/Source/WebCore/testing/InternalSettings.h
@@ -26,7 +26,6 @@
 
 #pragma once
 
-#include "ExceptionOr.h"
 #include "FontGenericFamilies.h"
 #include "InternalSettingsGenerated.h"
 #include "Settings.h"
@@ -34,6 +33,7 @@
 namespace WebCore {
 
 class Page;
+template<typename> class ExceptionOr;
 
 class InternalSettings : public InternalSettingsGenerated {
 public:

--- a/Source/WebCore/testing/MockPaymentCoordinator.h
+++ b/Source/WebCore/testing/MockPaymentCoordinator.h
@@ -39,6 +39,7 @@
 #include "PaymentCoordinatorClient.h"
 #include <wtf/HashSet.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/WeakPtr.h>
 #include <wtf/text/StringHash.h>
 
 namespace WebCore {

--- a/Source/WebCore/testing/WebFakeXRDevice.h
+++ b/Source/WebCore/testing/WebFakeXRDevice.h
@@ -28,7 +28,6 @@
 
 #if ENABLE(WEBXR)
 
-#include "ExceptionOr.h"
 #include "FakeXRBoundsPoint.h"
 #include "FakeXRInputSourceInit.h"
 #include "FakeXRViewInit.h"
@@ -43,7 +42,9 @@
 #include <wtf/Vector.h>
 
 namespace WebCore {
+
 class GraphicsContextGL;
+template<typename> class ExceptionOr;
 
 class FakeXRView final : public RefCounted<FakeXRView> {
 public:

--- a/Source/WebCore/testing/WebFakeXRInputController.cpp
+++ b/Source/WebCore/testing/WebFakeXRInputController.cpp
@@ -27,6 +27,7 @@
 #include "WebFakeXRInputController.h"
 
 #if ENABLE(WEBXR)
+#include "ExceptionOr.h"
 #include "WebFakeXRDevice.h"
 #include "XRHandJoint.h"
 #include <ranges>

--- a/Source/WebCore/workers/AbstractWorker.cpp
+++ b/Source/WebCore/workers/AbstractWorker.cpp
@@ -32,6 +32,7 @@
 #include "AbstractWorker.h"
 
 #include "ContentSecurityPolicy.h"
+#include "ExceptionOr.h"
 #include "OriginAccessPatterns.h"
 #include "ScriptExecutionContext.h"
 #include "SecurityOrigin.h"

--- a/Source/WebCore/workers/AbstractWorker.h
+++ b/Source/WebCore/workers/AbstractWorker.h
@@ -31,13 +31,14 @@
 #pragma once
 
 #include "EventTarget.h"
-#include "ExceptionOr.h"
 #include "FetchOptions.h"
 
 namespace WebCore {
 
+class Exception;
 struct FetchOptions;
 struct WorkerOptions;
+template<typename> class ExceptionOr;
 
 class AbstractWorker : public RefCounted<AbstractWorker>, public EventTarget {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(AbstractWorker);

--- a/Source/WebCore/workers/service/ExtendableEvent.h
+++ b/Source/WebCore/workers/service/ExtendableEvent.h
@@ -32,6 +32,7 @@
 namespace WebCore {
 
 class DOMPromise;
+template<typename> class ExceptionOr;
 
 class ExtendableEvent : public Event {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(ExtendableEvent);

--- a/Source/WebCore/workers/service/SWClientConnection.h
+++ b/Source/WebCore/workers/service/SWClientConnection.h
@@ -27,7 +27,6 @@
 
 #include "BackgroundFetchRecordIdentifier.h"
 #include "ExceptionData.h"
-#include "ExceptionOr.h"
 #include "NavigationPreloadState.h"
 #include "NotificationData.h"
 #include "PushPermissionState.h"
@@ -70,6 +69,7 @@ struct ServiceWorkerData;
 struct ServiceWorkerRegistrationData;
 struct ServiceWorkerRoute;
 struct WorkerFetchResult;
+template<typename> class ExceptionOr;
 
 class SWClientConnection : public RefCounted<SWClientConnection> {
 public:

--- a/Source/WebCore/workers/service/ServiceWorkerClient.h
+++ b/Source/WebCore/workers/service/ServiceWorkerClient.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include "ContextDestructionObserver.h"
-#include "ExceptionOr.h"
 #include "ScriptExecutionContextIdentifier.h"
 #include "ServiceWorkerClientData.h"
 #include <JavaScriptCore/Strong.h>
@@ -42,6 +41,8 @@ namespace WebCore {
 class ServiceWorkerGlobalScope;
 
 struct StructuredSerializeOptions;
+
+template<typename> class ExceptionOr;
 
 class ServiceWorkerClient : public RefCounted<ServiceWorkerClient>, public ContextDestructionObserver {
 public:

--- a/Source/WebCore/workers/service/ServiceWorkerRoute.cpp
+++ b/Source/WebCore/workers/service/ServiceWorkerRoute.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "ServiceWorkerRoute.h"
 
+#include "ExceptionOr.h"
 #include "FetchOptions.h"
 #include "HTTPParsers.h"
 #include "ResourceRequest.h"

--- a/Source/WebCore/workers/service/context/SWContextManager.h
+++ b/Source/WebCore/workers/service/context/SWContextManager.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include "BackgroundFetchInformation.h"
-#include "ExceptionOr.h"
 #include "PageIdentifier.h"
 #include "PushSubscriptionData.h"
 #include "ServiceWorkerClientData.h"
@@ -46,6 +45,8 @@ class SerializedScriptValue;
 class ServiceWorkerGlobalScope;
 
 struct NotificationPayload;
+
+template<typename> class ExceptionOr;
 
 class SWContextManager {
 public:

--- a/Source/WebCore/workers/service/server/SWServer.h
+++ b/Source/WebCore/workers/service/server/SWServer.h
@@ -28,7 +28,6 @@
 #include "BackgroundFetchRecordIdentifier.h"
 #include "BackgroundFetchStore.h"
 #include "ClientOrigin.h"
-#include "ExceptionOr.h"
 #include "NotificationPayload.h"
 #include "PageIdentifier.h"
 #include "SWServerDelegate.h"
@@ -84,6 +83,8 @@ struct ServiceWorkerContextData;
 struct ServiceWorkerRegistrationData;
 struct ServiceWorkerRoute;
 struct WorkerFetchResult;
+
+template<typename> class ExceptionOr;
 
 class SWServer : public RefCountedAndCanMakeWeakPtr<SWServer> {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(SWServer, WEBCORE_EXPORT);

--- a/Source/WebCore/worklets/Worklet.h
+++ b/Source/WebCore/worklets/Worklet.h
@@ -27,7 +27,6 @@
 
 #include "ActiveDOMObject.h"
 #include "ContextDestructionObserver.h"
-#include "ExceptionOr.h"
 #include "JSDOMPromiseDeferredForward.h"
 #include "ScriptWrappable.h"
 #include "WorkletOptions.h"

--- a/Source/WebCore/worklets/WorkletGlobalScope.h
+++ b/Source/WebCore/worklets/WorkletGlobalScope.h
@@ -28,7 +28,6 @@
 
 #include "Document.h"
 #include "EventTargetInterfaces.h"
-#include "ExceptionOr.h"
 #include "FetchRequestCredentials.h"
 #include "ScriptExecutionContext.h"
 #include "ScriptSourceCode.h"

--- a/Source/WebCore/worklets/WorkletGlobalScopeProxy.h
+++ b/Source/WebCore/worklets/WorkletGlobalScopeProxy.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include "ExceptionOr.h"
 #include "FetchRequestCredentials.h"
 #include "ScriptExecutionContext.h"
 #include <wtf/Forward.h>

--- a/Source/WebCore/xml/DOMParser.cpp
+++ b/Source/WebCore/xml/DOMParser.cpp
@@ -20,6 +20,7 @@
 #include "DOMParser.h"
 
 #include "CommonAtomStrings.h"
+#include "ExceptionOr.h"
 #include "HTMLDocument.h"
 #include "NodeInlines.h"
 #include "SVGDocument.h"

--- a/Source/WebCore/xml/DOMParser.h
+++ b/Source/WebCore/xml/DOMParser.h
@@ -18,8 +18,9 @@
 
 #pragma once
 
-#include "ExceptionOr.h"
 #include <wtf/WeakPtr.h>
+#include <wtf/text/AtomString.h>
+#include <wtf/text/WTFString.h>
 
 namespace WebCore {
 
@@ -27,6 +28,7 @@ class Document;
 class WeakPtrImplWithEventTargetData;
 class Settings;
 class TrustedHTML;
+template<typename> class ExceptionOr;
 
 class DOMParser : public RefCounted<DOMParser> {
 public:

--- a/Source/WebCore/xml/XMLHttpRequest.h
+++ b/Source/WebCore/xml/XMLHttpRequest.h
@@ -23,7 +23,6 @@
 
 #include "ActiveDOMObject.h"
 #include "EventTargetInterfaces.h"
-#include "ExceptionOr.h"
 #include "FormData.h"
 #include "ResourceResponse.h"
 #include "SharedBuffer.h"
@@ -53,6 +52,7 @@ class ThreadableLoader;
 class URLSearchParams;
 class XMLHttpRequestUpload;
 struct OwnedString;
+template<typename> class ExceptionOr;
 
 class XMLHttpRequest final : public ActiveDOMObject, public RefCounted<XMLHttpRequest>, private ThreadableLoaderClient, public XMLHttpRequestEventTarget {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED_EXPORT(XMLHttpRequest, WEBCORE_EXPORT);

--- a/Source/WebCore/xml/XPathEvaluator.h
+++ b/Source/WebCore/xml/XPathEvaluator.h
@@ -26,7 +26,14 @@
 
 #pragma once
 
-#include "ExceptionOr.h"
+#include <wtf/Ref.h>
+#include <wtf/RefCounted.h>
+
+namespace WTF {
+
+class String;
+
+} // namespace WTF
 
 namespace WebCore {
 
@@ -34,6 +41,7 @@ class Node;
 class XPathExpression;
 class XPathNSResolver;
 class XPathResult;
+template<typename> class ExceptionOr;
 
 class XPathEvaluator : public RefCounted<XPathEvaluator> {
 public:

--- a/Source/WebCore/xml/XPathExpression.h
+++ b/Source/WebCore/xml/XPathExpression.h
@@ -26,13 +26,21 @@
 
 #pragma once
 
-#include "ExceptionOr.h"
+#include <wtf/Ref.h>
+#include <wtf/RefCounted.h>
+
+namespace WTF {
+
+class String;
+
+} // namespace WTF
 
 namespace WebCore {
 
 class Node;
 class XPathNSResolver;
 class XPathResult;
+template<typename> class ExceptionOr;
 
 namespace XPath {
 class Expression;

--- a/Source/WebCore/xml/XPathParser.h
+++ b/Source/WebCore/xml/XPathParser.h
@@ -26,14 +26,20 @@
 
 #pragma once
 
-#include "ExceptionOr.h"
 #include "XPathPredicate.h"
 
 union YYSTYPE;
 
+namespace WTF {
+
+class String;
+
+} // namespace WTF
+
 namespace WebCore {
 
 class XPathNSResolver;
+template<typename> class ExceptionOr;
 
 namespace XPath {
 

--- a/Source/WebCore/xml/XPathResult.h
+++ b/Source/WebCore/xml/XPathResult.h
@@ -26,10 +26,11 @@
 
 #pragma once
 
-#include "ExceptionOr.h"
 #include "XPathValue.h"
 
 namespace WebCore {
+
+template<typename> class ExceptionOr;
 
 class XPathResult : public RefCounted<XPathResult> {
 public:

--- a/Source/WebKit/Shared/ApplePay/cocoa/DisbursementRequestCocoa.mm
+++ b/Source/WebKit/Shared/ApplePay/cocoa/DisbursementRequestCocoa.mm
@@ -37,6 +37,7 @@
 
 #import <pal/spi/cocoa/PassKitSPI.h>
 #import <wtf/RetainPtr.h>
+#import <wtf/URL.h>
 #import <wtf/cocoa/VectorCocoa.h>
 
 #import <pal/cocoa/PassKitSoftLink.h>

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginAnnotation.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginAnnotation.mm
@@ -40,6 +40,7 @@
 #import <WebCore/Event.h>
 #import <WebCore/EventLoop.h>
 #import <WebCore/EventNames.h>
+#import <WebCore/ExceptionOr.h>
 #import <WebCore/HTMLInputElement.h>
 #import <WebCore/HTMLNames.h>
 #import <WebCore/HTMLOptionElement.h>

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebPlatformStrategies.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebPlatformStrategies.cpp
@@ -47,6 +47,7 @@
 #include <WebCore/Color.h>
 #include <WebCore/Document.h>
 #include <WebCore/DocumentLoader.h>
+#include <WebCore/ExceptionOr.h>
 #include <WebCore/LoaderStrategy.h>
 #include <WebCore/LocalFrame.h>
 #include <WebCore/MediaStrategy.h>

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -177,6 +177,7 @@ class DocumentLoader;
 class DocumentSyncData;
 class DragData;
 class WeakPtrImplWithEventTargetData;
+class Exception;
 class FontAttributeChanges;
 class FontChanges;
 class Frame;

--- a/Source/WebKit/webpushd/WebPushDaemon.mm
+++ b/Source/WebKit/webpushd/WebPushDaemon.mm
@@ -40,6 +40,7 @@
 #import "_WKMockUserNotificationCenter.h"
 #import "_WKWebPushActionInternal.h"
 
+#import <WebCore/ExceptionOr.h>
 #import <WebCore/LocalizedStrings.h>
 #import <WebCore/NotificationData.h>
 #import <WebCore/NotificationPayload.h>

--- a/Tools/TestWebKitAPI/Tests/WebCore/CtapPinTest.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/CtapPinTest.cpp
@@ -37,6 +37,7 @@
 #include <WebCore/CryptoKeyAES.h>
 #include <WebCore/CryptoKeyEC.h>
 #include <WebCore/CryptoKeyHMAC.h>
+#include <WebCore/ExceptionOr.h>
 #include <WebCore/FidoConstants.h>
 #include <WebCore/Pin.h>
 #include <WebCore/WebAuthenticationConstants.h>

--- a/Tools/TestWebKitAPI/Tests/WebCore/HTMLParserIdioms.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/HTMLParserIdioms.cpp
@@ -27,6 +27,7 @@
 
 #include "Test.h"
 #include <WebCore/DocumentFragment.h>
+#include <WebCore/ExceptionOr.h>
 #include <WebCore/HTMLBodyElement.h>
 #include <WebCore/HTMLDivElement.h>
 #include <WebCore/HTMLDocument.h>

--- a/Tools/TestWebKitAPI/Tests/WebCore/LoginStatus.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/LoginStatus.cpp
@@ -25,6 +25,7 @@
 
 #include "config.h"
 
+#include <WebCore/ExceptionOr.h>
 #include <WebCore/LoginStatus.h>
 #include <WebCore/RegistrableDomain.h>
 #include <wtf/Seconds.h>

--- a/Tools/TestWebKitAPI/Tests/WebCore/RTCRtpSFrameTransformerTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/RTCRtpSFrameTransformerTests.cpp
@@ -27,6 +27,7 @@
 
 #if ENABLE(WEB_RTC)
 
+#include <WebCore/ExceptionOr.h>
 #include <WebCore/RTCRtpSFrameTransformer.h>
 #include <WebCore/SFrameUtils.h>
 #include <wtf/Vector.h>

--- a/Tools/TestWebKitAPI/Tests/WebCore/TimeRanges.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/TimeRanges.cpp
@@ -29,6 +29,7 @@
  */
 
 #include "config.h"
+#include <WebCore/ExceptionOr.h>
 #include <WebCore/TimeRanges.h>
 
 using namespace WebCore;


### PR DESCRIPTION
#### cacb6a982264d61454a247d85048c7a74930b34b
<pre>
Avoid including ExceptionOr.h in many header files
<a href="https://bugs.webkit.org/show_bug.cgi?id=292819">https://bugs.webkit.org/show_bug.cgi?id=292819</a>

Reviewed by Sam Weinig.

Remove #include &lt;ExceptionOr.h&gt; from as many header files as possible.

* Source/WebCore/Modules/ShapeDetection/BarcodeDetector.h:
* Source/WebCore/Modules/ShapeDetection/FaceDetector.h:
* Source/WebCore/Modules/ShapeDetection/TextDetector.h:
* Source/WebCore/Modules/WebGPU/GPUBuffer.h:
* Source/WebCore/Modules/WebGPU/GPUComputePassEncoder.h:
* Source/WebCore/Modules/WebGPU/GPURenderBundleEncoder.h:
* Source/WebCore/Modules/WebGPU/GPURenderPassEncoder.h:
* Source/WebCore/Modules/WebGPU/GPUTexture.h:
* Source/WebCore/Modules/applepay-ams-ui/ApplePayAMSUIPaymentHandler.h:
* Source/WebCore/Modules/applepay/ApplePayContactField.cpp:
* Source/WebCore/Modules/applepay/ApplePayContactField.h:
* Source/WebCore/Modules/applepay/ApplePayDeferredPaymentRequest.h:
* Source/WebCore/Modules/applepay/ApplePayMerchantCapability.cpp:
* Source/WebCore/Modules/applepay/ApplePayMerchantCapability.h:
* Source/WebCore/Modules/applepay/ApplePaySession.h:
* Source/WebCore/Modules/applepay/PaymentRequestValidator.h:
* Source/WebCore/Modules/applepay/PaymentSession.h:
* Source/WebCore/Modules/async-clipboard/ClipboardItem.cpp:
* Source/WebCore/Modules/async-clipboard/ClipboardItem.h:
* Source/WebCore/Modules/audiosession/DOMAudioSession.cpp:
* Source/WebCore/Modules/audiosession/DOMAudioSession.h:
* Source/WebCore/Modules/beacon/NavigatorBeacon.h:
* Source/WebCore/Modules/cache/DOMCacheEngine.h:
* Source/WebCore/Modules/compression/DecompressionStreamDecoder.h:
* Source/WebCore/Modules/encryptedmedia/MediaKeys.h:
* Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeySession.cpp:
* Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeySession.h:
* Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeys.h:
* Source/WebCore/Modules/entriesapi/DOMFileSystem.cpp:
* Source/WebCore/Modules/entriesapi/DOMFileSystem.h:
* Source/WebCore/Modules/entriesapi/FileSystemDirectoryReader.cpp:
* Source/WebCore/Modules/fetch/FetchBody.h:
* Source/WebCore/Modules/fetch/FetchBodyOwner.h:
* Source/WebCore/Modules/fetch/FetchHeaders.h:
* Source/WebCore/Modules/fetch/FetchRequest.h:
* Source/WebCore/Modules/fetch/FormDataConsumer.h:
* Source/WebCore/Modules/filesystemaccess/FileSystemSyncAccessHandle.h:
* Source/WebCore/Modules/highlight/Highlight.h:
* Source/WebCore/Modules/indexeddb/IDBCursor.cpp:
* Source/WebCore/Modules/indexeddb/IDBCursor.h:
* Source/WebCore/Modules/indexeddb/IDBFactory.h:
* Source/WebCore/Modules/indexeddb/IDBIndex.cpp:
* Source/WebCore/Modules/indexeddb/IDBKeyRange.cpp:
* Source/WebCore/Modules/indexeddb/IDBKeyRange.h:
* Source/WebCore/Modules/indexeddb/IDBObjectStore.h:
* Source/WebCore/Modules/indexeddb/IDBRequest.h:
* Source/WebCore/Modules/mediarecorder/MediaRecorder.h:
* Source/WebCore/Modules/mediarecorder/MediaRecorderErrorEvent.h:
* Source/WebCore/Modules/mediasession/MediaSession.h:
* Source/WebCore/Modules/mediasource/ManagedMediaSource.cpp:
* Source/WebCore/Modules/mediasource/MediaSource.h:
* Source/WebCore/Modules/mediasource/SourceBuffer.cpp:
* Source/WebCore/Modules/mediasource/SourceBuffer.h:
* Source/WebCore/Modules/mediastream/MediaDevices.h:
* Source/WebCore/Modules/mediastream/MediaStreamTrackProcessor.h:
* Source/WebCore/Modules/mediastream/PeerConnectionBackend.h:
* Source/WebCore/Modules/mediastream/RTCDTMFSender.h:
* Source/WebCore/Modules/mediastream/RTCDataChannel.cpp:
* Source/WebCore/Modules/mediastream/RTCDataChannel.h:
* Source/WebCore/Modules/mediastream/RTCIceCandidate.cpp:
* Source/WebCore/Modules/mediastream/RTCIceCandidate.h:
* Source/WebCore/Modules/mediastream/RTCRtpSFrameTransformer.cpp:
* Source/WebCore/Modules/mediastream/RTCRtpSFrameTransformer.h:
* Source/WebCore/Modules/mediastream/RTCRtpScriptTransform.cpp:
* Source/WebCore/Modules/mediastream/RTCRtpScriptTransformer.h:
* Source/WebCore/Modules/mediastream/RTCRtpTransceiverBackend.h:
* Source/WebCore/Modules/mediastream/RTCSessionDescription.h:
* Source/WebCore/Modules/mediastream/VideoTrackGenerator.h:
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp:
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.cpp:
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpTransceiverBackend.cpp:
* Source/WebCore/Modules/model-element/HTMLModelElement.h:
* Source/WebCore/Modules/notifications/NotificationJSONParser.h:
* Source/WebCore/Modules/notifications/NotificationOptionsPayload.h:
* Source/WebCore/Modules/notifications/NotificationPayload.h:
* Source/WebCore/Modules/paymentrequest/PaymentRequest.h:
* Source/WebCore/Modules/paymentrequest/PaymentRequestUpdateEvent.h:
* Source/WebCore/Modules/paymentrequest/PaymentResponse.h:
* Source/WebCore/Modules/plugins/YouTubePluginReplacement.cpp:
* Source/WebCore/Modules/push-api/PushMessageData.h:
* Source/WebCore/Modules/push-api/PushStrategy.h:
* Source/WebCore/Modules/push-api/PushSubscription.h:
* Source/WebCore/Modules/push-api/PushSubscriptionOptions.cpp:
* Source/WebCore/Modules/push-api/PushSubscriptionOptions.h:
* Source/WebCore/Modules/storage/WorkerStorageConnection.cpp:
* Source/WebCore/Modules/streams/ReadableStreamSink.h:
* Source/WebCore/Modules/streams/TransformStream.h:
* Source/WebCore/Modules/streams/WritableStream.h:
* Source/WebCore/Modules/streams/WritableStreamSink.h:
* Source/WebCore/Modules/url-pattern/URLPattern.h:
* Source/WebCore/Modules/url-pattern/URLPatternCanonical.cpp:
* Source/WebCore/Modules/url-pattern/URLPatternCanonical.h:
* Source/WebCore/Modules/url-pattern/URLPatternComponent.cpp:
* Source/WebCore/Modules/url-pattern/URLPatternConstructorStringParser.h:
* Source/WebCore/Modules/url-pattern/URLPatternTokenizer.h:
* Source/WebCore/Modules/webaudio/AudioBuffer.cpp:
* Source/WebCore/Modules/webaudio/AudioBuffer.h:
* Source/WebCore/Modules/webaudio/AudioDestinationNode.h:
* Source/WebCore/Modules/webaudio/AudioListener.h:
* Source/WebCore/Modules/webaudio/AudioNode.cpp:
* Source/WebCore/Modules/webaudio/AudioNode.h:
* Source/WebCore/Modules/webaudio/AudioWorkletProcessor.h:
* Source/WebCore/Modules/webaudio/BiquadFilterNode.cpp:
* Source/WebCore/Modules/webaudio/DelayNode.cpp:
* Source/WebCore/Modules/webaudio/MediaElementAudioSourceNode.cpp:
* Source/WebCore/Modules/webaudio/PannerNode.cpp:
* Source/WebCore/Modules/webaudio/PeriodicWave.h:
* Source/WebCore/Modules/webauthn/AuthenticatorAttestationResponse.cpp:
* Source/WebCore/Modules/webauthn/PublicKeyCredential.h:
* Source/WebCore/Modules/webauthn/fido/Pin.cpp:
* Source/WebCore/Modules/webcodecs/WebCodecsAudioDataAlgorithms.h:
* Source/WebCore/Modules/webcodecs/WebCodecsEncodedAudioChunk.h:
* Source/WebCore/Modules/webcodecs/WebCodecsEncodedVideoChunk.h:
* Source/WebCore/Modules/webdatabase/Database.cpp:
* Source/WebCore/Modules/webdatabase/Database.h:
* Source/WebCore/Modules/webdatabase/DatabaseManager.h:
* Source/WebCore/Modules/webdatabase/DatabaseTask.cpp:
* Source/WebCore/Modules/webdatabase/DatabaseTask.h:
* Source/WebCore/Modules/webdatabase/DatabaseTracker.cpp:
* Source/WebCore/Modules/webdatabase/DatabaseTracker.h:
* Source/WebCore/Modules/webdatabase/LocalDOMWindowWebDatabase.h:
* Source/WebCore/Modules/webdatabase/SQLResultSet.h:
* Source/WebCore/Modules/webdatabase/SQLResultSetRowList.h:
* Source/WebCore/Modules/webdatabase/SQLTransaction.cpp:
* Source/WebCore/Modules/webdatabase/SQLTransaction.h:
* Source/WebCore/Modules/websockets/WebSocket.h:
* Source/WebCore/Modules/webtransport/WebTransport.h:
* Source/WebCore/Modules/webtransport/WebTransportBidirectionalStream.h:
* Source/WebCore/Modules/webtransport/WebTransportDatagramDuplexStream.h:
* Source/WebCore/Modules/webxr/WebXRFrame.cpp:
* Source/WebCore/Modules/webxr/WebXRFrame.h:
* Source/WebCore/Modules/webxr/WebXRReferenceSpace.cpp:
* Source/WebCore/Modules/webxr/WebXRRigidTransform.cpp:
* Source/WebCore/Modules/webxr/WebXRRigidTransform.h:
* Source/WebCore/Modules/webxr/WebXRWebGLLayer.cpp:
* Source/WebCore/Modules/webxr/WebXRWebGLLayer.h:
* Source/WebCore/Modules/webxr/XRGPUBinding.h:
* Source/WebCore/Modules/webxr/XRWebGLBinding.cpp:
* Source/WebCore/Modules/webxr/XRWebGLBinding.h:
* Source/WebCore/animation/AnimationEffect.h:
* Source/WebCore/animation/DocumentTimeline.h:
* Source/WebCore/animation/WebAnimationUtilities.h:
* Source/WebCore/bindings/js/InternalReadableStream.h:
* Source/WebCore/bindings/js/InternalWritableStream.h:
* Source/WebCore/bindings/js/SerializedScriptValue.h:
* Source/WebCore/crypto/CryptoAlgorithm.cpp:
* Source/WebCore/crypto/CryptoAlgorithm.h:
* Source/WebCore/crypto/algorithms/CryptoAlgorithmAESCTR.cpp:
* Source/WebCore/crypto/algorithms/CryptoAlgorithmAESGCM.cpp:
* Source/WebCore/crypto/algorithms/CryptoAlgorithmAESKW.cpp:
* Source/WebCore/crypto/algorithms/CryptoAlgorithmPBKDF2.cpp:
* Source/WebCore/crypto/algorithms/CryptoAlgorithmRSASSA_PKCS1_v1_5.cpp:
* Source/WebCore/crypto/algorithms/CryptoAlgorithmX25519.cpp:
* Source/WebCore/crypto/cocoa/CryptoAlgorithmECDSAMac.cpp:
* Source/WebCore/crypto/cocoa/CryptoAlgorithmEd25519Cocoa.cpp:
* Source/WebCore/crypto/cocoa/CryptoKeyOKPCocoa.cpp:
* Source/WebCore/crypto/cocoa/CryptoUtilitiesCocoa.h:
* Source/WebCore/crypto/gcrypt/CryptoAlgorithmAESCBCGCrypt.cpp:
* Source/WebCore/crypto/gcrypt/CryptoAlgorithmHKDFGCrypt.cpp:
* Source/WebCore/crypto/gcrypt/CryptoAlgorithmHMACGCrypt.cpp:
* Source/WebCore/crypto/gcrypt/CryptoKeyOKPGCrypt.cpp:
* Source/WebCore/crypto/keys/CryptoKeyAES.h:
* Source/WebCore/crypto/keys/CryptoKeyEC.cpp:
* Source/WebCore/crypto/keys/CryptoKeyEC.h:
* Source/WebCore/crypto/keys/CryptoKeyHMAC.h:
* Source/WebCore/crypto/keys/CryptoKeyOKP.h:
* Source/WebCore/crypto/keys/CryptoKeyRSA.h:
* Source/WebCore/crypto/openssl/CryptoAlgorithmAESCBCOpenSSL.cpp:
* Source/WebCore/crypto/openssl/CryptoAlgorithmAESCFBOpenSSL.cpp:
* Source/WebCore/crypto/openssl/CryptoAlgorithmAESCTROpenSSL.cpp:
* Source/WebCore/crypto/openssl/CryptoAlgorithmAESGCMOpenSSL.cpp:
* Source/WebCore/crypto/openssl/CryptoAlgorithmAESKWOpenSSL.cpp:
* Source/WebCore/crypto/openssl/CryptoAlgorithmECDSAOpenSSL.cpp:
* Source/WebCore/crypto/openssl/CryptoAlgorithmHKDFOpenSSL.cpp:
* Source/WebCore/crypto/openssl/CryptoAlgorithmHMACOpenSSL.cpp:
* Source/WebCore/crypto/openssl/CryptoAlgorithmPBKDF2OpenSSL.cpp:
* Source/WebCore/crypto/openssl/CryptoAlgorithmRSASSA_PKCS1_v1_5OpenSSL.cpp:
* Source/WebCore/crypto/openssl/CryptoAlgorithmRSA_OAEPOpenSSL.cpp:
* Source/WebCore/crypto/openssl/CryptoAlgorithmRSA_PSSOpenSSL.cpp:
* Source/WebCore/crypto/openssl/CryptoKeyRSAOpenSSL.cpp:
* Source/WebCore/css/CSSPrimitiveValue.h:
* Source/WebCore/css/CSSRule.h:
* Source/WebCore/css/CSSStyleDeclaration.h:
* Source/WebCore/css/CSSStyleSheetObservableArray.h:
* Source/WebCore/css/DOMCSSRegisterCustomProperty.h:
* Source/WebCore/css/FontFace.h:
* Source/WebCore/css/MediaList.h:
* Source/WebCore/css/typedom/CSSStyleValueFactory.cpp:
* Source/WebCore/css/typedom/StylePropertyMap.cpp:
* Source/WebCore/css/typedom/color/CSSRGB.h:
* Source/WebCore/dom/BroadcastChannel.cpp:
* Source/WebCore/dom/BroadcastChannel.h:
* Source/WebCore/dom/DOMImplementation.h:
* Source/WebCore/dom/DOMPointReadOnly.h:
* Source/WebCore/dom/DataTransferItemList.h:
* Source/WebCore/dom/DatasetDOMStringMap.h:
* Source/WebCore/dom/DeviceOrientationAndMotionAccessController.h:
* Source/WebCore/dom/Event.h:
* Source/WebCore/dom/MessagePort.h:
* Source/WebCore/dom/MutationObserver.h:
* Source/WebCore/dom/NamedNodeMap.h:
* Source/WebCore/dom/NodeIterator.h:
* Source/WebCore/dom/Observable.h:
* Source/WebCore/dom/TextDecoder.h:
* Source/WebCore/dom/TreeWalker.h:
* Source/WebCore/dom/TrustedType.h:
* Source/WebCore/dom/TrustedTypePolicy.h:
* Source/WebCore/dom/ViewTransition.h:
* Source/WebCore/editing/TextCheckingHelper.h:
* Source/WebCore/editing/markup.h:
* Source/WebCore/fileapi/FileReader.h:
* Source/WebCore/fileapi/FileReaderSync.cpp:
* Source/WebCore/fileapi/FileReaderSync.h:
* Source/WebCore/html/CustomPaintCanvas.h:
* Source/WebCore/html/ImageBitmap.h:
* Source/WebCore/html/ImageData.h:
* Source/WebCore/html/MediaController.cpp:
* Source/WebCore/html/MediaControllerInterface.h:
* Source/WebCore/html/OffscreenCanvas.h:
* Source/WebCore/html/TimeRanges.h:
* Source/WebCore/html/URLSearchParams.h:
* Source/WebCore/html/canvas/CanvasGradient.h:
* Source/WebCore/html/canvas/CanvasPath.cpp:
* Source/WebCore/html/canvas/CanvasPath.h:
* Source/WebCore/html/canvas/CanvasPattern.h:
* Source/WebCore/html/canvas/GPUCanvasContext.h:
* Source/WebCore/html/canvas/ImageBitmapRenderingContext.h:
* Source/WebCore/html/canvas/WebGLRenderingContextBase.h:
* Source/WebCore/html/track/InbandDataTextTrack.cpp:
* Source/WebCore/inspector/DOMEditor.h:
* Source/WebCore/inspector/DOMPatchSupport.h:
* Source/WebCore/inspector/InspectorAuditAccessibilityObject.h:
* Source/WebCore/inspector/InspectorAuditDOMObject.h:
* Source/WebCore/inspector/InspectorAuditResourcesObject.h:
* Source/WebCore/inspector/InspectorFrontendHost.h:
* Source/WebCore/inspector/InspectorHistory.h:
* Source/WebCore/page/ChromeClient.h:
* Source/WebCore/page/Crypto.cpp:
* Source/WebCore/page/Crypto.h:
* Source/WebCore/page/DOMSelection.h:
* Source/WebCore/page/EventSource.h:
* Source/WebCore/page/Location.h:
* Source/WebCore/page/LoginStatus.h:
* Source/WebCore/page/NavigationTransition.h:
* Source/WebCore/page/NavigatorBase.h:
* Source/WebCore/page/Performance.h:
* Source/WebCore/page/PerformanceMark.cpp:
* Source/WebCore/page/PerformanceObserver.h:
* Source/WebCore/page/PerformanceUserTiming.h:
* Source/WebCore/page/PointerCaptureController.h:
* Source/WebCore/page/ShareDataReader.h:
* Source/WebCore/page/UndoManager.h:
* Source/WebCore/page/UserMessageHandler.h:
* Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm:
* Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.cpp:
* Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.h:
* Source/WebCore/platform/mediastream/RTCDTMFSenderBackend.h:
* Source/WebCore/platform/mediastream/RealtimeMediaSourceCenter.h:
* Source/WebCore/storage/Storage.cpp:
* Source/WebCore/storage/Storage.h:
* Source/WebCore/svg/SVGAngle.h:
* Source/WebCore/svg/SVGAngleValue.h:
* Source/WebCore/svg/SVGLengthContext.h:
* Source/WebCore/svg/SVGLengthValue.h:
* Source/WebCore/svg/SVGLocatable.h:
* Source/WebCore/svg/SVGPreserveAspectRatioValue.h:
* Source/WebCore/testing/InternalSettings.h:
* Source/WebCore/testing/MockPaymentCoordinator.h:
* Source/WebCore/testing/WebFakeXRDevice.h:
* Source/WebCore/testing/WebFakeXRInputController.cpp:
* Source/WebCore/workers/AbstractWorker.cpp:
* Source/WebCore/workers/AbstractWorker.h:
* Source/WebCore/workers/service/ExtendableEvent.h:
* Source/WebCore/workers/service/SWClientConnection.h:
* Source/WebCore/workers/service/ServiceWorkerClient.h:
* Source/WebCore/workers/service/ServiceWorkerRoute.cpp:
* Source/WebCore/workers/service/context/SWContextManager.h:
* Source/WebCore/workers/service/server/SWServer.h:
* Source/WebCore/worklets/Worklet.h:
* Source/WebCore/worklets/WorkletGlobalScope.h:
* Source/WebCore/worklets/WorkletGlobalScopeProxy.h:
* Source/WebCore/xml/DOMParser.cpp:
* Source/WebCore/xml/DOMParser.h:
* Source/WebCore/xml/XMLHttpRequest.h:
* Source/WebCore/xml/XPathEvaluator.h:
* Source/WebCore/xml/XPathExpression.h:
* Source/WebCore/xml/XPathParser.h:
* Source/WebCore/xml/XPathResult.h:
* Source/WebKit/Shared/ApplePay/cocoa/DisbursementRequestCocoa.mm:
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginAnnotation.mm:
* Source/WebKit/WebProcess/WebCoreSupport/WebPlatformStrategies.cpp:
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/webpushd/WebPushDaemon.mm:
* Tools/TestWebKitAPI/Tests/WebCore/CtapPinTest.cpp:
* Tools/TestWebKitAPI/Tests/WebCore/HTMLParserIdioms.cpp:
* Tools/TestWebKitAPI/Tests/WebCore/LoginStatus.cpp:
* Tools/TestWebKitAPI/Tests/WebCore/RTCRtpSFrameTransformerTests.cpp:
* Tools/TestWebKitAPI/Tests/WebCore/TimeRanges.cpp:

Canonical link: <a href="https://commits.webkit.org/294830@main">https://commits.webkit.org/294830@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bea27269b53c6009e9e79f743614e84b148b1e4d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/103245 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/22921 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/13241 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/108432 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/53888 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/105284 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/23257 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/31464 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/78486 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/35400 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/106251 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/18030 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/93142 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/58819 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/17871 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/11185 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/53243 "Built successfully") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/95920 "Build is in progress. Recent messages:") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/87679 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/11247 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/110791 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/30383 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/22430 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/87470 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/30748 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/89341 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87103 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31960 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/9673 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/24706 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16751 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/30312 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/35631 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/30118 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/33445 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/31680 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->