### PR TITLE
[Viewport Clipping] Disable fixed-position viewport clipping in element fullscreen

### DIFF
--- a/LayoutTests/fullscreen/full-screen-disables-viewport-clipping-expected.html
+++ b/LayoutTests/fullscreen/full-screen-disables-viewport-clipping-expected.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=false ] -->
+<html>
+<head>
+<script src="../resources/ui-helper.js"></script>
+<style>
+#target {
+    width: 100px;
+    height: 100px;
+    background-color: darkgray;
+}
+
+pre {
+    font-size: 10px;
+}
+</style>
+<script>
+window.testRunner?.waitUntilDone();
+
+async function waitForFullScreenChange(performActions) {
+    await new Promise(resolve => {
+        addEventListener("fullscreenchange", resolve, { once: true });
+        performActions();
+    });
+}
+
+addEventListener("load", async () => {
+    await UIHelper.setObscuredInsets(50, 0, 0, 0);
+    await UIHelper.ensurePresentationUpdate();
+    await waitForFullScreenChange(() => {
+        internals.withUserGesture(() => document.getElementById("target").requestFullscreen());
+    });
+
+    const options = internals.LAYER_TREE_INCLUDES_CLIPPING | internals.LAYER_TREE_INCLUDES_CONTENT_LAYERS;
+    document.getElementById("output").innerText = internals.layerTreeAsText(document, options);
+
+    await waitForFullScreenChange(() => document.webkitExitFullscreen());
+    window.testRunner?.notifyDone();
+});
+</script>
+</head>
+<body>
+    <pre id="output"></pre>
+    <div id="target"></div>
+</body>
+</html>

--- a/LayoutTests/fullscreen/full-screen-disables-viewport-clipping.html
+++ b/LayoutTests/fullscreen/full-screen-disables-viewport-clipping.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true ] -->
+<html>
+<head>
+<script src="../resources/ui-helper.js"></script>
+<style>
+#target {
+    width: 100px;
+    height: 100px;
+    background-color: darkgray;
+}
+
+pre {
+    font-size: 10px;
+}
+</style>
+<script>
+window.testRunner?.waitUntilDone();
+
+async function waitForFullScreenChange(performActions) {
+    await new Promise(resolve => {
+        addEventListener("fullscreenchange", resolve, { once: true });
+        performActions();
+    });
+}
+
+addEventListener("load", async () => {
+    await UIHelper.setObscuredInsets(50, 0, 0, 0);
+    await UIHelper.ensurePresentationUpdate();
+    await waitForFullScreenChange(() => {
+        internals.withUserGesture(() => document.getElementById("target").requestFullscreen());
+    });
+
+    const options = internals.LAYER_TREE_INCLUDES_CLIPPING | internals.LAYER_TREE_INCLUDES_CONTENT_LAYERS;
+    document.getElementById("output").innerText = internals.layerTreeAsText(document, options);
+
+    await waitForFullScreenChange(() => document.webkitExitFullscreen());
+    window.testRunner?.notifyDone();
+});
+</script>
+</head>
+<body>
+    <pre id="output"></pre>
+    <div id="target"></div>
+</body>
+</html>

--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -4200,6 +4200,11 @@ ViewportConstrainedSublayers RenderLayerCompositor::viewportConstrainedSublayers
         if (compositingAncestor != m_renderView.layer())
             return Anchor;
 
+#if ENABLE(FULLSCREEN_API)
+        if (RefPtr fullscreen = m_renderView.document().fullscreenIfExists(); fullscreen && fullscreen->isFullscreen())
+            return Anchor;
+#endif
+
         return ClippingAndAnchor;
     };
 


### PR DESCRIPTION
#### 2f4ece1e291d102695ddfa420552982a25d55a9e
<pre>
[Viewport Clipping] Disable fixed-position viewport clipping in element fullscreen
<a href="https://bugs.webkit.org/show_bug.cgi?id=292826">https://bugs.webkit.org/show_bug.cgi?id=292826</a>
<a href="https://rdar.apple.com/151018462">rdar://151018462</a>

Reviewed by Richard Robinson.

Turn the viewport clipping layer off for fixed-position objects in element fullscreen, since:

- There&apos;s no browser chrome that might partially obscure fixed-position objects.
- Everything is effectively forced to be fixed-position in fullscreen mode.

* LayoutTests/fullscreen/full-screen-disables-viewport-clipping-expected.html: Added.
* LayoutTests/fullscreen/full-screen-disables-viewport-clipping.html: Added.

Add a layout test to verify that the layer tree with content inset fill enabled vs. disabled is
identical in fullscreen.

* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::viewportConstrainedSublayers const):

Canonical link: <a href="https://commits.webkit.org/294763@main">https://commits.webkit.org/294763@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8e1434dd1f37ba9245e2b052f92a30ef65316c9d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/102983 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/22657 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/12977 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/108151 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/53624 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/105022 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/22984 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/31158 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78289 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/35239 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/105989 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17800 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/92919 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58624 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/17636 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/10962 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/52981 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/87448 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/11029 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/110524 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/30120 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/22187 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/87276 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/30484 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/89122 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86900 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22120 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31750 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/9461 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/24396 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/30047 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/35369 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/29855 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/33182 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/31417 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->