### PR TITLE
Deploy WeakPtr and CheckedPtr in DocumentThreadableLoader

### DIFF
--- a/Source/WebCore/loader/DocumentThreadableLoader.cpp
+++ b/Source/WebCore/loader/DocumentThreadableLoader.cpp
@@ -118,7 +118,7 @@ bool DocumentThreadableLoader::shouldSetHTTPHeadersToKeep() const
 }
 
 DocumentThreadableLoader::DocumentThreadableLoader(Document& document, ThreadableLoaderClient& client, BlockingBehavior blockingBehavior, ResourceRequest&& request, const ThreadableLoaderOptions& options, RefPtr<SecurityOrigin>&& origin, std::unique_ptr<ContentSecurityPolicy>&& contentSecurityPolicy, std::optional<CrossOriginEmbedderPolicy>&& crossOriginEmbedderPolicy, String&& referrer, ShouldLogError shouldLogError)
-    : m_client(&client)
+    : m_client(client)
     , m_document(document)
     , m_options(options)
     , m_origin(WTFMove(origin))
@@ -188,6 +188,16 @@ DocumentThreadableLoader::DocumentThreadableLoader(Document& document, Threadabl
     }
 
     makeCrossOriginAccessRequest(WTFMove(request));
+}
+
+void DocumentThreadableLoader::clearClient()
+{
+    m_client = nullptr;
+}
+
+inline CheckedPtr<ThreadableLoaderClient> DocumentThreadableLoader::checkedClient()
+{
+    return m_client.get();
 }
 
 bool DocumentThreadableLoader::checkURLSchemeAsCORSEnabled(const URL& url)
@@ -264,10 +274,11 @@ void DocumentThreadableLoader::cancel()
     Ref protectedThis { *this };
 
     // Cancel can re-enter and m_resource might be null here as a result.
