### PR TITLE
[Xcode] Use scheme scoping to build WebKit separate from internal projects

### DIFF
--- a/Configurations/CommonBase.xcconfig
+++ b/Configurations/CommonBase.xcconfig
@@ -76,6 +76,11 @@ OTHER_TAPI_FLAGS = $(inherited) $(WK_COMMON_OTHER_TAPI_FLAGS);
 WK_DEFAULT_WK_AUDIT_SPI[sdk=iphoneos*] = $(WK_NOT_$(USE_INTERNAL_SDK));
 WK_AUDIT_SPI = $(WK_DEFAULT_WK_AUDIT_SPI);
 
+// When building schemes in Dependency scope, include dependencies of aggregate
+// targets in the scope.
+WK_DEFAULT_DEPENDENCY_SCOPE_INCLUDES_DIRECT_DEPENDENCIES = YES;
+DEPENDENCY_SCOPE_INCLUDES_DIRECT_DEPENDENCIES = $(WK_DEFAULT_DEPENDENCY_SCOPE_INCLUDES_DIRECT_DEPENDENCIES);
+
 GCC_WARN_NON_VIRTUAL_DESTRUCTOR = YES;
 
 WK_COMMON_WARNING_CFLAGS = -Wall -Wc99-designator -Wconditional-uninitialized -Wextra -Wdeprecated-enum-enum-conversion -Wdeprecated-enum-float-conversion -Wenum-float-conversion -Wfinal-dtor-non-final-class -Wformat=2 -Wmisleading-indentation -Wpointer-to-int-cast -Wreorder-init-list -Wundef -Wunused-but-set-variable -Wvla;

--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -70,8 +70,23 @@
 				DDFA47232AA93E1D00C7C788 /* Check For Inappropriate Files In Framework */,
 			);
 			dependencies = (
-				932F5BE70822A1C700736975 /* PBXTargetDependency */,
+				DDDB90FB2DE65A6000341445 /* PBXTargetDependency */,
 				5D69E912152BE5470028D720 /* PBXTargetDependency */,
+				DDDB90FD2DE65A6000341445 /* PBXTargetDependency */,
+				DDDB90FF2DE65A6000341445 /* PBXTargetDependency */,
+				DDDB91012DE65A6000341445 /* PBXTargetDependency */,
+				DDDB91032DE65A6000341445 /* PBXTargetDependency */,
+				DDDB91052DE65A6000341445 /* PBXTargetDependency */,
+				DDDB91072DE65A6000341445 /* PBXTargetDependency */,
+				DDDB91092DE65A6000341445 /* PBXTargetDependency */,
+				DDDB910B2DE65A6000341445 /* PBXTargetDependency */,
+				DD8705C92DD3C822008AA5ED /* PBXTargetDependency */,
+				DD8705C52DD3C818008AA5ED /* PBXTargetDependency */,
+				DD8705C72DD3C81E008AA5ED /* PBXTargetDependency */,
+				DD8705C12DD3C813008AA5ED /* PBXTargetDependency */,
+				DD8705C32DD3C815008AA5ED /* PBXTargetDependency */,
+				DD8705BF2DD3C809008AA5ED /* PBXTargetDependency */,
+				932F5BE70822A1C700736975 /* PBXTargetDependency */,
 				5D6B2A57152B9E2E005231DE /* PBXTargetDependency */,
 			);
 			name = All;
@@ -2554,6 +2569,111 @@
 			proxyType = 1;
 			remoteGlobalIDString = 14BD6881215191310050DAFF;
 			remoteInfo = JSCLLIntSettingsExtractor;
+		};
+		DD8705BE2DD3C809008AA5ED /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0867D690FE84028FC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 44F93E012AE71F5300FFA37C;
+			remoteInfo = libJavaScriptCore;
+		};
+		DD8705C02DD3C813008AA5ED /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0867D690FE84028FC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 14BD6881215191310050DAFF;
+			remoteInfo = JSCLLIntSettingsExtractor;
+		};
+		DD8705C22DD3C815008AA5ED /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0867D690FE84028FC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 0FF922C314F46B130041A24E;
+			remoteInfo = JSCLLIntOffsetsExtractor;
+		};
+		DD8705C42DD3C818008AA5ED /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0867D690FE84028FC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 65FB3F6609D11E9100F49DEB;
+			remoteInfo = "Derived Sources";
+		};
+		DD8705C62DD3C81E008AA5ED /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0867D690FE84028FC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 53B4BD041F68AF8900D2BEA3;
+			remoteInfo = "Generate Unified Sources";
+		};
+		DD8705C82DD3C822008AA5ED /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0867D690FE84028FC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = E1AC2E2720F7B94C00B0897D;
+			remoteInfo = "Unlock Keychain";
+		};
+		DDDB90FA2DE65A6000341445 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0867D690FE84028FC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 0F93274E1C20BCBA00CF6564;
+			remoteInfo = dynbench;
+		};
+		DDDB90FC2DE65A6000341445 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0867D690FE84028FC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 1412111F0A48793C00480255;
+			remoteInfo = minidom;
+		};
+		DDDB90FE2DE65A6000341445 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0867D690FE84028FC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 651122F714046A4C002B101D;
+			remoteInfo = testRegExp;
+		};
+		DDDB91002DE65A6000341445 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0867D690FE84028FC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 0F6183381C45F62A0072450B;
+			remoteInfo = testair;
+		};
+		DDDB91022DE65A6000341445 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0867D690FE84028FC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 14BD59BE0A3E8F9000BAF59C;
+			remoteInfo = testapi;
+		};
+		DDDB91042DE65A6000341445 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0867D690FE84028FC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 0FEC85941BDB5CF10080FF74;
+			remoteInfo = testb3;
+		};
+		DDDB91062DE65A6000341445 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0867D690FE84028FC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 52CD0F592242F569004A18A5;
+			remoteInfo = testdfg;
+		};
+		DDDB91082DE65A6000341445 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0867D690FE84028FC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = FE533CA11F217DB30016A1FE;
+			remoteInfo = testmasm;
+		};
+		DDDB910A2DE65A6000341445 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0867D690FE84028FC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 79281BBD20B62B3E002E2A60;
+			remoteInfo = testmem;
 		};
 		FE533CAE1F217EC60016A1FE /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -13503,6 +13623,81 @@
 			isa = PBXTargetDependency;
 			target = 14BD6881215191310050DAFF /* JSCLLIntSettingsExtractor */;
 			targetProxy = DD4ABD8329A6D61A00530828 /* PBXContainerItemProxy */;
+		};
+		DD8705BF2DD3C809008AA5ED /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 44F93E012AE71F5300FFA37C /* libJavaScriptCore */;
+			targetProxy = DD8705BE2DD3C809008AA5ED /* PBXContainerItemProxy */;
+		};
+		DD8705C12DD3C813008AA5ED /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 14BD6881215191310050DAFF /* JSCLLIntSettingsExtractor */;
+			targetProxy = DD8705C02DD3C813008AA5ED /* PBXContainerItemProxy */;
+		};
+		DD8705C32DD3C815008AA5ED /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 0FF922C314F46B130041A24E /* JSCLLIntOffsetsExtractor */;
+			targetProxy = DD8705C22DD3C815008AA5ED /* PBXContainerItemProxy */;
+		};
+		DD8705C52DD3C818008AA5ED /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 65FB3F6609D11E9100F49DEB /* Derived Sources */;
+			targetProxy = DD8705C42DD3C818008AA5ED /* PBXContainerItemProxy */;
+		};
+		DD8705C72DD3C81E008AA5ED /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 53B4BD041F68AF8900D2BEA3 /* Generate Unified Sources */;
+			targetProxy = DD8705C62DD3C81E008AA5ED /* PBXContainerItemProxy */;
+		};
+		DD8705C92DD3C822008AA5ED /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = E1AC2E2720F7B94C00B0897D /* Unlock Keychain */;
+			targetProxy = DD8705C82DD3C822008AA5ED /* PBXContainerItemProxy */;
+		};
+		DDDB90FB2DE65A6000341445 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 0F93274E1C20BCBA00CF6564 /* dynbench */;
+			targetProxy = DDDB90FA2DE65A6000341445 /* PBXContainerItemProxy */;
+		};
+		DDDB90FD2DE65A6000341445 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 1412111F0A48793C00480255 /* minidom */;
+			targetProxy = DDDB90FC2DE65A6000341445 /* PBXContainerItemProxy */;
+		};
+		DDDB90FF2DE65A6000341445 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 651122F714046A4C002B101D /* testRegExp */;
+			targetProxy = DDDB90FE2DE65A6000341445 /* PBXContainerItemProxy */;
+		};
+		DDDB91012DE65A6000341445 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 0F6183381C45F62A0072450B /* testair */;
+			targetProxy = DDDB91002DE65A6000341445 /* PBXContainerItemProxy */;
+		};
+		DDDB91032DE65A6000341445 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 14BD59BE0A3E8F9000BAF59C /* testapi */;
+			targetProxy = DDDB91022DE65A6000341445 /* PBXContainerItemProxy */;
+		};
+		DDDB91052DE65A6000341445 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 0FEC85941BDB5CF10080FF74 /* testb3 */;
+			targetProxy = DDDB91042DE65A6000341445 /* PBXContainerItemProxy */;
+		};
+		DDDB91072DE65A6000341445 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 52CD0F592242F569004A18A5 /* testdfg */;
+			targetProxy = DDDB91062DE65A6000341445 /* PBXContainerItemProxy */;
+		};
+		DDDB91092DE65A6000341445 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = FE533CA11F217DB30016A1FE /* testmasm */;
+			targetProxy = DDDB91082DE65A6000341445 /* PBXContainerItemProxy */;
+		};
+		DDDB910B2DE65A6000341445 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 79281BBD20B62B3E002E2A60 /* testmem */;
+			targetProxy = DDDB910A2DE65A6000341445 /* PBXContainerItemProxy */;
 		};
 		FE533CAF1F217EC60016A1FE /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;

