### PR TITLE
REGRESSION(288714@main): CanvasRenderingContext2D font with normal line height fails to parse

### DIFF
--- a/LayoutTests/fast/canvas/font-line-height-normal-expected.txt
+++ b/LayoutTests/fast/canvas/font-line-height-normal-expected.txt
@@ -1,0 +1,5 @@
+
+PASS With "normal" line-height
+PASS Without line-height (equates to "normal")
+PASS With non-"normal" line-height value
+

--- a/LayoutTests/fast/canvas/font-line-height-normal.html
+++ b/LayoutTests/fast/canvas/font-line-height-normal.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<title>Test that CanvasRenderingContext2d.font does not fail with "normal" line height value</title>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<div id="log"></div>
+<script>
+  const canvas = document.createElement('canvas');
+  const ctx = canvas.getContext("2d");
+
+  test(function() {
+    ctx.font = 'normal normal 400 normal 12px/normal Arial, Helvetica, sans-serif';
+    assert_equals(ctx.font, '12px Arial, Helvetica, sans-serif');
+  }, `With "normal" line-height`);
+
+  test(function() {
+    ctx.font = 'normal normal 400 normal 12px Arial, Helvetica, sans-serif';
+    assert_equals(ctx.font, '12px Arial, Helvetica, sans-serif');
+  }, `Without line-height (equates to "normal")`);
+
+  test(function() {
+    ctx.font = 'normal normal 400 normal 12px/14px Arial, Helvetica, sans-serif';
+    assert_equals(ctx.font, '12px Arial, Helvetica, sans-serif');
+  }, `With non-"normal" line-height value`);
+</script>

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Font.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Font.cpp
@@ -46,6 +46,7 @@
 #include "CSSPropertyParserConsumer+Color.h"
 #include "CSSPropertyParserConsumer+Ident.h"
 #include "CSSPropertyParserConsumer+IntegerDefinitions.h"
+#include "CSSPropertyParserConsumer+KeywordDefinitions.h"
 #include "CSSPropertyParserConsumer+LengthPercentageDefinitions.h"
 #include "CSSPropertyParserConsumer+List.h"
 #include "CSSPropertyParserConsumer+MetaConsumer.h"

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+MetaConsumer.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+MetaConsumer.h
@@ -176,6 +176,8 @@ struct MetaConsumerUnroller<T, Ts...> {
 //    );
 template<typename T, typename... Ts>
 struct MetaConsumer {
+    static_assert(WTF::all<HasConsumerDefinition::check<T>(), HasConsumerDefinition::check<Ts>()...>);
+
     using Unroller = MetaConsumerUnroller<T, Ts...>;
 
     template<typename... F>

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+MetaConsumerDefinitions.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+MetaConsumerDefinitions.h
@@ -39,6 +39,20 @@ namespace CSSPropertyParserHelpers {
 
 template<typename> struct ConsumerDefinition;
 
+// Used to check that a specialization of ConsumerDefinition exists.
+struct HasConsumerDefinition {
+private:
+    template<typename T, typename U = decltype(ConsumerDefinition<T>{})>
+    static constexpr bool exists(int) { return true; }
+
+    template<typename T>
+    static constexpr bool exists(char) { return false; }
+
+public:
+    template<typename T>
+    static constexpr bool check() { return exists<T>(0); }
+};
+
 // FIXME: Bailing on infinity during validation does not seem to match the intent of the spec,
 // though due to the use of "implementation-defined" it may still be conforming. The spec states:
 //


### PR DESCRIPTION
#### 3606cb0acd00c283e98f1c9db98a5d54ce9fe7ef
<pre>
REGRESSION(288714@main): CanvasRenderingContext2D font with normal line height fails to parse
<a href="https://bugs.webkit.org/show_bug.cgi?id=291667">https://bugs.webkit.org/show_bug.cgi?id=291667</a>
<a href="https://rdar.apple.com/149459999">rdar://149459999</a>

Reviewed by Darin Adler.

Fixes regression in 288714@main that failed to parse the keyword `normal`
when parsing strings passed to `CanvasRenderingContext2D.font`.

The issue was due failing to include CSSPropertyParserConsumer+KeywordDefinitions.h
in CSSPropertyParserConsumer+Font.cpp, which meant that the `MetaConsumer` didn&apos;t have
a consumer for keyword values when being invoked in `consumeLineHeightUnresolved`.

To ensure this kind of issue can&apos;t happen in the future, we now statically assert
that all types passed to `MetaConsumer have `ConsumerDefinition` specializations
defined. Confirmed this works by just adding the assertion, which immediately caused
the build to fail pointing directly to `consumeLineHeightUnresolved`.

* LayoutTests/fast/canvas/font-line-height-normal-expected.txt: Added.
* LayoutTests/fast/canvas/font-line-height-normal.html: Added.
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Font.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+MetaConsumer.h:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+MetaConsumerDefinitions.h:

Canonical link: <a href="https://commits.webkit.org/294767@main">https://commits.webkit.org/294767@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d2edcfe177d284bed455be5f7fae9251f9cee334

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/102963 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/22637 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/12957 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/108131 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/53604 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/105002 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/22964 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/31138 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78276 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/35221 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/105969 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17781 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/92901 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58609 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/17616 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/10945 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/52961 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/87426 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/11012 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/110504 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/30100 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/22169 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/87260 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/30464 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/89105 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86890 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22123 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31735 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/9444 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/24368 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/30027 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/35349 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/29835 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/33162 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/31397 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->