### PR TITLE
REGRESSION (294151@main): [  MacOS iOS Wk2 ] http/tests/iframe-monitor/throttler.html is a consistent timeout

### DIFF
--- a/Source/WebCore/loader/ResourceMonitorThrottler.cpp
+++ b/Source/WebCore/loader/ResourceMonitorThrottler.cpp
@@ -130,6 +130,8 @@ void ResourceMonitorThrottler::clearAllData()
 {
     ASSERT(!isMainThread());
 
+    m_throttlersByHost.clear();
+
     if (m_persistence)
         m_persistence->deleteAllRecords();
 }

--- a/Source/WebKit/NetworkProcess/NetworkProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
@@ -3247,8 +3247,9 @@ ShouldRelaxThirdPartyCookieBlocking NetworkProcess::shouldRelaxThirdPartyCookieB
 void NetworkProcess::resetResourceMonitorThrottlerForTesting(PAL::SessionID sessionID, CompletionHandler<void()>&& completionHandler)
 {
     if (CheckedPtr session = networkSession(sessionID))
-        session->resetResourceMonitorThrottlerForTesting();
-    completionHandler();
+        session->clearResourceMonitorThrottlerData(WTFMove(completionHandler));
+    else
+        completionHandler();
 }
 #endif
 

--- a/Source/WebKit/NetworkProcess/NetworkSession.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkSession.cpp
@@ -964,16 +964,9 @@ Ref<WebCore::ResourceMonitorThrottlerHolder> NetworkSession::protectedResourceMo
 
 void NetworkSession::clearResourceMonitorThrottlerData(CompletionHandler<void()>&& completionHandler)
 {
-    if (RefPtr throttler = m_resourceMonitorThrottler)
-        throttler->clearAllData(WTFMove(completionHandler));
-    else
-        completionHandler();
+    protectedResourceMonitorThrottler()->clearAllData(WTFMove(completionHandler));
 }
 
-void NetworkSession::resetResourceMonitorThrottlerForTesting()
-{
-    m_resourceMonitorThrottler = nullptr;
-}
 #endif
 
 } // namespace WebKit

--- a/Source/WebKit/NetworkProcess/NetworkSession.h
+++ b/Source/WebKit/NetworkProcess/NetworkSession.h
@@ -299,7 +299,6 @@ public:
     Ref<WebCore::ResourceMonitorThrottlerHolder> protectedResourceMonitorThrottler();
 
     void clearResourceMonitorThrottlerData(CompletionHandler<void()>&&);
-    void resetResourceMonitorThrottlerForTesting();
 #endif
 
 #if HAVE(WEBCONTENTRESTRICTIONS_PATH_SPI)


### PR DESCRIPTION
#### 476ff0a8d21e4f837dbf599efe3d8f12feace99c
<pre>
REGRESSION (294151@main): [  MacOS iOS Wk2 ] http/tests/iframe-monitor/throttler.html is a consistent timeout
<a href="https://bugs.webkit.org/show_bug.cgi?id=292650">https://bugs.webkit.org/show_bug.cgi?id=292650</a>
<a href="https://rdar.apple.com/150816150">rdar://150816150</a>

Reviewed by Chris Dumez.

Fix test failures caused by incomplete throttler data cleanup between tests.

The throttler persistence was fixed in 294151@main, which exposed a regression
where throttler data wasn&apos;t being properly cleared between tests. This
caused the throttler to incorrectly restrict unloading in subsequent tests,
leading to test failures.

Fixed by ensuring all throttler data is cleared between tests.

* Source/WebCore/loader/ResourceMonitorThrottler.cpp:
(WebCore::ResourceMonitorThrottler::clearAllData):
* Source/WebKit/NetworkProcess/NetworkProcess.cpp:
(WebKit::NetworkProcess::resetResourceMonitorThrottlerForTesting):
* Source/WebKit/NetworkProcess/NetworkSession.cpp:
(WebKit::NetworkSession::clearResourceMonitorThrottlerData):
(WebKit::NetworkSession::resetResourceMonitorThrottlerForTesting): Deleted.
* Source/WebKit/NetworkProcess/NetworkSession.h:

Canonical link: <a href="https://commits.webkit.org/294807@main">https://commits.webkit.org/294807@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/38a4d30e7585f06e43a4c72f43232586955e9f6d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/103154 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/22829 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/13148 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/108322 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/53797 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/105193 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/23164 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/31329 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78420 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/35358 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/106160 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17959 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/93077 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58753 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/17805 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/11119 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/53152 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/87624 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/11182 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/110699 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/30291 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/22339 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/87408 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/30656 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/89276 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87038 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22147 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31889 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/9611 "Build is in progress. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Running apply-patch; Checked out pull request; Running run-layout-tests-in-stress-mode; 14 flakes") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/24615 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/30218 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/35540 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/30026 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/33353 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/31588 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->