### PR TITLE
Make WebCore::Site distinct from HashTableEmptyValueType

### DIFF
--- a/Source/WebCore/platform/Site.cpp
+++ b/Source/WebCore/platform/Site.cpp
@@ -30,17 +30,38 @@
 
 namespace WebCore {
 
+static const String& invalidProtocol()
+{
+    // Valid protocols from canonicalized URLs are always lower case.
+    static NeverDestroyed<String> protocol { "invalidProtocol"_s };
+    return protocol.get();
+}
+
+static String nonEmptyProtocol(String&& protocol)
+{
+    if (protocol.isEmpty())
+        return invalidProtocol();
+    return String(WTFMove(protocol));
+}
+
 Site::Site(const URL& url)
-    : m_protocol(url.protocol().toString())
+    : m_protocol(nonEmptyProtocol(url.protocol().toString()))
     , m_domain(url) { }
 
 Site::Site(String&& protocol, RegistrableDomain&& domain)
-    : m_protocol(WTFMove(protocol))
+    : m_protocol(nonEmptyProtocol(WTFMove(protocol)))
     , m_domain(WTFMove(domain)) { }
 
 Site::Site(const SecurityOriginData& data)
-    : m_protocol(data.protocol())
+    : m_protocol(nonEmptyProtocol(String(data.protocol())))
     , m_domain(data) { }
+
+const String& Site::protocol() const
+{
+    if (m_protocol == invalidProtocol()) [[unlikely]]
+        return emptyString();
+    return m_protocol;
+}
 
 unsigned Site::hash() const
 {

--- a/Source/WebCore/platform/Site.h
+++ b/Source/WebCore/platform/Site.h
@@ -40,7 +40,7 @@ public:
     Site(const Site&) = default;
     Site& operator=(const Site&) = default;
 
-    const String& protocol() const { return m_protocol; }
+    WEBCORE_EXPORT const String& protocol() const;
     const RegistrableDomain& domain() const { return m_domain; }
     WEBCORE_EXPORT String toString() const;
     bool isEmpty() const { return m_domain.isEmpty(); }

--- a/Tools/TestWebKitAPI/Tests/WebCore/RegistrableDomain.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/RegistrableDomain.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 
 #include <WebCore/RegistrableDomain.h>
+#include <WebCore/Site.h>
 #include <wtf/URL.h>
 
 using namespace WebCore;
@@ -97,6 +98,29 @@ TEST(RegistrableDomain, UncheckedCreateFromHost)
     // This test is important for matching cookies' domain attributes which often have a leading dot.
     auto dotWebkitDomainFromHost = RegistrableDomain::uncheckedCreateFromHost(".webkit.org"_s);
     ASSERT_EQ(dotWebkitDomainFromHost, webkitDomainFromString);
+}
+
+TEST(Site, EmptyMapKey)
+{
+    Site empty1 { URL() };
+    Site empty2 { URL("!@#$%^&*NotARealURL)(*&^"_s) };
+    Site empty3 { SecurityOriginData(String(), String(), std::nullopt) };
+    Site empty4 { String(), RegistrableDomain::fromRawString(String()) };
+    Site empty5 { String(), RegistrableDomain() };
+
+    HashMap<Site, int> map;
+    int integer { 1 };
+    for (const auto& site : { empty1, empty2, empty3, empty4 }) {
+        map.add(site, integer++);
+        EXPECT_TRUE(site.isEmpty());
+        EXPECT_EQ(map.size(), 1u);
+        EXPECT_EQ(map.get(site), 1);
+    }
+
+    map.add(empty5, 5);
+    EXPECT_TRUE(empty5.isEmpty());
+    EXPECT_EQ(map.size(), 2u);
+    EXPECT_EQ(map.get(empty5), 5);
 }
 
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### a6c5148743e3513a8a161e3955811b2046771327
<pre>
Make WebCore::Site distinct from HashTableEmptyValueType
<a href="https://bugs.webkit.org/show_bug.cgi?id=293155">https://bugs.webkit.org/show_bug.cgi?id=293155</a>

Reviewed by Sihui Liu.

Add an invalidProtocol for Sites constructed with empty protocols
similar to RegistrableDomain&apos;s use of nullOrigin, and for the same reason.

* Source/WebCore/platform/Site.cpp:
(WebCore::invalidProtocol):
(WebCore::nonEmptyProtocol):
(WebCore::Site::Site):
(WebCore::Site::protocol const):
* Source/WebCore/platform/Site.h:
(WebCore::Site::protocol const): Deleted.
* Tools/TestWebKitAPI/Tests/WebCore/RegistrableDomain.cpp:
(TestWebKitAPI::TEST(Site, EmptyMapKey)):

Canonical link: <a href="https://commits.webkit.org/295063@main">https://commits.webkit.org/295063@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8ba654e4be129667c1d78b205c294c2d48cf7247

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/103989 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/23693 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/14013 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/109185 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/54654 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/106029 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/24051 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/32237 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78996 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/106995 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/18680 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/93807 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59324 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/18468 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/11858 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/54017 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/88202 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/11916 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/111569 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/31145 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/22950 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88007 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/31509 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/90007 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87664 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32552 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10294 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/25539 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16880 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/31074 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/36385 "Failed to build and analyze WebKit") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/30867 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/34204 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/32428 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->