### PR TITLE
[Text-Wrap][Balance][Pretty] SlidingWidth now includes word-spacing when caching item widths.

### DIFF
--- a/LayoutTests/fast/css3-text/css3-text-wrap/text-wrap-balance-word-spacing-expected.html
+++ b/LayoutTests/fast/css3-text/css3-text-wrap/text-wrap-balance-word-spacing-expected.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Document</title>
+    <style>
+      body {
+        font-family: "Ahem";
+        font-size: 12px;
+        width: 500px;
+      }
+      .spacing-10 {
+        word-spacing: 10px;
+      }
+      .spacing-30 {
+        word-spacing: 30px;
+      }
+      .balance-first-line-spacing-30::first-line {
+        word-spacing: 30px;
+      }
+      .img1 {
+        background-color: green;
+        width: 20px;
+        height: 10px;
+      }
+      .img2 {
+        background-color: green;
+        width: 20px;
+        height: 10px;
+        margin-left: 30px;
+        margin-right: 30px;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="spacing-10">This passes if this div is one line </div>
+    <div class="spacing-30">This passes if this<br> div has the exact<br> correct breaking points</div>
+    <div class="spacing-30">This passes if this div has<br> the exact correct breaking<br> points</div>
+    <div class="balance-first-line-spacing-30">This passes if this div<br> has the exact correct breaking points</div>
+    <div>test<img class="img1">test <img class="img2"> test</div>
+  </body>
+</html>

--- a/LayoutTests/fast/css3-text/css3-text-wrap/text-wrap-balance-word-spacing.html
+++ b/LayoutTests/fast/css3-text/css3-text-wrap/text-wrap-balance-word-spacing.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Document</title>
+    <style>
+      body {
+        font-family: "Ahem";
+        font-size: 12px;
+        width: 500px;
+      }
+      .spacing-10-balance {
+        word-spacing: 10px;
+        text-wrap: balance;
+      }
+      .spacing-30-balance {
+        word-spacing: 30px;
+        text-wrap: balance;
+      }
+      .spacing-30 {
+        word-spacing: 30px;
+      }
+      .balance-first-line-spacing-30 {
+        text-wrap: balance;
+      }
+      .balance-first-line-spacing-30::first-line {
+        word-spacing: 30px;
+      }
+      .img1 {
+        background-color: green;
+        width: 20px;
+        height: 10px;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="spacing-10-balance">This passes if this div is one line </div>
+    <div class="spacing-30-balance">This passes if this div has the exact correct breaking points</div>
+    <div class="spacing-30">This passes if this div has the exact correct breaking points</div>
+    <div class="balance-first-line-spacing-30">This passes if this div has the exact correct breaking points</div>
+    <div class="spacing-30-balance">test<img class="img1">test <img class="img1"> test</div>
+  </body>
+</html>


### PR DESCRIPTION
#### fd6ce01093860ef27380994b3e78dd43a3d58e26
<pre>
[Text-Wrap][Balance][Pretty] SlidingWidth now includes word-spacing when caching item widths.
<a href="https://bugs.webkit.org/show_bug.cgi?id=292563">https://bugs.webkit.org/show_bug.cgi?id=292563</a>
&lt;<a href="https://rdar.apple.com/150893603">rdar://150893603</a>&gt;

Reviewed by Alan Baradlay.

This PR updates the inline width caches to account for word spacing when computing
constrained widths.

Combined changes:
* LayoutTests/fast/css3-text/css3-text-wrap/text-wrap-balance-word-spacing-expected.html: Added.
* LayoutTests/fast/css3-text/css3-text-wrap/text-wrap-balance-word-spacing.html: Added.
* Source/WebCore/layout/formattingContexts/inline/InlineContentConstrainer.cpp:
(WebCore::Layout::InlineContentConstrainer::updateCachedWidths):
(WebCore::Layout::InlineContentConstrainer::computeParagraphLevelConstraints):

Canonical link: <a href="https://commits.webkit.org/295034@main">https://commits.webkit.org/295034@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/825200739d4e5f33a8bdf1c2db82e9657c3d2c90

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/103866 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/23569 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/13890 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/109059 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/54527 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/105906 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/23922 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/32114 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/78913 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/54527 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/106872 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/18580 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/93697 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59242 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/18379 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/11748 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/53894 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/88136 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/11806 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/111446 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/31022 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/22875 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/87917 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/31384 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/89898 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87569 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22295 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32461 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10187 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/25388 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/30951 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/36261 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/30744 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/34081 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/32305 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->