### PR TITLE
SpeechRecognition interface and friends should be SecureContext

### DIFF
--- a/LayoutTests/http/wpt/mediastream/speechrecognition-insecure-expected.txt
+++ b/LayoutTests/http/wpt/mediastream/speechrecognition-insecure-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS SpeechRecognition and friends should not exist in insecure context
+

--- a/LayoutTests/http/wpt/mediastream/speechrecognition-insecure.html
+++ b/LayoutTests/http/wpt/mediastream/speechrecognition-insecure.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<head>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<script>
+if (window.internals)
+    internals.markContextAsInsecure();
+
+function with_iframe(url) {
+    return new Promise(function(resolve) {
+        var frame = document.createElement('iframe');
+        frame.className = 'test-iframe';
+        frame.src = url;
+        frame.onload = function() { resolve(frame); };
+        document.body.appendChild(frame);
+    });
+}
+
+promise_test(async () => {
+    const frame = await with_iframe("/");
+    const w = frame.contentWindow;
+    assert_equals(w.SpeechRecognition, undefined);
+    assert_equals(w.SpeechRecognitionAlternative, undefined);
+    assert_equals(w.SpeechRecognitionErrorEvent, undefined);
+    assert_equals(w.SpeechRecognitionEvent, undefined);
+    assert_equals(w.SpeechRecognitionResult, undefined);
+},'SpeechRecognition and friends should not exist in insecure context');
+</script>
+</body>
+</html>

--- a/Source/WebCore/Modules/speech/SpeechRecognition.idl
+++ b/Source/WebCore/Modules/speech/SpeechRecognition.idl
@@ -27,6 +27,7 @@
     ActiveDOMObject,
     EnabledBySetting=SpeechRecognitionEnabled,
     InterfaceName=webkitSpeechRecognition,
+    SecureContext,
     Exposed=Window
 ] interface SpeechRecognition : EventTarget {
     [CallWith=CurrentDocument] constructor();

--- a/Source/WebCore/Modules/speech/SpeechRecognitionAlternative.idl
+++ b/Source/WebCore/Modules/speech/SpeechRecognitionAlternative.idl
@@ -25,6 +25,7 @@
 
 [
     EnabledBySetting=SpeechRecognitionEnabled,
+    SecureContext,
     Exposed=Window
 ] interface SpeechRecognitionAlternative {
     readonly attribute DOMString transcript;

--- a/Source/WebCore/Modules/speech/SpeechRecognitionErrorEvent.idl
+++ b/Source/WebCore/Modules/speech/SpeechRecognitionErrorEvent.idl
@@ -25,6 +25,7 @@
 
 [
     EnabledBySetting=SpeechRecognitionEnabled,
+    SecureContext,
     Exposed=Window
 ] interface SpeechRecognitionErrorEvent : Event {
     constructor([AtomString] DOMString type, SpeechRecognitionErrorEventInit eventInitDict);

--- a/Source/WebCore/Modules/speech/SpeechRecognitionEvent.idl
+++ b/Source/WebCore/Modules/speech/SpeechRecognitionEvent.idl
@@ -25,6 +25,7 @@
 
 [
     EnabledBySetting=SpeechRecognitionEnabled,
+    SecureContext,
     Exposed=Window
 ] interface SpeechRecognitionEvent : Event {
     constructor([AtomString] DOMString type, SpeechRecognitionEventInit eventInitDict);

--- a/Source/WebCore/Modules/speech/SpeechRecognitionResult.idl
+++ b/Source/WebCore/Modules/speech/SpeechRecognitionResult.idl
@@ -25,6 +25,7 @@
 
 [
     EnabledBySetting=SpeechRecognitionEnabled,
+    SecureContext,
     Exposed=Window
 ] interface SpeechRecognitionResult {
     readonly attribute unsigned long length;


### PR DESCRIPTION
#### f60ba77b15ca7160f28b021ad5d20e6a03d1b5e1
<pre>
SpeechRecognition interface and friends should be SecureContext
<a href="https://rdar.apple.com/151240414">rdar://151240414</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=292941">https://bugs.webkit.org/show_bug.cgi?id=292941</a>

Reviewed by Brady Eidson, Per Arne Vollan, and Sihui Liu.

Align implementation with <a href="https://github.com/WebAudio/web-speech-api/pull/31.">https://github.com/WebAudio/web-speech-api/pull/31.</a>

* LayoutTests/http/wpt/mediastream/speechrecognition-insecure-expected.txt: Added.
* LayoutTests/http/wpt/mediastream/speechrecognition-insecure.html: Added.
* Source/WebCore/Modules/speech/SpeechRecognition.idl:
* Source/WebCore/Modules/speech/SpeechRecognitionAlternative.idl:
* Source/WebCore/Modules/speech/SpeechRecognitionErrorEvent.idl:
* Source/WebCore/Modules/speech/SpeechRecognitionEvent.idl:
* Source/WebCore/Modules/speech/SpeechRecognitionResult.idl:

Canonical link: <a href="https://commits.webkit.org/294887@main">https://commits.webkit.org/294887@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4f37a720c0d7b554c493836a458b967c96f0c7e9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/103341 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/23017 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/13338 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/108514 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/53984 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/105380 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/23357 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/31568 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78536 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/35475 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/106347 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/18108 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/93226 "Found 2 new API test failures: TestWebKitAPI.ProcessSwap.NavigatingToLockdownMode, TestWebKitAPI.ProcessSwap.LockdownModeEnabledByDefaultThenOptOut (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58869 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/17945 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/11267 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/53341 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/87746 "Found 1 new API test failure: TestWebKitAPI.ProcessSwap.NavigatingToLockdownMode (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/11329 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/110891 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/30479 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/22503 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/87531 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/30844 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/89423 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87168 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22206 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32033 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/9750 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/24813 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/30408 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/35727 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/30214 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/33541 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/31776 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->