### PR TITLE
[Safe CPP] Address Warnings in RenderTableCol.cpp

### DIFF
--- a/Source/WTF/wtf/CheckedPtr.h
+++ b/Source/WTF/wtf/CheckedPtr.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -212,6 +212,62 @@ inline bool is(const CheckedPtr<ArgType, ArgPtrTraits>& source)
     return is<ExpectedType>(source.get());
 }
 
+template<typename Target, typename Source, typename PtrTraits>
+inline CheckedPtr<match_constness_t<Source, Target>> uncheckedDowncast(CheckedPtr<Source, PtrTraits>& source)
+{
+    static_assert(!std::is_same_v<Source, Target>, "Unnecessary cast to same type");
+    static_assert(std::is_base_of_v<Source, Target>, "Should be a downcast");
+    RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(!source || is<Target>(*source));
+    return CheckedPtr<match_constness_t<Source, Target>>(static_cast<Target*>(source.get()));
+}
+
+template<typename Target, typename Source, typename PtrTraits>
+inline CheckedPtr<match_constness_t<Source, Target>> uncheckedDowncast(CheckedPtr<Source, PtrTraits>&& source)
+{
+    static_assert(!std::is_same_v<Source, Target>, "Unnecessary cast to same type");
+    static_assert(std::is_base_of_v<Source, Target>, "Should be a downcast");
+    RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(!source || is<Target>(*source));
+    return CheckedPtr<match_constness_t<Source, Target>>(static_cast<Target*>(WTFMove(source)));
+}
+
+template<typename Target, typename Source, typename PtrTraits>
+inline CheckedPtr<match_constness_t<Source, Target>> downcast(CheckedPtr<Source, PtrTraits>& source)
+{
+    static_assert(!std::is_same_v<Source, Target>, "Unnecessary cast to same type");
+    static_assert(std::is_base_of_v<Source, Target>, "Should be a downcast");
+    RELEASE_ASSERT(!source || is<Target>(*source));
+    return CheckedPtr<match_constness_t<Source, Target>>(static_cast<Target*>(source.get()));
+}
+
+template<typename Target, typename Source, typename PtrTraits>
+inline CheckedPtr<match_constness_t<Source, Target>> downcast(CheckedPtr<Source, PtrTraits>&& source)
+{
+    static_assert(!std::is_same_v<Source, Target>, "Unnecessary cast to same type");
+    static_assert(std::is_base_of_v<Source, Target>, "Should be a downcast");
+    RELEASE_ASSERT(!source || is<Target>(*source));
+    return CheckedPtr<match_constness_t<Source, Target>>(static_cast<Target*>(WTFMove(source)));
+}
+
+template<typename Target, typename Source, typename TargetPtrTraits = RawPtrTraits<Target>, typename SourcePtrTraits>
+inline CheckedPtr<match_constness_t<Source, Target>, TargetPtrTraits> dynamicDowncast(CheckedPtr<Source, SourcePtrTraits>& source)
+{
+    static_assert(!std::is_same_v<Source, Target>, "Unnecessary cast to same type");
+    static_assert(std::is_base_of_v<Source, Target>, "Should be a downcast");
+    if (!is<Target>(source))
+        return nullptr;
+    return CheckedPtr<match_constness_t<Source, Target>, TargetPtrTraits>(static_cast<Target*>(source.get()));
+}
+
+template<typename Target, typename Source, typename TargetPtrTraits = RawPtrTraits<Target>, typename SourcePtrTraits>
+inline CheckedPtr<match_constness_t<Source, Target>, TargetPtrTraits> dynamicDowncast(CheckedPtr<Source, SourcePtrTraits>&& source)
+{
+    static_assert(!std::is_same_v<Source, Target>, "Unnecessary cast to same type");
+    static_assert(std::is_base_of_v<Source, Target>, "Should be a downcast");
+    if (!is<Target>(source))
+        return nullptr;
+    return CheckedPtr<match_constness_t<Source, Target>, TargetPtrTraits>(static_cast<Target*>(WTFMove(source)));
+}
+
 template<typename P> struct HashTraits<CheckedPtr<P>> : SimpleClassHashTraits<CheckedPtr<P>> {
     static P* emptyValue() { return nullptr; }
     static bool isEmptyValue(const CheckedPtr<P>& value) { return !value; }
@@ -238,4 +294,3 @@ template<typename T> using PackedCheckedPtr = CheckedPtr<T, PackedPtrTraits<T>>;
 
 using WTF::CheckedPtr;
 using WTF::PackedCheckedPtr;
-

--- a/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -737,7 +737,6 @@ rendering/RenderTable.h
 rendering/RenderTableCaption.cpp
 rendering/RenderTableCell.cpp
 rendering/RenderTableCellInlines.h
-rendering/RenderTableCol.cpp
 rendering/RenderTableRow.cpp
 rendering/RenderTableRowInlines.h
 rendering/RenderTableSection.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
@@ -487,7 +487,6 @@ rendering/RenderTable.cpp
 rendering/RenderTableCaption.cpp
 rendering/RenderTableCell.cpp
 rendering/RenderTableCellInlines.h
-rendering/RenderTableCol.cpp
 rendering/RenderTableRow.cpp
 rendering/RenderTableSection.cpp
 rendering/RenderText.cpp

--- a/Source/WebCore/rendering/AutoTableLayout.cpp
+++ b/Source/WebCore/rendering/AutoTableLayout.cpp
@@ -32,6 +32,7 @@
 #include "RenderTableInlines.h"
 #include "RenderTableSection.h"
 #include "RenderView.h"
+#include <wtf/CheckedPtr.h>
 
 namespace WebCore {
 
@@ -157,7 +158,7 @@ void AutoTableLayout::fullRecalc()
 
     Length groupLogicalWidth;
     unsigned currentColumn = 0;
-    for (RenderTableCol* column = m_table->firstColumn(); column; column = column->nextColumn()) {
+    for (CheckedPtr column = m_table->firstColumn(); column; column = column->nextColumn()) {
         if (column->isTableColumnGroupWithColumnChildren())
             groupLogicalWidth = column->style().logicalWidth();
         else {

--- a/Source/WebCore/rendering/FixedTableLayout.cpp
+++ b/Source/WebCore/rendering/FixedTableLayout.cpp
@@ -27,6 +27,7 @@
 #include "RenderTableCol.h"
 #include "RenderTableInlines.h"
 #include "RenderTableSection.h"
+#include <wtf/CheckedPtr.h>
 
 /*
   The text below is from the CSS 2.1 specs.
@@ -87,7 +88,7 @@ float FixedTableLayout::calcWidthArray()
     m_width.fill(Length(LengthType::Auto));
 
     unsigned currentEffectiveColumn = 0;
-    for (RenderTableCol* col = m_table->firstColumn(); col; col = col->nextColumn()) {
+    for (CheckedPtr col = m_table->firstColumn(); col; col = col->nextColumn()) {
         // RenderTableCols don't have the concept of preferred logical width, but we need to clear their dirty bits
         // so that if we call setPreferredWidthsDirty(true) on a col or one of its descendants, we'll mark it's
         // ancestors as dirty.

--- a/Source/WebCore/rendering/RenderElement.h
+++ b/Source/WebCore/rendering/RenderElement.h
@@ -27,6 +27,7 @@
 #include "RenderObject.h"
 #include "RenderPtr.h"
 #include "RenderStyle.h"
+#include <wtf/CheckedRef.h>
 #include <wtf/MonotonicTime.h>
 #include <wtf/Packed.h>
 
@@ -68,6 +69,7 @@ public:
     bool hasInitializedStyle() const { return m_hasInitializedStyle; }
 
     const RenderStyle& style() const { return m_style; }
+    CheckedRef<const RenderStyle> protectedStyle() const { return m_style; }
     const RenderStyle* parentStyle() const { return !m_parent ? nullptr : &m_parent->style(); }
     const RenderStyle& firstLineStyle() const;
 

--- a/Source/WebCore/rendering/RenderTable.cpp
+++ b/Source/WebCore/rendering/RenderTable.cpp
@@ -58,6 +58,7 @@
 #include "RenderTreeBuilder.h"
 #include "RenderView.h"
 #include "StyleInheritedData.h"
+#include <wtf/CheckedPtr.h>
 #include <wtf/SetForScope.h>
 #include <wtf/StackStats.h>
 #include <wtf/TZoneMallocInlines.h>
@@ -1047,10 +1048,10 @@ void RenderTable::updateColumnCache() const
     ASSERT(!m_columnRenderersValid);
 
     unsigned columnIndex = 0;
-    for (RenderTableCol* columnRenderer = firstColumn(); columnRenderer; columnRenderer = columnRenderer->nextColumn()) {
+    for (CheckedPtr columnRenderer = firstColumn(); columnRenderer; columnRenderer = columnRenderer->nextColumn()) {
         if (columnRenderer->isTableColumnGroupWithColumnChildren())
             continue;
-        m_columnRenderers.append(columnRenderer);
+        m_columnRenderers.append(*columnRenderer);
         // FIXME: We should look to compute the effective column index successively from previous values instead of
         // calling colToEffCol(), which is in O(numEffCols()). Although it's unlikely that this is a hot function.
         m_effectiveColumnIndexMap.add(*columnRenderer, colToEffCol(columnIndex));
@@ -1063,10 +1064,10 @@ unsigned RenderTable::effectiveIndexOfColumn(const RenderTableCol& column) const
 {
     if (!m_columnRenderersValid)
         updateColumnCache();
-    const RenderTableCol* columnToUse = &column;
+    CheckedPtr<const RenderTableCol> columnToUse = &column;
     if (columnToUse->isTableColumnGroupWithColumnChildren())
         columnToUse = columnToUse->nextColumn(); // First column in column-group
-    auto it = m_effectiveColumnIndexMap.find(columnToUse);
+    auto it = m_effectiveColumnIndexMap.find(columnToUse.get());
     ASSERT(it != m_effectiveColumnIndexMap.end());
     if (it == m_effectiveColumnIndexMap.end())
         return std::numeric_limits<unsigned>::max();
@@ -1095,7 +1096,7 @@ LayoutUnit RenderTable::offsetLeftForColumn(const RenderTableCol& column) const
 
 LayoutUnit RenderTable::offsetWidthForColumn(const RenderTableCol& column) const
 {
-    const RenderTableCol* currentColumn = &column;
+    CheckedPtr<const RenderTableCol> currentColumn = &column;
     bool hasColumnChildren;
     if ((hasColumnChildren = currentColumn->isTableColumnGroupWithColumnChildren()))
         currentColumn = currentColumn->nextColumn(); // First column in column-group

--- a/Source/WebCore/rendering/RenderTable.h
+++ b/Source/WebCore/rendering/RenderTable.h
@@ -29,6 +29,7 @@
 #include "CollapsedBorderValue.h"
 #include "RenderBlock.h"
 #include <memory>
+#include <wtf/CheckedPtr.h>
 #include <wtf/HashMap.h>
 #include <wtf/Vector.h>
 

--- a/Source/WebCore/rendering/RenderTableCell.cpp
+++ b/Source/WebCore/rendering/RenderTableCell.cpp
@@ -48,6 +48,7 @@
 #include "StyleProperties.h"
 #include "TransformState.h"
 #include <ranges>
+#include <wtf/CheckedPtr.h>
 #include <wtf/StackStats.h>
 #include <wtf/TZoneMallocInlines.h>
 
@@ -174,7 +175,7 @@ void RenderTableCell::colSpanOrRowSpanChanged()
 Length RenderTableCell::logicalWidthFromColumns(RenderTableCol* firstColForThisCell, Length widthFromStyle) const
 {
     ASSERT(firstColForThisCell && firstColForThisCell == table()->colElement(col()));
-    RenderTableCol* tableCol = firstColForThisCell;
+    CheckedPtr tableCol = firstColForThisCell;
 
     unsigned colSpanCount = colSpan();
     LayoutUnit colWidthSum;
@@ -669,7 +670,7 @@ CollapsedBorderValue RenderTableCell::computeCollapsedStartBorder(IncludeBorderC
             if (!result.exists())
                 return result;
             // Next, apply the start border of the enclosing colgroup but only if it is adjacent to the cell's edge.
-            if (RenderTableCol* enclosingColumnGroup = colElt->enclosingColumnGroupIfAdjacentBefore()) {
+            if (CheckedPtr enclosingColumnGroup = colElt->enclosingColumnGroupIfAdjacentBefore()) {
                 result = chooseBorder(result, CollapsedBorderValue(enclosingColumnGroup->borderAdjoiningCellStartBorder(), includeColor ? enclosingColumnGroup->style().visitedDependentColorWithColorFilter(startColorProperty) : Color(), BorderPrecedence::ColumnGroup));
                 if (!result.exists())
                     return result;
@@ -692,7 +693,7 @@ CollapsedBorderValue RenderTableCell::computeCollapsedStartBorder(IncludeBorderC
                     return result;
                 // Next, if the previous col has a parent colgroup then its end border should be applied
                 // but only if it is adjacent to the cell's edge.
-                if (RenderTableCol* enclosingColumnGroup = colElt->enclosingColumnGroupIfAdjacentAfter()) {
+                if (CheckedPtr enclosingColumnGroup = colElt->enclosingColumnGroupIfAdjacentAfter()) {
                     result = chooseBorder(CollapsedBorderValue(enclosingColumnGroup->borderAdjoiningCellEndBorder(), includeColor ? enclosingColumnGroup->style().visitedDependentColorWithColorFilter(endColorProperty) : Color(), BorderPrecedence::ColumnGroup), result);
                     if (!result.exists())
                         return result;
@@ -784,7 +785,7 @@ CollapsedBorderValue RenderTableCell::computeCollapsedEndBorder(IncludeBorderCol
             if (!result.exists())
                 return result;
             // Next, if it has a parent colgroup then we apply its end border but only if it is adjacent to the cell.
-            if (RenderTableCol* enclosingColumnGroup = colElt->enclosingColumnGroupIfAdjacentAfter()) {
+            if (CheckedPtr enclosingColumnGroup = colElt->enclosingColumnGroupIfAdjacentAfter()) {
                 result = chooseBorder(result, CollapsedBorderValue(enclosingColumnGroup->borderAdjoiningCellEndBorder(), includeColor ? enclosingColumnGroup->style().visitedDependentColorWithColorFilter(endColorProperty) : Color(), BorderPrecedence::ColumnGroup));
                 if (!result.exists())
                     return result;
@@ -806,7 +807,7 @@ CollapsedBorderValue RenderTableCell::computeCollapsedEndBorder(IncludeBorderCol
                 if (!result.exists())
                     return result;
                 // If we have a parent colgroup, resolve the border only if it is adjacent to the cell.
-                if (RenderTableCol* enclosingColumnGroup = colElt->enclosingColumnGroupIfAdjacentBefore()) {
+                if (CheckedPtr enclosingColumnGroup = colElt->enclosingColumnGroupIfAdjacentBefore()) {
                     result = chooseBorder(result, CollapsedBorderValue(enclosingColumnGroup->borderAdjoiningCellStartBorder(), includeColor ? enclosingColumnGroup->style().visitedDependentColorWithColorFilter(startColorProperty) : Color(), BorderPrecedence::ColumnGroup));
                     if (!result.exists())
                         return result;
@@ -906,7 +907,7 @@ CollapsedBorderValue RenderTableCell::computeCollapsedBeforeBorder(IncludeBorder
             result = chooseBorder(result, CollapsedBorderValue(colElt->style().borderBefore(tableWritingMode()), includeColor ? colElt->style().visitedDependentColorWithColorFilter(beforeColorProperty) : Color(), BorderPrecedence::Column));
             if (!result.exists())
                 return result;
-            if (RenderTableCol* enclosingColumnGroup = colElt->enclosingColumnGroup()) {
+            if (CheckedPtr enclosingColumnGroup = colElt->enclosingColumnGroup()) {
                 result = chooseBorder(result, CollapsedBorderValue(enclosingColumnGroup->style().borderBefore(tableWritingMode()), includeColor ? enclosingColumnGroup->style().visitedDependentColorWithColorFilter(beforeColorProperty) : Color(), BorderPrecedence::ColumnGroup));
                 if (!result.exists())
                     return result;
@@ -994,7 +995,7 @@ CollapsedBorderValue RenderTableCell::computeCollapsedAfterBorder(IncludeBorderC
         if (colElt) {
             result = chooseBorder(result, CollapsedBorderValue(colElt->style().borderAfter(tableWritingMode()), includeColor ? colElt->style().visitedDependentColorWithColorFilter(afterColorProperty) : Color(), BorderPrecedence::Column));
             if (!result.exists()) return result;
-            if (RenderTableCol* enclosingColumnGroup = colElt->enclosingColumnGroup()) {
+            if (CheckedPtr enclosingColumnGroup = colElt->enclosingColumnGroup()) {
                 result = chooseBorder(result, CollapsedBorderValue(enclosingColumnGroup->style().borderAfter(tableWritingMode()), includeColor ? enclosingColumnGroup->style().visitedDependentColorWithColorFilter(afterColorProperty) : Color(), BorderPrecedence::ColumnGroup));
                 if (!result.exists())
                     return result;

--- a/Source/WebCore/rendering/RenderTableCol.cpp
+++ b/Source/WebCore/rendering/RenderTableCol.cpp
@@ -38,6 +38,8 @@
 #include "RenderTable.h"
 #include "RenderTableCaption.h"
 #include "RenderTableCell.h"
+#include "rendering/RenderObject.h"
+#include "rendering/style/RenderStyle.h"
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
@@ -67,21 +69,23 @@ RenderTableCol::~RenderTableCol() = default;
 void RenderTableCol::styleDidChange(StyleDifference diff, const RenderStyle* oldStyle)
 {
     RenderBox::styleDidChange(diff, oldStyle);
-    RenderTable* table = this->table();
+    CheckedPtr table = this->table();
     if (!table)
         return;
     // If border was changed, notify table.
     if (!oldStyle)
         return;
-    table->invalidateCollapsedBordersAfterStyleChangeIfNeeded(*oldStyle, style());
+
+    CheckedRef<const RenderStyle> newStyle = style();
+    table->invalidateCollapsedBordersAfterStyleChangeIfNeeded(*oldStyle, newStyle);
     if (oldStyle->width() != style().width()) {
         table->recalcSectionsIfNeeded();
-        for (auto& section : childrenOfType<RenderTableSection>(*table)) {
+        for (CheckedRef section : childrenOfType<RenderTableSection>(*table)) {
             unsigned nEffCols = table->numEffCols();
             for (unsigned j = 0; j < nEffCols; j++) {
-                unsigned rowCount = section.numRows();
+                unsigned rowCount = section->numRows();
                 for (unsigned i = 0; i < rowCount; i++) {
-                    RenderTableCell* cell = section.primaryCellAt(i, j);
+                    CheckedPtr cell = section->primaryCellAt(i, j);
                     if (!cell)
                         continue;
                     cell->setPreferredLogicalWidthsDirty(true);
@@ -103,7 +107,7 @@ void RenderTableCol::updateFromElement()
     if (m_span != oldSpan && parent()) {
         if (hasInitializedStyle())
             setNeedsLayoutAndPrefWidthsRecalc();
-        if (RenderTable* table = this->table())
+        if (CheckedPtr table = this->table())
             table->invalidateColumns();
     }
 }
@@ -117,7 +121,7 @@ void RenderTableCol::insertedIntoTree()
 void RenderTableCol::willBeRemovedFromTree()
 {
     RenderBox::willBeRemovedFromTree();
-    if (auto* table = this->table()) {
+    if (CheckedPtr table = this->table()) {
         // We only need to invalidate the column cache when only individual columns are being removed (as opposed to when the entire table is being collapsed).
         table->invalidateColumns();
     }
@@ -143,7 +147,7 @@ LayoutRect RenderTableCol::clippedOverflowRect(const RenderLayerModelObject* rep
     // might have propagated a background color or borders into.
     // FIXME: check for repaintContainer each time here?
 
-    auto* parentTable = table();
+    CheckedPtr parentTable = table();
     if (!parentTable)
         return { };
 
@@ -168,21 +172,22 @@ void RenderTableCol::clearPreferredLogicalWidthsDirtyBits()
 {
     setPreferredLogicalWidthsDirty(false);
 
-    for (auto& child : childrenOfType<RenderObject>(*this))
-        child.setPreferredLogicalWidthsDirty(false);
+    for (CheckedRef<RenderObject> child : childrenOfType<RenderObject>(*this))
+        child->setPreferredLogicalWidthsDirty(false);
 }
 
-RenderTable* RenderTableCol::table() const
+CheckedPtr<RenderTable> RenderTableCol::table() const
 {
-    auto table = parent();
+    CheckedPtr table = parent();
     if (table && !is<RenderTable>(*table))
         table = table->parent();
+
     return dynamicDowncast<RenderTable>(table);
 }
 
-RenderTableCol* RenderTableCol::enclosingColumnGroup() const
+CheckedPtr<RenderTableCol> RenderTableCol::enclosingColumnGroup() const
 {
-    auto* parentColumnGroup = dynamicDowncast<RenderTableCol>(*parent());
+    CheckedPtr parentColumnGroup = dynamicDowncast<RenderTableCol>(*parent());
     if (!parentColumnGroup)
         return nullptr;
 
@@ -191,21 +196,22 @@ RenderTableCol* RenderTableCol::enclosingColumnGroup() const
     return parentColumnGroup;
 }
 
-RenderTableCol* RenderTableCol::nextColumn() const
+CheckedPtr<RenderTableCol> RenderTableCol::nextColumn() const
 {
     // If |this| is a column-group, the next column is the colgroup's first child column.
-    if (RenderObject* firstChild = this->firstChild())
-        return downcast<RenderTableCol>(firstChild);
+    if (CheckedPtr firstChild = this->firstChild())
+        return dynamicDowncast<RenderTableCol>(*firstChild);
 
     // Otherwise it's the next column along.
-    RenderObject* next = nextSibling();
+    CheckedPtr next = nextSibling();
+    CheckedPtr parentElement = parent();
 
     // Failing that, the child is the last column in a column-group, so the next column is the next column/column-group after its column-group.
-    if (!next && is<RenderTableCol>(*parent()))
-        next = parent()->nextSibling();
+    if (!next && parentElement && is<RenderTableCol>(*parentElement))
+        next = parentElement->nextSibling();
 
     for (; next; next = next->nextSibling()) {
-        if (auto* column = dynamicDowncast<RenderTableCol>(*next))
+        if (CheckedPtr column = dynamicDowncast<RenderTableCol>(*next))
             return column;
     }
 
@@ -214,24 +220,28 @@ RenderTableCol* RenderTableCol::nextColumn() const
 
 const BorderValue& RenderTableCol::borderAdjoiningCellStartBorder() const
 {
-    return style().borderStart(table()->writingMode());
+    const WritingMode tableWritingMode = table()->writingMode();
+    return protectedStyle()->borderStart(tableWritingMode);
 }
 
 const BorderValue& RenderTableCol::borderAdjoiningCellEndBorder() const
 {
-    return style().borderEnd(table()->writingMode());
+    const WritingMode tableWritingMode = table()->writingMode();
+    return protectedStyle()->borderEnd(tableWritingMode);
 }
 
 const BorderValue& RenderTableCol::borderAdjoiningCellBefore(const RenderTableCell& cell) const
 {
+    const WritingMode tableWritingMode = table()->writingMode();
     ASSERT_UNUSED(cell, table()->colElement(cell.col() + cell.colSpan()) == this);
-    return style().borderStart(table()->writingMode());
+    return protectedStyle()->borderStart(tableWritingMode);
 }
 
 const BorderValue& RenderTableCol::borderAdjoiningCellAfter(const RenderTableCell& cell) const
 {
+    const WritingMode tableWritingMode = table()->writingMode();
     ASSERT_UNUSED(cell, table()->colElement(cell.col() - 1) == this);
-    return style().borderEnd(table()->writingMode());
+    return protectedStyle()->borderEnd(tableWritingMode);
 }
 
 LayoutUnit RenderTableCol::offsetLeft() const

--- a/Source/WebCore/rendering/RenderTableCol.h
+++ b/Source/WebCore/rendering/RenderTableCol.h
@@ -26,6 +26,8 @@
 #pragma once
 
 #include "RenderBox.h"
+#include <wtf/CheckedPtr.h>
+#include <wtf/CheckedRef.h>
 
 namespace WebCore {
 
@@ -49,12 +51,12 @@ public:
     bool isTableColumn() const { return style().display() == DisplayType::TableColumn; }
     bool isTableColumnGroup() const { return style().display() == DisplayType::TableColumnGroup; }
 
-    RenderTableCol* enclosingColumnGroup() const;
-    RenderTableCol* enclosingColumnGroupIfAdjacentBefore() const;
-    RenderTableCol* enclosingColumnGroupIfAdjacentAfter() const;
+    CheckedPtr<RenderTableCol> enclosingColumnGroup() const;
+    CheckedPtr<RenderTableCol> enclosingColumnGroupIfAdjacentBefore() const;
+    CheckedPtr<RenderTableCol> enclosingColumnGroupIfAdjacentAfter() const;
 
     // Returns the next column or column-group.
-    RenderTableCol* nextColumn() const;
+    CheckedPtr<RenderTableCol> nextColumn() const;
 
     const BorderValue& borderAdjoiningCellStartBorder() const;
     const BorderValue& borderAdjoiningCellEndBorder() const;
@@ -87,19 +89,19 @@ private:
     void styleDidChange(StyleDifference, const RenderStyle* oldStyle) override;
     void paint(PaintInfo&, const LayoutPoint&) override { }
 
-    RenderTable* table() const;
+    CheckedPtr<RenderTable> table() const;
 
     unsigned m_span { 1 };
 };
 
-inline RenderTableCol* RenderTableCol::enclosingColumnGroupIfAdjacentBefore() const
+inline CheckedPtr<RenderTableCol> RenderTableCol::enclosingColumnGroupIfAdjacentBefore() const
 {
     if (previousSibling())
         return nullptr;
     return enclosingColumnGroup();
 }
 
-inline RenderTableCol* RenderTableCol::enclosingColumnGroupIfAdjacentAfter() const
+inline CheckedPtr<RenderTableCol> RenderTableCol::enclosingColumnGroupIfAdjacentAfter() const
 {
     if (nextSibling())
         return nullptr;

--- a/Source/WebCore/rendering/RenderTableSection.cpp
+++ b/Source/WebCore/rendering/RenderTableSection.cpp
@@ -986,8 +986,8 @@ void RenderTableSection::paintCell(RenderTableCell* cell, PaintInfo& paintInfo, 
         // Note that we deliberately ignore whether or not the cell has a layer, since these backgrounds paint "behind" the
         // cell.
         if (RenderTableCol* column = table()->colElement(cell->col())) {
-            if (RenderTableCol* columnGroup = column->enclosingColumnGroup())
-                cell->paintBackgroundsBehindCell(paintInfo, cellPoint, columnGroup, cellPoint);
+            if (CheckedPtr columnGroup = column->enclosingColumnGroup())
+                cell->paintBackgroundsBehindCell(paintInfo, cellPoint, columnGroup.get(), cellPoint);
             cell->paintBackgroundsBehindCell(paintInfo, cellPoint, column, cellPoint);
         }
 


### PR DESCRIPTION
#### 548dd5dbfa84c67a969c9adeb6861633b12f4d39
<pre>
[Safe CPP] Address Warnings in RenderTableCol.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=293051">https://bugs.webkit.org/show_bug.cgi?id=293051</a>
<a href="https://rdar.apple.com/problem/151391328">rdar://problem/151391328</a>

Reviewed by Ryosuke Niwa.

Address safe cpp warnings in RenderTableCol.cpp.

To address the warnings I was required to implement downcast support into
CheckedPtrs. The implementation is based off of RefPtr&apos;s downcast support with
minor changes to account for differences between classes and implement the static_pointer_cast
directly into the function.

 * Source/WTF/wtf/CheckedPtr.h:
 (WTF::uncheckedDowncast):
 (WTF::downcast):
 (WTF::dynamicDowncast):
 * Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations:
 * Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations:
 * Source/WebCore/rendering/AutoTableLayout.cpp:
 (WebCore::AutoTableLayout::fullRecalc):
 * Source/WebCore/rendering/FixedTableLayout.cpp:
 (WebCore::FixedTableLayout::calcWidthArray):
 * Source/WebCore/rendering/RenderElement.h:
 (WebCore::RenderElement::protectedStyle const):
 * Source/WebCore/rendering/RenderTable.cpp:
 (WebCore::RenderTable::updateColumnCache const):
 (WebCore::RenderTable::effectiveIndexOfColumn const):
 (WebCore::RenderTable::offsetWidthForColumn const):
 * Source/WebCore/rendering/RenderTable.h:
 * Source/WebCore/rendering/RenderTableCell.cpp:
 (WebCore::RenderTableCell::logicalWidthFromColumns const):
 (WebCore::RenderTableCell::computeCollapsedStartBorder const):
 (WebCore::RenderTableCell::computeCollapsedEndBorder const):
(WebCore::RenderTableCell::computeCollapsedBeforeBorder const):
 (WebCore::RenderTableCell::computeCollapsedAfterBorder const):
 * Source/WebCore/rendering/RenderTableCol.cpp:
 (WebCore::RenderTableCol::styleDidChange):
 (WebCore::RenderTableCol::updateFromElement):
 (WebCore::RenderTableCol::willBeRemovedFromTree):
(WebCore::RenderTableCol::clippedOverflowRect const):
 (WebCore::RenderTableCol::clearPreferredLogicalWidthsDirtyBits):
 (WebCore::RenderTableCol::table const):
 (WebCore::RenderTableCol::enclosingColumnGroup const):
 (WebCore::RenderTableCol::nextColumn const):
 (WebCore::RenderTableCol::borderAdjoiningCellStartBorder const):
 (WebCore::RenderTableCol::borderAdjoiningCellEndBorder const):
 (WebCore::RenderTableCol::borderAdjoiningCellBefore const):
 (WebCore::RenderTableCol::borderAdjoiningCellAfter const):
 * Source/WebCore/rendering/RenderTableCol.h:
 (WebCore::RenderTableCol::enclosingColumnGroupIfAdjacentBefore const):
 (WebCore::RenderTableCol::enclosingColumnGroupIfAdjacentAfter const):
 * Source/WebCore/rendering/RenderTableSection.cpp:
 (WebCore::RenderTableSection::paintCell):

Canonical link: <a href="https://commits.webkit.org/295455@main">https://commits.webkit.org/295455@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dcafb7385d9b6ad19b14ada693917d0ce46b5542

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104443 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24147 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/14571 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/109650 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/55114 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/106483 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/24534 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/32694 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79319 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107449 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19086 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94271 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59645 "Found 1 new API test failure: /WPE/TestSSL:/webkit/WebKitWebView/ephemeral-tls-errors (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/18879 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/12343 "Passed tests") | [❌ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/54481 "Failed to compile WebKit") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/97122 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/88579 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/12401 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/112037 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/103060 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/31604 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23284 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88355 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/31968 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/90504 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88021 "Found 1 new API test failure: /WebKitGTK/TestCookieManager:/webkit/WebKitCookieManager/persistent-storage (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22583 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32907 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10686 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/26079 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/31533 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/36863 "Built successfully") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/127325 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Failed to compile JSC; Compiled JSC (cancelled)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/31323 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/127325 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Failed to compile JSC; Compiled JSC (cancelled)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/34662 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/32883 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->