### PR TITLE
Digital Credentials: switch ISO18013 string to use dashes

### DIFF
--- a/LayoutTests/http/wpt/identity/formats/ISO18013/mobiledocument.https.html
+++ b/LayoutTests/http/wpt/identity/formats/ISO18013/mobiledocument.https.html
@@ -35,7 +35,7 @@
         const allRequests = [];
         for (const data of invalidData) {
             const request = {
-                protocol: "iso.org.mdoc",
+                protocol: "org-iso-mdoc",
                 data,
             };
             await promise_rejects_js(
@@ -67,7 +67,7 @@
         );
 
         const idlValidRequest = {
-            protocol: "iso.org.mdoc",
+            protocol: "org-iso-mdoc",
             data: { deviceRequest: "abc", encryptionInfo: "123" },
         };
         options.digital.requests.push(idlValidRequest);
@@ -88,7 +88,7 @@
                 digital: {
                     requests: [
                         {
-                            protocol: "iso.org.mdoc",
+                            protocol: "org-iso-mdoc",
                             data: invalidRequest,
                         },
                     ],

--- a/Source/WebCore/Modules/identity/IdentityCredentialProtocol.idl
+++ b/Source/WebCore/Modules/identity/IdentityCredentialProtocol.idl
@@ -25,5 +25,5 @@
 
 enum IdentityCredentialProtocol {
     "openid4vp",
-    "org.iso.mdoc",
+    "org-iso-mdoc",
 };

--- a/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
+++ b/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
@@ -2475,13 +2475,7 @@ sub GetEnumerationValueName
     return "EmptyString" if $name eq "";
     return "WebRTC" if $name eq "webrtc";
 
-    my @parts = split("-", $name);
-    @parts = map {
-        my $part = $_;
-        my @dotParts = split(/\./, $part);
-        join("", map { $codeGenerator->WK_ucfirst($_) } @dotParts)
-    } @parts;
-    $name = join("", @parts);
+    $name = join("", map { $codeGenerator->WK_ucfirst($_) } split("-", $name));
     $name = "_$name" if $name =~ /^\d/;
     return $name;
 }

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestStandaloneEnumeration.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestStandaloneEnumeration.cpp
@@ -36,18 +36,14 @@ using namespace JSC;
 
 String convertEnumerationToString(TestStandaloneEnumeration enumerationValue)
 {
-    static const std::array<NeverDestroyed<String>, 5> values {
+    static const std::array<NeverDestroyed<String>, 3> values {
         MAKE_STATIC_STRING_IMPL("enumValue1"),
         MAKE_STATIC_STRING_IMPL("enumValue2"),
         MAKE_STATIC_STRING_IMPL("enum-value3"),
-        MAKE_STATIC_STRING_IMPL("enum.value.4"),
-        MAKE_STATIC_STRING_IMPL("enum-value.5"),
     };
     static_assert(static_cast<size_t>(TestStandaloneEnumeration::EnumValue1) == 0, "TestStandaloneEnumeration::EnumValue1 is not 0 as expected");
     static_assert(static_cast<size_t>(TestStandaloneEnumeration::EnumValue2) == 1, "TestStandaloneEnumeration::EnumValue2 is not 1 as expected");
     static_assert(static_cast<size_t>(TestStandaloneEnumeration::EnumValue3) == 2, "TestStandaloneEnumeration::EnumValue3 is not 2 as expected");
-    static_assert(static_cast<size_t>(TestStandaloneEnumeration::EnumValue4) == 3, "TestStandaloneEnumeration::EnumValue4 is not 3 as expected");
-    static_assert(static_cast<size_t>(TestStandaloneEnumeration::EnumValue5) == 4, "TestStandaloneEnumeration::EnumValue5 is not 4 as expected");
     ASSERT(static_cast<size_t>(enumerationValue) < std::size(values));
     return values[static_cast<size_t>(enumerationValue)];
 }
@@ -59,10 +55,8 @@ template<> JSString* convertEnumerationToJS(VM& vm, TestStandaloneEnumeration en
 
 template<> std::optional<TestStandaloneEnumeration> parseEnumerationFromString<TestStandaloneEnumeration>(const String& stringValue)
 {
-    static constexpr std::array<std::pair<ComparableASCIILiteral, TestStandaloneEnumeration>, 5> mappings {
-        std::pair<ComparableASCIILiteral, TestStandaloneEnumeration> { "enum-value.5"_s, TestStandaloneEnumeration::EnumValue5 },
+    static constexpr std::array<std::pair<ComparableASCIILiteral, TestStandaloneEnumeration>, 3> mappings {
         std::pair<ComparableASCIILiteral, TestStandaloneEnumeration> { "enum-value3"_s, TestStandaloneEnumeration::EnumValue3 },
-        std::pair<ComparableASCIILiteral, TestStandaloneEnumeration> { "enum.value.4"_s, TestStandaloneEnumeration::EnumValue4 },
         std::pair<ComparableASCIILiteral, TestStandaloneEnumeration> { "enumValue1"_s, TestStandaloneEnumeration::EnumValue1 },
         std::pair<ComparableASCIILiteral, TestStandaloneEnumeration> { "enumValue2"_s, TestStandaloneEnumeration::EnumValue2 },
     };
@@ -79,7 +73,7 @@ template<> std::optional<TestStandaloneEnumeration> parseEnumeration<TestStandal
 
 template<> ASCIILiteral expectedEnumerationValues<TestStandaloneEnumeration>()
 {
-    return "\"enumValue1\", \"enumValue2\", \"enum-value3\", \"enum.value.4\", \"enum-value.5\""_s;
+    return "\"enumValue1\", \"enumValue2\", \"enum-value3\""_s;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/bindings/scripts/test/TestStandaloneEnumeration.idl
+++ b/Source/WebCore/bindings/scripts/test/TestStandaloneEnumeration.idl
@@ -32,7 +32,5 @@
     "enumValue1",
     "enumValue2",
     "enum-value3",
-    "enum.value.4",
-    "enum-value.5",
 };
 


### PR DESCRIPTION
#### a1baa5ba070f0b6de8282dd367174a13a57d04b5
<pre>
Digital Credentials: switch ISO18013 string to use dashes
<a href="https://rdar.apple.com/151292272">rdar://151292272</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=292976">https://bugs.webkit.org/show_bug.cgi?id=292976</a>

Reviewed by Anne van Kesteren.

Switch the string representation of the ISO18013 enumeration value to use dashes instead of underscores.
Also reverts changes to the IDL parser that were made to support the old format, so dots are not longer supported.

Canonical link: <a href="https://commits.webkit.org/294982@main">https://commits.webkit.org/294982@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7c86175e9c211939379cef5947d3a6324435c522

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/103462 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/23144 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/13463 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/108636 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/54106 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/105501 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/23494 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/31695 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78616 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/106468 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/18211 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/93328 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58951 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/18033 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/11375 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/53463 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/87826 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/11435 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/111015 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/30609 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/22571 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/87614 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/30970 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/89528 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87255 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22264 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32130 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/9841 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/24954 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/30537 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/35849 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/30337 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/33668 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/31898 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->