--- a/Source/ThirdParty/ANGLE/ANGLE.xcodeproj/project.pbxproj
+++ b/Source/ThirdParty/ANGLE/ANGLE.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 				314C6E8C2CD2FA12001EA6B3 /* PBXTargetDependency */,
 				314C6E8A2CD2F9F8001EA6B3 /* PBXTargetDependency */,
 				31DB79572491C35400982878 /* PBXTargetDependency */,
+				DD8705BD2DD3C7EA008AA5ED /* PBXTargetDependency */,
 			);
 			name = ANGLE;
 			productName = ANGLE;
@@ -1074,6 +1075,13 @@
 			proxyType = 1;
 			remoteGlobalIDString = 7BF5549A2C81EDE0002B101E;
 			remoteInfo = translator;
+		};
+		DD8705BC2DD3C7EA008AA5ED /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = FB39D0701200ED9200088E69 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = FFDA50C4269F845100AE11E2;
+			remoteInfo = ANGLEMetalLib;
 		};
 		FF194FF52744331A006A97A3 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -4575,6 +4583,11 @@
 			isa = PBXTargetDependency;
 			target = 7BF5549A2C81EDE0002B101E /* translator */;
 			targetProxy = 7BF555922C81F4A0002B101E /* PBXContainerItemProxy */;
+		};
+		DD8705BD2DD3C7EA008AA5ED /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = FFDA50C4269F845100AE11E2 /* ANGLEMetalLib */;
+			targetProxy = DD8705BC2DD3C7EA008AA5ED /* PBXContainerItemProxy */;
 		};
 		FF194FF62744331A006A97A3 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;

--- a/Source/ThirdParty/gtest/xcode/gtest.xcodeproj/project.pbxproj
+++ b/Source/ThirdParty/gtest/xcode/gtest.xcodeproj/project.pbxproj
@@ -22,6 +22,21 @@
 			name = Check;
 			productName = Check;
 		};
+		DD8706092DD3CA3F008AA5ED /* All */ = {
+			isa = PBXAggregateTarget;
+			buildConfigurationList = DD87060D2DD3CA3F008AA5ED /* Build configuration list for PBXAggregateTarget "All" */;
+			buildPhases = (
+			);
+			dependencies = (
+				DD87060F2DD3CA45008AA5ED /* PBXTargetDependency */,
+				DD8706132DD3CA4F008AA5ED /* PBXTargetDependency */,
+				DD8706112DD3CA46008AA5ED /* PBXTargetDependency */,
+			);
+			name = All;
+			packageProductDependencies = (
+			);
+			productName = All;
+		};
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
@@ -197,6 +212,27 @@
 			proxyType = 1;
 			remoteGlobalIDString = 40C84989101A36A60083642A;
 			remoteInfo = "sample1_unittest-static";
+		};
+		DD87060E2DD3CA45008AA5ED /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0867D690FE84028FC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 40C848F9101A209C0083642A;
+			remoteInfo = "gtest-static";
+		};
+		DD8706102DD3CA46008AA5ED /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0867D690FE84028FC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 8D07F2BC0486CC7A007CD1D0;
+			remoteInfo = "gtest-framework";
+		};
+		DD8706122DD3CA4F008AA5ED /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0867D690FE84028FC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 40C8490A101A217E0083642A;
+			remoteInfo = "gtest_main-static";
 		};
 /* End PBXContainerItemProxy section */
 
@@ -702,6 +738,7 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
+				DD8706092DD3CA3F008AA5ED /* All */,
 				40C848F9101A209C0083642A /* gtest-static */,
 				8D07F2BC0486CC7A007CD1D0 /* gtest-framework */,
 				40C8490A101A217E0083642A /* gtest_main-static */,
@@ -864,6 +901,21 @@
 			isa = PBXTargetDependency;
 			target = 40C84989101A36A60083642A /* sample1_unittest-static */;
 			targetProxy = 40C849F8101A43490083642A /* PBXContainerItemProxy */;
+		};
+		DD87060F2DD3CA45008AA5ED /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 40C848F9101A209C0083642A /* gtest-static */;
+			targetProxy = DD87060E2DD3CA45008AA5ED /* PBXContainerItemProxy */;
+		};
+		DD8706112DD3CA46008AA5ED /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 8D07F2BC0486CC7A007CD1D0 /* gtest-framework */;
+			targetProxy = DD8706102DD3CA46008AA5ED /* PBXContainerItemProxy */;
+		};
+		DD8706132DD3CA4F008AA5ED /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 40C8490A101A217E0083642A /* gtest_main-static */;
+			targetProxy = DD8706122DD3CA4F008AA5ED /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -1105,6 +1157,24 @@
 			};
 			name = Release;
 		};
+		DD87060A2DD3CA3F008AA5ED /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+			};
+			name = Debug;
+		};
+		DD87060B2DD3CA3F008AA5ED /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+			};
+			name = Release;
+		};
+		DD87060C2DD3CA3F008AA5ED /* Production */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+			};
+			name = Production;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -1194,6 +1264,16 @@
 				4FADC24708B4156D00ABE55E /* Debug */,
 				4FADC24808B4156D00ABE55E /* Release */,
 				44C48E0414A409DE00A2D9C7 /* Production */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Production;
+		};
+		DD87060D2DD3CA3F008AA5ED /* Build configuration list for PBXAggregateTarget "All" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				DD87060A2DD3CA3F008AA5ED /* Debug */,
+				DD87060B2DD3CA3F008AA5ED /* Release */,
+				DD87060C2DD3CA3F008AA5ED /* Production */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Production;

--- a/Source/ThirdParty/libwebrtc/libwebrtc.xcodeproj/project.pbxproj
+++ b/Source/ThirdParty/libwebrtc/libwebrtc.xcodeproj/project.pbxproj
@@ -15,6 +15,15 @@
 			dependencies = (
 				31339FA92CEEFEDC0054D8D5 /* PBXTargetDependency */,
 				31339FA72CEEFED90054D8D5 /* PBXTargetDependency */,
+				DD8705CB2DD3C861008AA5ED /* PBXTargetDependency */,
+				DD8705CD2DD3C86A008AA5ED /* PBXTargetDependency */,
+				DD8705CF2DD3C86C008AA5ED /* PBXTargetDependency */,
+				DD8705D12DD3C86E008AA5ED /* PBXTargetDependency */,
+				DD8705D32DD3C871008AA5ED /* PBXTargetDependency */,
+				DD8705D52DD3C873008AA5ED /* PBXTargetDependency */,
+				DD8705D72DD3C875008AA5ED /* PBXTargetDependency */,
+				DD8705D92DD3C877008AA5ED /* PBXTargetDependency */,
+				DD8705DB2DD3C879008AA5ED /* PBXTargetDependency */,
 			);
 			name = libwebrtc;
 			packageProductDependencies = (
@@ -5780,6 +5789,69 @@
 			remoteInfo = webm;
 		};
 		DD2E76E727C6B69A00F2A74C /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = FB39D0701200ED9200088E69 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = DDF30D0527C5C003006A526F;
