### PR TITLE
[JSC] Avoid folding compare operations in DFG involving objects

### DIFF
--- a/JSTests/stress/operator-valueof.js
+++ b/JSTests/stress/operator-valueof.js
@@ -1,0 +1,52 @@
+function shouldBe(op, actual, expected) {
+    if (actual !== expected) {
+        throw new Error(`Bad value for ${op}: ${actual} (expected ${expected})`);
+    }
+}
+
+const N = 100000;
+
+let count = 0;
+class A {
+    valueOf() { count++; }
+}
+const a = new A();
+
+function lt() { a < a }
+function lte() { a <= a }
+function gt() { a > a }
+function gte() { a >= a }
+function eq() { a == a }
+function eqq() { a === a }
+
+count = 0;
+for (let i = 0; i != N; i++)
+    lt();
+shouldBe("lt", count, 2*N);
+
+count = 0;
+for (let i = 0; i != N; i++)
+    lte();
+shouldBe("lte", count, 2*N);
+
+count = 0;
+for (let i = 0; i != N; i++)
+    gt();
+shouldBe("gt", count, 2*N);
+
+count = 0;
+for (let i = 0; i != N; i++)
+    gte();
+shouldBe("gte", count, 2*N);
+
+// valueOf() should not be called for == or ===
+
+count = 0;
+for (let i = 0; i != N; i++)
+    eq();
+shouldBe("eq", count, 0);
+
+count = 0;
+for (let i = 0; i != N; i++)
+    eqq();
+shouldBe("eqq", count, 0);

--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
@@ -2346,8 +2346,8 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
                 || node->isBinaryUseKind(SymbolUse)
                 || node->isBinaryUseKind(StringUse)
                 || node->isBinaryUseKind(StringIdentUse)
-                || node->isBinaryUseKind(ObjectUse)
-                || node->isSymmetricBinaryUseKind(ObjectUse, ObjectOrOtherUse)
+                || (node->op() == CompareEq && node->isBinaryUseKind(ObjectUse))
+                || (node->op() == CompareEq && node->isSymmetricBinaryUseKind(ObjectUse, ObjectOrOtherUse))
                 || value.isType(SpecInt32Only)
                 || value.isType(SpecInt52Any)
                 || value.isType(SpecAnyIntAsDouble)
@@ -2355,7 +2355,7 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
                 || value.isType(SpecString)
                 || value.isType(SpecBoolean)
                 || value.isType(SpecSymbol)
-                || value.isType(SpecObject)
+                || (node->op() == CompareEq && value.isType(SpecObject))
                 || value.isType(SpecOther)) {
                 switch (node->op()) {
                 case CompareLess:


### PR DESCRIPTION
#### e936f3ef64041c804fc05bd2ec74e64ca0c46af4
<pre>
[JSC] Avoid folding compare operations in DFG involving objects
<a href="https://bugs.webkit.org/show_bug.cgi?id=290838">https://bugs.webkit.org/show_bug.cgi?id=290838</a>
<a href="https://rdar.apple.com/problem/148813062">rdar://problem/148813062</a>

Reviewed by Yusuke Suzuki.

We were folding expressions like `a &lt; a` into `false` in DFG even
for object types, which is incorrect in the case that the object
defines a custom `valueOf()` method.  Since `valueOf()` is not
checked by `==`, we can still fold those expressions.

* JSTests/stress/operator-valueof.js: Added.
(shouldBe):
(A.prototype.valueOf):
(A):
(lt):
(lte):
(gt):
(gte):
(eq):
(eqq):
* Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h:
(JSC::DFG::AbstractInterpreter&lt;AbstractStateType&gt;::executeEffects):

Canonical link: <a href="https://commits.webkit.org/295032@main">https://commits.webkit.org/295032@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1f079d54aa95accafe39b4ac2abef102be30eaf4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/103855 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/23558 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/13879 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/109048 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/54511 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/23910 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/32103 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78905 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/106861 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/18567 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/93680 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59234 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/18366 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/11730 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/53883 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/96530 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/88126 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/11789 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/111435 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/102466 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/31011 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/22865 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/87906 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/31373 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/89881 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87557 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22296 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32453 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10172 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/25376 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/30940 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/36250 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/126099 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/30733 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34901 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/34070 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/32294 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->