### PR TITLE
Unreviewed, reverting 294891@main (0a1ac6a9346a)

### DIFF
--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -7734,6 +7734,10 @@ imported/w3c/web-platform-tests/css/css-position/multicol/static-position/vrl-lt
 
 webkit.org/b/290407 imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-auto-relevancy-updates.html [ Pass Failure ]
 
+# webkit.org/b/290410 ([iOS Debug] 2 MediaRecorder tests are constantly crashing due to assertion failure.)
+[ Debug ] http/wpt/mediarecorder/MediaRecorder-audio-samplingrate-change.html [ Crash ]
+[ Debug ] http/wpt/mediarecorder/MediaRecorder-first-frame.html [ Crash ]
+
 webkit.org/b/290412 imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/current-time-root-scroller.html [ Pass Failure ]
 
 webkit.org/b/290413 [ Debug ] imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/javascript-url-return-value-handling-dynamic.html [ Failure ]

--- a/Source/WebCore/Modules/mediasource/MediaSource.cpp
+++ b/Source/WebCore/Modules/mediasource/MediaSource.cpp
@@ -477,11 +477,11 @@ Ref<MediaPromise> MediaSource::seekToTime(const MediaTime& time)
     return MediaPromise::createAndResolve();
 }
 
-PlatformTimeRanges MediaSource::seekable()
+Ref<TimeRanges> MediaSource::seekable()
 {
-    if (RefPtr mediaSourcePrivate = protectedPrivate())
-        return mediaSourcePrivate->seekable();
-    return { };
+    if (RefPtr msp = protectedPrivate())
+        return TimeRanges::create(msp->seekable());
+    return TimeRanges::create();
 }
 
 ExceptionOr<void> MediaSource::setLiveSeekableRange(double start, double end)

--- a/Source/WebCore/Modules/mediasource/MediaSource.h
+++ b/Source/WebCore/Modules/mediasource/MediaSource.h
@@ -110,7 +110,7 @@ public:
     void elementIsShuttingDown();
     void detachFromElement();
     bool isSeeking() const { return !!m_pendingSeekTarget; }
-    PlatformTimeRanges seekable();
+    Ref<TimeRanges> seekable();
     ExceptionOr<void> setLiveSeekableRange(double start, double end);
     ExceptionOr<void> clearLiveSeekableRange();
 

--- a/Source/WebCore/Modules/mediasource/MediaSourceInterfaceMainThread.cpp
+++ b/Source/WebCore/Modules/mediasource/MediaSourceInterfaceMainThread.cpp
@@ -65,7 +65,7 @@ PlatformTimeRanges MediaSourceInterfaceMainThread::buffered() const
     return m_mediaSource->buffered();
 }
 
-PlatformTimeRanges MediaSourceInterfaceMainThread::seekable() const
+Ref<TimeRanges> MediaSourceInterfaceMainThread::seekable() const
 {
     return m_mediaSource->seekable();
 }

--- a/Source/WebCore/Modules/mediasource/MediaSourceInterfaceMainThread.h
+++ b/Source/WebCore/Modules/mediasource/MediaSourceInterfaceMainThread.h
@@ -43,7 +43,7 @@ private:
     bool isClosed() const final;
     MediaTime duration() const final;
     PlatformTimeRanges buffered() const final;
-    PlatformTimeRanges seekable() const final;
+    Ref<TimeRanges> seekable() const final;
     bool isStreamingContent() const final;
     bool attachToElement(WeakPtr<HTMLMediaElement>&&) final;
     void detachFromElement() final;

--- a/Source/WebCore/Modules/mediasource/MediaSourceInterfaceProxy.h
+++ b/Source/WebCore/Modules/mediasource/MediaSourceInterfaceProxy.h
@@ -50,7 +50,7 @@ public:
     virtual bool isClosed() const = 0;
     virtual MediaTime duration() const = 0;
     virtual PlatformTimeRanges buffered() const = 0;
-    virtual PlatformTimeRanges seekable() const = 0;
+    virtual Ref<TimeRanges> seekable() const = 0;
     virtual bool isStreamingContent() const = 0;
     virtual bool attachToElement(WeakPtr<HTMLMediaElement>&&) = 0;
     virtual void detachFromElement() = 0;

--- a/Source/WebCore/Modules/mediasource/MediaSourceInterfaceWorker.cpp
+++ b/Source/WebCore/Modules/mediasource/MediaSourceInterfaceWorker.cpp
@@ -78,11 +78,11 @@ PlatformTimeRanges MediaSourceInterfaceWorker::buffered() const
     return PlatformTimeRanges::emptyRanges();
 }
 