+			remoteInfo = absl;
+		};
+		DD8705CA2DD3C861008AA5ED /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = FB39D0701200ED9200088E69 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 5C63FA7A1E418411002CA531;
+			remoteInfo = boringssl;
+		};
+		DD8705CC2DD3C86A008AA5ED /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = FB39D0701200ED9200088E69 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 5C4B490E1E42C336002651C8;
+			remoteInfo = opus;
+		};
+		DD8705CE2DD3C86C008AA5ED /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = FB39D0701200ED9200088E69 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 5C08848B1E4A97E300403995;
+			remoteInfo = srtp;
+		};
+		DD8705D02DD3C86E008AA5ED /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = FB39D0701200ED9200088E69 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 5C0884D21E4A980100403995;
+			remoteInfo = yuv;
+		};
+		DD8705D22DD3C871008AA5ED /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = FB39D0701200ED9200088E69 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 4105EB69212E01D2008C0C20;
+			remoteInfo = vpx;
+		};
+		DD8705D42DD3C873008AA5ED /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = FB39D0701200ED9200088E69 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 41F77D15215BE45E00E72967;
+			remoteInfo = yasm;
+		};
+		DD8705D62DD3C875008AA5ED /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = FB39D0701200ED9200088E69 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = CDEBB11824C0187400ADBD44;
+			remoteInfo = webm;
+		};
+		DD8705D82DD3C877008AA5ED /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = FB39D0701200ED9200088E69 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = DDEBB11824C0187400ADBD44;
+			remoteInfo = aom;
+		};
+		DD8705DA2DD3C879008AA5ED /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = FB39D0701200ED9200088E69 /* Project object */;
 			proxyType = 1;
@@ -27153,11 +27225,23 @@
 		};
 		31339FA72CEEFED90054D8D5 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
+			platformFilters = (
+				ios,
+				macos,
+				tvos,
+				xros,
+			);
 			target = FB39D0D01200F0E300088E69 /* libwebrtc.dylib */;
 			targetProxy = 31339FA62CEEFED90054D8D5 /* PBXContainerItemProxy */;
 		};
 		31339FA92CEEFEDC0054D8D5 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
+			platformFilters = (
+				ios,
+				macos,
+				tvos,
+				xros,
+			);
 			target = 449CF1592ADEDE8500F22CAF /* Fuzzers (libwebrtc) */;
 			targetProxy = 31339FA82CEEFEDC0054D8D5 /* PBXContainerItemProxy */;
 		};
@@ -27436,6 +27520,105 @@
 			isa = PBXTargetDependency;
 			target = DDF30D0527C5C003006A526F /* absl */;
 			targetProxy = DD2E76E727C6B69A00F2A74C /* PBXContainerItemProxy */;
+		};
+		DD8705CB2DD3C861008AA5ED /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			platformFilters = (
+				ios,
+				macos,
+				tvos,
+				xros,
+			);
+			target = 5C63FA7A1E418411002CA531 /* boringssl */;
+			targetProxy = DD8705CA2DD3C861008AA5ED /* PBXContainerItemProxy */;
+		};
+		DD8705CD2DD3C86A008AA5ED /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			platformFilters = (
+				ios,
+				macos,
+				tvos,
+				xros,
+			);
+			target = 5C4B490E1E42C336002651C8 /* opus */;
+			targetProxy = DD8705CC2DD3C86A008AA5ED /* PBXContainerItemProxy */;
+		};
+		DD8705CF2DD3C86C008AA5ED /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			platformFilters = (
+				ios,
+				macos,
+				tvos,
+				xros,
+			);
+			target = 5C08848B1E4A97E300403995 /* srtp */;
+			targetProxy = DD8705CE2DD3C86C008AA5ED /* PBXContainerItemProxy */;
+		};
+		DD8705D12DD3C86E008AA5ED /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			platformFilters = (
+				ios,
+				macos,
+				tvos,
+				xros,
+			);
+			target = 5C0884D21E4A980100403995 /* yuv */;
+			targetProxy = DD8705D02DD3C86E008AA5ED /* PBXContainerItemProxy */;
+		};
+		DD8705D32DD3C871008AA5ED /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			platformFilters = (
+				ios,
+				macos,
+				tvos,
+				xros,
+			);
+			target = 4105EB69212E01D2008C0C20 /* vpx */;
+			targetProxy = DD8705D22DD3C871008AA5ED /* PBXContainerItemProxy */;
+		};
+		DD8705D52DD3C873008AA5ED /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			platformFilters = (
+				ios,
+				macos,
+				tvos,
+				xros,
+			);
+			target = 41F77D15215BE45E00E72967 /* yasm */;
+			targetProxy = DD8705D42DD3C873008AA5ED /* PBXContainerItemProxy */;
+		};
+		DD8705D72DD3C875008AA5ED /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			platformFilters = (
+				ios,
+				macos,
+				tvos,
+				xros,
+			);
+			target = CDEBB11824C0187400ADBD44 /* webm */;
+			targetProxy = DD8705D62DD3C875008AA5ED /* PBXContainerItemProxy */;
+		};
+		DD8705D92DD3C877008AA5ED /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			platformFilters = (
+				ios,
+				macos,
+				tvos,
+				xros,
+			);
+			target = DDEBB11824C0187400ADBD44 /* aom */;
+			targetProxy = DD8705D82DD3C877008AA5ED /* PBXContainerItemProxy */;
+		};
+		DD8705DB2DD3C879008AA5ED /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			platformFilters = (
+				ios,
+				macos,
+				tvos,
+				xros,
+			);
+			target = DDF30D0527C5C003006A526F /* absl */;
+			targetProxy = DD8705DA2DD3C879008AA5ED /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 

--- a/Source/WebGPU/WebGPU.xcodeproj/project.pbxproj
+++ b/Source/WebGPU/WebGPU.xcodeproj/project.pbxproj
@@ -6,6 +6,23 @@
 	objectVersion = 55;
 	objects = {
 
+/* Begin PBXAggregateTarget section */
+		DD8705E02DD3C8A3008AA5ED /* All */ = {
+			isa = PBXAggregateTarget;
+			buildConfigurationList = DD8705E42DD3C8A3008AA5ED /* Build configuration list for PBXAggregateTarget "All" */;
+			buildPhases = (
+			);
+			dependencies = (
+				DD8705E62DD3C8AA008AA5ED /* PBXTargetDependency */,
+				DD8705E82DD3C8AB008AA5ED /* PBXTargetDependency */,
+			);
+			name = All;
+			packageProductDependencies = (
+			);
+			productName = All;
+		};
+/* End PBXAggregateTarget section */
+
 /* Begin PBXBuildFile section */
 		0D212A652BC26336001160BF /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0D212A642BC26336001160BF /* CoreGraphics.framework */; };
 		0D30F93729F1F94A0055D9F1 /* ExternalTexture.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0D30F93629F1F94A0055D9F1 /* ExternalTexture.mm */; };
@@ -258,6 +275,20 @@
 			proxyType = 1;
 			remoteGlobalIDString = 1CA5B4F02A6F28C400E5F297;
 			remoteInfo = wgslfuzz;
+		};
+		DD8705E52DD3C8AA008AA5ED /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 1CEBD7DA2716AFBA00A5254D /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 1CEBD7F12716B2CC00A5254D;
+			remoteInfo = WGSL;
+		};
+		DD8705E72DD3C8AB008AA5ED /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 1CEBD7DA2716AFBA00A5254D /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 1CEBD7E22716AFBA00A5254D;
+			remoteInfo = WebGPU;
 		};
 /* End PBXContainerItemProxy section */
 
@@ -1165,6 +1196,9 @@
 					97FA1A7E29C085740052D650 = {
 						CreatedOnToolsVersion = 14.3;
 					};
+					DD8705E02DD3C8A3008AA5ED = {
+						CreatedOnToolsVersion = 16.3;
+					};
 				};
 			};
 			buildConfigurationList = 1CEBD7DD2716AFBA00A5254D /* Build configuration list for PBXProject "WebGPU" */;
@@ -1180,6 +1214,7 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
+				DD8705E02DD3C8A3008AA5ED /* All */,
 				1CEBD7E22716AFBA00A5254D /* WebGPU */,
 				1CEBD7F12716B2CC00A5254D /* WGSL */,
 				97FA1A7E29C085740052D650 /* wgslc */,
@@ -1385,6 +1420,16 @@
 			target = 1CA5B4F02A6F28C400E5F297 /* wgslfuzz */;
 			targetProxy = 31EAB9DE2CD039A100E92E40 /* PBXContainerItemProxy */;
 		};
+		DD8705E62DD3C8AA008AA5ED /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 1CEBD7F12716B2CC00A5254D /* WGSL */;
+			targetProxy = DD8705E52DD3C8AA008AA5ED /* PBXContainerItemProxy */;
+		};
+		DD8705E82DD3C8AB008AA5ED /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 1CEBD7E22716AFBA00A5254D /* WebGPU */;
+			targetProxy = DD8705E72DD3C8AB008AA5ED /* PBXContainerItemProxy */;
+		};
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
@@ -1493,6 +1538,24 @@
 			};
 			name = Production;
 		};
