### PR TITLE
[Win] [Gardening] Add test expectations for `focus-visible-024` and `focus-visible-025`

### DIFF
--- a/LayoutTests/platform/win/imported/w3c/web-platform-tests/css/selectors/focus-visible-024-expected.txt
+++ b/LayoutTests/platform/win/imported/w3c/web-platform-tests/css/selectors/focus-visible-024-expected.txt
@@ -1,0 +1,7 @@
+Target A
+Target B
+
+PASS ":focus-visible" should be a valid selector
+FAIL :focus-visible matches after accesskey on DIV assert_equals: outline-style for DIV#targetA should be solid expected "solid" but got "none"
+FAIL :focus-visible matches after accesskey on BUTTON assert_equals: outline-style for BUTTON#targetB should be solid expected "solid" but got "none"
+

--- a/LayoutTests/platform/win/imported/w3c/web-platform-tests/css/selectors/focus-visible-025-expected.txt
+++ b/LayoutTests/platform/win/imported/w3c/web-platform-tests/css/selectors/focus-visible-025-expected.txt
@@ -1,0 +1,8 @@
+Initial
+Target A
+Target B
+
+PASS ":focus-visible" should be a valid selector
+FAIL :focus-visible matches after accesskey on DIV after previous mouse focus assert_equals: outline-style for DIV#targetA should be solid expected "solid" but got "none"
+FAIL :focus-visible matches after accesskey on BUTTON after previous mouse focus assert_equals: outline-style for BUTTON#targetB should be solid expected "solid" but got "none"
+


### PR DESCRIPTION
#### 4017aeecf2420abdb726dc80110c720636eb2653
<pre>
[Win] [Gardening] Add test expectations for `focus-visible-024` and `focus-visible-025`

<a href="https://bugs.webkit.org/show_bug.cgi?id=292833">https://bugs.webkit.org/show_bug.cgi?id=292833</a>

Unreviewed Gardening. Forgot to do it in previous PR.

* LayoutTests/platform/win/imported/w3c/web-platform-tests/css/selectors/focus-visible-024-expected.txt:
* LayoutTests/platform/win/imported/w3c/web-platform-tests/css/selectors/focus-visible-025-expected.txt:

Canonical link: <a href="https://commits.webkit.org/294766@main">https://commits.webkit.org/294766@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5948669312360a984c71579462ea9862be5270d7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/103015 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/22690 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/13009 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/108183 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/53658 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/23018 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/31190 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78313 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/35260 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/106021 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17833 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/92949 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58647 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/17672 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/10990 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/53013 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/87483 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/11057 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/110556 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/30152 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/22216 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/87301 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/30517 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/89150 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86925 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22122 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31774 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/9489 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/24442 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/30079 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/29887 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/33214 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/31449 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->