### PR TITLE
[scroll-animations] https://scroll-driven-animations.style/demos/3d-shoe-explorer/css/ animations break after navigating away then back to page

### DIFF
--- a/LayoutTests/animations/no-cancelation-when-entering-page-cache-expected.txt
+++ b/LayoutTests/animations/no-cancelation-when-entering-page-cache-expected.txt
@@ -1,0 +1,3 @@
+This tests that CSS Animations do not get canceled when restored from the page cache.
+
+PASS: animation was not canceled when restored from the page cache.

--- a/LayoutTests/animations/no-cancelation-when-entering-page-cache.html
+++ b/LayoutTests/animations/no-cancelation-when-entering-page-cache.html
@@ -1,0 +1,67 @@
+<!-- webkit-test-runner [ UsesBackForwardCache=true ] -->
+<style>
+
+body {
+    /* make the page scrollable */
+    height: 5000px;
+}
+
+@keyframes move {
+    to { margin-left: 100px }
+}
+
+#target {
+    width: 100px;
+    height: 100px;
+    background-color: blue;
+    animation: move auto;
+    animation-timeline: scroll();
+}
+
+</style>
+
+<p>
+    This tests that CSS Animations do not get canceled when restored from the page cache.
+</p>
+
+<div id="target"></div>
+<div id="results"></div>
+
+<script>
+
+window.testRunner?.dumpAsText();
+window.testRunner?.waitUntilDone();
+
+const finish = message => {
+    document.getElementById("results").innerText = message;
+    window.testRunner?.notifyDone();
+}
+
+const animation = document.getAnimations()[0];
+
+requestAnimationFrame(() => {
+    // We need to wait a frame for animations to have been updated and the current time to be resolved.
+    if (!animation.currentTime)
+        finish("FAIL: animation was not initially running.");
+
+    setTimeout(() => window.location.href = "resources/page-cache-helper.html", 200);
+});
+
+var enteredPageCache = false;
+document.addEventListener("visibilitychange", event => {
+    if (document.hidden)
+        enteredPageCache = true;
+    else if (enteredPageCache) {
+        // We need to wait a frame for animations to have been updated and for the current time
+        // to be unresolved in case the animation was canceled during render tree tear down when
+        // entering the page cache.
+        requestAnimationFrame(() => {
+            if (animation.currentTime)
+                finish("PASS: animation was not canceled when restored from the page cache.")
+            else
+                finish("FAIL: animation was canceled when restored from the page cache.")
+        });
+    }
+});
+
+</script>

--- a/Source/WebCore/animation/StyleOriginatedAnimation.cpp
+++ b/Source/WebCore/animation/StyleOriginatedAnimation.cpp
@@ -226,7 +226,7 @@ AnimationEffectPhase StyleOriginatedAnimation::phaseWithoutEffect() const
         return AnimationEffectPhase::Idle;
 
     // Since we don't have an effect, the duration will be zero so the phase is 'before' if the current time is less than zero.
-    return *animationCurrentTime < 0_s ? AnimationEffectPhase::Before : AnimationEffectPhase::After;
+    return *animationCurrentTime < animationCurrentTime->matchingZero() ? AnimationEffectPhase::Before : AnimationEffectPhase::After;
 }
 
 WebAnimationTime StyleOriginatedAnimation::effectTimeAtStart() const

--- a/Source/WebCore/style/Styleable.cpp
+++ b/Source/WebCore/style/Styleable.cpp
@@ -315,6 +315,12 @@ OptionSet<AnimationImpact> Styleable::applyKeyframeEffects(RenderStyle& targetSt
 
 void Styleable::cancelStyleOriginatedAnimations() const
 {
+    // It is important we don't cancel style-originated animations when entering the page cache
+    // since any JS wrapper that is kept alive in the page cache could be associated with an animation
+    // that itself has not been kept alive (or rather canceled) when entering the page cache.
+    if (element.protectedDocument()->backForwardCacheState() != Document::NotInBackForwardCache)
+        return;
+
     cancelStyleOriginatedAnimations({ });
     if (CheckedPtr styleOriginatedTimelinesController = element.protectedDocument()->styleOriginatedTimelinesController())
         styleOriginatedTimelinesController->unregisterNamedTimelinesAssociatedWithElement(*this);


### PR DESCRIPTION
#### c152324493769faa042332fd62826b37258d67bc
<pre>
[scroll-animations] <a href="https://scroll-driven-animations.style/demos/3d-shoe-explorer/css/">https://scroll-driven-animations.style/demos/3d-shoe-explorer/css/</a> animations break after navigating away then back to page
<a href="https://bugs.webkit.org/show_bug.cgi?id=284732">https://bugs.webkit.org/show_bug.cgi?id=284732</a>
<a href="https://rdar.apple.com/141528296">rdar://141528296</a>

Reviewed by Antti Koivisto.

The demo at <a href="https://scroll-driven-animations.style/demos/3d-shoe-explorer/css/">https://scroll-driven-animations.style/demos/3d-shoe-explorer/css/</a> shows a 3d model of sorts that is rendered via &lt;canvas&gt;.
To perform the rotation of the model, the demo uses a `requestAnimationFrame` loop to query the current time of scroll-driven CSS
animations in the document. The animation object itself is cached upon page load. As the page enters the back-forward cache, the
wrapper object itself is preserved, but the `CSSAnimation` is canceled during page teardown under `BackForwardCache::trySuspendPage()`.
As the page is restored from the page cache, the wrapper object will no longer provide a valid current time since its associated
animation has been canceled.

To address this we no longer cancel style-originated animations when entering the page cache.

Running the new test with multiple iterations uncovered an unsafe comparison in `StyleOriginatedAnimation::phaseWithoutEffect()`
between a `WebAnimationTime` and a `Seconds` value, so we also address this.

* LayoutTests/animations/no-cancelation-when-entering-page-cache-expected.txt: Added.
* LayoutTests/animations/no-cancelation-when-entering-page-cache.html: Added.
* Source/WebCore/animation/StyleOriginatedAnimation.cpp:
(WebCore::StyleOriginatedAnimation::phaseWithoutEffect const):
* Source/WebCore/style/Styleable.cpp:
(WebCore::Styleable::cancelStyleOriginatedAnimations const):

Canonical link: <a href="https://commits.webkit.org/294899@main">https://commits.webkit.org/294899@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1823011757cb5797eb015846c1fc3fd3a9d37937

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/103455 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/23137 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/13456 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/108629 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/54099 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/105494 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/23487 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/31688 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78610 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/106461 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/18203 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/93320 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58945 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/18026 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/11366 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/53456 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/87821 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/11426 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/111008 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/30602 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/22567 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/87607 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/30963 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/89519 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87248 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32123 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/9834 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/24942 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16776 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/30530 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/35842 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/30330 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/33661 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/31891 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->