### PR TITLE
[JSC] Implement `DisposableStack` prototype methods

### DIFF
--- a/JSTests/stress/disposable-stack-prototype-basic.js
+++ b/JSTests/stress/disposable-stack-prototype-basic.js
@@ -1,0 +1,153 @@
+//@ requireOptions("--useExplicitResourceManagement=1")
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`expected ${expected} but got ${actual}`);
+}
+
+function shouldThrow(func, errorType, message) {
+    let error;
+    try { func(); } catch (e) { error = e; }
+    if (!(error instanceof errorType))
+        throw new Error(`Expected ${errorType.name}!`);
+    if (message !== undefined)
+        shouldBe(String(error), message);
+}
+
+// DisposableStack.prototype.adopt
+{
+    let called = false;
+    const value = { foo: 1 };
+    const stack = new DisposableStack();
+    const ret = stack.adopt(value, v => { shouldBe(v, value); called = true; });
+    shouldBe(ret, value);
+    stack.dispose();
+    shouldBe(called, true);
+}
+{
+    const stack = new DisposableStack();
+    shouldThrow(() => stack.adopt({}, 1), TypeError);
+}
+{
+    const stack = new DisposableStack();
+    stack.dispose();
+    shouldThrow(() => stack.adopt({}, () => {}), ReferenceError);
+}
+{
+    shouldThrow(() => DisposableStack.prototype.adopt.call({}, {}, () => {}), TypeError);
+}
+
+// DisposableStack.prototype.defer
+{
+    const order = [];
+    const stack = new DisposableStack();
+    stack.defer(() => order.push(1));
+    stack.defer(() => order.push(2));
+    stack.dispose();
+    shouldBe(order.join(","), "2,1");
+}
+{
+    const stack = new DisposableStack();
+    shouldThrow(() => stack.defer(0), TypeError);
+}
+{
+    const stack = new DisposableStack();
+    stack.dispose();
+    shouldThrow(() => stack.defer(() => {}), ReferenceError);
+}
+
+// DisposableStack.prototype.dispose
+{
+    let count = 0;
+    const stack = new DisposableStack();
+    stack.defer(() => ++count);
+    stack.dispose();
+    stack.dispose();
+    shouldBe(count, 1);
+}
+{
+    const stack = new DisposableStack();
+    stack.defer(() => { throw new Error("first"); });
+    stack.defer(() => { throw new Error("second"); });
+    shouldThrow(() => stack.dispose(), SuppressedError);
+}
+{
+    const stack = new DisposableStack();
+    stack.defer(() => { throw new Error("only"); });
+    shouldThrow(() => stack.dispose(), Error, "Error: only");
+}
+{
+    const stack = new DisposableStack();
+    shouldBe(stack.dispose(), undefined);
+}
+
+// DisposableStack.prototype.use
+{
+    const res = {
+        disposed: false,
+        [Symbol.dispose]() { this.disposed = true; }
+    };
+    const stack = new DisposableStack();
+    const ret = stack.use(res);
+    shouldBe(ret, res);
+    stack.dispose();
+    shouldBe(res.disposed, true);
+}
+{
+    const order = [];
+    const stack = new DisposableStack();
+    const a = { [Symbol.dispose]() { order.push("use1"); } };
+    const b = { [Symbol.dispose]() { order.push("use2"); } };
+    stack.use(a);
+    stack.defer(() => order.push("defer"));
+    stack.adopt({}, () => order.push("adopt"));
+    stack.use(b);
+    stack.dispose();
+    shouldBe(order.join(","), "use2,adopt,defer,use1");
+}
+{
+    const stack = new DisposableStack();
+    shouldThrow(() => stack.use(42), TypeError);
+}
+{
+    const stack = new DisposableStack();
+    stack.dispose();
+    shouldThrow(() => stack.use({}), ReferenceError);
+}
+{
+    const stack = new DisposableStack();
+    stack.use(null);
+    stack.use(undefined);
+    stack.dispose();
+    shouldBe(stack.disposed, true);
+}
+
+// DisposableStack.prototype.move
+{
+    let called = false;
+    const stack1 = new DisposableStack();
+    stack1.defer(() => called = true);
+    const stack2 = stack1.move();
+    shouldThrow(() => stack1.defer(() => {}), ReferenceError);
+    stack2.dispose();
+    shouldBe(called, true);
+    shouldBe(stack1.disposed, true);
+}
+{
+    const stack = new DisposableStack();
+    stack.dispose();
+    shouldThrow(() => stack.move(), ReferenceError);
+}
+{
+    shouldThrow(() => DisposableStack.prototype.move.call({}), TypeError);
+}
+{
+    const order = [];
+    const s1 = new DisposableStack();
+    s1.adopt("v", () => order.push("adopt"));
+    s1.defer(() => order.push("defer"));
+    s1.use({ [Symbol.dispose]() { order.push("use"); } });
+    const s2 = s1.move();
+    s2.dispose();
+    shouldBe(order.join(","), "use,defer,adopt");
+}

