### PR TITLE
REGRESSION (293442@main): Crash when resolving style for color inputs

### DIFF
--- a/LayoutTests/fast/forms/color/color-style-resolution-crash-expected.txt
+++ b/LayoutTests/fast/forms/color/color-style-resolution-crash-expected.txt
@@ -1,0 +1,2 @@
+
+PASS if no crash.

--- a/LayoutTests/fast/forms/color/color-style-resolution-crash.html
+++ b/LayoutTests/fast/forms/color/color-style-resolution-crash.html
@@ -1,0 +1,29 @@
+<style></style>
+<script>
+
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+(async () => {
+    const testStyle = document.styleSheets[0];
+
+    try {
+        testStyle.insertRule(`@keyframes {}`, testStyle.cssRules.length);
+    } catch {}
+
+    try {
+        testStyle.insertRule(`& { 29%; container-type: inline-size; }`, testStyle.cssRules.length);
+    } catch {}
+
+    const input = document.createElement('input');
+    document.documentElement.appendChild(input);
+    input.type = 'color';
+    testRunner?.notifyDone();
+})();
+
+</script>
+<body>
+    <p>PASS if no crash.</p>
+</body>

--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -98,17 +98,7 @@ RenderTheme::RenderTheme()
 
 RenderTheme::~RenderTheme() = default;
 
