### PR TITLE
[cocoa] Disable CHIPS

### DIFF
--- a/LayoutTests/http/tests/cookies/resources/setCookies.cgi
+++ b/LayoutTests/http/tests/cookies/resources/setCookies.cgi
@@ -3,8 +3,9 @@ use strict;
 binmode STDOUT;
 
 print "Content-Type: text/plain\n";
-print "Access-Control-Allow-Origin: *\n";
+print "Access-Control-Allow-Origin: " . $ENV{"HTTP_ORIGIN"} . "\n";
 print "Access-Control-Allow-Headers: X-SET-COOKIE\n";
+print "Access-Control-Allow-Credentials: true\n";
 print "Cache-Control: no-store\n";
 print 'Cache-Control: no-cache="set-cookie"' . "\n";
 

--- a/LayoutTests/http/tests/navigation/ping-attribute/cross-site-url-anchor-cookie-expected.txt
+++ b/LayoutTests/http/tests/navigation/ping-attribute/cross-site-url-anchor-cookie-expected.txt
@@ -1,0 +1,5 @@
+PASS successfullyParsed is true
+
+TEST COMPLETE
+PASS step3: echo-cookies returned the expected value
+ Navigate and send ping

--- a/LayoutTests/http/tests/navigation/ping-attribute/cross-site-url-anchor-cookie-preexisting-cookie-expected.txt
+++ b/LayoutTests/http/tests/navigation/ping-attribute/cross-site-url-anchor-cookie-preexisting-cookie-expected.txt
@@ -1,0 +1,5 @@
+PASS successfullyParsed is true
+
+TEST COMPLETE
+PASS step3: echo-cookies returned the expected value
+ Navigate and send ping

--- a/LayoutTests/http/tests/navigation/ping-attribute/cross-site-url-anchor-cookie-preexisting-cookie.html
+++ b/LayoutTests/http/tests/navigation/ping-attribute/cross-site-url-anchor-cookie-preexisting-cookie.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html><!-- webkit-test-runner [ OptInPartitionedCookiesEnabled=true ] -->
+<html><head>
+<title>Ping</title>
+<script src="/js-test-resources/js-test.js"></script>
+<script src="resources/utilities.js"></script>
+<script>
+if (window.testRunner && window.internals) {
+    testRunner.dumpAsText();
+    internals.settings.setHyperlinkAuditingEnabled(true);
+    testRunner.waitUntilDone();
+}
+
+function test()
+{
+    let anchor = document.getElementById("a");
+    location.hash = "step3";
+    a.href = location.href.replace("127.0.0.1", "localhost");
+    clickElement(anchor);
+}
+
+window.onload = function ()
+{
+    if (location.hash == "") {
+        testRunner.setStatisticsShouldBlockThirdPartyCookies(true, () => {
+            location.href = location.href.replace("127.0.0.1", "localhost") + "#step1";
+        }, false, true);
+    } else if (location.hash == "#step1") {
+        document.cookie = "firstParty=value";
+        location.hash = "step2";
+        location.href = location.href.replace("localhost", "127.0.0.1");
+    } else if (location.hash == "#step2") {
+        clearLastPingResultAndRunTest(test);
+    } else if (location.hash == "#step3") {
+        setTimeout(() => {
+            fetch("http://localhost:8000/cookies/resources/echo-cookies.py").then((r) => r.text()).then((text) => {
+                let expected = "Cookies are:\n";
+                if (text == expected)
+                    testPassed(`step3: echo-cookies returned the expected value`);
+                else
+                    testFailed(`step3: echo-cookies returned ${text}, expected ${expected}`);
+                testRunner.notifyDone();
+            });
+        }, 500);
+    }
+}
+</script>
+</head>
+<body>
+<img src="non-existent-image.jpg">
+<a id="a" ping="http://localhost:8000/navigation/resources/save-ping-and-set-cookies-and-redirect-to-save-ping.py">Navigate and send ping</a>
+</body></html>

