### PR TITLE
Make more functions in DrawingAreaProxy pure virtual

### DIFF
--- a/Source/WebKit/UIProcess/DrawingAreaProxy.h
+++ b/Source/WebKit/UIProcess/DrawingAreaProxy.h
@@ -89,8 +89,7 @@ public:
     virtual void windowScreenDidChange(WebCore::PlatformDisplayID) { }
     virtual std::optional<WebCore::FramesPerSecond> displayNominalFramesPerSecond() { return std::nullopt; }
 
-    // FIXME: These should be pure virtual.
-    virtual void setBackingStoreIsDiscardable(bool) { }
+    virtual void setBackingStoreIsDiscardable(bool) = 0;
 
     const WebCore::IntSize& size() const { return m_size; }
     bool setSize(const WebCore::IntSize&, const WebCore::IntSize& scrollOffset = { });
@@ -100,7 +99,7 @@ public:
     virtual void windowKindDidChange() { }
 
     virtual void adjustTransientZoom(double, WebCore::FloatPoint) { }
-    virtual void commitTransientZoom(double, WebCore::FloatPoint) { }
+    virtual void commitTransientZoom(double, WebCore::FloatPoint) = 0;
 
     virtual void viewIsBecomingVisible() { }
     virtual void viewIsBecomingInvisible() { }
@@ -168,10 +167,9 @@ private:
     virtual void sizeDidChange() = 0;
 
     // Message handlers.
-    // FIXME: These should be pure virtual.
-    virtual void enterAcceleratedCompositingMode(uint64_t /* backingStoreStateID */, const LayerTreeContext&) { }
-    virtual void updateAcceleratedCompositingMode(uint64_t /* backingStoreStateID */, const LayerTreeContext&) { }
-    virtual void didFirstLayerFlush(uint64_t /* backingStoreStateID */, const LayerTreeContext&) { }
+    virtual void enterAcceleratedCompositingMode(uint64_t /* backingStoreStateID */, const LayerTreeContext&) = 0;
+    virtual void updateAcceleratedCompositingMode(uint64_t /* backingStoreStateID */, const LayerTreeContext&) = 0;
+    virtual void didFirstLayerFlush(uint64_t /* backingStoreStateID */, const LayerTreeContext&);
 #if PLATFORM(MAC)
     RunLoop::Timer m_viewExposedRectChangedTimer;
     std::optional<WebCore::FloatRect> m_lastSentViewExposedRect;


### PR DESCRIPTION
#### e1d58496dbadc08a3d44cd6286407b6bb0004e6e
<pre>
Make more functions in DrawingAreaProxy pure virtual
<a href="https://bugs.webkit.org/show_bug.cgi?id=292900">https://bugs.webkit.org/show_bug.cgi?id=292900</a>

Reviewed by NOBODY (OOPS!).

Make more functions in DrawingAreaProxy pure virtual

* Source/WebKit/UIProcess/DrawingAreaProxy.h:
(WebKit::DrawingAreaProxy::setBackingStoreIsDiscardable):
(WebKit::DrawingAreaProxy::enterAcceleratedCompositingMode):
(WebKit::DrawingAreaProxy::updateAcceleratedCompositingMode):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e1d58496dbadc08a3d44cd6286407b6bb0004e6e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/103253 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/22929 "Hash e1d58496 for PR 45283 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/13249 "Hash e1d58496 for PR 45283 does not build (failure)") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/108423 "Hash e1d58496 for PR 45283 does not build (failure)") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/53896 "Hash e1d58496 for PR 45283 does not build (failure)") 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/23266 "Hash e1d58496 for PR 45283 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/31439 "Hash e1d58496 for PR 45283 does not build (failure)") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/108423 "Hash e1d58496 for PR 45283 does not build (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/53896 "Hash e1d58496 for PR 45283 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/106259 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/130/builds/23266 "Hash e1d58496 for PR 45283 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/138/builds/13249 "Hash e1d58496 for PR 45283 does not build (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/108423 "Hash e1d58496 for PR 45283 does not build (failure)") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/130/builds/23266 "Hash e1d58496 for PR 45283 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/138/builds/13249 "Hash e1d58496 for PR 45283 does not build (failure)") | [❌ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/53251 "Hash e1d58496 for PR 45283 does not build (failure)") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/130/builds/23266 "Hash e1d58496 for PR 45283 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/138/builds/13249 "Hash e1d58496 for PR 45283 does not build (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/110799 "Hash e1d58496 for PR 45283 does not build (failure)") | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/30391 "Hash e1d58496 for PR 45283 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/123/builds/31439 "Hash e1d58496 for PR 45283 does not build (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/110799 "Hash e1d58496 for PR 45283 does not build (failure)") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/30756 "Hash e1d58496 for PR 45283 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/138/builds/13249 "Hash e1d58496 for PR 45283 does not build (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/110799 "Hash e1d58496 for PR 45283 does not build (failure)") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/138/builds/13249 "Hash e1d58496 for PR 45283 does not build (failure)") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/24714 "Hash e1d58496 for PR 45283 does not build (failure)") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/30320 "Hash e1d58496 for PR 45283 does not build (failure)") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/35639 "Failed to build and analyze WebKit") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/30126 "Hash e1d58496 for PR 45283 does not build (failure)") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/33453 "Hash e1d58496 for PR 45283 does not build (failure)") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/31688 "Hash e1d58496 for PR 45283 does not build (failure)") | | | 
<!--EWS-Status-Bubble-End-->