### PR TITLE
AX: Use ElementName instead of TagName across live and isolated objects

### DIFF
--- a/Source/WebCore/accessibility/AXCoreObject.h
+++ b/Source/WebCore/accessibility/AXCoreObject.h
@@ -34,6 +34,7 @@
 #include "LayoutRect.h"
 #include "LocalFrameLoaderClient.h"
 #include "LocalizedStrings.h"
+#include "NodeName.h"
 #include "SimpleRange.h"
 #include "TextChecking.h"
 #include "TextIteratorBehavior.h"
@@ -1541,6 +1542,9 @@ public:
     virtual AXCoreObject* exposedTableAncestor(bool includeSelf = false) const = 0;
 
     virtual AccessibilityChildrenVector documentLinks() = 0;
+
+    virtual bool hasElementName(ElementName tag) const = 0;
+    virtual ElementName elementName() const = 0;
 
     virtual bool hasAttachmentTag() const = 0;
     virtual bool hasBodyTag() const = 0;

--- a/Source/WebCore/accessibility/AXLogger.cpp
+++ b/Source/WebCore/accessibility/AXLogger.cpp
@@ -742,6 +742,9 @@ TextStream& operator<<(WTF::TextStream& stream, AXProperty property)
     case AXProperty::DocumentURI:
         stream << "DocumentURI";
         break;
+    case AXProperty::ElementName:
+        stream << "ElementName";
+        break;
     case AXProperty::EmbeddedImageDescription:
         stream << "EmbeddedImageDescription";
         break;
@@ -1160,9 +1163,6 @@ TextStream& operator<<(WTF::TextStream& stream, AXProperty property)
         break;
     case AXProperty::SupportsSetSize:
         stream << "SupportsSetSize";
-        break;
-    case AXProperty::TagName:
-        stream << "TagName";
         break;
     case AXProperty::TextContentPrefixFromListMarker:
         stream << "TextContentPrefixFromListMarker";

--- a/Source/WebCore/accessibility/AXObjectCache.h
+++ b/Source/WebCore/accessibility/AXObjectCache.h
@@ -1016,6 +1016,9 @@ bool isRowGroup(Node*);
 ContainerNode* composedParentIgnoringDocumentFragments(Node&);
 ContainerNode* composedParentIgnoringDocumentFragments(Node*);
 
+ElementName elementName(Node*);
+ElementName elementName(Node&);
+
 // Returns true if the element has an attribute that will result in an accname being computed.
 // https://www.w3.org/TR/accname-1.2/
 bool hasAccNameAttribute(Element&);

--- a/Source/WebCore/accessibility/AXTextMarker.cpp
+++ b/Source/WebCore/accessibility/AXTextMarker.cpp
@@ -194,7 +194,7 @@ std::optional<BoundaryPoint> AXTextMarker::boundaryPoint() const
     RefPtr node = characterOffset.node;
 
     int offset = characterOffset.startIndex + characterOffset.offset;
-    if (AccessibilityObject::replacedNodeNeedsCharacter(*node) || node->hasTagName(HTMLNames::brTag))
+    if (AccessibilityObject::replacedNodeNeedsCharacter(*node) || WebCore::elementName(*node) == ElementName::HTML_br)
         node = nodeAndOffsetForReplacedNode(*node, offset, characterOffset.offset);
     if (!node)
         return std::nullopt;

--- a/Source/WebCore/accessibility/AccessibilityARIAGridRow.cpp
+++ b/Source/WebCore/accessibility/AccessibilityARIAGridRow.cpp
@@ -130,7 +130,7 @@ AccessibilityTable* AccessibilityARIAGridRow::parentTable() const
         // The parent table for an ARIA grid row should be an ARIA table.
         // Unless the row is a native tr element.
         if (auto* ancestorTable = dynamicDowncast<AccessibilityTable>(ancestor))
-            return ancestorTable->isExposable() && (ancestorTable->isAriaTable() || node()->hasTagName(HTMLNames::trTag));
+            return ancestorTable->isExposable() && (ancestorTable->isAriaTable() || elementName() == ElementName::HTML_tr);
 
         return false;
     }));

--- a/Source/WebCore/accessibility/AccessibilityList.cpp
+++ b/Source/WebCore/accessibility/AccessibilityList.cpp
@@ -77,8 +77,8 @@ bool AccessibilityList::isUnorderedList() const
     if (ariaRoleAttribute() == AccessibilityRole::List)
         return true;
 
-    auto* node = this->node();
-    return node && (node->hasTagName(menuTag) || node->hasTagName(ulTag));
+    auto elementName = this->elementName();
+    return elementName == ElementName::HTML_menu || elementName == ElementName::HTML_ul;
 }
 
 bool AccessibilityList::isOrderedList() const
@@ -87,14 +87,12 @@ bool AccessibilityList::isOrderedList() const
     if (ariaRoleAttribute() == AccessibilityRole::Directory)
         return true;
 
-    auto* node = this->node();
-    return node && node->hasTagName(olTag);
+    return elementName() == ElementName::HTML_ol;
 }
 
 bool AccessibilityList::isDescriptionList() const
 {
-    auto* node = this->node();
-    return node && node->hasTagName(dlTag);
+    return elementName() == ElementName::HTML_dl;
 }
 
 bool AccessibilityList::childHasPseudoVisibleListItemMarkers(const Node* node)
@@ -178,7 +176,7 @@ AccessibilityRole AccessibilityList::determineAccessibilityRoleWithCleanChildren
                 if (!hasVisibleMarkers && (renderListItem->style().listStyleType().type != ListStyleType::Type::None || renderListItem->style().listStyleImage() || childHasPseudoVisibleListItemMarkers(renderListItem->element())))
                     hasVisibleMarkers = true;
                 listItemCount++;
