### PR TITLE
[Page color sampling] Fall back to sampled page top color when scrolling against the top of the page

### DIFF
--- a/LayoutTests/fast/page-color-sampling/basic-fixed-container-edge-sampling.html
+++ b/LayoutTests/fast/page-color-sampling/basic-fixed-container-edge-sampling.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true useFlexibleViewport=true ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true pageTopColorSamplingEnabled=true useFlexibleViewport=true ] -->
 <html>
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <head>

--- a/LayoutTests/fast/page-color-sampling/color-sampling-fixed-ancestor-with-relative-container.html
+++ b/LayoutTests/fast/page-color-sampling/color-sampling-fixed-ancestor-with-relative-container.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true useFlexibleViewport=true ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true pageTopColorSamplingEnabled=true useFlexibleViewport=true ] -->
 <html>
 <head>
     <meta charset="utf-8">

--- a/LayoutTests/fast/page-color-sampling/color-sampling-fixed-container-under-subscroller.html
+++ b/LayoutTests/fast/page-color-sampling/color-sampling-fixed-container-under-subscroller.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true useFlexibleViewport=true AsyncOverflowScrollingEnabled=true ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true pageTopColorSamplingEnabled=true useFlexibleViewport=true AsyncOverflowScrollingEnabled=true ] -->
 <html>
 <head>
     <meta charset="utf-8">

--- a/LayoutTests/fast/page-color-sampling/color-sampling-fixed-descendant-in-relative-container.html
+++ b/LayoutTests/fast/page-color-sampling/color-sampling-fixed-descendant-in-relative-container.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true useFlexibleViewport=true ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true pageTopColorSamplingEnabled=true useFlexibleViewport=true ] -->
 <html>
 <head>
     <meta charset="utf-8">

--- a/LayoutTests/fast/page-color-sampling/color-sampling-ignores-backdrop-filters.html
+++ b/LayoutTests/fast/page-color-sampling/color-sampling-ignores-backdrop-filters.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true useFlexibleViewport=true ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true pageTopColorSamplingEnabled=true useFlexibleViewport=true ] -->
 <html>
 <head>
     <meta charset="utf-8">

--- a/LayoutTests/fast/page-color-sampling/color-sampling-ignores-empty-container.html
+++ b/LayoutTests/fast/page-color-sampling/color-sampling-ignores-empty-container.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true useFlexibleViewport=true ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true pageTopColorSamplingEnabled=true useFlexibleViewport=true ] -->
 <html>
 <head>
     <meta charset="utf-8">

--- a/LayoutTests/fast/page-color-sampling/color-sampling-ignores-images.html
+++ b/LayoutTests/fast/page-color-sampling/color-sampling-ignores-images.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true useFlexibleViewport=true ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true pageTopColorSamplingEnabled=true useFlexibleViewport=true ] -->
 <html>
 <head>
     <meta charset="utf-8">

--- a/LayoutTests/fast/page-color-sampling/color-sampling-ignores-non-fixed-content.html
+++ b/LayoutTests/fast/page-color-sampling/color-sampling-ignores-non-fixed-content.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true useFlexibleViewport=true ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true pageTopColorSamplingEnabled=true useFlexibleViewport=true ] -->
 <html>
 <head>
     <meta charset="utf-8">

--- a/LayoutTests/fast/page-color-sampling/color-sampling-ignores-subscrollers.html
+++ b/LayoutTests/fast/page-color-sampling/color-sampling-ignores-subscrollers.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true useFlexibleViewport=true ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true pageTopColorSamplingEnabled=true useFlexibleViewport=true ] -->
 <html>
 <head>
     <meta charset="utf-8">

--- a/LayoutTests/fast/page-color-sampling/color-sampling-ignores-text.html
+++ b/LayoutTests/fast/page-color-sampling/color-sampling-ignores-text.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true useFlexibleViewport=true ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true pageTopColorSamplingEnabled=true useFlexibleViewport=true ] -->
 <html>
 <head>
     <meta charset="utf-8">

