### PR TITLE
Unreviewed Build fix for forward declaration of 'WebCore::Settings'

### DIFF
--- a/Source/WebKit/WebProcess/Model/WebModelPlayerProvider.cpp
+++ b/Source/WebKit/WebProcess/Model/WebModelPlayerProvider.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "WebModelPlayerProvider.h"
 
+#include "Settings.h"
 #include "WebPage.h"
 #include "WebProcess.h"
 #include <WebCore/ModelPlayer.h>


### PR DESCRIPTION
#### 9343a64ca269332a3cc98b794e91aabae662e06c
<pre>
Unreviewed Build fix for forward declaration of &apos;WebCore::Settings&apos;
<a href="https://rdar.apple.com/151332172">rdar://151332172</a>

Unreviewed build fix.

* Source/WebKit/WebProcess/Model/WebModelPlayerProvider.cpp:

Canonical link: <a href="https://commits.webkit.org/294926@main">https://commits.webkit.org/294926@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f1aca98d629f4f513f410e6a116978f9b754a6f1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/103538 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/23220 "Hash f1aca98d for PR 45388 does not build (failure)") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/138/builds/13541 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/108714 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/54183 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/23573 "Hash f1aca98d for PR 45388 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/31771 "Hash f1aca98d for PR 45388 does not build (failure)") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/108714 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/54183 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/106544 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/130/builds/23573 "Hash f1aca98d for PR 45388 does not build (failure)") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/138/builds/13541 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/108714 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/130/builds/23573 "Hash f1aca98d for PR 45388 does not build (failure)") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/138/builds/13541 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/53539 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/130/builds/23573 "Hash f1aca98d for PR 45388 does not build (failure)") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/138/builds/13541 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/111092 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/30685 "Hash f1aca98d for PR 45388 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/123/builds/31771 "Hash f1aca98d for PR 45388 does not build (failure)") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/111092 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/31046 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/138/builds/13541 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/111092 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/138/builds/13541 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/25036 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16793 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/30613 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/35925 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/30413 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/33744 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/31974 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->