### PR TITLE
css/css-view-transitions/pseudo-element-animations fails to read 'opacity' computed style.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-element-animations-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-element-animations-expected.txt
@@ -1,5 +1,142 @@
 
+CSS Animations and Web Animations on view transition pseudos
+
+
+
+
+
+
+/* Override UA stylesheet to avoid any impact on our tests */
+:root {
+  view-transition-name: none;
+}
+:root::view-transition,
+:root::view-transition-group(*),
+:root::view-transition-image-pair(*),
+:root::view-transition-old(*),
+:root::view-transition-new(*) {
+  animation: unset;
+}
+
+@keyframes css-anim {
+  from { margin-left: 100px; }
+  to { margin-left: 100px; }
+}
+
+
 PASS The specified CSS Animations work on view transition pseudos.
-FAIL The specified CSS Animations and script animations work on view transition pseudos assert_equals: expected "0.5" but got ""
-FAIL The specified CSS Animations are removed if setting display:none. assert_equals: Has 3 CSS Animations. expected 3 but got 5
+PASS The specified CSS Animations and script animations work on view transition pseudos
+FAIL The specified CSS Animations are removed if setting display:none. assert_equals: All CSS Animation were removed. expected 0 but got 2
+
+
+"use strict";
+
+promise_test(async t => {
+  document.documentElement.style.viewTransitionName = "test";
+  const ruleText =
+    ":root::view-transition, :root::view-transition-group(test) {" +
+    "  animation: css-anim 10s;"
+    "}";
+  const index = document.styleSheets[0].cssRules.length;
+  document.styleSheets[0].insertRule(ruleText, index);
+
+  let viewTransition = document.startViewTransition(() => {});
+  await viewTransition.ready;
+
+  let anims = document.documentElement.getAnimations({ subtree: true });
+  assert_equals(anims.length, 2, "Has 2 CSS Animations.");
+  let style = getComputedStyle(document.documentElement,
+    "::view-transition-group(test)");
+  assert_equals(style.marginLeft, "100px");
+
+  viewTransition.skipTransition();
+  document.styleSheets[0].deleteRule(index);
+  document.documentElement.style.viewTransitionName = "none";
+}, "The specified CSS Animations work on view transition pseudos.");
+
+promise_test(async t => {
+  document.documentElement.style.viewTransitionName = "test";
+  const ruleText =
+    ":root::view-transition, :root::view-transition-group(test) {" +
+    "animation: css-anim 10s;"
+    "}";
+  const index = document.styleSheets[0].cssRules.length;
+  document.styleSheets[0].insertRule(ruleText, index);
+
+  let viewTransition = document.startViewTransition(() => {});
+  await viewTransition.ready;
+
+  let anim1 = document.documentElement.animate(
+    { opacity: [0.5, 0.5] },
+    { duration: 10000, pseudoElement: '::view-transition-group(test)' }
+  );
+  await anim1.ready;
+
+  let kf = new KeyframeEffect(
+    document.documentElement,
+    { translate: ["200px", "200px"] },
+    { duration: 10000, pseudoElement: '::view-transition-old(test)' }
+  );
+  let anim2 = new Animation(kf, document.timeline);
+  anim2.play();
+  await anim2.ready;
+
+  let anims = document.documentElement.getAnimations({ subtree: true });
+  assert_equals(anims.length, 4,
+    "Has 2 CSS Animations and 2 script animations.");
+
+  let style = getComputedStyle(document.documentElement,
+    "::view-transition-group(test)");
+  assert_equals(style.marginLeft, "100px");
+  assert_equals(style.opacity, "0.5");
+  assert_equals(
+    getComputedStyle(document.documentElement,
+      "::view-transition-old(test)").translate,
+    "200px"
+  );
+
+  anim1.finish();
+  anim2.finish();
+  viewTransition.skipTransition();
+  document.styleSheets[0].deleteRule(index);
+  document.documentElement.style.viewTransitionName = "none";
+}, "The specified CSS Animations and script animations work on view "+
+   "transition pseudos");
+
+promise_test(async t => {
+  document.documentElement.style.viewTransitionName = "test";
+  let ruleText =
+    ":root::view-transition, " +
+    ":root::view-transition-group(test), " +
+    ":root::view-transition-image-pair(test) {" +
+    "  animation: css-anim 10s;"
+    "}";
+  const index = document.styleSheets[0].cssRules.length;
+  document.styleSheets[0].insertRule(ruleText, index);
+
+  let viewTransition = document.startViewTransition(() => {});
+  await viewTransition.ready;
+
+  let anims = document.documentElement.getAnimations({ subtree: true });
+  assert_equals(anims.length, 3, "Has 3 CSS Animations.");
+
+  // Make the pseudo-element display:none.
+  ruleText = ":root::view-transition-image-pair(test) { display: none; }";
+  document.styleSheets[0].insertRule(ruleText, index + 1);
+  anims = document.documentElement.getAnimations({ subtree: true });
+  assert_equals(anims.length, 2, "One CSS Animation was removed.");
+
+  // Destroy all frames.
+  document.documentElement.style.display = "none";
+  anims = document.documentElement.getAnimations({ subtree: true });
+  assert_equals(anims.length, 0, "All CSS Animation were removed.");
+
+  viewTransition.skipTransition();
+  document.styleSheets[0].deleteRule(index + 1);
+  document.styleSheets[0].deleteRule(index);
+  document.documentElement.style.viewTransitionName = "none";
+  document.documentElement.style.display = "inline";
+}, "The specified CSS Animations are removed if setting display:none.");
+
+
 

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -1751,7 +1751,7 @@ TransformationMatrix RenderLayer::currentTransform(OptionSet<RenderStyle::Transf
 
     // Query the animatedStyle() to obtain the current transformation, when accelerated transform animations are running.
     auto styleable = Styleable::fromRenderer(renderer());
-    if ((styleable && styleable->isRunningAcceleratedTransformAnimation()) || !options.contains(RenderStyle::TransformOperationOption::TransformOrigin)) {
+    if ((styleable && styleable->isRunningAcceleratedAnimationOfProperty(CSSPropertyTransform)) || !options.contains(RenderStyle::TransformOperationOption::TransformOrigin)) {
         std::unique_ptr<RenderStyle> animatedStyle = renderer().animatedStyle();
 
         TransformationMatrix transform;

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -1527,7 +1527,7 @@ void RenderLayerBacking::updateGeometry(const RenderLayer* compositedAncestor)
 
     bool isRunningAcceleratedTransformAnimation = false;
     if (auto styleable = Styleable::fromRenderer(renderer()))
-        isRunningAcceleratedTransformAnimation = styleable->isRunningAcceleratedTransformAnimation();
+        isRunningAcceleratedTransformAnimation = styleable->isRunningAcceleratedAnimationOfProperty(CSSPropertyTransform);
 
     updateTransform(style);
     updateOpacity(style);

--- a/Source/WebCore/style/Styleable.cpp
+++ b/Source/WebCore/style/Styleable.cpp
@@ -225,14 +225,14 @@ bool Styleable::mayHaveNonZeroOpacity() const
     return false;
 }
 
-bool Styleable::isRunningAcceleratedTransformAnimation() const
+bool Styleable::isRunningAcceleratedAnimationOfProperty(CSSPropertyID property) const
 {
     auto* effectStack = keyframeEffectStack();
     if (!effectStack)
         return false;
 
     for (const auto& effect : effectStack->sortedEffects()) {
-        if (effect->isCurrentlyAffectingProperty(CSSPropertyTransform, KeyframeEffect::Accelerated::Yes))
+        if (effect->isCurrentlyAffectingProperty(property, KeyframeEffect::Accelerated::Yes))
             return true;
     }
 

--- a/Source/WebCore/style/Styleable.h
+++ b/Source/WebCore/style/Styleable.h
@@ -79,7 +79,7 @@ struct Styleable {
 
     bool mayHaveNonZeroOpacity() const;
 
-    bool isRunningAcceleratedTransformAnimation() const;
+    bool isRunningAcceleratedAnimationOfProperty(CSSPropertyID) const;
 
     bool hasRunningAcceleratedAnimations() const;
 


### PR DESCRIPTION
#### ab265bfb1c613dad4684d189f2ae2d977d57e213
<pre>
css/css-view-transitions/pseudo-element-animations fails to read &apos;opacity&apos; computed style.
<a href="https://bugs.webkit.org/show_bug.cgi?id=293031">https://bugs.webkit.org/show_bug.cgi?id=293031</a>
&lt;<a href="https://rdar.apple.com/151351674">rdar://151351674</a>&gt;

Reviewed by Antoine Quint.

The test is getting the computed style, and trying to read opacity, which should
work since that&apos;s being animated.

This is because computeRenderStyleForProperty detects that &apos;opacity&apos; could be
accelerated, and tries to use the originating element&apos;s animated style (and then
the cached pseudo style off of it).

Change this code to actually lookup the keyframes and check for an accelerated
animation of the current property, and then access the animated style (of the
pseudo&apos;s renderer, not the originating element&apos;s) if so.

I am unsure why this test now dumps the test file into the output, but we pass
an extra check, and I&apos;ll followup to fix the remaining failure (which then makes
the weird output go away).

* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-element-animations-expected.txt:
* Source/WebCore/css/ComputedStyleExtractor.cpp:
(WebCore::computeRenderStyleForProperty):
(WebCore::ComputedStyleExtractor::customPropertyValue const):
(WebCore::ComputedStyleExtractor::propertyValue const):
(WebCore::ComputedStyleExtractor::layerCount const):
* Source/WebCore/style/Styleable.cpp:
(WebCore::Styleable::isRunningAcceleratedTransformAnimation const):
(WebCore::Styleable::isRunningAcceleratedAnimationOfProperty const):
* Source/WebCore/style/Styleable.h:

Canonical link: <a href="https://commits.webkit.org/295141@main">https://commits.webkit.org/295141@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2d6d6631c3a6379860b5d04b29c8451e06824d5a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104205 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/23909 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/14236 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/109404 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/54873 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/106245 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/24277 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/32453 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/79145 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107211 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/18861 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94010 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59472 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/18675 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/12047 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/54233 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/88375 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/12106 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/111787 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/31361 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/23120 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/88166 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/31725 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/90198 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87827 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22358 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32720 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/10469 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/25825 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/31290 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/36603 "Built successfully") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/31084 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/34420 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/32644 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->