### PR TITLE
Revert 290351@main "Move ResourceMonitor throttler from UIProcess to NetworkProcess"

### DIFF
--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
@@ -115,10 +115,6 @@
 #include <WebCore/MockContentFilterSettings.h>
 #endif
 
-#if ENABLE(CONTENT_EXTENSIONS)
-#include <WebCore/ResourceMonitorThrottlerHolder.h>
-#endif
-
 #define CONNECTION_RELEASE_LOG(channel, fmt, ...) RELEASE_LOG(channel, "%p - [webProcessIdentifier=%" PRIu64 "] NetworkConnectionToWebProcess::" fmt, this, this->webProcessIdentifier().toUInt64(), ##__VA_ARGS__)
 #define CONNECTION_RELEASE_LOG_ERROR(channel, fmt, ...) RELEASE_LOG_ERROR(channel, "%p - [webProcessIdentifier=%" PRIu64 "] NetworkConnectionToWebProcess::" fmt, this, this->webProcessIdentifier().toUInt64(), ##__VA_ARGS__)
 
@@ -1796,17 +1792,6 @@ void NetworkConnectionToWebProcess::updateSharedPreferencesForWebProcess(SharedP
     if (CheckedPtr session = networkSession())
         session->protectedStorageManager()->updateSharedPreferencesForConnection(protectedConnection(), m_sharedPreferencesForWebProcess);
 }
-
-#if ENABLE(CONTENT_EXTENSIONS)
-void NetworkConnectionToWebProcess::shouldOffloadIFrameForHost(const String& host, CompletionHandler<void(bool)>&& completionHandler)
-{
-    CONNECTION_RELEASE_LOG(ResourceMonitoring, "shouldOffloadIFrameForHost: (host=%" SENSITIVE_LOG_STRING ")", host.utf8().data());
-    if (CheckedPtr session = networkSession())
-        session->protectedResourceMonitorThrottler()->tryAccess(host, ContinuousApproximateTime::now(), WTFMove(completionHandler));
-    else
-        completionHandler(false);
-}
-#endif
 
 } // namespace WebKit
 

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
@@ -486,10 +486,6 @@ private:
         std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebPaymentMessages() const final;
 #endif // ENABLE(APPLE_PAY_REMOTE_UI)
 
-#if ENABLE(CONTENT_EXTENSIONS)
-    void shouldOffloadIFrameForHost(const String& host, CompletionHandler<void(bool)>&&);
-#endif
-
     Ref<IPC::Connection> m_connection;
     Ref<NetworkProcess> m_networkProcess;
     PAL::SessionID m_sessionID;

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in
@@ -149,8 +149,4 @@ messages -> NetworkConnectionToWebProcess WantsDispatchMessage {
 
     SetLoginStatus(WebCore::RegistrableDomain domain, enum:uint8_t WebCore::IsLoggedIn loggedInStatus, std::optional<WebCore::LoginStatus> lastAuthentication) -> ()
     IsLoggedIn(WebCore::RegistrableDomain domain) -> (bool result)
-
-#if ENABLE(CONTENT_EXTENSIONS)
-    ShouldOffloadIFrameForHost(String host) -> (bool wasGranted)
-#endif
 }

--- a/Source/WebKit/NetworkProcess/NetworkProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
@@ -1768,11 +1768,6 @@ void NetworkProcess::deleteWebsiteDataImpl(PAL::SessionID sessionID, OptionSet<W
         session->clearAlternativeServices(modifiedSince);
 #endif
 
-#if ENABLE(CONTENT_EXTENSIONS)
-    if (websiteDataTypes.contains(WebsiteDataType::DiskCache) && session)
-        session->clearResourceMonitorThrottlerData([clearTasksHandler] { });
-#endif
-
     if (NetworkStorageManager::canHandleTypes(websiteDataTypes) && session)
         session->protectedStorageManager()->deleteDataModifiedSince(websiteDataTypes, modifiedSince, [clearTasksHandler] { });
 }
@@ -3236,15 +3231,5 @@ ShouldRelaxThirdPartyCookieBlocking NetworkProcess::shouldRelaxThirdPartyCookieB
 {
     return pageID && m_pagesWithRelaxedThirdPartyCookieBlocking.contains(*pageID) ? ShouldRelaxThirdPartyCookieBlocking::Yes : ShouldRelaxThirdPartyCookieBlocking::No;
 }
-
-#if ENABLE(CONTENT_EXTENSIONS)
-void NetworkProcess::resetResourceMonitorThrottlerForTesting(PAL::SessionID sessionID, CompletionHandler<void()>&& completionHandler)
-{
-    if (CheckedPtr session = networkSession(sessionID))
-        session->clearResourceMonitorThrottlerData(WTFMove(completionHandler));
-    else
-        completionHandler();
-}
-#endif
 
 } // namespace WebKit

