### PR TITLE
View transitions don't ignore IB split fragments.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/ib-split-at-start-ignored-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/ib-split-at-start-ignored-expected.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<title>View transitions: ib split fragmented elements skipped</title>
+<link rel="help" href="https://www.w3.org/TR/css-view-transitions-1/">
+<link rel="author" href="mailto:mattwoodrow@apple.com">
+
+<style>
+html {
+  background: pink;
+}
+</style>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/ib-split-at-start-ignored-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/ib-split-at-start-ignored-ref.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<title>View transitions: ib split fragmented elements skipped</title>
+<link rel="help" href="https://www.w3.org/TR/css-view-transitions-1/">
+<link rel="author" href="mailto:mattwoodrow@apple.com">
+
+<style>
+html {
+  background: pink;
+}
+</style>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/ib-split-at-start-ignored.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/ib-split-at-start-ignored.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html class=reftest-wait>
+<title>View transitions: ib split fragmented elements skipped</title>
+<link rel="help" href="https://www.w3.org/TR/css-view-transitions-1/">
+<link rel="author" href="mailto:mattwoodrow@apple.com">
+<link rel="match" href="ib-split-at-start-ignored-ref.html">
+
+<script src="/common/reftest-wait.js"></script>
+<style>
+#target {
+  view-transition-name: target;
+}
+#inner {
+  width: 200px;
+  height: 200px;
+  background: red;
+}
+
+::view-transition {
+  background: pink;
+}
+::view-transition-group(root) {
+  animation-duration: 500s;
+  visibility: hidden;
+}
+::view-transition-group(target) {
+  border: 1px solid black;
+}
+</style>
+<span id=target>
+  <div id=inner></div>
+</span>
+
+<script>
+failIfNot(document.startViewTransition, "Missing document.startViewTransition");
+
+function runTransition() {
+  document.startViewTransition().ready.then(takeScreenshot);
+}
+
+requestAnimationFrame(() => requestAnimationFrame(runTransition))
+</script>

--- a/Source/WebCore/dom/ViewTransition.cpp
+++ b/Source/WebCore/dom/ViewTransition.cpp
@@ -498,6 +498,11 @@ static bool rendererIsFragmented(const RenderLayerModelObject& renderer)
     // https://drafts.csswg.org/css-view-transitions-1/#capture-old-state-algorithm
     // View transitions explicitly excludes splitting of inline boxes across lines.
 
+    // https://drafts.csswg.org/css-break-4/#fragmentation-model
+    // A box can be broken into multiple fragments by block-in-inline splitting.
+    if (renderer.hasContinuationChainNode() || renderer.isContinuation())
+        return true;
+
     CheckedPtr box = dynamicDowncast<RenderBox>(renderer);
     if (!box)
         return false;


### PR DESCRIPTION
#### 356bc659108197612e764ea2f6bd199955fb4de0
<pre>
View transitions don&apos;t ignore IB split fragments.
<a href="https://bugs.webkit.org/show_bug.cgi?id=290923">https://bugs.webkit.org/show_bug.cgi?id=290923</a>
&lt;<a href="https://rdar.apple.com/148432507">rdar://148432507</a>&gt;

Reviewed by NOBODY (OOPS!).

Adds new tests for fragments created by an IB-split.

Explanation of why this fixes the bug (OOPS!).

* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/ib-split-at-start-ignored-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/ib-split-at-start-ignored-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/ib-split-at-start-ignored.html: Added.
* Source/WebCore/dom/ViewTransition.cpp:
(WebCore::rendererIsFragmented):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/356bc659108197612e764ea2f6bd199955fb4de0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105198 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24912 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15337 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110415 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/55867 "Built successfully") 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/107239 "Build is in progress. Recent messages:OS: Sequoia (15.3), Xcode: 16.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Passed bindings tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/25472 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33456 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79903 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108204 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19864 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94954 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60210 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/19625 "") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13030 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55254 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/89320 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13074 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/112991 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32362 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23841 "Found 1 new test failure: imported/w3c/web-platform-tests/html/browsers/the-window-object/open-close/open-features-tokenization-noreferrer.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88978 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32728 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91172 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88609 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33507 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11298 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/27776 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32286 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/37702 "Failed to build and analyze WebKit") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32073 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35416 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33634 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->