### PR TITLE
[Permissions API] Report the true permission state of Geolocation only when that API has been used since the page load

### DIFF
--- a/Source/WebCore/Modules/geolocation/Geolocation.cpp
+++ b/Source/WebCore/Modules/geolocation/Geolocation.cpp
@@ -640,6 +640,7 @@ void Geolocation::requestPermission()
         return;
 
     m_allowGeolocation = InProgress;
+    m_hasBeenRequested = true;
 
     // Ask the embedder: it maintains the geolocation challenge policy itself.
     GeolocationController::from(page)->requestPermission(*this);
@@ -661,6 +662,7 @@ void Geolocation::resetIsAllowed()
 {
     m_allowGeolocation = Unknown;
     revokeAuthorizationTokenIfNecessary();
+    m_hasBeenRequested = false;
 }
 
 void Geolocation::makeSuccessCallbacks(GeolocationPosition& position)

--- a/Source/WebCore/Modules/geolocation/Geolocation.h
+++ b/Source/WebCore/Modules/geolocation/Geolocation.h
@@ -75,6 +75,8 @@ public:
     WEBCORE_EXPORT void resetIsAllowed();
     bool isAllowed() const { return m_allowGeolocation == Yes; }
 
+    bool hasBeenRequested() const { return m_hasBeenRequested; }
+
     void positionChanged();
     void setError(GeolocationError&);
     bool shouldBlockGeolocationRequests();
@@ -160,6 +162,8 @@ private:
     Watchers m_watchers;
     GeoNotifierSet m_pendingForPermissionNotifiers;
     RefPtr<GeolocationPosition> m_lastPosition;
+
+    bool m_hasBeenRequested { false };
 
     enum { Unknown, InProgress, Yes, No } m_allowGeolocation { Unknown };
     String m_authorizationToken;

--- a/Source/WebCore/Modules/geolocation/NavigatorGeolocation.cpp
+++ b/Source/WebCore/Modules/geolocation/NavigatorGeolocation.cpp
@@ -73,6 +73,14 @@ Geolocation* NavigatorGeolocation::geolocation(Navigator& navigator)
     return NavigatorGeolocation::from(navigator)->geolocation();
 }
 
