### PR TITLE
[webkitbugspy] Add ability to set see_also field for bugs

### DIFF
--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/bugzilla.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/bugzilla.py
@@ -283,8 +283,9 @@ class Tracker(GenericTracker):
             else:
                 sys.stderr.write("Failed to fetch comments for '{}'\n".format(issue.link))
 
-        if member in ('duplicates', 'references'):
+        if member in ('duplicates', 'references', 'see_also'):
             issue._references = []
+            issue._related_links = []
             refs = set()
 
             for text in chain(
@@ -311,6 +312,7 @@ class Tracker(GenericTracker):
             response = response.json().get('bugs', []) if response.status_code == 200 else None
             if response:
                 for link in response[0].get('see_also', []):
+                    issue._related_links.append(link)
                     candidate = GenericTracker.from_string(link) or self.from_string(link)
                     if not candidate or candidate.link in refs or candidate.id == issue.id:
                         continue
@@ -339,7 +341,7 @@ class Tracker(GenericTracker):
 
         return issue
 
-    def set(self, issue, assignee=None, opened=None, why=None, project=None, component=None, version=None, original=None, keywords=None, source_changes=None, state=None, substate=None, **properties):
+    def set(self, issue, assignee=None, opened=None, why=None, project=None, component=None, version=None, original=None, keywords=None, source_changes=None, state=None, substate=None, see_also=None, **properties):
         update_dict = dict()
 
         if properties:
@@ -400,6 +402,9 @@ class Tracker(GenericTracker):
 
         if keywords is not None:
             update_dict['keywords'] = dict(set=keywords)
+
+        if see_also is not None:
+            update_dict['see_also'] = dict(add=see_also)
 
         if update_dict:
             update_dict['ids'] = [issue.id]

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/github.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/github.py
@@ -238,6 +238,7 @@ with 'repo' and 'workflow' access and appropriate 'Expiration' for your {host} u
         issue._project = self.name
         issue._keywords = []  # We don't yet have a defined idiom for "keywords" in GitHub Issues
         issue._classification = ''  # We don't yet have a defined idiom for "classification" in GitHub issues
+        issue._related_links = []  # We don't yet have a defined idiom for "related links" in GitHub issues
         issue._source_changes = []  # We need to parse the issue to find any source changes
 
         if member in ('title', 'timestamp', 'modified', 'creator', 'opened', 'assignee', 'description', 'project', 'component', 'version', 'labels', 'milestone'):
@@ -340,7 +341,7 @@ with 'repo' and 'workflow' access and appropriate 'Expiration' for your {host} u
 
         return issue
 
-    def set(self, issue, assignee=None, opened=None, why=None, project=None, component=None, version=None, labels=None, original=None, source_changes=None, state=None, substate=None, **properties):
+    def set(self, issue, assignee=None, opened=None, why=None, project=None, component=None, version=None, labels=None, original=None, source_changes=None, state=None, substate=None, see_also=None, **properties):
         update_dict = dict()
 
         if properties:
@@ -432,6 +433,10 @@ with 'repo' and 'workflow' access and appropriate 'Expiration' for your {host} u
 
         if state or substate:
             sys.stderr.write('GitHub does not support state at this time\n')
+            return None
+
+        if see_also:
+            sys.stderr.write('GitHub does not support the see_also field at this time\n')
             return None
 
         if issue and original:

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/issue.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/issue.py
@@ -73,6 +73,7 @@ class Issue(object):
         self._watchers = None
         self._comments = None
         self._references = None
+        self._related_links = None
 
         self._labels = None
         self._project = None
@@ -206,6 +207,15 @@ class Issue(object):
         if self._references is None:
             self.tracker.populate(self, 'references')
         return self._references or []
+
+    @property
+    def related_links(self):
+        if self._related_links is None:
+            self.tracker.populate(self, 'see_also')
+        return self._related_links
+
+    def add_related_links(self, see_also):
+        return self.tracker.set(self, see_also=see_also)
 
     def add_comment(self, text):
         return self.tracker.add_comment(self, text)

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/bugzilla.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/bugzilla.py
@@ -166,6 +166,8 @@ class Bugzilla(Base, mocks.Requests):
                 issue['related']['regressed_by'] = data['regressed_by']
             if data.get('regressions'):
                 issue['related']['regressions'] = data['regressions']
+            if data.get('see_also'):
+                issue['related_links'] = data['see_also']['add']
 
             keywords = data.get('keywords', {})
             if keywords:
@@ -241,7 +243,7 @@ class Bugzilla(Base, mocks.Requests):
                     ) for user in issue.get('watchers', [])
                 ], see_also=[
                     'https://{}/show_bug.cgi?id={}'.format(self.hosts[0], n) for n in issue.get('references', [])
-                ],
+                ] + issue.get('related_links', []),
             )],
         ), url=url)
 

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/radar.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/radar.py
@@ -204,6 +204,7 @@ class Tracker(GenericTracker):
     def populate(self, issue, member=None):
         issue._link = 'rdar://{}'.format(issue.id)
         issue._labels = []
+        issue._related_links = []  # We don't yet have a defined idiom for "related links" in radar
         if (not self.client or not self.library) and member:
             sys.stderr.write('radarclient inaccessible on this machine\n')
             return issue
@@ -316,7 +317,7 @@ class Tracker(GenericTracker):
         return issue
 
     @handle_access_exception
