### PR TITLE
premierleague.com: scrubbing through video content invokes text selection UI

### DIFF
--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -849,7 +849,7 @@ bool EventHandler::canMouseDownStartSelect(const MouseEventWithHitTestResults& e
     if (!node || !node->renderer())
         return true;
 
-    if (node->protectedDocument()->quirks().shouldAvoidStartingSelectionOnMouseDown(*node))
+    if (node->protectedDocument()->quirks().shouldAvoidStartingSelectionOnMouseDownOverPointerCursor(*node))
         return false;
 
     if (ImageOverlay::isOverlayText(*node))

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -1717,22 +1717,19 @@ bool Quirks::needsBingGestureEventQuirk(EventTarget* target) const
 }
 
 // spotify.com rdar://140707449
-bool Quirks::shouldAvoidStartingSelectionOnMouseDown(const Node& target) const
+bool Quirks::shouldAvoidStartingSelectionOnMouseDownOverPointerCursor(const Node& target) const
 {
-#if PLATFORM(MAC)
     if (!needsQuirks())
         return false;
 
-    if (!m_quirksData.shouldAvoidStartingSelectionOnMouseDown)
+    if (!m_quirksData.shouldAvoidStartingSelectionOnMouseDownOverPointerCursor)
         return false;
 
     if (CheckedPtr style = target.renderStyle()) {
-        if (style->usedTouchActions().contains(TouchAction::None) && style->cursor() == CursorType::Pointer)
+        if (style->cursor() == CursorType::Pointer)
             return true;
     }
-#else
-    UNUSED_PARAM(target);
-#endif
+
     return false;
 }
 
@@ -2555,6 +2552,9 @@ static void handlePremierLeagueQuirks(QuirksData& quirksData, const URL& quirksU
 
     // premierleague.com: rdar://68938833
     quirksData.shouldDispatchPlayPauseEventsOnResume = true;
+
+    // premierleague.com: rdar://136791737
+    quirksData.shouldAvoidStartingSelectionOnMouseDownOverPointerCursor = true;
 }
 
 static void handleSFUSDQuirks(QuirksData& quirksData, const URL& quirksURL, const String& quirksDomainString, const URL& documentURL)
@@ -2603,9 +2603,7 @@ static void handleSpotifyQuirks(QuirksData& quirksData, const URL& quirksURL, co
 
     // spotify.com rdar://138918575
     quirksData.needsBodyScrollbarWidthNoneDisabledQuirk = true;
-#if PLATFORM(MAC)
-    quirksData.shouldAvoidStartingSelectionOnMouseDown = true;
-#endif
+    quirksData.shouldAvoidStartingSelectionOnMouseDownOverPointerCursor = true;
 }
 
 static void handleVictoriasSecretQuirks(QuirksData& quirksData, const URL& quirksURL, const String& quirksDomainString, const URL& documentURL)

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -244,7 +244,7 @@ public:
 
     bool needsBingGestureEventQuirk(EventTarget*) const;
 
-    bool shouldAvoidStartingSelectionOnMouseDown(const Node&) const;
+    WEBCORE_EXPORT bool shouldAvoidStartingSelectionOnMouseDownOverPointerCursor(const Node&) const;
 
     bool shouldReuseLiveRangeForSelectionUpdate() const;
 

