### PR TITLE
Update FileSystem::pathByAppendingComponents() to take in a std::span

### DIFF
--- a/Source/WTF/wtf/FileSystem.cpp
+++ b/Source/WTF/wtf/FileSystem.cpp
@@ -770,7 +770,7 @@ String pathByAppendingComponent(StringView path, StringView component)
     return fromStdFileSystemPath(toStdFileSystemPath(path) / toStdFileSystemPath(component));
 }
 
-String pathByAppendingComponents(StringView path, const Vector<StringView>& components)
+String pathByAppendingComponents(StringView path, std::span<const StringView> components)
 {
     auto fsPath = toStdFileSystemPath(path);
     for (auto& component : components)

--- a/Source/WTF/wtf/FileSystem.h
+++ b/Source/WTF/wtf/FileSystem.h
@@ -95,7 +95,7 @@ WTF_EXPORT_PRIVATE bool updateFileModificationTime(const String& path); // Sets 
 WTF_EXPORT_PRIVATE std::optional<WallTime> fileCreationTime(const String&); // Not all platforms store file creation time.
 WTF_EXPORT_PRIVATE bool isHiddenFile(const String&);
 WTF_EXPORT_PRIVATE String pathByAppendingComponent(StringView path, StringView component);
-WTF_EXPORT_PRIVATE String pathByAppendingComponents(StringView path, const Vector<StringView>& components);
+WTF_EXPORT_PRIVATE String pathByAppendingComponents(StringView path, std::span<const StringView> components);
 WTF_EXPORT_PRIVATE String lastComponentOfPathIgnoringTrailingSlash(const String& path);
 WTF_EXPORT_PRIVATE bool makeAllDirectories(const String& path);
 WTF_EXPORT_PRIVATE String pathFileName(const String&);

--- a/Source/WTF/wtf/cocoa/FileSystemCocoa.mm
+++ b/Source/WTF/wtf/cocoa/FileSystemCocoa.mm
@@ -189,7 +189,7 @@ NSString *createTemporaryDirectory(NSString *directoryPrefix)
 std::pair<FileHandle, CString> createTemporaryFileInDirectory(const String& directory, const String& suffix)
 {
     auto fsSuffix = fileSystemRepresentation(suffix);
-    auto templatePath = pathByAppendingComponents(directory, { StringView { "XXXXXX"_s }, StringView { suffix } });
+    auto templatePath = pathByAppendingComponents(directory, std::initializer_list<StringView>({ "XXXXXX"_s, suffix }));
     auto fsTemplatePath = fileSystemRepresentation(templatePath);
     auto fileHandle = FileHandle::adopt(mkstemps(fsTemplatePath.mutableSpanIncludingNullTerminator().data(), fsSuffix.length()));
     return { WTFMove(fileHandle), WTFMove(fsTemplatePath) };

--- a/Source/WTF/wtf/posix/FileSystemPOSIX.cpp
+++ b/Source/WTF/wtf/posix/FileSystemPOSIX.cpp
@@ -256,7 +256,7 @@ String pathByAppendingComponent(StringView path, StringView component)
     return makeString(path, '/', component);
 }
 
-String pathByAppendingComponents(StringView path, const Vector<StringView>& components)
+String pathByAppendingComponents(StringView path, std::span<const StringView> components)
 {
     StringBuilder builder;
     builder.append(path);

--- a/Source/WebCore/workers/service/server/SWScriptStorage.cpp
+++ b/Source/WebCore/workers/service/server/SWScriptStorage.cpp
@@ -73,7 +73,7 @@ String SWScriptStorage::saltPath() const
 
 String SWScriptStorage::registrationDirectory(const ServiceWorkerRegistrationKey& registrationKey) const
 {
-    return FileSystem::pathByAppendingComponents(m_directory, { sha2Hash(registrationKey.topOrigin().toString()), sha2Hash(registrationKey.scope()) });
+    return FileSystem::pathByAppendingComponents(m_directory, std::initializer_list<StringView>({ sha2Hash(registrationKey.topOrigin().toString()), sha2Hash(registrationKey.scope()) }));
 }
 
 String SWScriptStorage::scriptPath(const ServiceWorkerRegistrationKey& registrationKey, const URL& scriptURL) const

--- a/Source/WebKit/NetworkProcess/storage/BackgroundFetchStoreManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/BackgroundFetchStoreManager.cpp
@@ -111,7 +111,7 @@ void BackgroundFetchStoreManager::clearFetch(const String& identifier, Completio
         return;
     }
 
-    auto filePath = FileSystem::pathByAppendingComponents(m_path, { identifier });
+    auto filePath = FileSystem::pathByAppendingComponents(m_path, std::initializer_list<StringView>({ identifier }));
     m_ioQueue->dispatch([queue = Ref { m_taskQueue }, directoryPath = m_path.isolatedCopy(), identifier = identifier.isolatedCopy(), callback = WTFMove(callback)]() mutable {
         for (auto& fileName : FileSystem::listDirectory(directoryPath)) {
             if (fileName.startsWith(identifier))
@@ -133,7 +133,7 @@ void BackgroundFetchStoreManager::clearAllFetches(const Vector<String>& identifi
     }
 
     auto filePaths = map(identifiers, [this](auto& identifier) -> String {
-        return FileSystem::pathByAppendingComponents(m_path, { identifier });
+        return FileSystem::pathByAppendingComponents(m_path, std::initializer_list<StringView>({ identifier }));
     });
     m_ioQueue->dispatch([queue = Ref { m_taskQueue }, filePaths = crossThreadCopy(WTFMove(filePaths)), callback = WTFMove(callback)]() mutable {
         for (auto& filePath : filePaths) {
@@ -183,7 +183,7 @@ void BackgroundFetchStoreManager::storeFetchAfterQuotaCheck(const String& identi
         return;
     }
 
-    auto filePath = FileSystem::pathByAppendingComponents(m_path, { identifier });
+    auto filePath = FileSystem::pathByAppendingComponents(m_path, std::initializer_list<StringView>({ identifier }));
     m_ioQueue->dispatch([queue = Ref { m_taskQueue }, filePath = WTFMove(filePath).isolatedCopy(), responseBodyIndexToClear, data = WTFMove(data), callback = WTFMove(callback)]() mutable {
         // FIXME: Cover the case of partial write.
         auto writtenSize = FileSystem::overwriteEntireFile(filePath, data);

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageDiskStore.cpp
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageDiskStore.cpp
@@ -65,7 +65,7 @@ static SHA1::Digest computeSHA1(std::span<const uint8_t> span, FileSystem::Salt 
 
 static String recordFilePathWithDirectory(const String& directory, const NetworkCache::Key& key)
 {
-    return FileSystem::pathByAppendingComponents(directory, { key.partitionHashAsString(), key.type(), key.hashAsString() });
+    return FileSystem::pathByAppendingComponents(directory, std::initializer_list<StringView>({ key.partitionHashAsString(), key.type(), key.hashAsString() }));
 }
 
 struct RecordMetaData {

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageManager.cpp
@@ -186,7 +186,7 @@ HashSet<WebCore::ClientOrigin> CacheStorageManager::originsOfCacheStorageData(co
 {
     HashSet<WebCore::ClientOrigin> result;
     for (auto& originName : FileSystem::listDirectory(rootDirectory)) {
-        auto originFile = FileSystem::pathByAppendingComponents(rootDirectory, { originName, originFileName });
+        auto originFile = FileSystem::pathByAppendingComponents(rootDirectory, std::initializer_list<StringView>({ originName, originFileName }));
         if (auto origin = WebCore::StorageUtilities::readOriginFromFile(originFile))
             result.add(*origin);
     }

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
@@ -105,7 +105,7 @@ static String originDirectoryPath(const String& rootPath, const WebCore::ClientO
 
     auto encodedTopOrigin = encode(origin.topOrigin.toString(), salt);
     auto encodedOpeningOrigin = encode(origin.clientOrigin.toString(), salt);
-    return FileSystem::pathByAppendingComponents(rootPath, { encodedTopOrigin, encodedOpeningOrigin });
+    return FileSystem::pathByAppendingComponents(rootPath, std::initializer_list<StringView> { encodedTopOrigin, encodedOpeningOrigin });
 }
 
 static String originFilePath(const String& directory)

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebsiteDataManager.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebsiteDataManager.cpp
@@ -1092,9 +1092,9 @@ static String webkitWebsiteDataManagerGetFaviconDatabasePath(WebKitWebsiteDataMa
         return { };
 
     if (!manager->priv->baseCacheDirectory.isNull())
-        return FileSystem::pathByAppendingComponents(FileSystem::stringFromFileSystemRepresentation(manager->priv->baseCacheDirectory.data()), { "icondatabase"_s, "WebpageIcons.db"_s });
+        return FileSystem::pathByAppendingComponents(FileSystem::stringFromFileSystemRepresentation(manager->priv->baseCacheDirectory.data()), std::initializer_list<StringView>({ "icondatabase"_s, "WebpageIcons.db"_s }));
 
-    return FileSystem::pathByAppendingComponents(WebsiteDataStore::defaultBaseCacheDirectory(), { "icondatabase"_s, "WebpageIcons.db"_s });
+    return FileSystem::pathByAppendingComponents(WebsiteDataStore::defaultBaseCacheDirectory(), std::initializer_list<StringView>({ "icondatabase"_s, "WebpageIcons.db"_s }));
 }
 
 /**

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerConfigurationCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerConfigurationCocoa.mm
@@ -46,10 +46,10 @@ String WebExtensionControllerConfiguration::createStorageDirectoryPath(std::opti
     String identifierPath = identifier ? identifier->toString().convertToASCIIUppercase() : "Default"_s;
 
     if (processHasContainer())
-        return FileSystem::pathByAppendingComponents(libraryPath, { "WebKit"_s, "WebExtensions"_s, identifierPath });
+        return FileSystem::pathByAppendingComponents(libraryPath, std::initializer_list<StringView>({ "WebKit"_s, "WebExtensions"_s, identifierPath }));
 
     String appDirectoryName = NSBundle.mainBundle.bundleIdentifier ?: NSProcessInfo.processInfo.processName;
-    return FileSystem::pathByAppendingComponents(libraryPath, { "WebKit"_s, appDirectoryName, "WebExtensions"_s, identifierPath });
+    return FileSystem::pathByAppendingComponents(libraryPath, std::initializer_list<StringView>({ "WebKit"_s, appDirectoryName, "WebExtensions"_s, identifierPath }));
 }
 
 String WebExtensionControllerConfiguration::createTemporaryStorageDirectoryPath()

--- a/Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm
+++ b/Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm
@@ -364,7 +364,7 @@ String WebsiteDataStore::defaultCookieStorageFile(const String& baseDirectory)
     if (baseDirectory.isEmpty())
         return { };
 
-    return FileSystem::pathByAppendingComponents(baseDirectory, { "Cookies"_s, "Cookies.binarycookies"_s });
+    return FileSystem::pathByAppendingComponents(baseDirectory, std::initializer_list<StringView>({ "Cookies"_s, "Cookies.binarycookies"_s }));
 }
 
 String WebsiteDataStore::defaultSearchFieldHistoryDirectory(const String& baseDirectory)

--- a/Source/WebKit/webpushd/WebPushDaemonMain.mm
+++ b/Source/WebKit/webpushd/WebPushDaemonMain.mm
@@ -122,7 +122,7 @@ static String getWebPushDirectoryPathWithMigrationIfNecessary()
 {
 #if PLATFORM(MAC) && !ENABLE(RELOCATABLE_WEBPUSHD)
     String libraryPath = NSSearchPathForDirectoriesInDomains(NSLibraryDirectory, NSUserDomainMask, YES)[0];
-    String oldPath = FileSystem::pathByAppendingComponents(libraryPath, { "WebKit"_s, "WebPush"_s });
+    String oldPath = FileSystem::pathByAppendingComponents(libraryPath, std::initializer_list<StringView>({ "WebKit"_s, "WebPush"_s }));
 
     RetainPtr containerURL = [[NSFileManager defaultManager] containerURLForSecurityApplicationGroupIdentifier:@"group.com.apple.webkit.webpushd"];
 
@@ -131,7 +131,7 @@ static String getWebPushDirectoryPathWithMigrationIfNecessary()
     RELEASE_ASSERT_WITH_MESSAGE(canReadContainer, "Could not access webpushd group container: %s", error.description.UTF8String);
 
     String containerPath = [containerURL path];
-    String newPath = FileSystem::pathByAppendingComponents(containerPath, { "Library"_s, "WebKit"_s, "WebPush"_s });
+    String newPath = FileSystem::pathByAppendingComponents(containerPath, std::initializer_list<StringView>({ "Library"_s, "WebKit"_s, "WebPush"_s }));
 
     String oldDatabasePath = FileSystem::pathByAppendingComponent(oldPath, "PushDatabase.db"_s);
     String newDatabasePath = FileSystem::pathByAppendingComponent(newPath, "PushDatabase.db"_s);
@@ -144,7 +144,7 @@ static String getWebPushDirectoryPathWithMigrationIfNecessary()
     return newPath;
 #else
     String libraryPath = NSSearchPathForDirectoriesInDomains(NSLibraryDirectory, NSUserDomainMask, YES)[0];
-    return FileSystem::pathByAppendingComponents(libraryPath, { "WebKit"_s, "WebPush"_s });
+    return FileSystem::pathByAppendingComponents(libraryPath, std::initializer_list<StringView>({ "WebKit"_s, "WebPush"_s }));
 #endif
 }
 

--- a/Tools/TestWebKitAPI/Tests/WTF/FileSystem.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/FileSystem.cpp
@@ -351,11 +351,11 @@ TEST_F(FileSystemTest, deleteNonEmptyDirectory)
     auto temporaryTestFolder = FileSystem::createTemporaryFile("deleteNonEmptyDirectoryTest"_s);
 
     EXPECT_TRUE(FileSystem::deleteFile(temporaryTestFolder));
-    EXPECT_TRUE(FileSystem::makeAllDirectories(FileSystem::pathByAppendingComponents(temporaryTestFolder, { "subfolder"_s })));
+    EXPECT_TRUE(FileSystem::makeAllDirectories(FileSystem::pathByAppendingComponents(temporaryTestFolder, std::initializer_list<StringView>({ "subfolder"_s }))));
     createTestFile(FileSystem::pathByAppendingComponent(temporaryTestFolder, "file1.txt"_s));
     createTestFile(FileSystem::pathByAppendingComponent(temporaryTestFolder, "file2.txt"_s));
-    createTestFile(FileSystem::pathByAppendingComponents(temporaryTestFolder, { "subfolder"_s, "file3.txt"_s }));
-    createTestFile(FileSystem::pathByAppendingComponents(temporaryTestFolder, { "subfolder"_s, "file4.txt"_s }));
+    createTestFile(FileSystem::pathByAppendingComponents(temporaryTestFolder, std::initializer_list<StringView>({ "subfolder"_s, "file3.txt"_s })));
+    createTestFile(FileSystem::pathByAppendingComponents(temporaryTestFolder, std::initializer_list<StringView>({ "subfolder"_s, "file4.txt"_s })));
     EXPECT_FALSE(FileSystem::deleteEmptyDirectory(temporaryTestFolder));
     EXPECT_TRUE(FileSystem::fileExists(temporaryTestFolder));
     EXPECT_TRUE(FileSystem::deleteNonEmptyDirectory(temporaryTestFolder));
@@ -580,7 +580,7 @@ TEST_F(FileSystemTest, makeAllDirectories)
     EXPECT_TRUE(FileSystem::fileExists(tempEmptyFolderPath()));
     EXPECT_EQ(FileSystem::fileType(tempEmptyFolderPath()), FileSystem::FileType::Directory);
     EXPECT_TRUE(FileSystem::makeAllDirectories(tempEmptyFolderPath()));
-    String subFolderPath = FileSystem::pathByAppendingComponents(tempEmptyFolderPath(), { "subFolder1"_s, "subFolder2"_s, "subFolder3"_s });
+    String subFolderPath = FileSystem::pathByAppendingComponents(tempEmptyFolderPath(), std::initializer_list<StringView>({ "subFolder1"_s, "subFolder2"_s, "subFolder3"_s }));
     EXPECT_FALSE(FileSystem::fileExists(subFolderPath));
     EXPECT_TRUE(FileSystem::makeAllDirectories(subFolderPath));
     EXPECT_TRUE(FileSystem::fileExists(subFolderPath));
@@ -795,7 +795,7 @@ TEST_F(FileSystemTest, updateFileModificationTime)
 
 TEST_F(FileSystemTest, pathFileName)
 {
-    auto testPath = FileSystem::pathByAppendingComponents(tempEmptyFolderPath(), { "subfolder"_s, "filename.txt"_s });
+    auto testPath = FileSystem::pathByAppendingComponents(tempEmptyFolderPath(), std::initializer_list<StringView>({ "subfolder"_s, "filename.txt"_s }));
     EXPECT_STREQ("filename.txt", FileSystem::pathFileName(testPath).utf8().data());
 
 #if OS(UNIX)
@@ -817,7 +817,7 @@ TEST_F(FileSystemTest, pathFileName)
 
 TEST_F(FileSystemTest, parentPath)
 {
-    auto testPath = FileSystem::pathByAppendingComponents(tempEmptyFolderPath(), { "subfolder"_s, "filename.txt"_s });
+    auto testPath = FileSystem::pathByAppendingComponents(tempEmptyFolderPath(), std::initializer_list<StringView>({ "subfolder"_s, "filename.txt"_s }));
     EXPECT_STREQ(FileSystem::pathByAppendingComponent(tempEmptyFolderPath(), "subfolder"_s).utf8().data(), FileSystem::parentPath(testPath).utf8().data());
 #if OS(UNIX)
     EXPECT_STREQ("/var/tmp", FileSystem::parentPath("/var/tmp/example.txt"_s).utf8().data());
@@ -851,19 +851,19 @@ TEST_F(FileSystemTest, pathByAppendingComponent)
 TEST_F(FileSystemTest, pathByAppendingComponents)
 {
     EXPECT_STREQ(tempEmptyFolderPath().utf8().data(), FileSystem::pathByAppendingComponents(tempEmptyFolderPath(), { }).utf8().data());
-    EXPECT_STREQ(FileSystem::pathByAppendingComponent(tempEmptyFolderPath(), "file.txt"_s).utf8().data(), FileSystem::pathByAppendingComponents(tempEmptyFolderPath(), { "file.txt"_s }).utf8().data());
+    EXPECT_STREQ(FileSystem::pathByAppendingComponent(tempEmptyFolderPath(), "file.txt"_s).utf8().data(), FileSystem::pathByAppendingComponents(tempEmptyFolderPath(), std::initializer_list<StringView>({ "file.txt"_s })).utf8().data());
 #if OS(UNIX)
-    EXPECT_STREQ("/var/tmp/file.txt", FileSystem::pathByAppendingComponents("/"_s, { "var"_s, "tmp"_s, "file.txt"_s }).utf8().data());
-    EXPECT_STREQ("/var/tmp/file.txt", FileSystem::pathByAppendingComponents("/var"_s, { "tmp"_s, "file.txt"_s }).utf8().data());
-    EXPECT_STREQ("/var/tmp/file.txt", FileSystem::pathByAppendingComponents("/var/"_s, { "tmp"_s, "file.txt"_s }).utf8().data());
-    EXPECT_STREQ("/var/tmp/file.txt", FileSystem::pathByAppendingComponents("/var/tmp"_s, { "file.txt"_s }).utf8().data());
+    EXPECT_STREQ("/var/tmp/file.txt", FileSystem::pathByAppendingComponents("/"_s, std::initializer_list<StringView>({ "var"_s, "tmp"_s, "file.txt"_s })).utf8().data());
+    EXPECT_STREQ("/var/tmp/file.txt", FileSystem::pathByAppendingComponents("/var"_s, std::initializer_list<StringView>({ "tmp"_s, "file.txt"_s })).utf8().data());
+    EXPECT_STREQ("/var/tmp/file.txt", FileSystem::pathByAppendingComponents("/var/"_s, std::initializer_list<StringView>({ "tmp"_s, "file.txt"_s })).utf8().data());
+    EXPECT_STREQ("/var/tmp/file.txt", FileSystem::pathByAppendingComponents("/var/tmp"_s, std::initializer_list<StringView>({ "file.txt"_s })).utf8().data());
 #endif
 #if OS(WINDOWS)
-    EXPECT_STREQ("C:\\Foo\\Bar\\File.txt", FileSystem::pathByAppendingComponents("C:\\"_s, { "Foo"_s, "Bar"_s, "File.txt"_s }).utf8().data());
-    EXPECT_STREQ("C:\\Foo\\Bar\\File.txt", FileSystem::pathByAppendingComponents("C:\\Foo"_s, { "Bar"_s, "File.txt"_s }).utf8().data());
-    EXPECT_STREQ("C:\\Foo\\Bar\\File.txt", FileSystem::pathByAppendingComponents("C:\\Foo\\"_s, { "Bar"_s, "File.txt"_s }).utf8().data());
-    EXPECT_STREQ("C:\\Foo\\Bar\\File.txt", FileSystem::pathByAppendingComponents("C:\\Foo\\Bar"_s, { "File.txt"_s }).utf8().data());
-    EXPECT_STREQ("C:\\Foo\\Bar\\File.txt", FileSystem::pathByAppendingComponents("C:\\Foo\\Bar\\"_s, { "File.txt"_s }).utf8().data());
+    EXPECT_STREQ("C:\\Foo\\Bar\\File.txt", FileSystem::pathByAppendingComponents("C:\\"_s, std::initializer_list<StringView>({ "Foo"_s, "Bar"_s, "File.txt"_s })).utf8().data());
+    EXPECT_STREQ("C:\\Foo\\Bar\\File.txt", FileSystem::pathByAppendingComponents("C:\\Foo"_s, std::initializer_list<StringView>({ "Bar"_s, "File.txt"_s })).utf8().data());
+    EXPECT_STREQ("C:\\Foo\\Bar\\File.txt", FileSystem::pathByAppendingComponents("C:\\Foo\\"_s, std::initializer_list<StringView>({ "Bar"_s, "File.txt"_s })).utf8().data());
+    EXPECT_STREQ("C:\\Foo\\Bar\\File.txt", FileSystem::pathByAppendingComponents("C:\\Foo\\Bar"_s, std::initializer_list<StringView>({ "File.txt"_s })).utf8().data());
+    EXPECT_STREQ("C:\\Foo\\Bar\\File.txt", FileSystem::pathByAppendingComponents("C:\\Foo\\Bar\\"_s, std::initializer_list<StringView>({ "File.txt"_s })).utf8().data());
 #endif
 }
 
@@ -874,8 +874,8 @@ TEST_F(FileSystemTest, listDirectory)
     createTestFile(FileSystem::pathByAppendingComponent(tempEmptyFolderPath(), "bar.png"_s));
     createTestFile(FileSystem::pathByAppendingComponent(tempEmptyFolderPath(), "foo.png"_s));
     FileSystem::makeAllDirectories(FileSystem::pathByAppendingComponent(tempEmptyFolderPath(), "subfolder"_s));
-    createTestFile(FileSystem::pathByAppendingComponents(tempEmptyFolderPath(), { "subfolder"_s, "c.txt"_s }));
-    createTestFile(FileSystem::pathByAppendingComponents(tempEmptyFolderPath(), { "subfolder"_s, "d.txt"_s }));
+    createTestFile(FileSystem::pathByAppendingComponents(tempEmptyFolderPath(), std::initializer_list<StringView>({ "subfolder"_s, "c.txt"_s })));
+    createTestFile(FileSystem::pathByAppendingComponents(tempEmptyFolderPath(), std::initializer_list<StringView>({ "subfolder"_s, "d.txt"_s })));
 
     auto matches = FileSystem::listDirectory(tempEmptyFolderPath());
     ASSERT_EQ(matches.size(), 5U);
@@ -925,8 +925,8 @@ TEST_F(FileSystemTest, realPath)
     FileSystem::makeAllDirectories(subFolderPath);
     auto resolvedSubFolderPath = FileSystem::realPath(subFolderPath);
     EXPECT_STREQ(FileSystem::realPath(FileSystem::pathByAppendingComponent(subFolderPath, ".."_s)).utf8().data(), resolvedTempEmptyFolderPath.utf8().data()); // Should resolve "..".
-    EXPECT_STREQ(FileSystem::realPath(FileSystem::pathByAppendingComponents(subFolderPath, { ".."_s, "subfolder"_s })).utf8().data(), resolvedSubFolderPath.utf8().data()); // Should resolve "..".
-    EXPECT_STREQ(FileSystem::realPath(FileSystem::pathByAppendingComponents(subFolderPath, { ".."_s, "."_s, "."_s, "subfolder"_s })).utf8().data(), resolvedSubFolderPath.utf8().data()); // Should resolve ".." and "."
+    EXPECT_STREQ(FileSystem::realPath(FileSystem::pathByAppendingComponents(subFolderPath, std::initializer_list<StringView>({ ".."_s, "subfolder"_s }))).utf8().data(), resolvedSubFolderPath.utf8().data()); // Should resolve "..".
+    EXPECT_STREQ(FileSystem::realPath(FileSystem::pathByAppendingComponents(subFolderPath, std::initializer_list<StringView>({ ".."_s, "."_s, "."_s, "subfolder"_s }))).utf8().data(), resolvedSubFolderPath.utf8().data()); // Should resolve ".." and "."
 }
 #endif
 

--- a/Tools/TestWebKitAPI/Tests/WebCore/win/WebCoreBundle.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/win/WebCoreBundle.cpp
@@ -55,14 +55,14 @@ TEST_F(WebCoreBundleTest, BundleRootPath)
 TEST_F(WebCoreBundleTest, BundlePathFromPath)
 {
     auto actual = WebCore::webKitBundlePath("WebInspectorUI\\Protocol\\InspectorBackendCommands.js"_s);
-    auto expected = FileSystem::pathByAppendingComponents(m_root, { "WebInspectorUI"_s, "Protocol"_s, "InspectorBackendCommands.js"_s });
+    auto expected = FileSystem::pathByAppendingComponents(m_root, std::initializer_list<StringView>({ "WebInspectorUI"_s, "Protocol"_s, "InspectorBackendCommands.js"_s }));
     EXPECT_STREQ(expected.utf8().data(), actual.utf8().data());
 }
 
 TEST_F(WebCoreBundleTest, BundlePathFromNameTypeDirectory)
 {
     auto actual = WebCore::webKitBundlePath("InspectorBackendCommands"_s, "js"_s, "WebInspectorUI\\Protocol"_s);
-    auto expected = FileSystem::pathByAppendingComponents(m_root, { "WebInspectorUI"_s, "Protocol"_s, "InspectorBackendCommands.js"_s });
+    auto expected = FileSystem::pathByAppendingComponents(m_root, std::initializer_list<StringView>({ "WebInspectorUI"_s, "Protocol"_s, "InspectorBackendCommands.js"_s }));
     EXPECT_STREQ(expected.utf8().data(), actual.utf8().data());
 
     actual = WebCore::webKitBundlePath("file-does-not"_s, "exist"_s, "file"_s);
@@ -73,7 +73,7 @@ TEST_F(WebCoreBundleTest, BundlePathFromNameTypeDirectory)
 TEST_F(WebCoreBundleTest, BundlePathFromComponents)
 {
     auto actual = WebCore::webKitBundlePath({ "WebInspectorUI"_s, "Protocol"_s, "InspectorBackendCommands.js"_s });
-    auto expected = FileSystem::pathByAppendingComponents(m_root, { "WebInspectorUI"_s, "Protocol"_s, "InspectorBackendCommands.js"_s });
+    auto expected = FileSystem::pathByAppendingComponents(m_root, std::initializer_list<StringView>({ "WebInspectorUI"_s, "Protocol"_s, "InspectorBackendCommands.js"_s }));
     EXPECT_STREQ(expected.utf8().data(), actual.utf8().data());
 }
 


### PR DESCRIPTION
#### 3d0598740a712c651f60ab388da20b90956fe366
<pre>
Update FileSystem::pathByAppendingComponents() to take in a std::span
<a href="https://bugs.webkit.org/show_bug.cgi?id=293099">https://bugs.webkit.org/show_bug.cgi?id=293099</a>

Reviewed by Darin Adler.

Update FileSystem::pathByAppendingComponents() to take in a std::span
instead of a `const Vector&amp;`. This avoids having to construct a Vector
at many of the call sites.

* Source/WTF/wtf/FileSystem.cpp:
(WTF::FileSystemImpl::pathByAppendingComponents):
* Source/WTF/wtf/FileSystem.h:
* Source/WTF/wtf/cocoa/FileSystemCocoa.mm:
(WTF::FileSystemImpl::createTemporaryFileInDirectory):
* Source/WTF/wtf/posix/FileSystemPOSIX.cpp:
(WTF::FileSystemImpl::pathByAppendingComponents):
* Source/WebCore/workers/service/server/SWScriptStorage.cpp:
(WebCore::SWScriptStorage::registrationDirectory const):
* Source/WebKit/NetworkProcess/storage/BackgroundFetchStoreManager.cpp:
(WebKit::BackgroundFetchStoreManager::clearFetch):
(WebKit::BackgroundFetchStoreManager::clearAllFetches):
(WebKit::BackgroundFetchStoreManager::storeFetchAfterQuotaCheck):
* Source/WebKit/NetworkProcess/storage/CacheStorageDiskStore.cpp:
(WebKit::recordFilePathWithDirectory):
* Source/WebKit/NetworkProcess/storage/CacheStorageManager.cpp:
(WebKit::CacheStorageManager::originsOfCacheStorageData):
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp:
(WebKit::originDirectoryPath):
* Source/WebKit/UIProcess/API/glib/WebKitWebsiteDataManager.cpp:
(webkitWebsiteDataManagerGetFaviconDatabasePath):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerConfigurationCocoa.mm:
(WebKit::WebExtensionControllerConfiguration::createStorageDirectoryPath):
* Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm:
(WebKit::WebsiteDataStore::defaultCookieStorageFile):
* Source/WebKit/webpushd/WebPushDaemonMain.mm:
(WebKit::getWebPushDirectoryPathWithMigrationIfNecessary):
* Tools/TestWebKitAPI/Tests/WTF/FileSystem.cpp:
(TestWebKitAPI::TEST_F(FileSystemTest, deleteNonEmptyDirectory)):
(TestWebKitAPI::TEST_F(FileSystemTest, makeAllDirectories)):
(TestWebKitAPI::TEST_F(FileSystemTest, pathFileName)):
(TestWebKitAPI::TEST_F(FileSystemTest, parentPath)):
(TestWebKitAPI::TEST_F(FileSystemTest, pathByAppendingComponents)):
(TestWebKitAPI::TEST_F(FileSystemTest, listDirectory)):
(TestWebKitAPI::TEST_F(FileSystemTest, realPath)):
* Tools/TestWebKitAPI/Tests/WebCore/win/WebCoreBundle.cpp:
(TEST_F(WebCoreBundleTest, BundlePathFromPath)):
(TEST_F(WebCoreBundleTest, BundlePathFromNameTypeDirectory)):
(TEST_F(WebCoreBundleTest, BundlePathFromComponents)):

Canonical link: <a href="https://commits.webkit.org/295020@main">https://commits.webkit.org/295020@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3ca2d08d4b6c541670e57fc8fad4bbc2acadd6eb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/103816 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/23518 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/13838 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/109009 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/54468 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/105856 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/23871 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/32064 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/78878 "Build was cancelled. Recent messages:Printed configuration") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/106822 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/18543 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/93657 "Build was cancelled. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; run-api-tests (cancelled)") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/59212 "Build was cancelled. Recent messages:Printed configuration") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/18345 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/11706 "Passed tests") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/53844 "Build was cancelled. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Compiled WebKit (cancelled)") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/96491 "Build was cancelled. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled JSC (warnings); jscore-tests (cancelled)") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/88105 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/11768 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/111396 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/102427 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/30972 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/22841 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/87884 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/31334 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/89858 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/87531 "Build was cancelled. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; 101 api tests failed or timed out; 101 api tests failed or timed out") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22288 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32423 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10150 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/25336 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/30900 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/36203 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/126060 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/30694 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34895 "Found 1 new JSC stress test failure: wasm.yaml/wasm/stress/cc-int-to-int-no-jit.js.default-wasm (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/34029 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/32255 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->