### PR TITLE
AutoFill unexpectedly scrolls to reveal text fields when inserting text

### DIFF
--- a/LayoutTests/editing/inserting/no-scroll-after-text-event-created-from-bindings-expected.txt
+++ b/LayoutTests/editing/inserting/no-scroll-after-text-event-created-from-bindings-expected.txt
@@ -1,0 +1,11 @@
+Verifies that dispatching a TextEvent created from bindings inside an editable element does not trigger scrolling.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS pageYOffsetBefore is pageYOffsetAfter
+PASS textField.value is "a"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/editing/inserting/no-scroll-after-text-event-created-from-bindings.html
+++ b/LayoutTests/editing/inserting/no-scroll-after-text-event-created-from-bindings.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/js-test.js"></script>
+<script src="../../resources/ui-helper.js"></script>
+<script>
+jsTestIsAsync = true;
+
+addEventListener("load", async () => {
+    description("Verifies that dispatching a TextEvent created from bindings inside an editable element does not trigger scrolling.");
+
+    await UIHelper.renderingUpdate();
+    scrollTo(0, 0);
+    pageYOffsetBefore = pageYOffset;
+
+    textField = document.querySelector("input");
+    textField.focus({ preventScroll: true });
+
+    const event = document.createEvent("TextEvent");
+    event.initTextEvent("textInput", true, true, null, "a");
+    textField.dispatchEvent(event);
+    pageYOffsetAfter = pageYOffset;
+
+    await UIHelper.renderingUpdate();
+    shouldBe("pageYOffsetBefore", "pageYOffsetAfter");
+    shouldBeEqualToString("textField.value", "a");
+
+    document.querySelector(".tall").remove();
+    finishJSTest();
+});
+</script>
+<style>
+.tall {
+    width: 100%;
+    height: 5000px;
+}
+
+input {
+    font-size: 18px;
+}
+</style>
+</head>
+<body>
+    <div class="tall"></div>
+    <input type="text" />
+</body>
+</html>

--- a/Source/WebCore/editing/Editor.cpp
+++ b/Source/WebCore/editing/Editor.cpp
@@ -1471,7 +1471,7 @@ bool Editor::insertTextWithoutSendingTextEvent(const String& text, bool selectIn
             // should be moved from Editor to a page-level like object. If it must remain a frame-specific concept
             // then this code should conditionalize revealing selection on whether the ignoreSelectionChanges() bit
             // is set for the newly focused frame.
-            if (client() && client()->shouldRevealCurrentSelectionAfterInsertion()) {
+            if ((!triggeringEvent || triggeringEvent->isTrusted()) && client() && client()->shouldRevealCurrentSelectionAfterInsertion()) {
                 if (RefPtr page = document->page())
                     page->revealCurrentSelection();
             }


### PR DESCRIPTION
#### 76c14537ee04f6d8e72072a80b580e64a81fe835
<pre>
AutoFill unexpectedly scrolls to reveal text fields when inserting text
<a href="https://bugs.webkit.org/show_bug.cgi?id=293098">https://bugs.webkit.org/show_bug.cgi?id=293098</a>
<a href="https://rdar.apple.com/149708409">rdar://149708409</a>

Reviewed by Aditya Keerthi and Abrar Rahman Protyasha.

When performing AutoFill, Safari&apos;s injected script creates and dispatches `TextEvent`s in each text
field to simulate text input, in such a way that the resulting DOM events dispatched to the page
closely match those dispatched when typing manually.

While generally good for AutoFill compatibility, this results in some unwanted behaviors, such as
the scroll position potentially flickering if some of the form fields lie offscreen, due to the fact
that we&apos;ll attempt to reveal the selection when dispatching `TextEvent`.

We already avoid scrolling to reveal the selection when using `document.execCommand(…)` to insert
text, so we can fix this bug by applying a similar treatment to the case where `TextEvent` DOM
events are untrusted (created using `Document.createEvent` / `Event.initTextEvent`).

* LayoutTests/editing/inserting/no-scroll-after-text-event-created-from-bindings-expected.txt: Added.
* LayoutTests/editing/inserting/no-scroll-after-text-event-created-from-bindings.html: Added.

Add a test that inserts text by creating and dispatching a `TextEvent` in a focused field.

* Source/WebCore/editing/Editor.cpp:
(WebCore::Editor::insertTextWithoutSendingTextEvent):

Canonical link: <a href="https://commits.webkit.org/295008@main">https://commits.webkit.org/295008@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ce43d75891c0f51264c40dd16f75abf766dcba3a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/103804 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/23506 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/13826 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/108996 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/54456 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/105844 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/23859 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/32052 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78861 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/106810 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/18520 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/93639 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59195 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/18322 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/11688 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/53832 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/88090 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/11745 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/111384 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/30960 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/22824 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/87863 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/31322 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/89840 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87518 "Found 101 new API test failures: /WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/sequence, /TestWebKit:WebKit.InjectedBundleInitializationUserDataCallbackWins, /TestWebKit:WebKit.GeolocationBasicWithHighAccuracy, /WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/cancel-sequence, /TestWebKit:WebKit.ForceRepaint, /TestWebKit:WebKit.PendingAPIRequestURL, /WebKitGTK/TestUIClient:/webkit/WebKitWebView/mediaKeySystem-permission-requests, /TestWebKit:WebKit.PreventEmptyUserAgent, /TestWebKit:WebKit2.ProvisionalURLAfterWillSendRequestCallback, /WebKitGTK/TestDownloads:/webkit/Downloads/contex-menu-download-actions ... (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22282 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32410 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10128 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/25321 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/30888 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/36191 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/30682 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/34017 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/32243 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->