### PR TITLE
[Grid][Containment] Grid with inline-size containment and auto-fit columns is incorrectly sized.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/contain-inline-size-grid-auto-fit-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/contain-inline-size-grid-auto-fit-expected.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="width: 100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/contain-inline-size-grid-auto-fit.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/contain-inline-size-grid-auto-fit.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://www.w3.org/TR/css-contain-2/#containment-size">
+<link rel="help" href="https://drafts.csswg.org/css-grid-2/#auto-repeat">
+<link rel="match" href="../reference/ref-filled-green-100px-square.xht">
+<style>
+.container {
+  width: 100px;
+}
+.grid {
+  display: grid;
+  height: 100px;
+  grid-template-columns: repeat(auto-fit, minmax(0, 1fr));
+  contain: inline-size;
+}
+.grid-item {
+  background-color: green;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div class="container">
+  <div class="grid">
+    <div class="grid-item">
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/Source/WebCore/rendering/RenderGrid.h
+++ b/Source/WebCore/rendering/RenderGrid.h
@@ -34,6 +34,11 @@
 #include "RenderBlock.h"
 #include <wtf/TZoneMalloc.h>
 
+namespace WTF {
+template<typename T>
+class Range;
+}
+
 namespace WebCore {
 
 class GridArea;
@@ -181,6 +186,7 @@ private:
 
     unsigned clampAutoRepeatTracks(GridTrackSizingDirection, unsigned autoRepeatTracks) const;
 
+    WTF::Range<size_t> autoRepeatTracksRange(GridTrackSizingDirection) const;
     std::unique_ptr<OrderedTrackIndexSet> computeEmptyTracksForAutoRepeat(GridTrackSizingDirection) const;
 
     enum class ShouldUpdateGridAreaLogicalSize : bool { No, Yes };
@@ -287,6 +293,7 @@ private:
 
     AutoRepeatType autoRepeatColumnsType() const;
     AutoRepeatType autoRepeatRowsType() const;
+    AutoRepeatType autoRepeatType(GridTrackSizingDirection direction) const { return direction == GridTrackSizingDirection::ForColumns ? autoRepeatColumnsType() : autoRepeatRowsType(); }
 
     bool canCreateIntrinsicLogicalHeightsForRowSizingFirstPassCache() const;
 


### PR DESCRIPTION
#### 348ac9f493b2119efabc54d7f02eefbb6fc6b4c8
<pre>
[Grid][Containment] Grid with inline-size containment and auto-fit columns is incorrectly sized.
<a href="https://bugs.webkit.org/show_bug.cgi?id=256047">https://bugs.webkit.org/show_bug.cgi?id=256047</a>
<a href="https://rdar.apple.com/problem/108897961">rdar://problem/108897961</a>

Reviewed by Alan Baradlay.

css-contain states that laying out a size containment box and its
contents is done in two phases:
Accorind to the css-contain spec, laying out a size containment box and
its contents is done in two phases:
1.) Sizing the size containment box as if it was empty
2.) Laying out its contents using the fixed size computed from 1
<a href="https://www.w3.org/TR/css-contain-2/#containment-size">https://www.w3.org/TR/css-contain-2/#containment-size</a>

In grid this seems to be currently implemented by interleaving size
containment logic with the rest of normal flow grid layout. In other
words, we will check to see if size containment is applied at various
points during grid layout and slightly switch up or add some new logic
if it is.

This seems like it can be a bit problematic with certain types of
content such as a grid with inline-size containment and auto-fit
columns. This is because in that case we will create and hold onto an
empty set of tracks during grid item placement. In normal circumstances,
one reason these would be created is for auto-fit tracks without any
grid items in them as they are supposed to get collapsed to 0. We seem
to do this in order to trick grid layout to collapse any auto-fit tracks
in order to achieve the &quot;sizing as if empty,&quot; effect but fail to recover
for normal flow grid layout.

Consider the following test case:
&lt;style&gt;
.grid {
  contain: inline-size;
  display: grid;
  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
  border: 1px solid blue;
}
.grid-item {
  border: 3px solid red;
}
&lt;/style&gt;
&lt;div class=&quot;grid&quot;&gt;
  &lt;div class=&quot;grid-item&quot;&gt;
    This box should fill the container column width
  &lt;/div&gt;
&lt;/div&gt;

Currently what will happen is that we collapse all of the tracks since
they are auto-fit tracks and inline-size containment is being applied on
the box. This results in a grid size of 0 which for &quot;sizing as if empty,&quot; is ok
since that is the indicated behavior. However, since we tricked grid
layout into this state by creating an empty track list we fail to
recover during normal flow grid layout code.

In this patch I change our behavior to help us compute the correct
geometry in these cases in two ways:

1.) Stop creating and setting empty tracks during item placement in the
presence of size containment.
  - Doing this has implications for the rest of grid layout and is
    hard/error prone to recover from.
2.) Instead check for size containment when sizes of the grid that are
based off the track sizes (computeGridContainerIntrinsicSizes and
computeTrackBasedSizes) and filter out the auto-fit tracks.
  - The former is used during intrinsic logical width computation and
    the latter is used when computing the content/track based logical
    height of the grid. It seems like these are the places instead we
    should be checking if size containment is applied and computing a
    slightly different value.

In the context of the test case above this would mean we perform grid
layout as normal, but when we get to computeGridContainerIntrinsicSizes
we slightly adjust our logic to return the correct intrinsic sizes for
size containment. Instead of triggering the track collapsing logic as
before we will simply filter out the auto-fit tracks when computing the
sum of the track sizes which has the same effect.

(WebCore::GridTrackSizingAlgorithm::computeTrackBasedSize const):
Here we simply filter out the auto-fit tracks and provide the
potentially modified vector of tracks to accumulate over. This
is needed in order to properly consider the correct number of gaps
as the gaps associated with collapsed auto-fit tracks also collapse to
0.

(WebCore::GridTrackSizingAlgorithm::computeGridContainerIntrinsicSizes):
Instead of filtering out the auto-fit tracks like above we need to just
skip over them. This is so that we properly call setGrowthLimitCap on
the track that is held onto by GridTrackSizingAlgorithm.

Canonical link: <a href="https://commits.webkit.org/295023@main">https://commits.webkit.org/295023@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c6d4370526b8167c8ae03aa7ed4edb9828cc0e75

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/103568 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/23250 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/13571 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/108744 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/54214 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/105608 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/23605 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/31801 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78699 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/106574 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/18308 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/93427 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59034 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/18125 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/11474 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/53569 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/87908 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/11533 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/111122 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/30715 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/22653 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/87693 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/31076 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/89627 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87337 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22289 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32214 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/9934 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/25067 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/30643 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/35955 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/30443 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/33774 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/32004 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->