### PR TITLE
SWServer::registerServiceWorkerClient is not clearing m_clientIdentifiersPerOrigin identifiers list properly

### DIFF
--- a/Source/WebCore/platform/ScriptExecutionContextIdentifier.h
+++ b/Source/WebCore/platform/ScriptExecutionContextIdentifier.h
@@ -48,7 +48,7 @@ public:
     {
     }
 
-    operator bool() const { return !!m_object; }
+    explicit operator bool() const { return !!m_object; }
 
     const WTF::UUID& object() const { return m_object; }
     ProcessIdentifier processIdentifier() const { return m_processIdentifier; }

--- a/Source/WebCore/workers/service/server/SWServer.cpp
+++ b/Source/WebCore/workers/service/server/SWServer.cpp
@@ -1204,9 +1204,10 @@ void SWServer::registerServiceWorkerClient(ClientOrigin&& clientOrigin, ServiceW
             m_clientsById.remove(previousIdentifier);
             m_clientsToBeCreatedById.remove(previousIdentifier);
             m_clientToControllingRegistration.remove(previousIdentifier);
-            m_clientIdentifiersPerOrigin.ensure(clientOrigin, [] {
+            bool isRemoved = m_clientIdentifiersPerOrigin.ensure(clientOrigin, [] {
                 return Clients { };
-            }).iterator->value.identifiers.remove(previousIdentifier);
+            }).iterator->value.identifiers.removeFirst(previousIdentifier);
+            ASSERT_UNUSED(isRemoved, isRemoved);
         } else {
             ASSERT(m_visibleClientIdToInternalClientIdMap.get(data.identifier.object().toString()) == clientIdentifier);
             ASSERT(m_clientsById.contains(clientIdentifier));


### PR DESCRIPTION
#### ac0a643535c3e12f0c341b56f36750851333b43c
<pre>
SWServer::registerServiceWorkerClient is not clearing m_clientIdentifiersPerOrigin identifiers list properly
<a href="https://bugs.webkit.org/show_bug.cgi?id=292866">https://bugs.webkit.org/show_bug.cgi?id=292866</a>
<a href="https://rdar.apple.com/150678359">rdar://150678359</a>

Reviewed by Chris Dumez.

We were calling Vector::remove using a ScriptExecutionContextIdentifier which was casted as a boolean to a size_t.
We were then removing a Vector entry based on a position and not based on the value to remove.

We instead call removeFirst and make ScriptExecutionContextIdentifier bool conversion explicit.
We add a debug ASSERT to catch potential removal mismatch in existing tests.

* Source/WebCore/platform/ScriptExecutionContextIdentifier.h:
(WebCore::ProcessQualified&lt;WTF::UUID&gt;::operator bool const):
* Source/WebCore/workers/service/server/SWServer.cpp:
(WebCore::SWServer::registerServiceWorkerClient):

Canonical link: <a href="https://commits.webkit.org/294832@main">https://commits.webkit.org/294832@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0b7c0fa0cf2b55f0fb4df8ee542f55b7d319e14f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/103116 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/22791 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/13110 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/108284 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/53759 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/105155 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/23123 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/31291 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78398 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/35336 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/106122 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17924 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/93040 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58731 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/17768 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/11081 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/53114 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/87578 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/11145 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/110657 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/30253 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/22303 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/87379 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/30618 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/89239 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87004 "Found 2 new API test failures: /WebKitGTK/TestCookieManager:/webkit/WebKitCookieManager/persistent-storage, /WebKitGTK/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/autoplay-policy (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22160 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31861 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/9576 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/24576 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/30180 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/35502 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/29988 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/33315 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/31550 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->