--- a/LayoutTests/fast/page-color-sampling/color-sampling-ignores-transparent-pointer-events-none-container.html
+++ b/LayoutTests/fast/page-color-sampling/color-sampling-ignores-transparent-pointer-events-none-container.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true useFlexibleViewport=true ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true pageTopColorSamplingEnabled=true useFlexibleViewport=true ] -->
 <html>
 <head>
     <meta charset="utf-8">

--- a/LayoutTests/fast/page-color-sampling/color-sampling-in-position-sticky.html
+++ b/LayoutTests/fast/page-color-sampling/color-sampling-in-position-sticky.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true useFlexibleViewport=true ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true pageTopColorSamplingEnabled=true useFlexibleViewport=true ] -->
 <html>
 <head>
     <meta charset="utf-8">

--- a/LayoutTests/fast/page-color-sampling/color-sampling-includes-subframes.html
+++ b/LayoutTests/fast/page-color-sampling/color-sampling-includes-subframes.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true useFlexibleViewport=true ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true pageTopColorSamplingEnabled=true useFlexibleViewport=true ] -->
 <html>
 <head>
     <meta charset="utf-8">

--- a/LayoutTests/fast/page-color-sampling/color-sampling-while-rubber-banding.html
+++ b/LayoutTests/fast/page-color-sampling/color-sampling-while-rubber-banding.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true useFlexibleViewport=true ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true pageTopColorSamplingEnabled=true useFlexibleViewport=true ] -->
 <html>
 <head>
     <meta charset="utf-8">

--- a/LayoutTests/fast/page-color-sampling/maintain-sampled-color-when-scrolled-to-top-expected.txt
+++ b/LayoutTests/fast/page-color-sampling/maintain-sampled-color-when-scrolled-to-top-expected.txt
@@ -1,0 +1,7 @@
+PASS colorsAfterScrollingDown.top is "rgb(255, 99, 71)"
+PASS colorsAfterScrollingBackUp.top is "rgb(255, 99, 71)"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+relative
+

--- a/LayoutTests/fast/page-color-sampling/maintain-sampled-color-when-scrolled-to-top.html
+++ b/LayoutTests/fast/page-color-sampling/maintain-sampled-color-when-scrolled-to-top.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true pageTopColorSamplingEnabled=true useFlexibleViewport=true ] -->
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <style>
+        body, html {
+            width: 100%;
+            margin: 0;
+            font-family: system-ui;
+        }
+
+        header {
+            position: relative;
+            top: 0;
+            height: 100px;
+            width: 100%;
+            background: tomato;
+            color: white;
+            text-align: center;
+            font-size: 20px;
+            line-height: 100px;
+        }
+
+        .tall {
+            width: 10px;
+            height: 5000px;
+        }
+    </style>
+    <script src="../../resources/js-test.js"></script>
+    <script src="../../resources/ui-helper.js"></script>
+    <script>
+    jsTestIsAsync = true;
+
+    addEventListener("load", async () => {
+        const header = document.querySelector("header");
+        addEventListener("scroll", () => {
+            header.style.position = pageYOffset > 0 ? "fixed" : "relative";
+            header.textContent = header.style.position;
+        });
+
+        await UIHelper.setObscuredInsets(80, 0, 0, 0);
+        scrollTo(0, 100);
+        await UIHelper.ensurePresentationUpdate();
+        colorsAfterScrollingDown = await UIHelper.fixedContainerEdgeColors();
+
+        scrollTo(0, 0);
+        await UIHelper.ensurePresentationUpdate();
+        colorsAfterScrollingBackUp = await UIHelper.fixedContainerEdgeColors();
+
+        shouldBeEqualToString("colorsAfterScrollingDown.top", "rgb(255, 99, 71)");
+        shouldBeEqualToString("colorsAfterScrollingBackUp.top", "rgb(255, 99, 71)");
+        finishJSTest();
+    });
+    </script>
+</head>
+<body>
+<header>relative</header>
+<div class="tall"></div>
+</body>
+</html>

--- a/LayoutTests/fast/page-color-sampling/page-color-sampling-skips-border-top.html
+++ b/LayoutTests/fast/page-color-sampling/page-color-sampling-skips-border-top.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true useFlexibleViewport=true ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true pageTopColorSamplingEnabled=true useFlexibleViewport=true ] -->
 <html>
 <head>
 <meta charset="utf-8">