+		DD8705E12DD3C8A3008AA5ED /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+			};
+			name = Debug;
+		};
+		DD8705E22DD3C8A3008AA5ED /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+			};
+			name = Release;
+		};
+		DD8705E32DD3C8A3008AA5ED /* Production */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+			};
+			name = Production;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -1542,6 +1605,16 @@
 				97FA1A8329C085740052D650 /* Debug */,
 				97FA1A8429C085740052D650 /* Release */,
 				97FA1A8529C085740052D650 /* Production */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Production;
+		};
+		DD8705E42DD3C8A3008AA5ED /* Build configuration list for PBXAggregateTarget "All" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				DD8705E12DD3C8A3008AA5ED /* Debug */,
+				DD8705E22DD3C8A3008AA5ED /* Release */,
+				DD8705E32DD3C8A3008AA5ED /* Production */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Production;

--- a/Source/WebInspectorUI/WebInspectorUI.xcodeproj/project.pbxproj
+++ b/Source/WebInspectorUI/WebInspectorUI.xcodeproj/project.pbxproj
@@ -6,12 +6,38 @@
 	objectVersion = 55;
 	objects = {
 
+/* Begin PBXAggregateTarget section */
+		DD8706652DD3F0CC008AA5ED /* WebInspectorUI (Platform Filters) */ = {
+			isa = PBXAggregateTarget;
+			buildConfigurationList = DD8706692DD3F0CC008AA5ED /* Build configuration list for PBXAggregateTarget "WebInspectorUI (Platform Filters)" */;
+			buildPhases = (
+			);
+			dependencies = (
+				DD87066B2DD3F0D5008AA5ED /* PBXTargetDependency */,
+			);
+			name = "WebInspectorUI (Platform Filters)";
+			packageProductDependencies = (
+			);
+			productName = "WebInspectorUI (Platform Filters)";
+		};
+/* End PBXAggregateTarget section */
+
 /* Begin PBXBuildFile section */
 		1C60FF1614E6E3F7006CD77D /* localizedStrings.js in Resources */ = {isa = PBXBuildFile; fileRef = 1C60FF1314E6E35D006CD77D /* localizedStrings.js */; };
 		1C78EE1717611340002F6AA5 /* WebInspectorUI.c in Sources */ = {isa = PBXBuildFile; fileRef = 1C78EE1617611340002F6AA5 /* WebInspectorUI.c */; };
 		DDE9931A278D0D8000F60D26 /* libWebKitAdditions.a in Product Dependencies */ = {isa = PBXBuildFile; fileRef = DDE992FB278D078100F60D26 /* libWebKitAdditions.a */; };
 		DDE9931D278D0DA400F60D26 /* JavaScriptCore.framework in Product Dependencies */ = {isa = PBXBuildFile; fileRef = DDE9931C278D0D9900F60D26 /* JavaScriptCore.framework */; };
 /* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		DD87066A2DD3F0D5008AA5ED /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A54C224D148B23DE00373FA3 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = A54C2256148B23DF00373FA3;
+			remoteInfo = WebInspectorUI;
+		};
+/* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
 		DDE992FA278D076300F60D26 /* Product Dependencies */ = {
@@ -150,6 +176,7 @@
 			projectRoot = "";
 			targets = (
 				A54C2256148B23DF00373FA3 /* WebInspectorUI */,
+				DD8706652DD3F0CC008AA5ED /* WebInspectorUI (Platform Filters) */,
 			);
 		};
 /* End PBXProject section */
@@ -169,7 +196,13 @@
 		1C60FF1214E6D9AF006CD77D /* Copy User Interface Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
 			name = "Copy User Interface Resources";
+			outputPaths = (
+			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "if [[ \"${ACTION}\" == \"installapi\" || \"${ACTION}\" == \"installhdrs\" ]]; then\n    exit\nfi\n\n/usr/bin/perl \"${SRCROOT}/Scripts/copy-user-interface-resources.pl\"\n";
@@ -205,6 +238,17 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		DD87066B2DD3F0D5008AA5ED /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			platformFilters = (
+				macos,
+			);
+			target = A54C2256148B23DF00373FA3 /* WebInspectorUI */;
+			targetProxy = DD87066A2DD3F0D5008AA5ED /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
 		1C60FF1314E6E35D006CD77D /* localizedStrings.js */ = {
@@ -260,6 +304,24 @@
 			};
 			name = Release;
 		};
+		DD8706662DD3F0CC008AA5ED /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+			};
+			name = Debug;
+		};
+		DD8706672DD3F0CC008AA5ED /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+			};
+			name = Release;
+		};
+		DD8706682DD3F0CC008AA5ED /* Production */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+			};
+			name = Production;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -279,6 +341,16 @@
 				A54C226D148B23DF00373FA3 /* Debug */,
 				A54C226E148B23DF00373FA3 /* Release */,
 				1C60FE3614E5F47E006CD77D /* Production */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Production;
+		};
+		DD8706692DD3F0CC008AA5ED /* Build configuration list for PBXAggregateTarget "WebInspectorUI (Platform Filters)" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				DD8706662DD3F0CC008AA5ED /* Debug */,
+				DD8706672DD3F0CC008AA5ED /* Release */,
+				DD8706682DD3F0CC008AA5ED /* Production */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Production;

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -15,6 +15,10 @@
 				E3067ED02B758FEA007C7A03 /* Create symlinks for extensions */,
 			);
 			dependencies = (
+				DD8705FB2DD3C9AF008AA5ED /* PBXTargetDependency */,
+				DD8705FD2DD3C9B0008AA5ED /* PBXTargetDependency */,
+				DD8705F92DD3C9AC008AA5ED /* PBXTargetDependency */,
+				DD8705F72DD3C99E008AA5ED /* PBXTargetDependency */,
 				5C400E6A29DB8AB500446F6F /* PBXTargetDependency */,
 				5CE4B62329CF880B0038F565 /* PBXTargetDependency */,
 				5CE4B62529CF880B0038F565 /* PBXTargetDependency */,
@@ -97,9 +101,26 @@
 			buildPhases = (
 			);
 			dependencies = (
+				DD87065F2DD3F075008AA5ED /* PBXTargetDependency */,
+				DD8706352DD3E5BF008AA5ED /* PBXTargetDependency */,
+				DD8706372DD3E5C0008AA5ED /* PBXTargetDependency */,
+				DD8706392DD3E5C2008AA5ED /* PBXTargetDependency */,
+				DD87063B2DD3E5C3008AA5ED /* PBXTargetDependency */,
 				07438C862D4DA1D400BD1E68 /* PBXTargetDependency */,
-				CD0C36DB2639D3AF004E35D8 /* PBXTargetDependency */,
 				CD0C36DD2639D3B4004E35D8 /* PBXTargetDependency */,
+				DD87063D2DD3E5CE008AA5ED /* PBXTargetDependency */,
+				DD87063F2DD3E5CF008AA5ED /* PBXTargetDependency */,
+				DD8706412DD3E5D0008AA5ED /* PBXTargetDependency */,
+				DD8706432DD3E5D2008AA5ED /* PBXTargetDependency */,
+				DD8706452DD3E5D4008AA5ED /* PBXTargetDependency */,
+				DD8706472DD3E5D6008AA5ED /* PBXTargetDependency */,
+				DD87064B2DD3E5E2008AA5ED /* PBXTargetDependency */,
+				DD87064D2DD3E5E3008AA5ED /* PBXTargetDependency */,
+				DD87064F2DD3E5E7008AA5ED /* PBXTargetDependency */,
+				DD8706512DD3E5EA008AA5ED /* PBXTargetDependency */,
+				DD8706532DD3E5EC008AA5ED /* PBXTargetDependency */,
+				DD8706552DD3E5F1008AA5ED /* PBXTargetDependency */,
+				DD8706572DD3E5F3008AA5ED /* PBXTargetDependency */,
 			);
 			name = Everything;
 			productName = Everything;
@@ -2963,13 +2984,6 @@
 			remoteGlobalIDString = BC3DE46515A91763008D26FC;
 			remoteInfo = WebKit2Service;
 		};
-		CD0C36DA2639D3AF004E35D8 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 0867D690FE84028FC02AAC07 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 1A50DB38110A3C13000D3FE5;
-			remoteInfo = "Framework & XPC Services";
-		};
 		CD0C36DC2639D3B4004E35D8 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 0867D690FE84028FC02AAC07 /* Project object */;
@@ -2983,6 +2997,160 @@
 			proxyType = 1;
 			remoteGlobalIDString = C0CE72851247E66800BC0EC4;
 			remoteInfo = "Derived Sources";
