### PR TITLE
Expose allowsFollowingLink/allowsFollowingImageURL  to _WKContextMenuElementInfo

### DIFF
--- a/Source/WebCore/page/ContextMenuContext.cpp
+++ b/Source/WebCore/page/ContextMenuContext.cpp
@@ -43,6 +43,8 @@ ContextMenuContext::ContextMenuContext(Type type, const HitTestResult& hitTestRe
     , m_hitTestResult(hitTestResult)
     , m_event(WTFMove(event))
     , m_hasEntireImage(hitTestResult.hasEntireImage())
+    , m_allowsFollowingLink(hitTestResult.allowsFollowingLink())
+    , m_allowsFollowingImageURL(hitTestResult.allowsFollowingImageURL())
 {
 }
 

--- a/Source/WebCore/page/ContextMenuContext.h
+++ b/Source/WebCore/page/ContextMenuContext.h
@@ -65,6 +65,8 @@ public:
     const String& selectedText() const { return m_selectedText; }
 
     bool hasEntireImage() const { return m_hasEntireImage; }
+    bool allowsFollowingLink() const { return m_allowsFollowingLink; }
+    bool allowsFollowingImageURL() const { return m_allowsFollowingImageURL; }
 
 #if ENABLE(SERVICE_CONTROLS)
     void setControlledImage(Image* controlledImage) { m_controlledImage = controlledImage; }
@@ -85,6 +87,8 @@ private:
     RefPtr<Event> m_event;
     String m_selectedText;
     bool m_hasEntireImage { false };
+    bool m_allowsFollowingLink { false };
+    bool m_allowsFollowingImageURL { false };
 
 #if ENABLE(SERVICE_CONTROLS)
     RefPtr<Image> m_controlledImage;

--- a/Source/WebCore/rendering/HitTestResult.cpp
+++ b/Source/WebCore/rendering/HitTestResult.cpp
@@ -57,6 +57,7 @@
 #include "VisibleUnits.h"
 #include "XLinkNames.h"
 #include <wtf/TZoneMallocInlines.h>
+#include "OriginAccessPatterns.h"
 
 #if ENABLE(SERVICE_CONTROLS)
 #include "ImageControlsMac.h"
@@ -217,6 +218,32 @@ bool HitTestResult::isSelected() const
         return false;
 
     return frame->selection().contains(m_hitTestLocation.point());
+}
+
+bool HitTestResult::allowsFollowingLink() const
+{
+    auto linkURL = absoluteLinkURL();
+    if (linkURL.isEmpty())
+        return false;
+
+    auto* innerFrame = innerNodeFrame();
+    if (!innerFrame)
+        return false;
+
+    return innerFrame->protectedDocument()->protectedSecurityOrigin()->canDisplay(linkURL, OriginAccessPatternsForWebProcess::singleton());
+}
+
+bool HitTestResult::allowsFollowingImageURL() const
+{
+    auto linkURL = absoluteImageURL();
+    if (linkURL.isEmpty())
+        return false;
+
+    auto* innerFrame = innerNodeFrame();
+    if (!innerFrame)
+        return false;
+
+    return innerFrame->protectedDocument()->protectedSecurityOrigin()->canDisplay(linkURL, OriginAccessPatternsForWebProcess::singleton());
 }
 
 String HitTestResult::selectedText() const

--- a/Source/WebCore/rendering/HitTestResult.h
+++ b/Source/WebCore/rendering/HitTestResult.h
@@ -97,6 +97,8 @@ public:
     WEBCORE_EXPORT LocalFrame* frame() const;
     WEBCORE_EXPORT LocalFrame* targetFrame() const;
     WEBCORE_EXPORT bool isSelected() const;
+    WEBCORE_EXPORT bool allowsFollowingLink() const;
+    WEBCORE_EXPORT bool allowsFollowingImageURL() const;
     WEBCORE_EXPORT String selectedText() const;
     WEBCORE_EXPORT String spellingToolTip(TextDirection&) const;
     String replacedString() const;

