### PR TITLE
[Computed Style Gen] Push additional work from CSSComputedStyleDeclaration to Style::Extractor to work towards more efficient serialization

### DIFF
--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -1048,10 +1048,8 @@ auto KeyframeEffect::getKeyframes() -> Vector<ComputedKeyframe>
                         styleString = styleProperties->getPropertyValue(cssPropertyId);
                 }
             }
-            if (styleString.isEmpty()) {
-                if (auto cssValue = computedStyleExtractor.valueForPropertyInStyle(style, cssPropertyId, CSSValuePool::singleton(), nullptr, Style::ExtractorState::PropertyValueType::Computed))
-                    styleString = cssValue->cssText(CSS::defaultSerializationContext());
-            }
+            if (styleString.isEmpty())
+                styleString = computedStyleExtractor.propertyValueSerializationInStyle(style, cssPropertyId, CSS::defaultSerializationContext(), CSSValuePool::singleton(), nullptr, Style::ExtractorState::PropertyValueType::Computed);
             computedKeyframe.styleStrings.set(cssPropertyId, styleString);
         };
 

--- a/Source/WebCore/animation/WebAnimation.cpp
+++ b/Source/WebCore/animation/WebAnimation.cpp
@@ -1808,14 +1808,16 @@ ExceptionOr<void> WebAnimation::commitStyles()
         if (m_replaceState == ReplaceState::Removed)
             effect->animation()->resolve(*animatedStyle, { nullptr });
         return WTF::switchOn(property,
-            [&] (CSSPropertyID propertyId) {
-                if (auto cssValue = computedStyleExtractor.valueForPropertyInStyle(*animatedStyle, propertyId, CSSValuePool::singleton(), nullptr, Style::ExtractorState::PropertyValueType::Computed))
-                    return inlineStyle->setProperty(propertyId, cssValue->cssText(CSS::defaultSerializationContext()), { styledElement->document() });
+            [&](CSSPropertyID propertyId) {
+                auto string = computedStyleExtractor.propertyValueSerializationInStyle(*animatedStyle, propertyId, CSS::defaultSerializationContext(), CSSValuePool::singleton(), nullptr, Style::ExtractorState::PropertyValueType::Computed);
+                if (!string.isEmpty())
+                    return inlineStyle->setProperty(propertyId, WTFMove(string), { styledElement->document() });
                 return false;
             },
-            [&] (const AtomString& customProperty) {
-                if (auto cssValue = computedStyleExtractor.customPropertyValue(customProperty))
-                    return inlineStyle->setCustomProperty(customProperty, cssValue->cssText(CSS::defaultSerializationContext()), { styledElement->document() });
+            [&](const AtomString& customProperty) {
+                auto string = computedStyleExtractor.customPropertyValueSerialization(customProperty, CSS::defaultSerializationContext());
+                if (!string.isEmpty())
+                    return inlineStyle->setCustomProperty(customProperty, WTFMove(string), { styledElement->document() });
                 return false;
             }
         );

--- a/Source/WebCore/css/CSSComputedStyleDeclaration.h
+++ b/Source/WebCore/css/CSSComputedStyleDeclaration.h
@@ -73,14 +73,15 @@ private:
     ExceptionOr<void> setPropertyInternal(CSSPropertyID, const String& value, IsImportant) final;
     Ref<MutableStyleProperties> copyProperties() const final;
 
-    RefPtr<CSSValue> getPropertyCSSValue(CSSPropertyID, Style::Extractor::UpdateLayout = Style::Extractor::UpdateLayout::Yes) const;
     Ref<Element> protectedElement() const { return m_element; }
 
     const Settings* settings() const final;
     RefPtr<const Settings> protectedSettings() const;
     const FixedVector<CSSPropertyID>& exposedComputedCSSPropertyIDs() const;
 
-    mutable Ref<Element> m_element;
+    Style::Extractor extractor() const;
+
+    const Ref<Element> m_element;
     std::optional<Style::PseudoElementIdentifier> m_pseudoElementIdentifier { std::nullopt };
     bool m_isEmpty { false };
     bool m_allowVisitedStyle { false };

--- a/Source/WebCore/css/typedom/ComputedStylePropertyMapReadOnly.cpp
+++ b/Source/WebCore/css/typedom/ComputedStylePropertyMapReadOnly.cpp
@@ -58,8 +58,7 @@ RefPtr<CSSValue> ComputedStylePropertyMapReadOnly::propertyValue(CSSPropertyID p
 
 String ComputedStylePropertyMapReadOnly::shorthandPropertySerialization(CSSPropertyID propertyID) const
 {
-    auto value = propertyValue(propertyID);
-    return value ? value->cssText(CSS::defaultSerializationContext()) : String();
+    return Style::Extractor { m_element.get() }.propertyValueSerialization(propertyID, CSS::defaultSerializationContext(), Style::Extractor::UpdateLayout::Yes, Style::ExtractorState::PropertyValueType::Computed);
 }
 
 RefPtr<CSSValue> ComputedStylePropertyMapReadOnly::customPropertyValue(const AtomString& property) const

--- a/Source/WebCore/inspector/agents/InspectorAnimationAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorAnimationAgent.cpp
@@ -160,15 +160,19 @@ static Ref<JSON::ArrayOf<Inspector::Protocol::Animation::Keyframe>> buildObjectF
             for (auto property : properties) {
                 --count;
                 WTF::switchOn(property,
-                    [&] (CSSPropertyID cssPropertyId) {
-                        stylePayloadBuilder.append(nameString(cssPropertyId), ": "_s);
-                        if (auto value = computedStyleExtractor.valueForPropertyInStyle(style, cssPropertyId, CSSValuePool::singleton(), renderer))
-                            stylePayloadBuilder.append(value->cssText(CSS::defaultSerializationContext()));
+                    [&](CSSPropertyID cssPropertyId) {
+                        stylePayloadBuilder.append(
+                            nameString(cssPropertyId),
+                            ": "_s,
+                            computedStyleExtractor.propertyValueSerializationInStyle(style, cssPropertyId, CSS::defaultSerializationContext(), CSSValuePool::singleton(), renderer)
+                        );
                     },
-                    [&] (const AtomString& customProperty) {
-                        stylePayloadBuilder.append(customProperty, ": "_s);
-                        if (auto value = computedStyleExtractor.customPropertyValue(customProperty))
-                            stylePayloadBuilder.append(value->cssText(CSS::defaultSerializationContext()));
+                    [&](const AtomString& customProperty) {
+                        stylePayloadBuilder.append(
+                            customProperty,
+                            ": "_s,
+                            computedStyleExtractor.customPropertyValueSerialization(customProperty, CSS::defaultSerializationContext())
+                        );
                     }
                 );
                 stylePayloadBuilder.append(';');

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -1314,8 +1314,8 @@ inline static bool changedCustomPaintWatchedProperty(const RenderStyle& a, const
                     CSSPropertyID propertyID = cssPropertyID(name);
                     if (!propertyID)
                         continue;
-                    valueA = extractor.valueForPropertyInStyle(a, propertyID, pool);
-                    valueB = extractor.valueForPropertyInStyle(b, propertyID, pool);
+                    valueA = extractor.propertyValueInStyle(a, propertyID, pool);
+                    valueB = extractor.propertyValueInStyle(b, propertyID, pool);
                 }
 
                 if ((valueA && !valueB) || (!valueA && valueB))

--- a/Source/WebCore/style/StyleExtractorCustom.h
+++ b/Source/WebCore/style/StyleExtractorCustom.h
@@ -260,7 +260,7 @@ template<CSSPropertyID propertyID> Ref<CSSValue> extractZoomAdjustedInsetValue(E
     if (!offset.isAuto())
         return ExtractorConverter::convertLength(state, offset);
 
-    auto offsetUsedStyleRelative = [&](RenderBox& box) -> LayoutUnit {
+    auto offsetUsedStyleRelative = [&](const RenderBox& box) -> LayoutUnit {
         // For relatively positioned boxes, the offset is with respect to the top edges
         // of the box itself. This ties together top/bottom and left/right to be
         // opposites of each other.
@@ -288,7 +288,7 @@ template<CSSPropertyID propertyID> Ref<CSSValue> extractZoomAdjustedInsetValue(E
     if (box->isRelativelyPositioned())
         return ExtractorConverter::convertNumberAsPixels(state, offsetUsedStyleRelative(*box));
 
-    auto offsetUsedStyleOutOfFlowPositioned = [&](RenderBlock& container, RenderBox& box) {
+    auto offsetUsedStyleOutOfFlowPositioned = [&](const RenderBlock& container, const RenderBox& box) {
         // For out-of-flow positioned boxes, the offset is how far an box's margin
         // edge is offset below the edge of the box's containing block.
         // See http://www.w3.org/TR/CSS2/visuren.html#position-props

--- a/Source/WebCore/style/StyleExtractorState.h
+++ b/Source/WebCore/style/StyleExtractorState.h
@@ -45,7 +45,7 @@ struct ExtractorState {
     Ref<Element> element;
     const std::optional<Style::PseudoElementIdentifier>& pseudoElementIdentifier;
 
-    RenderElement* renderer;
+    const RenderElement* renderer;
 
     bool allowVisitedStyle;
 

--- a/Source/WebCore/svg/properties/SVGPropertyAnimator.h
+++ b/Source/WebCore/svg/properties/SVGPropertyAnimator.h
@@ -85,12 +85,10 @@ protected:
 
         // Don't include any properties resulting from CSS Transitions/Animations or SMIL animations, as we want to retrieve the "base value".
         targetElement.setUseOverrideComputedStyle(true);
-        RefPtr value = Style::Extractor(&targetElement).propertyValue(id);
+        auto serialization = Style::Extractor(&targetElement).propertyValueSerialization(id, CSS::defaultSerializationContext());
         targetElement.setUseOverrideComputedStyle(false);
-        if (!value)
-            return String();
 
-        return value->cssText(CSS::defaultSerializationContext());
+        return serialization;
     }
 
     String computeInheritedCSSPropertyValue(SVGElement& targetElement) const


### PR DESCRIPTION
#### 5ac2036bd91d75f603356785bbf947f2a184daa5
<pre>
[Computed Style Gen] Push additional work from CSSComputedStyleDeclaration to Style::Extractor to work towards more efficient serialization
<a href="https://bugs.webkit.org/show_bug.cgi?id=292992">https://bugs.webkit.org/show_bug.cgi?id=292992</a>

Reviewed by Darin Adler.

Eventually, we would like to be able to implement CSSComputedStyleDeclaration.getPropertyValue()
without requiring an intermediate CSSValue. As a step toward that, we need to move serialization
down to Style::Extractor to make the creation of the CSSValue an implementation detail.

* Source/WebCore/css/CSSComputedStyleDeclaration.cpp:
* Source/WebCore/css/CSSComputedStyleDeclaration.h:
    - Factor Style::Extractor into a helper.
    - Call new propertyValueSerialization()/customPropertyValueSerialization() functions.

* Source/WebCore/animation/KeyframeEffect.cpp:
* Source/WebCore/animation/WebAnimation.cpp:
* Source/WebCore/inspector/agents/InspectorAnimationAgent.cpp:
* Source/WebCore/css/typedom/ComputedStylePropertyMapReadOnly.cpp:
* Source/WebCore/svg/properties/SVGPropertyAnimator.h:
    - Call new propertyValueSerialization() function.

* Source/WebCore/style/StyleExtractor.cpp:
(WebCore::Style::Extractor::customPropertyValueSerialization const):
(WebCore::Style::Extractor::customPropertyText const): Deleted.
    - Rename customPropertyText to customPropertyValueSerialization() to match propertyValueSerialization().

(WebCore::Style::Extractor::computeStyle const):
(WebCore::Style::Extractor::propertyValue const):
    - Factor RenderStyle preparation out of propertyValue() so it can be shared with propertyValueSerialization().

(WebCore::Style::Extractor::propertyValueSerialization const):
    - Moved logic from CSSComputedStyleDeclaration here to hide intermediate CSSValue creation. Eventually
      this will be able to serialize properties without CSSValues.

* Source/WebCore/style/StyleExtractorCustom.h:
* Source/WebCore/style/StyleExtractorState.h:
    - Make the RenderElement stored in Style::ExtractorState const.

Canonical link: <a href="https://commits.webkit.org/294963@main">https://commits.webkit.org/294963@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/321b7f748f8dd6f6a534c2d0fde29a3c5219bf4b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/103500 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/23182 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/13502 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/108676 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/54145 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/105539 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/23533 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/31733 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78650 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/106506 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/18245 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/93365 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58985 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/18066 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/11412 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/53501 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/87856 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/11472 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/111054 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/30647 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/22606 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/87646 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/31008 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/89565 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87287 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22248 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32165 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/9878 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/24998 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/30575 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/35887 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/30375 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/33706 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/31936 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->