### PR TITLE
CoreAudioSharedUnit constructor should not create Timer directly

### DIFF
--- a/Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.h
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.h
@@ -215,9 +215,9 @@ private:
 
     std::atomic<uint64_t> m_microphoneProcsCalled { 0 };
     uint64_t m_microphoneProcsCalledLastTime { 0 };
-    Timer m_verifyCapturingTimer;
+    std::unique_ptr<Timer> m_verifyCapturingTimer;
 
-    Timer m_updateMutedStateTimer;
+    std::unique_ptr<Timer> m_updateMutedStateTimer;
 
     std::optional<size_t> m_minimumMicrophoneSampleFrames;
     bool m_isReconfiguring { false };


### PR DESCRIPTION
#### a9b27d355d14e9ad29425d08bc5e6b14d8e56883
<pre>
CoreAudioSharedUnit constructor should not create Timer directly
<a href="https://rdar.apple.com/151369760">rdar://151369760</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=293041">https://bugs.webkit.org/show_bug.cgi?id=293041</a>

Reviewed by Eric Carlson.

CoreAudioSharedUnit may be instantiated in UIProcess when getUserMedia is called.
In that case, if WebThread is used, CoreAudioSharedUnit constructor will trigger a release assert from the Timer constructor.

To prevent this, we lazy initialize all Timer CoreAudioSharedUnit members.

Covered by added API test.

* Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.cpp:
(WebCore::CoreAudioSharedUnit::CoreAudioSharedUnit):
(WebCore::CoreAudioSharedUnit::startInternal):
(WebCore::CoreAudioSharedUnit::isProducingMicrophoneSamplesChanged):
(WebCore::CoreAudioSharedUnit::updateMutedState):
(WebCore::CoreAudioSharedUnit::verifyIsCapturing):
(WebCore::CoreAudioSharedUnit::stopInternal):
* Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.h:
* Tools/TestWebKitAPI/Tests/WebKit/GetUserMedia.mm:
(TestWebKitAPI::(WebKit, GetUserMediaWithWebThread)):

Canonical link: <a href="https://commits.webkit.org/294965@main">https://commits.webkit.org/294965@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/689c2eba12f2c57d156129b2530d20a52b80aa76

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/103621 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/23304 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/13624 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/108797 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/54268 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/105661 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/23659 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/31854 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78740 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/106627 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/18354 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/93479 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59075 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/18166 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/11526 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/53622 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/87948 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/11585 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/111175 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/30768 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/22690 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/87734 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/31129 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/89679 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87381 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22250 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32260 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/9983 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/25123 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/30696 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/36008 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/30496 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/33827 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/32057 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->