### PR TITLE
Leverage singleElementSpan() in a few more places

### DIFF
--- a/Source/WebCore/html/canvas/CanvasPath.cpp
+++ b/Source/WebCore/html/canvas/CanvasPath.cpp
@@ -244,7 +244,7 @@ void CanvasPath::rect(float x, float y, float width, float height)
 
 ExceptionOr<void> CanvasPath::roundRect(float x, float y, float width, float height, const RadiusVariant& radii)
 {
-    return roundRect(x, y, width, height, std::span(&radii, 1));
+    return roundRect(x, y, width, height, singleElementSpan(radii));
 }
 
 ExceptionOr<void> CanvasPath::roundRect(float x, float y, float width, float height, std::span<const RadiusVariant> radii)

--- a/Source/WebCore/html/shadow/TextControlInnerElements.cpp
+++ b/Source/WebCore/html/shadow/TextControlInnerElements.cpp
@@ -175,7 +175,7 @@ void TextControlInnerTextElement::updateInnerTextElementEditabilityImpl(bool isE
     const auto& value = isEditable ? plaintextOnlyAtom() : falseAtom();
     if (initialization) {
         Attribute attribute(contenteditableAttr, value);
-        parserSetAttributes(std::span(&attribute, 1));
+        parserSetAttributes(singleElementSpan(attribute));
     } else
         setAttributeWithoutSynchronization(contenteditableAttr, value);
 }

--- a/Source/WebCore/xml/XMLErrors.cpp
+++ b/Source/WebCore/xml/XMLErrors.cpp
@@ -89,7 +89,7 @@ static inline Ref<Element> createXHTMLParserErrorHeader(Document& document, Stri
     Ref reportElement = document.createElement(QualifiedName(nullAtom(), "parsererror"_s, xhtmlNamespaceURI), true);
 
     Attribute reportAttribute(styleAttr, "display: block; white-space: pre; border: 2px solid #c77; padding: 0 1em 0 1em; margin: 1em; background-color: #fdd; color: black"_s);
-    reportElement->parserSetAttributes(std::span(&reportAttribute, 1));
+    reportElement->parserSetAttributes(singleElementSpan(reportAttribute));
 
     Ref h3 = HTMLHeadingElement::create(h3Tag, document);
     reportElement->parserAppendChild(h3);
@@ -97,7 +97,7 @@ static inline Ref<Element> createXHTMLParserErrorHeader(Document& document, Stri
 
     Ref fixed = HTMLDivElement::create(document);
     Attribute fixedAttribute(styleAttr, "font-family:monospace;font-size:12px"_s);
-    fixed->parserSetAttributes(std::span(&fixedAttribute, 1));
+    fixed->parserSetAttributes(singleElementSpan(fixedAttribute));
     reportElement->parserAppendChild(fixed);
 
     fixed->parserAppendChild(Text::create(document, WTFMove(errorMessages)));
@@ -150,7 +150,7 @@ void XMLErrors::insertErrorMessageBlock()
     if (document->transformSourceDocument()) {
         Attribute attribute(styleAttr, "white-space: normal"_s);
         Ref paragraph = HTMLParagraphElement::create(document);
-        paragraph->parserSetAttributes(std::span(&attribute, 1));
+        paragraph->parserSetAttributes(singleElementSpan(attribute));
         paragraph->parserAppendChild(document->createTextNode("This document was created as the result of an XSL transformation. The line and column numbers given are from the transformed result."_s));
         reportElement->parserAppendChild(WTFMove(paragraph));
     }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm
@@ -328,7 +328,7 @@ public:
     }
     template<typename T> void encodeInteger(T object)
     {
-        encodeSpan(std::span(&object, 1));
+        encodeSpan(singleElementSpan(object));
     }
 private:
     Vector<uint8_t> m_bytes;


### PR DESCRIPTION
#### 93a025cbc95585ce3936b0eb06ad757149771d43
<pre>
Leverage singleElementSpan() in a few more places
<a href="https://bugs.webkit.org/show_bug.cgi?id=292903">https://bugs.webkit.org/show_bug.cgi?id=292903</a>

Reviewed by Anne van Kesteren.

This is a step towards our safer cpp style since calling the std::span
constructor explicitly is not considered safe.

Canonical link: <a href="https://commits.webkit.org/294850@main">https://commits.webkit.org/294850@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a0aa65e33b2d351c068c25b4b73324fcaa7ce0db

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/103240 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/22916 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/13236 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/108410 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/53883 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/105279 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/23252 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/31481 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78468 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/35397 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/106246 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/18024 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/93137 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58801 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/17864 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/11180 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/53238 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/87672 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/11242 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/110786 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/30378 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/22442 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/87469 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/30743 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/89336 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87102 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22171 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31954 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/9668 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/24701 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/30307 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/35626 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/30113 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/33440 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/31675 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->