-    def set(self, issue, assignee=None, opened=None, why=None, project=None, component=None, version=None, original=None, keywords=None, source_changes=None, state=None, substate=None, resolution=None, **properties):
+    def set(self, issue, assignee=None, opened=None, why=None, project=None, component=None, version=None, original=None, keywords=None, source_changes=None, state=None, substate=None, resolution=None, see_also=None, **properties):
         if not self.client or not self.library:
             sys.stderr.write('radarclient inaccessible on this machine\n')
             return None
@@ -436,6 +437,10 @@ class Tracker(GenericTracker):
         if source_changes:
             did_change = True
             radar.sourceChanges = '\n'.join(source_changes)
+
+        if see_also:
+            sys.stderr.write('Radar does not support the see_also field at this time\n')
+            return None
 
         if did_change:
             radar.commit_changes()

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/bugzilla_unittest.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/bugzilla_unittest.py
@@ -748,3 +748,15 @@ What component in 'WebKit' should the bug be associated with?:
             captured.stderr.getvalue(),
             'Bugzilla does not support source changes at this time\n',
         )
+
+    def test_related_links(self):
+        with mocks.Bugzilla(self.URL.split('://')[1], environment=wkmocks.Environment(
+                BUGS_EXAMPLE_COM_USERNAME='tcontributor@example.com',
+                BUGS_EXAMPLE_COM_PASSWORD='password',
+        ), users=mocks.USERS, issues=mocks.ISSUES), mocks.Radar(users=mocks.USERS, issues=mocks.ISSUES, projects=mocks.PROJECTS,):
+
+            tracker = bugzilla.Tracker(self.URL)
+            self.assertEqual(tracker.issue(1).related_links, [])
+            self.assertTrue(tracker.issue(1).add_related_links([f'{self.URL}/show_bug.cgi?id=2', 'other.tracker.com/123']))
+            self.assertEqual(tracker.issue(1).related_links, [f'{self.URL}/show_bug.cgi?id=2', 'other.tracker.com/123'])
+            self.assertEqual(tracker.issue(1).references, [tracker.issue(2)])

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/github_unittest.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/github_unittest.py
@@ -495,3 +495,14 @@ Documentation URL: https://docs.github.com/rest/reference/pulls#create-a-pull-re
             captured.stderr.getvalue(),
             'GitHub does not support source changes at this time\n',
         )
+
+    def test_related_links(self):
+        with OutputCapture() as captured, mocks.GitHub(self.URL.split('://')[1], issues=mocks.ISSUES):
+            tracker = github.Tracker(self.URL)
+            self.assertEqual(tracker.issue(1).references, [])
+            self.assertIsNone(tracker.issue(1).add_related_links(['12345']))
+
+        self.assertEqual(
+            captured.stderr.getvalue(),
+            'GitHub does not support the see_also field at this time\n',
+        )

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/radar_unittest.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/radar_unittest.py
@@ -579,3 +579,14 @@ What version of 'WebKit Text' should the bug be associated with?:
                     'Repo1, merged, a4daad5b9fbd26d557088037f54dc0935a437182',
                     'Repo2, merged, 604395a516c13cff80d4b0400e43a4c322dbb32f',
                 ])
+
+    def test_related_links(self):
+        with OutputCapture() as captured, mocks.Radar(issues=mocks.ISSUES):
+            tracker = radar.Tracker()
+            self.assertEqual(tracker.issue(1).references, [])
+            self.assertIsNone(tracker.issue(1).add_related_links(['12345']))
+
+        self.assertEqual(
+            captured.stderr.getvalue(),
+            'Radar does not support the see_also field at this time\n',
+        )


### PR DESCRIPTION
#### 675b03ad0fde8ec9116b51a893f8766e3cf84871
<pre>
[webkitbugspy] Add ability to set see_also field for bugs
<a href="https://rdar.apple.com/151183507">rdar://151183507</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=292893">https://bugs.webkit.org/show_bug.cgi?id=292893</a>

Reviewed by Jonathan Bedard and Sam Sneddon.

Set the &apos;see_also&apos; field in bugzilla by calling Issue.add_related_link.
This should be passed in as a list of string URLs.

&apos;see_also&apos; is stored in Issue.related_links as a new property since links that are not currently
tracked by webkitbugspy (GitHub, etc.) would not be populated in Issue.references.

* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/bugzilla.py:
(Tracker.populate):
(Tracker.set):
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/github.py:
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/issue.py:
(Issue.__init__):
(Issue):
(Issue.related_links):
(Issue.add_related_links):
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/bugzilla.py:
(Bugzilla._issue):
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/radar.py:
(Tracker.populate):
(Tracker.set):
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/bugzilla_unittest.py:
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/github_unittest.py:
(test_source_changes):
(test_related_links):
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/radar_unittest.py:

Canonical link: <a href="https://commits.webkit.org/295169@main">https://commits.webkit.org/295169@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4e98ecc6dddb16f0ed4c5f784a6a7371c8043133

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104299 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/131/builds/24003 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/138/builds/14416 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/109500 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/54967 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/106339 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/24375 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/123/builds/32550 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/109500 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/54967 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/107305 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/130/builds/24375 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/138/builds/14416 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/109500 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 webkitpy~~](https://ews-build.webkit.org/#/builders/6/builds/103777 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/130/builds/24375 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/138/builds/14416 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/54327 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/130/builds/24375 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/138/builds/14416 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/111881 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/31456 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/123/builds/32550 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/111881 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/31820 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/138/builds/14416 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/111881 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/138/builds/14416 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/25924 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16933 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/31384 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/31178 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/34514 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/32738 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->