### PR TITLE
svg update render replaced intrinsic size on attribute change

### DIFF
--- a/Source/WebCore/rendering/RenderReplaced.h
+++ b/Source/WebCore/rendering/RenderReplaced.h
@@ -50,6 +50,7 @@ public:
     void computeIntrinsicRatioInformation(FloatSize& intrinsicSize, FloatSize& intrinsicRatio) const override;
 
     virtual bool paintsContent() const { return true; }
+    void setIntrinsicSize(const LayoutSize& intrinsicSize) { m_intrinsicSize = intrinsicSize; }
 
 protected:
     RenderReplaced(Type, Element&, RenderStyle&&, OptionSet<ReplacedFlag> = { });
@@ -66,7 +67,6 @@ protected:
 
     void styleDidChange(StyleDifference, const RenderStyle* oldStyle) override;
 
-    void setIntrinsicSize(const LayoutSize& intrinsicSize) { m_intrinsicSize = intrinsicSize; }
     virtual void intrinsicSizeChanged();
     virtual bool hasRelativeIntrinsicLogicalWidth() const { return false; }
 

--- a/Source/WebCore/rendering/svg/RenderSVGRoot.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGRoot.cpp
@@ -107,7 +107,7 @@ void RenderSVGRoot::computeIntrinsicRatioInformation(FloatSize& intrinsicSize, F
     ASSERT(!shouldApplySizeContainment());
 
     // https://www.w3.org/TR/SVG/coords.html#IntrinsicSizing
-    intrinsicSize = calculateIntrinsicSize();
+    intrinsicSize = this->intrinsicSize();
 
     if (style().aspectRatioType() == AspectRatioType::Ratio) {
         intrinsicRatio = FloatSize::narrowPrecision(style().aspectRatioLogicalWidth(), style().aspectRatioLogicalHeight());

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.cpp
@@ -98,7 +98,7 @@ void LegacyRenderSVGRoot::computeIntrinsicRatioInformation(FloatSize& intrinsicS
     ASSERT(!shouldApplySizeContainment());
 
     // https://www.w3.org/TR/SVG/coords.html#IntrinsicSizing
-    intrinsicSize = calculateIntrinsicSize();
+    intrinsicSize = this->intrinsicSize();
 
     if (style().aspectRatioType() == AspectRatioType::Ratio) {
         intrinsicRatio = FloatSize::narrowPrecision(style().aspectRatioLogicalWidth(), style().aspectRatioLogicalHeight()); 

--- a/Source/WebCore/svg/SVGSVGElement.cpp
+++ b/Source/WebCore/svg/SVGSVGElement.cpp
@@ -214,6 +214,15 @@ void SVGSVGElement::attributeChanged(const QualifiedName& name, const AtomString
             length = SVGLengthValue(SVGLengthMode::Width, "100%"_s);
         }
         Ref { m_width }->setBaseValInternal(length);
+        if (auto* renderReplaced = dynamicDowncast<RenderReplaced>(renderer())) {
+            auto intrinsicWidth = LayoutUnit(floatValueForLength(this->intrinsicWidth(), 0));
+            if (!intrinsicWidth)
+                intrinsicWidth = 300;
+            auto intrinsicHeight = LayoutUnit(floatValueForLength(this->intrinsicHeight(), 0));
+            if (!intrinsicHeight)
+                intrinsicHeight = 150;
+            renderReplaced->setIntrinsicSize({ intrinsicWidth, intrinsicHeight });
+        }
         break;
     }
     case AttributeNames::heightAttr: {
@@ -224,6 +233,16 @@ void SVGSVGElement::attributeChanged(const QualifiedName& name, const AtomString
             length = SVGLengthValue(SVGLengthMode::Height, "100%"_s);
         }
         Ref { m_height }->setBaseValInternal(length);
+        if (auto* renderReplaced = dynamicDowncast<RenderReplaced>(renderer())) {
+            auto intrinsicWidth = LayoutUnit(floatValueForLength(this->intrinsicWidth(), 0));
+            if (!intrinsicWidth)
+                intrinsicWidth = 300;
+            auto intrinsicHeight = LayoutUnit(floatValueForLength(this->intrinsicHeight(), 0));
+            if (!intrinsicHeight)
+                intrinsicHeight = 150;
+            renderReplaced->setIntrinsicSize({ intrinsicWidth, intrinsicHeight });
+        }
+
         break;
     }
     default:


### PR DESCRIPTION
#### cdb0dfc1d93e8c139cd4a45f3cbf959cfacfdb0d
<pre>
svg update render replaced intrinsic size on attribute change
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cdb0dfc1d93e8c139cd4a45f3cbf959cfacfdb0d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/103813 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/23515 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/13835 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/109006 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/54465 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/105853 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/23868 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/32061 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78868 "Found 120 new test failures: css2.1/20110323/replaced-intrinsic-004.htm css2.1/20110323/replaced-intrinsic-ratio-001.htm fast/shadow-dom/svg-animate-href-change-in-shadow-tree.html fast/shadow-dom/svg-animate-href-in-shadow-tree.html fast/shadow-dom/svg-feimage-href-in-shadow-tree.html fast/shadow-dom/svg-linear-gradient-dynamic-update-href-in-shadow-tree.html fast/shadow-dom/svg-linear-gradient-href-in-shadow-tree.html fast/shadow-dom/svg-mpath-href-change-in-shadow-tree.html fast/shadow-dom/svg-mpath-href-in-shadow-tree.html fast/shadow-dom/svg-radial-gradient-dynamic-update-href-in-shadow-tree.html ... (failure)") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/106819 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/18526 "Build was cancelled. Recent messages:OS: Sequoia (15.2), Xcode: 16.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; 14 new passes 4 flakes 29 failures; Uploaded test results; 14 new passes 8 flakes 29 failures; Compiled WebKit (cancelled)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/93650 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59202 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/18336 "Found 60 new test failures: imported/w3c/web-platform-tests/css/css-display/accessibility/display-contents-role-and-label.html imported/w3c/web-platform-tests/css/css-flexbox/align-items-007.html imported/w3c/web-platform-tests/css/css-flexbox/aspect-ratio-intrinsic-size-007.html imported/w3c/web-platform-tests/css/css-flexbox/flex-aspect-ratio-img-column-013.html imported/w3c/web-platform-tests/css/css-flexbox/flex-aspect-ratio-img-column-014.html imported/w3c/web-platform-tests/css/css-flexbox/flex-aspect-ratio-img-column-015.html imported/w3c/web-platform-tests/css/css-flexbox/flex-aspect-ratio-img-column-018.html imported/w3c/web-platform-tests/css/css-flexbox/flex-aspect-ratio-img-row-008.html imported/w3c/web-platform-tests/css/css-flexbox/flex-aspect-ratio-img-row-009.html imported/w3c/web-platform-tests/css/css-flexbox/flex-aspect-ratio-img-row-010.html ... (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/11699 "Found 60 new test failures: compositing/transforms/transformed-replaced-with-shadow-children.html css2.1/20110323/replaced-intrinsic-004.htm fast/frames/frame-append-body-child-crash.html fast/frames/message-port-postMessage-unload-event.html fast/shadow-dom/svg-animate-href-change-in-shadow-tree.html fast/shadow-dom/svg-animate-href-in-shadow-tree.html fast/shadow-dom/svg-feimage-href-in-shadow-tree.html fast/shadow-dom/svg-linear-gradient-dynamic-update-href-in-shadow-tree.html fast/shadow-dom/svg-linear-gradient-href-in-shadow-tree.html fast/shadow-dom/svg-mpath-href-change-in-shadow-tree.html ... (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/53841 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/88096 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/11756 "Build was cancelled. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Running apply-patch; Checked out pull request; Running run-layout-tests-in-stress-mode; Exiting early after 60 failures. 45277 tests run. 60 failures; Uploaded test results; Exiting early after 60 failures. 45255 tests run. 60 failures; compiling") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/111393 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/30969 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/22838 "Found 60 new test failures: css2.1/20110323/replaced-intrinsic-004.htm fast/shadow-dom/svg-animate-href-change-in-shadow-tree.html fast/shadow-dom/svg-animate-href-in-shadow-tree.html fast/shadow-dom/svg-feimage-href-in-shadow-tree.html fast/shadow-dom/svg-linear-gradient-dynamic-update-href-in-shadow-tree.html fast/shadow-dom/svg-linear-gradient-href-in-shadow-tree.html fast/shadow-dom/svg-mpath-href-change-in-shadow-tree.html fast/shadow-dom/svg-mpath-href-in-shadow-tree.html fast/shadow-dom/svg-radial-gradient-dynamic-update-href-in-shadow-tree.html fast/shadow-dom/svg-radial-gradient-href-in-shadow-tree.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/87870 "Found 118 new test failures: css2.1/20110323/replaced-intrinsic-004.htm css2.1/20110323/replaced-intrinsic-ratio-001.htm fast/shadow-dom/svg-animate-href-change-in-shadow-tree.html fast/shadow-dom/svg-animate-href-in-shadow-tree.html fast/shadow-dom/svg-feimage-href-in-shadow-tree.html fast/shadow-dom/svg-linear-gradient-dynamic-update-href-in-shadow-tree.html fast/shadow-dom/svg-linear-gradient-href-in-shadow-tree.html fast/shadow-dom/svg-mpath-href-change-in-shadow-tree.html fast/shadow-dom/svg-mpath-href-in-shadow-tree.html fast/shadow-dom/svg-radial-gradient-dynamic-update-href-in-shadow-tree.html ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/31331 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/89851 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87526 "Passed tests") | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32416 "Found 2 new test failures: interaction-region/clip-path.html interaction-region/icon-masking.html (failure)") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/10139 "Build was cancelled. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Running apply-patch; Checked out pull request; Skipped layout-tests; Exiting early after 60 failures. 44444 tests run. 60 failures; Uploaded test results; Exiting early after 60 failures. 44214 tests run. 60 failures; Compiled WebKit (cancelled)") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/25331 "Hash cdb0dfc1 for PR 45465 does not build (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/30897 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/36200 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/30691 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/34026 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/32252 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->