--- a/LayoutTests/fast/page-color-sampling/page-color-sampling-skips-small-elements.html
+++ b/LayoutTests/fast/page-color-sampling/page-color-sampling-skips-small-elements.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true useFlexibleViewport=true ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true pageTopColorSamplingEnabled=true useFlexibleViewport=true ] -->
 <html>
 <head>
     <meta charset="utf-8">

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -1926,7 +1926,22 @@ FixedContainerEdges LocalFrameView::fixedContainerEdges(BoxSideSet sides) const
     if (!page)
         return { };
 
-    if (!hasViewportConstrainedObjects())
+    bool mayUseSampledTopColor = [&] {
+        if (scrollPosition().y() > minimumScrollPosition().y())
+            return false;
+
+        auto lastColor = page->lastTopFixedContainerColor();
+        if (!lastColor.isVisible())
+            return false;
+
+        auto sampledTopColor = page->sampledPageTopColor();
+        if (!sampledTopColor.isVisible())
+            return false;
+
+        return PageColorSampler::colorsAreSimilar(lastColor, sampledTopColor);
+    }();
+
+    if (!hasViewportConstrainedObjects() && !mayUseSampledTopColor)
         return { };
 
     RefPtr document = m_frame->document();
@@ -1938,7 +1953,6 @@ FixedContainerEdges LocalFrameView::fixedContainerEdges(BoxSideSet sides) const
     static constexpr auto sampleRectThickness = 2;
     static constexpr auto sampleRectMargin = 4;
     static constexpr auto thinBorderWidth = 10;
