### PR TITLE
[JSC] Allow CodeBlock hash computation from concurrent compiler thread

### DIFF
--- a/Source/JavaScriptCore/bytecode/CodeBlock.h
+++ b/Source/JavaScriptCore/bytecode/CodeBlock.h
@@ -203,8 +203,6 @@ public:
     String inferredNameWithHash() const;
     CodeBlockHash hash() const;
     bool hasHash() const;
-    bool isSafeToComputeHash() const;
-    CString hashAsStringIfPossible() const;
     CString sourceCodeForTools() const;
     CString sourceCodeOnOneLine() const; // As sourceCodeForTools(), but replaces all whitespace runs with a single space.
     void dumpAssumingJITType(PrintStream&, JITType) const;

--- a/Source/JavaScriptCore/bytecode/CodeBlockHash.cpp
+++ b/Source/JavaScriptCore/bytecode/CodeBlockHash.cpp
@@ -34,7 +34,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace JSC {
 
-CodeBlockHash::CodeBlockHash(std::span<const char, 6> string)
+CodeBlockHash::CodeBlockHash(std::span<const char, stringLength> string)
     : m_hash(sixCharacterHashStringToInteger(string))
 {
 }

--- a/Source/JavaScriptCore/bytecode/CodeBlockHash.h
+++ b/Source/JavaScriptCore/bytecode/CodeBlockHash.h
@@ -27,6 +27,7 @@
 
 #include "CodeSpecializationKind.h"
 #include <wtf/PrintStream.h>
+#include <wtf/SixCharacterHash.h>
 
 // CodeBlock hashes are useful for informally identifying code blocks. They correspond
 // to the low 32 bits of a SHA1 hash of the source code with two low bit flipped
@@ -36,38 +37,63 @@
 // toString(const CodeBlockHash&). Finally, we support CodeBlockHashes for native
 // functions, in which case the hash is replaced by the function address.
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace JSC {
 
 class SourceCode;
 
 class CodeBlockHash {
 public:
-    CodeBlockHash()
-        : m_hash(0)
-    {
-    }
-    
+    static constexpr size_t stringLength = 6;
+
+    CodeBlockHash() = default;
+
     explicit CodeBlockHash(unsigned hash)
         : m_hash(hash)
     {
     }
-    
+
     CodeBlockHash(const SourceCode&, CodeSpecializationKind);
-    
-    explicit CodeBlockHash(std::span<const char, 6>);
+
+    explicit CodeBlockHash(std::span<const char, stringLength>);
 
     bool isSet() const { return !!m_hash; }
-    bool operator!() const { return !isSet(); }
-    
+    explicit operator bool() const { return isSet(); }
+
     unsigned hash() const { return m_hash; }
-    
+
     void dump(PrintStream&) const;
-    
+
     // Comparison methods useful for bisection.
     friend auto operator<=>(const CodeBlockHash&, const CodeBlockHash&) = default;
-    
+
 private:
-    unsigned m_hash;
+    unsigned m_hash { };
 };
 
 } // namespace JSC
+namespace WTF {
+
+template<> class StringTypeAdapter<JSC::CodeBlockHash> {
+public:
+    explicit StringTypeAdapter(const JSC::CodeBlockHash& hash)
+        : m_hash { hash }
+    {
+    }
+
+    unsigned length() const { return JSC::CodeBlockHash::stringLength; }
+    bool is8Bit() const { return true; }
+    template<typename CharacterType> void writeTo(std::span<CharacterType> destination) const
+    {
+        auto buffer = integerToSixCharacterHashString(m_hash.hash());
+        StringImpl::copyCharacters(destination, std::span<const LChar>(std::bit_cast<const LChar*>(buffer.data()), buffer.size()));
+    }
+
+private:
+    JSC::CodeBlockHash m_hash;
+};
+
+} // namespace WTF
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/JavaScriptCore/bytecode/InlineCallFrame.cpp
+++ b/Source/JavaScriptCore/bytecode/InlineCallFrame.cpp
@@ -50,11 +50,6 @@ CodeBlockHash InlineCallFrame::hash() const
     return baselineCodeBlock->hash();
 }
 
