### PR TITLE
Validation error `buffer state != Unmapped` on `copyBufferToTexture` despite buffer being unmapped

### DIFF
--- a/Source/WebGPU/WebGPU/Buffer.mm
+++ b/Source/WebGPU/WebGPU/Buffer.mm
@@ -231,7 +231,7 @@ void Buffer::setCommandEncoder(CommandEncoder& commandEncoder, bool mayModifyBuf
 #endif
         commandEncoder.addBuffer(m_buffer);
 
-    if (m_state == State::Mapped || m_state == State::MappedAtCreation)
+    if (m_state != State::Unmapped)
         commandEncoder.incrementBufferMapCount();
     if (isDestroyed())
         commandEncoder.makeSubmitInvalid();
@@ -371,13 +371,13 @@ void Buffer::mapAsync(WGPUMapModeFlags mode, size_t offset, size_t size, Complet
     }
 
     setState(State::MappingPending);
+    incrementBufferMapCount();
 
     m_mapMode = mode;
 
     device->protectedQueue()->onSubmittedWorkDone([protectedThis = Ref { *this }, offset, rangeSize, callback = WTFMove(callback)](WGPUQueueWorkDoneStatus status) mutable {
         if (protectedThis->m_state == State::MappingPending) {
             protectedThis->setState(State::Mapped);
-            protectedThis->incrementBufferMapCount();
 
             protectedThis->m_mappingRange = { offset, offset + rangeSize };
 

--- a/Source/WebGPU/WebGPU/CommandEncoder.mm
+++ b/Source/WebGPU/WebGPU/CommandEncoder.mm
@@ -911,11 +911,6 @@ NSString* CommandEncoder::errorValidatingImageCopyBuffer(const WGPUImageCopyBuff
     if (!isValidToUseWith(buffer, *this))
         return @"buffer is not valid";
 
-    if (!buffer->isDestroyed()) {
-        if (buffer->state() != Buffer::State::Unmapped)
-            return @"buffer state != Unmapped";
-    }
-
     if (imageCopyBuffer.layout.bytesPerRow != WGPU_COPY_STRIDE_UNDEFINED && (imageCopyBuffer.layout.bytesPerRow % 256))
         return @"imageCopyBuffer.layout.bytesPerRow is not a multiple of 256";
 

--- a/Source/WebGPU/WebGPU/CommandEncoder.swift
+++ b/Source/WebGPU/WebGPU/CommandEncoder.swift
@@ -639,12 +639,6 @@ extension WebGPU.CommandEncoder {
             return "buffer is not valid";
         }
 
-        if !buffer.isDestroyed() {
-            if buffer.state() != WebGPU.Buffer.State.Unmapped {
-                return "buffer state != Unmapped";
-            }
-        }
-
         if imageCopyBuffer.layout.bytesPerRow != WGPU_COPY_STRIDE_UNDEFINED && (imageCopyBuffer.layout.bytesPerRow % 256 != 0) {
             return "imageCopyBuffer.layout.bytesPerRow is not a multiple of 256"
         }


### PR DESCRIPTION
#### 0b97b321245432d5d263d658447ad725780049a6
<pre>
Validation error `buffer state != Unmapped` on `copyBufferToTexture` despite buffer being unmapped
<a href="https://bugs.webkit.org/show_bug.cgi?id=293062">https://bugs.webkit.org/show_bug.cgi?id=293062</a>
<a href="https://rdar.apple.com/151415851">rdar://151415851</a>

Reviewed by Tadeu Zagallo.

CommandEncoder should allow operations on mapped buffers, only
at GPUQueue.submit() time should that be an error.

Test: api,validation,image_copy,* continues to pass.

* Source/WebGPU/WebGPU/CommandEncoder.mm:
(WebGPU::CommandEncoder::errorValidatingImageCopyBuffer const):

Canonical link: <a href="https://commits.webkit.org/295158@main">https://commits.webkit.org/295158@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5094c3ae5ead4295dbf5ddfc168505fcda5285a6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/103906 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/23609 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/13930 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/109099 "Built successfully") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/54567 "") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/23964 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/32154 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78930 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/54567 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/106912 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/18606 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/93731 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59258 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/18402 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/53934 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/88156 "1 api test failed or timed out") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/11841 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/111486 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/31062 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/22896 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/87940 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/31425 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/89932 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87594 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22366 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32488 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10219 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/25428 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/30991 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/36301 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/30784 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/34121 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/32345 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->