### PR TITLE
[RenderInline][Cleanup] Adopt RenderChildIterator in RenderInline code

### DIFF
--- a/Source/WebCore/rendering/RenderInline.cpp
+++ b/Source/WebCore/rendering/RenderInline.cpp
@@ -140,11 +140,15 @@ static RenderElement* inFlowPositionedInlineAncestor(RenderElement* p)
 static void updateStyleOfAnonymousBlockContinuations(const RenderBlock& block, const RenderStyle* newStyle, const RenderStyle* oldStyle)
 {
     // If any descendant blocks exist then they will be in the next anonymous block and its siblings.
-    for (RenderBox* box = block.nextSiblingBox(); box && box->isAnonymousBlock(); box = box->nextSiblingBox()) {
-        if (box->style().position() == newStyle->position())
+    for (auto& box : childrenOfType<RenderBox>(block)) {
+        if (dynamicDowncast<RenderBox>(box) == nullptr)
+            break;
+        if (!box.isAnonymousBlock())
+            break;
+        if (box.style().position() == newStyle->position())
             continue;
 
-        CheckedPtr block = dynamicDowncast<RenderBlock>(*box);
+        CheckedPtr block = dynamicDowncast<RenderBlock>(box);
         if (!block)
             continue;
 
@@ -158,7 +162,7 @@ static void updateStyleOfAnonymousBlockContinuations(const RenderBlock& block, c
             continue;
         auto blockStyle = RenderStyle::createAnonymousStyleWithDisplay(block->style(), DisplayType::Block);
         blockStyle.setPosition(newStyle->position());
-        block->setStyle(WTFMove(blockStyle));
+        const_cast<RenderBlock*>(block.get())->setStyle(WTFMove(blockStyle));
     }
 }
 


### PR DESCRIPTION
#### 1acc189a43ad3d3d1895f1bd9b3c4281c2bd7c62
<pre>
[RenderInline][Cleanup] Adopt RenderChildIterator in RenderInline code
<a href="https://bugs.webkit.org/show_bug.cgi?id=292907">https://bugs.webkit.org/show_bug.cgi?id=292907</a>

Reviewed by NOBODY (OOPS!).

Adopt RenderChildIterator in RenderInline code

* Source/WebCore/rendering/RenderInline.cpp:
(WebCore::updateStyleOfAnonymousBlockContinuations):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1acc189a43ad3d3d1895f1bd9b3c4281c2bd7c62

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105988 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25737 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/16131 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/111184 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/56584 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/108027 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/26386 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34240 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80511 "Found 5 new test failures: fast/css/relative-positioned-block-nested-with-inline-parent-dynamic-removed.html fast/css/relative-positioned-block-nested-with-inline-parent-multiple-descendant-blocks-dynamic.html fast/css/relative-positioned-block-with-inline-ancestor-dynamic.html fast/css/relative-positioned-block-with-inline-parent-dynamic-removed.html fast/css/relative-positioned-block-with-inline-parent-dynamic.html (failure)") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108992 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/20814 "Found 6 new test failures: fast/css/relative-positioned-block-nested-with-inline-parent-dynamic-removed.html fast/css/relative-positioned-block-nested-with-inline-parent-multiple-descendant-blocks-dynamic.html fast/css/relative-positioned-block-with-inline-ancestor-dynamic.html fast/css/relative-positioned-block-with-inline-parent-dynamic-removed.html fast/css/relative-positioned-block-with-inline-parent-dynamic.html http/tests/site-isolation/page-scale.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95653 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60831 "Found 144 new API test failures: /WPE/TestUIClient:/webkit/WebKitWebView/query-permission-requests, /WPE/TestWebsiteData:/webkit/WebKitWebsiteData/deviceidhashsalt, /WPE/TestLoaderClient:/webkit/WebKitWebView/load-twice-and-reload, /WPE/TestCookieManager:/webkit/WebKitCookieManager/ephemeral, /WPE/TestWebKitWebView:/webkit/WebKitWebView/is-playing-audio, /WPE/TestConsoleMessage:/webkit/WebKitConsoleMessage/network-error, /WPE/TestWebsiteData:/webkit/WebKitWebsiteData/configuration, /WPE/TestCookieManager:/webkit/WebKitCookieManager/delete-cookies, /WPE/TestWebKitWebView:/webkit/WebKitWebView/terminate-unresponsive-web-process, /WPE/TestSSL:/webkit/WebKitWebView/insecure-content ... (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/20427 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13750 "Found 5 new test failures: fast/css/relative-positioned-block-nested-with-inline-parent-dynamic-removed.html fast/css/relative-positioned-block-nested-with-inline-parent-multiple-descendant-blocks-dynamic.html fast/css/relative-positioned-block-with-inline-ancestor-dynamic.html fast/css/relative-positioned-block-with-inline-parent-dynamic-removed.html fast/css/relative-positioned-block-with-inline-parent-dynamic.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/56022 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/90195 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13786 "Found 5 new test failures: fast/css/relative-positioned-block-nested-with-inline-parent-dynamic-removed.html fast/css/relative-positioned-block-nested-with-inline-parent-multiple-descendant-blocks-dynamic.html fast/css/relative-positioned-block-with-inline-ancestor-dynamic.html fast/css/relative-positioned-block-with-inline-parent-dynamic-removed.html fast/css/relative-positioned-block-with-inline-parent-dynamic.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/114038 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33126 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24440 "Found 5 new test failures: fast/css/relative-positioned-block-nested-with-inline-parent-dynamic-removed.html fast/css/relative-positioned-block-nested-with-inline-parent-multiple-descendant-blocks-dynamic.html fast/css/relative-positioned-block-with-inline-ancestor-dynamic.html fast/css/relative-positioned-block-with-inline-parent-dynamic-removed.html fast/css/relative-positioned-block-with-inline-parent-dynamic.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89590 "Found 5 new test failures: fast/css/relative-positioned-block-nested-with-inline-parent-dynamic-removed.html fast/css/relative-positioned-block-nested-with-inline-parent-multiple-descendant-blocks-dynamic.html fast/css/relative-positioned-block-with-inline-ancestor-dynamic.html fast/css/relative-positioned-block-with-inline-parent-dynamic-removed.html fast/css/relative-positioned-block-with-inline-parent-dynamic.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33490 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91881 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89271 "Found 100 new API test failures: /TestWebKit:WebKit.PageLoadDidChangeLocationWithinPage, /TestWebKit:WebKit.AboutBlankLoad, /TestWebKit:WebKit.PreventEmptyUserAgent, /TestWebKit:WebKit.PrivateBrowsingPushStateNoHistoryCallback, /WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/content-type, /WebKitGTK/TestUIClient:/webkit/WebKitWebView/pointer-lock-permission-request, /TestWebKit:WebKit.HitTestResultNodeHandle, /TestWebKit:WebKit2TextFieldBeginAndEditEditingTest.TextFieldDidBeginShouldNotBeDispatchedForAlreadyFocusedField, /TestWebKit:WebKit.Find, /WebKitGTK/TestWebProcessExtensions:/webkit/WebKitWebProcessExtension/dom-input-element-is-user-edited ... (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34134 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11967 "Found 5 new test failures: fast/css/relative-positioned-block-nested-with-inline-parent-dynamic-removed.html fast/css/relative-positioned-block-nested-with-inline-parent-multiple-descendant-blocks-dynamic.html fast/css/relative-positioned-block-with-inline-ancestor-dynamic.html fast/css/relative-positioned-block-with-inline-parent-dynamic-removed.html fast/css/relative-positioned-block-with-inline-parent-dynamic.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/28670 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/33051 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/38463 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32797 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/36146 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34395 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->