+		};
+		DD8705F62DD3C99E008AA5ED /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0867D690FE84028FC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 8DC2EF4F0486A6940098B216;
+			remoteInfo = WebKit;
+		};
+		DD8705F82DD3C9AC008AA5ED /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0867D690FE84028FC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 7B9FC59C28A28F87007570E7;
+			remoteInfo = WebKitPlatform;
+		};
+		DD8705FA2DD3C9AF008AA5ED /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0867D690FE84028FC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 2D7DEBD821269C6B00B9F73C;
+			remoteInfo = "Generate Unified Sources";
+		};
+		DD8705FC2DD3C9B0008AA5ED /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0867D690FE84028FC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = C0CE72851247E66800BC0EC4;
+			remoteInfo = "Derived Sources";
+		};
+		DD8706342DD3E5BF008AA5ED /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0867D690FE84028FC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 2D7DEBD821269C6B00B9F73C;
+			remoteInfo = "Generate Unified Sources";
+		};
+		DD8706362DD3E5C0008AA5ED /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0867D690FE84028FC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = C0CE72851247E66800BC0EC4;
+			remoteInfo = "Derived Sources";
+		};
+		DD8706382DD3E5C2008AA5ED /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0867D690FE84028FC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 7B9FC59C28A28F87007570E7;
+			remoteInfo = WebKitPlatform;
+		};
+		DD87063A2DD3E5C3008AA5ED /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0867D690FE84028FC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 8DC2EF4F0486A6940098B216;
+			remoteInfo = WebKit;
+		};
+		DD87063C2DD3E5CE008AA5ED /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0867D690FE84028FC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = BC3DE46515A91763008D26FC;
+			remoteInfo = WebContent;
+		};
+		DD87063E2DD3E5CF008AA5ED /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0867D690FE84028FC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 7A7E8DE12748392500DCC97A;
+			remoteInfo = WebContent.CaptivePortal;
+		};
+		DD8706402DD3E5D0008AA5ED /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0867D690FE84028FC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 372EBB382017E64300085064;
+			remoteInfo = WebContent.Development;
+		};
+		DD8706422DD3E5D2008AA5ED /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0867D690FE84028FC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = BC8283B016B4BF7700A278FE;
+			remoteInfo = Networking;
+		};
+		DD8706442DD3E5D4008AA5ED /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0867D690FE84028FC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 2D9FB216237523830049F936;
+			remoteInfo = GPU;
+		};
+		DD8706462DD3E5D6008AA5ED /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0867D690FE84028FC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 2D56C1BA28A367A00081BD25;
+			remoteInfo = Model;
+		};
+		DD87064A2DD3E5E2008AA5ED /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0867D690FE84028FC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 5CAF7A9926F93A750003F19E;
+			remoteInfo = adattributiond;
+		};
+		DD87064C2DD3E5E3008AA5ED /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0867D690FE84028FC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 5C1579CC27165B2F00ED5280;
+			remoteInfo = webpushd;
+		};
+		DD87064E2DD3E5E7008AA5ED /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0867D690FE84028FC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 517B5F5A275A8D3E002DC22D;
+			remoteInfo = webpushtool;
+		};
+		DD8706502DD3E5EA008AA5ED /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0867D690FE84028FC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 5CE4B60829CF87680038F565;
+			remoteInfo = NetworkingExtension;
+		};
+		DD8706522DD3E5EC008AA5ED /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0867D690FE84028FC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 5CE4B61529CF877F0038F565;
+			remoteInfo = GPUExtension;
+		};
+		DD8706542DD3E5F1008AA5ED /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0867D690FE84028FC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 5CA5A2C929CBBA1A000F1046;
+			remoteInfo = WebContentExtension;
+		};
+		DD8706562DD3E5F3008AA5ED /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0867D690FE84028FC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 5C139DA129DB82E500D5117B;
+			remoteInfo = WebContentCaptivePortalExtension;
+		};
+		DD87065E2DD3F075008AA5ED /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0867D690FE84028FC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = E1AC2E2720F7B94C00B0897D;
+			remoteInfo = "Unlock Keychain";
 		};
 		DFBD8A3B2718B38C00BEC5B0 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -21299,11 +21467,6 @@
 			target = BC3DE46515A91763008D26FC /* WebContent */;
 			targetProxy = BCA8D46715BCE0D6009DC1F1 /* PBXContainerItemProxy */;
 		};
-		CD0C36DB2639D3AF004E35D8 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = 1A50DB38110A3C13000D3FE5 /* Framework, XPC Services, Extensions, and daemons */;
-			targetProxy = CD0C36DA2639D3AF004E35D8 /* PBXContainerItemProxy */;
-		};
 		CD0C36DD2639D3B4004E35D8 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = CD95493426159004008372D9 /* WebKitSwift */;
@@ -21313,6 +21476,116 @@
 			isa = PBXTargetDependency;
 			target = C0CE72851247E66800BC0EC4 /* Derived Sources */;
 			targetProxy = DD5698242DC1812C00050321 /* PBXContainerItemProxy */;
+		};
+		DD8705F72DD3C99E008AA5ED /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 8DC2EF4F0486A6940098B216 /* WebKit */;
+			targetProxy = DD8705F62DD3C99E008AA5ED /* PBXContainerItemProxy */;
+		};
+		DD8705F92DD3C9AC008AA5ED /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 7B9FC59C28A28F87007570E7 /* WebKitPlatform */;
+			targetProxy = DD8705F82DD3C9AC008AA5ED /* PBXContainerItemProxy */;
+		};
+		DD8705FB2DD3C9AF008AA5ED /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 2D7DEBD821269C6B00B9F73C /* Generate Unified Sources */;
+			targetProxy = DD8705FA2DD3C9AF008AA5ED /* PBXContainerItemProxy */;
+		};
+		DD8705FD2DD3C9B0008AA5ED /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = C0CE72851247E66800BC0EC4 /* Derived Sources */;
+			targetProxy = DD8705FC2DD3C9B0008AA5ED /* PBXContainerItemProxy */;
+		};
+		DD8706352DD3E5BF008AA5ED /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 2D7DEBD821269C6B00B9F73C /* Generate Unified Sources */;
+			targetProxy = DD8706342DD3E5BF008AA5ED /* PBXContainerItemProxy */;
+		};
+		DD8706372DD3E5C0008AA5ED /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = C0CE72851247E66800BC0EC4 /* Derived Sources */;
+			targetProxy = DD8706362DD3E5C0008AA5ED /* PBXContainerItemProxy */;
+		};
+		DD8706392DD3E5C2008AA5ED /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 7B9FC59C28A28F87007570E7 /* WebKitPlatform */;
+			targetProxy = DD8706382DD3E5C2008AA5ED /* PBXContainerItemProxy */;
+		};
+		DD87063B2DD3E5C3008AA5ED /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 8DC2EF4F0486A6940098B216 /* WebKit */;
+			targetProxy = DD87063A2DD3E5C3008AA5ED /* PBXContainerItemProxy */;
+		};
+		DD87063D2DD3E5CE008AA5ED /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = BC3DE46515A91763008D26FC /* WebContent */;
+			targetProxy = DD87063C2DD3E5CE008AA5ED /* PBXContainerItemProxy */;
+		};
+		DD87063F2DD3E5CF008AA5ED /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 7A7E8DE12748392500DCC97A /* WebContent.CaptivePortal */;
+			targetProxy = DD87063E2DD3E5CF008AA5ED /* PBXContainerItemProxy */;
+		};
+		DD8706412DD3E5D0008AA5ED /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 372EBB382017E64300085064 /* WebContent.Development */;
+			targetProxy = DD8706402DD3E5D0008AA5ED /* PBXContainerItemProxy */;
+		};
+		DD8706432DD3E5D2008AA5ED /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = BC8283B016B4BF7700A278FE /* Networking */;
+			targetProxy = DD8706422DD3E5D2008AA5ED /* PBXContainerItemProxy */;
+		};
+		DD8706452DD3E5D4008AA5ED /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 2D9FB216237523830049F936 /* GPU */;
+			targetProxy = DD8706442DD3E5D4008AA5ED /* PBXContainerItemProxy */;
+		};
+		DD8706472DD3E5D6008AA5ED /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 2D56C1BA28A367A00081BD25 /* Model */;
+			targetProxy = DD8706462DD3E5D6008AA5ED /* PBXContainerItemProxy */;
+		};
+		DD87064B2DD3E5E2008AA5ED /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 5CAF7A9926F93A750003F19E /* adattributiond */;
+			targetProxy = DD87064A2DD3E5E2008AA5ED /* PBXContainerItemProxy */;
+		};
+		DD87064D2DD3E5E3008AA5ED /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 5C1579CC27165B2F00ED5280 /* webpushd */;
+			targetProxy = DD87064C2DD3E5E3008AA5ED /* PBXContainerItemProxy */;
+		};
+		DD87064F2DD3E5E7008AA5ED /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 517B5F5A275A8D3E002DC22D /* webpushtool */;
+			targetProxy = DD87064E2DD3E5E7008AA5ED /* PBXContainerItemProxy */;
+		};
+		DD8706512DD3E5EA008AA5ED /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 5CE4B60829CF87680038F565 /* NetworkingExtension */;
+			targetProxy = DD8706502DD3E5EA008AA5ED /* PBXContainerItemProxy */;
+		};
+		DD8706532DD3E5EC008AA5ED /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 5CE4B61529CF877F0038F565 /* GPUExtension */;
+			targetProxy = DD8706522DD3E5EC008AA5ED /* PBXContainerItemProxy */;
+		};
+		DD8706552DD3E5F1008AA5ED /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 5CA5A2C929CBBA1A000F1046 /* WebContentExtension */;
+			targetProxy = DD8706542DD3E5F1008AA5ED /* PBXContainerItemProxy */;
+		};
+		DD8706572DD3E5F3008AA5ED /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 5C139DA129DB82E500D5117B /* WebContentCaptivePortalExtension */;
+			targetProxy = DD8706562DD3E5F3008AA5ED /* PBXContainerItemProxy */;
+		};
+		DD87065F2DD3F075008AA5ED /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = E1AC2E2720F7B94C00B0897D /* Unlock Keychain */;
+			targetProxy = DD87065E2DD3F075008AA5ED /* PBXContainerItemProxy */;
 		};
 		DFBD8A3C2718B38C00BEC5B0 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;

