### PR TITLE
[WebGPU] Infinite loop prevention does not need to be applied to concrete initialization

### DIFF
--- a/LayoutTests/fast/webgpu/nocrash/fuzz-292959-expected.txt
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-292959-expected.txt
@@ -1,0 +1,2 @@
+CONSOLE MESSAGE: Pass
+

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-292959.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-292959.html
@@ -1,0 +1,103 @@
+<style>
+  :root { background: #102030e0; color: #99ddbbcc; font-size: 15px; }
+</style>
+<script id="shared">
+const log = console.log;
+
+</script>
+<script>
+globalThis.testRunner?.waitUntilDone();
+
+async function window0() {
+let adapter0 = await navigator.gpu.requestAdapter({});
+let promise0 = adapter0.requestDevice({
+  requiredFeatures: ['shader-f16'],
+  requiredLimits: {
+    maxBindGroups: 4,
+  },
+});
+let device0 = await promise0;
+// START
+let commandEncoder73 = device0.createCommandEncoder({});
+let computePassEncoder22 = commandEncoder73.beginComputePass();
+let veryExplicitBindGroupLayout0_ = device0.createBindGroupLayout({
+    entries: [{
+        binding: 0,
+        visibility: GPUShaderStage.FRAGMENT,
+        sampler: {
+            type: 'filtering'
+        }
+    }, {
+        binding: 76,
+        visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+        sampler: {
+            type: 'filtering'
+        },
+    }, ],
+});
+let pipelineLayout0_ = device0.createPipelineLayout({
+    bindGroupLayouts: [veryExplicitBindGroupLayout0_]
+});
+let shaderModule4 = device0.createShaderModule({
+    code: `
+enable f16;
+
+var<workgroup> vw0: array<f16, 120>;
+
+@compute @workgroup_size(1, 1, 1) fn compute3() {
+  while true {
+    return;
+  }
+  vw0[119] = workgroupUniformLoad(&vw0)[119];
+  vw0[119] = workgroupUniformLoad(&vw0)[119];
+  vw0[119] = workgroupUniformLoad(&vw0)[119];
+}
+`,
+});
+let pipeline9 = device0.createComputePipeline({
+    layout: pipelineLayout0_,
+    compute: {
+        module: shaderModule4,
+        entryPoint: 'compute3'
+    }
+});
+computePassEncoder22.setPipeline(pipeline9);
+let sampler8_ = device0.createSampler({
+    addressModeV: 'repeat',
+    addressModeW: 'mirror-repeat',
+    lodMinClamp: 93.91,
+    lodMaxClamp: 96.57
+});
+let sampler2_ = device0.createSampler({
+    magFilter: 'linear',
+    minFilter: 'linear',
+    mipmapFilter: 'linear',
+    lodMaxClamp: 95.71,
+    maxAnisotropy: 6
+});
+let bindGroup9_ = device0.createBindGroup({
+    layout: veryExplicitBindGroupLayout0_,
+    entries: [{
+        binding: 76,
+        resource: sampler8_
+    }, {
+        binding: 0,
+        resource: sampler2_
+    }],
+});
+computePassEncoder22.setBindGroup(0, bindGroup9_, []);
+computePassEncoder22.dispatchWorkgroups(1, 1);
+computePassEncoder22.end();
+let commandBuffer0 = commandEncoder73.finish();
+device0.queue.submit([commandBuffer0]);
+// END
+  await device0.queue.onSubmittedWorkDone();
+  log('Pass');
+}
+globalThis.testRunner?.dumpAsText();
+globalThis.testRunner?.waitUntilDone();
+onload = async () => {
+  await window0();
+  globalThis.testRunner?.notifyDone();
+};
+</script>

--- a/Source/WebGPU/WGSL/AST/ASTForStatement.h
+++ b/Source/WebGPU/WGSL/AST/ASTForStatement.h
@@ -38,6 +38,8 @@ public:
     Expression* maybeTest() { return m_test; }
     Statement* maybeUpdate() { return m_update; }
     CompoundStatement& body() { return m_body; }
+    bool isInternallyGenerated() const { return m_isInternallyGenerated; }
+    void setInternallyGenerated() { m_isInternallyGenerated = true; }
 
 private:
     ForStatement(SourceSpan span, Statement::Ptr initializer, Expression::Ptr test, Statement::Ptr update, CompoundStatement::Ref&& body)
@@ -52,6 +54,7 @@ private:
     Expression::Ptr m_test;
     Statement::Ptr m_update;
     CompoundStatement::Ref m_body;
+    bool m_isInternallyGenerated { false };
 };
 
 } // namespace WGSL::AST

--- a/Source/WebGPU/WGSL/GlobalVariableRewriter.cpp
+++ b/Source/WebGPU/WGSL/GlobalVariableRewriter.cpp
@@ -2552,6 +2552,7 @@ void RewriteGlobalVariables::storeInitialValue(AST::Expression& target, AST::Sta
             &forUpdate,
             forBody
         );
+        forStatement.setInternallyGenerated();
 
         statements.append(AST::Statement::Ref(forStatement));
         return;

