### PR TITLE
CoreAudioSharedUnit should reset AVAudioApplication inputMuted value when stopping

### DIFF
--- a/Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.cpp
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.cpp
@@ -586,6 +586,8 @@ void CoreAudioSharedUnit::cleanupAudioUnit()
     }
 
     updateVoiceActivityDetection();
+    updateMutedState();
+
     m_ioUnit = nullptr;
 
     m_microphoneSampleBuffer = nullptr;
@@ -694,7 +696,7 @@ void CoreAudioSharedUnit::isProducingMicrophoneSamplesChanged()
 
 void CoreAudioSharedUnit::updateMutedState(SyncUpdate syncUpdate)
 {
-    UInt32 muteUplinkOutput = !isProducingMicrophoneSamples();
+    UInt32 muteUplinkOutput = m_ioUnit && isProducingData() && !isProducingMicrophoneSamples();
 
     if (syncUpdate == SyncUpdate::No && muteUplinkOutput) {
         RELEASE_LOG_INFO(WebRTC, "CoreAudioSharedUnit::updateMutedState(%p) delaying mute in case unit gets stopped or unmuted soon", this);
@@ -824,6 +826,7 @@ void CoreAudioSharedUnit::stopInternal()
     setIsInBackground(false);
 #endif
     updateVoiceActivityDetection();
+    updateMutedState();
 }
 
 void CoreAudioSharedUnit::registerSpeakerSamplesProducer(CoreAudioSpeakerSamplesProducer& producer)


### PR DESCRIPTION
#### 837bc76bb9ea8bf42aead392034e6d4c421ee798
<pre>
CoreAudioSharedUnit should reset AVAudioApplication inputMuted value when stopping
<a href="https://bugs.webkit.org/show_bug.cgi?id=292977">https://bugs.webkit.org/show_bug.cgi?id=292977</a>
<a href="https://rdar.apple.com/149707813">rdar://149707813</a>

Reviewed by Eric Carlson.

AVAudioApplication inputMuted value is shared for the whole application, as WebKit.GPU process is doing process attribution.
Before the patch, when CoreAudioSharedUnit is stopped, the inputMuted state would not be updated, it would remain either to YES or NO.
When CoreAudioSharedUnit would restart, it would anyway set the inputMuted state to NO.

The downside is that, the application embedding the WKWebView may want to record audio after the WKWebView page stopped using microphone.
If WebKit.GPU process does not set back inputMuted state to NO&lt; the application may record silence.

To prevent this in the short term, we set back inputMuted state to NO when stopping.
In particular, we now only set inputMuted to YES in CoreAudioSharedUnit::updateMutedState if the audio unit is running but microphone samples are not needed.

Manually tested.

* Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.cpp:
(WebCore::CoreAudioSharedUnit::cleanupAudioUnit):
(WebCore::CoreAudioSharedUnit::updateMutedState):
(WebCore::CoreAudioSharedUnit::stopInternal):

Canonical link: <a href="https://commits.webkit.org/295195@main">https://commits.webkit.org/295195@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b5254e3131ca65ba17a58a0231d1b22a209bc8cc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104389 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24093 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/14509 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/109591 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/55057 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/106429 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/24470 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/32640 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79258 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/55057 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107395 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19022 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94207 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59588 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/18830 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/12282 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/54419 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/88515 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/12334 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/111975 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/31546 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/23237 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88296 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/31910 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/90451 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87962 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22395 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32862 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10627 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/26014 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/31474 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/36799 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/31268 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/34604 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/32828 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->