### PR TITLE
[webkitpy] Add VisionOSDevicePort.

### DIFF
--- a/Tools/Scripts/webkitpy/common/system/platforminfo.py
+++ b/Tools/Scripts/webkitpy/common/system/platforminfo.py
@@ -93,6 +93,9 @@ class PlatformInfo(object):
     def is_watchos(self):
         return self.os_name == 'watchos'
 
+    def is_visionos(self):
+        return self.os_name == 'visionos'
+
     def is_win(self):
         return self.os_name == 'win'
 
@@ -237,6 +240,8 @@ class PlatformInfo(object):
             return 'mac'
         if sys_platform == 'ios' or sys_platform == 'watchos':
             return 'ios'
+        if sys_platform == 'visionos':
+            return 'visionos'
         if sys_platform.startswith('haiku'):
             return 'haiku'
         if sys_platform.startswith('linux'):

--- a/Tools/Scripts/webkitpy/port/factory.py
+++ b/Tools/Scripts/webkitpy/port/factory.py
@@ -107,6 +107,7 @@ class PortFactory(object):
         'watch_simulator.WatchSimulatorPort',
         'watch_device.WatchDevicePort',
         'visionos_simulator.VisionOSSimulatorPort',
+        'visionos_device.VisionOSDevicePort',
         'jsc_only.JscOnlyPort',
         'mac.MacCatalystPort',
         'mac.MacPort',

--- a/Tools/Scripts/webkitpy/port/visionos_device.py
+++ b/Tools/Scripts/webkitpy/port/visionos_device.py
@@ -1,0 +1,124 @@
+# Copyright (C) 2014-2019 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import logging
+
+from webkitcorepy import Version
+
+from webkitpy.common.memoized import memoized
+from webkitpy.common.system.crashlogs import CrashLogs
+from webkitpy.port.config import apple_additions
+from webkitpy.port.device import Device
+from webkitpy.port.visionos import VisionOSPort
+
+_log = logging.getLogger(__name__)
+
+
+class VisionOSDevicePort(VisionOSPort):
+    port_name = 'visionos-device'
+
+    ARCHITECTURES = ['arm64e', 'arm64']
+    DEFAULT_ARCHITECTURE = 'arm64'
+    VERSION_FALLBACK_ORDER = ['visionos-1', 'visionos-2']
+
+    DEVICE_MANAGER = apple_additions().device_manager() if apple_additions() else None
+
+    SDK = apple_additions().get_sdk('xros') if apple_additions() else 'xros'
+    NO_ON_DEVICE_TESTING = 'On-device testing is not supported in this configuration'
+    NO_DEVICE_MANAGER = NO_ON_DEVICE_TESTING
+
+    def _driver_class(self):
+        if apple_additions():
+            return apple_additions().device_driver()
+        return super(VisionOSDevicePort, self)._driver_class()
+
+    @classmethod
+    def determine_full_port_name(cls, host, options, port_name):
+        if port_name == cls.port_name:
+            xros_sdk_version = host.platform.xcode_sdk_version(cls.SDK)
+            if not xros_sdk_version:
+                raise Exception("Please install the visionOS SDK.")
+            port_name = port_name + '-' + str(xros_sdk_version.major)
+        return port_name
+
+    def path_to_crash_logs(self):
+        if not apple_additions():
+            raise RuntimeError(self.NO_ON_DEVICE_TESTING)
+        return apple_additions().device_crash_log_path()
+
+    def _look_for_all_crash_logs_in_log_dir(self, newer_than):
+        log_list = {}
+        for device in self.devices():
+            crash_log = CrashLogs(device, self.path_to_crash_logs(), crash_logs_to_skip=self._crash_logs_to_skip_for_host.get(device, []))
+            log_list.update(crash_log.find_all_logs(newer_than=newer_than))
+        return log_list
+
+    def _get_crash_log(self, name, pid, stdout, stderr, newer_than, time_fn=None, sleep_fn=None, wait_for_log=True, target_host=None):
+        if target_host:
+            return super(VisionOSDevicePort, self)._get_crash_log(name, pid, stdout, stderr, newer_than, time_fn=time_fn, sleep_fn=sleep_fn, wait_for_log=wait_for_log, target_host=target_host)
+
+        # We need to search every device since one was not specified.
+        for device in self.devices():
+            stderr_out, crashlog = super(VisionOSDevicePort, self)._get_crash_log(name, pid, stdout, stderr, newer_than, time_fn=time_fn, sleep_fn=sleep_fn, wait_for_log=False, target_host=device)
+            if crashlog:
+                return (stderr, crashlog)
+        return (stderr, None)
+
+    def supports_layout_tests(self):
+        return self.DEVICE_MANAGER is not None
+
+    def abspath_for_test(self, test_name, target_host=None):
+        if not apple_additions() or type(target_host) is not Device:
+            return super(VisionOSDevicePort, self).abspath_for_test(test_name, target_host)
+        return apple_additions().device_abspath_for_test(test_name, target_host)
+
+    @memoized
+    def device_version(self):
+        if self.get_option('version'):
+            return Version.from_string(self.get_option('version'))
+
+        if not self.DEVICE_MANAGER:
+            raise RuntimeError(self.NO_ON_DEVICE_TESTING)
+
+        if not self.DEVICE_MANAGER.available_devices(host=self.host):
+            raise RuntimeError('No devices are available')
+        version = None
+        for device in self.DEVICE_MANAGER.available_devices(host=self.host):
+            if not device.platform.is_visionos():
+                continue
+            if not version:
+                version = device.platform.os_version
+            else:
+                if device.platform.os_version != version:
+                    raise RuntimeError('Multiple connected devices have different visionOS versions')
+        return version
+
+    # FIXME: These need device implementations <rdar://problem/30497991>.
+    def check_for_leaks(self, process_name, process_id):
+        pass
+
+    def operating_system(self):
+        return 'visionos-device'
+
+    def clean_up_test_run(self):
+        super(VisionOSDevicePort, self).clean_up_test_run()
+        apple_additions().device_clean_up_test_run(self, self._path_to_driver(), self._build_path())

