### PR TITLE
Don't include VM.h in JSObject.h

### DIFF
--- a/Source/JavaScriptCore/builtins/BuiltinUtils.h
+++ b/Source/JavaScriptCore/builtins/BuiltinUtils.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include "CommonIdentifiers.h"
 #include "ConstructAbility.h"
 #include "ConstructorKind.h"
 #include "ImplementationVisibility.h"

--- a/Source/JavaScriptCore/bytecode/ArrayProfile.h
+++ b/Source/JavaScriptCore/bytecode/ArrayProfile.h
@@ -27,6 +27,7 @@
 
 #include "ConcurrentJSLock.h"
 #include "Structure.h"
+#include <wtf/OptionSet.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 

--- a/Source/JavaScriptCore/bytecode/BytecodeIntrinsicRegistry.h
+++ b/Source/JavaScriptCore/bytecode/BytecodeIntrinsicRegistry.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include "Identifier.h"
+#include "Strong.h"
 #include <wtf/Noncopyable.h>
 #include <wtf/RobinHoodHashMap.h>
 #include <wtf/TZoneMalloc.h>

--- a/Source/JavaScriptCore/interpreter/CachedCall.h
+++ b/Source/JavaScriptCore/interpreter/CachedCall.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "ArgList.h"
 #include "CallLinkInfoBase.h"
 #include "ExceptionHelpers.h"
 #include "JSFunction.h"

--- a/Source/JavaScriptCore/jit/AssemblyHelpers.h
+++ b/Source/JavaScriptCore/jit/AssemblyHelpers.h
@@ -37,6 +37,7 @@
 #include "JITCode.h"
 #include "JSBigInt.h"
 #include "JSCell.h"
+#include "JSString.h"
 #include "MacroAssembler.h"
 #include "MarkedSpace.h"
 #include "RegisterAtOffsetList.h"

--- a/Source/JavaScriptCore/runtime/ArrayPrototypeInlines.h
+++ b/Source/JavaScriptCore/runtime/ArrayPrototypeInlines.h
@@ -27,6 +27,7 @@
 
 #include "ArrayConstructor.h"
 #include "ArrayPrototype.h"
+#include "CommonIdentifiers.h"
 #include "Error.h"
 #include "ExceptionHelpers.h"
 #include "GetVM.h"

