### PR TITLE
Adopt std::clamp() in more places

### DIFF
--- a/Source/WTF/wtf/text/StringBuilder.cpp
+++ b/Source/WTF/wtf/text/StringBuilder.cpp
@@ -37,7 +37,7 @@ static constexpr unsigned maxCapacity = String::MaxLength;
 unsigned StringBuilder::expandedCapacity(unsigned capacity, unsigned requiredCapacity)
 {
     static constexpr unsigned minimumCapacity = 16;
-    return std::max(requiredCapacity, std::max(minimumCapacity, std::min(capacity * 2, maxCapacity)));
+    return std::max(requiredCapacity, std::clamp(capacity * 2, minimumCapacity, maxCapacity));
 }
 
 void StringBuilder::didOverflow()

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUCompositorIntegrationImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUCompositorIntegrationImpl.cpp
@@ -71,8 +71,8 @@ Vector<MachSendRight> CompositorIntegrationImpl::recreateRenderBuffers(int width
     }
 
     constexpr int max2DTextureSize = 16384;
-    width = std::max(1, std::min(max2DTextureSize, width));
-    height = std::max(1, std::min(max2DTextureSize, height));
+    width = std::clamp(width, 1, max2DTextureSize);
+    height = std::clamp(height, 1, max2DTextureSize);
     IOSurface::Format colorFormat;
     switch (textureFormat) {
     case TextureFormat::Rgba8unorm:

--- a/Source/WebCore/Modules/mediasession/MediaSession.cpp
+++ b/Source/WebCore/Modules/mediasession/MediaSession.cpp
@@ -382,7 +382,7 @@ std::optional<double> MediaSession::currentPosition() const
 
     auto elapsedTime = (MonotonicTime::now() - m_timeAtLastPositionUpdate) * actualPlaybackRate;
 
-    return std::max(0., std::min(*m_lastReportedPosition + elapsedTime.value(), m_positionState->duration));
+    return std::clamp(*m_lastReportedPosition + elapsedTime.value(), 0., m_positionState->duration);
 }
 
 Document* MediaSession::document() const

--- a/Source/WebCore/Modules/webaudio/BaseAudioContext.cpp
+++ b/Source/WebCore/Modules/webaudio/BaseAudioContext.cpp
@@ -357,7 +357,7 @@ ExceptionOr<Ref<ScriptProcessorNode>> BaseAudioContext::createScriptProcessor(si
     case 0:
 #if USE(AUDIO_SESSION)
         // Pick a value between 256 (2^8) and 16384 (2^14), based on the buffer size of the current AudioSession:
-        bufferSize = 1 << std::max<size_t>(8, std::min<size_t>(14, std::log2(AudioSession::sharedSession().bufferSize())));
+        bufferSize = 1 << std::clamp<size_t>(std::log2(AudioSession::sharedSession().bufferSize()), 8, 14);
 #else
         bufferSize = 2048;
 #endif

--- a/Source/WebCore/accessibility/AccessibilityAttachment.cpp
+++ b/Source/WebCore/accessibility/AccessibilityAttachment.cpp
@@ -52,7 +52,7 @@ bool AccessibilityAttachment::hasProgress(float* progress) const
 {
     auto& progressString = getAttribute(progressAttr);
     bool validProgress;
-    float result = std::max<float>(std::min<float>(progressString.toFloat(&validProgress), 1), 0);
+    float result = std::clamp<float>(progressString.toFloat(&validProgress), 0, 1);
     if (progress)
         *progress = result;
     return validProgress;

--- a/Source/WebCore/accessibility/AccessibilityTableCell.cpp
+++ b/Source/WebCore/accessibility/AccessibilityTableCell.cpp
@@ -399,10 +399,10 @@ unsigned AccessibilityTableCell::colSpan() const
     if (auto colSpan = parseHTMLInteger(getAttribute(colspanAttr)); colSpan && *colSpan >= 1) {
         // https://html.spec.whatwg.org/multipage/tables.html
         // If colspan is greater than 1000, let it be 1000 instead.
-        return std::min(std::max(*colSpan, 1), 1000);
+        return std::clamp(*colSpan, 1, 1000);
     }
     if (auto ariaColSpan = parseHTMLInteger(getAttribute(aria_colspanAttr)); ariaColSpan && *ariaColSpan >= 1)
-        return std::min(std::max(*ariaColSpan, 1), 1000);
+        return std::clamp(*ariaColSpan, 1, 1000);
     return 1;
 }
 

--- a/Source/WebCore/animation/AnimationEffectTiming.cpp
+++ b/Source/WebCore/animation/AnimationEffectTiming.cpp
@@ -180,7 +180,7 @@ BasicEffectTiming AnimationEffectTiming::getBasicTiming(const ResolutionData& da
         auto animationIsBackwards = data.playbackRate < 0;
 
         // https://drafts.csswg.org/web-animations-1/#before-active-boundary-time
-        auto beforeActiveBoundaryTime = std::max(std::min(startDelay, endTime), endTime.matchingZero());
+        auto beforeActiveBoundaryTime = std::clamp(startDelay, endTime.matchingZero(), endTime);
 
         // An animation effect is in the before phase if the animation effect's local time is not unresolved and
         // either of the following conditions are met:
@@ -191,7 +191,7 @@ BasicEffectTiming AnimationEffectTiming::getBasicTiming(const ResolutionData& da
             return AnimationEffectPhase::Before;
 
         // https://drafts.csswg.org/web-animations-1/#active-after-boundary-time
-        auto activeAfterBoundaryTime = std::max(std::min(startDelay + activeDuration, endTime), endTime.matchingZero());
+        auto activeAfterBoundaryTime = std::clamp(startDelay + activeDuration, endTime.matchingZero(), endTime);
 
         // An animation effect is in the after phase if the animation effect's local time is not unresolved
         // and either of the following conditions are met:
@@ -236,7 +236,7 @@ BasicEffectTiming AnimationEffectTiming::getBasicTiming(const ResolutionData& da
             // If the fill mode is forwards or both, return the result of evaluating
             // max(min(local time - start delay, active duration), 0).
             if (fill == FillMode::Forwards || fill == FillMode::Both)
-                return std::max(std::min(*localTime - startDelay, activeDuration), localTime->matchingZero());
+                return std::clamp(*localTime - startDelay, localTime->matchingZero(), activeDuration);
             // Otherwise, return an unresolved time value.
             return std::nullopt;
         }

--- a/Source/WebCore/animation/StyleOriginatedAnimation.cpp
+++ b/Source/WebCore/animation/StyleOriginatedAnimation.cpp
@@ -297,7 +297,7 @@ void StyleOriginatedAnimation::invalidateDOMEvents(WebAnimationTime cancelationT
             // Web Animations spec does not specify how to account for them.
             auto zero = timing.activeDuration.matchingZero();
             intervalStart = std::max(zero, timing.activeDuration);
-            intervalEnd = std::max(zero, std::min(timing.endTime, timing.activeDuration));
+            intervalEnd = std::clamp(timing.endTime, zero, timing.activeDuration);
         } else {
             auto activeDuration = timing.activeDuration.time()->milliseconds();
             intervalStart = std::max(0_s, Seconds::fromMilliseconds(std::min(-timing.delay, activeDuration)));

--- a/Source/WebCore/animation/WebAnimation.cpp
+++ b/Source/WebCore/animation/WebAnimation.cpp
@@ -1913,7 +1913,7 @@ std::optional<double> WebAnimation::overallProgress() const
         return 0;
 
     // Otherwise, overallProgress = min(max(current time / animation's associated effect end, 0), 1)
-    return std::min(std::max(*currentTime / endTime, 0.0), 1.0);
+    return std::clamp(*currentTime / endTime, 0.0, 1.0);
 }
 
 void WebAnimation::setBindingsRangeStart(TimelineRangeValue&& rangeStartValue)

--- a/Source/WebCore/bindings/js/JSDOMConvertNumbers.cpp
+++ b/Source/WebCore/bindings/js/JSDOMConvertNumbers.cpp
@@ -365,7 +365,7 @@ template<> ConversionResult<IDLLongLong> convertToIntegerClamp<IDLLongLong>(JSC:
 
     RETURN_IF_EXCEPTION(scope, ConversionResult<IDLLongLong>::exception());
 
-    return std::isnan(x) ? 0 : static_cast<int64_t>(std::min<double>(std::max<double>(x, -kJSMaxInteger), kJSMaxInteger));
+    return std::isnan(x) ? 0 : static_cast<int64_t>(std::clamp<double>(x, -kJSMaxInteger, kJSMaxInteger));
 }
 
 template<> ConversionResult<IDLUnsignedLongLong> convertToIntegerClamp<IDLUnsignedLongLong>(JSC::JSGlobalObject& lexicalGlobalObject, JSC::JSValue value)
@@ -380,7 +380,7 @@ template<> ConversionResult<IDLUnsignedLongLong> convertToIntegerClamp<IDLUnsign
 
     RETURN_IF_EXCEPTION(scope, ConversionResult<IDLUnsignedLongLong>::exception());
 
-    return std::isnan(x) ? 0 : static_cast<uint64_t>(std::min<double>(std::max<double>(x, 0), kJSMaxInteger));
+    return std::isnan(x) ? 0 : static_cast<uint64_t>(std::clamp<double>(x, 0, kJSMaxInteger));
 }
 
 template<> ConversionResult<IDLLongLong> convertToInteger<IDLLongLong>(JSC::JSGlobalObject& lexicalGlobalObject, JSC::JSValue value)

--- a/Source/WebCore/css/typedom/numeric/CSSMathClamp.cpp
+++ b/Source/WebCore/css/typedom/numeric/CSSMathClamp.cpp
@@ -89,7 +89,7 @@ auto CSSMathClamp::toSumValue() const -> std::optional<SumValue>
     if (!validateSumValue(upper, &lower->first().units))
         return std::nullopt;
 
-    value->first().value = std::max(lower->first().value, std::min(value->first().value, upper->first().value));
+    value->first().value = std::clamp(value->first().value, lower->first().value, upper->first().value);
     return value;
 }
 

--- a/Source/WebCore/dom/ViewportArguments.cpp
+++ b/Source/WebCore/dom/ViewportArguments.cpp
@@ -52,7 +52,7 @@ static inline float clampLengthValue(float value)
 
     // Limits as previously defined in the css-device-adapt spec.
     if (value != ViewportArguments::ValueAuto)
-        return std::min<float>(10000, std::max<float>(value, 1));
+        return std::clamp<float>(value, 1, 10000);
     return value;
 }
 
@@ -63,7 +63,7 @@ static inline float clampScaleValue(float value)
 
     // Limits as previously defined in the css-device-adapt spec.
     if (value != ViewportArguments::ValueAuto)
-        return std::min<float>(10, std::max<float>(value, 0.1));
+        return std::clamp<float>(value, 0.1, 10);
     return value;
 }
 
@@ -130,7 +130,7 @@ ViewportAttributes ViewportArguments::resolve(const FloatSize& initialViewportSi
     }
 
     // Constrain initial-scale value to minimum-scale/maximum-scale range.
-    result.initialScale = std::min(result.maximumScale, std::max(result.minimumScale, result.initialScale));
+    result.initialScale = std::clamp(result.initialScale, result.minimumScale, result.maximumScale);
 
     // Resolve width value.
     if (resultWidth == ViewportArguments::ValueAuto) {

--- a/Source/WebCore/editing/Editor.cpp
+++ b/Source/WebCore/editing/Editor.cpp
@@ -2580,7 +2580,7 @@ void Editor::setComposition(const String& text, const Vector<CompositionUnderlin
                 renderer->repaint();
 
             unsigned start = std::min(baseOffset + selectionStart, extentOffset);
-            unsigned end = std::min(std::max(start, baseOffset + selectionEnd), extentOffset);
+            unsigned end = std::clamp(baseOffset + selectionEnd, start, extentOffset);
             auto range = SimpleRange { { *baseNode, start }, { *baseNode, end } };
             document->selection().setSelectedRange(range, Affinity::Downstream, FrameSelection::ShouldCloseTyping::No);
         }

--- a/Source/WebCore/editing/TextIterator.cpp
+++ b/Source/WebCore/editing/TextIterator.cpp
@@ -2355,7 +2355,7 @@ nextMatch:
             unsigned wordBoundaryContextStart = matchStart;
             U16_BACK_1(m_buffer.span(), 0, wordBoundaryContextStart);
             wordBoundaryContextStart = startOfLastWordBoundaryContext(m_buffer.subspan(0, wordBoundaryContextStart));
-            overlap = std::min(size - 1, std::max(overlap, size - wordBoundaryContextStart));
+            overlap = std::clamp(overlap, size - wordBoundaryContextStart, size - 1);
         }
         memcpySpan(m_buffer.mutableSpan(), m_buffer.span().last(overlap));
         m_prefixLength -= std::min(m_prefixLength, size - overlap);

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -4872,7 +4872,7 @@ double HTMLMediaElement::nextScanRate()
     if (m_scanDirection == Backward)
         rate *= -1;
 #if PLATFORM(IOS_FAMILY)
-    rate = std::min(std::max(rate, minFastReverseRate()), maxFastForwardRate());
+    rate = std::clamp(rate, minFastReverseRate(), maxFastForwardRate());
 #endif
     return rate;
 }

--- a/Source/WebCore/html/HTMLMeterElement.cpp
+++ b/Source/WebCore/html/HTMLMeterElement.cpp
@@ -113,7 +113,7 @@ void HTMLMeterElement::setMax(double max)
 double HTMLMeterElement::value() const
 {
     double value = parseHTMLFloatingPointNumberValue(attributeWithoutSynchronization(valueAttr), 0);
-    return std::min(std::max(value, min()), max());
+    return std::clamp(value, min(), max());
 }
 
 void HTMLMeterElement::setValue(double value)
