### PR TITLE
`option` element should not trim label value

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -867,7 +867,6 @@ imported/w3c/web-platform-tests/workers/interfaces/WorkerGlobalScope/onerror/mes
 [ Debug ] imported/w3c/web-platform-tests/css/css-properties-values-api/registered-property-revert.html [ Skip ]
 [ Debug ] imported/w3c/web-platform-tests/css/css-scoping/slotted-matches.html [ Skip ]
 imported/w3c/web-platform-tests/html/rendering/replaced-elements/the-option-element/option-label-whitespace.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/html/rendering/replaced-elements/the-option-element/option-label-whitespace-2.html [ ImageOnlyFailure ]
 
 # Cookie tests that are flaky since their import because they fail and and out some kind of unique id.
 imported/w3c/web-platform-tests/cookies/prefix/__host.document-cookie.html [ Pass Failure ]

--- a/LayoutTests/fast/forms/HTMLOptionElement_label03-expected.html
+++ b/LayoutTests/fast/forms/HTMLOptionElement_label03-expected.html
@@ -1,6 +1,0 @@
-<!DOCTYPE html>
-<body>
-    <select>
-        <option> </option>
-    </select>
-</body>

--- a/LayoutTests/fast/forms/HTMLOptionElement_label03.html
+++ b/LayoutTests/fast/forms/HTMLOptionElement_label03.html
@@ -1,7 +1,0 @@
-<!DOCTYPE html>
-<!-- Even though the label is nothing but whitespace, it exists, so it it used. -->
-<body>
-    <select>
-        <option label=" ">white space label should display empty string</option>
-    </select>
-</body>

--- a/Source/WebCore/html/HTMLOptionElement.cpp
+++ b/Source/WebCore/html/HTMLOptionElement.cpp
@@ -286,7 +286,7 @@ String HTMLOptionElement::label() const
 {
     String label = attributeWithoutSynchronization(labelAttr);
     if (!label.isNull())
-        return label.trim(isASCIIWhitespace);
+        return label;
     return collectOptionInnerText().trim(isASCIIWhitespace).simplifyWhiteSpace(isASCIIWhitespace);
 }
 


### PR DESCRIPTION
#### 8a518f208fde570152037786aead6b654c1840f0
<pre>
`option` element should not trim label value
<a href="https://bugs.webkit.org/show_bug.cgi?id=292994">https://bugs.webkit.org/show_bug.cgi?id=292994</a>
<a href="https://rdar.apple.com/151309514">rdar://151309514</a>

Reviewed by Aditya Keerthi.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

This patch removes the case where we were trimming label attribute value
for any leading and trailing whitespace.

While web specification [1] does not state any such thing:

[1] <a href="https://html.spec.whatwg.org/multipage/form-elements.html#concept-option-label">https://html.spec.whatwg.org/multipage/form-elements.html#concept-option-label</a>

&quot;The label of an option element is the value of the label content attribute,
if there is one and its value is not the empty string, or, otherwise,
the value of the element&apos;s text IDL attribute.&quot;

Similarly, following issue was also raised to clarify behavior and relevant
WPT tests were added [2], which we now progress with this patch:

[2] <a href="https://github.com/whatwg/html/issues/10955">https://github.com/whatwg/html/issues/10955</a>

* LayoutTests/TestExpectations:
* Source/WebCore/html/HTMLOptionElement.cpp:
(WebCore::HTMLOptionElement::label const):

&gt; Removed in favor of WPT test:
* LayoutTests/fast/forms/HTMLOptionElement_label03-expected.html: Removed.
* LayoutTests/fast/forms/HTMLOptionElement_label03.html: Removed.

Canonical link: <a href="https://commits.webkit.org/295708@main">https://commits.webkit.org/295708@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/04b8ae0517b039975f6e4df291d8ee6a2bc8a35f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105840 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25591 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15984 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/111037 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/56437 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/107881 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/26281 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34094 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80387 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108846 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/20705 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95509 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60715 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/20344 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13606 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55875 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/90094 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13644 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/113887 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32980 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24324 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89465 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33344 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91739 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89136 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22740 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34006 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11813 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/28497 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32905 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/38316 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32651 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/36000 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34249 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->