### PR TITLE
Sync `replaced-elements/the-option-element` from WPT upstream

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -874,6 +874,8 @@ imported/w3c/web-platform-tests/workers/interfaces/WorkerGlobalScope/onerror/mes
 [ Debug ] imported/w3c/web-platform-tests/css/css-position/position-absolute-crash-chrome-013.html [ Skip ]
 [ Debug ] imported/w3c/web-platform-tests/css/css-properties-values-api/registered-property-revert.html [ Skip ]
 [ Debug ] imported/w3c/web-platform-tests/css/css-scoping/slotted-matches.html [ Skip ]
+imported/w3c/web-platform-tests/html/rendering/replaced-elements/the-option-element/option-label-whitespace.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/html/rendering/replaced-elements/the-option-element/option-label-whitespace-2.html [ ImageOnlyFailure ]
 
 # Cookie tests that are flaky since their import because they fail and and out some kind of unique id.
 imported/w3c/web-platform-tests/cookies/prefix/__host.document-cookie.html [ Pass Failure ]

--- a/LayoutTests/imported/w3c/resources/resource-files.json
+++ b/LayoutTests/imported/w3c/resources/resource-files.json
@@ -9901,6 +9901,8 @@
         "web-platform-tests/html/rendering/replaced-elements/images/input-image-content-ref.html",
         "web-platform-tests/html/rendering/replaced-elements/images/revoked-blob-print-ref.html",
         "web-platform-tests/html/rendering/replaced-elements/images/space-ref.html",
+        "web-platform-tests/html/rendering/replaced-elements/the-option-element/option-label-whitespace-2-ref.html",
+        "web-platform-tests/html/rendering/replaced-elements/the-option-element/option-label-whitespace-ref.html",
         "web-platform-tests/html/rendering/replaced-elements/the-option-element/option-with-br-ref.html",
         "web-platform-tests/html/rendering/replaced-elements/the-option-element/select-multiple-covered-by-abspos-ref.html",
         "web-platform-tests/html/rendering/replaced-elements/the-select-element/select-1-block-size-ref.html",

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/replaced-elements/the-option-element/option-label-whitespace-2-expected-mismatch.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/replaced-elements/the-option-element/option-label-whitespace-2-expected-mismatch.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<select>
+  <option></option>
+</select>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/replaced-elements/the-option-element/option-label-whitespace-2-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/replaced-elements/the-option-element/option-label-whitespace-2-ref.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<select>
+  <option></option>
+</select>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/replaced-elements/the-option-element/option-label-whitespace-2.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/replaced-elements/the-option-element/option-label-whitespace-2.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<link rel=author href="mailto:jarhar@chromium.org">
+<link rel=help href="https://github.com/whatwg/html/issues/10955">
+<link rel=mismatch href="option-label-whitespace-2-ref.html">
+
+<select>
+  <option label="  "></option>
+</select>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/replaced-elements/the-option-element/option-label-whitespace-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/replaced-elements/the-option-element/option-label-whitespace-expected.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<select multiple>
+  <option>no label attribute</option>
+  <option>empty label attribute</option>
+  <option></option>
+</select>
+<br>
+
+<select>
+  <option>empty label attribute</option>
+</select>
+<br>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/replaced-elements/the-option-element/option-label-whitespace-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/replaced-elements/the-option-element/option-label-whitespace-ref.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<select multiple>
+  <option>no label attribute</option>
+  <option>empty label attribute</option>
+  <option></option>
+</select>
+<br>
+
+<select>
+  <option>empty label attribute</option>
+</select>
+<br>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/replaced-elements/the-option-element/option-label-whitespace.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/replaced-elements/the-option-element/option-label-whitespace.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<link rel=author href="mailto:jarhar@chromium.org">
+<link rel=help href="https://github.com/whatwg/html/issues/10955">
+<link rel=match href="option-label-whitespace-ref.html">
+
+<select multiple>
+  <option>no label attribute</option>
+  <option label="">empty label attribute</option>
+  <option label="  ">whitespace label attribute</option>
+</select>
+<br>
+
+<select>
+  <option label="">empty label attribute</option>
+</select>
+<br>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/replaced-elements/the-option-element/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/replaced-elements/the-option-element/w3c-import.log
@@ -14,6 +14,12 @@ Property values requiring vendor prefixes:
 None
 ------------------------------------------------------------------------
 List of files:
+/LayoutTests/imported/w3c/web-platform-tests/html/rendering/replaced-elements/the-option-element/option-label-whitespace-2-expected-mismatch.html
+/LayoutTests/imported/w3c/web-platform-tests/html/rendering/replaced-elements/the-option-element/option-label-whitespace-2-ref.html
+/LayoutTests/imported/w3c/web-platform-tests/html/rendering/replaced-elements/the-option-element/option-label-whitespace-2.html
+/LayoutTests/imported/w3c/web-platform-tests/html/rendering/replaced-elements/the-option-element/option-label-whitespace-expected.html
+/LayoutTests/imported/w3c/web-platform-tests/html/rendering/replaced-elements/the-option-element/option-label-whitespace-ref.html
+/LayoutTests/imported/w3c/web-platform-tests/html/rendering/replaced-elements/the-option-element/option-label-whitespace.html
 /LayoutTests/imported/w3c/web-platform-tests/html/rendering/replaced-elements/the-option-element/option-with-br-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/html/rendering/replaced-elements/the-option-element/option-with-br-ref.html
 /LayoutTests/imported/w3c/web-platform-tests/html/rendering/replaced-elements/the-option-element/option-with-br.html


### PR DESCRIPTION
#### 31f65f967b1c45b01faa2df6b2a7b800212ca2ec
<pre>
Sync `replaced-elements/the-option-element` from WPT upstream

<a href="https://bugs.webkit.org/show_bug.cgi?id=292978">https://bugs.webkit.org/show_bug.cgi?id=292978</a>
<a href="https://rdar.apple.com/151295421">rdar://151295421</a>

Reviewed by Tim Nguyen.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/b8f6a4649eb1e482750be3f6dfed2129c6345291">https://github.com/web-platform-tests/wpt/commit/b8f6a4649eb1e482750be3f6dfed2129c6345291</a>

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/resources/resource-files.json:
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/replaced-elements/the-option-element/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/replaced-elements/the-option-element/option-label-whitespace-2-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/replaced-elements/the-option-element/option-label-whitespace-2.html:
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/replaced-elements/the-option-element/option-label-whitespace-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/replaced-elements/the-option-element/option-label-whitespace-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/replaced-elements/the-option-element/option-label-whitespace.html:
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/replaced-elements/the-option-element/option-label-whitespace-2-expected-mismatch.html:

Canonical link: <a href="https://commits.webkit.org/294897@main">https://commits.webkit.org/294897@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/683dfaffa7fb987723090190a62d83952ebda42b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/103466 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/23148 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/13467 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/108640 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/54111 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/23498 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/31699 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78619 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/106472 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/18215 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/93330 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58954 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/18035 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/11377 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/53467 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/87829 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/11437 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/111019 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/30613 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/22573 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/87617 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/30974 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/89530 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87258 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22211 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32133 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/9843 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/24956 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/30541 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/30341 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/33672 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/31902 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->