### PR TITLE
Use type abstractions in WasmOMGIRGenerator.cpp

### DIFF
--- a/Source/JavaScriptCore/b3/B3Type.h
+++ b/Source/JavaScriptCore/b3/B3Type.h
@@ -142,6 +142,11 @@ constexpr Type pointerType()
     return Int64;
 }
 
+constexpr Type wasmRefType()
+{
+    return Int64;
+}
+
 constexpr Type registerType()
 {
     if (isRegister64Bit())


### PR DESCRIPTION
#### 191882239332f2e7f4366f667cf09db2454545df
<pre>
Use type abstractions in WasmOMGIRGenerator.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=293048">https://bugs.webkit.org/show_bug.cgi?id=293048</a>

Reviewed by Justin Michaud.

This step is needed to be able to have WasmOMGIRGenerator32.cpp follow WasmOMGIRGenerator.cpp more closely.

In particular, appropriately use:
- ConstPtrValue instead of Const64Value,
- WasmConstRefValue instead of Const64Value,
- pointerType() instead of Int64 or B3::Int64,
- uintptr_t instead of uint64_t for two assertions (in addCurrentMemory and in addCallIndirect),
- new abstraction wasmRefType instead of pointerType() in emitCatchTableImpl for CatchRef and CatchAllRef, and
- WidthPtr instead of Width::Width64 to allocateSpill in prepareForTailCallImpl.

Additionally, remove ConstIntPtrValue (because ConstPtrValue fulfills the same role),
make TRACE_CF more verbose, and correct one indentation issue.

Finally the order of two lines is swapped, to reduce the need for repeated preprocessor #ifdefs in the 32bit version side.

* Source/JavaScriptCore/b3/B3Type.h:
(JSC::B3::wasmRefType): add abstraction wasmRefType() returning Int64
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp:
(JSC::Wasm::OMGIRGenerator::fixupPointerPlusOffset): ConstPtrValue instead of Const64Value
(JSC::Wasm::OMGIRGenerator::OMGIRGenerator): swap order of two lines pinning registers
(JSC::Wasm::OMGIRGenerator::addArguments): ConstPtrValue instead of Const64Value
(JSC::Wasm::OMGIRGenerator::addRefIsNull): WasmConstRefValue instead of Const64Value
(JSC::Wasm::OMGIRGenerator::addTableGet): WasmConstRefValue instead of Const64Value
(JSC::Wasm::OMGIRGenerator::addRefAsNonNull): WasmConstRefValue instead of Const64Value
(JSC::Wasm::OMGIRGenerator::addCurrentMemory): uintptr_t instead of uint64_t and pointerType() instead of Int64
(JSC::Wasm::OMGIRGenerator::traceCF): make more verbose
(JSC::Wasm::OMGIRGenerator::getGlobal): pointerType() instead of B3::Int64
(JSC::Wasm::OMGIRGenerator::setGlobal): pointerType() instead of B3::Int64
(JSC::Wasm::OMGIRGenerator::fixupPointerPlusOffsetForAtomicOps): ConstPtrValue instead of Const64Value
(JSC::Wasm::OMGIRGenerator::addI31GetS): WasmConstRefValue instead of Const64Value
(JSC::Wasm::OMGIRGenerator::addI31GetU): WasmConstRefValue instead of Const64Value
(JSC::Wasm::OMGIRGenerator::pushArrayNew): WasmConstRefValue instead of Const64Value
(JSC::Wasm::OMGIRGenerator::addArrayGet): WasmConstRefValue instead of Const64Value
(JSC::Wasm::OMGIRGenerator::emitArrayNullCheck): WasmConstRefValue instead of Const64Value
(JSC::Wasm::OMGIRGenerator::addArrayLen): WasmConstRefValue instead of Const64Value
(JSC::Wasm::OMGIRGenerator::addStructNew): WasmConstRefValue instead of Const64Value
(JSC::Wasm::OMGIRGenerator::addStructNewDefault): WasmConstRefValue instead of Const64Value
(JSC::Wasm::OMGIRGenerator::addStructGet): WasmConstRefValue instead of Const64Value
(JSC::Wasm::OMGIRGenerator::addStructSet): WasmConstRefValue instead of Const64Value
(JSC::Wasm::OMGIRGenerator::emitRefTestOrCast): pointerType() instead of Int64
(JSC::Wasm::OMGIRGenerator::emitLoadRTTFromFuncref): pointerType() instead of B3::Int64
(JSC::Wasm::OMGIRGenerator::emitCatchTableImpl): wasmRefType() instead of pointerType()
(JSC::Wasm::OMGIRGenerator::addBranchNull): WasmConstRefValue instead of Const64Value
(JSC::Wasm::prepareForTailCallImpl): fix indentation and use WidthPtr instead of Width::Width64
(JSC::Wasm::OMGIRGenerator::addCallIndirect): uintptr_t instead of uint64_t, pointerType() instead of Int64, and ConstPtrValue instead of Const64Value
(JSC::Wasm::OMGIRGenerator::addCallRef): WasmConstRefValue instead of Const64Value

Canonical link: <a href="https://commits.webkit.org/295108@main">https://commits.webkit.org/295108@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/428f70fe0ee93f2bc3d7f3e2fc7565a2e1d624d3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/103647 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/23330 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/13650 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/108823 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/54295 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/23728 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/31880 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78766 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/106653 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/18405 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/93502 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59100 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/18215 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/11549 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/53648 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/96322 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/87998 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/11608 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/111201 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/102258 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/30795 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/22713 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/87759 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/31155 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/89702 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87407 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22339 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32282 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10006 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/25155 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/30722 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/36034 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/125891 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/30526 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34869 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/33853 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/32086 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->