### PR TITLE
DigitalCredentialsCoordinator should unregister its message receiver in its destructor

### DIFF
--- a/Source/WebKit/WebProcess/DigitalCredentials/DigitalCredentialsCoordinator.cpp
+++ b/Source/WebKit/WebProcess/DigitalCredentials/DigitalCredentialsCoordinator.cpp
@@ -45,8 +45,14 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(DigitalCredentialsCoordinator);
 
 DigitalCredentialsCoordinator::DigitalCredentialsCoordinator(WebPage& page)
     : m_page(page)
+    , m_pageIdentifier(page.identifier())
 {
-    WebProcess::singleton().addMessageReceiver(Messages::DigitalCredentialsCoordinator::messageReceiverName(), m_page->identifier(), *this);
+    WebProcess::singleton().addMessageReceiver(Messages::DigitalCredentialsCoordinator::messageReceiverName(), m_pageIdentifier, *this);
+}
+
+DigitalCredentialsCoordinator::~DigitalCredentialsCoordinator()
+{
+    WebProcess::singleton().removeMessageReceiver(Messages::DigitalCredentialsCoordinator::messageReceiverName(), m_pageIdentifier);
 }
 
 Ref<DigitalCredentialsCoordinator> DigitalCredentialsCoordinator::create(WebPage& webPage)

--- a/Source/WebKit/WebProcess/DigitalCredentials/DigitalCredentialsCoordinator.h
+++ b/Source/WebKit/WebProcess/DigitalCredentials/DigitalCredentialsCoordinator.h
@@ -42,6 +42,8 @@ struct DigitalCredentialsResponseData;
 struct ExceptionData;
 struct MobileDocumentRequest;
 struct OpenID4VPRequest;
+struct PageIdentifierType;
+using PageIdentifier = ObjectIdentifier<PageIdentifierType>;
 }
 
 namespace WebKit {
@@ -53,6 +55,7 @@ class DigitalCredentialsCoordinator : public WebCore::CredentialRequestCoordinat
 
 public:
     explicit DigitalCredentialsCoordinator(WebPage&);
+    ~DigitalCredentialsCoordinator();
 
     static Ref<DigitalCredentialsCoordinator> create(WebPage&);
     void ref() const final { RefCounted::ref(); }
@@ -69,6 +72,7 @@ private:
 
     RefPtr<WebPage> protectedPage() const;
     WeakPtr<WebPage> m_page;
+    const WebCore::PageIdentifier m_pageIdentifier;
     Vector<WebCore::UnvalidatedDigitalCredentialRequest> m_rawRequests;
 };
 


### PR DESCRIPTION
#### 4899869f41a1fec52533fee1db89628b891f8dc9
<pre>
DigitalCredentialsCoordinator should unregister its message receiver in its destructor
<a href="https://bugs.webkit.org/show_bug.cgi?id=292872">https://bugs.webkit.org/show_bug.cgi?id=292872</a>
<a href="https://rdar.apple.com/151155753">rdar://151155753</a>

Reviewed by Pascoe and Charlie Wolfe.

In 294746@main we added a message registration but not a message unregistration, and that imbalance
causes assertions when running tests on platforms where HAVE_DIGITAL_CREDENTIALS_UI is 1, such as
TestWebKitAPI.SOAuthorizationPopUp.InterceptionSucceedCloseByItself.

* Source/WebKit/WebProcess/DigitalCredentials/DigitalCredentialsCoordinator.cpp:
(WebKit::DigitalCredentialsCoordinator::DigitalCredentialsCoordinator):
(WebKit::DigitalCredentialsCoordinator::~DigitalCredentialsCoordinator):
* Source/WebKit/WebProcess/DigitalCredentials/DigitalCredentialsCoordinator.h:

Canonical link: <a href="https://commits.webkit.org/294796@main">https://commits.webkit.org/294796@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/73573c010aef4b9e0a9df18b7d313bf33d909fbc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/103150 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/22825 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/13144 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/108318 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/53793 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/23159 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/31325 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/108318 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/53793 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/106156 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/130/builds/23159 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/93070 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/108318 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/130/builds/23159 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/53148 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/130/builds/23159 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/11174 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/110695 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/30287 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/22331 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/110695 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/30652 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/89268 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/110695 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/9605 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/24611 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16724 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/30214 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/35536 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/30022 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/33349 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/31584 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->