### PR TITLE
[WPE] WPE Platform: WPE_SETTING_TOPLEVEL_DEFAULT_SIZE should be handled by WPEToplevel

### DIFF
--- a/Source/WebKit/WPEPlatform/wpe/WPEToplevel.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEToplevel.cpp
@@ -86,10 +86,17 @@ static void wpeToplevelConstructed(GObject* object)
     G_OBJECT_CLASS(wpe_toplevel_parent_class)->constructed(object);
 
     s_toplevelList = g_list_prepend(s_toplevelList, object);
+
+    auto* toplevel = WPE_TOPLEVEL(object);
+    auto* priv = toplevel->priv;
+    auto* settings = wpe_display_get_settings(priv->display.get());
+    GVariant* toplevelSize = wpe_settings_get_value(settings, WPE_SETTING_TOPLEVEL_DEFAULT_SIZE, nullptr);
+    g_variant_get(toplevelSize, "(uu)", &priv->width, &priv->height);
+
 #if USE(ATK)
     auto* atkRoot = atk_get_root();
     if (WPE_IS_APPLICATION_ACCESSIBLE_ATK(atkRoot))
-        wpeApplicationAccessibleAtkToplevelCreated(WPE_APPLICATION_ACCESSIBLE_ATK(atkRoot), WPE_TOPLEVEL(object));
+        wpeApplicationAccessibleAtkToplevelCreated(WPE_APPLICATION_ACCESSIBLE_ATK(atkRoot), toplevel);
 #endif
 }
 

--- a/Source/WebKit/WPEPlatform/wpe/WPEView.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEView.cpp
@@ -176,17 +176,6 @@ static void wpeViewGetProperty(GObject* object, guint propId, GValue* value, GPa
     }
 }
 
-static void wpeViewConstructed(GObject* object)
-{
-    G_OBJECT_CLASS(wpe_view_parent_class)->constructed(object);
-    auto* view = WPE_VIEW(object);
-    auto* priv = view->priv;
-    auto settings = wpe_display_get_settings(priv->display.get());
-
-    GVariant* toplevelSize = wpe_settings_get_value(settings, WPE_SETTING_TOPLEVEL_DEFAULT_SIZE, nullptr);
-    g_variant_get(toplevelSize, "(uu)", &priv->width, &priv->height);
-}
-
 static void wpeViewDispose(GObject* object)
 {
     wpe_view_set_toplevel(WPE_VIEW(object), nullptr);
@@ -208,7 +197,6 @@ static void wpe_view_class_init(WPEViewClass* viewClass)
     GObjectClass* objectClass = G_OBJECT_CLASS(viewClass);
     objectClass->set_property = wpeViewSetProperty;
     objectClass->get_property = wpeViewGetProperty;
-    objectClass->constructed = wpeViewConstructed;
     objectClass->dispose = wpeViewDispose;
 
 #if USE(ATK)


### PR DESCRIPTION
#### c69376f356f4186ba50f1080eea91c8f1d29d7bb
<pre>
[WPE] WPE Platform: WPE_SETTING_TOPLEVEL_DEFAULT_SIZE should be handled by WPEToplevel
<a href="https://bugs.webkit.org/show_bug.cgi?id=292922">https://bugs.webkit.org/show_bug.cgi?id=292922</a>

Reviewed by Alejandro G. Castro.

* Source/WebKit/WPEPlatform/wpe/WPEToplevel.cpp:
(wpeToplevelConstructed):
* Source/WebKit/WPEPlatform/wpe/WPEView.cpp:
(wpe_view_class_init):
(wpeViewConstructed): Deleted.

Canonical link: <a href="https://commits.webkit.org/294950@main">https://commits.webkit.org/294950@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b1be4274c09124a5a27a2661d95819caea4a06a7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/103288 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/22964 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/13285 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/108461 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/53931 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/23303 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/31515 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78493 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/35425 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/106294 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/18061 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/93176 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58826 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/17896 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/53287 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/87702 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/11280 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/110835 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/30426 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/22464 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/87489 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/30791 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/89374 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87125 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31986 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/9702 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/24749 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16810 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/30355 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/35674 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/30161 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/33488 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/31723 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->