### PR TITLE
Allocate compactible and non-compactible types out of entirely different heaps

### DIFF
--- a/Source/JavaScriptCore/heap/StructureAlignedMemoryAllocator.cpp
+++ b/Source/JavaScriptCore/heap/StructureAlignedMemoryAllocator.cpp
@@ -86,7 +86,7 @@ void* StructureAlignedMemoryAllocator::tryReallocateMemory(void*, size_t)
 #if !USE(SYSTEM_MALLOC)
 
 static const bmalloc_type structureHeapType { BMALLOC_TYPE_INITIALIZER(MarkedBlock::blockSize, MarkedBlock::blockSize, "Structure Heap") };
-static pas_primitive_heap_ref structureHeap { BMALLOC_AUXILIARY_HEAP_REF_INITIALIZER(&structureHeapType) };
+static pas_primitive_heap_ref structureHeap { BMALLOC_AUXILIARY_HEAP_REF_INITIALIZER(&structureHeapType, pas_bmalloc_heap_ref_kind_compact) };
 
 #endif
 
@@ -120,7 +120,7 @@ public:
     {
 #if !USE(SYSTEM_MALLOC)
         if (!m_useDebugHeap) [[likely]]
-            return bmalloc_try_allocate_auxiliary_with_alignment_inline(&structureHeap, MarkedBlock::blockSize, MarkedBlock::blockSize, pas_maybe_compact_allocation_mode);
+            return bmalloc_try_allocate_auxiliary_with_alignment_inline(&structureHeap, MarkedBlock::blockSize, MarkedBlock::blockSize, pas_always_compact_allocation_mode);
 #endif
 
         size_t freeIndex;

--- a/Source/bmalloc/bmalloc/CompactAllocationMode.h
+++ b/Source/bmalloc/bmalloc/CompactAllocationMode.h
@@ -27,6 +27,7 @@
 
 #include "BAssert.h"
 #include "BInline.h"
+#include <cstdint>
 
 #if BUSE(LIBPAS)
 BALLOW_UNSAFE_BUFFER_USAGE_BEGIN
@@ -36,7 +37,7 @@ BALLOW_UNSAFE_BUFFER_USAGE_END
 
 namespace bmalloc {
 
-enum class CompactAllocationMode {
+enum class CompactAllocationMode : uint8_t {
     NonCompact,
     Compact
 };
@@ -51,7 +52,7 @@ BINLINE constexpr pas_allocation_mode asPasAllocationMode(CompactAllocationMode 
     case CompactAllocationMode::NonCompact:
         return pas_non_compact_allocation_mode;
     case CompactAllocationMode::Compact:
-        return pas_maybe_compact_allocation_mode;
+        return pas_always_compact_allocation_mode;
     }
     RELEASE_BASSERT_NOT_REACHED();
 }

--- a/Source/bmalloc/bmalloc/DebugHeap.cpp
+++ b/Source/bmalloc/bmalloc/DebugHeap.cpp
@@ -242,21 +242,21 @@ void* pas_debug_heap_realloc(void* ptr, size_t size)
 void* pas_debug_heap_malloc_compact(size_t size)
 {
     auto debugHeap = DebugHeap::getExisting();
-    PAS_PROFILE(DEBUG_HEAP_ALLOCATION, debugHeap, size, 1, pas_maybe_compact_allocation_mode);
+    PAS_PROFILE(DEBUG_HEAP_ALLOCATION, debugHeap, size, 1, pas_always_compact_allocation_mode);
     return debugHeap->malloc(size, FailureAction::ReturnNull);
 }
 
 void* pas_debug_heap_memalign_compact(size_t alignment, size_t size)
 {
     auto debugHeap = DebugHeap::getExisting();
-    PAS_PROFILE(DEBUG_HEAP_ALLOCATION, debugHeap, size, alignment, pas_maybe_compact_allocation_mode);
+    PAS_PROFILE(DEBUG_HEAP_ALLOCATION, debugHeap, size, alignment, pas_always_compact_allocation_mode);
     return debugHeap->memalign(alignment, size, FailureAction::ReturnNull);
 }
 
 void* pas_debug_heap_realloc_compact(void* ptr, size_t size)
 {
     auto debugHeap = DebugHeap::getExisting();
-    PAS_PROFILE(DEBUG_HEAP_REALLOCATION, debugHeap, ptr, size, pas_maybe_compact_allocation_mode);
+    PAS_PROFILE(DEBUG_HEAP_REALLOCATION, debugHeap, ptr, size, pas_always_compact_allocation_mode);
     return debugHeap->realloc(ptr, size, FailureAction::ReturnNull);
 }
 

--- a/Source/bmalloc/bmalloc/IsoHeap.cpp
+++ b/Source/bmalloc/bmalloc/IsoHeap.cpp
@@ -90,7 +90,7 @@ void* isoAllocateCompact(pas_heap_ref& heapRef)
         }
     }
 
