### PR TITLE
[Flex] Use inline capacity for FlexLayoutItems and FlexLineStates.

### DIFF
--- a/Source/WebCore/rendering/RenderFlexibleBox.cpp
+++ b/Source/WebCore/rendering/RenderFlexibleBox.cpp
@@ -64,57 +64,6 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(RenderFlexibleBox);
 
-class FlexLayoutItem {
-public:
-    FlexLayoutItem(RenderBox& flexItem, LayoutUnit flexBaseContentSize, LayoutUnit mainAxisBorderAndPadding, LayoutUnit mainAxisMargin, std::pair<LayoutUnit, LayoutUnit> minMaxSizes, bool everHadLayout)
-        : renderer(flexItem)
-        , flexBaseContentSize(flexBaseContentSize)
-        , mainAxisBorderAndPadding(mainAxisBorderAndPadding)
-        , mainAxisMargin(mainAxisMargin)
-        , minMaxSizes(minMaxSizes)
-        , hypotheticalMainContentSize(constrainSizeByMinMax(flexBaseContentSize))
-        , frozen(false)
-        , everHadLayout(everHadLayout)
-    {
-        ASSERT(!flexItem.isOutOfFlowPositioned());
-    }
-
-    LayoutUnit hypotheticalMainAxisMarginBoxSize() const
-    {
-        return hypotheticalMainContentSize + mainAxisBorderAndPadding + mainAxisMargin;
-    }
-
-    LayoutUnit flexBaseMarginBoxSize() const
-    {
-        return flexBaseContentSize + mainAxisBorderAndPadding + mainAxisMargin;
-    }
-
-    LayoutUnit flexedMarginBoxSize() const
-    {
-        return flexedContentSize + mainAxisBorderAndPadding + mainAxisMargin;
-    }
-
-    const RenderStyle& style() const
-    {
-        return renderer->style();
-    }
-
-    LayoutUnit constrainSizeByMinMax(const LayoutUnit size) const
-    {
-        return std::max(minMaxSizes.first, std::min(size, minMaxSizes.second));
-    }
-
-    CheckedRef<RenderBox> renderer;
-    LayoutUnit flexBaseContentSize;
-    const LayoutUnit mainAxisBorderAndPadding;
-    mutable LayoutUnit mainAxisMargin;
-    const std::pair<LayoutUnit, LayoutUnit> minMaxSizes;
-    const LayoutUnit hypotheticalMainContentSize;
-    LayoutUnit flexedContentSize;
-    bool frozen { false };
-    bool everHadLayout { false };
-};
-
 struct RenderFlexibleBox::LineState {
     LineState(LayoutUnit crossAxisOffset, LayoutUnit crossAxisExtent, std::optional<BaselineAlignmentState> baselineAlignmentState, FlexLayoutItems&& flexLayoutItems)
         : crossAxisOffset(crossAxisOffset)
@@ -1458,7 +1407,7 @@ void RenderFlexibleBox::performFlexLayout(RelayoutChildren relayoutChildren)
     repositionLogicalHeightDependentFlexItems(lineStates, gapBetweenLines);
 }
 
-std::optional<RenderFlexibleBox::FlexingLineData> RenderFlexibleBox::computeNextFlexLine(size_t& nextIndex, const Vector<FlexLayoutItem>& allItems, LayoutUnit lineBreakLength, LayoutUnit gapBetweenItems)
+std::optional<RenderFlexibleBox::FlexingLineData> RenderFlexibleBox::computeNextFlexLine(size_t& nextIndex, const FlexLayoutItems& allItems, LayoutUnit lineBreakLength, LayoutUnit gapBetweenItems)
 {
     if (nextIndex >= allItems.size())
         return { };
@@ -1827,7 +1776,7 @@ void RenderFlexibleBox::maybeCacheFlexItemMainIntrinsicSize(RenderBox& flexItem,
     }
 }
 
-FlexLayoutItem RenderFlexibleBox::constructFlexLayoutItem(RenderBox& flexItem, RelayoutChildren relayoutChildren)
+RenderFlexibleBox::FlexLayoutItem RenderFlexibleBox::constructFlexLayoutItem(RenderBox& flexItem, RelayoutChildren relayoutChildren)
 {
     auto everHadLayout = flexItem.everHadLayout();
     flexItem.clearOverridingSize();


### PR DESCRIPTION
#### d3e922b38c77506b7fd4c965535a9fc6456041aa
<pre>
[Flex] Use inline capacity for FlexLayoutItems and FlexLineStates.
<a href="https://bugs.webkit.org/show_bug.cgi?id=292874">https://bugs.webkit.org/show_bug.cgi?id=292874</a>
<a href="https://rdar.apple.com/151159201">rdar://151159201</a>

Reviewed by Alan Baradlay.

Flex layout is a fairly hot codepath as it appears on traces of
benchmarks. There are two main Vectors that are used during flex layout:
FlexLayoutItems and FlexLineStates which are ephemeral and used to
hold onto flex items and various bits of state. When looking at traces
we can see a fair amount of samples related to increases in capacity for
these Vectors.

We recently sprinkled some inline capacity to certain other Vectors in
flex layout so I am building upon that and adding the same to these.

I chose four as the inline capacity for FlexLayoutItems to match the same
value we chose in the previous patch. I opted to change the existing
inline capacity of FlexItemFrameRects to match as it seems like the
value that was chosen in 122238@main was in response to review feedback
and there was not really any indication anywhere that is was based on
looking at existing web content or benchmarks, which is where our new
value comes from.

I chose two as the inline capacity for FlexLineStates by logging the
number of flex lines when performing basic browsing on various pages. It
turns out that one is the most common number of flex lines based on my
web surfing. However, I ended up choosing two for this since this
appears on benchmarks fairly frequently and is so close to the value
I observed on the web.

With this patch I no longer see any samples related to Vector capacity
in flex layout. FlexLayoutItem needed to move into the header in order
to use inline capacity for FlexLayoutItems.

Canonical link: <a href="https://commits.webkit.org/294847@main">https://commits.webkit.org/294847@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/58977042edefdecffa2b9284e13b348d85ccef0b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/103168 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/22843 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/13162 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/108336 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/53811 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/105207 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/23178 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/31343 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78426 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/35368 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/106174 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/93080 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58759 "Found 1 new API test failure: /WPE/TestSSL:/webkit/WebKitWebView/ephemeral-tls-errors (failure)") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/11122 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/53166 "Built successfully") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/11185 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/110713 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/30305 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/22347 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/87417 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/30670 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/89279 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87047 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22169 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31900 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/9614 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/24629 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/30232 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/35554 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/30040 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/33367 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/31602 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->