### PR TITLE
Make String and BasicRawSentinelNode no longer compact-allocated

### DIFF
--- a/Source/WTF/wtf/Bag.h
+++ b/Source/WTF/wtf/Bag.h
@@ -157,10 +157,6 @@ private:
     typename PtrTraits::StorageType m_head { nullptr };
 };
 
-template<typename T>
-using PackedBag = Bag<T, PackedPtrTraits<T>>;
-
 } // namespace WTF
 
 using WTF::Bag;
-using WTF::PackedBag;

--- a/Source/WTF/wtf/SentinelLinkedList.h
+++ b/Source/WTF/wtf/SentinelLinkedList.h
@@ -47,7 +47,7 @@ enum SentinelTag { Sentinel };
 
 template<typename T, typename PassedPtrTraits = RawPtrTraits<T>>
 class BasicRawSentinelNode {
-    WTF_MAKE_FAST_COMPACT_ALLOCATED;
+    WTF_MAKE_FAST_ALLOCATED;
 public:
     using PtrTraits = typename PassedPtrTraits::template RebindTraits<BasicRawSentinelNode>;
 
@@ -315,11 +315,7 @@ IGNORE_GCC_WARNINGS_END
     other.m_sentinel.setPrev(&other.m_sentinel);
 }
 
-template<typename T>
-using PackedRawSentinelNode = BasicRawSentinelNode<T, PackedPtrTraits<T>>;
-
 }
 
 using WTF::BasicRawSentinelNode;
-using WTF::PackedRawSentinelNode;
 using WTF::SentinelLinkedList;

--- a/Source/WTF/wtf/text/WTFString.h
+++ b/Source/WTF/wtf/text/WTFString.h
@@ -55,7 +55,7 @@ template<bool isSpecialCharacter(UChar), typename CharacterType, std::size_t Ext
 enum class TrailingZerosPolicy : bool { Keep, Truncate };
 
 class String final {
-    WTF_MAKE_FAST_COMPACT_ALLOCATED;
+    WTF_MAKE_FAST_ALLOCATED;
 public:
     // Construct a null string, distinguishable from an empty string.
     String() = default;

--- a/Tools/lldb/lldbWebKitTester/main.cpp
+++ b/Tools/lldb/lldbWebKitTester/main.cpp
@@ -88,10 +88,10 @@ static void testSummaryProviders()
     OptionSet<ExampleFlags> exampleFlagsSimple { ExampleFlags::A, ExampleFlags::D, ExampleFlags::C };
     OptionSet<ExampleFlags> exampleFlagsAliasedFlag { ExampleFlags::AAlias, ExampleFlags::D };
 
-    CompactPointerTuple<String*, uint8_t> exampleCompactPointerTupleEmpty;
-    CompactPointerTuple<String*, uint8_t> exampleCompactPointerTupleSimple { &an8BitString, 7 };
-    CompactPointerTuple<String*, uint8_t> exampleCompactPointerTupleMaxTypeValue { &an8BitString, 255 };
-    CompactPointerTuple<String*, bool> exampleCompactPointerTupleSimpleBool { &an8BitString, true };
+    CompactPointerTuple<StringImpl*, uint8_t> exampleCompactPointerTupleEmpty;
+    CompactPointerTuple<StringImpl*, uint8_t> exampleCompactPointerTupleSimple { an8BitStringImpl, 7 };
+    CompactPointerTuple<StringImpl*, uint8_t> exampleCompactPointerTupleMaxTypeValue { an8BitStringImpl, 255 };
+    CompactPointerTuple<StringImpl*, bool> exampleCompactPointerTupleSimpleBool { an8BitStringImpl, true };
     
     URL aURL("https://www.example.com"_s);
 


### PR DESCRIPTION
#### cc8467615f35d9086ffe10278905a447fe95f11f
<pre>
Make String and BasicRawSentinelNode no longer compact-allocated
<a href="https://bugs.webkit.org/show_bug.cgi?id=293082">https://bugs.webkit.org/show_bug.cgi?id=293082</a>
<a href="https://rdar.apple.com/151423026">rdar://151423026</a>

Reviewed by Mark Lam.

Makes WTF::BasicRawSentinelNode and WTF::String fast-allocated instead of
compact-allocated since they are not used in any compact or packed
pointers. Also removes the unused aliases WTF::PackedRawSentinelNode and
WTF::PackedBag, and removes our sole usage of a compact WTF::String pointer
from lldbWebKitTester.

* Source/WTF/wtf/Bag.h:
* Source/WTF/wtf/SentinelLinkedList.h:
* Source/WTF/wtf/text/WTFString.h:
* Tools/lldb/lldbWebKitTester/main.cpp:
(testSummaryProviders):

Canonical link: <a href="https://commits.webkit.org/295029@main">https://commits.webkit.org/295029@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/462a942da7c4eea8f0eaa9940ce415b25e20aa5a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/103741 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/23443 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/13763 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/108931 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/54393 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/105781 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/23790 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/31989 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78824 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/106747 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/18457 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/93583 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59158 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/18268 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/11631 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/53769 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/96416 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/88045 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/11689 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/111321 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/102352 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/30897 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/22780 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/87824 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/31258 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/89784 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87475 "Found 101 new API test failures: /WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/sequence, /TestWebKit:WebKit.InjectedBundleInitializationUserDataCallbackWins, /TestWebKit:WebKit.GeolocationBasicWithHighAccuracy, /WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/cancel-sequence, /TestWebKit:WebKit.ForceRepaint, /TestWebKit:WebKit.PendingAPIRequestURL, /WebKitGTK/TestUIClient:/webkit/WebKitWebView/mediaKeySystem-permission-requests, /TestWebKit:WebKit.PreventEmptyUserAgent, /TestWebKit:WebKit2.ProvisionalURLAfterWillSendRequestCallback, /WebKitGTK/TestDownloads:/webkit/Downloads/contex-menu-download-actions ... (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22292 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32350 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10080 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/25254 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/30825 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/36128 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/125985 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/30619 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34879 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/33954 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/32180 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->