### PR TITLE
Sync `cors` from WPT upstream

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/cors/304.htm
+++ b/LayoutTests/imported/w3c/web-platform-tests/cors/304.htm
@@ -29,7 +29,7 @@ function req(url, id, t, ready) {
   client.onreadystatechange = function() {
     if (client.readyState == client.DONE) {
       t.step(function() {
-        assert_true(client.status != 299, "req " + id + " server says: " + client.responseText)
+        assert_not_equals(client.status, 299, "req " + id + " server says: " + client.responseText)
       })
       ready(client)
     }

--- a/LayoutTests/imported/w3c/web-platform-tests/cors/META.yml
+++ b/LayoutTests/imported/w3c/web-platform-tests/cors/META.yml
@@ -1,6 +1,5 @@
 spec: https://fetch.spec.whatwg.org/#http-cors-protocol
 suggested_reviewers:
-  - zqzhang
   - odinho
   - hillbrad
   - jdm

--- a/LayoutTests/imported/w3c/web-platform-tests/cors/WEB_FEATURES.yml
+++ b/LayoutTests/imported/w3c/web-platform-tests/cors/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: cors
+  files: "**"

--- a/LayoutTests/imported/w3c/web-platform-tests/cors/access-control-expose-headers-parsing.window.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/cors/access-control-expose-headers-parsing.window.js
@@ -1,13 +1,11 @@
-// META: script=/common/get-host-info.sub.js
-
 promise_test(() => fetch("resources/access-control-expose-headers.json").then(res => res.json()).then(runTests), "Loading JSON…");
 
 function runTests(allTestData) {
   allTestData.forEach(testData => {
     const encodedInput = encodeURIComponent(testData.input);
     promise_test(() => {
-      const relativeURL = "cors/resources/expose-headers.py?expose=" + encodedInput,
-            url = new URL(relativeURL, get_host_info().HTTP_REMOTE_ORIGIN);
+      const relativeURL = "resources/expose-headers.py?expose=" + encodedInput,
+            url = new URL(relativeURL, location.href).href.replace("://", "://élève.");
       return fetch(url).then(res => {
         assert_equals(res.headers.get("content-language"), "mkay");
         assert_equals(res.headers.get("bb-8"), (testData.exposed ? "hey" : null));

--- a/LayoutTests/imported/w3c/web-platform-tests/cors/basic.htm
+++ b/LayoutTests/imported/w3c/web-platform-tests/cors/basic.htm
@@ -6,57 +6,49 @@
 
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
+<script src=/common/utils.js></script>
 <script src=support.js?pipe=sub></script>
 <div id=log></div>
 
 <script>
+function cors(desc, scheme, subdomain = "", port = location.port) {
+    const sameorigin = !scheme;
+    const base =
+        sameorigin ? "" : `${scheme}://${subdomain}${location.hostname}:${port}${dirname(location.pathname)}`;
 
-var counter = 0;
-
-function cors(desc, scheme, subdomain, port) {
-    if (!scheme) {
-        var url = "";
-    } else {
-        if (!port) {
-            port = location.port;
-        }
-        var url = scheme + "://" + (subdomain ? subdomain + "." : "") + location.hostname + ":" + port + dirname(location.pathname)
-    }
-    async_test(desc).step(function() {
-        var client = new XMLHttpRequest();
-        this.count = counter++;
-
-        client.open("GET", url + "resources/cors-makeheader.py?get_value=hest_er_best&origin=none&" + this.count);
-
-        client.onreadystatechange = this.step_func(function(e) {
-            // First request, test that it fails with no origin
-            if (client.readyState < 4) return;
-            if (!url)
-                assert_true(client.response.indexOf("hest_er_best") != -1, "Got response");
-            else
-                assert_false(!!client.response, "Got CORS-disallowed response");
-
-            client = new XMLHttpRequest();
-            client.open("GET", url + "resources/cors-makeheader.py?get_value=hest_er_best&" + this.count);
-            client.onreadystatechange = this.step_func(function(e) {
-                // Second request, test that it passes with the allowed-origin
-                if (client.readyState < 4) return;
-                assert_true(client.response.indexOf("hest_er_best") != -1, "Got CORS-allowed response");
-                this.done();
-            });
-            client.send();
-        });
+    async_test((t) => {
+        const client = new XMLHttpRequest();
+        client.open("GET", `${base}resources/cors-makeheader.py?get_value=hest_er_best&origin=none&${token()}`);
         client.send();
-    });
+
+        client.onload = t.step_func_done(() => {
+            assert_true(sameorigin, "Cross origin request must be rejected.");
+            assert_true(client.response.includes("hest_er_best"), "Got response");
+        });
+        client.onerror = t.step_func_done(() => {
+            assert_false(sameorigin, "Same origin request must be accepted.");
+        });
+    }, `${desc}, origin: none`);
+
+    async_test((t) => {
+        const client = new XMLHttpRequest();
+        client.open("GET", `${base}resources/cors-makeheader.py?get_value=hest_er_best&${token()}`);
+        client.send();
+
+        client.onload = t.step_func_done(() => {
+            assert_true(client.response.includes("hest_er_best"), "Got response");
+        });
+        client.onerror = t.unreached_func("Should be accepted");
+    }, `${desc}, origin: echo`);
 }
 
 cors("Same domain basic usage");
-cors("Cross domain basic usage", "http", "www1");
+cors("Cross domain basic usage", "http", "www1.");
 cors("Same domain different port", "http", undefined, PORT);
 
-cors("Cross domain different port", "http", "www1", PORT);
+cors("Cross domain different port", "http", "www1.", PORT);
 
-cors("Cross domain different protocol", "https", "www1", PORTS);
+cors("Cross domain different protocol", "https", "www1.", PORTS);
 
 cors("Same domain different protocol different port", "https", undefined, PORTS);
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cors/client-hint-request-headers-2.tentative.htm
+++ b/LayoutTests/imported/w3c/web-platform-tests/cors/client-hint-request-headers-2.tentative.htm
@@ -23,6 +23,9 @@ test(function() {
     client.setRequestHeader('dpr', '2.0')
     client.setRequestHeader('width', '35')
     client.setRequestHeader('viewport-width', '42')
+    client.setRequestHeader('rtt', '1')
+    client.setRequestHeader('downlink', '1.0')
+    client.setRequestHeader('ect', '2g')
     client.send(null)
 
     const res = JSON.parse(client.response)
@@ -36,6 +39,9 @@ test(function() {
     assert_equals(res['dpr'], '2.0')
     assert_equals(res['width'], '35')
     assert_equals(res['viewport-width'], '42')
+    assert_equals(res['rtt'], '1')
+    assert_equals(res['downlink'], '1.0')
+    assert_equals(res['ect'], '2g')
 }, 'Client hint headers are simple headers')
 
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/cors/client-hint-request-headers-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cors/client-hint-request-headers-expected.txt
@@ -6,4 +6,7 @@ PASS Unextractable device-memory client hint header is disallowed
 PASS Unextractable DPR client hint header is disallowed
 PASS Unextractable width client hint header is disallowed
 PASS Unextractable viewport-width client hint header is disallowed
+PASS Test invalid rtt value is disallowed
+PASS Test invalid downlink value is disallowed
+PASS Test invalid ect value is disallowed
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cors/client-hint-request-headers.htm
+++ b/LayoutTests/imported/w3c/web-platform-tests/cors/client-hint-request-headers.htm
@@ -46,4 +46,37 @@ test(function() {
     assert_throws_dom("NetworkError", function() { client.send(null) })
 }, 'Unextractable viewport-width client hint header is disallowed')
 
+test(function() {
+    var client = new XMLHttpRequest()
+    client.open('GET', CROSSDOMAIN + 'resources/cors-makeheader.py?headers=x-print', false)
+    client.setRequestHeader('rtt', '')
+    assert_throws_dom("NetworkError", function() { client.send(null) })
+    client = new XMLHttpRequest()
+    client.open('GET', CROSSDOMAIN + 'resources/cors-makeheader.py?headers=x-print', false)
+    client.setRequestHeader('rtt', '-1')
+    assert_throws_dom("NetworkError", function() { client.send(null) })
+}, 'Test invalid rtt value is disallowed')
+
+test(function() {
+    var client = new XMLHttpRequest()
+    client.open('GET', CROSSDOMAIN + 'resources/cors-makeheader.py?headers=x-print', false)
+    client.setRequestHeader('downlink', '')
+    assert_throws_dom("NetworkError", function() { client.send(null) })
+    client = new XMLHttpRequest()
+    client.open('GET', CROSSDOMAIN + 'resources/cors-makeheader.py?headers=x-print', false)
+    client.setRequestHeader('downlink', '-1.0')
+    assert_throws_dom("NetworkError", function() { client.send(null) })
+}, 'Test invalid downlink value is disallowed')
+
+test(function() {
+    var client = new XMLHttpRequest()
+    client.open('GET', CROSSDOMAIN + 'resources/cors-makeheader.py?headers=x-print', false)
+    client.setRequestHeader('ect', '')
+    assert_throws_dom("NetworkError", function() { client.send(null) })
+    client = new XMLHttpRequest()
+    client.open('GET', CROSSDOMAIN + 'resources/cors-makeheader.py?headers=x-print', false)
+    client.setRequestHeader('ect', '6g')
+    assert_throws_dom("NetworkError", function() { client.send(null) })
+}, 'Test invalid ect value is disallowed')
+
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/cors/credentials-flag-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cors/credentials-flag-expected.txt
@@ -3,8 +3,8 @@ CORS - Access-Control-Allow-Credentials
 
 PASS Setting withCredentials on a sync XHR object should not throw
 PASS Don't send cookie by default
-FAIL Don't send cookie part 2 assert_equals: Cookie sent in withCredentials=true sync request expected "COOKIE" but got "NO_COOKIE"
-FAIL Don't obey Set-Cookie when withCredentials=false assert_equals: third expected "COOKIE" but got "NO_COOKIE"
+PASS Don't send cookie part 2
+PASS Don't obey Set-Cookie when withCredentials=false
 PASS Access-Control-Allow-Credentials: TRUE should be disallowed (async)
 PASS Access-Control-Allow-Credentials: True should be disallowed (async)
 PASS Access-Control-Allow-Credentials: "true" should be disallowed (async)

--- a/LayoutTests/imported/w3c/web-platform-tests/cors/origin-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cors/origin-expected.txt
@@ -8,7 +8,7 @@ PASS Allow origin: http://web-platform.test:8800
 PASS Allow origin: _http://web-platform.test:8800
 PASS Allow origin: _http://web-platform.test:8800___[tab]_
 PASS Allow origin: [tab]http://web-platform.test:8800
-PASS Disallow origin: http://not-web-platform.test.web-platform.test:8800
+PASS Disallow origin: http://www1.web-platform.test:8800
 PASS Disallow origin: //web-platform.test:8800
 PASS Disallow origin: ://web-platform.test:8800
 PASS Disallow origin: ftp://web-platform.test:8800
@@ -52,7 +52,7 @@ PASS Disallow origin: null *
 PASS Disallow origin:
 PASS Disallow origin: http://web-platform.test:8800/cors/origin.htm
 PASS Disallow origin: http://web-platform.test:8800/cors/
-PASS Disallow origin: http://not-web-platform.test:8800/cors/
+PASS Disallow origin: http://www1.web-platform.test:8800/cors/
 PASS Disallow origin: test:8800
 PASS Disallow origin: .test:8800
 PASS Disallow origin: *.test:8800

--- a/LayoutTests/imported/w3c/web-platform-tests/cors/redirect-origin-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cors/redirect-origin-expected.txt
@@ -1,47 +1,47 @@
 CORS redirect handling
 
 
-FAIL local (*) to remote (*), expect origin=http://web-platform.test:8800 assert_true: Got response expected true got false
-FAIL local (*) to remote (http://web-platform.test:8800), expect origin=http://web-platform.test:8800 assert_true: Got response expected true got false
+PASS local (*) to remote (*), expect origin=http://web-platform.test:8800
+PASS local (*) to remote (http://web-platform.test:8800), expect origin=http://web-platform.test:8800
 PASS local (*) to remote (null), expect to fail
 PASS local (*) to remote (none), expect to fail
-FAIL local (http://web-platform.test:8800) to remote (*), expect origin=http://web-platform.test:8800 assert_true: Got response expected true got false
-FAIL local (http://web-platform.test:8800) to remote (http://web-platform.test:8800), expect origin=http://web-platform.test:8800 assert_true: Got response expected true got false
+PASS local (http://web-platform.test:8800) to remote (*), expect origin=http://web-platform.test:8800
+PASS local (http://web-platform.test:8800) to remote (http://web-platform.test:8800), expect origin=http://web-platform.test:8800
 PASS local (http://web-platform.test:8800) to remote (null), expect to fail
 PASS local (http://web-platform.test:8800) to remote (none), expect to fail
-FAIL local (null) to remote (*), expect origin=http://web-platform.test:8800 assert_true: Got response expected true got false
-FAIL local (none) to remote (*), expect origin=http://web-platform.test:8800 assert_true: Got response expected true got false
-FAIL remote (*) to local (*), expect origin=null assert_true: Got response expected true got false
+PASS local (null) to remote (*), expect origin=http://web-platform.test:8800
+PASS local (none) to remote (*), expect origin=http://web-platform.test:8800
+PASS remote (*) to local (*), expect origin=null
 PASS remote (*) to local (http://web-platform.test:8800), expect to fail
-FAIL remote (*) to local (null), expect origin=null assert_true: Got response expected true got false
+PASS remote (*) to local (null), expect origin=null
 PASS remote (*) to local (none), expect to fail
-FAIL remote (http://web-platform.test:8800) to local (*), expect origin=null assert_true: Got response expected true got false
+PASS remote (http://web-platform.test:8800) to local (*), expect origin=null
 PASS remote (http://web-platform.test:8800) to local (http://web-platform.test:8800), expect to fail
-FAIL remote (http://web-platform.test:8800) to local (null), expect origin=null assert_true: Got response expected true got false
+PASS remote (http://web-platform.test:8800) to local (null), expect origin=null
 PASS remote (http://web-platform.test:8800) to local (none), expect to fail
 PASS remote (null) to local (*), expect to fail
 PASS remote (none) to local (*), expect to fail
-FAIL remote (*) to remote (*), expect origin=http://web-platform.test:8800 assert_true: Got response expected true got false
-FAIL remote (*) to remote (http://web-platform.test:8800), expect origin=http://web-platform.test:8800 assert_true: Got response expected true got false
+PASS remote (*) to remote (*), expect origin=http://web-platform.test:8800
+PASS remote (*) to remote (http://web-platform.test:8800), expect origin=http://web-platform.test:8800
 PASS remote (*) to remote (null), expect to fail
 PASS remote (*) to remote (none), expect to fail
-FAIL remote (http://web-platform.test:8800) to remote (*), expect origin=http://web-platform.test:8800 assert_true: Got response expected true got false
-FAIL remote (http://web-platform.test:8800) to remote (http://web-platform.test:8800), expect origin=http://web-platform.test:8800 assert_true: Got response expected true got false
+PASS remote (http://web-platform.test:8800) to remote (*), expect origin=http://web-platform.test:8800
+PASS remote (http://web-platform.test:8800) to remote (http://web-platform.test:8800), expect origin=http://web-platform.test:8800
 PASS remote (http://web-platform.test:8800) to remote (null), expect to fail
 PASS remote (http://web-platform.test:8800) to remote (none), expect to fail
 PASS remote (null) to remote (*), expect to fail
 PASS remote (none) to remote (*), expect to fail
-FAIL remote (*) to remote2 (*), expect origin=null assert_true: Got response expected true got false
+PASS remote (*) to remote2 (*), expect origin=null
 PASS remote (*) to remote2 (http://web-platform.test:8800), expect to fail
-FAIL remote (*) to remote2 (null), expect origin=null assert_true: Got response expected true got false
+PASS remote (*) to remote2 (null), expect origin=null
 PASS remote (*) to remote2 (none), expect to fail
-FAIL remote (http://web-platform.test:8800) to remote2 (*), expect origin=null assert_true: Got response expected true got false
+PASS remote (http://web-platform.test:8800) to remote2 (*), expect origin=null
 PASS remote (http://web-platform.test:8800) to remote2 (http://web-platform.test:8800), expect to fail
-FAIL remote (http://web-platform.test:8800) to remote2 (null), expect origin=null assert_true: Got response expected true got false
+PASS remote (http://web-platform.test:8800) to remote2 (null), expect origin=null
 PASS remote (http://web-platform.test:8800) to remote2 (none), expect to fail
 PASS remote (null) to remote2 (*), expect to fail
 PASS remote (none) to remote2 (*), expect to fail
-PASS remote (*) to remote (http://not-web-platform.test.web-platform.test:8800), expect to fail
-PASS remote (*) to remote2 (http://not-web-platform.test.web-platform.test:8800), expect to fail
-PASS remote (http://not-web-platform.test.web-platform.test:8800) to remote (*), expect to fail
+PASS remote (*) to remote (http://www1.web-platform.test:8800), expect to fail
+PASS remote (*) to remote2 (http://www1.web-platform.test:8800), expect to fail
+PASS remote (http://www1.web-platform.test:8800) to remote (*), expect to fail
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cors/remote-origin-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cors/remote-origin-expected.txt
@@ -1,32 +1,32 @@
 Access-Control-Allow-Origin handling
 
 
-FAIL Allow origin: * assert_equals: Request Origin: should be http://not-web-platform.test expected "http://not-web-platform.test" but got "http://not-web-platform.test:8800"
-FAIL Allow origin: _*__ assert_equals: Request Origin: should be http://not-web-platform.test expected "http://not-web-platform.test" but got "http://not-web-platform.test:8800"
-FAIL Allow origin: [tab]* assert_equals: Request Origin: should be http://not-web-platform.test expected "http://not-web-platform.test" but got "http://not-web-platform.test:8800"
-FAIL Allow origin: http://not-web-platform.test assert_equals: expected "load" but got "error"
-FAIL Allow origin: _http://not-web-platform.test assert_equals: expected "load" but got "error"
-FAIL Allow origin: _http://not-web-platform.test___[tab]_ assert_equals: expected "load" but got "error"
-FAIL Allow origin: [tab]http://not-web-platform.test assert_equals: expected "load" but got "error"
+PASS Allow origin: *
+PASS Allow origin: _*__
+PASS Allow origin: [tab]*
+PASS Allow origin: http://www1.web-platform.test:8800
+PASS Allow origin: _http://www1.web-platform.test:8800
+PASS Allow origin: _http://www1.web-platform.test:8800___[tab]_
+PASS Allow origin: [tab]http://www1.web-platform.test:8800
 PASS Disallow origin: http://web-platform.test:8800
-PASS Disallow origin: //not-web-platform.test
-PASS Disallow origin: ://not-web-platform.test
-PASS Disallow origin: ftp://not-web-platform.test
-PASS Disallow origin: http:://not-web-platform.test
-PASS Disallow origin: http:/not-web-platform.test
-PASS Disallow origin: http:not-web-platform.test
-PASS Disallow origin: not-web-platform.test
-PASS Disallow origin: http://not-web-platform.test?
-PASS Disallow origin: http://not-web-platform.test/
-PASS Disallow origin: http://not-web-platform.test_/
-PASS Disallow origin: http://not-web-platform.test#
-PASS Disallow origin: http://not-web-platform.test%23
-PASS Disallow origin: http://not-web-platform.test:80
-PASS Disallow origin: http://not-web-platform.test,_*
-PASS Disallow origin: http://not-web-platform.test\0
-PASS Disallow origin: HTTP://NOT-WEB-PLATFORM.TEST
-PASS Disallow origin: HTTP://not-web-platform.test
-PASS Disallow origin: http://NOT-WEB-PLATFORM.TEST
+PASS Disallow origin: //www1.web-platform.test:8800
+PASS Disallow origin: ://www1.web-platform.test:8800
+PASS Disallow origin: ftp://www1.web-platform.test:8800
+PASS Disallow origin: http:://www1.web-platform.test:8800
+PASS Disallow origin: http:/www1.web-platform.test:8800
+PASS Disallow origin: http:www1.web-platform.test:8800
+PASS Disallow origin: www1.web-platform.test:8800
+PASS Disallow origin: http://www1.web-platform.test:8800?
+PASS Disallow origin: http://www1.web-platform.test:8800/
+PASS Disallow origin: http://www1.web-platform.test:8800_/
+PASS Disallow origin: http://www1.web-platform.test:8800#
+PASS Disallow origin: http://www1.web-platform.test:8800%23
+PASS Disallow origin: http://www1.web-platform.test:8800:80
+PASS Disallow origin: http://www1.web-platform.test:8800,_*
+PASS Disallow origin: http://www1.web-platform.test:8800\0
+PASS Disallow origin: HTTP://WWW1.WEB-PLATFORM.TEST:8800
+PASS Disallow origin: HTTP://www1.web-platform.test:8800
+PASS Disallow origin: http://WWW1.WEB-PLATFORM.TEST:8800
 PASS Disallow origin: -
 PASS Disallow origin: **
 PASS Disallow origin: \0*
@@ -35,15 +35,15 @@ PASS Disallow origin: '*'
 PASS Disallow origin: "*"
 PASS Disallow origin: *_*
 PASS Disallow origin: *http://*
-PASS Disallow origin: *http://not-web-platform.test
-PASS Disallow origin: *_http://not-web-platform.test
-PASS Disallow origin: *,_http://not-web-platform.test
-PASS Disallow origin: \0http://not-web-platform.test
-PASS Disallow origin: null_http://not-web-platform.test
+PASS Disallow origin: *http://www1.web-platform.test:8800
+PASS Disallow origin: *_http://www1.web-platform.test:8800
+PASS Disallow origin: *,_http://www1.web-platform.test:8800
+PASS Disallow origin: \0http://www1.web-platform.test:8800
+PASS Disallow origin: null_http://www1.web-platform.test:8800
 PASS Disallow origin: http://example.net
 PASS Disallow origin: null
 PASS Disallow origin:
 PASS Disallow origin: http://web-platform.test:8800/cors/remote-origin.htm
 PASS Disallow origin: http://web-platform.test:8800/cors/
-PASS Disallow origin: http://not-web-platform.test:8800/cors/
+PASS Disallow origin: http://www1.web-platform.test:8800/cors/
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cors/resources/304.py
+++ b/LayoutTests/imported/w3c/web-platform-tests/cors/resources/304.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 # A header used to correlate requests and responses
 state_header = b"content-language"
 
@@ -36,12 +34,12 @@ def main(request, response):
             # what are you doing here? This should be a fresh request.
             return error(u"If-None-Match on first request")
         else:
-            status = 200, u"OK"
+            status = 200, b"OK"
             headers.append((b"Access-Control-Allow-Origin", b"*"))
             headers.append((b"Content-Type", b"text/plain"))
             headers.append((b"Cache-Control", b"private, max-age=3, must-revalidate"))
             headers.append((b"ETag", etag))
-            return status, headers, u"Success"
+            return status, headers, b"Success"
     else:  # even requests are the second in a pair, and should have a good INM.
         if inm != etag:
             # Bad browser.
@@ -58,5 +56,5 @@ def main(request, response):
                 headers.append((b"Access-Control-Expose-Headers", b"a"))
             elif req_num == 8:
                 headers.append((b"Access-Control-Allow-Origin", b"other.origin.example:80"))
-            status = 304, u"Not Modified"
-            return status, headers, u""
+            status = 304, b"Not Modified"
+            return status, headers, b""

--- a/LayoutTests/imported/w3c/web-platform-tests/cors/resources/cache-304.py
+++ b/LayoutTests/imported/w3c/web-platform-tests/cors/resources/cache-304.py
@@ -1,10 +1,10 @@
 def main(request, response):
     match = request.headers.get(b"If-None-Match", None)
     if match is not None and match == b"mybestscript-v1":
-        response.status = (304, u"YEP")
-        return u""
+        response.status = (304, b"YEP")
+        return b""
     response.headers.set(b"Access-Control-Allow-Origin", b"*")
     response.headers.set(b"Cache-Control", b"must-revalidate")
     response.headers.set(b"ETag", b"mybestscript-v1")
     response.headers.set(b"Content-Type", b"text/javascript")
-    return u"function hep() { }"
+    return b"function hep() { }"

--- a/LayoutTests/imported/w3c/web-platform-tests/cors/resources/cors-headers.asis
+++ b/LayoutTests/imported/w3c/web-platform-tests/cors/resources/cors-headers.asis
@@ -4,6 +4,7 @@ Access-Control-Expose-Headers: X-Custom-Header, X-Custom-Header-Empty, X-Custom-
 Access-Control-Expose-Headers: X-Second-Expose
 Access-Control-Expose-Headers: Date
 Content-Type: text/plain
+Content-Length: 4
 X-Custom-Header: test
 X-Custom-Header: test
 Set-Cookie: test1=t1;max-age=2

--- a/LayoutTests/imported/w3c/web-platform-tests/cors/resources/cors-makeheader.py
+++ b/LayoutTests/imported/w3c/web-platform-tests/cors/resources/cors-makeheader.py
@@ -3,7 +3,7 @@ import json
 from wptserve.utils import isomorphic_decode
 
 def main(request, response):
-    origin = request.GET.first(b"origin", request.headers.get(b'origin'))
+    origin = request.GET.first(b"origin", request.headers.get(b'origin') or b'none')
 
     if b"check" in request.GET:
         token = request.GET.first(b"token")
@@ -64,6 +64,6 @@ def main(request, response):
     body = json.dumps(headers)
 
     if code:
-        return (code, u"StatusText"), [], body
+        return (code, b"StatusText"), [], body
     else:
         return body

--- a/LayoutTests/imported/w3c/web-platform-tests/cors/resources/expose-headers.py
+++ b/LayoutTests/imported/w3c/web-platform-tests/cors/resources/expose-headers.py
@@ -2,6 +2,7 @@ def main(request, response):
     response.add_required_headers = False
     output =  b"HTTP/1.1 221 ALL YOUR BASE BELONG TO H1\r\n"
     output += b"Access-Control-Allow-Origin: *\r\n"
+    output += b"Connection: close\r\n"
     output += b"BB-8: hey\r\n"
     output += b"Content-Language: mkay\r\n"
     output += request.GET.first(b"expose") + b"\r\n"

--- a/LayoutTests/imported/w3c/web-platform-tests/cors/resources/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/cors/resources/w3c-import.log
@@ -23,6 +23,9 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/cors/resources/cors-makeheader.py
 /LayoutTests/imported/w3c/web-platform-tests/cors/resources/expose-headers.py
 /LayoutTests/imported/w3c/web-platform-tests/cors/resources/image-tainting-checker.sub.html
+/LayoutTests/imported/w3c/web-platform-tests/cors/resources/preflight-cache-partitioning-iframe.sub.html
+/LayoutTests/imported/w3c/web-platform-tests/cors/resources/preflight-cache-partitioning.sub.html
+/LayoutTests/imported/w3c/web-platform-tests/cors/resources/preflight-partitioning.py
 /LayoutTests/imported/w3c/web-platform-tests/cors/resources/preflight.py
 /LayoutTests/imported/w3c/web-platform-tests/cors/resources/remote-xhrer.html
 /LayoutTests/imported/w3c/web-platform-tests/cors/resources/status.py

--- a/LayoutTests/imported/w3c/web-platform-tests/cors/response-headers-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cors/response-headers-expected.txt
@@ -11,6 +11,8 @@ PASS getResponseHeader: Content-Language: readable by default
 PASS getResponseHeader: Expires: readable by default
 PASS getResponseHeader: Last-Modified: readable by default
 PASS getResponseHeader: Pragma: readable by default
+PASS getResponseHeader: Content-Length: readable by default
+PASS getResponseHeader: Content-Type: readable by default
 PASS getResponseHeader: Server: unreadable by default
 PASS getResponseHeader: X-Powered-By: unreadable by default
 PASS getResponseHeader: Combined testing of cors response headers

--- a/LayoutTests/imported/w3c/web-platform-tests/cors/response-headers.htm
+++ b/LayoutTests/imported/w3c/web-platform-tests/cors/response-headers.htm
@@ -44,6 +44,8 @@ default_readable("Content-Language", "nn");
 default_readable("Expires", "Thu, 01 Dec 1994 16:00:00 GMT");
 default_readable("Last-Modified", "Thu, 01 Dec 1994 10:00:00 GMT");
 default_readable("Pragma", "no-cache");
+default_readable("Content-Length", "4");
+default_readable("Content-Type", "text/plain");
 
 
 function default_unreadable(head) {

--- a/LayoutTests/imported/w3c/web-platform-tests/cors/simple-requests-ch.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cors/simple-requests-ch.tentative-expected.txt
@@ -3,7 +3,7 @@ Simple requests
 Simple requests shouldn't trigger preflight
 
 
-FAIL No preflight GET and {"save-data":"on","device-memory":"2.0","dpr":"3.0","width":"1200","viewport-width":"1300"}  A network error occurred.
-FAIL No preflight HEAD and {"save-data":"on","device-memory":"2.0","dpr":"3.0","width":"1200","viewport-width":"1300"}  A network error occurred.
-FAIL No preflight POST and {"save-data":"on","device-memory":"2.0","dpr":"3.0","width":"1200","viewport-width":"1300"}  A network error occurred.
+FAIL No preflight GET and {"save-data":"on","device-memory":"2.0","dpr":"3.0","width":"1200","viewport-width":"1300","rtt":"1","downlink":"1.0","ect":"2g"}  A network error occurred.
+FAIL No preflight HEAD and {"save-data":"on","device-memory":"2.0","dpr":"3.0","width":"1200","viewport-width":"1300","rtt":"1","downlink":"1.0","ect":"2g"}  A network error occurred.
+FAIL No preflight POST and {"save-data":"on","device-memory":"2.0","dpr":"3.0","width":"1200","viewport-width":"1300","rtt":"1","downlink":"1.0","ect":"2g"}  A network error occurred.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cors/simple-requests-ch.tentative.htm
+++ b/LayoutTests/imported/w3c/web-platform-tests/cors/simple-requests-ch.tentative.htm
@@ -51,7 +51,10 @@ check_simple_headers({
                         'device-memory': '2.0',
                         'dpr': '3.0',
                         'width': '1200',
-                        'viewport-width': '1300'
+                        'viewport-width': '1300',
+                        'rtt': '1',
+                        'downlink': '1.0',
+                        'ect': '2g'
                      })
 
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/cors/support.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/cors/support.js
@@ -3,14 +3,15 @@ function dirname(path) {
 }
 
 /* This subdomain should point to this same location */
-var SUBDOMAIN = "{{hosts[alt][]}}"
+var SUBDOMAIN = 'www1'
 var SUBDOMAIN2 = 'www2'
 var PORT = {{ports[http][1]}}
 //XXX HTTPS
 var PORTS = {{ports[https][0]}}
 
 /* Changes http://example.com/abc/def/cool.htm to http://www1.example.com/abc/def/ */
-var CROSSDOMAIN     = location.protocol + '//' + SUBDOMAIN + ':' + location.port + dirname(location.pathname)
-var REMOTE_HOST     = SUBDOMAIN
+var CROSSDOMAIN     = dirname(location.href)
+                        .replace('://', '://' + SUBDOMAIN + '.')
+var REMOTE_HOST     = SUBDOMAIN + '.' + location.host
 var REMOTE_PROTOCOL = location.protocol
 var REMOTE_ORIGIN   = REMOTE_PROTOCOL + '//' + REMOTE_HOST

--- a/LayoutTests/imported/w3c/web-platform-tests/cors/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/cors/w3c-import.log
@@ -17,6 +17,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/cors/304.htm
 /LayoutTests/imported/w3c/web-platform-tests/cors/META.yml
 /LayoutTests/imported/w3c/web-platform-tests/cors/README.md
+/LayoutTests/imported/w3c/web-platform-tests/cors/WEB_FEATURES.yml
 /LayoutTests/imported/w3c/web-platform-tests/cors/access-control-expose-headers-parsing.window.js
 /LayoutTests/imported/w3c/web-platform-tests/cors/basic.htm
 /LayoutTests/imported/w3c/web-platform-tests/cors/client-hint-request-headers-2.tentative.htm
@@ -26,6 +27,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/cors/image-tainting-in-cross-origin-iframe.sub.html
 /LayoutTests/imported/w3c/web-platform-tests/cors/late-upload-events.htm
 /LayoutTests/imported/w3c/web-platform-tests/cors/origin.htm
+/LayoutTests/imported/w3c/web-platform-tests/cors/preflight-cache-partitioning.sub.window.js
 /LayoutTests/imported/w3c/web-platform-tests/cors/preflight-cache.htm
 /LayoutTests/imported/w3c/web-platform-tests/cors/preflight-failure.htm
 /LayoutTests/imported/w3c/web-platform-tests/cors/redirect-origin.htm

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/cors/origin-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/cors/origin-expected.txt
@@ -8,7 +8,7 @@ PASS Allow origin: http://web-platform.test:8800
 PASS Allow origin: _http://web-platform.test:8800
 PASS Allow origin: _http://web-platform.test:8800___[tab]_
 PASS Allow origin: [tab]http://web-platform.test:8800
-PASS Disallow origin: http://not-web-platform.test.web-platform.test:8800
+PASS Disallow origin: http://www1.web-platform.test:8800
 PASS Disallow origin: //web-platform.test:8800
 PASS Disallow origin: ://web-platform.test:8800
 PASS Disallow origin: ftp://web-platform.test:8800
@@ -52,7 +52,7 @@ PASS Disallow origin: null *
 PASS Disallow origin:
 PASS Disallow origin: http://web-platform.test:8800/cors/origin.htm
 PASS Disallow origin: http://web-platform.test:8800/cors/
-PASS Disallow origin: http://not-web-platform.test:8800/cors/
+PASS Disallow origin: http://www1.web-platform.test:8800/cors/
 PASS Disallow origin: test:8800
 PASS Disallow origin: .test:8800
 PASS Disallow origin: *.test:8800

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/cors/redirect-origin-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/cors/redirect-origin-expected.txt
@@ -1,47 +1,47 @@
 CORS redirect handling
 
 
-FAIL local (*) to remote (*), expect origin=http://web-platform.test:8800 assert_true: Got response expected true got false
-FAIL local (*) to remote (http://web-platform.test:8800), expect origin=http://web-platform.test:8800 assert_true: Got response expected true got false
+PASS local (*) to remote (*), expect origin=http://web-platform.test:8800
+PASS local (*) to remote (http://web-platform.test:8800), expect origin=http://web-platform.test:8800
 PASS local (*) to remote (null), expect to fail
 PASS local (*) to remote (none), expect to fail
-FAIL local (http://web-platform.test:8800) to remote (*), expect origin=http://web-platform.test:8800 assert_true: Got response expected true got false
-FAIL local (http://web-platform.test:8800) to remote (http://web-platform.test:8800), expect origin=http://web-platform.test:8800 assert_true: Got response expected true got false
+PASS local (http://web-platform.test:8800) to remote (*), expect origin=http://web-platform.test:8800
+PASS local (http://web-platform.test:8800) to remote (http://web-platform.test:8800), expect origin=http://web-platform.test:8800
 PASS local (http://web-platform.test:8800) to remote (null), expect to fail
 PASS local (http://web-platform.test:8800) to remote (none), expect to fail
-FAIL local (null) to remote (*), expect origin=http://web-platform.test:8800 assert_true: Got response expected true got false
-FAIL local (none) to remote (*), expect origin=http://web-platform.test:8800 assert_true: Got response expected true got false
-FAIL remote (*) to local (*), expect origin=null assert_true: Got response expected true got false
+PASS local (null) to remote (*), expect origin=http://web-platform.test:8800
+PASS local (none) to remote (*), expect origin=http://web-platform.test:8800
+PASS remote (*) to local (*), expect origin=null
 PASS remote (*) to local (http://web-platform.test:8800), expect to fail
-FAIL remote (*) to local (null), expect origin=null assert_true: Got response expected true got false
+PASS remote (*) to local (null), expect origin=null
 PASS remote (*) to local (none), expect to fail
-FAIL remote (http://web-platform.test:8800) to local (*), expect origin=null assert_true: Got response expected true got false
+PASS remote (http://web-platform.test:8800) to local (*), expect origin=null
 PASS remote (http://web-platform.test:8800) to local (http://web-platform.test:8800), expect to fail
-FAIL remote (http://web-platform.test:8800) to local (null), expect origin=null assert_true: Got response expected true got false
+PASS remote (http://web-platform.test:8800) to local (null), expect origin=null
 PASS remote (http://web-platform.test:8800) to local (none), expect to fail
 PASS remote (null) to local (*), expect to fail
 PASS remote (none) to local (*), expect to fail
-FAIL remote (*) to remote (*), expect origin=http://web-platform.test:8800 assert_true: Got response expected true got false
-FAIL remote (*) to remote (http://web-platform.test:8800), expect origin=http://web-platform.test:8800 assert_true: Got response expected true got false
+PASS remote (*) to remote (*), expect origin=http://web-platform.test:8800
+PASS remote (*) to remote (http://web-platform.test:8800), expect origin=http://web-platform.test:8800
 PASS remote (*) to remote (null), expect to fail
 PASS remote (*) to remote (none), expect to fail
-FAIL remote (http://web-platform.test:8800) to remote (*), expect origin=http://web-platform.test:8800 assert_true: Got response expected true got false
-FAIL remote (http://web-platform.test:8800) to remote (http://web-platform.test:8800), expect origin=http://web-platform.test:8800 assert_true: Got response expected true got false
+PASS remote (http://web-platform.test:8800) to remote (*), expect origin=http://web-platform.test:8800
+PASS remote (http://web-platform.test:8800) to remote (http://web-platform.test:8800), expect origin=http://web-platform.test:8800
 PASS remote (http://web-platform.test:8800) to remote (null), expect to fail
 PASS remote (http://web-platform.test:8800) to remote (none), expect to fail
 PASS remote (null) to remote (*), expect to fail
 PASS remote (none) to remote (*), expect to fail
-FAIL remote (*) to remote2 (*), expect origin=null assert_true: Got response expected true got false
+PASS remote (*) to remote2 (*), expect origin=null
 PASS remote (*) to remote2 (http://web-platform.test:8800), expect to fail
-FAIL remote (*) to remote2 (null), expect origin=null assert_true: Got response expected true got false
+PASS remote (*) to remote2 (null), expect origin=null
 PASS remote (*) to remote2 (none), expect to fail
-FAIL remote (http://web-platform.test:8800) to remote2 (*), expect origin=null assert_true: Got response expected true got false
+PASS remote (http://web-platform.test:8800) to remote2 (*), expect origin=null
 PASS remote (http://web-platform.test:8800) to remote2 (http://web-platform.test:8800), expect to fail
-FAIL remote (http://web-platform.test:8800) to remote2 (null), expect origin=null assert_true: Got response expected true got false
+PASS remote (http://web-platform.test:8800) to remote2 (null), expect origin=null
 PASS remote (http://web-platform.test:8800) to remote2 (none), expect to fail
 PASS remote (null) to remote2 (*), expect to fail
 PASS remote (none) to remote2 (*), expect to fail
-PASS remote (*) to remote (http://not-web-platform.test.web-platform.test:8800), expect to fail
-PASS remote (*) to remote2 (http://not-web-platform.test.web-platform.test:8800), expect to fail
-PASS remote (http://not-web-platform.test.web-platform.test:8800) to remote (*), expect to fail
+PASS remote (*) to remote (http://www1.web-platform.test:8800), expect to fail
+PASS remote (*) to remote2 (http://www1.web-platform.test:8800), expect to fail
+PASS remote (http://www1.web-platform.test:8800) to remote (*), expect to fail
 

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/cors/remote-origin-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/cors/remote-origin-expected.txt
@@ -1,32 +1,32 @@
 Access-Control-Allow-Origin handling
 
 
-FAIL Allow origin: * assert_equals: Request Origin: should be http://not-web-platform.test expected "http://not-web-platform.test" but got "http://not-web-platform.test:8800"
-FAIL Allow origin: _*__ assert_equals: Request Origin: should be http://not-web-platform.test expected "http://not-web-platform.test" but got "http://not-web-platform.test:8800"
-FAIL Allow origin: [tab]* assert_equals: Request Origin: should be http://not-web-platform.test expected "http://not-web-platform.test" but got "http://not-web-platform.test:8800"
-FAIL Allow origin: http://not-web-platform.test assert_equals: expected "load" but got "error"
-FAIL Allow origin: _http://not-web-platform.test assert_equals: expected "load" but got "error"
-FAIL Allow origin: _http://not-web-platform.test___[tab]_ assert_equals: expected "load" but got "error"
-FAIL Allow origin: [tab]http://not-web-platform.test assert_equals: expected "load" but got "error"
+PASS Allow origin: *
+PASS Allow origin: _*__
+PASS Allow origin: [tab]*
+PASS Allow origin: http://www1.web-platform.test:8800
+PASS Allow origin: _http://www1.web-platform.test:8800
+PASS Allow origin: _http://www1.web-platform.test:8800___[tab]_
+PASS Allow origin: [tab]http://www1.web-platform.test:8800
 PASS Disallow origin: http://web-platform.test:8800
-PASS Disallow origin: //not-web-platform.test
-PASS Disallow origin: ://not-web-platform.test
-PASS Disallow origin: ftp://not-web-platform.test
-PASS Disallow origin: http:://not-web-platform.test
-PASS Disallow origin: http:/not-web-platform.test
-PASS Disallow origin: http:not-web-platform.test
-PASS Disallow origin: not-web-platform.test
-PASS Disallow origin: http://not-web-platform.test?
-PASS Disallow origin: http://not-web-platform.test/
-PASS Disallow origin: http://not-web-platform.test_/
-PASS Disallow origin: http://not-web-platform.test#
-PASS Disallow origin: http://not-web-platform.test%23
-PASS Disallow origin: http://not-web-platform.test:80
-PASS Disallow origin: http://not-web-platform.test,_*
-PASS Disallow origin: http://not-web-platform.test\0
-PASS Disallow origin: HTTP://NOT-WEB-PLATFORM.TEST
-PASS Disallow origin: HTTP://not-web-platform.test
-PASS Disallow origin: http://NOT-WEB-PLATFORM.TEST
+PASS Disallow origin: //www1.web-platform.test:8800
+PASS Disallow origin: ://www1.web-platform.test:8800
+PASS Disallow origin: ftp://www1.web-platform.test:8800
+PASS Disallow origin: http:://www1.web-platform.test:8800
+PASS Disallow origin: http:/www1.web-platform.test:8800
+PASS Disallow origin: http:www1.web-platform.test:8800
+PASS Disallow origin: www1.web-platform.test:8800
+PASS Disallow origin: http://www1.web-platform.test:8800?
+PASS Disallow origin: http://www1.web-platform.test:8800/
+PASS Disallow origin: http://www1.web-platform.test:8800_/
+PASS Disallow origin: http://www1.web-platform.test:8800#
+PASS Disallow origin: http://www1.web-platform.test:8800%23
+PASS Disallow origin: http://www1.web-platform.test:8800:80
+PASS Disallow origin: http://www1.web-platform.test:8800,_*
+PASS Disallow origin: http://www1.web-platform.test:8800\0
+PASS Disallow origin: HTTP://WWW1.WEB-PLATFORM.TEST:8800
+PASS Disallow origin: HTTP://www1.web-platform.test:8800
+PASS Disallow origin: http://WWW1.WEB-PLATFORM.TEST:8800
 PASS Disallow origin: -
 PASS Disallow origin: **
 PASS Disallow origin: \0*
@@ -35,15 +35,15 @@ PASS Disallow origin: '*'
 PASS Disallow origin: "*"
 PASS Disallow origin: *_*
 PASS Disallow origin: *http://*
-PASS Disallow origin: *http://not-web-platform.test
-PASS Disallow origin: *_http://not-web-platform.test
-PASS Disallow origin: *,_http://not-web-platform.test
-PASS Disallow origin: \0http://not-web-platform.test
-PASS Disallow origin: null_http://not-web-platform.test
+PASS Disallow origin: *http://www1.web-platform.test:8800
+PASS Disallow origin: *_http://www1.web-platform.test:8800
+PASS Disallow origin: *,_http://www1.web-platform.test:8800
+PASS Disallow origin: \0http://www1.web-platform.test:8800
+PASS Disallow origin: null_http://www1.web-platform.test:8800
 PASS Disallow origin: http://example.net
 PASS Disallow origin: null
 PASS Disallow origin:
 PASS Disallow origin: http://web-platform.test:8800/cors/remote-origin.htm
 PASS Disallow origin: http://web-platform.test:8800/cors/
-PASS Disallow origin: http://not-web-platform.test:8800/cors/
+PASS Disallow origin: http://www1.web-platform.test:8800/cors/
 


### PR DESCRIPTION
#### b8171da0b5a99ae921e337928b568cd033bd0ed1
<pre>
Sync `cors` from WPT upstream
<a href="https://bugs.webkit.org/show_bug.cgi?id=293061">https://bugs.webkit.org/show_bug.cgi?id=293061</a>
<a href="https://rdar.apple.com/151409835">rdar://151409835</a>

Reviewed by Tim Nguyen.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/1d3fbb842fe3ad007c5f920f717455c83ce557ed">https://github.com/web-platform-tests/wpt/commit/1d3fbb842fe3ad007c5f920f717455c83ce557ed</a>

* LayoutTests/imported/w3c/web-platform-tests/cors/304.htm:
* LayoutTests/imported/w3c/web-platform-tests/cors/META.yml:
* LayoutTests/imported/w3c/web-platform-tests/cors/WEB_FEATURES.yml: Added.
* LayoutTests/imported/w3c/web-platform-tests/cors/access-control-expose-headers-parsing.window.js:
(runTests):
* LayoutTests/imported/w3c/web-platform-tests/cors/basic.htm:
* LayoutTests/imported/w3c/web-platform-tests/cors/client-hint-request-headers-2.tentative.htm:
* LayoutTests/imported/w3c/web-platform-tests/cors/client-hint-request-headers-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cors/client-hint-request-headers.htm:
* LayoutTests/imported/w3c/web-platform-tests/cors/credentials-flag-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cors/origin-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cors/redirect-origin-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cors/remote-origin-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cors/resources/304.py:
(main):
* LayoutTests/imported/w3c/web-platform-tests/cors/resources/cache-304.py:
(main):
* LayoutTests/imported/w3c/web-platform-tests/cors/resources/cors-headers.asis:
* LayoutTests/imported/w3c/web-platform-tests/cors/resources/cors-makeheader.py:
(main):
* LayoutTests/imported/w3c/web-platform-tests/cors/resources/expose-headers.py:
(main):
* LayoutTests/imported/w3c/web-platform-tests/cors/resources/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/cors/response-headers-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cors/response-headers.htm:
* LayoutTests/imported/w3c/web-platform-tests/cors/simple-requests-ch.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cors/simple-requests-ch.tentative.htm:
* LayoutTests/imported/w3c/web-platform-tests/cors/support.js:
* LayoutTests/imported/w3c/web-platform-tests/cors/w3c-import.log:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/cors/origin-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/cors/redirect-origin-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/cors/remote-origin-expected.txt:

Canonical link: <a href="https://commits.webkit.org/300755@main">https://commits.webkit.org/300755@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dd42cd845e41a208a98fb729f1f3c0d935003cf4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/123475 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/43190 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/33886 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/130193 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/75614 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/79ec3ae9-cd2f-4b3e-9c50-0bde79472d83) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/43913 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/51784 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/93861 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62305 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0cbae6cf-8994-4e7d-ba90-4094695b43d3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/126428 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/34989 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/110471 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74493 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/96a885ee-c05b-4804-995b-d95c513283be) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/33960 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/28629 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/73710 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/104704 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/28854 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/132912 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/50426 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38388 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/102354 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/50801 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/106693 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102206 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26040 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47562 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/25791 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/47233 "Hash dd42cd84 for PR 45446 does not build (failure)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/50280 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/49754 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53101 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/51429 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->