### PR TITLE
BrowsingContextGroup should only be shared from opener to opened WKWebViews

### DIFF
--- a/Source/WebKit/UIProcess/API/APIPageConfiguration.cpp
+++ b/Source/WebKit/UIProcess/API/APIPageConfiguration.cpp
@@ -51,11 +51,9 @@ namespace API {
 using namespace WebKit;
 
 PageConfiguration::Data::Data()
-    : openedSite(aboutBlankURL()) { }
-
-Ref<WebKit::BrowsingContextGroup> PageConfiguration::Data::createBrowsingContextGroup()
+    : openerInfo(Box<std::optional<OpenerInfo>>::create(std::nullopt))
+    , openedSite(aboutBlankURL())
 {
-    return BrowsingContextGroup::create();
 }
 
 Ref<WebKit::WebProcessPool> PageConfiguration::Data::createWebProcessPool()
@@ -104,16 +102,6 @@ void PageConfiguration::copyDataFrom(const PageConfiguration& other)
     m_data = other.m_data;
 }
 
-BrowsingContextGroup& PageConfiguration::browsingContextGroup() const
-{
-    return m_data.browsingContextGroup.get();
-}
-
-void PageConfiguration::setBrowsingContextGroup(RefPtr<BrowsingContextGroup>&& group)
-{
-    m_data.browsingContextGroup = WTFMove(group);
-}
-
 const std::optional<WebCore::WindowFeatures>& PageConfiguration::windowFeatures() const
 {
     return m_data.windowFeatures;
@@ -146,12 +134,17 @@ void PageConfiguration::setOpenedMainFrameName(const WTF::String& name)
 
 auto PageConfiguration::openerInfo() const -> const std::optional<OpenerInfo>&
 {
-    return m_data.openerInfo;
+    return *m_data.openerInfo;
 }
 
 void PageConfiguration::setOpenerInfo(std::optional<OpenerInfo>&& info)
 {
-    m_data.openerInfo = WTFMove(info);
+    m_data.openerInfo = Box<std::optional<OpenerInfo>>::create(WTFMove(info));
+}
+
+void PageConfiguration::consumeOpenerInfo()
+{
+    *m_data.openerInfo = std::nullopt;
 }
 
 bool PageConfiguration::OpenerInfo::operator==(const OpenerInfo&) const = default;

--- a/Source/WebKit/UIProcess/API/APIPageConfiguration.h
+++ b/Source/WebKit/UIProcess/API/APIPageConfiguration.h
@@ -106,16 +106,15 @@ public:
     Ref<PageConfiguration> copy() const;
     void copyDataFrom(const PageConfiguration&);
 
-    WebKit::BrowsingContextGroup& browsingContextGroup() const;
-    void setBrowsingContextGroup(RefPtr<WebKit::BrowsingContextGroup>&&);
-
     struct OpenerInfo {
         Ref<WebKit::WebProcessProxy> process;
+        Ref<WebKit::BrowsingContextGroup> browsingContextGroup;
         WebCore::FrameIdentifier frameID;
         bool operator==(const OpenerInfo&) const;
     };
     const std::optional<OpenerInfo>& openerInfo() const;
     void setOpenerInfo(std::optional<OpenerInfo>&&);
+    void consumeOpenerInfo();
 
     const WebCore::Site& openedSite() const;
     void setOpenedSite(const WebCore::Site&);
@@ -489,7 +488,6 @@ private:
         private:
             mutable RefPtr<T> m_value;
         };
-        static Ref<WebKit::BrowsingContextGroup> createBrowsingContextGroup();
         static Ref<WebKit::WebProcessPool> createWebProcessPool();
         static Ref<WebKit::WebUserContentControllerProxy> createWebUserContentControllerProxy();
         static Ref<WebKit::WebPreferences> createWebPreferences();
@@ -503,7 +501,6 @@ private:
         uintptr_t defaultMediaTypesRequiringUserActionForPlayback();
 #endif
 
-        LazyInitializedRef<WebKit::BrowsingContextGroup, createBrowsingContextGroup> browsingContextGroup;
         LazyInitializedRef<WebKit::WebProcessPool, createWebProcessPool> processPool;
         LazyInitializedRef<WebKit::WebUserContentControllerProxy, createWebUserContentControllerProxy> userContentController;
         LazyInitializedRef<WebKit::WebPreferences, createWebPreferences> preferences;
@@ -518,7 +515,7 @@ private:
 #endif
         RefPtr<WebKit::WebPageGroup> pageGroup;
         WeakPtr<WebKit::WebPageProxy> relatedPage;
-        std::optional<OpenerInfo> openerInfo;
+        Box<std::optional<OpenerInfo>> openerInfo;
         WebCore::Site openedSite;
         WTF::String openedMainFrameName;
         std::optional<WebCore::WindowFeatures> windowFeatures;

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2671,6 +2671,7 @@ public:
 
     BrowsingContextGroup& browsingContextGroup() const { return m_browsingContextGroup; }
     Ref<BrowsingContextGroup> protectedBrowsingContextGroup() const;
