### PR TITLE
Rename Purpose HTTP request header to Sec-Purpose

### DIFF
--- a/LayoutTests/http/tests/cache/resources/prefetched-main-resource.py
+++ b/LayoutTests/http/tests/cache/resources/prefetched-main-resource.py
@@ -3,7 +3,7 @@
 import os
 import sys
 
-purpose = os.environ.get('HTTP_PURPOSE', '')
+purpose = os.environ.get('HTTP_SEC_PURPOSE', '')
 
 sys.stdout.write(
     'Cache-Control: max-age=3600\r\n'

--- a/LayoutTests/http/wpt/prefetch/resources/main-resource-redirect-no-prefetch.py
+++ b/LayoutTests/http/wpt/prefetch/resources/main-resource-redirect-no-prefetch.py
@@ -6,6 +6,6 @@ def main(request, response):
 <script>
   window.opener.postMessage('{result}', '*');
 </script>
-""".format(result=request.headers.get("Purpose", ""))
+""".format(result=request.headers.get("Sec-Purpose", ""))
 
     return headers, document

--- a/LayoutTests/http/wpt/prefetch/resources/main-resource-skip-disk-cache.py
+++ b/LayoutTests/http/wpt/prefetch/resources/main-resource-skip-disk-cache.py
@@ -20,4 +20,4 @@ def main(request, response):
 <body onload="test()">
 """
 
-    return headers, document % {'prefetch': isomorphic_decode(request.headers.get(b"Purpose", b"")), 'url': request.url }
+    return headers, document % {'prefetch': isomorphic_decode(request.headers.get(b"Sec-Purpose", b"")), 'url': request.url }

--- a/LayoutTests/http/wpt/prefetch/resources/prefetched-main-resource-redirect.py
+++ b/LayoutTests/http/wpt/prefetch/resources/prefetched-main-resource-redirect.py
@@ -1,5 +1,5 @@
 def main(request, response):
-    if b"prefetch" in request.headers.get(b"Purpose"):
+    if b"prefetch" in request.headers.get(b"Sec-Purpose"):
         headers = [(b"Cache-Control", b"max-age=3600"), (b"Location", b"/WebKit/prefetch/resources/main-resource-redirect-no-prefetch.py")]
         return 302, headers, ""
     return 200, [], "FAIL"

--- a/LayoutTests/imported/w3c/web-platform-tests/preload/prefetch-headers-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/preload/prefetch-headers-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL Prefetch should include Sec-Purpose=prefetch and Sec-Fetch-Dest=empty headers assert_equals: expected (string) "prefetch" but got (undefined) undefined
-FAIL Prefetch should not include proprietary headers (X-moz/Purpose) assert_false: expected false got true
+PASS Prefetch should include Sec-Purpose=prefetch and Sec-Fetch-Dest=empty headers
+PASS Prefetch should not include proprietary headers (X-moz/Purpose)
 PASS Prefetch should respect CORS mode
 

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/preload/prefetch-headers-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/preload/prefetch-headers-expected.txt
@@ -1,5 +1,5 @@
 
 FAIL Prefetch should include Sec-Purpose=prefetch and Sec-Fetch-Dest=empty headers assert_equals: expected (string) "empty" but got (undefined) undefined
-FAIL Prefetch should not include proprietary headers (X-moz/Purpose) assert_false: expected false got true
+PASS Prefetch should not include proprietary headers (X-moz/Purpose)
 PASS Prefetch should respect CORS mode
 

--- a/Source/WebCore/loader/cache/CachedRawResource.cpp
+++ b/Source/WebCore/loader/cache/CachedRawResource.cpp
@@ -291,8 +291,8 @@ static bool shouldIgnoreHeaderForCacheReuse(HTTPHeaderName name)
     case HTTPHeaderName::Accept:
     case HTTPHeaderName::CacheControl:
     case HTTPHeaderName::Pragma:
-    case HTTPHeaderName::Purpose:
     case HTTPHeaderName::Referer:
+    case HTTPHeaderName::SecPurpose:
     case HTTPHeaderName::UserAgent:
         return true;
 

--- a/Source/WebCore/loader/cache/CachedResource.cpp
+++ b/Source/WebCore/loader/cache/CachedResource.cpp
@@ -225,7 +225,7 @@ void CachedResource::load(CachedResourceLoader& cachedResourceLoader)
     }
 
     if (type() == Type::LinkPrefetch)
-        m_resourceRequest.setHTTPHeaderField(HTTPHeaderName::Purpose, "prefetch"_s);
+        m_resourceRequest.setHTTPHeaderField(HTTPHeaderName::SecPurpose, "prefetch"_s);
     m_resourceRequest.setPriority(loadPriority());
 
     // Navigation algorithm is setting up the request before sending it to CachedResourceLoader?CachedResource.

--- a/Source/WebCore/platform/network/HTTPHeaderNames.in
+++ b/Source/WebCore/platform/network/HTTPHeaderNames.in
@@ -77,7 +77,6 @@ Location
 Origin
 Ping-From
 Ping-To
-Purpose
 Pragma
 Proxy-Authorization
 Range
@@ -89,6 +88,7 @@ Reporting-Endpoints
 Sec-Fetch-Dest
 Sec-Fetch-Mode
 Sec-Fetch-Site
+Sec-Purpose
 Sec-WebSocket-Accept
 Sec-WebSocket-Extensions
 Sec-WebSocket-Key

--- a/Source/WebCore/platform/network/ResourceRequestBase.cpp
+++ b/Source/WebCore/platform/network/ResourceRequestBase.cpp
@@ -436,7 +436,7 @@ void ResourceRequestBase::clearPurpose()
 {
     updateResourceRequest();
 
-    m_requestData.m_httpHeaderFields.remove(HTTPHeaderName::Purpose);
+    m_requestData.m_httpHeaderFields.remove(HTTPHeaderName::SecPurpose);
 
     m_platformRequestUpdated = false;
 }

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
@@ -2023,7 +2023,7 @@ void NetworkResourceLoader::logSlowCacheRetrieveIfNeeded(const NetworkCache::Cac
 bool NetworkResourceLoader::isCrossOriginPrefetch() const
 {
     auto& request = originalRequest();
-    return request.httpHeaderField(HTTPHeaderName::Purpose) == "prefetch"_s && !m_parameters.protectedSourceOrigin()->canRequest(request.url(), connectionToWebProcess().originAccessPatterns());
+    return request.httpHeaderField(HTTPHeaderName::SecPurpose) == "prefetch"_s && !m_parameters.protectedSourceOrigin()->canRequest(request.url(), connectionToWebProcess().originAccessPatterns());
 }
 
 void NetworkResourceLoader::setWorkerStart(MonotonicTime value)


### PR DESCRIPTION
#### 0ae28b188526faaf93da30c524b4a1c221f6fa93
<pre>
Rename Purpose HTTP request header to Sec-Purpose
<a href="https://bugs.webkit.org/show_bug.cgi?id=292854">https://bugs.webkit.org/show_bug.cgi?id=292854</a>

Reviewed by Youenn Fablet.

Although &lt;link rel=prefetch&gt; is disabled by default, let&apos;s at least
keep the header name up-to-date.

Canonical link: <a href="https://commits.webkit.org/294826@main">https://commits.webkit.org/294826@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a5a823971ab7f1562468c2bfb7c5f2aea8ce9413

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/103115 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/22790 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/13109 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/108283 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/53758 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/105154 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/23160 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/31290 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78389 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/35335 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/106121 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17957 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/93039 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58722 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/17804 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/11080 "Found 1 new test failure: http/tests/xmlhttprequest/cross-origin-cookie-storage.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/53113 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/87610 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/11144 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/110656 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/30252 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/22304 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/87382 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/30617 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/89238 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87007 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31860 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/9575 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/24574 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16748 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/30179 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/35501 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/29987 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/33314 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/31549 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->