### PR TITLE
[iOS Debug] 2 MediaRecorder tests are constantly crashing due to assertion failure.

### DIFF
--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -7734,10 +7734,6 @@ imported/w3c/web-platform-tests/css/css-position/multicol/static-position/vrl-lt
 
 webkit.org/b/290407 imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-auto-relevancy-updates.html [ Pass Failure ]
 
-# webkit.org/b/290410 ([iOS Debug] 2 MediaRecorder tests are constantly crashing due to assertion failure.)
-[ Debug ] http/wpt/mediarecorder/MediaRecorder-audio-samplingrate-change.html [ Crash ]
-[ Debug ] http/wpt/mediarecorder/MediaRecorder-first-frame.html [ Crash ]
-
 webkit.org/b/290412 imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/current-time-root-scroller.html [ Pass Failure ]
 
 webkit.org/b/290413 [ Debug ] imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/javascript-url-return-value-handling-dynamic.html [ Failure ]

--- a/Source/WebCore/Modules/mediasource/MediaSource.cpp
+++ b/Source/WebCore/Modules/mediasource/MediaSource.cpp
@@ -477,11 +477,11 @@ Ref<MediaPromise> MediaSource::seekToTime(const MediaTime& time)
     return MediaPromise::createAndResolve();
 }
 
-Ref<TimeRanges> MediaSource::seekable()
+PlatformTimeRanges MediaSource::seekable()
 {
-    if (RefPtr msp = protectedPrivate())
-        return TimeRanges::create(msp->seekable());
-    return TimeRanges::create();
+    if (RefPtr mediaSourcePrivate = protectedPrivate())
+        return mediaSourcePrivate->seekable();
+    return { };
 }
 
 ExceptionOr<void> MediaSource::setLiveSeekableRange(double start, double end)

--- a/Source/WebCore/Modules/mediasource/MediaSource.h
+++ b/Source/WebCore/Modules/mediasource/MediaSource.h
@@ -110,7 +110,7 @@ public:
     void elementIsShuttingDown();
     void detachFromElement();
     bool isSeeking() const { return !!m_pendingSeekTarget; }
-    Ref<TimeRanges> seekable();
+    PlatformTimeRanges seekable();
     ExceptionOr<void> setLiveSeekableRange(double start, double end);
     ExceptionOr<void> clearLiveSeekableRange();
 

--- a/Source/WebCore/Modules/mediasource/MediaSourceInterfaceMainThread.cpp
+++ b/Source/WebCore/Modules/mediasource/MediaSourceInterfaceMainThread.cpp
@@ -65,7 +65,7 @@ PlatformTimeRanges MediaSourceInterfaceMainThread::buffered() const
     return m_mediaSource->buffered();
 }
 
-Ref<TimeRanges> MediaSourceInterfaceMainThread::seekable() const
+PlatformTimeRanges MediaSourceInterfaceMainThread::seekable() const
 {
     return m_mediaSource->seekable();
 }

--- a/Source/WebCore/Modules/mediasource/MediaSourceInterfaceMainThread.h
+++ b/Source/WebCore/Modules/mediasource/MediaSourceInterfaceMainThread.h
@@ -43,7 +43,7 @@ private:
     bool isClosed() const final;
     MediaTime duration() const final;
     PlatformTimeRanges buffered() const final;
-    Ref<TimeRanges> seekable() const final;
+    PlatformTimeRanges seekable() const final;
     bool isStreamingContent() const final;
     bool attachToElement(WeakPtr<HTMLMediaElement>&&) final;
     void detachFromElement() final;

--- a/Source/WebCore/Modules/mediasource/MediaSourceInterfaceProxy.h
+++ b/Source/WebCore/Modules/mediasource/MediaSourceInterfaceProxy.h
@@ -50,7 +50,7 @@ public:
     virtual bool isClosed() const = 0;
     virtual MediaTime duration() const = 0;
     virtual PlatformTimeRanges buffered() const = 0;
-    virtual Ref<TimeRanges> seekable() const = 0;
+    virtual PlatformTimeRanges seekable() const = 0;
     virtual bool isStreamingContent() const = 0;
     virtual bool attachToElement(WeakPtr<HTMLMediaElement>&&) = 0;
     virtual void detachFromElement() = 0;

--- a/Source/WebCore/Modules/mediasource/MediaSourceInterfaceWorker.cpp
+++ b/Source/WebCore/Modules/mediasource/MediaSourceInterfaceWorker.cpp
@@ -78,11 +78,11 @@ PlatformTimeRanges MediaSourceInterfaceWorker::buffered() const
     return PlatformTimeRanges::emptyRanges();
 }
 
-Ref<TimeRanges> MediaSourceInterfaceWorker::seekable() const
+PlatformTimeRanges MediaSourceInterfaceWorker::seekable() const
 {
     if (RefPtr mediaSourcePrivate = m_handle->mediaSourcePrivate(); mediaSourcePrivate && !isClosed())
-        return TimeRanges::create(mediaSourcePrivate->seekable());
-    return TimeRanges::create();
+        return mediaSourcePrivate->seekable();
+    return { };
 }
 
 bool MediaSourceInterfaceWorker::isStreamingContent() const

