### PR TITLE
AX: AXIsolatedObject::setProperty does unsafe access to accessibility-thread only data structure, AXIsolatedTree::m_readerThreadNodeMap, when caching AXProperty::{Font, TextColor}

### DIFF
--- a/LayoutTests/accessibility/mac/text-color-explicit-changing-expected.txt
+++ b/LayoutTests/accessibility/mac/text-color-explicit-changing-expected.txt
@@ -1,0 +1,18 @@
+This test ensures that when text color is specified expclitly, it is not overriden by a parent.
+
+Attributes in range {0, 24}:
+AXFont: {
+    AXFontFamily = Times;
+    AXFontName = "Times-Roman";
+    AXFontSize = 16;
+}
+AXForegroundColor: (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; sRGB IEC61966-2.1) ( 0 0 0 1 )
+AXBackgroundColor: (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; sRGB IEC61966-2.1) ( 0 0 0 0 )
+What color is this text?
+
+PASS: The attributed string matched expectations after changing styles.
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+What color is this text?

--- a/LayoutTests/accessibility/mac/text-color-explicit-changing.html
+++ b/LayoutTests/accessibility/mac/text-color-explicit-changing.html
@@ -1,0 +1,48 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+
+<div id="a" style="color: black">
+    <div id="b" style="color: black">
+        What color is this text?
+    </div>
+</div>
+
+<script>
+var output = "This test ensures that when text color is specified expclitly, it is not overriden by a parent.\n\n";
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    var a = document.getElementById("a");
+    var text = accessibilityController.accessibleElementById("b").childAtIndex(0);
+    var markerRange = text.textMarkerRangeForElement(text);
+    output += `${text.attributedStringForTextMarkerRange(markerRange)}\n\n`;
+
+    a.style.color = "red";
+    var expected = `Attributes in range {0, 24}:
+AXFont: {
+    AXFontFamily = Times;
+    AXFontName = "Times-Roman";
+    AXFontSize = 16;
+}
+AXForegroundColor: (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; sRGB IEC61966-2.1) ( 0 0 0 1 )
+AXBackgroundColor: (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; sRGB IEC61966-2.1) ( 0 0 0 0 )
+What color is this text?`;
+
+    setTimeout(async function() {
+        await waitFor(() => expected === text.attributedStringForTextMarkerRange(markerRange));
+        output += `PASS: The attributed string matched expectations after changing styles.\n`;
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>
+

--- a/Source/WebCore/accessibility/AXObjectCache.h
+++ b/Source/WebCore/accessibility/AXObjectCache.h
@@ -397,6 +397,12 @@ public:
     void onSlottedContentChange(const HTMLSlotElement&);
     void onStyleChange(Element&, OptionSet<Style::Change>, const RenderStyle* oldStyle, const RenderStyle* newStyle);
     void onStyleChange(RenderText&, StyleDifference, const RenderStyle* oldStyle, const RenderStyle& newStyle);
+#if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
+    // Returns true if the font changes, requiring all descendants to update the Font property.
+    bool onFontChange(Element&, const RenderStyle*, const RenderStyle*);
+    // Returns true if the text color changes, requiring all descendants to update the TextColor property.
+    bool onTextColorChange(Element&, const RenderStyle*, const RenderStyle*);
+#endif
     void onTextSecurityChanged(HTMLInputElement&);
     void onTitleChange(Document&);
     void onValidityChange(Element&);

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
@@ -179,6 +179,15 @@ private:
     template<typename T> std::optional<T> optionalAttributeValue(AXProperty) const;
     template<typename T> T propertyValue(AXProperty) const;
 
+#ifndef NDEBUG
+    // The color of |this| without any ancestry traversal.
+    Color cachedTextColor() const;
+#if PLATFORM(COCOA)
+    // The font of |this| without any ancestry traversal.
+    RetainPtr<CTFontRef> cachedFont() const;
+#endif // PLATFORM(COCOA)
+#endif // NDEBUG
+
     // The following method performs a lazy caching of the given property.
     // If the property is already in m_properties, returns the existing value.
     // If not, retrieves the property from the main thread and cache it for later use.

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
@@ -800,9 +800,17 @@ void AXIsolatedTree::updateNodeProperties(AccessibilityObject& axObject, const A
         case AXProperty::BackgroundColor:
             properties.append({ AXProperty::BackgroundColor, axObject.backgroundColor() });
             break;
-        case AXProperty::Font:
-            properties.append({ AXProperty::Font, axObject.font() });
+        case AXProperty::Font: {
+            if (RefPtr parent = axObject.parentObject()) {
+                RetainPtr font = axObject.font();
+                if (font != parent->font()) {
+                    properties.append({ AXProperty::Font, WTFMove(font) });
+                    break;
+                }
+            }
+            properties.append({ AXProperty::Font, nullptr });
             break;
+        }
         case AXProperty::HasLinethrough:
             properties.append({ AXProperty::HasLinethrough, axObject.lineDecorationStyle().hasLinethrough });
             break;
@@ -821,9 +829,18 @@ void AXIsolatedTree::updateNodeProperties(AccessibilityObject& axObject, const A
         case AXProperty::LinethroughColor:
             properties.append({ AXProperty::LinethroughColor, axObject.lineDecorationStyle().linethroughColor });
             break;
-        case AXProperty::TextColor:
-            properties.append({ AXProperty::TextColor, axObject.textColor() });
+        case AXProperty::TextColor: {
+            if (RefPtr parent = axObject.parentObject()) {
+                auto color = axObject.textColor();
+                if (color != parent->textColor()) {
+                    properties.append({ AXProperty::TextColor, color });
+                    break;
+                }
+            }
+            // Setting text color to nullptr will remove it from the property map, and allow it to be inherited from an ancestor.
+            properties.append({ AXProperty::TextColor, nullptr });
             break;
+        }
         case AXProperty::TextRuns:
             properties.append({ AXProperty::TextRuns, std::make_shared<AXTextRuns>(axObject.textRuns()) });
             break;

--- a/Source/WebCore/accessibility/isolatedtree/mac/AXIsolatedObjectMac.mm
+++ b/Source/WebCore/accessibility/isolatedtree/mac/AXIsolatedObjectMac.mm
@@ -121,7 +121,7 @@ AttributedStringStyle AXIsolatedObject::stylesForAttributedString() const
 {
     return {
         font(),
-        colorAttributeValue(AXProperty::TextColor),
+        textColor(),
         colorAttributeValue(AXProperty::BackgroundColor),
         boolAttributeValue(AXProperty::IsSubscript),
         boolAttributeValue(AXProperty::IsSuperscript),

--- a/Source/WebCore/style/StyleTreeResolver.h
+++ b/Source/WebCore/style/StyleTreeResolver.h
@@ -116,6 +116,12 @@ private:
         bool needsUpdateQueryContainerDependentStyle { false };
         IsInDisplayNoneTree isInDisplayNoneTree { IsInDisplayNoneTree::No };
 
+#if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
+        // Used to determine whether the AXObjectCache has already propagated down font and color updates for the current subtree.
+        bool didAXUpdateFontSubtree { false };
+        bool didAXUpdateTextColorSubtree { false };
+#endif
+
         Parent(Document&);
         Parent(Element&, const RenderStyle&, OptionSet<Change>, DescendantsToResolve, IsInDisplayNoneTree);
     };
@@ -130,7 +136,11 @@ private:
     void pushEnclosingScope();
     void popScope();
 
+#if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
+    void pushParent(Element&, const RenderStyle&, OptionSet<Change>, DescendantsToResolve, IsInDisplayNoneTree, bool, bool);
+#else
     void pushParent(Element&, const RenderStyle&, OptionSet<Change>, DescendantsToResolve, IsInDisplayNoneTree);
+#endif
     void popParent();
     void popParentsToDepth(unsigned depth);
 


### PR DESCRIPTION
#### c9b5c99e115ef3d76bd4f5240e813e92c4a07047
<pre>
AX: AXIsolatedObject::setProperty does unsafe access to accessibility-thread only data structure, AXIsolatedTree::m_readerThreadNodeMap, when caching AXProperty::{Font, TextColor}
<a href="https://bugs.webkit.org/show_bug.cgi?id=292823">https://bugs.webkit.org/show_bug.cgi?id=292823</a>
<a href="https://rdar.apple.com/151077899">rdar://151077899</a>

Reviewed by Tyler Wilcock.

294634@main made it possible for AXIsoaltedObject::parentObject() to be called on the main thread,
since it started making calls in setProperty in order to determine the parent object&apos;s style.

Instead of using the isoalted object, we can do the same diff-ing of Text Color and Font with live
objects. We need to do this in two places: when updating the property and during initialization.

To ensure we aren&apos;t updating the Font or Text Color property multiple times, we only update once
per subtree that had a Font/Color change, utilizing the parent stack in the style tree resolver.

At the same time, our new way of caching Font and Text Color using ancestors allows us to stop
caching these properties on static text, and instead cache them on any Element. This maintains
our previous optimization, and prevents possible duplication of properties.

This patch was co-authored by Tyler Wilcock.

* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::onStyleChange):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp:
(WebCore::AXIsolatedObject::setProperty):
(WebCore::defaultTextColor):
(WebCore::getColor):
(WebCore::AXIsolatedObject::cachedTextColor const):
(WebCore::getFont):
(WebCore::AXIsolatedObject::cachedFont const):
(WebCore::AXIsolatedObject::colorAttributeValue const):
(WebCore::AXIsolatedObject::fontAttributeValue const):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h:
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp:
(WebCore::AXIsolatedTree::updateNodeProperties):

Canonical link: <a href="https://commits.webkit.org/294909@main">https://commits.webkit.org/294909@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/943307227f65f0897b6866a835acf044d7a63e7e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/103335 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/23011 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/13332 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/108508 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/53978 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/105374 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/23351 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/31562 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78528 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/35480 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/106341 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/18104 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/93220 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58861 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/17940 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/11261 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/53334 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/87742 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/11323 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/110889 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/30473 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/22499 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/87529 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/30838 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/89417 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87166 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22218 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32026 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/9744 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/24807 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/30402 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/35721 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/30208 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/33535 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/31770 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->