--- a/JSTests/test262/config.yaml
+++ b/JSTests/test262/config.yaml
@@ -48,11 +48,17 @@ skip:
     - test/staging/sm/Temporal
     # Explicit Resource Management
     - test/staging/explicit-resource-management
-    - test/built-ins/DisposableStack/prototype
     - test/built-ins/AsyncDisposableStack
     - test/language/statements/using
     - test/language/statements/await-using
   files:
+    # Depends on AsyncDisposableStack
+    - test/built-ins/DisposableStack/prototype/use/this-does-not-have-internal-disposablestate-throws.js
+    - test/built-ins/DisposableStack/prototype/dispose/this-does-not-have-internal-disposablestate-throws.js
+    - test/built-ins/DisposableStack/prototype/adopt/this-does-not-have-internal-disposablestate-throws.js
+    - test/built-ins/DisposableStack/prototype/move/this-does-not-have-internal-disposablestate-throws.js
+    - test/built-ins/DisposableStack/prototype/defer/this-does-not-have-internal-disposablestate-throws.js
+
     # https://github.com/claudepache/es-legacy-function-reflection
     - test/built-ins/ThrowTypeError/unique-per-realm-function-proto.js
     - test/built-ins/Function/prototype/restricted-property-arguments.js

--- a/Source/JavaScriptCore/CMakeLists.txt
+++ b/Source/JavaScriptCore/CMakeLists.txt
@@ -342,6 +342,7 @@ set(JavaScriptCore_BUILTINS_SOURCES
     ${JAVASCRIPTCORE_DIR}/builtins/AsyncFunctionPrototype.js
     ${JAVASCRIPTCORE_DIR}/builtins/AsyncGeneratorPrototype.js
     ${JAVASCRIPTCORE_DIR}/builtins/AsyncIteratorPrototype.js
+    ${JAVASCRIPTCORE_DIR}/builtins/DisposableStackPrototype.js
     ${JAVASCRIPTCORE_DIR}/builtins/FunctionPrototype.js
     ${JAVASCRIPTCORE_DIR}/builtins/GeneratorPrototype.js
     ${JAVASCRIPTCORE_DIR}/builtins/GlobalOperations.js

--- a/Source/JavaScriptCore/DerivedSources.make
+++ b/Source/JavaScriptCore/DerivedSources.make
@@ -111,6 +111,7 @@ JavaScriptCore_BUILTINS_SOURCES = \
     $(JavaScriptCore)/builtins/AsyncFunctionPrototype.js \
     $(JavaScriptCore)/builtins/AsyncGeneratorPrototype.js \
     $(JavaScriptCore)/builtins/AsyncIteratorPrototype.js \
+    $(JavaScriptCore)/builtins/DisposableStackPrototype.js \
     $(JavaScriptCore)/builtins/FunctionPrototype.js \
     $(JavaScriptCore)/builtins/GeneratorPrototype.js \
     $(JavaScriptCore)/builtins/GlobalOperations.js \

--- a/Source/JavaScriptCore/builtins/BuiltinNames.h
+++ b/Source/JavaScriptCore/builtins/BuiltinNames.h
@@ -220,6 +220,9 @@ namespace JSC {
     macro(iteratorHelperCreate) \
     macro(syncIterator) \
     macro(includes) \
+    macro(ReferenceError) \
+    macro(SuppressedError) \
+    macro(DisposableStack) \
 
 
 namespace Symbols {

--- a/Source/JavaScriptCore/builtins/DisposableStackPrototype.js
+++ b/Source/JavaScriptCore/builtins/DisposableStackPrototype.js
@@ -1,0 +1,186 @@
+/*
+ * Copyright (C) 2025 Sosuke Suzuki <aosukeke@gmail.com>.
+ *
+ * Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// https://tc39.es/proposal-explicit-resource-management/#sec-createdisposableresource
+@linkTimeConstant
+function createSyncDisposableResource(value /* , method */)
+{
+    'use strict';
+
+    var method;
+    if (@argumentCount() < 2) {
+        if (@isUndefinedOrNull(value))
+            value = @undefined;
+        else {
+            if (!@isObject(value))
+                @throwTypeError("Disposable value must be an object");
+            method = value.@@dispose;
+            if (method === @undefined)
+                @throwTypeError("@@dispose must not be an undefined");
+        }
+    } else {
+        method = @argument(1);
+        if (!@isCallable(method))
+            @throwTypeError("Callback that is called on dispose must be callable");
+    }
+
+    return { value, method };
+}
+
+// https://tc39.es/proposal-explicit-resource-management/#sec-adddisposableresource
+@linkTimeConstant
+function addSyncDisposableResource(disposeCapability, value /* , method */)
+{
+    'use strict';
+
+    @assert(@isArray(disposeCapability));
+
+    var resource;
+    if (@argumentCount() < 3) {
+        if (@isUndefinedOrNull(value))
+            return;
+        resource = @createSyncDisposableResource(value);
+    } else {
+        @assert(value === @undefined);
+        resource = @createSyncDisposableResource(@undefined, @argument(2));
+    }
+
+    @arrayPush(disposeCapability, resource);
+}
+
+// https://tc39.es/proposal-explicit-resource-management/#sec-disposablestack.prototype.adopt
+function adopt(value, onDispose)
+{
+    'use strict';
+
+    if (!@isDisposableStack(this))
+        @throwTypeError("DisposableStack.prototype.adopt requires that |this| be a DisposableStack object");
+
+    if (@getDisposableStackInternalField(this, @disposableStackFieldState) === @DisposableStackStateDisposed)
+        throw new @ReferenceError("DisposableStack.prototype.adopt requires that |this| be a pending DisposableStack object");
+
+    if (!@isCallable(onDispose))
+        @throwTypeError("DisposableStack.prototype.adopt requires that onDispose argument be a callable");
+
+    var closure = () => { onDispose.@call(@undefined, value); }
+    @addSyncDisposableResource(@getDisposableStackInternalField(this, @disposableStackFieldCapability), @undefined, closure);
+
+    return value;
+}
+
+// https://tc39.es/proposal-explicit-resource-management/#sec-disposablestack.prototype.defer
+@overriddenName="defer"
+function deferMethod(onDispose)
+{
+    'use strict';
+
+    if (!@isDisposableStack(this))
+        @throwTypeError("DisposableStack.prototype.defer requires that |this| be a DisposableStack object");
+
+    if (@getDisposableStackInternalField(this, @disposableStackFieldState) === @DisposableStackStateDisposed)
+        throw new @ReferenceError("DisposableStack.prototype.defer requires that |this| be a pending DisposableStack object");
+
+    if (!@isCallable(onDispose))
+        @throwTypeError("DisposableStack.prototype.defer requires that onDispose argument be a callable");
+
+    @addSyncDisposableResource(@getDisposableStackInternalField(this, @disposableStackFieldCapability), @undefined, onDispose);
+
+    return @undefined;
+}
+
+// https://tc39.es/proposal-explicit-resource-management/#sec-disposablestack.prototype.dispose
+function dispose()
+{
+    'use strict';
+
+    if (!@isDisposableStack(this))
+        @throwTypeError("DisposableStack.prototype.dispose requires that |this| be a DisposableStack object");
+
+    if (@getDisposableStackInternalField(this, @disposableStackFieldState) === @DisposableStackStateDisposed)
+        return @undefined;
+
+    @putDisposableStackInternalField(this, @disposableStackFieldState, @DisposableStackStateDisposed);
+
+    var stack = @getDisposableStackInternalField(this, @disposableStackFieldCapability);
+    @assert(@isArray(stack));
+
+    var i = stack.length;
+    var thrown = false;
+    var suppressed;
+
+    while (i) {
+        var resource = stack[--i];
+        try {
+            resource.method.@call(resource.value);
+        } catch (e) {
+            if (thrown)
+                suppressed = new @SuppressedError(e, suppressed);
+            else {
+                thrown = true;
+                suppressed = e;
+            }
+        }
+    }
+
+    @putDisposableStackInternalField(this, @disposableStackFieldCapability, []);
+    if (thrown)
+        throw suppressed;
+}
+
+// https://tc39.es/proposal-explicit-resource-management/#sec-disposablestack.prototype.move
+function move()
+{
+    'use strict';
+
+    if (!@isDisposableStack(this))
+        @throwTypeError("DisposableStack.prototype.move requires that |this| be a DisposableStack object");
+
+    if (@getDisposableStackInternalField(this, @disposableStackFieldState) === @DisposableStackStateDisposed)
+        throw new @ReferenceError("DisposableStack.prototype.move requires that |this| be a pending DisposableStack object");
+
+    var newDisposableStack = new @DisposableStack();
+    @putDisposableStackInternalField(newDisposableStack, @disposableStackFieldCapability, @getDisposableStackInternalField(this, @disposableStackFieldCapability));
+
+    @putDisposableStackInternalField(this, @disposableStackFieldCapability, []);
+    @putDisposableStackInternalField(this, @disposableStackFieldState, @DisposableStackStateDisposed);
+
+    return newDisposableStack;
+}
+
+// https://tc39.es/proposal-explicit-resource-management/#sec-disposablestack.prototype.use
+function use(value)
+{
+    'use strict';
+
+    if (!@isDisposableStack(this))
+        @throwTypeError("DisposableStack.prototype.use requires that |this| be a DisposableStack object");
+
+    if (@getDisposableStackInternalField(this, @disposableStackFieldState) === @DisposableStackStateDisposed)
+        throw new @ReferenceError("DisposableStack.prototype.use requires that |this| be a pending DisposableStack object");
+
+    @addSyncDisposableResource(@getDisposableStackInternalField(this, @disposableStackFieldCapability), value);
+
+    return value;
+}

--- a/Source/JavaScriptCore/bytecode/BytecodeIntrinsicRegistry.cpp
+++ b/Source/JavaScriptCore/bytecode/BytecodeIntrinsicRegistry.cpp
@@ -36,6 +36,7 @@
 #include "JSArrayIterator.h"
 #include "JSAsyncFromSyncIterator.h"
 #include "JSAsyncGenerator.h"
+#include "JSDisposableStack.h"
 #include "JSGenerator.h"
 #include "JSGlobalObject.h"
 #include "JSIteratorHelper.h"
@@ -139,6 +140,10 @@ BytecodeIntrinsicRegistry::BytecodeIntrinsicRegistry(VM& vm)
     m_regExpStringIteratorFieldDone.set(m_vm, jsNumber(static_cast<int32_t>(JSRegExpStringIterator::Field::Done)));
     m_iteratorHelperFieldGenerator.set(m_vm, jsNumber(static_cast<int32_t>(JSIteratorHelper::Field::Generator)));
     m_iteratorHelperFieldUnderlyingIterator.set(m_vm, jsNumber(static_cast<int32_t>(JSIteratorHelper::Field::UnderlyingIterator)));
+    m_disposableStackFieldState.set(m_vm, jsNumber(static_cast<int32_t>(JSDisposableStack::Field::State)));
+    m_disposableStackFieldCapability.set(m_vm, jsNumber(static_cast<int32_t>(JSDisposableStack::Field::Capability)));
+    m_DisposableStackStatePending.set(m_vm, jsNumber(static_cast<int32_t>(JSDisposableStack::State::Pending)));
+    m_DisposableStackStateDisposed.set(m_vm, jsNumber(static_cast<int32_t>(JSDisposableStack::State::Disposed)));
 }
 
 std::optional<BytecodeIntrinsicRegistry::Entry> BytecodeIntrinsicRegistry::lookup(const Identifier& ident) const

--- a/Source/JavaScriptCore/bytecode/BytecodeIntrinsicRegistry.h
+++ b/Source/JavaScriptCore/bytecode/BytecodeIntrinsicRegistry.h
@@ -61,6 +61,7 @@ enum class LinkTimeConstant : int32_t;
     macro(getRegExpStringIteratorInternalField) \
     macro(getProxyInternalField) \
     macro(getWrapForValidIteratorInternalField) \
+    macro(getDisposableStackInternalField) \
     macro(idWithProfile) \
     macro(isAsyncFromSyncIterator) \
     macro(isObject) \
@@ -84,6 +85,7 @@ enum class LinkTimeConstant : int32_t;
     macro(isUndefinedOrNull) \
     macro(isWrapForValidIterator) \
     macro(isRegExpStringIterator) \
+    macro(isDisposableStack) \
     macro(tailCallForwardArguments) \
     macro(throwTypeError) \
     macro(throwRangeError) \
@@ -103,6 +105,7 @@ enum class LinkTimeConstant : int32_t;
     macro(putMapIteratorInternalField) \
     macro(putSetIteratorInternalField) \
     macro(putRegExpStringIteratorInternalField) \
+    macro(putDisposableStackInternalField) \
     macro(superSamplerBegin) \
     macro(superSamplerEnd) \
     macro(toNumber) \
@@ -198,6 +201,10 @@ enum class LinkTimeConstant : int32_t;
     macro(regExpStringIteratorFieldGlobal) \
     macro(regExpStringIteratorFieldFullUnicode) \
     macro(regExpStringIteratorFieldDone) \
+    macro(disposableStackFieldState) \
+    macro(disposableStackFieldCapability) \
+    macro(DisposableStackStatePending) \
+    macro(DisposableStackStateDisposed) \
 
 
 #define JSC_COMMON_BYTECODE_INTRINSIC_CONSTANTS_CUSTOM_EACH_NAME(macro) \

--- a/Source/JavaScriptCore/bytecode/LinkTimeConstant.h
+++ b/Source/JavaScriptCore/bytecode/LinkTimeConstant.h
@@ -151,6 +151,9 @@ class JSGlobalObject;
     v(asyncFromSyncIteratorCreate, nullptr) \
     v(regExpStringIteratorCreate, nullptr) \
     v(iteratorHelperCreate, nullptr) \
+    v(ReferenceError, nullptr) \
+    v(SuppressedError, nullptr) \
+    v(DisposableStack, nullptr) \
 
 
 #define DECLARE_LINK_TIME_CONSTANT(name, code) name,

--- a/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h
+++ b/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h
@@ -944,6 +944,7 @@ namespace JSC {
         RegisterID* emitIsEmpty(RegisterID* dst, RegisterID* src);
         RegisterID* emitIsDerivedArray(RegisterID* dst, RegisterID* src) { return emitIsCellWithType(dst, src, DerivedArrayType); }
         RegisterID* emitIsAsyncFromSyncIterator(RegisterID* dst, RegisterID* src) { return emitIsCellWithType(dst, src, JSAsyncFromSyncIteratorType); }
+        RegisterID* emitIsDisposableStack(RegisterID* dst, RegisterID* src) { return emitIsCellWithType(dst, src, DisposableStackType); }
         void emitRequireObjectCoercible(RegisterID* value, ASCIILiteral error);
 
         void emitIteratorOpen(RegisterID* iterator, RegisterID* nextOrIndex, RegisterID* symbolIterator, CallArguments& iterable, const ThrowableExpressionData*);

--- a/Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp
+++ b/Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp
@@ -36,6 +36,7 @@
 #include "JSAsyncFromSyncIterator.h"
 #include "JSAsyncGenerator.h"
 #include "JSCInlines.h"
+#include "JSDisposableStack.h"
 #include "JSGenerator.h"
 #include "JSImmutableButterfly.h"
 #include "JSIteratorHelper.h"
@@ -1695,6 +1696,17 @@ static JSWrapForValidIterator::Field wrapForValidIteratorInternalFieldIndex(Byte
     return JSWrapForValidIterator::Field::IteratedNextMethod;
 }
 
+static JSDisposableStack::Field disposableStackInternalFieldIndex(BytecodeIntrinsicNode* node)
+{
+    ASSERT(node->entry().type() == BytecodeIntrinsicRegistry::Type::Emitter);
+    if (node->entry().emitter() == &BytecodeIntrinsicNode::emit_intrinsic_disposableStackFieldState)
+        return JSDisposableStack::Field::State;
+    if (node->entry().emitter() == &BytecodeIntrinsicNode::emit_intrinsic_disposableStackFieldCapability)
+        return JSDisposableStack::Field::Capability;
+    RELEASE_ASSERT_NOT_REACHED();
+    return JSDisposableStack::Field::State;
+}
+
 static JSRegExpStringIterator::Field regExpStringIteratorInternalFieldIndex(BytecodeIntrinsicNode* node)
 {
     ASSERT(node->entry().type() == BytecodeIntrinsicRegistry::Type::Emitter);
@@ -1863,6 +1875,19 @@ RegisterID* BytecodeIntrinsicNode::emit_intrinsic_getWrapForValidIteratorInterna
     RELEASE_ASSERT(node->m_expr->isBytecodeIntrinsicNode());
     unsigned index = static_cast<unsigned>(wrapForValidIteratorInternalFieldIndex(static_cast<BytecodeIntrinsicNode*>(node->m_expr)));
     ASSERT(index < JSWrapForValidIterator::numberOfInternalFields);
+    ASSERT(!node->m_next);
+
+    return generator.emitGetInternalField(generator.finalDestination(dst), base.get(), index);
+}
+
+RegisterID* BytecodeIntrinsicNode::emit_intrinsic_getDisposableStackInternalField(BytecodeGenerator& generator, RegisterID* dst)
+{
+    ArgumentListNode* node = m_args->m_listNode;
+    RefPtr<RegisterID> base = generator.emitNode(node);
+    node = node->m_next;
+    RELEASE_ASSERT(node->m_expr->isBytecodeIntrinsicNode());
+    unsigned index = static_cast<unsigned>(disposableStackInternalFieldIndex(static_cast<BytecodeIntrinsicNode*>(node->m_expr)));
+    ASSERT(index < JSDisposableStack::numberOfInternalFields);
     ASSERT(!node->m_next);
 
     return generator.emitGetInternalField(generator.finalDestination(dst), base.get(), index);
@@ -2091,6 +2116,22 @@ RegisterID* BytecodeIntrinsicNode::emit_intrinsic_putRegExpStringIteratorInterna
     return generator.move(dst, generator.emitPutInternalField(base.get(), index, value.get()));
 }
 
+RegisterID* BytecodeIntrinsicNode::emit_intrinsic_putDisposableStackInternalField(BytecodeGenerator& generator, RegisterID* dst)
+{
+    ArgumentListNode* node = m_args->m_listNode;
+    RefPtr<RegisterID> base = generator.emitNode(node);
+    node = node->m_next;
+    RELEASE_ASSERT(node->m_expr->isBytecodeIntrinsicNode());
+    unsigned index = static_cast<unsigned>(disposableStackInternalFieldIndex(static_cast<BytecodeIntrinsicNode*>(node->m_expr)));
+    ASSERT(index < JSDisposableStack::numberOfInternalFields);
+    node = node->m_next;
+    RefPtr<RegisterID> value = generator.emitNode(node);
+
+    ASSERT(!node->m_next);
+
+    return generator.move(dst, generator.emitPutInternalField(base.get(), index, value.get()));
+}
+
 RegisterID* BytecodeIntrinsicNode::emit_intrinsic_superSamplerBegin(BytecodeGenerator& generator, RegisterID* dst)
 {
     ASSERT(!m_args->m_listNode);
@@ -2286,6 +2327,7 @@ CREATE_INTRINSIC_FOR_BRAND_CHECK(isUndefinedOrNull, IsUndefinedOrNull)
 CREATE_INTRINSIC_FOR_BRAND_CHECK(isWrapForValidIterator, IsWrapForValidIterator)
 CREATE_INTRINSIC_FOR_BRAND_CHECK(isRegExpStringIterator, IsRegExpStringIterator)
 CREATE_INTRINSIC_FOR_BRAND_CHECK(isAsyncFromSyncIterator, IsAsyncFromSyncIterator)
+CREATE_INTRINSIC_FOR_BRAND_CHECK(isDisposableStack, IsDisposableStack)
 
 #undef CREATE_INTRINSIC_FOR_BRAND_CHECK
 

--- a/Source/JavaScriptCore/runtime/CommonIdentifiers.h
+++ b/Source/JavaScriptCore/runtime/CommonIdentifiers.h
@@ -319,7 +319,12 @@
     macro(error) \
     macro(suppressed) \
     macro(SuppressedError) \
-    macro(DisposableStack)
+    macro(DisposableStack) \
+    macro(adopt) \
+    macro(disposed) \
+    macro(dispose) \
+    macro(use) \
+    macro(move) \
 
 #define JSC_COMMON_IDENTIFIERS_EACH_PRIVATE_FIELD(macro) \
     macro(constructor)

--- a/Source/JavaScriptCore/runtime/JSDisposableStack.cpp
+++ b/Source/JavaScriptCore/runtime/JSDisposableStack.cpp
@@ -57,6 +57,11 @@ void JSDisposableStack::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     Base::visitChildren(thisObject, visitor);
 }
 
+bool JSDisposableStack::disposed()
+{
+    return internalField(Field::State).get().asInt32() == static_cast<int32_t>(State::Disposed);
+}
+
 DEFINE_VISIT_CHILDREN(JSDisposableStack);
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/JSDisposableStack.h
+++ b/Source/JavaScriptCore/runtime/JSDisposableStack.h
@@ -71,6 +71,8 @@ public:
     static JSDisposableStack* createWithInitialValues(VM&);
     static JSDisposableStack* create(VM&, Structure*);
 
+    bool disposed();
+
 private:
     JSDisposableStack(VM& vm, Structure* structure)
         : Base(vm, structure)

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -1688,6 +1688,19 @@ capitalName ## Constructor* lowerName ## Constructor = featureFlag ? capitalName
             JSGlobalObject* globalObject = jsCast<JSGlobalObject*>(init.owner);
             init.set(globalObject->m_aggregateErrorStructure.constructor(globalObject));
         });
