### PR TITLE
Add --site-isolation option to run-webkit-tests

### DIFF
--- a/Tools/Scripts/run-api-tests
+++ b/Tools/Scripts/run-api-tests
@@ -145,6 +145,8 @@ def parse_args(args):
         optparse.make_option('--additional-env-var', type='string', action='append', default=[],
                              help='Passes that environment variable to the tests (--additional-env-var=NAME=VALUE)'),
 
+        optparse.make_option('--site-isolation', action='store_true', default=False,
+                             help='Enable Site Isolation'),
         optparse.make_option('--remote-layer-tree', action='store_true', default=False,
                              help='Use the remote layer tree drawing model (macOS WebKit2 only)'),
         optparse.make_option('--no-remote-layer-tree', action='store_true', default=False,

--- a/Tools/Scripts/webkitpy/api_tests/runner.py
+++ b/Tools/Scripts/webkitpy/api_tests/runner.py
@@ -94,6 +94,8 @@ class Runner(object):
             args.append('--gtest_also_run_disabled_tests=1')
         if (port.get_option('remote_layer_tree')):
             args.append('--remote-layer-tree')
+        if (port.get_option('site_isolation')):
+            args.append('--site-isolation')
         if (port.get_option('no_remote_layer_tree')):
             args.append('--no-remote-layer-tree')
         if (port.get_option('use_gpu_process')):

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ResourceLoadStatistics.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ResourceLoadStatistics.mm
@@ -1219,6 +1219,10 @@ TEST(ResourceLoadStatistics, BackForwardPerPageData)
     doneFlag = false;
     [dataStore _loadedSubresourceDomainsFor:webView.get() completionHandler:^(NSArray<NSString *> *domains) {
         EXPECT_EQ(static_cast<int>([domains count]), 1);
+        if (domains.count != 1) {
+            doneFlag = true;
+            return;
+        }
         EXPECT_WK_STREQ([domains objectAtIndex:0], @"example1.com");
         doneFlag = true;
     }];
@@ -1232,6 +1236,10 @@ TEST(ResourceLoadStatistics, BackForwardPerPageData)
     doneFlag = false;
     [dataStore _loadedSubresourceDomainsFor:webView.get() completionHandler:^(NSArray<NSString *> *domains) {
         EXPECT_EQ(static_cast<int>([domains count]), 1);
+        if (domains.count != 1) {
+            doneFlag = true;
+            return;
+        }
         EXPECT_WK_STREQ([domains objectAtIndex:0], @"example2.com");
         doneFlag = true;
     }];
@@ -1245,6 +1253,10 @@ TEST(ResourceLoadStatistics, BackForwardPerPageData)
     doneFlag = false;
     [dataStore _loadedSubresourceDomainsFor:webView.get() completionHandler:^(NSArray<NSString *> *domains) {
         EXPECT_EQ(static_cast<int>([domains count]), 1);
+        if (domains.count != 1) {
+            doneFlag = true;
+            return;
+        }
         EXPECT_WK_STREQ([domains objectAtIndex:0], @"example1.com");
         doneFlag = true;
     }];
@@ -1258,6 +1270,10 @@ TEST(ResourceLoadStatistics, BackForwardPerPageData)
     doneFlag = false;
     [dataStore _loadedSubresourceDomainsFor:webView.get() completionHandler:^(NSArray<NSString *> *domains) {
         EXPECT_EQ(static_cast<int>([domains count]), 1);
+        if (domains.count != 1) {
+            doneFlag = true;
+            return;
+        }
         EXPECT_WK_STREQ([domains objectAtIndex:0], @"example2.com");
         doneFlag = true;
     }];


### PR DESCRIPTION
#### a03a043a089fa6d2dc2a427e459733e37c708b76
<pre>
Add --site-isolation option to run-webkit-tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=293135">https://bugs.webkit.org/show_bug.cgi?id=293135</a>
<a href="https://rdar.apple.com/151477838">rdar://151477838</a>

Reviewed by Jonathan Bedard.

Also, fix the only crash when running with this mode, changing
ResourceLoadStatistics.BackForwardPerPageData from a crash to a failure.

* Tools/Scripts/run-api-tests:
(parse_args):
* Tools/Scripts/webkitpy/api_tests/runner.py:
(Runner.command_for_port):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ResourceLoadStatistics.mm:
(TEST(ResourceLoadStatistics, BackForwardPerPageData)):

Canonical link: <a href="https://commits.webkit.org/295021@main">https://commits.webkit.org/295021@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ae42bf406a949be04fc2686069c1c0f2319b2c56

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/103838 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/131/builds/23548 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/13862 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/109031 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/54494 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/105878 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/23893 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/32086 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/78892 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/106844 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/18553 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/93666 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59221 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/103314 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/18353 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/11715 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/53866 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/88113 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/11774 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/111418 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/30994 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/22854 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/87895 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/31356 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/89866 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/87546 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32437 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/10158 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/25359 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16855 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/30923 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/30716 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/34053 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/32277 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->