--- a/Source/JavaScriptCore/runtime/CachedTypes.h
+++ b/Source/JavaScriptCore/runtime/CachedTypes.h
@@ -36,6 +36,7 @@ namespace JSC {
 class BytecodeCacheError;
 class CachedBytecode;
 class SourceCodeKey;
+class SourceProvider;
 class UnlinkedCodeBlock;
 class UnlinkedFunctionCodeBlock;
 class UnlinkedFunctionExecutable;

--- a/Source/JavaScriptCore/runtime/DirectArguments.h
+++ b/Source/JavaScriptCore/runtime/DirectArguments.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "CagedBarrierPtr.h"
+#include "CommonIdentifiers.h"
 #include "DirectArgumentsOffset.h"
 #include "GenericArgumentsImpl.h"
 #include <wtf/CagedPtr.h>

--- a/Source/JavaScriptCore/runtime/IdentifierInlines.h
+++ b/Source/JavaScriptCore/runtime/IdentifierInlines.h
@@ -28,8 +28,27 @@
 #include "CallFrame.h"
 #include "Identifier.h"
 #include "Symbol.h"
+#include "VM.h"
 
 namespace JSC  {
+
+inline Identifier::Identifier(VM& vm, std::span<const LChar> string)
+    : m_string(add(vm, string))
+{
+    ASSERT(m_string.impl()->isAtom());
+}
+
+inline Identifier::Identifier(VM& vm, std::span<const UChar> string)
+    : m_string(add(vm, string))
+{
+    ASSERT(m_string.impl()->isAtom());
+}
+
+ALWAYS_INLINE Identifier::Identifier(VM& vm, ASCIILiteral literal)
+    : m_string(add(vm, literal))
+{
+    ASSERT(m_string.impl()->isAtom());
+}
 
 inline Identifier::Identifier(VM& vm, AtomStringImpl* string)
     : m_string(string)
@@ -53,6 +72,40 @@ inline Identifier::Identifier(VM& vm, const AtomString& string)
 #else
     UNUSED_PARAM(vm);
 #endif
+}
+
+inline Identifier::Identifier(VM& vm, const String& string)
+    : m_string(add(vm, string.impl()))
+{
+    ASSERT(m_string.impl()->isAtom());
+}
+
+inline Identifier::Identifier(VM& vm, StringImpl* rep)
+    : m_string(add(vm, rep))
+{
+    ASSERT(m_string.impl()->isAtom());
+}
+
+inline Ref<AtomStringImpl> Identifier::add(VM& vm, ASCIILiteral literal)
+{
+    if (literal.length() == 1)
+        return vm.smallStrings.singleCharacterStringRep(literal.characterAt(0));
+    return AtomStringImpl::add(literal);
+}
+
+
+template <typename T>
+Ref<AtomStringImpl> Identifier::add(VM& vm, std::span<const T> string)
+{
+    if (string.size() == 1) {
+        T c = string.front();
+        if (canUseSingleCharacterString(c))
+            return vm.smallStrings.singleCharacterStringRep(c);
+    }
+    if (string.empty())
+        return *static_cast<AtomStringImpl*>(StringImpl::empty());
+
+    return *AtomStringImpl::add(string);
 }
 
 inline Ref<AtomStringImpl> Identifier::add(VM& vm, StringImpl* r)

--- a/Source/JavaScriptCore/runtime/JSObject.h
+++ b/Source/JavaScriptCore/runtime/JSObject.h
@@ -36,16 +36,12 @@
 #include "IndexingHeaderInlines.h"
 #include "JSCast.h"
 #include "MathCommon.h"
-#include "ObjectInitializationScope.h"
 #include "PropertySlot.h"
 #include "PropertyStorage.h"
 #include "PutDirectIndexMode.h"
 #include "PutPropertySlot.h"
 #include "Structure.h"
 #include "StructureTransitionTable.h"
-#include "VM.h"
-#include "JSString.h"
-#include "SparseArrayValueMap.h"
 #include <wtf/StdLibExtras.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
@@ -67,12 +63,15 @@ class Exception;
 class GetterSetter;
 class InternalFunction;
 class JSFunction;
+class JSString;
 class LLIntOffsetsExtractor;
 class MarkedBlock;
+class ObjectInitializationScope;
 class PropertyDescriptor;
 class PropertyNameArray;
 class Structure;
 class ThrowScope;
+class VM;
 struct HashTable;
 struct HashTableValue;
 
@@ -151,12 +150,12 @@ public:
         
     inline bool mayInterceptIndexedAccesses();
 
-    JSValue get(JSGlobalObject*, PropertyName) const;
-    JSValue get(JSGlobalObject*, unsigned propertyName) const;
+    inline JSValue get(JSGlobalObject*, PropertyName) const; // Defined in JSObjectInlines.h
+    inline JSValue get(JSGlobalObject*, unsigned propertyName) const; // Defined in JSObjectInlines.h
     JSValue get(JSGlobalObject*, uint64_t propertyName) const;
 
     template<typename T, typename PropertyNameType>
-    T getAs(JSGlobalObject*, PropertyNameType) const;
+    inline T getAs(JSGlobalObject*, PropertyNameType) const; // Defined in JSObjectInlines.h
 
     template<bool checkNullStructure = false>
     bool getPropertySlot(JSGlobalObject*, PropertyName, PropertySlot&);
@@ -208,58 +207,11 @@ public:
         return m_butterfly->vectorLength();
     }
     
