### PR TITLE
[Site Isolation] Fix fast/loader/policy-delegate-action-hit-test-zoomed.html

### DIFF
--- a/LayoutTests/platform/mac-site-isolation/TestExpectations
+++ b/LayoutTests/platform/mac-site-isolation/TestExpectations
@@ -12280,7 +12280,6 @@ fast/loader/images-enabled-unset-can-block-image-and-can-reload-in-place.html [ 
 fast/loader/main-document-url-for-non-http-loads.html [ Failure ]
 fast/loader/onload-bad-scheme-for-frame.html [ Failure ]
 fast/loader/onload-willSendRequest-null-for-frame.html [ Failure ]
-fast/loader/policy-delegate-action-hit-test-zoomed.html [ Failure ]
 fast/loader/redirect-to-invalid-url-using-javascript-disallowed.html [ Failure ]
 fast/loader/redirect-to-invalid-url-using-meta-refresh-calls-policy-delegate.html [ Failure ]
 fast/loader/redirect-to-invalid-url-using-meta-refresh-disallowed-async-delegates.html [ Failure ]

--- a/Tools/WebKitTestRunner/InjectedBundle/EventSendingController.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/EventSendingController.cpp
@@ -41,8 +41,6 @@
 
 namespace WTR {
 
-static const float ZoomMultiplierRatio = 1.2f;
-
 struct MenuItemPrivateData {
     MenuItemPrivateData(WKBundlePageRef page, WKContextMenuItemRef item) :
         m_page(page),
@@ -475,45 +473,33 @@ JSValueRef EventSendingController::contextClick(JSContextRef context)
 
 void EventSendingController::textZoomIn()
 {
-    auto& injectedBundle = InjectedBundle::singleton();
-    double zoomFactor = WKBundlePageGetTextZoomFactor(injectedBundle.page()->page()) * ZoomMultiplierRatio;
-
     auto body = adoptWK(WKMutableDictionaryCreate());
     setValue(body, "SubMessage", "SetTextZoom");
-    setValue(body, "ZoomFactor", zoomFactor);
+    setValue(body, "ZoomIn", true);
     postSynchronousPageMessage("EventSender", body);
 }
 
 void EventSendingController::textZoomOut()
 {
-    auto& injectedBundle = InjectedBundle::singleton();
-    double zoomFactor = WKBundlePageGetTextZoomFactor(injectedBundle.page()->page()) / ZoomMultiplierRatio;
-
     auto body = adoptWK(WKMutableDictionaryCreate());
     setValue(body, "SubMessage", "SetTextZoom");
-    setValue(body, "ZoomFactor", zoomFactor);
+    setValue(body, "ZoomIn", false);
     postSynchronousPageMessage("EventSender", body);
 }
 
 void EventSendingController::zoomPageIn()
 {
-    auto& injectedBundle = InjectedBundle::singleton();
-    double zoomFactor = WKBundlePageGetPageZoomFactor(injectedBundle.page()->page()) * ZoomMultiplierRatio;
-
     auto body = adoptWK(WKMutableDictionaryCreate());
     setValue(body, "SubMessage", "SetPageZoom");
-    setValue(body, "ZoomFactor", zoomFactor);
+    setValue(body, "ZoomIn", true);
     postSynchronousPageMessage("EventSender", body);
 }
 
 void EventSendingController::zoomPageOut()
 {
-    auto& injectedBundle = InjectedBundle::singleton();
-    double zoomFactor = WKBundlePageGetPageZoomFactor(injectedBundle.page()->page()) / ZoomMultiplierRatio;
-
     auto body = adoptWK(WKMutableDictionaryCreate());
     setValue(body, "SubMessage", "SetPageZoom");
-    setValue(body, "ZoomFactor", zoomFactor);
+    setValue(body, "ZoomIn", false);
     postSynchronousPageMessage("EventSender", body);
 }
 

--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -128,6 +128,8 @@ static constexpr auto pathSeparator = '/';
 const WTF::Seconds TestController::defaultShortTimeout = 5_s;
 const WTF::Seconds TestController::noTimeout = -1_s;
 
+static const double ZoomMultiplierRatio = 1.2;
+
 static WKURLRef blankURL()
 {
     static WKURLRef staticBlankURL = WKURLCreateWithUTF8CString("about:blank");
@@ -2610,14 +2612,14 @@ void TestController::didReceiveSynchronousMessageFromInjectedBundle(WKStringRef 
         if (WKStringIsEqualToUTF8CString(subMessageName, "SetPageZoom")) {
             auto* page = mainWebView()->page();
             WKPageSetTextZoomFactor(page, 1);
-            WKPageSetPageZoomFactor(page, doubleValue(dictionary, "ZoomFactor"));
+            WKPageSetPageZoomFactor(page, WKPageGetPageZoomFactor(page) * (booleanValue(dictionary, "ZoomIn") ? ZoomMultiplierRatio : (1.0 / ZoomMultiplierRatio)));
             return completionHandler(nullptr);
         }
 
         if (WKStringIsEqualToUTF8CString(subMessageName, "SetTextZoom")) {
             auto* page = mainWebView()->page();
             WKPageSetPageZoomFactor(page, 1);
-            WKPageSetTextZoomFactor(page, doubleValue(dictionary, "ZoomFactor"));
+            WKPageSetTextZoomFactor(page, WKPageGetTextZoomFactor(page) * (booleanValue(dictionary, "ZoomIn") ? ZoomMultiplierRatio : (1.0 / ZoomMultiplierRatio)));
             return completionHandler(nullptr);
         }
 


### PR DESCRIPTION
#### e4963ad7465d5c673273c5feca1e26d0cacf0308
<pre>
[Site Isolation] Fix fast/loader/policy-delegate-action-hit-test-zoomed.html
<a href="https://bugs.webkit.org/show_bug.cgi?id=293053">https://bugs.webkit.org/show_bug.cgi?id=293053</a>
<a href="https://rdar.apple.com/151392044">rdar://151392044</a>

Reviewed by Alex Christensen.

`WKBundlePageGetPageZoomFactor` won’t always return the correct zoom level with site isolation. Replace
its use in WKTR.

* LayoutTests/platform/mac-site-isolation/TestExpectations:
* Tools/WebKitTestRunner/InjectedBundle/EventSendingController.cpp:
(WTR::EventSendingController::textZoomIn):
(WTR::EventSendingController::textZoomOut):
(WTR::EventSendingController::zoomPageIn):
(WTR::EventSendingController::zoomPageOut):
* Tools/WebKitTestRunner/TestController.cpp:
(WTR::TestController::didReceiveSynchronousMessageFromInjectedBundle):

Canonical link: <a href="https://commits.webkit.org/295066@main">https://commits.webkit.org/295066@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cbae5357dab5a833334c0f2c4b8bd2fd2fde730b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/103877 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/23580 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/13901 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/109070 "Built successfully") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/54538 "") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/105917 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/23933 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/32125 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78917 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/54538 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/106883 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/18589 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/93711 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59246 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/18385 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/11762 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/53905 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/88140 "Found 1 new API test failure: TestWebKitAPI.CARingBufferTest.FetchTimeBoundsConsistent (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/11820 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/111457 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/31033 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/22879 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/87924 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/31395 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/89912 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87577 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32467 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10201 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/25399 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16881 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/30962 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/30755 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/34092 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/32316 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->