### PR TITLE
[WPE] WPE Platform: add support for text/uri-list items in clipboard

### DIFF
--- a/Source/WebKit/WPEPlatform/wpe/WPEClipboard.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPEClipboard.h
@@ -77,9 +77,6 @@ WPE_API WPEClipboardContent *wpe_clipboard_content_ref        (WPEClipboardConte
 WPE_API void                 wpe_clipboard_content_unref      (WPEClipboardContent *content);
 WPE_API void                 wpe_clipboard_content_set_text   (WPEClipboardContent *content,
                                                                const char          *text);
-WPE_API void  	      	     wpe_clipboard_content_set_markup (WPEClipboardContent *content,
-                                                               const char          *markup,
-                                                               gssize               length);
 WPE_API void                 wpe_clipboard_content_set_bytes  (WPEClipboardContent *content,
                                                                const char          *format,
                                                                GBytes              *bytes);


### PR DESCRIPTION
#### 3c6d8ae984d705a3f8c17cae643c58b1b33456fd
<pre>
[WPE] WPE Platform: add support for text/uri-list items in clipboard
<a href="https://bugs.webkit.org/show_bug.cgi?id=292917">https://bugs.webkit.org/show_bug.cgi?id=292917</a>

Reviewed by Alejandro G. Castro.

And remove the API to set markup since it&apos;s just a wrapper around
wpe_clipboard_content_set_bytes().

* Source/WebKit/UIProcess/wpe/WebPasteboardProxyWPE.cpp:
(WebKit::setClipboardContentFromSpan):
(WebKit::WebPasteboardProxy::writeToClipboard):
(WebKit::WebPasteboardProxy::writeCustomData):
(WebKit::pasteboardItemInfoFromFormats):
* Source/WebKit/WPEPlatform/wpe/WPEClipboard.cpp:
(wpe_clipboard_set_content):
(wpe_clipboard_content_serialize):
(wpe_clipboard_content_set_markup): Deleted.
* Source/WebKit/WPEPlatform/wpe/WPEClipboard.h:

Canonical link: <a href="https://commits.webkit.org/294837@main">https://commits.webkit.org/294837@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8fa103b816758b2b18b18d83a3253e3b8c96f800

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/103273 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/22949 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/13269 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/108444 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/53916 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/23288 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/31488 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/78488 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/35414 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/106279 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/18050 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/93165 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58821 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/17890 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/53271 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/87696 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/11269 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/110819 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/30411 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/22447 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/87484 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/30776 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/89363 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/87120 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31976 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/9691 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/24734 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16755 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/30340 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/35659 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/30146 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/33473 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/31708 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->