+    m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::ReferenceError)].initLater([] (const Initializer<JSCell>& init) {
+        JSGlobalObject* globalObject = jsCast<JSGlobalObject*>(init.owner);
+        init.set(globalObject->m_referenceErrorStructure.constructor(globalObject));
+    });
+    m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::SuppressedError)].initLater([] (const Initializer<JSCell>& init) {
+        JSGlobalObject* globalObject = jsCast<JSGlobalObject*>(init.owner);
+        init.set(globalObject->m_suppressedErrorStructure.constructor(globalObject));
+    });
+    m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::DisposableStack)].initLater([] (const Initializer<JSCell>& init) {
+        JSGlobalObject* globalObject = jsCast<JSGlobalObject*>(init.owner);
+        init.set(globalObject->m_disposableStackStructure.constructor(globalObject));
+    });
+
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::typedArrayLength)].initLater([] (const Initializer<JSCell>& init) {
             init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 0, "typedArrayViewLength"_s, typedArrayViewPrivateFuncLength, ImplementationVisibility::Private));
         });


### PR DESCRIPTION
#### b13d5c891b8dcc8601700fb30d56719664926b6f
<pre>
[JSC] Implement `DisposableStack` prototype methods
<a href="https://bugs.webkit.org/show_bug.cgi?id=293095">https://bugs.webkit.org/show_bug.cgi?id=293095</a>

