### PR TITLE
[Swift in WebKit] Fix Swift 6 strict concurrency errors in `WKGroupSession.swift`

### DIFF
--- a/Source/WebKit/WebKitSwift/GroupActivities/WKGroupSession.h
+++ b/Source/WebKit/WebKitSwift/GroupActivities/WKGroupSession.h
@@ -45,6 +45,7 @@ typedef NS_ENUM(NSInteger, WKGroupSessionState) {
 @property (nonatomic, copy, readonly, nullable) NSURL *fallbackURL;
 @end
 
+NS_SWIFT_UI_ACTOR
 @interface WKGroupSession : NSObject
 @property (nonatomic, readonly) WKURLActivity *activity;
 @property (nonatomic, readonly, copy) NSUUID *uuid;
@@ -56,6 +57,7 @@ typedef NS_ENUM(NSInteger, WKGroupSessionState) {
 - (void)coordinateWithCoordinator:(AVPlaybackCoordinator *)playbackCoordinator;
 @end
 
+NS_SWIFT_UI_ACTOR
 @interface WKGroupSessionObserver : NSObject
 @property (nonatomic, copy, nullable) void (^newSessionCallback)(WKGroupSession *);
 @end

--- a/Source/WebKit/WebKitSwift/GroupActivities/WKGroupSession.swift
+++ b/Source/WebKit/WebKitSwift/GroupActivities/WKGroupSession.swift
@@ -135,13 +135,9 @@ fileprivate extension WKGroupSessionState {
     override init() {
         super.init()
 
-        // FIXME: rdar://151088688 Fix Swift 6 strict concurrency errors in `WKGroupSession.swift`.
-
-        incomingSessionsTask = Task.detached { [weak self] in
+        incomingSessionsTask = Task { [weak self] in
             for await newSession in URLActivity.sessions() {
-                DispatchQueue.main.async { [weak self] in
-                    self?.receivedSession(newSession)
-                }
+                self?.receivedSession(newSession)
             }
         }
     }


### PR DESCRIPTION
#### 239520ecb567d6e9bb5a439f67439123348b7091
<pre>
[Swift in WebKit] Fix Swift 6 strict concurrency errors in `WKGroupSession.swift`
<a href="https://bugs.webkit.org/show_bug.cgi?id=293037">https://bugs.webkit.org/show_bug.cgi?id=293037</a>
<a href="https://rdar.apple.com/151088688">rdar://151088688</a>

Reviewed by Aditya Keerthi.

The existing code is not provably concurrency-safe because it involved
sending `WKGroupSession` across actor boundaries albeit `WKGroupSession`
not being Sendable.

Fix by using a more straightforward approach and just call `receivedSession`
directly, which is guaranteed to execute on the main actor since the relevant
types are now properly annotated.

* Source/WebKit/WebKitSwift/GroupActivities/WKGroupSession.h:
* Source/WebKit/WebKitSwift/GroupActivities/WKGroupSession.swift:

Canonical link: <a href="https://commits.webkit.org/294993@main">https://commits.webkit.org/294993@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1a0ff622eaa1d30a4a1da5bfd9acb5bdc744a0bd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/103767 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/23469 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/13789 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/108958 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/54419 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/23818 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/32015 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/108958 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/54419 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/106773 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/18484 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/93613 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/108958 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/18296 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/53795 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/88069 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/11719 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/111347 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/30923 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/22799 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/87836 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/31284 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/89814 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/87488 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/32374 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/10103 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/25280 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16838 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/30851 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/36154 "Built successfully") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/30645 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/33980 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/32206 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->