### PR TITLE
[Gardening] Unskip passing `focus-visible` WPT tests

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -1820,8 +1820,6 @@ imported/w3c/web-platform-tests/css/selectors/old-tests/css3-modsel-173b.xml [ I
 webkit.org/b/185859 imported/w3c/web-platform-tests/css/selectors/focus-visible-002.html [ Skip ]
 webkit.org/b/185859 imported/w3c/web-platform-tests/css/selectors/focus-visible-003.html [ Skip ]
 webkit.org/b/185859 imported/w3c/web-platform-tests/css/selectors/focus-visible-004.html [ Skip ]
-webkit.org/b/234139 imported/w3c/web-platform-tests/css/selectors/focus-visible-024.html [ Skip ]
-webkit.org/b/234139 imported/w3c/web-platform-tests/css/selectors/focus-visible-025.html [ Skip ]
 webkit.org/b/217904 imported/w3c/web-platform-tests/css/selectors/is-where-visited.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/selectors/xml-class-selector.xml [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/selectors/case-insensitive-parent.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/focus-visible-024-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/focus-visible-024-expected.txt
@@ -1,0 +1,7 @@
+Target A
+Target B
+
+PASS ":focus-visible" should be a valid selector
+PASS :focus-visible matches after accesskey on DIV
+PASS :focus-visible matches after accesskey on BUTTON
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/focus-visible-025-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/focus-visible-025-expected.txt
@@ -1,0 +1,8 @@
+Initial
+Target A
+Target B
+
+PASS ":focus-visible" should be a valid selector
+PASS :focus-visible matches after accesskey on DIV after previous mouse focus
+PASS :focus-visible matches after accesskey on BUTTON after previous mouse focus
+

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/css/selectors/focus-visible-024-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/css/selectors/focus-visible-024-expected.txt
@@ -1,0 +1,7 @@
+Target A
+Target B
+
+PASS ":focus-visible" should be a valid selector
+FAIL :focus-visible matches after accesskey on DIV assert_equals: outline-style for DIV#targetA should be solid expected "solid" but got "none"
+FAIL :focus-visible matches after accesskey on BUTTON assert_equals: outline-style for BUTTON#targetB should be solid expected "solid" but got "none"
+

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/css/selectors/focus-visible-025-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/css/selectors/focus-visible-025-expected.txt
@@ -1,0 +1,8 @@
+Initial
+Target A
+Target B
+
+PASS ":focus-visible" should be a valid selector
+FAIL :focus-visible matches after accesskey on DIV after previous mouse focus assert_equals: outline-style for DIV#targetA should be solid expected "solid" but got "none"
+FAIL :focus-visible matches after accesskey on BUTTON after previous mouse focus assert_equals: outline-style for BUTTON#targetB should be solid expected "solid" but got "none"
+

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/selectors/focus-visible-024-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/selectors/focus-visible-024-expected.txt
@@ -1,0 +1,7 @@
+Target A
+Target B
+
+PASS ":focus-visible" should be a valid selector
+FAIL :focus-visible matches after accesskey on DIV assert_equals: outline-style for DIV#targetA should be solid expected "solid" but got "none"
+FAIL :focus-visible matches after accesskey on BUTTON assert_equals: outline-style for BUTTON#targetB should be solid expected "solid" but got "none"
+

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/selectors/focus-visible-025-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/selectors/focus-visible-025-expected.txt
@@ -1,0 +1,8 @@
+Initial
+Target A
+Target B
+
+PASS ":focus-visible" should be a valid selector
+FAIL :focus-visible matches after accesskey on DIV after previous mouse focus assert_equals: outline-style for DIV#targetA should be solid expected "solid" but got "none"
+FAIL :focus-visible matches after accesskey on BUTTON after previous mouse focus assert_equals: outline-style for BUTTON#targetB should be solid expected "solid" but got "none"
+


### PR DESCRIPTION
#### 7f83c2aee85d849be4de5a0ef1a528d21e8e6138
<pre>
[Gardening] Unskip passing `focus-visible` WPT tests

<a href="https://bugs.webkit.org/show_bug.cgi?id=292831">https://bugs.webkit.org/show_bug.cgi?id=292831</a>

Unreviewed Gardening.

This patch is to enable two of passing WPT tests cases so we can find
any potential future regressions easily.

* LayoutTests/TestExpectations:

&gt; Add missing test expectation:
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/focus-visible-024-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/focus-visible-025-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/css/selectors/focus-visible-025-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/css/selectors/focus-visible-024-expected.txt:
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/selectors/focus-visible-025-expected.txt:
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/selectors/focus-visible-024-expected.txt:

Canonical link: <a href="https://commits.webkit.org/294764@main">https://commits.webkit.org/294764@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bfe126f2c330d0812f560e8a5db084b5c3841155

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/103008 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/22683 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/13002 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/108176 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/53650 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/23009 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/31183 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78306 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/35255 "Found 2 new test failures: imported/w3c/web-platform-tests/css/selectors/focus-visible-024.html imported/w3c/web-platform-tests/css/selectors/focus-visible-025.html (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/106014 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17824 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/92942 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58641 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/17663 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/10984 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/53006 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/87473 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/11051 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/110549 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/30145 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/22209 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/87295 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/30510 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/89144 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86919 "Found 101 new API test failures: /WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/sequence, /TestWebKit:WebKit.InjectedBundleInitializationUserDataCallbackWins, /TestWebKit:WebKit.GeolocationBasicWithHighAccuracy, /WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/cancel-sequence, /TestWebKit:WebKit.ForceRepaint, /TestWebKit:WebKit.PendingAPIRequestURL, /WebKitGTK/TestUIClient:/webkit/WebKitWebView/mediaKeySystem-permission-requests, /TestWebKit:WebKit.PreventEmptyUserAgent, /TestWebKit:WebKit2.ProvisionalURLAfterWillSendRequestCallback, /WebKitGTK/TestDownloads:/webkit/Downloads/contex-menu-download-actions ... (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22121 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31766 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/9483 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/24429 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/30072 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/29880 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/33207 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/31442 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->