### PR TITLE
css/css-view-transitions/content-with-transform-new-image fails with fuzzy text.

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7097,7 +7097,6 @@ imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/navigate-
 # -- View Transitions -- #
 # Reftest failures:
 imported/w3c/web-platform-tests/css/css-view-transitions/content-with-clip-root.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-view-transitions/content-with-transform-old-image.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-view-transitions/fractional-box-new.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-view-transitions/fractional-box-old.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-view-transitions/fractional-box-with-overflow-children-old.html [ ImageOnlyFailure ]
@@ -7107,7 +7106,6 @@ imported/w3c/web-platform-tests/css/css-view-transitions/inline-with-offset-from
 imported/w3c/web-platform-tests/css/css-view-transitions/root-style-change-during-animation.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-view-transitions/snapshot-containing-block-absolute.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-view-transitions/span-with-overflowing-text.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-view-transitions/content-with-transform-new-image.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-view-transitions/fractional-box-with-overflow-children-new.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-view-transitions/new-content-captures-different-size.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-view-transitions/snapshot-containing-block-static.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/content-with-transform-new-image-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/content-with-transform-new-image-expected.html
@@ -7,7 +7,7 @@
   contain: paint;
   width: 100px;
   height: 100px;
-  transform: scale(2.0, 3.0);
+  transform: scale3d(2.0, 3.0, 1.0);
 }
 
 .embedded {

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/content-with-transform-old-image-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/content-with-transform-old-image-expected.html
@@ -7,7 +7,7 @@
   contain: paint;
   width: 100px;
   height: 100px;
-  transform: scale(2.0, 3.0);
+  transform: scale3d(2.0, 3.0, 1.0);
 }
 
 .embedded {

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/inline-with-offset-from-containing-block-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/inline-with-offset-from-containing-block-expected.html
@@ -6,7 +6,7 @@
 
 <style>
   .outer {
-    transform: scale(2);
+    transform: scale3d(2, 2, 1);
     width: 100vw;
     text-align: center;
   }


### PR DESCRIPTION
#### 6cc8b5619a394bc0a606d48ce172cf1acef0e3f6
<pre>
css/css-view-transitions/content-with-transform-new-image fails with fuzzy text.
<a href="https://bugs.webkit.org/show_bug.cgi?id=293035">https://bugs.webkit.org/show_bug.cgi?id=293035</a>
&lt;<a href="https://rdar.apple.com/151354019">rdar://151354019</a>&gt;

Reviewed by Tim Nguyen.

WebKit doesn&apos;t currently support rasterizing composited content at anything
other than 1.0 scale, so any transforms are only applied afterwards.
Non-composited transforms get applied during rasterization.

These tests end up using compositing for view transition captures, but the
reference files don&apos;t use compositing.

Use a 3d transform to force compositing for the reference, so that they match.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/content-with-transform-new-image-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/content-with-transform-old-image-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/inline-with-offset-from-containing-block-expected.html:

Canonical link: <a href="https://commits.webkit.org/294981@main">https://commits.webkit.org/294981@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ff788d8d77ad8fd3650b7f808eb784eaa7ade0dd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/103593 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/23275 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/13596 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/108769 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/54240 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/23631 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/31826 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78717 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/106599 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/18331 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/93452 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59052 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/18142 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/11499 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/53594 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/87926 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/11558 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/111147 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/30740 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/22672 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/87710 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/31101 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/89652 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87358 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22263 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32234 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/9957 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/25094 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/30668 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/30468 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/33799 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/32029 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->