--- a/LayoutTests/http/tests/navigation/ping-attribute/cross-site-url-anchor-cookie.html
+++ b/LayoutTests/http/tests/navigation/ping-attribute/cross-site-url-anchor-cookie.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html><!-- webkit-test-runner [ OptInPartitionedCookiesEnabled=true ] -->
+<html><head>
+<title>Ping</title>
+<script src="/js-test-resources/js-test.js"></script>
+<script src="resources/utilities.js"></script>
+<script>
+if (window.testRunner && window.internals) {
+    testRunner.dumpAsText();
+    internals.settings.setHyperlinkAuditingEnabled(true);
+    testRunner.waitUntilDone();
+}
+
+function test()
+{
+    testRunner.setStatisticsShouldBlockThirdPartyCookies(true, () => {
+        let anchor = document.getElementById("a");
+        location.hash = "finish";
+        a.href = location.href.replace("127.0.0.1", "localhost");
+        clickElement(anchor);
+    }, false, true);
+}
+
+window.onload = function ()
+{
+    if (location.hash == "") {
+        clearLastPingResultAndRunTest(test);
+    } else if (location.hash == "#finish") {
+        setTimeout(() => {
+            fetch("http://localhost:8000/cookies/resources/echo-cookies.py").then((r) => r.text()).then((text) => {
+                let expected = "Cookies are:\n";
+                if (text == expected)
+                    testPassed(`step3: echo-cookies returned the expected value`);
+                else
+                    testFailed(`step3: echo-cookies returned ${text}, expected ${expected}`);
+                testRunner.notifyDone();
+            });
+        }, 500);
+    }
+
+}
+</script>
+</head>
+<body>
+<img src="non-existent-image.jpg">
+<a id="a" ping="http://localhost:8000/navigation/resources/save-ping-and-set-cookies-and-redirect-to-save-ping.py">Navigate and send ping</a>
+</body></html>

--- a/LayoutTests/http/tests/resourceLoadStatistics/only-partitioned-cookies-after-redirect-expected.txt
+++ b/LayoutTests/http/tests/resourceLoadStatistics/only-partitioned-cookies-after-redirect-expected.txt
@@ -1,0 +1,5 @@
+PASS successfullyParsed is true
+
+TEST COMPLETE
+PASS step10: echo-cookies returned the expected value
+

