### PR TITLE
Remove `InjectedBundle::m_useWorkQueue`

### DIFF
--- a/Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.h
@@ -185,7 +185,6 @@ private:
     WKBundleFrameRef m_topLoadingFrame { nullptr };
 
     bool m_dumpPixels { false };
-    bool m_useWorkQueue { false };
     bool m_pixelResultIsPending { false };
     bool m_accessibilityIsolatedTreeMode { false };
 

--- a/Tools/WebKitTestRunner/TestController.h
+++ b/Tools/WebKitTestRunner/TestController.h
@@ -461,6 +461,9 @@ public:
     bool useWPEPlatformAPI() const { return m_useWPEPlatformAPI; }
 #endif
 
+    void setUseWorkQueue(bool useWorkQueue) { m_useWorkQueue = useWorkQueue; }
+    bool useWorkQueue() const { return m_useWorkQueue; }
+
 private:
     WKRetainPtr<WKPageConfigurationRef> generatePageConfiguration(const TestOptions&);
     WKRetainPtr<WKContextConfigurationRef> generateContextConfiguration(const TestOptions&) const;
@@ -814,6 +817,7 @@ private:
     bool m_dumpFullScreenCallbacks { false };
     bool m_waitBeforeFinishingFullscreenExit { false };
     bool m_scrollDuringEnterFullscreen { false };
+    bool m_useWorkQueue { false };
 
 #if PLATFORM(WPE)
     bool m_useWPEPlatformAPI { false };