--- a/Source/WebCore/Modules/mediasource/MediaSourceInterfaceWorker.h
+++ b/Source/WebCore/Modules/mediasource/MediaSourceInterfaceWorker.h
@@ -43,7 +43,7 @@ private:
     bool isClosed() const final;
     MediaTime duration() const final;
     PlatformTimeRanges buffered() const final;
-    Ref<TimeRanges> seekable() const final;
+    PlatformTimeRanges seekable() const final;
     bool isStreamingContent() const final;
     bool attachToElement(WeakPtr<HTMLMediaElement>&&) final;
     void detachFromElement() final;

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -6273,15 +6273,20 @@ Ref<TimeRanges> HTMLMediaElement::played()
 
 Ref<TimeRanges> HTMLMediaElement::seekable() const
 {
+    return TimeRanges::create(platformSeekable());
+}
+
+PlatformTimeRanges HTMLMediaElement::platformSeekable() const
+{
 #if ENABLE(MEDIA_SOURCE)
     if (m_mediaSource)
         return m_mediaSource->seekable();
 #endif
 
     if (m_player)
-        return TimeRanges::create(m_player->seekable());
+        return m_player->seekable();
 
-    return TimeRanges::create();
+    return { };
 }
 
 double HTMLMediaElement::seekableTimeRangesLastModifiedTime() const

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -317,6 +317,7 @@ public:
     void updatePlaybackRate();
     Ref<TimeRanges> played() override;
     Ref<TimeRanges> seekable() const override;
+    PlatformTimeRanges platformSeekable() const;
     double seekableTimeRangesLastModifiedTime() const;
     double liveUpdateInterval() const;
     WEBCORE_EXPORT bool ended() const;