-    static constexpr auto minimumCoverageForLeftAndRightSides = 0.5;
 
     struct FixedContainerResult {
         RefPtr<Element> container;
@@ -1953,6 +1967,24 @@ FixedContainerEdges LocalFrameView::fixedContainerEdges(BoxSideSet sides) const
         fixedRect.intersect(view->unscaledDocumentRect());
     fixedRect.contract({ sampleRectMargin });
     unclampedFixedRect.contract({ sampleRectMargin });
+
+    auto lengthOnSide = [](BoxSide side, const LayoutRect& rect) -> LayoutUnit {
+        switch (side) {
+        case BoxSide::Top:
+        case BoxSide::Bottom:
+            return rect.width();
+        case BoxSide::Right:
+        case BoxSide::Left:
+            return rect.height();
+        }
+        return { };
+    };
+
+    auto isNearlyViewportSized = [&](BoxSide side, const RenderObject& renderer) {
+        static constexpr auto minimumRatio = 0.8;
+        auto elementRect = enclosingLayoutRect(renderer.absoluteBoundingBoxRect());
+        return lengthOnSide(side, elementRect) > minimumRatio * lengthOnSide(side, fixedRect);
+    };
 
     auto midpointOnSide = [&](BoxSide side, const LayoutRect& rect) -> LayoutPoint {
         switch (side) {
@@ -2012,7 +2044,7 @@ FixedContainerEdges LocalFrameView::fixedContainerEdges(BoxSideSet sides) const
         return { hitTestRect };
     };
 
-    auto primaryBackgroundColorForRenderer = [](const RenderElement& renderer) -> Color {
+    auto primaryBackgroundColorForRenderer = [&](BoxSide side, const RenderElement& renderer) -> Color {
         CheckedPtr box = dynamicDowncast<RenderBox>(renderer);
         if (!box)
             return { };
@@ -2025,6 +2057,9 @@ FixedContainerEdges LocalFrameView::fixedContainerEdges(BoxSideSet sides) const
 
         auto& styleColor = renderer.style().backgroundColor();
         if (!styleColor.isResolvedColor())
+            return { };
+
+        if (!isNearlyViewportSized(side, renderer))
             return { };
 
         return styleColor.resolvedColor();
@@ -2056,9 +2091,7 @@ FixedContainerEdges LocalFrameView::fixedContainerEdges(BoxSideSet sides) const
         }
 
         if (side == BoxSide::Left || side == BoxSide::Right) {
-            FloatRect fixedRectEdge = computeSampleRectIgnoringBorderWidth(fixedRect, side);
-            FloatRect intersectionRect = intersection(fixedRectEdge, renderer.absoluteBoundingBoxRect());
-            if (intersectionRect.area() / fixedRectEdge.area() < minimumCoverageForLeftAndRightSides)
+            if (!isNearlyViewportSized(side, renderer))
                 return TooSmall;
         }
 
@@ -2108,15 +2141,14 @@ FixedContainerEdges LocalFrameView::fixedContainerEdges(BoxSideSet sides) const
         for (CheckedRef ancestor : lineageOfType<RenderElement>(*renderer)) {
             if (ancestor->hasBackdropFilter())
                 foundBackdropFilter = true;
-            else if (auto color = primaryBackgroundColorForRenderer(ancestor); color.isVisible()) {
+            else if (auto color = primaryBackgroundColorForRenderer(side, ancestor); color.isVisible()) {
                 if (!primaryBackgroundColor.isVisible())
                     primaryBackgroundColor = WTFMove(color);
                 else if (primaryBackgroundColor != color)
                     hasMultipleBackgroundColors = true;
             }
 
-            auto candidateResult = containerEdgeCandidateResult(side, ancestor);
-            switch (candidateResult) {
+            switch (containerEdgeCandidateResult(side, ancestor)) {
             case NoLayer:
             case NotFixedOrSticky:
             case IsScrollable:
@@ -2219,6 +2251,31 @@ FixedContainerEdges LocalFrameView::fixedContainerEdges(BoxSideSet sides) const
 
         edges.colors.setAt(side, PageColorSampler::predominantColor(*page, computeSamplingRect(result.container->renderStyle(), side)));
     }
+
+    auto edgeColorFromSampledTopColor = [&] -> std::optional<Color> {
+        if (scrollPosition().y() > minimumScrollPosition().y())
+            return { };
+
+        auto lastColor = page->lastTopFixedContainerColor();
+        if (!lastColor.isVisible())
+            return { };
+
+        auto sampledTopColor = page->sampledPageTopColor();
+        if (!sampledTopColor.isVisible())
+            return { };
+
+        auto newColor = edges.predominantColor(BoxSide::Top);
+        if (newColor.isVisible() && !PageColorSampler::colorsAreSimilar(newColor, sampledTopColor))
+            return { };
+
+        if (!PageColorSampler::colorsAreSimilar(lastColor, sampledTopColor))
+            return { };
+
+        return sampledTopColor;
+    };
+
+    if (auto color = edgeColorFromSampledTopColor())
+        edges.colors.setAt(BoxSide::Top, WTFMove(*color));
 
     return edges;
 }

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -1821,6 +1821,8 @@ void Page::didCommitLoad()
         geolocationController->didNavigatePage();
 #endif
 
+    m_lastTopFixedContainerColor = { };
+
     m_elementTargetingController->reset();
 
     m_reportedScriptsWithTelemetry.clear();

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -887,6 +887,9 @@ public:
     WEBCORE_EXPORT Color pageExtendedBackgroundColor() const;
     WEBCORE_EXPORT Color sampledPageTopColor() const;
 
+    void setLastTopFixedContainerColor(Color&& color) { m_lastTopFixedContainerColor = WTFMove(color); }
+    Color lastTopFixedContainerColor() const { return m_lastTopFixedContainerColor; }
+
 #if ENABLE(WEB_PAGE_SPATIAL_BACKDROP)
     WEBCORE_EXPORT std::optional<SpatialBackdropSource> spatialBackdropSource() const;
 #endif
@@ -1681,6 +1684,7 @@ private:
 
     Color m_underPageBackgroundColorOverride;
     std::optional<Color> m_sampledPageTopColor;
+    Color m_lastTopFixedContainerColor;
 
     const bool m_httpsUpgradeEnabled { true };
     mutable Markable<MediaSessionGroupIdentifier> m_mediaSessionGroupIdentifier;

--- a/Source/WebCore/page/PageColorSampler.h
+++ b/Source/WebCore/page/PageColorSampler.h
@@ -38,6 +38,7 @@ enum class PredominantColorType : uint8_t;
 class PageColorSampler {
 public:
     static std::optional<Color> sampleTop(Page&);
+    static bool colorsAreSimilar(const Color&, const Color&);
 
     static constexpr auto nearlyTransparentAlphaThreshold = 0.1;
     static Variant<PredominantColorType, Color> predominantColor(Page&, const LayoutRect&);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -4962,8 +4962,11 @@ void WebPage::willCommitLayerTree(RemoteLayerTreeTransaction& layerTransaction, 
     layerTransaction.setThemeColor(page->themeColor());
     layerTransaction.setPageExtendedBackgroundColor(page->pageExtendedBackgroundColor());
     layerTransaction.setSampledPageTopColor(page->sampledPageTopColor());
-    if (std::exchange(m_needsFixedContainerEdgesUpdate, false))
-        layerTransaction.setFixedContainerEdges(frameView->fixedContainerEdges(sidesRequiringFixedContainerEdges()));
+    if (std::exchange(m_needsFixedContainerEdgesUpdate, false)) {
+        auto fixedContainerEdges = frameView->fixedContainerEdges(sidesRequiringFixedContainerEdges());
+        protectedCorePage()->setLastTopFixedContainerColor(fixedContainerEdges.predominantColor(BoxSide::Top));
+        layerTransaction.setFixedContainerEdges(WTFMove(fixedContainerEdges));
+    }
 
     layerTransaction.setBaseLayoutViewportSize(frameView->baseLayoutViewportSize());
     layerTransaction.setMinStableLayoutViewportOrigin(frameView->minStableLayoutViewportOrigin());

--- a/Tools/WebKitTestRunner/TestOptions.cpp
+++ b/Tools/WebKitTestRunner/TestOptions.cpp
@@ -215,6 +215,7 @@ const TestFeatures& TestOptions::defaults()
             { "useHardwareKeyboardMode", false },
             { "enableMetalDebugDevice", false },
             { "enableMetalShaderValidation", false },
+            { "pageTopColorSamplingEnabled", false },
         };
         features.doubleTestRunnerFeatures = {
             { "contentInset.top", 0 },
@@ -290,6 +291,7 @@ const std::unordered_map<std::string, TestHeaderKeyType>& TestOptions::keyTypeMa
         { "useHardwareKeyboardMode", TestHeaderKeyType::BoolTestRunner },
         { "enableMetalDebugDevice", TestHeaderKeyType::BoolTestRunner },
         { "enableMetalShaderValidation", TestHeaderKeyType::BoolTestRunner },
+        { "pageTopColorSamplingEnabled", TestHeaderKeyType::BoolTestRunner },
 
         { "contentInset.top", TestHeaderKeyType::DoubleTestRunner },
         { "obscuredInset.top", TestHeaderKeyType::DoubleTestRunner },

--- a/Tools/WebKitTestRunner/TestOptions.h
+++ b/Tools/WebKitTestRunner/TestOptions.h
@@ -89,6 +89,7 @@ public:
     bool shouldIgnoreWebProcessTermination() const { return boolTestRunnerFeatureValue("ignoreWebProcessTermination"); }
     bool enableMetalDebugDevice() const { return boolTestRunnerFeatureValue("enableMetalDebugDevice"); }
     bool enableMetalShaderValidation() const { return boolTestRunnerFeatureValue("enableMetalShaderValidation"); }
+    bool pageTopColorSamplingEnabled() const { return boolTestRunnerFeatureValue("pageTopColorSamplingEnabled"); }
     double contentInsetTop() const { return doubleTestRunnerFeatureValue("contentInset.top"); }
     double obscuredInsetTop() const { return doubleTestRunnerFeatureValue("obscuredInset.top"); }
     double horizontalSystemMinimumLayoutMargin() const { return doubleTestRunnerFeatureValue("horizontalSystemMinimumLayoutMargin"); }

--- a/Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm
+++ b/Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm
@@ -343,6 +343,14 @@ void TestController::platformCreateWebView(WKPageConfigurationRef, const TestOpt
             [copiedConfiguration _setContentSecurityPolicyModeForExtension:_WKContentSecurityPolicyModeForExtensionManifestV3];
     }
 
+    static constexpr auto sampledPageTopColorMaxDifference = 30;
+    static constexpr auto sampledPageTopColorMinHeight = 5;
+    [copiedConfiguration _setSampledPageTopColorMaxDifference:options.pageTopColorSamplingEnabled() ? sampledPageTopColorMaxDifference : 0];
+    [copiedConfiguration _setSampledPageTopColorMinHeight:options.pageTopColorSamplingEnabled() ? sampledPageTopColorMinHeight : 0];
+#if HAVE(INLINE_PREDICTIONS)
+    [copiedConfiguration setAllowsInlinePredictions:options.allowsInlinePredictions()];
+#endif
+
     configureWebpagePreferences(copiedConfiguration.get(), options);
 
     auto applicationManifest = options.applicationManifest();
@@ -717,9 +725,6 @@ void TestController::configureWebpagePreferences(WKWebViewConfiguration *configu
     [webpagePreferences setPreferredContentMode:contentMode(options)];
 #endif
     configuration.defaultWebpagePreferences = webpagePreferences.get();
-#if HAVE(INLINE_PREDICTIONS)
-    configuration.allowsInlinePredictions = options.allowsInlinePredictions();
-#endif
 }
 
 WKRetainPtr<WKStringRef> TestController::takeViewPortSnapshot()


### PR DESCRIPTION
#### 5ef25ef2658b96afe8e64feb13b42129cf5c8d1d
<pre>
[Page color sampling] Fall back to sampled page top color when scrolling against the top of the page
<a href="https://bugs.webkit.org/show_bug.cgi?id=292876">https://bugs.webkit.org/show_bug.cgi?id=292876</a>
<a href="https://rdar.apple.com/150782380">rdar://150782380</a>

Reviewed by Abrar Rahman Protyasha.

Make some more adjustments to the page color sampling heuristic, for compatibility with the
following websites:

• <a href="http://showcase.commercialtype.com">http://showcase.commercialtype.com</a>
• <a href="https://www.mocanashville.org">https://www.mocanashville.org</a>
• <a href="https://www.amazon.com">https://www.amazon.com</a>

See below for more details.

* LayoutTests/fast/page-color-sampling/basic-fixed-container-edge-sampling.html:
* LayoutTests/fast/page-color-sampling/color-sampling-fixed-ancestor-with-relative-container.html:
* LayoutTests/fast/page-color-sampling/color-sampling-fixed-container-under-subscroller.html:
* LayoutTests/fast/page-color-sampling/color-sampling-fixed-descendant-in-relative-container.html:
* LayoutTests/fast/page-color-sampling/color-sampling-ignores-backdrop-filters.html:
* LayoutTests/fast/page-color-sampling/color-sampling-ignores-empty-container.html:
* LayoutTests/fast/page-color-sampling/color-sampling-ignores-images.html:
* LayoutTests/fast/page-color-sampling/color-sampling-ignores-non-fixed-content.html:
* LayoutTests/fast/page-color-sampling/color-sampling-ignores-subscrollers.html:
* LayoutTests/fast/page-color-sampling/color-sampling-ignores-text.html:
* LayoutTests/fast/page-color-sampling/color-sampling-ignores-transparent-pointer-events-none-container.html:
* LayoutTests/fast/page-color-sampling/color-sampling-in-position-sticky.html:
* LayoutTests/fast/page-color-sampling/color-sampling-includes-subframes.html:
* LayoutTests/fast/page-color-sampling/color-sampling-while-rubber-banding.html:

Adjust existing layout tests — add `pageTopColorSamplingEnabled=true` to ensure that we&apos;re
exercising the full extent of the fixed container edge sampling heuristic.

* LayoutTests/fast/page-color-sampling/maintain-sampled-color-when-scrolled-to-top-expected.txt: Added.
* LayoutTests/fast/page-color-sampling/maintain-sampled-color-when-scrolled-to-top.html: Added.

Add a new layout test that only makes the top header element fixed when the user is not scrolled to
the top of the page.

* LayoutTests/fast/page-color-sampling/page-color-sampling-skips-border-top.html:
* LayoutTests/fast/page-color-sampling/page-color-sampling-skips-small-elements.html:
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::fixedContainerEdges const):

Implement two main adjustments here:

1.  Be a bit more restrictive when collecting elements with background colors, such that we ignore
    any elements that are do not (nearly) span the entire width or height of the layout viewport,
    depending on which side we&apos;re sampling for. This prevents top fixed colors from thrashing on
    showcase.commercialtype.com, and also prevents a flash of white when scrolling down on
    www.amazon.com due to the fact that the text field (with a white background) briefly takes up
    most of the sampled pixels.

2.  On various websites (www.amazon.com, www.mocanashville.org, and several others), a site nav or
    fixed top header will only be fixed when the user is scrolled; when the scroll offset is 0, the
    header becomes non-viewport-constrained, or otherwise undergoes style changes that cause it to
    be ignored by the fixed sampling strategy.

    To mitigate a flash from fixed element background to page background color in cases like this,
    we leverage existing logic to sample the top of the page (including non-fixed, non-sticky
    elements and respecting images, text, etc.), and fall back on this page top color in cases where
    the last known top fixed container color is similar to the page top sampled color, and we&apos;re
    scrolled to (or past) the top of the page.

* Source/WebCore/page/Page.cpp:
(WebCore::Page::didCommitLoad):
* Source/WebCore/page/Page.h:
(WebCore::Page::setLastTopFixedContainerColor):
(WebCore::Page::lastTopFixedContainerColor const):
* Source/WebCore/page/PageColorSampler.cpp:
(WebCore::PageColorSampler::colorsAreSimilar):

Pull this helper lambda out into a static method, so that we can use it in `fixedContainerEdges`
above.

(WebCore::PageColorSampler::predominantColor):

Also adjust a parameter representing the predominant sampled color min. ratio (0.5); this leads to
some false positives on CommercialType&apos;s home page. This predominance ratio was initially set to
this (fairly) low value, because page color sampling found text, images, and other replaced objects.
Since we no longer paint those in the sampling snapshot (i.e. the sampling heuristic is way more
accurate), we can raise this bar.

* Source/WebCore/page/PageColorSampler.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::willCommitLayerTree):

Add logic to keep track of the last top fixed container edge background color, if present. This is
cleared out in `didCommitLoad` (above), and consulted in `fixedContainerEdges` (above).

* Tools/WebKitTestRunner/TestOptions.cpp:
(WTR::TestOptions::defaults):
(WTR::TestOptions::keyTypeMapping):
* Tools/WebKitTestRunner/TestOptions.h:
(WTR::TestOptions::pageTopColorSamplingEnabled const):
* Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm:
(WTR::TestController::platformCreateWebView):
(WTR::TestController::configureWebpagePreferences):

Add a new `TestOption` for `pageTopColorSamplingEnabled`, which (when `true`) sets both of the
following properties on the web view configuration:

```
-_sampledPageTopColorMaxDifference  -&gt; 30
-_sampledPageTopColorMinHeight      -&gt; 5
```

…note that these numbers are chosen for consistency with Safari. If needed, we could split this out
into separate test options if an individual layout tests needs to exercise different values, but for
now this is a bit cleaner, since each test doesn&apos;t need to specify its own sampling parameters.

Also move logic to set `allowsInlinePredictions` out of `configureWebpagePreferences` (which should
just be about `WKWebpagePreferences`) and into the call site instead.

Canonical link: <a href="https://commits.webkit.org/294820@main">https://commits.webkit.org/294820@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b4ac2a1b4b63cb8c83df35b232c443cae42a642f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/103227 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/22903 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/13222 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/108396 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/53870 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/105266 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/23238 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/31403 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78457 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/53870 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/106233 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/18016 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/93129 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58790 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/17858 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/11172 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/53225 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/87665 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/11234 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/110773 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/30365 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/22382 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/87456 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/30730 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/89328 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87089 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22154 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31946 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/9660 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/24688 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/30294 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/35613 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/30100 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/33427 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/31662 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->