+Geolocation* NavigatorGeolocation::optionalGeolocation(Navigator& navigator)
+{
+    NavigatorGeolocation* supplement = static_cast<NavigatorGeolocation*>(Supplement<Navigator>::from(&navigator, supplementName()));
+    if (!supplement)
+        return nullptr;
+    return supplement->m_geolocation.get();
+}
+
 Geolocation* NavigatorGeolocation::geolocation() const
 {
     if (!m_geolocation)

--- a/Source/WebCore/Modules/geolocation/NavigatorGeolocation.h
+++ b/Source/WebCore/Modules/geolocation/NavigatorGeolocation.h
@@ -39,6 +39,7 @@ public:
     static NavigatorGeolocation* from(Navigator&);
 
     static Geolocation* geolocation(Navigator&);
+    static Geolocation* optionalGeolocation(Navigator&);
     Geolocation* geolocation() const;
 
 #if PLATFORM(IOS_FAMILY)

--- a/Source/WebCore/Modules/permissions/Permissions.h
+++ b/Source/WebCore/Modules/permissions/Permissions.h
@@ -40,11 +40,13 @@ class String;
 
 namespace WebCore {
 
+class Document;
 class NavigatorBase;
 class PermissionStatus;
 class ScriptExecutionContext;
 enum class PermissionName : uint8_t;
 enum class PermissionQuerySource : uint8_t;
+enum class PermissionState : uint8_t;
 
 template<typename IDLType> class DOMPromiseDeferred;
 

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -12226,8 +12226,10 @@ void WebPageProxy::queryPermission(const ClientOrigin& clientOrigin, const Permi
     } else if (descriptor.name == PermissionName::Geolocation) {
 #if ENABLE(GEOLOCATION)
         name = "geolocation"_s;
-        // FIXME: We should set shouldChangeDeniedToPrompt after the first
-        // permission request like we do for notifications.
+
+        // The decision to change denied to prompt is made directly in the WebProcess.
+        // (See the Permissions API code).
+        shouldChangeDeniedToPrompt = false;
 #endif
     } else if (descriptor.name == PermissionName::Notifications || descriptor.name == PermissionName::Push) {
 #if ENABLE(NOTIFICATIONS)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/PermissionsAPI.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/PermissionsAPI.mm
@@ -27,6 +27,9 @@
 
 #import "PlatformUtilities.h"
 #import "TestWKWebView.h"
+#import <WebKit/WKContext.h>
+#import <WebKit/WKGeolocationManager.h>
+#import <WebKit/WKGeolocationPosition.h>
 #import <WebKit/WKSecurityOriginRef.h>
 #import <WebKit/WKString.h>
 #import <WebKit/WKWebViewConfigurationPrivate.h>
@@ -35,8 +38,18 @@
 
 static bool didReceiveMessage;
 static bool didReceiveQueryPermission;
-static WKPermissionDecision permissionDecision;
+static WKPermissionDecision queryPermissionDelegateResult;
 static RetainPtr<WKScriptMessage> scriptMessage;
+static bool didReceiveGeolocationRequest;
+static bool requestGeolocationPermissionDelegateResult;
+
+enum class RequestGeolocationSincePageLoad : bool { No, Yes };
+enum class GeolocationPermissionState {
+    GrantedPermanently,
+    DeniedPermanently,
+    GrantedFromPrompt,
+    DeniedFromPrompt
+};
 
 @interface PermissionsAPIMessageHandler : NSObject <WKScriptMessageHandler>
 @end
@@ -57,7 +70,19 @@ static RetainPtr<WKScriptMessage> scriptMessage;
 @implementation PermissionsAPIUIDelegate
 - (void)_webView:(WKWebView *)webView queryPermission:(NSString*) name forOrigin:(WKSecurityOrigin *)origin completionHandler:(void (^)(WKPermissionDecision state))completionHandler {
     didReceiveQueryPermission = true;
-    completionHandler(permissionDecision);
+    completionHandler(queryPermissionDelegateResult);
+}
+@end
+
+
+@interface PermissionsAPIAndGeolocationRequestUIDelegate : PermissionsAPIUIDelegate
+- (void)_webView:(WKWebView *)webView requestGeolocationPermissionForFrame:(WKFrameInfo *)frame decisionHandler:(void (^)(BOOL allowed))decisionHandler;
+@end
+
+@implementation PermissionsAPIAndGeolocationRequestUIDelegate
+- (void)_webView:(WKWebView *)webView requestGeolocationPermissionForFrame:(WKFrameInfo *)frame decisionHandler:(void (^)(BOOL allowed))decisionHandler {
+    didReceiveGeolocationRequest = true;
+    decisionHandler(requestGeolocationPermissionDelegateResult);
 }
 @end
 
@@ -77,16 +102,16 @@ static void urlEncodeIfNeeded(uint8_t byte, StringBuilder& buffer)
 
 TEST(PermissionsAPI, DataURL)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     configuration.get()._allowTopNavigationToDataURLs = YES;
-    auto messageHandler = adoptNS([[PermissionsAPIMessageHandler alloc] init]);
+    RetainPtr messageHandler = adoptNS([[PermissionsAPIMessageHandler alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"msg"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get()]);
-    auto delegate = adoptNS([[PermissionsAPIUIDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get()]);
+    RetainPtr delegate = adoptNS([[PermissionsAPIUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
 
-    permissionDecision = WKPermissionDecisionDeny;
+    queryPermissionDelegateResult = WKPermissionDecisionDeny;
     didReceiveMessage = false;
     didReceiveQueryPermission = false;
 
@@ -114,15 +139,15 @@ TEST(PermissionsAPI, DataURL)
 
 TEST(PermissionsAPI, OnChange)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto messageHandler = adoptNS([[PermissionsAPIMessageHandler alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr messageHandler = adoptNS([[PermissionsAPIMessageHandler alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"msg"];
 
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get()]);
-    auto delegate = adoptNS([[PermissionsAPIUIDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get()]);
+    RetainPtr delegate = adoptNS([[PermissionsAPIUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
 
-    permissionDecision = WKPermissionDecisionGrant;
+    queryPermissionDelegateResult = WKPermissionDecisionGrant;
     didReceiveMessage = false;
     didReceiveQueryPermission = false;
 
@@ -143,7 +168,7 @@ TEST(PermissionsAPI, OnChange)
     EXPECT_STREQ(((NSString *)[scriptMessage body]).UTF8String, "granted");
 
     didReceiveMessage = false;
-    permissionDecision = WKPermissionDecisionPrompt;
+    queryPermissionDelegateResult = WKPermissionDecisionPrompt;
 
     auto originString = adoptWK(WKStringCreateWithUTF8CString("https://example.com/"));
     auto origin = adoptWK(WKSecurityOriginCreateFromString(originString.get()));
@@ -151,6 +176,123 @@ TEST(PermissionsAPI, OnChange)
 
     TestWebKitAPI::Util::run(&didReceiveMessage);
     EXPECT_STREQ(((NSString *)[scriptMessage body]).UTF8String, "prompt");
+}
+
+static void testPermissionsAPIForGeolocation(GeolocationPermissionState geolocationPermissionState, RequestGeolocationSincePageLoad requestGeolocationSincePageLoad, String expectedResult)
+{
+    RetainPtr pool = adoptNS([[WKProcessPool alloc] init]);
+
+    WKGeolocationProviderV1 providerCallback;
+    zeroBytes(providerCallback);
+    providerCallback.base.version = 1;
+    providerCallback.startUpdating = [] (WKGeolocationManagerRef manager, const void*) {
+        WKGeolocationManagerProviderDidChangePosition(manager, adoptWK(WKGeolocationPositionCreate(0, 50.644358, 3.345453, 2.53)).get());
+    };
+    WKGeolocationManagerSetProvider(WKContextGetGeolocationManager((WKContextRef)pool.get()), &providerCallback.base);
+
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    configuration.get().processPool = pool.get();
+
+    RetainPtr messageHandler = adoptNS([[PermissionsAPIMessageHandler alloc] init]);
+    [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"msg"];
+
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get()]);
+    RetainPtr delegate = adoptNS([[PermissionsAPIAndGeolocationRequestUIDelegate alloc] init]);
+    [webView setUIDelegate:delegate.get()];
+
+    switch (geolocationPermissionState) {
+    case GeolocationPermissionState::GrantedPermanently:
+        queryPermissionDelegateResult = WKPermissionDecisionGrant;
+        break;
+    case GeolocationPermissionState::DeniedPermanently:
+        queryPermissionDelegateResult = WKPermissionDecisionDeny;
+        break;
+    case GeolocationPermissionState::GrantedFromPrompt:
+        queryPermissionDelegateResult = WKPermissionDecisionPrompt;
+        requestGeolocationPermissionDelegateResult = true;
+        break;
+    case GeolocationPermissionState::DeniedFromPrompt:
+        queryPermissionDelegateResult = WKPermissionDecisionPrompt;
+        requestGeolocationPermissionDelegateResult = false;
+        break;
+    }
+
+    didReceiveMessage = false;
+    didReceiveQueryPermission = false;
+
+    NSString *scriptWithGeolocationRequestedSincePageLoad = @"<script>"
+        "let success = () => {"
+        "    navigator.permissions.query({ name : 'geolocation' }).then((permissionStatus) => {"
+        "        window.webkit.messageHandlers.msg.postMessage(permissionStatus.state);"
+        "    }, () => {"
+        "        window.webkit.messageHandlers.msg.postMessage('FAIL');"
+        "    });"
+        "};"
+        "let failure = () => {"
+        "    navigator.permissions.query({ name : 'geolocation' }).then((permissionStatus) => {"
+        "        window.webkit.messageHandlers.msg.postMessage(permissionStatus.state);"
+        "    }, () => {"
+        "        window.webkit.messageHandlers.msg.postMessage('FAIL');"
+        "    });"
+        "};"
+        "navigator.geolocation.getCurrentPosition(success, failure);"
+        "</script>";
+
+    NSString *scriptWithoutGeolocationRequestedSincePageLoad = @"<script>"
+        "navigator.permissions.query({ name : 'geolocation' }).then((permissionStatus) => {"
+        "    window.webkit.messageHandlers.msg.postMessage(permissionStatus.state);"
+        "}, () => {"
+        "    window.webkit.messageHandlers.msg.postMessage('FAIL');"
+        "});"
+        "</script>";
+
+    if (requestGeolocationSincePageLoad == RequestGeolocationSincePageLoad::Yes)
+        [webView synchronouslyLoadHTMLString:scriptWithGeolocationRequestedSincePageLoad baseURL:[NSURL URLWithString:@"https://example.com/"]];
+    else
+        [webView synchronouslyLoadHTMLString:scriptWithoutGeolocationRequestedSincePageLoad baseURL:[NSURL URLWithString:@"https://example.com/"]];
+
+    TestWebKitAPI::Util::run(&didReceiveMessage);
+    EXPECT_STREQ(((NSString *)[scriptMessage body]).UTF8String, expectedResult.utf8().data());
+}
+
+TEST(PermissionsAPI, GeolocationPermissionGrantedFromPromptAndGeolocationRequestedSinceLoad)
+{
+    testPermissionsAPIForGeolocation(GeolocationPermissionState::GrantedFromPrompt, RequestGeolocationSincePageLoad::Yes, "granted"_s);
+}
+
+TEST(PermissionsAPI, GeolocationPermissionGrantedFromPromptAndGeolocationNotRequestedSinceLoad)
+{
+    testPermissionsAPIForGeolocation(GeolocationPermissionState::GrantedFromPrompt, RequestGeolocationSincePageLoad::No, "prompt"_s);
+}
+
+TEST(PermissionsAPI, GeolocationPermissionDeniedFromPromptAndGeolocationRequestedSinceLoad)
+{
+    testPermissionsAPIForGeolocation(GeolocationPermissionState::DeniedFromPrompt, RequestGeolocationSincePageLoad::Yes, "denied"_s);
+}
+
+TEST(PermissionsAPI, GeolocationPermissionDeniedFromPromptAndGeolocationNotRequestedSinceLoad)
+{
+    testPermissionsAPIForGeolocation(GeolocationPermissionState::DeniedFromPrompt, RequestGeolocationSincePageLoad::No, "prompt"_s);
+}
+
+TEST(PermissionsAPI, GeolocationPermissionGrantedPermanentlyAndGeolocationRequestedSinceLoad)
+{
+    testPermissionsAPIForGeolocation(GeolocationPermissionState::GrantedPermanently, RequestGeolocationSincePageLoad::Yes, "granted"_s);
+}
+
+TEST(PermissionsAPI, GeolocationPermissionGrantedPermanentlyAndGeolocationNotRequestedSinceLoad)
+{
+    testPermissionsAPIForGeolocation(GeolocationPermissionState::GrantedPermanently, RequestGeolocationSincePageLoad::No, "granted"_s);
+}
+
+TEST(PermissionsAPI, GeolocationPermissionDeniedPermanentlyAndGeolocationRequestedSinceLoad)
+{
+    testPermissionsAPIForGeolocation(GeolocationPermissionState::DeniedPermanently, RequestGeolocationSincePageLoad::Yes, "denied"_s);
+}
+
+TEST(PermissionsAPI, GeolocationPermissionDeniedPermanentlyAndGeolocationNotRequestedSinceLoad)
+{
+    testPermissionsAPIForGeolocation(GeolocationPermissionState::DeniedPermanently, RequestGeolocationSincePageLoad::No, "prompt"_s);
 }
 
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### 386b21db7bdc2fc5135138027639ef8bf8a0402b
<pre>
[Permissions API] Report the true permission state of Geolocation only when that API has been used since the page load
<a href="https://bugs.webkit.org/show_bug.cgi?id=293089">https://bugs.webkit.org/show_bug.cgi?id=293089</a>
<a href="https://rdar.apple.com/151426960">rdar://151426960</a>

Reviewed by Youenn Fablet.

The current behavior of the Permissions API is:
- Return PROMPT in all cases where the permission state of the Geolocation API is DENIED.
- Return GRANTED in all cases where the permission state of the Geolocation API is GRANTED.

This PR changes WebKit&apos;s Permissions API to behave like so:
(On both MacOS and iOS).

User action                                   || Client tells WebKit || WebKit tells website    ||
----------------------------------------------||---------------------||-------------------------||
User says GRANTED to prompt once              || PROMPT              || GRANTED                 || geolocation requested by page since page load
                                              || PROMPT              || PROMPT                  || not requested since page load
User says GRANTED to prompt twice (24h grant) || PROMPT              || GRANTED                 || geolocation requested by page since page load
                                              || PROMPT              || PROMPT                  || not requested since page load
User says DENIED to prompt once               || PROMPT              || DENIED                  || geolocation requested by page since page load
                                              || PROMPT              || PROMPT                  || not requested since page load
User says DENIED to prompt twice (24h grant)  || PROMPT              || DENIED                  || geolocation requested by page since page load
                                              || PROMPT              || PROMPT                  || not requested since page load
User says GRANTED in permanent settings       || GRANTED             || GRANTED                 ||
User says DENIED in permanent settings        || DENIED              || DENIED                  || geolocation requested by page since page load
                                              || DENIED              || PROMPT (fingerprinting) || not requested since page load

The &quot;Client tells WebKit&quot; column represents how the client&apos;s implementation of the queryPermission
delegate behaves. Given this behavior, this PR makes changes so that the Permissions API behaves
like the &quot;WebKit tells website&quot; column.

WebKit&apos;s position is that the geolocation permission state should only be revealed to a site if
that site is willing to show a prompt asking for permission to use that API.

Prompts for geolocation are shown when one of the functions of the Geolocation API are called
(for example navigator.geolocation.getCurrentPosition). So the Permissions API should only reveal
the true permission state of the Geolocation API if such a function has been called since the page
load. If you reload the page, WebKit forgets that you&apos;ve tried to use the API.

The only exception to this rule is that if a user has permanently GRANTED--the user is indicating
that they trust this site, so the Permissions API will return the true state regardless of if the
site has attempted to get the geolocation. It&apos;s important to note that these settings (both permanent
and for a prompt) are per-site settings.

We don&apos;t make this exception in the case of permanently DENIED--as fingerprinting countermeasure,
we still return PROMPT in the case where Geolocation hasn&apos;t been requested.

Implementation details:

Navigator has a Geolocation object. On this object, we add a property (m_hasBeenRequested) which
gets set any time permission to get geolocation is requested. The Geolocation object is reset
every page load and so is this property.

When Permissions::query is called, it gets the permission state from the client. For geolocation,
clients return GRANTED or DENIED only in the cases where the user has granted or denied *permanently*.
If no permanent setting has been set, and user has simply granted or denied via a prompt, clients
return PROMPT. But if the user grants or denies via a prompt, the m_allowGeolocation property gets
set on the Geolocation object.

This means that Permissions::queryPermission can see that:
- If the result returned by client is GRANTED or DENIED --&gt; that&apos;s a permanent setting
- If the result returned by client is PROMPT and Geolocation has been requested --&gt; the user has
  responded to the prompt and their answer is contained in Geolocation::isAllowed()

The behavior in the table is tested by new API tests. These tests work on both MacOS and iOS.

* Source/WebCore/Modules/geolocation/Geolocation.cpp:
(WebCore::Geolocation::requestPermission):
(WebCore::Geolocation::resetIsAllowed):
* Source/WebCore/Modules/geolocation/Geolocation.h:

We add the new property m_hasBeenRequested here with a function to access it.

To access Geolocation&apos;s m_hasBeenRequested property, the Permissions API
code first gets the Geolocation from the NavigatorGeolocation. This is
supplement to the WebPage. Service workers don&apos;t have a WebPage and thus
don&apos;t have a NavigationGeolocation object. So we want to make sure
we don&apos;t try to createa Geolocation object in this case because attempting
to delete it later will result in a crash (we delete it by accessing it
from the supplement first--which doesn&apos;t exist in the worker case).

* Source/WebCore/Modules/permissions/Permissions.cpp:
(WebCore::Permissions::query):
(WebCore::Permissions::determineGeolocationPermissionState):

This function decides if the permission state is a permanent one, or a temporary
user-response to a prompt. It contains the logic to change GRANTED and DENIED to
PROMPT in cases where the Geolocation API hasn&apos;t been used since the page load.
(The main logic of the above table is implemented here).

* Source/WebCore/Modules/permissions/Permissions.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::queryPermission):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/PermissionsAPI.mm:
(-[PermissionsAPIUIDelegate _webView:queryPermission:forOrigin:completionHandler:]):
(-[PermissionsAPIAndGeolocationRequestUIDelegate _webView:requestGeolocationPermissionForFrame:decisionHandler:]):
(TestWebKitAPI::TEST(PermissionsAPI, DataURL)):
(TestWebKitAPI::TEST(PermissionsAPI, OnChange)):
(TestWebKitAPI::testPermissionsAPIForGeolocation):
(TestWebKitAPI::TEST(PermissionsAPI, GeolocationPermissionGrantedFromPromptAndGeolcationRequestedSinceLoad)):
(TestWebKitAPI::TEST(PermissionsAPI, GeolocationPermissionGrantedFromPromptAndGeolocationNotRequestedSinceLoad)):
(TestWebKitAPI::TEST(PermissionsAPI, GeolcolationPermissionDeniedFromPromptAndGeolocationRequestedSinceLoad)):
(TestWebKitAPI::TEST(PermissionsAPI, GeolcolationPermissionDeniedFromPromptAndGeolocationNotRequestedSinceLoad)):
(TestWebKitAPI::TEST(PermissionsAPI, GeolcolationPermissionGrantedPermanentlyAndGeolocationRequestedSinceLoad)):
(TestWebKitAPI::TEST(PermissionsAPI, GeolcolationPermissionGrantedPermanentlyAndGeolocationNotRequestedSinceLoad)):
(TestWebKitAPI::TEST(PermissionsAPI, GeolcolationPermissionDeniedPermanentlyAndGeolocationRequestedSinceLoad)):
(TestWebKitAPI::TEST(PermissionsAPI, GeolcolationPermissionDeniedPermanentlyAndGeolocationNotRequestedSinceLoad)):

Canonical link: <a href="https://commits.webkit.org/295237@main">https://commits.webkit.org/295237@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a034119ea8ba2ebf04ee4931cc9c372943196530

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104371 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24075 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/14490 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/109573 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/55039 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/106411 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/24449 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/32622 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79245 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107377 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19002 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94192 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59575 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/18802 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/12266 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/54400 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/88499 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/12319 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/111954 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/31528 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23226 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88282 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/31892 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/90436 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87947 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22426 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32851 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10616 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/26995 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/31456 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/36781 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/31250 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/34586 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/32810 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->