### PR TITLE
[GTK][WPE] FrameDamageHistory is used from main and compositor threads without a lock

### DIFF
--- a/Source/WebCore/page/ChromeClient.h
+++ b/Source/WebCore/page/ChromeClient.h
@@ -120,6 +120,7 @@ class Node;
 class Page;
 class PopupMenu;
 class PopupMenuClient;
+class Region;
 class RegistrableDomain;
 class SearchPopupMenu;
 class SVGImageElement;
@@ -759,8 +760,7 @@ public:
 
 #if ENABLE(DAMAGE_TRACKING)
     virtual void resetDamageHistoryForTesting() { }
-
-    virtual WebCore::FrameDamageHistory* damageHistoryForTesting() const { return nullptr; }
+    virtual void foreachRegionInDamageHistoryForTesting(Function<void(const Region&)>&&) const { }
 #endif
 
     WEBCORE_EXPORT virtual ~ChromeClient();

--- a/Source/WebCore/platform/graphics/Damage.h
+++ b/Source/WebCore/platform/graphics/Damage.h
@@ -113,6 +113,14 @@ public:
     ALWAYS_INLINE bool isEmpty() const  { return m_rects.isEmpty(); }
     ALWAYS_INLINE Mode mode() const { return m_mode; }
 
+    Region regionForTesting() const
+    {
+        Region region;
+        for (const auto& rect : m_rects)
+            region.unite(Region { rect });
+        return region;
+    }
+
     // Removes empty and overlapping rects. May clip to grid.
     Rects rectsForPainting() const
     {
@@ -351,26 +359,6 @@ private:
     IntRect m_minimumBoundingRectangle;
 
     friend bool operator==(const Damage&, const Damage&) = default;
-};
-
-class FrameDamageHistory {
-    WTF_MAKE_FAST_ALLOCATED;
-public:
-    const Vector<Region>& damageInformation() const { return m_damageInfo; }
-
-    void addDamage(const Damage& damage)
-    {
-        Region region;
-        for (const auto& rect : damage.rects()) {
-            Region subRegion(rect);
-            region.unite(subRegion);
-        }
-        m_damageInfo.append(WTFMove(region));
-    }
-
-private:
-    // Use a Region to remove overlaps so that Damage rects are more predictable from the testing perspective.
-    Vector<Region> m_damageInfo;
 };
 
 static inline WTF::TextStream& operator<<(WTF::TextStream& ts, const Damage& damage)

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -7871,13 +7871,9 @@ ExceptionOr<Vector<Internals::FrameDamage>> Internals::getFrameDamageHistory() c
     if (!document || !document->page())
         return Exception { ExceptionCode::NotSupportedError };
 
-    const auto* damageForTesting = document->page()->chrome().client().damageHistoryForTesting();
-    if (!damageForTesting)
-        return Exception { ExceptionCode::NotSupportedError };
-
     Vector<Internals::FrameDamage> damageDetails;
     size_t sequenceId = 0;
-    for (const auto& region : damageForTesting->damageInformation()) {
+    document->page()->chrome().client().foreachRegionInDamageHistoryForTesting([&](const auto& region) {
         FrameDamage details;
         details.sequenceId = sequenceId++;
 
@@ -7889,7 +7885,7 @@ ExceptionOr<Vector<Internals::FrameDamage>> Internals::getFrameDamageHistory() c
             return DOMRectReadOnly::create(rect.x(), rect.y(), rect.width(), rect.height());
         });
         damageDetails.append(WTFMove(details));
-    }
+    });
 
     return damageDetails;
 }

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -2364,27 +2364,17 @@ void WebChromeClient::resetDamageHistoryForTesting()
     if (!m_page)
         return;
 
-    const auto* drawingArea = m_page->drawingArea();
-    if (!drawingArea)
-        return;
-
-    if (auto* frameDamageForTesting = drawingArea->frameDamageForTesting())
-        frameDamageForTesting->resetFrameDamageHistory();
+    if (auto* drawingArea = m_page->drawingArea())
+        drawingArea->resetDamageHistoryForTesting();
 }
 
-WebCore::FrameDamageHistory* WebChromeClient::damageHistoryForTesting() const
+void WebChromeClient::foreachRegionInDamageHistoryForTesting(Function<void(const Region&)>&& callback) const
 {
     if (!m_page)
-        return nullptr;
+        return;
 
-    const auto* drawingArea = m_page->drawingArea();
-    if (!drawingArea)
-        return nullptr;
-
-    if (const auto* frameDamageForTesting = drawingArea->frameDamageForTesting())
-        return frameDamageForTesting->frameDamageHistory();
-
-    return nullptr;
+    if (const auto* drawingArea = m_page->drawingArea())
+        drawingArea->foreachRegionInDamageHistoryForTesting(WTFMove(callback));
 }
 #endif
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
@@ -562,8 +562,7 @@ private:
 
 #if ENABLE(DAMAGE_TRACKING)
     void resetDamageHistoryForTesting() final;