--- a/Source/WebKitLegacy/WebKitLegacy.xcodeproj/project.pbxproj
+++ b/Source/WebKitLegacy/WebKitLegacy.xcodeproj/project.pbxproj
@@ -29,6 +29,20 @@
 			name = "Generate Unified Sources";
 			productName = "Generate Unified Sources";
 		};
+		DD8705ED2DD3C957008AA5ED /* All */ = {
+			isa = PBXAggregateTarget;
+			buildConfigurationList = DD8705F12DD3C957008AA5ED /* Build configuration list for PBXAggregateTarget "All" */;
+			buildPhases = (
+			);
+			dependencies = (
+				DD8705F32DD3C967008AA5ED /* PBXTargetDependency */,
+				DD8705F52DD3C967008AA5ED /* PBXTargetDependency */,
+			);
+			name = All;
+			packageProductDependencies = (
+			);
+			productName = All;
+		};
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
@@ -683,6 +697,20 @@
 			proxyType = 1;
 			remoteGlobalIDString = 5C9D925022D7E835008E9266;
 			remoteInfo = "Generate Unified Sources";
+		};
+		DD8705F22DD3C967008AA5ED /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0867D690FE84028FC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 5C9D925022D7E835008E9266;
+			remoteInfo = "Generate Unified Sources";
+		};
+		DD8705F42DD3C967008AA5ED /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0867D690FE84028FC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 9398100A0824BF01008DF038;
+			remoteInfo = WebKitLegacy;
 		};
 /* End PBXContainerItemProxy section */
 
@@ -3131,6 +3159,7 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
+				DD8705ED2DD3C957008AA5ED /* All */,
 				9398100A0824BF01008DF038 /* WebKitLegacy */,
 				5C9D925022D7E835008E9266 /* Generate Unified Sources */,
 				537CF83D22EFC4C900C6EBB3 /* Apply Configuration to XCFileLists */,
@@ -3574,6 +3603,16 @@
 			target = 5C9D925022D7E835008E9266 /* Generate Unified Sources */;
 			targetProxy = 5C9D925522D7E841008E9266 /* PBXContainerItemProxy */;
 		};
+		DD8705F32DD3C967008AA5ED /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 5C9D925022D7E835008E9266 /* Generate Unified Sources */;
+			targetProxy = DD8705F22DD3C967008AA5ED /* PBXContainerItemProxy */;
+		};
+		DD8705F52DD3C967008AA5ED /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 9398100A0824BF01008DF038 /* WebKitLegacy */;
+			targetProxy = DD8705F42DD3C967008AA5ED /* PBXContainerItemProxy */;
+		};
 /* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
@@ -3689,6 +3728,24 @@
 			};
 			name = Production;
 		};
+		DD8705EE2DD3C957008AA5ED /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+			};
+			name = Debug;
+		};
+		DD8705EF2DD3C957008AA5ED /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+			};
+			name = Release;
+		};
+		DD8705F02DD3C957008AA5ED /* Production */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+			};
+			name = Production;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -3728,6 +3785,16 @@
 				5C9D925122D7E836008E9266 /* Debug */,
 				5C9D925222D7E836008E9266 /* Release */,
 				5C9D925322D7E836008E9266 /* Production */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Production;
+		};
+		DD8705F12DD3C957008AA5ED /* Build configuration list for PBXAggregateTarget "All" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				DD8705EE2DD3C957008AA5ED /* Debug */,
+				DD8705EF2DD3C957008AA5ED /* Release */,
+				DD8705F02DD3C957008AA5ED /* Production */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Production;

--- a/Source/bmalloc/bmalloc.xcodeproj/project.pbxproj
+++ b/Source/bmalloc/bmalloc.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 			);
 			dependencies = (
 				0F7EB8561F95505400F1ABCB /* PBXTargetDependency */,
+				DD8705BB2DD3C7D2008AA5ED /* PBXTargetDependency */,
 			);
 			name = All;
 			productName = All;
@@ -717,6 +718,13 @@
 			remoteInfo = bmalloc;
 		};
 		DD4BEC2329CBA3FC00398E35 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 145F6837179DC45F00D65598 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = DD4BEC1729CBA36000398E35;
+			remoteInfo = libpas;
+		};
+		DD8705BA2DD3C7D2008AA5ED /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 145F6837179DC45F00D65598 /* Project object */;
 			proxyType = 1;
@@ -3087,6 +3095,11 @@
 			isa = PBXTargetDependency;
 			target = DD4BEC1729CBA36000398E35 /* libpas */;
 			targetProxy = DD4BEC2329CBA3FC00398E35 /* PBXContainerItemProxy */;
+		};
+		DD8705BB2DD3C7D2008AA5ED /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = DD4BEC1729CBA36000398E35 /* libpas */;
+			targetProxy = DD8705BA2DD3C7D2008AA5ED /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 

--- a/Tools/DumpRenderTree/DumpRenderTree.xcodeproj/project.pbxproj
+++ b/Tools/DumpRenderTree/DumpRenderTree.xcodeproj/project.pbxproj
@@ -35,6 +35,8 @@
 			buildPhases = (
 			);
 			dependencies = (
+				DD8706082DD3CA24008AA5ED /* PBXTargetDependency */,
+				DD8706592DD3E855008AA5ED /* PBXTargetDependency */,
 				CEB754D41BBDA26D009F0401 /* PBXTargetDependency */,
 				2D403F211508736C005358D2 /* PBXTargetDependency */,
 				A134E52D188FC09200901D06 /* PBXTargetDependency */,
@@ -174,6 +176,20 @@
 			proxyType = 1;
 			remoteGlobalIDString = A1158D7E18927E7A0088C17B;
 			remoteInfo = DumpRenderTree.app;
+		};
+		DD8706072DD3CA24008AA5ED /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 08FB7793FE84155DC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 0F18E6F21D6B9CAE0027E547;
+			remoteInfo = "Derived Sources";
+		};
+		DD8706582DD3E855008AA5ED /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 08FB7793FE84155DC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = A1321C9D188F9A3600125434;
+			remoteInfo = "DumpRenderTree (Library)";
 		};
 /* End PBXContainerItemProxy section */
 
@@ -1153,6 +1169,16 @@
 			isa = PBXTargetDependency;
 			target = A1158D7E18927E7A0088C17B /* DumpRenderTree.app */;
 			targetProxy = CEB754D31BBDA26D009F0401 /* PBXContainerItemProxy */;
+		};
+		DD8706082DD3CA24008AA5ED /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 0F18E6F21D6B9CAE0027E547 /* Derived Sources */;
+			targetProxy = DD8706072DD3CA24008AA5ED /* PBXContainerItemProxy */;
+		};
+		DD8706592DD3E855008AA5ED /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = A1321C9D188F9A3600125434 /* DumpRenderTree (Library) */;
+			targetProxy = DD8706582DD3E855008AA5ED /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 

