### PR TITLE
Remove createdFromBindings() and m_createdFromBindings from TextEvent

### DIFF
--- a/Source/WebCore/dom/TextEvent.cpp
+++ b/Source/WebCore/dom/TextEvent.cpp
@@ -70,7 +70,6 @@ TextEvent::TextEvent()
     : UIEvent(EventInterfaceType::TextEvent)
     , m_shouldSmartReplace(false)
     , m_shouldMatchStyle(false)
-    , m_createdFromBindings(true)
     , m_mailBlockquoteHandling(MailBlockquoteHandling::RespectBlockquote)
 {
 }

--- a/Source/WebCore/dom/TextEvent.h
+++ b/Source/WebCore/dom/TextEvent.h
@@ -64,7 +64,6 @@ namespace WebCore {
 
         bool shouldSmartReplace() const { return m_shouldSmartReplace; }
         bool shouldMatchStyle() const { return m_shouldMatchStyle; }
-        bool createdFromBindings() const { return m_createdFromBindings; }
         MailBlockquoteHandling mailBlockquoteHandling() const { return m_mailBlockquoteHandling; }
         DocumentFragment* pastingFragment() const { return m_pastingFragment.get(); }
         const Vector<DictationAlternative>& dictationAlternatives() const { return m_dictationAlternatives; }
@@ -84,7 +83,6 @@ namespace WebCore {
         RefPtr<DocumentFragment> m_pastingFragment;
         bool m_shouldSmartReplace;
         bool m_shouldMatchStyle;
-        bool m_createdFromBindings { false };
         MailBlockquoteHandling m_mailBlockquoteHandling;
         Vector<DictationAlternative> m_dictationAlternatives;
     };

--- a/Source/WebCore/editing/Editor.cpp
+++ b/Source/WebCore/editing/Editor.cpp
@@ -1252,7 +1252,7 @@ void Editor::appliedEditing(CompositeEditCommand& command)
 
     bool wasUserEdit = [&command] {
         RefPtr typingCommand = dynamicDowncast<TypingCommand>(command);
-        return !typingCommand || !typingCommand->triggeringEventWasCreatedFromBindings();
+        return !typingCommand || !typingCommand->triggeringEventIsUntrusted();
     }();
     notifyTextFromControls(composition->startingRootEditableElement(), composition->endingRootEditableElement(), wasUserEdit);
 

--- a/Source/WebCore/editing/TypingCommand.cpp
+++ b/Source/WebCore/editing/TypingCommand.cpp
@@ -243,10 +243,7 @@ void TypingCommand::insertText(Ref<Document>&& document, const String& text, Eve
 
     String newText = dispatchBeforeTextInsertedEvent(text, selectionForInsertion, compositionType == TextCompositionType::Pending);
 
-    bool eventWasCreatedFromBindings = [&] {
-        RefPtr textEvent = dynamicDowncast<TextEvent>(triggeringEvent);
-        return textEvent && textEvent->createdFromBindings();
-    }();
+    bool triggeringEventIsUntrusted = triggeringEvent && !triggeringEvent->isTrusted();
 
     // Set the starting and ending selection appropriately if we are using a selection
     // that is different from the current selection.  In the future, we should change EditCommand
@@ -261,7 +258,7 @@ void TypingCommand::insertText(Ref<Document>&& document, const String& text, Eve
         lastTypingCommand->setCompositionType(compositionType);
         lastTypingCommand->setShouldRetainAutocorrectionIndicator(options.contains(Option::RetainAutocorrectionIndicator));
         lastTypingCommand->setShouldPreventSpellChecking(options.contains(Option::PreventSpellChecking));
-        lastTypingCommand->setTriggeringEventWasCreatedFromBindings(eventWasCreatedFromBindings);
+        lastTypingCommand->setTriggeringEventIsUntrusted(triggeringEventIsUntrusted);
 #if HAVE(INLINE_PREDICTIONS)
         if (compositionType != TextCompositionType::None)
             lastTypingCommand->insertText(newText, options.contains(Option::SelectInsertedText));
@@ -273,7 +270,7 @@ void TypingCommand::insertText(Ref<Document>&& document, const String& text, Eve
 
     RefPtr frame = document->frame();
     auto command = TypingCommand::create(WTFMove(document), Type::InsertText, newText, options, compositionType);
-    command->setTriggeringEventWasCreatedFromBindings(eventWasCreatedFromBindings);
+    command->setTriggeringEventIsUntrusted(triggeringEventIsUntrusted);
     applyTextInsertionCommand(frame.get(), command.get(), selectionForInsertion, currentSelection);
 }
 

--- a/Source/WebCore/editing/TypingCommand.h
+++ b/Source/WebCore/editing/TypingCommand.h
@@ -80,8 +80,8 @@ public:
     void deleteSelection(bool smartDelete);
     void setCompositionType(TextCompositionType type) { m_compositionType = type; }
     void setIsAutocompletion(bool isAutocompletion) { m_isAutocompletion = isAutocompletion; }
-    bool triggeringEventWasCreatedFromBindings() const { return m_triggeringEventWasCreatedFromBindings; }
-    void setTriggeringEventWasCreatedFromBindings(bool value) { m_triggeringEventWasCreatedFromBindings = value; }
+    bool triggeringEventIsUntrusted() const { return m_triggeringEventIsUntrusted; }
+    void setTriggeringEventIsUntrusted(bool value) { m_triggeringEventIsUntrusted = value; }
 
 #if PLATFORM(IOS_FAMILY)
     void setEndingSelectionOnLastInsertCommand(const VisibleSelection& selection);
@@ -164,7 +164,7 @@ private:
 
     bool m_shouldRetainAutocorrectionIndicator;
     bool m_shouldPreventSpellChecking;
-    bool m_triggeringEventWasCreatedFromBindings { false };
+    bool m_triggeringEventIsUntrusted { false };
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### deb9744efaba1b9e70ed8cb32488f1e1a6fe8e80
<pre>
Remove createdFromBindings() and m_createdFromBindings from TextEvent
<a href="https://bugs.webkit.org/show_bug.cgi?id=293117">https://bugs.webkit.org/show_bug.cgi?id=293117</a>

Reviewed by Abrar Rahman Protyasha.

This method and state on `TextEvent` is redundant with the trusted state that&apos;s already present on
`WebCore::Event`. Remove it, and use `isTrusted()` at the former call site instead.

* Source/WebCore/dom/TextEvent.cpp:
(WebCore::TextEvent::TextEvent):
* Source/WebCore/dom/TextEvent.h:
* Source/WebCore/editing/Editor.cpp:
(WebCore::Editor::appliedEditing):
* Source/WebCore/editing/TypingCommand.cpp:
(WebCore::TypingCommand::insertText):
* Source/WebCore/editing/TypingCommand.h:

Also rename `setTriggeringEventWasCreatedFromBindings` → `setTriggeringEventIsUntrusted` to maintain
consistency.

Canonical link: <a href="https://commits.webkit.org/295014@main">https://commits.webkit.org/295014@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8692e7ac212395f4f8c084dafca3125231884d2f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/103807 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/23509 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/13829 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/109003 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/54459 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/105847 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/23862 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/32055 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78864 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/106813 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/18524 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/93641 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59198 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/18331 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/11690 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/53835 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/88094 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/11747 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/111387 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/30963 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/22835 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/87865 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/31325 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/89842 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87521 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22284 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32413 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10130 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/25325 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/30891 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/36194 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/30685 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/34020 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/32246 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->