-
-    WebCore::FrameDamageHistory* damageHistoryForTesting() const final;
+    void foreachRegionInDamageHistoryForTesting(Function<void(const WebCore::Region&)>&& callback) const final;
 #endif
 
     void setNeedsFixedContainerEdgesUpdate() final;

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.cpp
@@ -797,9 +797,16 @@ void DrawingAreaCoordinatedGraphics::preferredBufferFormatsDidChange()
 #endif
 
 #if ENABLE(DAMAGE_TRACKING)
-FrameDamageForTesting* DrawingAreaCoordinatedGraphics::frameDamageForTesting() const
+void DrawingAreaCoordinatedGraphics::resetDamageHistoryForTesting()
 {
-    return m_layerTreeHost ? m_layerTreeHost->frameDamageForTesting() : nullptr;
+    if (m_layerTreeHost)
+        m_layerTreeHost->resetDamageHistoryForTesting();
+}
+
+void DrawingAreaCoordinatedGraphics::foreachRegionInDamageHistoryForTesting(Function<void(const Region&)>&& callback) const
+{
+    if (m_layerTreeHost)
+        m_layerTreeHost->foreachRegionInDamageHistoryForTesting(WTFMove(callback));
 }
 #endif
 

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.h
@@ -99,7 +99,8 @@ private:
 #endif
 
 #if ENABLE(DAMAGE_TRACKING)
-    FrameDamageForTesting* frameDamageForTesting() const override;
+    void resetDamageHistoryForTesting() override;
+    void foreachRegionInDamageHistoryForTesting(Function<void(const WebCore::Region&)>&&) const override;
 #endif
 
 #if PLATFORM(GTK)

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
@@ -660,6 +660,30 @@ void LayerTreeHost::preferredBufferFormatsDidChange()
 }
 #endif
 
+#if ENABLE(DAMAGE_TRACKING)
+void LayerTreeHost::notifyFrameDamageForTesting(Region&& damageRegion)
+{
+    Locker locker { m_frameDamageHistoryForTestingLock };
+    m_frameDamageHistoryForTesting.append(WTFMove(damageRegion));
+}
+
+void LayerTreeHost::resetDamageHistoryForTesting()
+{
+    {
+        Locker locker { m_frameDamageHistoryForTestingLock };
+        m_frameDamageHistoryForTesting.clear();
+    }
+    m_compositor->enableFrameDamageNotificationForTesting();
+}
+
+void LayerTreeHost::foreachRegionInDamageHistoryForTesting(Function<void(const Region&)>&& callback)
+{
+    Locker locker { m_frameDamageHistoryForTestingLock };
+    for (const auto& region : m_frameDamageHistoryForTesting)
+        callback(region);
+}
+#endif
+
 } // namespace WebKit
 
 #endif // USE(COORDINATED_GRAPHICS)

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.h
@@ -43,10 +43,6 @@
 #include "ThreadedDisplayRefreshMonitor.h"
 #endif
 
-#if ENABLE(DAMAGE_TRACKING)
-#include "FrameDamageForTesting.h"
-#endif
-
 namespace WebCore {
 class TextureMapper;
 class TransformationMatrix;
@@ -57,11 +53,7 @@ class AcceleratedSurface;
 class CoordinatedSceneState;
 class LayerTreeHost;
 
-class ThreadedCompositor : public ThreadSafeRefCounted<ThreadedCompositor>, public CanMakeThreadSafeCheckedPtr<ThreadedCompositor>
-#if ENABLE(DAMAGE_TRACKING)
-    , public FrameDamageForTesting
-#endif
-{
+class ThreadedCompositor : public ThreadSafeRefCounted<ThreadedCompositor>, public CanMakeThreadSafeCheckedPtr<ThreadedCompositor> {
     WTF_MAKE_TZONE_ALLOCATED(ThreadedCompositor);
     WTF_MAKE_NONCOPYABLE(ThreadedCompositor);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(ThreadedCompositor);
@@ -106,8 +98,7 @@ public:
 
 #if ENABLE(DAMAGE_TRACKING)
     void setDamagePropagation(WebCore::Damage::Propagation);
-    WebCore::FrameDamageHistory* frameDamageHistory() const { return m_frameDamageHistory.get(); }
-    void resetFrameDamageHistory();
+    void enableFrameDamageNotificationForTesting();
 #endif
 
 private:
@@ -165,8 +156,11 @@ private:
     } m_fpsCounter;
 
 #if ENABLE(DAMAGE_TRACKING)
-    WebCore::Damage::Propagation m_damagePropagation { WebCore::Damage::Propagation::None };
-    std::unique_ptr<WebCore::TextureMapperDamageVisualizer> m_damageVisualizer;
+    struct {
+        WebCore::Damage::Propagation propagation { WebCore::Damage::Propagation::None };
+        std::unique_ptr<WebCore::TextureMapperDamageVisualizer> visualizer;
+        std::atomic<bool> shouldNotifyFrameDamageForTesting { false };
+    } m_damage;
 #endif
 
     std::atomic<uint32_t> m_compositionRequestID { 0 };
@@ -181,9 +175,6 @@ private:
     } m_display;
 
     Ref<ThreadedDisplayRefreshMonitor> m_displayRefreshMonitor;
-#endif
-#if ENABLE(DAMAGE_TRACKING)
-    std::unique_ptr<WebCore::FrameDamageHistory> m_frameDamageHistory;
 #endif
 };
 

