### PR TITLE
Fix format of test262-runner script output

### DIFF
--- a/Tools/Scripts/test262/Runner.pm
+++ b/Tools/Scripts/test262/Runner.pm
@@ -859,6 +859,9 @@ sub processResult {
 
     my $exitSignalNumber = $exitCode & 0x7f if $scenario ne 'skip';
 
+    # JSC exits with code 3 if the program throws an uncaught exception.
+    # So, set $exitSignalNumber to 0 to indicate that the program
+    # didn't crash.
     if ($scenario ne 'skip' && $exitSignalNumber == 3) {
         $exitSignalNumber = 0;
     }
@@ -878,9 +881,9 @@ sub processResult {
 
         my $newFail = '';
         $newFail = '! NEW ' if $isnewfailure;
-        $newFail = "$newFail (Exit code: $exitCode) " if $exitSignalNumber;
+        $newFail = "$newFail" if $exitSignalNumber;
         my $failMsg = '';
-        $failMsg = "FAIL $file ($scenario)\n";
+        $failMsg = "FAIL $file ($scenario) (Exit code: $exitCode)\n";
 
         my $featuresList = '';
 

--- a/Tools/Scripts/webkitperl/test262_unittest/fixtures/mock-jsc-fail.pl
+++ b/Tools/Scripts/webkitperl/test262_unittest/fixtures/mock-jsc-fail.pl
@@ -29,4 +29,5 @@
 
 print("Exception: Test262: This test fails.");
 
-exit(1);
+# JSC exits with code 3 for uncaught exceptions.
+exit(3);


### PR DESCRIPTION
#### aec2264a0c9619f39108afdce870ed7a0596033b
<pre>
Fix format of test262-runner script output
<a href="https://bugs.webkit.org/show_bug.cgi?id=292934">https://bugs.webkit.org/show_bug.cgi?id=292934</a>

Reviewed by Jonathan Bedard.

This fixes a bug introduced by <a href="https://commits.webkit.org/294801@main">https://commits.webkit.org/294801@main</a> .
That commit changed the output format for new test failures; this output
is parsed by a testing script. This patch changes the output to what
the testing script expects.

Also, change the `mock-jsc-fail.pl` to exit with error code 3 since
it&apos;s supposed to be simulating what JSC does when there&apos;s an uncaught
exception.

* Tools/Scripts/test262/Runner.pm:
(processResult):
* Tools/Scripts/webkitperl/test262_unittest/fixtures/mock-jsc-fail.pl:

Canonical link: <a href="https://commits.webkit.org/294867@main">https://commits.webkit.org/294867@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/782dcd57b8f5b5721230ac2258da93d8c5f0e532

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/103345 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/23021 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/13342 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/108518 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/53988 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/105384 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/23361 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/31572 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78538 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/35471 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/106351 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/18113 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/93230 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58871 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/17950 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/11271 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/53345 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/96020 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/87751 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/11333 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/110895 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/101956 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/30483 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/22508 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/87536 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/30848 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/89427 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87173 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32034 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/9754 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/24817 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16763 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/30412 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/125589 "Built successfully") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/30220 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34821 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/33545 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/31781 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->