-    if (m_client && m_resource) {
+    CheckedPtr client = m_client.get();
+    if (client && m_resource) {
         // FIXME: This error is sent to the client in didFail(), so it should not be an internal one. Use LocalFrameLoaderClient::cancelledError() instead.
         ResourceError error(errorDomainWebKitInternal, 0, m_resource->url(), "Load cancelled"_s, ResourceError::Type::Cancellation);
-        m_client->didFail(m_document->identifier(), error); // May destroy the client.
+        client->didFail(m_document->identifier(), error); // May destroy the client.
     }
     clearResource();
     m_client = nullptr;
@@ -276,14 +287,14 @@ void DocumentThreadableLoader::cancel()
 void DocumentThreadableLoader::computeIsDone()
 {
     if (!m_async || m_preflightChecker || !m_resource) {
-        if (m_client)
-            m_client->notifyIsDone(m_async && !m_preflightChecker && !m_resource);
+        if (CheckedPtr client = m_client.get())
+            client->notifyIsDone(m_async && !m_preflightChecker && !m_resource);
         return;
     }
     platformStrategies()->loaderStrategy()->isResourceLoadFinished(*protectedResource(), [weakThis = WeakPtr { *this }](bool isDone) {
         RefPtr protectedThis = weakThis.get();
-        if (protectedThis && protectedThis->m_client)
-            protectedThis->m_client->notifyIsDone(isDone);
+        if (CheckedPtr client = protectedThis ? protectedThis->m_client.get() : nullptr)
+            client->notifyIsDone(isDone);
     });
 }
 
@@ -388,9 +399,10 @@ void DocumentThreadableLoader::redirectReceived(CachedResource& resource, Resour
 
 void DocumentThreadableLoader::dataSent(CachedResource& resource, unsigned long long bytesSent, unsigned long long totalBytesToBeSent)
 {
-    ASSERT(m_client);
+    CheckedPtr client = m_client.get();
+    ASSERT(client);
     ASSERT_UNUSED(resource, &resource == m_resource);
-    m_client->didSendData(bytesSent, totalBytesToBeSent);
+    client->didSendData(bytesSent, totalBytesToBeSent);
 }
 
 void DocumentThreadableLoader::responseReceived(const CachedResource& resource, const ResourceResponse& response, CompletionHandler<void()>&& completionHandler)
@@ -415,7 +427,8 @@ void DocumentThreadableLoader::responseReceived(const CachedResource& resource, 
 
 void DocumentThreadableLoader::didReceiveResponse(ResourceLoaderIdentifier identifier, ResourceResponse&& response)
 {
-    ASSERT(m_client);
+    CheckedPtr client = m_client.get();
+    ASSERT(client);
     ASSERT(response.type() != ResourceResponse::Type::Error);
 
     // https://fetch.spec.whatwg.org/commit-snapshots/6257e220d70f560a037e46f1b4206325400db8dc/#main-fetch step 17.
@@ -432,21 +445,20 @@ void DocumentThreadableLoader::didReceiveResponse(ResourceLoaderIdentifier ident
         return;
 
     if (options().filteringPolicy == ResponseFilteringPolicy::Disable) {
-        m_client->didReceiveResponse(m_document->identifier(), identifier, WTFMove(response));
+        client->didReceiveResponse(m_document->identifier(), identifier, WTFMove(response));
         return;
     }
 
     if (response.type() == ResourceResponse::Type::Default) {
-        m_client->didReceiveResponse(m_document->identifier(), identifier, ResourceResponse::filter(response, m_options.credentials == FetchOptions::Credentials::Include ? ResourceResponse::PerformExposeAllHeadersCheck::No : ResourceResponse::PerformExposeAllHeadersCheck::Yes));
+        client->didReceiveResponse(m_document->identifier(), identifier, ResourceResponse::filter(response, m_options.credentials == FetchOptions::Credentials::Include ? ResourceResponse::PerformExposeAllHeadersCheck::No : ResourceResponse::PerformExposeAllHeadersCheck::Yes));
         if (response.tainting() == ResourceResponse::Tainting::Opaque) {
             clearResource();
-            if (m_client)
-                m_client->didFinishLoading(m_document->identifier(), identifier, { });
+            client->didFinishLoading(m_document->identifier(), identifier, { });
         }
         return;
     }
     ASSERT(response.type() == ResourceResponse::Type::Opaqueredirect || response.source() == ResourceResponse::Source::ServiceWorker || response.source() == ResourceResponse::Source::MemoryCache);
-    m_client->didReceiveResponse(m_document->identifier(), identifier, WTFMove(response));
+    client->didReceiveResponse(m_document->identifier(), identifier, WTFMove(response));
 }
 
 void DocumentThreadableLoader::dataReceived(CachedResource& resource, const SharedBuffer& buffer)
@@ -457,12 +469,13 @@ void DocumentThreadableLoader::dataReceived(CachedResource& resource, const Shar
 
 void DocumentThreadableLoader::didReceiveData(const SharedBuffer& buffer)
 {
-    ASSERT(m_client);
+    CheckedPtr client = m_client.get();
+    ASSERT(client);
 
     if (m_delayCallbacksForIntegrityCheck)
         return;
 
-    m_client->didReceiveData(buffer);
+    client->didReceiveData(buffer);
 }
 
 void DocumentThreadableLoader::finishedTimingForWorkerLoad(CachedResource& resource, const ResourceTiming& resourceTiming)
@@ -477,7 +490,7 @@ void DocumentThreadableLoader::finishedTimingForWorkerLoad(const ResourceTiming&
 {
     ASSERT(m_options.initiatorContext == InitiatorContext::Worker);
 
-    m_client->didFinishTiming(resourceTiming);
+    checkedClient()->didFinishTiming(resourceTiming);
 }
 
 void DocumentThreadableLoader::notifyFinished(CachedResource& resource, const NetworkLoadMetrics& metrics, LoadWillContinueInAnotherProcess)
@@ -493,7 +506,8 @@ void DocumentThreadableLoader::notifyFinished(CachedResource& resource, const Ne
 
 void DocumentThreadableLoader::didFinishLoading(std::optional<ResourceLoaderIdentifier> identifier, const NetworkLoadMetrics& metrics)
 {
-    ASSERT(m_client);
+    CheckedPtr client = m_client.get();
+    ASSERT(client);
 
     if (m_delayCallbacksForIntegrityCheck) {
         CachedResourceHandle resource = m_resource;
@@ -508,24 +522,25 @@ void DocumentThreadableLoader::didFinishLoading(std::optional<ResourceLoaderIden
         if (resource->resourceBuffer())
             buffer = resource->resourceBuffer()->makeContiguous();
         if (options().filteringPolicy == ResponseFilteringPolicy::Disable) {
-            m_client->didReceiveResponse(m_document->identifier(), identifier, WTFMove(response));
+            client->didReceiveResponse(m_document->identifier(), identifier, WTFMove(response));
             if (buffer)
-                m_client->didReceiveData(*buffer);
+                client->didReceiveData(*buffer);
         } else {
             ASSERT(response.type() == ResourceResponse::Type::Default);
 
-            m_client->didReceiveResponse(m_document->identifier(), identifier, ResourceResponse::filter(response, m_options.credentials == FetchOptions::Credentials::Include ? ResourceResponse::PerformExposeAllHeadersCheck::No : ResourceResponse::PerformExposeAllHeadersCheck::Yes));
+            client->didReceiveResponse(m_document->identifier(), identifier, ResourceResponse::filter(response, m_options.credentials == FetchOptions::Credentials::Include ? ResourceResponse::PerformExposeAllHeadersCheck::No : ResourceResponse::PerformExposeAllHeadersCheck::Yes));
             if (buffer)
-                m_client->didReceiveData(*buffer);
+                client->didReceiveData(*buffer);
         }
     }
 
-    m_client->didFinishLoading(m_document->identifier(), identifier, metrics);
+    client->didFinishLoading(m_document->identifier(), identifier, metrics);
 }
 
 void DocumentThreadableLoader::didFail(std::optional<ResourceLoaderIdentifier>, const ResourceError& error)
 {
-    ASSERT(m_client);
+    CheckedPtr client = m_client.get();
+    ASSERT(client);
     if (m_bypassingPreflightForServiceWorkerRequest && error.isCancellation()) {
         clearResource();
 
@@ -537,8 +552,8 @@ void DocumentThreadableLoader::didFail(std::optional<ResourceLoaderIdentifier>, 
     if (m_shouldLogError == ShouldLogError::Yes)
         logError(protectedDocument(), error, m_options.initiatorType);
 
-    if (m_client)
-        m_client->didFail(m_document->identifier(), error); // May cause the client to get destroyed.
+    if (client)
+        client->didFail(m_document->identifier(), error); // May cause the client to get destroyed.
 }
 
 Ref<Document> DocumentThreadableLoader::protectedDocument()
@@ -568,7 +583,7 @@ void DocumentThreadableLoader::preflightFailure(std::optional<ResourceLoaderIden
     if (m_shouldLogError == ShouldLogError::Yes)
         logError(protectedDocument(), error, m_options.initiatorType);
 
-    m_client->didFail(m_document->identifier(), error);
+    checkedClient()->didFail(m_document->identifier(), error);
 }
 
 void DocumentThreadableLoader::loadRequest(ResourceRequest&& request, SecurityCheckPolicy securityCheck)
@@ -793,9 +808,10 @@ void DocumentThreadableLoader::logErrorAndFail(const ResourceError& error)
             document->addConsoleMessage(MessageSource::Security, MessageLevel::Error, error.localizedDescription());
         logError(document, error, m_options.initiatorType);
     }
-    ASSERT(m_client);
-    if (m_client)
-        m_client->didFail(m_document->identifier(), error); // May cause the client to get destroyed.
+    CheckedPtr client = m_client.get();
+    ASSERT(client);
+    if (client)
+        client->didFail(m_document->identifier(), error); // May cause the client to get destroyed.
 }
 
 } // namespace WebCore

--- a/Source/WebCore/loader/DocumentThreadableLoader.h
+++ b/Source/WebCore/loader/DocumentThreadableLoader.h
@@ -62,7 +62,7 @@ class CachedRawResource;
         void cancel() override;
         virtual void setDefersLoading(bool);
         void computeIsDone() final;
-        void clearClient() { m_client = nullptr; }
+        void clearClient();
 
         friend CrossOriginPreflightChecker;
         friend class InspectorInstrumentation;
@@ -119,6 +119,7 @@ class CachedRawResource;
         Document& document() { return *m_document; }
         Ref<Document> protectedDocument();
 
+        inline CheckedPtr<ThreadableLoaderClient> checkedClient();
         const ThreadableLoaderOptions& options() const { return m_options; }
         const String& referrer() const { return m_referrer; }
         bool isLoading() { return m_resource || m_preflightChecker; }
@@ -135,7 +136,7 @@ class CachedRawResource;
         CachedResourceHandle<CachedRawResource> protectedResource() const;
 
         CachedResourceHandle<CachedRawResource> m_resource;
-        ThreadableLoaderClient* m_client; // FIXME: Use a smart pointer.
+        WeakPtr<ThreadableLoaderClient> m_client;
         WeakPtr<Document, WeakPtrImplWithEventTargetData> m_document;
         ThreadableLoaderOptions m_options;
         bool m_responsesCanBeOpaque { true };


### PR DESCRIPTION
#### aa4e74f15376013bec08a212ad512996d859c28c
<pre>
Deploy WeakPtr and CheckedPtr in DocumentThreadableLoader
<a href="https://bugs.webkit.org/show_bug.cgi?id=293074">https://bugs.webkit.org/show_bug.cgi?id=293074</a>

Reviewed by NOBODY (OOPS!).

Use WeakPtr and CheckedPtr in place of a raw pointer.

* Source/WebCore/loader/DocumentThreadableLoader.cpp:
(WebCore::DocumentThreadableLoader::DocumentThreadableLoader):
(WebCore::DocumentThreadableLoader::clearClient):
(WebCore::DocumentThreadableLoader::checkedClient):
(WebCore::DocumentThreadableLoader::cancel):
(WebCore::DocumentThreadableLoader::computeIsDone):
(WebCore::DocumentThreadableLoader::dataSent):
(WebCore::DocumentThreadableLoader::didReceiveResponse):
(WebCore::DocumentThreadableLoader::didReceiveData):
(WebCore::DocumentThreadableLoader::finishedTimingForWorkerLoad):
(WebCore::DocumentThreadableLoader::didFinishLoading):
(WebCore::DocumentThreadableLoader::didFail):
(WebCore::DocumentThreadableLoader::preflightFailure):
(WebCore::DocumentThreadableLoader::logErrorAndFail):
* Source/WebCore/loader/DocumentThreadableLoader.h:
(WebCore::DocumentThreadableLoader::clearClient): Deleted.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aa4e74f15376013bec08a212ad512996d859c28c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/103711 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/23413 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/13733 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/108901 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/54363 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/105751 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/23758 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/31959 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/108901 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/54363 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/106717 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/18435 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/93553 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/108901 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/18241 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/11601 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/53739 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/88023 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/11660 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/111291 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/30867 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/22758 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/87797 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/31228 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/89754 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87448 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32329 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10052 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/25224 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/30795 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/36098 "Built successfully") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/30589 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/33924 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/32150 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->