### PR TITLE
Tab Crash When ASSERTION FAILED: startList->size() == endList->size()

### DIFF
--- a/LayoutTests/webanimations/mismatching-animation-range-longhands-when-copying-expected.txt
+++ b/LayoutTests/webanimations/mismatching-animation-range-longhands-when-copying-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it does not crash.

--- a/LayoutTests/webanimations/mismatching-animation-range-longhands-when-copying.html
+++ b/LayoutTests/webanimations/mismatching-animation-range-longhands-when-copying.html
@@ -1,0 +1,22 @@
+<html>
+<head>
+<style>
+* { animation-range: entry exit; }
+#htmlvar00001, #htmlvar00003 {-webkit-text-security: circle }
+#htmlvar00006 {animation-range-start: normal, normal; }
+</style>
+<script>
+function jsfuzzer() {
+    window.testRunner?.dumpAsText();
+    document.execCommand('selectAll', false);
+    window.testRunner?.execCommand('copy');
+    document.getElementById("htmlvar00001").remove();
+}
+</script>
+</head>
+<body onload=jsfuzzer()>
+<p>This test passes if it does not crash.</p>
+<span id="htmlvar00001">
+<map id="htmlvar00006">
+</body>
+</html>

--- a/Source/WebCore/css/ShorthandSerializer.cpp
+++ b/Source/WebCore/css/ShorthandSerializer.cpp
@@ -1392,7 +1392,9 @@ String ShorthandSerializer::serializeAnimationRange() const
     auto* startList = dynamicDowncast<CSSValueList>(startValue);
     auto* endList = dynamicDowncast<CSSValueList>(endValue);
     if (startList && endList) {
-        ASSERT(startList->size() == endList->size());
+        if (startList->size() != endList->size())
+            return emptyString();
+
         for (unsigned i = 0; i < startList->size(); i++) {
             auto start = startList->item(i);
             RefPtr startPair = dynamicDowncast<CSSValuePair>(start);


### PR DESCRIPTION
#### a8cec25e37d5737ee8ed63daec5e713d15c4d6f9
<pre>
Tab Crash When ASSERTION FAILED: startList-&gt;size() == endList-&gt;size()
<a href="https://bugs.webkit.org/show_bug.cgi?id=291738">https://bugs.webkit.org/show_bug.cgi?id=291738</a>
<a href="https://rdar.apple.com/150018184">rdar://150018184</a>

Reviewed by Anne van Kesteren.

Selecting an element that has `animation-range-start` and `animation-range-end` values
with mismatching lengths would trigger the assertion that both values would have the
same length under `ShorthandSerializer::serializeAnimationRange()`.

We now account for that possibility and fallback to returning the empty string.

We also add a new test that would have crashed in Debug to the assertion failure prior
to this fix.

* LayoutTests/webanimations/mismatching-animation-range-longhands-when-copying-expected.txt: Added.
* LayoutTests/webanimations/mismatching-animation-range-longhands-when-copying.html: Added.
* Source/WebCore/css/ShorthandSerializer.cpp:
(WebCore::ShorthandSerializer::serializeAnimationRange const):

Canonical link: <a href="https://commits.webkit.org/294999@main">https://commits.webkit.org/294999@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8ff0a26d2f6c8c5054d91b9a3c070fe7da85a8e1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/103534 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/23216 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/13537 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/108710 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/54192 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/105574 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/23569 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/31767 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78675 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/106540 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/18275 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/93399 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59009 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/18088 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/11446 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/53535 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/87880 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/11505 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/111088 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/30681 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Debug-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/87670 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/31042 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/89599 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87313 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32188 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/9907 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/25032 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16842 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/30609 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/35921 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/30409 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/33740 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/31970 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->