### PR TITLE
REGRESSION (293217@main): continual text scaling animation after switching app back to Safari on iOS on old.reddit.com

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/properties-value-inherit-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/properties-value-inherit-001-expected.txt
@@ -400,25 +400,25 @@ PASS left length(in) / events
 PASS left percentage(%) / values
 PASS left percentage(%) / events
 PASS color color(rgba) / values
-PASS color color(rgba) / events
+FAIL color color(rgba) / events assert_equals: Expected TransitionEnd events triggered on .transition expected "" but got "color:2s"
 PASS font-size length(pt) / values
-PASS font-size length(pt) / events
+FAIL font-size length(pt) / events assert_equals: Expected TransitionEnd events triggered on .transition expected "" but got "font-size:2s"
 PASS font-size length(pc) / values
-PASS font-size length(pc) / events
+FAIL font-size length(pc) / events assert_equals: Expected TransitionEnd events triggered on .transition expected "" but got "font-size:2s"
 PASS font-size length(px) / values
-PASS font-size length(px) / events
+FAIL font-size length(px) / events assert_equals: Expected TransitionEnd events triggered on .transition expected "" but got "font-size:2s"
 PASS font-size length(em) / values
-PASS font-size length(em) / events
+FAIL font-size length(em) / events assert_equals: Expected TransitionEnd events triggered on .transition expected "" but got "font-size:2s"
 PASS font-size length(ex) / values
-PASS font-size length(ex) / events
+FAIL font-size length(ex) / events assert_equals: Expected TransitionEnd events triggered on .transition expected "" but got "font-size:2s"
 PASS font-size length(mm) / values
-PASS font-size length(mm) / events
+FAIL font-size length(mm) / events assert_equals: Expected TransitionEnd events triggered on .transition expected "" but got "font-size:2s"
 PASS font-size length(cm) / values
-PASS font-size length(cm) / events
+FAIL font-size length(cm) / events assert_equals: Expected TransitionEnd events triggered on .transition expected "" but got "font-size:2s"
 PASS font-size length(in) / values
-PASS font-size length(in) / events
+FAIL font-size length(in) / events assert_equals: Expected TransitionEnd events triggered on .transition expected "" but got "font-size:2s"
 PASS font-size percentage(%) / values
-PASS font-size percentage(%) / events
+FAIL font-size percentage(%) / events assert_equals: Expected TransitionEnd events triggered on .transition expected "" but got "font-size:2s"
 PASS font-weight font-weight(keyword) / values
 PASS font-weight font-weight(keyword) / events
 PASS font-weight font-weight(numeric) / values

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/css/css-transitions/properties-value-inherit-001-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/css/css-transitions/properties-value-inherit-001-expected.txt
@@ -400,25 +400,25 @@ PASS left length(in) / events
 PASS left percentage(%) / values
 PASS left percentage(%) / events
 PASS color color(rgba) / values
-PASS color color(rgba) / events
+FAIL color color(rgba) / events assert_equals: Expected TransitionEnd events triggered on .transition expected "" but got "color:2s"
 PASS font-size length(pt) / values
-PASS font-size length(pt) / events
+FAIL font-size length(pt) / events assert_equals: Expected TransitionEnd events triggered on .transition expected "" but got "font-size:2s"
 PASS font-size length(pc) / values
-PASS font-size length(pc) / events
+FAIL font-size length(pc) / events assert_equals: Expected TransitionEnd events triggered on .transition expected "" but got "font-size:2s"
 PASS font-size length(px) / values
-PASS font-size length(px) / events
+FAIL font-size length(px) / events assert_equals: Expected TransitionEnd events triggered on .transition expected "" but got "font-size:2s"
 PASS font-size length(em) / values
-PASS font-size length(em) / events
+FAIL font-size length(em) / events assert_equals: Expected TransitionEnd events triggered on .transition expected "" but got "font-size:2s"
 PASS font-size length(ex) / values
-PASS font-size length(ex) / events
+FAIL font-size length(ex) / events assert_equals: Expected TransitionEnd events triggered on .transition expected "" but got "font-size:2s"
 PASS font-size length(mm) / values
-PASS font-size length(mm) / events
+FAIL font-size length(mm) / events assert_equals: Expected TransitionEnd events triggered on .transition expected "" but got "font-size:2s"
 PASS font-size length(cm) / values
