### PR TITLE
[WebGPU] Atomic loads can cause crashes with pathological codegen

### DIFF
--- a/LayoutTests/fast/webgpu/nocrash/fuzz-292945-expected.txt
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-292945-expected.txt
@@ -1,0 +1,5 @@
+CONSOLE MESSAGE: promises created
+CONSOLE MESSAGE: the end
+CONSOLE MESSAGE: fuzz-292945.html
+CONSOLE MESSAGE: Pass
+

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-292945.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-292945.html
@@ -1,0 +1,82 @@
+<style>
+  :root { background: #102030e0; color: #99ddbbcc; font-size: 15px; }
+</style>
+<script id="shared">
+const log = console.log;
+
+</script>
+<script>
+globalThis.testRunner?.waitUntilDone();
+
+async function worker0() {
+let adapter0 = await navigator.gpu.requestAdapter({});
+let device0 = await adapter0.requestDevice();
+// START
+shaderModule0 = device0.createShaderModule({
+  code : `
+fn fn0() {
+  for (var it1=u32(vp2.fract); it1<(u32(28465.3) );) {
+  }
+}
+
+var<workgroup> vw0: atomic<i32>;
+var<private> vp2 = modf(f32());
+
+@compute @workgroup_size(111) fn compute0() {
+  vp2 = modf(f32(atomicLoad(&(vw0))));
+  fn0();
+}
+`});
+device0.createComputePipeline(
+  {layout : 'auto', compute : {module : shaderModule0, }})
+// END
+  await device0.queue.onSubmittedWorkDone();
+}
+
+onload = async () => {
+  try {
+  let sharedScript = document.querySelector('#shared').textContent;
+
+  let promises = [ worker0() ];
+  log('promises created');
+  let results = await Promise.allSettled(promises);
+  for (let result of results) {
+    if (result.status === 'rejected') { throw result.reason; }
+  }
+  log('the end')
+  log(location);
+  } catch (e) {
+    log('error');
+    log(e);
+    log(e[Symbol.toStringTag]);
+    log(e.stack);
+    if (e instanceof GPUPipelineError) {
+      log(`${e} - ${e.reason}`);
+      
+    } else if (e instanceof DOMException) {
+      if (e.name === 'OperationError') {
+      log(e.message);
+      
+      } else if (e.name === 'InvalidStateError') {
+      } else {
+        log(e);
+        
+      }
+    } else if (e instanceof GPUValidationError) {
+      
+    } else if (e instanceof GPUOutOfMemoryError) {
+      
+    } else if (e instanceof TypeError) {
+      log(e);
+      
+    } else {
+      log('unexpected error type');
+      log(e);
+      
+    }
+  }
+  log('Pass');
+  globalThis.testRunner?.dumpAsText();
+  globalThis.testRunner?.notifyDone();
+};
+</script>

--- a/Source/WebGPU/WGSL/Metal/MetalCodeGenerator.cpp
+++ b/Source/WebGPU/WGSL/Metal/MetalCodeGenerator.cpp
@@ -69,12 +69,12 @@ static void dumpMetalCodeIfNeeded(StringBuilder& stringBuilder)
 }
 #endif
 
-String generateMetalCode(ShaderModule& shaderModule, PrepareResult& prepareResult, const HashMap<String, ConstantValue>& constantValues)
+String generateMetalCode(ShaderModule& shaderModule, PrepareResult& prepareResult, const HashMap<String, ConstantValue>& constantValues, unsigned appleGPUFamily)
 {
     StringBuilder stringBuilder;
     stringBuilder.append(metalCodePrologue());
 
-    Metal::emitMetalFunctions(stringBuilder, shaderModule, prepareResult, constantValues);
+    Metal::emitMetalFunctions(stringBuilder, shaderModule, prepareResult, constantValues, appleGPUFamily);
 
 #if PLATFORM(COCOA)
     dumpMetalCodeIfNeeded(stringBuilder);

--- a/Source/WebGPU/WGSL/Metal/MetalCodeGenerator.h
+++ b/Source/WebGPU/WGSL/Metal/MetalCodeGenerator.h
@@ -36,7 +36,7 @@ struct PrepareResult;
 namespace Metal {
 
 // Can't fail. Any failure checks need to be done earlier, in the backend-agnostic part of the compiler.
-String generateMetalCode(ShaderModule&, PrepareResult&, const HashMap<String, ConstantValue>&);
+String generateMetalCode(ShaderModule&, PrepareResult&, const HashMap<String, ConstantValue>&, unsigned appleGPUFamily);
 
 } // namespace Metal
 } // namespace WGSL

