### PR TITLE
Don't include SerializedScriptValue.h in HistoryItem.h

### DIFF
--- a/Source/WebCore/dom/ToggleEventTask.cpp
+++ b/Source/WebCore/dom/ToggleEventTask.cpp
@@ -27,6 +27,7 @@
 #include "ToggleEventTask.h"
 
 #include "EventNames.h"
+#include "TaskSource.h"
 #include "ToggleEvent.h"
 
 namespace WebCore {

--- a/Source/WebCore/history/HistoryItem.h
+++ b/Source/WebCore/history/HistoryItem.h
@@ -33,9 +33,7 @@
 #include "FrameLoaderTypes.h"
 #include "IntPoint.h"
 #include "IntRect.h"
-#include "LengthBox.h"
 #include "PolicyContainer.h"
-#include "SerializedScriptValue.h"
 #include <memory>
 #include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/TZoneMalloc.h>
@@ -60,6 +58,7 @@ class FormData;
 class HistoryItem;
 class Image;
 class ResourceRequest;
+class SerializedScriptValue;
 
 class HistoryItemClient : public RefCounted<HistoryItemClient> {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(HistoryItemClient, WEBCORE_EXPORT);

--- a/Source/WebCore/inspector/agents/InspectorDOMAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorDOMAgent.h
@@ -78,6 +78,7 @@ class RenderObject;
 class RevalidateStyleAttributeTask;
 class ShadowRoot;
 
+enum class ExceptionCode : uint8_t;
 enum class PlatformEventModifier : uint8_t;
 
 struct Styleable;

--- a/Source/WebCore/loader/DocumentThreadableLoader.h
+++ b/Source/WebCore/loader/DocumentThreadableLoader.h
@@ -38,6 +38,7 @@
 #include "ResourceResponse.h"
 #include "SecurityOrigin.h"
 #include "ThreadableLoader.h"
+#include "ThreadableLoaderClient.h"
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {

--- a/Source/WebCore/page/NavigationDestination.h
+++ b/Source/WebCore/page/NavigationDestination.h
@@ -29,6 +29,7 @@
 #include "LocalDOMWindowProperty.h"
 #include "NavigationHistoryEntry.h"
 #include "ScriptWrappable.h"
+#include "SerializedScriptValue.h"
 
 namespace JSC {
 class JSValue;

--- a/Source/WebCore/page/NavigationHistoryEntry.cpp
+++ b/Source/WebCore/page/NavigationHistoryEntry.cpp
@@ -74,6 +74,8 @@ Ref<NavigationHistoryEntry> NavigationHistoryEntry::create(Navigation& navigatio
     return entry;
 }
 
+NavigationHistoryEntry::~NavigationHistoryEntry() = default;
+
 ScriptExecutionContext* NavigationHistoryEntry::scriptExecutionContext() const
 {
     return ContextDestructionObserver::scriptExecutionContext();

--- a/Source/WebCore/page/NavigationHistoryEntry.h
+++ b/Source/WebCore/page/NavigationHistoryEntry.h
@@ -49,6 +49,8 @@ public:
     static Ref<NavigationHistoryEntry> create(Navigation&, Ref<HistoryItem>&&);
     static Ref<NavigationHistoryEntry> create(Navigation&, const NavigationHistoryEntry&);
 
+    ~NavigationHistoryEntry();
+
     void ref() const final { RefCounted::ref(); }
     void deref() const final { RefCounted::deref(); }
 

--- a/Source/WebCore/page/NavigationTransition.h
+++ b/Source/WebCore/page/NavigationTransition.h
@@ -32,6 +32,7 @@
 namespace WebCore {
 
 class DOMPromise;
+class DeferredPromise;
 class Exception;
 
 class NavigationTransition final : public RefCounted<NavigationTransition> {


### PR DESCRIPTION
#### 0d4f3be93819f430a6e2745c1eacbb86945f52dc
<pre>
Don&apos;t include SerializedScriptValue.h in HistoryItem.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=293042">https://bugs.webkit.org/show_bug.cgi?id=293042</a>

Reviewed by Antoine Quint.

Removed #include of SerializedScriptValue.h since a forward declaration suffices.

* Source/WebCore/dom/ToggleEventTask.cpp:
* Source/WebCore/history/HistoryItem.h:
* Source/WebCore/inspector/agents/InspectorDOMAgent.h:
* Source/WebCore/loader/DocumentThreadableLoader.h:
* Source/WebCore/page/NavigationDestination.h:
* Source/WebCore/page/NavigationHistoryEntry.cpp:
* Source/WebCore/page/NavigationHistoryEntry.h:
* Source/WebCore/page/NavigationTransition.h:

Canonical link: <a href="https://commits.webkit.org/294996@main">https://commits.webkit.org/294996@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5bc0b9e79c64e48c723eb5b5ee08504442043856

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/103727 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/23429 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/13749 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/108917 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/54379 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/105767 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/23836 "Failed to checkout and rebase branch from PR 45426") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/31975 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78816 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/106733 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/18446 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/93577 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59150 "Found 1 new API test failure: /WPE/TestSSL:/webkit/WebKitWebView/ephemeral-tls-errors (failure)") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/18255 "layout-tests (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/11625 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/53755 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/88034 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/11683 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/111307 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/30883 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/22770 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/87819 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/31244 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/89778 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87469 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22271 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32340 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10074 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/25240 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/30811 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/36114 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/30605 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/33940 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/32166 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->