### PR TITLE
Expose fragment ranges for testing.

### DIFF
--- a/Source/WebCore/dom/AbstractRange.h
+++ b/Source/WebCore/dom/AbstractRange.h
@@ -51,7 +51,7 @@ public:
 };
 
 WEBCORE_EXPORT SimpleRange makeSimpleRange(const AbstractRange&);
-SimpleRange makeSimpleRange(const Ref<AbstractRange>&);
+WEBCORE_EXPORT SimpleRange makeSimpleRange(const Ref<AbstractRange>&);
 std::optional<SimpleRange> makeSimpleRange(const AbstractRange*);
 std::optional<SimpleRange> makeSimpleRange(const RefPtr<AbstractRange>&);
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -39,6 +39,7 @@
 #import "ContentAsStringIncludesChildFrames.h"
 #import "DefaultWebBrowserChecks.h"
 #import "DiagnosticLoggingClient.h"
+#import "EditingRange.h"
 #import "FindClient.h"
 #import "FullscreenClient.h"
 #import "GlobalFindInPageState.h"

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h
@@ -156,6 +156,8 @@ struct WKAppPrivacyReportTestingData {
 
 - (void)_setMediaVolumeForTesting:(float)volume;
 
+- (void)_textFragmentRangesWithCompletionHandlerForTesting:(void(^)(NSArray<NSValue *> *fragmentRanges))completionHandler WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+
 @property (nonatomic, readonly) _WKRectEdge _fixedContainerEdges;
 #if TARGET_OS_IPHONE
 @property (nonatomic, readonly) UIColor *_sampledLeftFixedPositionContentColor;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
@@ -1004,6 +1004,19 @@ static void dumpCALayer(TextStream& ts, CALayer *layer, bool traverse)
     };
 }
 
