### PR TITLE
[SwiftUI] WebView does not expand its contents into the safe area, unlike WKWebView

### DIFF
--- a/Source/WebKit/_WebKit_SwiftUI/API/WebView.swift
+++ b/Source/WebKit/_WebKit_SwiftUI/API/WebView.swift
@@ -68,14 +68,17 @@ public struct WebView: View {
     private let storage: Storage
 
     public var body: some View {
-        WebViewRepresentable(page: storage.webPage)
-            .onChange(of: storage.url, initial: true) {
-                guard let url = storage.url else {
-                    return
-                }
+        GeometryReader { proxy in
+            WebViewRepresentable(page: storage.webPage, safeAreaInsets: proxy.safeAreaInsets)
+                .onChange(of: storage.url, initial: true) {
+                    guard let url = storage.url else {
+                        return
+                    }
 
-                storage.webPage.load(URLRequest(url: url))
-            }
+                    storage.webPage.load(URLRequest(url: url))
+                }
+                .ignoresSafeArea()
+        }
     }
 }
 

--- a/Source/WebKit/_WebKit_SwiftUI/Implementation/CocoaWebViewAdapter.swift
+++ b/Source/WebKit/_WebKit_SwiftUI/Implementation/CocoaWebViewAdapter.swift
@@ -32,6 +32,34 @@ typealias CocoaView = NSView
 
 @MainActor
 class CocoaWebViewAdapter: CocoaView, PlatformTextSearching {
+
+#if os(iOS)
+    var extrinsicSafeAreaInsets: EdgeInsets? = nil {
+        didSet {
+            guard oldValue != extrinsicSafeAreaInsets else {
+                return
+            }
+            safeAreaInsetsDidChange()
+        }
+    }
+
+    override var safeAreaInsets: UIEdgeInsets {
+        guard let extrinsicSafeAreaInsets else {
+            return .zero
+        }
+
+        var leftSafeArea = extrinsicSafeAreaInsets.leading
+        var rightSafeArea = extrinsicSafeAreaInsets.trailing
+
+        if effectiveUserInterfaceLayoutDirection == .rightToLeft {
+            leftSafeArea = extrinsicSafeAreaInsets.trailing
+            rightSafeArea = extrinsicSafeAreaInsets.leading
+        }
+
+        return UIEdgeInsets(top: extrinsicSafeAreaInsets.top, left: leftSafeArea, bottom: extrinsicSafeAreaInsets.bottom, right: rightSafeArea)
+    }
+#endif
+
     // MARK: PlatformTextSearching conformance
 
 #if os(macOS)

--- a/Source/WebKit/_WebKit_SwiftUI/Implementation/WebViewRepresentable.swift
+++ b/Source/WebKit/_WebKit_SwiftUI/Implementation/WebViewRepresentable.swift
@@ -27,6 +27,7 @@ internal import SwiftUI
 @MainActor
 struct WebViewRepresentable {
     let page: WebPage
+    let safeAreaInsets: EdgeInsets
 
     func makePlatformView(context: Context) -> CocoaWebViewAdapter {
         // FIXME: Make this more robust by figuring out what happens when a WebPage moves between representables.
@@ -37,6 +38,7 @@ struct WebViewRepresentable {
 
         let parent = CocoaWebViewAdapter()
         parent.webView = page.backingWebView
+        parent.extrinsicSafeAreaInsets = safeAreaInsets
         page.isBoundToWebView = true
 
         return parent
@@ -46,6 +48,7 @@ struct WebViewRepresentable {
         let webView = page.backingWebView
         let environment = context.environment
 
+        platformView.extrinsicSafeAreaInsets = safeAreaInsets
         platformView.webView = webView
 
         webView.allowsBackForwardNavigationGestures = environment.webViewAllowsBackForwardNavigationGestures.value != .disabled


### PR DESCRIPTION
#### 85cb80c9147359579ee6857de3b12fb4f82e18f9
<pre>
[SwiftUI] WebView does not expand its contents into the safe area, unlike WKWebView
<a href="https://bugs.webkit.org/show_bug.cgi?id=292884">https://bugs.webkit.org/show_bug.cgi?id=292884</a>
<a href="https://rdar.apple.com/150775620">rdar://150775620</a>

Reviewed by Aditya Keerthi and Richard Robinson.

Currently, WebViews do not expand its content into unsafe areas. This
causes an odd white gap in the safe areas.

Use a GeometryReader on WebView to read the safe area insets
and apply ignoresSafeArea. Then, propagate the safe area insets
to CocoaWebViewAdapter, and re-apply the safe area insets to the
CocoaWebViewAdapter. By doing so, the CocoaWebViewAdapter, which is
a UIView, will have the correct safe area insets and pass that down to
its UIScrollView, which should now automatically inset the content
correctly.

* Source/WebKit/_WebKit_SwiftUI/API/WebView.swift:
(WebView.body):
* Source/WebKit/_WebKit_SwiftUI/Implementation/CocoaWebViewAdapter.swift:
(CocoaWebViewAdapter.extrinsicSafeAreaInsets):
(CocoaWebViewAdapter.safeAreaInsets):
* Source/WebKit/_WebKit_SwiftUI/Implementation/WebViewRepresentable.swift:
(WebViewRepresentable.makePlatformView(_:)):
(WebViewRepresentable.updatePlatformView(_:context:)):

Canonical link: <a href="https://commits.webkit.org/294925@main">https://commits.webkit.org/294925@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/51cd70bdae7b14b04d4ab93646ed7a9aecf29a94

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/103530 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/23212 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/13533 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/108706 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/54175 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/23565 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/31763 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/78676 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/106536 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/18274 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/93395 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/59010 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/18087 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/53531 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/87879 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/11501 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/111084 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/30677 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/22626 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/87668 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/31038 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/89595 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/87311 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/32187 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/9903 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/25028 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16792 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/30605 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/35917 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/30405 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/33736 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/31966 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->