### PR TITLE
Remove CSSMotionPathEnabled preference

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -1286,20 +1286,6 @@ CSSMediaProgressFunctionEnabled:
     WebCore:
       default: false
 
-CSSMotionPathEnabled:
-  type: bool
-  status: stable
-  category: css
-  humanReadableName: "CSS Motion Path"
-  humanReadableDescription: "Enable CSS Motion Path support"
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
-
 CSSOMViewScrollingAPIEnabled:
   type: bool
   status: stable

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -6294,7 +6294,6 @@
                 "animation-wrapper": "PathOperationWrapper",
                 "animation-wrapper-acceleration": "threaded-only",
                 "style-builder-converter": "PathOperation",
-                "settings-flag": "cssMotionPathEnabled",
                 "parser-function": "consumeOffsetPath",
                 "parser-grammar-unused": "none | <ray()> | <path()> | <url> | [ <basic-shape> && <coord-box>? ] | <coord-box>",
                 "parser-grammar-unused-reason": "Needs support for transforming parsed input to minimal form and the strong value representation."
@@ -6312,7 +6311,6 @@
                 "animation-wrapper-requires-additional-parameters": ["{ LengthWrapper::Flags::IsLengthPercentage }"],
                 "animation-wrapper-acceleration": "threaded-only",
                 "style-builder-converter": "Length",
-                "settings-flag": "cssMotionPathEnabled",
                 "parser-grammar": "<length-percentage>"
             },
             "specification": {
@@ -6331,7 +6329,6 @@
                 "animation-wrapper": "LengthPointOrAutoWrapper",
                 "animation-wrapper-acceleration": "threaded-only",
                 "style-builder-converter": "PositionOrAutoOrNormal",
-                "settings-flag": "cssMotionPathEnabled",
                 "parser-grammar": "normal | auto | <position>"
             },
             "specification": {
@@ -6349,7 +6346,6 @@
                 "animation-wrapper": "LengthPointOrAutoWrapper",
                 "animation-wrapper-acceleration": "threaded-only",
                 "style-builder-converter": "PositionOrAuto",
-                "settings-flag": "cssMotionPathEnabled",
                 "parser-grammar": "auto | <position>"
             },
             "specification": {
@@ -6369,7 +6365,6 @@
                 "animation-wrapper-requires-override-parameters": [],
                 "animation-wrapper-acceleration": "threaded-only",
                 "style-builder-converter": "OffsetRotate",
-                "settings-flag": "cssMotionPathEnabled",
                 "parser-grammar": "[ [ auto | reverse ] || <angle> ]@(type=CSSOffsetRotateValue)"
             },
             "specification": {
@@ -6385,8 +6380,7 @@
                     "offset-distance",
                     "offset-rotate",
                     "offset-anchor"
-                ],
-                "settings-flag": "cssMotionPathEnabled"
+                ]
             },
             "specification": {
                 "category": "css-motion-path",


### PR DESCRIPTION
#### c4686b75922e16697de01b4fa825d2ad40403790
<pre>
Remove CSSMotionPathEnabled preference
<a href="https://bugs.webkit.org/show_bug.cgi?id=292864">https://bugs.webkit.org/show_bug.cgi?id=292864</a>

Reviewed by Vitor Roriz.

Has been enabled for at least two years on main.

Canonical link: <a href="https://commits.webkit.org/294884@main">https://commits.webkit.org/294884@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a8169f0029c1675a4d63abcb9c383eca712b3420

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/103105 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/22780 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/13099 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/108273 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/53748 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/105144 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/23112 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/31280 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78387 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/35329 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/106111 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17917 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/93030 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58720 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/17760 "Found 2 new test failures: imported/w3c/web-platform-tests/fetch/api/basic/accept-header.any.html imported/w3c/web-platform-tests/fetch/api/idlharness.any.html (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/11071 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/53103 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/95780 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/87571 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/11135 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/110646 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/101716 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/30242 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/22294 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/87377 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/30607 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/89229 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87002 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31852 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/9566 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/24564 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16769 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/30169 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/35491 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/125349 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/29977 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34771 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/33304 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/31539 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->