--- a/LayoutTests/http/tests/resourceLoadStatistics/only-partitioned-cookies-after-redirect.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/only-partitioned-cookies-after-redirect.html
@@ -1,0 +1,154 @@
+<!DOCTYPE html><!-- webkit-test-runner [ OptInPartitionedCookiesEnabled=true ] -->
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Test for Partitioned Cookies With and Without User Interaction</title>
+    <script src="/js-test-resources/js-test.js"></script>
+    <script src="resources/util.js"></script>
+</head>
+<body>
+<script>
+    const partitionHost = "127.0.0.1:8000";
+    const thirdPartyOrigin = "http://localhost:8000";
+    const thirdPartyBaseUrl = thirdPartyOrigin + "/resourceLoadStatistics/resources";
+    const firstPartyCookieName = "firstPartyCookie";
+    const firstPartyCookieName2 = "firstPartyCookie2";
+    const partitionedCookieName = "partitionedCookie";
+    const subPathToSetFirstPartyCookie = "/set-cookie.py?name=" + firstPartyCookieName + "&value=value";
+    const subPathToSetFirstPartyCookie2 = "/set-cookie.py?name=" + firstPartyCookieName2 + "&value=value";
+    const subPathToSetPartitionedCookie = "/set-cookie.py?name=" + partitionedCookieName + "&value=value";
+    const fragmentWithReturnUrl = "http://127.0.0.1:8000/resourceLoadStatistics/only-partitioned-cookies-after-redirect.html";
+    const thirdPartyUrlWithFragment = fragmentWithReturnUrl.replace("127.0.0.1", "localhost");
+    const subPathToGetCookies = "/get-cookies.py?name1=" + firstPartyCookieName + "&name2=" + partitionedCookieName + "&name3=" + firstPartyCookieName2;
+
+    function finishTest() {
+        setEnableFeature(false, function() {
+            testRunner.notifyDone();
+        });
+    }
+
+    function openIframe(url, onLoadHandler) {
+        const element = document.createElement("iframe");
+        element.src = url;
+        if (onLoadHandler) {
+            element.onload = onLoadHandler;
+        }
+        document.body.appendChild(element);
+    }
+
+    function runTest() {
+        switch (document.location.hash) {
+            case "#step1":
+                document.location.hash = "step2";
+                fetch(thirdPartyOrigin + "/cookies/resources/setCookies.cgi", { credentials: "include", headers: { "X-SET-COOKIE": "firstPartyCookie=value;Path=/" } }).then((r) => r.text()).then((text) => {
+                    let expected = "";
+                    if (text == expected) {
+                        testPassed(`setCookies returned the expected value`);
+                        runTest();
+                    } else {
+                        testFailed(`setCookies returned ${text}, expected ${expected}`);
+                        finishTest();
+                    }
+                });
+                break;
+            case "#step2":
+                document.location.href = thirdPartyUrlWithFragment + "#step3";
+                break;
+            case "#step3":
+                document.location.hash = "step4";
+                fetch(thirdPartyOrigin + "/cookies/resources/echo-cookies.py").then((r) => r.text()).then((text) => {
+                    let expected = "Cookies are:\n";
+                    if (text == expected) {
+                        testPassed(`step3: echo-cookies returned the expected value`);
+                        runTest();
+                    } else {
+                        testFailed(`step3: echo-cookies returned ${text}, expected ${expected}`);
+                        finishTest();
+                    }
+                });
+                break;
+            case "#step4":
+                document.location.hash = "step5";
+                fetch(thirdPartyOrigin + "/cookies/resources/setCookies.cgi", { credentials: "include", headers: { "X-SET-COOKIE": "firstPartyCookie=value;Path=/" } }).then((r) => r.text()).then((text) => {
+                    let expected = "";
+                    if (text == expected) {
+                        testPassed(`step4: setCookies returned the expected value`);
+                        runTest();
+                    } else {
+                        testFailed(`step4: setCookies returned ${text}, expected ${expected}`);
+                        finishTest();
+                    }
+                });
+                break;
+            case "#step5":
+                document.location.hash = "step6";
+                fetch(thirdPartyOrigin + "/cookies/resources/echo-cookies.py").then((r) => r.text()).then((text) => {
+                    let expected = "Cookies are:\nfirstPartyCookie = value\n";
+                    if (text == expected) {
+                        testPassed(`step5: echo-cookies returned the expected value`);
+                        runTest();
+                    } else {
+                        testFailed(`step5: echo-cookies returned ${text}, expected ${expected}`);
+                        finishTest();
+                    }
+                });
+                break;
+            case "#step6":
+                document.location.href = fragmentWithReturnUrl + "#step7";
+                break;
+            case "#step7":
+                document.location.hash = "step8";
+                fetch(thirdPartyOrigin + "/cookies/resources/setCookies.cgi", { credentials: "include", headers: { "X-SET-COOKIE": "firstPartyCookieSetAsThirdParty=value;Path=/" } }).then((r) => r.text()).then((text) => {
+                    let expected = "";
+                    if (text == expected) {
+                        testPassed(`step7: setCookies returned the expected value`);
+                        runTest();
+                    } else {
+                        testFailed(`step7: setCookies returned ${text}, expected ${expected}`);
+                        finishTest();
+                    }
+                });
+                break;
+            case "#step8":
+                document.location.hash = "step9";
+                fetch("/resources/redirect.py?url=" + thirdPartyOrigin + "/cookies/resources/setCookies.cgi", { credentials: "include", headers: { "X-SET-COOKIE": "firstPartyCookieSetAsThirdPartyAfterRedirect=value;Path=/" } }).then((r) => r.text()).then((text) => {
+                    let expected = "";
+                    if (text == expected) {
+                        testPassed(`step8: setCookies returned the expected value`);
+                        runTest();
+                    } else {
+                        testFailed(`step8: setCookies returned ${text}, expected ${expected}`);
+                        finishTest();
+                    }
+                });
+                break;
+            case "#step9":
+                document.location.href = thirdPartyUrlWithFragment + "#step10";
+                break;
+            case "#step10":
+                document.location.hash = "step10";
+                fetch(thirdPartyOrigin + "/cookies/resources/echo-cookies.py").then((r) => r.text()).then((text) => {
+                    let expected = "Cookies are:\nfirstPartyCookie = value\n";
+                    if (text == expected)
+                        testPassed(`step10: echo-cookies returned the expected value`);
+                    else
+                        testFailed(`step10: echo-cookies returned ${text}, expected ${expected}`);
+                    finishTest();
+                });
+                break;
+        }
+    }
+
+    if (document.location.host === partitionHost && document.location.hash == "" && window.testRunner && window.internals) {
+        testRunner.waitUntilDone();
+        setEnableFeature(true, function() {
+            testRunner.dumpAsText();
+            document.location.hash = "step1";
+            testRunner.setStatisticsShouldBlockThirdPartyCookies(true, runTest, false, true);
+        });
+    } else {
+        runTest();
+    }
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/websocket/tests/hybi/websocket-allowed-setting-cookie-as-third-party-with-third-party-cookie-blocking.https-expected.txt
+++ b/LayoutTests/http/tests/websocket/tests/hybi/websocket-allowed-setting-cookie-as-third-party-with-third-party-cookie-blocking.https-expected.txt
@@ -1,0 +1,19 @@
+Tests WebSocket Set-Cookie behavior for third-parties with existing cookies.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS document.location.host is "127.0.0.1:8443"
+
+Setting third-party cookie 'foo' through cross-origin WebSocket handshake.
+
+Opening localhost third-party iframe to check its cookies.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+
+
+--------
+Frame: '<!--frame1-->'
+--------
+Cookies are:

