### PR TITLE
css/css-view-transitions/auto-name-get-animations.html fails due to serializing the generated value for view transition 'match-element'.

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7118,7 +7118,6 @@ imported/w3c/web-platform-tests/css/css-view-transitions/scroller.html [ ImageOn
 imported/w3c/web-platform-tests/css/css-view-transitions/iframe-and-main-frame-transition-old-main-new-iframe.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-view-transitions/iframe-and-main-frame-transition-old-main-old-iframe.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-view-transitions/paint-holding-in-iframe.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-view-transitions/auto-name-get-animations.html [ Failure ]
 imported/w3c/web-platform-tests/css/css-view-transitions/fractional-translation-from-transform.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-view-transitions/nested-elements-in-overflow.html [ ImageOnlyFailure ]
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/auto-name-get-animations-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/auto-name-get-animations-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Generated view-transition-names should not be reflected in script assert_array_equals: lengths differ, expected array ["::view-transition-group(match-element)", "::view-transition-new(match-element)", "::view-transition-old(match-element)"] length 3, got ["::view-transition-group(-ua-auto-61)", "::view-transition-old(-ua-auto-61)", "::view-transition-new(-ua-auto-61)", "::view-transition-group(-ua-auto-62)", "::view-transition-old(-ua-auto-62)", "::view-transition-new(-ua-auto-62)"] length 6
+PASS Generated view-transition-names should not be reflected in script
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/auto-name-get-animations.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/auto-name-get-animations.html
@@ -60,8 +60,8 @@ main.switch .item1 {
     assert_array_equals(pseudos,
       [
         "::view-transition-group(match-element)",
-        "::view-transition-new(match-element)",
-        "::view-transition-old(match-element)"]);
+        "::view-transition-old(match-element)",
+        "::view-transition-new(match-element)"]);
   }, "Generated view-transition-names should not be reflected in script");
 </script>
 

--- a/Source/WebCore/animation/WebAnimationUtilities.cpp
+++ b/Source/WebCore/animation/WebAnimationUtilities.cpp
@@ -327,6 +327,22 @@ String pseudoElementIdentifierAsString(const std::optional<Style::PseudoElementI
     static NeverDestroyed<const String> targetText(MAKE_STATIC_STRING_IMPL("::target-text"));
     static NeverDestroyed<const String> viewTransition(MAKE_STATIC_STRING_IMPL("::view-transition"));
     static NeverDestroyed<const String> webkitScrollbar(MAKE_STATIC_STRING_IMPL("::-webkit-scrollbar"));
+
+    auto viewTransitionPseudoString = [&] {
+        switch (pseudoElementIdentifier->pseudoId) {
+        case PseudoId::ViewTransitionGroup:
+            return "::view-transition-group"_s;
+        case PseudoId::ViewTransitionImagePair:
+            return "::view-transition-image-pair"_s;
+        case PseudoId::ViewTransitionOld:
+            return "::view-transition-old"_s;
+        case PseudoId::ViewTransitionNew:
+            return "::view-transition-new"_s;
+        default:
+            return ""_s;
+        }
+    };
+
     switch (pseudoElementIdentifier->pseudoId) {
     case PseudoId::After:
         return after;
@@ -351,13 +367,12 @@ String pseudoElementIdentifierAsString(const std::optional<Style::PseudoElementI
     case PseudoId::ViewTransition:
         return viewTransition;
     case PseudoId::ViewTransitionGroup:
-        return makeString("::view-transition-group"_s, '(', pseudoElementIdentifier->nameArgument, ')');
     case PseudoId::ViewTransitionImagePair:
-        return makeString("::view-transition-image-pair"_s, '(', pseudoElementIdentifier->nameArgument, ')');
     case PseudoId::ViewTransitionOld:
-        return makeString("::view-transition-old"_s, '(', pseudoElementIdentifier->nameArgument, ')');
     case PseudoId::ViewTransitionNew:
-        return makeString("::view-transition-new"_s, '(', pseudoElementIdentifier->nameArgument, ')');
+        if (pseudoElementIdentifier->nameArgument.startsWith("-ua-auto-"_s))
+            return makeString(viewTransitionPseudoString(), "(match-element)"_s);
+        return makeString(viewTransitionPseudoString(), '(', pseudoElementIdentifier->nameArgument, ')');
     case PseudoId::WebKitScrollbar:
         return webkitScrollbar;
     default:


### PR DESCRIPTION
#### 2343c3fb824a0fd2af3fdf6c875222275e324750
<pre>
css/css-view-transitions/auto-name-get-animations.html fails due to serializing the generated value for view transition &apos;match-element&apos;.
<a href="https://bugs.webkit.org/show_bug.cgi?id=292963">https://bugs.webkit.org/show_bug.cgi?id=292963</a>
&lt;<a href="https://rdar.apple.com/151262330">rdar://151262330</a>&gt;

Reviewed by NOBODY (OOPS!).

&apos;match-element&apos; pseudo element selectors should be serialised using the keyword,
not the generated unique string.

This also fixes the test to have the &apos;old&apos; pseudo element first, as defined in
the view-transition spec
(<a href="https://drafts.csswg.org/css-view-transitions-1/#">https://drafts.csswg.org/css-view-transitions-1/#</a>::view-transition-image-pair).

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/auto-name-get-animations-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/auto-name-get-animations.html:
* Source/WebCore/animation/WebAnimationUtilities.cpp:
(WebCore::pseudoElementIdentifierAsString):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2343c3fb824a0fd2af3fdf6c875222275e324750

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/103388 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/23070 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/13388 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/108562 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/54031 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/105427 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/23415 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/31621 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78566 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/35503 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/106394 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/18144 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/93263 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58900 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/17979 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/11306 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/53388 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/87779 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/11368 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/110938 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/30535 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/22531 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/87563 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/30896 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/89461 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87202 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32065 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/9785 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/24862 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/30463 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/35774 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/30263 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/33594 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/31824 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->