### PR TITLE
Update FilterEffect::apply() to take in a span instead of a `const Vector&`

### DIFF
--- a/Source/WebCore/platform/graphics/coreimage/FEColorMatrixCoreImageApplier.h
+++ b/Source/WebCore/platform/graphics/coreimage/FEColorMatrixCoreImageApplier.h
@@ -44,7 +44,7 @@ public:
     static bool supportsCoreImageRendering(const FEColorMatrix&);
 
 private:
-    bool apply(const Filter&, const FilterImageVector& inputs, FilterImage& result) const final;
+    bool apply(const Filter&, std::span<const Ref<FilterImage>> inputs, FilterImage& result) const final;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/coreimage/FEColorMatrixCoreImageApplier.mm
+++ b/Source/WebCore/platform/graphics/coreimage/FEColorMatrixCoreImageApplier.mm
@@ -53,7 +53,7 @@ bool FEColorMatrixCoreImageApplier::supportsCoreImageRendering(const FEColorMatr
         || effect.type() == ColorMatrixType::FECOLORMATRIX_TYPE_MATRIX;
 }
 
-bool FEColorMatrixCoreImageApplier::apply(const Filter&, const FilterImageVector& inputs, FilterImage& result) const
+bool FEColorMatrixCoreImageApplier::apply(const Filter&, std::span<const Ref<FilterImage>> inputs, FilterImage& result) const
 {
     ASSERT(inputs.size() == 1);
     Ref input = inputs[0];

--- a/Source/WebCore/platform/graphics/coreimage/FEComponentTransferCoreImageApplier.h
+++ b/Source/WebCore/platform/graphics/coreimage/FEComponentTransferCoreImageApplier.h
@@ -44,7 +44,7 @@ public:
     static bool supportsCoreImageRendering(const FEComponentTransfer&);
 
 private:
-    bool apply(const Filter&, const FilterImageVector& inputs, FilterImage& result) const final;
+    bool apply(const Filter&, std::span<const Ref<FilterImage>> inputs, FilterImage& result) const final;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/coreimage/FEComponentTransferCoreImageApplier.mm
+++ b/Source/WebCore/platform/graphics/coreimage/FEComponentTransferCoreImageApplier.mm
@@ -58,7 +58,7 @@ bool FEComponentTransferCoreImageApplier::supportsCoreImageRendering(const FECom
         && isNullOrLinear(effect.alphaFunction());
 }
 
-bool FEComponentTransferCoreImageApplier::apply(const Filter&, const FilterImageVector& inputs, FilterImage& result) const
+bool FEComponentTransferCoreImageApplier::apply(const Filter&, std::span<const Ref<FilterImage>> inputs, FilterImage& result) const
 {
     ASSERT(inputs.size() == 1);
     Ref input = inputs[0];

--- a/Source/WebCore/platform/graphics/coreimage/SourceGraphicCoreImageApplier.h
+++ b/Source/WebCore/platform/graphics/coreimage/SourceGraphicCoreImageApplier.h
@@ -41,7 +41,7 @@ public:
     using Base::Base;
 
 private:
-    bool apply(const Filter&, const FilterImageVector& inputs, FilterImage& result) const final;
+    bool apply(const Filter&, std::span<const Ref<FilterImage>> inputs, FilterImage& result) const final;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/coreimage/SourceGraphicCoreImageApplier.mm
+++ b/Source/WebCore/platform/graphics/coreimage/SourceGraphicCoreImageApplier.mm
@@ -41,7 +41,7 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(SourceGraphicCoreImageApplier);
 
-bool SourceGraphicCoreImageApplier::apply(const Filter&, const FilterImageVector& inputs, FilterImage& result) const
+bool SourceGraphicCoreImageApplier::apply(const Filter&, std::span<const Ref<FilterImage>> inputs, FilterImage& result) const
 {
     Ref input = inputs[0];
 

--- a/Source/WebCore/platform/graphics/cpu/arm/filters/FEBlendNeonApplier.cpp
+++ b/Source/WebCore/platform/graphics/cpu/arm/filters/FEBlendNeonApplier.cpp
@@ -170,7 +170,7 @@ void FEBlendNeonApplier::applyPlatform(unsigned char* srcPixelArrayA, unsigned c
     }
 }
 
-bool FEBlendNeonApplier::apply(const Filter&, const FilterImageVector& inputs, FilterImage& result) const
+bool FEBlendNeonApplier::apply(const Filter&, std::span<const Ref<FilterImage>> inputs, FilterImage& result) const
 {
     Ref input = inputs[0];
     Ref input2 = inputs[1];

--- a/Source/WebCore/platform/graphics/cpu/arm/filters/FEBlendNeonApplier.h
+++ b/Source/WebCore/platform/graphics/cpu/arm/filters/FEBlendNeonApplier.h
@@ -45,7 +45,7 @@ public:
     using Base::Base;
 
 private:
-    bool apply(const Filter&, const FilterImageVector& inputs, FilterImage& result) const final;
+    bool apply(const Filter&, std::span<const Ref<FilterImage>> inputs, FilterImage& result) const final;
     void applyPlatform(unsigned char* srcPixelArrayA, unsigned char* srcPixelArrayB, unsigned char* dstPixelArray, unsigned colorArrayLength) const;
 };
 

--- a/Source/WebCore/platform/graphics/cpu/arm/filters/FECompositeNeonArithmeticApplier.cpp
+++ b/Source/WebCore/platform/graphics/cpu/arm/filters/FECompositeNeonArithmeticApplier.cpp
@@ -96,7 +96,7 @@ inline void FECompositeNeonArithmeticApplier::applyPlatform(const uint8_t* sourc
     computePixels<1, 1>(source, destination, pixelArrayLength, k1, k2, k3, k4);
 }
 
-bool FECompositeNeonArithmeticApplier::apply(const Filter&, const FilterImageVector& inputs, FilterImage& result) const
+bool FECompositeNeonArithmeticApplier::apply(const Filter&, std::span<const Ref<FilterImage>> inputs, FilterImage& result) const
 {
     Ref input = inputs[0];
     Ref input2 = inputs[1];

--- a/Source/WebCore/platform/graphics/cpu/arm/filters/FECompositeNeonArithmeticApplier.h
+++ b/Source/WebCore/platform/graphics/cpu/arm/filters/FECompositeNeonArithmeticApplier.h
@@ -49,7 +49,7 @@ private:
 
     static inline void applyPlatform(const uint8_t* source, uint8_t* destination, unsigned pixelArrayLength, float k1, float k2, float k3, float k4);
 
-    bool apply(const Filter&, const FilterImageVector& inputs, FilterImage& result) const final;
+    bool apply(const Filter&, std::span<const Ref<FilterImage>> inputs, FilterImage& result) const final;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/filters/FEColorMatrix.cpp
+++ b/Source/WebCore/platform/graphics/filters/FEColorMatrix.cpp
@@ -116,7 +116,7 @@ Vector<float> FEColorMatrix::normalizedFloats(const Vector<float>& values)
     return normalizedValues;
 }
 
-bool FEColorMatrix::resultIsAlphaImage(const FilterImageVector&) const
+bool FEColorMatrix::resultIsAlphaImage(std::span<const Ref<FilterImage>>) const
 {
     return m_type == ColorMatrixType::FECOLORMATRIX_TYPE_LUMINANCETOALPHA;
 }

--- a/Source/WebCore/platform/graphics/filters/FEColorMatrix.h
+++ b/Source/WebCore/platform/graphics/filters/FEColorMatrix.h
@@ -58,7 +58,7 @@ private:
 
     bool operator==(const FilterEffect& other) const override { return areEqual<FEColorMatrix>(*this, other); }
 
-    bool resultIsAlphaImage(const FilterImageVector& inputs) const override;
+    bool resultIsAlphaImage(std::span<const Ref<FilterImage>> inputs) const override;
 
     OptionSet<FilterRenderingMode> supportedFilterRenderingModes() const override;
 

--- a/Source/WebCore/platform/graphics/filters/FEDisplacementMap.cpp
+++ b/Source/WebCore/platform/graphics/filters/FEDisplacementMap.cpp
@@ -81,7 +81,7 @@ FloatRect FEDisplacementMap::calculateImageRect(const Filter& filter, std::span<
     return filter.maxEffectRect(primitiveSubregion);
 }
 
-const DestinationColorSpace& FEDisplacementMap::resultColorSpace(const FilterImageVector& inputs) const
+const DestinationColorSpace& FEDisplacementMap::resultColorSpace(std::span<const Ref<FilterImage>> inputs) const
 {
     // Spec: The 'color-interpolation-filters' property only applies to the 'in2' source image
     // and does not apply to the 'in' source image. The 'in' source image must remain in its
@@ -90,7 +90,7 @@ const DestinationColorSpace& FEDisplacementMap::resultColorSpace(const FilterIma
     return inputs[0]->colorSpace();
 }
 
-void FEDisplacementMap::transformInputsColorSpace(const FilterImageVector& inputs) const
+void FEDisplacementMap::transformInputsColorSpace(std::span<const Ref<FilterImage>> inputs) const
 {
     // Do not transform the first primitive input, as per the spec.
     ASSERT(inputs.size() == 2);

--- a/Source/WebCore/platform/graphics/filters/FEDisplacementMap.h
+++ b/Source/WebCore/platform/graphics/filters/FEDisplacementMap.h
@@ -61,8 +61,8 @@ private:
 
     FloatRect calculateImageRect(const Filter&, std::span<const FloatRect> inputImageRects, const FloatRect& primitiveSubregion) const override;
 
-    const DestinationColorSpace& resultColorSpace(const FilterImageVector&) const override;
-    void transformInputsColorSpace(const FilterImageVector& inputs) const override;
+    const DestinationColorSpace& resultColorSpace(std::span<const Ref<FilterImage>>) const override;
+    void transformInputsColorSpace(std::span<const Ref<FilterImage>> inputs) const override;
 
     std::unique_ptr<FilterEffectApplier> createSoftwareApplier() const override;
 

--- a/Source/WebCore/platform/graphics/filters/FEGaussianBlur.cpp
+++ b/Source/WebCore/platform/graphics/filters/FEGaussianBlur.cpp
@@ -148,7 +148,7 @@ IntOutsets FEGaussianBlur::calculateOutsets(const FloatSize& stdDeviation)
     return { outsetSize.height(), outsetSize.width(), outsetSize.height(), outsetSize.width() };
 }
 
-bool FEGaussianBlur::resultIsAlphaImage(const FilterImageVector& inputs) const
+bool FEGaussianBlur::resultIsAlphaImage(std::span<const Ref<FilterImage>> inputs) const
 {
     return inputs[0]->isAlphaImage();
 }

--- a/Source/WebCore/platform/graphics/filters/FEGaussianBlur.h
+++ b/Source/WebCore/platform/graphics/filters/FEGaussianBlur.h
@@ -57,7 +57,7 @@ private:
 
     FloatRect calculateImageRect(const Filter&, std::span<const FloatRect> inputImageRects, const FloatRect& primitiveSubregion) const override;
 
-    bool resultIsAlphaImage(const FilterImageVector& inputs) const override;
+    bool resultIsAlphaImage(std::span<const Ref<FilterImage>> inputs) const override;
 
     OptionSet<FilterRenderingMode> supportedFilterRenderingModes() const override;
 

--- a/Source/WebCore/platform/graphics/filters/FEMorphology.cpp
+++ b/Source/WebCore/platform/graphics/filters/FEMorphology.cpp
@@ -86,7 +86,7 @@ FloatRect FEMorphology::calculateImageRect(const Filter& filter, std::span<const
     return filter.clipToMaxEffectRect(imageRect, primitiveSubregion);
 }
 
-bool FEMorphology::resultIsAlphaImage(const FilterImageVector& inputs) const
+bool FEMorphology::resultIsAlphaImage(std::span<const Ref<FilterImage>> inputs) const
 {
     return inputs[0]->isAlphaImage();
 }

--- a/Source/WebCore/platform/graphics/filters/FEMorphology.h
+++ b/Source/WebCore/platform/graphics/filters/FEMorphology.h
@@ -56,7 +56,7 @@ private:
 
     FloatRect calculateImageRect(const Filter&, std::span<const FloatRect> inputImageRects, const FloatRect& primitiveSubregion) const override;
 
-    bool resultIsAlphaImage(const FilterImageVector& inputs) const override;
+    bool resultIsAlphaImage(std::span<const Ref<FilterImage>> inputs) const override;
 
     std::unique_ptr<FilterEffectApplier> createSoftwareApplier() const override;
 

--- a/Source/WebCore/platform/graphics/filters/FEOffset.cpp
+++ b/Source/WebCore/platform/graphics/filters/FEOffset.cpp
@@ -90,7 +90,7 @@ IntOutsets FEOffset::calculateOutsets(const FloatSize& offset)
     return outsets;
 }
 
-bool FEOffset::resultIsAlphaImage(const FilterImageVector& inputs) const
+bool FEOffset::resultIsAlphaImage(std::span<const Ref<FilterImage>> inputs) const
 {
     return inputs[0]->isAlphaImage();
 }

--- a/Source/WebCore/platform/graphics/filters/FEOffset.h
+++ b/Source/WebCore/platform/graphics/filters/FEOffset.h
@@ -49,7 +49,7 @@ private:
 
     FloatRect calculateImageRect(const Filter&, std::span<const FloatRect> inputImageRects, const FloatRect& primitiveSubregion) const override;
 
-    bool resultIsAlphaImage(const FilterImageVector& inputs) const override;
+    bool resultIsAlphaImage(std::span<const Ref<FilterImage>> inputs) const override;
 
     std::unique_ptr<FilterEffectApplier> createSoftwareApplier() const override;
 

--- a/Source/WebCore/platform/graphics/filters/FETile.cpp
+++ b/Source/WebCore/platform/graphics/filters/FETile.cpp
@@ -43,7 +43,7 @@ FloatRect FETile::calculateImageRect(const Filter& filter, std::span<const Float
     return filter.maxEffectRect(primitiveSubregion);
 }
 
-bool FETile::resultIsAlphaImage(const FilterImageVector& inputs) const
+bool FETile::resultIsAlphaImage(std::span<const Ref<FilterImage>> inputs) const
 {
     return inputs[0]->isAlphaImage();
 }

--- a/Source/WebCore/platform/graphics/filters/FETile.h
+++ b/Source/WebCore/platform/graphics/filters/FETile.h
@@ -37,7 +37,7 @@ private:
 
     FloatRect calculateImageRect(const Filter&, std::span<const FloatRect> inputImageRects, const FloatRect& primitiveSubregion) const override;
 
-    bool resultIsAlphaImage(const FilterImageVector& inputs) const override;
+    bool resultIsAlphaImage(std::span<const Ref<FilterImage>> inputs) const override;
 
     std::unique_ptr<FilterEffectApplier> createSoftwareApplier() const override;
 

--- a/Source/WebCore/platform/graphics/filters/FilterEffect.h
+++ b/Source/WebCore/platform/graphics/filters/FilterEffect.h
@@ -51,7 +51,7 @@ public:
     unsigned numberOfImageInputs() const { return filterType() == FilterEffect::Type::SourceGraphic ? 1 : numberOfEffectInputs(); }
     FilterImageVector takeImageInputs(FilterImageVector& stack) const;
 
-    RefPtr<FilterImage> apply(const Filter&, const FilterImageVector& inputs, FilterResults&, const std::optional<FilterEffectGeometry>& = std::nullopt);
+    RefPtr<FilterImage> apply(const Filter&, std::span<const Ref<FilterImage>> inputs, FilterResults&, const std::optional<FilterEffectGeometry>& = std::nullopt);
     FilterStyle createFilterStyle(GraphicsContext&, const Filter&, const FilterStyle& input, const std::optional<FilterEffectGeometry>& = std::nullopt) const;
 
     WTF::TextStream& externalRepresentation(WTF::TextStream&, FilterRepresentation) const override;
@@ -73,15 +73,15 @@ protected:
     virtual FloatRect calculateImageRect(const Filter&, std::span<const FloatRect> inputImageRects, const FloatRect& primitiveSubregion) const;
 
     // Solid black image with different alpha values.
-    virtual bool resultIsAlphaImage(const FilterImageVector&) const { return false; }
+    virtual bool resultIsAlphaImage(std::span<const Ref<FilterImage>>) const { return false; }
 
     virtual bool resultIsValidPremultiplied() const { return true; }
 
-    virtual const DestinationColorSpace& resultColorSpace(const FilterImageVector&) const { return m_operatingColorSpace; }
+    virtual const DestinationColorSpace& resultColorSpace(std::span<const Ref<FilterImage>>) const { return m_operatingColorSpace; }
 
-    virtual void transformInputsColorSpace(const FilterImageVector& inputs) const;
+    virtual void transformInputsColorSpace(std::span<const Ref<FilterImage>> inputs) const;
     
-    void correctPremultipliedInputs(const FilterImageVector& inputs) const;
+    void correctPremultipliedInputs(std::span<const Ref<FilterImage>> inputs) const;
 
     std::unique_ptr<FilterEffectApplier> createApplier(const Filter&) const;
 

--- a/Source/WebCore/platform/graphics/filters/FilterEffectApplier.h
+++ b/Source/WebCore/platform/graphics/filters/FilterEffectApplier.h
@@ -43,7 +43,7 @@ public:
     FilterEffectApplier() = default;
     virtual ~FilterEffectApplier() = default;
     
-    virtual bool apply(const Filter&, const FilterImageVector& inputs, FilterImage& result) const = 0;
+    virtual bool apply(const Filter&, std::span<const Ref<FilterImage>> inputs, FilterImage& result) const = 0;
 };
 
 template<typename FilterEffectType>

--- a/Source/WebCore/platform/graphics/filters/FilterResults.cpp
+++ b/Source/WebCore/platform/graphics/filters/FilterResults.cpp
@@ -65,7 +65,7 @@ bool FilterResults::canCacheResult(const FilterImage& result) const
     return totalMemoryCost <= maxAllowedMemoryCost;
 }
 
