### PR TITLE
Model Element reports extra memory cost to JSC

### DIFF
--- a/Source/WebCore/Modules/model-element/HTMLModelElement.h
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.h
@@ -181,6 +181,11 @@ public:
     WEBCORE_EXPORT String inlinePreviewUUIDForTesting() const;
 #endif
 
+    size_t memoryCost() const;
+#if ENABLE(RESOURCE_USAGE)
+    size_t externalMemoryCost() const;
+#endif
+
 private:
     HTMLModelElement(const QualifiedName&, Document&);
 
@@ -249,6 +254,8 @@ private:
 
     LayoutSize contentSize() const;
 
+    void reportExtraMemoryCost();
+
 #if ENABLE(MODEL_PROCESS)
     bool autoplay() const;
     void updateAutoplay();
@@ -269,6 +276,8 @@ private:
     URL m_sourceURL;
     CachedResourceHandle<CachedRawResource> m_resource;
     SharedBufferBuilder m_data;
+    mutable std::atomic<size_t> m_dataMemoryCost { 0 };
+    size_t m_reportedDataMemoryCost { 0 };
     WeakPtr<ModelPlayerProvider> m_modelPlayerProvider;
     RefPtr<Model> m_model;
     UniqueRef<ReadyPromise> m_readyPromise;
@@ -285,6 +294,7 @@ private:
     double m_playbackRate { 1.0 };
     URL m_environmentMapURL;
     SharedBufferBuilder m_environmentMapData;
+    mutable std::atomic<size_t> m_environmentMapDataMemoryCost { 0 };
     CachedResourceHandle<CachedRawResource> m_environmentMapResource;
     UniqueRef<EnvironmentMapPromise> m_environmentMapReadyPromise;
 #endif

--- a/Source/WebCore/Modules/model-element/HTMLModelElement.idl
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.idl
@@ -28,7 +28,9 @@
     EnabledBySetting=ModelElementEnabled,
     ExportToWrappedFunction,
     Exposed=Window,
-    JSGenerateToNativeObject
+    JSGenerateToNativeObject,
+    ReportExtraMemoryCost,
+    ReportExternalMemoryCost
 ] interface HTMLModelElement : HTMLElement {
     [CEReactions=NotNeeded, Reflect] attribute unsigned long width;
     [CEReactions=NotNeeded, Reflect] attribute unsigned long height;


### PR DESCRIPTION
#### 910c6466a03f7b130f5ecb1119bbd15a188ae963
<pre>
Model Element reports extra memory cost to JSC
<a href="https://bugs.webkit.org/show_bug.cgi?id=293150">https://bugs.webkit.org/show_bug.cgi?id=293150</a>
<a href="https://rdar.apple.com/143763757">rdar://143763757</a>

Reviewed by Ada Chan and Keith Miller.

Extra memory use is calculated based on resources loaded into the
HTMLModelElement (model data and, if available, environment data).
Additionally, memory cost members are atomic since they could be called
from GC threads via memoryCost().
Overall, this change should make GC more aggressive on the Model Element
and help with cases like page reloading.

* Source/WebCore/Modules/model-element/HTMLModelElement.cpp:
(WebCore::HTMLModelElement::didFinishLoading):
(WebCore::HTMLModelElement::didFailLoading):
(WebCore::HTMLModelElement::didFinishEnvironmentMapLoading):
(WebCore::HTMLModelElement::environmentMapResourceFinished):
(WebCore::HTMLModelElement::modelResourceFinished):
(WebCore::HTMLModelElement::reportExtraMemoryCost):
(WebCore::HTMLModelElement::memoryCost const):
(WebCore::HTMLModelElement::externalMemoryCost const):
* Source/WebCore/Modules/model-element/HTMLModelElement.h:
* Source/WebCore/Modules/model-element/HTMLModelElement.idl:

Canonical link: <a href="https://commits.webkit.org/295220@main">https://commits.webkit.org/295220@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/107a82a1fdc49f04addd9540e3f68d00609cf167

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104388 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24092 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/14508 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/109590 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/55056 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/106428 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/24469 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/32639 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79257 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107394 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19019 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94206 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59587 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/18828 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/12281 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/54418 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/88513 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/12333 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/111974 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/31545 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23236 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88295 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/31909 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/90450 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87961 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22412 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32860 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10626 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/26013 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/31473 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/36798 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/31267 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/34603 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/32827 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->