-    bool canHaveExistingOwnIndexedGetterSetterProperties()
-    {
-        if (!hasIndexedProperties(indexingType()))
-            return false;
-
-        switch (indexingType()) {
-        case ALL_BLANK_INDEXING_TYPES:
-        case ALL_UNDECIDED_INDEXING_TYPES:
-        case ALL_INT32_INDEXING_TYPES:
-        case ALL_CONTIGUOUS_INDEXING_TYPES:
-        case ALL_DOUBLE_INDEXING_TYPES:
-            return false;
-        case ALL_ARRAY_STORAGE_INDEXING_TYPES: {
-            SparseArrayValueMap* map = m_butterfly->arrayStorage()->m_sparseMap.get();
-            if (!map)
-                return false;
-            return map->hasAnyKindOfGetterSetterProperties();
-        }
-        default:
-            RELEASE_ASSERT_NOT_REACHED();
-        }
-    }
+    inline bool canHaveExistingOwnIndexedGetterSetterProperties(); // Defined in RenderObjectInlines.h
 
     // This is only valid after using canPerformFastPropertyEnumerationCommon().
     // This code is not checking getOwnPropertySlot override etc.
-    unsigned canHaveExistingOwnIndexedProperties() const
-    {
-        if (!hasIndexedProperties(indexingType()))
-            return false;
-
-        switch (indexingType()) {
-        case ALL_BLANK_INDEXING_TYPES:
-        case ALL_UNDECIDED_INDEXING_TYPES:
-            return false;
-        case ALL_INT32_INDEXING_TYPES:
-        case ALL_CONTIGUOUS_INDEXING_TYPES:
-        case ALL_DOUBLE_INDEXING_TYPES:
-            return m_butterfly->publicLength();
-        case ALL_ARRAY_STORAGE_INDEXING_TYPES: {
-            ArrayStorage* storage = m_butterfly->arrayStorage();
-            unsigned usedVectorLength = std::min(storage->length(), storage->vectorLength());
-            if (usedVectorLength)
-                return true;
-            SparseArrayValueMap* map = storage->m_sparseMap.get();
-            if (!map)
-                return false;
-            return map->size();
-        }
-        default:
-            RELEASE_ASSERT_NOT_REACHED();
-        }
-    }
+    inline unsigned canHaveExistingOwnIndexedProperties() const; // Defined in RenderObjectInlines.h
 
     static bool putInlineForJSObject(JSCell*, JSGlobalObject*, PropertyName, JSValue, PutPropertySlot&);
     
@@ -587,111 +539,17 @@ public:
         }
     }
 
-    void initializeIndex(ObjectInitializationScope& scope, unsigned i, JSValue v)
-    {
-        initializeIndex(scope, i, v, indexingType());
-    }
+    inline void initializeIndex(ObjectInitializationScope&, unsigned, JSValue); // Defined in JSObjectInlines.h
 
     // NOTE: Clients of this method may call it more than once for any index, and this is supposed
     // to work.
-    ALWAYS_INLINE void initializeIndex(ObjectInitializationScope& scope, unsigned i, JSValue v, IndexingType indexingType)
-    {
-        VM& vm = scope.vm();
-        Butterfly* butterfly = m_butterfly.get();
-        switch (indexingType) {
-        case ALL_UNDECIDED_INDEXING_TYPES: {
-            setIndexQuicklyToUndecided(vm, i, v);
-            break;
-        }
-        case ALL_INT32_INDEXING_TYPES: {
-            ASSERT(i < butterfly->publicLength());
-            ASSERT(i < butterfly->vectorLength());
-            if (!v.isInt32()) {
-                convertInt32ToDoubleOrContiguousWhilePerformingSetIndex(vm, i, v);
-                break;
-            }
-            [[fallthrough]];
-        }
-        case ALL_CONTIGUOUS_INDEXING_TYPES: {
-            ASSERT(i < butterfly->publicLength());
-            ASSERT(i < butterfly->vectorLength());
-            butterfly->contiguous().at(this, i).set(vm, this, v);
-            break;
-        }
-        case ALL_DOUBLE_INDEXING_TYPES: {
-            ASSERT(i < butterfly->publicLength());
-            ASSERT(i < butterfly->vectorLength());
-            if (!v.isNumber()) {
-                convertDoubleToContiguousWhilePerformingSetIndex(vm, i, v);
-                return;
-            }
-            double value = v.asNumber();
-            if (value != value) {
-                convertDoubleToContiguousWhilePerformingSetIndex(vm, i, v);
-                return;
-            }
-            butterfly->contiguousDouble().at(this, i) = value;
-            break;
-        }
-        case ALL_ARRAY_STORAGE_INDEXING_TYPES: {
-            ArrayStorage* storage = butterfly->arrayStorage();
-            ASSERT(i < storage->length());
-            ASSERT(i < storage->m_numValuesInVector);
-            storage->m_vector[i].set(vm, this, v);
-            break;
-        }
-        default:
-            RELEASE_ASSERT_NOT_REACHED();
-        }
-    }
-        
-    void initializeIndexWithoutBarrier(ObjectInitializationScope& scope, unsigned i, JSValue v)
-    {
-        initializeIndexWithoutBarrier(scope, i, v, indexingType());
-    }
+    ALWAYS_INLINE void initializeIndex(ObjectInitializationScope&, unsigned, JSValue, IndexingType); // Defined in JSObjectInlines.h
+
+    inline void initializeIndexWithoutBarrier(ObjectInitializationScope&, unsigned, JSValue); // Defined in JSObjectInlines.h
 
     // This version of initializeIndex is for cases where you know that you will not need any
     // barriers. This implies not having any data format conversions.
