### PR TITLE
Remove `Internals::setTrackingPreventionEnabled`

### DIFF
--- a/LayoutTests/http/tests/clear-site-data/set-and-clear-cookies.https.html
+++ b/LayoutTests/http/tests/clear-site-data/set-and-clear-cookies.https.html
@@ -26,7 +26,7 @@
 
             switch (document.location.hash) {
                 case "":
-                    internals.setTrackingPreventionEnabled(true);
+                    testRunner.setStatisticsEnabled(true);
                     testRunner.setStatisticsIsRunningTest(true);
                     testRunner.setOnlyAcceptFirstPartyCookies(false);
                     testRunner.dumpChildFramesAsText();
@@ -90,12 +90,12 @@
                     injectThirdPartyIframe(iframeUrls.resetCookies);
                     break;
                 case "#8":
-                    internals.setTrackingPreventionEnabled(false);
+                    testRunner.setStatisticsEnabled(false);
                     testRunner.setStatisticsIsRunningTest(false);
                     finishJSTest();
                     break;
                 default:
-                    internals.setTrackingPreventionEnabled(false);
+                    testRunner.setStatisticsEnabled(false);
                     testRunner.setStatisticsIsRunningTest(false);
                     testFailed("Unknown location hash value.");
                     finishJSTest();

--- a/LayoutTests/http/tests/cookies/accept-partitioned-first-and-third-party-cookies.https.html
+++ b/LayoutTests/http/tests/cookies/accept-partitioned-first-and-third-party-cookies.https.html
@@ -30,7 +30,7 @@
 
             switch (document.location.hash) {
                 case "":
-                    internals.setTrackingPreventionEnabled(true);
+                    testRunner.setStatisticsEnabled(true);
                     testRunner.setStatisticsIsRunningTest(true);
                     testRunner.setOnlyAcceptFirstPartyCookies(false);
                     testRunner.dumpChildFramesAsText();
@@ -71,12 +71,12 @@
                     injectThirdPartyIframe(iframeUrls.resetCookies);
                     break;
                 case "#7":
-                    internals.setTrackingPreventionEnabled(false);
+                    testRunner.setStatisticsEnabled(false);
                     testRunner.setStatisticsIsRunningTest(false);
                     finishJSTest();
                     break;
                 default:
-                    internals.setTrackingPreventionEnabled(false);
+                    testRunner.setStatisticsEnabled(false);
                     testRunner.setStatisticsIsRunningTest(false);
                     testFailed("Unknown location hash value.");
                     finishJSTest();

--- a/LayoutTests/http/tests/media/media-stream/enumerate-devices-source-id.html
+++ b/LayoutTests/http/tests/media/media-stream/enumerate-devices-source-id.html
@@ -9,8 +9,7 @@
         <script>
             window.jsTestIsAsync = true;
 
-            if (internals)
-                internals.setTrackingPreventionEnabled(false);
+            testRunner?.setStatisticsEnabled(false);
 
             if (window.testRunner)
                 testRunner.setUserMediaPermission(true);
@@ -52,8 +51,7 @@
                 devices.forEach(device => checkID(self.origin, device));
 
                 debug('');
-                if (internals)
-                    internals.setTrackingPreventionEnabled(true);
+                testRunner?.setStatisticsEnabled(true);
                 finishJSTest();
             }
 

--- a/LayoutTests/http/tests/navigation/statistics.html
+++ b/LayoutTests/http/tests/navigation/statistics.html
@@ -9,7 +9,7 @@
 if (window.testRunner) {
     testRunner.dumpAsText();
     testRunner.dumpBackForwardList();
-    window.internals.setTrackingPreventionEnabled(true);
+    testRunner.setStatisticsEnabled(true);
     testRunner.waitUntilDone();
 }
 onload = function() {

--- a/LayoutTests/http/tests/referrer-policy-anchor/origin-when-cross-origin/cross-origin-http-http.html
+++ b/LayoutTests/http/tests/referrer-policy-anchor/origin-when-cross-origin/cross-origin-http-http.html
@@ -4,8 +4,7 @@
 <script>
 if (window.testRunner)
     testRunner.waitUntilDone();
-if (window.internals)
-    internals.setTrackingPreventionEnabled(false);
+testRunner?.setStatisticsEnabled(false);
 
 function clickLink() {
     // Should be the origin, not the full URL, because we are cross-origin.

--- a/LayoutTests/http/tests/referrer-policy-iframe/no-referrer-when-downgrade/cross-origin-http-UpgradeMixedContent.https.html
+++ b/LayoutTests/http/tests/referrer-policy-iframe/no-referrer-when-downgrade/cross-origin-http-UpgradeMixedContent.https.html
@@ -8,18 +8,16 @@
 description("Tests the behavior of no-referrer-when-downgrade referrer policy when cross origin from HTTPS to HTTP.");
 jsTestIsAsync = true;
 
-if (window.internals) {
+if (window.internals)
     internals.settings.setAllowDisplayOfInsecureContent(true);
-    internals.setTrackingPreventionEnabled(false);
-}
+testRunner?.setStatisticsEnabled(false);
 
 window.onmessage = function(event) {
     testFailed("Document should not be loaded");
     referrer = event.data.referrer;
     // Should be the empty string
     shouldBeEqualToString("referrer", "");
-    if (window.internals)
-        internals.setTrackingPreventionEnabled(true);
+    testRunner?.setStatisticsEnabled(true);
     finishJSTest();
 }
 

--- a/LayoutTests/http/tests/referrer-policy-iframe/no-referrer-when-downgrade/cross-origin-http-http.html
+++ b/LayoutTests/http/tests/referrer-policy-iframe/no-referrer-when-downgrade/cross-origin-http-http.html
@@ -8,15 +8,13 @@
 description("Tests the behavior of no-referrer-when-downgrade referrer policy when cross origin.");
 jsTestIsAsync = true;
 
-if (window.internals)
-    internals.setTrackingPreventionEnabled(false);
+testRunner?.setStatisticsEnabled(false);
 
 window.onmessage = function(event) {
     referrer = event.data.referrer;
     // Should be the full URL
     shouldBeEqualToString("referrer", "http://127.0.0.1:8000/referrer-policy-iframe/no-referrer-when-downgrade/cross-origin-http-http.html");
-    if (window.internals)
-        internals.setTrackingPreventionEnabled(true);
+    testRunner?.setStatisticsEnabled(true);
     finishJSTest();
 }
 </script>

--- a/LayoutTests/http/tests/referrer-policy-iframe/no-referrer-when-downgrade/cross-origin-http.https.html
+++ b/LayoutTests/http/tests/referrer-policy-iframe/no-referrer-when-downgrade/cross-origin-http.https.html
@@ -8,17 +8,15 @@
 description("Tests the behavior of no-referrer-when-downgrade referrer policy when cross origin from HTTPS to HTTP.");
 jsTestIsAsync = true;
 
-if (window.internals) {
+if (window.internals)
     internals.settings.setAllowDisplayOfInsecureContent(true);
-    internals.setTrackingPreventionEnabled(false);
-}
+testRunner?.setStatisticsEnabled(false);
 
 window.onmessage = function(event) {
     referrer = event.data.referrer;
     // Should be the empty string
     shouldBeEqualToString("referrer", "");
-    if (window.internals)
-        internals.setTrackingPreventionEnabled(true);
+    testRunner?.setStatisticsEnabled(true);
     finishJSTest();
 }
 </script>

--- a/LayoutTests/http/tests/referrer-policy-iframe/no-referrer-when-downgrade/same-origin.html
+++ b/LayoutTests/http/tests/referrer-policy-iframe/no-referrer-when-downgrade/same-origin.html
@@ -8,15 +8,13 @@
 description("Tests the behavior of no-referrer-when-downgrade referrer policy when same origin.");
 jsTestIsAsync = true;
 
-if (window.internals)
-    internals.setTrackingPreventionEnabled(false);
+testRunner?.setStatisticsEnabled(false);
 
 window.onmessage = function(event) {
     referrer = event.data.referrer;
     // Should be the full URL
     shouldBeEqualToString("referrer", "http://127.0.0.1:8000/referrer-policy-iframe/no-referrer-when-downgrade/same-origin.html");
-    if (window.internals)
-        internals.setTrackingPreventionEnabled(true);
+    testRunner?.setStatisticsEnabled(true);
     finishJSTest();
 }
 </script>

--- a/LayoutTests/http/tests/referrer-policy-iframe/no-referrer/cross-origin-http-UpgradeMixedContent.https.html
+++ b/LayoutTests/http/tests/referrer-policy-iframe/no-referrer/cross-origin-http-UpgradeMixedContent.https.html
@@ -8,21 +8,20 @@
 description("Tests the behavior of no-referrer referrer policy when cross origin from HTTPS to HTTP.");
 jsTestIsAsync = true;
 
-if (window.internals) {
+if (window.internals)
     internals.settings.setAllowDisplayOfInsecureContent(true);
-    internals.setTrackingPreventionEnabled(false);
-}
+testRunner?.setStatisticsEnabled(false);
 
 window.onmessage = function(event) {
     testFailed("Document should not be loaded");
     referrer = event.data.referrer;
     // Should be the empty string
     shouldBeEqualToString("referrer", "");
-    if (window.internals)
-        internals.setTrackingPreventionEnabled(true);
+    testRunner?.setStatisticsEnabled(true);
     finishJSTest();
 }
 setTimeout(() => {
+    testRunner?.setStatisticsEnabled(true);
     testPassed("Loading insecure iframe timed out");
     finishJSTest();
 }, 500);

--- a/LayoutTests/http/tests/referrer-policy-iframe/no-referrer/cross-origin-http-http.html
+++ b/LayoutTests/http/tests/referrer-policy-iframe/no-referrer/cross-origin-http-http.html
@@ -8,15 +8,13 @@
 description("Tests the behavior of no-referrer referrer policy when cross origin.");
 jsTestIsAsync = true;
 
-if (window.internals)
-    internals.setTrackingPreventionEnabled(false);
+testRunner?.setStatisticsEnabled(false);
 
 window.onmessage = function(event) {
     referrer = event.data.referrer;
     // Should be the empty string
     shouldBeEqualToString("referrer", "");
-    if (window.internals)
-        internals.setTrackingPreventionEnabled(true);
+    testRunner?.setStatisticsEnabled(true);
     finishJSTest();
 }
 </script>

--- a/LayoutTests/http/tests/referrer-policy-iframe/no-referrer/cross-origin-http.https.html
+++ b/LayoutTests/http/tests/referrer-policy-iframe/no-referrer/cross-origin-http.https.html
@@ -8,17 +8,15 @@
 description("Tests the behavior of no-referrer referrer policy when cross origin from HTTPS to HTTP.");
 jsTestIsAsync = true;
 
-if (window.internals) {
+if (window.internals)
     internals.settings.setAllowDisplayOfInsecureContent(true);
-    internals.setTrackingPreventionEnabled(false);
-}
+testRunner?.setStatisticsEnabled(false);
 
 window.onmessage = function(event) {
     referrer = event.data.referrer;
     // Should be the empty string
     shouldBeEqualToString("referrer", "");
-    if (window.internals)
-        internals.setTrackingPreventionEnabled(true);
+    testRunner?.setStatisticsEnabled(true);
     finishJSTest();
 }
 </script>

--- a/LayoutTests/http/tests/referrer-policy-iframe/no-referrer/same-origin.html
+++ b/LayoutTests/http/tests/referrer-policy-iframe/no-referrer/same-origin.html
@@ -8,15 +8,13 @@
 description("Tests the behavior of no-referrer referrer policy when same origin.");
 jsTestIsAsync = true;
 
-if (window.internals)
-    internals.setTrackingPreventionEnabled(false);
+testRunner?.setStatisticsEnabled(false);
 
 window.onmessage = function(event) {
     referrer = event.data.referrer;
     // Should be the empty string
     shouldBeEqualToString("referrer", "");
-    if (window.internals)
-        internals.setTrackingPreventionEnabled(true);
+    testRunner?.setStatisticsEnabled(true);
     finishJSTest();
 }
 </script>

--- a/LayoutTests/http/tests/referrer-policy-iframe/origin-when-cross-origin/cross-origin-http-UpgradeMixedContent.https.html
+++ b/LayoutTests/http/tests/referrer-policy-iframe/origin-when-cross-origin/cross-origin-http-UpgradeMixedContent.https.html
@@ -8,18 +8,16 @@
 description("Tests the behavior of origin-when-cross-origin referrer policy when cross origin from HTTPS to HTTP.");
 jsTestIsAsync = true;
 
-if (window.internals) {
+if (window.internals)
     internals.settings.setAllowDisplayOfInsecureContent(true);
-    internals.setTrackingPreventionEnabled(false);
-}
+testRunner?.setStatisticsEnabled(false);
 
 window.onmessage = function(event) {
     testFailed("Document should not be loaded");
     referrer = event.data.referrer;
     // Should be the origin, not the full URL, because we are cross-origin.
     shouldBeEqualToString("referrer", "https://127.0.0.1:8443/");
-    if (window.internals)
-        internals.setTrackingPreventionEnabled(true);
+    testRunner?.setStatisticsEnabled(true);
     finishJSTest();
 }
 setTimeout(() => {

--- a/LayoutTests/http/tests/referrer-policy-iframe/origin-when-cross-origin/cross-origin-http-http.html
+++ b/LayoutTests/http/tests/referrer-policy-iframe/origin-when-cross-origin/cross-origin-http-http.html
@@ -8,15 +8,13 @@
 description("Tests the behavior of origin-when-cross-origin referrer policy when cross origin.");
 jsTestIsAsync = true;
 
-if (window.internals)
-    internals.setTrackingPreventionEnabled(false);
+testRunner?.setStatisticsEnabled(false);
 
 window.onmessage = function(event) {
     referrer = event.data.referrer;
     // Should be the origin, not the full URL, because we are cross-origin.
     shouldBeEqualToString("referrer", "http://127.0.0.1:8000/");
-    if (window.internals)
-        internals.setTrackingPreventionEnabled(true);
+    testRunner?.setStatisticsEnabled(true);
     finishJSTest();
 }
 </script>

--- a/LayoutTests/http/tests/referrer-policy-iframe/origin-when-cross-origin/cross-origin-http.https.html
+++ b/LayoutTests/http/tests/referrer-policy-iframe/origin-when-cross-origin/cross-origin-http.https.html
@@ -8,17 +8,15 @@
 description("Tests the behavior of origin-when-cross-origin referrer policy when cross origin from HTTPS to HTTP.");
 jsTestIsAsync = true;
 
-if (window.internals) {
+if (window.internals)
     internals.settings.setAllowDisplayOfInsecureContent(true);
-    internals.setTrackingPreventionEnabled(false);
-}
+testRunner?.setStatisticsEnabled(false);
 
 window.onmessage = function(event) {
     referrer = event.data.referrer;
     // Should be the origin, not the full URL, because we are cross-origin.
     shouldBeEqualToString("referrer", "https://127.0.0.1:8443/");
-    if (window.internals)
-        internals.setTrackingPreventionEnabled(true);
+    testRunner?.setStatisticsEnabled(true);
     finishJSTest();
 }
 </script>

--- a/LayoutTests/http/tests/referrer-policy-iframe/origin-when-cross-origin/same-origin.html
+++ b/LayoutTests/http/tests/referrer-policy-iframe/origin-when-cross-origin/same-origin.html
@@ -8,15 +8,13 @@
 description("Tests the behavior of origin-when-cross-origin referrer policy when same origin.");
 jsTestIsAsync = true;
 
-if (window.internals)
-    internals.setTrackingPreventionEnabled(false);
+testRunner?.setStatisticsEnabled(false);
 
 window.onmessage = function(event) {
     referrer = event.data.referrer;
     // Should be the full URL because we are same-origin.
     shouldBeEqualToString("referrer", "http://127.0.0.1:8000/referrer-policy-iframe/origin-when-cross-origin/same-origin.html");
-    if (window.internals)
-        internals.setTrackingPreventionEnabled(true);
+    testRunner?.setStatisticsEnabled(true);
     finishJSTest();
 }
 </script>

--- a/LayoutTests/http/tests/referrer-policy-iframe/origin/cross-origin-http-UpgradeMixedContent.https.html
+++ b/LayoutTests/http/tests/referrer-policy-iframe/origin/cross-origin-http-UpgradeMixedContent.https.html
@@ -8,18 +8,16 @@
 description("Tests the behavior of origin referrer policy when cross origin from HTTPS to HTTP.");
 jsTestIsAsync = true;
 
-if (window.internals) {
+if (window.internals)
     internals.settings.setAllowDisplayOfInsecureContent(true);
-    internals.setTrackingPreventionEnabled(false);
-}
+testRunner?.setStatisticsEnabled(false);
 
 window.onmessage = function(event) {
     testFailed("Document should not be loaded");
     referrer = event.data.referrer;
     // Should be the origin
     shouldBeEqualToString("referrer", "https://127.0.0.1:8443/");
-    if (window.internals)
-        internals.setTrackingPreventionEnabled(true);
+    testRunner?.setStatisticsEnabled(true);
     finishJSTest();
 }
 setTimeout(() => {

--- a/LayoutTests/http/tests/referrer-policy-iframe/origin/cross-origin-http-http.html
+++ b/LayoutTests/http/tests/referrer-policy-iframe/origin/cross-origin-http-http.html
@@ -8,15 +8,13 @@
 description("Tests the behavior of origin referrer policy when cross origin.");
 jsTestIsAsync = true;
 
-if (window.internals)
-    internals.setTrackingPreventionEnabled(false);
+testRunner?.setStatisticsEnabled(false);
 
 window.onmessage = function(event) {
     referrer = event.data.referrer;
     // Should be the origin
     shouldBeEqualToString("referrer", "http://127.0.0.1:8000/");
-    if (window.internals)
-        internals.setTrackingPreventionEnabled(true);
+    testRunner?.setStatisticsEnabled(true);
     finishJSTest();
 }
 </script>

--- a/LayoutTests/http/tests/referrer-policy-iframe/origin/cross-origin-http.https.html
+++ b/LayoutTests/http/tests/referrer-policy-iframe/origin/cross-origin-http.https.html
@@ -8,17 +8,16 @@
 description("Tests the behavior of origin referrer policy when cross origin from HTTPS to HTTP.");
 jsTestIsAsync = true;
 
-if (window.internals) {
+if (window.internals)
     internals.settings.setAllowDisplayOfInsecureContent(true);
-    internals.setTrackingPreventionEnabled(false);
-}
+
+testRunner?.setStatisticsEnabled(false);
 
 window.onmessage = function(event) {
     referrer = event.data.referrer;
     // Should be the origin
     shouldBeEqualToString("referrer", "https://127.0.0.1:8443/");
-    if (window.internals)
-        internals.setTrackingPreventionEnabled(true);
+    testRunner?.setStatisticsEnabled(true);
     finishJSTest();
 }
 </script>

--- a/LayoutTests/http/tests/referrer-policy-iframe/origin/same-origin.html
+++ b/LayoutTests/http/tests/referrer-policy-iframe/origin/same-origin.html
@@ -8,15 +8,13 @@
 description("Tests the behavior of origin referrer policy when same origin.");
 jsTestIsAsync = true;
 
-if (window.internals)
-    internals.setTrackingPreventionEnabled(false);
+testRunner?.setStatisticsEnabled(false);
 
 window.onmessage = function(event) {
     referrer = event.data.referrer;
     // Should be the origin
     shouldBeEqualToString("referrer", "http://127.0.0.1:8000/");
-    if (window.internals)
-        internals.setTrackingPreventionEnabled(true);
+    testRunner?.setStatisticsEnabled(true);
     finishJSTest();
 }
 </script>

--- a/LayoutTests/http/tests/referrer-policy-iframe/same-origin/cross-origin-http-UpgradeMixedContent.https.html
+++ b/LayoutTests/http/tests/referrer-policy-iframe/same-origin/cross-origin-http-UpgradeMixedContent.https.html
@@ -8,18 +8,16 @@
 description("Tests the behavior of same-origin referrer policy when cross origin from HTTPS to HTTP.");
 jsTestIsAsync = true;
 
-if (window.internals) {
+if (window.internals)
     internals.settings.setAllowDisplayOfInsecureContent(true);
-    internals.setTrackingPreventionEnabled(false);
-}
+testRunner?.setStatisticsEnabled(false);
 
 window.onmessage = function(event) {
     testFailed("Document should not be loaded");
     referrer = event.data.referrer;
     // Should be the empty string because we are cross-origin.
     shouldBeEqualToString("referrer", "");
-    if (window.internals)
-        internals.setTrackingPreventionEnabled(true);
+    testRunner?.setStatisticsEnabled(true);
     finishJSTest();
 }
 setTimeout(() => {

--- a/LayoutTests/http/tests/referrer-policy-iframe/same-origin/cross-origin-http-http.html
+++ b/LayoutTests/http/tests/referrer-policy-iframe/same-origin/cross-origin-http-http.html
@@ -8,15 +8,13 @@
 description("Tests the behavior of same-origin referrer policy when cross origin.");
 jsTestIsAsync = true;
 
-if (window.internals)
-    internals.setTrackingPreventionEnabled(false);
+testRunner?.setStatisticsEnabled(false);
 
 window.onmessage = function(event) {
     referrer = event.data.referrer;
     // Should be the empty string because we are cross-origin.
     shouldBeEqualToString("referrer", "");
-    if (window.internals)
-        internals.setTrackingPreventionEnabled(true);
+    testRunner?.setStatisticsEnabled(true);
     finishJSTest();
 }
 </script>

--- a/LayoutTests/http/tests/referrer-policy-iframe/same-origin/cross-origin-http.https.html
+++ b/LayoutTests/http/tests/referrer-policy-iframe/same-origin/cross-origin-http.https.html
@@ -8,17 +8,15 @@
 description("Tests the behavior of same-origin referrer policy when cross origin from HTTPS to HTTP.");
 jsTestIsAsync = true;
 
-if (window.internals) {
+if (window.internals)
     internals.settings.setAllowDisplayOfInsecureContent(true);
-    internals.setTrackingPreventionEnabled(false);
-}
+testRunner?.setStatisticsEnabled(false);
 
 window.onmessage = function(event) {
     referrer = event.data.referrer;
     // Should be the empty string because we are cross-origin.
     shouldBeEqualToString("referrer", "");
-    if (window.internals)
-        internals.setTrackingPreventionEnabled(true);
+    testRunner?.setStatisticsEnabled(true);
     finishJSTest();
 }
 </script>

--- a/LayoutTests/http/tests/referrer-policy-iframe/same-origin/same-origin.html
+++ b/LayoutTests/http/tests/referrer-policy-iframe/same-origin/same-origin.html
@@ -8,15 +8,13 @@
 description("Tests the behavior of same-origin referrer policy when same origin.");
 jsTestIsAsync = true;
 
-if (window.internals)
-    internals.setTrackingPreventionEnabled(false);
+testRunner?.setStatisticsEnabled(false);
 
 window.onmessage = function(event) {
     referrer = event.data.referrer;
     // Should be the full URL because we are same-origin.
     shouldBeEqualToString("referrer", "http://127.0.0.1:8000/referrer-policy-iframe/same-origin/same-origin.html");
-    if (window.internals)
-        internals.setTrackingPreventionEnabled(true);
+    testRunner?.setStatisticsEnabled(true);
     finishJSTest();
 }
 </script>

--- a/LayoutTests/http/tests/referrer-policy-iframe/strict-origin-when-cross-origin/cross-origin-http-UpgradeMixedContent.https.html
+++ b/LayoutTests/http/tests/referrer-policy-iframe/strict-origin-when-cross-origin/cross-origin-http-UpgradeMixedContent.https.html
@@ -8,18 +8,16 @@
 description("Tests the behavior of strict-origin-when-cross-origin referrer policy when cross origin from HTTPS to HTTP.");
 jsTestIsAsync = true;
 
-if (window.internals) {
+if (window.internals)
     internals.settings.setAllowDisplayOfInsecureContent(true);
-    internals.setTrackingPreventionEnabled(false);
-}
+testRunner?.setStatisticsEnabled(false);
 
 window.onmessage = function(event) {
     testFailed("Document should not be loaded");
     referrer = event.data.referrer;
     // Should be the empty string because we are cross-origin and going from HTTPS to HTTP.
     shouldBeEqualToString("referrer", "");
-    if (window.internals)
-        internals.setTrackingPreventionEnabled(true);
+    testRunner?.setStatisticsEnabled(true);
     finishJSTest();
 }
 setTimeout(() => {

--- a/LayoutTests/http/tests/referrer-policy-iframe/strict-origin-when-cross-origin/cross-origin-http-http.html
+++ b/LayoutTests/http/tests/referrer-policy-iframe/strict-origin-when-cross-origin/cross-origin-http-http.html
@@ -8,15 +8,13 @@
 description("Tests the behavior of strict-origin-when-cross-origin referrer policy when cross origin.");
 jsTestIsAsync = true;
 
-if (window.internals)
-    internals.setTrackingPreventionEnabled(false);
+testRunner?.setStatisticsEnabled(false);
 
 window.onmessage = function(event) {
     referrer = event.data.referrer;
     // Should be the origin, not the full URL, because we are cross-origin.
     shouldBeEqualToString("referrer", "http://127.0.0.1:8000/");
-    if (window.internals)
-        internals.setTrackingPreventionEnabled(true);
+    testRunner?.setStatisticsEnabled(true);
     finishJSTest();
 }
 </script>

--- a/LayoutTests/http/tests/referrer-policy-iframe/strict-origin-when-cross-origin/cross-origin-http.https.html
+++ b/LayoutTests/http/tests/referrer-policy-iframe/strict-origin-when-cross-origin/cross-origin-http.https.html
@@ -8,17 +8,15 @@
 description("Tests the behavior of strict-origin-when-cross-origin referrer policy when cross origin from HTTPS to HTTP.");
 jsTestIsAsync = true;
 
-if (window.internals) {
+if (window.internals)
     internals.settings.setAllowDisplayOfInsecureContent(true);
-    internals.setTrackingPreventionEnabled(false);
-}
+testRunner?.setStatisticsEnabled(false);
 
 window.onmessage = function(event) {
     referrer = event.data.referrer;
     // Should be the empty string because we are cross-origin and going from HTTPS to HTTP.
     shouldBeEqualToString("referrer", "");
-    if (window.internals)
-        internals.setTrackingPreventionEnabled(true);
+    testRunner?.setStatisticsEnabled(true);
     finishJSTest();
 }
 </script>

--- a/LayoutTests/http/tests/referrer-policy-iframe/strict-origin-when-cross-origin/same-origin.html
+++ b/LayoutTests/http/tests/referrer-policy-iframe/strict-origin-when-cross-origin/same-origin.html
@@ -8,15 +8,13 @@
 description("Tests the behavior of strict-origin-when-cross-origin referrer policy when same origin.");
 jsTestIsAsync = true;
 
-if (window.internals)
-    internals.setTrackingPreventionEnabled(false);
+testRunner?.setStatisticsEnabled(false);
 
 window.onmessage = function(event) {
     referrer = event.data.referrer;
     // Should be the full URL because we are same-origin.
     shouldBeEqualToString("referrer", "http://127.0.0.1:8000/referrer-policy-iframe/strict-origin-when-cross-origin/same-origin.html");
-    if (window.internals)
-        internals.setTrackingPreventionEnabled(true);
+    testRunner?.setStatisticsEnabled(true);
     finishJSTest();
 }
 </script>

--- a/LayoutTests/http/tests/referrer-policy-iframe/strict-origin/cross-origin-http-UpgradeMixedContent.https.html
+++ b/LayoutTests/http/tests/referrer-policy-iframe/strict-origin/cross-origin-http-UpgradeMixedContent.https.html
@@ -8,21 +8,20 @@
 description("Tests the behavior of strict-origin referrer policy when cross origin from HTTPS to HTTP.");
 jsTestIsAsync = true;
 
-if (window.internals) {
+if (window.internals)
     internals.settings.setAllowDisplayOfInsecureContent(true);
-    internals.setTrackingPreventionEnabled(false);
-}
+testRunner?.setStatisticsEnabled(false);
 
 window.onmessage = function(event) {
     testFailed("Document should not be loaded");
     referrer = event.data.referrer;
     // Should be the empty string because we are going from HTTPS to HTTP.
     shouldBeEqualToString("referrer", "");
-    if (window.internals)
-        internals.setTrackingPreventionEnabled(true);
+    testRunner?.setStatisticsEnabled(true);
     finishJSTest();
 }
 setTimeout(() => {
+    testRunner?.setStatisticsEnabled(true);
     testPassed("Loading insecure iframe timed out");
     finishJSTest();
 }, 500);

--- a/LayoutTests/http/tests/referrer-policy-iframe/strict-origin/cross-origin-http-http.html
+++ b/LayoutTests/http/tests/referrer-policy-iframe/strict-origin/cross-origin-http-http.html
@@ -8,15 +8,13 @@
 description("Tests the behavior of strict-origin referrer policy when cross origin.");
 jsTestIsAsync = true;
 
-if (window.internals)
-    internals.setTrackingPreventionEnabled(false);
+testRunner?.setStatisticsEnabled(false);
 
 window.onmessage = function(event) {
     referrer = event.data.referrer;
     // Should be the origin, not the full URL.
     shouldBeEqualToString("referrer", "http://127.0.0.1:8000/");
-    if (window.internals)
-        internals.setTrackingPreventionEnabled(true);
+    testRunner?.setStatisticsEnabled(true);
     finishJSTest();
 }
 </script>

--- a/LayoutTests/http/tests/referrer-policy-iframe/strict-origin/cross-origin-http.https.html
+++ b/LayoutTests/http/tests/referrer-policy-iframe/strict-origin/cross-origin-http.https.html
@@ -8,17 +8,15 @@
 description("Tests the behavior of strict-origin referrer policy when cross origin from HTTPS to HTTP.");
 jsTestIsAsync = true;
 
-if (window.internals) {
+if (window.internals)
     internals.settings.setAllowDisplayOfInsecureContent(true);
-    internals.setTrackingPreventionEnabled(false);
-}
+testRunner?.setStatisticsEnabled(false);
 
 window.onmessage = function(event) {
     referrer = event.data.referrer;
     // Should be the empty string because we are going from HTTPS to HTTP.
     shouldBeEqualToString("referrer", "");
-    if (window.internals)
-        internals.setTrackingPreventionEnabled(true);
+    testRunner?.setStatisticsEnabled(true);
     finishJSTest();
 }
 </script>

--- a/LayoutTests/http/tests/referrer-policy-iframe/strict-origin/same-origin.html
+++ b/LayoutTests/http/tests/referrer-policy-iframe/strict-origin/same-origin.html
@@ -8,15 +8,13 @@
 description("Tests the behavior of strict-origin referrer policy when same origin.");
 jsTestIsAsync = true;
 
-if (window.internals)
-    internals.setTrackingPreventionEnabled(false);
+testRunner?.setStatisticsEnabled(false);
 
 window.onmessage = function(event) {
     referrer = event.data.referrer;
     // Should be the origin, not the full URL.
     shouldBeEqualToString("referrer", "http://127.0.0.1:8000/");
-    if (window.internals)
-        internals.setTrackingPreventionEnabled(true);
+    testRunner?.setStatisticsEnabled(true);
     finishJSTest();
 }
 </script>

--- a/LayoutTests/http/tests/referrer-policy-iframe/unsafe-url/cross-origin-http-UpgradeMixedContent.https.html
+++ b/LayoutTests/http/tests/referrer-policy-iframe/unsafe-url/cross-origin-http-UpgradeMixedContent.https.html
@@ -8,18 +8,16 @@
 description("Tests the behavior of unsafe-url referrer policy when cross origin from HTTPS to HTTP.");
 jsTestIsAsync = true;
 
-if (window.internals) {
+if (window.internals)
     internals.settings.setAllowDisplayOfInsecureContent(true);
-    internals.setTrackingPreventionEnabled(false);
-}
+testRunner?.setStatisticsEnabled(false);
 
 window.onmessage = function(event) {
     testFailed("Document should not be loaded");
     referrer = event.data.referrer;
     // Should be the full URL
     shouldBeEqualToString("referrer", "https://127.0.0.1:8443/referrer-policy-iframe/unsafe-url/cross-origin-http.https.html");
-    if (window.internals)
-        internals.setTrackingPreventionEnabled(true);
+    testRunner?.setStatisticsEnabled(true);
     finishJSTest();
 }
 setTimeout(() => {

--- a/LayoutTests/http/tests/referrer-policy-iframe/unsafe-url/cross-origin-http-http.html
+++ b/LayoutTests/http/tests/referrer-policy-iframe/unsafe-url/cross-origin-http-http.html
@@ -8,15 +8,13 @@
 description("Tests the behavior of unsafe-url referrer policy when cross origin.");
 jsTestIsAsync = true;
 
-if (window.internals)
-    internals.setTrackingPreventionEnabled(false);
+testRunner?.setStatisticsEnabled(false);
 
 window.onmessage = function(event) {
     referrer = event.data.referrer;
     // Should be the full URL
     shouldBeEqualToString("referrer", "http://127.0.0.1:8000/referrer-policy-iframe/unsafe-url/cross-origin-http-http.html");
-    if (window.internals)
-        internals.setTrackingPreventionEnabled(true);
+    testRunner?.setStatisticsEnabled(true);
     finishJSTest();
 }
 </script>

--- a/LayoutTests/http/tests/referrer-policy-iframe/unsafe-url/cross-origin-http.https.html
+++ b/LayoutTests/http/tests/referrer-policy-iframe/unsafe-url/cross-origin-http.https.html
@@ -8,17 +8,15 @@
 description("Tests the behavior of unsafe-url referrer policy when cross origin from HTTPS to HTTP.");
 jsTestIsAsync = true;
 
-if (window.internals) {
+if (window.internals)
     internals.settings.setAllowDisplayOfInsecureContent(true);
-    internals.setTrackingPreventionEnabled(false);
-}
+testRunner?.setStatisticsEnabled(false);
 
 window.onmessage = function(event) {
     referrer = event.data.referrer;
     // Should be the full URL
     shouldBeEqualToString("referrer", "https://127.0.0.1:8443/referrer-policy-iframe/unsafe-url/cross-origin-http.https.html");
-    if (window.internals)
-        internals.setTrackingPreventionEnabled(true);
+    testRunner?.setStatisticsEnabled(true);
     finishJSTest();
 }
 </script>

--- a/LayoutTests/http/tests/referrer-policy-iframe/unsafe-url/same-origin.html
+++ b/LayoutTests/http/tests/referrer-policy-iframe/unsafe-url/same-origin.html
@@ -8,15 +8,13 @@
 description("Tests the behavior of unsafe-url referrer policy when same origin.");
 jsTestIsAsync = true;
 
-if (window.internals)
-    internals.setTrackingPreventionEnabled(false);
+testRunner?.setStatisticsEnabled(false);
 
 window.onmessage = function(event) {
     referrer = event.data.referrer;
     // Should be the full URL
     shouldBeEqualToString("referrer", "http://127.0.0.1:8000/referrer-policy-iframe/unsafe-url/same-origin.html");
-    if (window.internals)
-        internals.setTrackingPreventionEnabled(true);
+    testRunner?.setStatisticsEnabled(true);
     finishJSTest();
 }
 </script>

--- a/LayoutTests/http/tests/referrer-policy-img/no-referrer-when-downgrade/cross-origin-http-UpgradeMixedContent.https.html
+++ b/LayoutTests/http/tests/referrer-policy-img/no-referrer-when-downgrade/cross-origin-http-UpgradeMixedContent.https.html
@@ -8,10 +8,9 @@
 description("Tests the behavior of no-referrer-when-downgrade referrer policy when cross origin from HTTPS to HTTP.");
 jsTestIsAsync = true;
 
-if (window.internals) {
+if (window.internals)
     internals.settings.setAllowDisplayOfInsecureContent(true);
-    internals.setTrackingPreventionEnabled(false);
-}
+testRunner?.setStatisticsEnabled(false);
 
 if (window.testRunner) {
     testRunner.setStatisticsShouldDowngradeReferrer(false, function () {
@@ -22,8 +21,7 @@ if (window.testRunner) {
         img.onload = function() { testPassed('referrer is "' + expected + '"'); finishJSTest(); }
         img.onerror = function() { testFailed("referrer is not as expected"); finishJSTest(); }
         img.src = "http://127.0.0.1:8000/referrer-policy/resources/image.py?expected=" + expected;
-        if (window.internals)
-            internals.setTrackingPreventionEnabled(true);
+        testRunner?.setStatisticsEnabled(true);
     });
 }
 

--- a/LayoutTests/http/tests/referrer-policy-img/no-referrer-when-downgrade/cross-origin-http-http.html
+++ b/LayoutTests/http/tests/referrer-policy-img/no-referrer-when-downgrade/cross-origin-http-http.html
@@ -8,8 +8,7 @@
 description("Tests the behavior of no-referrer-when-downgrade referrer policy when cross origin.");
 jsTestIsAsync = true;
 
-if (window.internals)
-    internals.setTrackingPreventionEnabled(false);
+testRunner?.setStatisticsEnabled(false);
 
 if (window.testRunner) {
     testRunner.setStatisticsShouldDowngradeReferrer(false, function () {
@@ -20,8 +19,7 @@ if (window.testRunner) {
         img.onload = function() { testPassed('referrer is "' + expected + '"'); finishJSTest(); }
         img.onerror = function() { testFailed("referrer is not as expected"); finishJSTest(); }
         img.src = "http://127.0.0.1:8000/referrer-policy/resources/image.py?expected=" + expected;
-        if (window.internals)
-            internals.setTrackingPreventionEnabled(true);
+        testRunner?.setStatisticsEnabled(true);
     }); 
 }
 

--- a/LayoutTests/http/tests/referrer-policy-img/no-referrer-when-downgrade/cross-origin-http.https.html
+++ b/LayoutTests/http/tests/referrer-policy-img/no-referrer-when-downgrade/cross-origin-http.https.html
@@ -8,10 +8,9 @@
 description("Tests the behavior of no-referrer-when-downgrade referrer policy when cross origin from HTTPS to HTTP.");
 jsTestIsAsync = true;
 
-if (window.internals) {
+if (window.internals)
     internals.settings.setAllowDisplayOfInsecureContent(true);
-    internals.setTrackingPreventionEnabled(false);
-}
+testRunner?.setStatisticsEnabled(false);
 
 if (window.testRunner) {
     testRunner.setStatisticsShouldDowngradeReferrer(false, function () {
@@ -22,8 +21,7 @@ if (window.testRunner) {
         img.onload = function() { testPassed('referrer is "' + expected + '"'); finishJSTest(); }
         img.onerror = function() { testFailed("referrer is not as expected"); finishJSTest(); }
         img.src = "http://127.0.0.1:8000/referrer-policy/resources/image.py?expected=" + expected;
-        if (window.internals)
-            internals.setTrackingPreventionEnabled(true);
+        testRunner?.setStatisticsEnabled(true);
     });
 }
 

--- a/LayoutTests/http/tests/referrer-policy-img/no-referrer-when-downgrade/same-origin.html
+++ b/LayoutTests/http/tests/referrer-policy-img/no-referrer-when-downgrade/same-origin.html
@@ -8,8 +8,7 @@
 description("Tests the behavior of no-referrer-when-downgrade referrer policy when same origin.");
 jsTestIsAsync = true;
 
-if (window.internals)
-    internals.setTrackingPreventionEnabled(false);
+testRunner?.setStatisticsEnabled(false);
 
 if (window.testRunner) {
     testRunner.setStatisticsShouldDowngradeReferrer(false, function () {
@@ -20,8 +19,7 @@ if (window.testRunner) {
         img.onload = function() { testPassed('referrer is "' + expected + '"'); finishJSTest(); }
         img.onerror = function() { testFailed("referrer is not as expected"); finishJSTest(); }
         img.src = "http://127.0.0.1:8000/referrer-policy/resources/image.py?expected=" + expected;
-        if (window.internals)
-            internals.setTrackingPreventionEnabled(true);
+        testRunner?.setStatisticsEnabled(true);
     });
 }
 

--- a/LayoutTests/http/tests/referrer-policy-img/no-referrer/cross-origin-http-UpgradeMixedContent.https.html
+++ b/LayoutTests/http/tests/referrer-policy-img/no-referrer/cross-origin-http-UpgradeMixedContent.https.html
@@ -8,10 +8,9 @@
 description("Tests the behavior of no-referrer referrer policy when cross origin from HTTPS to HTTP, but the request is upgraded to HTTPS.");
 jsTestIsAsync = true;
 
-if (window.internals) {
+if (window.internals)
     internals.settings.setAllowDisplayOfInsecureContent(true);
-    internals.setTrackingPreventionEnabled(false);
-}
+testRunner?.setStatisticsEnabled(false);
 
 function loadImage() {
     // Should be the empty string
@@ -21,8 +20,7 @@ function loadImage() {
     img.onload = function() { testPassed('referrer is "' + expected + '"'); finishJSTest(); }
     img.onerror = function() { testFailed("referrer is not as expected"); finishJSTest(); }
     img.src = "http://localhost:8000/referrer-policy/resources/image.py?expected=" + expected;
-    if (window.internals)
-        internals.setTrackingPreventionEnabled(true);
+    testRunner?.setStatisticsEnabled(true);
 }
 
 </script>

--- a/LayoutTests/http/tests/referrer-policy-img/no-referrer/cross-origin-http-http.html
+++ b/LayoutTests/http/tests/referrer-policy-img/no-referrer/cross-origin-http-http.html
@@ -8,8 +8,7 @@
 description("Tests the behavior of no-referrer referrer policy when cross origin.");
 jsTestIsAsync = true;
 
-if (window.internals)
-    internals.setTrackingPreventionEnabled(false);
+testRunner?.setStatisticsEnabled(false);
 
 function loadImage() {
     // Should be the empty string
@@ -19,8 +18,7 @@ function loadImage() {
     img.onload = function() { testPassed('referrer is "' + expected + '"'); finishJSTest(); }
     img.onerror = function() { testFailed("referrer is not as expected"); finishJSTest(); }
     img.src = "http://localhost:8000/referrer-policy/resources/image.py?expected=" + expected;
-    if (window.internals)
-        internals.setTrackingPreventionEnabled(true);
+    testRunner?.setStatisticsEnabled(true);
 }
 
 </script>

--- a/LayoutTests/http/tests/referrer-policy-img/no-referrer/cross-origin-http.https.html
+++ b/LayoutTests/http/tests/referrer-policy-img/no-referrer/cross-origin-http.https.html
@@ -8,10 +8,9 @@
 description("Tests the behavior of no-referrer referrer policy when cross origin from HTTPS to HTTP.");
 jsTestIsAsync = true;
 
-if (window.internals) {
+if (window.internals)
     internals.settings.setAllowDisplayOfInsecureContent(true);
-    internals.setTrackingPreventionEnabled(false);
-}
+testRunner?.setStatisticsEnabled(false);
 
 function loadImage() {
     // Should be the empty string
@@ -21,8 +20,7 @@ function loadImage() {
     img.onload = function() { testPassed('referrer is "' + expected + '"'); finishJSTest(); }
     img.onerror = function() { testFailed("referrer is not as expected"); finishJSTest(); }
     img.src = "http://localhost:8000/referrer-policy/resources/image.py?expected=" + expected;
-    if (window.internals)
-        internals.setTrackingPreventionEnabled(true);
+    testRunner?.setStatisticsEnabled(true);
 }
 
 </script>

--- a/LayoutTests/http/tests/referrer-policy-img/no-referrer/same-origin.html
+++ b/LayoutTests/http/tests/referrer-policy-img/no-referrer/same-origin.html
@@ -8,8 +8,7 @@
 description("Tests the behavior of no-referrer referrer policy when same origin.");
 jsTestIsAsync = true;
 
-if (window.internals)
-    internals.setTrackingPreventionEnabled(false);
+testRunner?.setStatisticsEnabled(false);
 
 function loadImage() {
     // Should be the empty string
@@ -19,8 +18,7 @@ function loadImage() {
     img.onload = function() { testPassed('referrer is "' + expected + '"'); finishJSTest(); }
     img.onerror = function() { testFailed("referrer is not as expected"); finishJSTest(); }
     img.src = "http://localhost:8000/referrer-policy/resources/image.py?expected=" + expected;
-    if (window.internals)
-        internals.setTrackingPreventionEnabled(true);
+    testRunner?.setStatisticsEnabled(true);
 }
 
 </script>

--- a/LayoutTests/http/tests/referrer-policy-img/origin-when-cross-origin/cross-origin-http-UpgradeMixedContent.https.html
+++ b/LayoutTests/http/tests/referrer-policy-img/origin-when-cross-origin/cross-origin-http-UpgradeMixedContent.https.html
@@ -8,10 +8,9 @@
 description("Tests the behavior of origin-when-cross-origin referrer policy when cross origin from HTTPS to HTTP.");
 jsTestIsAsync = true;
 
-if (window.internals) {
+if (window.internals)
     internals.settings.setAllowDisplayOfInsecureContent(true);
-    internals.setTrackingPreventionEnabled(false);
-}
+testRunner?.setStatisticsEnabled(false);
 
 function loadImage() {
     // Should be the origin, not the full URL, because we are cross-origin.
@@ -21,8 +20,7 @@ function loadImage() {
     img.onload = function() { testPassed('referrer is "' + expected + '"'); finishJSTest(); }
     img.onerror = function() { testFailed("referrer is not origin-when-cross-origin"); finishJSTest(); }
     img.src = "http://localhost:8000/referrer-policy/resources/image.py?expected=" + expected;
-    if (window.internals)
-        internals.setTrackingPreventionEnabled(true);
+    testRunner?.setStatisticsEnabled(true);
 }
 
 </script>

--- a/LayoutTests/http/tests/referrer-policy-img/origin-when-cross-origin/cross-origin-http-http.html
+++ b/LayoutTests/http/tests/referrer-policy-img/origin-when-cross-origin/cross-origin-http-http.html
@@ -8,8 +8,7 @@
 description("Tests the behavior of origin-when-cross-origin referrer policy when cross origin.");
 jsTestIsAsync = true;
 
-if (window.internals)
-    internals.setTrackingPreventionEnabled(false);
+testRunner?.setStatisticsEnabled(false);
 
 function loadImage() {
     // Should be the origin, not the full URL, because we are cross-origin.
@@ -19,8 +18,7 @@ function loadImage() {
     img.onload = function() { testPassed('referrer is "' + expected + '"'); finishJSTest(); }
     img.onerror = function() { testFailed("referrer is not as expected"); finishJSTest(); }
     img.src = "http://localhost:8000/referrer-policy/resources/image.py?expected=" + expected;
-    if (window.internals)
-        internals.setTrackingPreventionEnabled(true);
+    testRunner?.setStatisticsEnabled(true);
 }
 
 </script>

--- a/LayoutTests/http/tests/referrer-policy-img/origin-when-cross-origin/cross-origin-http.https.html
+++ b/LayoutTests/http/tests/referrer-policy-img/origin-when-cross-origin/cross-origin-http.https.html
@@ -8,10 +8,9 @@
 description("Tests the behavior of origin-when-cross-origin referrer policy when cross origin from HTTPS to HTTP.");
 jsTestIsAsync = true;
 
-if (window.internals) {
+if (window.internals)
     internals.settings.setAllowDisplayOfInsecureContent(true);
-    internals.setTrackingPreventionEnabled(false);
-}
+testRunner?.setStatisticsEnabled(false);
 
 function loadImage() {
     // Should be the origin, not the full URL, because we are cross-origin.
@@ -21,8 +20,7 @@ function loadImage() {
     img.onload = function() { testPassed('referrer is "' + expected + '"'); finishJSTest(); }
     img.onerror = function() { testFailed("referrer is not as expected"); finishJSTest(); }
     img.src = "http://localhost:8000/referrer-policy/resources/image.py?expected=" + expected;
-    if (window.internals)
-        internals.setTrackingPreventionEnabled(true);
+    testRunner?.setStatisticsEnabled(true);
 }
 
 </script>

--- a/LayoutTests/http/tests/referrer-policy-img/origin-when-cross-origin/same-origin.html
+++ b/LayoutTests/http/tests/referrer-policy-img/origin-when-cross-origin/same-origin.html
@@ -8,8 +8,7 @@
 description("Tests the behavior of origin-when-cross-origin referrer policy when same origin.");
 jsTestIsAsync = true;
 
-if (window.internals)
-    internals.setTrackingPreventionEnabled(false);
+testRunner?.setStatisticsEnabled(false);
 
 function loadImage() {
     // Should be the full URL because we are same-origin.
@@ -19,8 +18,7 @@ function loadImage() {
     img.onload = function() { testPassed('referrer is "' + expected + '"'); finishJSTest(); }
     img.onerror = function() { testFailed("referrer is not as expected"); finishJSTest(); }
     img.src = "http://127.0.0.1:8000/referrer-policy/resources/image.py?expected=" + expected;
-    if (window.internals)
-        internals.setTrackingPreventionEnabled(true);
+    testRunner?.setStatisticsEnabled(true);
 }
 
 </script>

--- a/LayoutTests/http/tests/referrer-policy-img/origin/cross-origin-http-UpgradeMixedContent.https.html
+++ b/LayoutTests/http/tests/referrer-policy-img/origin/cross-origin-http-UpgradeMixedContent.https.html
@@ -8,10 +8,9 @@
 description("Tests the behavior of origin referrer policy when cross origin from HTTPS to HTTP.");
 jsTestIsAsync = true;
 
-if (window.internals) {
+if (window.internals)
     internals.settings.setAllowDisplayOfInsecureContent(true);
-    internals.setTrackingPreventionEnabled(false);
-}
+testRunner?.setStatisticsEnabled(false);
 
 function loadImage() {
     let expected = "https://127.0.0.1:8443/";
@@ -20,8 +19,7 @@ function loadImage() {
     img.onload = function() { testPassed('referrer is "' + expected + '"'); finishJSTest(); }
     img.onerror = function() { testFailed("referrer is not as expected"); finishJSTest(); }
     img.src = "http://127.0.0.1:8000/referrer-policy/resources/image.py?expected=" + expected;
-    if (window.internals)
-        internals.setTrackingPreventionEnabled(true);
+    testRunner?.setStatisticsEnabled(true);
 }
 
 </script>

--- a/LayoutTests/http/tests/referrer-policy-img/origin/cross-origin-http-http.html
+++ b/LayoutTests/http/tests/referrer-policy-img/origin/cross-origin-http-http.html
@@ -8,8 +8,7 @@
 description("Tests the behavior of origin referrer policy when cross origin.");
 jsTestIsAsync = true;
 
-if (window.internals)
-    internals.setTrackingPreventionEnabled(false);
+testRunner?.setStatisticsEnabled(false);
 
 function loadImage() {
     // Should be the origin
@@ -19,8 +18,7 @@ function loadImage() {
     img.onload = function() { testPassed('referrer is "' + expected + '"'); finishJSTest(); }
     img.onerror = function() { testFailed("referrer is not as expected"); finishJSTest(); }
     img.src = "http://127.0.0.1:8000/referrer-policy/resources/image.py?expected=" + expected;
-    if (window.internals)
-        internals.setTrackingPreventionEnabled(true);
+    testRunner?.setStatisticsEnabled(true);
 }
 
 </script>

--- a/LayoutTests/http/tests/referrer-policy-img/origin/cross-origin-http.https.html
+++ b/LayoutTests/http/tests/referrer-policy-img/origin/cross-origin-http.https.html
@@ -8,10 +8,9 @@
 description("Tests the behavior of origin referrer policy when cross origin from HTTPS to HTTP.");
 jsTestIsAsync = true;
 
-if (window.internals) {
+if (window.internals)
     internals.settings.setAllowDisplayOfInsecureContent(true);
-    internals.setTrackingPreventionEnabled(false);
-}
+testRunner?.setStatisticsEnabled(false);
 
 function loadImage() {
     // Should be the origin
@@ -21,8 +20,7 @@ function loadImage() {
     img.onload = function() { testPassed('referrer is "' + expected + '"'); finishJSTest(); }
     img.onerror = function() { testFailed("referrer is not as expected"); finishJSTest(); }
     img.src = "http://127.0.0.1:8000/referrer-policy/resources/image.py?expected=" + expected;
-    if (window.internals)
-        internals.setTrackingPreventionEnabled(true);
+    testRunner?.setStatisticsEnabled(true);
 }
 
 </script>

--- a/LayoutTests/http/tests/referrer-policy-img/origin/same-origin.html
+++ b/LayoutTests/http/tests/referrer-policy-img/origin/same-origin.html
@@ -8,8 +8,7 @@
 description("Tests the behavior of origin referrer policy when same origin.");
 jsTestIsAsync = true;
 
-if (window.internals)
-    internals.setTrackingPreventionEnabled(false);
+testRunner?.setStatisticsEnabled(false);
 
 function loadImage() {
     // Should be the origin
@@ -19,8 +18,7 @@ function loadImage() {
     img.onload = function() { testPassed('referrer is "' + expected + '"'); finishJSTest(); }
     img.onerror = function() { testFailed("referrer is not as expected"); finishJSTest(); }
     img.src = "http://127.0.0.1:8000/referrer-policy/resources/image.py?expected=" + expected;
-    if (window.internals)
-        internals.setTrackingPreventionEnabled(true);
+    testRunner?.setStatisticsEnabled(true);
 }
 
 </script>

--- a/LayoutTests/http/tests/referrer-policy-img/same-origin/cross-origin-http-http.html
+++ b/LayoutTests/http/tests/referrer-policy-img/same-origin/cross-origin-http-http.html
@@ -8,8 +8,7 @@
 description("Tests the behavior of same-origin referrer policy when cross origin.");
 jsTestIsAsync = true;
 
-if (window.internals)
-    internals.setTrackingPreventionEnabled(false);
+testRunner?.setStatisticsEnabled(false);
 
 function loadImage() {
     // Should be the empty string because we are cross-origin.
@@ -19,8 +18,7 @@ function loadImage() {
     img.onload = function() { testPassed('referrer is "' + expected + '"'); finishJSTest(); }
     img.onerror = function() { testFailed("referrer is not as expected"); finishJSTest(); }
     img.src = "http://localhost:8000/referrer-policy/resources/image.py?expected=" + expected;
-    if (window.internals)
-        internals.setTrackingPreventionEnabled(true);
+    testRunner?.setStatisticsEnabled(true);
 }
 
 </script>

--- a/LayoutTests/http/tests/referrer-policy-img/same-origin/cross-origin-http.https.html
+++ b/LayoutTests/http/tests/referrer-policy-img/same-origin/cross-origin-http.https.html
@@ -8,10 +8,9 @@
 description("Tests the behavior of same-origin referrer policy when cross origin from HTTPS to HTTP.");
 jsTestIsAsync = true;
 
-if (window.internals) {
+if (window.internals)
     internals.settings.setAllowDisplayOfInsecureContent(true);
-    internals.setTrackingPreventionEnabled(false);
-}
+testRunner?.setStatisticsEnabled(false);
 
 function loadImage() {
     // Should be the empty string because we are cross-origin.
@@ -21,8 +20,7 @@ function loadImage() {
     img.onload = function() { testPassed('referrer is "' + expected + '"'); finishJSTest(); }
     img.onerror = function() { testFailed("referrer is not as expected"); finishJSTest(); }
     img.src = "http://localhost:8000/referrer-policy/resources/image.py?expected=" + expected;
-    if (window.internals)
-        internals.setTrackingPreventionEnabled(true);
+    testRunner?.setStatisticsEnabled(true);
 }
 
 </script>

--- a/LayoutTests/http/tests/referrer-policy-img/same-origin/same-origin.html
+++ b/LayoutTests/http/tests/referrer-policy-img/same-origin/same-origin.html
@@ -8,8 +8,7 @@
 description("Tests the behavior of same-origin referrer policy when same origin.");
 jsTestIsAsync = true;
 
-if (window.internals)
-    internals.setTrackingPreventionEnabled(false);
+testRunner?.setStatisticsEnabled(false);
 
 function loadImage() {
     // Should be the full URL because we are same-origin.
@@ -19,8 +18,7 @@ function loadImage() {
     img.onload = function() { testPassed('referrer is "' + expected + '"'); finishJSTest(); }
     img.onerror = function() { testFailed("referrer is not as expected"); finishJSTest(); }
     img.src = "http://127.0.0.1:8000/referrer-policy/resources/image.py?expected=" + expected;
-    if (window.internals)
-        internals.setTrackingPreventionEnabled(true);
+    testRunner?.setStatisticsEnabled(true);
 }
 
 </script>

--- a/LayoutTests/http/tests/referrer-policy-img/strict-origin-when-cross-origin/cross-origin-http-UpgradeMixedContent.https.html
+++ b/LayoutTests/http/tests/referrer-policy-img/strict-origin-when-cross-origin/cross-origin-http-UpgradeMixedContent.https.html
@@ -8,10 +8,9 @@
 description("Tests the behavior of strict-origin-when-cross-origin referrer policy when cross origin from HTTPS to HTTP.");
 jsTestIsAsync = true;
 
-if (window.internals) {
+if (window.internals)
     internals.settings.setAllowDisplayOfInsecureContent(true);
-    internals.setTrackingPreventionEnabled(false);
-}
+testRunner?.setStatisticsEnabled(false);
 
 function loadImage() {
     // Should be origin because we are cross-origin and going from HTTPS to HTTP, with HTTP upgraded to HTTPS.
@@ -21,8 +20,7 @@ function loadImage() {
     img.onload = function() { testPassed('referrer is "' + expected + '"'); finishJSTest(); }
     img.onerror = function() { testFailed("referrer is not strict-origin-when-cross-origin"); finishJSTest(); }
     img.src = "http://localhost:8000/referrer-policy/resources/image.py?expected=" + expected;
-    if (window.internals)
-        internals.setTrackingPreventionEnabled(true);
+    testRunner?.setStatisticsEnabled(true);
 }
 
 </script>

--- a/LayoutTests/http/tests/referrer-policy-img/strict-origin-when-cross-origin/cross-origin-http-http.html
+++ b/LayoutTests/http/tests/referrer-policy-img/strict-origin-when-cross-origin/cross-origin-http-http.html
@@ -8,8 +8,7 @@
 description("Tests the behavior of strict-origin-when-cross-origin referrer policy when cross origin.");
 jsTestIsAsync = true;
 
-if (window.internals)
-    internals.setTrackingPreventionEnabled(false);
+testRunner?.setStatisticsEnabled(false);
 
 function loadImage() {
     // Should be the origin, not the full URL, because we are cross-origin.
@@ -19,8 +18,7 @@ function loadImage() {
     img.onload = function() { testPassed('referrer is "' + expected + '"'); finishJSTest(); }
     img.onerror = function() { testFailed("referrer is not as expected"); finishJSTest(); }
     img.src = "http://localhost:8000/referrer-policy/resources/image.py?expected=" + expected;
-    if (window.internals)
-        internals.setTrackingPreventionEnabled(true);
+    testRunner?.setStatisticsEnabled(true);
 }
 
 </script>

--- a/LayoutTests/http/tests/referrer-policy-img/strict-origin-when-cross-origin/cross-origin-http.https.html
+++ b/LayoutTests/http/tests/referrer-policy-img/strict-origin-when-cross-origin/cross-origin-http.https.html
@@ -8,10 +8,9 @@
 description("Tests the behavior of strict-origin-when-cross-origin referrer policy when cross origin from HTTPS to HTTP.");
 jsTestIsAsync = true;
 
-if (window.internals) {
+if (window.internals)
     internals.settings.setAllowDisplayOfInsecureContent(true);
-    internals.setTrackingPreventionEnabled(false);
-}
+testRunner?.setStatisticsEnabled(false);
 
 function loadImage() {
     // Should be the empty string because we are cross-origin and going from HTTPS to HTTP.
@@ -21,8 +20,7 @@ function loadImage() {
     img.onload = function() { testPassed('referrer is "' + expected + '"'); finishJSTest(); }
     img.onerror = function() { testFailed("referrer is not as expected"); finishJSTest(); }
     img.src = "http://localhost:8000/referrer-policy/resources/image.py?expected=" + expected;
-    if (window.internals)
-        internals.setTrackingPreventionEnabled(true);
+    testRunner?.setStatisticsEnabled(true);
 }
 
 </script>

--- a/LayoutTests/http/tests/referrer-policy-img/strict-origin-when-cross-origin/same-origin.html
+++ b/LayoutTests/http/tests/referrer-policy-img/strict-origin-when-cross-origin/same-origin.html
@@ -8,8 +8,7 @@
 description("Tests the behavior of strict-origin-when-cross-origin referrer policy when same origin.");
 jsTestIsAsync = true;
 
-if (window.internals)
-    internals.setTrackingPreventionEnabled(false);
+testRunner?.setStatisticsEnabled(false);
 
 function loadImage() {
     // Should be the full URL because we are same-origin.
@@ -19,8 +18,7 @@ function loadImage() {
     img.onload = function() { testPassed('referrer is "' + expected + '"'); finishJSTest(); }
     img.onerror = function() { testFailed("referrer is not as expected"); finishJSTest(); }
     img.src = "http://127.0.0.1:8000/referrer-policy/resources/image.py?expected=" + expected;
-    if (window.internals)
-        internals.setTrackingPreventionEnabled(true);
+    testRunner?.setStatisticsEnabled(true);
 }
 
 </script>

--- a/LayoutTests/http/tests/referrer-policy-img/strict-origin/cross-origin-http-UpgradeMixedContent.https.html
+++ b/LayoutTests/http/tests/referrer-policy-img/strict-origin/cross-origin-http-UpgradeMixedContent.https.html
@@ -8,10 +8,9 @@
 description("Tests the behavior of strict-origin referrer policy when cross origin from HTTPS to HTTP.");
 jsTestIsAsync = true;
 
-if (window.internals) {
+if (window.internals)
     internals.settings.setAllowDisplayOfInsecureContent(true);
-    internals.setTrackingPreventionEnabled(false);
-}
+testRunner?.setStatisticsEnabled(false);
 
 function loadImage() {
     // Should be the origin because we are going from HTTPS to HTTP, with HTTP upgraded to HTTPS.
@@ -21,8 +20,7 @@ function loadImage() {
     img.onload = function() { testPassed('referrer is "' + expected + '"'); finishJSTest(); }
     img.onerror = function() { testFailed("referrer is not strict-origin"); finishJSTest(); }
     img.src = "http://localhost:8000/referrer-policy/resources/image.py?expected=" + expected;
-    if (window.internals)
-        internals.setTrackingPreventionEnabled(true);
+    testRunner?.setStatisticsEnabled(true);
 }
 
 </script>

--- a/LayoutTests/http/tests/referrer-policy-img/strict-origin/cross-origin-http-http.html
+++ b/LayoutTests/http/tests/referrer-policy-img/strict-origin/cross-origin-http-http.html
@@ -8,8 +8,7 @@
 description("Tests the behavior of strict-origin referrer policy when cross origin.");
 jsTestIsAsync = true;
 
-if (window.internals)
-    internals.setTrackingPreventionEnabled(false);
+testRunner?.setStatisticsEnabled(false);
 
 function loadImage() {
     // Should be the origin, not the full URL.
@@ -19,8 +18,7 @@ function loadImage() {
     img.onload = function() { testPassed('referrer is "' + expected + '"'); finishJSTest(); }
     img.onerror = function() { testFailed("referrer is not as expected"); finishJSTest(); }
     img.src = "http://localhost:8000/referrer-policy/resources/image.py?expected=" + expected;
-    if (window.internals)
-        internals.setTrackingPreventionEnabled(true);
+    testRunner?.setStatisticsEnabled(true);
 }
 
 </script>

--- a/LayoutTests/http/tests/referrer-policy-img/strict-origin/cross-origin-http.https.html
+++ b/LayoutTests/http/tests/referrer-policy-img/strict-origin/cross-origin-http.https.html
@@ -8,10 +8,9 @@
 description("Tests the behavior of strict-origin referrer policy when cross origin from HTTPS to HTTP.");
 jsTestIsAsync = true;
 
-if (window.internals) {
+if (window.internals)
     internals.settings.setAllowDisplayOfInsecureContent(true);
-    internals.setTrackingPreventionEnabled(false);
-}
+testRunner?.setStatisticsEnabled(false);
 
 function loadImage() {
     // Should be the empty string because we are going from HTTPS to HTTP.
@@ -21,8 +20,7 @@ function loadImage() {
     img.onload = function() { testPassed('referrer is "' + expected + '"'); finishJSTest(); }
     img.onerror = function() { testFailed("referrer is not as expected"); finishJSTest(); }
     img.src = "http://localhost:8000/referrer-policy/resources/image.py?expected=" + expected;
-    if (window.internals)
-        internals.setTrackingPreventionEnabled(true);
+    testRunner?.setStatisticsEnabled(true);
 }
 
 </script>

--- a/LayoutTests/http/tests/referrer-policy-img/strict-origin/same-origin.html
+++ b/LayoutTests/http/tests/referrer-policy-img/strict-origin/same-origin.html
@@ -8,8 +8,7 @@
 description("Tests the behavior of strict-origin referrer policy when same origin.");
 jsTestIsAsync = true;
 
-if (window.internals)
-    internals.setTrackingPreventionEnabled(false);
+testRunner?.setStatisticsEnabled(false);
 
 function loadImage() {
     // Should be the origin, not the full URL.
@@ -19,8 +18,7 @@ function loadImage() {
     img.onload = function() { testPassed('referrer is "' + expected + '"'); finishJSTest(); }
     img.onerror = function() { testFailed("referrer is not as expected"); finishJSTest(); }
     img.src = "http://127.0.0.1:8000/referrer-policy/resources/image.py?expected=" + expected;
-    if (window.internals)
-        internals.setTrackingPreventionEnabled(true);
+    testRunner?.setStatisticsEnabled(true);
 }
 
 </script>

--- a/LayoutTests/http/tests/referrer-policy-img/unsafe-url/cross-origin-http-UpgradeMixedContent.https.html
+++ b/LayoutTests/http/tests/referrer-policy-img/unsafe-url/cross-origin-http-UpgradeMixedContent.https.html
@@ -8,10 +8,9 @@
 description("Tests the behavior of unsafe-url referrer policy when cross origin from HTTPS to HTTP.");
 jsTestIsAsync = true;
 
-if (window.internals) {
+if (window.internals)
     internals.settings.setAllowDisplayOfInsecureContent(true);
-    internals.setTrackingPreventionEnabled(false);
-}
+testRunner?.setStatisticsEnabled(false);
 
 if (window.testRunner) {
     testRunner.setStatisticsShouldDowngradeReferrer(false, function () {
@@ -22,8 +21,7 @@ if (window.testRunner) {
         img.onload = function() { testPassed('referrer is "' + expected + '"'); finishJSTest(); }
         img.onerror = function() { testFailed("referrer is not unsafe-url"); finishJSTest(); }
         img.src = "http://localhost:8000/referrer-policy/resources/image.py?expected=" + expected;
-        if (window.internals)
-            internals.setTrackingPreventionEnabled(true);
+        testRunner?.setStatisticsEnabled(true);
     });
 }
 

--- a/LayoutTests/http/tests/referrer-policy-img/unsafe-url/cross-origin-http-http.html
+++ b/LayoutTests/http/tests/referrer-policy-img/unsafe-url/cross-origin-http-http.html
@@ -8,8 +8,7 @@
 description("Tests the behavior of unsafe-url referrer policy when cross origin.");
 jsTestIsAsync = true;
 
-if (window.internals)
-    internals.setTrackingPreventionEnabled(false);
+testRunner?.setStatisticsEnabled(false);
 
 if (window.testRunner) {
     testRunner.setStatisticsShouldDowngradeReferrer(false, function () {
@@ -20,8 +19,7 @@ if (window.testRunner) {
         img.onload = function() { testPassed('referrer is "' + expected + '"'); finishJSTest(); }
         img.onerror = function() { testFailed("referrer is not as expected"); finishJSTest(); }
         img.src = "http://127.0.0.1:8000/referrer-policy/resources/image.py?expected=" + expected;
-        if (window.internals)
-            internals.setTrackingPreventionEnabled(true);
+        testRunner?.setStatisticsEnabled(true);
     });
 }
 

--- a/LayoutTests/http/tests/referrer-policy-img/unsafe-url/cross-origin-http.https.html
+++ b/LayoutTests/http/tests/referrer-policy-img/unsafe-url/cross-origin-http.https.html
@@ -8,10 +8,10 @@
 description("Tests the behavior of unsafe-url referrer policy when cross origin from HTTPS to HTTP.");
 jsTestIsAsync = true;
 
-if (window.internals) {
+if (window.internals)
     internals.settings.setAllowDisplayOfInsecureContent(true);
-    internals.setTrackingPreventionEnabled(false);
-}
+testRunner?.setStatisticsEnabled(false);
+
 
 if (window.testRunner) {
     testRunner.setStatisticsShouldDowngradeReferrer(false, function () {
@@ -22,8 +22,7 @@ if (window.testRunner) {
         img.onload = function() { testPassed('referrer is "' + expected + '"'); finishJSTest(); }
         img.onerror = function() { testFailed("referrer is not as expected"); finishJSTest(); }
         img.src = "http://localhost:8000/referrer-policy/resources/image.py?expected=" + expected;
-        if (window.internals)
-            internals.setTrackingPreventionEnabled(true);
+        testRunner?.setStatisticsEnabled(true);
     });
 }
 

--- a/LayoutTests/http/tests/referrer-policy-img/unsafe-url/same-origin.html
+++ b/LayoutTests/http/tests/referrer-policy-img/unsafe-url/same-origin.html
@@ -16,8 +16,7 @@ function loadImage() {
     img.onload = function() { testPassed('referrer is "' + expected + '"'); finishJSTest(); }
     img.onerror = function() { testFailed("referrer is not as expected"); finishJSTest(); }
     img.src = "http://127.0.0.1:8000/referrer-policy/resources/image.py?expected=" + expected;
-    if (window.internals)
-        internals.setTrackingPreventionEnabled(true);
+    testRunner?.setStatisticsEnabled(true);
 }
 
 </script>

--- a/LayoutTests/http/tests/referrer-policy-script/unsafe-url/cross-origin-http-http.html
+++ b/LayoutTests/http/tests/referrer-policy-script/unsafe-url/cross-origin-http-http.html
@@ -8,8 +8,7 @@
 description("Tests the behavior of unsafe-url referrer policy when cross origin.");
 jsTestIsAsync = true;
 
-if (window.internals)
-    internals.setTrackingPreventionEnabled(true);
+testRunner?.setStatisticsEnabled(false);
 
 function checkReferrer(value) {
     referrer = value;

--- a/LayoutTests/http/tests/referrer-policy/no-referrer-when-downgrade/cross-origin-http-UpgradeMixedContent.https.html
+++ b/LayoutTests/http/tests/referrer-policy/no-referrer-when-downgrade/cross-origin-http-UpgradeMixedContent.https.html
@@ -9,23 +9,20 @@
 description("Tests the behavior of no-referrer-when-downgrade referrer policy when cross origin from HTTPS to HTTP.");
 jsTestIsAsync = true;
 
-if (window.internals) {
+if (window.internals)
     internals.settings.setAllowDisplayOfInsecureContent(true);
-    internals.setTrackingPreventionEnabled(false);
-}
+testRunner?.setStatisticsEnabled(false);
 
 window.onmessage = function(event) {
     referrer = event.data.referrer;
     // Should be the empty string
     shouldBeEqualToString("referrer", "");
-    if (window.internals)
-        internals.setTrackingPreventionEnabled(true);
+    testRunner?.setStatisticsEnabled(true);
     finishJSTest();
 }
 
 setTimeout(() => {
-    if (window.internals)
-        internals.setTrackingPreventionEnabled(true);
+    testRunner?.setStatisticsEnabled(true);
     testPassed("Timeout reached, insecure iframe not loaded");
     finishJSTest();
 }, 500);

--- a/LayoutTests/http/tests/referrer-policy/no-referrer-when-downgrade/cross-origin-http-http.html
+++ b/LayoutTests/http/tests/referrer-policy/no-referrer-when-downgrade/cross-origin-http-http.html
@@ -9,15 +9,13 @@
 description("Tests the behavior of no-referrer-when-downgrade referrer policy when cross origin.");
 jsTestIsAsync = true;
 
-if (window.internals)
-    internals.setTrackingPreventionEnabled(false);
+testRunner?.setStatisticsEnabled(false);
 
 window.onmessage = function(event) {
     referrer = event.data.referrer;
     // Should be the full URL
     shouldBeEqualToString("referrer", "http://127.0.0.1:8000/referrer-policy/no-referrer-when-downgrade/cross-origin-http-http.html");
-    if (window.internals)
-        internals.setTrackingPreventionEnabled(true);
+    testRunner?.setStatisticsEnabled(true);
     finishJSTest();
 }
 

--- a/LayoutTests/http/tests/referrer-policy/no-referrer-when-downgrade/cross-origin-http.https.html
+++ b/LayoutTests/http/tests/referrer-policy/no-referrer-when-downgrade/cross-origin-http.https.html
@@ -9,17 +9,15 @@
 description("Tests the behavior of no-referrer-when-downgrade referrer policy when cross origin from HTTPS to HTTP.");
 jsTestIsAsync = true;
 
-if (window.internals) {
+if (window.internals)
     internals.settings.setAllowDisplayOfInsecureContent(true);
-    internals.setTrackingPreventionEnabled(false);
-}
+testRunner?.setStatisticsEnabled(false);
 
 window.onmessage = function(event) {
     referrer = event.data.referrer;
     // Should be the empty string
     shouldBeEqualToString("referrer", "");
-    if (window.internals)
-        internals.setTrackingPreventionEnabled(true);
+    testRunner?.setStatisticsEnabled(true);
     finishJSTest();
 }
 

--- a/LayoutTests/http/tests/referrer-policy/no-referrer-when-downgrade/same-origin.html
+++ b/LayoutTests/http/tests/referrer-policy/no-referrer-when-downgrade/same-origin.html
@@ -9,15 +9,13 @@
 description("Tests the behavior of no-referrer-when-downgrade referrer policy when same origin.");
 jsTestIsAsync = true;
 
-if (window.internals)
-    internals.setTrackingPreventionEnabled(false);
+testRunner?.setStatisticsEnabled(false);
 
 window.onmessage = function(event) {
     referrer = event.data.referrer;
     // Should be the full URL
     shouldBeEqualToString("referrer", "http://127.0.0.1:8000/referrer-policy/no-referrer-when-downgrade/same-origin.html");
-    if (window.internals)
-        internals.setTrackingPreventionEnabled(true);
+    testRunner?.setStatisticsEnabled(true);
     finishJSTest();
 }
 

--- a/LayoutTests/http/tests/referrer-policy/no-referrer/cross-origin-http-UpgradeMixedContent.https.html
+++ b/LayoutTests/http/tests/referrer-policy/no-referrer/cross-origin-http-UpgradeMixedContent.https.html
@@ -11,20 +11,18 @@ jsTestIsAsync = true;
 
 if (window.internals) {
     internals.settings.setAllowDisplayOfInsecureContent(true);
-    internals.setTrackingPreventionEnabled(false);
+    testRunner?.setStatisticsEnabled(false);
 }
 
 window.onmessage = function(event) {
     referrer = event.data.referrer;
     // Should be the empty string
     shouldBeEqualToString("referrer", "");
-    if (window.internals)
-        internals.setTrackingPreventionEnabled(true);
+    testRunner?.setStatisticsEnabled(true);
     finishJSTest();
 }
 setTimeout(() => {
-    if (window.internals)
-        internals.setTrackingPreventionEnabled(true);
+    testRunner?.setStatisticsEnabled(true);
     testPassed("Timeout reached, insecure iframe not loaded");
     finishJSTest();
 }, 500);

--- a/LayoutTests/http/tests/referrer-policy/no-referrer/cross-origin-http-http.html
+++ b/LayoutTests/http/tests/referrer-policy/no-referrer/cross-origin-http-http.html
@@ -9,15 +9,13 @@
 description("Tests the behavior of no-referrer referrer policy when cross origin.");
 jsTestIsAsync = true;
 
-if (window.internals)
-    internals.setTrackingPreventionEnabled(false);
+testRunner?.setStatisticsEnabled(false);
 
 window.onmessage = function(event) {
     referrer = event.data.referrer;
     // Should be the empty string
     shouldBeEqualToString("referrer", "");
-    if (window.internals)
-        internals.setTrackingPreventionEnabled(true);
+    testRunner?.setStatisticsEnabled(true);
     finishJSTest();
 }
 </script>

--- a/LayoutTests/http/tests/referrer-policy/no-referrer/cross-origin-http.https.html
+++ b/LayoutTests/http/tests/referrer-policy/no-referrer/cross-origin-http.https.html
@@ -9,17 +9,15 @@
 description("Tests the behavior of no-referrer referrer policy when cross origin from HTTPS to HTTP.");
 jsTestIsAsync = true;
 
-if (window.internals) {
+if (window.internals)
     internals.settings.setAllowDisplayOfInsecureContent(true);
-    internals.setTrackingPreventionEnabled(false);
-}
+testRunner?.setStatisticsEnabled(false);
 
 window.onmessage = function(event) {
     referrer = event.data.referrer;
     // Should be the empty string
     shouldBeEqualToString("referrer", "");
-    if (window.internals)
-        internals.setTrackingPreventionEnabled(true);
+    testRunner?.setStatisticsEnabled(true);
     finishJSTest();
 }
 </script>

--- a/LayoutTests/http/tests/referrer-policy/no-referrer/same-origin.html
+++ b/LayoutTests/http/tests/referrer-policy/no-referrer/same-origin.html
@@ -9,15 +9,13 @@
 description("Tests the behavior of no-referrer referrer policy when same origin.");
 jsTestIsAsync = true;
 
-if (window.internals)
-    internals.setTrackingPreventionEnabled(false);
+testRunner?.setStatisticsEnabled(false);
 
 window.onmessage = function(event) {
     referrer = event.data.referrer;
     // Should be the empty string
     shouldBeEqualToString("referrer", "");
-    if (window.internals)
-        internals.setTrackingPreventionEnabled(true);
+    testRunner?.setStatisticsEnabled(true);
     finishJSTest();
 }
 </script>

--- a/LayoutTests/http/tests/referrer-policy/origin-when-cross-origin/cross-origin-http-UpgradeMixedContent.https.html
+++ b/LayoutTests/http/tests/referrer-policy/origin-when-cross-origin/cross-origin-http-UpgradeMixedContent.https.html
@@ -9,22 +9,19 @@
 description("Tests the behavior of origin-when-cross-origin referrer policy when cross origin from HTTPS to HTTP.");
 jsTestIsAsync = true;
 
-if (window.internals) {
+if (window.internals)
     internals.settings.setAllowDisplayOfInsecureContent(true);
-    internals.setTrackingPreventionEnabled(false);
-}
+testRunner?.setStatisticsEnabled(false);
 
 window.onmessage = function(event) {
     referrer = event.data.referrer;
     // Should be the origin, not the full URL, because we are cross-origin.
     shouldBeEqualToString("referrer", "https://127.0.0.1:8443/");
-    if (window.internals)
-        internals.setTrackingPreventionEnabled(true);
+    testRunner?.setStatisticsEnabled(true);
     finishJSTest();
 }
 setTimeout(() => {
-    if (window.internals)
-        internals.setTrackingPreventionEnabled(true);
+    testRunner?.setStatisticsEnabled(true);
     testPassed("Timeout reached, insecure iframe not loaded");
     finishJSTest();
 }, 500);

--- a/LayoutTests/http/tests/referrer-policy/origin-when-cross-origin/cross-origin-http-http.html
+++ b/LayoutTests/http/tests/referrer-policy/origin-when-cross-origin/cross-origin-http-http.html
@@ -9,15 +9,13 @@
 description("Tests the behavior of origin-when-cross-origin referrer policy when cross origin.");
 jsTestIsAsync = true;
 
-if (window.internals)
-    internals.setTrackingPreventionEnabled(false);
+testRunner?.setStatisticsEnabled(false);
 
 window.onmessage = function(event) {
     referrer = event.data.referrer;
     // Should be the origin, not the full URL, because we are cross-origin.
     shouldBeEqualToString("referrer", "http://127.0.0.1:8000/");
-    if (window.internals)
-        internals.setTrackingPreventionEnabled(true);
+    testRunner?.setStatisticsEnabled(true);
     finishJSTest();
 }
 </script>

--- a/LayoutTests/http/tests/referrer-policy/origin-when-cross-origin/cross-origin-http.https.html
+++ b/LayoutTests/http/tests/referrer-policy/origin-when-cross-origin/cross-origin-http.https.html
@@ -9,17 +9,15 @@
 description("Tests the behavior of origin-when-cross-origin referrer policy when cross origin from HTTPS to HTTP.");
 jsTestIsAsync = true;
 
-if (window.internals) {
+if (window.internals)
     internals.settings.setAllowDisplayOfInsecureContent(true);
-    internals.setTrackingPreventionEnabled(false);
-}
+testRunner?.setStatisticsEnabled(false);
 
 window.onmessage = function(event) {
     referrer = event.data.referrer;
     // Should be the origin, not the full URL, because we are cross-origin.
     shouldBeEqualToString("referrer", "https://127.0.0.1:8443/");
-    if (window.internals)
-        internals.setTrackingPreventionEnabled(true);
+    testRunner?.setStatisticsEnabled(true);
     finishJSTest();
 }
 </script>

--- a/LayoutTests/http/tests/referrer-policy/origin-when-cross-origin/same-origin.html
+++ b/LayoutTests/http/tests/referrer-policy/origin-when-cross-origin/same-origin.html
@@ -9,15 +9,13 @@
 description("Tests the behavior of origin-when-cross-origin referrer policy when same origin.");
 jsTestIsAsync = true;
 
-if (window.internals)
-    internals.setTrackingPreventionEnabled(false);
+testRunner?.setStatisticsEnabled(false);
 
 window.onmessage = function(event) {
     referrer = event.data.referrer;
     // Should be the full URL because we are same-origin.
     shouldBeEqualToString("referrer", "http://127.0.0.1:8000/referrer-policy/origin-when-cross-origin/same-origin.html");
-    if (window.internals)
-        internals.setTrackingPreventionEnabled(true);
+    testRunner?.setStatisticsEnabled(true);
     finishJSTest();
 }
 </script>

--- a/LayoutTests/http/tests/referrer-policy/origin/cross-origin-http-UpgradeMixedContent.https.html
+++ b/LayoutTests/http/tests/referrer-policy/origin/cross-origin-http-UpgradeMixedContent.https.html
@@ -9,22 +9,19 @@
 description("Tests the behavior of origin referrer policy when cross origin from HTTPS to HTTP.");
 jsTestIsAsync = true;
 
-if (window.internals) {
+if (window.internals)
     internals.settings.setAllowDisplayOfInsecureContent(true);
-    internals.setTrackingPreventionEnabled(false);
-}
+testRunner?.setStatisticsEnabled(false);
 
 window.onmessage = function(event) {
     referrer = event.data.referrer;
     // Should be the origin
     shouldBeEqualToString("referrer", "https://127.0.0.1:8443/");
-    if (window.internals)
-        internals.setTrackingPreventionEnabled(true);
+    testRunner?.setStatisticsEnabled(true);
     finishJSTest();
 }
 setTimeout(() => {
-    if (window.internals)
-        internals.setTrackingPreventionEnabled(true);
+    testRunner?.setStatisticsEnabled(true);
     testPassed("Timeout reached, insecure iframe not loaded");
     finishJSTest();
 }, 500);

--- a/LayoutTests/http/tests/referrer-policy/origin/cross-origin-http-http.html
+++ b/LayoutTests/http/tests/referrer-policy/origin/cross-origin-http-http.html
@@ -9,15 +9,13 @@
 description("Tests the behavior of origin referrer policy when cross origin.");
 jsTestIsAsync = true;
 
-if (window.internals)
-    internals.setTrackingPreventionEnabled(false);
+testRunner?.setStatisticsEnabled(false);
 
 window.onmessage = function(event) {
     referrer = event.data.referrer;
     // Should be the origin
     shouldBeEqualToString("referrer", "http://127.0.0.1:8000/");
-    if (window.internals)
-        internals.setTrackingPreventionEnabled(true);
+    testRunner?.setStatisticsEnabled(true);
     finishJSTest();
 }
 </script>

--- a/LayoutTests/http/tests/referrer-policy/origin/cross-origin-http.https.html
+++ b/LayoutTests/http/tests/referrer-policy/origin/cross-origin-http.https.html
@@ -9,17 +9,15 @@
 description("Tests the behavior of origin referrer policy when cross origin from HTTPS to HTTP.");
 jsTestIsAsync = true;
 
-if (window.internals) {
+if (window.internals)
     internals.settings.setAllowDisplayOfInsecureContent(true);
-    internals.setTrackingPreventionEnabled(false);
-}
+testRunner?.setStatisticsEnabled(false);
 
 window.onmessage = function(event) {
     referrer = event.data.referrer;
     // Should be the origin
     shouldBeEqualToString("referrer", "https://127.0.0.1:8443/");
-    if (window.internals)
-        internals.setTrackingPreventionEnabled(true);
+    testRunner?.setStatisticsEnabled(true);
     finishJSTest();
 }
 </script>

--- a/LayoutTests/http/tests/referrer-policy/origin/same-origin.html
+++ b/LayoutTests/http/tests/referrer-policy/origin/same-origin.html
@@ -9,15 +9,13 @@
 description("Tests the behavior of origin referrer policy when same origin.");
 jsTestIsAsync = true;
 
-if (window.internals)
-    internals.setTrackingPreventionEnabled(false);
+testRunner?.setStatisticsEnabled(false);
 
 window.onmessage = function(event) {
     referrer = event.data.referrer;
     // Should be the origin
     shouldBeEqualToString("referrer", "http://127.0.0.1:8000/");
-    if (window.internals)
-        internals.setTrackingPreventionEnabled(true);
+    testRunner?.setStatisticsEnabled(true);
     finishJSTest();
 }
 </script>

--- a/LayoutTests/http/tests/referrer-policy/same-origin/cross-origin-http-UpgradeMixedContent.https.html
+++ b/LayoutTests/http/tests/referrer-policy/same-origin/cross-origin-http-UpgradeMixedContent.https.html
@@ -9,22 +9,19 @@
 description("Tests the behavior of same-origin referrer policy when cross origin from HTTPS to HTTP.");
 jsTestIsAsync = true;
 
-if (window.internals) {
+if (window.internals)
     internals.settings.setAllowDisplayOfInsecureContent(true);
-    internals.setTrackingPreventionEnabled(false);
-}
+testRunner?.setStatisticsEnabled(false);
 
 window.onmessage = function(event) {
     referrer = event.data.referrer;
     // Should be the empty string because we are cross-origin.
     shouldBeEqualToString("referrer", "");
-    if (window.internals)
-        internals.setTrackingPreventionEnabled(true);
+    testRunner?.setStatisticsEnabled(true);
     finishJSTest();
 }
 setTimeout(() => {
-    if (window.internals)
-        internals.setTrackingPreventionEnabled(true);
+    testRunner?.setStatisticsEnabled(true);
     testPassed("Timeout reached, insecure iframe not loaded");
     finishJSTest();
 }, 500);

--- a/LayoutTests/http/tests/referrer-policy/same-origin/cross-origin-http-http.html
+++ b/LayoutTests/http/tests/referrer-policy/same-origin/cross-origin-http-http.html
@@ -9,15 +9,13 @@
 description("Tests the behavior of same-origin referrer policy when cross origin.");
 jsTestIsAsync = true;
 
-if (window.internals)
-    internals.setTrackingPreventionEnabled(false);
+testRunner?.setStatisticsEnabled(false);
 
 window.onmessage = function(event) {
     referrer = event.data.referrer;
     // Should be the empty string because we are cross-origin.
     shouldBeEqualToString("referrer", "");
-    if (window.internals)
-        internals.setTrackingPreventionEnabled(true);
+    testRunner?.setStatisticsEnabled(true);
     finishJSTest();
 }
 </script>

--- a/LayoutTests/http/tests/referrer-policy/same-origin/cross-origin-http.https.html
+++ b/LayoutTests/http/tests/referrer-policy/same-origin/cross-origin-http.https.html
@@ -9,17 +9,15 @@
 description("Tests the behavior of same-origin referrer policy when cross origin from HTTPS to HTTP.");
 jsTestIsAsync = true;
 
-if (window.internals) {
+if (window.internals)
     internals.settings.setAllowDisplayOfInsecureContent(true);
-    internals.setTrackingPreventionEnabled(false);
-}
+testRunner?.setStatisticsEnabled(false);
 
 window.onmessage = function(event) {
     referrer = event.data.referrer;
     // Should be the empty string because we are cross-origin.
     shouldBeEqualToString("referrer", "");
-    if (window.internals)
-        internals.setTrackingPreventionEnabled(true);
+    testRunner?.setStatisticsEnabled(true);
     finishJSTest();
 }
 </script>

--- a/LayoutTests/http/tests/referrer-policy/same-origin/same-origin.html
+++ b/LayoutTests/http/tests/referrer-policy/same-origin/same-origin.html
@@ -9,15 +9,13 @@
 description("Tests the behavior of same-origin referrer policy when same origin.");
 jsTestIsAsync = true;
 
-if (window.internals)
-    internals.setTrackingPreventionEnabled(false);
+testRunner?.setStatisticsEnabled(false);
 
 window.onmessage = function(event) {
     referrer = event.data.referrer;
     // Should be the full URL because we are same-origin.
     shouldBeEqualToString("referrer", "http://127.0.0.1:8000/referrer-policy/same-origin/same-origin.html");
-    if (window.internals)
-        internals.setTrackingPreventionEnabled(true);
+    testRunner?.setStatisticsEnabled(true);
     finishJSTest();
 }
 </script>

--- a/LayoutTests/http/tests/referrer-policy/strict-origin-when-cross-origin/cross-origin-http-UpgradeMixedContent.https.html
+++ b/LayoutTests/http/tests/referrer-policy/strict-origin-when-cross-origin/cross-origin-http-UpgradeMixedContent.https.html
@@ -9,22 +9,19 @@
 description("Tests the behavior of strict-origin-when-cross-origin referrer policy when cross origin from HTTPS to HTTP.");
 jsTestIsAsync = true;
 
-if (window.internals) {
+if (window.internals)
     internals.settings.setAllowDisplayOfInsecureContent(true);
-    internals.setTrackingPreventionEnabled(false);
-}
+testRunner?.setStatisticsEnabled(false);
 
 window.onmessage = function(event) {
     referrer = event.data.referrer;
     // Should be the empty string because we are cross-origin and going from HTTPS to HTTP.
     shouldBeEqualToString("referrer", "");
-    if (window.internals)
-        internals.setTrackingPreventionEnabled(true);
+    testRunner?.setStatisticsEnabled(true);
     finishJSTest();
 }
 setTimeout(() => {
-    if (window.internals)
-        internals.setTrackingPreventionEnabled(true);
+    testRunner?.setStatisticsEnabled(true);
     testPassed("Timeout reached, insecure iframe not loaded");
     finishJSTest();
 }, 500);

--- a/LayoutTests/http/tests/referrer-policy/strict-origin-when-cross-origin/cross-origin-http-http.html
+++ b/LayoutTests/http/tests/referrer-policy/strict-origin-when-cross-origin/cross-origin-http-http.html
@@ -9,15 +9,13 @@
 description("Tests the behavior of strict-origin-when-cross-origin referrer policy when cross origin.");
 jsTestIsAsync = true;
 
-if (window.internals)
-    internals.setTrackingPreventionEnabled(false);
+testRunner?.setStatisticsEnabled(false);
 
 window.onmessage = function(event) {
     referrer = event.data.referrer;
     // Should be the origin, not the full URL, because we are cross-origin.
     shouldBeEqualToString("referrer", "http://127.0.0.1:8000/");
-    if (window.internals)
-        internals.setTrackingPreventionEnabled(true);
+    testRunner?.setStatisticsEnabled(true);
     finishJSTest();
 }
 </script>

--- a/LayoutTests/http/tests/referrer-policy/strict-origin-when-cross-origin/cross-origin-http.https.html
+++ b/LayoutTests/http/tests/referrer-policy/strict-origin-when-cross-origin/cross-origin-http.https.html
@@ -9,17 +9,15 @@
 description("Tests the behavior of strict-origin-when-cross-origin referrer policy when cross origin from HTTPS to HTTP.");
 jsTestIsAsync = true;
 
-if (window.internals) {
+if (window.internals)
     internals.settings.setAllowDisplayOfInsecureContent(true);
-    internals.setTrackingPreventionEnabled(false);
-}
+testRunner?.setStatisticsEnabled(false);
 
 window.onmessage = function(event) {
     referrer = event.data.referrer;
     // Should be the empty string because we are cross-origin and going from HTTPS to HTTP.
     shouldBeEqualToString("referrer", "");
-    if (window.internals)
-        internals.setTrackingPreventionEnabled(true);
+    testRunner?.setStatisticsEnabled(true);
     finishJSTest();
 }
 </script>

--- a/LayoutTests/http/tests/referrer-policy/strict-origin-when-cross-origin/same-origin.html
+++ b/LayoutTests/http/tests/referrer-policy/strict-origin-when-cross-origin/same-origin.html
@@ -9,15 +9,13 @@
 description("Tests the behavior of strict-origin-when-cross-origin referrer policy when same origin.");
 jsTestIsAsync = true;
 
-if (window.internals)
-    internals.setTrackingPreventionEnabled(false);
+testRunner?.setStatisticsEnabled(false);
 
 window.onmessage = function(event) {
     referrer = event.data.referrer;
     // Should be the full URL because we are same-origin.
     shouldBeEqualToString("referrer", "http://127.0.0.1:8000/referrer-policy/strict-origin-when-cross-origin/same-origin.html");
-    if (window.internals)
-        internals.setTrackingPreventionEnabled(true);
+    testRunner?.setStatisticsEnabled(true);
     finishJSTest();
 }
 </script>

--- a/LayoutTests/http/tests/referrer-policy/strict-origin/cross-origin-http-UpgradeMixedContent.https.html
+++ b/LayoutTests/http/tests/referrer-policy/strict-origin/cross-origin-http-UpgradeMixedContent.https.html
@@ -9,22 +9,19 @@
 description("Tests the behavior of strict-origin referrer policy when cross origin from HTTPS to HTTP.");
 jsTestIsAsync = true;
 
-if (window.internals) {
+if (window.internals)
     internals.settings.setAllowDisplayOfInsecureContent(true);
-    internals.setTrackingPreventionEnabled(false);
-}
+testRunner?.setStatisticsEnabled(false);
 
 window.onmessage = function(event) {
     referrer = event.data.referrer;
     // Should be the empty string because we are going from HTTPS to HTTP.
     shouldBeEqualToString("referrer", "");
-    if (window.internals)
-        internals.setTrackingPreventionEnabled(true);
+    testRunner?.setStatisticsEnabled(true);
     finishJSTest();
 }
 setTimeout(() => {
-    if (window.internals)
-        internals.setTrackingPreventionEnabled(true);
+    testRunner?.setStatisticsEnabled(true);
     testPassed("Timeout reached, insecure iframe not loaded");
     finishJSTest();
 }, 500);

--- a/LayoutTests/http/tests/referrer-policy/strict-origin/cross-origin-http-http.html
+++ b/LayoutTests/http/tests/referrer-policy/strict-origin/cross-origin-http-http.html
@@ -9,15 +9,13 @@
 description("Tests the behavior of strict-origin referrer policy when cross origin.");
 jsTestIsAsync = true;
 
-if (window.internals)
-    internals.setTrackingPreventionEnabled(false);
+testRunner?.setStatisticsEnabled(false);
 
 window.onmessage = function(event) {
     referrer = event.data.referrer;
     // Should be the origin, not the full URL.
     shouldBeEqualToString("referrer", "http://127.0.0.1:8000/");
-    if (window.internals)
-        internals.setTrackingPreventionEnabled(true);
+    testRunner?.setStatisticsEnabled(true);
     finishJSTest();
 }
 </script>

--- a/LayoutTests/http/tests/referrer-policy/strict-origin/cross-origin-http.https.html
+++ b/LayoutTests/http/tests/referrer-policy/strict-origin/cross-origin-http.https.html
@@ -9,17 +9,15 @@
 description("Tests the behavior of strict-origin referrer policy when cross origin from HTTPS to HTTP.");
 jsTestIsAsync = true;
 
-if (window.internals) {
+if (window.internals)
     internals.settings.setAllowDisplayOfInsecureContent(true);
-    internals.setTrackingPreventionEnabled(false);
-}
+testRunner?.setStatisticsEnabled(false);
 
 window.onmessage = function(event) {
     referrer = event.data.referrer;
     // Should be the empty string because we are going from HTTPS to HTTP.
     shouldBeEqualToString("referrer", "");
-    if (window.internals)
-        internals.setTrackingPreventionEnabled(true);
+    testRunner?.setStatisticsEnabled(true);
     finishJSTest();
 }
 </script>

--- a/LayoutTests/http/tests/referrer-policy/strict-origin/same-origin.html
+++ b/LayoutTests/http/tests/referrer-policy/strict-origin/same-origin.html
@@ -10,14 +10,13 @@ description("Tests the behavior of strict-origin referrer policy when same origi
 jsTestIsAsync = true;
 
 if (window.internals)
-    internals.setTrackingPreventionEnabled(false);
+    testRunner?.setStatisticsEnabled(false);
 
 window.onmessage = function(event) {
     referrer = event.data.referrer;
     // Should be the origin, not the full URL.
     shouldBeEqualToString("referrer", "http://127.0.0.1:8000/");
-    if (window.internals)
-        internals.setTrackingPreventionEnabled(true);
+    testRunner?.setStatisticsEnabled(true);
     finishJSTest();
 }
 </script>

--- a/LayoutTests/http/tests/referrer-policy/unsafe-url/cross-origin-http-UpgradeMixedContent.https.html
+++ b/LayoutTests/http/tests/referrer-policy/unsafe-url/cross-origin-http-UpgradeMixedContent.https.html
@@ -9,23 +9,20 @@
 description("Tests the behavior of unsafe-url referrer policy when cross origin from HTTPS to HTTP.");
 jsTestIsAsync = true;
 
-if (window.internals) {
+if (window.internals)
     internals.settings.setAllowDisplayOfInsecureContent(true);
-    internals.setTrackingPreventionEnabled(false);
-}
+testRunner?.setStatisticsEnabled(false);
 
 window.onmessage = function(event) {
     referrer = event.data.referrer;
     // Should be the full URL
     shouldBeEqualToString("referrer", "https://127.0.0.1:8443/referrer-policy/unsafe-url/cross-origin-http.https.html");
-    if (window.internals)
-        internals.setTrackingPreventionEnabled(true);
+    testRunner?.setStatisticsEnabled(true);
     finishJSTest();
 }
 
 setTimeout(() => {
-    if (window.internals)
-        internals.setTrackingPreventionEnabled(true);
+    testRunner?.setStatisticsEnabled(true);
     testPassed("Timeout reached, insecure iframe not loaded");
     finishJSTest();
 }, 500);

--- a/LayoutTests/http/tests/referrer-policy/unsafe-url/cross-origin-http-http.html
+++ b/LayoutTests/http/tests/referrer-policy/unsafe-url/cross-origin-http-http.html
@@ -9,15 +9,13 @@
 description("Tests the behavior of unsafe-url referrer policy when cross origin.");
 jsTestIsAsync = true;
 
-if (window.internals)
-    internals.setTrackingPreventionEnabled(false);
+testRunner?.setStatisticsEnabled(false);
 
 window.onmessage = function(event) {
     referrer = event.data.referrer;
     // Should be the full URL
     shouldBeEqualToString("referrer", "http://127.0.0.1:8000/referrer-policy/unsafe-url/cross-origin-http-http.html");
-    if (window.internals)
-        internals.setTrackingPreventionEnabled(true);
+    testRunner?.setStatisticsEnabled(true);
     finishJSTest();
 }
 

--- a/LayoutTests/http/tests/referrer-policy/unsafe-url/cross-origin-http.https.html
+++ b/LayoutTests/http/tests/referrer-policy/unsafe-url/cross-origin-http.https.html
@@ -11,15 +11,14 @@ jsTestIsAsync = true;
 
 if (window.internals) {
     internals.settings.setAllowDisplayOfInsecureContent(true);
-    internals.setTrackingPreventionEnabled(false);
+    testRunner?.setStatisticsEnabled(false);
 }
 
 window.onmessage = function(event) {
     referrer = event.data.referrer;
     // Should be the full URL
     shouldBeEqualToString("referrer", "https://127.0.0.1:8443/referrer-policy/unsafe-url/cross-origin-http.https.html");
-    if (window.internals)
-        internals.setTrackingPreventionEnabled(true);
+    testRunner?.setStatisticsEnabled(true);
     finishJSTest();
 }
 

--- a/LayoutTests/http/tests/referrer-policy/unsafe-url/same-origin.html
+++ b/LayoutTests/http/tests/referrer-policy/unsafe-url/same-origin.html
@@ -9,15 +9,13 @@
 description("Tests the behavior of unsafe-url referrer policy when same origin.");
 jsTestIsAsync = true;
 
-if (window.internals)
-    internals.setTrackingPreventionEnabled(false);
+testRunner?.setStatisticsEnabled(false);
 
 window.onmessage = function(event) {
     referrer = event.data.referrer;
     // Should be the full URL
     shouldBeEqualToString("referrer", "http://127.0.0.1:8000/referrer-policy/unsafe-url/same-origin.html");
-    if (window.internals)
-        internals.setTrackingPreventionEnabled(true);
+    testRunner?.setStatisticsEnabled(true);
     finishJSTest();
 }
 </script>

--- a/LayoutTests/http/tests/resourceLoadStatistics/capped-lifetime-for-cookie-set-in-js-24-hours.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/capped-lifetime-for-cookie-set-in-js-24-hours.html
@@ -9,8 +9,7 @@
     description("Check that cookies created by JavaScript with max-age or expiry longer than a week get capped to a week.");
     jsTestIsAsync = true;
 
-    if (internals)
-        internals.setTrackingPreventionEnabled(true);
+    testRunner?.setStatisticsEnabled(true);
 
     let passedTests = 0;
     function checkThatCookieDoesNotExpireAfter(cookieData, maxAgeInSeconds) {
@@ -73,8 +72,7 @@
     } else
         testFailed("No internals object.");
 
-    if (internals)
-        internals.setTrackingPreventionEnabled(false);
+    testRunner?.setStatisticsEnabled(false);
 
     finishJSTest();
 </script>

--- a/LayoutTests/http/tests/resourceLoadStatistics/capped-lifetime-for-cookie-set-in-js.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/capped-lifetime-for-cookie-set-in-js.html
@@ -9,8 +9,7 @@
     description("Check that cookies created by JavaScript with max-age or expiry longer than a week get capped to a week.");
     jsTestIsAsync = true;
 
-    if (internals)
-        internals.setTrackingPreventionEnabled(true);
+    testRunner?.setStatisticsEnabled(true);
 
     let passedTests = 0;
     function checkThatCookieDoesNotExpireAfter(cookieData, maxAgeInSeconds) {
@@ -73,8 +72,7 @@
     } else
         testFailed("No internals object.");
 
-    if (internals)
-        internals.setTrackingPreventionEnabled(false);
+    testRunner?.setStatisticsEnabled(false);
 
     finishJSTest();
 </script>

--- a/LayoutTests/http/tests/resourceLoadStatistics/do-not-block-top-level-navigation-redirect.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/do-not-block-top-level-navigation-redirect.html
@@ -8,7 +8,7 @@
     description("Tests that blocking is not applied to top-level navigation redirects.");
     jsTestIsAsync = true;
 
-    internals.setTrackingPreventionEnabled(true);
+    testRunner?.setStatisticsEnabled(true);
 
     function doRedirect()
     {

--- a/LayoutTests/http/tests/resourceLoadStatistics/prevalent-resource-without-user-interaction.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/prevalent-resource-without-user-interaction.html
@@ -16,7 +16,7 @@
             testFailed("Cookie not deleted: " + document.cookie);
         else
             testPassed("Cookie deleted.");
-        internals.setTrackingPreventionEnabled(false);
+        testRunner?.setStatisticsEnabled(false);
         setEnableFeature(false, function() {
             testRunner.notifyDone();
         });

--- a/LayoutTests/http/tests/resourceLoadStatistics/resources/util.js
+++ b/LayoutTests/http/tests/resourceLoadStatistics/resources/util.js
@@ -2,13 +2,13 @@ function setEnableFeature(enable, completionHandler) {
     if (typeof completionHandler !== "function")
         testFailed("setEnableFeature() requires a completion handler function.");
     if (enable) {
-        internals.setTrackingPreventionEnabled(true);
+        testRunner.setStatisticsEnabled(true);
         testRunner.setStatisticsIsRunningTest(true);
         completionHandler();
     } else {
         testRunner.statisticsResetToConsistentState(function() {
             testRunner.setStatisticsIsRunningTest(false);
-            internals.setTrackingPreventionEnabled(false);
+            testRunner.setStatisticsEnabled(false);
             completionHandler();
         });
     }

--- a/LayoutTests/http/tests/webAPIStatistics/canvas-read-and-write-data-collection.html
+++ b/LayoutTests/http/tests/webAPIStatistics/canvas-read-and-write-data-collection.html
@@ -4,7 +4,7 @@
     <title>Test for canvas read and write data collection in resource load statistics</title>
 </head>
 <script>
-    internals.setTrackingPreventionEnabled(false);
+    testRunner?.setStatisticsEnabled(false);
 </script>
 <body>
 <p> Tests for canvas read and write data collection in ResourceLoadStatistics plist by rendering and reading text on the canvas and dumping the entire resource load statistics map. </p>
@@ -31,7 +31,7 @@
         testRunner.dumpAsText();
         testRunner.dumpResourceLoadStatistics();
         testRunner.waitUntilDone();
-        internals.setTrackingPreventionEnabled(true);
+        testRunner?.setStatisticsEnabled(true);
         runTestRunnerTest();
     }
 </script>

--- a/LayoutTests/http/tests/webAPIStatistics/font-load-data-collection.html
+++ b/LayoutTests/http/tests/webAPIStatistics/font-load-data-collection.html
@@ -4,7 +4,7 @@
     <title>Test for font loading data collection in resource load statistics</title>
 </head>
 <script>
-    internals.setTrackingPreventionEnabled(false);
+    testRunner?.setStatisticsEnabled(false);
 </script>
 <body>
 <p> Tests for font loading data collection in ResourceLoadStatistics plist by loading fonts and dumping the entire resource load statistics map. The test tries to load various fonts through a comma separated font-family list to draw a string with many m's since they differ in width more prominently among fonts. </p>
@@ -38,7 +38,7 @@
         testRunner.dumpAsText();
         testRunner.dumpResourceLoadStatistics();
         testRunner.waitUntilDone();
-        internals.setTrackingPreventionEnabled(true);
+        testRunner?.setStatisticsEnabled(true);
         runTestRunnerTest();
     }
 </script>

--- a/LayoutTests/http/tests/webAPIStatistics/navigator-functions-accessed-data-collection.html
+++ b/LayoutTests/http/tests/webAPIStatistics/navigator-functions-accessed-data-collection.html
@@ -4,7 +4,7 @@
     <title>Test for navigator functions accessed data collection in resource load statistics</title>
 </head>
 <script>
-    internals.setTrackingPreventionEnabled(false);
+    testRunner?.setStatisticsEnabled(false);
 </script>
 <body>
 <p> Tests for navigator functions accessed data collection in ResourceLoadStatistics plist by querying for all the navigator properties and dumping the entire resource load statistics map. </p>
@@ -33,7 +33,7 @@
         testRunner.dumpAsText();
         testRunner.dumpResourceLoadStatistics();
         testRunner.waitUntilDone();
-        internals.setTrackingPreventionEnabled(true);
+        testRunner?.setStatisticsEnabled(true);
         runTestRunnerTest();
     }
 </script>

--- a/LayoutTests/http/tests/webAPIStatistics/screen-functions-accessed-data-collection.html
+++ b/LayoutTests/http/tests/webAPIStatistics/screen-functions-accessed-data-collection.html
@@ -4,7 +4,7 @@
     <title>Test for screen functions accessed data collection in resource load statistics</title>
 </head>
 <script>
-    internals.setTrackingPreventionEnabled(false);
+    testRunner?.setStatisticsEnabled(false);
 </script>
 <body>
 <p> Tests for screen functions accessed data collection in ResourceLoadStatistics plist by querying for all the screen properties and dumping the entire resource load statistics map. </p>
@@ -35,7 +35,7 @@
         testRunner.dumpAsText();
         testRunner.dumpResourceLoadStatistics();
         testRunner.waitUntilDone();
-        internals.setTrackingPreventionEnabled(true);
+        testRunner?.setStatisticsEnabled(true);
         runTestRunnerTest();
     }
 </script>

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -5811,11 +5811,6 @@ String Internals::resourceLoadStatisticsForURL(const DOMURL& url)
     return ResourceLoadObserver::shared().statisticsForURL(url.href());
 }
 
-void Internals::setTrackingPreventionEnabled(bool enable)
-{
-    DeprecatedGlobalSettings::setTrackingPreventionEnabled(enable);
-}
-
 String Internals::composedTreeAsText(Node& node)
 {
     if (!is<ContainerNode>(node))

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -940,7 +940,6 @@ public:
     void setShowAllPlugins(bool);
 
     String resourceLoadStatisticsForURL(const DOMURL&);
-    void setTrackingPreventionEnabled(bool);
 
     bool isReadableStreamDisturbed(ReadableStream&);
     JSC::JSValue cloneArrayBuffer(JSC::JSGlobalObject&, JSC::JSValue, JSC::JSValue, JSC::JSValue);

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -1113,7 +1113,6 @@ enum ContentsFormat {
     boolean isReadableStreamDisturbed(ReadableStream stream);
 
     DOMString resourceLoadStatisticsForURL(DOMURL url);
-    undefined setTrackingPreventionEnabled(boolean enable);
 
     undefined setCanShowModalDialogOverride(boolean allow);
 


### PR DESCRIPTION
#### 147f7a0360dd0ab1a9df0a5574b1c888ee5a4686
<pre>
Remove `Internals::setTrackingPreventionEnabled`
<a href="https://bugs.webkit.org/show_bug.cgi?id=293151">https://bugs.webkit.org/show_bug.cgi?id=293151</a>
<a href="https://rdar.apple.com/151488601">rdar://151488601</a>

Reviewed by NOBODY (OOPS!).

Replace use of internals.setTrackingPreventionEnabled and replace it with
testRunner.setStatisticsEnabled, with works with site isolation.

* LayoutTests/http/tests/clear-site-data/set-and-clear-cookies.https.html:
* LayoutTests/http/tests/cookies/accept-partitioned-first-and-third-party-cookies.https.html:
* LayoutTests/http/tests/media/media-stream/enumerate-devices-source-id.html:
* LayoutTests/http/tests/navigation/statistics.html:
* LayoutTests/http/tests/referrer-policy-anchor/origin-when-cross-origin/cross-origin-http-http.html:
* LayoutTests/http/tests/referrer-policy-iframe/no-referrer-when-downgrade/cross-origin-http-UpgradeMixedContent.https.html:
* LayoutTests/http/tests/referrer-policy-iframe/no-referrer-when-downgrade/cross-origin-http-http.html:
* LayoutTests/http/tests/referrer-policy-iframe/no-referrer-when-downgrade/cross-origin-http.https.html:
* LayoutTests/http/tests/referrer-policy-iframe/no-referrer-when-downgrade/same-origin.html:
* LayoutTests/http/tests/referrer-policy-iframe/no-referrer/cross-origin-http-UpgradeMixedContent.https.html:
* LayoutTests/http/tests/referrer-policy-iframe/no-referrer/cross-origin-http-http.html:
* LayoutTests/http/tests/referrer-policy-iframe/no-referrer/cross-origin-http.https.html:
* LayoutTests/http/tests/referrer-policy-iframe/no-referrer/same-origin.html:
* LayoutTests/http/tests/referrer-policy-iframe/origin-when-cross-origin/cross-origin-http-UpgradeMixedContent.https.html:
* LayoutTests/http/tests/referrer-policy-iframe/origin-when-cross-origin/cross-origin-http-http.html:
* LayoutTests/http/tests/referrer-policy-iframe/origin-when-cross-origin/cross-origin-http.https.html:
* LayoutTests/http/tests/referrer-policy-iframe/origin-when-cross-origin/same-origin.html:
* LayoutTests/http/tests/referrer-policy-iframe/origin/cross-origin-http-UpgradeMixedContent.https.html:
* LayoutTests/http/tests/referrer-policy-iframe/origin/cross-origin-http-http.html:
* LayoutTests/http/tests/referrer-policy-iframe/origin/cross-origin-http.https.html:
* LayoutTests/http/tests/referrer-policy-iframe/origin/same-origin.html:
* LayoutTests/http/tests/referrer-policy-iframe/same-origin/cross-origin-http-UpgradeMixedContent.https.html:
* LayoutTests/http/tests/referrer-policy-iframe/same-origin/cross-origin-http-http.html:
* LayoutTests/http/tests/referrer-policy-iframe/same-origin/cross-origin-http.https.html:
* LayoutTests/http/tests/referrer-policy-iframe/same-origin/same-origin.html:
* LayoutTests/http/tests/referrer-policy-iframe/strict-origin-when-cross-origin/cross-origin-http-UpgradeMixedContent.https.html:
* LayoutTests/http/tests/referrer-policy-iframe/strict-origin-when-cross-origin/cross-origin-http-http.html:
* LayoutTests/http/tests/referrer-policy-iframe/strict-origin-when-cross-origin/cross-origin-http.https.html:
* LayoutTests/http/tests/referrer-policy-iframe/strict-origin-when-cross-origin/same-origin.html:
* LayoutTests/http/tests/referrer-policy-iframe/strict-origin/cross-origin-http-UpgradeMixedContent.https.html:
* LayoutTests/http/tests/referrer-policy-iframe/strict-origin/cross-origin-http-http.html:
* LayoutTests/http/tests/referrer-policy-iframe/strict-origin/cross-origin-http.https.html:
* LayoutTests/http/tests/referrer-policy-iframe/strict-origin/same-origin.html:
* LayoutTests/http/tests/referrer-policy-iframe/unsafe-url/cross-origin-http-UpgradeMixedContent.https.html:
* LayoutTests/http/tests/referrer-policy-iframe/unsafe-url/cross-origin-http-http.html:
* LayoutTests/http/tests/referrer-policy-iframe/unsafe-url/cross-origin-http.https.html:
* LayoutTests/http/tests/referrer-policy-iframe/unsafe-url/same-origin.html:
* LayoutTests/http/tests/referrer-policy-img/no-referrer-when-downgrade/cross-origin-http-UpgradeMixedContent.https.html:
* LayoutTests/http/tests/referrer-policy-img/no-referrer-when-downgrade/cross-origin-http-http.html:
* LayoutTests/http/tests/referrer-policy-img/no-referrer-when-downgrade/cross-origin-http.https.html:
* LayoutTests/http/tests/referrer-policy-img/no-referrer-when-downgrade/same-origin.html:
* LayoutTests/http/tests/referrer-policy-img/no-referrer/cross-origin-http-UpgradeMixedContent.https.html:
* LayoutTests/http/tests/referrer-policy-img/no-referrer/cross-origin-http-http.html:
* LayoutTests/http/tests/referrer-policy-img/no-referrer/cross-origin-http.https.html:
* LayoutTests/http/tests/referrer-policy-img/no-referrer/same-origin.html:
* LayoutTests/http/tests/referrer-policy-img/origin-when-cross-origin/cross-origin-http-UpgradeMixedContent.https.html:
* LayoutTests/http/tests/referrer-policy-img/origin-when-cross-origin/cross-origin-http-http.html:
* LayoutTests/http/tests/referrer-policy-img/origin-when-cross-origin/cross-origin-http.https.html:
* LayoutTests/http/tests/referrer-policy-img/origin-when-cross-origin/same-origin.html:
* LayoutTests/http/tests/referrer-policy-img/origin/cross-origin-http-UpgradeMixedContent.https.html:
* LayoutTests/http/tests/referrer-policy-img/origin/cross-origin-http-http.html:
* LayoutTests/http/tests/referrer-policy-img/origin/cross-origin-http.https.html:
* LayoutTests/http/tests/referrer-policy-img/origin/same-origin.html:
* LayoutTests/http/tests/referrer-policy-img/same-origin/cross-origin-http-http.html:
* LayoutTests/http/tests/referrer-policy-img/same-origin/cross-origin-http.https.html:
* LayoutTests/http/tests/referrer-policy-img/same-origin/same-origin.html:
* LayoutTests/http/tests/referrer-policy-img/strict-origin-when-cross-origin/cross-origin-http-UpgradeMixedContent.https.html:
* LayoutTests/http/tests/referrer-policy-img/strict-origin-when-cross-origin/cross-origin-http-http.html:
* LayoutTests/http/tests/referrer-policy-img/strict-origin-when-cross-origin/cross-origin-http.https.html:
* LayoutTests/http/tests/referrer-policy-img/strict-origin-when-cross-origin/same-origin.html:
* LayoutTests/http/tests/referrer-policy-img/strict-origin/cross-origin-http-UpgradeMixedContent.https.html:
* LayoutTests/http/tests/referrer-policy-img/strict-origin/cross-origin-http-http.html:
* LayoutTests/http/tests/referrer-policy-img/strict-origin/cross-origin-http.https.html:
* LayoutTests/http/tests/referrer-policy-img/strict-origin/same-origin.html:
* LayoutTests/http/tests/referrer-policy-img/unsafe-url/cross-origin-http-UpgradeMixedContent.https.html:
* LayoutTests/http/tests/referrer-policy-img/unsafe-url/cross-origin-http-http.html:
* LayoutTests/http/tests/referrer-policy-img/unsafe-url/cross-origin-http.https.html:
* LayoutTests/http/tests/referrer-policy-img/unsafe-url/same-origin.html:
* LayoutTests/http/tests/referrer-policy-script/unsafe-url/cross-origin-http-http.html:
* LayoutTests/http/tests/referrer-policy/no-referrer-when-downgrade/cross-origin-http-UpgradeMixedContent.https.html:
* LayoutTests/http/tests/referrer-policy/no-referrer-when-downgrade/cross-origin-http-http.html:
* LayoutTests/http/tests/referrer-policy/no-referrer-when-downgrade/cross-origin-http.https.html:
* LayoutTests/http/tests/referrer-policy/no-referrer-when-downgrade/same-origin.html:
* LayoutTests/http/tests/referrer-policy/no-referrer/cross-origin-http-UpgradeMixedContent.https.html:
* LayoutTests/http/tests/referrer-policy/no-referrer/cross-origin-http-http.html:
* LayoutTests/http/tests/referrer-policy/no-referrer/cross-origin-http.https.html:
* LayoutTests/http/tests/referrer-policy/no-referrer/same-origin.html:
* LayoutTests/http/tests/referrer-policy/origin-when-cross-origin/cross-origin-http-UpgradeMixedContent.https.html:
* LayoutTests/http/tests/referrer-policy/origin-when-cross-origin/cross-origin-http-http.html:
* LayoutTests/http/tests/referrer-policy/origin-when-cross-origin/cross-origin-http.https.html:
* LayoutTests/http/tests/referrer-policy/origin-when-cross-origin/same-origin.html:
* LayoutTests/http/tests/referrer-policy/origin/cross-origin-http-UpgradeMixedContent.https.html:
* LayoutTests/http/tests/referrer-policy/origin/cross-origin-http-http.html:
* LayoutTests/http/tests/referrer-policy/origin/cross-origin-http.https.html:
* LayoutTests/http/tests/referrer-policy/origin/same-origin.html:
* LayoutTests/http/tests/referrer-policy/same-origin/cross-origin-http-UpgradeMixedContent.https.html:
* LayoutTests/http/tests/referrer-policy/same-origin/cross-origin-http-http.html:
* LayoutTests/http/tests/referrer-policy/same-origin/cross-origin-http.https.html:
* LayoutTests/http/tests/referrer-policy/same-origin/same-origin.html:
* LayoutTests/http/tests/referrer-policy/strict-origin-when-cross-origin/cross-origin-http-UpgradeMixedContent.https.html:
* LayoutTests/http/tests/referrer-policy/strict-origin-when-cross-origin/cross-origin-http-http.html:
* LayoutTests/http/tests/referrer-policy/strict-origin-when-cross-origin/cross-origin-http.https.html:
* LayoutTests/http/tests/referrer-policy/strict-origin-when-cross-origin/same-origin.html:
* LayoutTests/http/tests/referrer-policy/strict-origin/cross-origin-http-UpgradeMixedContent.https.html:
* LayoutTests/http/tests/referrer-policy/strict-origin/cross-origin-http-http.html:
* LayoutTests/http/tests/referrer-policy/strict-origin/cross-origin-http.https.html:
* LayoutTests/http/tests/referrer-policy/strict-origin/same-origin.html:
* LayoutTests/http/tests/referrer-policy/unsafe-url/cross-origin-http-UpgradeMixedContent.https.html:
* LayoutTests/http/tests/referrer-policy/unsafe-url/cross-origin-http-http.html:
* LayoutTests/http/tests/referrer-policy/unsafe-url/cross-origin-http.https.html:
* LayoutTests/http/tests/referrer-policy/unsafe-url/same-origin.html:
* LayoutTests/http/tests/resourceLoadStatistics/capped-lifetime-for-cookie-set-in-js-24-hours.html:
* LayoutTests/http/tests/resourceLoadStatistics/capped-lifetime-for-cookie-set-in-js.html:
* LayoutTests/http/tests/resourceLoadStatistics/do-not-block-top-level-navigation-redirect.html:
* LayoutTests/http/tests/resourceLoadStatistics/prevalent-resource-without-user-interaction.html:
* LayoutTests/http/tests/resourceLoadStatistics/resources/util.js:
(setEnableFeature):
* LayoutTests/http/tests/webAPIStatistics/canvas-read-and-write-data-collection.html:
* LayoutTests/http/tests/webAPIStatistics/font-load-data-collection.html:
* LayoutTests/http/tests/webAPIStatistics/navigator-functions-accessed-data-collection.html:
* LayoutTests/http/tests/webAPIStatistics/screen-functions-accessed-data-collection.html:
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::setTrackingPreventionEnabled): Deleted.
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/147f7a0360dd0ab1a9df0a5574b1c888ee5a4686

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/103893 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/23596 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/13917 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/109086 "Built successfully") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/54554 "") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/105933 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/23951 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/32141 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78927 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/54554 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/106899 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/18596 "Exiting early after 10 failures. 660 tests run. 2 flakes") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/93717 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59255 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/18392 "Exiting early after 10 failures. 652 tests run. 2 flakes") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/11768 "Found 60 new test failures: compositing/transforms/transformed-replaced-with-shadow-children.html compositing/visible-rect/animated-from-none.html fonts/monospace.html fonts/sans-serif.html fonts/serif.html fonts/unicode-character-font-crash.html fonts/use-typo-metrics-1.html http/tests/referrer-policy-anchor/origin-when-cross-origin/cross-origin-http-http.html http/tests/referrer-policy-iframe/no-referrer-when-downgrade/cross-origin-http-UpgradeMixedContent.https.html http/tests/referrer-policy-iframe/no-referrer-when-downgrade/cross-origin-http-http.html ... (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/53921 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/88147 "1 api test failed or timed out") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/11827 "Exiting early after 10 failures. 740 tests run. 2 flakes") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/111473 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/31049 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/22888 "55 flakes 1 failures") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/87939 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/31411 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/89918 "Exiting early after 10 failures. 4461 tests run. 2 flakes") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87593 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32475 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10206 "10 flakes 2 failures") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/25415 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/30978 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/36288 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/30771 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/34108 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/32332 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->