--- a/Source/WebKit/Shared/ContextMenuContextData.cpp
+++ b/Source/WebKit/Shared/ContextMenuContextData.cpp
@@ -53,6 +53,8 @@ ContextMenuContextData::ContextMenuContextData(const IntPoint& menuLocation, con
     , m_webHitTestResultData({ context.hitTestResult(), true })
     , m_selectedText(context.selectedText())
     , m_hasEntireImage(context.hasEntireImage())
+    , m_allowsFollowingLink(context.allowsFollowingLink())
+    , m_allowsFollowingImageURL(context.allowsFollowingImageURL())
 #if ENABLE(SERVICE_CONTROLS)
     , m_selectionIsEditable(false)
 #endif
@@ -155,6 +157,8 @@ ContextMenuContextData::ContextMenuContextData(WebCore::ContextMenuContext::Type
     , std::optional<WebCore::ShareableBitmapHandle>&& potentialQRCodeViewportSnapshotImageHandle
 #endif // ENABLE(CONTEXT_MENU_QR_CODE_DETECTION)
     , bool hasEntireImage
+    , bool allowsFollowingLink
+    , bool allowsFollowingImageURL
 )
     : m_type(type)
     , m_menuLocation(WTFMove(menuLocation))
@@ -162,6 +166,8 @@ ContextMenuContextData::ContextMenuContextData(WebCore::ContextMenuContext::Type
     , m_webHitTestResultData(WTFMove(webHitTestResultData))
     , m_selectedText(WTFMove(selectedText))
     , m_hasEntireImage(hasEntireImage)
+    , m_allowsFollowingLink(allowsFollowingLink)
+    , m_allowsFollowingImageURL(allowsFollowingImageURL)
 #if ENABLE(SERVICE_CONTROLS)
     , m_controlledSelection(WTFMove(controlledSelection))
     , m_selectedTelephoneNumbers(WTFMove(selectedTelephoneNumbers))

--- a/Source/WebKit/Shared/ContextMenuContextData.h
+++ b/Source/WebKit/Shared/ContextMenuContextData.h
@@ -71,6 +71,8 @@ public:
         , std::optional<WebCore::ShareableBitmapHandle>&& potentialQRCodeViewportSnapshotImageHandle
 #endif // ENABLE(CONTEXT_MENU_QR_CODE_DETECTION)
         , bool hasEntireImage
+        , bool allowsFollowingLink
+        , bool allowsFollowingImageURL
     );
 
     Type type() const { return m_type; }
@@ -82,6 +84,8 @@ public:
     const String& selectedText() const { return m_selectedText; }
 
     bool hasEntireImage() const { return m_hasEntireImage; }
+    bool allowsFollowingLink() const { return m_allowsFollowingLink; }
+    bool allowsFollowingImageURL() const { return m_allowsFollowingImageURL; }
 
 #if ENABLE(SERVICE_CONTROLS)
     ContextMenuContextData(const WebCore::IntPoint& menuLocation, WebCore::AttributedString&& controlledSelection, const Vector<String>& selectedTelephoneNumbers, bool isEditable)
@@ -140,6 +144,8 @@ private:
     std::optional<WebHitTestResultData> m_webHitTestResultData;
     String m_selectedText;
     bool m_hasEntireImage { false };
+    bool m_allowsFollowingLink { false };
+    bool m_allowsFollowingImageURL { false };
 
 #if ENABLE(SERVICE_CONTROLS)
     void setImage(WebCore::Image&);

--- a/Source/WebKit/Shared/ContextMenuContextData.serialization.in
+++ b/Source/WebKit/Shared/ContextMenuContextData.serialization.in
@@ -43,6 +43,8 @@ class WebKit::ContextMenuContextData {
     std::optional<WebCore::ShareableBitmapHandle> createPotentialQRCodeViewportSnapshotImageReadOnlyHandle();
 #endif // ENABLE(CONTEXT_MENU_QR_CODE_DETECTION)
     bool hasEntireImage();
+    bool allowsFollowingLink();
+    bool allowsFollowingImageURL();
 };
 
 #endif // ENABLE(CONTEXT_MENUS)

--- a/Source/WebKit/Shared/WebHitTestResultData.cpp
+++ b/Source/WebKit/Shared/WebHitTestResultData.cpp
@@ -106,6 +106,8 @@ WebHitTestResultData::WebHitTestResultData(const HitTestResult& hitTestResult, c
     , toolTipText(toolTipText)
     , hasLocalDataForLinkURL(hitTestResult.hasLocalDataForLinkURL())
     , hasEntireImage(hitTestResult.hasEntireImage())
+    , allowsFollowingLink(hitTestResult.allowsFollowingLink())
+    , allowsFollowingImageURL(hitTestResult.allowsFollowingImageURL())
 {
     if (auto* scrollbar = hitTestResult.scrollbar())
         isScrollbar = scrollbar->orientation() == ScrollbarOrientation::Horizontal ? IsScrollbar::Horizontal : IsScrollbar::Vertical;
@@ -136,6 +138,8 @@ WebHitTestResultData::WebHitTestResultData(const HitTestResult& hitTestResult, b
     , frameInfo(frameInfoDataFromHitTestResult(hitTestResult))
     , hasLocalDataForLinkURL(hitTestResult.hasLocalDataForLinkURL())
     , hasEntireImage(hitTestResult.hasEntireImage())
+    , allowsFollowingLink(hitTestResult.allowsFollowingLink())
+    , allowsFollowingImageURL(hitTestResult.allowsFollowingImageURL())
 {
     if (auto* scrollbar = hitTestResult.scrollbar())
         isScrollbar = scrollbar->orientation() == ScrollbarOrientation::Horizontal ? IsScrollbar::Horizontal : IsScrollbar::Vertical;
@@ -174,7 +178,7 @@ WebHitTestResultData::WebHitTestResultData(const HitTestResult& hitTestResult, b
     }
 }
 
-WebHitTestResultData::WebHitTestResultData(const String& absoluteImageURL, const String& absolutePDFURL, const String& absoluteLinkURL, const String& absoluteMediaURL, const String& linkLabel, const String& linkTitle, const String& linkSuggestedFilename, const String& imageSuggestedFilename, bool isContentEditable, const WebCore::IntRect& elementBoundingBox, const WebKit::WebHitTestResultData::IsScrollbar& isScrollbar, bool isSelected, bool isTextNode, bool isOverTextInsideFormControlElement, bool isDownloadableMedia, bool mediaIsInFullscreen, bool isActivePDFAnnotation, const WebHitTestResultData::ElementType& elementType, std::optional<FrameInfoData>&& frameInfo, std::optional<WebCore::RemoteUserInputEventData> remoteUserInputEventData, const String& lookupText, const String& toolTipText, const String& imageText, std::optional<WebCore::SharedMemory::Handle>&& imageHandle, const RefPtr<WebCore::ShareableBitmap>& imageBitmap, const String& sourceImageMIMEType, const String& linkLocalDataMIMEType, bool hasLocalDataForLinkURL, bool hasEntireImage,
+WebHitTestResultData::WebHitTestResultData(const String& absoluteImageURL, const String& absolutePDFURL, const String& absoluteLinkURL, const String& absoluteMediaURL, const String& linkLabel, const String& linkTitle, const String& linkSuggestedFilename, const String& imageSuggestedFilename, bool isContentEditable, const WebCore::IntRect& elementBoundingBox, const WebKit::WebHitTestResultData::IsScrollbar& isScrollbar, bool isSelected, bool isTextNode, bool isOverTextInsideFormControlElement, bool isDownloadableMedia, bool mediaIsInFullscreen, bool isActivePDFAnnotation, const WebHitTestResultData::ElementType& elementType, std::optional<FrameInfoData>&& frameInfo, std::optional<WebCore::RemoteUserInputEventData> remoteUserInputEventData, const String& lookupText, const String& toolTipText, const String& imageText, std::optional<WebCore::SharedMemory::Handle>&& imageHandle, const RefPtr<WebCore::ShareableBitmap>& imageBitmap, const String& sourceImageMIMEType, const String& linkLocalDataMIMEType, bool hasLocalDataForLinkURL, bool hasEntireImage, bool allowsFollowingLink, bool allowsFollowingImageURL,
 #if PLATFORM(MAC)
     const WebHitTestResultPlatformData& platformData,
 #endif
@@ -207,6 +211,8 @@ WebHitTestResultData::WebHitTestResultData(const String& absoluteImageURL, const
         , linkLocalDataMIMEType(linkLocalDataMIMEType)
         , hasLocalDataForLinkURL(hasLocalDataForLinkURL)
         , hasEntireImage(hasEntireImage)
+        , allowsFollowingLink(allowsFollowingLink)
+        , allowsFollowingImageURL(allowsFollowingImageURL)
 #if PLATFORM(MAC)
         , platformData(platformData)
 #endif

--- a/Source/WebKit/Shared/WebHitTestResultData.h
+++ b/Source/WebKit/Shared/WebHitTestResultData.h
@@ -102,6 +102,8 @@ struct WebHitTestResultData {
     String linkLocalDataMIMEType;
     bool hasLocalDataForLinkURL;
     bool hasEntireImage;
+    bool allowsFollowingLink;
+    bool allowsFollowingImageURL;
 
 #if PLATFORM(MAC)
     WebHitTestResultPlatformData platformData;
@@ -118,7 +120,7 @@ struct WebHitTestResultData {
     WebHitTestResultData& operator=(const WebHitTestResultData&) = default;
     WebHitTestResultData(const WebCore::HitTestResult&, const String& toolTipText);
     WebHitTestResultData(const WebCore::HitTestResult&, bool includeImage);
-    WebHitTestResultData(const String& absoluteImageURL, const String& absolutePDFURL, const String& absoluteLinkURL, const String& absoluteMediaURL, const String& linkLabel, const String& linkTitle, const String& linkSuggestedFilename, const String& imageSuggestedFilename, bool isContentEditable, const WebCore::IntRect& elementBoundingBox, const WebKit::WebHitTestResultData::IsScrollbar&, bool isSelected, bool isTextNode, bool isOverTextInsideFormControlElement, bool isDownloadableMedia, bool mediaIsInFullscreen, bool isActivePDFAnnotation, const WebKit::WebHitTestResultData::ElementType&, std::optional<FrameInfoData>&&, std::optional<WebCore::RemoteUserInputEventData>, const String& lookupText, const String& toolTipText, const String& imageText, std::optional<WebCore::SharedMemory::Handle>&& imageHandle, const RefPtr<WebCore::ShareableBitmap>& imageBitmap, const String& sourceImageMIMEType, const String& linkLocalDataMIMEType, bool hasLocalDataForLinkURL, bool hasEntireImage,
+    WebHitTestResultData(const String& absoluteImageURL, const String& absolutePDFURL, const String& absoluteLinkURL, const String& absoluteMediaURL, const String& linkLabel, const String& linkTitle, const String& linkSuggestedFilename, const String& imageSuggestedFilename, bool isContentEditable, const WebCore::IntRect& elementBoundingBox, const WebKit::WebHitTestResultData::IsScrollbar&, bool isSelected, bool isTextNode, bool isOverTextInsideFormControlElement, bool isDownloadableMedia, bool mediaIsInFullscreen, bool isActivePDFAnnotation, const WebKit::WebHitTestResultData::ElementType&, std::optional<FrameInfoData>&&, std::optional<WebCore::RemoteUserInputEventData>, const String& lookupText, const String& toolTipText, const String& imageText, std::optional<WebCore::SharedMemory::Handle>&& imageHandle, const RefPtr<WebCore::ShareableBitmap>& imageBitmap, const String& sourceImageMIMEType, const String& linkLocalDataMIMEType, bool hasLocalDataForLinkURL, bool hasEntireImage, bool allowsFollowingLink, bool allowsFollowingImageURL,
 #if PLATFORM(MAC)
         const WebHitTestResultPlatformData&,
 #endif

--- a/Source/WebKit/Shared/WebHitTestResultData.serialization.in
+++ b/Source/WebKit/Shared/WebHitTestResultData.serialization.in
@@ -64,6 +64,8 @@ struct WebKit::WebHitTestResultData {
     String linkLocalDataMIMEType;
     bool hasLocalDataForLinkURL;
     bool hasEntireImage;
+    bool allowsFollowingLink;
+    bool allowsFollowingImageURL;
 
 #if PLATFORM(MAC)
     WebKit::WebHitTestResultPlatformData platformData;

--- a/Source/WebKit/UIProcess/API/APIContextMenuElementInfoMac.h
+++ b/Source/WebKit/UIProcess/API/APIContextMenuElementInfoMac.h
@@ -49,18 +49,24 @@ public:
     WebKit::WebPageProxy* page() { return m_page.get(); }
     const WTF::String& qrCodePayloadString() const { return m_qrCodePayloadString; }
     bool hasEntireImage() const { return m_hasEntireImage; }
+    bool allowsFollowingLink() const { return m_allowsFollowingLink; }
+    bool allowsFollowingImageURL() const { return m_allowsFollowingImageURL; }
 
 private:
     ContextMenuElementInfoMac(const WebKit::ContextMenuContextData& data, WebKit::WebPageProxy& page)
         : m_hitTestResultData(data.webHitTestResultData().value())
         , m_page(page)
         , m_qrCodePayloadString(data.qrCodePayloadString())
-        , m_hasEntireImage(data.hasEntireImage()) { }
+        , m_hasEntireImage(data.hasEntireImage())
+        , m_allowsFollowingLink(data.allowsFollowingLink())
+        , m_allowsFollowingImageURL(data.allowsFollowingImageURL()) { }
 
     WebKit::WebHitTestResultData m_hitTestResultData;
     WeakPtr<WebKit::WebPageProxy> m_page;
     WTF::String m_qrCodePayloadString;
     bool m_hasEntireImage { false };
+    bool m_allowsFollowingLink { false };
+    bool m_allowsFollowingImageURL { false };
 };
 
 } // namespace API

--- a/Source/WebKit/UIProcess/API/APIHitTestResult.h
+++ b/Source/WebKit/UIProcess/API/APIHitTestResult.h
@@ -86,6 +86,10 @@ public:
 
     bool hasLocalDataForLinkURL() const { return m_data.hasLocalDataForLinkURL; }
 
+    bool allowsFollowingLink() const { return m_data.allowsFollowingLink; }
+
+    bool allowsFollowingImageURL() const { return m_data.allowsFollowingImageURL; }
+
 private:
     explicit HitTestResult(const WebKit::WebHitTestResultData& hitTestResultData, WebKit::WebPageProxy* page)
         : m_data(hitTestResultData)

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKContextMenuElementInfo.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKContextMenuElementInfo.h
@@ -38,6 +38,9 @@ WK_CLASS_AVAILABLE(macos(10.12))
 @property (nonatomic, readonly, copy, nullable) NSString *qrCodePayloadString WK_API_AVAILABLE(macos(14.0));
 @property (nonatomic, readonly) BOOL hasEntireImage WK_API_AVAILABLE(macos(14.0));
 
+@property (nonatomic, readonly) BOOL allowsFollowingLink WK_API_AVAILABLE(macos(WK_MAC_TBA));
+@property (nonatomic, readonly) BOOL allowsFollowingImageURL WK_API_AVAILABLE(macos(WK_MAC_TBA));
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKContextMenuElementInfo.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKContextMenuElementInfo.mm
@@ -68,6 +68,16 @@
     return _contextMenuElementInfoMac->hasEntireImage();
 }
 
+- (BOOL)allowsFollowingLink
+{
+    return _contextMenuElementInfoMac->allowsFollowingLink();
+}
+
+- (BOOL)allowsFollowingImageURL
+{
+    return _contextMenuElementInfoMac->allowsFollowingImageURL();
+}
+
 // MARK: WKObject protocol implementation
 
 - (API::Object&)_apiObject

--- a/Tools/TestWebKitAPI/Tests/mac/ContextMenuTests.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/ContextMenuTests.mm
@@ -840,6 +840,46 @@ TEST(ContextMenuTests, HitTestResultLinkWithInvalidURL)
     EXPECT_NOT_NULL([elementInfo hitTestResult]);
 }
 
+TEST(ContextMenuTests, ContextMenuElementInfoAllowsFollowingImageURLTrue)
+{
+    CGFloat iconWidth = 215;
+    CGFloat iconHeight = 174;
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, iconWidth * 2, iconHeight * 2)]);
+    [webView synchronouslyLoadHTMLString:@"<img src='icon.png'></img>"];
+
+    _WKContextMenuElementInfo *elementInfo = [webView rightClickAtPointAndWaitForContextMenu:NSMakePoint(iconWidth, iconHeight)];
+    EXPECT_TRUE(elementInfo.allowsFollowingImageURL);
+}
+
+TEST(ContextMenuTests, ContextMenuElementInfoAllowsFollowingImageURLFalse)
+{
+    CGFloat iconWidth = 215;
+    CGFloat iconHeight = 174;
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, iconWidth * 2, iconHeight * 2)]);
+    [webView synchronouslyLoadHTMLString:@"<img src='file:///icon.png'></img>"];
+
+    _WKContextMenuElementInfo *elementInfo = [webView rightClickAtPointAndWaitForContextMenu:NSMakePoint(iconWidth, iconHeight)];
+    EXPECT_FALSE(elementInfo.allowsFollowingImageURL);
+}
+
+TEST(ContextMenuTests, ContextMenuElementInfoAllowsFollowingLinkTrue)
+{
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    [webView synchronouslyLoadHTMLString:@"<a href='icon.png' style='font-size: 100px;'>Link</a>"];
+
+    _WKContextMenuElementInfo *elementInfo = [webView rightClickAtPointAndWaitForContextMenu:NSMakePoint(50, 350)];
+    EXPECT_TRUE(elementInfo.allowsFollowingLink);
+}
+
+TEST(ContextMenuTests, ContextMenuElementInfoAllowsFollowingLinkFalse)
+{
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    [webView synchronouslyLoadHTMLString:@"<a href='file:///simple.html' style='font-size: 100px;'>Hello world</a>"];
+
+    _WKContextMenuElementInfo *elementInfo = [webView rightClickAtPointAndWaitForContextMenu:NSMakePoint(50, 350)];
+    EXPECT_FALSE(elementInfo.allowsFollowingLink);
+}
+
 } // namespace TestWebKitAPI
 
 #endif // PLATFORM(MAC)


### PR DESCRIPTION
#### 8382ad6be4b4ca4bd47108bbef1c951115a5c5e8
<pre>
Expose allowsFollowingLink/allowsFollowingImageURL  to _WKContextMenuElementInfo
Need the bug URL (OOPS!).
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

This will allow the UI process to get more informations when a context
menu is shown.

allowsFollowingLink will be true iff the context menu is over a link
that can be followed. allowsFollowingImageURL will be true iff it&apos;s over
an image whose URL can be followed.

* Source/WebCore/page/ContextMenuContext.cpp:
(WebCore::ContextMenuContext::ContextMenuContext):
* Source/WebCore/page/ContextMenuContext.h:
(WebCore::ContextMenuContext::allowsFollowingLink const):
(WebCore::ContextMenuContext::allowsFollowingImageURL const):
* Source/WebCore/rendering/HitTestResult.cpp:
(WebCore::HitTestResult::allowsFollowingLink const):
(WebCore::HitTestResult::allowsFollowingImageURL const):
* Source/WebCore/rendering/HitTestResult.h:
* Source/WebKit/Shared/ContextMenuContextData.cpp:
(WebKit::ContextMenuContextData::ContextMenuContextData):
* Source/WebKit/Shared/ContextMenuContextData.h:
(WebKit::ContextMenuContextData::allowsFollowingLink const):
(WebKit::ContextMenuContextData::allowsFollowingImageURL const):
* Source/WebKit/Shared/ContextMenuContextData.serialization.in:
* Source/WebKit/Shared/WebHitTestResultData.cpp:
(WebKit::WebHitTestResultData::WebHitTestResultData):
* Source/WebKit/Shared/WebHitTestResultData.h:
* Source/WebKit/Shared/WebHitTestResultData.serialization.in:
* Source/WebKit/UIProcess/API/APIContextMenuElementInfoMac.h:
* Source/WebKit/UIProcess/API/APIHitTestResult.h:
(API::HitTestResult::allowsFollowingLink const):
(API::HitTestResult::allowsFollowingImageURL const):
* Source/WebKit/UIProcess/API/Cocoa/_WKContextMenuElementInfo.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKContextMenuElementInfo.mm:
(-[_WKContextMenuElementInfo allowsFollowingLink]):
(-[_WKContextMenuElementInfo allowsFollowingImageURL]):
* Tools/TestWebKitAPI/Tests/mac/ContextMenuTests.mm:
(TestWebKitAPI::TEST(ContextMenuTests, ContextMenuElementInfoAllowsFollowingImageURLTrue)):
(TestWebKitAPI::TEST(ContextMenuTests, ContextMenuElementInfoAllowsFollowingImageURLFalse)):
(TestWebKitAPI::TEST(ContextMenuTests, ContextMenuElementInfoAllowsFollowingLinkTrue)):
(TestWebKitAPI::TEST(ContextMenuTests, ContextMenuElementInfoAllowsFollowingLinkFalse)):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8382ad6be4b4ca4bd47108bbef1c951115a5c5e8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/103563 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/131/builds/23245 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/138/builds/13566 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/108739 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/54209 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/105603 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/23600 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/123/builds/31796 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/108739 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/54209 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/106569 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/130/builds/23600 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/138/builds/13566 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/108739 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/130/builds/23600 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/138/builds/13566 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/53564 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/130/builds/23600 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/138/builds/13566 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/111117 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/30710 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/123/builds/31796 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/111117 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/31071 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/138/builds/13566 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/111117 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/138/builds/13566 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/25062 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/30638 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/35950 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/30438 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/33769 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/31999 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->