### PR TITLE
Add signpost to Performance.measure

### DIFF
--- a/Source/WTF/wtf/MonotonicTime.cpp
+++ b/Source/WTF/wtf/MonotonicTime.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include <wtf/MonotonicTime.h>
 
+#include <wtf/ContinuousTime.h>
 #include <wtf/PrintStream.h>
 #include <wtf/WallTime.h>
 
@@ -36,6 +37,13 @@ WallTime MonotonicTime::approximateWallTime() const
     if (isInfinity())
         return WallTime::fromRawSeconds(m_value);
     return *this - now() + WallTime::now();
+}
+
+ContinuousTime MonotonicTime::approximateContinuousTime() const
+{
+    if (isInfinity())
+        return ContinuousTime::fromRawSeconds(m_value);
+    return *this - now() + ContinuousTime::now();
 }
 
 void MonotonicTime::dump(PrintStream& out) const

--- a/Source/WTF/wtf/MonotonicTime.h
+++ b/Source/WTF/wtf/MonotonicTime.h
@@ -31,6 +31,7 @@
 
 namespace WTF {
 
+class ContinuousTime;
 class WallTime;
 class PrintStream;
 
@@ -54,6 +55,7 @@ public:
     
     MonotonicTime approximateMonotonicTime() const { return *this; }
     WTF_EXPORT_PRIVATE WallTime approximateWallTime() const;
+    WTF_EXPORT_PRIVATE ContinuousTime approximateContinuousTime() const;
 
     WTF_EXPORT_PRIVATE void dump(PrintStream&) const;
 

--- a/Source/WTF/wtf/SystemTracing.h
+++ b/Source/WTF/wtf/SystemTracing.h
@@ -274,6 +274,7 @@ WTF_EXTERN_C_END
     M(StreamClientConnection) \
     M(ScrollingPerformanceTestFingerDownInterval) \
     M(ScrollingPerformanceTestMomentumInterval) \
+    M(WebKitPerformance) \
 
 #define DECLARE_WTF_SIGNPOST_NAME_ENUM(name) WTFOSSignpostName ## name,
 


### PR DESCRIPTION
#### a4ab006bdf55fb59302f8cffb4c8ade78cdf0dad
<pre>
Add signpost to Performance.measure
<a href="https://bugs.webkit.org/show_bug.cgi?id=293036">https://bugs.webkit.org/show_bug.cgi?id=293036</a>
<a href="https://rdar.apple.com/151355439">rdar://151355439</a>

Reviewed by Mark Lam.

This patch adds code emitting synthetic signpost in performance.measure.
Many recent benchmarks started using performance.mark and
performance.measure. This patch adds environment variable
&quot;WebKitPerformanceSignpostEnabled=1&quot; and when it is provided,
emitting signpost for performance.measure&apos;s interval.
I discussed with Ben and he suggested using environment variable to
enable / disable signpost for our measurement.

This number is not strictly correct: signpost requires continuous time
while PerformanceEntry&apos;s time is monotonic time. If the system sleeps
during the measurement period, we will see wrong signpost region.
However, this is just for debugging purpose and this is fine for our use
case. If we would like to fix this, we need to keep continuous time in
all of our metrics pipeline (e.g. fetch&apos;s resource statistics). And it
is a bit too overkill for this feature.

* Source/WTF/wtf/MonotonicTime.cpp:
(WTF::MonotonicTime::approximateContinuousTime const):
* Source/WTF/wtf/MonotonicTime.h:
* Source/WTF/wtf/SystemTracing.h:
* Source/WebCore/page/Performance.cpp:
(WebCore::isSignpostEnabled):
(WebCore::Performance::measure):

Canonical link: <a href="https://commits.webkit.org/295144@main">https://commits.webkit.org/295144@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/22010fb13a478916519cebed68a116c140fd235d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104217 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/23921 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/14251 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/109417 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/54885 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/106257 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/24289 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/32466 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/79157 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107223 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/18875 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94025 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/59484 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/18687 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/12063 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/54245 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/96892 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/88384 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/12122 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/111799 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/102828 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/31373 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/23129 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/88181 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/31737 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/90214 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/87843 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32731 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/10479 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/25837 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16918 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/31302 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/36615 "Failed to build and analyze WebKit") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/126462 "Built successfully") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/31096 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34964 "Found 1 new JSC stress test failure: wasm.yaml/wasm/stress/cc-int-to-int-no-jit.js.default-wasm (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/34432 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/32656 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->