### PR TITLE
[JSC] Run tier-up check injection phase later

### DIFF
--- a/Source/JavaScriptCore/dfg/DFGPlan.cpp
+++ b/Source/JavaScriptCore/dfg/DFGPlan.cpp
@@ -320,8 +320,6 @@ Plan::CompilationPath Plan::compileInThreadImpl()
     case JITCompilationMode::UnlinkedDFG: {
         dfg.m_fixpointState = FixpointConverged;
 
-        RUN_PHASE(performTierUpCheckInjection);
-
         RUN_PHASE(performFastStoreBarrierInsertion);
         RUN_PHASE(performStoreBarrierClustering);
         RUN_PHASE(performCleanUp);
@@ -330,6 +328,8 @@ Plan::CompilationPath Plan::compileInThreadImpl()
         RUN_PHASE(performPhantomInsertion);
         RUN_PHASE(performStackLayout);
         RUN_PHASE(performVirtualRegisterAllocation);
+        RUN_PHASE(performTierUpCheckInjection);
+
         if (m_mode == JITCompilationMode::UnlinkedDFG) {
             if (DFG::canCompileUnlinked(dfg) == DFG::CannotCompile) {
                 m_finalizer = makeUnique<FailedFinalizer>(*this);


### PR DESCRIPTION
#### 50dbf91cc9774efbb9c0fe34e841ca8e39168bb2
<pre>
[JSC] Run tier-up check injection phase later
<a href="https://bugs.webkit.org/show_bug.cgi?id=292870">https://bugs.webkit.org/show_bug.cgi?id=292870</a>
<a href="https://rdar.apple.com/151149529">rdar://151149529</a>

Reviewed by NOBODY (OOPS!).

The nodes injected by performTierUpCheckInjection() seem
to be impeding optimization phases that come after.
So let&apos;s inject the tier-up counter nodes later.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/50dbf91cc9774efbb9c0fe34e841ca8e39168bb2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/103129 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/22804 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/13123 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/108297 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/53772 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/23137 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/31304 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78399 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/35346 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/106135 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17933 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/93054 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58732 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/17778 "Found 60 new test failures: imported/w3c/web-platform-tests/css/css-shapes/spec-examples/shape-outside-019.html imported/w3c/web-platform-tests/dom/nodes/remove-unscopable.html imported/w3c/web-platform-tests/fetch/api/basic/header-value-null-byte.any.serviceworker.html imported/w3c/web-platform-tests/fetch/api/body/formdata.any.html imported/w3c/web-platform-tests/fetch/api/headers/header-values-normalize.any.serviceworker.html imported/w3c/web-platform-tests/fetch/api/headers/header-values-normalize.any.sharedworker.html imported/w3c/web-platform-tests/fetch/api/headers/header-values.any.sharedworker.html imported/w3c/web-platform-tests/fetch/api/headers/headers-basic.any.sharedworker.html imported/w3c/web-platform-tests/fetch/api/headers/headers-casing.any.sharedworker.html imported/w3c/web-platform-tests/fetch/api/headers/headers-combine.any.sharedworker.html ... (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/11096 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/53127 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/95804 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/87587 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/11159 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/110670 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/101740 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/30266 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/22316 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/87389 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/30631 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/89253 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87016 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31875 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/9590 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/24590 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/30193 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/35515 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/125373 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/30001 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34778 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/33328 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/31563 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->