-    void* result = bmalloc_iso_allocate_inline(&heapRef, pas_maybe_compact_allocation_mode);
+    void* result = bmalloc_iso_allocate_inline(&heapRef, pas_always_compact_allocation_mode);
     BPROFILE_ALLOCATION(COMPACTIBLE, result, typeSize);
     return result;
 }
@@ -106,7 +106,7 @@ void* isoTryAllocateCompact(pas_heap_ref& heapRef)
         }
     }
 
-    void* result = bmalloc_try_iso_allocate_inline(&heapRef, pas_maybe_compact_allocation_mode);
+    void* result = bmalloc_try_iso_allocate_inline(&heapRef, pas_always_compact_allocation_mode);
     BPROFILE_TRY_ALLOCATION(COMPACTIBLE, result, typeSize);
     return result;
 }

--- a/Source/bmalloc/bmalloc/IsoHeap.h
+++ b/Source/bmalloc/bmalloc/IsoHeap.h
@@ -74,7 +74,7 @@ struct IsoHeapBase {
     static pas_heap_ref& provideHeap()
     {
         static const bmalloc_type type = BMALLOC_TYPE_INITIALIZER(sizeof(LibPasBmallocHeapType), alignof(LibPasBmallocHeapType), __PRETTY_FUNCTION__);
-        static pas_heap_ref heap = BMALLOC_HEAP_REF_INITIALIZER(&type);
+        static pas_heap_ref heap = BMALLOC_HEAP_REF_INITIALIZER(&type, pas_bmalloc_heap_ref_kind_non_compact);
         return heap;
     }
 };

--- a/Source/bmalloc/bmalloc/TZoneHeap.cpp
+++ b/Source/bmalloc/bmalloc/TZoneHeap.cpp
@@ -91,12 +91,12 @@ void* tzoneAllocateCompactSlow(size_t requestedSize, const TZoneSpecification& s
         heapRef = tzoneHeapManager->heapRefForTZoneType(spec);
         *spec.addressOfHeapRef = heapRef;
     }
-    return bmalloc_iso_allocate_inline(TO_PAS_HEAPREF(heapRef), pas_maybe_compact_allocation_mode);
+    return bmalloc_iso_allocate_inline(TO_PAS_HEAPREF(heapRef), pas_always_compact_allocation_mode);
 }
 
 void* tzoneAllocateCompact(HeapRef heapRef)
 {
-    return bmalloc_iso_allocate_inline(TO_PAS_HEAPREF(heapRef), pas_maybe_compact_allocation_mode);
+    return bmalloc_iso_allocate_inline(TO_PAS_HEAPREF(heapRef), pas_always_compact_allocation_mode);
 }
 
 void* tzoneAllocateNonCompact(HeapRef heapRef)

--- a/Source/bmalloc/bmalloc/TZoneHeap.h
+++ b/Source/bmalloc/bmalloc/TZoneHeap.h
@@ -35,6 +35,7 @@
 
 #include "Algorithm.h"
 #include "BInline.h"
+#include "CompactAllocationMode.h"
 
 #define BUSE_TZONE_SPEC_NAME_ARG 0
 #if BUSE_TZONE_SPEC_NAME_ARG
