### PR TITLE
[WTR] Replace invalid UTF-8 bytes instead of crashing

### DIFF
--- a/Tools/Scripts/webkitpy/port/driver.py
+++ b/Tools/Scripts/webkitpy/port/driver.py
@@ -797,9 +797,9 @@ class Driver(object):
                     # FIXME: This can likely be removed once <rdar://problem/18701447> is fixed.
                     deadline += 10 * 60 * 1000
                 if asan_violation_detected:
-                    self._crash_report_from_driver += string_utils.decode(err_line, target_type=str)
+                    self._crash_report_from_driver += string_utils.decode(err_line, target_type=str, errors="replace")
                 else:
-                    self.error_from_test += string_utils.decode(err_line, target_type=str)
+                    self.error_from_test += string_utils.decode(err_line, target_type=str, errors="replace")
 
         if asan_violation_detected and not self._crashed_process_name:
             self._crashed_process_name = self._server_process.process_name()


### PR DESCRIPTION
#### 3d5b2ebc628068d224d40e5ee8a205dc8a9c3f62
<pre>
[WTR] Replace invalid UTF-8 bytes instead of crashing
<a href="https://bugs.webkit.org/show_bug.cgi?id=292925">https://bugs.webkit.org/show_bug.cgi?id=292925</a>

Reviewed by Patrick Griffis.

Currently, if invalid UTF-8 is printed to stderr, the test runner
crashes with an error like this:

UnicodeDecodeError raised: &apos;utf-8&apos; codec can&apos;t decode byte 0xd6 in
position 179: invalid continuation byte

This is particularly a problem when running tests with environment
variables used by various libraries for debugging, as any improper
encoding will not only crash, but leave you with very few cues of what
caused it.

This patch makes the test runner code that reads stderr use
errors=&quot;replace&quot; when decoding UTF-8: any invalid UTF-8 sequences will
be replaced by U+FFFD � REPLACEMENT CHARACTER.

This allows users to continue debugging in the presence of invalid UTF-8
in stderr logs. Any invalid UTF-8 sequences can still be found by
searching for the replacement character.

The specific invalid sequence is lost. Personally, I would prefer if
stderr was collected as a bytestring so that the -stderr.txt file
contained byte-by-byte match of what the test runner emitted, but the
refactor necessary to be able to accomplish that is outside of the scope
of this patch.

* Tools/Scripts/webkitpy/port/driver.py:
(Driver._read_block):

Canonical link: <a href="https://commits.webkit.org/295135@main">https://commits.webkit.org/295135@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fabeb1ac8d76e2480588c394fde2fab0491c3b50

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/103293 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/22969 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/13290 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/108466 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/53936 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/105332 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/23308 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/31520 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78499 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/35429 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/106299 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/18066 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/93183 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58832 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/102769 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/18652 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/11225 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/53292 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/87707 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/11287 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/110840 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/30431 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/22471 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/87495 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/30796 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/89381 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87132 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22354 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31991 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/9709 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/24754 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/30360 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/30166 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/33493 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/31728 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->