--- a/Source/WebKit/WebProcess/WebPage/DrawingArea.h
+++ b/Source/WebKit/WebProcess/WebPage/DrawingArea.h
@@ -70,10 +70,6 @@ class LayerTreeHost;
 struct WebPageCreationParameters;
 struct WebPreferencesStore;
 
-#if ENABLE(DAMAGE_TRACKING)
-class FrameDamageForTesting;
-#endif
-
 class DrawingArea : public RefCounted<DrawingArea>, public IPC::MessageReceiver, public WebCore::DisplayRefreshMonitorFactory {
     WTF_MAKE_TZONE_ALLOCATED(DrawingArea);
     WTF_MAKE_NONCOPYABLE(DrawingArea);
@@ -181,7 +177,8 @@ public:
 #endif
 
 #if ENABLE(DAMAGE_TRACKING)
-    virtual FrameDamageForTesting* frameDamageForTesting() const { return nullptr; }
+    virtual void resetDamageHistoryForTesting() { }
+    virtual void foreachRegionInDamageHistoryForTesting(Function<void(const WebCore::Region&)>&&) const { }
 #endif
 
     virtual void adoptLayersFromDrawingArea(DrawingArea&) { }


### PR DESCRIPTION
#### 47a7a7efca62377bac72d306ee142ec67bd7d0b5
<pre>
[GTK][WPE] FrameDamageHistory is used from main and compositor threads without a lock
<a href="https://bugs.webkit.org/show_bug.cgi?id=292860">https://bugs.webkit.org/show_bug.cgi?id=292860</a>

Reviewed by Alejandro G. Castro.

Remove FrameDamageHistory and move the handling of frame damage history
to LayerTreeHost that protects its access with a lock.

* Source/WebCore/page/ChromeClient.h:
(WebCore::ChromeClient::foreachRegionInDamageHistoryForTesting const):
(WebCore::ChromeClient::damageHistoryForTesting const): Deleted.
* Source/WebCore/platform/graphics/Damage.h:
(WebCore::Damage::regionForTesting const):
(WebCore::FrameDamageHistory::damageInformation const): Deleted.
(WebCore::FrameDamageHistory::addDamage): Deleted.
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::getFrameDamageHistory const):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::resetDamageHistoryForTesting):
(WebKit::WebChromeClient::foreachRegionInDamageHistoryForTesting const):
(WebKit::WebChromeClient::damageHistoryForTesting const): Deleted.
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h:
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.cpp:
(WebKit::DrawingAreaCoordinatedGraphics::resetDamageHistoryForTesting):
(WebKit::DrawingAreaCoordinatedGraphics::foreachRegionInDamageHistoryForTesting const):
(WebKit::DrawingAreaCoordinatedGraphics::frameDamageForTesting const): Deleted.
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.h:
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp:
(WebKit::LayerTreeHost::notifyFrameDamageForTesting):
(WebKit::LayerTreeHost::resetDamageHistoryForTesting):
(WebKit::LayerTreeHost::foreachRegionInDamageHistoryForTesting):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.h:
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.cpp:
(WebKit::m_compositingRunLoop):
(WebKit::ThreadedCompositor::setDamagePropagation):
(WebKit::ThreadedCompositor::enableFrameDamageNotificationForTesting):
(WebKit::ThreadedCompositor::paintToCurrentGLContext):
(WebKit::ThreadedCompositor::resetFrameDamageHistory): Deleted.
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.h:
(WebKit::ThreadedCompositor::frameDamageHistory const): Deleted.
* Source/WebKit/WebProcess/WebPage/DrawingArea.h:
(WebKit::DrawingArea::resetDamageHistoryForTesting):
(WebKit::DrawingArea::foreachRegionInDamageHistoryForTesting const):
(WebKit::DrawingArea::frameDamageForTesting const): Deleted.

Canonical link: <a href="https://commits.webkit.org/294836@main">https://commits.webkit.org/294836@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/285f7cc5658f6e36e364b9d9384663a48e80462d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/103109 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/22784 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/13103 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/108277 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/53752 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/105148 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/23116 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/31284 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78385 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/35328 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/106115 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17913 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/93028 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58718 "Found 1 new API test failure: /WPE/TestCookieManager:/webkit/WebKitCookieManager/persistent-storage (failure)") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/11069 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/53107 "Built successfully") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/11133 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/110650 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/30246 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/22295 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/87372 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/30611 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/89227 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86997 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31855 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/9564 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/24568 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16754 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/30173 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/35495 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/29981 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/33308 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/31543 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->