### PR TITLE
REGRESSION(294690@main): Broke TestWebKitAPI.SafeBrowsing.URLObservation

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/SafeBrowsing.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/SafeBrowsing.mm
@@ -380,6 +380,12 @@ TEST(SafeBrowsing, DISABLED_URLObservation)
 
     auto webViewWithWarning = [&] () -> RetainPtr<WKWebView> {
         auto webView = adoptNS([WKWebView new]);
+        auto navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
+        navigationDelegate.get().decidePolicyForNavigationAction = ^(WKNavigationAction *action, void (^decisionHandler)(WKNavigationActionPolicy)) {
+            TestWebKitAPI::Util::runFor(0.01_s);
+            decisionHandler(WKNavigationActionPolicyAllow);
+        };
+        [webView setNavigationDelegate:navigationDelegate.get()];
         [webView configuration].preferences.fraudulentWebsiteWarningEnabled = YES;
         [webView addObserver:observer.get() forKeyPath:@"URL" options:NSKeyValueObservingOptionNew context:nil];
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ServiceWorkerBasic.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ServiceWorkerBasic.mm
@@ -3871,6 +3871,7 @@ static bool shouldServiceWorkerPSONNavigationDelegateAllowNavigationResponse = t
 
 - (void)webView:(WKWebView *)webView decidePolicyForNavigationAction:(WKNavigationAction *)navigationAction decisionHandler:(void (^)(WKNavigationActionPolicy))decisionHandler
 {
+    TestWebKitAPI::Util::runFor(0.01_s);
     decisionHandler(shouldServiceWorkerPSONNavigationDelegateAllowNavigation ? WKNavigationActionPolicyAllow : WKNavigationActionPolicyCancel);
 }
 
@@ -3881,8 +3882,7 @@ static bool shouldServiceWorkerPSONNavigationDelegateAllowNavigationResponse = t
 
 @end
 
-// FIXME: Re-enable this test once webkit.org/b/292932 is resolved.
-TEST(ServiceWorker, DISABLED_WindowClientNavigate)
+TEST(ServiceWorker, WindowClientNavigate)
 {
     [WKWebsiteDataStore _allowWebsiteDataRecordsForAllOrigins];
 
@@ -3952,8 +3952,7 @@ TEST(ServiceWorker, DISABLED_WindowClientNavigate)
     shouldServiceWorkerPSONNavigationDelegateAllowNavigationResponse = true;
 }
 
-// FIXME: Re-enable this test once webkit.org/b/292932 is resolved.
-TEST(ServiceWorker, DISABLED_WindowClientNavigateCrossOrigin)
+TEST(ServiceWorker, WindowClientNavigateCrossOrigin)
 {
     [WKWebsiteDataStore _allowWebsiteDataRecordsForAllOrigins];
 


### PR DESCRIPTION
#### 119f566618868cf26381261489d8db3ce96204d7
<pre>
REGRESSION(294690@main): Broke TestWebKitAPI.SafeBrowsing.URLObservation
<a href="https://rdar.apple.com/151224257">rdar://151224257</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=292932">https://bugs.webkit.org/show_bug.cgi?id=292932</a>

Unreviewed, tests.

These tests relied on SafeBrowsing blocking for several milliseconds in
decidePolicyForNavigationAction.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/SafeBrowsing.mm:
(TEST(SafeBrowsing, DISABLED_URLObservation)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ServiceWorkerBasic.mm:
(-[ServiceWorkerPSONNavigationDelegate webView:decidePolicyForNavigationAction:decisionHandler:]):
((ServiceWorker, WindowClientNavigate)):
((ServiceWorker, WindowClientNavigateCrossOrigin)):
((ServiceWorker, DISABLED_WindowClientNavigate)): Deleted.
((ServiceWorker, DISABLED_WindowClientNavigateCrossOrigin)): Deleted.

Canonical link: <a href="https://commits.webkit.org/295570@main">https://commits.webkit.org/295570@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/25ff2549a80d53a6c42a666904d31b75daaa96fe

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105374 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25090 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15513 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110581 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/56018 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/107415 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/25559 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33628 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80034 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108380 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19938 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95100 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60343 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/19674 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13184 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55423 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/89403 "Found 1 new API test failure: TestWebKitAPI.WebKit.QuotaDelegate (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13226 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/113274 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32526 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23976 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89107 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32889 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91324 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88750 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22658 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33638 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11433 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/27991 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32451 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32213 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35561 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33797 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->