### PR TITLE
[Site Isolation] Add basic support for webarchive generation

### DIFF
--- a/Source/WebCore/loader/archive/Archive.h
+++ b/Source/WebCore/loader/archive/Archive.h
@@ -42,7 +42,7 @@ public:
     virtual bool shouldUseMainResourceEncoding() const = 0;
     virtual bool shouldUseMainResourceURL() const = 0;
 
-    ArchiveResource* mainResource() { return m_mainResource.get(); }
+    ArchiveResource* mainResource() const { return m_mainResource.get(); }
     const Vector<Ref<ArchiveResource>>& subresources() const { return m_subresources; }
     const Vector<Ref<Archive>>& subframeArchives() const { return m_subframeArchives; }
     WEBCORE_EXPORT Expected<Vector<String>, ArchiveError> saveResourcesToDisk(const String& directory);

--- a/Source/WebCore/loader/archive/ArchiveResource.cpp
+++ b/Source/WebCore/loader/archive/ArchiveResource.cpp
@@ -48,14 +48,21 @@ RefPtr<ArchiveResource> ArchiveResource::create(RefPtr<FragmentedSharedBuffer>&&
 {
     if (!data)
         return nullptr;
+
+    return ArchiveResource::createWithData(data.releaseNonNull(), url, mimeType, textEncoding, frameName, response, relativeFilePath);
+}
+
+Ref<ArchiveResource> ArchiveResource::createWithData(Ref<FragmentedSharedBuffer>&& data, const URL& url, const String& mimeType, const String& textEncoding, const String& frameName, const ResourceResponse& response, const String& relativeFilePath)
+{
     if (response.isNull()) {
         ResourceResponse syntheticResponse(URL { url }, String { mimeType }, data->size(), String { textEncoding });
         // Provide a valid HTTP status code for http URLs since we have logic in WebCore that validates it.
         if (url.protocolIsInHTTPFamily())
             syntheticResponse.setHTTPStatusCode(200);
-        return adoptRef(*new ArchiveResource(data.releaseNonNull(), url, mimeType, textEncoding, frameName, WTFMove(syntheticResponse), relativeFilePath));
+        return adoptRef(*new ArchiveResource(WTFMove(data), url, mimeType, textEncoding, frameName, WTFMove(syntheticResponse), relativeFilePath));
     }
-    return adoptRef(*new ArchiveResource(data.releaseNonNull(), url, mimeType, textEncoding, frameName, response, relativeFilePath));
+
+    return adoptRef(*new ArchiveResource(WTFMove(data), url, mimeType, textEncoding, frameName, response, relativeFilePath));
 }
 
 RefPtr<ArchiveResource> ArchiveResource::create(RefPtr<FragmentedSharedBuffer>&& data, const URL& url, const ResourceResponse& response)

--- a/Source/WebCore/loader/archive/ArchiveResource.h
+++ b/Source/WebCore/loader/archive/ArchiveResource.h
@@ -37,6 +37,7 @@ class ArchiveResource : public SubstituteResource {
 public:
     static RefPtr<ArchiveResource> create(RefPtr<FragmentedSharedBuffer>&&, const URL&, const ResourceResponse&);
     WEBCORE_EXPORT static RefPtr<ArchiveResource> create(RefPtr<FragmentedSharedBuffer>&&, const URL&, const String& mimeType, const String& textEncoding, const String& frameName, const ResourceResponse& = ResourceResponse(), const String& fileName = { });
+    WEBCORE_EXPORT static Ref<ArchiveResource> createWithData(Ref<FragmentedSharedBuffer>&&, const URL&, const String& mimeType, const String& textEncoding, const String& frameName, const ResourceResponse& = ResourceResponse(), const String& fileName = { });
 
     const String& mimeType() const { return m_mimeType; }
     const String& textEncoding() const { return m_textEncoding; }

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -3637,6 +3637,24 @@ enum class WebCore::WasPrivateRelayed : bool;
     std::optional<WebCore::CertificateInfo> certificateInfo;
 };
 
+#if PLATFORM(COCOA)
+[RefCounted, CreateUsing=createWithData] class WebCore::ArchiveResource {
+    Ref<WebCore::FragmentedSharedBuffer> protectedData();
+    URL url();
+    String mimeType();
+    String textEncoding();
+    String frameName();
+    WebCore::ResourceResponse response();
+    String relativeFilePath();
+};
+
+[RefCounted, CreateUsing=create] class WebCore::LegacyWebArchive {
+    Ref<WebCore::ArchiveResource> protectedMainResource();
+    Vector<Ref<WebCore::ArchiveResource>> subresources();
+    Vector<WebCore::FrameIdentifier> subframeIdentifiers();
+};
+#endif
+
 enum class WebCore::ReferrerPolicy : uint8_t {
     EmptyString,
     NoReferrer,

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -2173,7 +2173,7 @@ inline OptionSet<WebKit::FindOptions> toFindOptions(WKFindConfiguration *configu
 - (void)createWebArchiveDataWithCompletionHandler:(void (^)(NSData *, NSError *))completionHandler
 {
     THROW_IF_SUSPENDED;
-    _page->getWebArchiveOfFrame(nullptr, [completionHandler = makeBlockPtr(completionHandler)](API::Data* data) {
+    _page->getWebArchive([completionHandler = makeBlockPtr(completionHandler)](API::Data* data) {
         if (data)
             completionHandler(wrapper(data), nil);
         else

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -6392,6 +6392,20 @@ void WebPageProxy::getWebArchiveOfFrame(WebFrameProxy* frame, CompletionHandler<
     sendWithAsyncReply(Messages::WebPage::GetWebArchiveOfFrame(frame ? std::optional(frame->frameID()) : std::nullopt), toAPIDataCallback(WTFMove(callback)));
 }
 
+void WebPageProxy::getWebArchive(CompletionHandler<void(API::Data*)>&& completionHandler)
+{
+#if PLATFORM(COCOA)
+    if (!protectedPreferences()->siteIsolationEnabled()) {
+        getWebArchiveOfFrame(nullptr, WTFMove(completionHandler));
+        return;
+    }
+
+    getWebArchiveData(WTFMove(completionHandler));
+#else
+    getWebArchiveOfFrame(nullptr, WTFMove(completionHandler));
+#endif
+}
+
 void WebPageProxy::getAccessibilityTreeData(CompletionHandler<void(API::Data*)>&& callback)
 {
     sendWithAsyncReply(Messages::WebPage::GetAccessibilityTreeData(), toAPIDataCallback(WTFMove(callback)));

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1582,6 +1582,10 @@ public:
     void getSelectionAsWebArchiveData(CompletionHandler<void(API::Data*)>&&);
     void getSourceForFrame(WebFrameProxy*, CompletionHandler<void(const String&)>&&);
     void getWebArchiveOfFrame(WebFrameProxy*, CompletionHandler<void(API::Data*)>&&);
+#if PLATFORM(COCOA)
+    void getWebArchiveData(CompletionHandler<void(API::Data*)>&&);
+#endif
+    void getWebArchive(CompletionHandler<void(API::Data*)>&&);
     void runJavaScriptInMainFrame(RunJavaScriptParameters&&, bool, CompletionHandler<void(Expected<JavaScriptEvaluationResult, std::optional<WebCore::ExceptionDetails>>)>&&);
     void runJavaScriptInFrameInScriptWorld(RunJavaScriptParameters&&, std::optional<WebCore::FrameIdentifier>, API::ContentWorld&, bool, CompletionHandler<void(Expected<JavaScriptEvaluationResult, std::optional<WebCore::ExceptionDetails>>)>&&);
     void getAccessibilityTreeData(CompletionHandler<void(API::Data*)>&&);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -193,6 +193,7 @@ class ImageBuffer;
 class IntPoint;
 class IntRect;
 class KeyboardEvent;
+class LegacyWebArchive;
 class LocalFrame;
 class LocalFrameView;
 class MediaPlaybackTargetContext;
@@ -2219,6 +2220,9 @@ private:
     void getSelectionAsWebArchiveData(CompletionHandler<void(const std::optional<IPC::SharedBufferReference>&)>&&);
     void getSourceForFrame(WebCore::FrameIdentifier, CompletionHandler<void(const String&)>&&);
     void getWebArchiveOfFrame(std::optional<WebCore::FrameIdentifier>, CompletionHandler<void(const std::optional<IPC::SharedBufferReference>&)>&&);
+#if PLATFORM(COCOA)
+    void getWebArchives(CompletionHandler<void(HashMap<WebCore::FrameIdentifier, Ref<WebCore::LegacyWebArchive>>&&)>&&);
+#endif
     void getWebArchiveOfFrameWithFileName(WebCore::FrameIdentifier, const Vector<WebCore::MarkupExclusionRule>&, const String& fileName, CompletionHandler<void(const std::optional<IPC::SharedBufferReference>&)>&&);
     void runJavaScript(WebFrame*, RunJavaScriptParameters&&, ContentWorldIdentifier, bool, CompletionHandler<void(Expected<JavaScriptEvaluationResult, std::optional<WebCore::ExceptionDetails>>)>&&);
     void runJavaScriptInFrameInScriptWorld(RunJavaScriptParameters&&, std::optional<WebCore::FrameIdentifier>, const ContentWorldData&, bool, CompletionHandler<void(Expected<JavaScriptEvaluationResult, std::optional<WebCore::ExceptionDetails>>)>&&);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -234,6 +234,9 @@ messages -> WebPage WantsAsyncDispatchMessage {
     GetSourceForFrame(WebCore::FrameIdentifier frameID) -> (String string)
     GetWebArchiveOfFrame(std::optional<WebCore::FrameIdentifier> frameID) -> (std::optional<IPC::SharedBufferReference> dataReference)
     GetWebArchiveOfFrameWithFileName(WebCore::FrameIdentifier frameID, Vector<WebCore::MarkupExclusionRule> markupExclusionRules, String fileName) -> (std::optional<IPC::SharedBufferReference> dataReference)
+#if PLATFORM(COCOA)
+    GetWebArchives() -> (HashMap<WebCore::FrameIdentifier, Ref<WebCore::LegacyWebArchive>> frameArchives)
+#endif
 
     RunJavaScriptInFrameInScriptWorld(struct WebKit::RunJavaScriptParameters parameters, std::optional<WebCore::FrameIdentifier> frameID, struct WebKit::ContentWorldData world, bool wantsResult) -> (Expected<WebKit::JavaScriptEvaluationResult, std::optional<WebCore::ExceptionDetails>> result)
 


### PR DESCRIPTION
#### 29d6acce4d23b6012258b0587f9e289a60b75b21
<pre>
[Site Isolation] Add basic support for webarchive generation
<a href="https://bugs.webkit.org/show_bug.cgi?id=293087">https://bugs.webkit.org/show_bug.cgi?id=293087</a>
<a href="https://rdar.apple.com/151424329">rdar://151424329</a>

Reviewed by Ryosuke Niwa.

In existing implementation, when creating webarchive for a web page, the web process that hosts the web page will
collect data for all frames and put the data in a single webarchive. With site isolation, this will not work because
frames can be put in different web processes and frame data needs to be fetched from different processes. To support
webarchive genereation with site isolation, this patch makes UI process collect frame webarchives from all web processes
of the page, and combined them into one webarchive based on subframe identifiers in the webarchives.

* Source/WebCore/loader/archive/Archive.h:
(WebCore::Archive::mainResource const):
(WebCore::Archive::mainResource): Deleted.
* Source/WebCore/loader/archive/ArchiveResource.cpp:
(WebCore::ArchiveResource::create):
(WebCore::ArchiveResource::createWithData):
* Source/WebCore/loader/archive/ArchiveResource.h:
(WebCore::ArchiveResource::createWithData):
* Source/WebCore/loader/archive/cf/LegacyWebArchive.cpp:
(WebCore::LegacyWebArchive::LegacyWebArchive):
(WebCore::LegacyWebArchive::create):
(WebCore::LegacyWebArchive::createFromSelection):
* Source/WebCore/loader/archive/cf/LegacyWebArchive.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView createWebArchiveDataWithCompletionHandler:]):
* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
(WebKit::WebPageProxy::getWebArchiveData):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::getWebArchive):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::getWebArchives):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm:
(TestWebKitAPI::(SiteIsolation, CreateWebArchive)):

Canonical link: <a href="https://commits.webkit.org/295026@main">https://commits.webkit.org/295026@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5bed5487a5fe7c35015c5450aae9f19aae6f461c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/103821 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/23523 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/13853 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/109014 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/54473 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/105861 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/23876 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/32069 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78881 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/106827 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/18541 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/93670 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59207 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/18343 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/11719 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/53849 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/88103 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/11778 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/111401 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/30977 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/22845 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/87885 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/31339 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/89870 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87532 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22291 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32424 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10162 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/25341 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; compiling") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/30905 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/36217 "Built successfully") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/30699 "Build was cancelled. Recent messages:OS: Sequoia (15.2), Xcode: 16.2; Running apply-patch; Checked out pull request; compiling") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/34034 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/32260 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->