-PlatformTimeRanges MediaSourceInterfaceWorker::seekable() const
+Ref<TimeRanges> MediaSourceInterfaceWorker::seekable() const
 {
     if (RefPtr mediaSourcePrivate = m_handle->mediaSourcePrivate(); mediaSourcePrivate && !isClosed())
-        return mediaSourcePrivate->seekable();
-    return { };
+        return TimeRanges::create(mediaSourcePrivate->seekable());
+    return TimeRanges::create();
 }
 
 bool MediaSourceInterfaceWorker::isStreamingContent() const

--- a/Source/WebCore/Modules/mediasource/MediaSourceInterfaceWorker.h
+++ b/Source/WebCore/Modules/mediasource/MediaSourceInterfaceWorker.h
@@ -43,7 +43,7 @@ private:
     bool isClosed() const final;
     MediaTime duration() const final;
     PlatformTimeRanges buffered() const final;
-    PlatformTimeRanges seekable() const final;
+    Ref<TimeRanges> seekable() const final;
     bool isStreamingContent() const final;
     bool attachToElement(WeakPtr<HTMLMediaElement>&&) final;
     void detachFromElement() final;

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -6273,20 +6273,15 @@ Ref<TimeRanges> HTMLMediaElement::played()
 
 Ref<TimeRanges> HTMLMediaElement::seekable() const
 {
-    return TimeRanges::create(platformSeekable());
-}
-
-PlatformTimeRanges HTMLMediaElement::platformSeekable() const
-{
 #if ENABLE(MEDIA_SOURCE)
     if (m_mediaSource)
         return m_mediaSource->seekable();
 #endif
 
     if (m_player)
-        return m_player->seekable();
+        return TimeRanges::create(m_player->seekable());
 
-    return { };
+    return TimeRanges::create();
 }
 
 double HTMLMediaElement::seekableTimeRangesLastModifiedTime() const

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -317,7 +317,6 @@ public:
     void updatePlaybackRate();
     Ref<TimeRanges> played() override;
     Ref<TimeRanges> seekable() const override;
-    PlatformTimeRanges platformSeekable() const;
     double seekableTimeRangesLastModifiedTime() const;
     double liveUpdateInterval() const;
     WEBCORE_EXPORT bool ended() const;

