### PR TITLE
Add --a-option and --b-option to compare-optimization-tracing for per-build JSC flags

### DIFF
--- a/Tools/Scripts/compare-optimization-tracing
+++ b/Tools/Scripts/compare-optimization-tracing
@@ -37,10 +37,11 @@ from collections import defaultdict
 #
 # Usage Examples:
 # compare-optimization-tracing -v -a <BUILD_A_PATH> -b <BUILD_B_PATH> --test <SINGLE_TEST_PATH> --filter FTL
+# compare-optimization-tracing -v -a <BUILD_A_PATH> --a-option "--usePartialLoopUnrolling=0 --maxLoopUnrollingCount=5" -b <BUILD_B_PATH> --b-option "--usePartialLoopUnrolling=1 --maxLoopUnrollingCount=10" --test <SINGLE_TEST_PATH> --filter FTL
 # compare-optimization-tracing -v -a <BUILD_A_PATH> -b <BUILD_B_PATH> --test "-e \"testList='crypto'\" cli.js" --cwd <BENCHMARK_WORKING_DIR> --filter FTL
 # compare-optimization-tracing -v -a <BUILD_A_PATH> -b <BUILD_B_PATH> --test-list <TEST_LIST_FILE_PATH> --cwd <BENCHMARK_WORKING_DIR> --filter FTL
 
-def run_jsc_and_capture(verbose, build_path, jsc_args, cwd):
+def run_jsc_and_capture(verbose, build_path, jsc_args, cwd, extra_options=""):
     jsc_binary = os.path.join(build_path, "jsc")
     env = os.environ.copy()
     env["DYLD_FRAMEWORK_PATH"] = build_path
@@ -51,7 +52,7 @@ def run_jsc_and_capture(verbose, build_path, jsc_args, cwd):
         "--dumpOptimizationTracing=1",
     ]
 
-    command = [jsc_binary] + jsc_args + required_options
+    command = [jsc_binary] + jsc_args + required_options + shlex.split(extra_options)
 
     if verbose:
         def human_friendly_quote(arg):
@@ -125,12 +126,12 @@ def run_comparison_for_test(args, jsc_args, test_name):
 
     if args.verbose:
         print("Running build A...")
-    output_a = run_jsc_and_capture(args.verbose, args.build_a, jsc_args, args.cwd)
+    output_a = run_jsc_and_capture(args.verbose, args.build_a, jsc_args, args.cwd, extra_options=args.a_option)
     categories_a = extract_lines_by_category(output_a, args.filter)
 
     if args.verbose:
         print("Running build B...")
-    output_b = run_jsc_and_capture(args.verbose, args.build_b, jsc_args, args.cwd)
+    output_b = run_jsc_and_capture(args.verbose, args.build_b, jsc_args, args.cwd, extra_options=args.b_option)
     categories_b = extract_lines_by_category(output_b, args.filter)
 
     all_categories = set(categories_a.keys()).union(categories_b.keys())
@@ -168,7 +169,9 @@ def run_comparison_for_test(args, jsc_args, test_name):
 def main():
     parser = argparse.ArgumentParser(description="Compare JIT output categorized by optimization between two JSC builds.")
     parser.add_argument('-a', '--build-a', required=True, help="Path to build A")
+    parser.add_argument('--a-option', default="", help="Extra JSC options for build A (quoted string of space-delimited options)")
     parser.add_argument('-b', '--build-b', required=True, help="Path to build B")
+    parser.add_argument('--b-option', default="", help="Extra JSC options for build B (quoted string of space-delimited options)")
     parser.add_argument('--test', help="Test file or CLI args (quoted)")
     parser.add_argument('--test-list', help="Path to a file with one test name per line (replaces 'crypto' in --test)")
     parser.add_argument('--cwd', default='.', help="Working directory (default: current directory)")


### PR DESCRIPTION
#### af38380d36af7ebfc0cfb294f0cef3d791e01218
<pre>
Add --a-option and --b-option to compare-optimization-tracing for per-build JSC flags
<a href="https://bugs.webkit.org/show_bug.cgi?id=292999">https://bugs.webkit.org/show_bug.cgi?id=292999</a>
<a href="https://rdar.apple.com/151314894">rdar://151314894</a>

Reviewed by Mark Lam.

This patch enhances the compare-optimization-tracing tool to allow passing custom JSC options
to each build independently using the new --a-option and --b-option flags.

- These options are appended to the JSC invocation for build A and build B, respectively.
- Arguments must be passed as quoted, space-delimited strings.
- Enables more flexible comparisons when testing different JIT configurations.

Example usage:
  compare-optimization-tracing \
    -a &lt;BUILD_A_PATH&gt; --a-option &quot;--usePartialLoopUnrolling=0 --maxLoopUnrollingCount=5&quot; \
    -b &lt;BUILD_B_PATH&gt; --b-option &quot;--usePartialLoopUnrolling=1 --maxLoopUnrollingCount=10&quot; \
    --test &lt;SINGLE_TEST_PATH&gt; --filter FTL -v

* Tools/Scripts/compare-optimization-tracing:
(run_jsc_and_capture):
(run_comparison_for_test):
(main):

Canonical link: <a href="https://commits.webkit.org/294914@main">https://commits.webkit.org/294914@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/80eb5dd64b4d27775c9fff51d0077b66aa674896

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/103512 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/23194 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/13514 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/108688 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/54157 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/105551 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/23546 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/31745 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/78655 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/54157 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/106518 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/18258 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/93379 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58989 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/18075 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/11426 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/53513 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/87867 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/11485 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/111066 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/30659 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/22612 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/87650 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/31020 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/89579 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87292 "Passed tests") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/32171 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/9888 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/25010 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16785 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/30587 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/30387 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/33718 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/31948 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->