@@ -116,6 +117,7 @@ struct SizeAndAlignment {
 struct TZoneSpecification {
     HeapRef* addressOfHeapRef;
     unsigned size;
+    CompactAllocationMode allocationMode;
     SizeAndAlignment::Value sizeAndAlignment;
 #if BUSE_TZONE_SPEC_NAME_ARG
     const char* name;
@@ -144,6 +146,7 @@ public: \
     using HeapRef = ::bmalloc::api::HeapRef; \
     using SizeAndAlignment = ::bmalloc::api::SizeAndAlignment; \
     using TZoneMallocFallback = ::bmalloc::api::TZoneMallocFallback; \
+    using CompactAllocationMode = ::bmalloc::CompactAllocationMode; \
 private: \
     static _exportMacro HeapRef s_heapRef; \
     static _exportMacro const TZoneSpecification s_heapSpec; \
@@ -191,7 +194,7 @@ private: \
 private: \
     static _exportMacro BNO_INLINE void* operatorNewSlow(size_t size) \
     { \
-        static const TZoneSpecification s_heapSpec = { &s_heapRef, sizeof(_type), SizeAndAlignment::encode<_type>() TZONE_SPEC_NAME_ARG(#_type) }; \
+        static const TZoneSpecification s_heapSpec = { &s_heapRef, sizeof(_type), CompactAllocationMode:: _compactMode, SizeAndAlignment::encode<_type>() TZONE_SPEC_NAME_ARG(#_type) }; \
         if constexpr (::bmalloc::api::requiresCompactPointers<_type>()) \
             return ::bmalloc::api::tzoneAllocateCompactSlow(size, s_heapSpec); \
         return ::bmalloc::api::tzoneAllocate ## _compactMode ## Slow(size, s_heapSpec); \

--- a/Source/bmalloc/bmalloc/TZoneHeapInlines.h
+++ b/Source/bmalloc/bmalloc/TZoneHeapInlines.h
@@ -38,6 +38,7 @@ public: \
     using HeapRef = ::bmalloc::api::HeapRef; \
     using SizeAndAlignment = ::bmalloc::api::SizeAndAlignment; \
     using TZoneMallocFallback = ::bmalloc::api::TZoneMallocFallback; \
+    using CompactAllocationMode = ::bmalloc::CompactAllocationMode; \
     \
     BINLINE void* operator new(size_t, void* p) { return p; } \
     BINLINE void* operator new[](size_t, void* p) { return p; } \
@@ -54,7 +55,7 @@ public: \
     void* operator new(size_t size) \
     { \
         static HeapRef s_heapRef; \
-        static const TZoneSpecification s_heapSpec = { &s_heapRef, sizeof(_type), SizeAndAlignment::encode<_type>() TZONE_SPEC_NAME_ARG(#_type) }; \
+        static const TZoneSpecification s_heapSpec = { &s_heapRef, sizeof(_type), CompactAllocationMode:: _compactMode, SizeAndAlignment::encode<_type>() TZONE_SPEC_NAME_ARG(#_type) }; \
     \
         if (!s_heapRef || size != sizeof(_type)) { [[unlikely]] \
             if constexpr (::bmalloc::api::requiresCompactPointers<_type>()) \
@@ -89,7 +90,7 @@ private: \
 #define MAKE_BTZONE_MALLOCED_IMPL(_type, _compactMode) \
 ::bmalloc::api::HeapRef _type::s_heapRef; \
 \
-const TZoneSpecification _type::s_heapSpec = { &_type::s_heapRef, sizeof(_type), SizeAndAlignment::encode<_type>() TZONE_SPEC_NAME_ARG(#_type) }; \
+const TZoneSpecification _type::s_heapSpec = { &_type::s_heapRef, sizeof(_type), CompactAllocationMode:: _compactMode, SizeAndAlignment::encode<_type>() TZONE_SPEC_NAME_ARG(#_type) }; \
 \
 void* _type::operatorNewSlow(size_t size) \
 { \

--- a/Source/bmalloc/bmalloc/TZoneHeapManager.h
+++ b/Source/bmalloc/bmalloc/TZoneHeapManager.h
@@ -70,6 +70,7 @@ class TZoneHeapManager {
         unsigned usedBucketBitmap;
         Vector<unsigned> bucketUseCounts;
 #endif
+        TZoneBucket nonCompactBucket;
         TZoneBucket buckets[1];
     };
 

--- a/Source/bmalloc/bmalloc/bmalloc.cpp
+++ b/Source/bmalloc/bmalloc/bmalloc.cpp
@@ -46,7 +46,7 @@ static const bmalloc_type primitiveGigacageType = BMALLOC_TYPE_INITIALIZER(1, 1,
 } // anonymous namespace
 
 pas_primitive_heap_ref gigacageHeaps[static_cast<size_t>(Gigacage::NumberOfKinds)] = {
-    BMALLOC_AUXILIARY_HEAP_REF_INITIALIZER(&primitiveGigacageType),
+    BMALLOC_AUXILIARY_HEAP_REF_INITIALIZER(&primitiveGigacageType, pas_bmalloc_heap_ref_kind_non_compact),
 };
 #endif
 

--- a/Source/bmalloc/libpas/src/libpas/bmalloc_heap.c
+++ b/Source/bmalloc/libpas/src/libpas/bmalloc_heap.c
@@ -53,15 +53,23 @@ pas_heap bmalloc_common_primitive_heap =
         BMALLOC_HEAP_CONFIG,
         &bmalloc_intrinsic_runtime_config.base);
 
+const bmalloc_type bmalloc_compact_primitive_type = BMALLOC_TYPE_INITIALIZER(1, 1, "Compact Primitive");
+
+pas_primitive_heap_ref bmalloc_compact_primitive_heap_ref =  BMALLOC_AUXILIARY_HEAP_REF_INITIALIZER(&bmalloc_compact_primitive_type, pas_bmalloc_heap_ref_kind_compact);
+
 pas_allocator_counts bmalloc_allocator_counts;
 
 PAS_NEVER_INLINE void* bmalloc_try_allocate_casual(size_t size, pas_allocation_mode allocation_mode)
 {
+    if (allocation_mode == pas_always_compact_allocation_mode && PAS_USE_COMPACT_ONLY_HEAP)
+        return (void*)bmalloc_try_allocate_auxiliary(&bmalloc_compact_primitive_heap_ref, size, allocation_mode);
     return (void*)bmalloc_try_allocate_impl_casual_case(size, 1, allocation_mode).begin;
 }
 
 PAS_NEVER_INLINE void* bmalloc_allocate_casual(size_t size, pas_allocation_mode allocation_mode)
 {
+    if (allocation_mode == pas_always_compact_allocation_mode && PAS_USE_COMPACT_ONLY_HEAP)
+        return (void*)bmalloc_allocate_auxiliary(&bmalloc_compact_primitive_heap_ref, size, allocation_mode);
     return (void*)bmalloc_allocate_impl_casual_case(size, 1, allocation_mode).begin;
 }
 

--- a/Source/bmalloc/libpas/src/libpas/bmalloc_heap_innards.h
+++ b/Source/bmalloc/libpas/src/libpas/bmalloc_heap_innards.h
@@ -39,6 +39,7 @@ PAS_BEGIN_EXTERN_C;
 
 PAS_API extern const bmalloc_type bmalloc_common_primitive_type;
 PAS_API extern pas_heap bmalloc_common_primitive_heap;
+PAS_API extern pas_primitive_heap_ref bmalloc_compact_primitive_heap_ref;
 PAS_API extern pas_intrinsic_heap_support bmalloc_common_primitive_heap_support;
 PAS_API extern pas_allocator_counts bmalloc_allocator_counts;
 

--- a/Source/bmalloc/libpas/src/libpas/bmalloc_heap_ref.h
+++ b/Source/bmalloc/libpas/src/libpas/bmalloc_heap_ref.h
@@ -31,24 +31,37 @@
 
 PAS_BEGIN_EXTERN_C;
 
-#define BMALLOC_HEAP_REF_INITIALIZER(passed_type) \
+enum pas_bmalloc_heap_ref_kind {
+    /* Every object in this heap must be able to be referenced by a compact
+       pointer. */
+    pas_bmalloc_heap_ref_kind_compact,
+
+    /* Objects in this heap may potentially not be safely referenced via
+       compact pointer. */
+    pas_bmalloc_heap_ref_kind_non_compact
+};
+
+typedef enum pas_bmalloc_heap_ref_kind pas_bmalloc_heap_ref_kind;
+
+#define BMALLOC_HEAP_REF_INITIALIZER(passed_type, heap_ref_kind) \
     ((pas_heap_ref){ \
          .type = (const pas_heap_type*)(passed_type), \
          .heap = NULL, \
-         .allocator_index = 0 \
+         .allocator_index = 0, \
+         .is_non_compact_heap = (heap_ref_kind == pas_bmalloc_heap_ref_kind_non_compact) \
      })
 
-#define BMALLOC_PRIMITIVE_HEAP_REF_INITIALIZER_IMPL(passed_type) \
+#define BMALLOC_PRIMITIVE_HEAP_REF_INITIALIZER_IMPL(passed_type, heap_ref_kind) \
     ((pas_primitive_heap_ref){ \
-         .base = BMALLOC_HEAP_REF_INITIALIZER(passed_type), \
+         .base = BMALLOC_HEAP_REF_INITIALIZER(passed_type, heap_ref_kind), \
          .cached_index = UINT_MAX \
      })
 
-#define BMALLOC_FLEX_HEAP_REF_INITIALIZER(passed_type) \
-    BMALLOC_PRIMITIVE_HEAP_REF_INITIALIZER_IMPL(passed_type)
+#define BMALLOC_FLEX_HEAP_REF_INITIALIZER(passed_type, heap_ref_kind) \
+    BMALLOC_PRIMITIVE_HEAP_REF_INITIALIZER_IMPL(passed_type, heap_ref_kind)
 
-#define BMALLOC_AUXILIARY_HEAP_REF_INITIALIZER(passed_type) \
-    BMALLOC_PRIMITIVE_HEAP_REF_INITIALIZER_IMPL(passed_type)
+#define BMALLOC_AUXILIARY_HEAP_REF_INITIALIZER(passed_type, heap_ref_kind) \
+    BMALLOC_PRIMITIVE_HEAP_REF_INITIALIZER_IMPL(passed_type, heap_ref_kind)
 
 PAS_END_EXTERN_C;
 

--- a/Source/bmalloc/libpas/src/libpas/pas_allocation_mode.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_allocation_mode.h
@@ -30,6 +30,11 @@
 
 PAS_BEGIN_EXTERN_C;
 
+#ifndef PAS_USE_COMPACT_ONLY_HEAP
+#define PAS_USE_COMPACT_ONLY_HEAP 0
+#define PAS_USE_COMPACT_ONLY_TZONE_HEAP 0
+#endif
+
 enum pas_allocation_mode {
     /* We are allocating an object from ordinary memory and don't plan on
        compacting its address. */

--- a/Source/bmalloc/libpas/src/libpas/pas_heap.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_heap.c
@@ -77,6 +77,7 @@ pas_heap* pas_heap_create(pas_heap_ref* heap_ref,
     heap->heap_ref = heap_ref;
     heap->heap_ref_kind = heap_ref_kind;
     heap->config_kind = config->kind;
+    heap->is_non_compact_heap = heap_ref->is_non_compact_heap;
 
     // PGM being enabled in the config does not guarantee it will be called during runtime.
     if (config->pgm_enabled)

--- a/Source/bmalloc/libpas/src/libpas/pas_heap.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_heap.h
@@ -49,8 +49,9 @@ struct pas_heap {
     const pas_heap_type* type;
     pas_heap_ref* heap_ref;
     pas_compact_heap_ptr next_heap;
-    pas_heap_config_kind config_kind : 6;
+    pas_heap_config_kind config_kind : 5;
     pas_heap_ref_kind heap_ref_kind : 2;
+    bool is_non_compact_heap : 1;
 };
 
 PAS_API pas_heap* pas_heap_create(pas_heap_ref* heap_ref,

--- a/Source/bmalloc/libpas/src/libpas/pas_heap_ref_prefix.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_heap_ref_prefix.h
@@ -36,6 +36,7 @@ struct __pas_heap_ref {
     const __pas_heap_type* type;
     __pas_heap* heap; /* initialize to NULL */
     unsigned allocator_index; /* initialize to 0 */
+    bool is_non_compact_heap; /* initialize to false */
 };
 
 __PAS_END_EXTERN_C;

--- a/Source/bmalloc/libpas/src/libpas/pas_try_allocate.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_try_allocate.h
@@ -77,7 +77,7 @@ pas_try_allocate_impl_inline_only(
     pas_try_allocate_common_fast_inline_only try_allocate_common_fast_inline_only)
 {
     static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_OTHER);
-    
+
     pas_local_allocator_result allocator;
     unsigned allocator_index;
     pas_thread_local_cache* cache;

--- a/Source/bmalloc/libpas/src/libpas/pas_try_allocate_intrinsic.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_try_allocate_intrinsic.h
@@ -78,6 +78,7 @@ PAS_BEGIN_EXTERN_C;
         .heap_ref = NULL, \
         .next_heap = PAS_COMPACT_PTR_INITIALIZER, \
         .config_kind = (passed_config).kind, \
+        .is_non_compact_heap = true, \
     }
 
 static PAS_ALWAYS_INLINE pas_allocation_result

--- a/Source/bmalloc/libpas/src/test/ExpendableMemoryTests.cpp
+++ b/Source/bmalloc/libpas/src/test/ExpendableMemoryTests.cpp
@@ -42,7 +42,7 @@ using namespace std;
 namespace {
 
 static const bmalloc_type theType = BMALLOC_TYPE_INITIALIZER(42, 2, "foo");
-pas_heap_ref theHeap = BMALLOC_HEAP_REF_INITIALIZER(&theType);
+pas_heap_ref theHeap = BMALLOC_HEAP_REF_INITIALIZER(&theType, pas_bmalloc_heap_ref_kind_non_compact);
 
 void testPayloadImpl(pas_heap_ref& heap, bool firstRun)
 {
@@ -197,7 +197,7 @@ void testSoManyHeaps()
     pas_scavenger_suspend();
     
     for (unsigned i = numHeaps; i--;)
-        heaps[i] = BMALLOC_HEAP_REF_INITIALIZER(&theType);
+        heaps[i] = BMALLOC_HEAP_REF_INITIALIZER(&theType, pas_bmalloc_heap_ref_kind_non_compact);
 
     for (unsigned i = 0; i < numHeaps; ++i)
         testPayloadImpl(heaps[i], !i);
@@ -222,7 +222,7 @@ void testRage(unsigned numHeaps, function<unsigned(unsigned)> allocationSize, un
     pas_primitive_heap_ref* heaps = new pas_primitive_heap_ref[numHeaps];
 
     for (unsigned i = numHeaps; i--;)
-        heaps[i] = BMALLOC_FLEX_HEAP_REF_INITIALIZER(new bmalloc_type(BMALLOC_TYPE_INITIALIZER(1, 1, "test")));
+        heaps[i] = BMALLOC_FLEX_HEAP_REF_INITIALIZER(new bmalloc_type(BMALLOC_TYPE_INITIALIZER(1, 1, "test")), pas_bmalloc_heap_ref_kind_non_compact);
 
     mutex lock;
     unsigned numThreadsDone = 0;
@@ -257,7 +257,8 @@ void testRematerializeAfterSearchOfDecommitted()
     static constexpr unsigned someOtherSize = 5000;
     
     pas_primitive_heap_ref heapRef = BMALLOC_FLEX_HEAP_REF_INITIALIZER(
-        new bmalloc_type(BMALLOC_TYPE_INITIALIZER(1, 1, "test")));
+        new bmalloc_type(BMALLOC_TYPE_INITIALIZER(1, 1, "test")),
+        pas_bmalloc_heap_ref_kind_non_compact);
     pas_heap* heap = bmalloc_flex_heap_ref_get_heap(&heapRef);
 
     void* ptr = bmalloc_allocate_flex(&heapRef, initialSize, pas_non_compact_allocation_mode);
@@ -310,7 +311,8 @@ void testBasicSizeClass(unsigned firstSize, unsigned secondSize)
     static constexpr bool verbose = false;
     
     pas_primitive_heap_ref heapRef = BMALLOC_FLEX_HEAP_REF_INITIALIZER(
-        new bmalloc_type(BMALLOC_TYPE_INITIALIZER(1, 1, "test")));
+        new bmalloc_type(BMALLOC_TYPE_INITIALIZER(1, 1, "test")),
+        pas_bmalloc_heap_ref_kind_non_compact);
 
     if (verbose)
         cout << "Allocating " << firstSize << "\n";

--- a/Source/bmalloc/libpas/src/test/IsoHeapChaosTests.cpp
+++ b/Source/bmalloc/libpas/src/test/IsoHeapChaosTests.cpp
@@ -106,7 +106,8 @@ pas_heap_ref* createBmallocHeapRefForSize(size_t size)
 
     return new pas_heap_ref(
         BMALLOC_HEAP_REF_INITIALIZER(
-            new bmalloc_type(BMALLOC_TYPE_INITIALIZER((unsigned)size, 1, strdup(stringOut.str().c_str())))));
+            new bmalloc_type(BMALLOC_TYPE_INITIALIZER((unsigned)size, 1, strdup(stringOut.str().c_str()))),
+            pas_bmalloc_heap_ref_kind_non_compact));
 }
 #endif // PAS_ENABLE_BMALLOC
 
@@ -1144,7 +1145,7 @@ void addAllTests()
             "bmalloc-gigacage",
             [] () {
                 static const bmalloc_type gigacageType = BMALLOC_TYPE_INITIALIZER(1, 1, "Gigacage");
-                gigacageHeapRef = BMALLOC_AUXILIARY_HEAP_REF_INITIALIZER(&gigacageType);
+                gigacageHeapRef = BMALLOC_AUXILIARY_HEAP_REF_INITIALIZER(&gigacageType, pas_bmalloc_heap_ref_kind_compact);
 
                 size_t reservationSize = 1000000000;
                 void* reservation = malloc(reservationSize);

--- a/Source/bmalloc/libpas/src/test/LotsOfHeapsAndThreads.cpp
+++ b/Source/bmalloc/libpas/src/test/LotsOfHeapsAndThreads.cpp
@@ -42,7 +42,7 @@ void testLotsOfHeapsAndThreads(unsigned numHeaps, unsigned numThreads, unsigned 
     pas_heap_ref* heaps = new pas_heap_ref[numHeaps];
 
     for (unsigned i = numHeaps; i--;)
-        heaps[i] = BMALLOC_HEAP_REF_INITIALIZER(new bmalloc_type(BMALLOC_TYPE_INITIALIZER(16, 16, "test")));
+        heaps[i] = BMALLOC_HEAP_REF_INITIALIZER(new bmalloc_type(BMALLOC_TYPE_INITIALIZER(16, 16, "test")), pas_bmalloc_heap_ref_kind_non_compact);
 
     for (unsigned i = numThreads; i--;) {
         threads[i] = thread([&] () {

--- a/Source/bmalloc/libpas/src/test/MemalignTests.cpp
+++ b/Source/bmalloc/libpas/src/test/MemalignTests.cpp
@@ -40,7 +40,7 @@ void testMemalignArray(size_t size, size_t typeSize, size_t typeAlignment)
     bmalloc_type type = BMALLOC_TYPE_INITIALIZER(static_cast<unsigned>(typeSize),
                                                  static_cast<unsigned>(typeAlignment),
                                                  "test");
-    pas_heap_ref heapRef = BMALLOC_HEAP_REF_INITIALIZER(&type);
+    pas_heap_ref heapRef = BMALLOC_HEAP_REF_INITIALIZER(&type, pas_bmalloc_heap_ref_kind_non_compact);
     pas_segregated_view view;
     pas_segregated_size_directory* directory;
 

--- a/Source/bmalloc/libpas/src/test/TLCDecommitTests.cpp
+++ b/Source/bmalloc/libpas/src/test/TLCDecommitTests.cpp
@@ -68,7 +68,7 @@ void testTLCDecommit(unsigned numHeaps,
 
     pas_heap_ref* heaps = new pas_heap_ref[numHeaps];
     for (size_t index = numHeaps; index--;)
-        heaps[index] = BMALLOC_HEAP_REF_INITIALIZER(new bmalloc_type(BMALLOC_TYPE_INITIALIZER(42, 2, "test")));
+        heaps[index] = BMALLOC_HEAP_REF_INITIALIZER(new bmalloc_type(BMALLOC_TYPE_INITIALIZER(42, 2, "test")), pas_bmalloc_heap_ref_kind_non_compact);
 
     vector<void*> objects;
     for (size_t index = 0; index < numHeaps; ++index) {
@@ -191,7 +191,8 @@ void testChaosThenDecommit(unsigned numHeaps, unsigned typeSize, unsigned maxObj
     pas_heap_ref* heapRefs = new pas_heap_ref[numHeaps];
     for (unsigned index = numHeaps; index--;) {
         heapRefs[index] = BMALLOC_HEAP_REF_INITIALIZER(
-            new bmalloc_type(BMALLOC_TYPE_INITIALIZER(typeSize, 1, "test")));
+            new bmalloc_type(BMALLOC_TYPE_INITIALIZER(typeSize, 1, "test")),
+            pas_bmalloc_heap_ref_kind_non_compact);
     }
     
     vector<vector<void*>> objects;
@@ -261,7 +262,8 @@ vector<void*> prepareToTestDLCDecommitThenStuff(unsigned numHeaps)
     pas_heap_ref* heaps = new pas_heap_ref[numHeaps];
     for (size_t index = numHeaps; index--;)
         heaps[index] = BMALLOC_HEAP_REF_INITIALIZER(
-            new bmalloc_type(BMALLOC_TYPE_INITIALIZER(512, 512, "test")));
+            new bmalloc_type(BMALLOC_TYPE_INITIALIZER(512, 512, "test")),
+            pas_bmalloc_heap_ref_kind_non_compact);
 
     vector<void*> objects;
     for (size_t index = 0; index < numHeaps; ++index) {
@@ -361,7 +363,8 @@ void testAllocateFromStoppedBaselineImpl()
     }
 
     pas_heap_ref heapRef = BMALLOC_HEAP_REF_INITIALIZER(
-        new bmalloc_type(BMALLOC_TYPE_INITIALIZER(32, 1, "test")));
+        new bmalloc_type(BMALLOC_TYPE_INITIALIZER(32, 1, "test")),
+        pas_bmalloc_heap_ref_kind_non_compact);
 
     void* ptr = bmalloc_iso_allocate(&heapRef, pas_non_compact_allocation_mode);
     CHECK(ptr);


### PR DESCRIPTION
#### bf96ec01cb51a1cb6d43df161854da51ddcebc6c
<pre>
Allocate compactible and non-compactible types out of entirely different heaps
<a href="https://bugs.webkit.org/show_bug.cgi?id=292695">https://bugs.webkit.org/show_bug.cgi?id=292695</a>
<a href="https://rdar.apple.com/150893097">rdar://150893097</a>

Reviewed by Mark Lam.

Separates any allocations with a compact allocation mode from
non-compact allocations on a heap level. For general allocations,
we select between the bmalloc common intrinsic heap and a new
auxiliary compact primitive heap based on the allocation mode. For
TZone heaps, this means we create separate buckets for compact and
non-compact types. Both of these mechanisms are disabled by default
for the time being, but in the future we may be able to use this
mechanism to efficiently compress pointers into these heaps using
a base + 32-bit offset encoding.

* Source/JavaScriptCore/heap/StructureAlignedMemoryAllocator.cpp:
(JSC::StructureMemoryManager::tryMallocStructureBlock):
* Source/bmalloc/bmalloc/CompactAllocationMode.h:
(bmalloc::asPasAllocationMode):
* Source/bmalloc/bmalloc/DebugHeap.cpp:
(pas_debug_heap_malloc_compact):
(pas_debug_heap_memalign_compact):
(pas_debug_heap_realloc_compact):
* Source/bmalloc/bmalloc/IsoHeap.cpp:
(bmalloc::api::isoAllocateCompact):
(bmalloc::api::isoTryAllocateCompact):
* Source/bmalloc/bmalloc/IsoHeap.h:
(bmalloc::api::IsoHeapBase::provideHeap):
* Source/bmalloc/bmalloc/TZoneHeap.cpp:
(bmalloc::api::tzoneAllocateCompactSlow):
(bmalloc::api::tzoneAllocateCompact):
* Source/bmalloc/bmalloc/TZoneHeap.h:
* Source/bmalloc/bmalloc/TZoneHeapInlines.h:
* Source/bmalloc/bmalloc/TZoneHeapManager.cpp:
(bmalloc::api::nameForTypeNonCompact):
(bmalloc::api::TZoneHeapManager::populateBucketsForSizeClass):
(bmalloc::api::TZoneHeapManager::heapRefForTZoneType):
(bmalloc::api::TZoneHeapManager::TZoneHeapManager::heapRefForTZoneTypeDifferentSize):
* Source/bmalloc/bmalloc/TZoneHeapManager.h:
* Source/bmalloc/bmalloc/bmalloc.cpp:
(bmalloc::api::mallocOutOfLine):
* Source/bmalloc/libpas/src/libpas/bmalloc_heap.c:
(bmalloc_try_allocate_casual):
(bmalloc_allocate_casual):
* Source/bmalloc/libpas/src/libpas/bmalloc_heap_inlines.h:
(bmalloc_try_allocate_auxiliary_inline):
(bmalloc_allocate_auxiliary_inline):
(bmalloc_try_allocate_auxiliary_zeroed_inline):
(bmalloc_allocate_auxiliary_zeroed_inline):
(bmalloc_try_allocate_auxiliary_with_alignment_inline):
(bmalloc_allocate_auxiliary_with_alignment_inline):
(bmalloc_try_reallocate_auxiliary_inline):
(bmalloc_reallocate_auxiliary_inline):
(bmalloc_try_allocate_inline):
(bmalloc_try_allocate_with_alignment_inline):
(bmalloc_try_allocate_zeroed_inline):
(bmalloc_allocate_inline):
(bmalloc_allocate_with_alignment_inline):
(bmalloc_allocate_zeroed_inline):
(bmalloc_try_reallocate_inline):
(bmalloc_reallocate_inline):
* Source/bmalloc/libpas/src/libpas/bmalloc_heap_innards.h:
* Source/bmalloc/libpas/src/libpas/bmalloc_heap_ref.h:
* Source/bmalloc/libpas/src/libpas/pas_allocation_mode.h:
* Source/bmalloc/libpas/src/libpas/pas_heap.c:
(pas_heap_create):
* Source/bmalloc/libpas/src/libpas/pas_heap.h:
* Source/bmalloc/libpas/src/libpas/pas_heap_ref_prefix.h:
* Source/bmalloc/libpas/src/libpas/pas_try_allocate.h:
(pas_try_allocate_impl_inline_only):
* Source/bmalloc/libpas/src/libpas/pas_try_allocate_intrinsic.h:

Canonical link: <a href="https://commits.webkit.org/295119@main">https://commits.webkit.org/295119@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/30e402660c05d8ae45ee502ae0e7cc1054d51476

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104130 "9 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/23834 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/14154 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/109326 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/54798 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/24202 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/32378 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/79107 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107136 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/18803 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/93941 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/59434 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/18611 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/11981 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/54158 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/96805 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/88326 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/12037 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/111712 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/102741 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/31286 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/23072 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/88123 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/31650 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/90128 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/87783 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22347 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32662 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10414 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/25750 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/31215 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/36528 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/126375 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/31009 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34947 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/34345 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/32569 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->