-    ALWAYS_INLINE void initializeIndexWithoutBarrier(ObjectInitializationScope&, unsigned i, JSValue v, IndexingType indexingType)
-    {
-        Butterfly* butterfly = m_butterfly.get();
-        switch (indexingType) {
-        case ALL_UNDECIDED_INDEXING_TYPES: {
-            RELEASE_ASSERT_NOT_REACHED();
-            break;
-        }
-        case ALL_INT32_INDEXING_TYPES: {
-            ASSERT(i < butterfly->publicLength());
-            ASSERT(i < butterfly->vectorLength());
-            RELEASE_ASSERT(v.isInt32());
-            [[fallthrough]];
-        }
-        case ALL_CONTIGUOUS_INDEXING_TYPES: {
-            ASSERT(i < butterfly->publicLength());
-            ASSERT(i < butterfly->vectorLength());
-            butterfly->contiguous().at(this, i).setWithoutWriteBarrier(v);
-            break;
-        }
-        case ALL_DOUBLE_INDEXING_TYPES: {
-            ASSERT(i < butterfly->publicLength());
-            ASSERT(i < butterfly->vectorLength());
-            RELEASE_ASSERT(v.isNumber());
-            double value = v.asNumber();
-            RELEASE_ASSERT(value == value);
-            butterfly->contiguousDouble().at(this, i) = value;
-            break;
-        }
-        case ALL_ARRAY_STORAGE_INDEXING_TYPES: {
-            ArrayStorage* storage = butterfly->arrayStorage();
-            ASSERT(i < storage->length());
-            ASSERT(i < storage->m_numValuesInVector);
-            storage->m_vector[i].setWithoutWriteBarrier(v);
-            break;
-        }
-        default:
-            RELEASE_ASSERT_NOT_REACHED();
-        }
-    }
+    ALWAYS_INLINE void initializeIndexWithoutBarrier(ObjectInitializationScope&, unsigned, JSValue, IndexingType); // Defined in JSObjectInlines.h
         
     bool hasSparseMap()
     {
@@ -944,11 +802,11 @@ public:
     JS_EXPORT_PRIVATE Butterfly* allocateMoreOutOfLineStorage(VM&, size_t oldSize, size_t newSize);
 
     // Call this when you do not need to change the structure.
-    void setButterfly(VM&, Butterfly*);
-    
+    inline void setButterfly(VM&, Butterfly*); // Defined in JSObjectInlines.h
+
     // Call this if you do need to change the structure, or if you changed something about a structure
     // in-place.
-    void nukeStructureAndSetButterfly(VM&, StructureID oldStructureID, Butterfly*);
+    inline void nukeStructureAndSetButterfly(VM&, StructureID oldStructureID, Butterfly*); // Defined in JSObjectInlines.h
 
     void setStructure(VM&, Structure*);
 
@@ -1410,31 +1268,6 @@ inline void JSObject::setStructure(VM& vm, Structure* structure)
     JSCell::setStructure(vm, structure);
 }
 
