### PR TITLE
ASAN_ILL crash in WebCore::Document::resolveStyle

### DIFF
--- a/LayoutTests/fast/css/invalid-style-tree-crash-expected.txt
+++ b/LayoutTests/fast/css/invalid-style-tree-crash-expected.txt
@@ -1,0 +1,2 @@
+
+This test passes if WebKit does not crash.

--- a/LayoutTests/fast/css/invalid-style-tree-crash.html
+++ b/LayoutTests/fast/css/invalid-style-tree-crash.html
@@ -1,0 +1,26 @@
+<style></style>
+<script>
+	if (window.testRunner) {
+		testRunner.dumpAsText();
+		testRunner.waitUntilDone();
+	}
+	(async () => {
+		const testStyle = document.styleSheets[0];
+
+		try {
+			testStyle.insertRule(`@keyframes {}`, testStyle.cssRules.length);
+		} catch {}
+
+		try {
+			testStyle.insertRule(`& { 29%; container-type: inline-size; }`, testStyle.cssRules.length);
+		} catch {}
+
+		const input = document.createElement('input');
+		document.documentElement.appendChild(input);
+		input.type = 'color';
+		testRunner?.notifyDone();
+	})();
+</script>
+<body>
+	<p>This test passes if WebKit does not crash.</p>
+</body>

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -4601,7 +4601,7 @@ const RenderStyle* Element::resolveComputedStyle(ResolveComputedStyleMode mode)
     for (auto& element : makeReversedRange(elementsRequiringComputedStyle)) {
         if (computedStyle && computedStyle->containerType() != ContainerType::Normal && mode != ResolveComputedStyleMode::Editability) {
             // If we find a query container we need to bail out and do full style update to resolve it.
-            if (document->updateStyleIfNeeded())
+            if (!document->inStyleRecalc() && document->updateStyleIfNeeded())
                 return this->computedStyle();
         };
         auto style = document->styleForElementIgnoringPendingStylesheets(*element, computedStyle);


### PR DESCRIPTION
#### 8df4bb526b92b78d44a2e55232c1465e5b4fa644
<pre>
ASAN_ILL crash in WebCore::Document::resolveStyle
<a href="https://bugs.webkit.org/show_bug.cgi?id=292946">https://bugs.webkit.org/show_bug.cgi?id=292946</a>
<a href="https://rdar.apple.com/149686209">rdar://149686209</a>

Reviewed by NOBODY (OOPS!).

Avoid re-entrancy by not calling updateStyleIfNeeded() during style resolution.

* LayoutTests/fast/css/invalid-style-tree-crash-expected.txt: Added.
* LayoutTests/fast/css/invalid-style-tree-crash.html: Added.
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::resolveComputedStyle):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8df4bb526b92b78d44a2e55232c1465e5b4fa644

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/103344 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/23020 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/13341 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/108517 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/53987 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/105383 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/23360 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/31571 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78539 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/35474 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/106350 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/18112 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/93227 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58872 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/17949 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/11268 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/53344 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/87750 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/11330 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/110894 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/30482 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/22507 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/87532 "2 flakes 63 failures") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/30847 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/89424 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87169 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32039 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/9751 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/24816 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/30411 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/35730 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/30218 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/33544 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/31779 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->