Reviewed by Yusuke Suzuki.

This patch implements following `DisposableStack`&apos;s prototype methods
from Explicit Resource Management Proposal[1]:

- `adopt`[2]
- `defer`[3]
- `dispose`[4]
- `disposed`[5]
- `move`[6]
- `use`[7]

[1]: <a href="https://github.com/tc39/proposal-explicit-resource-management">https://github.com/tc39/proposal-explicit-resource-management</a>
[2]: <a href="https://tc39.es/proposal-explicit-resource-management/#sec-disposablestack.prototype.adopt">https://tc39.es/proposal-explicit-resource-management/#sec-disposablestack.prototype.adopt</a>
[3]: <a href="https://tc39.es/proposal-explicit-resource-management/#sec-disposablestack.prototype.defer">https://tc39.es/proposal-explicit-resource-management/#sec-disposablestack.prototype.defer</a>
[4]: <a href="https://tc39.es/proposal-explicit-resource-management/#sec-disposablestack.prototype.dispose">https://tc39.es/proposal-explicit-resource-management/#sec-disposablestack.prototype.dispose</a>
[5]: <a href="https://tc39.es/proposal-explicit-resource-management/#sec-disposablestack.prototype.disposed">https://tc39.es/proposal-explicit-resource-management/#sec-disposablestack.prototype.disposed</a>
[6]: <a href="https://tc39.es/proposal-explicit-resource-management/#sec-disposablestack.prototype.move">https://tc39.es/proposal-explicit-resource-management/#sec-disposablestack.prototype.move</a>
[7]: <a href="https://tc39.es/proposal-explicit-resource-management/#sec-disposablestack.prototype.use">https://tc39.es/proposal-explicit-resource-management/#sec-disposablestack.prototype.use</a>

