### PR TITLE
[WPE][GTK] Add API to configure proxy autoconfig

### DIFF
--- a/Source/WebCore/platform/Soup.cmake
+++ b/Source/WebCore/platform/Soup.cmake
@@ -18,6 +18,7 @@ list(APPEND WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/network/soup/SoupNetworkSession.h
     platform/network/soup/SoupVersioning.h
     platform/network/soup/URLSoup.h
+    platform/network/soup/WebKitAutoconfigProxyResolver.h
 )
 
 list(APPEND WebCore_SYSTEM_INCLUDE_DIRECTORIES

--- a/Source/WebKit/UIProcess/API/glib/WebKitNetworkProxySettings.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitNetworkProxySettings.h.in
@@ -55,6 +55,10 @@ webkit_network_proxy_settings_new                  (const gchar                *
                                                     const gchar* const         *ignore_hosts);
 
 WEBKIT_API WebKitNetworkProxySettings *
+webkit_network_proxy_settings_new_for_proxy_autoconfig
+                                                   (const gchar                *pac_url);
+
+WEBKIT_API WebKitNetworkProxySettings *
 webkit_network_proxy_settings_copy                 (WebKitNetworkProxySettings *proxy_settings);
 
 WEBKIT_API void
@@ -64,6 +68,10 @@ WEBKIT_API void
 webkit_network_proxy_settings_add_proxy_for_scheme (WebKitNetworkProxySettings *proxy_settings,
                                                     const gchar                *scheme,
                                                     const gchar                *proxy_uri);
+
+WEBKIT_API gboolean
+webkit_network_proxy_settings_get_is_proxy_autoconfig_supported
+                                                   (void);
 
 G_END_DECLS
 
@@ -78,6 +86,9 @@ G_END_DECLS
  * to a #WebKitNetworkSession. You need to call webkit_network_session_set_network_proxy_settings()
  * with %WEBKIT_NETWORK_PROXY_MODE_CUSTOM and a WebKitNetworkProxySettings.
  *
+ * Since 2.50, you may use webkit_network_proxy_settings_new_for_proxy_autoconfig()
+ * to specify a custom proxy autoconfig file. You still need to use %WEBKIT_NETWORK_PROXY_MODE_CUSTOM.
+ *
  * Since: 2.16
  */
 #else
@@ -90,6 +101,9 @@ G_END_DECLS
  * WebKitNetworkProxySettings can be used to provide a custom proxy configuration
  * to a #WebKitWebsiteDataManager. You need to call webkit_website_data_manager_set_network_proxy_settings()
  * with %WEBKIT_NETWORK_PROXY_MODE_CUSTOM and a WebKitNetworkProxySettings.
+ *
+ * Since 2.50, you may use webkit_network_proxy_settings_new_for_proxy_autoconfig()
+ * to specify a custom proxy autoconfig file. You still need to use %WEBKIT_NETWORK_PROXY_MODE_CUSTOM.
  *
  * Since: 2.16
  */


### PR DESCRIPTION
#### 6a3d04f64b85e80f5569a53a35e101421c600ddc
<pre>
[WPE][GTK] Add API to configure proxy autoconfig
<a href="https://bugs.webkit.org/show_bug.cgi?id=291316">https://bugs.webkit.org/show_bug.cgi?id=291316</a>

Reviewed by NOBODY (OOPS!).

WebKit already supports proxy autoconfig, but only if configured via
system proxy settings. It also supports a custom proxy autoconfig
setting (not matching the system setting) only for use by WebDriver.
Let&apos;s add this support to the API as well, so applications can provide a
proxy autoconfig URL setting in their proxy configuration dialogs. Most
GNOME apps probably won&apos;t ever use this because GNOME apps should use
system proxy settings, but some applications like Evolution want to
allow the user the flexibility to use proxy autoconfig only for the app
and not for the rest of the system.

I had a few API design decisions to make here. First, I wanted to
reflect that proxy autoconfig may not actually be supported by the
system -- the API currently depends on glib-networking, but this may
change in the future -- so I added a non-method function that tests
whether proxy autoconfig is supported, and made the new constructor
failable.

My biggest question was whether to add a new WebKitNetworkProxyMode,
WEBKIT_NETWORK_PROXY_MODE_AUTOCONFIG. I really wanted to, to match
the SoupNetworkProxySettingsMode enum, but ultimately this made things
too complicated. Problem is the WebKitNetworkProxySettings object keeps
track of its own mode, but also the user is expected to separately pass
the mode to webkit_network_session_set_proxy_settings(). We could check
and emit a critical if the application passes the wrong
WebKitNetworkProxySettings object with the wrong WebKitNetworkProxyMode,
but it&apos;s nicer and easier to dodge this problem altogether by not
exposing any new mode. WEBKIT_NETWORK_PROXY_MODE_CUSTOM will just mean
&quot;check the WebKitNetworkProxySettings,&quot; same as it did before. There are
just two different types of WebKitNetworkProxySettings objects now: the
original one that wraps GSimpleProxyResolver, and the new one that just
contains the PAC URL.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6a3d04f64b85e80f5569a53a35e101421c600ddc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/103514 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/23196 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/13516 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/108690 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/54159 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/105553 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/23548 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/31747 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78656 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/106520 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/18254 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/93376 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58990 "Found 1 new API test failure: /WPE/TestWebKitNetworkSession:/webkit/WebKitNetworkSession/proxy-autoconfig (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/18072 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/11423 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/53515 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/87863 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/11482 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/111068 "Built successfully") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/102125 "Build is in progress. Recent messages:") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/30661 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/22615 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/87652 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/31022 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/89576 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87295 "run-api-tests-without-change (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32174 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/9885 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/25012 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/30589 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/35901 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/30389 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/33720 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/31950 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->