--- a/Source/WebCore/platform/cocoa/PlaybackSessionModel.h
+++ b/Source/WebCore/platform/cocoa/PlaybackSessionModel.h
@@ -43,7 +43,7 @@ class PlaybackSessionModelClient;
 
 namespace WebCore {
 
-class TimeRanges;
+class PlatformTimeRanges;
 class PlaybackSessionModelClient;
 struct MediaSelectionOption;
 struct SpatialVideoMetadata;
@@ -126,7 +126,7 @@ public:
     virtual bool isScrubbing() const = 0;
     virtual double defaultPlaybackRate() const = 0;
     virtual double playbackRate() const = 0;
-    virtual Ref<TimeRanges> seekableRanges() const = 0;
+    virtual PlatformTimeRanges seekableRanges() const = 0;
     virtual double seekableTimeRangesLastModifiedTime() const = 0;
     virtual double liveUpdateInterval() const = 0;
     virtual bool canPlayFastReverse() const = 0;
@@ -170,7 +170,7 @@ public:
     virtual void bufferedTimeChanged(double) { }
     virtual void playbackStartedTimeChanged(double /* playbackStartedTime */) { }
     virtual void rateChanged(OptionSet<PlaybackSessionModel::PlaybackState>, double /* playbackRate */, double /* defaultPlaybackRate */) { }
-    virtual void seekableRangesChanged(const TimeRanges&, double /* lastModified */, double /* liveInterval */) { }
+    virtual void seekableRangesChanged(const PlatformTimeRanges&, double /* lastModified */, double /* liveInterval */) { }
     virtual void canPlayFastReverseChanged(bool) { }
     virtual void audioMediaSelectionOptionsChanged(const Vector<MediaSelectionOption>& /* options */, uint64_t /* selectedIndex */) { }
     virtual void legibleMediaSelectionOptionsChanged(const Vector<MediaSelectionOption>& /* options */, uint64_t /* selectedIndex */) { }

--- a/Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.h
+++ b/Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.h
@@ -115,7 +115,7 @@ public:
     bool isScrubbing() const final { return false; }
     double defaultPlaybackRate() const final;
     double playbackRate() const final;
-    Ref<TimeRanges> seekableRanges() const final;
+    PlatformTimeRanges seekableRanges() const final;
     double seekableTimeRangesLastModifiedTime() const final;
     double liveUpdateInterval() const final;
     bool canPlayFastReverse() const final;

--- a/Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.mm
+++ b/Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.mm
@@ -208,12 +208,11 @@ void PlaybackSessionModelMediaElement::updateForEventName(const WTF::AtomString&
     if (all
         || eventName == eventNames().progressEvent) {
         auto bufferedTime = this->bufferedTime();
-        auto seekableRanges = this->seekableRanges();
         auto seekableTimeRangesLastModifiedTime = this->seekableTimeRangesLastModifiedTime();
         auto liveUpdateInterval = this->liveUpdateInterval();
         for (auto& client : m_clients) {
             client->bufferedTimeChanged(bufferedTime);
-            client->seekableRangesChanged(seekableRanges, seekableTimeRangesLastModifiedTime, liveUpdateInterval);
+            client->seekableRangesChanged(seekableRanges(), seekableTimeRangesLastModifiedTime, liveUpdateInterval);
         }
     }
 
@@ -663,11 +662,11 @@ double PlaybackSessionModelMediaElement::playbackRate() const
     return 0;
 }
 
-Ref<TimeRanges> PlaybackSessionModelMediaElement::seekableRanges() const
+PlatformTimeRanges PlaybackSessionModelMediaElement::seekableRanges() const
 {
     if (RefPtr mediaElement = m_mediaElement; mediaElement && mediaElement->supportsSeeking())
-        return mediaElement->seekable();
-    return TimeRanges::create();
+        return mediaElement->platformSeekable();
+    return { };
 }
 
 double PlaybackSessionModelMediaElement::seekableTimeRangesLastModifiedTime() const

--- a/Source/WebCore/platform/graphics/MediaPlayerPrivate.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlayerPrivate.cpp
@@ -49,9 +49,11 @@ std::optional<VideoFrameMetadata> MediaPlayerPrivateInterface::videoFrameMetadat
 
 const PlatformTimeRanges& MediaPlayerPrivateInterface::seekable() const
 {
-    if (maxTimeSeekable() == MediaTime::zeroTime())
+    auto maxTimeSeekable = this->maxTimeSeekable();
+    if (maxTimeSeekable == MediaTime::zeroTime())
         return PlatformTimeRanges::emptyRanges();
-    m_seekable = { minTimeSeekable(), maxTimeSeekable() };
+    ASSERT(maxTimeSeekable.isValid());
+    m_seekable = { minTimeSeekable(), maxTimeSeekable };
     return m_seekable;
 }
 

--- a/Source/WebCore/platform/graphics/PlatformTimeRanges.cpp
+++ b/Source/WebCore/platform/graphics/PlatformTimeRanges.cpp
@@ -203,10 +203,8 @@ MediaTime PlatformTimeRanges::minimumBufferedTime() const
 
 void PlatformTimeRanges::add(const MediaTime& start, const MediaTime& end, AddTimeRangeOption addTimeRangeOption)
 {
-#if !PLATFORM(MAC) // https://bugs.webkit.org/show_bug.cgi?id=180253
     ASSERT(start.isValid());
     ASSERT(end.isValid());
-#endif
     ASSERT(start <= end);
 
     auto startTime = start;

--- a/Source/WebCore/platform/graphics/cocoa/NullPlaybackSessionInterface.h
+++ b/Source/WebCore/platform/graphics/cocoa/NullPlaybackSessionInterface.h
@@ -87,7 +87,7 @@ private:
     void currentTimeChanged(double, double) final { }
     void bufferedTimeChanged(double) final { }
     void rateChanged(OptionSet<PlaybackSessionModel::PlaybackState>, double, double) final { }
-    void seekableRangesChanged(const TimeRanges&, double, double) final { }
+    void seekableRangesChanged(const PlatformTimeRanges&, double, double) final { }
     void canPlayFastReverseChanged(bool) final { }
     void audioMediaSelectionOptionsChanged(const Vector<MediaSelectionOption>&, uint64_t) final { }
     void legibleMediaSelectionOptionsChanged(const Vector<MediaSelectionOption>&, uint64_t) final { }

--- a/Source/WebCore/platform/ios/PlaybackSessionInterfaceAVKit.h
+++ b/Source/WebCore/platform/ios/PlaybackSessionInterfaceAVKit.h
@@ -50,7 +50,7 @@ public:
     void currentTimeChanged(double, double) final;
     void bufferedTimeChanged(double) final { }
     void rateChanged(OptionSet<PlaybackSessionModel::PlaybackState>, double, double) final;
-    void seekableRangesChanged(const TimeRanges&, double, double) final;
+    void seekableRangesChanged(const PlatformTimeRanges&, double, double) final;
     void canPlayFastReverseChanged(bool) final;
     void audioMediaSelectionOptionsChanged(const Vector<MediaSelectionOption>&, uint64_t) final;
     void legibleMediaSelectionOptionsChanged(const Vector<MediaSelectionOption>&, uint64_t) final;

--- a/Source/WebCore/platform/ios/PlaybackSessionInterfaceAVKit.mm
+++ b/Source/WebCore/platform/ios/PlaybackSessionInterfaceAVKit.mm
@@ -255,9 +255,9 @@ void PlaybackSessionInterfaceAVKit::rateChanged(OptionSet<PlaybackSessionModel::
         [m_contentSource setRate:playbackState.contains(PlaybackSessionModel::PlaybackState::Playing) ? playbackRate : 0];
 }
 
-void PlaybackSessionInterfaceAVKit::seekableRangesChanged(const TimeRanges& timeRanges, double, double)
+void PlaybackSessionInterfaceAVKit::seekableRangesChanged(const PlatformTimeRanges& timeRanges, double, double)
 {
-    [m_contentSource setSeekableTimeRanges:makeNSArray(timeRanges.ranges()).get()];
+    [m_contentSource setSeekableTimeRanges:makeNSArray(timeRanges).get()];
 }
 
 void PlaybackSessionInterfaceAVKit::canPlayFastReverseChanged(bool canPlayFastReverse)

--- a/Source/WebCore/platform/ios/PlaybackSessionInterfaceAVKitLegacy.h
+++ b/Source/WebCore/platform/ios/PlaybackSessionInterfaceAVKitLegacy.h
@@ -46,7 +46,7 @@ public:
     void currentTimeChanged(double currentTime, double anchorTime) final;
     void bufferedTimeChanged(double) final;
     void rateChanged(OptionSet<PlaybackSessionModel::PlaybackState>, double playbackRate, double defaultPlaybackRate) final;
-    void seekableRangesChanged(const TimeRanges&, double lastModifiedTime, double liveUpdateInterval) final;
+    void seekableRangesChanged(const PlatformTimeRanges&, double lastModifiedTime, double liveUpdateInterval) final;
     void canPlayFastReverseChanged(bool) final;
     void audioMediaSelectionOptionsChanged(const Vector<MediaSelectionOption>& options, uint64_t selectedIndex) final;
     void legibleMediaSelectionOptionsChanged(const Vector<MediaSelectionOption>& options, uint64_t selectedIndex) final;

--- a/Source/WebCore/platform/ios/PlaybackSessionInterfaceAVKitLegacy.mm
+++ b/Source/WebCore/platform/ios/PlaybackSessionInterfaceAVKitLegacy.mm
@@ -139,9 +139,9 @@ void PlaybackSessionInterfaceAVKitLegacy::rateChanged(OptionSet<PlaybackSessionM
         [m_playerController setRate:playbackState.contains(PlaybackSessionModel::PlaybackState::Playing) ? playbackRate : 0. fromJavaScript:YES];
 }
 
-void PlaybackSessionInterfaceAVKitLegacy::seekableRangesChanged(const TimeRanges& timeRanges, double lastModifiedTime, double liveUpdateInterval)
+void PlaybackSessionInterfaceAVKitLegacy::seekableRangesChanged(const PlatformTimeRanges& timeRanges, double lastModifiedTime, double liveUpdateInterval)
 {
-    [m_playerController setSeekableTimeRanges:makeNSArray(timeRanges.ranges()).get()];
+    [m_playerController setSeekableTimeRanges:makeNSArray(timeRanges).get()];
     [m_playerController setSeekableTimeRangesLastModifiedTime:lastModifiedTime];
     [m_playerController setLiveUpdateInterval:liveUpdateInterval];
 }

--- a/Source/WebCore/platform/ios/PlaybackSessionInterfaceIOS.h
+++ b/Source/WebCore/platform/ios/PlaybackSessionInterfaceIOS.h
@@ -70,7 +70,7 @@ public:
     void currentTimeChanged(double currentTime, double anchorTime) override = 0;
     void bufferedTimeChanged(double) override = 0;
     void rateChanged(OptionSet<PlaybackSessionModel::PlaybackState>, double playbackRate, double defaultPlaybackRate) override = 0;
-    void seekableRangesChanged(const TimeRanges&, double lastModifiedTime, double liveUpdateInterval) override = 0;
+    void seekableRangesChanged(const PlatformTimeRanges&, double lastModifiedTime, double liveUpdateInterval) override = 0;
     void canPlayFastReverseChanged(bool) override = 0;
     void audioMediaSelectionOptionsChanged(const Vector<MediaSelectionOption>& options, uint64_t selectedIndex) override = 0;
     void legibleMediaSelectionOptionsChanged(const Vector<MediaSelectionOption>& options, uint64_t selectedIndex) override = 0;

--- a/Source/WebCore/platform/ios/PlaybackSessionInterfaceTVOS.h
+++ b/Source/WebCore/platform/ios/PlaybackSessionInterfaceTVOS.h
@@ -44,7 +44,7 @@ public:
     void currentTimeChanged(double, double) final { }
     void bufferedTimeChanged(double) final { }
     void rateChanged(OptionSet<PlaybackSessionModel::PlaybackState>, double, double) final { }
-    void seekableRangesChanged(const TimeRanges&, double, double) final { }
+    void seekableRangesChanged(const PlatformTimeRanges&, double, double) final { }
     void canPlayFastReverseChanged(bool) final { }
     void audioMediaSelectionOptionsChanged(const Vector<MediaSelectionOption>&, uint64_t) final { }
     void legibleMediaSelectionOptionsChanged(const Vector<MediaSelectionOption>&, uint64_t) final { }

--- a/Source/WebCore/platform/ios/WebVideoFullscreenControllerAVKit.mm
+++ b/Source/WebCore/platform/ios/WebVideoFullscreenControllerAVKit.mm
@@ -160,7 +160,7 @@ private:
     bool isScrubbing() const override { return false; }
     double defaultPlaybackRate() const override;
     double playbackRate() const override;
-    Ref<TimeRanges> seekableRanges() const override;
+    PlatformTimeRanges seekableRanges() const override;
     double seekableTimeRangesLastModifiedTime() const override;
     double liveUpdateInterval() const override;
     bool canPlayFastReverse() const override;
@@ -190,7 +190,7 @@ private:
     void currentTimeChanged(double currentTime, double anchorTime) override;
     void bufferedTimeChanged(double) override;
     void rateChanged(OptionSet<PlaybackSessionModel::PlaybackState>, double playbackRate, double defaultPlaybackRate) override;
-    void seekableRangesChanged(const TimeRanges&, double lastModifiedTime, double liveUpdateInterval) override;
+    void seekableRangesChanged(const PlatformTimeRanges&, double lastModifiedTime, double liveUpdateInterval) override;
     void canPlayFastReverseChanged(bool) override;
     void audioMediaSelectionOptionsChanged(const Vector<MediaSelectionOption>& options, uint64_t selectedIndex) override;
     void legibleMediaSelectionOptionsChanged(const Vector<MediaSelectionOption>& options, uint64_t selectedIndex) override;
@@ -470,11 +470,11 @@ void VideoFullscreenControllerContext::videoDimensionsChanged(const FloatSize& v
         client->videoDimensionsChanged(videoDimensions);
 }
 
-void VideoFullscreenControllerContext::seekableRangesChanged(const TimeRanges& timeRanges, double lastModifiedTime, double liveUpdateInterval)
+void VideoFullscreenControllerContext::seekableRangesChanged(const PlatformTimeRanges& timeRanges, double lastModifiedTime, double liveUpdateInterval)
 {
     if (WebThreadIsCurrent()) {
-        RunLoop::protectedMain()->dispatch([protectedThis = Ref { *this }, platformTimeRanges = timeRanges.ranges(), lastModifiedTime, liveUpdateInterval] {
-            protectedThis->seekableRangesChanged(TimeRanges::create(platformTimeRanges), lastModifiedTime, liveUpdateInterval);
+        RunLoop::protectedMain()->dispatch([protectedThis = Ref { *this }, timeRanges, lastModifiedTime, liveUpdateInterval] {
+            protectedThis->seekableRangesChanged(timeRanges, lastModifiedTime, liveUpdateInterval);
         });
         return;
     }
@@ -931,10 +931,10 @@ double VideoFullscreenControllerContext::playbackRate() const
     return m_playbackModel ? m_playbackModel->playbackRate() : 0;
 }
 
-Ref<TimeRanges> VideoFullscreenControllerContext::seekableRanges() const
+PlatformTimeRanges VideoFullscreenControllerContext::seekableRanges() const
 {
     ASSERT(isUIThread());
-    return m_playbackModel ? m_playbackModel->seekableRanges() : TimeRanges::create();
+    return m_playbackModel ? m_playbackModel->seekableRanges() : PlatformTimeRanges::emptyRanges();
 }
 
 double VideoFullscreenControllerContext::seekableTimeRangesLastModifiedTime() const

--- a/Source/WebCore/platform/mac/PlaybackSessionInterfaceMac.h
+++ b/Source/WebCore/platform/mac/PlaybackSessionInterfaceMac.h
@@ -61,7 +61,7 @@ public:
     void durationChanged(double) final;
     void currentTimeChanged(double /*currentTime*/, double /*anchorTime*/) final;
     void rateChanged(OptionSet<PlaybackSessionModel::PlaybackState>, double /* playbackRate */, double /* defaultPlaybackRate */) final;
-    void seekableRangesChanged(const TimeRanges&, double /*lastModifiedTime*/, double /*liveUpdateInterval*/) final;
+    void seekableRangesChanged(const PlatformTimeRanges&, double /*lastModifiedTime*/, double /*liveUpdateInterval*/) final;
     void audioMediaSelectionOptionsChanged(const Vector<MediaSelectionOption>& /*options*/, uint64_t /*selectedIndex*/) final;
     void legibleMediaSelectionOptionsChanged(const Vector<MediaSelectionOption>& /*options*/, uint64_t /*selectedIndex*/) final;
     void audioMediaSelectionIndexChanged(uint64_t) final;

--- a/Source/WebCore/platform/mac/PlaybackSessionInterfaceMac.mm
+++ b/Source/WebCore/platform/mac/PlaybackSessionInterfaceMac.mm
@@ -154,25 +154,11 @@ void PlaybackSessionInterfaceMac::skipAd()
         model->skipAd();
 }
 #endif
-#if ENABLE(WEB_PLAYBACK_CONTROLS_MANAGER)
-static RetainPtr<NSMutableArray> timeRangesToArray(const TimeRanges& timeRanges)
-{
-    RetainPtr<NSMutableArray> rangeArray = adoptNS([[NSMutableArray alloc] init]);
 
-    for (unsigned i = 0; i < timeRanges.length(); i++) {
-        const PlatformTimeRanges& ranges = timeRanges.ranges();
-        CMTimeRange range = PAL::CMTimeRangeMake(PAL::toCMTime(ranges.start(i)), PAL::toCMTime(ranges.end(i)));
-        [rangeArray addObject:[NSValue valueWithCMTimeRange:range]];
-    }
-
-    return rangeArray;
-}
-#endif
-
-void PlaybackSessionInterfaceMac::seekableRangesChanged(const TimeRanges& timeRanges, double, double)
+void PlaybackSessionInterfaceMac::seekableRangesChanged(const PlatformTimeRanges& timeRanges, double, double)
 {
 #if ENABLE(WEB_PLAYBACK_CONTROLS_MANAGER)
-    [playBackControlsManager() setSeekableTimeRanges:timeRangesToArray(timeRanges).get()];
+    [playBackControlsManager() setSeekableTimeRanges:makeNSArray(timeRanges).get()];
 #else
     UNUSED_PARAM(timeRanges);
 #endif
@@ -268,7 +254,7 @@ void PlaybackSessionInterfaceMac::setPlayBackControlsManager(WebPlaybackControls
     manager.hasEnabledVideo = duration > 0;
     manager.defaultPlaybackRate = m_playbackSessionModel->defaultPlaybackRate();
     manager.rate = m_playbackSessionModel->isPlaying() ? m_playbackSessionModel->playbackRate() : 0.;
-    manager.seekableTimeRanges = timeRangesToArray(m_playbackSessionModel->seekableRanges()).get();
+    manager.seekableTimeRanges = makeNSArray(m_playbackSessionModel->seekableRanges()).get();
     manager.canTogglePlayback = YES;
     manager.playing = m_playbackSessionModel->isPlaying();
     [manager setAudioMediaSelectionOptions:m_playbackSessionModel->audioMediaSelectionOptions() withSelectedIndex:static_cast<NSUInteger>(m_playbackSessionModel->audioMediaSelectedIndex())];

--- a/Source/WebKit/Platform/ios/PlaybackSessionInterfaceLMK.h
+++ b/Source/WebKit/Platform/ios/PlaybackSessionInterfaceLMK.h
@@ -49,7 +49,7 @@ public:
     void currentTimeChanged(double, double) final;
     void bufferedTimeChanged(double) final { }
     void rateChanged(OptionSet<WebCore::PlaybackSessionModel::PlaybackState>, double, double) final;
-    void seekableRangesChanged(const WebCore::TimeRanges&, double, double) final;
+    void seekableRangesChanged(const WebCore::PlatformTimeRanges&, double, double) final;
     void canPlayFastReverseChanged(bool) final;
     void audioMediaSelectionOptionsChanged(const Vector<WebCore::MediaSelectionOption>&, uint64_t) final;
     void legibleMediaSelectionOptionsChanged(const Vector<WebCore::MediaSelectionOption>&, uint64_t) final;

--- a/Source/WebKit/Platform/ios/PlaybackSessionInterfaceLMK.mm
+++ b/Source/WebKit/Platform/ios/PlaybackSessionInterfaceLMK.mm
@@ -287,13 +287,11 @@ void PlaybackSessionInterfaceLMK::rateChanged(OptionSet<WebCore::PlaybackSession
         [m_player setPlaybackRate:playbackState.contains(WebCore::PlaybackSessionModel::PlaybackState::Playing) ? playbackRate : 0];
 }
 
-void PlaybackSessionInterfaceLMK::seekableRangesChanged(const WebCore::TimeRanges& timeRanges, double, double)
+void PlaybackSessionInterfaceLMK::seekableRangesChanged(const WebCore::PlatformTimeRanges& timeRanges, double, double)
 {
     RetainPtr seekableRanges = adoptNS([[NSMutableArray alloc] initWithCapacity:timeRanges.length()]);
     for (unsigned i = 0; i < timeRanges.length(); ++i) {
-        double lowerBound = timeRanges.start(i).releaseReturnValue();
-        double upperBound = timeRanges.end(i).releaseReturnValue();
-        RetainPtr timeRange = adoptNS([allocWKSLinearMediaTimeRangeInstance() initWithLowerBound:lowerBound upperBound:upperBound]);
+        RetainPtr timeRange = adoptNS([allocWKSLinearMediaTimeRangeInstance() initWithLowerBound:timeRanges.start(i).toDouble() upperBound:timeRanges.end(i).toDouble()]);
         [seekableRanges addObject:timeRange.get()];
     }
 

--- a/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.h
+++ b/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.h
@@ -81,7 +81,7 @@ public:
     void bufferedTimeChanged(double);
     void playbackStartedTimeChanged(double);
     void rateChanged(OptionSet<WebCore::PlaybackSessionModel::PlaybackState>, double playbackRate, double defaultPlaybackRate);
-    void seekableRangesChanged(WebCore::TimeRanges&, double lastModifiedTime, double liveUpdateInterval);
+    void seekableRangesChanged(const WebCore::PlatformTimeRanges&, double lastModifiedTime, double liveUpdateInterval);
     void canPlayFastReverseChanged(bool);
     void audioMediaSelectionOptionsChanged(const Vector<WebCore::MediaSelectionOption>& options, uint64_t index);
     void legibleMediaSelectionOptionsChanged(const Vector<WebCore::MediaSelectionOption>& options, uint64_t index);
@@ -164,7 +164,7 @@ private:
     bool isScrubbing() const final { return m_isScrubbing; }
     double defaultPlaybackRate() const final { return m_defaultPlaybackRate; }
     double playbackRate() const final { return m_playbackRate; }
-    Ref<WebCore::TimeRanges> seekableRanges() const final { return m_seekableRanges.copyRef(); }
+    WebCore::PlatformTimeRanges seekableRanges() const final { return m_seekableRanges; }
     double seekableTimeRangesLastModifiedTime() const final { return m_seekableTimeRangesLastModifiedTime; }
     double liveUpdateInterval() const { return m_liveUpdateInterval; }
     bool canPlayFastReverse() const final { return m_canPlayFastReverse; }
@@ -210,7 +210,7 @@ private:
     bool m_isScrubbing { false };
     double m_defaultPlaybackRate { 0 };
     double m_playbackRate { 0 };
-    Ref<WebCore::TimeRanges> m_seekableRanges { WebCore::TimeRanges::create() };
+    WebCore::PlatformTimeRanges m_seekableRanges;
     double m_seekableTimeRangesLastModifiedTime { 0 };
     double m_liveUpdateInterval { 0 };
     bool m_canPlayFastReverse { false };
@@ -289,7 +289,7 @@ private:
     void swapFullscreenModes(PlaybackSessionContextIdentifier, PlaybackSessionContextIdentifier);
     void currentTimeChanged(PlaybackSessionContextIdentifier, double currentTime, double hostTime);
     void bufferedTimeChanged(PlaybackSessionContextIdentifier, double bufferedTime);
-    void seekableRangesVectorChanged(PlaybackSessionContextIdentifier, Vector<std::pair<double, double>> ranges, double lastModifiedTime, double liveUpdateInterval);
+    void seekableRangesVectorChanged(PlaybackSessionContextIdentifier, const WebCore::PlatformTimeRanges&, double lastModifiedTime, double liveUpdateInterval);
     void canPlayFastReverseChanged(PlaybackSessionContextIdentifier, bool value);
     void audioMediaSelectionOptionsChanged(PlaybackSessionContextIdentifier, Vector<WebCore::MediaSelectionOption> options, uint64_t selectedIndex);
     void legibleMediaSelectionOptionsChanged(PlaybackSessionContextIdentifier, Vector<WebCore::MediaSelectionOption> options, uint64_t selectedIndex);

--- a/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.messages.in
+++ b/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.messages.in
@@ -30,7 +30,7 @@
 messages -> PlaybackSessionManagerProxy {
     CurrentTimeChanged(WebCore::MediaPlayerClientIdentifier contextId, double currentTime, double hostTime)
     BufferedTimeChanged(WebCore::MediaPlayerClientIdentifier contextId, double bufferedTime)
-    SeekableRangesVectorChanged(WebCore::MediaPlayerClientIdentifier contextId, Vector<std::pair<double, double>> ranges, double lastModifiedTime, double liveUpdateInterval)
+    SeekableRangesVectorChanged(WebCore::MediaPlayerClientIdentifier contextId, WebCore::PlatformTimeRanges ranges, double lastModifiedTime, double liveUpdateInterval)
     CanPlayFastReverseChanged(WebCore::MediaPlayerClientIdentifier contextId, bool value)
     AudioMediaSelectionOptionsChanged(WebCore::MediaPlayerClientIdentifier contextId, Vector<WebCore::MediaSelectionOption> options, uint64_t selectedIndex)
     LegibleMediaSelectionOptionsChanged(WebCore::MediaPlayerClientIdentifier contextId, Vector<WebCore::MediaSelectionOption> options, uint64_t selectedIndex)

--- a/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.mm
+++ b/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.mm
@@ -378,9 +378,9 @@ void PlaybackSessionModelContext::rateChanged(OptionSet<WebCore::PlaybackSession
         client->rateChanged(m_playbackState, m_playbackRate, m_defaultPlaybackRate);
 }
 
-void PlaybackSessionModelContext::seekableRangesChanged(WebCore::TimeRanges& seekableRanges, double lastModifiedTime, double liveUpdateInterval)
+void PlaybackSessionModelContext::seekableRangesChanged(const WebCore::PlatformTimeRanges& seekableRanges, double lastModifiedTime, double liveUpdateInterval)
 {
-    INFO_LOG_IF_POSSIBLE(LOGIDENTIFIER, seekableRanges.ranges());
+    INFO_LOG_IF_POSSIBLE(LOGIDENTIFIER, seekableRanges);
     m_seekableRanges = seekableRanges;
     m_seekableTimeRangesLastModifiedTime = lastModifiedTime;
     m_liveUpdateInterval = liveUpdateInterval;
@@ -738,15 +738,8 @@ void PlaybackSessionManagerProxy::bufferedTimeChanged(PlaybackSessionContextIden
     ensureModel(contextId)->bufferedTimeChanged(bufferedTime);
 }
 
-void PlaybackSessionManagerProxy::seekableRangesVectorChanged(PlaybackSessionContextIdentifier contextId, Vector<std::pair<double, double>> ranges, double lastModifiedTime, double liveUpdateInterval)
+void PlaybackSessionManagerProxy::seekableRangesVectorChanged(PlaybackSessionContextIdentifier contextId, const WebCore::PlatformTimeRanges& timeRanges, double lastModifiedTime, double liveUpdateInterval)
 {
-    Ref<TimeRanges> timeRanges = TimeRanges::create();
-    for (const auto& range : ranges) {
-        ASSERT(isfinite(range.first));
-        ASSERT(!isfinite(range.second) || range.second >= range.first);
-        timeRanges->add(range.first, range.second);
-    }
-
     ensureModel(contextId)->seekableRangesChanged(timeRanges, lastModifiedTime, liveUpdateInterval);
 }
 

--- a/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.h
+++ b/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.h
@@ -91,7 +91,7 @@ private:
     void bufferedTimeChanged(double) final;
     void playbackStartedTimeChanged(double playbackStartedTime) final;
     void rateChanged(OptionSet<WebCore::PlaybackSessionModel::PlaybackState>, double playbackRate, double defaultPlaybackRate) final;
-    void seekableRangesChanged(const WebCore::TimeRanges&, double lastModifiedTime, double liveUpdateInterval) final;
+    void seekableRangesChanged(const WebCore::PlatformTimeRanges&, double lastModifiedTime, double liveUpdateInterval) final;
     void canPlayFastReverseChanged(bool value) final;
     void audioMediaSelectionOptionsChanged(const Vector<WebCore::MediaSelectionOption>& options, uint64_t selectedIndex) final;
     void legibleMediaSelectionOptionsChanged(const Vector<WebCore::MediaSelectionOption>& options, uint64_t selectedIndex) final;
@@ -173,7 +173,7 @@ private:
     void bufferedTimeChanged(PlaybackSessionContextIdentifier, double bufferedTime);
     void playbackStartedTimeChanged(PlaybackSessionContextIdentifier, double playbackStartedTime);
     void rateChanged(PlaybackSessionContextIdentifier, OptionSet<WebCore::PlaybackSessionModel::PlaybackState>, double playbackRate, double defaultPlaybackRate);
-    void seekableRangesChanged(PlaybackSessionContextIdentifier, const WebCore::TimeRanges&, double lastModifiedTime, double liveUpdateInterval);
+    void seekableRangesChanged(PlaybackSessionContextIdentifier, const WebCore::PlatformTimeRanges&, double lastModifiedTime, double liveUpdateInterval);
     void canPlayFastReverseChanged(PlaybackSessionContextIdentifier, bool value);
     void audioMediaSelectionOptionsChanged(PlaybackSessionContextIdentifier, const Vector<WebCore::MediaSelectionOption>& options, uint64_t selectedIndex);
     void legibleMediaSelectionOptionsChanged(PlaybackSessionContextIdentifier, const Vector<WebCore::MediaSelectionOption>& options, uint64_t selectedIndex);

--- a/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.mm
+++ b/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.mm
@@ -99,7 +99,7 @@ void PlaybackSessionInterfaceContext::playbackStartedTimeChanged(double playback
         manager->playbackStartedTimeChanged(m_contextId, playbackStartedTime);
 }
 
-void PlaybackSessionInterfaceContext::seekableRangesChanged(const WebCore::TimeRanges& ranges, double lastModifiedTime, double liveUpdateInterval)
+void PlaybackSessionInterfaceContext::seekableRangesChanged(const WebCore::PlatformTimeRanges& ranges, double lastModifiedTime, double liveUpdateInterval)
 {
     if (RefPtr manager = m_manager.get())
         manager->seekableRangesChanged(m_contextId, ranges, lastModifiedTime, liveUpdateInterval);
@@ -412,15 +412,9 @@ void PlaybackSessionManager::rateChanged(PlaybackSessionContextIdentifier contex
     m_page->send(Messages::PlaybackSessionManagerProxy::RateChanged(contextId, playbackState, playbackRate, defaultPlaybackRate));
 }
 
-void PlaybackSessionManager::seekableRangesChanged(PlaybackSessionContextIdentifier contextId, const WebCore::TimeRanges& timeRanges, double lastModifiedTime, double liveUpdateInterval)
+void PlaybackSessionManager::seekableRangesChanged(PlaybackSessionContextIdentifier contextId, const WebCore::PlatformTimeRanges& timeRanges, double lastModifiedTime, double liveUpdateInterval)
 {
-    Vector<std::pair<double, double>> rangesVector;
-    for (unsigned i = 0; i < timeRanges.length(); i++) {
-        double start = timeRanges.ranges().start(i).toDouble();
-        double end = timeRanges.ranges().end(i).toDouble();
-        rangesVector.append({ start, end });
-    }
-    m_page->send(Messages::PlaybackSessionManagerProxy::SeekableRangesVectorChanged(contextId, WTFMove(rangesVector), lastModifiedTime, liveUpdateInterval));
+    m_page->send(Messages::PlaybackSessionManagerProxy::SeekableRangesVectorChanged(contextId, timeRanges, lastModifiedTime, liveUpdateInterval));
 }
 
 void PlaybackSessionManager::canPlayFastReverseChanged(PlaybackSessionContextIdentifier contextId, bool value)


### PR DESCRIPTION
#### f20e6647a915e6560ca12a4b5277cb547df9fc80
<pre>
[iOS Debug] 2 MediaRecorder tests are constantly crashing due to assertion failure.
<a href="https://bugs.webkit.org/show_bug.cgi?id=290410">https://bugs.webkit.org/show_bug.cgi?id=290410</a>
<a href="https://rdar.apple.com/147863063">rdar://147863063</a>

Reviewed by Youenn Fablet.

When sending the PlatformTimeRanges to the UI process, we converted each
TimeRange to a Vector&lt;pair&lt;double, double&gt;&gt;. When the TimeRanges contained
+infinity, the conversion from MediaTime::positiveInfinity -&gt; double -&gt; MediaTime were lossy
and caused the generated PlatformTimeRanges to fail the assertion `end.isValid()`

We remove this unnecessary TimesRanges to Vector when sending it over IPC
and instead use the standard serialiser.
In addition, stop using WebCore::TimeRanges and instead have
seekableRangesChanged() and seekableRanges() return PlatformTimeRanges object.
This also removes a slight layering violation that had existed for a long
time.

Covered by existing tests.

* LayoutTests/platform/ios/TestExpectations: Change test TestExpectations as tests won&apos;t cause an assertion on debug build anymore.
* Source/WebCore/platform/graphics/PlatformTimeRanges.cpp:
(WebCore::PlatformTimeRanges::add): Assert that the end is valid on all platform.
* Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.cpp: Add missing header.

Canonical link: <a href="https://commits.webkit.org/294943@main">https://commits.webkit.org/294943@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/352848df6518d1c333178684592f219bf5dd05fc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/103557 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/23239 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/13560 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/108733 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/54203 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/105597 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/23594 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/31790 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78690 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/106563 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/18299 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/93420 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59024 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/18114 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/11467 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/53558 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/87902 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/11526 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/111111 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/30704 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/22646 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/87686 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/31065 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/89620 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87341 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22236 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32209 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/9928 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/25056 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/30632 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/35944 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/30432 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/33763 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/31993 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->