* JSTests/stress/disposable-stack-prototype-basic.js: Added.
(shouldBe):
(shouldThrow):
(shouldBe.order.join):
* JSTests/test262/config.yaml:
* Source/JavaScriptCore/CMakeLists.txt:
* Source/JavaScriptCore/DerivedSources.make:
* Source/JavaScriptCore/builtins/BuiltinNames.h:
* Source/JavaScriptCore/builtins/DisposableStackPrototype.js: Added.
(linkTimeConstant.createSyncDisposableResource):
(linkTimeConstant.addSyncDisposableResource):
(adopt):
(overriddenName.string_appeared_here.deferMethod):
(dispose):
(move):
(use):
* Source/JavaScriptCore/bytecode/BytecodeIntrinsicRegistry.cpp:
(JSC::BytecodeIntrinsicRegistry::BytecodeIntrinsicRegistry):
* Source/JavaScriptCore/bytecode/BytecodeIntrinsicRegistry.h:
* Source/JavaScriptCore/bytecode/LinkTimeConstant.h:
* Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h:
(JSC::BytecodeGenerator::emitIsDisposableStack):
* Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp:
(JSC::disposableStackInternalFieldIndex):
(JSC::BytecodeIntrinsicNode::emit_intrinsic_getDisposableStackInternalField):
(JSC::BytecodeIntrinsicNode::emit_intrinsic_putDisposableStackInternalField):
* Source/JavaScriptCore/runtime/CommonIdentifiers.h:
* Source/JavaScriptCore/runtime/DisposableStackPrototype.cpp:
(JSC::DisposableStackPrototype::finishCreation):
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/JSDisposableStack.cpp:
(JSC::JSDisposableStack::disposed):
* Source/JavaScriptCore/runtime/JSDisposableStack.h:
* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
(JSC::JSGlobalObject::init):

Canonical link: <a href="https://commits.webkit.org/295505@main">https://commits.webkit.org/295505@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f70f61e952ee569ea5cf9553aea8b703acf96f39

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105283 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24995 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15420 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110494 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/55938 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/25429 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33538 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/79974 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108289 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19834 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95030 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60280 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/19589 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13104 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55337 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/97957 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/89289 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13148 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/113112 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/103901 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32442 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23903 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/89048 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32805 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91246 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88686 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22614 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33578 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11366 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/27866 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32365 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/37777 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/128205 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32143 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/35049 "Found 2 new JSC stress test failures: wasm.yaml/wasm/gc/ref-i31-eq.js.default-wasm, wasm.yaml/wasm/gc/ref-i31-eq.js.wasm-collect-continuously (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35487 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33712 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->