-            } else if (node && node->hasTagName(liTag)) {
+            } else if (WebCore::elementName(node.get()) == ElementName::HTML_li) {
                 // Inline elements that are in a list with an explicit role should also count.
                 if (m_ariaRole == AccessibilityRole::List)
                     listItemCount++;

--- a/Source/WebCore/accessibility/AccessibilityMathMLElement.cpp
+++ b/Source/WebCore/accessibility/AccessibilityMathMLElement.cpp
@@ -59,7 +59,7 @@ AccessibilityRole AccessibilityMathMLElement::determineAccessibilityRole()
         return m_ariaRole;
 
     Node* node = m_renderer->node();
-    if (node && node->hasTagName(MathMLNames::mathTag))
+    if (WebCore::elementName(node) == ElementName::MathML_math)
         return AccessibilityRole::DocumentMath;
 
     // It's not clear which role a platform should choose for a math element.
@@ -69,7 +69,7 @@ AccessibilityRole AccessibilityMathMLElement::determineAccessibilityRole()
 
 void AccessibilityMathMLElement::addChildren()
 {
-    if (!hasTagName(MathMLNames::mfencedTag)) {
+    if (!hasElementName(ElementName::MathML_mfenced)) {
         AccessibilityRenderObject::addChildren();
         return;
     }
@@ -183,37 +183,39 @@ bool AccessibilityMathMLElement::isMathSeparatorOperator() const
 
 bool AccessibilityMathMLElement::isMathText() const
 {
-    return node() && (node()->hasTagName(MathMLNames::mtextTag) || hasTagName(MathMLNames::msTag));
+    auto elementName = this->elementName();
+    return elementName == ElementName::MathML_mtext || elementName == ElementName::MathML_ms;
 }
 
 bool AccessibilityMathMLElement::isMathNumber() const
 {
-    return node() && node()->hasTagName(MathMLNames::mnTag);
+    return elementName() == ElementName::MathML_mn;
 }
 
 bool AccessibilityMathMLElement::isMathIdentifier() const
 {
-    return node() && node()->hasTagName(MathMLNames::miTag);
+    return elementName() == ElementName::MathML_mi;
 }
 
 bool AccessibilityMathMLElement::isMathMultiscript() const
 {
-    return node() && node()->hasTagName(MathMLNames::mmultiscriptsTag);
+    return elementName() == ElementName::MathML_mmultiscripts;
 }
 
 bool AccessibilityMathMLElement::isMathTable() const
 {
-    return node() && node()->hasTagName(MathMLNames::mtableTag);
+    return elementName() == ElementName::MathML_mtable;
 }
 
 bool AccessibilityMathMLElement::isMathTableRow() const
 {
-    return node() && (node()->hasTagName(MathMLNames::mtrTag) || hasTagName(MathMLNames::mlabeledtrTag));
+    auto elementName = this->elementName();
+    return elementName == ElementName::MathML_mtr || elementName == ElementName::MathML_mlabeledtr;
 }
 
 bool AccessibilityMathMLElement::isMathTableCell() const
 {
-    return node() && node()->hasTagName(MathMLNames::mtdTag);
+    return elementName() == ElementName::MathML_mtd;
 }
 
 bool AccessibilityMathMLElement::isMathScriptObject(AccessibilityMathScriptObjectType type) const
@@ -304,14 +306,15 @@ AXCoreObject* AccessibilityMathMLElement::mathDenominatorObject()
 
 AXCoreObject* AccessibilityMathMLElement::mathUnderObject()
 {
-    if (!isMathUnderOver() || !node())
+    if (!isMathUnderOver() || !element())
         return nullptr;
 
     const auto& children = this->unignoredChildren();
     if (children.size() < 2)
         return nullptr;
 
-    if (node()->hasTagName(MathMLNames::munderTag) || node()->hasTagName(MathMLNames::munderoverTag))
+    auto elementName = this->elementName();
+    if (elementName == ElementName::MathML_munder || elementName == ElementName::MathML_munderover)
         return children[1].ptr();
 
     return nullptr;
@@ -323,10 +326,10 @@ AXCoreObject* AccessibilityMathMLElement::mathOverObject()
         return nullptr;
 
     const auto& children = unignoredChildren();
-    if (children.size() >= 2 && node()->hasTagName(MathMLNames::moverTag))
+    if (children.size() >= 2 && elementName() == ElementName::MathML_mover)
         return children[1].ptr();
 
-    if (children.size() >= 3 && node()->hasTagName(MathMLNames::munderoverTag))
+    if (children.size() >= 3 && elementName() == ElementName::MathML_munderover)
         return children[2].ptr();
 
     return nullptr;
@@ -354,7 +357,8 @@ AXCoreObject* AccessibilityMathMLElement::mathSubscriptObject()
     if (children.size() < 2)
         return nullptr;
 
-    if (node()->hasTagName(MathMLNames::msubTag) || node()->hasTagName(MathMLNames::msubsupTag))
+    auto elementName = this->elementName();
+    if (elementName == ElementName::MathML_msub || elementName == ElementName::MathML_msubsup)
         return children[1].ptr();
 
     return nullptr;
@@ -368,10 +372,11 @@ AXCoreObject* AccessibilityMathMLElement::mathSuperscriptObject()
     const auto& children = unignoredChildren();
     unsigned count = children.size();
 
-    if (count >= 2 && node()->hasTagName(MathMLNames::msupTag))
+    auto elementName = this->elementName();
+    if (count >= 2 && elementName == ElementName::MathML_msup)
         return children[1].ptr();
 
-    if (count >= 3 && node()->hasTagName(MathMLNames::msubsupTag))
+    if (count >= 3 && elementName == ElementName::MathML_msubsup)
         return children[2].ptr();
 
     return nullptr;
@@ -413,7 +418,7 @@ void AccessibilityMathMLElement::mathPrescripts(AccessibilityMathMultiscriptPair
                     prescriptPair.second = nullptr;
                 }
             }
-        } else if (child->hasTagName(MathMLNames::mprescriptsTag))
+        } else if (WebCore::elementName(*child) == ElementName::MathML_mprescripts)
             foundPrescript = true;
     }
 
