### PR TITLE
Use a strong type to represent months to reduce ambiguity

### DIFF
--- a/Source/JavaScriptCore/dfg/DFGOperations.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOperations.cpp
@@ -4976,7 +4976,7 @@ JSC_DEFINE_JIT_OPERATION(operationDateGetMonth, EncodedJSValue, (VM* vmPointer, 
     const GregorianDateTime* gregorianDateTime = date->gregorianDateTime(vm.dateCache);
     if (!gregorianDateTime)
         OPERATION_RETURN(scope, JSValue::encode(jsNaN()));
-    OPERATION_RETURN(scope, JSValue::encode(jsNumber(gregorianDateTime->month())));
+    OPERATION_RETURN(scope, JSValue::encode(jsNumber(gregorianDateTime->tm_month())));
 }
 
 JSC_DEFINE_JIT_OPERATION(operationDateGetUTCMonth, EncodedJSValue, (VM* vmPointer, DateInstance* date))
@@ -4989,7 +4989,7 @@ JSC_DEFINE_JIT_OPERATION(operationDateGetUTCMonth, EncodedJSValue, (VM* vmPointe
     const GregorianDateTime* gregorianDateTime = date->gregorianDateTimeUTC(vm.dateCache);
     if (!gregorianDateTime)
         OPERATION_RETURN(scope, JSValue::encode(jsNaN()));
-    OPERATION_RETURN(scope, JSValue::encode(jsNumber(gregorianDateTime->month())));
+    OPERATION_RETURN(scope, JSValue::encode(jsNumber(gregorianDateTime->tm_month())));
 }
 
 JSC_DEFINE_JIT_OPERATION(operationDateGetDate, EncodedJSValue, (VM* vmPointer, DateInstance* date))

--- a/Source/JavaScriptCore/runtime/DateConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/DateConstructor.cpp
@@ -103,7 +103,15 @@ static inline double makeDay(double year, double month, double date)
     int32_t monthInt32 = toInt32(mm);
     if (yearInt32 != ym || monthInt32 != mm)
         return PNaN;
-    double days = dateToDaysFrom1970(yearInt32, monthInt32, 1);
+
+    yearInt32 += monthInt32 / 12;
+    monthInt32 %= 12;
+    if (monthInt32 < 0) {
+        yearInt32--;
+        monthInt32 += 12;
+    }
+
+    double days = dateToDaysFrom1970(yearInt32, WTF::Month { static_cast<unsigned>(monthInt32) + 1 }, 1);
     return days + date - 1;
 }
 

--- a/Source/JavaScriptCore/runtime/DateConversion.cpp
+++ b/Source/JavaScriptCore/runtime/DateConversion.cpp
@@ -70,9 +70,9 @@ String formatDateTime(const GregorianDateTime& t, DateTimeFormat format, bool as
         if (asUTCVariant) {
             builder.append(", "_s);
             appendNumber<2>(builder, t.monthDay());
-            builder.append(' ', WTF::monthName[t.month()]);
+            builder.append(' ', WTF::monthName(t.month()));
         } else {
-            builder.append(' ', WTF::monthName[t.month()], ' ');
+            builder.append(' ', WTF::monthName(t.month()), ' ');
             appendNumber<2>(builder, t.monthDay());
         }
         builder.append(' ');

--- a/Source/JavaScriptCore/runtime/DatePrototype.cpp
+++ b/Source/JavaScriptCore/runtime/DatePrototype.cpp
@@ -199,10 +199,21 @@ static bool fillStructuresUsingDateArgs(JSGlobalObject* globalObject, CallFrame*
     }
     // months
     if (maxArgs >= 2 && idx < numArgs) {
-        double months = callFrame->uncheckedArgument(idx++).toIntegerPreserveNaN(globalObject);
+        double monthsDouble = callFrame->uncheckedArgument(idx++).toIntegerPreserveNaN(globalObject);
         RETURN_IF_EXCEPTION(scope, false);
-        ok = ok && std::isfinite(months);
-        t->setMonth(toInt32(months));
+        ok = ok && std::isfinite(monthsDouble);
+        auto months = toInt32(monthsDouble);
+        if (months < 0 || months > 12) {
+            auto year = t->year();
+            year += months / 12;
+            months %= 12;
+            if (months < 0) {
+                year--;
+                months += 12;
+            }
+            t->setYear(year);
+        }
+        t->setMonth(WTF::Month { static_cast<unsigned>(months) + 1 });
     }
     // days
     if (idx < numArgs) {
@@ -334,7 +345,7 @@ JSC_DEFINE_HOST_FUNCTION(dateProtoFuncToISOString, (JSGlobalObject* globalObject
         ms += msPerSecond;
 
     int year = gregorianDateTime->year();
-    int month = gregorianDateTime->month() + 1;
+    auto month = gregorianDateTime->month();
     int day = gregorianDateTime->monthDay();
     int hour = gregorianDateTime->hour();
     int minute = gregorianDateTime->minute();
@@ -440,7 +451,7 @@ JSC_DEFINE_HOST_FUNCTION(dateProtoFuncGetMonth, (JSGlobalObject* globalObject, C
     const GregorianDateTime* gregorianDateTime = thisDateObj->gregorianDateTime(vm.dateCache);
     if (!gregorianDateTime)
         return JSValue::encode(jsNaN());
-    return JSValue::encode(jsNumber(gregorianDateTime->month()));
+    return JSValue::encode(jsNumber(gregorianDateTime->tm_month()));
 }
 
 JSC_DEFINE_HOST_FUNCTION(dateProtoFuncGetUTCMonth, (JSGlobalObject* globalObject, CallFrame* callFrame))
@@ -455,7 +466,7 @@ JSC_DEFINE_HOST_FUNCTION(dateProtoFuncGetUTCMonth, (JSGlobalObject* globalObject
     const GregorianDateTime* gregorianDateTime = thisDateObj->gregorianDateTimeUTC(vm.dateCache);
     if (!gregorianDateTime)
         return JSValue::encode(jsNaN());
-    return JSValue::encode(jsNumber(gregorianDateTime->month()));
+    return JSValue::encode(jsNumber(gregorianDateTime->tm_month()));
 }
 
 JSC_DEFINE_HOST_FUNCTION(dateProtoFuncGetDate, (JSGlobalObject* globalObject, CallFrame* callFrame))

--- a/Source/JavaScriptCore/runtime/ISO8601.cpp
+++ b/Source/JavaScriptCore/runtime/ISO8601.cpp
@@ -1056,15 +1056,15 @@ static std::optional<PlainDate> parseDate(StringParsingBuffer<CharacterType>& bu
     }
     // We ensured that buffer has enough length for month and day. We do not need to check length.
 
-    unsigned month = 0;
+    WTF::Month month;
     auto firstMonthCharacter = *buffer;
     if (firstMonthCharacter == '0' || firstMonthCharacter == '1') {
         buffer.advance();
         auto secondMonthCharacter = *buffer;
         if (!isASCIIDigit(secondMonthCharacter))
             return std::nullopt;
-        month = (secondMonthCharacter - '0') + 10 * (firstMonthCharacter - '0');
-        if (!month || month > 12)
+        month = WTF::Month { static_cast<unsigned>((secondMonthCharacter - '0') + 10 * (firstMonthCharacter - '0')) };
+        if (!month.ok())
             return std::nullopt;
         buffer.advance();
     } else
@@ -1243,14 +1243,14 @@ static bool isAmbiguousCalendarTime(StringParsingBuffer<CharacterType>& buffer)
     }
 
     // Any YYYY is valid, we just need to check the MM and DD.
-    unsigned month = (buffer[0] - '0') * 10 + (buffer[1] - '0');
-    if (!month || month > 12)
+    WTF::Month month { static_cast<unsigned>((buffer[0] - '0') * 10 + (buffer[1] - '0')) };
+    if (!month.ok())
         return false;
 
     buffer.advanceBy(monthPartLength);
     if (buffer.hasCharactersRemaining()) {
         unsigned day = (buffer[0] - '0') * 10 + (buffer[1] - '0');
-        if (!day || day > daysInMonth(month))
+        if (!day || day > JSC::ISO8601::daysInMonth(month))
             return false;
     }
 
@@ -1325,7 +1325,7 @@ std::optional<ExactTime> parseInstant(StringView string)
 
 uint8_t dayOfWeek(PlainDate plainDate)
 {
-    Int128 dateDays = static_cast<Int128>(dateToDaysFrom1970(plainDate.year(), plainDate.month() - 1, plainDate.day()));
+    Int128 dateDays = static_cast<Int128>(dateToDaysFrom1970(plainDate.year(), plainDate.month(), plainDate.day()));
     int weekDay = static_cast<int>((dateDays + 4) % 7);
     if (weekDay < 0)
         weekDay += 7;
@@ -1334,7 +1334,7 @@ uint8_t dayOfWeek(PlainDate plainDate)
 
 uint16_t dayOfYear(PlainDate plainDate)
 {
-    return dayInYear(plainDate.year(), plainDate.month() - 1, plainDate.day()) + 1; // Always start with 1 (1/1 is 1).
+    return dayInYear(plainDate.year(), plainDate.month(), plainDate.day()) + 1; // Always start with 1 (1/1 is 1).
 }
 
 uint8_t weekOfYear(PlainDate plainDate)
@@ -1352,7 +1352,7 @@ uint8_t weekOfYear(PlainDate plainDate)
         // > The long years, with 53 weeks in them, can be described by any of the following equivalent definitions:
         // >  - any year ending on Thursday (D, ED) and any leap year ending on Friday (DC)
 
-        int32_t dayOfWeekForJanuaryFirst = ISO8601::dayOfWeek(PlainDate { plainDate.year(), 1, 1 });
+        int32_t dayOfWeekForJanuaryFirst = ISO8601::dayOfWeek(PlainDate { plainDate.year(), WTF::January, 1 });
 
         // Any year ending on Thursday (D, ED) -> this year's 1/1 is Friday.
         if (dayOfWeekForJanuaryFirst == 5)
@@ -1374,21 +1374,16 @@ uint8_t weekOfYear(PlainDate plainDate)
     return week;
 }
 
-static constexpr uint8_t daysInMonths[2][12] = {
-    { 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31 },
-    { 31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31 }
-};
-
 // https://tc39.es/proposal-temporal/#sec-temporal-isodaysinmonth
-uint8_t daysInMonth(int32_t year, uint8_t month)
+uint8_t daysInMonth(int32_t year, WTF::Month month)
 {
-    return daysInMonths[isLeapYear(year)][month - 1];
+    return WTF::daysInMonth(month, isLeapYearEnum(year));
 }
 
-uint8_t daysInMonth(uint8_t month)
+uint8_t daysInMonth(WTF::Month month)
 {
-    constexpr unsigned isLeapYear = 1;
-    return daysInMonths[isLeapYear][month - 1];
+    // FIXME: Why does this assume leap year?
+    return WTF::daysInMonth(month, IsLeapYear::Yes);
 }
 
 // https://tc39.es/proposal-temporal/#sec-temporal-formattimezoneoffsetstring
@@ -1487,7 +1482,7 @@ String temporalDateTimeToString(PlainDate plainDate, PlainTime plainTime, std::t
     return makeString(temporalDateToString(plainDate), 'T', temporalTimeToString(plainTime, precision));
 }
 
-String monthCode(uint32_t month)
+String monthCode(WTF::Month month)
 {
     return makeString('M', pad('0', 2, month));
 }
@@ -1507,9 +1502,9 @@ uint8_t monthFromCode(StringView monthCode)
     return result;
 }
 
-ExactTime ExactTime::fromISOPartsAndOffset(int32_t year, uint8_t month, uint8_t day, unsigned hour, unsigned minute, unsigned second, unsigned millisecond, unsigned microsecond, unsigned nanosecond, int64_t offset)
+ExactTime ExactTime::fromISOPartsAndOffset(int32_t year, WTF::Month month, uint8_t day, unsigned hour, unsigned minute, unsigned second, unsigned millisecond, unsigned microsecond, unsigned nanosecond, int64_t offset)
 {
-    ASSERT(month >= 1 && month <= 12);
+    ASSERT(month.ok());
     ASSERT(day >= 1 && day <= 31);
     ASSERT(hour <= 23);
     ASSERT(minute <= 59);
@@ -1518,7 +1513,7 @@ ExactTime ExactTime::fromISOPartsAndOffset(int32_t year, uint8_t month, uint8_t 
     ASSERT(microsecond <= 999);
     ASSERT(nanosecond <= 999);
 
-    Int128 dateDays = static_cast<Int128>(dateToDaysFrom1970(year, month - 1, day));
+    Int128 dateDays = static_cast<Int128>(dateToDaysFrom1970(year, month, day));
     Int128 utcNanoseconds = dateDays * nsPerDay + hour * nsPerHour + minute * nsPerMinute + second * nsPerSecond + millisecond * nsPerMillisecond + microsecond * nsPerMicrosecond + nanosecond;
     return ExactTime { utcNanoseconds - offset };
 }
@@ -1715,7 +1710,7 @@ ExactTime ExactTime::now()
 }
 
 // https://tc39.es/proposal-temporal/#sec-temporal-isodatetimewithinlimits
-bool isDateTimeWithinLimits(int32_t year, uint8_t month, uint8_t day, unsigned hour, unsigned minute, unsigned second, unsigned millisecond, unsigned microsecond, unsigned nanosecond)
+bool isDateTimeWithinLimits(int32_t year, WTF::Month month, uint8_t day, unsigned hour, unsigned minute, unsigned second, unsigned millisecond, unsigned microsecond, unsigned nanosecond)
 {
     Int128 nanoseconds = ExactTime::fromISOPartsAndOffset(year, month, day, hour, minute, second, millisecond, microsecond, nanosecond, 0).epochNanoseconds();
     if (nanoseconds <= (ExactTime::minValue - ExactTime::nsPerDay))

--- a/Source/JavaScriptCore/runtime/ISO8601.h
+++ b/Source/JavaScriptCore/runtime/ISO8601.h
@@ -107,7 +107,8 @@ public:
     {
         return ExactTime(Int128 { epochMilliseconds } * ExactTime::nsPerMillisecond);
     }
-    static ExactTime fromISOPartsAndOffset(int32_t y, uint8_t mon, uint8_t d, unsigned h, unsigned min, unsigned s, unsigned ms, unsigned micros, unsigned ns, int64_t offset);
+
+    static ExactTime fromISOPartsAndOffset(int32_t year, WTF::Month, uint8_t day, unsigned hours, unsigned minutes, unsigned seconds, unsigned milliseconds, unsigned microseconds, unsigned nanoseconds, int64_t offset);
 
     int64_t epochMilliseconds() const
     {
@@ -211,16 +212,11 @@ static_assert(sizeof(PlainTime) <= sizeof(uint64_t));
 class PlainDate {
     WTF_MAKE_TZONE_ALLOCATED(PlainDate);
 public:
-    constexpr PlainDate()
-        : m_year(0)
-        , m_month(1)
-        , m_day(1)
-    {
-    }
+    constexpr PlainDate() = default;
 
-    constexpr PlainDate(int32_t year, unsigned month, unsigned day)
+    constexpr PlainDate(int32_t year, WTF::Month month, unsigned day)
         : m_year(year)
-        , m_month(month)
+        , m_month(static_cast<unsigned>(month))
         , m_day(day)
     {
     }
@@ -228,13 +224,14 @@ public:
     friend bool operator==(const PlainDate&, const PlainDate&) = default;
 
     int32_t year() const { return m_year; }
-    uint8_t month() const { return m_month; }
+    WTF::Month month() const { return WTF::Month { static_cast<unsigned>(m_month) }; }
+    int32_t monthInt() const { return m_month; }
     uint8_t day() const { return m_day; }
 
 private:
-    int32_t m_year : 21; // ECMAScript max / min date's year can be represented <= 20 bits.
-    int32_t m_month : 5; // Starts with 1.
-    int32_t m_day : 6; // Starts with 1.
+    int32_t m_year : 21 { 0 }; // ECMAScript max / min date's year can be represented <= 20 bits.
+    int32_t m_month : 5 { 1 }; // Starts with 1.
+    int32_t m_day : 6 { 1 }; // Starts with 1.
 };
 static_assert(sizeof(PlainDate) == sizeof(int32_t));
 
@@ -274,20 +271,20 @@ uint8_t dayOfWeek(PlainDate);
 uint16_t dayOfYear(PlainDate);
 uint8_t weeksInYear(int32_t year);
 uint8_t weekOfYear(PlainDate);
-uint8_t daysInMonth(int32_t year, uint8_t month);
-uint8_t daysInMonth(uint8_t month);
+uint8_t daysInMonth(int32_t year, WTF::Month);
+uint8_t daysInMonth(WTF::Month);
 String formatTimeZoneOffsetString(int64_t);
 String temporalTimeToString(PlainTime, std::tuple<Precision, unsigned>);
 String temporalDateToString(PlainDate);
 String temporalDateTimeToString(PlainDate, PlainTime, std::tuple<Precision, unsigned>);
-String monthCode(uint32_t);
+String monthCode(WTF::Month);
 uint8_t monthFromCode(StringView);
 
 bool isValidDuration(const Duration&);
 
 std::optional<ExactTime> parseInstant(StringView);
 
-bool isDateTimeWithinLimits(int32_t year, uint8_t month, uint8_t day, unsigned hour, unsigned minute, unsigned second, unsigned millisecond, unsigned microsecond, unsigned nanosecond);
+bool isDateTimeWithinLimits(int32_t year, WTF::Month, uint8_t day, unsigned hour, unsigned minute, unsigned second, unsigned millisecond, unsigned microsecond, unsigned nanosecond);
 bool isYearWithinLimits(double year);
 
 } // namespace ISO8601

--- a/Source/JavaScriptCore/runtime/JSDateMath.cpp
+++ b/Source/JavaScriptCore/runtime/JSDateMath.cpp
@@ -342,7 +342,7 @@ double DateCache::localTimeToMS(double milliseconds, WTF::TimeType inputTimeType
     return milliseconds;
 }
 
-std::tuple<int32_t, int32_t, int32_t> DateCache::yearMonthDayFromDaysWithCache(int32_t days)
+std::tuple<int32_t, WTF::Month, int32_t> DateCache::yearMonthDayFromDaysWithCache(int32_t days)
 {
     if (m_yearMonthDayCache) {
         // Check conservatively if the given 'days' has
@@ -351,7 +351,7 @@ std::tuple<int32_t, int32_t, int32_t> DateCache::yearMonthDayFromDaysWithCache(i
         int32_t newDay = m_yearMonthDayCache->m_day + (days - cachedDays);
         if (newDay >= 1 && newDay <= 28) {
             int32_t year = m_yearMonthDayCache->m_year;
-            int32_t month = m_yearMonthDayCache->m_month;
+            auto month = m_yearMonthDayCache->m_month;
             m_yearMonthDayCache = { days, year, month, newDay };
             return std::tuple { year, month, newDay };
         }

--- a/Source/JavaScriptCore/runtime/JSDateMath.h
+++ b/Source/JavaScriptCore/runtime/JSDateMath.h
@@ -166,7 +166,7 @@ private:
     struct YearMonthDayCache {
         int32_t m_days { 0 };
         int32_t m_year { 0 };
-        int32_t m_month { 0 };
+        WTF::Month m_month { WTF::January };
         int32_t m_day { 0 };
     };
 
@@ -187,7 +187,7 @@ private:
         return m_timeZoneCache.get();
     }
 
-    std::tuple<int32_t, int32_t, int32_t> yearMonthDayFromDaysWithCache(int32_t days);
+    std::tuple<int32_t, WTF::Month, int32_t> yearMonthDayFromDaysWithCache(int32_t days);
 
     std::unique_ptr<OpaqueICUTimeZone, OpaqueICUTimeZoneDeleter> m_timeZoneCache;
     std::array<DSTCache, 2> m_caches;

--- a/Source/JavaScriptCore/runtime/TemporalCalendar.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalCalendar.cpp
@@ -232,8 +232,9 @@ ISO8601::PlainDate TemporalCalendar::isoDateFromFields(JSGlobalObject* globalObj
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     if (overflow == TemporalOverflow::Constrain) {
-        month = std::min<unsigned>(month, 12);
-        day = std::min<unsigned>(day, ISO8601::daysInMonth(year, month));
+        auto monthUInt = std::min<unsigned>(month, 12);
+        month = monthUInt;
+        day = std::min<unsigned>(day, ISO8601::daysInMonth(year, WTF::Month { monthUInt }));
     }
 
     auto plainDate = TemporalPlainDate::toPlainDate(globalObject, ISO8601::Duration(year, month, 0, day, 0, 0, 0, 0, 0, 0));
@@ -255,7 +256,7 @@ static bool balanceISODate(double& year, double& month, double& day)
     if (!ISO8601::isYearWithinLimits(year))
         return false;
 
-    double daysFrom1970 = day + dateToDaysFrom1970(static_cast<int>(year), static_cast<int>(month - 1), 1) - 1;
+    double daysFrom1970 = day + dateToDaysFrom1970(static_cast<int>(year), WTF::Month { static_cast<unsigned>(month) }, 1) - 1;
 
     double balancedYear = std::floor(daysFrom1970 / 365.2425) + 1970;
     if (!ISO8601::isYearWithinLimits(balancedYear))
@@ -277,16 +278,16 @@ static bool balanceISODate(double& year, double& month, double& day)
     auto dayInYear = static_cast<unsigned>(daysFrom1970 - daysUntilYear + 1);
 
     unsigned daysUntilMonth = 0;
-    unsigned balancedMonth = 1;
-    for (; balancedMonth < 12; balancedMonth++) {
-        auto monthDays = balancedMonth != 2 ? ISO8601::daysInMonth(balancedMonth) : ISO8601::daysInMonth(static_cast<int>(balancedYear), balancedMonth);
+    WTF::Month balancedMonth = WTF::January;
+    for (; balancedMonth < WTF::December; ++balancedMonth) {
+        auto monthDays = balancedMonth != WTF::February ? ISO8601::daysInMonth(balancedMonth) : ISO8601::daysInMonth(static_cast<int>(balancedYear), balancedMonth);
         if (daysUntilMonth + monthDays >= dayInYear)
             break;
         daysUntilMonth += monthDays;
     }
 
     year = balancedYear;
-    month = balancedMonth;
+    month = static_cast<unsigned>(balancedMonth);
     day = dayInYear - daysUntilMonth;
     return true;
 }
@@ -301,13 +302,13 @@ ISO8601::PlainDate TemporalCalendar::isoDateAdd(JSGlobalObject* globalObject, co
     TemporalDuration::balance(balancedDuration, TemporalUnit::Day);
 
     double year = plainDate.year() + duration.years();
-    double month = plainDate.month() + duration.months();
+    double month = plainDate.monthInt() + duration.months();
     if (month < 1 || month > 12) {
         year += std::floor((month - 1) / 12);
         month = nonNegativeModulo((month - 1), 12) + 1;
     }
 
-    double daysInMonth = ISO8601::daysInMonth(year, month);
+    double daysInMonth = ISO8601::daysInMonth(year, WTF::Month { static_cast<unsigned>(month) });
     double day = plainDate.day();
     if (overflow == TemporalOverflow::Constrain)
         day = std::min<double>(day, daysInMonth);
@@ -359,7 +360,7 @@ ISO8601::Duration TemporalCalendar::isoDateDifference(JSGlobalObject* globalObje
             return { years, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
         }
 
-        double months = date2.month() - date1.month();
+        double months = date2.monthInt() - date1.monthInt();
         if (midSign != sign) {
             years -= sign;
             months += 12 * sign;
@@ -398,8 +399,8 @@ ISO8601::Duration TemporalCalendar::isoDateDifference(JSGlobalObject* globalObje
         return { years, months, 0, days, 0, 0, 0, 0, 0, 0 };
     }
 
-    double days = dateToDaysFrom1970(static_cast<int>(date2.year()), static_cast<int>(date2.month() - 1), static_cast<int>(date2.day()))
-        - dateToDaysFrom1970(static_cast<int>(date1.year()), static_cast<int>(date1.month() - 1), static_cast<int>(date1.day()));
+    double days = dateToDaysFrom1970(static_cast<int>(date2.year()), date2.month(), static_cast<int>(date2.day()))
+        - dateToDaysFrom1970(static_cast<int>(date1.year()), date1.month(), static_cast<int>(date1.day()));
 
     double weeks = 0;
     if (largestUnit == TemporalUnit::Week) {

--- a/Source/JavaScriptCore/runtime/TemporalInstant.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalInstant.cpp
@@ -400,7 +400,7 @@ String TemporalInstant::toString(ISO8601::ExactTime exactTime, JSObject* timeZon
     }
 
     builder.append(makeString(pad('0', yearLength, std::abs(gregorianDateTime.year())),
-        '-', pad('0', 2, gregorianDateTime.month() + 1),
+        '-', pad('0', 2, gregorianDateTime.month()),
         '-', pad('0', 2, gregorianDateTime.monthDay()),
         'T', pad('0', 2, gregorianDateTime.hour()),
         ':', pad('0', 2, gregorianDateTime.minute())));

--- a/Source/JavaScriptCore/runtime/TemporalPlainDate.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainDate.cpp
@@ -100,7 +100,7 @@ ISO8601::PlainDate TemporalPlainDate::toPlainDate(JSGlobalObject* globalObject, 
         throwRangeError(globalObject, scope, "month is out of range"_s);
         return { };
     }
-    unsigned month = static_cast<unsigned>(monthDouble);
+    WTF::Month month { static_cast<unsigned>(monthDouble) };
 
     double daysInMonth = ISO8601::daysInMonth(year, month);
     if (!(dayDouble >= 1 && dayDouble <= daysInMonth)) {
@@ -301,7 +301,7 @@ ISO8601::PlainDate TemporalPlainDate::with(JSGlobalObject* globalObject, JSObjec
     RETURN_IF_EXCEPTION(scope, { });
 
     double y = optionalYear.value_or(year());
-    double m = optionalMonth.value_or(month());
+    double m = optionalMonth.value_or(static_cast<unsigned>(month()));
     double d = optionalDay.value_or(day());
     RELEASE_AND_RETURN(scope, TemporalCalendar::isoDateFromFields(globalObject, y, m, d, overflow));
 }

--- a/Source/JavaScriptCore/runtime/TemporalPlainDate.h
+++ b/Source/JavaScriptCore/runtime/TemporalPlainDate.h
@@ -67,6 +67,7 @@ public:
     uint8_t dayOfWeek() const;
     uint16_t dayOfYear() const;
     uint8_t weekOfYear() const;
+    unsigned monthInt() const { return static_cast<unsigned>(month()); } // [1, 12] range.
 
     String toString(JSGlobalObject*, JSValue options) const;
     String toString() const

--- a/Source/JavaScriptCore/runtime/TemporalPlainDatePrototype.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainDatePrototype.cpp
@@ -138,7 +138,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainDatePrototypeFuncGetISOFields, (JSGlobalOb
     JSObject* fields = constructEmptyObject(globalObject);
     fields->putDirect(vm, vm.propertyNames->calendar, plainDate->calendar());
     fields->putDirect(vm, vm.propertyNames->isoDay, jsNumber(plainDate->day()));
-    fields->putDirect(vm, vm.propertyNames->isoMonth, jsNumber(plainDate->month()));
+    fields->putDirect(vm, vm.propertyNames->isoMonth, jsNumber(plainDate->monthInt()));
     fields->putDirect(vm, vm.propertyNames->isoYear, jsNumber(plainDate->year()));
     return JSValue::encode(fields);
 }
@@ -371,7 +371,7 @@ JSC_DEFINE_CUSTOM_GETTER(temporalPlainDatePrototypeGetterMonth, (JSGlobalObject*
     if (!plainDate)
         return throwVMTypeError(globalObject, scope, "Temporal.PlainDate.prototype.month called on value that's not a PlainDate"_s);
 
-    return JSValue::encode(jsNumber(plainDate->month()));
+    return JSValue::encode(jsNumber(plainDate->monthInt()));
 }
 
 JSC_DEFINE_CUSTOM_GETTER(temporalPlainDatePrototypeGetterMonthCode, (JSGlobalObject* globalObject, EncodedJSValue thisValue, PropertyName))

--- a/Source/JavaScriptCore/runtime/TemporalPlainDateTime.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainDateTime.cpp
@@ -182,7 +182,7 @@ static void incrementDay(ISO8601::Duration& duration)
     double month = duration.months();
     double day = duration.days();
 
-    double daysInMonth = ISO8601::daysInMonth(year, month);
+    double daysInMonth = ISO8601::daysInMonth(year, WTF::Month { static_cast<unsigned>(month) });
     if (day < daysInMonth) {
         duration.setDays(day + 1);
         return;
@@ -225,7 +225,7 @@ String TemporalPlainDateTime::toString(JSGlobalObject* globalObject, JSValue opt
 
     double extraDays = duration.days();
     duration.setYears(year());
-    duration.setMonths(month());
+    duration.setMonths(static_cast<unsigned>(month()));
     duration.setDays(day());
     if (extraDays) {
         ASSERT(extraDays == 1);
@@ -285,7 +285,7 @@ TemporalPlainDateTime* TemporalPlainDateTime::with(JSGlobalObject* globalObject,
     RETURN_IF_EXCEPTION(scope, { });
 
     double y = optionalYear.value_or(year());
-    double m = optionalMonth.value_or(month());
+    double m = optionalMonth.value_or(static_cast<unsigned>(month()));
     double d = optionalDay.value_or(day());
     auto plainDate = TemporalCalendar::isoDateFromFields(globalObject, y, m, d, overflow);
     RETURN_IF_EXCEPTION(scope, { });
@@ -350,7 +350,7 @@ TemporalPlainDateTime* TemporalPlainDateTime::round(JSGlobalObject* globalObject
 
     double extraDays = duration.days();
     duration.setYears(year());
-    duration.setMonths(month());
+    duration.setMonths(static_cast<unsigned>(month()));
     duration.setDays(day());
     if (extraDays) {
         ASSERT(extraDays == 1);

--- a/Source/JavaScriptCore/runtime/TemporalPlainDateTime.h
+++ b/Source/JavaScriptCore/runtime/TemporalPlainDateTime.h
@@ -72,6 +72,7 @@ public:
     uint8_t dayOfWeek() const;
     uint16_t dayOfYear() const;
     uint8_t weekOfYear() const;
+    unsigned monthInt() const { return static_cast<unsigned>(month()); } // [1, 12] range.
 
     String toString(JSGlobalObject*, JSValue options) const;
     String toString(std::tuple<Precision, unsigned> precision = { Precision::Auto, 0 }) const

--- a/Source/JavaScriptCore/runtime/TemporalPlainDateTimePrototype.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainDateTimePrototype.cpp
@@ -155,7 +155,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainDateTimePrototypeFuncGetISOFields, (JSGlob
     fields->putDirect(vm, vm.propertyNames->isoMicrosecond, jsNumber(plainDateTime->microsecond()));
     fields->putDirect(vm, vm.propertyNames->isoMillisecond, jsNumber(plainDateTime->millisecond()));
     fields->putDirect(vm, vm.propertyNames->isoMinute, jsNumber(plainDateTime->minute()));
-    fields->putDirect(vm, vm.propertyNames->isoMonth, jsNumber(plainDateTime->month()));
+    fields->putDirect(vm, vm.propertyNames->isoMonth, jsNumber(plainDateTime->monthInt()));
     fields->putDirect(vm, vm.propertyNames->isoNanosecond, jsNumber(plainDateTime->nanosecond()));
     fields->putDirect(vm, vm.propertyNames->isoSecond, jsNumber(plainDateTime->second()));
     fields->putDirect(vm, vm.propertyNames->isoYear, jsNumber(plainDateTime->year()));
@@ -404,7 +404,7 @@ JSC_DEFINE_CUSTOM_GETTER(temporalPlainDateTimePrototypeGetterMonth, (JSGlobalObj
     if (!plainDateTime)
         return throwVMTypeError(globalObject, scope, "Temporal.PlainDateTime.prototype.month called on value that's not a PlainDateTime"_s);
 
-    return JSValue::encode(jsNumber(plainDateTime->month()));
+    return JSValue::encode(jsNumber(plainDateTime->monthInt()));
 }
 
 JSC_DEFINE_CUSTOM_GETTER(temporalPlainDateTimePrototypeGetterMonthCode, (JSGlobalObject* globalObject, EncodedJSValue thisValue, PropertyName))

--- a/Source/WTF/wtf/DateMath.cpp
+++ b/Source/WTF/wtf/DateMath.cpp
@@ -102,9 +102,8 @@ static Vector<UChar>& innerTimeZoneOverride() WTF_REQUIRES_LOCK(innerTimeZoneOve
 
 /* Constants */
 
-const std::array<ASCIILiteral, 12> monthName { "Jan"_s, "Feb"_s, "Mar"_s, "Apr"_s, "May"_s, "Jun"_s, "Jul"_s, "Aug"_s, "Sep"_s, "Oct"_s, "Nov"_s, "Dec"_s };
-const std::array<ASCIILiteral, 12> monthFullName { "January"_s, "February"_s, "March"_s, "April"_s, "May"_s, "June"_s, "July"_s, "August"_s, "September"_s, "October"_s, "November"_s, "December"_s };
-
+const std::array<ASCIILiteral, 12> monthNames { "Jan"_s, "Feb"_s, "Mar"_s, "Apr"_s, "May"_s, "Jun"_s, "Jul"_s, "Aug"_s, "Sep"_s, "Oct"_s, "Nov"_s, "Dec"_s };
+const std::array<ASCIILiteral, 12> monthFullNames { "January"_s, "February"_s, "March"_s, "April"_s, "May"_s, "June"_s, "July"_s, "August"_s, "September"_s, "October"_s, "November"_s, "December"_s };
 
 ASCIILiteral weekdayName(Weekday weekday)
 {
@@ -112,16 +111,30 @@ ASCIILiteral weekdayName(Weekday weekday)
     return weekdayName[weekday.c_encoding()];
 }
 
-// Day of year for the first day of each month, where index 0 is January, and day 0 is January 1.
-// First for non-leap years, then for leap years.
-const std::array<std::array<int, 12>, 2> firstDayOfMonth {
-    std::array<int, 12> { 0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334 },
-    std::array<int, 12> { 0, 31, 60, 91, 121, 152, 182, 213, 244, 274, 305, 335 }
-};
+ASCIILiteral monthName(Month month)
+{
+    return monthNames[static_cast<unsigned>(month) - 1];
+}
 
-const std::array<int8_t, 12> daysInMonths {
-    31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31
-};
+uint16_t firstDayOfMonth(Month month, IsLeapYear isLeapYear)
+{
+    static constexpr std::array<uint16_t, 12> nonLeapYearDays { 0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334 };
+    static constexpr std::array<uint16_t, 12> leapYearDays { 0, 31, 60, 91, 121, 152, 182, 213, 244, 274, 305, 335 };
+    unsigned index = static_cast<unsigned>(month) - 1;
+    return isLeapYear == IsLeapYear::Yes ? leapYearDays[index] : nonLeapYearDays[index];
+}
+
+uint8_t daysInMonth(Month month, IsLeapYear isLeapYear)
+{
+    static constexpr std::array<uint8_t, 12> daysInMonthsNonLeapYear {
+        31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31
+    };
+    static constexpr std::array<uint8_t, 12> daysInMonthsLeapYear {
+        31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31
+    };
+    auto index = static_cast<unsigned>(month) - 1;
+    return isLeapYear == IsLeapYear::Yes ? daysInMonthsLeapYear[index] : daysInMonthsNonLeapYear[index];
+}
 
 #if !OS(WINDOWS) || HAVE(TM_GMTOFF)
 static inline void getLocalTime(const time_t* localTime, struct tm* localTM)
@@ -322,10 +335,10 @@ LocalTimeOffset calculateLocalTimeOffset(double ms, TimeType inputTimeType)
     int year = msToYear(ms);
     int equivalentYear = equivalentYearForDST(year);
     if (year != equivalentYear) {
-        bool leapYear = isLeapYear(year);
+        auto leapYear = isLeapYearEnum(year);
         int dayInYearLocal = dayInYear(ms, year);
         int dayInMonth = dayInMonthFromDayInYear(dayInYearLocal, leapYear);
-        int month = monthFromDayInYear(dayInYearLocal, leapYear);
+        auto month = monthFromDayInYear(dayInYearLocal, leapYear);
         double day = dateToDaysFrom1970(equivalentYear, month, dayInMonth);
         ms = (day * msPerDay) + msToMilliseconds(ms);
     }
@@ -359,9 +372,9 @@ void initializeDates()
     equivalentYearForDST(2000); // Need to call once to initialize a static used in this function.
 }
 
-static inline double ymdhmsToMilliseconds(int year, long mon, long day, long hour, long minute, long second, double milliseconds)
+static inline double ymdhmsToMilliseconds(int year, Month month, long day, long hour, long minute, long second, double milliseconds)
 {
-    int mday = firstDayOfMonth[isLeapYear(year)][mon - 1];
+    int mday = firstDayOfMonth(month, isLeapYearEnum(year));
     double ydays = daysFrom1970ToYear(year);
 
     double dateMilliseconds = milliseconds + second * msPerSecond + minute * (secondsPerMinute * msPerSecond) + hour * (secondsPerHour * msPerSecond) + (mday + day - 1 + ydays) * (secondsPerDay * msPerSecond);
@@ -670,7 +683,7 @@ double parseES5Date(std::span<const LChar> dateString, bool& isLocalTime)
         milliseconds = 0;
     }
         
-    return ymdhmsToMilliseconds(year, month, day, hours, minutes, seconds, milliseconds) - (timeZoneSeconds * msPerSecond);
+    return ymdhmsToMilliseconds(year, Month { static_cast<unsigned>(month) }, day, hours, minutes, seconds, milliseconds) - (timeZoneSeconds * msPerSecond);
 }
 
 // Odd case where 'exec' is allowed to be 0, to accomodate a caller in WebCore.
@@ -962,7 +975,7 @@ double parseDate(std::span<const LChar> dateString, bool& isLocalTime)
     }
     ASSERT(year);
 
-    return ymdhmsToMilliseconds(year.value(), month + 1, day, hour, minute, second, 0) - offset * (secondsPerMinute * msPerSecond);
+    return ymdhmsToMilliseconds(year.value(), Month { static_cast<unsigned>(month) + 1 }, day, hour, minute, second, 0) - offset * (secondsPerMinute * msPerSecond);
 }
 
 double parseDate(std::span<const LChar> dateString)
@@ -977,10 +990,10 @@ double parseDate(std::span<const LChar> dateString)
 }
 
 // See http://tools.ietf.org/html/rfc2822#section-3.3 for more information.
-String makeRFC2822DateString(Weekday dayOfWeek, unsigned day, unsigned month, unsigned year, unsigned hours, unsigned minutes, unsigned seconds, int utcOffset)
+String makeRFC2822DateString(Weekday dayOfWeek, unsigned day, Month month, unsigned year, unsigned hours, unsigned minutes, unsigned seconds, int utcOffset)
 {
     StringBuilder stringBuilder;
-    stringBuilder.append(weekdayName(dayOfWeek), ", "_s, day, ' ', monthName[month], ' ', year, ' ');
+    stringBuilder.append(weekdayName(dayOfWeek), ", "_s, day, ' ', monthName(month), ' ', year, ' ');
 
     appendTwoDigitNumber(stringBuilder, hours);
     stringBuilder.append(':');

--- a/Source/WTF/wtf/DateMath.h
+++ b/Source/WTF/wtf/DateMath.h
@@ -49,6 +49,7 @@
 #include <time.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/WallTime.h>
+#include <wtf/text/StringConcatenateNumbers.h>
 #include <wtf/text/WTFString.h>
 
 namespace WTF {
@@ -63,12 +64,60 @@ enum TimeType {
 // 0 is Sunday, 1 is Monday, 2 is Tuesday, ...
 class Weekday {
 public:
-    explicit Weekday(unsigned weekday)
+    constexpr explicit Weekday(unsigned weekday)
         : m_weekday(static_cast<uint8_t>(weekday == 7 ? 0 : weekday))
     { }
-    unsigned c_encoding() const { return m_weekday; }
+    constexpr unsigned c_encoding() const { return m_weekday; }
 private:
     uint8_t m_weekday;
+};
+
+// FIXME: Replace with std::chrono::month once supported by the Playstation port.
+// The API matches std::chrono::month to facilitate transition.
+// 1 is January, 2 is February, 3 is March, ...
+class Month {
+public:
+    Month() = default;
+    constexpr explicit Month(unsigned month)
+        : m_month(static_cast<uint8_t>(month))
+    { }
+    constexpr bool ok() const { return m_month >= 1 && m_month <= 12; }
+    constexpr Month& operator++()
+    {
+        ++m_month;
+        return *this;
+    }
+    constexpr Month& operator--()
+    {
+        --m_month;
+        return *this;
+    }
+    constexpr explicit operator unsigned() const { return m_month; }
+    friend constexpr std::strong_ordering operator<=>(const Month&, const Month&) = default;
+
+private:
+    uint8_t m_month;
+};
+
+inline constexpr Month January { 1 };
+inline constexpr Month February { 2 };
+inline constexpr Month March { 3 };
+inline constexpr Month April { 4 };
+inline constexpr Month May { 5 };
+inline constexpr Month June { 6 };
+inline constexpr Month July { 7 };
+inline constexpr Month August { 8 };
+inline constexpr Month September { 9 };
+inline constexpr Month October { 10 };
+inline constexpr Month November { 11 };
+inline constexpr Month December { 12 };
+
+template<>
+class StringTypeAdapter<WTF::Month> : public StringTypeAdapter<unsigned> {
+public:
+    explicit StringTypeAdapter(WTF::Month month)
+        : StringTypeAdapter<unsigned>(static_cast<unsigned>(month))
+    { }
 };
 
 struct LocalTimeOffset {
@@ -94,8 +143,8 @@ int equivalentYearForDST(int year);
 WTF_EXPORT_PRIVATE double parseES5Date(std::span<const LChar> dateString, bool& isLocalTime);
 WTF_EXPORT_PRIVATE double parseDate(std::span<const LChar> dateString);
 WTF_EXPORT_PRIVATE double parseDate(std::span<const LChar> dateString, bool& isLocalTime);
-// dayOfWeek: [0, 6] 0 being Monday, day: [1, 31], month: [0, 11], year: ex: 2011, hours: [0, 23], minutes: [0, 59], seconds: [0, 59], utcOffset: [-720,720]. 
-WTF_EXPORT_PRIVATE String makeRFC2822DateString(Weekday dayOfWeek, unsigned day, unsigned month, unsigned year, unsigned hours, unsigned minutes, unsigned seconds, int utcOffset);
+// dayOfWeek: [0, 6] 0 being Monday, day: [1, 31], month: [1, 12], year: ex: 2011, hours: [0, 23], minutes: [0, 59], seconds: [0, 59], utcOffset: [-720,720].
+WTF_EXPORT_PRIVATE String makeRFC2822DateString(Weekday, unsigned day, Month, unsigned year, unsigned hours, unsigned minutes, unsigned seconds, int utcOffset);
 
 inline double jsCurrentTime()
 {
@@ -103,12 +152,14 @@ inline double jsCurrentTime()
     return floor(WallTime::now().secondsSinceEpoch().milliseconds());
 }
 
-extern WTF_EXPORT_PRIVATE const std::array<ASCIILiteral, 12> monthName;
-extern WTF_EXPORT_PRIVATE const std::array<ASCIILiteral, 12> monthFullName;
-extern WTF_EXPORT_PRIVATE const std::array<std::array<int, 12>, 2> firstDayOfMonth;
-extern WTF_EXPORT_PRIVATE const std::array<int8_t, 12> daysInMonths;
+extern WTF_EXPORT_PRIVATE const std::array<ASCIILiteral, 12> monthNames;
+extern WTF_EXPORT_PRIVATE const std::array<ASCIILiteral, 12> monthFullNames;
+enum class IsLeapYear : bool { No, Yes };
+WTF_EXPORT_PRIVATE uint16_t firstDayOfMonth(Month, IsLeapYear);
+WTF_EXPORT_PRIVATE uint8_t daysInMonth(Month, IsLeapYear = IsLeapYear::No);
 
 WTF_EXPORT_PRIVATE ASCIILiteral weekdayName(Weekday);
+WTF_EXPORT_PRIVATE ASCIILiteral monthName(Month);
 
 static constexpr double hoursPerDay = 24.0;
 static constexpr double minutesPerHour = 60.0;
@@ -212,6 +263,11 @@ inline bool isLeapYear(int year)
     return true;
 }
 
+inline IsLeapYear isLeapYearEnum(int year)
+{
+    return isLeapYear(year) ? IsLeapYear::Yes : IsLeapYear::No;
+}
+
 inline int daysInYear(int year)
 {
     return 365 + isLeapYear(year);
@@ -235,7 +291,7 @@ inline int32_t timeInDay(Int64Milliseconds ms, int days)
     return static_cast<int32_t>(ms.value() - days * Int64Milliseconds::msPerDay);
 }
 
-inline std::tuple<int32_t, int32_t, int32_t> yearMonthDayFromDays(int32_t passedDays)
+inline std::tuple<int32_t, Month, int32_t> yearMonthDayFromDays(int32_t passedDays)
 {
     int32_t days = passedDays;
     days += Int64Milliseconds::daysOffset;
@@ -262,26 +318,27 @@ inline std::tuple<int32_t, int32_t, int32_t> yearMonthDayFromDays(int32_t passed
     days += isLeap;
 
     // Check if the date is after February.
-    int32_t month = 0;
+    Month month { January };
     int32_t day = 0;
     if (days >= 31 + 28 + (isLeap ? 1 : 0)) {
         days -= 31 + 28 + (isLeap ? 1 : 0);
         // Find the date starting from March.
-        for (int i = 2; i < 12; i++) {
-            if (days < daysInMonths[i]) {
+        for (Month i = March; i <= December; ++i) {
+            auto daysForMonth = daysInMonth(i);
+            if (days < daysForMonth) {
                 month = i;
                 day = days + 1;
                 break;
             }
-            days -= daysInMonths[i];
+            days -= daysForMonth;
         }
     } else {
         // Check January and February.
         if (days < 31) {
-            month = 0;
+            month = January;
             day = days + 1;
         } else {
-            month = 1;
+            month = February;
             day = days - 31 + 1;
         }
     }
@@ -289,17 +346,9 @@ inline std::tuple<int32_t, int32_t, int32_t> yearMonthDayFromDays(int32_t passed
     return std::tuple { year, month, day };
 }
 
-inline int32_t daysFromYearMonth(int32_t year, int32_t month)
+inline int32_t daysFromYearMonth(int32_t year, Month month)
 {
-    year += month / 12;
-    month %= 12;
-    if (month < 0) {
-        year--;
-        month += 12;
-    }
-
-    ASSERT(month >= 0);
-    ASSERT(month < 12);
+    ASSERT(month.ok());
 
     // yearDelta is an arbitrary number such that:
     // a) yearDelta = -1 (mod 400)
@@ -318,13 +367,13 @@ inline int32_t daysFromYearMonth(int32_t year, int32_t month)
     int32_t dayFromYear = 365 * year1 + year1 / 4 - year1 / 100 + year1 / 400 - baseDay;
 
     if ((year % 4 != 0) || (year % 100 == 0 && year % 400 != 0))
-        return dayFromYear + firstDayOfMonth[0][month];
-    return dayFromYear + firstDayOfMonth[1][month];
+        return dayFromYear + firstDayOfMonth(month, IsLeapYear::No);
+    return dayFromYear + firstDayOfMonth(month, IsLeapYear::Yes);
 }
 
-inline int dayInYear(int year, int month, int day)
+inline int dayInYear(int year, Month month, int day)
 {
-    return firstDayOfMonth[isLeapYear(year)][month] + day - 1;
+    return firstDayOfMonth(month, isLeapYearEnum(year)) + day - 1;
 }
 
 inline int dayInYear(double ms, int year)
@@ -334,16 +383,8 @@ inline int dayInYear(double ms, int year)
 }
 
 // Returns the number of days from 1970-01-01 to the specified date.
-inline double dateToDaysFrom1970(int year, int month, int day)
+inline double dateToDaysFrom1970(int year, Month month, int day)
 {
-    year += month / 12;
-
-    month %= 12;
-    if (month < 0) {
-        month += 12;
-        --year;
-    }
-
     double yearday = floor(daysFrom1970ToYear(year));
     ASSERT((year >= 1970 && yearday >= 0) || (year < 1970 && yearday < 0));
     return yearday + dayInYear(year, month, day);
@@ -402,38 +443,38 @@ inline Weekday weekDay(int32_t days)
     return Weekday { unsignedCast(result >= 0 ? result : result + 7) };
 }
 
-inline int monthFromDayInYear(int dayInYear, bool leapYear)
+inline Month monthFromDayInYear(int dayInYear, IsLeapYear leapYear)
 {
     const int d = dayInYear;
     int step;
 
     if (d < (step = 31))
-        return 0;
-    step += (leapYear ? 29 : 28);
+        return January;
+    step += (leapYear == IsLeapYear::Yes ? 29 : 28);
     if (d < step)
-        return 1;
+        return February;
     if (d < (step += 31))
-        return 2;
+        return March;
     if (d < (step += 30))
-        return 3;
+        return April;
     if (d < (step += 31))
-        return 4;
+        return May;
     if (d < (step += 30))
-        return 5;
+        return June;
     if (d < (step += 31))
-        return 6;
+        return July;
     if (d < (step += 31))
-        return 7;
+        return August;
     if (d < (step += 30))
-        return 8;
+        return September;
     if (d < (step += 31))
-        return 9;
+        return October;
     if (d < step + 30)
-        return 10;
-    return 11;
+        return November;
+    return December;
 }
 
-inline int dayInMonthFromDayInYear(int dayInYear, bool leapYear)
+inline int dayInMonthFromDayInYear(int dayInYear, IsLeapYear leapYear)
 {
     auto checkMonth = [] (int dayInYear, int& startDayOfThisMonth, int& startDayOfNextMonth, int daysInThisMonth) -> bool {
         startDayOfThisMonth = startDayOfNextMonth;
@@ -447,7 +488,7 @@ inline int dayInMonthFromDayInYear(int dayInYear, bool leapYear)
 
     if (d <= next)
         return d + 1;
-    const int daysInFeb = (leapYear ? 29 : 28);
+    const int daysInFeb = (leapYear == IsLeapYear::Yes ? 29 : 28);
     if (checkMonth(d, step, next, daysInFeb))
         return d - step;
     if (checkMonth(d, step, next, 31))
@@ -483,7 +524,7 @@ inline double timeToMS(double hour, double min, double sec, double ms)
 // ECMA 262 - 15.9.1.9.
 inline int32_t equivalentYear(int32_t year)
 {
-    auto weekDay = WTF::weekDay(daysFromYearMonth(year, 0));
+    auto weekDay = WTF::weekDay(daysFromYearMonth(year, January));
     int recentYear = (isLeapYear(year) ? 1956 : 1967) + (weekDay.c_encoding() * 12) % 28;
     // Find the year in the range 2008..2037 that is equivalent mod 28.
     // Add 3*28 to give a positive argument to the modulus operator.
@@ -518,6 +559,8 @@ WTF_EXPORT_PRIVATE LocalTimeOffset calculateLocalTimeOffset(double utcInMillisec
 
 } // namespace WTF
 
+using WTF::IsLeapYear;
+using WTF::LocalTimeOffset;
 using WTF::calculateLocalTimeOffset;
 using WTF::dateToDaysFrom1970;
 using WTF::dayInMonthFromDayInYear;
@@ -526,9 +569,9 @@ using WTF::daysFrom1970ToYear;
 using WTF::daysInYear;
 using WTF::getTimeZoneOverride;
 using WTF::isLeapYear;
+using WTF::isLeapYearEnum;
 using WTF::isTimeZoneValid;
 using WTF::jsCurrentTime;
-using WTF::LocalTimeOffset;
 using WTF::makeRFC2822DateString;
 using WTF::minutesPerHour;
 using WTF::monthFromDayInYear;

--- a/Source/WTF/wtf/GregorianDateTime.cpp
+++ b/Source/WTF/wtf/GregorianDateTime.cpp
@@ -79,7 +79,7 @@ void GregorianDateTime::setToCurrentLocalTime()
     }
 
     m_year = systemTime.wYear;
-    m_month = systemTime.wMonth - 1;
+    m_month = Month { systemTime.wMonth };
     m_monthDay = systemTime.wDay;
     m_yearDay = dayInYear(m_year, m_month, m_monthDay);
     m_weekDay = Weekday { systemTime.wDayOfWeek };
@@ -98,7 +98,7 @@ void GregorianDateTime::setToCurrentLocalTime()
 #endif
 
     m_year = localTM.tm_year + 1900;
-    m_month = localTM.tm_mon;
+    m_month = Month { static_cast<unsigned>(localTM.tm_mon) + 1 }; // tm_mon is in [0, 11] range.
     m_monthDay = localTM.tm_mday;
     m_yearDay = localTM.tm_yday;
     m_weekDay = Weekday { unsignedCast(localTM.tm_wday) };

--- a/Source/WTF/wtf/GregorianDateTime.h
+++ b/Source/WTF/wtf/GregorianDateTime.h
@@ -37,7 +37,7 @@ class GregorianDateTime final {
 public:
     GregorianDateTime() = default;
     WTF_EXPORT_PRIVATE explicit GregorianDateTime(double ms, LocalTimeOffset);
-    explicit GregorianDateTime(int year, int month, int yearDay, int monthDay, Weekday weekDay, int hour, int minute, int second, int utcOffsetInMinute, bool isDST)
+    explicit GregorianDateTime(int year, Month month, int yearDay, int monthDay, Weekday weekDay, int hour, int minute, int second, int utcOffsetInMinute, bool isDST)
         : m_year(year)
         , m_month(month)
         , m_yearDay(yearDay)
@@ -52,7 +52,8 @@ public:
     }
 
     inline int year() const { return m_year; }
-    inline int month() const { return m_month; }
+    inline Month month() const { return m_month; }
+    inline int tm_month() const { return static_cast<unsigned>(m_month) - 1; } // tm_mon is in [0, 11] range.
     inline int yearDay() const { return m_yearDay; }
     inline int monthDay() const { return m_monthDay; }
     inline Weekday weekDay() const { return m_weekDay; }
@@ -63,7 +64,7 @@ public:
     inline int isDST() const { return m_isDST; }
 
     inline void setYear(int year) { m_year = year; }
-    inline void setMonth(int month) { m_month = month; }
+    inline void setMonth(Month month) { m_month = month; }
     inline void setYearDay(int yearDay) { m_yearDay = yearDay; }
     inline void setMonthDay(int monthDay) { m_monthDay = monthDay; }
     inline void setWeekDay(Weekday weekDay) { m_weekDay = weekDay; }
@@ -92,7 +93,7 @@ public:
         zeroBytes(ret);
 
         ret.tm_year = m_year - 1900;
-        ret.tm_mon = m_month;
+        ret.tm_mon = tm_month();
         ret.tm_yday = m_yearDay;
         ret.tm_mday = m_monthDay;
         ret.tm_wday = m_weekDay.c_encoding();
@@ -110,7 +111,7 @@ public:
 
 private:
     int m_year { 0 };
-    int m_month { 0 };
+    Month m_month { 0 };
     int m_yearDay { 0 };
     int m_monthDay { 0 };
     Weekday m_weekDay { 0 };

--- a/Source/WebCore/html/FTPDirectoryDocument.cpp
+++ b/Source/WebCore/html/FTPDirectoryDocument.cpp
@@ -223,19 +223,20 @@ static String processFileDateString(const FTPTime& fileTime)
     now.setToCurrentLocalTime();
 
     if (fileTime.tm_year == now.year()) {
-        if (fileTime.tm_mon == now.month()) {
+        if (fileTime.tm_mon == now.tm_month()) {
             if (fileTime.tm_mday == now.monthDay())
                 return makeString("Today"_s, timeOfDay);
             if (fileTime.tm_mday == now.monthDay() - 1)
                 return makeString("Yesterday"_s, timeOfDay);
         }
         
-        if (now.monthDay() == 1 && (now.month() == fileTime.tm_mon + 1 || (now.month() == 0 && fileTime.tm_mon == 11)) &&
-            wasLastDayOfMonth(fileTime.tm_year, fileTime.tm_mon, fileTime.tm_mday))
-                return makeString("Yesterday"_s, timeOfDay);
+        if (now.monthDay() == 1 && (now.tm_month() == fileTime.tm_mon + 1 || (now.month() == WTF::January && fileTime.tm_mon == 11))
+            && wasLastDayOfMonth(fileTime.tm_year, fileTime.tm_mon, fileTime.tm_mday)) {
+            return makeString("Yesterday"_s, timeOfDay);
+        }
     }
 
-    if (fileTime.tm_year == now.year() - 1 && fileTime.tm_mon == 12 && fileTime.tm_mday == 31 && now.month() == 1 && now.monthDay() == 1)
+    if (fileTime.tm_year == now.year() - 1 && fileTime.tm_mon == 12 && fileTime.tm_mday == 31 && now.month() == WTF::February && now.monthDay() == 1)
         return makeString("Yesterday"_s, timeOfDay);
 
     static constexpr std::array months = { "Jan"_s, "Feb"_s, "Mar"_s, "Apr"_s, "May"_s, "Jun"_s, "Jul"_s, "Aug"_s, "Sep"_s, "Oct"_s, "Nov"_s, "Dec"_s, "???"_s };

--- a/Source/WebCore/html/shadow/DateTimeFieldElements.cpp
+++ b/Source/WebCore/html/shadow/DateTimeFieldElements.cpp
@@ -246,7 +246,7 @@ void DateTimeMinuteFieldElement::setValueAsDate(const DateComponents& date)
 WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(DateTimeMonthFieldElement);
 
 DateTimeMonthFieldElement::DateTimeMonthFieldElement(Document& document, DateTimeFieldElementFieldOwner& fieldOwner)
-    : DateTimeNumericFieldElement(document, fieldOwner, Range(1, 12), fieldOwner.placeholderDate().month() + 1)
+    : DateTimeNumericFieldElement(document, fieldOwner, Range(1, 12), static_cast<unsigned>(fieldOwner.placeholderDate().month()))
 {
 }
 
@@ -270,8 +270,7 @@ void DateTimeMonthFieldElement::populateDateTimeFieldsState(DateTimeFieldsState&
 
 void DateTimeMonthFieldElement::setValueAsDate(const DateComponents& date)
 {
-    // DateComponents represents months from 0 (January) to 11 (December).
-    setValueAsInteger(date.month() + 1);
+    setValueAsInteger(static_cast<unsigned>(date.month()));
 }
 
 WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(DateTimeSecondFieldElement);
@@ -307,7 +306,7 @@ void DateTimeSecondFieldElement::setValueAsDate(const DateComponents& date)
 WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(DateTimeSymbolicMonthFieldElement);
 
 DateTimeSymbolicMonthFieldElement::DateTimeSymbolicMonthFieldElement(Document& document, DateTimeFieldElementFieldOwner& fieldOwner, const Vector<String>& labels)
-    : DateTimeSymbolicFieldElement(document, fieldOwner, labels, fieldOwner.placeholderDate().month())
+    : DateTimeSymbolicFieldElement(document, fieldOwner, labels, static_cast<unsigned>(fieldOwner.placeholderDate().month()) - 1)
 {
 }
 
@@ -331,7 +330,7 @@ void DateTimeSymbolicMonthFieldElement::populateDateTimeFieldsState(DateTimeFiel
 
 void DateTimeSymbolicMonthFieldElement::setValueAsDate(const DateComponents& date)
 {
-    setValueAsInteger(date.month());
+    setValueAsInteger(static_cast<unsigned>(date.month()) - 1);
 }
 
 WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(DateTimeYearFieldElement);

--- a/Source/WebCore/platform/DateComponents.cpp
+++ b/Source/WebCore/platform/DateComponents.cpp
@@ -33,7 +33,6 @@
 
 #include <limits.h>
 #include <wtf/ASCIICType.h>
-#include <wtf/DateMath.h>
 #include <wtf/MathExtras.h>
 #include <wtf/text/MakeString.h>
 #include <wtf/text/ParsingUtilities.h>
@@ -47,18 +46,13 @@ static constexpr int minimumWeekNumber = 1;
 // HTML defines maximum week of year is 53.
 static constexpr int maximumWeekNumber = 53;
 
-static constexpr int maximumMonthInMaximumYear = 8; // This is September, since months are 0 based.
+static constexpr WTF::Month maximumMonthInMaximumYear = WTF::September;
 static constexpr int maximumDayInMaximumMonth = 13;
 static constexpr int maximumWeekInMaximumYear = 37; // The week of 275760-09-13
 
-static constexpr std::array<int, 12> daysInMonth { 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31 };
-
-// 'month' is 0-based.
-static int maxDayOfMonth(int year, int month)
+static int maxDayOfMonth(int year, WTF::Month month)
 {
-    if (month != 1) // February?
-        return daysInMonth[month];
-    return isLeapYear(year) ? 29 : 28;
+    return daysInMonth(month, isLeapYearEnum(year));
 }
 
 // 'month' is 0-based.
@@ -141,7 +135,7 @@ template<typename CharacterType> bool DateComponents::parseYear(StringParsingBuf
     return true;
 }
 
-static bool withinHTMLDateLimits(int year, int month)
+static bool withinHTMLDateLimits(int year, WTF::Month month)
 {
     if (year < DateComponents::minimumYear())
         return false;
@@ -150,7 +144,7 @@ static bool withinHTMLDateLimits(int year, int month)
     return month <= maximumMonthInMaximumYear;
 }
 
-static bool withinHTMLDateLimits(int year, int month, int monthDay)
+static bool withinHTMLDateLimits(int year, WTF::Month month, int monthDay)
 {
     if (year < DateComponents::minimumYear())
         return false;
@@ -161,7 +155,7 @@ static bool withinHTMLDateLimits(int year, int month, int monthDay)
     return monthDay <= maximumDayInMaximumMonth;
 }
 
-static bool withinHTMLDateLimits(int year, int month, int monthDay, int hour, int minute, int second, int millisecond)
+static bool withinHTMLDateLimits(int year, WTF::Month month, int monthDay, int hour, int minute, int second, int millisecond)
 {
     if (year < DateComponents::minimumYear())
         return false;
@@ -233,15 +227,15 @@ bool DateComponents::addDay(int dayDiff)
     if (day > maxDayOfMonth(m_year, m_month)) {
         day = m_monthDay;
         int year = m_year;
-        int month = m_month;
+        auto month = m_month;
         int maxDay = maxDayOfMonth(year, month);
         for (; dayDiff > 0; --dayDiff) {
             ++day;
             if (day > maxDay) {
                 day = 1;
                 ++month;
-                if (month >= 12) { // month is 0-origin.
-                    month = 0;
+                if (month > WTF::December) {
+                    month = WTF::January;
                     ++year;
                 }
                 maxDay = maxDayOfMonth(year, month);
@@ -252,15 +246,15 @@ bool DateComponents::addDay(int dayDiff)
         m_year = year;
         m_month = month;
     } else if (day < 1) {
-        int month = m_month;
+        auto month = m_month;
         int year = m_year;
         day = m_monthDay;
         for (; dayDiff < 0; ++dayDiff) {
             --day;
             if (day < 1) {
                 --month;
-                if (month < 0) {
-                    month = 11;
+                if (month < WTF::January) {
+                    month = WTF::December;
                     --year;
                 }
                 day = maxDayOfMonth(year, month);
@@ -373,15 +367,15 @@ template<typename CharacterType> bool DateComponents::parseMonth(StringParsingBu
     if (!skipExactly(buffer, '-'))
         return false;
 
-    auto month = parseIntWithinLimits(buffer, 2, 1, 12);
-    if (!month)
-        return false;
-    --*month;
-
-    if (!withinHTMLDateLimits(m_year, *month))
+    auto monthInt = parseIntWithinLimits(buffer, 2, 1, 12);
+    if (!monthInt)
         return false;
 
-    m_month = *month;
+    WTF::Month month { static_cast<unsigned>(*monthInt) };
+    if (!withinHTMLDateLimits(m_year, month))
+        return false;
+
+    m_month = month;
     m_type = DateComponentsType::Month;
     return true;
 }
@@ -586,8 +580,9 @@ bool DateComponents::setMillisecondsSinceEpochForDateInternal(double ms)
 {
     m_year = msToYear(ms);
     int yearDay = dayInYear(ms, m_year);
-    m_month = monthFromDayInYear(yearDay, isLeapYear(m_year));
-    m_monthDay = dayInMonthFromDayInYear(yearDay, isLeapYear(m_year));
+    auto isLeapYear = isLeapYearEnum(m_year);
+    m_month = monthFromDayInYear(yearDay, isLeapYear);
+    m_monthDay = dayInMonthFromDayInYear(yearDay, isLeapYear);
     return true;
 }
 
@@ -652,7 +647,7 @@ bool DateComponents::setMonthsSinceEpoch(double months)
     if (doubleYear < minimumYear() || maximumYear() < doubleYear)
         return false;
     int year = static_cast<int>(doubleYear);
-    int month = static_cast<int>(doubleMonth);
+    WTF::Month month { static_cast<unsigned>(doubleMonth) + 1 };
     if (!withinHTMLDateLimits(year, month))
         return false;
     m_year = year;
@@ -721,7 +716,7 @@ double DateComponents::millisecondsSinceEpoch() const
     case DateComponentsType::Time:
         return millisecondsSinceEpochForTime();
     case DateComponentsType::Week:
-        return (dateToDaysFrom1970(m_year, 0, 1) + offsetTo1stWeekStart(m_year) + (m_week - 1) * 7) * msPerDay;
+        return (dateToDaysFrom1970(m_year, WTF::January, 1) + offsetTo1stWeekStart(m_year) + (m_week - 1) * 7) * msPerDay;
     case DateComponentsType::Invalid:
         break;
     }
@@ -732,7 +727,7 @@ double DateComponents::millisecondsSinceEpoch() const
 double DateComponents::monthsSinceEpoch() const
 {
     ASSERT(m_type == DateComponentsType::Month);
-    return (m_year - 1970) * 12 + m_month;
+    return (m_year - 1970) * 12 + static_cast<unsigned>(m_month) - 1;
 }
 
 String DateComponents::toStringForTime(SecondFormat format) const
@@ -769,11 +764,11 @@ String DateComponents::toString(SecondFormat format) const
 {
     switch (m_type) {
     case DateComponentsType::Date:
-        return makeString(pad('0', 4, m_year), '-', pad('0', 2, m_month + 1), '-', pad('0', 2, m_monthDay));
+        return makeString(pad('0', 4, m_year), '-', pad('0', 2, m_month), '-', pad('0', 2, m_monthDay));
     case DateComponentsType::DateTimeLocal:
-        return makeString(pad('0', 4, m_year), '-', pad('0', 2, m_month + 1), '-', pad('0', 2, m_monthDay), 'T', toStringForTime(format));
+        return makeString(pad('0', 4, m_year), '-', pad('0', 2, m_month), '-', pad('0', 2, m_monthDay), 'T', toStringForTime(format));
     case DateComponentsType::Month:
-        return makeString(pad('0', 4, m_year), '-', pad('0', 2, m_month + 1));
+        return makeString(pad('0', 4, m_year), '-', pad('0', 2, m_month));
     case DateComponentsType::Time:
         return toStringForTime(format);
     case DateComponentsType::Week:

--- a/Source/WebCore/platform/DateComponents.h
+++ b/Source/WebCore/platform/DateComponents.h
@@ -32,6 +32,7 @@
 
 #include <optional>
 #include <unicode/utypes.h>
+#include <wtf/DateMath.h>
 #include <wtf/Forward.h>
 
 namespace WebCore {
@@ -59,25 +60,14 @@ enum class DateComponentsType : uint8_t {
 // * DateTime or DateTimeLocal type: year-month-day hour-minute-second-millisecond
 class DateComponents {
 public:
-    DateComponents()
-        : m_millisecond(0)
-        , m_second(0)
-        , m_minute(0)
-        , m_hour(0)
-        , m_monthDay(0)
-        , m_month(0)
-        , m_year(0)
-        , m_week(0)
-        , m_type(DateComponentsType::Invalid)
-    {
-    }
+    DateComponents() = default;
 
     int millisecond() const { return m_millisecond; }
     int second() const { return m_second; }
     int minute() const { return m_minute; }
     int hour() const { return m_hour; }
     int monthDay() const { return m_monthDay; }
-    int month() const { return m_month; }
+    WTF::Month month() const { return m_month; }
     int fullYear() const { return m_year; }
     int week() const { return m_week; }
     DateComponentsType type() const { return m_type; }
@@ -192,16 +182,16 @@ private:
         Saturday,
     };
 
-    int m_millisecond; // 0 - 999
-    int m_second;
-    int m_minute;
-    int m_hour;
-    int m_monthDay; // 1 - 31
-    int m_month; // 0:January - 11:December
-    int m_year; //  1582 -
-    int m_week; // 1 - 53
+    int m_millisecond { 0 }; // 0 - 999
+    int m_second { 0 };
+    int m_minute { 0 };
+    int m_hour { 0 };
+    int m_monthDay { 1 }; // 1 - 31
+    WTF::Month m_month { 1 }; // 1: January - 12: December
+    int m_year { 0 }; //  1582 -
+    int m_week { 0 }; // 1 - 53
 
-    DateComponentsType m_type;
+    DateComponentsType m_type { DateComponentsType::Invalid };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/network/soup/CookieSoup.cpp
+++ b/Source/WebCore/platform/network/soup/CookieSoup.cpp
@@ -89,7 +89,7 @@ static SoupDate* msToSoupDate(double ms)
 {
     int year = msToYear(ms);
     int dayOfYear = dayInYear(ms, year);
-    bool leapYear = isLeapYear(year);
+    auto leapYear = isLeapYearEnum(year);
 
     // monthFromDayInYear() returns a value in the [0,11] range, while soup_date_new() expects
     // a value in the [1,12] range, meaning we have to manually adjust the month value.

--- a/Source/WebCore/platform/text/LocaleICU.cpp
+++ b/Source/WebCore/platform/text/LocaleICU.cpp
@@ -211,7 +211,7 @@ std::unique_ptr<Vector<String>> LocaleICU::createLabelVector(const UDateFormat* 
 
 static std::unique_ptr<Vector<String>> createFallbackMonthLabels()
 {
-    return makeUnique<Vector<String>>(std::span { WTF::monthFullName });
+    return makeUnique<Vector<String>>(std::span { WTF::monthFullNames });
 }
 
 const Vector<String>& LocaleICU::monthLabels()
@@ -346,9 +346,7 @@ const Vector<String>& LocaleICU::shortMonthLabels()
             return m_shortMonthLabels;
         }
     }
-    m_shortMonthLabels.reserveCapacity(std::size(WTF::monthName));
-    for (unsigned i = 0; i < std::size(WTF::monthName); ++i)
-        m_shortMonthLabels.append(WTF::monthName[i]);
+    m_shortMonthLabels = std::span { WTF::monthNames };
     return m_shortMonthLabels;
 }
 

--- a/Source/WebCore/platform/text/LocaleNone.cpp
+++ b/Source/WebCore/platform/text/LocaleNone.cpp
@@ -68,7 +68,7 @@ const Vector<String>& LocaleNone::monthLabels()
 {
     if (!m_monthLabels.isEmpty())
         return m_monthLabels;
-    m_monthLabels = { WTF::monthFullName, std::size(WTF::monthFullName) };
+    m_monthLabels = std::span { WTF::monthFullNames };
     return m_monthLabels;
 }
 
@@ -111,7 +111,7 @@ const Vector<String>& LocaleNone::shortMonthLabels()
 {
     if (!m_shortMonthLabels.isEmpty())
         return m_shortMonthLabels;
-    m_shortMonthLabels = { WTF::monthName, std::size(WTF::monthName) };
+    m_shortMonthLabels = std::span { WTF::monthNames };
     return m_shortMonthLabels;
 }
 

--- a/Source/WebCore/platform/text/PlatformLocale.cpp
+++ b/Source/WebCore/platform/text/PlatformLocale.cpp
@@ -58,6 +58,7 @@ private:
 
     String zeroPadString(const String&, size_t width);
     void appendNumber(int number, size_t width);
+    void appendMonth(WTF::Month month, size_t width) { appendNumber(static_cast<unsigned>(month), width); }
 
     StringBuilder m_builder;
     Locale& m_localizer;
@@ -101,26 +102,30 @@ void DateTimeStringBuilder::visitField(DateTimeFormat::FieldType fieldType, int 
         // Always use padding width of 4 so it matches DateTimeEditElement.
         appendNumber(m_date.fullYear(), 4);
         return;
-    case DateTimeFormat::FieldTypeMonth:
+    case DateTimeFormat::FieldTypeMonth: {
+        auto monthIndex = static_cast<unsigned>(m_date.month()) - 1;
         if (numberOfPatternCharacters == 3)
-            m_builder.append(m_localizer.shortMonthLabels()[m_date.month()]);
+            m_builder.append(m_localizer.shortMonthLabels()[monthIndex]);
         else if (numberOfPatternCharacters == 4)
-            m_builder.append(m_localizer.monthLabels()[m_date.month()]);
+            m_builder.append(m_localizer.monthLabels()[monthIndex]);
         else {
             // Always use padding width of 2 so it matches DateTimeEditElement.
-            appendNumber(m_date.month() + 1, 2);
+            appendMonth(m_date.month(), 2);
         }
         return;
-    case DateTimeFormat::FieldTypeMonthStandAlone:
+    }
+    case DateTimeFormat::FieldTypeMonthStandAlone: {
+        auto monthIndex = static_cast<unsigned>(m_date.month()) - 1;
         if (numberOfPatternCharacters == 3)
-            m_builder.append(m_localizer.shortStandAloneMonthLabels()[m_date.month()]);
+            m_builder.append(m_localizer.shortStandAloneMonthLabels()[monthIndex]);
         else if (numberOfPatternCharacters == 4)
-            m_builder.append(m_localizer.standAloneMonthLabels()[m_date.month()]);
+            m_builder.append(m_localizer.standAloneMonthLabels()[monthIndex]);
         else {
             // Always use padding width of 2 so it matches DateTimeEditElement.
-            appendNumber(m_date.month() + 1, 2);
+            appendMonth(m_date.month(), 2);
         }
         return;
+    }
     case DateTimeFormat::FieldTypeDayOfMonth:
         // Always use padding width of 2 so it matches DateTimeEditElement.
         appendNumber(m_date.monthDay(), 2);

--- a/Source/WebCore/platform/text/cocoa/LocaleCocoa.mm
+++ b/Source/WebCore/platform/text/cocoa/LocaleCocoa.mm
@@ -126,7 +126,7 @@ const Vector<String>& LocaleCocoa::monthLabels()
         m_monthLabels = makeVector<String>(array);
         return m_monthLabels;
     }
-    m_monthLabels = std::span { WTF::monthFullName };
+    m_monthLabels = std::span { WTF::monthFullNames };
     return m_monthLabels;
 }
 
@@ -229,7 +229,7 @@ const Vector<String>& LocaleCocoa::shortMonthLabels()
         m_shortMonthLabels = makeVector<String>(array);
         return m_shortMonthLabels;
     }
-    m_shortMonthLabels = std::span { WTF::monthName };
+    m_shortMonthLabels = std::span { WTF::monthNames };
     return m_shortMonthLabels;
 }
 

--- a/Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.cpp
+++ b/Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.cpp
@@ -292,8 +292,9 @@ OperatingDate OperatingDate::fromWallTime(WallTime time)
     double ms = time.secondsSinceEpoch().milliseconds();
     int year = msToYear(ms);
     int yearDay = dayInYear(ms, year);
-    int month = monthFromDayInYear(yearDay, isLeapYear(year));
-    int monthDay = dayInMonthFromDayInYear(yearDay, isLeapYear(year));
+    auto isLeapYear = isLeapYearEnum(year);
+    auto month = monthFromDayInYear(yearDay, isLeapYear);
+    int monthDay = dayInMonthFromDayInYear(yearDay, isLeapYear);
     return OperatingDate { year, month, monthDay };
 }
 
@@ -3251,7 +3252,7 @@ void ResourceLoadStatisticsStore::includeTodayAsOperatingDateIfNecessary()
     auto insertOperatingDateStatement = m_database.prepareStatement("INSERT OR IGNORE INTO OperatingDates (year, month, monthDay) SELECT ?, ?, ?;"_s);
     if (!insertOperatingDateStatement
         || insertOperatingDateStatement->bindInt(1, today.year()) != SQLITE_OK
-        || insertOperatingDateStatement->bindInt(2, today.month()) != SQLITE_OK
+        || insertOperatingDateStatement->bindInt(2, today.monthIntForDatabase()) != SQLITE_OK
         || insertOperatingDateStatement->bindInt(3, today.monthDay()) != SQLITE_OK
         || insertOperatingDateStatement->step() != SQLITE_DONE) {
         ITP_RELEASE_LOG_DATABASE_ERROR("includeTodayAsOperatingDateIfNecessary: failed to step insertOperatingDateStatement");
@@ -3303,7 +3304,7 @@ void ResourceLoadStatisticsStore::insertExpiredStatisticForTesting(const Registr
         auto insertOperatingDateStatement = m_database.prepareStatement("INSERT OR IGNORE INTO OperatingDates (year, month, monthDay) SELECT ?, ?, ?;"_s);
         if (!insertOperatingDateStatement
             || insertOperatingDateStatement->bindInt(1, dateToInsert.year()) != SQLITE_OK
-            || insertOperatingDateStatement->bindInt(2, dateToInsert.month()) != SQLITE_OK
+            || insertOperatingDateStatement->bindInt(2, dateToInsert.monthIntForDatabase()) != SQLITE_OK
             || insertOperatingDateStatement->bindInt(3, dateToInsert.monthDay()) != SQLITE_OK
             || insertOperatingDateStatement->step() != SQLITE_DONE) {
             ITP_RELEASE_LOG_DATABASE_ERROR("insertExpiredStatisticForTesting: failed to step insertOperatingDateStatement");

--- a/Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.h
+++ b/Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.h
@@ -62,21 +62,27 @@ public:
     static OperatingDate today(Seconds timeAdvanceForTesting);
     Seconds secondsSinceEpoch() const;
     int year() const { return m_year; }
-    int month() const { return m_month; }
+    WTF::Month month() const { return m_month; }
+    int monthIntForDatabase() const { return static_cast<unsigned>(m_month) - 1; } // [0, 11] range.
     int monthDay() const { return m_monthDay; }
 
     friend bool operator==(const OperatingDate&, const OperatingDate&) = default;
     friend auto operator<=>(const OperatingDate& a, const OperatingDate& b) { return a.secondsSinceEpoch() <=> b.secondsSinceEpoch(); }
     
-    OperatingDate(int year, int month, int monthDay)
+    OperatingDate(int year, WTF::Month month, int monthDay)
         : m_year(year)
         , m_month(month)
         , m_monthDay(monthDay)
     { }
 
+    // databaseMonth is in [0, 11] range.
+    OperatingDate(int year, int databaseMonth, int monthDay)
+        : OperatingDate(year, WTF::Month { static_cast<unsigned>(databaseMonth) + 1 }, monthDay)
+    { }
+
 private:
     int m_year { 0 };
-    int m_month { 0 }; // [0, 11].
+    WTF::Month m_month { WTF::January };
     int m_monthDay { 0 }; // [1, 31].
 };
 

--- a/Tools/TestWebKitAPI/Tests/WTF/DateMath.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/DateMath.cpp
@@ -36,10 +36,10 @@ namespace TestWebKitAPI {
 
 TEST(WTF_DateMath, dateToDaysFrom1970)
 {
-    EXPECT_EQ(0.0, dateToDaysFrom1970(1970, 0, 1));
-    EXPECT_EQ(157.0, dateToDaysFrom1970(1970, 5, 7));
-    EXPECT_EQ(-145.0, dateToDaysFrom1970(1969, 7, 9));
-    EXPECT_EQ(16322, dateToDaysFrom1970(2014, 8, 9));
+    EXPECT_EQ(0.0, dateToDaysFrom1970(1970, WTF::January, 1));
+    EXPECT_EQ(157.0, dateToDaysFrom1970(1970, WTF::June, 7));
+    EXPECT_EQ(-145.0, dateToDaysFrom1970(1969, WTF::August, 9));
+    EXPECT_EQ(16322, dateToDaysFrom1970(2014, WTF::September, 9));
 }
 
 
@@ -100,37 +100,37 @@ TEST(WTF_DateMath, msToHours)
 
 TEST(WTF_DateMath, dayInYear)
 {
-    EXPECT_EQ(59, dayInYear(2015, 2, 1));
-    EXPECT_EQ(60, dayInYear(2012, 2, 1));
-    EXPECT_EQ(0, dayInYear(2015, 0, 1));
-    EXPECT_EQ(31, dayInYear(2015, 1, 1));
+    EXPECT_EQ(59, dayInYear(2015, WTF::March, 1));
+    EXPECT_EQ(60, dayInYear(2012, WTF::March, 1));
+    EXPECT_EQ(0, dayInYear(2015, WTF::January, 1));
+    EXPECT_EQ(31, dayInYear(2015, WTF::February, 1));
 }
 
 TEST(WTF_DateMath, monthFromDayInYear)
 {
-    EXPECT_EQ(2, monthFromDayInYear(59, false));
-    EXPECT_EQ(1, monthFromDayInYear(59, true));
-    EXPECT_EQ(2, monthFromDayInYear(60, true));
-    EXPECT_EQ(0, monthFromDayInYear(0, false));
-    EXPECT_EQ(0, monthFromDayInYear(0, true));
-    EXPECT_EQ(1, monthFromDayInYear(31, true));
-    EXPECT_EQ(1, monthFromDayInYear(31, false));
+    EXPECT_EQ(WTF::March, monthFromDayInYear(59, WTF::IsLeapYear::No));
+    EXPECT_EQ(WTF::February, monthFromDayInYear(59, WTF::IsLeapYear::Yes));
+    EXPECT_EQ(WTF::March, monthFromDayInYear(60, WTF::IsLeapYear::Yes));
+    EXPECT_EQ(WTF::January, monthFromDayInYear(0, WTF::IsLeapYear::No));
+    EXPECT_EQ(WTF::January, monthFromDayInYear(0, WTF::IsLeapYear::Yes));
+    EXPECT_EQ(WTF::February, monthFromDayInYear(31, WTF::IsLeapYear::Yes));
+    EXPECT_EQ(WTF::February, monthFromDayInYear(31, WTF::IsLeapYear::No));
 }
 
 TEST(WTF_DateMath, dayInMonthFromDayInYear)
 {
-    EXPECT_EQ(1, dayInMonthFromDayInYear(0, false));
-    EXPECT_EQ(1, dayInMonthFromDayInYear(0, true));
-    EXPECT_EQ(1, dayInMonthFromDayInYear(59, false));
-    EXPECT_EQ(29, dayInMonthFromDayInYear(59, true));
-    EXPECT_EQ(1, dayInMonthFromDayInYear(60, true));
-    EXPECT_EQ(1, dayInMonthFromDayInYear(0, false));
-    EXPECT_EQ(1, dayInMonthFromDayInYear(0, true));
-    EXPECT_EQ(31, dayInMonthFromDayInYear(30, true));
-    EXPECT_EQ(31, dayInMonthFromDayInYear(30, false));
-    EXPECT_EQ(31, dayInMonthFromDayInYear(365, true));
-    EXPECT_EQ(32, dayInMonthFromDayInYear(365, false));
-    EXPECT_EQ(32, dayInMonthFromDayInYear(366, true));
+    EXPECT_EQ(1, dayInMonthFromDayInYear(0, WTF::IsLeapYear::No));
+    EXPECT_EQ(1, dayInMonthFromDayInYear(0, WTF::IsLeapYear::Yes));
+    EXPECT_EQ(1, dayInMonthFromDayInYear(59, WTF::IsLeapYear::No));
+    EXPECT_EQ(29, dayInMonthFromDayInYear(59, WTF::IsLeapYear::Yes));
+    EXPECT_EQ(1, dayInMonthFromDayInYear(60, WTF::IsLeapYear::Yes));
+    EXPECT_EQ(1, dayInMonthFromDayInYear(0, WTF::IsLeapYear::No));
+    EXPECT_EQ(1, dayInMonthFromDayInYear(0, WTF::IsLeapYear::Yes));
+    EXPECT_EQ(31, dayInMonthFromDayInYear(30, WTF::IsLeapYear::Yes));
+    EXPECT_EQ(31, dayInMonthFromDayInYear(30, WTF::IsLeapYear::No));
+    EXPECT_EQ(31, dayInMonthFromDayInYear(365, WTF::IsLeapYear::Yes));
+    EXPECT_EQ(32, dayInMonthFromDayInYear(365, WTF::IsLeapYear::No));
+    EXPECT_EQ(32, dayInMonthFromDayInYear(366, WTF::IsLeapYear::Yes));
 }
 
 static bool isPacificTimeZone()


### PR DESCRIPTION
#### 692ea7ec0424116e60fcd13e5504a1b6232321f4
<pre>
Use a strong type to represent months to reduce ambiguity
<a href="https://bugs.webkit.org/show_bug.cgi?id=292816">https://bugs.webkit.org/show_bug.cgi?id=292816</a>

Reviewed by NOBODY (OOPS!).

Use a strong type to represent months to reduce ambiguity.
We used to use an integer, sometimes in the [0, 11] range,
sometimes a [1, 12] range.

Using WTF::Month for now, until std::chrono::month becomes available
on the Playstation port.

* Source/JavaScriptCore/dfg/DFGOperations.cpp:
(JSC::DFG::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/runtime/DateConstructor.cpp:
(JSC::makeDay):
* Source/JavaScriptCore/runtime/DateConversion.cpp:
(JSC::formatDateTime):
* Source/JavaScriptCore/runtime/DatePrototype.cpp:
(JSC::fillStructuresUsingDateArgs):
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/ISO8601.cpp:
(JSC::ISO8601::dayOfWeek):
(JSC::ISO8601::dayOfYear):
(JSC::ISO8601::weekOfYear):
(JSC::ISO8601::daysInMonth):
(JSC::ISO8601::ExactTime::fromISOPartsAndOffset):
* Source/JavaScriptCore/runtime/ISO8601.h:
* Source/JavaScriptCore/runtime/JSDateMath.cpp:
(JSC::DateCache::yearMonthDayFromDaysWithCache):
* Source/JavaScriptCore/runtime/JSDateMath.h:
* Source/JavaScriptCore/runtime/TemporalCalendar.cpp:
(JSC::balanceISODate):
(JSC::TemporalCalendar::isoDateDifference):
* Source/JavaScriptCore/runtime/TemporalInstant.cpp:
* Source/JavaScriptCore/runtime/TemporalPlainDatePrototype.cpp:
(JSC::JSC_DEFINE_CUSTOM_GETTER):
* Source/JavaScriptCore/runtime/TemporalPlainDateTimePrototype.cpp:
(JSC::JSC_DEFINE_CUSTOM_GETTER):
* Source/WTF/wtf/DateMath.cpp:
(WTF::monthName):
(WTF::firstDayOfMonth):
(WTF::daysInMonth):
(WTF::calculateLocalTimeOffset):
(WTF::ymdhmsToMilliseconds):
(WTF::parseES5Date):
(WTF::parseDate):
(WTF::makeRFC2822DateString):
* Source/WTF/wtf/DateMath.h:
(WTF::Weekday::Weekday):
(WTF::Weekday::c_encoding const):
(WTF::Month::Month):
(WTF::Month::operator++):
(WTF::Month::operator--):
(WTF::Month::operator unsigned const):
(WTF::isLeapYear):
(WTF::daysInYear):
(WTF::yearMonthDayFromDays):
(WTF::daysFromYearMonth):
(WTF::dayInYear):
(WTF::dateToDaysFrom1970):
(WTF::monthFromDayInYear):
(WTF::dayInMonthFromDayInYear):
(WTF::equivalentYear):
* Source/WTF/wtf/GregorianDateTime.cpp:
(WTF::GregorianDateTime::setToCurrentLocalTime):
* Source/WTF/wtf/GregorianDateTime.h:
* Source/WebCore/html/FTPDirectoryDocument.cpp:
(WebCore::processFileDateString):
* Source/WebCore/html/shadow/DateTimeFieldElements.cpp:
(WebCore::DateTimeMonthFieldElement::DateTimeMonthFieldElement):
(WebCore::DateTimeMonthFieldElement::setValueAsDate):
(WebCore::DateTimeSymbolicMonthFieldElement::DateTimeSymbolicMonthFieldElement):
(WebCore::DateTimeSymbolicMonthFieldElement::setValueAsDate):
* Source/WebCore/platform/DateComponents.cpp:
(WebCore::maxDayOfMonth):
(WebCore::DateComponents::maxWeekNumberInYear const):
(WebCore::withinHTMLDateLimits):
(WebCore::DateComponents::addDay):
(WebCore::DateComponents::parseMonth):
(WebCore::DateComponents::setMillisecondsSinceEpochForDateInternal):
(WebCore::DateComponents::setMonthsSinceEpoch):
(WebCore::DateComponents::millisecondsSinceEpoch const):
(WebCore::DateComponents::monthsSinceEpoch const):
(WebCore::DateComponents::toString const):
(): Deleted.
* Source/WebCore/platform/DateComponents.h:
(WebCore::DateComponents::month const):
(WebCore::DateComponents::DateComponents): Deleted.
* Source/WebCore/platform/network/soup/CookieSoup.cpp:
(WebCore::msToSoupDate):
* Source/WebCore/platform/text/LocaleICU.cpp:
(WebCore::createFallbackMonthLabels):
(WebCore::LocaleICU::shortMonthLabels):
* Source/WebCore/platform/text/LocaleNone.cpp:
(WebCore::LocaleNone::monthLabels):
(WebCore::LocaleNone::shortMonthLabels):
* Source/WebCore/platform/text/PlatformLocale.cpp:
(WebCore::DateTimeStringBuilder::visitField):
* Source/WebCore/platform/text/cocoa/LocaleCocoa.mm:
(WebCore::LocaleCocoa::monthLabels):
(WebCore::LocaleCocoa::shortMonthLabels):
* Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.cpp:
(WebKit::OperatingDate::fromWallTime):
(WebKit::ResourceLoadStatisticsStore::updateOperatingDatesParameters):
(WebKit::ResourceLoadStatisticsStore::includeTodayAsOperatingDateIfNecessary):
(WebKit::ResourceLoadStatisticsStore::insertExpiredStatisticForTesting):
* Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.h:
(WebKit::OperatingDate::month const):
(WebKit::OperatingDate::monthInt const):
(WebKit::OperatingDate::OperatingDate):
* Tools/TestWebKitAPI/Tests/WTF/DateMath.cpp:
(TestWebKitAPI::TEST(WTF_DateMath, dateToDaysFrom1970)):
(TestWebKitAPI::TEST(WTF_DateMath, isLeapYear)):
(TestWebKitAPI::TEST(WTF_DateMath, dayInYear)):
(TestWebKitAPI::TEST(WTF_DateMath, monthFromDayInYear)):
(TestWebKitAPI::TEST(WTF_DateMath, dayInMonthFromDayInYear)):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/692ea7ec0424116e60fcd13e5504a1b6232321f4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/103030 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/22705 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/13024 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/108198 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/53673 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/105069 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/23033 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/31205 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78327 "Found 1 new test failure: js/date-constructor.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/35272 "Found 1 new test failure: js/date-constructor.html (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/106036 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17846 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/92964 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58661 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/17685 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/11004 "Found 1 new test failure: js/date-constructor.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/53028 "Built successfully") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/95705 "Found 61 jsc stress test failures: jsc-layout-tests.yaml/js/script-tests/date-constructor.js.layout, jsc-layout-tests.yaml/js/script-tests/date-constructor.js.layout-dfg-eager-no-cjit, jsc-layout-tests.yaml/js/script-tests/date-constructor.js.layout-ftl-eager-no-cjit, jsc-layout-tests.yaml/js/script-tests/date-constructor.js.layout-ftl-no-cjit, jsc-layout-tests.yaml/js/script-tests/date-constructor.js.layout-no-cjit ...") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/87496 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/11071 "Found 2 new test failures: fast/forms/month/input-valueasnumber-month.html js/date-constructor.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/110571 "Built successfully") | 
| [❌ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/101641 "Found 61 new JSC stress test failures: jsc-layout-tests.yaml/js/script-tests/date-constructor.js.layout, jsc-layout-tests.yaml/js/script-tests/date-constructor.js.layout-dfg-eager-no-cjit, jsc-layout-tests.yaml/js/script-tests/date-constructor.js.layout-ftl-eager-no-cjit, jsc-layout-tests.yaml/js/script-tests/date-constructor.js.layout-ftl-no-cjit, jsc-layout-tests.yaml/js/script-tests/date-constructor.js.layout-no-cjit, jsc-layout-tests.yaml/js/script-tests/date-constructor.js.layout-no-ftl, jsc-layout-tests.yaml/js/script-tests/date-constructor.js.layout-no-llint, mozilla-tests.yaml/ecma/Date/15.9.3.1-1.js.mozilla-dfg-eager-no-cjit-validate-phases, mozilla-tests.yaml/ecma/Date/15.9.3.1-1.js.mozilla-ftl-eager-no-cjit-validate-phases, mozilla-tests.yaml/ecma/Date/15.9.5.25-1.js.mozilla-dfg-eager-no-cjit-validate-phases ... (failure)") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/30167 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/22228 "Found 2 new test failures: fast/forms/month/input-valueasnumber-month.html js/date-constructor.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/87314 "Found 2 new test failures: fast/forms/month/input-valueasnumber-month.html js/date-constructor.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/30532 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/89164 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86938 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31787 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/9503 "Found 2 new test failures: fast/forms/month/input-valueasnumber-month.html js/date-constructor.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/24462 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/30094 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/35416 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/125274 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/29902 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34751 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/33229 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/31464 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->