### PR TITLE
AX: Move rowHeader to AXCoreObject

### DIFF
--- a/Source/WebCore/accessibility/AXCoreObject.cpp
+++ b/Source/WebCore/accessibility/AXCoreObject.cpp
@@ -967,6 +967,32 @@ AXCoreObject* AXCoreObject::columnHeader()
     return nullptr;
 }
 
+AXCoreObject* AXCoreObject::rowHeader()
+{
+    const auto& rowChildren = unignoredChildren();
+    if (rowChildren.isEmpty())
+        return nullptr;
+
+    bool isARIAGridRow = this->isARIAGridRow();
+
+    Ref firstCell = rowChildren[0].get();
+    if (!isARIAGridRow && !firstCell->hasElementName(ElementName::HTML_th))
+        return nullptr;
+
+    // Verify that the row header is not part of an entire row of headers.
+    // In that case, it is unlikely this is a row header (for non-grid rows).
+    for (const auto& child : rowChildren) {
+        // We found a non-header cell, so this is not an entire row of headers -- return the original header cell.
+        if (!isARIAGridRow && !child->hasElementName(ElementName::HTML_th))
+            return firstCell.ptr();
+
+        // For grid rows, the first header encountered is the row header.
+        if (isARIAGridRow && child->isRowHeader())
+            return child.ptr();
+    }
+    return nullptr;
+}
+
 AXCoreObject::AccessibilityChildrenVector AXCoreObject::columnHeaders()
 {
     AccessibilityChildrenVector headers;

--- a/Source/WebCore/accessibility/AXCoreObject.h
+++ b/Source/WebCore/accessibility/AXCoreObject.h
@@ -812,7 +812,6 @@ public:
     virtual bool isAccessibilityObject() const = 0;
     virtual bool isAccessibilityRenderObject() const = 0;
     virtual bool isAccessibilityTableInstance() const = 0;
-    virtual bool isAccessibilityARIAGridRowInstance() const = 0;
     virtual bool isAccessibilityARIAGridCellInstance() const = 0;
     virtual bool isAXIsolatedObjectInstance() const = 0;
     virtual bool isAXRemoteFrame() const = 0;
@@ -903,9 +902,10 @@ public:
     // Table row support.
     virtual bool isTableRow() const = 0;
     virtual unsigned rowIndex() const = 0;
-    virtual AXCoreObject* rowHeader() { return nullptr; }
+    AXCoreObject* rowHeader();
 
     // ARIA tree/grid row support.
+    virtual bool isARIAGridRow() const = 0;
     virtual bool isARIATreeGridRow() const = 0;
     virtual AccessibilityChildrenVector disclosedRows() = 0; // Also implemented by ARIATreeItems.
     virtual AXCoreObject* disclosedByRow() const = 0;

--- a/Source/WebCore/accessibility/AXLogger.cpp
+++ b/Source/WebCore/accessibility/AXLogger.cpp
@@ -843,6 +843,9 @@ TextStream& operator<<(WTF::TextStream& stream, AXProperty property)
     case AXProperty::IsGrabbed:
         stream << "IsGrabbed";
         break;
+    case AXProperty::IsARIAGridRow:
+        stream << "IsARIAGridRow";
+        break;
     case AXProperty::IsARIATreeGridRow:
         stream << "IsARIATreeGridRow";
         break;
@@ -1094,9 +1097,6 @@ TextStream& operator<<(WTF::TextStream& stream, AXProperty property)
         break;
     case AXProperty::Rows:
         stream << "Rows";
-        break;
-    case AXProperty::RowHeader:
-        stream << "RowHeader";
         break;
     case AXProperty::RowHeaders:
         stream << "RowHeaders";

--- a/Source/WebCore/accessibility/AccessibilityARIAGridRow.cpp
+++ b/Source/WebCore/accessibility/AccessibilityARIAGridRow.cpp
@@ -136,13 +136,4 @@ AccessibilityTable* AccessibilityARIAGridRow::parentTable() const
     }));
 }
 
-AccessibilityObject* AccessibilityARIAGridRow::rowHeader()
-{
-    for (const auto& child : unignoredChildren()) {
-        if (child->isRowHeader())
-            return &downcast<AccessibilityObject>(child.get());
-    }
-    return nullptr;
-}
-
 } // namespace WebCore

--- a/Source/WebCore/accessibility/AccessibilityARIAGridRow.h
+++ b/Source/WebCore/accessibility/AccessibilityARIAGridRow.h
@@ -42,17 +42,24 @@ public:
 
     AccessibilityChildrenVector disclosedRows() final;
     AccessibilityObject* disclosedByRow() const final;