--- a/Source/WebCore/page/QuirksData.h
+++ b/Source/WebCore/page/QuirksData.h
@@ -81,6 +81,7 @@ struct WEBCORE_EXPORT QuirksData {
     bool shouldUseLegacySelectPopoverDismissalBehaviorInDataActivationQuirk : 1 { false };
     bool shouldDispatchPlayPauseEventsOnResume : 1 { false };
     bool shouldUnloadHeavyFrames : 1 { false };
+    bool shouldAvoidStartingSelectionOnMouseDownOverPointerCursor : 1 { false };
 
     // Requires check at moment of use
     std::optional<bool> needsDisableDOMPasteAccessQuirk;
@@ -125,7 +126,6 @@ struct WEBCORE_EXPORT QuirksData {
     bool needsFormControlToBeMouseFocusableQuirk : 1 { false };
     bool needsPrimeVideoUserSelectNoneQuirk : 1 { false };
     bool needsZomatoEmailLoginLabelQuirk : 1 { false };
-    bool shouldAvoidStartingSelectionOnMouseDown : 1 { false };
 #endif
 
 #if ENABLE(DESKTOP_CONTENT_MODE_QUIRKS)

--- a/Source/WebKit/Shared/ios/InteractionInformationAtPosition.h
+++ b/Source/WebKit/Shared/ios/InteractionInformationAtPosition.h
@@ -59,7 +59,7 @@ struct InteractionInformationAtPosition {
         Selectable,
         UnselectableDueToFocusableElement,
         UnselectableDueToLargeElementBounds,
-        UnselectableDueToUserSelectNone,
+        UnselectableDueToUserSelectNoneOrQuirk,
         UnselectableDueToMediaControls,
     };
 

--- a/Source/WebKit/Shared/ios/InteractionInformationAtPosition.serialization.in
+++ b/Source/WebKit/Shared/ios/InteractionInformationAtPosition.serialization.in
@@ -26,7 +26,7 @@
     Selectable,
     UnselectableDueToFocusableElement,
     UnselectableDueToLargeElementBounds,
-    UnselectableDueToUserSelectNone,
+    UnselectableDueToUserSelectNoneOrQuirk,
     UnselectableDueToMediaControls,
 };
 

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -3684,7 +3684,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     if (![self ensurePositionInformationIsUpToDate:request])
         return NO;
 
-    if (gesture == WKBEGestureTypeLoupe && _positionInformation.selectability == WebKit::InteractionInformationAtPosition::Selectability::UnselectableDueToUserSelectNone)
+    if (gesture == WKBEGestureTypeLoupe && _positionInformation.selectability == WebKit::InteractionInformationAtPosition::Selectability::UnselectableDueToUserSelectNoneOrQuirk)
         return NO;
 
     if (_positionInformation.preventTextInteraction)

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -81,6 +81,7 @@
 #import <WebCore/DiagnosticLoggingClient.h>
 #import <WebCore/DiagnosticLoggingKeys.h>
 #import <WebCore/Document.h>
+#import <WebCore/DocumentInlines.h>
 #import <WebCore/DocumentLoader.h>
 #import <WebCore/DocumentMarkerController.h>
 #import <WebCore/DragController.h>
@@ -132,6 +133,7 @@
 #import <WebCore/LocalFrameView.h>
 #import <WebCore/MediaSessionManagerIOS.h>
 #import <WebCore/Node.h>
+#import <WebCore/NodeInlines.h>
 #import <WebCore/NodeList.h>
 #import <WebCore/NodeRenderStyle.h>
 #import <WebCore/NotImplemented.h>
@@ -3659,7 +3661,7 @@ static void selectionPositionInformation(WebPage& page, const InteractionInforma
 
     info.selectability = ([&] {
         if (renderer->style().usedUserSelect() == UserSelect::None)
-            return InteractionInformationAtPosition::Selectability::UnselectableDueToUserSelectNone;
+            return InteractionInformationAtPosition::Selectability::UnselectableDueToUserSelectNoneOrQuirk;
 
         if (RefPtr element = dynamicDowncast<Element>(*hitNode)) {
             if (isAssistableElement(*element))
@@ -3674,6 +3676,9 @@ static void selectionPositionInformation(WebPage& page, const InteractionInforma
             if (hostVideoElementIgnoringImageOverlay(*hitNode))
                 return InteractionInformationAtPosition::Selectability::UnselectableDueToMediaControls;
         }
+
+        if (hitNode->protectedDocument()->quirks().shouldAvoidStartingSelectionOnMouseDownOverPointerCursor(*hitNode))
+            return InteractionInformationAtPosition::Selectability::UnselectableDueToUserSelectNoneOrQuirk;
 
         return InteractionInformationAtPosition::Selectability::Selectable;
     })();


### PR DESCRIPTION
#### 9bd7581a8b84b83608c38da38bdf3938c0715f80
<pre>
premierleague.com: scrubbing through video content invokes text selection UI
<a href="https://bugs.webkit.org/show_bug.cgi?id=292998">https://bugs.webkit.org/show_bug.cgi?id=292998</a>
<a href="https://rdar.apple.com/136791737">rdar://136791737</a>

Reviewed by Abrar Rahman Protyasha.

Augment an existing quirk, `shouldAvoidStartingSelectionOnMouseDownOverPointerCursor`, such that it
prevents text selection over all elements with `cursor: pointer;`, and extend it so that it applies
to premierleague.com as well.

* Source/WebCore/page/Quirks.cpp:
(WebCore::Quirks::shouldAvoidStartingSelectionOnMouseDownOverPointerCursor const):

Pull this quirk out of `PLATFORM(MAC)`, so that it can apply to iOS as well when using a trackpad to
select text.

(WebCore::handleSpotifyQuirks):
* Source/WebCore/page/Quirks.h:
* Source/WebCore/page/QuirksData.h:
* Source/WebKit/Shared/ios/InteractionInformationAtPosition.h:
* Source/WebKit/Shared/ios/InteractionInformationAtPosition.serialization.in:

Rename `UnselectableDueToUserSelectNone` to `UnselectableDueToUserSelectNoneOrQuirk`, and set the
flag when we&apos;re interacting with a target node where the quirk is active.

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView textInteractionGesture:shouldBeginAtPoint:]):
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::selectionPositionInformation):

Canonical link: <a href="https://commits.webkit.org/294931@main">https://commits.webkit.org/294931@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ba53f6edd702191676793567fea5d6c7d345448d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/103529 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/23211 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/13531 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/108705 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/54174 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/105569 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/23564 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/31762 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78670 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/106535 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/18272 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/93391 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59004 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/18086 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/11438 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/53530 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/87878 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/11497 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/111083 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/30676 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/22625 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/87665 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/31037 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/89591 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87308 "Found 102 new API test failures: /WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/sequence, /TestWebKit:WebKit.InjectedBundleInitializationUserDataCallbackWins, /TestWebKit:WebKit.GeolocationBasicWithHighAccuracy, /WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/cancel-sequence, /TestWebKit:WebKit.ForceRepaint, /TestWebKit:WebKit.PendingAPIRequestURL, /WebKitGTK/TestUIClient:/webkit/WebKitWebView/mediaKeySystem-permission-requests, /TestWebKit:WebKit.PreventEmptyUserAgent, /TestWebKit:WebKit2.ProvisionalURLAfterWillSendRequestCallback, /WebKitGTK/TestDownloads:/webkit/Downloads/contex-menu-download-actions ... (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22228 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32186 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/9899 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/25027 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/30604 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/35916 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/30404 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/33735 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/31965 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->