@@ -432,7 +437,7 @@ void AccessibilityMathMLElement::mathPostscripts(AccessibilityMathMultiscriptPai
     std::pair<AccessibilityObject*, AccessibilityObject*> postscriptPair;
     bool foundBaseElement = false;
     for (Node* child = node()->firstChild(); child; child = child->nextSibling()) {
-        if (child->hasTagName(MathMLNames::mprescriptsTag))
+        if (WebCore::elementName(*child) == ElementName::MathML_mprescripts)
             break;
 
         AccessibilityObject* axChild = axObjectCache()->getOrCreate(*child);

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
@@ -333,13 +333,14 @@ AccessibilityRole AccessibilityNodeObject::determineAccessibilityRoleFromNode(Tr
     if (is<HTMLImageElement>(*element) && element->hasAttributeWithoutSynchronization(usemapAttr))
         return AccessibilityRole::ImageMap;
 
-    if (element->hasTagName(liTag))
+    auto elementName = element->elementName();
+    if (elementName == ElementName::HTML_li)
         return AccessibilityRole::ListItem;
-    if (element->hasTagName(buttonTag))
+    if (elementName == ElementName::HTML_button)
         return buttonRoleType();
-    if (element->hasTagName(legendTag))
+    if (elementName == ElementName::HTML_legend)
         return AccessibilityRole::Legend;
-    if (element->hasTagName(canvasTag))
+    if (elementName == ElementName::HTML_canvas)
         return AccessibilityRole::Canvas;
 
     if (RefPtr input = dynamicDowncast<HTMLInputElement>(*element))
@@ -351,66 +352,66 @@ AccessibilityRole AccessibilityNodeObject::determineAccessibilityRoleFromNode(Tr
     if (headingLevel())
         return AccessibilityRole::Heading;
 
-    if (element->hasTagName(codeTag))
+    if (elementName == ElementName::HTML_code)
         return AccessibilityRole::Code;
-    if (element->hasTagName(delTag) || element->hasTagName(sTag))
+    if (elementName == ElementName::HTML_del || elementName == ElementName::HTML_s)
         return AccessibilityRole::Deletion;
-    if (element->hasTagName(insTag))
+    if (elementName == ElementName::HTML_ins)
         return AccessibilityRole::Insertion;
-    if (element->hasTagName(subTag))
+    if (elementName == ElementName::HTML_sub)
         return AccessibilityRole::Subscript;
-    if (element->hasTagName(supTag))
+    if (elementName == ElementName::HTML_sup)
         return AccessibilityRole::Superscript;
-    if (element->hasTagName(strongTag))
+    if (elementName == ElementName::HTML_strong)
         return AccessibilityRole::Strong;
 
-    if (element->hasTagName(kbdTag)
-        || element->hasTagName(preTag)
-        || element->hasTagName(sampTag)
-        || element->hasTagName(varTag)
-        || element->hasTagName(citeTag))
+    if (elementName == ElementName::HTML_kbd
+        || elementName == ElementName::HTML_pre
+        || elementName == ElementName::HTML_samp
+        || elementName == ElementName::HTML_var
+        || elementName == ElementName::HTML_cite)
         return treatStyleFormatGroupAsInline == TreatStyleFormatGroupAsInline::Yes ? AccessibilityRole::Inline : AccessibilityRole::TextGroup;
 
-    if (element->hasTagName(ddTag))
+    if (elementName == ElementName::HTML_dd)
         return AccessibilityRole::DescriptionListDetail;
-    if (element->hasTagName(dtTag))
+    if (elementName == ElementName::HTML_dt)
         return AccessibilityRole::DescriptionListTerm;
-    if (element->hasTagName(dlTag))
+    if (elementName == ElementName::HTML_dl)
         return AccessibilityRole::DescriptionList;
 
-    if (element->hasTagName(menuTag)
-        || element->hasTagName(olTag)
-        || element->hasTagName(ulTag))
+    if (elementName == ElementName::HTML_menu
+        || elementName == ElementName::HTML_ol
+        || elementName == ElementName::HTML_ul)
         return AccessibilityRole::List;
 
-    if (element->hasTagName(fieldsetTag))
+    if (elementName == ElementName::HTML_fieldset)
         return AccessibilityRole::Group;
-    if (element->hasTagName(figureTag))
+    if (elementName == ElementName::HTML_figure)
         return AccessibilityRole::Figure;
-    if (element->hasTagName(pTag))
+    if (elementName == ElementName::HTML_p)
         return AccessibilityRole::Paragraph;
 
     if (is<HTMLLabelElement>(*element))
         return AccessibilityRole::Label;
-    if (element->hasTagName(dfnTag)) {
+    if (elementName == ElementName::HTML_dfn) {
         // Confusingly, the `dfn` element represents a term being defined, making it equivalent to the "term" ARIA
         // role rather than the "definition" ARIA role. The "definition" ARIA role has no HTML equivalent.
         // https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-dfn-element
         // https://w3c.github.io/aria/#term and https://w3c.github.io/aria/#definition
         return AccessibilityRole::Term;
     }
-    if (element->hasTagName(divTag) && !isNonNativeTextControl())
+    if (elementName == ElementName::HTML_div && !isNonNativeTextControl())
         return AccessibilityRole::Generic;
     if (is<HTMLFormElement>(*element))
         return AccessibilityRole::Form;
-    if (element->hasTagName(articleTag))
+    if (elementName == ElementName::HTML_article)
         return AccessibilityRole::DocumentArticle;
-    if (element->hasTagName(mainTag))
+    if (elementName == ElementName::HTML_main)
         return AccessibilityRole::LandmarkMain;
-    if (element->hasTagName(navTag))
+    if (elementName == ElementName::HTML_nav)
         return AccessibilityRole::LandmarkNavigation;
 
-    if (element->hasTagName(asideTag)) {
+    if (elementName == ElementName::HTML_aside) {
         if (ariaRoleAttribute() == AccessibilityRole::LandmarkComplementary || !isDescendantOfElementType({ asideTag, articleTag, sectionTag, navTag }))
             return AccessibilityRole::LandmarkComplementary;
 
@@ -419,25 +420,25 @@ AccessibilityRole AccessibilityNodeObject::determineAccessibilityRoleFromNode(Tr
         return WebCore::hasAccNameAttribute(*element) ? AccessibilityRole::LandmarkComplementary : AccessibilityRole::Generic;
     }
 
-    if (element->hasTagName(searchTag))
+    if (elementName == ElementName::HTML_search)
         return AccessibilityRole::LandmarkSearch;
 
-    if (element->hasTagName(sectionTag)) {
+    if (elementName == ElementName::HTML_section) {
         // https://w3c.github.io/html-aam/#el-section
         // The default role attribute value for the section element, region, became a landmark in ARIA 1.1.
         // The HTML AAM spec says it is "strongly recommended" that ATs only convey and provide navigation
         // for section elements which have names.
         return WebCore::hasAccNameAttribute(*element) ? AccessibilityRole::LandmarkRegion : AccessibilityRole::TextGroup;
     }
-    if (element->hasTagName(addressTag))
+    if (elementName == ElementName::HTML_address)
         return AccessibilityRole::Group;
-    if (element->hasTagName(blockquoteTag))
+    if (elementName == ElementName::HTML_blockquote)
         return AccessibilityRole::Blockquote;
-    if (element->hasTagName(captionTag) || element->hasTagName(figcaptionTag))
+    if (elementName == ElementName::HTML_caption || elementName == ElementName::HTML_figcaption)
         return AccessibilityRole::Caption;
-    if (element->hasTagName(dialogTag))
+    if (elementName == ElementName::HTML_dialog)
         return AccessibilityRole::ApplicationDialog;
-    if (element->hasTagName(markTag) || equalLettersIgnoringASCIICase(getAttribute(roleAttr), "mark"_s))
+    if (elementName == ElementName::HTML_mark || equalLettersIgnoringASCIICase(getAttribute(roleAttr), "mark"_s))
         return AccessibilityRole::Mark;
     if (is<HTMLDetailsElement>(*element))
         return AccessibilityRole::Details;
@@ -457,17 +458,17 @@ AccessibilityRole AccessibilityNodeObject::determineAccessibilityRoleFromNode(Tr
 #endif
 
 #if ENABLE(MODEL_ELEMENT)
-    if (element->hasTagName(modelTag))
+    if (elementName == ElementName::HTML_model)
         return AccessibilityRole::Model;
 #endif
 
     // The HTML element should not be exposed as an element. That's what the RenderView element does.
-    if (element->hasTagName(htmlTag))
+    if (elementName == ElementName::HTML_html)
         return AccessibilityRole::Ignored;
 
     // There should only be one banner/contentInfo per page. If header/footer are being used within an article or section then it should not be exposed as whole page's banner/contentInfo.
     // https://w3c.github.io/html-aam/#el-header
-    if (element->hasTagName(headerTag)) {
+    if (elementName == ElementName::HTML_header) {
         if (!isDescendantOfElementType({ articleTag, asideTag, mainTag, navTag, sectionTag }))
             return AccessibilityRole::LandmarkBanner;
         return AccessibilityRole::Generic;
@@ -476,19 +477,19 @@ AccessibilityRole AccessibilityNodeObject::determineAccessibilityRoleFromNode(Tr
     // http://webkit.org/b/190138 Footers should become contentInfo's if scoped to body (and consequently become a landmark).
     // It should remain a footer if scoped to main, sectioning elements (article, aside, nav, section) or root sectioning element (blockquote, details, dialog, fieldset, figure, td).
     // https://w3c.github.io/html-aam/#el-footer
-    if (element->hasTagName(footerTag)) {
+    if (elementName == ElementName::HTML_footer) {
         if (!isDescendantOfElementType({ articleTag, asideTag, navTag, sectionTag, mainTag, blockquoteTag, detailsTag, dialogTag, fieldsetTag, figureTag, tdTag }))
             return AccessibilityRole::LandmarkContentInfo;
         return AccessibilityRole::Footer;
     }
 
-    if (element->hasTagName(timeTag))
+    if (elementName == ElementName::HTML_time)
         return AccessibilityRole::Time;
-    if (element->hasTagName(hrTag))
+    if (elementName == ElementName::HTML_hr)
         return AccessibilityRole::HorizontalRule;
-    if (element->hasTagName(emTag))
+    if (elementName == ElementName::HTML_em)
         return AccessibilityRole::Emphasis;
-    if (element->hasTagName(hgroupTag))
+    if (elementName == ElementName::HTML_hgroup)
         return AccessibilityRole::Group;
 
     // If the element does not have role, but it has ARIA attributes, or accepts tab focus, accessibility should fallback to exposing it as a group.
@@ -607,7 +608,7 @@ void AccessibilityNodeObject::addChildren()
         return;
 
     // The only time we add children from the DOM tree to a node with a renderer is when it's a canvas.
-    if (renderer() && !node->hasTagName(canvasTag))
+    if (renderer() && WebCore::elementName(*node) != ElementName::HTML_canvas)
         return;
 
     CheckedPtr cache = axObjectCache();
@@ -637,8 +638,8 @@ void AccessibilityNodeObject::addChildren()
 
 bool AccessibilityNodeObject::canHaveChildren() const
 {
-    // When <noscript> is not being used (its renderer() == 0), ignore its children.
-    if (node() && !renderer() && node()->hasTagName(noscriptTag))
+    // When <noscript> is not being used (its renderer() == 0), ignore its children
+    if (node() && !renderer() && WebCore::elementName(node()) == ElementName::HTML_noscript)
         return false;
     // If this is an AccessibilityRenderObject, then it's okay if this object
     // doesn't have a node - there are some renderers that don't have associated
@@ -703,7 +704,7 @@ bool AccessibilityNodeObject::computeIsIgnored() const
     if (node->isTextNode() && !renderer()) {
         RefPtr parent = node->parentNode();
         // Fallback content in iframe nodes should be ignored.
-        if (parent && parent->hasTagName(iframeTag) && parent->renderer())
+        if (WebCore::elementName(parent.get()) == ElementName::HTML_iframe && parent->renderer())
             return true;
 
         // Whitespace only text elements should be ignored when they have no renderer.
@@ -782,7 +783,8 @@ bool AccessibilityNodeObject::isNativeImage() const
     if (is<HTMLImageElement>(*node))
         return true;
 
-    if (node->hasTagName(appletTag) || node->hasTagName(embedTag) || node->hasTagName(objectTag))
+    auto elementName = WebCore::elementName(node);
+    if (elementName == ElementName::HTML_applet || elementName == ElementName::HTML_embed || elementName == ElementName::HTML_object)
         return true;
 
     if (RefPtr input = dynamicDowncast<HTMLInputElement>(*node))
@@ -985,18 +987,18 @@ AXCoreObject::AccessibilityChildrenVector AccessibilityNodeObject::radioButtonGr
 
 unsigned AccessibilityNodeObject::headingTagLevel() const
 {
-    const auto& tag = tagName();
-    if (tag == h1Tag)
+    auto elementName = this->elementName();
+    if (elementName == ElementName::HTML_h1)
         return 1;
-    if (tag == h2Tag)
+    if (elementName == ElementName::HTML_h2)
         return 2;
-    if (tag == h3Tag)
+    if (elementName == ElementName::HTML_h3)
         return 3;
-    if (tag == h4Tag)
+    if (elementName == ElementName::HTML_h4)
         return 4;
-    if (tag == h5Tag)
+    if (elementName == ElementName::HTML_h5)
         return 5;
-    if (tag == h6Tag)
+    if (elementName == ElementName::HTML_h6)
         return 6;
 
     return 0;
@@ -1086,11 +1088,7 @@ bool AccessibilityNodeObject::isBusy() const
 
 bool AccessibilityNodeObject::isFieldset() const
 {
-    Node* node = this->node();
-    if (!node)
-        return false;
-
-    return node->hasTagName(fieldsetTag);
+    return elementName() == ElementName::HTML_fieldset;
 }
 
 AccessibilityButtonState AccessibilityNodeObject::checkboxOrRadioValue() const
@@ -1213,10 +1211,11 @@ bool AccessibilityNodeObject::toggleDetailsAncestor()
 
 static RefPtr<Element> nodeActionElement(Node& node)
 {
+    auto elementName = WebCore::elementName(node);
     if (RefPtr input = dynamicDowncast<HTMLInputElement>(node)) {
         if (!input->isDisabledFormControl() && (input->isRadioButton() || input->isCheckbox() || input->isTextButton() || input->isFileUpload() || input->isImageButton()))
             return input;
-    } else if (node.hasTagName(buttonTag) || node.hasTagName(selectTag))
+    } else if (elementName == ElementName::HTML_button || elementName == ElementName::HTML_select)
         return &downcast<Element>(node);
 
     return nullptr;
@@ -1568,7 +1567,7 @@ bool AccessibilityNodeObject::isGenericFocusableElement() const
     // cases already, so we don't need to include them here.
     if (role == AccessibilityRole::WebArea)
         return false;
-    if (node() && node()->hasTagName(bodyTag))
+    if (elementName() == ElementName::HTML_body)
         return false;
 
     // An SVG root is focusable by default, but it's probably not interactive, so don't
@@ -1609,7 +1608,7 @@ AccessibilityObject* AccessibilityNodeObject::captionForFigure() const
 
     Node* node = this->node();
     for (Node* child = node->firstChild(); child; child = child->nextSibling()) {
-        if (child->hasTagName(figcaptionTag))
+        if (WebCore::elementName(*child) == ElementName::HTML_figcaption)
             return cache->getOrCreate(*child);
     }
     return nullptr;
@@ -1617,7 +1616,7 @@ AccessibilityObject* AccessibilityNodeObject::captionForFigure() const
 
 bool AccessibilityNodeObject::usesAltTagForTextComputation() const
 {
-    bool usesAltTag = isImage() || isInputImage() || isNativeImage() || isCanvas() || (node() && node()->hasTagName(imgTag));
+    bool usesAltTag = isImage() || isInputImage() || isNativeImage() || isCanvas() || elementName() == ElementName::HTML_img;
 #if ENABLE(MODEL_ELEMENT)
     usesAltTag |= isModel();
 #endif
@@ -1864,7 +1863,7 @@ void AccessibilityNodeObject::visibleText(Vector<AccessibilityText>& textOrder) 
     }
 
     // If this node isn't rendered, there's no inner text we can extract from a select element.
-    if (!isAccessibilityRenderObject() && node->hasTagName(selectTag))
+    if (!isAccessibilityRenderObject() && WebCore::elementName(*node) == ElementName::HTML_select)
         return;
 
     if (dependsOnTextUnderElement()) {
@@ -1963,7 +1962,8 @@ String AccessibilityNodeObject::alternativeTextForWebArea() const
     }
 
     if (auto* owner = document->ownerElement()) {
-        if (owner->hasTagName(frameTag) || owner->hasTagName(iframeTag)) {
+        auto elementName = owner->elementName();
+        if (elementName == ElementName::HTML_frame || elementName == ElementName::HTML_iframe) {
             const AtomString& title = owner->attributeWithoutSynchronization(titleAttr);
             if (!title.isEmpty())
                 return title;
@@ -2324,7 +2324,7 @@ String AccessibilityNodeObject::title() const
     }
 
     // For <select> elements, title should be empty if they are not rendered or have role PopUpButton.
-    if (node && node->hasTagName(selectTag)
+    if (WebCore::elementName(*node) == ElementName::HTML_select
         && (!isAccessibilityRenderObject() || roleValue() == AccessibilityRole::PopUpButton))
         return { };
 

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -76,6 +76,7 @@
 #include "LocalizedStrings.h"
 #include "MathMLNames.h"
 #include "NodeList.h"
+#include "NodeName.h"
 #include "NodeTraversal.h"
 #include "Page.h"
 #include "PositionInlines.h"
@@ -1914,8 +1915,8 @@ std::optional<VisiblePosition> AccessibilityObject::previousLineStartPositionInt
 
 bool AccessibilityObject::hasRowGroupTag() const
 {
-    const auto& tag = tagName();
-    return tag == theadTag || tag == tbodyTag || tag == tfootTag;
+    auto elementName = this->elementName();
+    return elementName == ElementName::HTML_thead || elementName == ElementName::HTML_tbody || elementName == ElementName::HTML_tfoot;
 }
 
 bool AccessibilityObject::isVisited() const
@@ -1945,7 +1946,7 @@ bool AccessibilityObject::dependsOnTextUnderElement() const
     switch (roleValue()) {
     case AccessibilityRole::PopUpButton:
         // Native popup buttons should not use their descendant's text as a title. That value is retrieved through stringValue().
-        if (hasTagName(selectTag))
+        if (hasElementName(ElementName::HTML_select))
             break;
         [[fallthrough]];
     case AccessibilityRole::Summary:
@@ -2451,10 +2452,9 @@ bool AccessibilityObject::ignoredFromModalPresence() const
     return !isModalDescendant(*modalNode);
 }
 
-bool AccessibilityObject::hasTagName(const QualifiedName& tagName) const
+bool AccessibilityObject::hasElementName(ElementName name) const
 {
-    RefPtr element = dynamicDowncast<Element>(node());
-    return element && element->hasTagName(tagName);
+    return elementName() == name;
 }
 
 bool AccessibilityObject::hasAttribute(const QualifiedName& attribute) const
@@ -2840,7 +2840,8 @@ String AccessibilityObject::embeddedImageDescription() const
 
 bool AccessibilityObject::supportsDatetimeAttribute() const
 {
-    return hasTagName(insTag) || hasTagName(delTag) || hasTagName(timeTag);
+    auto elementName = this->elementName();
+    return elementName == ElementName::HTML_ins || elementName == ElementName::HTML_del || elementName == ElementName::HTML_time;
 }
 
 String AccessibilityObject::datetimeAttributeValue() const
@@ -4047,10 +4048,10 @@ AccessibilityObject* AccessibilityObject::radioGroupAncestor() const
     });
 }
 
-const AtomString& AccessibilityObject::tagName() const
+ElementName AccessibilityObject::elementName() const
 {
     auto* element = this->element();
-    return element ? element->localName() : nullAtom();
+    return element ? element->elementName() : ElementName::Unknown;
 }
 
 bool AccessibilityObject::isStyleFormatGroup() const
@@ -4058,21 +4059,17 @@ bool AccessibilityObject::isStyleFormatGroup() const
     if (isCode())
         return true;
 
-    Node* node = this->node();
-    if (!node)
-        return false;
-    
-    return node->hasTagName(kbdTag) || node->hasTagName(codeTag)
-    || node->hasTagName(preTag) || node->hasTagName(sampTag)
-    || node->hasTagName(varTag) || node->hasTagName(citeTag)
-    || node->hasTagName(insTag) || node->hasTagName(delTag)
-    || node->hasTagName(supTag) || node->hasTagName(subTag);
+    auto elementName = this->elementName();
+    return elementName == ElementName::HTML_kbd || elementName == ElementName::HTML_code
+    || elementName == ElementName::HTML_pre || elementName == ElementName::HTML_samp
+    || elementName == ElementName::HTML_var || elementName == ElementName::HTML_cite
+    || elementName == ElementName::HTML_ins || elementName == ElementName::HTML_del
+    || elementName == ElementName::HTML_sup || elementName == ElementName::HTML_sub;
 }
 
 bool AccessibilityObject::isFigureElement() const
 {
-    Node* node = this->node();
-    return node && node->hasTagName(figureTag);
+    return elementName() == ElementName::HTML_figure;
 }
 
 bool AccessibilityObject::isKeyboardFocusable() const
@@ -4084,8 +4081,7 @@ bool AccessibilityObject::isKeyboardFocusable() const
 
 bool AccessibilityObject::isOutput() const
 {
-    Node* node = this->node();
-    return node && node->hasTagName(outputTag);
+    return elementName() == ElementName::HTML_output;
 }
     
 bool AccessibilityObject::isContainedBySecureField() const

--- a/Source/WebCore/accessibility/AccessibilityObject.h
+++ b/Source/WebCore/accessibility/AccessibilityObject.h
@@ -564,13 +564,13 @@ public:
 
     String nameAttribute() const final;
     int getIntegralAttribute(const QualifiedName&) const;
-    bool hasTagName(const QualifiedName&) const;
-    bool hasAttachmentTag() const final { return hasTagName(HTMLNames::attachmentTag); }
-    bool hasBodyTag() const final { return hasTagName(HTMLNames::bodyTag); }
-    bool hasMarkTag() const final { return hasTagName(HTMLNames::markTag); }
+    bool hasElementName(const ElementName) const final;
+    bool hasAttachmentTag() const final { return hasElementName(ElementName::HTML_attachment); }
+    bool hasBodyTag() const final { return hasElementName(ElementName::HTML_body); }
+    bool hasMarkTag() const final { return hasElementName(ElementName::HTML_mark); }
     bool hasRowGroupTag() const final;
 
-    const AtomString& tagName() const;
+    ElementName elementName() const final;
     bool hasDisplayContents() const;
 
     std::optional<SimpleRange> simpleRange() const final;

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -1345,11 +1345,12 @@ bool AccessibilityRenderObject::computeIsIgnored() const
     // objects are often containers with meaningful information, the inclusion of a span can have
     // the side effect of causing the immediate parent accessible to be ignored. This is especially
     // problematic for platforms which have distinct roles for textual block elements.
-    if (node && node->hasTagName(spanTag))
+    auto elementName = WebCore::elementName(node);
+    if (elementName == ElementName::HTML_span)
         return true;
 
     // Other non-ignored host language elements
-    if (node && node->hasTagName(dfnTag))
+    if (elementName == ElementName::HTML_dfn)
         return false;
     
     if (isStyleFormatGroup())
@@ -1818,7 +1819,7 @@ RefPtr<Element> AccessibilityRenderObject::rootEditableElementForPosition(const 
     for (RefPtr ancestor = position.anchorElementAncestor(); ancestor && ancestor != rootEditableElement; ancestor = ancestor->parentElement()) {
         if (elementIsTextControl(*ancestor))
             result = ancestor;
-        if (ancestor->hasTagName(bodyTag))
+        if (ancestor->elementName() == ElementName::HTML_body)
             break;
     }
     return result ? result : rootEditableElement;
@@ -2166,7 +2167,8 @@ AccessibilityObject* AccessibilityRenderObject::observableObject() const
 String AccessibilityRenderObject::expandedTextValue() const
 {
     if (AccessibilityObject* parent = parentObject()) {
-        if (parent->hasTagName(abbrTag) || parent->hasTagName(acronymTag))
+        auto parentName = parent->elementName();
+        if (parentName == ElementName::HTML_abbr || parentName == ElementName::HTML_acronym)
             return parent->getAttribute(titleAttr);
     }
 
@@ -2176,8 +2178,10 @@ String AccessibilityRenderObject::expandedTextValue() const
 bool AccessibilityRenderObject::supportsExpandedTextValue() const
 {
     if (roleValue() == AccessibilityRole::StaticText) {
-        if (AccessibilityObject* parent = parentObject())
-            return parent->hasTagName(abbrTag) || parent->hasTagName(acronymTag);
+        if (AccessibilityObject* parent = parentObject()) {
+            auto parentName = parent->elementName();
+            return parentName == ElementName::HTML_abbr || parentName == ElementName::HTML_acronym;
+        }
     }
     
     return false;
@@ -2474,7 +2478,7 @@ void AccessibilityRenderObject::addCanvasChildren()
 {
     // Add the unrendered canvas children as AX nodes, unless we're not using a canvas renderer
     // because JS is disabled for example.
-    if (!node() || !node()->hasTagName(canvasTag) || (renderer() && !renderer()->isRenderHTMLCanvas()))
+    if (elementName() != ElementName::HTML_canvas || (renderer() && !renderer()->isRenderHTMLCanvas()))
         return;
 
     // If it's a canvas, it won't have rendered children, but it might have accessible fallback content.

--- a/Source/WebCore/accessibility/AccessibilitySVGObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilitySVGObject.cpp
@@ -268,7 +268,7 @@ bool AccessibilitySVGObject::inheritsPresentationalRole() const
         return false;
 
     for (AccessibilityObject* parent = parentObject(); parent; parent = parent->parentObject()) {
-        if (is<AccessibilityRenderObject>(*parent) && parent->hasTagName(SVGNames::textTag))
+        if (is<AccessibilityRenderObject>(*parent) && parent->hasElementName(ElementName::SVG_text))
             return parent->roleValue() == AccessibilityRole::Presentational;
     }
 

--- a/Source/WebCore/accessibility/atspi/AccessibilityObjectAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AccessibilityObjectAtspi.cpp
@@ -857,9 +857,9 @@ UncheckedKeyHashMap<String, String> AccessibilityObjectAtspi::attributes() const
 
     RefPtr liveObject = dynamicDowncast<AccessibilityObject>(m_coreObject);
 
-    String tagName = liveObject->tagName();
-    if (!tagName.isEmpty())
-        map.add("tag"_s, tagName);
+    auto tagName = tagNameForElementName(liveObject->elementName());
+    if (tagName != TagName::Unknown)
+        map.add("tag"_s, tagNameAsString(tagName));
 
     if (auto* element = m_coreObject->element()) {
         String id = element->getIdAttribute().string();

--- a/Source/WebCore/accessibility/ios/AccessibilityObjectIOS.mm
+++ b/Source/WebCore/accessibility/ios/AccessibilityObjectIOS.mm
@@ -246,7 +246,7 @@ static unsigned blockquoteLevel(RenderObject* renderer)
 
     unsigned result = 0;
     for (Node* node = renderer->node(); node; node = node->parentNode()) {
-        if (node->hasTagName(HTMLNames::blockquoteTag))
+        if (WebCore::elementName(*node) == ElementName::HTML_blockquote)
             ++result;
     }
 

--- a/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
+++ b/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
@@ -870,7 +870,7 @@ static AccessibilityObjectWrapper *ancestorWithRole(const AXCoreObject& descenda
 {
     // If an SVG group element has a title, it should be an accessible element on iOS.
     Node* node = self.axBackingObject->node();
-    if (node && node->hasTagName(SVGNames::gTag) && [[self accessibilityLabel] length] > 0)
+    if (WebCore::elementName(node) == ElementName::SVG_g && [[self accessibilityLabel] length] > 0)
         return YES;
     
     return NO;
@@ -2107,11 +2107,11 @@ static RenderObject* rendererForView(WAKView* view)
     // Use this to check if an object is the child of a summary object.
     // And return the summary's parent, which is the expandable details object.
     return Accessibility::findAncestor<AccessibilityObject>(object, true, [&] (const AccessibilityObject& object) {
-        const auto& tag = object.tagName();
-        if (tag == summaryTag)
+        auto elementName = object.elementName();
+        if (elementName == ElementName::HTML_summary)
             foundSummary = true;
 
-        return tag == detailsTag && foundSummary;
+        return elementName == ElementName::HTML_details && foundSummary;
     });
 }
 
@@ -2119,7 +2119,7 @@ static RenderObject* rendererForView(WAKView* view)
 {
     // Use this to check if an object is inside a details object.
     if (AccessibilityObject* details = Accessibility::findAncestor<AccessibilityObject>(*object, true, [] (const AccessibilityObject& object) {
-        return object.hasTagName(detailsTag);
+        return object.hasElementName(ElementName::HTML_details);
     }))
         return details;
     return nil;

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
@@ -107,34 +107,36 @@ void AXIsolatedObject::initializeProperties(const Ref<AccessibilityObject>& axOb
 
         // These properties are cached for all objects, ignored and unignored.
         setProperty(AXProperty::HasClickHandler, object.hasClickHandler());
-        const auto& tag = object.tagName();
-        if (tag == bodyTag)
-            setProperty(AXProperty::TagName, TagName::body);
-        else if (tag == h1Tag)
-            setProperty(AXProperty::TagName, TagName::h1);
-        else if (tag == h2Tag)
-            setProperty(AXProperty::TagName, TagName::h2);
-        else if (tag == h3Tag)
-            setProperty(AXProperty::TagName, TagName::h3);
-        else if (tag == h4Tag)
-            setProperty(AXProperty::TagName, TagName::h4);
-        else if (tag == h5Tag)
-            setProperty(AXProperty::TagName, TagName::h5);
-        else if (tag == h6Tag)
-            setProperty(AXProperty::TagName, TagName::h6);
+        auto elementName = object.elementName();
+        if (elementName == ElementName::HTML_body)
+            setProperty(AXProperty::ElementName, ElementName::HTML_body);
+        else if (elementName == ElementName::HTML_h1)
+            setProperty(AXProperty::ElementName, ElementName::HTML_h1);
+        else if (elementName == ElementName::HTML_h2)
+            setProperty(AXProperty::ElementName, ElementName::HTML_h2);
+        else if (elementName == ElementName::HTML_h3)
+            setProperty(AXProperty::ElementName, ElementName::HTML_h3);
+        else if (elementName == ElementName::HTML_h4)
+            setProperty(AXProperty::ElementName, ElementName::HTML_h4);
+        else if (elementName == ElementName::HTML_h5)
+            setProperty(AXProperty::ElementName, ElementName::HTML_h5);
+        else if (elementName == ElementName::HTML_h6)
+            setProperty(AXProperty::ElementName, ElementName::HTML_h6);
+        else if (elementName == ElementName::HTML_th)
+            setProperty(AXProperty::ElementName, ElementName::HTML_th);
 #if ENABLE(AX_THREAD_TEXT_APIS)
-        else if (tag == markTag)
-            setProperty(AXProperty::TagName, TagName::mark);
-        else if (tag == attachmentTag)
-            setProperty(AXProperty::TagName, TagName::attachment);
-        else if (tag == theadTag)
-            setProperty(AXProperty::TagName, TagName::thead);
-        else if (tag == tbodyTag)
-            setProperty(AXProperty::TagName, TagName::tbody);
-        else if (tag == tfootTag)
-            setProperty(AXProperty::TagName, TagName::tfoot);
-        else if (tag == outputTag)
-            setProperty(AXProperty::TagName, TagName::output);
+        else if (elementName == ElementName::HTML_mark)
+            setProperty(AXProperty::ElementName, ElementName::HTML_mark);
+        else if (elementName == ElementName::HTML_attachment)
+            setProperty(AXProperty::ElementName, ElementName::HTML_attachment);
+        else if (elementName == ElementName::HTML_thead)
+            setProperty(AXProperty::ElementName, ElementName::HTML_thead);
+        else if (elementName == ElementName::HTML_tbody)
+            setProperty(AXProperty::ElementName, ElementName::HTML_tbody);
+        else if (elementName == ElementName::HTML_tfoot)
+            setProperty(AXProperty::ElementName, ElementName::HTML_tfoot);
+        else if (elementName == ElementName::HTML_output)
+            setProperty(AXProperty::ElementName, ElementName::HTML_output);
 
         setProperty(AXProperty::TextRuns, std::make_shared<AXTextRuns>(object.textRuns()));
         setProperty(AXProperty::TextEmissionBehavior, object.textEmissionBehavior());
@@ -680,7 +682,7 @@ void AXIsolatedObject::setProperty(AXProperty property, AXPropertyValueVariant&&
         [](AXTextRunLineID typedValue) { return !typedValue; },
 #endif // ENABLE(AX_THREAD_TEXT_APIS)
         [] (WallTime& time) { return !time; },
-        [] (TagName& tag) { return tag == TagName::Unknown; },
+        [] (ElementName& name) { return name == ElementName::Unknown; },
         [] (DateComponentsType& typedValue) { return typedValue == DateComponentsType::Invalid; },
         [] (AccessibilityOrientation) { return false; },
         [] (OptionSet<SpeakAs>& typedValue) { return typedValue.isEmpty(); },
@@ -2001,8 +2003,8 @@ Vector<AXTextMarkerRange> AXIsolatedObject::misspellingRanges() const
 
 bool AXIsolatedObject::hasRowGroupTag() const
 {
-    auto tag = propertyValue<TagName>(AXProperty::TagName);
-    return tag == TagName::thead || tag == TagName::tbody || tag == TagName::tfoot;
+    auto elementName = this->elementName();
+    return elementName == ElementName::HTML_thead || elementName == ElementName::HTML_tbody || elementName == ElementName::HTML_tfoot;
 }
 
 bool AXIsolatedObject::hasSameFont(AXCoreObject& otherObject)
@@ -2337,19 +2339,19 @@ AXIsolatedObject* AXIsolatedObject::headerContainer()
 
 unsigned AXIsolatedObject::headingTagLevel() const
 {
-    TagName tag = propertyValue<TagName>(AXProperty::TagName);
-    switch (tag) {
-    case TagName::h1:
+    auto name = elementName();
+    switch (name) {
+    case ElementName::HTML_h1:
         return 1;
-    case TagName::h2:
+    case ElementName::HTML_h2:
         return 2;
-    case TagName::h3:
+    case ElementName::HTML_h3:
         return 3;
-    case TagName::h4:
+    case ElementName::HTML_h4:
         return 4;
-    case TagName::h5:
+    case ElementName::HTML_h5:
         return 5;
-    case TagName::h6:
+    case ElementName::HTML_h6:
         return 6;
     default:
         return 0;

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
@@ -32,6 +32,7 @@
 #include "AXObjectCache.h"
 #include "IntPoint.h"
 #include "LayoutRect.h"
+#include "NodeName.h"
 #include "Path.h"
 #include "RenderStyleConstants.h"
 #include <wtf/Forward.h>
@@ -64,9 +65,9 @@ public:
     bool hasClickHandler() const final { return boolAttributeValue(AXProperty::HasClickHandler); }
     FloatRect relativeFrame() const final;
 
-    bool hasAttachmentTag() const final { return propertyValue<TagName>(AXProperty::TagName) == TagName::attachment; }
-    bool hasBodyTag() const final { return propertyValue<TagName>(AXProperty::TagName) == TagName::body; }
-    bool hasMarkTag() const final { return propertyValue<TagName>(AXProperty::TagName) == TagName::mark; }
+    bool hasAttachmentTag() const final { return elementName() == ElementName::HTML_attachment; }
+    bool hasBodyTag() const final { return elementName() == ElementName::HTML_body; }
+    bool hasMarkTag() const final { return elementName() == ElementName::HTML_mark; }
     bool hasRowGroupTag() const final;
 
     const AccessibilityChildrenVector& children(bool updateChildrenIfNeeded = true) final;
@@ -217,7 +218,7 @@ private:
     bool isAttachment() const final { return boolAttributeValue(AXProperty::IsAttachment); }
 
     bool isKeyboardFocusable() const final { return boolAttributeValue(AXProperty::IsKeyboardFocusable); }
-    bool isOutput() const final { return propertyValue<TagName>(AXProperty::TagName) == TagName::output; }
+    bool isOutput() const final { return elementName() == ElementName::HTML_output; }
 
     // Table support.
     AXIsolatedObject* exposedTableAncestor(bool includeSelf = false) const final { return Accessibility::exposedTableAncestor(*this, includeSelf); }
@@ -268,7 +269,7 @@ private:
     bool isVisited() const final { return boolAttributeValue(AXProperty::IsVisited); }
     bool isRequired() const final { return boolAttributeValue(AXProperty::IsRequired); }
     bool isExpanded() const final { return boolAttributeValue(AXProperty::IsExpanded); }
-    bool isDescriptionList() const { return propertyValue<TagName>(AXProperty::TagName) == TagName::dl; }
+    bool isDescriptionList() const final { return elementName() == ElementName::HTML_dl; }
     std::optional<InputType::Type> inputType() const final { return optionalAttributeValue<InputType::Type>(AXProperty::InputType); };
     FloatPoint screenRelativePosition() const final;
     IntPoint remoteFrameOffset() const final;
@@ -566,6 +567,8 @@ private:
     bool isInDescriptionListTerm() const final;
 
     String nameAttribute() const final { return stringAttributeValue(AXProperty::NameAttribute); }
+    bool hasElementName(ElementName name) const final { return elementName() == name; };
+    ElementName elementName() const final { return propertyValue<ElementName>(AXProperty::ElementName); }
 #if PLATFORM(COCOA)
     bool hasApplePDFAnnotationAttribute() const final { return boolAttributeValue(AXProperty::HasApplePDFAnnotationAttribute); }
     RetainPtr<id> remoteFramePlatformElement() const final;

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
@@ -34,7 +34,6 @@
 #include "ColorHash.h"
 #include "PageIdentifier.h"
 #include "RenderStyleConstants.h"
-#include "TagName.h"
 #include <wtf/HashMap.h>
 #include <wtf/Lock.h>
 #include <wtf/RefPtr.h>
@@ -127,6 +126,7 @@ enum class AXProperty : uint16_t {
     DocumentEncoding,
     DocumentLinks,
     DocumentURI,
+    ElementName,
     EmbeddedImageDescription,
     ExpandedTextValue,
     ExplicitAutoCompleteValue,
@@ -271,7 +271,6 @@ enum class AXProperty : uint16_t {
     SupportsPath,
     SupportsPosInSet,
     SupportsSetSize,
-    TagName,
     TextContentPrefixFromListMarker,
 #if !ENABLE(AX_THREAD_TEXT_APIS)
     // Rather than caching text content as property when ENABLE(AX_THREAD_TEXT_APIS), we should
@@ -301,7 +300,7 @@ using AXPropertySet = HashSet<AXProperty, IntHash<AXProperty>, WTF::StrongEnumHa
 using AXIDAndCharacterRange = std::pair<Markable<AXID>, CharacterRange>;
 
 // If this type is modified, the switchOn statment in AXIsolatedObject::setProperty must be updated as well.
-using AXPropertyValueVariant = Variant<std::nullptr_t, Markable<AXID>, String, bool, int, unsigned, double, float, uint64_t, WallTime, DateComponentsType, AccessibilityButtonState, Color, std::shared_ptr<URL>, LayoutRect, FloatPoint, FloatRect, InputType::Type, IntPoint, IntRect, std::pair<unsigned, unsigned>, Vector<AccessibilityText>, Vector<AXID>, Vector<std::pair<Markable<AXID>, Markable<AXID>>>, Vector<String>, std::shared_ptr<Path>, OptionSet<AXAncestorFlag>, Vector<Vector<Markable<AXID>>>, CharacterRange, std::shared_ptr<AXIDAndCharacterRange>, TagName, AccessibilityOrientation
+using AXPropertyValueVariant = Variant<std::nullptr_t, Markable<AXID>, String, bool, int, unsigned, double, float, uint64_t, WallTime, DateComponentsType, AccessibilityButtonState, Color, std::shared_ptr<URL>, LayoutRect, FloatPoint, FloatRect, InputType::Type, IntPoint, IntRect, std::pair<unsigned, unsigned>, Vector<AccessibilityText>, Vector<AXID>, Vector<std::pair<Markable<AXID>, Markable<AXID>>>, Vector<String>, std::shared_ptr<Path>, OptionSet<AXAncestorFlag>, Vector<Vector<Markable<AXID>>>, CharacterRange, std::shared_ptr<AXIDAndCharacterRange>, ElementName, AccessibilityOrientation
 #if PLATFORM(COCOA)
     , RetainPtr<NSAttributedString>
     , RetainPtr<NSView>

--- a/Source/WebCore/accessibility/mac/AccessibilityObjectMac.mm
+++ b/Source/WebCore/accessibility/mac/AccessibilityObjectMac.mm
@@ -394,16 +394,16 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         return "AXCodeStyleGroup"_s;
 
     using namespace HTMLNames;
-    const auto& tag = tagName();
-    if (tag == kbdTag)
+    auto elementName = this->elementName();
+    if (elementName == ElementName::HTML_kbd)
         return "AXKeyboardInputStyleGroup"_s;
-    if (tag == preTag)
+    if (elementName == ElementName::HTML_pre)
         return "AXPreformattedStyleGroup"_s;
-    if (tag == sampTag)
+    if (elementName == ElementName::HTML_samp)
         return "AXSampleStyleGroup"_s;
-    if (tag == varTag)
+    if (elementName == ElementName::HTML_var)
         return "AXVariableStyleGroup"_s;
-    if (tag == citeTag)
+    if (elementName == ElementName::HTML_cite)
         return "AXCiteStyleGroup"_s;
     ASSERT_WITH_MESSAGE(!isStyleFormatGroup(), "Should've been able to compute a subrole for style format group object");
 


### PR DESCRIPTION
#### 1d898339cf40cb4413bb9ace932b45068d399595
<pre>
AX: Use ElementName instead of TagName across live and isolated objects
<a href="https://bugs.webkit.org/show_bug.cgi?id=292996">https://bugs.webkit.org/show_bug.cgi?id=292996</a>
<a href="https://rdar.apple.com/151312403">rdar://151312403</a>

Reviewed by Tyler Wilcock.

Our use of TagName on the isolated tree differed from our live tree tags, which
were qualified names/atom strings. This difference makes moving implementations
to AXCoreObject less graceful.

Moving to ElementName, a uint16_t, for both the live and isolated objects, allows us
to share methods like hasElementName and elementName, without conversions betweeen
types.

Because of this change, many places had to be updated to use Elements, rather than
Nodes, which requires a downcast. This doesn&apos;t add complexity, however, because
previously when using `hasTagName`, we would have to downcast to HTMLElement every
time. There were some cases I optimized as well, to only require one downcast
instead of one per tag-name check, which we would do in the past.

* Source/WebCore/accessibility/AXCoreObject.h:
* Source/WebCore/accessibility/AXLogger.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::elementName):
(WebCore::isRowGroup):
(WebCore::isAccessibilityList):
(WebCore::AXObjectCache::handleChildrenChanged):
(WebCore::AXObjectCache::handleAttributeChange):
(WebCore::AXObjectCache::traverseToOffsetInRange):
(WebCore::isReplacedNodeOrBR):
(WebCore::characterOffsetNodeIsBR):
(WebCore::canHaveRelations):
(WebCore::AXObjectCache::addLabelForRelation):
* Source/WebCore/accessibility/AXObjectCache.h:
* Source/WebCore/accessibility/AXTextMarker.cpp:
(WebCore::AXTextMarker::boundaryPoint const):
* Source/WebCore/accessibility/AccessibilityARIAGridRow.cpp:
(WebCore::AccessibilityARIAGridRow::parentTable const):
* Source/WebCore/accessibility/AccessibilityList.cpp:
(WebCore::AccessibilityList::isUnorderedList const):
(WebCore::AccessibilityList::isOrderedList const):
(WebCore::AccessibilityList::isDescriptionList const):
(WebCore::AccessibilityList::determineAccessibilityRoleWithCleanChildren):
* Source/WebCore/accessibility/AccessibilityMathMLElement.cpp:
(WebCore::AccessibilityMathMLElement::determineAccessibilityRole):
(WebCore::AccessibilityMathMLElement::addChildren):
(WebCore::AccessibilityMathMLElement::isMathText const):
(WebCore::AccessibilityMathMLElement::isMathNumber const):
(WebCore::AccessibilityMathMLElement::isMathIdentifier const):
(WebCore::AccessibilityMathMLElement::isMathMultiscript const):
(WebCore::AccessibilityMathMLElement::isMathTable const):
(WebCore::AccessibilityMathMLElement::isMathTableRow const):
(WebCore::AccessibilityMathMLElement::isMathTableCell const):
(WebCore::AccessibilityMathMLElement::mathUnderObject):
(WebCore::AccessibilityMathMLElement::mathOverObject):
(WebCore::AccessibilityMathMLElement::mathSubscriptObject):
(WebCore::AccessibilityMathMLElement::mathSuperscriptObject):
(WebCore::AccessibilityMathMLElement::mathPrescripts):
(WebCore::AccessibilityMathMLElement::mathPostscripts):
* Source/WebCore/accessibility/AccessibilityNodeObject.cpp:
(WebCore::AccessibilityNodeObject::determineAccessibilityRoleFromNode const):
(WebCore::AccessibilityNodeObject::addChildren):
(WebCore::AccessibilityNodeObject::canHaveChildren const):
(WebCore::AccessibilityNodeObject::computeIsIgnored const):
(WebCore::AccessibilityNodeObject::isNativeImage const):
(WebCore::AccessibilityNodeObject::headingTagLevel const):
(WebCore::AccessibilityNodeObject::isFieldset const):
(WebCore::nodeActionElement):
(WebCore::AccessibilityNodeObject::isGenericFocusableElement const):
(WebCore::AccessibilityNodeObject::captionForFigure const):
(WebCore::AccessibilityNodeObject::usesAltTagForTextComputation const):
(WebCore::AccessibilityNodeObject::visibleText const):
(WebCore::AccessibilityNodeObject::alternativeTextForWebArea const):
(WebCore::AccessibilityNodeObject::title const):
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::hasRowGroupTag const):
(WebCore::AccessibilityObject::dependsOnTextUnderElement const):
(WebCore::AccessibilityObject::hasElementName const):
(WebCore::AccessibilityObject::supportsDatetimeAttribute const):
(WebCore::AccessibilityObject::elementName const):
(WebCore::AccessibilityObject::isStyleFormatGroup const):
(WebCore::AccessibilityObject::isFigureElement const):
(WebCore::AccessibilityObject::isOutput const):
(WebCore::AccessibilityObject::hasTagName const): Deleted.
(WebCore::AccessibilityObject::tagName const): Deleted.
* Source/WebCore/accessibility/AccessibilityObject.h:
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::AccessibilityRenderObject::computeIsIgnored const):
(WebCore::AccessibilityRenderObject::rootEditableElementForPosition const):
(WebCore::AccessibilityRenderObject::expandedTextValue const):
(WebCore::AccessibilityRenderObject::supportsExpandedTextValue const):
(WebCore::AccessibilityRenderObject::addCanvasChildren):
* Source/WebCore/accessibility/AccessibilitySVGObject.cpp:
(WebCore::AccessibilitySVGObject::inheritsPresentationalRole const):
* Source/WebCore/accessibility/AccessibilityTable.cpp:
(WebCore::AccessibilityTable::isDataTable const):
(WebCore::AccessibilityTable::computeCellSlots):
* Source/WebCore/accessibility/AccessibilityTableCell.cpp:
(WebCore::AccessibilityTableCell::computeIsIgnored const):
(WebCore::AccessibilityTableCell::isTableHeaderCell const):
(WebCore::AccessibilityTableCell::isColumnHeader const):
(WebCore::AccessibilityTableCell::isRowHeader const):
(WebCore::AccessibilityTableCell::titleUIElement const):
* Source/WebCore/accessibility/atspi/AccessibilityObjectAtspi.cpp:
(WebCore::AccessibilityObjectAtspi::attributes const):
* Source/WebCore/accessibility/ios/AccessibilityObjectIOS.mm:
(WebCore::blockquoteLevel):
* Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm:
(-[WebAccessibilityObjectWrapper isSVGGroupElement]):
(-[WebAccessibilityObjectWrapper detailParentForSummaryObject:]):
(-[WebAccessibilityObjectWrapper detailParentForObject:]):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp:
(WebCore::AXIsolatedObject::initializeProperties):
(WebCore::AXIsolatedObject::setProperty):
(WebCore::AXIsolatedObject::hasRowGroupTag const):
(WebCore::AXIsolatedObject::headingTagLevel const):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h:
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h:
* Source/WebCore/accessibility/mac/AccessibilityObjectMac.mm:
(WebCore::AccessibilityObject::subrolePlatformString const):

Canonical link: <a href="https://commits.webkit.org/295005@main">https://commits.webkit.org/295005@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b715ef12b4f53904958430a4a8b6c8678826e672

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/103768 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/23470 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/13790 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/108959 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/54420 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/105808 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/23819 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/32016 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78834 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/106774 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/18483 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/93608 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59168 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/18295 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/11657 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/53796 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/88068 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/11714 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/111348 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/30924 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/22800 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/87837 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/31285 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/89809 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87490 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22279 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32381 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10099 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/25281 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/30852 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/36155 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/30646 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/33981 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/32207 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->