--- a/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
+++ b/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
@@ -114,12 +114,13 @@ DEFINE_VOLATILE_HELPER(pack_float_to_unorm4x8, PackFloatToUnorm4x8)
 
 class FunctionDefinitionWriter : public AST::Visitor {
 public:
-    FunctionDefinitionWriter(ShaderModule& shaderModule, StringBuilder& stringBuilder, PrepareResult& prepareResult, const HashMap<String, ConstantValue>& constantValues)
+    FunctionDefinitionWriter(ShaderModule& shaderModule, StringBuilder& stringBuilder, PrepareResult& prepareResult, const HashMap<String, ConstantValue>& constantValues, unsigned appleGPUFamily)
         : m_helperGenerator(stringBuilder)
         , m_output(stringBuilder)
         , m_shaderModule(shaderModule)
         , m_prepareResult(prepareResult)
         , m_constantValues(constantValues)
+        , m_metalAppleGPUFamily(appleGPUFamily)
     {
     }
 
@@ -188,6 +189,7 @@ public:
 
     StringBuilder& stringBuilder() { return m_body; }
     Indentation<4>& indent() { return m_indent; }
+    unsigned metalAppleGPUFamily() const { return m_metalAppleGPUFamily; }
 
 private:
     void emitNecessaryHelpers();
@@ -214,6 +216,7 @@ private:
     HashSet<AST::Function*> m_visitedFunctions;
     PrepareResult& m_prepareResult;
     const HashMap<String, ConstantValue>& m_constantValues;
+    unsigned m_metalAppleGPUFamily { 0 };
 };
 
 static ASCIILiteral serializeAddressSpace(AddressSpace addressSpace)
@@ -1884,7 +1887,11 @@ static void atomicFunction(ASCIILiteral name, FunctionDefinitionWriter* writer, 
 
 static void emitAtomicLoad(FunctionDefinitionWriter* writer, AST::CallExpression& call)
 {
+    if (writer->metalAppleGPUFamily() >= 9)
+        writer->stringBuilder().append("({ volatile auto __wgslAtomicLoadResult = "_s);
     atomicFunction("atomic_load_explicit"_s, writer, call);
+    if (writer->metalAppleGPUFamily() >= 9)
+        writer->stringBuilder().append("; __wgslAtomicLoadResult; })"_s);
 }
 
 static void emitAtomicStore(FunctionDefinitionWriter* writer, AST::CallExpression& call)
@@ -2543,7 +2550,7 @@ void FunctionDefinitionWriter::visit(AST::DiscardStatement&)
 #if CPU(X86_64)
     m_body.append("__asm volatile(\"\"); discard_fragment()"_s);
 #else
-    m_body.append("{ volatile bool __wgslDiscardFragmentWorkaround = true; if (__wgslDiscardFragmentWorkaround) discard_fragment(); }"_s);
+    m_body.append("discard_fragment();"_s);
 #endif
 }
 
@@ -2899,9 +2906,9 @@ void FunctionDefinitionWriter::serializeConstant(const Type* type, ConstantValue
         });
 }
 
-void emitMetalFunctions(StringBuilder& stringBuilder, ShaderModule& shaderModule, PrepareResult& prepareResult, const HashMap<String, ConstantValue>& constantValues)
+void emitMetalFunctions(StringBuilder& stringBuilder, ShaderModule& shaderModule, PrepareResult& prepareResult, const HashMap<String, ConstantValue>& constantValues, unsigned appleGPUFamily)
 {
-    FunctionDefinitionWriter functionDefinitionWriter(shaderModule, stringBuilder, prepareResult, constantValues);
+    FunctionDefinitionWriter functionDefinitionWriter(shaderModule, stringBuilder, prepareResult, constantValues, appleGPUFamily);
     functionDefinitionWriter.write();
 }
 

--- a/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.h
+++ b/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.h
@@ -35,7 +35,7 @@ struct PrepareResult;
 
 namespace Metal {
 
-void emitMetalFunctions(StringBuilder&, ShaderModule&, PrepareResult&, const HashMap<String, ConstantValue>&);
+void emitMetalFunctions(StringBuilder&, ShaderModule&, PrepareResult&, const HashMap<String, ConstantValue>&, unsigned appleGPUFamily);
 
 } // namespace Metal
 } // namespace WGSL

--- a/Source/WebGPU/WGSL/WGSL.cpp
+++ b/Source/WebGPU/WGSL/WGSL.cpp
@@ -120,7 +120,7 @@ inline Variant<PrepareResult, Error> prepareImpl(ShaderModule& shaderModule, con
     return result;
 }
 