-    AccessibilityObject* rowHeader() final;
 
 private:
     explicit AccessibilityARIAGridRow(AXID, RenderObject&);
     explicit AccessibilityARIAGridRow(AXID, Node&);
     bool isAccessibilityARIAGridRowInstance() const final { return true; }
 
+    bool isARIAGridRow() const final { return true; }
     bool isARIATreeGridRow() const final;
     AccessibilityTable* parentTable() const final;
 };
 
 } // namespace WebCore 
 
-SPECIALIZE_TYPE_TRAITS_ACCESSIBILITY(AccessibilityARIAGridRow, isAccessibilityARIAGridRowInstance())
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::AccessibilityARIAGridRow)
+    static bool isType(const WebCore::AccessibilityObject& object) { return object.isAccessibilityARIAGridRowInstance(); }
+    static bool isType(const WebCore::AXCoreObject& object)
+    {
+        auto* accessibilityObject = dynamicDowncast<WebCore::AccessibilityObject>(object);
+        return accessibilityObject && accessibilityObject->isAccessibilityARIAGridRowInstance();
+    }
+SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/accessibility/AccessibilityObject.h
+++ b/Source/WebCore/accessibility/AccessibilityObject.h
@@ -107,7 +107,7 @@ public:
     virtual bool isAccessibilitySVGRoot() const { return false; }
     bool isAccessibilityTableInstance() const override { return false; }
     virtual bool isAccessibilityTableColumnInstance() const { return false; }
-    bool isAccessibilityARIAGridRowInstance() const override { return false; }
+    virtual bool isAccessibilityARIAGridRowInstance() const { return false; }
     bool isAccessibilityARIAGridCellInstance() const override { return false; }
     virtual bool isAccessibilityLabelInstance() const { return false; }
     virtual bool isAccessibilityListBoxInstance() const { return false; }
@@ -167,6 +167,7 @@ public:
     bool ignoredByRowAncestor() const;
 
     // ARIA tree/grid row support.
+    bool isARIAGridRow() const override { return false; }
     bool isARIATreeGridRow() const override { return false; }
     AccessibilityChildrenVector disclosedRows() override; // ARIATreeItem implementation. AccessibilityARIAGridRow overrides this method.
     AccessibilityObject* disclosedByRow() const override { return nullptr; }

--- a/Source/WebCore/accessibility/AccessibilityTableRow.cpp
+++ b/Source/WebCore/accessibility/AccessibilityTableRow.cpp
@@ -127,26 +127,6 @@ void AccessibilityTableRow::setRowIndex(unsigned rowIndex)
 #endif
 }
 