+    std::optional<WebCore::FrameIdentifier> openerFrameIdentifier() const { return m_openerFrameIdentifier; }
 
     WebPageProxyTesting* pageForTesting() const;
     RefPtr<WebPageProxyTesting> protectedPageForTesting() const;
@@ -3866,6 +3867,7 @@ private:
 
     RefPtr<WebPageProxy> m_pageToCloneSessionStorageFrom;
     Ref<BrowsingContextGroup> m_browsingContextGroup;
+    const std::optional<WebCore::FrameIdentifier> m_openerFrameIdentifier;
 
 #if ENABLE(CONTEXT_MENUS)
     bool m_waitingForContextMenuToShow { false };

--- a/Source/WebKit/UIProcess/win/AutomationSessionClientWin.cpp
+++ b/Source/WebKit/UIProcess/win/AutomationSessionClientWin.cpp
@@ -53,7 +53,6 @@ void AutomationSessionClient::requestNewPageWithOptions(WebKit::WebAutomationSes
         if (processProxy->pageCount()) {
             Ref firstPage = *processProxy->pages().begin();
             Ref configuration = firstPage->configuration().copy();
-            Ref browsingContextGroup = firstPage->protectedBrowsingContextGroup();
 
             WebCore::WindowFeatures windowFeatures;
             // FIXME: Attributes of the window of firstPage should be set to windowFeatures.
@@ -61,7 +60,6 @@ void AutomationSessionClient::requestNewPageWithOptions(WebKit::WebAutomationSes
             //        https://webkit.org/b/290979
             configuration->setWindowFeatures(WTFMove(windowFeatures));
             configuration->setRelatedPage(firstPage);
-            configuration->setBrowsingContextGroup(WTFMove(browsingContextGroup));
             configuration->setControlledByAutomation(true);
 
             NavigationActionData navigationActionData {


### PR DESCRIPTION
#### ca2fc5fb29dc49a4b9696ecbeb4aeb175c4234d3
<pre>
BrowsingContextGroup should only be shared from opener to opened WKWebViews
<a href="https://bugs.webkit.org/show_bug.cgi?id=293027">https://bugs.webkit.org/show_bug.cgi?id=293027</a>
<a href="https://rdar.apple.com/151345757">rdar://151345757</a>

Reviewed by Sihui Liu.

When WKUIDelegate.createWebViewWithConfiguration is called, it gives the application
a WKWebViewConfiguration to use to make a WKWebView and put it in the same
BrowsingContextGroup.  If a WKWebViewConfiguration is reused, we need to not
use the same BrowsingContextGroup, which is web compatible because there is no
opener relationship to maintain in that case.  To implement this, we consume
the configuration&apos;s opener info when making a WebPageProxy so the configuration
can be further copied and reused without adding more pages to the BrowsingContextGroup.

An app can copy the opener&apos;s configuration and use that configuration to load
the opener site in an auxiliary WKWebView before responding to
WKUIDelegate.createWebViewWithConfiguration. When this happens with site isolation off,
the auxiliary WKWebView loads in its own process.  When this happens with site isolation
on before this PR, it would try to load in the process that was waiting for the reply
to Messages::WebPageProxy::CreateNewPage, which caused a deadlock.  This solution
avoids the deadlock, increases compatibility, and allows the authentication to proceed.

This fixes the last API test in the SOAuthorizationPopUp group with site isolation on.

* Source/WebKit/UIProcess/API/APIPageConfiguration.cpp:
(API::PageConfiguration::Data::Data):
(API::PageConfiguration::openerInfo const const):
(API::PageConfiguration::setOpenerInfo):
(API::PageConfiguration::consumeOpenerInfo):
(API::PageConfiguration::Data::createBrowsingContextGroup): Deleted.
(API::PageConfiguration::browsingContextGroup const): Deleted.
(API::PageConfiguration::setBrowsingContextGroup): Deleted.
* Source/WebKit/UIProcess/API/APIPageConfiguration.h:
(API::PageConfiguration::Data::initializer):
* Source/WebKit/UIProcess/Cocoa/UIDelegate.mm:
(WebKit::UIDelegate::UIClient::createNewPage):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::m_pageForTesting):
(WebKit::WebPageProxy::initializeWebPage):
(WebKit::WebPageProxy::createNewPage):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm:
(TestWebKitAPI::TEST(SiteIsolation, LoadDuringOpen)):
(TestWebKitAPI::TEST(SiteIsolation, ChildNavigatingToDomainLoadedOnADifferentPage)):
(TestWebKitAPI::TEST(SiteIsolation, ReuseConfigurationLoadHTMLString)):

Canonical link: <a href="https://commits.webkit.org/294968@main">https://commits.webkit.org/294968@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c7726c67de87079e961d124d8b04d3d751bd859e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/103606 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/23288 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/13609 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/108782 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/54253 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/105646 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/23644 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/31839 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78728 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/106612 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/18340 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/93464 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59063 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/18152 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/11511 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/53607 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/87933 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/11570 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/111160 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/30753 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/22677 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/87724 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/31114 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/89664 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87371 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32246 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/9968 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/25107 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16824 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/30681 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/35993 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/30481 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/33812 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/32042 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->