### PR TITLE
REGRESSION (Safari 18.4): Declarative shadow DOM and custom elements do not work with parseUnsafeHTML

### DIFF
--- a/LayoutTests/fast/custom-elements/connected-callback-expected.txt
+++ b/LayoutTests/fast/custom-elements/connected-callback-expected.txt
@@ -1,0 +1,5 @@
+This tests using parseHTMLUnsafe to create a declarative shadow DOM.
+connectedCallback should be called on a custom element inside the shadow DOM.
+
+PASS
+

--- a/LayoutTests/fast/custom-elements/connected-callback.html
+++ b/LayoutTests/fast/custom-elements/connected-callback.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<body>
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+window.customElements.define('inner-element', class extends HTMLElement {
+    connectedCallback() { result.textContent = 'PASS'; }
+});
+</script>
+<p>This tests using <code>parseHTMLUnsafe</code> to create a declarative shadow DOM.<br>
+connectedCallback should be called on a custom element inside the shadow DOM.</p>
+<div id="result">FAIL</div>
+<div id="container"></div>
+<script>
+container.append(...Document.parseHTMLUnsafe('<outer-element><template shadowrootmode="open"><inner-element></inner-element></template></outer-element>').childNodes);
+</script>
+</body>

--- a/Source/WebCore/dom/ShadowRoot.cpp
+++ b/Source/WebCore/dom/ShadowRoot.cpp
@@ -128,6 +128,12 @@ ShadowRoot::~ShadowRoot()
 Node::InsertedIntoAncestorResult ShadowRoot::insertedIntoAncestor(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
 {
     DocumentFragment::insertedIntoAncestor(insertionType, parentOfInsertedTree);
+    if (!hasScopedCustomElementRegistry() && usesNullCustomElementRegistry() && !parentOfInsertedTree.usesNullCustomElementRegistry()) {
+        if (RefPtr registry = CustomElementRegistry::registryForElement(*host())) {
+            clearUsesNullCustomElementRegistry();
+            setCustomElementRegistry(*registry);
+        }
+    }
     if (insertionType.connectedToDocument) {
         protectedDocument()->didInsertInDocumentShadowRoot(*this);
         if (m_hasScopedCustomElementRegistry) {


### PR DESCRIPTION
#### 6d35fd51666a7bb5d1fc952bd2be46d4d847b006
<pre>
REGRESSION (Safari 18.4): Declarative shadow DOM and custom elements do not work with parseUnsafeHTML
<a href="https://bugs.webkit.org/show_bug.cgi?id=292968">https://bugs.webkit.org/show_bug.cgi?id=292968</a>
<a href="https://rdar.apple.com/151273154">rdar://151273154</a>

Reviewed by Chris Dumez.

The regression was caused by the refactoring to support custom element registry per TreeScope.

When a shadow root is inserted into a document tree with a non-null custom-element registry,
we should update the associated custom element registry to that of the destination document
like elements except when the shadow root is specified to use a scoped custom element registry.

* LayoutTests/fast/custom-elements/connected-callback-expected.txt: Added.
* LayoutTests/fast/custom-elements/connected-callback.html: Added.
* Source/WebCore/dom/ShadowRoot.cpp:
(WebCore::ShadowRoot::insertedIntoAncestor):

Canonical link: <a href="https://commits.webkit.org/295050@main">https://commits.webkit.org/295050@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f2690830e44a6e4034fb3430d2c317df69a8b81a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/103907 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/23610 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/13931 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/109100 "Built successfully") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/54568 "") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/105947 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/23965 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/32155 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78931 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/54568 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/106913 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/18611 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/93729 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59259 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/18407 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/11780 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/53935 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/88159 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/11839 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/111487 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/31063 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/22899 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/87948 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/31426 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/89930 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87602 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32482 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10217 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/25429 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16871 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/30992 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/36302 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/30785 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/34122 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/32346 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->