--- a/Tools/WebKitTestRunner/TestInvocation.cpp
+++ b/Tools/WebKitTestRunner/TestInvocation.cpp
@@ -363,6 +363,7 @@ void TestInvocation::didReceiveMessageFromInjectedBundle(WKStringRef messageName
     }
 
     if (WKStringIsEqualToUTF8CString(messageName, "Done")) {
+        TestController::singleton().setUseWorkQueue(false);
         auto messageBodyDictionary = dictionaryValue(messageBody);
         m_pixelResultIsPending = booleanValue(messageBodyDictionary, "PixelResultIsPending");
         if (!m_pixelResultIsPending) {
@@ -481,11 +482,13 @@ void TestInvocation::didReceiveMessageFromInjectedBundle(WKStringRef messageName
     }
 
     if (WKStringIsEqualToUTF8CString(messageName, "QueueBackNavigation")) {
+        TestController::singleton().setUseWorkQueue(true);
         TestController::singleton().workQueueManager().queueBackNavigation(uint64Value(messageBody));
         return;
     }
 
     if (WKStringIsEqualToUTF8CString(messageName, "QueueForwardNavigation")) {
+        TestController::singleton().setUseWorkQueue(true);
         TestController::singleton().workQueueManager().queueForwardNavigation(uint64Value(messageBody));
         return;
     }
@@ -495,6 +498,7 @@ void TestInvocation::didReceiveMessageFromInjectedBundle(WKStringRef messageName
         auto url = toWTFString(stringValue(loadDataDictionary, "url"));
         auto target = toWTFString(stringValue(loadDataDictionary, "target"));
         auto shouldOpenExternalURLs = booleanValue(loadDataDictionary, "shouldOpenExternalURLs");
+        TestController::singleton().setUseWorkQueue(true);
         TestController::singleton().workQueueManager().queueLoad(url, target, shouldOpenExternalURLs);
         return;
     }
@@ -504,22 +508,26 @@ void TestInvocation::didReceiveMessageFromInjectedBundle(WKStringRef messageName
         auto contentWK = stringValue(loadDataDictionary, "content");
         auto baseURLWK = stringValue(loadDataDictionary, "baseURL");
         auto unreachableURLWK = stringValue(loadDataDictionary, "unreachableURL");
+        TestController::singleton().setUseWorkQueue(true);
         TestController::singleton().workQueueManager().queueLoadHTMLString(toWTFString(contentWK), baseURLWK ? toWTFString(baseURLWK) : String(), unreachableURLWK ? toWTFString(unreachableURLWK) : String());
         return;
     }
 
     if (WKStringIsEqualToUTF8CString(messageName, "QueueReload")) {
+        TestController::singleton().setUseWorkQueue(true);
         TestController::singleton().workQueueManager().queueReload();
         return;
     }
 
     if (WKStringIsEqualToUTF8CString(messageName, "QueueLoadingScript")) {
+        TestController::singleton().setUseWorkQueue(true);
         WKStringRef script = stringValue(messageBody);
         TestController::singleton().workQueueManager().queueLoadingScript(toWTFString(script));
         return;
     }
 
     if (WKStringIsEqualToUTF8CString(messageName, "QueueNonLoadingScript")) {
+        TestController::singleton().setUseWorkQueue(true);
         WKStringRef script = stringValue(messageBody);
         TestController::singleton().workQueueManager().queueNonLoadingScript(toWTFString(script));
         return;
@@ -662,6 +670,7 @@ void TestInvocation::didReceiveMessageFromInjectedBundle(WKStringRef messageName
 #endif
 
     if (WKStringIsEqualToUTF8CString(messageName, "ReloadFromOrigin")) {
+        TestController::singleton().setUseWorkQueue(true);
         TestController::singleton().reloadFromOrigin();
         return;
     }
@@ -789,8 +798,8 @@ WKRetainPtr<WKTypeRef> TestInvocation::didReceiveSynchronousMessageFromInjectedB
         return nullptr;
     }
 
-    if (WKStringIsEqualToUTF8CString(messageName, "IsWorkQueueEmpty"))
-        return adoptWK(WKBooleanCreate(TestController::singleton().workQueueManager().isWorkQueueEmpty()));
+    if (WKStringIsEqualToUTF8CString(messageName, "ShouldProcessWorkQueue"))
+        return adoptWK(WKBooleanCreate(TestController::singleton().useWorkQueue() && !TestController::singleton().workQueueManager().isWorkQueueEmpty()));
 
     if (WKStringIsEqualToUTF8CString(messageName, "DidReceiveServerRedirectForProvisionalNavigation"))
         return adoptWK(WKBooleanCreate(TestController::singleton().didReceiveServerRedirectForProvisionalNavigation()));


### PR DESCRIPTION
#### e4ba89abfce46538ce501f32c4635a5f5c87ae12
<pre>
Remove `InjectedBundle::m_useWorkQueue`
<a href="https://bugs.webkit.org/show_bug.cgi?id=293143">https://bugs.webkit.org/show_bug.cgi?id=293143</a>
<a href="https://rdar.apple.com/151484255">rdar://151484255</a>

Reviewed by Pascoe.

* Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.cpp:
(WTR::InjectedBundle::done):
(WTR::InjectedBundle::reloadFromOrigin):
(WTR::InjectedBundle::shouldProcessWorkQueue const):
(WTR::InjectedBundle::queueBackNavigation):
(WTR::InjectedBundle::queueForwardNavigation):
(WTR::InjectedBundle::queueLoad):
(WTR::InjectedBundle::queueLoadHTMLString):
(WTR::InjectedBundle::queueReload):
(WTR::InjectedBundle::queueLoadingScript):
(WTR::InjectedBundle::queueNonLoadingScript):
* Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.h:
* Tools/WebKitTestRunner/TestController.h:
(WTR::TestController::setUseWorkQueue):
(WTR::TestController::useWorkQueue const):
* Tools/WebKitTestRunner/TestInvocation.cpp:
(WTR::TestInvocation::didReceiveMessageFromInjectedBundle):
(WTR::TestInvocation::didReceiveSynchronousMessageFromInjectedBundle):

Canonical link: <a href="https://commits.webkit.org/295049@main">https://commits.webkit.org/295049@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c4edf7bf8807f4b762990339183897c4ba7705dc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/103864 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/23567 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/13888 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/109057 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/54525 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/105904 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/23982 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/32112 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78911 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/106870 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/18622 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/93691 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59240 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/18418 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/11742 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/53892 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/88169 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/11800 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/111444 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/31020 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/22872 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/87916 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/31382 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/89892 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87568 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32458 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10181 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/25386 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16870 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/30949 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/30742 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/34079 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/32303 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->