+- (void)_textFragmentRangesWithCompletionHandlerForTesting:(void(^)(NSArray<NSValue *> *fragmentRanges))completionHandler
+{
+    _page->getTextFragmentRanges([completion = makeBlockPtr(completionHandler)](const Vector<WebKit::EditingRange> editingRanges) {
+        RetainPtr<NSMutableArray<NSValue *>> resultRanges = [NSMutableArray array];
+        for (auto editingRange : editingRanges) {
+            NSRange resultRange = editingRange;
+            if (resultRange.location != NSNotFound)
+                [resultRanges addObject:[NSValue valueWithRange:resultRange]];
+        }
+        completion(resultRanges.get());
+    });
+}
+
 - (void)_cancelFixedColorExtensionFadeAnimationsForTesting
 {
 #if ENABLE(CONTENT_INSET_BACKGROUND_FILL)

--- a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
@@ -824,7 +824,16 @@ void WebPageProxy::createTextFragmentDirectiveFromSelection(CompletionHandler<vo
         return;
 
     protectedLegacyMainFrameProcess()->sendWithAsyncReply(Messages::WebPage::CreateTextFragmentDirectiveFromSelection(), WTFMove(completionHandler), webPageIDInMainFrameProcess());
+}
 
+void WebPageProxy::getTextFragmentRanges(CompletionHandler<void(const Vector<EditingRange>&&)>&& completionHandler)
+{
+    if (!hasRunningProcess()) {
+        completionHandler({ });
+        return;
+    }
+
+    protectedLegacyMainFrameProcess()->sendWithAsyncReply(Messages::WebPage::GetTextFragmentRanges(), WTFMove(completionHandler), webPageIDInMainFrameProcess());
 }
 
 #if ENABLE(APP_HIGHLIGHTS)

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2368,6 +2368,7 @@ public:
     void copyLinkWithHighlight();
 
     void createTextFragmentDirectiveFromSelection(CompletionHandler<void(URL&&)>&&);
+    void getTextFragmentRanges(CompletionHandler<void(const Vector<EditingRange>&&)>&&);
 
 #if ENABLE(APP_HIGHLIGHTS)
     void createAppHighlightInSelectedRange(WebCore::CreateNewGroupForHighlight, WebCore::HighlightRequestOriginatedInApp);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1802,6 +1802,7 @@ public:
 #endif
 
     void createTextFragmentDirectiveFromSelection(CompletionHandler<void(URL&&)>&&);
+    void getTextFragmentRanges(CompletionHandler<void(const Vector<EditingRange>&&)>&&);
 
 #if ENABLE(APP_HIGHLIGHTS)
     WebCore::CreateNewGroupForHighlight highlightIsNewGroup() const;

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -726,7 +726,8 @@ messages -> WebPage WantsAsyncDispatchMessage {
 #endif
 
     CreateTextFragmentDirectiveFromSelection() -> (URL url)
-    
+    GetTextFragmentRanges() -> (Vector<WebKit::EditingRange> textFragmentEditingRanges)
+
     HandleWheelEvent(WebCore::FrameIdentifier frameID, WebKit::WebWheelEvent event, OptionSet<WebCore::WheelEventProcessingSteps> processingSteps, std::optional<bool> willStartSwipe) -> (std::optional<WebCore::ScrollingNodeID> scrollingNodeID, enum:uint8_t std::optional<WebCore::WheelScrollGestureState> gestureState, bool handled, struct std::optional<WebCore::RemoteUserInputEventData> remoteUserInputEventData)
 
 #if PLATFORM(IOS_FAMILY)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKFragmentDirectiveGeneration.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKFragmentDirectiveGeneration.mm
@@ -56,4 +56,16 @@ TEST(FragmentDirectiveGeneration, GenerateFragment)
     TestWebKitAPI::Util::run(&done);
 }
 
+TEST(FragmentDirectiveGeneration, VerifyFragmentRanges)
+{
+    RetainPtr webView = createWebViewForFragmentDirectiveGenerationWithHTML(@"Test Page", @"location.href = \"#:~:text=Page\"");
+
+    __block bool done = false;
+    [webView _textFragmentRangesWithCompletionHandlerForTesting:^(NSArray<NSValue *> * fragmentRanges) {
+        EXPECT_TRUE(NSEqualRanges(fragmentRanges[0].rangeValue, NSMakeRange(5, 4)));
+        done = true;
+    }];
+    TestWebKitAPI::Util::run(&done);
+}
+
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### f13a765177da98919f5857208c0606f5193f7d55
<pre>
Expose fragment ranges for testing.
<a href="https://bugs.webkit.org/show_bug.cgi?id=292871">https://bugs.webkit.org/show_bug.cgi?id=292871</a>
<a href="https://rdar.apple.com/151151068">rdar://151151068</a>

Reviewed by Wenson Hsieh.

We would like to build some more extensive testing
tools that ensure that fragment generation is working
in all cases. We need to verify that the fragments
are in the correct location, so adding this SPI to
expose their locations in the document.

* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _textFragmentRangesWithCompletionHandler:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h:
* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
(WebKit::WebPageProxy::createTextFragmentDirectiveFromSelection):
(WebKit::WebPageProxy::getTextFragmentRanges):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::getTextFragmentRanges):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKFragmentDirectiveGeneration.mm:
(TestWebKitAPI::TEST(FragmentDirectiveGeneration, VerifyFragmentRanges)):

Canonical link: <a href="https://commits.webkit.org/294911@main">https://commits.webkit.org/294911@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/40952caf8b8b3dc5a59e2525b5427f4846034f3b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/103497 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/23179 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/13499 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/108673 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/54142 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/105536 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/23530 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/31730 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/78652 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/106503 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/18248 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/93363 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58986 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/18068 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/11410 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/53498 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/87859 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/11470 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/111051 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/30644 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/22605 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/87648 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/31005 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/89563 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87289 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22217 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32166 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/9876 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/24995 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/30572 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/35884 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/30372 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/33703 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/31933 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->