-static bool parentOfElementUsesPrimitiveAppearance(const Element& element)
-{
-    if (RefPtr parent = element.parentOrShadowHostElement()) {
-        if (CheckedPtr computedStyle = parent->computedStyle())
-            return computedStyle->usedAppearance() == StyleAppearance::None;
-    }
-
-    return false;
-}
-
-StyleAppearance RenderTheme::adjustAppearanceForElement(RenderStyle& style, const Element* element, StyleAppearance autoAppearance) const
+StyleAppearance RenderTheme::adjustAppearanceForElement(RenderStyle& style, const RenderStyle& parentStyle, const Element* element, StyleAppearance autoAppearance) const
 {
     if (!element) {
         style.setUsedAppearance(StyleAppearance::None);
@@ -126,7 +116,7 @@ StyleAppearance RenderTheme::adjustAppearanceForElement(RenderStyle& style, cons
     if ((autoAppearance == StyleAppearance::ColorWellSwatch
         || autoAppearance == StyleAppearance::ColorWellSwatchOverlay
         || autoAppearance == StyleAppearance::ColorWellSwatchWrapper)
-        && parentOfElementUsesPrimitiveAppearance(*element)) {
+        && (parentStyle.usedAppearance() == StyleAppearance::None)) {
             style.setUsedAppearance(StyleAppearance::None);
             return StyleAppearance::None;
     }
@@ -252,10 +242,10 @@ bool RenderTheme::hasAppearanceForElementTypeFromUAStyle(const Element& element)
         || (element.isInUserAgentShadowTree() && element.userAgentPart() == UserAgentParts::webkitListButton());
 }
 
-void RenderTheme::adjustStyle(RenderStyle& style, const Element* element)
+void RenderTheme::adjustStyle(RenderStyle& style, const RenderStyle& parentStyle, const Element* element)
 {
     auto autoAppearance = autoAppearanceForElement(style, element);
-    auto appearance = adjustAppearanceForElement(style, element, autoAppearance);
+    auto appearance = adjustAppearanceForElement(style, parentStyle, element, autoAppearance);
     if (appearance == StyleAppearance::None || appearance == StyleAppearance::Base)
         return;
 

--- a/Source/WebCore/rendering/RenderTheme.h
+++ b/Source/WebCore/rendering/RenderTheme.h
@@ -68,7 +68,7 @@ public:
     // metrics and defaults given the contents of the style.  This includes sophisticated operations like
     // selection of control size based off the font, the disabling of appearance when CSS properties that
     // disable native appearance are set, or if the appearance is not supported by the theme.
-    void adjustStyle(RenderStyle&, const Element*);
+    void adjustStyle(RenderStyle&, const RenderStyle& parentStyle, const Element*);
 
     virtual bool canCreateControlPartForRenderer(const RenderObject&) const { return false; }
     virtual bool canCreateControlPartForBorderOnly(const RenderObject&) const { return false; }
@@ -430,7 +430,7 @@ protected:
 
 private:
     StyleAppearance autoAppearanceForElement(RenderStyle&, const Element*) const;
-    StyleAppearance adjustAppearanceForElement(RenderStyle&, const Element*, StyleAppearance) const;
+    StyleAppearance adjustAppearanceForElement(RenderStyle&, const RenderStyle& parentStyle, const Element*, StyleAppearance) const;
 
     Color spellingMarkerColor(OptionSet<StyleColorOptions>) const;
     Color dictationAlternativesMarkerColor(OptionSet<StyleColorOptions>) const;

--- a/Source/WebCore/style/StyleAdjuster.cpp
+++ b/Source/WebCore/style/StyleAdjuster.cpp
@@ -718,7 +718,7 @@ void Adjuster::adjust(RenderStyle& style) const
 
     // Let the theme also have a crack at adjusting the style.
     if (style.hasAppearance())
-        adjustThemeStyle(style);
+        adjustThemeStyle(style, m_parentStyle);
 
     // This should be kept in sync with requiresRenderingConsolidationForViewTransition
     if (style.preserves3D()) {
@@ -938,7 +938,7 @@ void Adjuster::adjustAnimatedStyle(RenderStyle& style, OptionSet<AnimationImpact
         style.setUsedZIndex(0);
 }
 
-void Adjuster::adjustThemeStyle(RenderStyle& style) const
+void Adjuster::adjustThemeStyle(RenderStyle& style, const RenderStyle& parentStyle) const
 {
     ASSERT(style.hasAppearance());
     auto isOldWidthAuto = style.width().isAuto();
@@ -946,7 +946,7 @@ void Adjuster::adjustThemeStyle(RenderStyle& style) const
     auto isOldHeightAuto = style.height().isAuto();
     auto isOldMinHeightAuto = style.minHeight().isAuto();
 
-    RenderTheme::singleton().adjustStyle(style, m_element.get());
+    RenderTheme::singleton().adjustStyle(style, parentStyle, m_element.get());
 
     if (style.containsSize()) {
         if (style.containIntrinsicWidthType() != ContainIntrinsicSizeType::None) {

--- a/Source/WebCore/style/StyleAdjuster.h
+++ b/Source/WebCore/style/StyleAdjuster.h
@@ -75,7 +75,7 @@ private:
     void adjustDisplayContentsStyle(RenderStyle&) const;
     void adjustForSiteSpecificQuirks(RenderStyle&) const;
 
-    void adjustThemeStyle(RenderStyle&) const;
+    void adjustThemeStyle(RenderStyle&, const RenderStyle& parentStyle) const;
 
     static OptionSet<EventListenerRegionType> computeEventListenerRegionTypes(const Document&, const RenderStyle&, const EventTarget&, OptionSet<EventListenerRegionType>);
 


### PR DESCRIPTION
#### e37afd3cf5cf2058c4c9ddb63dad6ab5509af0a2
<pre>
REGRESSION (293442@main): Crash when resolving style for color inputs
<a href="https://bugs.webkit.org/show_bug.cgi?id=292946">https://bugs.webkit.org/show_bug.cgi?id=292946</a>
<a href="https://rdar.apple.com/149686209">rdar://149686209</a>

Reviewed by Richard Robinson.

293442@main introduced a call to `computedStyle()` in the middle of style
adjustment, in order to support propagating `appearance: none` across the
color input subtree.

This is incorrect, as it introduces re-entrancy during style calculation,
and is caught by a RELEASE_ASSERT.

Fix by passing down the parent style from `StyleAdjuster` and checking its
used appearance. Note that the shadow host style is not checked, since the
children of the shadow tree can also be styled, and their children should
be able to lose appearance too.

Thanks to Pratiksha Choudhury for the test case.

* LayoutTests/fast/forms/color/color-style-resolution-crash-expected.txt: Added.
* LayoutTests/fast/forms/color/color-style-resolution-crash.html: Added.
* Source/WebCore/rendering/RenderTheme.cpp:
(WebCore::RenderTheme::adjustAppearanceForElement const):
(WebCore::RenderTheme::hasAppearanceForElementTypeFromUAStyle):
(WebCore::parentOfElementUsesPrimitiveAppearance): Deleted.
* Source/WebCore/rendering/RenderTheme.h:
* Source/WebCore/style/StyleAdjuster.cpp:
(WebCore::Style::Adjuster::adjust const):
(WebCore::Style::Adjuster::adjustThemeStyle const):
* Source/WebCore/style/StyleAdjuster.h:

Canonical link: <a href="https://commits.webkit.org/295035@main">https://commits.webkit.org/295035@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cc1325d2912e5c27c1877813d3279ccdc812fe6d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/103576 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/23258 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/13579 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/108752 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/54223 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/105616 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/23613 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/31809 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78705 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/106582 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/18317 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/93436 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59040 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/18138 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/11483 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/53577 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/87914 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/11542 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/111130 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/30723 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/22657 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/87698 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/31084 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/89636 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87346 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32223 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/9942 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/25077 "Hash cc1325d2 for PR 45410 does not build (failure)") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16861 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/30651 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/35963 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/30451 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/33782 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/32012 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->