--- a/Source/WebCore/platform/cocoa/PlaybackSessionModel.h
+++ b/Source/WebCore/platform/cocoa/PlaybackSessionModel.h
@@ -43,7 +43,7 @@ class PlaybackSessionModelClient;
 
 namespace WebCore {
 
-class PlatformTimeRanges;
+class TimeRanges;
 class PlaybackSessionModelClient;
 struct MediaSelectionOption;
 struct SpatialVideoMetadata;
@@ -126,7 +126,7 @@ public:
     virtual bool isScrubbing() const = 0;
     virtual double defaultPlaybackRate() const = 0;
     virtual double playbackRate() const = 0;
-    virtual PlatformTimeRanges seekableRanges() const = 0;
+    virtual Ref<TimeRanges> seekableRanges() const = 0;
     virtual double seekableTimeRangesLastModifiedTime() const = 0;
     virtual double liveUpdateInterval() const = 0;
     virtual bool canPlayFastReverse() const = 0;
@@ -170,7 +170,7 @@ public:
     virtual void bufferedTimeChanged(double) { }
     virtual void playbackStartedTimeChanged(double /* playbackStartedTime */) { }
     virtual void rateChanged(OptionSet<PlaybackSessionModel::PlaybackState>, double /* playbackRate */, double /* defaultPlaybackRate */) { }
-    virtual void seekableRangesChanged(const PlatformTimeRanges&, double /* lastModified */, double /* liveInterval */) { }
+    virtual void seekableRangesChanged(const TimeRanges&, double /* lastModified */, double /* liveInterval */) { }
     virtual void canPlayFastReverseChanged(bool) { }
     virtual void audioMediaSelectionOptionsChanged(const Vector<MediaSelectionOption>& /* options */, uint64_t /* selectedIndex */) { }
     virtual void legibleMediaSelectionOptionsChanged(const Vector<MediaSelectionOption>& /* options */, uint64_t /* selectedIndex */) { }

--- a/Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.h
+++ b/Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.h
@@ -115,7 +115,7 @@ public:
     bool isScrubbing() const final { return false; }
     double defaultPlaybackRate() const final;
     double playbackRate() const final;
-    PlatformTimeRanges seekableRanges() const final;
+    Ref<TimeRanges> seekableRanges() const final;
     double seekableTimeRangesLastModifiedTime() const final;
     double liveUpdateInterval() const final;
     bool canPlayFastReverse() const final;

--- a/Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.mm
+++ b/Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.mm
@@ -208,11 +208,12 @@ void PlaybackSessionModelMediaElement::updateForEventName(const WTF::AtomString&
     if (all
         || eventName == eventNames().progressEvent) {
         auto bufferedTime = this->bufferedTime();
+        auto seekableRanges = this->seekableRanges();
         auto seekableTimeRangesLastModifiedTime = this->seekableTimeRangesLastModifiedTime();
         auto liveUpdateInterval = this->liveUpdateInterval();
         for (auto& client : m_clients) {
             client->bufferedTimeChanged(bufferedTime);
-            client->seekableRangesChanged(seekableRanges(), seekableTimeRangesLastModifiedTime, liveUpdateInterval);
+            client->seekableRangesChanged(seekableRanges, seekableTimeRangesLastModifiedTime, liveUpdateInterval);
         }
     }
 
@@ -662,11 +663,11 @@ double PlaybackSessionModelMediaElement::playbackRate() const
     return 0;
 }
 
-PlatformTimeRanges PlaybackSessionModelMediaElement::seekableRanges() const
+Ref<TimeRanges> PlaybackSessionModelMediaElement::seekableRanges() const
 {
     if (RefPtr mediaElement = m_mediaElement; mediaElement && mediaElement->supportsSeeking())
-        return mediaElement->platformSeekable();
-    return { };
+        return mediaElement->seekable();
+    return TimeRanges::create();
 }
 
 double PlaybackSessionModelMediaElement::seekableTimeRangesLastModifiedTime() const

--- a/Source/WebCore/platform/graphics/MediaPlayerPrivate.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlayerPrivate.cpp
@@ -49,11 +49,9 @@ std::optional<VideoFrameMetadata> MediaPlayerPrivateInterface::videoFrameMetadat
 
 const PlatformTimeRanges& MediaPlayerPrivateInterface::seekable() const
 {
-    auto maxTimeSeekable = this->maxTimeSeekable();
-    if (maxTimeSeekable == MediaTime::zeroTime())
+    if (maxTimeSeekable() == MediaTime::zeroTime())
         return PlatformTimeRanges::emptyRanges();
-    ASSERT(maxTimeSeekable.isValid());
-    m_seekable = { minTimeSeekable(), maxTimeSeekable };
+    m_seekable = { minTimeSeekable(), maxTimeSeekable() };
     return m_seekable;
 }
 

--- a/Source/WebCore/platform/graphics/PlatformTimeRanges.cpp
+++ b/Source/WebCore/platform/graphics/PlatformTimeRanges.cpp
@@ -203,8 +203,10 @@ MediaTime PlatformTimeRanges::minimumBufferedTime() const
 
 void PlatformTimeRanges::add(const MediaTime& start, const MediaTime& end, AddTimeRangeOption addTimeRangeOption)
 {
+#if !PLATFORM(MAC) // https://bugs.webkit.org/show_bug.cgi?id=180253
     ASSERT(start.isValid());
     ASSERT(end.isValid());
+#endif
     ASSERT(start <= end);
 
     auto startTime = start;

--- a/Source/WebCore/platform/graphics/cocoa/NullPlaybackSessionInterface.h
+++ b/Source/WebCore/platform/graphics/cocoa/NullPlaybackSessionInterface.h
@@ -87,7 +87,7 @@ private:
     void currentTimeChanged(double, double) final { }
     void bufferedTimeChanged(double) final { }
     void rateChanged(OptionSet<PlaybackSessionModel::PlaybackState>, double, double) final { }
-    void seekableRangesChanged(const PlatformTimeRanges&, double, double) final { }
+    void seekableRangesChanged(const TimeRanges&, double, double) final { }
     void canPlayFastReverseChanged(bool) final { }
     void audioMediaSelectionOptionsChanged(const Vector<MediaSelectionOption>&, uint64_t) final { }
     void legibleMediaSelectionOptionsChanged(const Vector<MediaSelectionOption>&, uint64_t) final { }

--- a/Source/WebCore/platform/ios/PlaybackSessionInterfaceAVKit.h
+++ b/Source/WebCore/platform/ios/PlaybackSessionInterfaceAVKit.h
@@ -50,7 +50,7 @@ public:
     void currentTimeChanged(double, double) final;
     void bufferedTimeChanged(double) final { }
     void rateChanged(OptionSet<PlaybackSessionModel::PlaybackState>, double, double) final;
-    void seekableRangesChanged(const PlatformTimeRanges&, double, double) final;
+    void seekableRangesChanged(const TimeRanges&, double, double) final;
     void canPlayFastReverseChanged(bool) final;
     void audioMediaSelectionOptionsChanged(const Vector<MediaSelectionOption>&, uint64_t) final;
     void legibleMediaSelectionOptionsChanged(const Vector<MediaSelectionOption>&, uint64_t) final;

--- a/Source/WebCore/platform/ios/PlaybackSessionInterfaceAVKit.mm
+++ b/Source/WebCore/platform/ios/PlaybackSessionInterfaceAVKit.mm
@@ -255,9 +255,9 @@ void PlaybackSessionInterfaceAVKit::rateChanged(OptionSet<PlaybackSessionModel::
         [m_contentSource setRate:playbackState.contains(PlaybackSessionModel::PlaybackState::Playing) ? playbackRate : 0];
 }
 
-void PlaybackSessionInterfaceAVKit::seekableRangesChanged(const PlatformTimeRanges& timeRanges, double, double)
+void PlaybackSessionInterfaceAVKit::seekableRangesChanged(const TimeRanges& timeRanges, double, double)
 {
-    [m_contentSource setSeekableTimeRanges:makeNSArray(timeRanges).get()];
+    [m_contentSource setSeekableTimeRanges:makeNSArray(timeRanges.ranges()).get()];
 }
 
 void PlaybackSessionInterfaceAVKit::canPlayFastReverseChanged(bool canPlayFastReverse)

--- a/Source/WebCore/platform/ios/PlaybackSessionInterfaceAVKitLegacy.h
+++ b/Source/WebCore/platform/ios/PlaybackSessionInterfaceAVKitLegacy.h
@@ -46,7 +46,7 @@ public:
     void currentTimeChanged(double currentTime, double anchorTime) final;
     void bufferedTimeChanged(double) final;
     void rateChanged(OptionSet<PlaybackSessionModel::PlaybackState>, double playbackRate, double defaultPlaybackRate) final;
-    void seekableRangesChanged(const PlatformTimeRanges&, double lastModifiedTime, double liveUpdateInterval) final;
+    void seekableRangesChanged(const TimeRanges&, double lastModifiedTime, double liveUpdateInterval) final;
     void canPlayFastReverseChanged(bool) final;
     void audioMediaSelectionOptionsChanged(const Vector<MediaSelectionOption>& options, uint64_t selectedIndex) final;
     void legibleMediaSelectionOptionsChanged(const Vector<MediaSelectionOption>& options, uint64_t selectedIndex) final;

--- a/Source/WebCore/platform/ios/PlaybackSessionInterfaceAVKitLegacy.mm
+++ b/Source/WebCore/platform/ios/PlaybackSessionInterfaceAVKitLegacy.mm
@@ -139,9 +139,9 @@ void PlaybackSessionInterfaceAVKitLegacy::rateChanged(OptionSet<PlaybackSessionM
         [m_playerController setRate:playbackState.contains(PlaybackSessionModel::PlaybackState::Playing) ? playbackRate : 0. fromJavaScript:YES];
 }
 
-void PlaybackSessionInterfaceAVKitLegacy::seekableRangesChanged(const PlatformTimeRanges& timeRanges, double lastModifiedTime, double liveUpdateInterval)
+void PlaybackSessionInterfaceAVKitLegacy::seekableRangesChanged(const TimeRanges& timeRanges, double lastModifiedTime, double liveUpdateInterval)
 {
-    [m_playerController setSeekableTimeRanges:makeNSArray(timeRanges).get()];
+    [m_playerController setSeekableTimeRanges:makeNSArray(timeRanges.ranges()).get()];
     [m_playerController setSeekableTimeRangesLastModifiedTime:lastModifiedTime];
     [m_playerController setLiveUpdateInterval:liveUpdateInterval];
 }

--- a/Source/WebCore/platform/ios/PlaybackSessionInterfaceIOS.h
+++ b/Source/WebCore/platform/ios/PlaybackSessionInterfaceIOS.h
@@ -70,7 +70,7 @@ public:
     void currentTimeChanged(double currentTime, double anchorTime) override = 0;
     void bufferedTimeChanged(double) override = 0;
     void rateChanged(OptionSet<PlaybackSessionModel::PlaybackState>, double playbackRate, double defaultPlaybackRate) override = 0;
-    void seekableRangesChanged(const PlatformTimeRanges&, double lastModifiedTime, double liveUpdateInterval) override = 0;
+    void seekableRangesChanged(const TimeRanges&, double lastModifiedTime, double liveUpdateInterval) override = 0;
     void canPlayFastReverseChanged(bool) override = 0;
     void audioMediaSelectionOptionsChanged(const Vector<MediaSelectionOption>& options, uint64_t selectedIndex) override = 0;
     void legibleMediaSelectionOptionsChanged(const Vector<MediaSelectionOption>& options, uint64_t selectedIndex) override = 0;

--- a/Source/WebCore/platform/ios/PlaybackSessionInterfaceTVOS.h
+++ b/Source/WebCore/platform/ios/PlaybackSessionInterfaceTVOS.h
@@ -44,7 +44,7 @@ public:
     void currentTimeChanged(double, double) final { }
     void bufferedTimeChanged(double) final { }
     void rateChanged(OptionSet<PlaybackSessionModel::PlaybackState>, double, double) final { }
-    void seekableRangesChanged(const PlatformTimeRanges&, double, double) final { }
+    void seekableRangesChanged(const TimeRanges&, double, double) final { }
     void canPlayFastReverseChanged(bool) final { }
     void audioMediaSelectionOptionsChanged(const Vector<MediaSelectionOption>&, uint64_t) final { }
     void legibleMediaSelectionOptionsChanged(const Vector<MediaSelectionOption>&, uint64_t) final { }

--- a/Source/WebCore/platform/ios/WebVideoFullscreenControllerAVKit.mm
+++ b/Source/WebCore/platform/ios/WebVideoFullscreenControllerAVKit.mm
@@ -160,7 +160,7 @@ private:
     bool isScrubbing() const override { return false; }
     double defaultPlaybackRate() const override;
     double playbackRate() const override;
-    PlatformTimeRanges seekableRanges() const override;
+    Ref<TimeRanges> seekableRanges() const override;
     double seekableTimeRangesLastModifiedTime() const override;
     double liveUpdateInterval() const override;
     bool canPlayFastReverse() const override;
@@ -190,7 +190,7 @@ private:
     void currentTimeChanged(double currentTime, double anchorTime) override;
     void bufferedTimeChanged(double) override;
     void rateChanged(OptionSet<PlaybackSessionModel::PlaybackState>, double playbackRate, double defaultPlaybackRate) override;
-    void seekableRangesChanged(const PlatformTimeRanges&, double lastModifiedTime, double liveUpdateInterval) override;
+    void seekableRangesChanged(const TimeRanges&, double lastModifiedTime, double liveUpdateInterval) override;
     void canPlayFastReverseChanged(bool) override;
     void audioMediaSelectionOptionsChanged(const Vector<MediaSelectionOption>& options, uint64_t selectedIndex) override;
     void legibleMediaSelectionOptionsChanged(const Vector<MediaSelectionOption>& options, uint64_t selectedIndex) override;
@@ -470,11 +470,11 @@ void VideoFullscreenControllerContext::videoDimensionsChanged(const FloatSize& v
         client->videoDimensionsChanged(videoDimensions);
 }
 
-void VideoFullscreenControllerContext::seekableRangesChanged(const PlatformTimeRanges& timeRanges, double lastModifiedTime, double liveUpdateInterval)
+void VideoFullscreenControllerContext::seekableRangesChanged(const TimeRanges& timeRanges, double lastModifiedTime, double liveUpdateInterval)
 {
     if (WebThreadIsCurrent()) {
-        RunLoop::protectedMain()->dispatch([protectedThis = Ref { *this }, timeRanges, lastModifiedTime, liveUpdateInterval] {
-            protectedThis->seekableRangesChanged(timeRanges, lastModifiedTime, liveUpdateInterval);
+        RunLoop::protectedMain()->dispatch([protectedThis = Ref { *this }, platformTimeRanges = timeRanges.ranges(), lastModifiedTime, liveUpdateInterval] {
+            protectedThis->seekableRangesChanged(TimeRanges::create(platformTimeRanges), lastModifiedTime, liveUpdateInterval);
         });
         return;
     }
@@ -931,10 +931,10 @@ double VideoFullscreenControllerContext::playbackRate() const
     return m_playbackModel ? m_playbackModel->playbackRate() : 0;
 }
 
-PlatformTimeRanges VideoFullscreenControllerContext::seekableRanges() const
+Ref<TimeRanges> VideoFullscreenControllerContext::seekableRanges() const
 {
     ASSERT(isUIThread());
-    return m_playbackModel ? m_playbackModel->seekableRanges() : PlatformTimeRanges::emptyRanges();
+    return m_playbackModel ? m_playbackModel->seekableRanges() : TimeRanges::create();
 }
 
 double VideoFullscreenControllerContext::seekableTimeRangesLastModifiedTime() const

--- a/Source/WebCore/platform/mac/PlaybackSessionInterfaceMac.h
+++ b/Source/WebCore/platform/mac/PlaybackSessionInterfaceMac.h
@@ -61,7 +61,7 @@ public:
     void durationChanged(double) final;
     void currentTimeChanged(double /*currentTime*/, double /*anchorTime*/) final;
     void rateChanged(OptionSet<PlaybackSessionModel::PlaybackState>, double /* playbackRate */, double /* defaultPlaybackRate */) final;
-    void seekableRangesChanged(const PlatformTimeRanges&, double /*lastModifiedTime*/, double /*liveUpdateInterval*/) final;
+    void seekableRangesChanged(const TimeRanges&, double /*lastModifiedTime*/, double /*liveUpdateInterval*/) final;
     void audioMediaSelectionOptionsChanged(const Vector<MediaSelectionOption>& /*options*/, uint64_t /*selectedIndex*/) final;
     void legibleMediaSelectionOptionsChanged(const Vector<MediaSelectionOption>& /*options*/, uint64_t /*selectedIndex*/) final;
     void audioMediaSelectionIndexChanged(uint64_t) final;

--- a/Source/WebCore/platform/mac/PlaybackSessionInterfaceMac.mm
+++ b/Source/WebCore/platform/mac/PlaybackSessionInterfaceMac.mm
@@ -154,11 +154,25 @@ void PlaybackSessionInterfaceMac::skipAd()
         model->skipAd();
 }
 #endif
+#if ENABLE(WEB_PLAYBACK_CONTROLS_MANAGER)
+static RetainPtr<NSMutableArray> timeRangesToArray(const TimeRanges& timeRanges)
+{
+    RetainPtr<NSMutableArray> rangeArray = adoptNS([[NSMutableArray alloc] init]);
 
-void PlaybackSessionInterfaceMac::seekableRangesChanged(const PlatformTimeRanges& timeRanges, double, double)
+    for (unsigned i = 0; i < timeRanges.length(); i++) {
+        const PlatformTimeRanges& ranges = timeRanges.ranges();
+        CMTimeRange range = PAL::CMTimeRangeMake(PAL::toCMTime(ranges.start(i)), PAL::toCMTime(ranges.end(i)));
+        [rangeArray addObject:[NSValue valueWithCMTimeRange:range]];
+    }
+
+    return rangeArray;
+}
+#endif
+
+void PlaybackSessionInterfaceMac::seekableRangesChanged(const TimeRanges& timeRanges, double, double)
 {
 #if ENABLE(WEB_PLAYBACK_CONTROLS_MANAGER)
-    [playBackControlsManager() setSeekableTimeRanges:makeNSArray(timeRanges).get()];
+    [playBackControlsManager() setSeekableTimeRanges:timeRangesToArray(timeRanges).get()];
 #else
     UNUSED_PARAM(timeRanges);
 #endif
@@ -254,7 +268,7 @@ void PlaybackSessionInterfaceMac::setPlayBackControlsManager(WebPlaybackControls
     manager.hasEnabledVideo = duration > 0;
     manager.defaultPlaybackRate = m_playbackSessionModel->defaultPlaybackRate();
     manager.rate = m_playbackSessionModel->isPlaying() ? m_playbackSessionModel->playbackRate() : 0.;
-    manager.seekableTimeRanges = makeNSArray(m_playbackSessionModel->seekableRanges()).get();
+    manager.seekableTimeRanges = timeRangesToArray(m_playbackSessionModel->seekableRanges()).get();
     manager.canTogglePlayback = YES;
     manager.playing = m_playbackSessionModel->isPlaying();
     [manager setAudioMediaSelectionOptions:m_playbackSessionModel->audioMediaSelectionOptions() withSelectedIndex:static_cast<NSUInteger>(m_playbackSessionModel->audioMediaSelectedIndex())];

--- a/Source/WebKit/Platform/ios/PlaybackSessionInterfaceLMK.h
+++ b/Source/WebKit/Platform/ios/PlaybackSessionInterfaceLMK.h
@@ -49,7 +49,7 @@ public:
     void currentTimeChanged(double, double) final;
     void bufferedTimeChanged(double) final { }
     void rateChanged(OptionSet<WebCore::PlaybackSessionModel::PlaybackState>, double, double) final;
-    void seekableRangesChanged(const WebCore::PlatformTimeRanges&, double, double) final;
+    void seekableRangesChanged(const WebCore::TimeRanges&, double, double) final;
     void canPlayFastReverseChanged(bool) final;
     void audioMediaSelectionOptionsChanged(const Vector<WebCore::MediaSelectionOption>&, uint64_t) final;
     void legibleMediaSelectionOptionsChanged(const Vector<WebCore::MediaSelectionOption>&, uint64_t) final;

--- a/Source/WebKit/Platform/ios/PlaybackSessionInterfaceLMK.mm
+++ b/Source/WebKit/Platform/ios/PlaybackSessionInterfaceLMK.mm
@@ -287,7 +287,7 @@ void PlaybackSessionInterfaceLMK::rateChanged(OptionSet<WebCore::PlaybackSession
         [m_player setPlaybackRate:playbackState.contains(WebCore::PlaybackSessionModel::PlaybackState::Playing) ? playbackRate : 0];
 }
 
-void PlaybackSessionInterfaceLMK::seekableRangesChanged(const WebCore::PlatformTimeRanges& timeRanges, double, double)
+void PlaybackSessionInterfaceLMK::seekableRangesChanged(const WebCore::TimeRanges& timeRanges, double, double)
 {
     RetainPtr seekableRanges = adoptNS([[NSMutableArray alloc] initWithCapacity:timeRanges.length()]);
     for (unsigned i = 0; i < timeRanges.length(); ++i) {

--- a/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.h
+++ b/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.h
@@ -81,7 +81,7 @@ public:
     void bufferedTimeChanged(double);
     void playbackStartedTimeChanged(double);
     void rateChanged(OptionSet<WebCore::PlaybackSessionModel::PlaybackState>, double playbackRate, double defaultPlaybackRate);
-    void seekableRangesChanged(const WebCore::PlatformTimeRanges&, double lastModifiedTime, double liveUpdateInterval);
+    void seekableRangesChanged(WebCore::TimeRanges&, double lastModifiedTime, double liveUpdateInterval);
     void canPlayFastReverseChanged(bool);
     void audioMediaSelectionOptionsChanged(const Vector<WebCore::MediaSelectionOption>& options, uint64_t index);
     void legibleMediaSelectionOptionsChanged(const Vector<WebCore::MediaSelectionOption>& options, uint64_t index);
@@ -164,7 +164,7 @@ private:
     bool isScrubbing() const final { return m_isScrubbing; }
     double defaultPlaybackRate() const final { return m_defaultPlaybackRate; }
     double playbackRate() const final { return m_playbackRate; }
-    WebCore::PlatformTimeRanges seekableRanges() const final { return m_seekableRanges; }
+    Ref<WebCore::TimeRanges> seekableRanges() const final { return m_seekableRanges.copyRef(); }
     double seekableTimeRangesLastModifiedTime() const final { return m_seekableTimeRangesLastModifiedTime; }
     double liveUpdateInterval() const { return m_liveUpdateInterval; }
     bool canPlayFastReverse() const final { return m_canPlayFastReverse; }
@@ -210,7 +210,7 @@ private:
     bool m_isScrubbing { false };
     double m_defaultPlaybackRate { 0 };
     double m_playbackRate { 0 };
-    WebCore::PlatformTimeRanges m_seekableRanges;
+    Ref<WebCore::TimeRanges> m_seekableRanges { WebCore::TimeRanges::create() };
     double m_seekableTimeRangesLastModifiedTime { 0 };
     double m_liveUpdateInterval { 0 };
     bool m_canPlayFastReverse { false };
@@ -289,7 +289,7 @@ private:
     void swapFullscreenModes(PlaybackSessionContextIdentifier, PlaybackSessionContextIdentifier);
     void currentTimeChanged(PlaybackSessionContextIdentifier, double currentTime, double hostTime);
     void bufferedTimeChanged(PlaybackSessionContextIdentifier, double bufferedTime);
-    void seekableRangesVectorChanged(PlaybackSessionContextIdentifier, const WebCore::PlatformTimeRanges&, double lastModifiedTime, double liveUpdateInterval);
+    void seekableRangesVectorChanged(PlaybackSessionContextIdentifier, Vector<std::pair<double, double>> ranges, double lastModifiedTime, double liveUpdateInterval);
     void canPlayFastReverseChanged(PlaybackSessionContextIdentifier, bool value);
     void audioMediaSelectionOptionsChanged(PlaybackSessionContextIdentifier, Vector<WebCore::MediaSelectionOption> options, uint64_t selectedIndex);
     void legibleMediaSelectionOptionsChanged(PlaybackSessionContextIdentifier, Vector<WebCore::MediaSelectionOption> options, uint64_t selectedIndex);

--- a/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.messages.in
+++ b/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.messages.in
@@ -30,7 +30,7 @@
 messages -> PlaybackSessionManagerProxy {
     CurrentTimeChanged(WebCore::MediaPlayerClientIdentifier contextId, double currentTime, double hostTime)
     BufferedTimeChanged(WebCore::MediaPlayerClientIdentifier contextId, double bufferedTime)
-    SeekableRangesVectorChanged(WebCore::MediaPlayerClientIdentifier contextId, WebCore::PlatformTimeRanges ranges, double lastModifiedTime, double liveUpdateInterval)
+    SeekableRangesVectorChanged(WebCore::MediaPlayerClientIdentifier contextId, Vector<std::pair<double, double>> ranges, double lastModifiedTime, double liveUpdateInterval)
     CanPlayFastReverseChanged(WebCore::MediaPlayerClientIdentifier contextId, bool value)
     AudioMediaSelectionOptionsChanged(WebCore::MediaPlayerClientIdentifier contextId, Vector<WebCore::MediaSelectionOption> options, uint64_t selectedIndex)
     LegibleMediaSelectionOptionsChanged(WebCore::MediaPlayerClientIdentifier contextId, Vector<WebCore::MediaSelectionOption> options, uint64_t selectedIndex)

--- a/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.mm
+++ b/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.mm
@@ -378,9 +378,9 @@ void PlaybackSessionModelContext::rateChanged(OptionSet<WebCore::PlaybackSession
         client->rateChanged(m_playbackState, m_playbackRate, m_defaultPlaybackRate);
 }
 
-void PlaybackSessionModelContext::seekableRangesChanged(const WebCore::PlatformTimeRanges& seekableRanges, double lastModifiedTime, double liveUpdateInterval)
+void PlaybackSessionModelContext::seekableRangesChanged(WebCore::TimeRanges& seekableRanges, double lastModifiedTime, double liveUpdateInterval)
 {
-    INFO_LOG_IF_POSSIBLE(LOGIDENTIFIER, seekableRanges);
+    INFO_LOG_IF_POSSIBLE(LOGIDENTIFIER, seekableRanges.ranges());
     m_seekableRanges = seekableRanges;
     m_seekableTimeRangesLastModifiedTime = lastModifiedTime;
     m_liveUpdateInterval = liveUpdateInterval;
@@ -738,8 +738,15 @@ void PlaybackSessionManagerProxy::bufferedTimeChanged(PlaybackSessionContextIden
     ensureModel(contextId)->bufferedTimeChanged(bufferedTime);
 }
 
-void PlaybackSessionManagerProxy::seekableRangesVectorChanged(PlaybackSessionContextIdentifier contextId, const WebCore::PlatformTimeRanges& timeRanges, double lastModifiedTime, double liveUpdateInterval)
+void PlaybackSessionManagerProxy::seekableRangesVectorChanged(PlaybackSessionContextIdentifier contextId, Vector<std::pair<double, double>> ranges, double lastModifiedTime, double liveUpdateInterval)
 {
+    Ref<TimeRanges> timeRanges = TimeRanges::create();
+    for (const auto& range : ranges) {
+        ASSERT(isfinite(range.first));
+        ASSERT(!isfinite(range.second) || range.second >= range.first);
+        timeRanges->add(range.first, range.second);
+    }
+
     ensureModel(contextId)->seekableRangesChanged(timeRanges, lastModifiedTime, liveUpdateInterval);
 }
 

--- a/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.h
+++ b/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.h
@@ -91,7 +91,7 @@ private:
     void bufferedTimeChanged(double) final;
     void playbackStartedTimeChanged(double playbackStartedTime) final;
     void rateChanged(OptionSet<WebCore::PlaybackSessionModel::PlaybackState>, double playbackRate, double defaultPlaybackRate) final;
-    void seekableRangesChanged(const WebCore::PlatformTimeRanges&, double lastModifiedTime, double liveUpdateInterval) final;
+    void seekableRangesChanged(const WebCore::TimeRanges&, double lastModifiedTime, double liveUpdateInterval) final;
     void canPlayFastReverseChanged(bool value) final;
     void audioMediaSelectionOptionsChanged(const Vector<WebCore::MediaSelectionOption>& options, uint64_t selectedIndex) final;
     void legibleMediaSelectionOptionsChanged(const Vector<WebCore::MediaSelectionOption>& options, uint64_t selectedIndex) final;
@@ -173,7 +173,7 @@ private:
     void bufferedTimeChanged(PlaybackSessionContextIdentifier, double bufferedTime);
     void playbackStartedTimeChanged(PlaybackSessionContextIdentifier, double playbackStartedTime);
     void rateChanged(PlaybackSessionContextIdentifier, OptionSet<WebCore::PlaybackSessionModel::PlaybackState>, double playbackRate, double defaultPlaybackRate);
-    void seekableRangesChanged(PlaybackSessionContextIdentifier, const WebCore::PlatformTimeRanges&, double lastModifiedTime, double liveUpdateInterval);
+    void seekableRangesChanged(PlaybackSessionContextIdentifier, const WebCore::TimeRanges&, double lastModifiedTime, double liveUpdateInterval);
     void canPlayFastReverseChanged(PlaybackSessionContextIdentifier, bool value);
     void audioMediaSelectionOptionsChanged(PlaybackSessionContextIdentifier, const Vector<WebCore::MediaSelectionOption>& options, uint64_t selectedIndex);
     void legibleMediaSelectionOptionsChanged(PlaybackSessionContextIdentifier, const Vector<WebCore::MediaSelectionOption>& options, uint64_t selectedIndex);


### PR DESCRIPTION
#### 9b2540637dfdf5e1fd00ea0e548151b73478f9cb
<pre>
Unreviewed, reverting 294891@main (0a1ac6a9346a)
<a href="https://bugs.webkit.org/show_bug.cgi?id=292990">https://bugs.webkit.org/show_bug.cgi?id=292990</a>
<a href="https://rdar.apple.com/151306160">rdar://151306160</a>

Broke Internal visionOS builds

Reverted change:

    [iOS Debug] 2 MediaRecorder tests are constantly crashing due to assertion failure.
    <a href="https://bugs.webkit.org/show_bug.cgi?id=290410">https://bugs.webkit.org/show_bug.cgi?id=290410</a>
    <a href="https://rdar.apple.com/147863063">rdar://147863063</a>
    294891@main (0a1ac6a9346a)

Canonical link: <a href="https://commits.webkit.org/294906@main">https://commits.webkit.org/294906@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7ea210bf2f9b4cce7502f713dedd30bb49311e98

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/103490 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/23172 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/13491 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/108666 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/54135 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/105529 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/23523 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/31723 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/78642 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/54135 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/106496 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/18238 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/93354 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/58977 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/18058 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/11401 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/53491 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/87849 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/11461 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/111044 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/30637 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/22596 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/87635 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/30998 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/89554 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/87276 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/9867 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/24987 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16779 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/30565 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/35877 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/30365 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/33696 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/31926 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->