### PR TITLE
AX: figcaption should only contribute to img accname when it lacks other labelling techniques

### DIFF
--- a/LayoutTests/accessibility/ios-simulator/figure-element-expected.txt
+++ b/LayoutTests/accessibility/ios-simulator/figure-element-expected.txt
@@ -34,16 +34,16 @@ PASS !titleUIElement is true
 Test figure with figcaption element.
 figure5: [object AccessibilityUIElement]
 figure5 AXRoleDescription: figure
-figure5 AXLabel: Caption for Figure 5.
+figure5 AXLabel:
 figure5
-PASS titleUIElement.isEqual(figureCaption) || (isIgnored(titleUIElement) && isIgnored(figureCaption)) is true
+PASS titleEqualsCaption || (isIgnored(titleUIElement) && isIgnored(figureCaption)) is true
 
 Test figure with figcaption element and title attribute.
 figure6: [object AccessibilityUIElement]
 figure6 AXRoleDescription: figure
-figure6 AXLabel: Caption for Figure 6.
+figure6 AXLabel: Figure 6.
 figure6
-PASS titleUIElement.isEqual(figureCaption) || (isIgnored(titleUIElement) && isIgnored(figureCaption)) is true
+PASS titleEqualsCaption || (isIgnored(titleUIElement) && isIgnored(figureCaption)) is true
 
 PASS successfullyParsed is true
 

--- a/LayoutTests/accessibility/ios-simulator/figure-element.html
+++ b/LayoutTests/accessibility/ios-simulator/figure-element.html
@@ -65,10 +65,11 @@
             var titleUIElement = figure.titleUIElement();
             if (k >= 5) {
                 var figureCaption = accessibilityController.accessibleElementById("figCaption" + k);
-                shouldBeTrue("titleUIElement.isEqual(figureCaption) || (isIgnored(titleUIElement) && isIgnored(figureCaption))");
-            } else
+                var titleEqualsCaption = titleUIElement && titleUIElement.isEqual(figureCaption);
+                shouldBeTrue("titleEqualsCaption || (isIgnored(titleUIElement) && isIgnored(figureCaption))");
+            }
+            else
                 shouldBeTrue("!titleUIElement");
-
             debug("");
         }
 

--- a/LayoutTests/accessibility/mac/figure-element-expected.txt
+++ b/LayoutTests/accessibility/mac/figure-element-expected.txt
@@ -24,23 +24,23 @@ PASS: !titleUIElement === true
 Test figure with figcaption element.
 figure4 AXRole: AXGroup
 figure4 AXRoleDescription: figure
-figure4 AXDescription: Figcaption element
+figure4 AXDescription:
 figure4 customContent:
-PASS: titleUIElement.isEqual(figureCaption) === true
+PASS: !titleUIElement === true
 
 Test figure with figcaption element and title attribute.
 figure5 AXRole: AXGroup
 figure5 AXRoleDescription: figure
-figure5 AXDescription: Figcaption element
+figure5 AXDescription: title attribute
 figure5 customContent:
-PASS: titleUIElement.isEqual(figureCaption) === true
+PASS: !titleUIElement === true
 
 Test display:contents figure with figcaption element.
 figure6 AXRole: AXGroup
 figure6 AXRoleDescription: figure
-figure6 AXDescription: Figcaption element (display:contents)
+figure6 AXDescription:
 figure6 customContent:
-PASS: titleUIElement.isEqual(figureCaption) === true
+PASS: !titleUIElement === true
 
 
 PASS successfullyParsed is true

--- a/LayoutTests/imported/w3c/web-platform-tests/html-aam/figure-name-no-figcaption.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html-aam/figure-name-no-figcaption.tentative-expected.txt
@@ -20,28 +20,13 @@ figcaption
 figcaption
 labelledby
 
-FAIL figure with figcaption - no name assert_equals: <figure data-testname="figure with figcaption - no name" data-expectedlabel="" class="ex">
-  x
-  <figcaption>y</figcaption>
-</figure> expected "" but got "y"
-FAIL figure with figcaption and aria-label assert_equals: <figure data-testname="figure with figcaption and aria-label" aria-label="label" data-expectedlabel="label" class="ex">
-  x
-  <figcaption>y</figcaption>
-</figure> expected "label" but got "y"
-FAIL figure with figcaption and aria-labelledby pointing to another element assert_equals: <figure data-testname="figure with figcaption and aria-labelledby pointing to another element" aria-labelledby="labelledby" data-expectedlabel="labelledby" class="ex">
-  x
-  <figcaption>y</figcaption>
-</figure> expected "labelledby" but got "labelledby y"
+PASS figure with figcaption - no name
+PASS figure with figcaption and aria-label
+PASS figure with figcaption and aria-labelledby pointing to another element
 PASS figure with aria-labelledby pointing to figcaption
