### PR TITLE
[Content Filtering] Update URL filter enablement state on notification

### DIFF
--- a/Source/WebCore/platform/cocoa/ParentalControlsURLFilter.h
+++ b/Source/WebCore/platform/cocoa/ParentalControlsURLFilter.h
@@ -40,6 +40,7 @@ public:
     static ParentalControlsURLFilter& singleton();
 #endif
 
+    void resetIsEnabled();
     bool isEnabled() const;
     void isURLAllowed(const URL&, CompletionHandler<void(bool, NSData *)>&&);
     void allowURL(const URL&, CompletionHandler<void(bool)>&&);
@@ -50,8 +51,13 @@ private:
 #else
     ParentalControlsURLFilter();
 #endif
+    RetainPtr<WCRBrowserEngineClient> effectiveWCRBrowserEngineClient();
 
+    mutable std::optional<bool> m_isEnabled;
     RetainPtr<WCRBrowserEngineClient> m_wcrBrowserEngineClient;
+#if HAVE(WEBCONTENTRESTRICTIONS_PATH_SPI)
+    String m_configurationPath;
+#endif
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 2ec218319042bd9f074eb16a6915d16e1940a5f0
<pre>
[Content Filtering] Update URL filter enablement state on notification
<a href="https://bugs.webkit.org/show_bug.cgi?id=292910">https://bugs.webkit.org/show_bug.cgi?id=292910</a>
<a href="https://rdar.apple.com/150803975">rdar://150803975</a>

Reviewed by Per Arne Vollan.

In current implementation, we only check the enablement state of WCRBrowserEngineClient once at when
ParentalControlsURLFilter is created. The problem is, user can turn on and off the feature in system settings when the
app is running, in which case ParentalControlsURLFilter should update its enablement state accordingly, and not to block
URLs if the feature is disabled.

To fix this, this patch makes ParentalControlsURLFilter keep track of the enablement state of WCRBrowserEngineClient
in m_isEnabled. When ParentalControlsURLFilter needs to use m_wcrBrowserEngineClient for operation, it will check
m_isEnabled first; it only performs the operation if value of m_isEnabled is true (true means the content filter is on).
On receiving notification about enablement state change of WCRBrowserEngineClient, ParentalControlsURLFilter resets
m_isEnabled and will get the state from WCRBrowserEngineClient again on next operation; this keeps m_isEnabled up to
date.

* Source/WebCore/platform/cocoa/ParentalControlsURLFilter.h:
* Source/WebCore/platform/cocoa/ParentalControlsURLFilter.mm:
(WebCore::allFiltersWithConfigurationPath):
(WebCore::ParentalControlsURLFilter::filterWithConfigurationPath):
(WebCore::ParentalControlsURLFilter::ParentalControlsURLFilter):
(WebCore::webContentFilterTypeDidChange):
(WebCore::registerNotificationForWebContentFilterTypeChange):
(WebCore::ParentalControlsURLFilter::resetIsEnabled):
(WebCore::ParentalControlsURLFilter::isEnabled const):
(WebCore::ParentalControlsURLFilter::isURLAllowed):
(WebCore::ParentalControlsURLFilter::allowURL):
(WebCore::ParentalControlsURLFilter::effectiveWCRBrowserEngineClient):

Canonical link: <a href="https://commits.webkit.org/294854@main">https://commits.webkit.org/294854@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/616afdb6842b750fd92f9989fa29e03086451c30

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/103261 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/22937 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/13257 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/108431 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/53904 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/105300 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/23274 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/31497 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78480 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/35407 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/106267 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/18039 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/93154 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58813 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/17880 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/11197 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/53259 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/87686 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/11259 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/110807 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/30399 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/22455 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/87476 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/30764 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/89353 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87110 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22177 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31966 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/9684 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/24722 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/30328 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/35647 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/30134 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/33461 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/31696 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->