-AccessibilityObject* AccessibilityTableRow::rowHeader()
-{
-    const auto& rowChildren = unignoredChildren();
-    if (rowChildren.isEmpty())
-        return nullptr;
-    
-    Ref firstCell = rowChildren[0].get();
-    if (!firstCell->node() || !firstCell->node()->hasTagName(thTag))
-        return nullptr;
-
-    // Verify that the row header is not part of an entire row of headers.
-    // In that case, it is unlikely this is a row header.
-    for (const auto& child : rowChildren) {
-        // We found a non-header cell, so this is not an entire row of headers -- return the original header cell.
-        if (child->node() && !child->node()->hasTagName(thTag))
-            return &downcast<AccessibilityObject>(firstCell.get());
-    }
-    return nullptr;
-}
-
 void AccessibilityTableRow::addChildren()
 {
     // If the element specifies its cells through aria-owns, return that first.

--- a/Source/WebCore/accessibility/AccessibilityTableRow.h
+++ b/Source/WebCore/accessibility/AccessibilityTableRow.h
@@ -40,8 +40,6 @@ public:
     static Ref<AccessibilityTableRow> create(AXID, Node&);
     virtual ~AccessibilityTableRow();
 
-    // retrieves the "row" header (a th tag in the rightmost column)
-    AccessibilityObject* rowHeader() override;
     virtual AccessibilityTable* parentTable() const;
 
     void setRowIndex(unsigned);

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
@@ -343,10 +343,8 @@ void AXIsolatedObject::initializeProperties(const Ref<AccessibilityObject>& axOb
         setProperty(AXProperty::IsARIATreeGridRow, true);
         setObjectVectorProperty(AXProperty::DisclosedRows, object.disclosedRows());
         setObjectProperty(AXProperty::DisclosedByRow, object.disclosedByRow());
-    }
-
-    if (object.isARIATreeGridRow() || isTableRow)
-        setObjectProperty(AXProperty::RowHeader, object.rowHeader());
+    } else if (object.isAccessibilityARIAGridRowInstance())
+        setProperty(AXProperty::IsARIAGridRow, true);
 
     bool isTreeItem = object.isTreeItem();
     if (isTreeItem) {

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
@@ -253,10 +253,10 @@ private:
     // Table row support.
     bool isTableRow() const final { return boolAttributeValue(AXProperty::IsTableRow); }
     unsigned rowIndex() const final { return unsignedAttributeValue(AXProperty::RowIndex); }
-    AXIsolatedObject* rowHeader() final { return objectAttributeValue(AXProperty::RowHeader); };
 
     // ARIA tree/grid row support.
     bool isARIATreeGridRow() const final { return boolAttributeValue(AXProperty::IsARIATreeGridRow); }
+    bool isARIAGridRow() const final { return boolAttributeValue(AXProperty::IsARIAGridRow) || isARIATreeGridRow(); }
     AccessibilityChildrenVector disclosedRows() final { return tree()->objectsForIDs(vectorAttributeValue<AXID>(AXProperty::DisclosedRows)); }
     AXIsolatedObject* disclosedByRow() const final { return objectAttributeValue(AXProperty::DisclosedByRow); }
 
@@ -490,7 +490,6 @@ private:
     // Functions that should never be called on an isolated tree object. ASSERT that these are not reached;
     bool isAccessibilityRenderObject() const final;
     bool isAccessibilityTableInstance() const final;
-    bool isAccessibilityARIAGridRowInstance() const final { return false; }
     bool isAccessibilityARIAGridCellInstance() const final { return false; }
     bool isAXRemoteFrame() const final { return false; }
     bool isNativeTextControl() const final;

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
@@ -160,6 +160,7 @@ enum class AXProperty : uint16_t {
     InnerHTML,
     InternalLinkElement,
     IsGrabbed,
+    IsARIAGridRow,
     IsARIATreeGridRow,
     IsAnonymousMathOperator,
     IsAttachment,
@@ -248,7 +249,6 @@ enum class AXProperty : uint16_t {
 #endif
     RolePlatformString,
     Rows,
-    RowHeader,
     RowHeaders,
     RowIndex,
     RowIndexRange,


### PR DESCRIPTION
#### 7c604faeacdeac530781ab88889531783b830279
<pre>
AX: Move rowHeader to AXCoreObject
<a href="https://bugs.webkit.org/show_bug.cgi?id=293129">https://bugs.webkit.org/show_bug.cgi?id=293129</a>
<a href="https://rdar.apple.com/problem/151475547">rdar://problem/151475547</a>

Reviewed by Tyler Wilcock.

We can move rowHeader to a shared implementation in AXCoreObject, now
that we cache the right element names.

* Source/WebCore/accessibility/AXCoreObject.cpp:
(WebCore::AXCoreObject::rowHeader):
* Source/WebCore/accessibility/AXCoreObject.h:
(WebCore::AXCoreObject::rowHeader): Deleted.
* Source/WebCore/accessibility/AXLogger.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/accessibility/AccessibilityARIAGridRow.cpp:
(WebCore::AccessibilityARIAGridRow::rowHeader): Deleted.
* Source/WebCore/accessibility/AccessibilityARIAGridRow.h:
(isType):
* Source/WebCore/accessibility/AccessibilityObject.h:
(WebCore::AccessibilityObject::isAccessibilityARIAGridRowInstance const):
* Source/WebCore/accessibility/AccessibilityTableRow.cpp:
(WebCore::AccessibilityTableRow::rowHeader): Deleted.
* Source/WebCore/accessibility/AccessibilityTableRow.h:
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp:
(WebCore::AXIsolatedObject::initializeProperties):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h:
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h:

Canonical link: <a href="https://commits.webkit.org/295069@main">https://commits.webkit.org/295069@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/02198c258f35d1056b5fa2f7ef4bac213f5d9db8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/103886 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/23589 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/13910 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/109079 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/54660 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/105926 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/23942 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/32134 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78921 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/106892 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/18590 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/93707 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59250 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/18474 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/11758 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/53914 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/88206 "Found 1 new API test failure: TestWebKitAPI.CARingBufferTest.FetchTimeBoundsConsistent (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/11816 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/111466 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/31042 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/22883 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/87930 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/31404 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/89908 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87582 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22314 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32471 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10197 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/25550 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/30971 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/36281 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/30764 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/34101 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/32325 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->