-inline void JSObject::setButterfly(VM& vm, Butterfly* butterfly)
-{
-    if (isX86() || vm.heap.mutatorShouldBeFenced()) {
-        WTF::storeStoreFence();
-        m_butterfly.set(vm, this, butterfly);
-        WTF::storeStoreFence();
-        return;
-    }
-
-    m_butterfly.set(vm, this, butterfly);
-}
-
-inline void JSObject::nukeStructureAndSetButterfly(VM& vm, StructureID oldStructureID, Butterfly* butterfly)
-{
-    if (isX86() || vm.heap.mutatorShouldBeFenced()) {
-        setStructureIDDirectly(oldStructureID.nuke());
-        WTF::storeStoreFence();
-        m_butterfly.set(vm, this, butterfly);
-        WTF::storeStoreFence();
-        return;
-    }
-
-    m_butterfly.set(vm, this, butterfly);
-}
-
 inline JSObject* asObject(JSCell* cell)
 {
     ASSERT(cell);
@@ -1610,50 +1443,6 @@ ALWAYS_INLINE bool JSObject::getPropertySlot(JSGlobalObject* globalObject, Prope
     if (std::optional<uint32_t> index = parseIndex(propertyName))
         return getPropertySlot(globalObject, index.value(), slot);
     return false;
-}
-
-inline JSValue JSObject::get(JSGlobalObject* globalObject, PropertyName propertyName) const
-{
-    VM& vm = getVM(globalObject);
-    auto scope = DECLARE_THROW_SCOPE(vm);
-    PropertySlot slot(this, PropertySlot::InternalMethodType::Get);
-    bool hasProperty = const_cast<JSObject*>(this)->getPropertySlot(globalObject, propertyName, slot);
-
-    EXCEPTION_ASSERT(!scope.exception() || vm.hasPendingTerminationException() || !hasProperty);
-    RETURN_IF_EXCEPTION(scope, jsUndefined());
-
-    if (hasProperty)
-        RELEASE_AND_RETURN(scope, slot.getValue(globalObject, propertyName));
-
-    return jsUndefined();
-}
-
-inline JSValue JSObject::get(JSGlobalObject* globalObject, unsigned propertyName) const
-{
-    VM& vm = getVM(globalObject);
-    auto scope = DECLARE_THROW_SCOPE(vm);
-    PropertySlot slot(this, PropertySlot::InternalMethodType::Get);
-    bool hasProperty = const_cast<JSObject*>(this)->getPropertySlot(globalObject, propertyName, slot);
-
-    EXCEPTION_ASSERT(!scope.exception() || vm.hasPendingTerminationException() || !hasProperty);
-    RETURN_IF_EXCEPTION(scope, jsUndefined());
-
-    if (hasProperty)
-        RELEASE_AND_RETURN(scope, slot.getValue(globalObject, propertyName));
-
-    return jsUndefined();
-}
-
-template<typename T, typename PropertyNameType>
-inline T JSObject::getAs(JSGlobalObject* globalObject, PropertyNameType propertyName) const
-{
-    JSValue value = get(globalObject, propertyName);
-#if ASSERT_ENABLED || ENABLE(SECURITY_ASSERTIONS)
-    VM& vm = getVM(globalObject);
-    if (vm.exceptionForInspection())
-        return nullptr;
-#endif
-    return jsCast<T>(value);
 }
 
 inline bool JSObject::putDirect(VM& vm, PropertyName propertyName, JSValue value, unsigned attributes)

--- a/Source/JavaScriptCore/runtime/ObjectConstructor.h
+++ b/Source/JavaScriptCore/runtime/ObjectConstructor.h
@@ -20,9 +20,11 @@
 
 #pragma once
 
+#include "CommonIdentifiers.h"
 #include "InternalFunction.h"
 #include "JSGlobalObject.h"
 #include "ObjectPrototype.h"
+#include "VM.h"
 
 namespace JSC {
 

--- a/Source/JavaScriptCore/runtime/Operations.h
+++ b/Source/JavaScriptCore/runtime/Operations.h
@@ -25,6 +25,7 @@
 #include "ExceptionHelpers.h"
 #include "JSBigInt.h"
 #include "JSGlobalObject.h"
+#include "JSString.h"
 #include <wtf/text/MakeString.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN

--- a/Source/JavaScriptCore/runtime/PropertySlot.h
+++ b/Source/JavaScriptCore/runtime/PropertySlot.h
@@ -24,14 +24,17 @@
 #include "DisallowVMEntry.h"
 #include "GetVM.h"
 #include "JSCJSValue.h"
+#include "JSCPtrTag.h"
 #include "PropertyName.h"
 #include "PropertyOffset.h"
 #include "ScopeOffset.h"
+#include "Watchpoint.h"
 #include <wtf/Assertions.h>
 #include <wtf/ForbidHeapAllocation.h>
 #include <wtf/FunctionPtr.h>
 
 namespace JSC {
+
 class GetterSetter;
 class JSObject;
 class JSModuleEnvironment;

--- a/Source/JavaScriptCore/runtime/RegExp.h
+++ b/Source/JavaScriptCore/runtime/RegExp.h
@@ -47,10 +47,7 @@ public:
     static constexpr DestructionMode needsDestruction = NeedsDestruction;
 
     template<typename CellType, SubspaceAccess mode>
-    static GCClient::IsoSubspace* subspaceFor(VM& vm)
-    {
-        return &vm.regExpSpace();
-    }
+    static GCClient::IsoSubspace* subspaceFor(VM&); // Defined in RegExpInlines.h
 
     JS_EXPORT_PRIVATE static RegExp* create(VM&, const String& pattern, OptionSet<Yarr::Flags>);
     static void destroy(JSCell*);

--- a/Source/JavaScriptCore/runtime/RegExpInlines.h
+++ b/Source/JavaScriptCore/runtime/RegExpInlines.h
@@ -70,6 +70,12 @@ private:
 };
 #endif // REGEXP_FUNC_TEST_DATA_GEN
 
+template<typename CellType, SubspaceAccess mode>
+inline GCClient::IsoSubspace* RegExp::subspaceFor(VM& vm)
+{
+    return &vm.regExpSpace();
+}
+
 inline Structure* RegExp::createStructure(VM& vm, JSGlobalObject* globalObject, JSValue prototype)
 {
     return Structure::create(vm, globalObject, prototype, TypeInfo(CellType, StructureFlags), info());

--- a/Source/JavaScriptCore/runtime/Structure.h
+++ b/Source/JavaScriptCore/runtime/Structure.h
@@ -42,7 +42,6 @@
 #include "StructureTransitionTable.h"
 #include "TypeInfoBlob.h"
 #include "Watchpoint.h"
-#include "WriteBarrierInlines.h"
 #include <wtf/Atomics.h>
 #include <wtf/CompactPointerTuple.h>
 #include <wtf/CompactPtr.h>
@@ -224,10 +223,7 @@ public:
     ~Structure();
     
     template<typename CellType, SubspaceAccess>
-    static GCClient::IsoSubspace* subspaceFor(VM& vm)
-    {
-        return &vm.structureSpace();
-    }
+    inline static GCClient::IsoSubspace* subspaceFor(VM&); // Defined in StructureInlines.h
 
     JS_EXPORT_PRIVATE static bool isValidPrototype(JSValue);
 
@@ -252,13 +248,7 @@ protected:
     }
 
 private:
-    void finishCreation(VM& vm, CreatingEarlyCellTag)
-    {
-        Base::finishCreation(vm, this, CreatingEarlyCell);
-        ASSERT(m_prototype);
-        ASSERT(m_prototype.isNull());
-        ASSERT(!vm.structureStructure);
-    }
+    inline void finishCreation(VM&, CreatingEarlyCellTag); // Defined in StructureInlines.h
 
     void validateFlags();
 

--- a/Source/JavaScriptCore/runtime/StructureInlines.h
+++ b/Source/JavaScriptCore/runtime/StructureInlines.h
@@ -39,6 +39,7 @@
 #include "SymbolPrototype.h"
 #include "Watchpoint.h"
 #include "WebAssemblyGCStructure.h"
+#include "WriteBarrierInlines.h"
 #include <wtf/CompactRefPtr.h>
 #include <wtf/Threading.h>
 
@@ -96,6 +97,20 @@ inline Structure* Structure::create(VM& vm, Structure* previous, DeferredStructu
         RELEASE_ASSERT_NOT_REACHED();
         return nullptr;
     }
+}
+
+template<typename CellType, SubspaceAccess>
+inline GCClient::IsoSubspace* Structure::subspaceFor(VM& vm)
+{
+    return &vm.structureSpace();
+}
+
+inline void Structure::finishCreation(VM& vm, CreatingEarlyCellTag)
+{
+    Base::finishCreation(vm, this, CreatingEarlyCell);
+    ASSERT(m_prototype);
+    ASSERT(m_prototype.isNull());
+    ASSERT(!vm.structureStructure);
 }
 
 inline bool Structure::mayInterceptIndexedAccesses() const

--- a/Source/JavaScriptCore/runtime/StructureRareData.h
+++ b/Source/JavaScriptCore/runtime/StructureRareData.h
@@ -67,10 +67,7 @@ public:
     static constexpr unsigned StructureFlags = Base::StructureFlags | StructureIsImmortal;
 
     template<typename CellType, SubspaceAccess>
-    static GCClient::IsoSubspace* subspaceFor(VM& vm)
-    {
-        return &vm.structureRareDataSpace();
-    }
+    inline static GCClient::IsoSubspace* subspaceFor(VM&); // Defined in StructureRareDataInlines.h
 
     static StructureRareData* create(VM&, Structure*);
 

--- a/Source/JavaScriptCore/runtime/StructureRareDataInlines.h
+++ b/Source/JavaScriptCore/runtime/StructureRareDataInlines.h
@@ -30,6 +30,7 @@
 #include "JSString.h"
 #include "StructureChain.h"
 #include "StructureRareData.h"
+#include "VM.h"
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
@@ -71,6 +72,12 @@ public:
 private:
     PackedCellPtr<StructureRareData> m_structureRareData;
 };