@@ -124,7 +124,7 @@ void HTMLMeterElement::setValue(double value)
 double HTMLMeterElement::low() const
 {
     double low = parseHTMLFloatingPointNumberValue(attributeWithoutSynchronization(lowAttr), min());
-    return std::min(std::max(low, min()), max());
+    return std::clamp(low, min(), max());
 }
 
 void HTMLMeterElement::setLow(double low)
@@ -135,7 +135,7 @@ void HTMLMeterElement::setLow(double low)
 double HTMLMeterElement::high() const
 {
     double high = parseHTMLFloatingPointNumberValue(attributeWithoutSynchronization(highAttr), max());
-    return std::min(std::max(high, low()), max());
+    return std::clamp(high, low(), max());
 }
 
 void HTMLMeterElement::setHigh(double high)

--- a/Source/WebCore/html/MediaController.cpp
+++ b/Source/WebCore/html/MediaController.cpp
@@ -179,7 +179,7 @@ double MediaController::currentTime() const
 
     if (m_position == MediaPlayer::invalidTime()) {
         // Some clocks may return times outside the range of [0..duration].
-        m_position = std::max<double>(0, std::min(duration(), m_clock->currentTime()));
+        m_position = std::clamp<double>(m_clock->currentTime(), 0, duration());
         m_clearPositionTimer.startOneShot(0_s);
     }
 

--- a/Source/WebCore/html/StepRange.cpp
+++ b/Source/WebCore/html/StepRange.cpp
@@ -88,7 +88,7 @@ Decimal StepRange::alignValueForStep(const Decimal& currentValue, const Decimal&
 
 Decimal StepRange::clampValue(const Decimal& value) const
 {
-    const Decimal inRangeValue = std::max(m_minimum, std::min(value, m_maximum));
+    const Decimal inRangeValue = std::clamp(value, m_minimum, m_maximum);
     if (!m_hasStep)
         return inRangeValue;
     // Rounds inRangeValue to stepBase + N * step.

--- a/Source/WebCore/html/parser/HTMLParserIdioms.h
+++ b/Source/WebCore/html/parser/HTMLParserIdioms.h
@@ -160,7 +160,7 @@ inline unsigned clampHTMLNonNegativeIntegerToRange(StringView stringValue, unsig
     ASSERT(defaultValue <= max);
     auto optionalValue = parseHTMLNonNegativeInteger(stringValue);
     if (optionalValue)
-        return std::min(std::max(optionalValue.value(), min), max);
+        return std::clamp(optionalValue.value(), min, max);
 
     return optionalValue.error() == HTMLIntegerParsingError::PositiveOverflow ? max : defaultValue;
 }

--- a/Source/WebCore/html/shadow/DateTimeSymbolicFieldElement.cpp
+++ b/Source/WebCore/html/shadow/DateTimeSymbolicFieldElement.cpp
@@ -77,7 +77,7 @@ void DateTimeSymbolicFieldElement::setEmptyValue(EventBehavior eventBehavior)
 
 void DateTimeSymbolicFieldElement::setValueAsInteger(int newSelectedIndex, EventBehavior eventBehavior)
 {
-    m_selectedIndex = std::max(0, std::min(newSelectedIndex, static_cast<int>(m_symbols.size() - 1)));
+    m_selectedIndex = std::clamp(newSelectedIndex, 0, static_cast<int>(m_symbols.size() - 1));
     updateVisibleValue(eventBehavior);
 }
 

--- a/Source/WebCore/html/shadow/SliderThumbElement.cpp
+++ b/Source/WebCore/html/shadow/SliderThumbElement.cpp
@@ -273,7 +273,7 @@ void SliderThumbElement::setPositionFromPoint(const LayoutPoint& absolutePoint)
     thumbRenderer = nullptr;
     trackRenderer = nullptr;
 
-    position = std::max<LayoutUnit>(0, std::min(position, trackLength));
+    position = std::clamp<LayoutUnit>(position, 0, trackLength);
     auto ratio = Decimal::fromDouble(static_cast<double>(position) / trackLength);
     auto fraction = isInlineFlipped ? Decimal(1) - ratio : ratio;
     auto stepRange = input->createStepRange(AnyStepHandling::Reject);

--- a/Source/WebCore/inspector/InspectorFrontendClientLocal.cpp
+++ b/Source/WebCore/inspector/InspectorFrontendClientLocal.cpp
@@ -416,12 +416,12 @@ void InspectorFrontendClientLocal::showMainResourceForFrame(LocalFrame* frame)
 
 unsigned InspectorFrontendClientLocal::constrainedAttachedWindowHeight(unsigned preferredHeight, unsigned totalWindowHeight)
 {
-    return roundf(std::max(minimumAttachedHeight, std::min<float>(preferredHeight, totalWindowHeight * maximumAttachedHeightRatio)));
+    return roundf(std::clamp<float>(preferredHeight, minimumAttachedHeight, totalWindowHeight * maximumAttachedHeightRatio));
 }
 
 unsigned InspectorFrontendClientLocal::constrainedAttachedWindowWidth(unsigned preferredWidth, unsigned totalWindowWidth)
 {
-    return roundf(std::max(minimumAttachedWidth, std::min<float>(preferredWidth, totalWindowWidth - minimumAttachedInspectedWidth)));
+    return roundf(std::clamp<float>(preferredWidth, minimumAttachedWidth, totalWindowWidth - minimumAttachedInspectedWidth));
 }
 
 void InspectorFrontendClientLocal::sendMessageToBackend(const String& message)

--- a/Source/WebCore/layout/formattingContexts/FormattingGeometry.cpp
+++ b/Source/WebCore/layout/formattingContexts/FormattingGeometry.cpp
@@ -161,7 +161,7 @@ std::optional<LayoutUnit> FormattingGeometry::computedWidthValue(const Box& layo
         // If the available space in a given axis is definite, equal to min(max-content size,
         // max(min-content size, stretch-fit size)). Otherwise, equal to the max-content size in that axis.
         // FIXME: We don't yet have indefinite available size.
-        return std::min(intrinsicWidthConstraints.maximum, std::max(intrinsicWidthConstraints.minimum, containingBlockWidth));
+        return std::clamp(containingBlockWidth, intrinsicWidthConstraints.minimum, intrinsicWidthConstraints.maximum);
     }
     return { };
 }
@@ -316,7 +316,7 @@ LayoutUnit FormattingGeometry::shrinkToFitWidth(const Box& formattingContextRoot
         }
         return LayoutContext::createFormattingContext(*root, const_cast<LayoutState&>(layoutState))->computedIntrinsicWidthConstraints();
     }();
-    return std::min(std::max(computedIntrinsicWidthConstraints.minimum, availableWidth), computedIntrinsicWidthConstraints.maximum);
+    return std::clamp(availableWidth, computedIntrinsicWidthConstraints.minimum, computedIntrinsicWidthConstraints.maximum);
 }
 
 VerticalGeometry FormattingGeometry::outOfFlowNonReplacedVerticalGeometry(const ElementBox& layoutBox, const HorizontalConstraints& horizontalConstraints, const VerticalConstraints& verticalConstraints, const OverriddenVerticalValues& overriddenVerticalValues) const

--- a/Source/WebCore/layout/formattingContexts/block/tablewrapper/TableWrapperBlockFormattingContext.cpp
+++ b/Source/WebCore/layout/formattingContexts/block/tablewrapper/TableWrapperBlockFormattingContext.cpp
@@ -193,7 +193,7 @@ void TableWrapperBlockFormattingContext::computeWidthAndMarginForTableBox(const 
     auto computedMaxWidth = formattingGeometry.computedMaxWidth(tableBox, horizontalConstraintForResolvingWidth);
     auto computedMinWidth = formattingGeometry.computedMinWidth(tableBox, horizontalConstraintForResolvingWidth);
     // Use the generic shrink-to-fit-width logic as the initial width for the table.
-    auto usedWidth = std::min(std::max(intrinsicWidthConstraints.minimum, availableHorizontalSpace), intrinsicWidthConstraints.maximum);
+    auto usedWidth = std::clamp(availableHorizontalSpace, intrinsicWidthConstraints.minimum, intrinsicWidthConstraints.maximum);
     if (computedWidth || computedMinWidth || computedMaxWidth) {
         if (computedWidth) {
             // Normalize the computed width value first.

--- a/Source/WebCore/layout/formattingContexts/flex/FlexLayout.cpp
+++ b/Source/WebCore/layout/formattingContexts/flex/FlexLayout.cpp
@@ -436,7 +436,7 @@ FlexLayout::LinesCrossSizeList FlexLayout::crossSizeForFlexLines(const LineRange
         if (isSingleLineFlexContainer()) {
             auto minimumCrossSize = crossAxis.minimumSize.value_or(flexLinesCrossSizeList[lineIndex]);
             auto maximumCrossSize = crossAxis.maximumSize.value_or(LayoutUnit::max());
-            flexLinesCrossSizeList[lineIndex] = std::min(maximumCrossSize, std::max(minimumCrossSize, flexLinesCrossSizeList[lineIndex]));
+            flexLinesCrossSizeList[lineIndex] = std::clamp(flexLinesCrossSizeList[lineIndex], minimumCrossSize, maximumCrossSize);
         }
     }
     return flexLinesCrossSizeList;
@@ -497,7 +497,7 @@ FlexLayout::SizeList FlexLayout::computeCrossSizeForFlexItems(const LogicalFlexI
                         stretchedInnerCrossSize -= flexItem.crossAxis().borderAndPadding;
                     auto maximum = flexItem.crossAxis().maximumSize.value_or(stretchedInnerCrossSize);
                     auto minimum = flexItem.crossAxis().minimumSize.value_or(stretchedInnerCrossSize);
-                    return std::min(maximum, std::max(minimum, stretchedInnerCrossSize));
+                    return std::clamp(stretchedInnerCrossSize, minimum, maximum);
                 };
                 crossSizeList[flexItemIndex] = stretchedInnerCrossSize();
                 // FIXME: This requires re-layout to get percentage-sized descendants updated.

--- a/Source/WebCore/mathml/MathMLElement.cpp
+++ b/Source/WebCore/mathml/MathMLElement.cpp
@@ -77,7 +77,7 @@ unsigned MathMLElement::rowSpan() const
     if (!hasTagName(mtdTag))
         return 1u;
     auto& rowSpanValue = attributeWithoutSynchronization(rowspanAttr);
-    return std::max(1u, std::min(limitToOnlyHTMLNonNegative(rowSpanValue, 1u), HTMLTableCellElement::maxRowspan));
+    return std::clamp(limitToOnlyHTMLNonNegative(rowSpanValue, 1u), 1u, HTMLTableCellElement::maxRowspan);
 }
 
 void MathMLElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)

--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -363,12 +363,12 @@ FloatRect LocalDOMWindow::adjustWindowRect(Page& page, const FloatRect& pendingC
         window.setHeight(pendingChanges.height());
 
     FloatSize minimumSize = page.chrome().client().minimumWindowSize();
-    window.setWidth(std::min(std::max(minimumSize.width(), window.width()), screen.width()));
-    window.setHeight(std::min(std::max(minimumSize.height(), window.height()), screen.height()));
+    window.setWidth(std::clamp(window.width(), minimumSize.width(), screen.width()));
+    window.setHeight(std::clamp(window.height(), minimumSize.height(), screen.height()));
 
     // Constrain the window position within the valid screen area.
-    window.setX(std::max(screen.x(), std::min(window.x(), screen.maxX() - window.width())));
-    window.setY(std::max(screen.y(), std::min(window.y(), screen.maxY() - window.height())));
+    window.setX(std::clamp(window.x(), screen.x(), screen.maxX() - window.width()));
+    window.setY(std::clamp(window.y(), screen.y(), screen.maxY() - window.height()));
 
     return window;
 }

--- a/Source/WebCore/page/ViewportConfiguration.cpp
+++ b/Source/WebCore/page/ViewportConfiguration.cpp
@@ -393,7 +393,7 @@ double ViewportConfiguration::minimumScale() const
             minimumScale = m_viewLayoutSize.height() / contentHeight;
     }
 
-    minimumScale = std::min(std::max(minimumScale, m_configuration.minimumScale), m_configuration.maximumScale);
+    minimumScale = std::clamp(minimumScale, m_configuration.minimumScale, m_configuration.maximumScale);
 
     return minimumScale;
 }
