### PR TITLE
Process swapping a service worker client should reuse SWServer::unregisterServiceWorkerClient

### DIFF
--- a/LayoutTests/http/tests/workers/service/resultingClientId-worker.js
+++ b/LayoutTests/http/tests/workers/service/resultingClientId-worker.js
@@ -1,18 +1,30 @@
-onmessage = e => {
+onmessage = async e => {
     if (e.data === "getClientId") {
         e.source.postMessage(self.clientId);
+        return;
+    }
+    if (e.data === "pingResultingClientId") {
+        const client = await self.clients.get(self.resultingClientId);
+        if (client)
+            client.postMessage("pong");
         return;
     }
     e.source.postMessage(self.resultingClientId);
 };
 
-onfetch = e => {
+onfetch = async e => {
     self.clientId = e.clientId;
     if (e.resultingClientId)
         self.resultingClientId = e.resultingClientId;
 
     const text = `<html><body><script>
         onload = async () => {
+            navigator.serviceWorker.controller.postMessage("pingResultingClientId");
+            const pong = await new Promise(resolve => navigator.serviceWorker.onmessage = e => resolve(e.data));
+            if (pong != "pong") {
+                console.log("did not get pong but " + pong);
+                return;
+            }
             await fetch("/");
             history.back();
         };

--- a/Source/WebCore/workers/service/server/SWServer.h
+++ b/Source/WebCore/workers/service/server/SWServer.h
@@ -351,6 +351,9 @@ private:
 
     ResourceRequest createScriptRequest(const URL&, const ServiceWorkerJobData&, SWServerRegistration&);
 
+    enum class ShouldUpdateRegistrations : bool { No, Yes };
+    void unregisterServiceWorkerClientInternal(const ClientOrigin&, ScriptExecutionContextIdentifier, ShouldUpdateRegistrations);
+
     WeakPtr<SWServerDelegate> m_delegate;
 
     HashMap<SWServerConnectionIdentifier, Ref<Connection>> m_connections;


### PR DESCRIPTION
#### 10051ef2013ae5fc4ab0aedea7ccb0667ae277e2
<pre>
Process swapping a service worker client should reuse SWServer::unregisterServiceWorkerClient
<a href="https://bugs.webkit.org/show_bug.cgi?id=292868">https://bugs.webkit.org/show_bug.cgi?id=292868</a>
<a href="https://rdar.apple.com/151102931">rdar://151102931</a>

Reviewed by Per Arne Vollan.

When process-swapping, we were using a specific code path to remove the past identifier (with the past process ID) before populating the maps with the new identifier (with the new process ID).
We missed updating m_clientsByRegistrableDomain.

For that reason, we are now instead using the regular service worekr client unregister code path (from unregisterServiceWorkerClient).
Since we do not want to update the service worker registrations given this is just a replacement of clients, we introduce SWServer::unregisterServiceWorkerClientInternal,
which will always clear all map entries but will only update service worker registrations if asked to do so.

We call unregisterServiceWorkerClientInternal from the process-swapping code path (without updating service worker registrations),
as well as from the regular SWServer::unregisterServiceWorkerClient code path (with updating service worker registrations).

We update the test to make sure that using the resultingClientId allows post messaging to the context.

* LayoutTests/http/tests/workers/service/resultingClientId-worker.js:
(onmessage.async e):
(onfetch.async e.const.text.html.body.script.onload.async navigator):
(onfetch.async e):
* Source/WebCore/workers/service/server/SWServer.cpp:
(WebCore::SWServer::registerServiceWorkerClient):
(WebCore::SWServer::gatherClientData):
(WebCore::SWServer::unregisterServiceWorkerClientInternal):
(WebCore::SWServer::unregisterServiceWorkerClient):
* Source/WebCore/workers/service/server/SWServer.h:

Canonical link: <a href="https://commits.webkit.org/294997@main">https://commits.webkit.org/294997@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f27a29a2ff2646a37ca3c1e651bfb094f1efda84

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/103456 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/23138 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/13457 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/108630 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/54100 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/105495 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/23488 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/31689 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78611 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/106462 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/18205 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/93321 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58946 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/18032 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/11367 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/53457 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/87823 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/11427 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/111009 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/30603 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/22568 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/87608 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/30964 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/89520 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87249 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22273 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32127 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/9835 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/24943 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/30531 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/35843 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/30331 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/33662 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/31892 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->