-void FilterResults::setEffectResult(FilterEffect& effect, const FilterImageVector& inputs, Ref<FilterImage>&& result)
+void FilterResults::setEffectResult(FilterEffect& effect, std::span<const Ref<FilterImage>> inputs, Ref<FilterImage>&& result)
 {
     if (!canCacheResult(result))
         return;

--- a/Source/WebCore/platform/graphics/filters/FilterResults.h
+++ b/Source/WebCore/platform/graphics/filters/FilterResults.h
@@ -45,7 +45,7 @@ public:
     ImageBufferAllocator& allocator() const { return *m_allocator; }
 
     FilterImage* effectResult(FilterEffect&) const;
-    void setEffectResult(FilterEffect&, const FilterImageVector& inputs, Ref<FilterImage>&& result);
+    void setEffectResult(FilterEffect&, std::span<const Ref<FilterImage>> inputs, Ref<FilterImage>&& result);
     void clearEffectResult(FilterEffect&);
 
 private:

--- a/Source/WebCore/platform/graphics/filters/skia/FEColorMatrixSkiaApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/skia/FEColorMatrixSkiaApplier.cpp
@@ -43,7 +43,7 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(FEColorMatrixSkiaApplier);
 
-bool FEColorMatrixSkiaApplier::apply(const Filter&, const FilterImageVector& inputs, FilterImage& result) const
+bool FEColorMatrixSkiaApplier::apply(const Filter&, std::span<const Ref<FilterImage>> inputs, FilterImage& result) const
 {
     ASSERT(inputs.size() == 1);
     Ref input = inputs[0];

--- a/Source/WebCore/platform/graphics/filters/skia/FEColorMatrixSkiaApplier.h
+++ b/Source/WebCore/platform/graphics/filters/skia/FEColorMatrixSkiaApplier.h
@@ -42,7 +42,7 @@ public:
     using Base::Base;
 
 private:
-    bool apply(const Filter&, const FilterImageVector&, FilterImage&) const final;
+    bool apply(const Filter&, std::span<const Ref<FilterImage>>, FilterImage&) const final;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/filters/skia/FEComponentTransferSkiaApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/skia/FEComponentTransferSkiaApplier.cpp
@@ -43,7 +43,7 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(FEComponentTransferSkiaApplier);
 
-bool FEComponentTransferSkiaApplier::apply(const Filter&, const FilterImageVector& inputs, FilterImage& result) const
+bool FEComponentTransferSkiaApplier::apply(const Filter&, std::span<const Ref<FilterImage>> inputs, FilterImage& result) const
 {
     ASSERT(inputs.size() == 1);
     Ref input = inputs[0];

--- a/Source/WebCore/platform/graphics/filters/skia/FEComponentTransferSkiaApplier.h
+++ b/Source/WebCore/platform/graphics/filters/skia/FEComponentTransferSkiaApplier.h
@@ -43,7 +43,7 @@ public:
     using Base::Base;
 
 private:
-    bool apply(const Filter&, const FilterImageVector&, FilterImage&) const final;
+    bool apply(const Filter&, std::span<const Ref<FilterImage>>, FilterImage&) const final;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/filters/skia/FEDropShadowSkiaApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/skia/FEDropShadowSkiaApplier.cpp
@@ -44,7 +44,7 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(FEDropShadowSkiaApplier);
 
-bool FEDropShadowSkiaApplier::apply(const Filter& filter, const FilterImageVector& inputs, FilterImage& result) const
+bool FEDropShadowSkiaApplier::apply(const Filter& filter, std::span<const Ref<FilterImage>> inputs, FilterImage& result) const
 {
     ASSERT(inputs.size() == 1);
     Ref input = inputs[0];

--- a/Source/WebCore/platform/graphics/filters/skia/FEDropShadowSkiaApplier.h
+++ b/Source/WebCore/platform/graphics/filters/skia/FEDropShadowSkiaApplier.h
@@ -42,7 +42,7 @@ public:
     using Base::Base;
 
 private:
-    bool apply(const Filter&, const FilterImageVector&, FilterImage&) const final;
+    bool apply(const Filter&, std::span<const Ref<FilterImage>>, FilterImage&) const final;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/filters/skia/FEGaussianBlurSkiaApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/skia/FEGaussianBlurSkiaApplier.cpp
@@ -43,7 +43,7 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(FEGaussianBlurSkiaApplier);
 
-bool FEGaussianBlurSkiaApplier::apply(const Filter& filter, const FilterImageVector& inputs, FilterImage& result) const
+bool FEGaussianBlurSkiaApplier::apply(const Filter& filter, std::span<const Ref<FilterImage>> inputs, FilterImage& result) const
 {
     ASSERT(inputs.size() == 1);
     Ref input = inputs[0];

--- a/Source/WebCore/platform/graphics/filters/skia/FEGaussianBlurSkiaApplier.h
+++ b/Source/WebCore/platform/graphics/filters/skia/FEGaussianBlurSkiaApplier.h
@@ -40,7 +40,7 @@ public:
     using Base::Base;
 
 private:
-    bool apply(const Filter&, const FilterImageVector&, FilterImage&) const final;
+    bool apply(const Filter&, std::span<const Ref<FilterImage>>, FilterImage&) const final;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/filters/skia/SourceGraphicSkiaApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/skia/SourceGraphicSkiaApplier.cpp
@@ -42,7 +42,7 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(SourceGraphicSkiaApplier);
 
-bool SourceGraphicSkiaApplier::apply(const Filter&, const FilterImageVector& inputs, FilterImage& result) const
+bool SourceGraphicSkiaApplier::apply(const Filter&, std::span<const Ref<FilterImage>> inputs, FilterImage& result) const
 {
     Ref input = inputs[0];
 

--- a/Source/WebCore/platform/graphics/filters/skia/SourceGraphicSkiaApplier.h
+++ b/Source/WebCore/platform/graphics/filters/skia/SourceGraphicSkiaApplier.h
@@ -41,7 +41,7 @@ public:
     using Base::Base;
 
 private:
-    bool apply(const Filter&, const FilterImageVector&, FilterImage&) const final;
+    bool apply(const Filter&, std::span<const Ref<FilterImage>>, FilterImage&) const final;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/filters/software/FEBlendSoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FEBlendSoftwareApplier.cpp
@@ -38,7 +38,7 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(FEBlendSoftwareApplier);
 
-bool FEBlendSoftwareApplier::apply(const Filter&, const FilterImageVector& inputs, FilterImage& result) const
+bool FEBlendSoftwareApplier::apply(const Filter&, std::span<const Ref<FilterImage>> inputs, FilterImage& result) const
 {
     Ref input = inputs[0];
     Ref input2 = inputs[1];

--- a/Source/WebCore/platform/graphics/filters/software/FEBlendSoftwareApplier.h
+++ b/Source/WebCore/platform/graphics/filters/software/FEBlendSoftwareApplier.h
@@ -40,7 +40,7 @@ public:
     using Base::Base;
 
 private:
-    bool apply(const Filter&, const FilterImageVector& inputs, FilterImage& result) const final;
+    bool apply(const Filter&, std::span<const Ref<FilterImage>> inputs, FilterImage& result) const final;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/filters/software/FEColorMatrixSoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FEColorMatrixSoftwareApplier.cpp
@@ -257,7 +257,7 @@ void FEColorMatrixSoftwareApplier::applyPlatform(PixelBuffer& pixelBuffer) const
     applyPlatformUnaccelerated(pixelBuffer);
 }
 
-bool FEColorMatrixSoftwareApplier::apply(const Filter&, const FilterImageVector& inputs, FilterImage& result) const
+bool FEColorMatrixSoftwareApplier::apply(const Filter&, std::span<const Ref<FilterImage>> inputs, FilterImage& result) const
 {
     Ref input = inputs[0];
 

--- a/Source/WebCore/platform/graphics/filters/software/FEColorMatrixSoftwareApplier.h
+++ b/Source/WebCore/platform/graphics/filters/software/FEColorMatrixSoftwareApplier.h
@@ -39,7 +39,7 @@ public:
     FEColorMatrixSoftwareApplier(const FEColorMatrix&);
 
 private:
-    bool apply(const Filter&, const FilterImageVector& inputs, FilterImage& result) const final;
+    bool apply(const Filter&, std::span<const Ref<FilterImage>> inputs, FilterImage& result) const final;
 
     inline void matrix(float& red, float& green, float& blue, float& alpha) const;
     inline void saturateAndHueRotate(float& red, float& green, float& blue) const;

--- a/Source/WebCore/platform/graphics/filters/software/FEComponentTransferSoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FEComponentTransferSoftwareApplier.cpp
@@ -55,7 +55,7 @@ void FEComponentTransferSoftwareApplier::applyPlatform(PixelBuffer& pixelBuffer)
     }
 }
 
-bool FEComponentTransferSoftwareApplier::apply(const Filter&, const FilterImageVector& inputs, FilterImage& result) const
+bool FEComponentTransferSoftwareApplier::apply(const Filter&, std::span<const Ref<FilterImage>> inputs, FilterImage& result) const
 {
     Ref input = inputs[0];
     

--- a/Source/WebCore/platform/graphics/filters/software/FEComponentTransferSoftwareApplier.h
+++ b/Source/WebCore/platform/graphics/filters/software/FEComponentTransferSoftwareApplier.h
@@ -39,7 +39,7 @@ public:
     using Base::Base;
 
 private:
-    bool apply(const Filter&, const FilterImageVector& inputs, FilterImage& result) const final;
+    bool apply(const Filter&, std::span<const Ref<FilterImage>> inputs, FilterImage& result) const final;
 
     void applyPlatform(PixelBuffer&) const;
 };

--- a/Source/WebCore/platform/graphics/filters/software/FECompositeSoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FECompositeSoftwareApplier.cpp
@@ -42,7 +42,7 @@ FECompositeSoftwareApplier::FECompositeSoftwareApplier(const FEComposite& effect
     ASSERT(m_effect->operation() != CompositeOperationType::FECOMPOSITE_OPERATOR_ARITHMETIC);
 }
 
-bool FECompositeSoftwareApplier::apply(const Filter&, const FilterImageVector& inputs, FilterImage& result) const
+bool FECompositeSoftwareApplier::apply(const Filter&, std::span<const Ref<FilterImage>> inputs, FilterImage& result) const
 {
     Ref input = inputs[0];
     Ref input2 = inputs[1];

--- a/Source/WebCore/platform/graphics/filters/software/FECompositeSoftwareApplier.h
+++ b/Source/WebCore/platform/graphics/filters/software/FECompositeSoftwareApplier.h
@@ -37,7 +37,7 @@ public:
     FECompositeSoftwareApplier(const FEComposite&);
 
 private:
-    bool apply(const Filter&, const FilterImageVector& inputs, FilterImage& result) const final;
+    bool apply(const Filter&, std::span<const Ref<FilterImage>> inputs, FilterImage& result) const final;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/filters/software/FECompositeSoftwareArithmeticApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FECompositeSoftwareArithmeticApplier.cpp
@@ -131,7 +131,7 @@ inline void FECompositeSoftwareArithmeticApplier::applyPlatform(std::span<unsign
     }
 }
 
-bool FECompositeSoftwareArithmeticApplier::apply(const Filter&, const FilterImageVector& inputs, FilterImage& result) const
+bool FECompositeSoftwareArithmeticApplier::apply(const Filter&, std::span<const Ref<FilterImage>> inputs, FilterImage& result) const
 {
     Ref input = inputs[0];
     Ref input2 = inputs[1];

--- a/Source/WebCore/platform/graphics/filters/software/FECompositeSoftwareArithmeticApplier.h
+++ b/Source/WebCore/platform/graphics/filters/software/FECompositeSoftwareArithmeticApplier.h
@@ -49,7 +49,7 @@ private:
 
     static inline void applyPlatform(std::span<unsigned char> source, std::span<unsigned char> destination, int pixelArrayLength, float k1, float k2, float k3, float k4);
 
-    bool apply(const Filter&, const FilterImageVector& inputs, FilterImage& result) const final;
+    bool apply(const Filter&, std::span<const Ref<FilterImage>> inputs, FilterImage& result) const final;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/filters/software/FEConvolveMatrixSoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FEConvolveMatrixSoftwareApplier.cpp
@@ -302,7 +302,7 @@ void FEConvolveMatrixSoftwareApplier::applyPlatform(PaintingData& paintingData) 
         setOuterPixels(paintingData, clipRight, paintingData.targetOffset.y(), paintingData.width, clipBottom);
 }
 
-bool FEConvolveMatrixSoftwareApplier::apply(const Filter&, const FilterImageVector& inputs, FilterImage& result) const
+bool FEConvolveMatrixSoftwareApplier::apply(const Filter&, std::span<const Ref<FilterImage>> inputs, FilterImage& result) const
 {
     Ref input = inputs[0];
 

--- a/Source/WebCore/platform/graphics/filters/software/FEConvolveMatrixSoftwareApplier.h
+++ b/Source/WebCore/platform/graphics/filters/software/FEConvolveMatrixSoftwareApplier.h
@@ -44,7 +44,7 @@ public:
     FEConvolveMatrixSoftwareApplier(const FEConvolveMatrix& effect);
 
 private:
-    bool apply(const Filter&, const FilterImageVector& inputs, FilterImage& result) const final;
+    bool apply(const Filter&, std::span<const Ref<FilterImage>> inputs, FilterImage& result) const final;
 
     struct PaintingData {
         const Ref<const PixelBuffer> sourcePixelBuffer;

--- a/Source/WebCore/platform/graphics/filters/software/FEDisplacementMapSoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FEDisplacementMapSoftwareApplier.cpp
@@ -53,7 +53,7 @@ int FEDisplacementMapSoftwareApplier::yChannelIndex() const
     return static_cast<int>(m_effect->yChannelSelector()) - 1;
 }
 
-bool FEDisplacementMapSoftwareApplier::apply(const Filter& filter, const FilterImageVector& inputs, FilterImage& result) const
+bool FEDisplacementMapSoftwareApplier::apply(const Filter& filter, std::span<const Ref<FilterImage>> inputs, FilterImage& result) const
 {
     Ref input = inputs[0];
     Ref input2 = inputs[1];

--- a/Source/WebCore/platform/graphics/filters/software/FEDisplacementMapSoftwareApplier.h
+++ b/Source/WebCore/platform/graphics/filters/software/FEDisplacementMapSoftwareApplier.h
@@ -37,7 +37,7 @@ public:
     FEDisplacementMapSoftwareApplier(const FEDisplacementMap&);
 
 private:
-    bool apply(const Filter&, const FilterImageVector& inputs, FilterImage& result) const final;
+    bool apply(const Filter&, std::span<const Ref<FilterImage>> inputs, FilterImage& result) const final;
 
     static inline unsigned byteOffsetOfPixel(unsigned x, unsigned y, unsigned rowBytes)
     {

--- a/Source/WebCore/platform/graphics/filters/software/FEDropShadowSoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FEDropShadowSoftwareApplier.cpp
@@ -33,7 +33,7 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(FEDropShadowSoftwareApplier);
 
-bool FEDropShadowSoftwareApplier::apply(const Filter& filter, const FilterImageVector& inputs, FilterImage& result) const
+bool FEDropShadowSoftwareApplier::apply(const Filter& filter, std::span<const Ref<FilterImage>> inputs, FilterImage& result) const
 {
     Ref input = inputs[0];
 

--- a/Source/WebCore/platform/graphics/filters/software/FEDropShadowSoftwareApplier.h
+++ b/Source/WebCore/platform/graphics/filters/software/FEDropShadowSoftwareApplier.h
@@ -35,7 +35,7 @@ public:
     using Base::Base;
 
 private:
-    bool apply(const Filter&, const FilterImageVector& inputs, FilterImage& result) const final;
+    bool apply(const Filter&, std::span<const Ref<FilterImage>> inputs, FilterImage& result) const final;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/filters/software/FEFloodSoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FEFloodSoftwareApplier.cpp
@@ -33,7 +33,7 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(FEFloodSoftwareApplier);
 
-bool FEFloodSoftwareApplier::apply(const Filter&, const FilterImageVector&, FilterImage& result) const
+bool FEFloodSoftwareApplier::apply(const Filter&, std::span<const Ref<FilterImage>>, FilterImage& result) const
 {
     RefPtr resultImage = result.imageBuffer();
     if (!resultImage)

--- a/Source/WebCore/platform/graphics/filters/software/FEFloodSoftwareApplier.h
+++ b/Source/WebCore/platform/graphics/filters/software/FEFloodSoftwareApplier.h
@@ -37,7 +37,7 @@ public:
     using Base::Base;
 
 private:
-    bool apply(const Filter&, const FilterImageVector& inputs, FilterImage& result) const final;
+    bool apply(const Filter&, std::span<const Ref<FilterImage>> inputs, FilterImage& result) const final;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/filters/software/FEGaussianBlurSoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FEGaussianBlurSoftwareApplier.cpp
@@ -430,7 +430,7 @@ inline void FEGaussianBlurSoftwareApplier::applyPlatform(PixelBuffer& ioBuffer, 
     boxBlurGeneric(ioBuffer, tempBuffer, kernelSizeX, kernelSizeY, paintSize, isAlphaImage, edgeMode);
 }
 
-bool FEGaussianBlurSoftwareApplier::apply(const Filter& filter, const FilterImageVector& inputs, FilterImage& result) const
+bool FEGaussianBlurSoftwareApplier::apply(const Filter& filter, std::span<const Ref<FilterImage>> inputs, FilterImage& result) const
 {
     Ref input = inputs[0];
 

--- a/Source/WebCore/platform/graphics/filters/software/FEGaussianBlurSoftwareApplier.h
+++ b/Source/WebCore/platform/graphics/filters/software/FEGaussianBlurSoftwareApplier.h
@@ -41,7 +41,7 @@ public:
     using Base::Base;
 
 private:
-    bool apply(const Filter&, const FilterImageVector& inputs, FilterImage& result) const final;
+    bool apply(const Filter&, std::span<const Ref<FilterImage>> inputs, FilterImage& result) const final;
 
     struct ApplyParameters {
         RefPtr<PixelBuffer> ioBuffer;

--- a/Source/WebCore/platform/graphics/filters/software/FEImageSoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FEImageSoftwareApplier.cpp
@@ -35,7 +35,7 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(FEImageSoftwareApplier);
 
-bool FEImageSoftwareApplier::apply(const Filter& filter, const FilterImageVector&, FilterImage& result) const
+bool FEImageSoftwareApplier::apply(const Filter& filter, std::span<const Ref<FilterImage>>, FilterImage& result) const
 {
     RefPtr resultImage = result.imageBuffer();
     if (!resultImage)

--- a/Source/WebCore/platform/graphics/filters/software/FEImageSoftwareApplier.h
+++ b/Source/WebCore/platform/graphics/filters/software/FEImageSoftwareApplier.h
@@ -40,7 +40,7 @@ public:
     using Base::Base;
 
 private:
-    bool apply(const Filter&, const FilterImageVector& inputs, FilterImage& result) const final;
+    bool apply(const Filter&, std::span<const Ref<FilterImage>> inputs, FilterImage& result) const final;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/filters/software/FELightingSoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FELightingSoftwareApplier.cpp
@@ -172,7 +172,7 @@ void FELightingSoftwareApplier::applyPlatform(const LightingData& data) const
     }
 }
 
-bool FELightingSoftwareApplier::apply(const Filter& filter, const FilterImageVector& inputs, FilterImage& result) const
+bool FELightingSoftwareApplier::apply(const Filter& filter, std::span<const Ref<FilterImage>> inputs, FilterImage& result) const
 {
     Ref input = inputs[0];
 

--- a/Source/WebCore/platform/graphics/filters/software/FELightingSoftwareApplier.h
+++ b/Source/WebCore/platform/graphics/filters/software/FELightingSoftwareApplier.h
@@ -124,7 +124,7 @@ protected:
 
     virtual void applyPlatformParallel(const LightingData&, const LightSource::PaintingData&) const = 0;
     void applyPlatform(const LightingData&) const;
-    bool apply(const Filter&, const FilterImageVector& inputs, FilterImage& result) const final;
+    bool apply(const Filter&, std::span<const Ref<FilterImage>> inputs, FilterImage& result) const final;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/filters/software/FEMergeSoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FEMergeSoftwareApplier.cpp
@@ -32,7 +32,7 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(FEMergeSoftwareApplier);
 
-bool FEMergeSoftwareApplier::apply(const Filter&, const FilterImageVector& inputs, FilterImage& result) const
+bool FEMergeSoftwareApplier::apply(const Filter&, std::span<const Ref<FilterImage>> inputs, FilterImage& result) const
 {
     ASSERT(inputs.size() == m_effect->numberOfEffectInputs());
 

--- a/Source/WebCore/platform/graphics/filters/software/FEMergeSoftwareApplier.h
+++ b/Source/WebCore/platform/graphics/filters/software/FEMergeSoftwareApplier.h
@@ -37,7 +37,7 @@ public:
     using Base::Base;
 
 private:
-    bool apply(const Filter&, const FilterImageVector& inputs, FilterImage& result) const final;
+    bool apply(const Filter&, std::span<const Ref<FilterImage>> inputs, FilterImage& result) const final;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/filters/software/FEMorphologySoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FEMorphologySoftwareApplier.cpp
@@ -145,7 +145,7 @@ void FEMorphologySoftwareApplier::applyPlatform(const PaintingData& paintingData
     applyPlatformGeneric(paintingData, 0, paintingData.height);
 }
 
-bool FEMorphologySoftwareApplier::apply(const Filter& filter, const FilterImageVector& inputs, FilterImage& result) const
+bool FEMorphologySoftwareApplier::apply(const Filter& filter, std::span<const Ref<FilterImage>> inputs, FilterImage& result) const
 {
     Ref input = inputs[0];
 

--- a/Source/WebCore/platform/graphics/filters/software/FEMorphologySoftwareApplier.h
+++ b/Source/WebCore/platform/graphics/filters/software/FEMorphologySoftwareApplier.h
@@ -42,7 +42,7 @@ public:
     using Base::Base;
 
 private:
-    bool apply(const Filter&, const FilterImageVector& inputs, FilterImage& result) const final;
+    bool apply(const Filter&, std::span<const Ref<FilterImage>> inputs, FilterImage& result) const final;
 
     using ColumnExtrema = Vector<ColorComponents<uint8_t, 4>, 16>;
 

--- a/Source/WebCore/platform/graphics/filters/software/FEOffsetSoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FEOffsetSoftwareApplier.cpp
@@ -35,7 +35,7 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(FEOffsetSoftwareApplier);
 
-bool FEOffsetSoftwareApplier::apply(const Filter& filter, const FilterImageVector& inputs, FilterImage& result) const
+bool FEOffsetSoftwareApplier::apply(const Filter& filter, std::span<const Ref<FilterImage>> inputs, FilterImage& result) const
 {
     Ref input = inputs[0];
 

--- a/Source/WebCore/platform/graphics/filters/software/FEOffsetSoftwareApplier.h
+++ b/Source/WebCore/platform/graphics/filters/software/FEOffsetSoftwareApplier.h
@@ -37,7 +37,7 @@ public:
     using Base::Base;
 
 private:
-    bool apply(const Filter&, const FilterImageVector& inputs, FilterImage& result) const final;
+    bool apply(const Filter&, std::span<const Ref<FilterImage>> inputs, FilterImage& result) const final;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/filters/software/FETileSoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FETileSoftwareApplier.cpp
@@ -34,7 +34,7 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(FETileSoftwareApplier);
 
-bool FETileSoftwareApplier::apply(const Filter& filter, const FilterImageVector& inputs, FilterImage& result) const
+bool FETileSoftwareApplier::apply(const Filter& filter, std::span<const Ref<FilterImage>> inputs, FilterImage& result) const
 {
     Ref input = inputs[0];
 

--- a/Source/WebCore/platform/graphics/filters/software/FETileSoftwareApplier.h
+++ b/Source/WebCore/platform/graphics/filters/software/FETileSoftwareApplier.h
@@ -37,7 +37,7 @@ public:
     using Base::Base;
 
 private:
-    bool apply(const Filter&, const FilterImageVector& inputs, FilterImage& result) const final;
+    bool apply(const Filter&, std::span<const Ref<FilterImage>> inputs, FilterImage& result) const final;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/filters/software/FETurbulenceSoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FETurbulenceSoftwareApplier.cpp
@@ -342,7 +342,7 @@ void FETurbulenceSoftwareApplier::applyPlatform(const IntRect& filterRegion, con
     applyPlatformGeneric(filterRegion, filterScale, pixelBuffer, paintingData, stitchData, 0, height);
 }
 
-bool FETurbulenceSoftwareApplier::apply(const Filter& filter, const FilterImageVector&, FilterImage& result) const
+bool FETurbulenceSoftwareApplier::apply(const Filter& filter, std::span<const Ref<FilterImage>>, FilterImage& result) const
 {
     RefPtr destinationPixelBuffer = result.pixelBuffer(AlphaPremultiplication::Unpremultiplied);
     if (!destinationPixelBuffer)

--- a/Source/WebCore/platform/graphics/filters/software/FETurbulenceSoftwareApplier.h
+++ b/Source/WebCore/platform/graphics/filters/software/FETurbulenceSoftwareApplier.h
@@ -45,7 +45,7 @@ public:
     using Base::Base;
 
 private:
-    bool apply(const Filter&, const FilterImageVector& inputs, FilterImage& result) const final;
+    bool apply(const Filter&, std::span<const Ref<FilterImage>> inputs, FilterImage& result) const final;
 
     // Produces results in the range [1, 2**31 - 2]. Algorithm is:
     // r = (a * r) mod m where a = s_randAmplitude = 16807 and

--- a/Source/WebCore/platform/graphics/filters/software/SourceAlphaSoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/SourceAlphaSoftwareApplier.cpp
@@ -31,7 +31,7 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(SourceAlphaSoftwareApplier);
 
-bool SourceAlphaSoftwareApplier::apply(const Filter&, const FilterImageVector& inputs, FilterImage& result) const
+bool SourceAlphaSoftwareApplier::apply(const Filter&, std::span<const Ref<FilterImage>> inputs, FilterImage& result) const
 {
     Ref input = inputs[0];
 

--- a/Source/WebCore/platform/graphics/filters/software/SourceAlphaSoftwareApplier.h
+++ b/Source/WebCore/platform/graphics/filters/software/SourceAlphaSoftwareApplier.h
@@ -35,7 +35,7 @@ public:
     using Base::Base;
 
 private:
-    bool apply(const Filter&, const FilterImageVector& inputs, FilterImage& result) const final;
+    bool apply(const Filter&, std::span<const Ref<FilterImage>> inputs, FilterImage& result) const final;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/filters/software/SourceGraphicSoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/SourceGraphicSoftwareApplier.cpp
@@ -30,7 +30,7 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(SourceGraphicSoftwareApplier);
 
-bool SourceGraphicSoftwareApplier::apply(const Filter&, const FilterImageVector& inputs, FilterImage& result) const
+bool SourceGraphicSoftwareApplier::apply(const Filter&, std::span<const Ref<FilterImage>> inputs, FilterImage& result) const
 {
     Ref input = inputs[0];
 

--- a/Source/WebCore/platform/graphics/filters/software/SourceGraphicSoftwareApplier.h
+++ b/Source/WebCore/platform/graphics/filters/software/SourceGraphicSoftwareApplier.h
@@ -35,7 +35,7 @@ public:
     using Base::Base;
 
 private:
-    bool apply(const Filter&, const FilterImageVector& inputs, FilterImage& result) const final;
+    bool apply(const Filter&, std::span<const Ref<FilterImage>> inputs, FilterImage& result) const final;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 9c5696c73fd5c8e2563e78fe679a095effaf411d
<pre>
Update FilterEffect::apply() to take in a span instead of a `const Vector&amp;`
<a href="https://bugs.webkit.org/show_bug.cgi?id=292906">https://bugs.webkit.org/show_bug.cgi?id=292906</a>

Reviewed by Darin Adler.

Update FilterEffect::apply() to take in a span instead of a `const Vector&amp;`. This
avoids having to construct a Vector at one of the call sites.

Source/WebCore/platform/graphics/filters/FilterEffect.cpp:
(WebCore::FilterEffect::takeImageInputs):
Optimize function by leveraging the `Vector(size_t, Generator)` constructor.
This is a bit more efficient as it avoids the capacity checks in append().
Also avoid repeatedly calling takeLast() on the stack and instead just move
the value out of the stack and call `shrink()` once at the end.

Canonical link: <a href="https://commits.webkit.org/294878@main">https://commits.webkit.org/294878@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ee295676ebc12955c97791ae1c8f399a5bb04bf7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/103326 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/23002 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/13323 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/108499 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/53969 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/105365 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/23342 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/31553 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78523 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/35459 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/106332 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/18093 "layout-tests (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/93215 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58856 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/17930 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/11256 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/53325 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/87731 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/11318 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/110874 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/30464 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/22493 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/87520 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/30829 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/89412 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87157 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22198 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32017 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/9739 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/24798 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/30393 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/35712 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/30199 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/33526 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/31761 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->