--- a/Tools/Scripts/webkitpy/xcode/device_type.py
+++ b/Tools/Scripts/webkitpy/xcode/device_type.py
@@ -78,6 +78,7 @@ class DeviceType(object):
         elif self.hardware_family.lower().startswith('ipad') or self.hardware_family.lower().startswith('iphone'):
             self.software_variant = 'iOS'
         elif self.hardware_family.lower().split(' ')[-1].startswith('vision'):
+            self.hardware_family = 'Vision'
             self.software_variant = 'visionOS'
 
     def check_consistency(self):
@@ -88,6 +89,8 @@ class DeviceType(object):
                 assert self.software_variant == 'tvOS'
             elif self.hardware_family in ('iPhone', 'iPad'):
                 assert self.software_variant == 'iOS'
+            elif self.hardware_family == 'Vision':
+                assert self.software_variant == 'visionOS'
 
         if self.hardware_type is not None:
             assert self.hardware_family is not None


### PR DESCRIPTION
#### 588c4da089ce18071c3f0685c3380fb54476e413
<pre>
[webkitpy] Add VisionOSDevicePort.
<a href="https://bugs.webkit.org/show_bug.cgi?id=293140">https://bugs.webkit.org/show_bug.cgi?id=293140</a>
<a href="https://rdar.apple.com/151479231">rdar://151479231</a>

Reviewed by Sam Sneddon.

This PR adds a port for visionOS devices, as Vision is the only simulated
device type that doesn&apos;t have a matching device port.

* Tools/Scripts/webkitpy/common/system/platforminfo.py:
    (PlatformInfo):
        -&gt; (is_visionos): Returns true if the platform is visionOS.
        -&gt; (_determine_os_name): Adds a switch case that &apos;visionos&apos; if the platform is visionOS.
* Tools/Scripts/webkitpy/port/factory.py:
    (PortFactory):
        -&gt; (PORT_CLASSES): Add VisionOSDevicePort.
* Tools/Scripts/webkitpy/port/visionos.py:
    (VisionOSPort):
        -&gt; (CURRENT_VERSION): Bump to 2.
        -&gt; (default_baseline_search_path): Differentiate between simulator and device.
* Tools/Scripts/webkitpy/port/visionos_device.py: Added.
* Tools/Scripts/webkitpy/xcode/device_type.py:
    (DeviceType):
        -&gt; (_define_software_variant_from_hardware_family): Add handling for visionOS that is consistent with other platforms.
        -&gt; (check_consistency): Ditto.

Canonical link: <a href="https://commits.webkit.org/295033@main">https://commits.webkit.org/295033@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0e6e56f6e96afe830a636963361a6516fefac2fe

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/103851 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/23554 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/13875 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/109044 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/54512 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/105891 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/23906 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/32099 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78902 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/106857 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/18561 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/93685 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/59231 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/103327 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/18360 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/11735 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/53879 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/88121 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/11794 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/111431 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/31007 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/22864 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/87903 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/31369 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/89886 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87554 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32445 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10176 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/25372 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16860 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/30936 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/30729 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/34066 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/32290 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->