@@ -505,7 +505,7 @@ ViewportConfiguration::Parameters ViewportConfiguration::testingParameters()
 static inline bool applyViewportArgument(double& value, float viewportArgumentValue, float minimum, float maximum)
 {
     if (viewportArgumentValueIsValid(viewportArgumentValue)) {
-        value = std::min(maximum, std::max(minimum, viewportArgumentValue));
+        value = std::clamp(viewportArgumentValue, minimum, maximum);
         return true;
     }
 

--- a/Source/WebCore/platform/DictationCaretAnimator.cpp
+++ b/Source/WebCore/platform/DictationCaretAnimator.cpp
@@ -241,7 +241,7 @@ Path DictationCaretAnimator::makeDictationTailConePath(const FloatRect& rect) co
     const float minimumTailWidth = coneStart(height);
     const auto nonTruncatedTailWidth = coneEnd(height);
     const auto coneRectangleMorphConstant = (width - minimumTailWidth) / (nonTruncatedTailWidth - minimumTailWidth);
-    auto verticalOffset = -height * .3f + height * 0.5f * std::min(1.f, std::max(0.f, coneRectangleMorphConstant));
+    auto verticalOffset = -height * .3f + height * 0.5f * std::clamp(coneRectangleMorphConstant, 0.f, 1.f);
     bool isLTR = isLeftToRightLayout();
 
     const auto verticalOffsetLTR = isLTR ? verticalOffset : 0.f;

--- a/Source/WebCore/platform/PlatformSpeechSynthesisUtterance.h
+++ b/Source/WebCore/platform/PlatformSpeechSynthesisUtterance.h
@@ -60,15 +60,15 @@ public:
 
     // Range = [0, 1] where 1 is the default.
     float volume() const { return m_volume; }
-    void setVolume(float volume) { m_volume = std::max(std::min(1.0f, volume), 0.0f); }
+    void setVolume(float volume) { m_volume = std::clamp(volume, 0.0f, 1.0f); }
     
     // Range = [0.1, 10] where 1 is the default.
     float rate() const { return m_rate; }
-    void setRate(float rate) { m_rate = std::max(std::min(10.0f, rate), 0.1f); }
+    void setRate(float rate) { m_rate = std::clamp(rate, 0.1f, 10.0f); }
     
     // Range = [0, 2] where 1 is the default.
     float pitch() const { return m_pitch; }
-    void setPitch(float pitch) { m_pitch = std::max(std::min(2.0f, pitch), 0.0f); }
+    void setPitch(float pitch) { m_pitch = std::clamp(pitch, 0.0f, 2.0f); }
 
     MonotonicTime startTime() const { return m_startTime; }
     void setStartTime(MonotonicTime startTime) { m_startTime = startTime; }

--- a/Source/WebCore/platform/audio/AudioHardwareListener.h
+++ b/Source/WebCore/platform/audio/AudioHardwareListener.h
@@ -59,7 +59,7 @@ public:
         size_t minimum { 0 };
         size_t maximum { 0 };
         operator bool() const { return minimum && maximum; }
-        size_t nearest(size_t value) const { return std::min(std::max(value, minimum), maximum); }
+        size_t nearest(size_t value) const { return std::clamp(value, minimum, maximum); }
     };
     BufferSizeRange supportedBufferSizes() const { return m_supportedBufferSizes; }
 