-Variant<String, Error> generate(ShaderModule& shaderModule, PrepareResult& prepareResult, HashMap<String, ConstantValue>& constantValues)
+Variant<String, Error> generate(ShaderModule& shaderModule, PrepareResult& prepareResult, HashMap<String, ConstantValue>& constantValues, unsigned appleGPUFamily)
 {
     PhaseTimes phaseTimes;
     String result;
@@ -128,7 +128,7 @@ Variant<String, Error> generate(ShaderModule& shaderModule, PrepareResult& prepa
         return { *maybeError };
     {
         PhaseTimer phaseTimer("generateMetalCode", phaseTimes);
-        result = Metal::generateMetalCode(shaderModule, prepareResult, constantValues);
+        result = Metal::generateMetalCode(shaderModule, prepareResult, constantValues, appleGPUFamily);
     }
     logPhaseTimes(phaseTimes);
     return { result };

--- a/Source/WebGPU/WGSL/WGSL.h
+++ b/Source/WebGPU/WGSL/WGSL.h
@@ -233,7 +233,7 @@ struct PrepareResult {
 Variant<PrepareResult, Error> prepare(ShaderModule&, const HashMap<String, PipelineLayout*>&);
 Variant<PrepareResult, Error> prepare(ShaderModule&, const String& entryPointName, PipelineLayout*);
 
-Variant<String, Error> generate(ShaderModule&, PrepareResult&, HashMap<String, ConstantValue>&);
+Variant<String, Error> generate(ShaderModule&, PrepareResult&, HashMap<String, ConstantValue>&, unsigned appleGPUFamily = 4);
 
 std::optional<ConstantValue> evaluate(const AST::Expression&, const HashMap<String, ConstantValue>&);
 

--- a/Source/WebGPU/WebGPU/Device.h
+++ b/Source/WebGPU/WebGPU/Device.h
@@ -257,6 +257,8 @@ public:
         return nullptr;
     }
     void removeBufferFromCache(uint64_t address) { m_bufferMap.remove(address); }
+    uint32_t appleGPUFamily() const { return m_appleGPUFamily; }
+
 private:
     Device(id<MTLDevice>, id<MTLCommandQueue> defaultQueue, HardwareCapabilities&&, Adapter&);
     Device(Adapter&);
@@ -341,6 +343,7 @@ private:
     uint64_t m_computePipelineId { 0 };
     uint32_t m_bindGroupLayoutId { 0 };
     uint32_t m_bindGroupId { 0 };
+    uint32_t m_appleGPUFamily { 0 };
     bool m_supressAllErrors { false };
     const uint32_t m_maxVerticesPerDrawCall { 0 };
     bool m_shaderValidationEnabled { true };

--- a/Source/WebGPU/WebGPU/Device.mm
+++ b/Source/WebGPU/WebGPU/Device.mm
@@ -276,6 +276,25 @@ static uint32_t computeMaxCountForDevice(id<MTLDevice> device)
     return result;
 }
 
+static uint32_t computeAppleGPUFamily(id<MTLDevice> device)
+{
+#if ENABLE(WEBGPU_BY_DEFAULT)
+    if ([device supportsFamily:MTLGPUFamilyApple9])
+        return 9;
+    if ([device supportsFamily:MTLGPUFamilyApple8])
+        return 8;
+#endif
+    if ([device supportsFamily:MTLGPUFamilyApple7])
+        return 7;
+    if ([device supportsFamily:MTLGPUFamilyApple6])
+        return 6;
+    if ([device supportsFamily:MTLGPUFamilyApple5])
+        return 5;
+    if ([device supportsFamily:MTLGPUFamilyApple4])
+        return 4;
+    return 0xFF;
+}
+
 Device::Device(id<MTLDevice> device, id<MTLCommandQueue> defaultQueue, HardwareCapabilities&& capabilities, Adapter& adapter)
     : m_device(device)
     , m_defaultQueue(Queue::create(defaultQueue, adapter, *this))
@@ -283,6 +302,7 @@ Device::Device(id<MTLDevice> device, id<MTLCommandQueue> defaultQueue, HardwareC
     , m_capabilities(WTFMove(capabilities))
     , m_adapter(adapter)
     , m_instance(adapter.weakInstance())
+    , m_appleGPUFamily(computeAppleGPUFamily(device))
     , m_maxVerticesPerDrawCall(computeMaxCountForDevice(device))
 {
 #if ENABLE(WEBGPU_SWIFT)

--- a/Source/WebGPU/WebGPU/Pipeline.mm
+++ b/Source/WebGPU/WebGPU/Pipeline.mm
@@ -154,14 +154,14 @@ std::optional<LibraryCreationResult> createLibrary(id<MTLDevice> device, const S
         }
     }
 
-    auto generationResult = WGSL::generate(*ast, result, wgslConstantValues);
+    auto generationResult = WGSL::generate(*ast, result, wgslConstantValues, shaderModule.device().appleGPUFamily());
     if (auto* generationError = std::get_if<WGSL::Error>(&generationResult)) {
         *error = [NSError errorWithDomain:@"WebGPU" code:1 userInfo:@{ NSLocalizedDescriptionKey: generationError->message().createNSString().get() }];
         return std::nullopt;
     }
     auto& msl = std::get<String>(generationResult);
 
-    auto library = ShaderModule::createLibrary(device, msl, label, error);
+    auto library = ShaderModule::createLibrary(device, msl, label, error, shaderModule.device().appleGPUFamily());
     if (error && *error)
         return { };
 

--- a/Source/WebGPU/WebGPU/ShaderModule.h
+++ b/Source/WebGPU/WebGPU/ShaderModule.h
@@ -72,7 +72,7 @@ public:
     bool isValid() const { return std::holds_alternative<WGSL::SuccessfulCheck>(m_checkResult); }
 
     static WGSL::PipelineLayout convertPipelineLayout(const PipelineLayout&);
-    static id<MTLLibrary> createLibrary(id<MTLDevice>, const String& msl, String&& label, NSError **);
+    static id<MTLLibrary> createLibrary(id<MTLDevice>, const String& msl, String&& label, NSError **, uint32_t appleGPUFamily);
 
     WGSL::ShaderModule* ast() const;
 


### PR DESCRIPTION
#### f6cbd6bd81bc370994768b2cea2ac8adb5ca6958
<pre>
[WebGPU] Atomic loads can cause crashes with pathological codegen
<a href="https://bugs.webkit.org/show_bug.cgi?id=292945">https://bugs.webkit.org/show_bug.cgi?id=292945</a>
<a href="https://rdar.apple.com/150824375">rdar://150824375</a>

Reviewed by Tadeu Zagallo.

Insert volatile loads for atomic loads to prevent some compiler crashes
on certain devices.

* LayoutTests/fast/webgpu/nocrash/fuzz-292945-expected.txt: Added.
* LayoutTests/fast/webgpu/nocrash/fuzz-292945.html: Added.
Add test.

* Source/WebGPU/WGSL/Metal/MetalCodeGenerator.cpp:
(WGSL::Metal::generateMetalCode):
* Source/WebGPU/WGSL/Metal/MetalCodeGenerator.h:
* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::FunctionDefinitionWriter::FunctionDefinitionWriter):
(WGSL::Metal::FunctionDefinitionWriter::metalAppleGPUFamily const):
(WGSL::Metal::emitAtomicLoad):
(WGSL::Metal::FunctionDefinitionWriter::visit):
(WGSL::Metal::emitMetalFunctions):
* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.h:
* Source/WebGPU/WGSL/WGSL.cpp:
(WGSL::generate):
* Source/WebGPU/WGSL/WGSL.h:
* Source/WebGPU/WebGPU/Device.h:
(WebGPU::Device::appleGPUFamily const):
* Source/WebGPU/WebGPU/Device.mm:
(WebGPU::computeAppleGPUFamily):
(WebGPU::Device::Device):
* Source/WebGPU/WebGPU/Pipeline.mm:
(WebGPU::createLibrary):
* Source/WebGPU/WebGPU/ShaderModule.h:
* Source/WebGPU/WebGPU/ShaderModule.mm:
(WebGPU::ShaderModule::createLibrary):
(WebGPU::earlyCompileShaderModule):
(WebGPU::appleGPUFamilyToString): Deleted.

Canonical link: <a href="https://commits.webkit.org/295110@main">https://commits.webkit.org/295110@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d075af20038c08360dba959b3457b965f39ecd58

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/103891 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/23594 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/13915 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/109084 "Built successfully") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/54552 "") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/23948 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/32139 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78926 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/54552 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/106897 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/18598 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/93716 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59254 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/18393 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/11767 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/53919 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/88148 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/11826 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/111471 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/31047 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/22886 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/87933 "Found 5 new test failures: compositing/patterns/direct-pattern-compositing-size.html imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/event_order_loadstart_progress.html imported/w3c/web-platform-tests/html/semantics/embedded-content/the-canvas-element/security.pattern.canvas.fillStyle.cross.html imported/w3c/web-platform-tests/service-workers/service-worker/redirected-response.https.html imported/w3c/web-platform-tests/web-locks/workers.tentative.https.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/31409 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/89917 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87586 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22343 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32477 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10205 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/25413 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/30976 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/36286 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/30769 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/34106 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/32330 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->