--- a/LayoutTests/http/tests/websocket/tests/hybi/websocket-allowed-setting-cookie-as-third-party-with-third-party-cookie-blocking.https.html
+++ b/LayoutTests/http/tests/websocket/tests/hybi/websocket-allowed-setting-cookie-as-third-party-with-third-party-cookie-blocking.https.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <script src="../../../../js-test-resources/js-test.js"></script>
+    <script src="../../../cookies/resources/cookie-utilities.js"></script>
+    <script>
+        window.jsTestIsAsync = true;
+
+        async function testThirdPartyCookie()
+        {
+            shouldBeEqualToString("document.location.host", "127.0.0.1:8443");
+            debug("<br>Setting third-party cookie 'foo' through cross-origin WebSocket handshake.");
+            await setCookieUsingWebSocketFromHost("localhost");
+            let iframeElement = document.createElement("iframe");
+            iframeElement.src = "https://localhost:8443/cookies/resources/echo-cookies.py";
+            iframeElement.onload = finishJSTest;
+            debug("<br>Opening localhost third-party iframe to check its cookies.");
+            document.body.appendChild(iframeElement);
+        }
+
+        async function runTest()
+        {
+            switch (document.location.hash) {
+                case "":
+                    testRunner.setStatisticsShouldBlockThirdPartyCookies(true, () => {
+                        // Navigate to localhost to set first-party cookie 'setAsFirstParty'.
+                        document.location.href = "https://localhost:8443/websocket/tests/hybi/websocket-allowed-setting-cookie-as-third-party.https.html#setCookieAsFirstParty";
+                    }, false, true);
+                    break;
+                case "#setCookieAsFirstParty":
+                    await setCookie("setAsFirstParty", "value", {"SameSite": "None", "Secure": null});
+                    // Navigate back to 127.0.0.1 to test third-party cookie.
+                    document.location.href = "https://127.0.0.1:8443/websocket/tests/hybi/websocket-allowed-setting-cookie-as-third-party.https.html#didSetCookieAsFirstParty";
+                    break;
+                case "#didSetCookieAsFirstParty":
+                    testRunner.dumpChildFramesAsText();
+                    await testThirdPartyCookie();
+                    break;
+            }
+        }
+    </script>
+</head>
+<body>
+<div id="output"></div>
+<script>
+    description("Tests WebSocket Set-Cookie behavior for third-parties with existing cookies.");
+    runTest();
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/workers/service/basic-install-event-sw-fetch-third-party-expected.txt
+++ b/LayoutTests/http/tests/workers/service/basic-install-event-sw-fetch-third-party-expected.txt
@@ -1,0 +1,2 @@
+PASS: echo-cookies returned the expected value
+

