### PR TITLE
[WPE][GTK] WebKitNetworkProxySettings documentation still references the wrong functions

### DIFF
--- a/Source/WebKit/UIProcess/API/glib/WebKitNetworkProxySettings.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitNetworkProxySettings.h.in
@@ -70,12 +70,12 @@ G_END_DECLS
 #if ENABLE(2022_GLIB_API)
 /**
  * WebKitNetworkProxySettings:
- * @See_also: #WebKitWebsiteDataManager
+ * @See_also: #WebKitNetworkSession
  *
  * Configures network proxies.
  *
  * WebKitNetworkProxySettings can be used to provide a custom proxy configuration
- * to a #WebKitWebsiteDataManager. You need to call webkit_website_data_manager_set_network_proxy_settings()
+ * to a #WebKitNetworkSession. You need to call webkit_network_session_set_network_proxy_settings()
  * with %WEBKIT_NETWORK_PROXY_MODE_CUSTOM and a WebKitNetworkProxySettings.
  *
  * Since: 2.16
@@ -83,12 +83,12 @@ G_END_DECLS
 #else
 /**
  * WebKitNetworkProxySettings:
- * @See_also: #WebKitWebContext
+ * @See_also: #WebKitWebsiteDataManager
  *
  * Configures network proxies.
  *
  * WebKitNetworkProxySettings can be used to provide a custom proxy configuration
- * to a #WebKitWebContext. You need to call webkit_web_context_set_network_proxy_settings()
+ * to a #WebKitWebsiteDataManager. You need to call webkit_website_data_manager_set_network_proxy_settings()
  * with %WEBKIT_NETWORK_PROXY_MODE_CUSTOM and a WebKitNetworkProxySettings.
  *
  * Since: 2.16


### PR DESCRIPTION
#### 039123ac2dc0979ec3aa233a10a7a0937ffda6ab
<pre>
[WPE][GTK] WebKitNetworkProxySettings documentation still references the wrong functions
<a href="https://bugs.webkit.org/show_bug.cgi?id=292733">https://bugs.webkit.org/show_bug.cgi?id=292733</a>

Reviewed by Carlos Garcia Campos.

webkit_web_context_set_network_proxy_settings() was indeed replaced by
webkit_website_data_manager_set_network_proxy_settings(), which was then itself
replaced by webkit_network_session_set_network_proxy_settings(). I knew this,
but messed up the documentation anyway.

* Source/WebKit/UIProcess/API/glib/WebKitNetworkProxySettings.h.in:

Canonical link: <a href="https://commits.webkit.org/294901@main">https://commits.webkit.org/294901@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/29e3054fbb3cab3557475d3ad0f2c012cf577751

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/103396 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/23078 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/13396 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/108570 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/54039 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/23423 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/31629 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78573 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/35510 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/106402 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/18152 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/93271 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58907 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/17993 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/53396 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/87787 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/11377 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/110946 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/30543 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/22538 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/87568 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/30904 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/89469 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87209 "Build is in progress. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; run-api-tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22214 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32072 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/9791 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/24870 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/30471 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/35783 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/30271 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/33602 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/31832 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->