### PR TITLE
Only prevent full screen video HDR external constraining on macOS

### DIFF
--- a/LayoutTests/media/video-suppress-hdr-fullscreen-expected.txt
+++ b/LayoutTests/media/video-suppress-hdr-fullscreen-expected.txt
@@ -1,0 +1,21 @@
+
+Test how fullscreen influences suppress-HDR notification handling.
+
+RUN(internals.setPageShouldSuppressHDR(false))
+RUN(internals.setPageShouldSuppressHDR(true))
+RUN(internals.setPageShouldSuppressHDR(false))
+RUN(video.src = findMediaFile("video", "content/test"))
+EVENT(canplaythrough)
+RUN(video.play().then(playing);)
+EXPECTED (internals.isChangingPresentationMode(video) == 'false') OK
+RUN(internals.setPageShouldSuppressHDR(true))
+RUN(internals.setPageShouldSuppressHDR(false))
+RUN(video.webkitExitFullscreen())
+EVENT(webkitpresentationmodechanged)
+EXPECTED (internals.isChangingPresentationMode(video) == 'false') OK
+EXPECTED (video.webkitDisplayingFullscreen == 'false') OK
+EXPECTED (video.paused == 'false') OK
+RUN(internals.setPageShouldSuppressHDR(true))
+RUN(internals.setPageShouldSuppressHDR(false))
+END OF TEST
+

--- a/LayoutTests/media/video-suppress-hdr-fullscreen.html
+++ b/LayoutTests/media/video-suppress-hdr-fullscreen.html
@@ -1,0 +1,99 @@
+<!DOCTYPE html><!-- webkit-test-runner [ SupportHDRDisplayEnabled=true ] -->
+<html>
+<head>
+    <title>video-suppress-hdr-fullscreen</title>
+    <script src="video-test.js"></script>
+    <script src="media-file.js"></script>
+
+    <script>
+
+    // So that the non-failure output is the same if dynamic-range-limit:no-limit is not supported.
+    function testExpectedIfSupportsDynamicRangeLimit(testFuncString, expected)
+    {
+        if (CSS.supports("dynamic-range-limit", "no-limit")) {
+            try {
+                let {success, observed} = compare(testFuncString, expected, '==');
+                if (!success)
+                    reportExpected(success, testFuncString, '==', expected, observed)
+            } catch (ex) {
+                consoleWrite(ex);
+            }
+        }
+    }
+
+    function go()
+    {
+        if (!window.internals) {
+            failTest('This test requires window.internals.');
+            return;
+        }
+
+        findMediaElement();
+
+        testExpectedIfSupportsDynamicRangeLimit('video.style["dynamic-range-limit"]', '');
+        testExpectedIfSupportsDynamicRangeLimit('getComputedStyle(video)["dynamic-range-limit"]', 'no-limit');
+
+        run('internals.setPageShouldSuppressHDR(false)');
+        testExpectedIfSupportsDynamicRangeLimit('internals.effectiveDynamicRangeLimitValue(video)', 1.0);
+        run('internals.setPageShouldSuppressHDR(true)');
+        testExpectedIfSupportsDynamicRangeLimit('internals.effectiveDynamicRangeLimitValue(video)', 0.5);
+        run('internals.setPageShouldSuppressHDR(false)');
+        testExpectedIfSupportsDynamicRangeLimit('internals.effectiveDynamicRangeLimitValue(video)', 1.0);
+
+        internals.settings.setAllowsInlineMediaPlayback(false);
+        internals.settings.setAllowsInlineMediaPlaybackAfterFullscreen(true);
+        // Disable the Fullscreen API (element fullscreen) support
+        internals.settings.setFullScreenEnabled(false);
+        internals.setMockVideoPresentationModeEnabled(true);
+        internals.setMediaElementRestrictions(video, "NoRestrictions");
+
+        waitForEventOnce('canplaythrough', canplaythrough);
+        run('video.src = findMediaFile("video", "content/test")');
+    }
+
+    function canplaythrough()
+    {
+        run('video.play().then(playing);');
+    }
+
+    async function playing()
+    {
+        await testExpectedEventually("internals.isChangingPresentationMode(video)", false);
+
+        // Mock fullscreen is flaky (webkit.org/b/222573) so adapt to it for this test,
+        // where we're more interested in the implication: fullscreen+mac -> don't suppress HDR.
+        const isFullscreen = video.webkitDisplayingFullscreen;
+        const isMac = navigator.userAgent.includes('Macintosh');
+        const shouldSuppressHDR = !(isFullscreen && isMac);
+
+        testExpectedIfSupportsDynamicRangeLimit('internals.effectiveDynamicRangeLimitValue(video)', 1.0);
+        run('internals.setPageShouldSuppressHDR(true)');
+        testExpectedIfSupportsDynamicRangeLimit('internals.effectiveDynamicRangeLimitValue(video)', shouldSuppressHDR ? 0.5 : 1.0);
+        run('internals.setPageShouldSuppressHDR(false)');
+        testExpectedIfSupportsDynamicRangeLimit('internals.effectiveDynamicRangeLimitValue(video)', 1.0);
+
+        waitForEventOnce('webkitpresentationmodechanged', endfullscreen);
+        run('video.webkitExitFullscreen()');
+    }
+
+    async function endfullscreen()
+    {
+        await testExpectedEventually("internals.isChangingPresentationMode(video)", false);
+        testExpected('video.webkitDisplayingFullscreen', false);
+        testExpected('video.paused', false);
+
+        testExpectedIfSupportsDynamicRangeLimit('internals.effectiveDynamicRangeLimitValue(video)', 1.0);
+        run('internals.setPageShouldSuppressHDR(true)');
+        testExpectedIfSupportsDynamicRangeLimit('internals.effectiveDynamicRangeLimitValue(video)', 0.5);
+        run('internals.setPageShouldSuppressHDR(false)');
+        testExpectedIfSupportsDynamicRangeLimit('internals.effectiveDynamicRangeLimitValue(video)', 1.0);
+
+        endTest();
+    }
+    </script>
+</head>
+<body onload="go()">
+    <video controls></video>
+    <p>Test how fullscreen influences suppress-HDR notification handling.</p>
+</body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -3576,6 +3576,7 @@ webkit.org/b/113127 media/track/track-prefer-captions.html [ Timeout ]
 
 webkit.org/b/168373 media/media-fullscreen-loop-inline.html [ Timeout ]
 webkit.org/b/174242 media/media-fullscreen-pause-inline.html [ Skip ]
