### PR TITLE
Canonicalize CSS opacity values at parse time to remove serialization hack

### DIFF
--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -4387,7 +4387,7 @@
                 "animation-wrapper-requires-render-style": true,
                 "style-converter": "Opacity",
                 "svg": true,
-                "parser-grammar": "<alpha-value>"
+                "parser-grammar": "<opacity-value>"
             },
             "specification": {
                 "category": "svg",
@@ -4461,7 +4461,7 @@
                 "animation-wrapper-requires-render-style": true,
                 "style-converter": "Opacity",
                 "svg": true,
-                "parser-grammar": "<alpha-value>"
+                "parser-grammar": "<opacity-value>"
             },
             "specification": {
                 "category": "css-filters",
@@ -6474,7 +6474,7 @@
                 "animation-wrapper": "Wrapper<float>",
                 "animation-wrapper-acceleration": "always",
                 "style-converter": "Opacity",
-                "parser-grammar": "<alpha-value>"
+                "parser-grammar": "<opacity-value>"
             },
             "status": {
                 "comment": "Honor -webkit-opacity as a synonym for opacity. This was the only syntax that worked in Safari 1.1, and may be in use on some websites and widgets."
@@ -7376,7 +7376,7 @@
                 "animation-wrapper-requires-render-style": true,
                 "style-converter": "Opacity",
                 "svg": true,
-                "parser-grammar": "<alpha-value>"
+                "parser-grammar": "<opacity-value>"
             },
             "specification": {
                 "category": "svg",
@@ -7526,7 +7526,7 @@
                 "animation-wrapper-requires-render-style": true,
                 "style-converter": "Opacity",
                 "svg": true,
-                "parser-grammar": "<alpha-value>"
+                "parser-grammar": "<opacity-value>"
             },
             "specification": {
                 "category": "svg",
@@ -12906,11 +12906,11 @@
         }
     },
     "shared-grammar-rules": {
-        "<alpha-value>": {
-            "grammar": "<number> | <percentage>",
+        "<opacity-value>": {
+            "grammar": "<number-or-percentage-resolved-to-number>",
             "specification": {
                 "category": "css-color",
-                "url": "https://www.w3.org/TR/css-color-4/#typedef-alpha-value"
+                "url": "https://www.w3.org/TR/css-color-4/#typedef-opacity-opacity-value"
             }
         },
         "<marker-ref>": {

--- a/Source/WebCore/css/StyleProperties.cpp
+++ b/Source/WebCore/css/StyleProperties.cpp
@@ -62,20 +62,6 @@ Ref<ImmutableStyleProperties> StyleProperties::immutableCopyIfNeeded() const
 
 String serializeLonghandValue(const CSS::SerializationContext& context, CSSPropertyID property, const CSSValue& value)
 {
-    switch (property) {
-    case CSSPropertyFillOpacity:
-    case CSSPropertyFloodOpacity:
-    case CSSPropertyOpacity:
-    case CSSPropertyStopOpacity:
-    case CSSPropertyStrokeOpacity:
-        // FIXME: Handle this when creating the CSSValue for opacity, to be consistent with other CSS value serialization quirks.
-        // Opacity percentage values serialize as a fraction in the range 0-1, not "%".
-        if (auto* primitive = dynamicDowncast<CSSPrimitiveValue>(value); primitive && primitive->isPercentage())
-            return makeString(primitive->resolveAsPercentageDeprecated() / 100);
-        break;
-    default:
-        break;
-    }
     // Longhands set by mask and background shorthands can have comma-separated lists with implicit initial values in them.
     // We need to serialize those lists with the actual values, not as "initial".
     // Doing this for all CSSValueList with comma separators is better than checking the property is one of those longhands.


### PR DESCRIPTION
#### 1e9d44a3f626af69f611fab61cc12f7ce9797c77
<pre>
Canonicalize CSS opacity values at parse time to remove serialization hack
<a href="https://bugs.webkit.org/show_bug.cgi?id=292988">https://bugs.webkit.org/show_bug.cgi?id=292988</a>

Reviewed by NOBODY (OOPS!).

We have had a hack to convert percentage opacity values into number values at
serialization time for specified values. We solve this same problem elsewhere
by canonicalizing at parse time using the `&lt;number-or-percentage-resolved-to-number&gt;`
parser production.

* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/css/StyleProperties.cpp:
(WebCore::serializeLonghandValue):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1e9d44a3f626af69f611fab61cc12f7ce9797c77

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/103486 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/23168 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/13487 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/108662 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/54131 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/105525 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/23519 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/31719 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78638 "Found 1 new test failure: fast/css/parsing-opacity.html (failure)") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/106492 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/18237 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/93350 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58973 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/18057 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-color/parsing/opacity-valid.html (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/11397 "Found 2 new test failures: fast/css/parsing-opacity.html imported/w3c/web-platform-tests/css/css-color/parsing/opacity-valid.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/53487 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/87848 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/11457 "Found 2 new test failures: fast/css/parsing-opacity.html imported/w3c/web-platform-tests/css/css-color/parsing/opacity-valid.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/111040 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/30633 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/22595 "Found 2 new test failures: fast/css/parsing-opacity.html imported/w3c/web-platform-tests/css/css-color/parsing/opacity-valid.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/87636 "Found 2 new test failures: fast/css/parsing-opacity.html imported/w3c/web-platform-tests/css/css-color/parsing/opacity-valid.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/30994 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/89550 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87277 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32153 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/9863 "Found 2 new test failures: fast/css/parsing-opacity.html imported/w3c/web-platform-tests/css/css-color/parsing/opacity-valid.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/24983 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/30561 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/35873 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/30361 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/33692 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/31922 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->