--- a/Tools/MobileMiniBrowser/MobileMiniBrowser.xcodeproj/project.pbxproj
+++ b/Tools/MobileMiniBrowser/MobileMiniBrowser.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 			);
 			dependencies = (
 				DD2A1D0A2888D1D300342472 /* PBXTargetDependency */,
+				DD8706152DD3CA74008AA5ED /* PBXTargetDependency */,
 			);
 			name = "MobileMiniBrowser (Platform filters)";
 			productName = "MiniBrowser (Platform filters)";
@@ -69,6 +70,13 @@
 			proxyType = 1;
 			remoteGlobalIDString = CD1DAF911D709E3600017CF0;
 			remoteInfo = MobileMiniBrowser;
+		};
+		DD8706142DD3CA74008AA5ED /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = CD1DAF8A1D709E3600017CF0 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = CD498B3A1D76348000681FA7;
+			remoteInfo = MobileMiniBrowser.framework;
 		};
 /* End PBXContainerItemProxy section */
 

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -36,6 +36,13 @@
 				537CF84822EFD72000C6EBB3 /* Check .xcfilelists */,
 			);
 			dependencies = (
+				DDC299BE2DDFFCC5000AF281 /* PBXTargetDependency */,
+				DDC299C02DDFFCC5000AF281 /* PBXTargetDependency */,
+				DDC299C22DDFFCC5000AF281 /* PBXTargetDependency */,
+				DDC299C42DDFFCC5000AF281 /* PBXTargetDependency */,
+				DDC299C62DDFFCC5000AF281 /* PBXTargetDependency */,
+				DDC299C82DDFFCC5000AF281 /* PBXTargetDependency */,
+				DDC299CA2DDFFCC5000AF281 /* PBXTargetDependency */,
 				3A5DDAFC28D3F2A7004DA950 /* PBXTargetDependency */,
 				7B9FC58828A26D83007570E7 /* PBXTargetDependency */,
 				7C83E0301D0A5E1B00FEBCF3 /* PBXTargetDependency */,
@@ -1521,6 +1528,55 @@
 			proxyType = 1;
 			remoteGlobalIDString = BC57597F126E74AF006F0F12;
 			remoteInfo = InjectedBundle;
+		};
+		DDC299BD2DDFFCC5000AF281 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 08FB7793FE84155DC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 5C9D921422D7DA02008E9266;
+			remoteInfo = "Generate Unified Sources";
+		};
+		DDC299BF2DDFFCC5000AF281 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 08FB7793FE84155DC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = BC57597F126E74AF006F0F12;
+			remoteInfo = InjectedBundleTestWebKitAPI;
+		};
+		DDC299C12DDFFCC5000AF281 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 08FB7793FE84155DC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 7C83DE951D0A590C00FEBCF3;
+			remoteInfo = TestWTFLibrary;
+		};
+		DDC299C32DDFFCC5000AF281 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 08FB7793FE84155DC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = A17C58012C9AA12F009DD0B5;
+			remoteInfo = TestWebKitAPIApp;
+		};
+		DDC299C52DDFFCC5000AF281 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 08FB7793FE84155DC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 7CCE7E8B1A41144E00447C4C;
+			remoteInfo = TestWebKitAPILibrary;
+		};
+		DDC299C72DDFFCC5000AF281 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 08FB7793FE84155DC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = A17C46452C98E3430023F3C7;
+			remoteInfo = TestWebKitAPIResources;
+		};
+		DDC299C92DDFFCC5000AF281 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 08FB7793FE84155DC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = A13EBB481B87339E00097110;
+			remoteInfo = WebProcessPlugIn;
 		};
 		DDF3A83428930475005920CF /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -7895,6 +7951,41 @@
 			isa = PBXTargetDependency;
 			target = BC57597F126E74AF006F0F12 /* InjectedBundleTestWebKitAPI */;
 			targetProxy = BC575A95126E74E7006F0F12 /* PBXContainerItemProxy */;
+		};
+		DDC299BE2DDFFCC5000AF281 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 5C9D921422D7DA02008E9266 /* Generate Unified Sources */;
+			targetProxy = DDC299BD2DDFFCC5000AF281 /* PBXContainerItemProxy */;
+		};
+		DDC299C02DDFFCC5000AF281 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = BC57597F126E74AF006F0F12 /* InjectedBundleTestWebKitAPI */;
+			targetProxy = DDC299BF2DDFFCC5000AF281 /* PBXContainerItemProxy */;
+		};
+		DDC299C22DDFFCC5000AF281 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 7C83DE951D0A590C00FEBCF3 /* TestWTFLibrary */;
+			targetProxy = DDC299C12DDFFCC5000AF281 /* PBXContainerItemProxy */;
+		};
+		DDC299C42DDFFCC5000AF281 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = A17C58012C9AA12F009DD0B5 /* TestWebKitAPIApp */;
+			targetProxy = DDC299C32DDFFCC5000AF281 /* PBXContainerItemProxy */;
+		};
+		DDC299C62DDFFCC5000AF281 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 7CCE7E8B1A41144E00447C4C /* TestWebKitAPILibrary */;
+			targetProxy = DDC299C52DDFFCC5000AF281 /* PBXContainerItemProxy */;
+		};
+		DDC299C82DDFFCC5000AF281 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = A17C46452C98E3430023F3C7 /* TestWebKitAPIResources */;
+			targetProxy = DDC299C72DDFFCC5000AF281 /* PBXContainerItemProxy */;
+		};
+		DDC299CA2DDFFCC5000AF281 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = A13EBB481B87339E00097110 /* WebProcessPlugIn */;
+			targetProxy = DDC299C92DDFFCC5000AF281 /* PBXContainerItemProxy */;
 		};
 		DDF3A851289305E3005920CF /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;

--- a/Tools/WebKitTestRunner/WebKitTestRunner.xcodeproj/project.pbxproj
+++ b/Tools/WebKitTestRunner/WebKitTestRunner.xcodeproj/project.pbxproj
@@ -24,8 +24,11 @@
 			buildPhases = (
 			);
 			dependencies = (
+				DD8706192DD3CA95008AA5ED /* PBXTargetDependency */,
+				DD87061B2DD3CA99008AA5ED /* PBXTargetDependency */,
 				E3D8A94E2CC69CAF006B43E3 /* PBXTargetDependency */,
 				A115CCBC1B9D76C400E89159 /* PBXTargetDependency */,
+				DD8706172DD3CA91008AA5ED /* PBXTargetDependency */,
 				A115CCBA1B9D76BF00E89159 /* PBXTargetDependency */,
 			);
 			name = All;
@@ -239,6 +242,27 @@
 			proxyType = 1;
 			remoteGlobalIDString = BC952D7711F3BF5D003398B4;
 			remoteInfo = "Derived Sources";
+		};
+		DD8706162DD3CA91008AA5ED /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 08FB7793FE84155DC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = BC25186111D15D54002EBC01;
+			remoteInfo = WebKitTestRunnerInjectedBundle;
+		};
+		DD8706182DD3CA95008AA5ED /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 08FB7793FE84155DC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = BC952D7711F3BF5D003398B4;
+			remoteInfo = "Derived Sources";
+		};
+		DD87061A2DD3CA99008AA5ED /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 08FB7793FE84155DC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = A18510261B9ADE4800744AEB;
+			remoteInfo = "WebKitTestRunner (Library)";
 		};
 		E30604EF2CCB2B920033AC72 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -1497,6 +1521,21 @@
 			isa = PBXTargetDependency;
 			target = BC952D7711F3BF5D003398B4 /* Derived Sources */;
 			targetProxy = BC952ED611F3C38B003398B4 /* PBXContainerItemProxy */;
+		};
+		DD8706172DD3CA91008AA5ED /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = BC25186111D15D54002EBC01 /* WebKitTestRunnerInjectedBundle */;
+			targetProxy = DD8706162DD3CA91008AA5ED /* PBXContainerItemProxy */;
+		};
+		DD8706192DD3CA95008AA5ED /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = BC952D7711F3BF5D003398B4 /* Derived Sources */;
+			targetProxy = DD8706182DD3CA95008AA5ED /* PBXContainerItemProxy */;
+		};
+		DD87061B2DD3CA99008AA5ED /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = A18510261B9ADE4800744AEB /* WebKitTestRunner (Library) */;
+			targetProxy = DD87061A2DD3CA99008AA5ED /* PBXContainerItemProxy */;
 		};
 		E30604F02CCB2B920033AC72 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;

--- a/WebKit.xcworkspace/xcshareddata/xcschemes/Everything up to WebKit + Tools.xcscheme
+++ b/WebKit.xcworkspace/xcshareddata/xcschemes/Everything up to WebKit + Tools.xcscheme
@@ -56,10 +56,10 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "1CEBD7E22716AFBA00A5254D"
-               BuildableName = "WebGPU.framework"
-               BlueprintName = "WebGPU"
-               ReferencedContainer = "container:Source/WebGPU/WebGPU.xcodeproj">
+               BlueprintIdentifier = "31339FA12CEEFECC0054D8D5"
+               BuildableName = "libwebrtc"
+               BlueprintName = "libwebrtc"
+               ReferencedContainer = "container:Source/ThirdParty/libwebrtc/libwebrtc.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
          <BuildActionEntry