--- a/Source/WebKit/NetworkProcess/NetworkProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.h
@@ -574,10 +574,6 @@ private:
 
     void setShouldRelaxThirdPartyCookieBlockingForPage(WebPageProxyIdentifier);
 
-#if ENABLE(CONTENT_EXTENSIONS)
-    void resetResourceMonitorThrottlerForTesting(PAL::SessionID, CompletionHandler<void()>&&);
-#endif
-
     struct TaskIdentifierType;
     using TaskIdentifier = ObjectIdentifier<TaskIdentifierType>;
     void performDeleteWebsiteDataTask(TaskIdentifier);

--- a/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
@@ -272,8 +272,4 @@ messages -> NetworkProcess : AuxiliaryProcess WantsAsyncDispatchMessage {
     RestoreSessionStorage(PAL::SessionID sessionID, WebKit::WebPageProxyIdentifier pageID, HashMap<WebCore::ClientOrigin, HashMap<String, String>> localStorageMap) -> (bool succeeded)
 
     SetShouldRelaxThirdPartyCookieBlockingForPage(WebKit::WebPageProxyIdentifier pageID)
-
-#if ENABLE(CONTENT_EXTENSIONS)
-    ResetResourceMonitorThrottlerForTesting(PAL::SessionID sessionID) -> ();
-#endif
 }

--- a/Source/WebKit/NetworkProcess/NetworkSession.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkSession.cpp
@@ -175,9 +175,6 @@ NetworkSession::NetworkSession(NetworkProcess& networkProcess, const NetworkSess
 #if ENABLE(DECLARATIVE_WEB_PUSH)
     , m_isDeclarativeWebPushEnabled(parameters.isDeclarativeWebPushEnabled)
 #endif
-#if ENABLE(CONTENT_EXTENSIONS)
-    , m_resourceMonitorThrottlerDirectory(parameters.resourceMonitorThrottlerDirectory)
-#endif
 #if HAVE(WEBCONTENTRESTRICTIONS_PATH_SPI)
     , m_webContentRestrictionsConfigurationFile(parameters.webContentRestrictionsConfigurationFile)
 #endif
@@ -938,28 +935,5 @@ Ref<NetworkBroadcastChannelRegistry> NetworkSession::protectedBroadcastChannelRe
 {
     return m_broadcastChannelRegistry;
 }
-
-#if ENABLE(CONTENT_EXTENSIONS)
-WebCore::ResourceMonitorThrottlerHolder& NetworkSession::resourceMonitorThrottler()
-{
-    if (!m_resourceMonitorThrottler) {
-        RELEASE_LOG(ResourceMonitoring, "NetworkSession::resourceMonitorThrottler sessionID=%" PRIu64 ", ResourceMonitorThrottler is created.", m_sessionID.toUInt64());
-        m_resourceMonitorThrottler = WebCore::ResourceMonitorThrottlerHolder::create(m_resourceMonitorThrottlerDirectory);
-    }
-
-    return *m_resourceMonitorThrottler;
-}
-
-Ref<WebCore::ResourceMonitorThrottlerHolder> NetworkSession::protectedResourceMonitorThrottler()
-{
-    return resourceMonitorThrottler();
-}
-
-void NetworkSession::clearResourceMonitorThrottlerData(CompletionHandler<void()>&& completionHandler)
-{
-    protectedResourceMonitorThrottler()->clearAllData(WTFMove(completionHandler));
-}
-
-#endif
 
 } // namespace WebKit