+webkit.org/b/174242 media/video-suppress-hdr-fullscreen.html [ Skip ]
 webkit.org/b/137311 media/video-fullscreen-only-playback.html [ Timeout Crash ]
 webkit.org/b/262482 media/video-layer-crash.html [ Pass Crash ]
 

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -8008,13 +8008,15 @@ PlatformDynamicRangeLimit HTMLMediaElement::computePlayerDynamicRangeLimit() con
         return m_platformDynamicRangeLimit;
 
     bool shouldSuppressHDR = [this]() {
-        if (m_videoFullscreenMode == VideoFullscreenModeStandard)
-            return false;
+        if (!document().settings().suppressHDRShouldBeAllowedInFullscreenVideo()) {
+            if (m_videoFullscreenMode == VideoFullscreenModeStandard)
+                return false;
 
 #if ENABLE(FULLSCREEN_API)
-        if (m_isChildOfElementFullscreen)
-            return false;
+            if (m_isChildOfElementFullscreen)
+                return false;
 #endif
+        }
 
         if (Page* page = document().page())
             return page->shouldSuppressHDR();

--- a/Source/WebCore/page/Settings.yaml
+++ b/Source/WebCore/page/Settings.yaml
@@ -400,6 +400,13 @@ StorageBlockingPolicy:
     WebCore:
       default: StorageBlockingPolicy::AllowAll
 
+SuppressHDRShouldBeAllowedInFullscreenVideo:
+  type: bool
+  defaultValue:
+    WebCore:
+      PLATFORM(MAC): false
+      default: true
+
 TextAutosizingWindowSizeOverrideHeight:
   type: uint32_t
   webcoreOnChange: setNeedsRecalcStyleInAllFrames


### PR DESCRIPTION
#### 1c9259f43c89b497018b0c9503717b3ba56dac54
<pre>
Only prevent full screen video HDR external constraining on macOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=292904">https://bugs.webkit.org/show_bug.cgi?id=292904</a>
<a href="https://rdar.apple.com/151160054">rdar://151160054</a>

Reviewed by Simon Fraser.

In some situations the OS may request that the browser constrains (or
&quot;suppresses&quot;) HDR to some maximum level.
For full screen videos on macOS, we do NOT want to suppress HDR.
But on other OSes like iOS, the constraining request should now be
respected.

Note: This does not affect `dynamic-range-limit`, which is always
respected on all supported platforms.

* LayoutTests/media/video-suppress-hdr-fullscreen-expected.txt: Added.
* LayoutTests/media/video-suppress-hdr-fullscreen.html: Added.
* LayoutTests/platform/glib/TestExpectations:
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::computePlayerDynamicRangeLimit const):
* Source/WebCore/page/Settings.yaml:

Canonical link: <a href="https://commits.webkit.org/295178@main">https://commits.webkit.org/295178@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fb0fa0cea733f90e136f76a0452201d0ef473690

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104241 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/23945 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/14288 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/109441 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/54909 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/106281 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/24313 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/32490 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79169 "Found 1 new test failure: imported/w3c/web-platform-tests/html/semantics/forms/constraints/infinite_backtracking.html (failure)") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107247 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/18890 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94049 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59497 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/18700 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/12091 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/54269 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/88399 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/12150 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/111823 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/31397 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23142 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88189 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/31762 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/90242 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87851 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22381 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32744 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10494 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/25861 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/31326 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/36639 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/31120 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/34456 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/32680 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->