### PR TITLE
Update EventDispatcher::dispatchEvent() to take in a std::span instead of a const Vector&

### DIFF
--- a/Source/WebCore/Modules/indexeddb/IDBTransaction.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBTransaction.cpp
@@ -630,7 +630,7 @@ void IDBTransaction::dispatchEvent(Event& event)
 
     Ref protectedThis { *this };
 
-    EventDispatcher::dispatchEvent({ this, m_database.ptr() }, event);
+    EventDispatcher::dispatchEvent(std::initializer_list<EventTarget*>({ this, m_database.ptr() }), event);
 
     if (!event.isTrusted())
         return;

--- a/Source/WebCore/dom/EventDispatcher.cpp
+++ b/Source/WebCore/dom/EventDispatcher.cpp
@@ -253,20 +253,20 @@ void EventDispatcher::dispatchEvent(Node& node, Event& event)
 }
 
 template<typename T>
-static void dispatchEventWithType(const Vector<T*>& targets, Event& event)
+static void dispatchEventWithType(std::span<T* const> targets, Event& event)
 {
     ASSERT(targets.size() >= 1);
-    ASSERT(*targets.begin());
+    ASSERT(targets.front());
 
     EventPath eventPath { targets };
-    event.setTarget(RefPtr { *targets.begin() });
+    event.setTarget(RefPtr { targets.front() });
     event.setEventPath(eventPath);
     event.resetBeforeDispatch();
     dispatchEventInDOM(event, eventPath);
     event.resetAfterDispatch();
 }
 
-void EventDispatcher::dispatchEvent(const Vector<EventTarget*>& targets, Event& event)
+void EventDispatcher::dispatchEvent(std::span<EventTarget* const> targets, Event& event)
 {
     dispatchEventWithType<EventTarget>(targets, event);
 }

--- a/Source/WebCore/dom/EventDispatcher.h
+++ b/Source/WebCore/dom/EventDispatcher.h
@@ -32,7 +32,7 @@ class Node;
 namespace EventDispatcher {
 
 void dispatchEvent(Node&, Event&);
-void dispatchEvent(const Vector<EventTarget*>&, Event&);
+void dispatchEvent(std::span<EventTarget* const>, Event&);
 
 void dispatchScopedEvent(Node&, Event&);
 

--- a/Source/WebCore/dom/EventPath.cpp
+++ b/Source/WebCore/dom/EventPath.cpp
@@ -281,9 +281,9 @@ Vector<Ref<EventTarget>> EventPath::computePathUnclosedToTarget(const EventTarge
     return path;
 }
 
-EventPath::EventPath(const Vector<EventTarget*>& targets)
+EventPath::EventPath(std::span<EventTarget* const> targets)
 {
-    m_path = targets.map([&](auto* target) {
+    m_path = WTF::map(targets, [&](auto* target) {
         ASSERT(target);
         ASSERT(!is<Node>(target));
         return EventContext { EventContext::Type::Normal, nullptr, target, *targets.begin(), 0 };

--- a/Source/WebCore/dom/EventPath.h
+++ b/Source/WebCore/dom/EventPath.h
@@ -44,7 +44,7 @@ class Touch;
 class EventPath : public CanMakeSingleThreadWeakPtr<EventPath> {
 public:
     EventPath(Node& origin, Event&);
-    explicit EventPath(const Vector<EventTarget*>&);
+    explicit EventPath(std::span<EventTarget* const>);
     explicit EventPath(EventTarget&);
 
     bool isEmpty() const { return m_path.isEmpty(); }

--- a/Source/WebCore/html/OffscreenCanvas.cpp
+++ b/Source/WebCore/html/OffscreenCanvas.cpp
@@ -462,7 +462,7 @@ void OffscreenCanvas::queueTaskKeepingObjectAlive(TaskSource source, Function<vo
 
 void OffscreenCanvas::dispatchEvent(Event& event)
 {
-    EventDispatcher::dispatchEvent({ this }, event);
+    EventDispatcher::dispatchEvent(std::initializer_list<EventTarget*>({ this }), event);
 }
 
 std::unique_ptr<CSSParserContext> OffscreenCanvas::createCSSParserContext() const


### PR DESCRIPTION
#### 4468b14aea09a5549dc4e05cda0c94ed09542ef1
<pre>
Update EventDispatcher::dispatchEvent() to take in a std::span instead of a const Vector&amp;
<a href="https://bugs.webkit.org/show_bug.cgi?id=293097">https://bugs.webkit.org/show_bug.cgi?id=293097</a>

Reviewed by Darin Adler.

Update EventDispatcher::dispatchEvent() to take in a std::span instead of a const Vector&amp;.
This avoids having to construct a vector at some of the call sites.

* Source/WebCore/Modules/indexeddb/IDBRequest.cpp:
(WebCore::IDBRequest::dispatchEvent):
* Source/WebCore/Modules/indexeddb/IDBTransaction.cpp:
(WebCore::IDBTransaction::dispatchEvent):
* Source/WebCore/dom/EventDispatcher.cpp:
(WebCore::dispatchEventWithType):
(WebCore::EventDispatcher::dispatchEvent):
* Source/WebCore/dom/EventDispatcher.h:
* Source/WebCore/dom/EventPath.cpp:
(WebCore::EventPath::EventPath):
* Source/WebCore/dom/EventPath.h:
* Source/WebCore/html/OffscreenCanvas.cpp:
(WebCore::OffscreenCanvas::dispatchEvent):

Canonical link: <a href="https://commits.webkit.org/295022@main">https://commits.webkit.org/295022@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e6bd4a62ac9db9b90d41448126dfdf2c840dd460

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/103820 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/23522 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/13843 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/109013 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/54472 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/105860 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/23875 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/32068 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78880 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/106826 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/18540 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/93654 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59206 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/18342 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/11703 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/53848 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/88102 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/11767 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/111400 "Build was cancelled. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; compiling") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/30976 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/22846 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/111400 "Build was cancelled. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; compiling") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/31338 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/89855 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/111400 "Build was cancelled. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; compiling") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22287 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32421 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10148 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/25340 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/30904 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/36216 "Built successfully") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/30698 "Build was cancelled. Recent messages:OS: Sequoia (15.2), Xcode: 16.2; Running apply-patch; Checked out pull request; compiling") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/34033 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/32259 "Build was cancelled. Recent messages:OS: Sequoia (15.2), Xcode: 16.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; compiling") | | | 
<!--EWS-Status-Bubble-End-->