--- a/Source/WebKit/NetworkProcess/NetworkSession.h
+++ b/Source/WebKit/NetworkProcess/NetworkSession.h
@@ -59,7 +59,6 @@
 namespace WebCore {
 class CertificateInfo;
 class NetworkStorageSession;
-class ResourceMonitorThrottlerHolder;
 class ResourceRequest;
 class ResourceError;
 class SWServer;
@@ -293,13 +292,6 @@ public:
     bool isDeclarativeWebPushEnabled() const { return m_isDeclarativeWebPushEnabled; }
 #endif
 
-#if ENABLE(CONTENT_EXTENSIONS)
-    WebCore::ResourceMonitorThrottlerHolder& resourceMonitorThrottler();
-    Ref<WebCore::ResourceMonitorThrottlerHolder> protectedResourceMonitorThrottler();
-
-    void clearResourceMonitorThrottlerData(CompletionHandler<void()>&&);
-#endif
-
 #if HAVE(WEBCONTENTRESTRICTIONS_PATH_SPI)
     String webContentRestrictionsConfigurationFile() const { return m_webContentRestrictionsConfigurationFile; }
 #endif
@@ -415,10 +407,6 @@ protected:
 #endif
 #if ENABLE(DECLARATIVE_WEB_PUSH)
     bool m_isDeclarativeWebPushEnabled { false };
-#endif
-#if ENABLE(CONTENT_EXTENSIONS)
-    RefPtr<WebCore::ResourceMonitorThrottlerHolder> m_resourceMonitorThrottler;
-    String m_resourceMonitorThrottlerDirectory;
 #endif
 #if HAVE(WEBCONTENTRESTRICTIONS_PATH_SPI)
     String m_webContentRestrictionsConfigurationFile;

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
@@ -2028,13 +2028,6 @@ void NetworkProcessProxy::restoreLocalStorage(PAL::SessionID sessionID, HashMap<
     sendWithAsyncReply(Messages::NetworkProcess::RestoreLocalStorage(sessionID, WTFMove(localStorage)), WTFMove(completionHandler));
 }
 
-#if ENABLE(CONTENT_EXTENSIONS)
-void NetworkProcessProxy::resetResourceMonitorThrottlerForTesting(PAL::SessionID sessionID, CompletionHandler<void()>&& completionHandler)
-{
-    sendWithAsyncReply(Messages::NetworkProcess::ResetResourceMonitorThrottlerForTesting(sessionID), WTFMove(completionHandler));
-}
-#endif
-
 } // namespace WebKit
 
 #undef MESSAGE_CHECK_COMPLETION

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
@@ -344,10 +344,6 @@ public:
     void fetchLocalStorage(PAL::SessionID, CompletionHandler<void(std::optional<HashMap<WebCore::ClientOrigin, HashMap<String, String>>>&&)>&&);
     void restoreLocalStorage(PAL::SessionID, HashMap<WebCore::ClientOrigin, HashMap<String, String>>&&, CompletionHandler<void(bool)>&&);
 
-#if ENABLE(CONTENT_EXTENSIONS)
-    void resetResourceMonitorThrottlerForTesting(PAL::SessionID, CompletionHandler<void()>&&);
-#endif
-
 private:
     explicit NetworkProcessProxy();
 

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -16481,6 +16481,13 @@ void WebPageProxy::setPresentingApplicationAuditToken(const audit_token_t& prese
 }
 #endif
 