-PASS font-size length(cm) / events
+FAIL font-size length(cm) / events assert_equals: Expected TransitionEnd events triggered on .transition expected "" but got "font-size:2s"
 PASS font-size length(in) / values
-PASS font-size length(in) / events
+FAIL font-size length(in) / events assert_equals: Expected TransitionEnd events triggered on .transition expected "" but got "font-size:2s"
 PASS font-size percentage(%) / values
-PASS font-size percentage(%) / events
+FAIL font-size percentage(%) / events assert_equals: Expected TransitionEnd events triggered on .transition expected "" but got "font-size:2s"
 PASS font-weight font-weight(keyword) / values
 PASS font-weight font-weight(keyword) / events
 PASS font-weight font-weight(numeric) / values

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -644,8 +644,8 @@
             ],
             "codegen-properties": {
                 "accepts-quirky-length": true,
-                "animation-wrapper": "Wrapper<float>",
-                "animation-wrapper-requires-computed-getter": true,
+                "animation-wrapper": "FontSizeWrapper",
+                "animation-wrapper-requires-override-parameters": [],
                 "style-builder-custom": "All",
                 "style-extractor-custom": true,
                 "high-priority": true,

--- a/Source/WebCore/style/StyleInterpolationWrappers.h
+++ b/Source/WebCore/style/StyleInterpolationWrappers.h
@@ -427,6 +427,20 @@ private:
     void (RenderStyle::*m_setter)(T);
 };
 
+class FontSizeWrapper final : public Wrapper<float> {
+    WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(Animation);
+public:
+    FontSizeWrapper()
+        : Wrapper<float>(CSSPropertyID::CSSPropertyFontSize, &RenderStyle::computedFontSize, &RenderStyle::setFontSize)
+    {
+    }
+
+    bool equals(const RenderStyle& a, const RenderStyle& b) const final
+    {
+        return a.specifiedFontSize() == b.specifiedFontSize();
+    }
+};
+
 class DiscreteFontDescriptionWrapper : public WrapperBase {
     WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(Animation);
 public:


### PR DESCRIPTION
#### c17bcea6b77a1984245cc770b45d579ee8f936cd
<pre>
REGRESSION (293217@main): continual text scaling animation after switching app back to Safari on iOS on old.reddit.com
<a href="https://bugs.webkit.org/show_bug.cgi?id=293111">https://bugs.webkit.org/show_bug.cgi?id=293111</a>
<a href="https://rdar.apple.com/151129940">rdar://151129940</a>

Reviewed by Anne van Kesteren and Sam Weinig.

We&apos;re using the `font-size` including text auto-sizing (`RenderStyle::computedFontSize()`) instead of the `font-size`
as specified by the author (`RenderStyle::specifiedFontSize()`) to determine whether the `font-size` has changed when
considering whether to start a CSS Transition. In the case of Reddit, the `font-size` is specified to a static value
of `12px` but text auto-sizing on iOS will yield a different value. During the process of bringing Safari back to the
forefront, we end up considering the starting of transitions with computed font sizes before and after the application
of auto-sizing.

To avoid this, we change the `font-size` animation wrapper to consider the `font-size` specified by the author only
when determining whether the property has changed.

This yields some new WPT failures for `font-size` tests in `css/css-transitions/properties-value-inherit-001.html`
but it turns out we were the only browser &quot;passing&quot; those tests which are most likely wrong. We now have compatibility
with Chrome and Firefox (see <a href="https://wpt.fyi/results/css/css-transitions/properties-value-inherit-001.html).">https://wpt.fyi/results/css/css-transitions/properties-value-inherit-001.html).</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/properties-value-inherit-001-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/css/css-transitions/properties-value-inherit-001-expected.txt:
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/style/StyleInterpolationWrappers.h:

Canonical link: <a href="https://commits.webkit.org/295010@main">https://commits.webkit.org/295010@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/21ce49e1a21feda902ecbda1783432c99fd49d19

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/103823 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/23525 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/13846 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/109016 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/54475 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/105863 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/23878 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/123/builds/32071 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/109016 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/54475 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/106829 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/18544 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/93659 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/109016 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/18346 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/11708 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/53851 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/88106 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/11765 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/111403 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/30979 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/123/builds/32071 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/87878 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/31341 "Build was cancelled. Recent messages:OS: Sequoia (15.2), Xcode: 16.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; compiling") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/89860 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/87534 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/10152 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/25343 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16848 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/30907 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/36210 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/30701 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/34036 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/32262 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->