-FAIL figure with figcaption and title assert_equals: <figure data-testname="figure with figcaption and title" title="title" data-expectedlabel="title" class="ex">
-  x
-  <figcaption>y</figcaption>
-</figure> expected "title" but got "y"
-FAIL figure with figcaption and img without alt assert_equals: <figure data-testname="figure with figcaption and img without alt" data-expectedlabel="" class="ex">
-  <img src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==" data-testname="img without alt within a figure with figcaption" data-expectedlabel="figcaption" class="ex">
-  <figcaption>figcaption</figcaption>
-</figure> expected "" but got "figcaption"
-FAIL img without alt within a figure with figcaption assert_equals: <img src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==" data-testname="img without alt within a figure with figcaption" data-expectedlabel="figcaption" class="ex"> expected "figcaption" but got ""
+PASS figure with figcaption and title
+PASS figure with figcaption and img without alt
+PASS img without alt within a figure with figcaption
 PASS img without alt but with title within a figure with figcaption
 PASS img without alt within a figure with figcaption, and with other flow content within the figure
 

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -5661,14 +5661,10 @@ void AXObjectCache::addLabelForRelation(Element& origin)
 {
     bool addedRelation = false;
 
-    // LabelFor relations are established for <label for=...> and for <figcaption> elements.
+    // LabelFor relations are established for <label for=...>.
     if (RefPtr label = dynamicDowncast<HTMLLabelElement>(origin)) {
         if (RefPtr control = Accessibility::controlForLabelElement(*label))
             addedRelation = addRelation(origin, *control, AXRelation::LabelFor);
-    } else if (origin.elementName() == ElementName::HTML_figcaption) {
-        RefPtr parent = dynamicDowncast<Element>(origin.parentNode());
-        if (parent && parent->elementName() == ElementName::HTML_figure)
-            addedRelation = addRelation(RefPtr { getOrCreate(origin) }.get(), RefPtr { getOrCreate(*parent) }.get(), AXRelation::LabelFor);
     }
 
     if (addedRelation)

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -1221,6 +1221,14 @@ bool AccessibilityRenderObject::computeIsIgnored() const
         if (canSetFocusAttribute())
             return false;
 
+        // https://github.com/w3c/aria/pull/2224
+        // If the image is a descendant of a <figure>, don't ignore it due to <figure> potentially participating in its accname.
+        auto* node = m_renderer->node();
+        for (RefPtr ancestor = node ? node->parentNode() : nullptr; ancestor; ancestor = ancestor->parentNode()) {
+            if (auto* element = dynamicDowncast<HTMLElement>(ancestor.get()); element && element->hasTagName(figureTag))
+                return false;
+        }
+
         // First check the RenderImage's altText (which can be set through a style sheet, or come from the Element).
         // However, if this is not a native image, fallback to the attribute on the Element.
         // If the image is decorative (i.e. alt=""), it should be ignored even if a title, aria-label, etc. is supplied.


### PR DESCRIPTION
#### 6bd07e47c0a5e45c5dff17579ae09909a586db74
<pre>
AX: figcaption should only contribute to img accname when it lacks other labelling techniques
<a href="https://bugs.webkit.org/show_bug.cgi?id=292490">https://bugs.webkit.org/show_bug.cgi?id=292490</a>
<a href="https://rdar.apple.com/150597445">rdar://150597445</a>

Reviewed by Tyler Wilcock.

The &lt;figure&gt; and &lt;img&gt; elements&apos; accname calculation have been updated in html-aam. Specifically, &lt;figcaption&gt; only participates in accname for
&lt;img&gt; elements (with a shared &lt;figure&gt; ancestor) that lack other labelling techniques (e.g., alt attribute, ARIA, title attribute).

This PR implements html-aam&apos;s updated &lt;figure&gt; and &lt;img&gt; calculation, and also removes the &lt;figcaption&gt; AXObjectCache::addLabelForRelation()
labelFor relation for &lt;figure&gt; because it is no longer applicable and handled elsewhere. It also updates the
LayoutTests/.../accessibility/ios-simulator/figure-element.html test to fix a missing null check which caused an invalid failure. To simplify the
check for common types of flow content for &lt;img&gt; accname computation, the static helper function isFlowContent() has been added in AccessibilityNodeObject.cpp.

* LayoutTests/imported/w3c/web-platform-tests/html-aam/figure-name-no-figcaption.tentative-expected.txt: Updated test expectations.
* LayoutTests/accessibility/mac/figure-element-expected.txt: Updated test expectations.
* LayoutTests/accessibility/ios-simulator/figure-element.html: Fixed lack of null check for titleUIElement.
* LayoutTests/accessibility/ios-simulator/figure-element.txt: Updated test expectations.
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::addLabelForRelation):
* Source/WebCore/accessibility/AccessibilityNodeObject.cpp:
(WebCore::AccessibilityNodeObject::alternativeText const):
(WebCore::AccessibilityNodeObject::captionForFigure const):
(WebCore::isFlowContent):
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::AccessibilityRenderObject::computeIsIgnored const):

Canonical link: <a href="https://commits.webkit.org/295746@main">https://commits.webkit.org/295746@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5461d04e54d56eb6f25c6cea1b70048950db5f1e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105995 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25744 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/16138 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/111191 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/56591 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/108034 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/26394 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34247 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80515 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108999 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/20821 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95657 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60837 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/20430 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13754 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/56029 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/90200 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13790 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/114045 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33133 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24446 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89594 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33497 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91885 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89277 "Found 101 new API test failures: /TestWebKit:WebKit.PageLoadDidChangeLocationWithinPage, /TestWebKit:WebKit.AboutBlankLoad, /TestWebKit:WebKit.PreventEmptyUserAgent, /TestWebKit:WebKit.PrivateBrowsingPushStateNoHistoryCallback, /WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/content-type, /WebKitGTK/TestUIClient:/webkit/WebKitWebView/pointer-lock-permission-request, /TestWebKit:WebKit.HitTestResultNodeHandle, /TestWebKit:WebKit2TextFieldBeginAndEditEditingTest.TextFieldDidBeginShouldNotBeDispatchedForAlreadyFocusedField, /TestWebKit:WebKit.Find, /WebKitGTK/TestWebProcessExtensions:/webkit/WebKitWebProcessExtension/dom-input-element-is-user-edited ... (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22759 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34143 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11957 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/28678 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/33058 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/38470 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32804 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/36153 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34402 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->