-CString InlineCallFrame::hashAsStringIfPossible() const
-{
-    return baselineCodeBlock->hashAsStringIfPossible();
-}
-
 CString InlineCallFrame::inferredName() const
 {
     return jsCast<FunctionExecutable*>(baselineCodeBlock->ownerExecutable())->ecmaName().utf8();
@@ -62,7 +57,7 @@ CString InlineCallFrame::inferredName() const
 
 void InlineCallFrame::dumpBriefFunctionInformation(PrintStream& out) const
 {
-    out.print(inferredName(), "#", hashAsStringIfPossible());
+    out.print(inferredName(), "#", hash());
 }
 
 void InlineCallFrame::dumpInContext(PrintStream& out, DumpContext* context) const

--- a/Source/JavaScriptCore/bytecode/InlineCallFrame.h
+++ b/Source/JavaScriptCore/bytecode/InlineCallFrame.h
@@ -228,7 +228,6 @@ struct InlineCallFrame {
     
     CString inferredName() const;
     CodeBlockHash hash() const;
-    CString hashAsStringIfPossible() const;
     
     void setStackOffset(signed offset)
     {

--- a/Source/JavaScriptCore/ftl/FTLJITFinalizer.cpp
+++ b/Source/JavaScriptCore/ftl/FTLJITFinalizer.cpp
@@ -67,7 +67,7 @@ bool JITFinalizer::finalize()
         size_t baselineCodeSize = 0;
         if (auto jitCode = baselineCodeBlock->jitCode())
             baselineCodeSize = jitCode->size();
-        dataLogLn("FTL: codeSize:(", m_jitCode->size(), "),nodes:(", m_jitCode->numberOfCompiledDFGNodes(), "),baselineCodeSize:(", baselineCodeSize, "),bytecodeCost:(", baselineCodeBlock->bytecodeCost(), ")");
+        dataLogLn("FTL: name:(", codeBlock->inferredNameWithHash(), "),codeSize:(", m_jitCode->size(), "),nodes:(", m_jitCode->numberOfCompiledDFGNodes(), "),baselineCodeSize:(", baselineCodeSize, "),bytecodeCost:(", baselineCodeBlock->bytecodeCost(), ")");
     }
 
     if (m_plan.compilation()) [[unlikely]]

--- a/Source/JavaScriptCore/parser/SourceProvider.cpp
+++ b/Source/JavaScriptCore/parser/SourceProvider.cpp
@@ -42,6 +42,22 @@ SourceProvider::SourceProvider(const SourceOrigin& sourceOrigin, String&& source
 
 SourceProvider::~SourceProvider() = default;
 
+void SourceProvider::lockUnderlyingBuffer()
+{
+    if (!m_lockingCount++)
+        lockUnderlyingBufferImpl();
+}
+
+void SourceProvider::unlockUnderlyingBuffer()
+{
+    if (!--m_lockingCount)
+        unlockUnderlyingBufferImpl();
+}
+
+void SourceProvider::lockUnderlyingBufferImpl() { }
+
+void SourceProvider::unlockUnderlyingBufferImpl() { }
+
 void SourceProvider::getID()
 {
     if (!m_id) {

--- a/Source/JavaScriptCore/parser/SourceProvider.h
+++ b/Source/JavaScriptCore/parser/SourceProvider.h
@@ -48,182 +48,188 @@ class SourceCode;
 class UnlinkedFunctionExecutable;
 class UnlinkedFunctionCodeBlock;
 
-    enum class SourceProviderSourceType : uint8_t {
-        Program,
-        Module,
-        WebAssembly,
-        JSON,
-        ImportMap,
-    };
+enum class SourceProviderSourceType : uint8_t {
+    Program,
+    Module,
+    WebAssembly,
+    JSON,
+    ImportMap,
+};
 
-    using BytecodeCacheGenerator = Function<RefPtr<CachedBytecode>()>;
+using BytecodeCacheGenerator = Function<RefPtr<CachedBytecode>()>;
 
-    class SourceProvider : public RefCounted<SourceProvider> {
-    public:
-        static const intptr_t nullID = 1;
-        
-        JS_EXPORT_PRIVATE SourceProvider(const SourceOrigin&, String&& sourceURL, String&& preRedirectURL, SourceTaintedOrigin, const TextPosition& startPosition, SourceProviderSourceType);
+class SourceProvider : public ThreadSafeRefCounted<SourceProvider> {
+public:
+    static const intptr_t nullID = 1;
 
-        JS_EXPORT_PRIVATE virtual ~SourceProvider();
+    JS_EXPORT_PRIVATE SourceProvider(const SourceOrigin&, String&& sourceURL, String&& preRedirectURL, SourceTaintedOrigin, const TextPosition& startPosition, SourceProviderSourceType);
 
-        virtual unsigned hash() const = 0;
-        virtual StringView source() const = 0;
-        virtual RefPtr<CachedBytecode> cachedBytecode() const { return nullptr; }
-        virtual void cacheBytecode(const BytecodeCacheGenerator&) const { }
-        virtual void updateCache(const UnlinkedFunctionExecutable*, const SourceCode&, CodeSpecializationKind, const UnlinkedFunctionCodeBlock*) const { }
-        virtual void commitCachedBytecode() const { }
+    JS_EXPORT_PRIVATE virtual ~SourceProvider();
 
-        StringView getRange(int start, int end) const
-        {
-            return source().substring(start, end - start);
-        }
+    virtual unsigned hash() const = 0;
+    virtual StringView source() const = 0;
+    virtual RefPtr<CachedBytecode> cachedBytecode() const { return nullptr; }
+    virtual void cacheBytecode(const BytecodeCacheGenerator&) const { }
+    virtual void updateCache(const UnlinkedFunctionExecutable*, const SourceCode&, CodeSpecializationKind, const UnlinkedFunctionCodeBlock*) const { }
+    virtual void commitCachedBytecode() const { }
 
-        const SourceOrigin& sourceOrigin() const { return m_sourceOrigin; }
+    StringView getRange(int start, int end) const
+    {
+        return source().substring(start, end - start);
+    }
 
-        // This is NOT the path that should be used for computing relative paths from a script. Use SourceOrigin's URL for that, the values may or may not be the same...
-        const String& sourceURL() const { return m_sourceURL; }
-        const String& sourceURLStripped();
-        const String& preRedirectURL() const { return m_preRedirectURL; }
-        const String& sourceURLDirective() const { return m_sourceURLDirective; }
-        const String& sourceMappingURLDirective() const { return m_sourceMappingURLDirective; }
+    const SourceOrigin& sourceOrigin() const { return m_sourceOrigin; }
 
-        TextPosition startPosition() const { return m_startPosition; }
-        SourceProviderSourceType sourceType() const { return m_sourceType; }
+    // This is NOT the path that should be used for computing relative paths from a script. Use SourceOrigin's URL for that, the values may or may not be the same...
+    const String& sourceURL() const { return m_sourceURL; }
+    const String& sourceURLStripped();
+    const String& preRedirectURL() const { return m_preRedirectURL; }
+    const String& sourceURLDirective() const { return m_sourceURLDirective; }
+    const String& sourceMappingURLDirective() const { return m_sourceMappingURLDirective; }
 
-        SourceID asID()
-        {
-            if (!m_id)
-                getID();
-            return m_id;
-        }
+    TextPosition startPosition() const { return m_startPosition; }
+    SourceProviderSourceType sourceType() const { return m_sourceType; }
 
-        void setSourceURLDirective(const String& sourceURLDirective) { m_sourceURLDirective = sourceURLDirective; }
-        void setSourceMappingURLDirective(const String& sourceMappingURLDirective) { m_sourceMappingURLDirective = sourceMappingURLDirective; }
-        void setSourceTaintedOrigin(SourceTaintedOrigin taintedness) { m_taintedness = taintedness; }
+    SourceID asID()
+    {
+        if (!m_id)
+            getID();
+        return m_id;
+    }
 
-        SourceTaintedOrigin sourceTaintedOrigin() const { return m_taintedness; }
-        bool couldBeTainted() const { return m_taintedness != SourceTaintedOrigin::Untainted; }
+    void setSourceURLDirective(const String& sourceURLDirective) { m_sourceURLDirective = sourceURLDirective; }
+    void setSourceMappingURLDirective(const String& sourceMappingURLDirective) { m_sourceMappingURLDirective = sourceMappingURLDirective; }
+    void setSourceTaintedOrigin(SourceTaintedOrigin taintedness) { m_taintedness = taintedness; }
 
-    private:
-        JS_EXPORT_PRIVATE void getID();
+    SourceTaintedOrigin sourceTaintedOrigin() const { return m_taintedness; }
+    bool couldBeTainted() const { return m_taintedness != SourceTaintedOrigin::Untainted; }
 
-        SourceProviderSourceType m_sourceType;
-        SourceOrigin m_sourceOrigin;
-        String m_sourceURL;
-        String m_sourceURLStripped;
-        String m_preRedirectURL;
-        String m_sourceURLDirective;
-        String m_sourceMappingURLDirective;
-        TextPosition m_startPosition;
-        SourceID m_id { 0 };
-        SourceTaintedOrigin m_taintedness;
-    };
+    JS_EXPORT_PRIVATE void lockUnderlyingBuffer();
+    JS_EXPORT_PRIVATE void unlockUnderlyingBuffer();
 
-    DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(StringSourceProvider);
-    class StringSourceProvider : public SourceProvider {
-        WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(StringSourceProvider);
-    public:
-        static Ref<StringSourceProvider> create(const String& source, const SourceOrigin& sourceOrigin, String sourceURL, SourceTaintedOrigin taintedness, const TextPosition& startPosition = TextPosition(), SourceProviderSourceType sourceType = SourceProviderSourceType::Program)
-        {
-            return adoptRef(*new StringSourceProvider(source, sourceOrigin, taintedness, WTFMove(sourceURL), startPosition, sourceType));
-        }
-        
-        unsigned hash() const override
-        {
-            return m_source.get().hash();
-        }
+private:
+    JS_EXPORT_PRIVATE virtual void lockUnderlyingBufferImpl();
+    JS_EXPORT_PRIVATE virtual void unlockUnderlyingBufferImpl();
 
-        StringView source() const override
-        {
-            return m_source.get();
-        }
+    JS_EXPORT_PRIVATE void getID();
 
-    protected:
-        StringSourceProvider(const String& source, const SourceOrigin& sourceOrigin, SourceTaintedOrigin taintedness, String&& sourceURL, const TextPosition& startPosition, SourceProviderSourceType sourceType)
-            : SourceProvider(sourceOrigin, WTFMove(sourceURL), String(), taintedness, startPosition, sourceType)
-            , m_source(source.isNull() ? *StringImpl::empty() : *source.impl())
-        {
-        }
+    std::atomic<unsigned> m_lockingCount { 0 };
+    SourceProviderSourceType m_sourceType;
+    SourceOrigin m_sourceOrigin;
+    String m_sourceURL;
+    String m_sourceURLStripped;
+    String m_preRedirectURL;
+    String m_sourceURLDirective;
+    String m_sourceMappingURLDirective;
+    TextPosition m_startPosition;
+    SourceID m_id { 0 };
+    SourceTaintedOrigin m_taintedness;
+};
 
-    private:
-        Ref<StringImpl> m_source;
-    };
+DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(StringSourceProvider);
+class StringSourceProvider : public SourceProvider {
+    WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(StringSourceProvider);
+public:
+    static Ref<StringSourceProvider> create(const String& source, const SourceOrigin& sourceOrigin, String sourceURL, SourceTaintedOrigin taintedness, const TextPosition& startPosition = TextPosition(), SourceProviderSourceType sourceType = SourceProviderSourceType::Program)
+    {
+        return adoptRef(*new StringSourceProvider(source, sourceOrigin, taintedness, WTFMove(sourceURL), startPosition, sourceType));
+    }
+
+    unsigned hash() const override
+    {
+        return m_source.get().hash();
+    }
+
+    StringView source() const override
+    {
+        return m_source.get();
+    }
+
+protected:
+    StringSourceProvider(const String& source, const SourceOrigin& sourceOrigin, SourceTaintedOrigin taintedness, String&& sourceURL, const TextPosition& startPosition, SourceProviderSourceType sourceType)
+        : SourceProvider(sourceOrigin, WTFMove(sourceURL), String(), taintedness, startPosition, sourceType)
+        , m_source(source.isNull() ? *StringImpl::empty() : *source.impl())
+    {
+    }
+
+private:
+    Ref<StringImpl> m_source;
+};
 
 #if ENABLE(WEBASSEMBLY)
-    class BaseWebAssemblySourceProvider : public SourceProvider {
-    public:
-        virtual const uint8_t* data() = 0;
-        virtual size_t size() const = 0;
-        virtual void lockUnderlyingBuffer() { }
-        virtual void unlockUnderlyingBuffer() { }
+class BaseWebAssemblySourceProvider : public SourceProvider {
+public:
+    virtual const uint8_t* data() = 0;
+    virtual size_t size() const = 0;
+protected:
+    JS_EXPORT_PRIVATE BaseWebAssemblySourceProvider(const SourceOrigin&, String&& sourceURL);
+};
 
-    protected:
-        JS_EXPORT_PRIVATE BaseWebAssemblySourceProvider(const SourceOrigin&, String&& sourceURL);
-    };
+class WebAssemblySourceProvider final : public BaseWebAssemblySourceProvider {
+public:
+    static Ref<WebAssemblySourceProvider> create(Vector<uint8_t>&& data, const SourceOrigin& sourceOrigin, String sourceURL)
+    {
+        return adoptRef(*new WebAssemblySourceProvider(WTFMove(data), sourceOrigin, WTFMove(sourceURL)));
+    }
 
-    class WebAssemblySourceProvider final : public BaseWebAssemblySourceProvider {
-    public:
-        static Ref<WebAssemblySourceProvider> create(Vector<uint8_t>&& data, const SourceOrigin& sourceOrigin, String sourceURL)
-        {
-            return adoptRef(*new WebAssemblySourceProvider(WTFMove(data), sourceOrigin, WTFMove(sourceURL)));
-        }
+    unsigned hash() const final
+    {
+        return m_source.impl()->hash();
+    }
 
-        unsigned hash() const final
-        {
-            return m_source.impl()->hash();
-        }
+    StringView source() const final
+    {
+        return m_source;
+    }
 
-        StringView source() const final
-        {
-            return m_source;
-        }
+    const uint8_t* data() final
+    {
+        return m_data.data();
+    }
 
-        const uint8_t* data() final
-        {
-            return m_data.data();
-        }
+    size_t size() const final
+    {
+        return m_data.size();
+    }
 
-        size_t size() const final
-        {
-            return m_data.size();
-        }
+    const Vector<uint8_t>& dataVector() const
+    {
+        return m_data;
+    }
 
-        const Vector<uint8_t>& dataVector() const
-        {
-            return m_data;
-        }
+private:
+    WebAssemblySourceProvider(Vector<uint8_t>&& data, const SourceOrigin& sourceOrigin, String&& sourceURL)
+        : BaseWebAssemblySourceProvider(sourceOrigin, WTFMove(sourceURL))
+        , m_source("[WebAssembly source]"_s)
+        , m_data(WTFMove(data))
+    {
+    }
 
-    private:
-        WebAssemblySourceProvider(Vector<uint8_t>&& data, const SourceOrigin& sourceOrigin, String&& sourceURL)
-            : BaseWebAssemblySourceProvider(sourceOrigin, WTFMove(sourceURL))
-            , m_source("[WebAssembly source]"_s)
-            , m_data(WTFMove(data))
-        {
-        }
-
-        String m_source;
-        Vector<uint8_t> m_data;
-    };
-
-    // RAII class for managing a Wasm source provider's underlying buffer.
-    class WebAssemblySourceProviderBufferGuard {
-    public:
-        explicit WebAssemblySourceProviderBufferGuard(BaseWebAssemblySourceProvider* sourceProvider)
-            : m_sourceProvider(sourceProvider)
-        {
-            if (m_sourceProvider)
-                m_sourceProvider->lockUnderlyingBuffer();
-        }
-
-        ~WebAssemblySourceProviderBufferGuard()
-        {
-            if (m_sourceProvider)
-                m_sourceProvider->unlockUnderlyingBuffer();
-        }
-
-    private:
-        RefPtr<BaseWebAssemblySourceProvider> m_sourceProvider;
-    };
+    String m_source;
+    Vector<uint8_t> m_data;
+};
 #endif
+
+// RAII class for managing a source provider's underlying buffer.
+class SourceProviderBufferGuard {
+public:
+    explicit SourceProviderBufferGuard(SourceProvider* sourceProvider)
+        : m_sourceProvider(sourceProvider)
+    {
+        if (m_sourceProvider)
+            m_sourceProvider->lockUnderlyingBuffer();
+    }
+
+    ~SourceProviderBufferGuard()
+    {
+        if (m_sourceProvider)
+            m_sourceProvider->unlockUnderlyingBuffer();
+    }
+
+private:
+    // This must not be RefPtr. It is possible that this is used by the concurrent compiler and
+    // we are ensuring that this does not go away with different mechanism. But SourceProvider etc. can have main-thread-only affinity.
+    SourceProvider* m_sourceProvider { nullptr };
+};
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/FunctionExecutableDump.cpp
+++ b/Source/JavaScriptCore/runtime/FunctionExecutableDump.cpp
@@ -35,12 +35,12 @@ void FunctionExecutableDump::dump(PrintStream& out) const
 {
     out.print(m_executable->ecmaName().string(), "#");
     if (m_executable->isGeneratedForCall())
-        out.print(m_executable->codeBlockForCall()->hashAsStringIfPossible());
+        out.print(m_executable->codeBlockForCall()->hash());
     else
         out.print("<nogen>");
     out.print("/");
     if (m_executable->isGeneratedForConstruct())
-        out.print(m_executable->codeBlockForConstruct()->hashAsStringIfPossible());
+        out.print(m_executable->codeBlockForConstruct()->hash());
     else
         out.print("<nogen>");
     out.print(":[", RawPointer(m_executable), "]");

--- a/Source/JavaScriptCore/runtime/Options.cpp
+++ b/Source/JavaScriptCore/runtime/Options.cpp
@@ -852,31 +852,6 @@ void Options::notifyOptionsChanged()
             || Options::dumpOMGDisassembly())
             Options::needDisassemblySupport() = true;
 
-        if (Options::logJIT()
-            || Options::needDisassemblySupport()
-            || Options::dumpBytecodeAtDFGTime()
-            || Options::dumpGraphAtEachPhase()
-            || Options::dumpDFGGraphAtEachPhase()
-            || Options::dumpDFGFTLGraphAtEachPhase()
-            || Options::dumpB3GraphAtEachPhase()
-            || Options::dumpAirGraphAtEachPhase()
-            || Options::verboseCompilation()
-            || Options::verboseFTLCompilation()
-            || Options::logCompilationChanges()
-            || Options::validateGraph()
-            || Options::validateGraphAtEachPhase()
-            || Options::verboseOSR()
-            || Options::verboseCompilationQueue()
-            || Options::reportCompileTimes()
-            || Options::reportBaselineCompileTimes()
-            || Options::reportDFGCompileTimes()
-            || Options::reportFTLCompileTimes()
-            || Options::logPhaseTimes()
-            || Options::verboseCFA()
-            || Options::verboseDFGFailure()
-            || Options::verboseFTLFailure())
-            Options::alwaysComputeHash() = true;
-
         if (OptionsHelper::wasOverridden(jitPolicyScaleID))
             scaleJITPolicy();
 
@@ -916,9 +891,6 @@ void Options::notifyOptionsChanged()
             Options::forceAllFunctionsToUseSIMD() = true;
         }
     }
-
-    if (Options::dumpFuzzerAgentPredictions())
-        Options::alwaysComputeHash() = true;
 
     if (!Options::useConcurrentGC())
         Options::collectContinuously() = false;

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -194,7 +194,6 @@ bool hasCapacityToUseLargeGigacage();
     v(Bool, verboseDFGFailure, false, Normal, nullptr) \
     v(Bool, verboseFTLToJSThunk, false, Normal, nullptr) \
     v(Bool, verboseFTLFailure, false, Normal, nullptr) \
-    v(Bool, alwaysComputeHash, false, Normal, nullptr) \
     v(Bool, testTheFTL, false, Normal, nullptr) \
     v(Bool, verboseSanitizeStack, false, Normal, nullptr) \
     v(Bool, useGenerationalGC, true, Normal, nullptr) \

--- a/Source/JavaScriptCore/runtime/SamplingProfiler.cpp
+++ b/Source/JavaScriptCore/runtime/SamplingProfiler.cpp
@@ -504,8 +504,7 @@ void SamplingProfiler::processUnverifiedStackTraces()
                 location.lineColumn = codeBlock->lineColumnForBytecodeIndex(bytecodeIndex);
                 location.bytecodeIndex = bytecodeIndex;
             }
-            if (codeBlock->hasHash())
-                location.codeBlockHash = codeBlock->hash();
+            location.codeBlockHash = codeBlock->hash();
             location.jitType = jitType;
         };
 

--- a/Source/JavaScriptCore/tools/FunctionAllowlist.cpp
+++ b/Source/JavaScriptCore/tools/FunctionAllowlist.cpp
@@ -92,7 +92,7 @@ bool FunctionAllowlist::contains(CodeBlock* codeBlock) const
     if (m_entries.contains(name))
         return true;
 
-    String hash = String::fromUTF8(codeBlock->hashAsStringIfPossible().span());
+    String hash = makeString(codeBlock->hash());
     if (m_entries.contains(hash))
         return true;
 

--- a/Source/JavaScriptCore/tools/JSDollarVM.cpp
+++ b/Source/JavaScriptCore/tools/JSDollarVM.cpp
@@ -2021,7 +2021,7 @@ JSC_DEFINE_HOST_FUNCTION(functionWasmStreamingParserAddBytes, (JSGlobalObject* g
     BaseWebAssemblySourceProvider* provider = nullptr;
     if (auto* source = jsDynamicCast<JSSourceCode*>(value))
         provider = static_cast<BaseWebAssemblySourceProvider*>(source->sourceCode().provider());
-    WebAssemblySourceProviderBufferGuard guard(provider);
+    SourceProviderBufferGuard guard(provider);
 
     auto data = getWasmBufferFromValue(globalObject, value, guard);
     RETURN_IF_EXCEPTION(scope, encodedJSValue());
@@ -2121,7 +2121,7 @@ JSC_DEFINE_HOST_FUNCTION(functionWasmStreamingCompilerAddBytes, (JSGlobalObject*
     BaseWebAssemblySourceProvider* provider = nullptr;
     if (auto* source = jsDynamicCast<JSSourceCode*>(value))
         provider = static_cast<BaseWebAssemblySourceProvider*>(source->sourceCode().provider());
-    WebAssemblySourceProviderBufferGuard guard(provider);
+    SourceProviderBufferGuard guard(provider);
 
     auto data = getWasmBufferFromValue(globalObject, value, guard);
     RETURN_IF_EXCEPTION(scope, { });

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyHelpers.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyHelpers.h
@@ -69,7 +69,7 @@ ALWAYS_INLINE uint32_t toNonWrappingUint32(JSGlobalObject* globalObject, JSValue
     return { };
 }
 
-ALWAYS_INLINE std::span<const uint8_t> getWasmBufferFromValue(JSGlobalObject* globalObject, JSValue value, const WebAssemblySourceProviderBufferGuard&)
+ALWAYS_INLINE std::span<const uint8_t> getWasmBufferFromValue(JSGlobalObject* globalObject, JSValue value, const SourceProviderBufferGuard&)
 {
     VM& vm = getVM(globalObject);
     auto throwScope = DECLARE_THROW_SCOPE(vm);
@@ -116,7 +116,7 @@ ALWAYS_INLINE Vector<uint8_t> createSourceBufferFromValue(VM& vm, JSGlobalObject
     BaseWebAssemblySourceProvider* provider = nullptr;
     if (auto* source = jsDynamicCast<JSSourceCode*>(value))
         provider = static_cast<BaseWebAssemblySourceProvider*>(source->sourceCode().provider());
-    WebAssemblySourceProviderBufferGuard bufferGuard(provider);
+    SourceProviderBufferGuard bufferGuard(provider);
 
     auto data = getWasmBufferFromValue(globalObject, value, bufferGuard);
     RETURN_IF_EXCEPTION(throwScope, { });

--- a/Source/WebCore/bindings/js/ScriptBufferSourceProvider.h
+++ b/Source/WebCore/bindings/js/ScriptBufferSourceProvider.h
@@ -102,6 +102,24 @@ public:
         m_contiguousBuffer = nullptr;
     }
 
+    void lockUnderlyingBufferImpl() final
+    {
+        ASSERT(!m_buffer);
+        m_buffer = m_scriptBuffer.buffer();
+
+        if (!m_buffer)
+            return;
+
+        if (!m_buffer->isContiguous())
+            m_buffer = m_buffer->makeContiguous();
+    }
+
+    void unlockUnderlyingBufferImpl() final
+    {
+        ASSERT(m_buffer);
+        m_buffer = nullptr;
+    }
+
 private:
     ScriptBufferSourceProvider(const ScriptBuffer& scriptBuffer, const JSC::SourceOrigin& sourceOrigin, String&& sourceURL, String&& preRedirectURL, const TextPosition& startPosition, JSC::SourceProviderSourceType sourceType)
         : JSC::SourceProvider(sourceOrigin, WTFMove(sourceURL), WTFMove(preRedirectURL), JSC::SourceTaintedOrigin::Untainted, startPosition, sourceType)
@@ -110,6 +128,7 @@ private:
     }
 
     ScriptBuffer m_scriptBuffer;
+    RefPtr<const FragmentedSharedBuffer> m_buffer;
     mutable RefPtr<SharedBuffer> m_contiguousBuffer;
     mutable unsigned m_scriptHash { 0 };
     mutable String m_cachedScriptString;

--- a/Source/WebCore/bindings/js/WebAssemblyCachedScriptSourceProvider.h
+++ b/Source/WebCore/bindings/js/WebAssemblyCachedScriptSourceProvider.h
@@ -66,13 +66,13 @@ public:
         return Ref { downcast<SharedBuffer>(*m_buffer) }->span().data();
     }
 
-    void lockUnderlyingBuffer() final
+    void lockUnderlyingBufferImpl() final
     {
         ASSERT(!m_buffer);
         m_buffer = m_cachedScript->resourceBuffer();
     }
 
-    void unlockUnderlyingBuffer() final
+    void unlockUnderlyingBufferImpl() final
     {
         ASSERT(m_buffer);
         m_buffer = nullptr;

--- a/Source/WebCore/bindings/js/WebAssemblyScriptBufferSourceProvider.h
+++ b/Source/WebCore/bindings/js/WebAssemblyScriptBufferSourceProvider.h
@@ -62,7 +62,7 @@ public:
         return downcast<SharedBuffer>(*m_buffer).span().data();
     }
 
-    void lockUnderlyingBuffer() final
+    void lockUnderlyingBufferImpl() final
     {
         ASSERT(!m_buffer);
         m_buffer = m_scriptBuffer.buffer();
@@ -74,7 +74,7 @@ public:
             m_buffer = m_buffer->makeContiguous();
     }
 
-    void unlockUnderlyingBuffer() final
+    void unlockUnderlyingBufferImpl() final
     {
         ASSERT(m_buffer);
         m_buffer = nullptr;

--- a/Tools/Scripts/compare-optimization-tracing
+++ b/Tools/Scripts/compare-optimization-tracing
@@ -47,7 +47,6 @@ def run_jsc_and_capture(verbose, build_path, jsc_args, cwd, extra_options=""):
     env["DYLD_FRAMEWORK_PATH"] = build_path
 
     required_options = [
-        "--alwaysComputeHash=1",
         "--useConcurrentJIT=0",
         "--dumpOptimizationTracing=1",
     ]


### PR DESCRIPTION
#### 4f51c8d055c64c0c4c0343a07d08d4cacf322ea4
<pre>
[JSC] Allow CodeBlock hash computation from concurrent compiler thread
<a href="https://bugs.webkit.org/show_bug.cgi?id=293146">https://bugs.webkit.org/show_bug.cgi?id=293146</a>
<a href="https://rdar.apple.com/problem/151486734">rdar://problem/151486734</a>

Reviewed by Yijia Huang.

CodeBlockHash computation does not rely on any main thread concept. It
can run in the concurrent compiler thread. Thus, we do not need to
prohibit it.
The difficulty is that WebCore main thread could replace the
SourceProvider&apos;s underlying buffer when NetworkProcess cached the
result. It is fine if we are reading source data from the main thread,
but it is not fine when we are reading it from the concurrent compiler
thread since it can be possible that we replace and discard old source
data while the compiler thread is reading it. To avoid that, we already
have a mechanism &quot;SourceProviderBufferGuard&quot;. This was used only for
Wasm before, but this patch extends it to support normal JS source code
so that we can keep the data while reading it from the compiler thread.

* Source/JavaScriptCore/bytecode/CodeBlock.cpp:
(JSC::CodeBlock::inferredNameWithHash const):
(JSC::CodeBlock::hash const):
(JSC::CodeBlock::finishCreation):
(JSC::CodeBlock::isSafeToComputeHash const): Deleted.
(JSC::CodeBlock::hashAsStringIfPossible const): Deleted.
* Source/JavaScriptCore/bytecode/CodeBlock.h:
* Source/JavaScriptCore/bytecode/CodeBlockHash.cpp:
(JSC::CodeBlockHash::CodeBlockHash):
* Source/JavaScriptCore/bytecode/CodeBlockHash.h:
(JSC::CodeBlockHash::operator bool const):
(WTF::StringTypeAdapter&lt;JSC::CodeBlockHash&gt;::StringTypeAdapter):
(WTF::StringTypeAdapter&lt;JSC::CodeBlockHash&gt;::length const):
(WTF::StringTypeAdapter&lt;JSC::CodeBlockHash&gt;::is8Bit const):
(WTF::StringTypeAdapter&lt;JSC::CodeBlockHash&gt;::writeTo const):
(JSC::CodeBlockHash::operator! const): Deleted.
* Source/JavaScriptCore/bytecode/InlineCallFrame.cpp:
(JSC::InlineCallFrame::dumpBriefFunctionInformation const):
(JSC::InlineCallFrame::hashAsStringIfPossible const): Deleted.
* Source/JavaScriptCore/bytecode/InlineCallFrame.h:
* Source/JavaScriptCore/ftl/FTLJITFinalizer.cpp:
(JSC::FTL::JITFinalizer::finalize):
* Source/JavaScriptCore/parser/SourceProvider.cpp:
(JSC::SourceProvider::lockUnderlyingBuffer):
(JSC::SourceProvider::unlockUnderlyingBuffer):
* Source/JavaScriptCore/parser/SourceProvider.h:
(JSC::SourceProviderBufferGuard::SourceProviderBufferGuard):
(JSC::SourceProviderBufferGuard::~SourceProviderBufferGuard):
(JSC::BaseWebAssemblySourceProvider::lockUnderlyingBuffer): Deleted.
(JSC::BaseWebAssemblySourceProvider::unlockUnderlyingBuffer): Deleted.
(JSC::WebAssemblySourceProviderBufferGuard::WebAssemblySourceProviderBufferGuard): Deleted.
(JSC::WebAssemblySourceProviderBufferGuard::~WebAssemblySourceProviderBufferGuard): Deleted.
* Source/JavaScriptCore/runtime/FunctionExecutableDump.cpp:
(JSC::FunctionExecutableDump::dump const):
* Source/JavaScriptCore/runtime/Options.cpp:
(JSC::Options::notifyOptionsChanged):
* Source/JavaScriptCore/runtime/OptionsList.h:
* Source/JavaScriptCore/tools/FunctionAllowlist.cpp:
(JSC::FunctionAllowlist::contains const):
* Source/JavaScriptCore/tools/JSDollarVM.cpp:
* Source/JavaScriptCore/wasm/js/JSWebAssemblyHelpers.h:
(JSC::getWasmBufferFromValue):
(JSC::createSourceBufferFromValue):
* Source/WebCore/bindings/js/CachedScriptSourceProvider.h:
(WebCore::CachedScriptSourceProvider::create): Deleted.
(WebCore::CachedScriptSourceProvider::~CachedScriptSourceProvider): Deleted.
(WebCore::CachedScriptSourceProvider::CachedScriptSourceProvider): Deleted.
(WebCore::CachedScriptSourceProvider::m_cachedScript): Deleted.
* Source/WebCore/bindings/js/ScriptBufferSourceProvider.h:
* Tools/Scripts/compare-optimization-tracing:
(run_jsc_and_capture):

Canonical link: <a href="https://commits.webkit.org/295048@main">https://commits.webkit.org/295048@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/256e649a25ea9bfae5ca3422a1694231d385a6ab

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/103918 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/23621 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/13942 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/109111 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/54579 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/105958 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/23976 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/32166 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/78941 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/54579 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/106924 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/18616 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/93742 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/59269 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/18413 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/11794 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/53946 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/96593 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/88163 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/11852 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/111498 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/102529 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/31074 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/22905 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/87951 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/31437 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/89943 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87606 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32495 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10230 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/25440 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16869 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/31003 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/36313 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/126162 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/30796 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34912 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/34133 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/32357 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->