+
+template<typename CellType, SubspaceAccess>
+inline GCClient::IsoSubspace* StructureRareData::subspaceFor(VM& vm)
+{
+    return &vm.structureRareDataSpace();
+}
 
 inline void StructureRareData::setPreviousID(VM& vm, Structure* structure)
 {

--- a/Source/JavaScriptCore/runtime/SyntheticModuleRecord.cpp
+++ b/Source/JavaScriptCore/runtime/SyntheticModuleRecord.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "SyntheticModuleRecord.h"
 
+#include "ArgList.h"
 #include "BuiltinNames.h"
 #include "JSCInlines.h"
 #include "JSInternalPromise.h"

--- a/Source/JavaScriptCore/runtime/SyntheticModuleRecord.h
+++ b/Source/JavaScriptCore/runtime/SyntheticModuleRecord.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "AbstractModuleRecord.h"
+#include "ArgList.h"
 #include "SourceCode.h"
 
 namespace JSC {

--- a/Source/WebCore/bindings/js/JSDOMConvertStrings.h
+++ b/Source/WebCore/bindings/js/JSDOMConvertStrings.h
@@ -30,6 +30,7 @@
 #include "StringAdaptors.h"
 #include "TrustedType.h"
 #include <JavaScriptCore/JSGlobalObject.h>
+#include <JavaScriptCore/JSString.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
+++ b/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
@@ -28,6 +28,7 @@
 #pragma once
 
 #include <JavaScriptCore/BuiltinUtils.h>
+#include <JavaScriptCore/CommonIdentifiers.h>
 
 #if USE(APPLE_INTERNAL_SDK)
 #include <WebKitAdditions/WebCoreBuiltinNamesAdditions.h>


### PR DESCRIPTION
#### 9a35fe49323136ba3e71f8699bebe5ec17735373
<pre>
Don&apos;t include VM.h in JSObject.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=292828">https://bugs.webkit.org/show_bug.cgi?id=292828</a>

Reviewed by Justin Michaud and Mark Lam.

Move enough inline functions from *Inlines.h files so that we can avoid including VM.h
in JSObject.h to speed up build time.

* Source/JavaScriptCore/builtins/BuiltinUtils.h:
* Source/JavaScriptCore/bytecode/ArrayProfile.h:
* Source/JavaScriptCore/bytecode/BytecodeIntrinsicRegistry.h:
* Source/JavaScriptCore/interpreter/CachedCall.h:
* Source/JavaScriptCore/jit/AssemblyHelpers.h:
* Source/JavaScriptCore/runtime/ArrayPrototypeInlines.h:
* Source/JavaScriptCore/runtime/CachedTypes.h:
* Source/JavaScriptCore/runtime/DirectArguments.h:
* Source/JavaScriptCore/runtime/Identifier.h:
(JSC::Identifier::add): Deleted.
* Source/JavaScriptCore/runtime/IdentifierInlines.h:
(JSC::Identifier::Identifier):
(JSC::Identifier::add):
* Source/JavaScriptCore/runtime/JSObject.h:
(JSC::JSObject::canHaveExistingOwnIndexedGetterSetterProperties): Deleted.
(JSC::JSObject::canHaveExistingOwnIndexedProperties const): Deleted.
(JSC::JSObject::initializeIndex): Deleted.
(JSC::JSObject::initializeIndexWithoutBarrier): Deleted.
(JSC::JSObject::setButterfly): Deleted.
(JSC::JSObject::nukeStructureAndSetButterfly): Deleted.
(JSC::JSObject::get const): Deleted.
(JSC::JSObject::getAs const): Deleted.
* Source/JavaScriptCore/runtime/JSObjectInlines.h:
(JSC::JSObject::setButterfly):
(JSC::JSObject::nukeStructureAndSetButterfly):
(JSC::JSObject::get const):
(JSC::JSObject::getAs const):
(JSC::JSObject::initializeIndex):
(JSC::JSObject::initializeIndexWithoutBarrier):
(JSC::JSObject::canHaveExistingOwnIndexedGetterSetterProperties):
(JSC::JSObject::canHaveExistingOwnIndexedProperties const):
* Source/JavaScriptCore/runtime/ObjectConstructor.h:
* Source/JavaScriptCore/runtime/Operations.h:
* Source/JavaScriptCore/runtime/PropertySlot.h:
* Source/JavaScriptCore/runtime/RegExp.h:
* Source/JavaScriptCore/runtime/RegExpInlines.h:
(JSC::RegExp::subspaceFor):
* Source/JavaScriptCore/runtime/Structure.h:
(JSC::Structure::subspaceFor): Deleted.
* Source/JavaScriptCore/runtime/StructureInlines.h:
(JSC::Structure::subspaceFor):
(JSC::Structure::finishCreation):
* Source/JavaScriptCore/runtime/StructureRareData.h:
* Source/JavaScriptCore/runtime/StructureRareDataInlines.h:
(JSC::StructureRareData::subspaceFor):
* Source/JavaScriptCore/runtime/SyntheticModuleRecord.cpp:
* Source/JavaScriptCore/runtime/SyntheticModuleRecord.h:
* Source/WebCore/bindings/js/JSDOMConvertStrings.h:
* Source/WebCore/bindings/js/WebCoreBuiltinNames.h:

Canonical link: <a href="https://commits.webkit.org/294804@main">https://commits.webkit.org/294804@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/07a1a875cc419956fd36cbef75b20eae09ddda5f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/103167 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/22842 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/13161 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/108335 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/53810 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/105206 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/23177 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/31342 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/78435 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/35367 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/106173 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17967 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/93085 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58768 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/17813 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/11127 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/53165 "Built successfully") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/95842 "Failed to checkout and rebase branch from PR 45215") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/87621 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/11190 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/110712 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/101778 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/30304 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/22346 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/87428 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/30669 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/89284 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87058 "Found 1 new API test failure: /WebKitGTK/TestCookieManager:/webkit/WebKitCookieManager/replace-get-all-cookies (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22144 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31903 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/9619 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/24628 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/30231 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/35553 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/125411 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/30039 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34789 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/33366 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/31601 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->