### PR TITLE
Update LibraryPathDiagnosticsLogger's functions to take in spans

### DIFF
--- a/Source/WTF/wtf/darwin/LibraryPathDiagnostics.mm
+++ b/Source/WTF/wtf/darwin/LibraryPathDiagnostics.mm
@@ -72,8 +72,8 @@ public:
     void log(void);
 private:
     void logJSONPayload(const JSON::Object&);
-    void logString(const Vector<String>& path, const String&);
-    void logObject(const Vector<String>& path, Ref<JSON::Object>&&);
+    void logString(std::span<const String> path, const String&);
+    void logObject(std::span<const String> path, Ref<JSON::Object>&&);
     void logError(const char*, ...);
 
     void logExecutablePath(void);
@@ -103,7 +103,7 @@ void LibraryPathDiagnosticsLogger::logJSONPayload(const JSON::Object &object)
     os_log(m_osLog, "%{public}s", textRepresentation.utf8().data());
 }
 
-void LibraryPathDiagnosticsLogger::logString(const Vector<String>& path, const String& string)
+void LibraryPathDiagnosticsLogger::logString(std::span<const String> path, const String& string)
 {
     auto payload = JSON::Object::create();
     auto iter = path.rbegin();
@@ -117,7 +117,7 @@ void LibraryPathDiagnosticsLogger::logString(const Vector<String>& path, const S
     logJSONPayload(payload);
 }
 
-void LibraryPathDiagnosticsLogger::logObject(const Vector<String>& path, Ref<JSON::Object>&& object)
+void LibraryPathDiagnosticsLogger::logObject(std::span<const String> path, Ref<JSON::Object>&& object)
 {
     auto payload = JSON::Object::create();
     auto iter = path.rbegin();
@@ -146,7 +146,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 void LibraryPathDiagnosticsLogger::logExecutablePath(void)
 {
-    logString({ "Path"_s }, FileSystem::realPath(String::fromUTF8(_CFProcessPath())));
+    logString(std::initializer_list<String> { "Path"_s }, FileSystem::realPath(String::fromUTF8(_CFProcessPath())));
 }
 
 void LibraryPathDiagnosticsLogger::logDYLDSharedCacheInfo(void)
@@ -158,7 +158,7 @@ void LibraryPathDiagnosticsLogger::logDYLDSharedCacheInfo(void)
     sharedCacheInfo->setString("Path"_s, FileSystem::realPath(String::fromUTF8(dyld_shared_cache_file_path())));
     sharedCacheInfo->setString("UUID"_s, uuidToString(uuid));
 
-    logObject({ "SharedCache"_s }, WTFMove(sharedCacheInfo));
+    logObject(std::initializer_list<String> { "SharedCache"_s }, WTFMove(sharedCacheInfo));
 }
 
 #if HAVE(DYLD_DLOPEN_IMAGE_HEADER_SPI)
@@ -203,7 +203,7 @@ void LibraryPathDiagnosticsLogger::logDynamicLibraryInfo(const String& installNa
     libraryObject->setBoolean("InSharedCache"_s, isAddressInSharedRegion(header));
 #endif
 
-    logObject({ "Libraries"_s, installName }, WTFMove(libraryObject));
+    logObject(std::initializer_list<String> { "Libraries"_s, installName }, WTFMove(libraryObject));
 }
 
 void LibraryPathDiagnosticsLogger::logDynamicLibraryInfo(void)
@@ -235,7 +235,7 @@ void LibraryPathDiagnosticsLogger::logBundleInfo(const String& bundleIdentifier)
     else
         bundleInfo->setValue("Version"_s, JSON::Value::null());
 
-    logObject({ "Bundles"_s, bundleIdentifier }, WTFMove(bundleInfo));
+    logObject(std::initializer_list<String> { "Bundles"_s, bundleIdentifier }, WTFMove(bundleInfo));
 }
 
 void LibraryPathDiagnosticsLogger::logBundleInfo(void)
@@ -263,7 +263,7 @@ void LibraryPathDiagnosticsLogger::logCryptexCanaryInfo(canary_cryptex_t which, 
     cryptex->setString("Version"_s, String::fromUTF8(metadata->cm_get_version()));
     cryptex->setString("Variant"_s, String::fromUTF8(metadata->cm_get_variant()));
 
-    logObject({ "Canary"_s, description }, WTFMove(cryptex));
+    logObject(std::initializer_list<String> { "Canary"_s, description }, WTFMove(cryptex));
 }
 
 void LibraryPathDiagnosticsLogger::logCryptexCanaryInfo(void)


### PR DESCRIPTION
#### 147abebc6166dc3fd2210a887e61eb8096dfee80
<pre>
Update LibraryPathDiagnosticsLogger&apos;s functions to take in spans
<a href="https://bugs.webkit.org/show_bug.cgi?id=293138">https://bugs.webkit.org/show_bug.cgi?id=293138</a>

Reviewed by Geoffrey Garen.

Update LibraryPathDiagnosticsLogger&apos;s functions to take in spans instead
of Vectors. This avoids unnecessary construction of temporary vectors.

* Source/WTF/wtf/darwin/LibraryPathDiagnostics.mm:
(WTF::LibraryPathDiagnosticsLogger::logString):
(WTF::LibraryPathDiagnosticsLogger::logObject):
(WTF::LibraryPathDiagnosticsLogger::logExecutablePath):
(WTF::LibraryPathDiagnosticsLogger::logDYLDSharedCacheInfo):
(WTF::LibraryPathDiagnosticsLogger::logDynamicLibraryInfo):
(WTF::LibraryPathDiagnosticsLogger::logBundleInfo):
(WTF::LibraryPathDiagnosticsLogger::logCryptexCanaryInfo):

Canonical link: <a href="https://commits.webkit.org/295065@main">https://commits.webkit.org/295065@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f04a12e94be26d753e3c45f2d617773959c5b7af

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/103847 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/23550 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/13871 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/109040 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/54503 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/23902 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/32095 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78898 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/106853 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/18560 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/93679 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59227 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/18359 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/11729 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/53875 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/96522 "Built successfully and passed tests") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/88120 "Found 1 new API test failure: TestWebKitAPI.CARingBufferTest.FetchTimeBoundsConsistent (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/11788 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/111427 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/102458 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/31003 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/22862 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/87900 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/31365 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/89880 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87551 "Found 1 new API test failure: /WebKitGTK/TestCookieManager:/webkit/WebKitCookieManager/persistent-storage (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22310 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32444 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10171 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/25368 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/30932 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/36242 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/126091 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/30725 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34899 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/34062 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/32286 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->