### PR TITLE
Video player in Reddit doesn’t hide the progress bar for linked YouTube videos on iOS

### DIFF
--- a/LayoutTests/fast/css/match-result-cache-with-fast-path-inheritance-expected.html
+++ b/LayoutTests/fast/css/match-result-cache-with-fast-path-inheritance-expected.html
@@ -1,0 +1,4 @@
+<style>
+.square { width: 100px; height: 100px; background-color: green; }
+</style>
+<div class=square></div>

--- a/LayoutTests/fast/css/match-result-cache-with-fast-path-inheritance.html
+++ b/LayoutTests/fast/css/match-result-cache-with-fast-path-inheritance.html
@@ -1,0 +1,17 @@
+<style>
+.hidden { visibility: hidden }
+.square { width: 100px; height: 100px; }
+</style>
+<div id=c class=hidden>
+    <div id=t class=square></div>
+</div>
+<script>
+// Save to match result cache.
+t.style.backgroundColor = "red";
+document.body.offsetLeft;
+// Trigger fast-path inheritance.
+c.classList.remove("hidden");
+document.body.offsetLeft;
+// Retrieve from match result cache.
+t.style.backgroundColor = "green";
+</script>

--- a/Source/WebCore/style/MatchResultCache.cpp
+++ b/Source/WebCore/style/MatchResultCache.cpp
@@ -170,6 +170,14 @@ void MatchResultCache::update(CachedMatchResult& result, const RenderStyle& styl
     result.styleToUpdate.get() = RenderStyle::clone(style);
 }
 
+void MatchResultCache::updateForFastPathInherit(const Element& element, const RenderStyle& parentStyle)
+{
+    auto entry = m_entries.get(element);
+    if (!entry)
+        return;
+    entry->unadjustedStyle.style->fastPathInheritFrom(parentStyle);
+}
+
 void MatchResultCache::set(const Element& element, const UnadjustedStyle& unadjustedStyle)
 {
     // For now we cache match results if there is mutable inline style. This way we can avoid

--- a/Source/WebCore/style/MatchResultCache.h
+++ b/Source/WebCore/style/MatchResultCache.h
@@ -50,6 +50,7 @@ public:
 
     const std::optional<CachedMatchResult> resultWithCurrentInlineStyle(const Element&);
     static void update(CachedMatchResult&, const RenderStyle&);
+    void updateForFastPathInherit(const Element&, const RenderStyle& parentStyle);
     void set(const Element&, const UnadjustedStyle&);
 
 private:

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -160,6 +160,7 @@ ResolvedStyle TreeResolver::styleForStyleable(const Styleable& styleable, Resolu
         // If the only reason we are computing the style is that some parent inherited properties changed, we can just copy them.
         auto style = RenderStyle::clonePtr(*existingStyle);
         style->fastPathInheritFrom(parent().style);
+        m_document->styleScope().matchResultCache().updateForFastPathInherit(element, parent().style);
         return { WTFMove(style) };
     }
 


### PR DESCRIPTION
#### f5368c85b0d78ebeb667f6b8b457d80731d7cf92
<pre>
Video player in Reddit doesn’t hide the progress bar for linked YouTube videos on iOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=292921">https://bugs.webkit.org/show_bug.cgi?id=292921</a>
<a href="https://rdar.apple.com/150653562">rdar://150653562</a>

Reviewed by Alan Baradlay.

Fast-path inheritance fails to update the style in match result cache so if both of these optimizations
get used on the same element then we may return a stale style.

* LayoutTests/fast/css/match-result-cache-with-fast-path-inheritance-expected.html: Added.
* LayoutTests/fast/css/match-result-cache-with-fast-path-inheritance.html: Added.
* Source/WebCore/style/MatchResultCache.cpp:
(WebCore::Style::MatchResultCache::updateForFastPathInherit):

Add a function to update match result cache for fast-path inheritance.

* Source/WebCore/style/MatchResultCache.h:
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::styleForStyleable):

Canonical link: <a href="https://commits.webkit.org/294842@main">https://commits.webkit.org/294842@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8a4c150eeea292bd74d4aac7b11c12fe9d942878

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/103287 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/22963 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/13283 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/108460 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/53930 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/105326 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/23302 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/31514 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78494 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/35421 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/106293 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/18060 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/93177 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58827 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/17895 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/11219 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/53286 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/87701 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/11281 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/110834 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/30425 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/22466 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/87490 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/30790 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/89375 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87126 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22165 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31985 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/9703 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/24748 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/30354 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/35673 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/30160 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/33487 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/31722 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->