@@ -84,6 +84,20 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DD8705E02DD3C8A3008AA5ED"
+               BuildableName = "All"
+               BlueprintName = "All"
+               ReferencedContainer = "container:Source/WebGPU/WebGPU.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
                BlueprintIdentifier = "41816F7913859C550057AAA4"
                BuildableName = "All"
                BlueprintName = "All"
@@ -98,9 +112,9 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "A54C2256148B23DF00373FA3"
-               BuildableName = "WebInspectorUI.framework"
-               BlueprintName = "WebInspectorUI"
+               BlueprintIdentifier = "DD8706652DD3F0CC008AA5ED"
+               BuildableName = "WebInspectorUI (Platform Filters)"
+               BlueprintName = "WebInspectorUI (Platform Filters)"
                ReferencedContainer = "container:Source/WebInspectorUI/WebInspectorUI.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -112,9 +126,9 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "9398100A0824BF01008DF038"
-               BuildableName = "WebKitLegacy.framework"
-               BlueprintName = "WebKitLegacy"
+               BlueprintIdentifier = "DD8705ED2DD3C957008AA5ED"
+               BuildableName = "All"
+               BlueprintName = "All"
                ReferencedContainer = "container:Source/WebKitLegacy/WebKitLegacy.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>

--- a/WebKit.xcworkspace/xcshareddata/xcschemes/Everything up to WebKit.xcscheme
+++ b/WebKit.xcworkspace/xcshareddata/xcschemes/Everything up to WebKit.xcscheme
@@ -56,6 +56,20 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
+               BlueprintIdentifier = "31339FA12CEEFECC0054D8D5"
+               BuildableName = "libwebrtc"
+               BlueprintName = "libwebrtc"
+               ReferencedContainer = "container:Source/ThirdParty/libwebrtc/libwebrtc.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
                BlueprintIdentifier = "31DB794F2491C33300982878"
                BuildableName = "ANGLE"
                BlueprintName = "ANGLE"
@@ -70,9 +84,9 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "1CEBD7E22716AFBA00A5254D"
-               BuildableName = "WebGPU.framework"
-               BlueprintName = "WebGPU"
+               BlueprintIdentifier = "DD8705E02DD3C8A3008AA5ED"
+               BuildableName = "All"
+               BlueprintName = "All"
                ReferencedContainer = "container:Source/WebGPU/WebGPU.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -98,23 +112,9 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "A54C2256148B23DF00373FA3"
-               BuildableName = "WebInspectorUI.framework"
-               BlueprintName = "WebInspectorUI"
-               ReferencedContainer = "container:Source/WebInspectorUI/WebInspectorUI.xcodeproj">
-            </BuildableReference>
-         </BuildActionEntry>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "9398100A0824BF01008DF038"
-               BuildableName = "WebKitLegacy.framework"
-               BlueprintName = "WebKitLegacy"
+               BlueprintIdentifier = "DD8705ED2DD3C957008AA5ED"
+               BuildableName = "All"
+               BlueprintName = "All"
                ReferencedContainer = "container:Source/WebKitLegacy/WebKitLegacy.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -130,6 +130,20 @@
                BuildableName = "Everything"
                BlueprintName = "Everything"
                ReferencedContainer = "container:Source/WebKit/WebKit.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DD8706652DD3F0CC008AA5ED"
+               BuildableName = "WebInspectorUI (Platform Filters)"
+               BlueprintName = "WebInspectorUI (Platform Filters)"
+               ReferencedContainer = "container:Source/WebInspectorUI/WebInspectorUI.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
       </BuildActionEntries>
@@ -159,15 +173,6 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "5D247B6114689B8600E78B76"
-            BuildableName = "libWTF.a"
-            BlueprintName = "WTF"
-            ReferencedContainer = "container:Source/WTF/WTF.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">


### PR DESCRIPTION
#### 6d80705baee9dc3e3092c59fc4bfd59cce611137
<pre>
[Xcode] Use scheme scoping to build WebKit separate from internal projects
<a href="https://bugs.webkit.org/show_bug.cgi?id=292962">https://bugs.webkit.org/show_bug.cgi?id=292962</a>
<a href="https://rdar.apple.com/149564758">rdar://149564758</a>

Reviewed by NOBODY (OOPS!).

Prepare for adoption of scheme scoping [1] in &quot;All WebKit Tools&quot; and the
family of &quot;Everything up to WebKit&quot; schemes. This setting causes Xcode
to filter the build graph to only include targets that are listed in the
active scheme [2]. For WebKit, which can build internally as part of
Safari, this change makes it so that:

- Building WebKit never pulls in part of the Safari stack, adding to
  overall build time; and
- Whether a build of WebKit uses Safari frameworks from the SDK or from
  ToT no longer depends on the active workspace.

Scheme scoping requires that all our targets are either part of the
scheme, or in an aggregate target that&apos;s part of the scheme. This means
that some targets which were only added to the build graph transitively
or implicitly must be explicit declared, usually in a project&apos;s &quot;All&quot;
aggregate target.

Some projects did not have an &quot;All&quot; aggregate target, so add it there.

[1]: We cannot use scheme scoping in public builds yet because of a bug
related to DEPENDENCY_SCOPE_INCLUDES_DIRECT_DEPENDENCIES with public
Xcode (<a href="https://rdar.apple.com/136703410">rdar://136703410</a>) until Xcode 16.3. Because we support older
versions, these project changes will only benefit internal-only build
configurations for now. Schemes in WebKit.xcworkspace continue to be
unscoped, and this change should not impact their build order.

* Configurations/CommonBase.xcconfig:
[2]: By default, scheme scoping does not consider dependencies of
aggregate targets to be part of the scope. This does not work for
WebKit, because we use aggregate targets to make it possible to
introduce new targets to the build without needing to update every
scheme across all workspaces. Customize this behavior by setting
DEPENDENCY_SCOPE_INCLUDES_DIRECT_DEPENDENCIES project-wide.

* Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj:
* Source/ThirdParty/ANGLE/ANGLE.xcodeproj/project.pbxproj:
* Source/ThirdParty/gtest/xcode/gtest.xcodeproj/project.pbxproj:
* Source/ThirdParty/libwebrtc/libwebrtc.xcodeproj/project.pbxproj:
  Previously libwebrtc was only found implicitly when building platforms
  that use webrtc, i.e. non-watchOS platforms. When building with scheme
  scopeing, its &quot;All&quot; aggregate needs to be part of the scheme. But we
  still don&apos;t want it to build on watchOS. Add platform filters to every
  member of the &quot;All&quot; aggregate target to express this.
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebGPU/WebGPU.xcodeproj/project.pbxproj:
* Source/WebInspectorUI/WebInspectorUI.xcodeproj/project.pbxproj:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKitLegacy/WebKitLegacy.xcodeproj/project.pbxproj:
* Source/bmalloc/bmalloc.xcodeproj/project.pbxproj:
* Tools/DumpRenderTree/DumpRenderTree.xcodeproj/project.pbxproj:
* Tools/MobileMiniBrowser/MobileMiniBrowser.xcodeproj/project.pbxproj:

* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj: Also
  remove the embedded references to gtest.xcodeproj. By changing &quot;All
  WebKit Tools&quot; to use scheme scope, we can also enable implicit
  dependency resolution, without causing the scheme to pull in all of
  WebKit. This means we don&apos;t have to declare nested target dependencies
  in TestWebKitAPI, just to make it always build after gtest.

* Tools/WebKitTestRunner/WebKitTestRunner.xcodeproj/project.pbxproj:
* WebKit.xcworkspace/xcshareddata/xcschemes/All WebKit Tools.xcscheme:
  See above note on enabling implicit dependencies.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6d80705baee9dc3e3092c59fc4bfd59cce611137

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105469 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25180 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15608 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110670 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/56094 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/107510 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/25643 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33720 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80104 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108475 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/20015 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95193 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60413 "Passed tests") | 
| | [💥 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/19738 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13283 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55507 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/98115 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/89471 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13324 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/113427 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/104087 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32612 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24048 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89184 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32975 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91422 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88841 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/22647 "The change is no longer eligible for processing.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33718 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11522 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/28071 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32538 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/37953 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/128388 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32295 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/35094 "Found 1 new JSC stress test failure: wasm.yaml/wasm/gc/ref-i31-eq.js.wasm-slow-memory (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35642 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33881 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->