### PR TITLE
AX: Fix permitted values for aria-setsize, aria-posinset (both >= 1) and specify fallbacks

### DIFF
--- a/LayoutTests/accessibility/aria-setsize-posinset-expected.txt
+++ b/LayoutTests/accessibility/aria-setsize-posinset-expected.txt
@@ -12,9 +12,16 @@ PASS: axItem2.isAttributeSupported('AXARIASetSize') === false
 PASS: axItem2.isAttributeSupported('AXARIAPosInSet') === false
 Update aria-posinset to 4 for the item1.
 PASS: axItem1.numberAttributeValue('AXARIAPosInSet') === 4
+Set aria-posinset to foo and verify that posinset = 1 for invalid value fallback.
+PASS: axItem1.numberAttributeValue('AXARIAPosInSet') === 1
+Set aria-posinset to -50 and verify that posinset = 1 for invalid value fallback.
+PASS: axItem1.numberAttributeValue('AXARIAPosInSet') === 1
 Update aria-setsize to 101.
 PASS: axList.numberAttributeValue('AXARIASetSize') === 101
 Set aria-setsize to -1 and verify that the list still exposes the number of items.
+PASS: axList.numberAttributeValue('AXARIASetSize') === -1
+PASS: axList.isAttributeSupported('AXARIASetSize') === true
+Set aria-setsize to foo and verify that the list still exposes the number of items.
 PASS: axList.numberAttributeValue('AXARIASetSize') === -1
 PASS: axList.isAttributeSupported('AXARIASetSize') === true
 

--- a/LayoutTests/accessibility/aria-setsize-posinset.html
+++ b/LayoutTests/accessibility/aria-setsize-posinset.html
@@ -37,19 +37,30 @@
         output += "Update aria-posinset to 4 for the item1.\n";
         item1.ariaPosInSet = "4";
         setTimeout(async function() {
-            await waitFor(() => axItem1.numberAttributeValue('AXARIAPosInSet') === 4);
-            output += expect("axItem1.numberAttributeValue('AXARIAPosInSet')", "4");
+            output += await expectAsync("axItem1.numberAttributeValue('AXARIAPosInSet')", "4"); 
+
+            output += "Set aria-posinset to foo and verify that posinset = 1 for invalid value fallback.\n";
+            item1.ariaPosInSet = "foo";
+            output += await expectAsync("axItem1.numberAttributeValue('AXARIAPosInSet')", "1"); 
+    
+            output += "Set aria-posinset to -50 and verify that posinset = 1 for invalid value fallback.\n";
+            item1.ariaPosInSet = "-50";
+            output += await expectAsync("axItem1.numberAttributeValue('AXARIAPosInSet')", "1"); 
 
             output += "Update aria-setsize to 101.\n";
             list.ariaSetSize = "101";
-            await waitFor(() => axList.numberAttributeValue("AXARIASetSize") === 101);
-            output += expect("axList.numberAttributeValue('AXARIASetSize')", "101");
+            output += await expectAsync("axList.numberAttributeValue('AXARIASetSize')", "101");
+
 
             output += "Set aria-setsize to -1 and verify that the list still exposes the number of items.\n";
             list.ariaSetSize = "-1";
-            await waitFor(() => axList.numberAttributeValue("AXARIASetSize") === -1);
-            output += expect("axList.numberAttributeValue('AXARIASetSize')", "-1");
-            output += expect("axList.isAttributeSupported('AXARIASetSize')", "true");
+            output += await expectAsync("axList.numberAttributeValue('AXARIASetSize')", "-1"); 
+            output += await expectAsync("axList.isAttributeSupported('AXARIASetSize')", "true");
+
+            output += "Set aria-setsize to foo and verify that the list still exposes the number of items.\n";
+            list.ariaSetSize = "foo";
+            output += await expectAsync("axList.numberAttributeValue('AXARIASetSize')", "-1"); 
+            output += await expectAsync("axList.isAttributeSupported('AXARIASetSize')", "true");
 
             list.style.visibility = 'hidden';
             debug(output);

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -3217,12 +3217,18 @@ bool AccessibilityObject::supportsPosInSet() const
 
 int AccessibilityObject::setSize() const
 {
-    return getIntegralAttribute(aria_setsizeAttr);
+    // https://github.com/w3c/aria/pull/2341
+    // When aria-setsize isn't a positive integer (greater than or equal to 1), its value should be indeterminate, i.e., -1.
+    int setSize = getIntegralAttribute(aria_setsizeAttr);
+    return (setSize >= 1) ? setSize : -1;
 }
 
 int AccessibilityObject::posInSet() const
 {
-    return getIntegralAttribute(aria_posinsetAttr);
+    // https://github.com/w3c/aria/pull/2341
+    // When aria-posinset isn't a positive integer (greater than or equal to 1), its value should be 1.
+    int posInSet = getIntegralAttribute(aria_posinsetAttr);
+    return (posInSet >= 1) ? posInSet : 1;
 }
 
 String AccessibilityObject::identifierAttribute() const


### PR DESCRIPTION
#### 4220ccde4c539e01931759c21c682cd933d16131
<pre>
AX: Fix permitted values for aria-setsize, aria-posinset (both &gt;= 1) and specify fallbacks
<a href="https://bugs.webkit.org/show_bug.cgi?id=292844">https://bugs.webkit.org/show_bug.cgi?id=292844</a>
<a href="https://rdar.apple.com/151113693">rdar://151113693</a>

Reviewed by Tyler Wilcock.

ARIA (Core-AAM) has recently clarified treatment of aria-setsize and aria-posinset and specifically,
the meaning of supplying &quot;-1&quot; as a value for these two attributes. This PR updates aria-setsize/aria-posinset
treatment for invalid values, and thus what is exposed by the accessibility API in accordance with the ARIA spec update.
It also updates the /LayoutTests/accessibility/aria-setsize-posinset.html test to use the expectAsync() function.

* LayoutTests/accessibility/aria-setsize-posinset.html: Added additional tests and updated async tests.
* LayoutTests/accessibility/aria-setsize-posinset-expected.txt: Updated test expectations.
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::setSize const):
(WebCore::AccessibilityObject::posInSet const):

Canonical link: <a href="https://commits.webkit.org/295814@main">https://commits.webkit.org/295814@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/601c919e2334706d4f253c1a068ded0b31196d48

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/106197 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25946 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/16340 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/111394 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/56793 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/108236 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/26606 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34449 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80664 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/109201 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/21028 "Found 1 new test failure: http/tests/site-isolation/history/add-iframes-and-navigate-mainframe.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95830 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60990 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/20578 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13933 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/56233 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/90387 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13968 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/114255 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33335 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24582 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89739 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33699 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/92063 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89440 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22813 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34308 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/12119 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/28911 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/33260 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/38672 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/33006 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/36356 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34604 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->