--- a/Source/WebGPU/WGSL/Metal/MetalCodeGenerator.cpp
+++ b/Source/WebGPU/WGSL/Metal/MetalCodeGenerator.cpp
@@ -69,12 +69,12 @@ static void dumpMetalCodeIfNeeded(StringBuilder& stringBuilder)
 }
 #endif
 
-String generateMetalCode(ShaderModule& shaderModule, PrepareResult& prepareResult, const HashMap<String, ConstantValue>& constantValues, unsigned appleGPUFamily)
+String generateMetalCode(ShaderModule& shaderModule, PrepareResult& prepareResult, const HashMap<String, ConstantValue>& constantValues, DeviceState&& deviceState)
 {
     StringBuilder stringBuilder;
     stringBuilder.append(metalCodePrologue());
 
-    Metal::emitMetalFunctions(stringBuilder, shaderModule, prepareResult, constantValues, appleGPUFamily);
+    Metal::emitMetalFunctions(stringBuilder, shaderModule, prepareResult, constantValues, WTFMove(deviceState));
 
 #if PLATFORM(COCOA)
     dumpMetalCodeIfNeeded(stringBuilder);

--- a/Source/WebGPU/WGSL/Metal/MetalCodeGenerator.h
+++ b/Source/WebGPU/WGSL/Metal/MetalCodeGenerator.h
@@ -31,12 +31,13 @@ namespace WGSL {
 
 class ShaderModule;
 struct ConstantValue;
+struct DeviceState;
 struct PrepareResult;
 
 namespace Metal {
 
 // Can't fail. Any failure checks need to be done earlier, in the backend-agnostic part of the compiler.
-String generateMetalCode(ShaderModule&, PrepareResult&, const HashMap<String, ConstantValue>&, unsigned appleGPUFamily);
+String generateMetalCode(ShaderModule&, PrepareResult&, const HashMap<String, ConstantValue>&, DeviceState&&);
 
 } // namespace Metal
 } // namespace WGSL

--- a/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.h
+++ b/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.h
@@ -31,11 +31,12 @@ namespace WGSL {
 
 class ShaderModule;
 struct ConstantValue;
+struct DeviceState;
 struct PrepareResult;
 
 namespace Metal {
 
-void emitMetalFunctions(StringBuilder&, ShaderModule&, PrepareResult&, const HashMap<String, ConstantValue>&, unsigned appleGPUFamily);
+void emitMetalFunctions(StringBuilder&, ShaderModule&, PrepareResult&, const HashMap<String, ConstantValue>&, DeviceState&&);
 
 } // namespace Metal
 } // namespace WGSL

--- a/Source/WebGPU/WGSL/WGSL.cpp
+++ b/Source/WebGPU/WGSL/WGSL.cpp
@@ -120,7 +120,7 @@ inline Variant<PrepareResult, Error> prepareImpl(ShaderModule& shaderModule, con
     return result;
 }
 
-Variant<String, Error> generate(ShaderModule& shaderModule, PrepareResult& prepareResult, HashMap<String, ConstantValue>& constantValues, unsigned appleGPUFamily)
+Variant<String, Error> generate(ShaderModule& shaderModule, PrepareResult& prepareResult, HashMap<String, ConstantValue>& constantValues, DeviceState&& deviceState)
 {
     PhaseTimes phaseTimes;
     String result;
@@ -128,7 +128,7 @@ Variant<String, Error> generate(ShaderModule& shaderModule, PrepareResult& prepa
         return { *maybeError };
     {
         PhaseTimer phaseTimer("generateMetalCode", phaseTimes);
-        result = Metal::generateMetalCode(shaderModule, prepareResult, constantValues, appleGPUFamily);
+        result = Metal::generateMetalCode(shaderModule, prepareResult, constantValues, WTFMove(deviceState));
     }
     logPhaseTimes(phaseTimes);
     return { result };

--- a/Source/WebGPU/WGSL/WGSL.h
+++ b/Source/WebGPU/WGSL/WGSL.h
@@ -229,10 +229,15 @@ struct PrepareResult {
     CompilationScope compilationScope;
 };
 
+struct DeviceState {
+    unsigned appleGPUFamily { 4 };
+    bool shaderValidationEnabled { false };
+};
+
 Variant<PrepareResult, Error> prepare(ShaderModule&, const HashMap<String, PipelineLayout*>&);
 Variant<PrepareResult, Error> prepare(ShaderModule&, const String& entryPointName, PipelineLayout*);
 
-Variant<String, Error> generate(ShaderModule&, PrepareResult&, HashMap<String, ConstantValue>&, unsigned appleGPUFamily = 4);
+Variant<String, Error> generate(ShaderModule&, PrepareResult&, HashMap<String, ConstantValue>&, DeviceState&&);
 
 std::optional<ConstantValue> evaluate(const AST::Expression&, const HashMap<String, ConstantValue>&);
 

--- a/Source/WebGPU/WebGPU/Pipeline.mm
+++ b/Source/WebGPU/WebGPU/Pipeline.mm
@@ -154,14 +154,20 @@ std::optional<LibraryCreationResult> createLibrary(id<MTLDevice> device, const S
         }
     }
 
-    auto generationResult = WGSL::generate(*ast, result, wgslConstantValues, shaderModule.device().appleGPUFamily());
+    auto generationResult = WGSL::generate(*ast, result, wgslConstantValues, WGSL::DeviceState {
+        .appleGPUFamily = shaderModule.device().appleGPUFamily(),
+        .shaderValidationEnabled = shaderModule.device().isShaderValidationEnabled()
+    });
     if (auto* generationError = std::get_if<WGSL::Error>(&generationResult)) {
         *error = [NSError errorWithDomain:@"WebGPU" code:1 userInfo:@{ NSLocalizedDescriptionKey: generationError->message().createNSString().get() }];
         return std::nullopt;
     }
     auto& msl = std::get<String>(generationResult);
 
-    auto library = ShaderModule::createLibrary(device, msl, label, error, shaderModule.device().appleGPUFamily());
+    auto library = ShaderModule::createLibrary(device, msl, label, error, WGSL::DeviceState {
+        .appleGPUFamily = shaderModule.device().appleGPUFamily(),
+        .shaderValidationEnabled = shaderModule.device().isShaderValidationEnabled()
+    });
     if (error && *error)
         return { };
 

--- a/Source/WebGPU/WebGPU/ShaderModule.h
+++ b/Source/WebGPU/WebGPU/ShaderModule.h
@@ -72,7 +72,7 @@ public:
     bool isValid() const { return std::holds_alternative<WGSL::SuccessfulCheck>(m_checkResult); }
 
     static WGSL::PipelineLayout convertPipelineLayout(const PipelineLayout&);
-    static id<MTLLibrary> createLibrary(id<MTLDevice>, const String& msl, String&& label, NSError **, uint32_t appleGPUFamily);
+    static id<MTLLibrary> createLibrary(id<MTLDevice>, const String& msl, String&& label, NSError **, WGSL::DeviceState&&);
 
     WGSL::ShaderModule* ast() const;
 

--- a/Tools/TestWebKitAPI/Tests/WGSL/MetalGenerationTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WGSL/MetalGenerationTests.cpp
@@ -45,7 +45,10 @@ inline Expected<String, WGSL::FailedCheck> translate(const String& wgsl, const S
     if (auto* maybeError = std::get_if<WGSL::Error>(&prepareResult))
         return makeUnexpected(WGSL::FailedCheck { { *maybeError }, { } });
     HashMap<String, WGSL::ConstantValue> constantValues;
-    auto generationResult = WGSL::generate(ast, std::get<WGSL::PrepareResult>(prepareResult), constantValues);
+    auto generationResult = WGSL::generate(ast, std::get<WGSL::PrepareResult>(prepareResult), constantValues, WGSL::DeviceState {
+        .appleGPUFamily = 4,
+        .shaderValidationEnabled = false
+    });
     if (auto* maybeError = std::get_if<WGSL::Error>(&generationResult))
         return makeUnexpected(WGSL::FailedCheck { { *maybeError }, { } });
     return { WTFMove(std::get<String>(generationResult)) };


### PR DESCRIPTION
#### 4d4b88e9f8093076b4ae3960fcf7c17d70968e22
<pre>
[WebGPU] Infinite loop prevention does not need to be applied to concrete initialization
<a href="https://bugs.webkit.org/show_bug.cgi?id=292959">https://bugs.webkit.org/show_bug.cgi?id=292959</a>
<a href="https://rdar.apple.com/151196355">rdar://151196355</a>

Reviewed by Tadeu Zagallo.

Preventing against UB due to infinite loops is not needed for for loops
we emit ourselves to initialize data members.

* LayoutTests/fast/webgpu/nocrash/fuzz-292959-expected.txt: Added.
* LayoutTests/fast/webgpu/nocrash/fuzz-292959.html: Added.
Add regression test.

* Source/WebGPU/WGSL/AST/ASTForStatement.h:
No need to apply UB prevention to our own for loops.

* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::FunctionDefinitionWriter::emitNecessaryHelpers):
Disable optimization on __workgroup_uniform_load so the test passes on Apple9 devices.

(WGSL::Metal::FunctionDefinitionWriter::visit):

Canonical link: <a href="https://commits.webkit.org/295250@main">https://commits.webkit.org/295250@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0e32b1b0d9e3100319cdd67b3124d3550b33a06b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104477 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24187 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/14604 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/109684 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/55148 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/106517 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/24568 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/32731 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79328 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107483 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19111 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94301 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59655 "Found 1 new API test failure: /WPE/TestCookieManager:/webkit/WebKitCookieManager/persistent-storage (failure)") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/18899 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/12373 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/54517 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/88599 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/12431 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/112069 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/31638 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23302 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88370 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32002 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/90534 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88036 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22432 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32939 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10713 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/26115 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/31565 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/36905 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/31357 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/34696 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/32917 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->