--- a/Source/WebCore/platform/audio/Biquad.cpp
+++ b/Source/WebCore/platform/audio/Biquad.cpp
@@ -273,7 +273,7 @@ void Biquad::reset()
 void Biquad::setLowpassParams(size_t index, double cutoff, double resonance)
 {
     // Limit cutoff to 0 to 1.
-    cutoff = std::max(0.0, std::min(cutoff, 1.0));
+    cutoff = std::clamp(cutoff, 0.0, 1.0);
     
     if (cutoff == 1) {
         // When cutoff is 1, the z-transform is 1.
@@ -306,7 +306,7 @@ void Biquad::setLowpassParams(size_t index, double cutoff, double resonance)
 void Biquad::setHighpassParams(size_t index, double cutoff, double resonance)
 {
     // Limit cutoff to 0 to 1.
-    cutoff = std::max(0.0, std::min(cutoff, 1.0));
+    cutoff = std::clamp(cutoff, 0.0, 1.0);
 
     if (cutoff == 1) {
         // The z-transform is 0.
@@ -352,7 +352,7 @@ void Biquad::setNormalizedCoefficients(size_t index, double b0, double b1, doubl
 void Biquad::setLowShelfParams(size_t index, double frequency, double dbGain)
 {
     // Clip frequencies to between 0 and 1, inclusive.
-    frequency = std::max(0.0, std::min(frequency, 1.0));
+    frequency = std::clamp(frequency, 0.0, 1.0);
     
     double A = pow(10.0, dbGain / 40);
 
@@ -385,7 +385,7 @@ void Biquad::setLowShelfParams(size_t index, double frequency, double dbGain)
 void Biquad::setHighShelfParams(size_t index, double frequency, double dbGain)
 {
     // Clip frequencies to between 0 and 1, inclusive.
-    frequency = std::max(0.0, std::min(frequency, 1.0));
+    frequency = std::clamp(frequency, 0.0, 1.0);
 
     double A = pow(10.0, dbGain / 40);
 
@@ -418,7 +418,7 @@ void Biquad::setHighShelfParams(size_t index, double frequency, double dbGain)
 void Biquad::setPeakingParams(size_t index, double frequency, double Q, double dbGain)
 {
     // Clip frequencies to between 0 and 1, inclusive.
-    frequency = std::max(0.0, std::min(frequency, 1.0));
+    frequency = std::clamp(frequency, 0.0, 1.0);
 
     // Don't let Q go negative, which causes an unstable filter.
     Q = std::max(0.0, Q);
@@ -454,7 +454,7 @@ void Biquad::setPeakingParams(size_t index, double frequency, double Q, double d
 void Biquad::setAllpassParams(size_t index, double frequency, double Q)
 {
     // Clip frequencies to between 0 and 1, inclusive.
-    frequency = std::max(0.0, std::min(frequency, 1.0));
+    frequency = std::clamp(frequency, 0.0, 1.0);
 
     // Don't let Q go negative, which causes an unstable filter.
     Q = std::max(0.0, Q);
@@ -488,7 +488,7 @@ void Biquad::setAllpassParams(size_t index, double frequency, double Q)
 void Biquad::setNotchParams(size_t index, double frequency, double Q)
 {
     // Clip frequencies to between 0 and 1, inclusive.
-    frequency = std::max(0.0, std::min(frequency, 1.0));
+    frequency = std::clamp(frequency, 0.0, 1.0);
 
     // Don't let Q go negative, which causes an unstable filter.
     Q = std::max(0.0, Q);

--- a/Source/WebCore/platform/audio/HRTFKernel.cpp
+++ b/Source/WebCore/platform/audio/HRTFKernel.cpp
@@ -120,7 +120,7 @@ RefPtr<HRTFKernel> HRTFKernel::createInterpolatedKernel(HRTFKernel* kernel1, HRT
         return nullptr;
  
     ASSERT(x >= 0.0 && x < 1.0);
-    x = std::min(1.0f, std::max(0.0f, x));
+    x = std::clamp(x, 0.0f, 1.0f);
     
     float sampleRate1 = kernel1->sampleRate();
     float sampleRate2 = kernel2->sampleRate();

--- a/Source/WebCore/platform/audio/mac/AudioSessionMac.mm
+++ b/Source/WebCore/platform/audio/mac/AudioSessionMac.mm
@@ -424,7 +424,7 @@ void AudioSessionMac::setPreferredBufferSize(size_t bufferSize)
 
     size_t minBufferSize = static_cast<size_t>(bufferSizeRange.mMinimum);
     size_t maxBufferSize = static_cast<size_t>(bufferSizeRange.mMaximum);
-    UInt32 bufferSizeOut = std::min(maxBufferSize, std::max(minBufferSize, bufferSize));
+    UInt32 bufferSizeOut = std::clamp(bufferSize, minBufferSize, maxBufferSize);
 
     result = AudioObjectSetPropertyData(defaultDevice(), &bufferSizeAddress(), 0, 0, sizeof(bufferSizeOut), (void*)&bufferSizeOut);
 

--- a/Source/WebCore/platform/calc/CalculationExecutor.h
+++ b/Source/WebCore/platform/calc/CalculationExecutor.h
@@ -230,6 +230,7 @@ template<> struct OperatorExecutor<Clamp> {
     {
         if (std::isnan(min) || std::isnan(val) || std::isnan(max))
             return std::numeric_limits<T>::quiet_NaN();
+        // Unable to use std::clamp as `min` may be greater than `max`.
         return std::max(min, std::min(val, max));
     }
 

--- a/Source/WebCore/platform/graphics/FloatPoint.cpp
+++ b/Source/WebCore/platform/graphics/FloatPoint.cpp
@@ -47,6 +47,7 @@ FloatPoint::FloatPoint(const IntPoint& p) : m_x(p.x()), m_y(p.y())
 
 FloatPoint FloatPoint::constrainedBetween(const FloatPoint& min, const FloatPoint& max) const
 {
+    // Unable to use std::clamp() here as `min` may be greater than `max`.
     return {
         std::max(min.x(), std::min(max.x(), m_x)),
         std::max(min.y(), std::min(max.y(), m_y))

--- a/Source/WebCore/platform/graphics/FloatSize.cpp
+++ b/Source/WebCore/platform/graphics/FloatSize.cpp
@@ -39,6 +39,7 @@ namespace WebCore {
 
 FloatSize FloatSize::constrainedBetween(const FloatSize& min, const FloatSize& max) const
 {
+    // Unable to use std::clamp() here as `min` may be greater than `max`.
     return {
         std::max(min.width(), std::min(max.width(), m_width)),
         std::max(min.height(), std::min(max.height(), m_height))

--- a/Source/WebCore/platform/graphics/FontSelectionAlgorithm.h
+++ b/Source/WebCore/platform/graphics/FontSelectionAlgorithm.h
@@ -112,7 +112,7 @@ constexpr FontSelectionValue FontSelectionValue::minimumValue()
 
 constexpr FontSelectionValue FontSelectionValue::clampFloat(float value)
 {
-    return FontSelectionValue { std::max<float>(minimumValue(), std::min<float>(value, maximumValue())) };
+    return FontSelectionValue { std::clamp<float>(value, minimumValue(), maximumValue()) };
 }
 
 constexpr FontSelectionValue::FontSelectionValue(int rawValue, RawTag)

--- a/Source/WebCore/platform/graphics/IntPoint.cpp
+++ b/Source/WebCore/platform/graphics/IntPoint.cpp
@@ -40,6 +40,7 @@ IntPoint::IntPoint(const FloatPoint& p)
 
 IntPoint IntPoint::constrainedBetween(const IntPoint& min, const IntPoint& max) const
 {
+    // Unable to use std::clamp() here as `min` may be greater than `max`.
     return {
         std::max(min.x(), std::min(max.x(), m_x)),
         std::max(min.y(), std::min(max.y(), m_y))

--- a/Source/WebCore/platform/graphics/IntSize.cpp
+++ b/Source/WebCore/platform/graphics/IntSize.cpp
@@ -40,6 +40,7 @@ IntSize::IntSize(const FloatSize& s)
 
 IntSize IntSize::constrainedBetween(const IntSize& min, const IntSize& max) const
 {
+    // Unable to use std::clamp() here as `min` may be greater than `max`.
     return {
         std::max(min.width(), std::min(max.width(), m_width)),
         std::max(min.height(), std::min(max.height(), m_height))

--- a/Source/WebCore/platform/graphics/LayoutPoint.cpp
+++ b/Source/WebCore/platform/graphics/LayoutPoint.cpp
@@ -33,8 +33,8 @@ namespace WebCore {
 LayoutPoint LayoutPoint::constrainedBetween(const LayoutPoint& min, const LayoutPoint& max) const
 {
     return {
-        std::max(min.x(), std::min(max.x(), m_x)),
-        std::max(min.y(), std::min(max.y(), m_y))
+        std::clamp(m_x, min.x(), max.x()),
+        std::clamp(m_y, min.y(), max.y())
     };
 }
 

--- a/Source/WebCore/platform/graphics/LayoutSize.cpp
+++ b/Source/WebCore/platform/graphics/LayoutSize.cpp
@@ -33,8 +33,8 @@ namespace WebCore {
 LayoutSize LayoutSize::constrainedBetween(const LayoutSize& min, const LayoutSize& max) const
 {
     return {
-        std::max(min.width(), std::min(max.width(), m_width)),
-        std::max(min.height(), std::min(max.height(), m_height))
+        std::clamp(m_width, min.width(), max.width()),
+        std::clamp(m_height, min.height(), max.height())
     };
 }
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
@@ -1566,7 +1566,7 @@ MediaTime MediaPlayerPrivateAVFoundationObjC::currentTime() const
         itemTime += MediaTime::createWithDouble(elapsedMediaTime.seconds());
     }
 
-    return std::min(std::max(itemTime, MediaTime::zeroTime()), m_cachedDuration);
+    return std::clamp(itemTime, MediaTime::zeroTime(), m_cachedDuration);
 }
 
 bool MediaPlayerPrivateAVFoundationObjC::setCurrentTimeDidChangeCallback(MediaPlayer::CurrentTimeDidChangeCallback&& callback)

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
@@ -869,7 +869,7 @@ void GraphicsLayerCA::setBackfaceVisibility(bool visible)
 
 void GraphicsLayerCA::setOpacity(float opacity)
 {
-    float clampedOpacity = std::max(0.0f, std::min(opacity, 1.0f));
+    float clampedOpacity = std::clamp(opacity, 0.0f, 1.0f);
 
     if (clampedOpacity == m_opacity)
         return;

--- a/Source/WebCore/platform/graphics/ca/TileController.cpp
+++ b/Source/WebCore/platform/graphics/ca/TileController.cpp
@@ -663,9 +663,13 @@ IntSize TileController::computeTileSize()
     if (m_scrollability == Scrollability::NotScrollable) {
         IntSize scaledSize = expandedIntSize(boundsWithoutMargin().size() * tileGrid().scale());
         tileSize = scaledSize.constrainedBetween(IntSize(kDefaultTileSize, kDefaultTileSize), maxTileSize);
-    } else if (m_scrollability == Scrollability::VerticallyScrollable)
-        tileSize.setWidth(std::min(std::max<int>(ceilf(boundsWithoutMargin().width() * tileGrid().scale()), kDefaultTileSize), maxTileSize.width()));
-
+    } else if (m_scrollability == Scrollability::VerticallyScrollable) {
+        tileSize.setWidth(std::clamp<int>(
+            ceilf(boundsWithoutMargin().width() * tileGrid().scale()),
+            kDefaultTileSize,
+            maxTileSize.width()
+        ));
+    }
     LOG_WITH_STREAM(Tiling, stream << "TileController::tileSize newSize=" << tileSize);
 
     m_tileSizeLocked = true;

--- a/Source/WebCore/platform/graphics/cg/ImageDecoderCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/ImageDecoderCG.cpp
@@ -109,7 +109,7 @@ static RetainPtr<CFMutableDictionaryRef> createImageSourceThumbnailOptions()
 
 static RetainPtr<CFMutableDictionaryRef> appendImageSourceOption(RetainPtr<CFMutableDictionaryRef>&& options, SubsamplingLevel subsamplingLevel)
 {
-    subsamplingLevel = std::min(SubsamplingLevel::Last, std::max(SubsamplingLevel::First, subsamplingLevel));
+    subsamplingLevel = std::clamp(subsamplingLevel, SubsamplingLevel::First, SubsamplingLevel::Last);
     int subsampleInt = 1 << static_cast<int>(subsamplingLevel); // [0..3] => [1, 2, 4, 8]
     auto subsampleNumber = adoptCF(CFNumberCreate(nullptr,  kCFNumberIntType,  &subsampleInt));
     CFDictionarySetValue(options.get(), kCGImageSourceSubsampleFactor, subsampleNumber.get());

--- a/Source/WebCore/platform/graphics/cocoa/UnrealizedCoreTextFont.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/UnrealizedCoreTextFont.cpp
@@ -288,11 +288,11 @@ void UnrealizedCoreTextFont::modifyFromContext(const FontDescription& fontDescri
         m_slope = fontSelectionRequest.slope.value_or(normalItalicValue());
         m_fontStyleAxis = fontDescription.fontStyleAxis();
         if (auto weightValue = fontCreationContext.fontFaceCapabilities().weight)
-            m_weight = std::max(std::min(m_weight, static_cast<float>(weightValue->maximum)), static_cast<float>(weightValue->minimum));
+            m_weight = std::clamp<float>(m_weight, weightValue->minimum, weightValue->maximum);
         if (auto widthValue = fontCreationContext.fontFaceCapabilities().width)
-            m_width = std::max(std::min(m_width, static_cast<float>(widthValue->maximum)), static_cast<float>(widthValue->minimum));
+            m_width = std::clamp<float>(m_width, widthValue->minimum, widthValue->maximum);
         if (auto slopeValue = fontCreationContext.fontFaceCapabilities().weight)
-            m_slope = std::max(std::min(m_slope, static_cast<float>(slopeValue->maximum)), static_cast<float>(slopeValue->minimum));
+            m_slope = std::clamp<float>(m_slope, slopeValue->minimum, slopeValue->maximum);
         if (shouldEnhanceTextLegibility && fontTypeForPreparation == FontTypeForPreparation::SystemFont) {
             auto ctWeight = denormalizeCTWeight(m_weight);
             ctWeight = CTFontGetAccessibilityBoldWeightOfWeight(ctWeight);

--- a/Source/WebCore/platform/graphics/coretext/FontCoreText.cpp
+++ b/Source/WebCore/platform/graphics/coretext/FontCoreText.cpp
@@ -602,7 +602,7 @@ GlyphBufferAdvance Font::applyTransforms(GlyphBuffer& glyphBuffer, unsigned begi
 
     auto handler = ^(CFRange range, CGGlyph** newGlyphsPointer, CGSize** newAdvancesPointer, CGPoint** newOffsetsPointer, CFIndex** newIndicesPointer)
     {
-        range.location = std::min(std::max(range.location, static_cast<CFIndex>(0)), static_cast<CFIndex>(glyphBuffer.size()));
+        range.location = std::clamp<CFIndex>(range.location, 0, glyphBuffer.size());
         if (range.length < 0) {
             range.length = std::min(range.location, -range.length);
             range.location = range.location - range.length;

--- a/Source/WebCore/platform/graphics/filters/FEComponentTransfer.cpp
+++ b/Source/WebCore/platform/graphics/filters/FEComponentTransfer.cpp
@@ -260,7 +260,7 @@ FEComponentTransfer::LookupTable FEComponentTransfer::computeLookupTable(const C
                 double v1 = tableValues[k];
                 double v2 = tableValues[std::min((k + 1), (n - 1))];
                 double val = 255.0 * (v1 + (c * (n - 1) - k) * (v2 - v1));
-                val = std::max(0.0, std::min(255.0, val));
+                val = std::clamp(val, 0.0, 255.0);
                 values[i] = static_cast<uint8_t>(val);
             }
         },
@@ -275,7 +275,7 @@ FEComponentTransfer::LookupTable FEComponentTransfer::computeLookupTable(const C
                 unsigned k = static_cast<unsigned>((i * n) / 255.0);
                 k = std::min(k, n - 1);
                 double val = 255 * tableValues[k];
-                val = std::max(0.0, std::min(255.0, val));
+                val = std::clamp(val, 0.0, 255.0);
                 values[i] = static_cast<uint8_t>(val);
             }
         },
@@ -284,7 +284,7 @@ FEComponentTransfer::LookupTable FEComponentTransfer::computeLookupTable(const C
         {
             for (unsigned i = 0; i < values.size(); ++i) {
                 double val = transferFunction.slope * i + 255 * transferFunction.intercept;
-                val = std::max(0.0, std::min(255.0, val));
+                val = std::clamp(val, 0.0, 255.0);
                 values[i] = static_cast<uint8_t>(val);
             }
         },
@@ -294,7 +294,7 @@ FEComponentTransfer::LookupTable FEComponentTransfer::computeLookupTable(const C
             for (unsigned i = 0; i < values.size(); ++i) {
                 double exponent = transferFunction.exponent; // RCVT doesn't like passing a double and a float to pow, so promote this to double
                 double val = 255.0 * (transferFunction.amplitude * pow((i / 255.0), exponent) + transferFunction.offset);
-                val = std::max(0.0, std::min(255.0, val));
+                val = std::clamp(val, 0.0, 255.0);
                 values[i] = static_cast<uint8_t>(val);
             }
         }

--- a/Source/WebCore/platform/graphics/transforms/TransformationMatrix.cpp
+++ b/Source/WebCore/platform/graphics/transforms/TransformationMatrix.cpp
@@ -823,7 +823,7 @@ FloatQuad TransformationMatrix::projectQuad(const FloatQuad& q, bool* clamped) c
 static float clampEdgeValue(float f)
 {
     ASSERT(!std::isnan(f));
-    return std::min<float>(std::max<float>(f, -LayoutUnit::max() / 2), LayoutUnit::max() / 2);
+    return std::clamp<float>(f, -LayoutUnit::max() / 2, LayoutUnit::max() / 2);
 }
 
 LayoutRect TransformationMatrix::clampedBoundsOfProjectedQuad(const FloatQuad& q) const

--- a/Source/WebCore/platform/mediarecorder/MediaRecorderPrivate.cpp
+++ b/Source/WebCore/platform/mediarecorder/MediaRecorderPrivate.cpp
@@ -111,7 +111,7 @@ MediaRecorderPrivate::BitRates MediaRecorderPrivate::computeBitRates(const Media
         auto totalBitsPerSecond = *options.bitsPerSecond;
 
         if (hasAudio && hasVideo) {
-            auto audioBitsPerSecond =  std::min(LargeAudioBitRate, std::max(SmallAudioBitRate, totalBitsPerSecond / 10));
+            auto audioBitsPerSecond =  std::clamp(totalBitsPerSecond / 10, SmallAudioBitRate, LargeAudioBitRate);
             auto remainingBitsPerSecond = totalBitsPerSecond > audioBitsPerSecond ? (totalBitsPerSecond - audioBitsPerSecond) : 0;
             return { audioBitsPerSecond, std::max(remainingBitsPerSecond, SmallVideoBitRate) };
         }

--- a/Source/WebCore/platform/mediastream/MediaConstraints.h
+++ b/Source/WebCore/platform/mediastream/MediaConstraints.h
@@ -272,7 +272,7 @@ public:
         }
 
         if (m_ideal)
-            value = std::max(min, std::min(max, m_ideal.value()));
+            value = std::clamp(m_ideal.value(), min, max);
 
         return value;
     }

--- a/Source/WebCore/rendering/AttachmentLayout.mm
+++ b/Source/WebCore/rendering/AttachmentLayout.mm
@@ -214,7 +214,7 @@ static BOOL getAttachmentProgress(const RenderAttachment& attachment, float& pro
     if (progressString.isEmpty())
         return NO;
     bool validProgress;
-    progress = std::max<float>(std::min<float>(progressString.toFloat(&validProgress), 1), 0);
+    progress = std::clamp<float>(progressString.toFloat(&validProgress), 0, 1);
     return validProgress;
 }
 

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -386,7 +386,7 @@ void RenderBlockFlow::computeColumnCountAndWidth()
         desiredColumnCount = std::max<unsigned>(1, ((availWidth + colGap) / (colWidth + colGap)).toUnsigned());
         desiredColumnWidth = ((availWidth + colGap) / desiredColumnCount) - colGap;
     } else {
-        desiredColumnCount = std::max<unsigned>(std::min(colCount, ((availWidth + colGap) / (colWidth + colGap)).toUnsigned()), 1);
+        desiredColumnCount = std::clamp<unsigned>(((availWidth + colGap) / (colWidth + colGap)).toUnsigned(), 1, colCount);
         desiredColumnWidth = ((availWidth + colGap) / desiredColumnCount) - colGap;
     }
     setComputedColumnCountAndWidth(desiredColumnCount, desiredColumnWidth);

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -768,6 +768,7 @@ LayoutUnit RenderBox::constrainLogicalHeightByMinMax(LayoutUnit logicalHeight, s
     LayoutUnit minHeight = computedLogicalMinHeight ? computedLogicalMinHeight.value() : LayoutUnit();
     if (styleToUse.hasAspectRatio())
         constrainLogicalMinMaxSizesByAspectRatio(minHeight, maxHeight, logicalHeight, minimumSizeType, ConstrainDimension::Height);
+    // Unable to use std::clamp() as minHeight may be greater than maxHeight.
     logicalHeight = std::min(logicalHeight, maxHeight);
     return std::max(logicalHeight, minHeight);
 }
@@ -2813,7 +2814,7 @@ LayoutUnit RenderBox::computeIntrinsicLogicalWidthUsing(Length logicalWidthLengt
     if (logicalWidthLength.isFitContent()) {
         minLogicalWidth += borderAndPadding;
         maxLogicalWidth += borderAndPadding;
-        return std::max(minLogicalWidth, std::min(maxLogicalWidth, fillAvailableMeasure(availableLogicalWidth)));
+        return std::clamp(fillAvailableMeasure(availableLogicalWidth), minLogicalWidth, maxLogicalWidth);
     }
 
     ASSERT_NOT_REACHED();
@@ -2842,7 +2843,7 @@ LayoutUnit RenderBox::computeLogicalWidthUsing(SizeType widthType, Length logica
         logicalWidthResult = std::min(logicalWidthResult, shrinkLogicalWidthToAvoidFloats(marginStart, marginEnd, containingBlock));
 
     if (widthType == SizeType::MainOrPreferredSize && sizesLogicalWidthToFitContent(widthType))
-        return std::max(minPreferredLogicalWidth(), std::min(maxPreferredLogicalWidth(), logicalWidthResult));
+        return std::clamp(logicalWidthResult, minPreferredLogicalWidth(), maxPreferredLogicalWidth());
     return logicalWidthResult;
 }
 
@@ -3536,6 +3537,7 @@ LayoutUnit RenderBox::computeReplacedLogicalWidthRespectingMinMaxWidth(LayoutUni
     bool useLogicalWidthForMaxWidth = (shouldComputePreferred == ShouldComputePreferred::ComputePreferred && logicalMaxWidth.isPercentOrCalculated()) || logicalMaxWidth.isUndefined();
     auto minLogicalWidth =  useLogicalWidthForMinWidth ? logicalWidth : computeReplacedLogicalWidthUsing(SizeType::MinSize, logicalMinWidth);
     auto maxLogicalWidth =  useLogicalWidthForMaxWidth ? logicalWidth : computeReplacedLogicalWidthUsing(SizeType::MaxSize, logicalMaxWidth);
+    // Unable to use std::clamp as minLogicalWidth may be greater than maxLogicalWidth.
     return std::max(minLogicalWidth, std::min(logicalWidth, maxLogicalWidth));
 }
 
@@ -3693,6 +3695,7 @@ LayoutUnit RenderBox::computeReplacedLogicalHeightRespectingMinMaxHeight(LayoutU
     LayoutUnit maxLogicalHeight = logicalHeight;
     if (!replacedMinMaxLogicalHeightComputesAsNone(SizeType::MaxSize))
         maxLogicalHeight = computeReplacedLogicalHeightUsing(SizeType::MaxSize, style().logicalMaxHeight());
+    // Unable to use std::clamp as minLogicalHeight may be greater than maxLogicalHeight.
     return std::max(minLogicalHeight, std::min(logicalHeight, maxLogicalHeight));
 }
 
@@ -4084,7 +4087,7 @@ LayoutUnit RenderBox::computePositionedLogicalWidthUsing(SizeType widthType, Len
     if (shrinkToFit) {
         LayoutUnit preferredWidth = maxPreferredLogicalWidth() - inlineConstraints.bordersPlusPadding();
         LayoutUnit preferredMinWidth = minPreferredLogicalWidth() - inlineConstraints.bordersPlusPadding();
-        return std::min(std::max(preferredMinWidth, inlineConstraints.availableContentSpace()), preferredWidth);
+        return std::clamp(inlineConstraints.availableContentSpace(), preferredMinWidth, preferredWidth);
     }
 
     return std::max(0_lu, inlineConstraints.availableContentSpace());

--- a/Source/WebCore/rendering/RenderFlexibleBox.cpp
+++ b/Source/WebCore/rendering/RenderFlexibleBox.cpp
@@ -101,6 +101,7 @@ public:
 
     LayoutUnit constrainSizeByMinMax(const LayoutUnit size) const
     {
+        // Unable to use std::clamp here as minMaxSizes.first may be greater than minMaxSizes.second.
         return std::max(minMaxSizes.first, std::min(size, minMaxSizes.second));
     }
 

--- a/Source/WebCore/rendering/RenderFragmentContainer.cpp
+++ b/Source/WebCore/rendering/RenderFragmentContainer.cpp
@@ -460,12 +460,12 @@ LayoutRect RenderFragmentContainer::rectFlowPortionForBox(const RenderBox& box, 
             if (this != startFragment)
                 mappedRect.shiftYEdgeTo(std::max<LayoutUnit>(logicalTopForFragmentedFlowContent(), mappedRect.y()));
             if (this != endFragment)
-                mappedRect.setHeight(std::max<LayoutUnit>(0, std::min<LayoutUnit>(logicalBottomForFragmentedFlowContent() - mappedRect.y(), mappedRect.height())));
+                mappedRect.setHeight(std::clamp<LayoutUnit>(logicalBottomForFragmentedFlowContent() - mappedRect.y(), 0, mappedRect.height()));
         } else {
             if (this != startFragment)
                 mappedRect.shiftXEdgeTo(std::max<LayoutUnit>(logicalTopForFragmentedFlowContent(), mappedRect.x()));
             if (this != endFragment)
-                mappedRect.setWidth(std::max<LayoutUnit>(0, std::min<LayoutUnit>(logicalBottomForFragmentedFlowContent() - mappedRect.x(), mappedRect.width())));
+                mappedRect.setWidth(std::clamp<LayoutUnit>(logicalBottomForFragmentedFlowContent() - mappedRect.x(), 0, mappedRect.width()));
         }
     }
 

--- a/Source/WebCore/rendering/RenderListBox.cpp
+++ b/Source/WebCore/rendering/RenderListBox.cpp
@@ -659,7 +659,7 @@ void RenderListBox::panScroll(const IntPoint& panStartMousePosition)
     int yDelta = lastKnownMousePosition.y() - panStartMousePosition.y();
 
     // If the point is too far from the center we limit the speed
-    yDelta = std::max<int>(std::min<int>(yDelta, maxSpeed), -maxSpeed);
+    yDelta = std::clamp<int>(yDelta, -maxSpeed, maxSpeed);
     
     if (std::abs(yDelta) < iconRadius) // at the center we let the space for the icon
         return;

--- a/Source/WebCore/rendering/RenderScrollbarPart.cpp
+++ b/Source/WebCore/rendering/RenderScrollbarPart.cpp
@@ -98,6 +98,7 @@ void RenderScrollbarPart::computeScrollbarWidth()
     int width = calcScrollbarThicknessUsing(RenderBox::SizeType::MainOrPreferredSize, style().width());
     int minWidth = calcScrollbarThicknessUsing(RenderBox::SizeType::MinSize, style().minWidth());
     int maxWidth = style().maxWidth().isUndefined() ? width : calcScrollbarThicknessUsing(RenderBox::SizeType::MaxSize, style().maxWidth());
+    // Unable to use std::clamp as minWidth may be greater than maxWidth.
     setWidth(std::max(minWidth, std::min(maxWidth, width)));
     
     // Buttons and track pieces can all have margins along the axis of the scrollbar. 
@@ -112,6 +113,7 @@ void RenderScrollbarPart::computeScrollbarHeight()
     int height = calcScrollbarThicknessUsing(RenderBox::SizeType::MainOrPreferredSize, style().height());
     int minHeight = calcScrollbarThicknessUsing(RenderBox::SizeType::MinSize, style().minHeight());
     int maxHeight = style().maxHeight().isUndefined() ? height : calcScrollbarThicknessUsing(RenderBox::SizeType::MaxSize, style().maxHeight());
+    // Unable to use std::clamp here as minHeight may be greater than maxHeight.
     setHeight(std::max(minHeight, std::min(maxHeight, height)));
 
     // Buttons and track pieces can all have margins along the axis of the scrollbar. 

--- a/Source/WebCore/rendering/RenderText.cpp
+++ b/Source/WebCore/rendering/RenderText.cpp
@@ -684,8 +684,8 @@ Vector<FloatQuad> RenderText::absoluteQuadsForRange(unsigned start, unsigned end
 
     // Narrows |start| and |end| into |caretMinOffset| and |caretMaxOffset| to ignore unrendered leading 
     // and trailing whitespaces.
-    start = std::min(std::max(caretMinOffset, start), caretMaxOffset);
-    end = std::min(std::max(caretMinOffset, end), caretMaxOffset);
+    start = std::clamp(start, caretMinOffset, caretMaxOffset);
+    end = std::clamp(end, caretMinOffset, caretMaxOffset);
 
     Vector<FloatQuad> quads;
     for (auto& textBox : InlineIterator::textBoxesFor(*this)) {

--- a/Source/WebCore/rendering/style/GridArea.h
+++ b/Source/WebCore/rendering/style/GridArea.h
@@ -164,7 +164,7 @@ public:
     {
         ASSERT(m_type != Indefinite);
         m_startLine = std::max(m_startLine, 0);
-        m_endLine = std::max(std::min(m_endLine, max), 1);
+        m_endLine = std::clamp(m_endLine, 1, max);
         if (m_startLine >= m_endLine)
             m_startLine = m_endLine - 1;
     }
@@ -197,8 +197,8 @@ private:
         }
 #endif
 
-        m_startLine = std::max(GridPosition::min(), std::min(startLine, GridPosition::max() - 1));
-        m_endLine = std::max(GridPosition::min() + 1, std::min(endLine, GridPosition::max()));
+        m_startLine = std::clamp(startLine, GridPosition::min(), GridPosition::max() - 1);
+        m_endLine = std::clamp(endLine, GridPosition::min() + 1, GridPosition::max());
     }
 
     int m_startLine;

--- a/Source/WebCore/rendering/style/GridPositionsResolver.cpp
+++ b/Source/WebCore/rendering/style/GridPositionsResolver.cpp
@@ -401,7 +401,11 @@ unsigned GridPositionsResolver::explicitGridColumnCount(const RenderGrid& gridCo
         GridTrackSizingDirection direction = GridLayoutFunctions::flowAwareDirectionForGridItem(parent, gridContainer, GridTrackSizingDirection::ForColumns);
         return parent.gridSpanForGridItem(gridContainer, direction).integerSpan();
     }
-    return std::min<unsigned>(std::max(gridContainer.style().gridColumnTrackSizes().size() + gridContainer.autoRepeatCountForDirection(GridTrackSizingDirection::ForColumns), gridContainer.style().namedGridAreaColumnCount()), GridPosition::max());
+    return std::clamp<unsigned>(
+        gridContainer.style().gridColumnTrackSizes().size() + gridContainer.autoRepeatCountForDirection(GridTrackSizingDirection::ForColumns),
+        gridContainer.style().namedGridAreaColumnCount(),
+        GridPosition::max()
+    );
 }
 
 unsigned GridPositionsResolver::explicitGridRowCount(const RenderGrid& gridContainer)
@@ -411,7 +415,11 @@ unsigned GridPositionsResolver::explicitGridRowCount(const RenderGrid& gridConta
         GridTrackSizingDirection direction = GridLayoutFunctions::flowAwareDirectionForGridItem(parent, gridContainer, GridTrackSizingDirection::ForRows);
         return parent.gridSpanForGridItem(gridContainer, direction).integerSpan();
     }
-    return std::min<unsigned>(std::max(gridContainer.style().gridRowTrackSizes().size() + gridContainer.autoRepeatCountForDirection(GridTrackSizingDirection::ForRows), gridContainer.style().namedGridAreaRowCount()), GridPosition::max());
+    return std::clamp<unsigned>(
+        gridContainer.style().gridRowTrackSizes().size() + gridContainer.autoRepeatCountForDirection(GridTrackSizingDirection::ForRows),
+        gridContainer.style().namedGridAreaRowCount(),
+        GridPosition::max()
+    );
 }
 
 static unsigned lookAheadForNamedGridLine(int start, unsigned numberOfLines, NamedLineCollection& linesCollection)

--- a/Source/WebCore/rendering/style/TextSizeAdjustment.cpp
+++ b/Source/WebCore/rendering/style/TextSizeAdjustment.cpp
@@ -127,7 +127,7 @@ float AutosizeStatus::idempotentTextSize(float specifiedSize, float pageScale)
     // When the page scale is 1, the curve should be the identity.
     // Linearly interpolate between the curve above and identity based on the page scale.
     // Beware that depending on the specific values picked in the curve, this interpolation might change the shape of the curve for very small pageScales.
-    pageScale = std::min(std::max(pageScale, 0.5f), 1.0f);
+    pageScale = std::clamp(pageScale, 0.5f, 1.0f);
     auto scalePoint = [&](FloatPoint point) {
         float fraction = 3.0f - 3.0f * pageScale;
         point.setY(point.x() + (point.y() - point.x()) * fraction);

--- a/Source/WebCore/style/StyleBuilderConverter.h
+++ b/Source/WebCore/style/StyleBuilderConverter.h
@@ -1857,7 +1857,7 @@ inline float BuilderConverter::convertOpacity(BuilderState& builderState, const 
         return { };
 
     float opacity = primitiveValue->valueDividingBy100IfPercentage(builderState.cssToLengthConversionData());
-    return std::max(0.0f, std::min(1.0f, opacity));
+    return std::clamp(opacity, 0.0f, 1.0f);
 }
 
 inline Style::URL BuilderConverter::convertSVGURIReference(BuilderState& builderState, const CSSValue& value)

--- a/Source/WebCore/style/Styleable.cpp
+++ b/Source/WebCore/style/Styleable.cpp
@@ -711,7 +711,7 @@ static void updateCSSTransitionsForStyleableAndProperty(const Styleable& styleab
                 if (auto computedTimingProgress = effect->getComputedTiming().progress)
                     transformedProgress = *computedTimingProgress;
             }
-            auto reversingShorteningFactor = std::max(std::min(((transformedProgress * previouslyRunningTransition->reversingShorteningFactor()) + (1 - previouslyRunningTransition->reversingShorteningFactor())), 1.0), 0.0);
+            auto reversingShorteningFactor = std::clamp(((transformedProgress * previouslyRunningTransition->reversingShorteningFactor()) + (1 - previouslyRunningTransition->reversingShorteningFactor())), 0.0, 1.0);
             auto delay = matchingBackingAnimation->delay() < 0 ? Seconds(matchingBackingAnimation->delay()) * reversingShorteningFactor : Seconds(matchingBackingAnimation->delay());
             auto duration = Seconds(matchingBackingAnimation->duration().value_or(0)) * reversingShorteningFactor;
 

--- a/Source/WebCore/svg/animation/SVGSMILElement.cpp
+++ b/Source/WebCore/svg/animation/SVGSMILElement.cpp
@@ -851,7 +851,7 @@ SMILTime SVGSMILElement::resolveActiveEnd(SMILTime resolvedBegin, SMILTime resol
         minValue = 0;
         maxValue = SMILTime::indefinite();
     }
-    return resolvedBegin + std::min(maxValue, std::max(minValue, preliminaryActiveDuration));
+    return resolvedBegin + std::clamp(preliminaryActiveDuration, minValue, maxValue);
 }
 
 void SVGSMILElement::resolveInterval(bool first, SMILTime& beginResult, SMILTime& endResult) const

--- a/Source/WebGPU/WGSL/ConstantFunctions.h
+++ b/Source/WebGPU/WGSL/ConstantFunctions.h
@@ -903,7 +903,7 @@ UNARY_OPERATION(Abs, Number, [&]<typename T>(T n) -> T {
 
 BINARY_OPERATION(Atan2, Float, WRAP_STD(atan2))
 UNARY_OPERATION(Ceil, Float, WRAP_STD(ceil))
-TERNARY_OPERATION(Clamp, Number, [&](auto e, auto low, auto high) { return std::min(std::max(e, low), high); })
+TERNARY_OPERATION(Clamp, Number, [&](auto e, auto low, auto high) { return std::clamp(e, low, high); })
 
 UNARY_OPERATION(CountLeadingZeros, ConcreteInteger, [&]<typename T>(T arg) -> T {
     return std::countl_zero(static_cast<unsigned>(arg));
@@ -1419,7 +1419,7 @@ UNARY_OPERATION(ReverseBits, Integer, [&]<typename T>(T e) -> T {
 UNARY_OPERATION(Round, Float, WRAP_STD(rint))
 
 UNARY_OPERATION(Saturate, Float, [&](auto e) {
-    return std::min(std::max(e, static_cast<decltype(e)>(0)), static_cast<decltype(e)>(1));
+    return std::clamp(e, static_cast<decltype(e)>(0), static_cast<decltype(e)>(1));
 })
 
 UNARY_OPERATION(Sign, Number, [&]<typename T>(T e) -> T {
@@ -1435,7 +1435,7 @@ UNARY_OPERATION(Sign, Number, [&]<typename T>(T e) -> T {
 
 TERNARY_OPERATION(Smoothstep, Float, [&](auto low, auto high, auto x) {
     auto e = (x - low) / (high - low);
-    auto t = std::min(std::max(e, static_cast<decltype(e)>(0)), static_cast<decltype(e)>(1));
+    auto t = std::clamp(e, static_cast<decltype(e)>(0), static_cast<decltype(e)>(1));
     return t * t * (3.0 - 2.0 * t);
 })
 
@@ -1467,7 +1467,7 @@ CONSTANT_FUNCTION(Pack4x8snorm)
     std::array<int8_t, 4> packed;
     for (unsigned i = 0; i < 4; ++i) {
         auto e = std::get<float>(vector.elements[i]);
-        packed[i] = static_cast<int8_t>(std::floor(0.5 + 127 * std::min(1.f, std::max(-1.f, e))));
+        packed[i] = static_cast<int8_t>(std::floor(0.5 + 127 * std::clamp(e, -1.f, 1.f)));
     }
     return { { std::bit_cast<uint32_t>(packed) } };
 }
@@ -1479,7 +1479,7 @@ CONSTANT_FUNCTION(Pack4x8unorm)
     std::array<uint8_t, 4> packed;
     for (unsigned i = 0; i < 4; ++i) {
         auto e = std::get<float>(vector.elements[i]);
-        packed[i] = static_cast<uint8_t>(std::floor(0.5 + 255 * std::min(1.f, std::max(0.f, e))));
+        packed[i] = static_cast<uint8_t>(std::floor(0.5 + 255 * std::clamp(e, 0.f, 1.f)));
     }
     return { { std::bit_cast<uint32_t>(packed) } };
 }
@@ -1515,7 +1515,7 @@ CONSTANT_FUNCTION(Pack4xI8Clamp)
     std::array<uint8_t, 4> packed;
     for (unsigned i = 0; i < 4; ++i) {
         auto e = std::get<int32_t>(vector.elements[i]);
-        packed[i] = static_cast<uint8_t>(std::min(127, std::max(-128, e)));
+        packed[i] = static_cast<uint8_t>(std::clamp(e, -128, 127));
     }
     return { { std::bit_cast<uint32_t>(packed) } };
 }
@@ -1539,7 +1539,7 @@ CONSTANT_FUNCTION(Pack2x16snorm)
     std::array<int16_t, 2> packed;
     for (unsigned i = 0; i < 2; ++i) {
         auto e = std::get<float>(vector.elements[i]);
-        packed[i] = static_cast<int16_t>(std::floor(0.5 + 32767 * std::min(1.f, std::max(-1.f, e))));
+        packed[i] = static_cast<int16_t>(std::floor(0.5 + 32767 * std::clamp(e, -1.f, 1.f)));
     }
     return { { std::bit_cast<uint32_t>(packed) } };
 }
@@ -1551,7 +1551,7 @@ CONSTANT_FUNCTION(Pack2x16unorm)
     std::array<uint16_t, 2> packed;
     for (unsigned i = 0; i < 2; ++i) {
         auto e = std::get<float>(vector.elements[i]);
-        packed[i] = static_cast<uint16_t>(std::floor(0.5 + 65535 * std::min(1.f, std::max(0.f, e))));
+        packed[i] = static_cast<uint16_t>(std::floor(0.5 + 65535 * std::clamp(e, 0.f, 1.f)));
     }
     return { { std::bit_cast<uint32_t>(packed) } };
 }

--- a/Source/WebGPU/WebGPU/HardwareCapabilities.mm
+++ b/Source/WebGPU/WebGPU/HardwareCapabilities.mm
@@ -54,7 +54,7 @@ static uint64_t maxBufferSize(id<MTLDevice> device)
 #if PLATFORM(MAC) || PLATFORM(MACCATALYST)
     auto result = std::max<uint64_t>(std::min<uint64_t>(device.maxBufferLength, GB), std::min<uint64_t>(INT_MAX, device.maxBufferLength / 10));
 #else
-    auto result = std::max<uint64_t>(defaultMaxBufferSize, std::min<uint64_t>(INT_MAX, device.maxBufferLength / 10));
+    auto result = std::clamp<uint64_t>(device.maxBufferLength / 10, defaultMaxBufferSize, static_cast<uint64_t>(INT_MAX));
 #endif
     return multipleOf4(result);
 }

--- a/Source/WebKit/Shared/Cocoa/CoreIPCNSURLRequest.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCNSURLRequest.mm
@@ -248,8 +248,8 @@ RetainPtr<id> CoreIPCNSURLRequest::toID() const
 
     [dict setObject:[NSNumber numberWithUnsignedChar:static_cast<uint8_t>(m_data.networkServiceType)] forKey:@"networkServiceType"];
 
-    int clampedRequestPriority = std::min(std::max(m_data.requestPriority, -1),
-        static_cast<int>(WTF::enumToUnderlyingType(WebCore::ResourceLoadPriority::Highest)));
+    int clampedRequestPriority = std::clamp<int>(m_data.requestPriority, -1,
+        WTF::enumToUnderlyingType(WebCore::ResourceLoadPriority::Highest));
     [dict setObject:[NSNumber numberWithInt:clampedRequestPriority] forKey:@"requestPriority"];
 
     SET_DICT_FROM_OPTIONAL_PRIMITIVE(isHTTP, NSNumber, Bool);

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -912,7 +912,7 @@ static CGPoint contentOffsetBoundedInValidRange(UIScrollView *scrollView, CGPoin
     CGPoint minimumContentOffset = CGPointMake(-contentInsets.left, -contentInsets.top);
     CGPoint maximumContentOffset = CGPointMake(std::max(minimumContentOffset.x, contentSize.width + contentInsets.right - scrollViewSize.width), std::max(minimumContentOffset.y, contentSize.height + contentInsets.bottom - scrollViewSize.height));
 
-    return CGPointMake(std::max(std::min(contentOffset.x, maximumContentOffset.x), minimumContentOffset.x), std::max(std::min(contentOffset.y, maximumContentOffset.y), minimumContentOffset.y));
+    return CGPointMake(std::clamp(contentOffset.x, minimumContentOffset.x, maximumContentOffset.x), std::clamp(contentOffset.y, minimumContentOffset.y, maximumContentOffset.y));
 }
 
 static void changeContentOffsetBoundedInValidRange(UIScrollView *scrollView, WebCore::FloatPoint contentOffset)
@@ -1953,8 +1953,8 @@ static WebCore::FloatPoint constrainContentOffset(WebCore::FloatPoint contentOff
     double horizontalScale = unobscuredContentSize.width() * currentScale / targetRect.width();
     double verticalScale = unobscuredContentSize.height() * currentScale / targetRect.height();
 
-    horizontalScale = std::min(std::max(horizontalScale, minimumScale), maximumScale);
-    verticalScale = std::min(std::max(verticalScale, minimumScale), maximumScale);
+    horizontalScale = std::clamp(horizontalScale, minimumScale, maximumScale);
+    verticalScale = std::clamp(verticalScale, minimumScale, maximumScale);
 
     return fitEntireRect ? std::min(horizontalScale, verticalScale) : horizontalScale;
 }

--- a/Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp
+++ b/Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp
@@ -1848,8 +1848,8 @@ void WebAutomationSession::resetClickCount()
 void WebAutomationSession::simulateMouseInteraction(WebPageProxy& page, MouseInteraction interaction, MouseButton mouseButton, const WebCore::IntPoint& locationInViewport, const String& pointerType, CompletionHandler<void(std::optional<AutomationCommandError>)>&& completionHandler)
 {
     page.getWindowFrameWithCallback([this, protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler), page = Ref { page }, interaction, mouseButton, locationInViewport, pointerType](WebCore::FloatRect windowFrame) mutable {
-        auto clippedX = std::min(std::max(0.0f, (float)locationInViewport.x()), windowFrame.size().width());
-        auto clippedY = std::min(std::max(0.0f, (float)locationInViewport.y()), windowFrame.size().height());
+        auto clippedX = std::clamp<float>(locationInViewport.x(), 0, windowFrame.size().width());
+        auto clippedY = std::clamp<float>(locationInViewport.y(), 0, windowFrame.size().height());
         if (clippedX != locationInViewport.x() || clippedY != locationInViewport.y()) {
             completionHandler(AUTOMATION_COMMAND_ERROR_WITH_NAME(TargetOutOfBounds));
             return;
@@ -1937,8 +1937,8 @@ void WebAutomationSession::simulateKeyboardInteraction(WebPageProxy& page, Keybo
 void WebAutomationSession::simulateWheelInteraction(WebPageProxy& page, const WebCore::IntPoint& locationInViewport, const WebCore::IntSize& delta, AutomationCompletionHandler&& completionHandler)
 {
     page.getWindowFrameWithCallback([this, protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler), page = Ref { page }, locationInViewport, delta](WebCore::FloatRect windowFrame) mutable {
-        auto clippedX = std::min(std::max(0.0f, static_cast<float>(locationInViewport.x())), windowFrame.size().width());
-        auto clippedY = std::min(std::max(0.0f, static_cast<float>(locationInViewport.y())), windowFrame.size().height());
+        auto clippedX = std::clamp<float>(locationInViewport.x(), 0, windowFrame.size().width());
+        auto clippedY = std::clamp<float>(locationInViewport.y(), 0, windowFrame.size().height());
         if (clippedX != locationInViewport.x() || clippedY != locationInViewport.y()) {
             completionHandler(AUTOMATION_COMMAND_ERROR_WITH_NAME(TargetOutOfBounds));
             return;
@@ -2021,8 +2021,8 @@ void WebAutomationSession::performMouseInteraction(const Inspector::Protocol::Au
     }
 
     page->getWindowFrameWithCallback([this, protectedThis = Ref { *this }, callback = WTFMove(callback), page = Ref { *page }, floatX, floatY, mouseInteraction, mouseButton, keyModifiers](WebCore::FloatRect windowFrame) mutable {
-        floatX = std::min(std::max(0.0f, floatX), windowFrame.size().width());
-        floatY = std::min(std::max(0.0f, floatY), windowFrame.size().height());
+        floatX = std::clamp(floatX, 0.0f, windowFrame.size().width());
+        floatY = std::clamp(floatY, 0.0f, windowFrame.size().height());
 
         WebCore::IntPoint locationInViewport = WebCore::IntPoint(static_cast<int>(floatX), static_cast<int>(floatY));
 

--- a/Source/WebKit/UIProcess/Inspector/gtk/WebInspectorUIProxyGtk.cpp
+++ b/Source/WebKit/UIProcess/Inspector/gtk/WebInspectorUIProxyGtk.cpp
@@ -458,11 +458,11 @@ void WebInspectorUIProxy::platformAttach()
     if (m_attachmentSide == AttachmentSide::Bottom) {
         unsigned inspectedWindowHeight = gtk_widget_get_allocated_height(protectedInspectedPage()->viewWidget());
         unsigned maximumAttachedHeight = inspectedWindowHeight * 3 / 4;
-        platformSetAttachedWindowHeight(std::max(s_minimumAttachedHeight, std::min(s_defaultAttachedSize, maximumAttachedHeight)));
+        platformSetAttachedWindowHeight(std::clamp(s_defaultAttachedSize, s_minimumAttachedHeight, maximumAttachedHeight));
     } else {
         unsigned inspectedWindowWidth = gtk_widget_get_allocated_width(protectedInspectedPage()->viewWidget());
         unsigned maximumAttachedWidth = inspectedWindowWidth * 3 / 4;
-        platformSetAttachedWindowWidth(std::max(s_minimumAttachedWidth, std::min(s_defaultAttachedSize, maximumAttachedWidth)));
+        platformSetAttachedWindowWidth(std::clamp(s_defaultAttachedSize, s_minimumAttachedWidth, maximumAttachedWidth));
     }
 
     if (m_client && m_client->attach(*this))

--- a/Source/WebKit/UIProcess/Inspector/win/WebInspectorUIProxyWin.cpp
+++ b/Source/WebKit/UIProcess/Inspector/win/WebInspectorUIProxyWin.cpp
@@ -385,11 +385,11 @@ void WebInspectorUIProxy::platformAttach()
     if (m_attachmentSide == AttachmentSide::Bottom) {
         unsigned inspectedWindowHeight = (inspectedWindowRect.bottom - inspectedWindowRect.top) / deviceScaleFactor;
         unsigned maximumAttachedHeight = inspectedWindowHeight * s_maximumAttachedHeightRatio;
-        platformSetAttachedWindowHeight(std::max(s_minimumAttachedHeight, std::min(s_defaultAttachedSize, maximumAttachedHeight)));
+        platformSetAttachedWindowHeight(std::clamp(s_defaultAttachedSize, s_minimumAttachedHeight, maximumAttachedHeight));
     } else {
         unsigned inspectedWindowWidth = (inspectedWindowRect.right - inspectedWindowRect.left) / deviceScaleFactor;
         unsigned maximumAttachedWidth = inspectedWindowWidth * s_maximumAttachedHeightRatio;
-        platformSetAttachedWindowWidth(std::max(s_minimumAttachedWidth, std::min(s_defaultAttachedSize, maximumAttachedWidth)));
+        platformSetAttachedWindowWidth(std::clamp(s_defaultAttachedSize, s_minimumAttachedWidth, maximumAttachedWidth));
     }
     ::ShowWindow(m_inspectorViewWindow, SW_SHOW);
 }

--- a/Source/WebKit/UIProcess/ios/fullscreen/FullscreenTouchSecheuristic.cpp
+++ b/Source/WebKit/UIProcess/ios/fullscreen/FullscreenTouchSecheuristic.cpp
@@ -84,7 +84,7 @@ double FullscreenTouchSecheuristic::distanceScore(const CGPoint& nextLocation, c
 double FullscreenTouchSecheuristic::attenuationFactor(Seconds delta)
 {
     double normalizedTimeDelta = delta / m_parameters.rampDownSpeed;
-    return std::max(std::min(normalizedTimeDelta * m_weight, 1.0), 0.0);
+    return std::clamp(normalizedTimeDelta * m_weight, 0.0, 1.0);
 }
 
 }

--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
@@ -1804,7 +1804,7 @@ static constexpr NSString *kPrefersFullScreenDimmingKey = @"WebKitPrefersFullScr
     CGPoint translation = [_interactivePanDismissGestureRecognizer translationInView:_fullscreenViewController.get().view];
     CGPoint velocity = [_interactivePanDismissGestureRecognizer velocityInView:_fullscreenViewController.get().view];
     CGFloat progress = translation.y / (_fullscreenViewController.get().view.bounds.size.height / 2);
-    progress = std::min(1., std::max(0., progress));
+    progress = std::clamp(progress, 0., 1.);
 
     if (_interactivePanDismissGestureRecognizer.get().state == UIGestureRecognizerStateEnded) {
         _inInteractiveDismiss = false;

--- a/Source/WebKit/UIProcess/mac/ViewGestureControllerMac.mm
+++ b/Source/WebKit/UIProcess/mac/ViewGestureControllerMac.mm
@@ -99,7 +99,7 @@ double ViewGestureController::resistanceForDelta(double deltaScale, double curre
     // Outside of the extremes, resist further scaling.
     double limit = currentScale < minMagnification ? minMagnification : maxMagnification;
     double scaleDistance = std::abs(limit - currentScale);
-    double scalePercent = std::min(std::max(scaleDistance / limit, 0.), 1.);
+    double scalePercent = std::clamp(scaleDistance / limit, 0., 1.);
     double resistance = zoomOutResistance + scalePercent * (0.01 - zoomOutResistance);
 
     return resistance;
@@ -148,7 +148,7 @@ void ViewGestureController::handleMagnificationGestureEvent(NSEvent *event, Floa
     auto maxElasticMagnification = maxMagnification * 1.333;
 
     m_magnification += m_magnification * scaleWithResistance;
-    m_magnification = std::min(std::max(m_magnification, minElasticMagnification), maxElasticMagnification);
+    m_magnification = std::clamp(m_magnification, minElasticMagnification, maxElasticMagnification);
 
     LOG_WITH_STREAM(ViewGestures, stream << "ViewGestureController::handleMagnificationGestureEvent - gesture scale " << scale << " with resistance " << scaleWithResistance << " clamped to " << m_magnification << " origin in view coords " << origin);
 
@@ -215,7 +215,7 @@ void ViewGestureController::didCollectGeometryForSmartMagnificationGesture(Float
 
     auto minMagnification = page->minPageZoomFactor();
     auto maxMagnification = page->maxPageZoomFactor();
-    targetMagnification = std::min(std::max(targetMagnification, minMagnification), maxMagnification);
+    targetMagnification = std::clamp(targetMagnification, minMagnification, maxMagnification);
 
     // Allow panning between elements via double-tap while magnified, unless the target rect is
     // similar to the last one or the mouse has not moved, in which case we'll zoom all the way out.
@@ -294,7 +294,7 @@ void ViewGestureController::trackSwipeGesture(PlatformScrollEvent event, SwipeDi
         }
         if (phase == NSEventPhaseBegan)
             this->beginSwipeGesture(targetItem.get(), direction);
-        CGFloat clampedProgress = std::min(std::max(progress, minProgress), maxProgress);
+        CGFloat clampedProgress = std::clamp(progress, minProgress, maxProgress);
         this->handleSwipeGesture(targetItem.get(), clampedProgress, direction);
         if (phase == NSEventPhaseCancelled)
             swipeCancelled = true;
@@ -566,7 +566,7 @@ void ViewGestureController::handleSwipeGesture(WebBackForwardListItem* targetIte
     double swipingLayerOffset = floor(width * progress);
 
     double dimmingProgress = swipingLeft ? 1 - progress : -progress;
-    dimmingProgress = std::min(1., std::max(dimmingProgress, 0.));
+    dimmingProgress = std::clamp(dimmingProgress, 0., 1.);
     [m_swipeDimmingLayer setOpacity:dimmingProgress * swipeOverlayDimmingOpacity];
 
     double absoluteProgress = std::abs(progress);

--- a/Source/WebKit/UIProcess/mac/WebDataListSuggestionsDropdownMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebDataListSuggestionsDropdownMac.mm
@@ -468,7 +468,7 @@ static BOOL shouldShowDividersBetweenCells(const Vector<WebCore::DataListSuggest
     if (_suggestions.size() > 1)
         totalIntercellSpacingAndPadding += (_suggestions.size() - 1) * [_table intercellSpacing].height;
 
-    CGFloat width = std::min<CGFloat>(std::max(rect.width(), rect.height()), screenRect.size.width);
+    CGFloat width = std::clamp<CGFloat>(rect.width(), rect.height(), screenRect.size.width);
     CGFloat height = std::min<CGFloat>(totalIntercellSpacingAndPadding + std::min(totalCellHeight, maximumTotalHeightForDropdownCells), screenRect.size.height);
     CGFloat originX = std::max<CGFloat>(NSMinX(windowRect), 0);
     CGFloat originY = std::max<CGFloat>(NSMinY(windowRect) - height - dropdownTopMargin, 0);

--- a/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
@@ -122,7 +122,7 @@ MediaTime MediaPlayerPrivateRemote::TimeProgressEstimator::currentTimeWithLockHe
         return m_cachedMediaTime;
 
     auto calculatedCurrentTime = m_cachedMediaTime + MediaTime::createWithDouble(m_rate * (MonotonicTime::now() - m_cachedMediaTimeQueryTime).seconds());
-    calculatedCurrentTime = std::min(std::max(calculatedCurrentTime, MediaTime::zeroTime()), protectedParent()->duration());
+    calculatedCurrentTime = std::clamp(calculatedCurrentTime, MediaTime::zeroTime(), protectedParent()->duration());
     if (m_rate >= 0)
         calculatedCurrentTime = std::max(m_lastReturnedTime.value_or(calculatedCurrentTime), calculatedCurrentTime);
     else

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDiscretePresentationController.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDiscretePresentationController.mm
@@ -527,7 +527,7 @@ void PDFDiscretePresentationController::startTransitionAnimation(PageTransitionS
                 float distance = std::abs(relevantAxisForDirection(direction, endOffset - startOffset));
 
                 transitionDuration = Seconds { distance / velocity };
-                transitionDuration = std::min(std::max(transitionDuration, minimumTransitionDuration), maximumTransitionDuration);
+                transitionDuration = std::clamp(transitionDuration, minimumTransitionDuration, maximumTransitionDuration);
             }
         } else {
             auto timingFunctionPreset = isNextDirection(direction) ? CubicBezierTimingFunction::TimingFunctionPreset::EaseIn : CubicBezierTimingFunction::TimingFunctionPreset::EaseOut;

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -7168,7 +7168,7 @@ void WebPage::firstRectForCharacterRangeAsync(const EditingRange& editingRange, 
 
     auto rangeForFirstLine = EditingRange::fromRange(*frame, makeSimpleRange(range->start, WTFMove(endBoundary)));
 
-    rangeForFirstLine.location = std::min(std::max(rangeForFirstLine.location, editingRange.location), editingRange.location + editingRange.length);
+    rangeForFirstLine.location = std::clamp(rangeForFirstLine.location, editingRange.location, editingRange.location + editingRange.length);
     rangeForFirstLine.length = std::min(rangeForFirstLine.location + rangeForFirstLine.length, editingRange.location + editingRange.length) - rangeForFirstLine.location;
 
     completionHandler(rect, rangeForFirstLine);

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -505,7 +505,7 @@ static double scaleAfterViewportWidthChange(double currentScale, bool scaleToFit
     // end up zoomed too far in landscape->portrait, and too close in portrait->landscape.
     double widthToKeepInView = visibleHorizontalFraction * newContentSize.width();
     double newScale = unobscuredWidthInScrollViewCoordinates / widthToKeepInView;
-    scale = std::max(std::min(newScale, viewportConfiguration.maximumScale()), viewportConfiguration.minimumScale());
+    scale = std::clamp(newScale, viewportConfiguration.minimumScale(), viewportConfiguration.maximumScale());
     LOG(VisibleRects, "scaleAfterViewportWidthChange scaling content to fit: %.2f", scale);
     return scale;
 }
@@ -554,7 +554,7 @@ void WebPage::restorePageState(const HistoryItem& historyItem)
     FloatSize currentMinimumLayoutSizeInScrollViewCoordinates = m_viewportConfiguration.minimumLayoutSize();
     if (historyItem.minimumLayoutSizeInScrollViewCoordinates() == currentMinimumLayoutSizeInScrollViewCoordinates) {
         float boundedScale = historyItem.scaleIsInitial() ? m_viewportConfiguration.initialScale() : historyItem.pageScaleFactor();
-        boundedScale = std::min<float>(m_viewportConfiguration.maximumScale(), std::max<float>(m_viewportConfiguration.minimumScale(), boundedScale));
+        boundedScale = std::clamp<float>(boundedScale, m_viewportConfiguration.minimumScale(), m_viewportConfiguration.maximumScale());
         scalePage(boundedScale, IntPoint());
 
         std::optional<FloatPoint> scrollPosition;
@@ -4860,7 +4860,7 @@ void WebPage::viewportConfigurationChanged(ZoomToInitialScale zoomToInitialScale
 
     double scale;
     if (m_userHasChangedPageScaleFactor && zoomToInitialScale == ZoomToInitialScale::No)
-        scale = std::max(std::min(pageScaleFactor(), m_viewportConfiguration.maximumScale()), m_viewportConfiguration.minimumScale());
+        scale = std::clamp(pageScaleFactor(), m_viewportConfiguration.minimumScale(), m_viewportConfiguration.maximumScale());
     else
         scale = initialScale;
 
@@ -5002,7 +5002,7 @@ std::optional<float> WebPage::scaleFromUIProcess(const VisibleContentRectUpdateI
         scaleFromUIProcess = currentScale;
     }
     
-    scaleFromUIProcess = std::min<float>(m_viewportConfiguration.maximumScale(), std::max<float>(m_viewportConfiguration.minimumScale(), scaleFromUIProcess));
+    scaleFromUIProcess = std::clamp<float>(scaleFromUIProcess, m_viewportConfiguration.minimumScale(), m_viewportConfiguration.maximumScale());
     if (scalesAreEssentiallyEqual(currentScale, scaleFromUIProcess))
         return std::nullopt;
 

--- a/Source/WebKitLegacy/mac/WebView/WebWindowAnimation.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebWindowAnimation.mm
@@ -249,7 +249,7 @@ static void setScaledFrameForWindow(NSWindow *window, NSRect scaleFrame, NSRect 
 
 - (CGFloat)currentAlpha
 {
-    return std::max(static_cast<CGFloat>(0), std::min(static_cast<CGFloat>(1), _initialAlpha + [self currentValue] * (_finalAlpha - _initialAlpha)));
+    return std::clamp<CGFloat>(_initialAlpha + [self currentValue] * (_finalAlpha - _initialAlpha), 0, 1);
 }
 
 - (void)setCurrentProgress:(NSAnimationProgress)progress

--- a/Source/bmalloc/bmalloc/Scavenger.cpp
+++ b/Source/bmalloc/bmalloc/Scavenger.cpp
@@ -350,7 +350,7 @@ void Scavenger::threadRunLoop()
         if (!m_isInMiniMode) {
             timeSpentScavenging *= s_newWaitMultiplier;
             std::chrono::milliseconds newWaitTime = std::chrono::duration_cast<std::chrono::milliseconds>(timeSpentScavenging);
-            m_waitTime = std::min(std::max(newWaitTime, std::chrono::milliseconds(s_minWaitTimeMilliseconds)), std::chrono::milliseconds(s_maxWaitTimeMilliseconds));
+            m_waitTime = std::clamp(newWaitTime, std::chrono::milliseconds(s_minWaitTimeMilliseconds), std::chrono::milliseconds(s_maxWaitTimeMilliseconds));
         }
 
         if (verbose)


### PR DESCRIPTION
#### bb31295f8f7a44f8f0318f4ebb6aaacaf38e0308
<pre>
Adopt std::clamp() in more places
<a href="https://bugs.webkit.org/show_bug.cgi?id=292845">https://bugs.webkit.org/show_bug.cgi?id=292845</a>

Reviewed by NOBODY (OOPS!).

Adopt std::clamp() in more places. This simplifies the code a little.

* Source/WTF/wtf/text/StringBuilder.cpp:
(WTF::StringBuilder::expandedCapacity):
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUCompositorIntegrationImpl.cpp:
(WebCore::WebGPU::CompositorIntegrationImpl::recreateRenderBuffers):
* Source/WebCore/Modules/mediasession/MediaSession.cpp:
(WebCore::MediaSession::currentPosition const):
* Source/WebCore/Modules/webaudio/BaseAudioContext.cpp:
(WebCore::BaseAudioContext::createScriptProcessor):
* Source/WebCore/accessibility/AccessibilityAttachment.cpp:
(WebCore::AccessibilityAttachment::hasProgress const):
* Source/WebCore/accessibility/AccessibilityTableCell.cpp:
(WebCore::AccessibilityTableCell::colSpan const):
* Source/WebCore/animation/AnimationEffectTiming.cpp:
(WebCore::AnimationEffectTiming::getBasicTiming const):
* Source/WebCore/animation/StyleOriginatedAnimation.cpp:
(WebCore::StyleOriginatedAnimation::invalidateDOMEvents):
* Source/WebCore/animation/WebAnimation.cpp:
(WebCore::WebAnimation::overallProgress const):
* Source/WebCore/bindings/js/JSDOMConvertNumbers.cpp:
(WebCore::convertToIntegerClamp&lt;IDLLongLong&gt;):
(WebCore::convertToIntegerClamp&lt;IDLUnsignedLongLong&gt;):
* Source/WebCore/css/typedom/numeric/CSSMathClamp.cpp:
(WebCore::CSSMathClamp::toSumValue const):
* Source/WebCore/dom/ViewportArguments.cpp:
(WebCore::clampLengthValue):
(WebCore::clampScaleValue):
(WebCore::ViewportArguments::resolve const):
* Source/WebCore/editing/Editor.cpp:
(WebCore::Editor::setComposition):
* Source/WebCore/editing/TextIterator.cpp:
(WebCore::SearchBuffer::search):
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::nextScanRate):
* Source/WebCore/html/HTMLMeterElement.cpp:
(WebCore::HTMLMeterElement::value const):
(WebCore::HTMLMeterElement::low const):
(WebCore::HTMLMeterElement::high const):
* Source/WebCore/html/MediaController.cpp:
(WebCore::MediaController::currentTime const):
* Source/WebCore/html/StepRange.cpp:
(WebCore::StepRange::clampValue const):
* Source/WebCore/html/parser/HTMLParserIdioms.h:
(WebCore::clampHTMLNonNegativeIntegerToRange):
* Source/WebCore/html/shadow/DateTimeSymbolicFieldElement.cpp:
(WebCore::DateTimeSymbolicFieldElement::setValueAsInteger):
* Source/WebCore/html/shadow/SliderThumbElement.cpp:
(WebCore::SliderThumbElement::setPositionFromPoint):
* Source/WebCore/inspector/InspectorFrontendClientLocal.cpp:
(WebCore::InspectorFrontendClientLocal::constrainedAttachedWindowHeight):
(WebCore::InspectorFrontendClientLocal::constrainedAttachedWindowWidth):
* Source/WebCore/layout/formattingContexts/FormattingGeometry.cpp:
(WebCore::Layout::FormattingGeometry::computedWidthValue const):
(WebCore::Layout::FormattingGeometry::shrinkToFitWidth const):
* Source/WebCore/layout/formattingContexts/block/tablewrapper/TableWrapperBlockFormattingContext.cpp:
(WebCore::Layout::TableWrapperBlockFormattingContext::computeWidthAndMarginForTableBox):
* Source/WebCore/layout/formattingContexts/flex/FlexLayout.cpp:
(WebCore::Layout::FlexLayout::crossSizeForFlexLines const):
(WebCore::Layout::FlexLayout::computeCrossSizeForFlexItems const):
* Source/WebCore/mathml/MathMLElement.cpp:
(WebCore::MathMLElement::rowSpan const):
* Source/WebCore/page/LocalDOMWindow.cpp:
(WebCore::LocalDOMWindow::adjustWindowRect):
* Source/WebCore/page/ViewportConfiguration.cpp:
(WebCore::ViewportConfiguration::minimumScale const):
(WebCore::applyViewportArgument):
* Source/WebCore/platform/DictationCaretAnimator.cpp:
(WebCore::DictationCaretAnimator::makeDictationTailConePath const):
* Source/WebCore/platform/PlatformSpeechSynthesisUtterance.h:
(WebCore::PlatformSpeechSynthesisUtterance::setVolume):
(WebCore::PlatformSpeechSynthesisUtterance::setRate):
(WebCore::PlatformSpeechSynthesisUtterance::setPitch):
* Source/WebCore/platform/audio/AudioHardwareListener.h:
(WebCore::AudioHardwareListener::BufferSizeRange::nearest const):
* Source/WebCore/platform/audio/Biquad.cpp:
(WebCore::Biquad::setLowpassParams):
(WebCore::Biquad::setHighpassParams):
(WebCore::Biquad::setLowShelfParams):
(WebCore::Biquad::setHighShelfParams):
(WebCore::Biquad::setPeakingParams):
(WebCore::Biquad::setAllpassParams):
(WebCore::Biquad::setNotchParams):
* Source/WebCore/platform/audio/HRTFKernel.cpp:
(WebCore::HRTFKernel::createInterpolatedKernel):
* Source/WebCore/platform/audio/mac/AudioSessionMac.mm:
(WebCore::AudioSessionMac::setPreferredBufferSize):
* Source/WebCore/platform/calc/CalculationExecutor.h:
(WebCore::Calculation::OperatorExecutor&lt;Clamp&gt;::operator()):
* Source/WebCore/platform/graphics/FloatPoint.cpp:
(WebCore::FloatPoint::constrainedBetween const):
* Source/WebCore/platform/graphics/FloatSize.cpp:
(WebCore::FloatSize::constrainedBetween const):
* Source/WebCore/platform/graphics/FontSelectionAlgorithm.h:
(WebCore::FontSelectionValue::clampFloat):
* Source/WebCore/platform/graphics/GraphicsContext.cpp:
(WebCore::GraphicsContext::dashedLineCornerWidthForStrokeWidth const):
(WebCore::GraphicsContext::dashedLinePatternWidthForStrokeWidth const):
* Source/WebCore/platform/graphics/IntPoint.cpp:
(WebCore::IntPoint::constrainedBetween const):
* Source/WebCore/platform/graphics/IntSize.cpp:
(WebCore::IntSize::constrainedBetween const):
* Source/WebCore/platform/graphics/LayoutPoint.cpp:
(WebCore::LayoutPoint::constrainedBetween const):
* Source/WebCore/platform/graphics/LayoutSize.cpp:
(WebCore::LayoutSize::constrainedBetween const):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm:
(WebCore::MediaPlayerPrivateAVFoundationObjC::currentTime const):
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp:
(WebCore::GraphicsLayerCA::setOpacity):
* Source/WebCore/platform/graphics/ca/TileController.cpp:
(WebCore::TileController::computeTileSize):
* Source/WebCore/platform/graphics/cg/ImageDecoderCG.cpp:
(WebCore::appendImageSourceOption):
* Source/WebCore/platform/graphics/cocoa/UnrealizedCoreTextFont.cpp:
(WebCore::UnrealizedCoreTextFont::modifyFromContext):
* Source/WebCore/platform/graphics/coretext/FontCoreText.cpp:
(WebCore::Font::applyTransforms const):
* Source/WebCore/platform/graphics/filters/FEComponentTransfer.cpp:
(WebCore::FEComponentTransfer::computeLookupTable):
* Source/WebCore/platform/graphics/transforms/TransformationMatrix.cpp:
(WebCore::clampEdgeValue):
* Source/WebCore/platform/mediarecorder/MediaRecorderPrivate.cpp:
(WebCore::MediaRecorderPrivate::computeBitRates):
* Source/WebCore/platform/mediastream/MediaConstraints.h:
(WebCore::NumericConstraint::valueForCapabilityRange const):
* Source/WebCore/rendering/AttachmentLayout.mm:
(WebCore::getAttachmentProgress):
* Source/WebCore/rendering/CaretRectComputation.cpp:
(WebCore::computeCaretRectForEmptyElement):
* Source/WebCore/rendering/RenderBlockFlow.cpp:
(WebCore::RenderBlockFlow::computeColumnCountAndWidth):
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::constrainLogicalHeightByMinMax const):
(WebCore::RenderBox::computeIntrinsicLogicalWidthUsing const):
(WebCore::RenderBox::computeLogicalWidthUsing const):
(WebCore::RenderBox::computeReplacedLogicalWidthRespectingMinMaxWidth const):
(WebCore::RenderBox::computeReplacedLogicalHeightRespectingMinMaxHeight const):
(WebCore::RenderBox::computePositionedLogicalWidthUsing const):
* Source/WebCore/rendering/RenderFlexibleBox.cpp:
(WebCore::FlexLayoutItem::constrainSizeByMinMax const):
(WebCore::RenderFlexibleBox::marginBoxAscentForFlexItem):
* Source/WebCore/rendering/RenderFragmentContainer.cpp:
(WebCore::RenderFragmentContainer::rectFlowPortionForBox const):
* Source/WebCore/rendering/RenderListBox.cpp:
(WebCore::RenderListBox::panScroll):
* Source/WebCore/rendering/RenderScrollbarPart.cpp:
(WebCore::RenderScrollbarPart::computeScrollbarWidth):
(WebCore::RenderScrollbarPart::computeScrollbarHeight):
* Source/WebCore/rendering/RenderText.cpp:
(WebCore::RenderText::absoluteQuadsForRange const):
* Source/WebCore/rendering/style/GridArea.h:
(WebCore::GridSpan::clamp):
(WebCore::GridSpan::GridSpan):
* Source/WebCore/rendering/style/GridPositionsResolver.cpp:
(WebCore::GridPositionsResolver::explicitGridColumnCount):
(WebCore::GridPositionsResolver::explicitGridRowCount):
* Source/WebCore/rendering/style/TextSizeAdjustment.cpp:
(WebCore::AutosizeStatus::idempotentTextSize):
* Source/WebCore/style/StyleBuilderConverter.h:
(WebCore::Style::BuilderConverter::convertOpacity):
* Source/WebCore/style/Styleable.cpp:
(WebCore::updateCSSTransitionsForStyleableAndProperty):
* Source/WebCore/svg/animation/SVGSMILElement.cpp:
(WebCore::SVGSMILElement::resolveActiveEnd const):
* Source/WebGPU/WGSL/ConstantFunctions.h:
(WGSL::TERNARY_OPERATION):
(WGSL::UNARY_OPERATION):
(WGSL::CONSTANT_FUNCTION):
* Source/WebGPU/WebGPU/HardwareCapabilities.mm:
(WebGPU::maxBufferSize):
* Source/WebKit/Shared/Cocoa/CoreIPCNSURLRequest.mm:
(WebKit::CoreIPCNSURLRequest::toID const):
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(contentOffsetBoundedInValidRange):
(-[WKWebView _targetContentZoomScaleForRect:currentScale:fitEntireRect:minimumScale:maximumScale:]):
* Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp:
(WebKit::WebAutomationSession::simulateMouseInteraction):
(WebKit::WebAutomationSession::simulateWheelInteraction):
(WebKit::WebAutomationSession::performMouseInteraction):
* Source/WebKit/UIProcess/Inspector/gtk/WebInspectorUIProxyGtk.cpp:
(WebKit::WebInspectorUIProxy::platformAttach):
* Source/WebKit/UIProcess/Inspector/win/WebInspectorUIProxyWin.cpp:
(WebKit::WebInspectorUIProxy::platformAttach):
* Source/WebKit/UIProcess/ios/fullscreen/FullscreenTouchSecheuristic.cpp:
(WebKit::FullscreenTouchSecheuristic::attenuationFactor):
* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm:
(-[WKFullScreenWindowController _interactiveDismissChanged:]):
* Source/WebKit/UIProcess/mac/ViewGestureControllerMac.mm:
(WebKit::ViewGestureController::resistanceForDelta):
(WebKit::ViewGestureController::handleMagnificationGestureEvent):
(WebKit::ViewGestureController::didCollectGeometryForSmartMagnificationGesture):
(WebKit::ViewGestureController::trackSwipeGesture):
(WebKit::ViewGestureController::handleSwipeGesture):
* Source/WebKit/UIProcess/mac/WebDataListSuggestionsDropdownMac.mm:
(-[WKDataListSuggestionsController dropdownRectForElementRect:]):
* Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp:
(WebKit::MediaPlayerPrivateRemote::TimeProgressEstimator::currentTimeWithLockHeld const):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDiscretePresentationController.mm:
(WebKit::PDFDiscretePresentationController::startTransitionAnimation):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::firstRectForCharacterRangeAsync):
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::scaleAfterViewportWidthChange):
(WebKit::WebPage::restorePageState):
(WebKit::WebPage::viewportConfigurationChanged):
(WebKit::WebPage::scaleFromUIProcess const):
* Source/WebKitLegacy/mac/WebView/WebWindowAnimation.mm:
(-[WebWindowFadeAnimation currentAlpha]):
* Source/bmalloc/bmalloc/Scavenger.cpp:
(bmalloc::Scavenger::threadRunLoop):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bb31295f8f7a44f8f0318f4ebb6aaacaf38e0308

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/103186 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/22861 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/13180 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/108354 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/53829 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/105225 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/23196 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/31361 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78439 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/35377 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/106192 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17982 "Found 1 new test failure: fast/viewport/viewport-18.html (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/93098 "Found 16 new API test failures: TestWebKitAPI.WKWebExtensionAPIDevTools.MessagePassingToBackground, TestWebKitAPI.WKWebExtensionAPIDevTools.InspectedWindowReload, TestWebKitAPI.WKWebExtensionAPIDevTools.PortMessagePassingFromPanelToBackground, TestWebKitAPI.WKInspectorExtensionHost.UnregisterExtension, TestWebKitAPI.WKWebExtensionAPIDevTools.NetworkNavigatedEvent, TestWebKitAPI.WKInspectorDelegate.ShowURLExternally, TestWebKitAPI.WKWebExtensionAPIDevTools.MessagePassingFromPanelToDevToolsBackground, TestWebKitAPI.WKInspectorExtension.EvaluateScriptInExtensionTabCanReturnPromises, TestWebKitAPI.WKWebExtensionAPIDevTools.MessagePassingFromPanelToBackground, TestWebKitAPI.WKWebExtensionAPIDevTools.PanelsThemeName ... (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58772 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/17825 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/11140 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/53184 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/95861 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/87634 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/11203 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/110731 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/101797 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/30323 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/22358 "Found 1 new test failure: imported/w3c/web-platform-tests/scroll-animations/view-timelines/zero-intrinsic-iteration-duration.tentative.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/87435 "Found 1 new test failure: imported/w3c/web-platform-tests/service-workers/service-worker/redirected-response.https.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/30688 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/89297 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87072 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31918 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/9631 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/24647 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/30250 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/35572 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/125430 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/30059 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34794 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/33385 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/31621 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->