### PR TITLE
[scroll-animations] debug assertion hit under `JSCell::classInfo()` during document teardown when the last Document reference is dereferenced

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7896,4 +7896,6 @@ imported/w3c/web-platform-tests/css/cssom/adoptedstylesheets-adopt-style.tentati
 imported/w3c/web-platform-tests/wasm/jsapi/jspi/js-promise-integration.any.html [ Pass Failure ]
 imported/w3c/web-platform-tests/wasm/webapi/esm-integration/script-src-blocks-wasm.tentative.sub.html [ Pass Failure ]
 
+webkit.org/b/293108 webanimations/document-teardown-due-to-last-reference-crash.html [ Pass Timeout ]
+
 http/tests/iframe-memory-monitor/video-iframe.html [ Skip ]

--- a/LayoutTests/webanimations/document-teardown-due-to-last-reference-crash-expected.txt
+++ b/LayoutTests/webanimations/document-teardown-due-to-last-reference-crash-expected.txt
@@ -1,0 +1,1 @@
+PASS if this test does not crash.

--- a/LayoutTests/webanimations/document-teardown-due-to-last-reference-crash.html
+++ b/LayoutTests/webanimations/document-teardown-due-to-last-reference-crash.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<p>PASS if this test does not crash.</p>
+<script>
+
+(async function() {
+    window.testRunner?.dumpAsText();
+    window.testRunner?.waitUntilDone();
+
+    setTimeout(() => globalThis.testRunner?.notifyDone(), 5000);
+
+    window.history.back();
+    let timeline = new ScrollTimeline({ source: new Document().createElement('h4') });
+    let animationWeakRef = new WeakRef(new Animation());
+    animationWeakRef.deref().pause();
+    animationWeakRef.deref().timeline = timeline;
+    for (let i = 0; i < 40; ++i)
+        await true;
+    await animationWeakRef.deref().ready;
+    globalThis.testRunner?.notifyDone();
+})();
+
+</script>

--- a/Source/WebCore/animation/WebAnimation.cpp
+++ b/Source/WebCore/animation/WebAnimation.cpp
@@ -133,7 +133,9 @@ void WebAnimation::remove()
     // This object could be deleted after either clearing the effect or timeline relationship.
     Ref protectedThis { *this };
     setEffectInternal(nullptr);
-    setTimeline(nullptr);
+    setTimelineInternal(nullptr);
+    m_holdTime = std::nullopt;
+    m_startTime = std::nullopt;
 }
 
 void WebAnimation::suspendEffectInvalidation()


### PR DESCRIPTION
#### cdbbd6521df5500cf06b7e460d047131370c25b8
<pre>
[scroll-animations] debug assertion hit under `JSCell::classInfo()` during document teardown when the last Document reference is dereferenced
<a href="https://bugs.webkit.org/show_bug.cgi?id=293108">https://bugs.webkit.org/show_bug.cgi?id=293108</a>
<a href="https://rdar.apple.com/151306277">rdar://151306277</a>

Reviewed by Ryosuke Niwa.

When the last reference to a `Document` is dereferenced, document teardown occurs and we end up calling `WebAnimation::remove()`
for all animations still attached to the document under `AnimationTimeline::detachFromDocument()`. In `WebAnimation::remove()`
we ensure we clear strong references to the effect and timeline.

In 235621@main, we opted to use `setTimeline()` instead of `setTimelineInternal()` to clear the timeline reference, which would
reset some playback-related state and avoid a crash if using the DOM API `updatePlaybackRate()`. But with the advent of Scroll-driven
Animations, this is the source of a new issue where, if a Scroll-driven Animation has a pending pause task, then the &quot;setting
the timeline&quot; [1] procedure will resolve the ready promise which should not happen during document teardown caused by a dereference
of a final Document reference. Specifically we end up hitting `ASSERT(vm().heap.mutatorState() != MutatorState::Sweeping)` under
`JSCell::classInfo()`.

To fix this specific issue, we go back to using `setTimelineInternal()` in `WebAnimation::remove()` which will simply ensure we
reset the strong reference to the current timeline, without any further processing. As for the issue initially addressed in
235621@main, we reset both `m_holdTime` and `m_startTime` such that the playback state is reset appropriately.

[0] <a href="https://drafts.csswg.org/web-animations-1/#pending-pause-task">https://drafts.csswg.org/web-animations-1/#pending-pause-task</a>
[1] <a href="https://drafts.csswg.org/web-animations-2/#setting-the-timeline">https://drafts.csswg.org/web-animations-2/#setting-the-timeline</a>

* LayoutTests/TestExpectations:
* LayoutTests/webanimations/document-teardown-due-to-last-reference-crash-expected.txt: Added.
* LayoutTests/webanimations/document-teardown-due-to-last-reference-crash.html: Added.
* Source/WebCore/animation/WebAnimation.cpp:
(WebCore::WebAnimation::remove):

Canonical link: <a href="https://commits.webkit.org/295009@main">https://commits.webkit.org/295009@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2d35864feb2afc75726f91fad5d7d60f287b5815

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/103794 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/23496 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/13816 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/108986 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/54446 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/105834 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/23847 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/32042 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78855 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/106800 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/18509 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/93634 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59189 "Found 1 new API test failure: /WPE/TestSSL:/webkit/WebKitWebView/ephemeral-tls-errors (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/18312 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/11683 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/53822 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/88082 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/11740 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/111374 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/30950 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/22815 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/87857 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/31312 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/89835 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87511 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32399 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10123 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/25307 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16847 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/30878 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/36181 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/30672 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/34007 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/32233 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->