+#if ENABLE(CONTENT_EXTENSIONS)
+void WebPageProxy::shouldOffloadIFrameForHost(const String& host, CompletionHandler<void(bool)>&& completionHandler) const
+{
+    protectedWebsiteDataStore()->protectedResourceMonitorThrottler()->tryAccess(host, ContinuousApproximateTime::now(), WTFMove(completionHandler));
+}
+#endif
+
 bool WebPageProxy::canStartNavigationSwipeAtLastInteractionLocation() const
 {
     RefPtr client = pageClient();

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -3370,6 +3370,10 @@ private:
 
     RefPtr<SpeechRecognitionPermissionManager> protectedSpeechRecognitionPermissionManager();
 
+#if ENABLE(CONTENT_EXTENSIONS)
+    void shouldOffloadIFrameForHost(const String& host, CompletionHandler<void(bool)>&&) const;
+#endif
+
 #if PLATFORM(COCOA)
     String presentingApplicationBundleIdentifier() const;
 #endif

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -672,4 +672,8 @@ messages -> WebPageProxy {
     HasActiveNowPlayingSessionChanged(bool hasActiveNowPlayingSessionChanged)
 
     SetAllowsLayoutViewportHeightExpansion(bool newValue)
+
+#if ENABLE(CONTENT_EXTENSIONS)
+    ShouldOffloadIFrameForHost(String host) -> (bool wasGranted)
+#endif
 }

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
@@ -2905,9 +2905,24 @@ bool WebsiteDataStore::builtInNotificationsEnabled() const
 #endif
 
 #if ENABLE(CONTENT_EXTENSIONS)
+WebCore::ResourceMonitorThrottlerHolder& WebsiteDataStore::resourceMonitorThrottler()
+{
+    if (!m_resourceMonitorThrottler) {
+        RELEASE_LOG(ResourceMonitoring, "WebsiteDataStore::resourceMonitorThrottler sessionID=%" PRIu64 ", ResourceMonitorThrottler is created.", m_sessionID.toUInt64());
+        m_resourceMonitorThrottler = WebCore::ResourceMonitorThrottlerHolder::create();
+    }
+
+    return *m_resourceMonitorThrottler;
+}
+
+Ref<WebCore::ResourceMonitorThrottlerHolder> WebsiteDataStore::protectedResourceMonitorThrottler()
+{
+    return resourceMonitorThrottler();
+}
+
 void WebsiteDataStore::resetResourceMonitorThrottlerForTesting(CompletionHandler<void()>&& completionHandler)
 {
-    protectedNetworkProcess()->resetResourceMonitorThrottlerForTesting(m_sessionID, WTFMove(completionHandler));
+    protectedResourceMonitorThrottler()->clearAllData(WTFMove(completionHandler));
 }
 #endif
 

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
@@ -70,6 +70,10 @@
 #include <WebCore/SoupNetworkProxySettings.h>
 #endif
 
+#if ENABLE(CONTENT_EXTENSIONS)
+#include <WebCore/ResourceMonitorThrottlerHolder.h>
+#endif
+
 namespace API {
 class Data;
 class DownloadClient;
@@ -511,6 +515,8 @@ public:
 #endif
 
 #if ENABLE(CONTENT_EXTENSIONS)
+    WebCore::ResourceMonitorThrottlerHolder& resourceMonitorThrottler();
+    Ref<WebCore::ResourceMonitorThrottlerHolder> protectedResourceMonitorThrottler();
     void resetResourceMonitorThrottlerForTesting(CompletionHandler<void()>&&);
 #endif
 
@@ -665,6 +671,10 @@ private:
 #endif
     bool m_storageSiteValidationEnabled { false };
     HashSet<URL> m_persistedSiteURLs;
+
+#if ENABLE(CONTENT_EXTENSIONS)
+    RefPtr<WebCore::ResourceMonitorThrottlerHolder> m_resourceMonitorThrottler;
+#endif
 
     RemoveDataTaskCounter m_removeDataTaskCounter;
     uint64_t m_cookiesVersion { 0 };

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
@@ -2077,7 +2077,7 @@ void WebLocalFrameLoaderClient::didExceedNetworkUsageThreshold()
     if (document->shouldSkipResourceMonitorThrottling())
         action(true);
     else
-        WebProcess::singleton().ensureNetworkProcessConnection().protectedConnection()->sendWithAsyncReply(Messages::NetworkConnectionToWebProcess::ShouldOffloadIFrameForHost(url.host().toStringWithoutCopying()), WTFMove(action), 0);
+        webPage->sendWithAsyncReply(Messages::WebPageProxy::ShouldOffloadIFrameForHost(url.host().toStringWithoutCopying()), WTFMove(action));
 }
 
 #endif


### PR DESCRIPTION
#### 19d8580aa29c7a5ea5405bc58d95761fd294000a
<pre>
Revert 290351@main &quot;Move ResourceMonitor throttler from UIProcess to NetworkProcess&quot;
<a href="https://bugs.webkit.org/show_bug.cgi?id=293133">https://bugs.webkit.org/show_bug.cgi?id=293133</a>
<a href="https://rdar.apple.com/145190060">rdar://145190060</a>

Reviewed by NOBODY (OOPS!).

It shows regression on this commit.

* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp:
(WebKit::NetworkConnectionToWebProcess::shouldOffloadIFrameForHost): Deleted.
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h:
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in:
* Source/WebKit/NetworkProcess/NetworkProcess.cpp:
(WebKit::NetworkProcess::deleteWebsiteDataImpl):
(WebKit::NetworkProcess::resetResourceMonitorThrottlerForTesting): Deleted.
* Source/WebKit/NetworkProcess/NetworkProcess.h:
* Source/WebKit/NetworkProcess/NetworkProcess.messages.in:
* Source/WebKit/NetworkProcess/NetworkSession.cpp:
(WebKit::NetworkSession::resourceMonitorThrottler): Deleted.
(WebKit::NetworkSession::protectedResourceMonitorThrottler): Deleted.
(WebKit::NetworkSession::clearResourceMonitorThrottlerData): Deleted.
* Source/WebKit/NetworkProcess/NetworkSession.h:
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp:
(WebKit::NetworkProcessProxy::resetResourceMonitorThrottlerForTesting): Deleted.
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::shouldOffloadIFrameForHost const):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.messages.in:
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp:
(WebKit::WebsiteDataStore::resourceMonitorThrottler):
(WebKit::WebsiteDataStore::protectedResourceMonitorThrottler):
(WebKit::WebsiteDataStore::resetResourceMonitorThrottlerForTesting):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp:
(WebKit::WebLocalFrameLoaderClient::didExceedNetworkUsageThreshold):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/19d8580aa29c7a5ea5405bc58d95761fd294000a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/103840 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/23542 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/13864 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/109033 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/54496 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/23895 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/32088 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78895 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/106846 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/18557 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/93674 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59224 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/18356 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/53868 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/88117 "Found 1 new API test failure: TestWebKitAPI.CARingBufferTest.FetchTimeBoundsConsistent (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/11783 "Found 1 new test failure: imported/w3c/web-platform-tests/service-workers/service-worker/postmessage-to-client-message-queue.https.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/111420 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/30996 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/22856 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/87898 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/31358 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/89875 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87549 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32439 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10166 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/25361 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/30925 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/36235 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/30718 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/34055 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/32279 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->