--- a/LayoutTests/http/tests/workers/service/basic-install-event-sw-fetch-third-party.html
+++ b/LayoutTests/http/tests/workers/service/basic-install-event-sw-fetch-third-party.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html><!-- webkit-test-runner [ OptInPartitionedCookiesEnabled=true ] -->
+<html>
+<head>
+<script src="resources/sw-test-pre.js"></script>
+<script src="../../resourceLoadStatistics/resources/util.js"></script>
+</head>
+<body>
+<script>
+
+function finishTest() {
+    setEnableFeature(false, function() {
+        finishSWTest();
+    });
+}
+if (location.host == "127.0.0.1:8000" && location.hash == "") {
+    setEnableFeature(true, function() {
+        testRunner.setStatisticsShouldBlockThirdPartyCookies(true, () => {
+            location.href = location.href.replace("127.0.0.1", "localhost");
+        }, false, true);
+    });
+} else if (location.host == "localhost:8000" && location.hash == "") {
+    fetch("http://localhost:8000/cookies/resources/setCookies.cgi", { credentials: "include", headers: { "X-SET-COOKIE": "firstPartyCookie=value;Path=/" } }).then((r) => r.text()).then((text) => {
+        let expected = "";
+        if (text == expected) {
+            log(`PASS: setCookies returned the expected value`);
+            location.hash = "sw";
+            location.href = location.href.replace("localhost", "127.0.0.1");
+        } else {
+            log(`FAIL: setCookies returned ${text}, expected ${expected}`);
+            finishTest();
+        }
+    });
+} else if (location.host == "127.0.0.1:8000" && location.hash == "#sw") {
+    navigator.serviceWorker.addEventListener("message", function(event) {
+        if (event.data) {
+            log(`setCookies from serviceWorker returned  ${event.data}`);
+            location.hash = "finish";
+            location.href = location.href.replace("127.0.0.1", "localhost");
+        } else {
+            log("FAIL: service worker did not receive install event or did not resolve the extend lifetime promise");
+            finishTest();
+        }
+    
+    });
+    
+    navigator.serviceWorker.register("resources/basic-install-event-waitUntil-resolve-worker-then-fetch.js", { }).then(function(registration) {
+         waitForState(registration.installing, "installed").then(function() {
+             registration.waiting.postMessage("fetch");
+         });
+    }, function() {
+        log("FAIL: Failed to register the service worker");
+        finishTest();
+    });
+} else if (location.host == "localhost:8000" && location.hash == "#finish") {
+    fetch("http://localhost:8000/cookies/resources/echo-cookies.py").then((r) => r.text()).then((text) => {
+        let expected = "Cookies are:\nfirstPartyCookie = value\n";
+        if (text == expected)
+            log(`PASS: echo-cookies returned the expected value`);
+        else
+            log(`FAIL: echo-cookies returned ${text}, expected ${expected}`);
+        finishTest();
+    });
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/workers/service/resources/basic-install-event-waitUntil-resolve-worker-then-fetch.js
+++ b/LayoutTests/http/tests/workers/service/resources/basic-install-event-waitUntil-resolve-worker-then-fetch.js
@@ -1,0 +1,18 @@
+let resolvedExtendLifetimePromise = false;
+
+self.addEventListener("install", (event) => {
+    event.waitUntil(new Promise((resolve, reject) => {
+        setTimeout(() => {
+            resolvedExtendLifetimePromise = true;
+            resolve();
+        }, 50);
+    }));
+});
+
+self.addEventListener("message", (event) => {
+    fetch("http://localhost:8000/cookies/resources/setCookies.cgi", { credentials: "include", headers: { "X-SET-COOKIE": "firstPartyCookie=sw;Path=/" } }).then((r) => r.text()).then((text) => {
+        event.source.postMessage(`setCookies response: ${text}`);
+    });
+
+});
+

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -5432,18 +5432,18 @@ OpportunisticSweepingAndGarbageCollectionEnabled:
 
 OptInPartitionedCookiesEnabled:
   type: bool
-  status: stable
+  status: testable
   category: dom
   humanReadableName: "Opt-in partitioned cookies (CHIPS)"
   humanReadableDescription: "Enable opt-in partitioned cookies"
-  condition: HAVE(ALLOW_ONLY_PARTITIONED_COOKIES)
+  condition: HAVE(ALLOW_ONLY_PARTITIONED_COOKIES) && 0
   defaultValue:
     WebKitLegacy:
-      default: true
+      default: false
     WebKit:
-      default: true
+      default: false
     WebCore:
-      default: true
+      default: false
 
 OverlappingBackingStoreProvidersEnabled:
   type: bool


### PR DESCRIPTION
#### fad98f457b71db4145defe3478d0fdd719ff6300
<pre>
[cocoa] Disable CHIPS
<a href="https://bugs.webkit.org/show_bug.cgi?id=292371">https://bugs.webkit.org/show_bug.cgi?id=292371</a>
<a href="https://rdar.apple.com/149535707">rdar://149535707</a>

Reviewed by Wenson Hsieh and Alex Christensen.

Before 288413@main, Apple platforms blocked all third-party cookies by default.
In that commit, we enabled CHIPS (opt-in partitioned cookies), and that
required allowing partitioned third-party cookies while rejecting unpartitioned
cookies. The mechanism for rejecting unpartitioned third-party cookies is incomplete,
so this change disables CHIPS and returns to the previous shipping behavior.

We may land a different fix later or fix this in an underlying framework.

Adding some new tests that cover setting cross-site cookies in various
situations.

* LayoutTests/http/tests/cookies/resources/setCookies.cgi:
* LayoutTests/http/tests/navigation/ping-attribute/cross-site-url-anchor-cookie-expected.txt: Added.
* LayoutTests/http/tests/navigation/ping-attribute/cross-site-url-anchor-cookie-preexisting-cookie-expected.txt: Added.
* LayoutTests/http/tests/navigation/ping-attribute/cross-site-url-anchor-cookie-preexisting-cookie.html: Added.
* LayoutTests/http/tests/navigation/ping-attribute/cross-site-url-anchor-cookie.html: Added.
* LayoutTests/http/tests/resourceLoadStatistics/only-partitioned-cookies-after-redirect-expected.txt: Added.
* LayoutTests/http/tests/resourceLoadStatistics/only-partitioned-cookies-after-redirect.html: Added.
* LayoutTests/http/tests/websocket/tests/hybi/websocket-allowed-setting-cookie-as-third-party-with-third-party-cookie-blocking.https-expected.txt: Added.
* LayoutTests/http/tests/websocket/tests/hybi/websocket-allowed-setting-cookie-as-third-party-with-third-party-cookie-blocking.https.html: Added.
* LayoutTests/http/tests/workers/service/basic-install-event-sw-fetch-third-party-expected.txt: Added.
* LayoutTests/http/tests/workers/service/basic-install-event-sw-fetch-third-party.html: Added.
* LayoutTests/http/tests/workers/service/resources/basic-install-event-waitUntil-resolve-worker-then-fetch.js: Added.
(event.event.waitUntil.new.Promise):
(event.then.r.r.text.then):
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ResourceLoadStatistics.mm:
(TEST(ResourceLoadStatistics, BlockUnpartitionedThirdPartyCookies)):
(TEST(ResourceLoadStatistics, BlockUnpartitionedAndAllowPartitionedThirdPartyCookies)):

(cherry picked from commit d34e63ea0dd698ef0d3a3d779fbdfae02526126c)

Originally-landed-as: 8c26876e5fb1. <a href="https://rdar.apple.com/151480153">rdar://151480153</a>
Canonical link: <a href="https://commits.webkit.org/295121@main">https://commits.webkit.org/295121@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/777304b362da2d129a2fa091ebc211810548597a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/103850 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/23553 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/13874 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/109043 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/54506 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/105890 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/23983 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/32098 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78900 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/106856 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/18621 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/93684 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59229 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/18422 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/11734 "Found 3 new test failures: http/tests/navigation/ping-attribute/cross-site-url-anchor-cookie-preexisting-cookie.html http/tests/navigation/ping-attribute/cross-site-url-anchor-cookie.html http/tests/websocket/tests/hybi/websocket-allowed-setting-cookie-as-third-party-with-third-party-cookie-blocking.https.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/53878 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/96525 "Built successfully and passed tests") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/88168 "Found 1 new API test failure: TestWebKitAPI.CARingBufferTest.FetchTimeBoundsConsistent (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/11793 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/111430 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/102461 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/31006 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/22863 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/87905 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/31368 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/89885 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87556 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32449 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10175 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/25371 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16907 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/30935 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/36245 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/126094 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/30728 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34900 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/34065 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/32289 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->