### PR TITLE
[JSC] Switch from Shewchuk’s Algorithm to xsum Algorithm to Optimize `Math.sumPrecise`

### DIFF
--- a/JSTests/microbenchmarks/math-sumPrecise-10.js
+++ b/JSTests/microbenchmarks/math-sumPrecise-10.js
@@ -1,0 +1,9 @@
+//@ requireOptions("--useMathSumPreciseMethod=1")
+(function () {
+  var result = 0;
+  var values = Array(10).fill([1e20, 0.1, -1e20]).flat();
+  for (var i = 0; i < testLoopCount; ++i) {
+    if (Math.sumPrecise(values) === 1) result++;
+  }
+  if (result !== testLoopCount * 1) throw 'Error: bad: ' + result;
+})();

--- a/JSTests/microbenchmarks/math-sumPrecise-100.js
+++ b/JSTests/microbenchmarks/math-sumPrecise-100.js
@@ -1,0 +1,9 @@
+//@ requireOptions("--useMathSumPreciseMethod=1")
+(function () {
+  var result = 0;
+  var values = Array(100).fill([1e20, 0.1, -1e20]).flat();
+  for (var i = 0; i < testLoopCount; ++i) {
+    if (Math.sumPrecise(values) === 10) result++;
+  }
+  if (result !== testLoopCount * 1) throw 'Error: bad: ' + result;
+})();

--- a/JSTests/microbenchmarks/math-sumPrecise-1000.js
+++ b/JSTests/microbenchmarks/math-sumPrecise-1000.js
@@ -1,0 +1,9 @@
+//@ requireOptions("--useMathSumPreciseMethod=1")
+(function () {
+  var result = 0;
+  var values = Array(1_000).fill([1e20, 0.1, -1e20]).flat();
+  for (var i = 0; i < testLoopCount; ++i) {
+    if (Math.sumPrecise(values) === 100) result++;
+  }
+  if (result !== testLoopCount * 1) throw 'Error: bad: ' + result;
+})();

--- a/JSTests/microbenchmarks/math-sumPrecise-10000.js
+++ b/JSTests/microbenchmarks/math-sumPrecise-10000.js
@@ -1,0 +1,9 @@
+//@ requireOptions("--useMathSumPreciseMethod=1")
+(function () {
+  var result = 0;
+  var values = Array(10_000).fill([1e20, 0.1, -1e20]).flat();
+  for (var i = 0; i < testLoopCount; ++i) {
+    if (Math.sumPrecise(values) === 1_000) result++;
+  }
+  if (result !== testLoopCount * 1) throw 'Error: bad: ' + result;
+})();

--- a/Source/WTF/wtf/PreciseSum.cpp
+++ b/Source/WTF/wtf/PreciseSum.cpp
@@ -24,32 +24,38 @@
  */
 
 /*
- * This is the Math.sumPrecise() polyfill by Kevin Gibbons, ported to C++. Original LICENSE is as follows:
+ * This is a C++ port of the xsum implementation, 
+ * originally invented by Radford M. Neal, and ported by Keita Nonaka.
+ * 
+ * The original C implementation is from https://gitlab.com/radfordneal/xsum
+ * The C++ implementation is from https://github.com/Gumichocopengin8/xsum.cpp
  *
- * BSD 3-Clause License
+ * The LICENSE is as follows:
+ *
+ * This software for exact summation of floating-point values is licensed
+ * under the "MIT license", included here.
  * 
- * Copyright (c) 2024 Kevin Gibbons
+ * Copyright 2015, 2018, 2021, 2024 Radford M. Neal
+ * Copyright 2025 Keita Nonaka
  * 
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
  * 
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
  * 
- * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions
- * and the following disclaimer in the documentation and/or other materials provided with the distribution.
- * 
- * 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse
- * or promote products derived from this software without specific prior written permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED
- * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
- * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
- * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
- * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
- * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
 #include "config.h"
@@ -59,123 +65,358 @@
 
 namespace WTF {
 
-static constexpr double MAX_DOUBLE = 1.79769313486231570815e+308;
-static constexpr double PENULTIMATE_DOUBLE = 1.79769313486231550856e+308;
-static constexpr double MAX_ULP = MAX_DOUBLE - PENULTIMATE_DOUBLE;
-static constexpr double TWO_POW_1023 = 8.98846567431158e+307;
+namespace {
 
-ALWAYS_INLINE std::pair<double, double> twosum(double x, double y)
+constexpr int64_t XSUM_MANTISSA_BITS = 52; // Bits in fp mantissa, excludes implict 1
+constexpr int64_t XSUM_EXP_BITS = 11; // Bits in fp exponent
+constexpr int64_t XSUM_MANTISSA_MASK = (static_cast<int64_t>(1) << XSUM_MANTISSA_BITS) - 1; // Mask for mantissa bits
+constexpr int64_t XSUM_EXP_MASK = (1 << XSUM_EXP_BITS) - 1; // Mask for exponent
+constexpr int64_t XSUM_EXP_BIAS = (1 << (XSUM_EXP_BITS - 1)) - 1; // Bias added to signed exponent
+constexpr int64_t XSUM_SIGN_BIT = XSUM_MANTISSA_BITS + XSUM_EXP_BITS; // Position of sign bit
+constexpr uint64_t XSUM_SIGN_MASK = static_cast<uint64_t>(1) << XSUM_SIGN_BIT; // Mask for sign bit
+constexpr int64_t XSUM_SCHUNK_BITS = 64; // Bits in chunk of the small accumulator
+constexpr int64_t XSUM_LOW_EXP_BITS = 5; // # of low bits of exponent, in one chunk
+constexpr int64_t XSUM_LOW_EXP_MASK = (1 << XSUM_LOW_EXP_BITS) - 1; // Mask for low-order exponent bits
+constexpr int64_t XSUM_HIGH_EXP_BITS = XSUM_EXP_BITS - XSUM_LOW_EXP_BITS; // # of high exponent bits for index
+constexpr int64_t XSUM_SCHUNKS = (1 << XSUM_HIGH_EXP_BITS) + 3; // # of chunks in small accumulator
+constexpr int64_t XSUM_LOW_MANTISSA_BITS = 1 << XSUM_LOW_EXP_BITS; // Bits in low part of mantissa
+constexpr int64_t XSUM_LOW_MANTISSA_MASK = (static_cast<int64_t>(1) << XSUM_LOW_MANTISSA_BITS) - 1; // Mask for low bits
+constexpr int64_t XSUM_SMALL_CARRY_BITS = (XSUM_SCHUNK_BITS - 1) - XSUM_MANTISSA_BITS; // Bits sums can carry into
+constexpr int64_t XSUM_SMALL_CARRY_TERMS = (1 << XSUM_SMALL_CARRY_BITS) - 1; // # terms can add before need prop.
+
+} // anonymous namespace
+
+namespace Xsum {
+
+SmallAccumulator::SmallAccumulator(
+    int addsUntilPropagate,
+    int64_t inf,
+    int64_t nan
+) : chunk(XSUM_SCHUNKS, 0LL), addsUntilPropagate { addsUntilPropagate }, inf { inf }, nan { nan } { }
+
+} // namespace Xsum
+
+PreciseSum::PreciseSum()
+: m_smallAccumulator { XSUM_SMALL_CARRY_TERMS, 0, 0 }, m_sizeCount { 0 }, m_hasPosNumber { false } { }
+
+/*
+ADD A VECTOR OF FLOATING-POINT NUMBERS TO A SMALL ACCUMULATOR. Mixes
+calls of xsumCarryPropagate with calls of xsumAdd1NoCarry.
+*/
+void PreciseSum::addList(const std::span<const double> vec)
 {
-    double hi = x + y;
-    double lo = y - (hi - x);
-    return std::make_pair(hi, lo);
-}
+    size_t offset = 0;
+    size_t n = vec.size();
 
-void PreciseSum::add(double x)
-{
-    if (!(!x && std::signbit(x)))
-        m_everyValueIsNegativeZero = false;
-
-    unsigned actuallyUsedPartials = 0;
-
-    for (double y : m_partials) {
-        if (std::fabs(x) < std::fabs(y))
-            std::swap(x, y);
-
-        auto pair = twosum(x, y);
-        if (std::isinf(std::fabs(pair.first))) {
-            double sign = pair.first < 0 ? -1 : 1;
-            m_overflow += sign;
-
-            x = (x - sign * TWO_POW_1023) - sign * TWO_POW_1023;
-            if (std::fabs(x) < std::fabs(y))
-                std::swap(x, y);
-
-            pair = twosum(x, y);
+    while (0 < n) {
+        if (!m_smallAccumulator.addsUntilPropagate)
+            xsumCarryPropagate();
+        size_t m = std::min(static_cast<int>(n), m_smallAccumulator.addsUntilPropagate);
+        for (size_t i = 0; i < m; i++) {
+            const double value = vec[offset + i];
+            incrementWhenValueAdded(value);
+            xsumAdd1NoCarry(value);
         }
-
-        if (auto lo = pair.second) {
-            m_partials[actuallyUsedPartials] = lo;
-            ++actuallyUsedPartials;
-        }
-
-        x = pair.first;
+        m_smallAccumulator.addsUntilPropagate -= m;
+        offset += m;
+        n -= m;
     }
-
-    m_partials.shrink(actuallyUsedPartials);
-
-    if (x)
-        m_partials.append(x);
 }
 
+/*
+ADD ONE DOUBLE TO A SMALL ACCUMULATOR. This is equivalent to, but
+somewhat faster than, calling xsum_small_addv with a vector of one
+value.
+*/
+void PreciseSum::add(double value)
+{
+    incrementWhenValueAdded(value);
+    if (!m_smallAccumulator.addsUntilPropagate)
+        xsumCarryPropagate();
+    xsumAdd1NoCarry(value);
+    m_smallAccumulator.addsUntilPropagate -= 1;
+}
+
+/*
+RETURN THE RESULT OF ROUNDING A SMALL ACCUMULATOR. The rounding mode
+is to nearest, with ties to even. The small accumulator may be modified
+by this operation (by carry propagation being done), but the value it
+represents should not change.
+*/
 double PreciseSum::compute()
 {
-    if (m_everyValueIsNegativeZero)
+    if (m_smallAccumulator.nan)
+        return std::bit_cast<double>(m_smallAccumulator.nan);
+    if (m_smallAccumulator.inf)
+        return std::bit_cast<double>(m_smallAccumulator.inf);
+    if (!m_sizeCount)
         return -0.0;
 
-    int32_t n = m_partials.size() - 1;
-    double hi = 0;
-    double lo = 0;
-
-    if (m_overflow) {
-        double next = n >= 0 ? m_partials[n] : 0;
-        --n;
-        if (std::fabs(m_overflow) > 1 || (m_overflow > 0 && next > 0) || (m_overflow < 0 && next < 0))
-            return m_overflow > 0 ? std::numeric_limits<double>::infinity() : -std::numeric_limits<double>::infinity();
-
-        auto pair = twosum(m_overflow * TWO_POW_1023, next / 2);
-        hi = pair.first;
-        lo = pair.second * 2;
-
-        if (std::isinf(std::fabs(hi * 2))) {
-            // silly edge case: rounding to the maximum value
-            // MAX_DOUBLE has a 1 in the last place of its significand, so if we subtract exactly half a ULP from 2**1024, the result rounds away from it (i.e. to infinity) under ties-to-even
-            // but if the next partial has the opposite sign of the current value, we need to round towards MAX_DOUBLE instead
-            // this is the same as the "handle rounding" case below, but there's only one potentially-finite case we need to worry about, so we just hardcode that one
-            if (hi > 0) {
-                if (hi == TWO_POW_1023 && lo == -(MAX_ULP / 2) && n >= 0 && m_partials[n] < 0)
-                    return MAX_DOUBLE;
-                return std::numeric_limits<double>::infinity();
+    const int i = xsumCarryPropagate();
+    int64_t ivalue = m_smallAccumulator.chunk[i];
+    int64_t intv = 0;
+    if (i <= 1) {
+        if (!ivalue)
+            return !m_hasPosNumber ? -0.0 : 0.0;
+        if (!i) {
+            intv = 0 <= ivalue ? ivalue : -ivalue;
+            intv >>= 1;
+            if (ivalue < 0)
+                intv |= XSUM_SIGN_MASK;
+            return std::bit_cast<double>(intv);
+        }
+        int64_t intv = ivalue * (static_cast<int64_t>(1) << (XSUM_LOW_MANTISSA_BITS - 1)) + (m_smallAccumulator.chunk[0] >> 1);
+        if (intv < 0) {
+            if (intv > -(static_cast<int64_t>(1) << XSUM_MANTISSA_BITS)) {
+                intv = (-intv) | XSUM_SIGN_MASK;
+                return std::bit_cast<double>(intv);
             }
-
-            if (hi == -TWO_POW_1023 && lo == (MAX_ULP / 2) && n >= 0 && m_partials[n] > 0)
-                return -MAX_DOUBLE;
-            return -std::numeric_limits<double>::infinity();
-        }
-
-        if (lo) {
-            m_partials[n + 1] = lo;
-            ++n;
-            lo = 0;
-        }
-
-        hi *= 2;
+        } else if (static_cast<uint64_t>(intv) < static_cast<uint64_t>(1) << XSUM_MANTISSA_BITS)
+            return std::bit_cast<double>(intv);
     }
 
-    while (n >= 0) {
-        double x = hi;
-        double y = m_partials[n];
-        --n;
+    const double fltv = static_cast<double>(ivalue);
+    intv = std::bit_cast<int64_t>(fltv);
+    int e = (intv >> XSUM_MANTISSA_BITS) & XSUM_EXP_MASK;
+    int more = 2 + XSUM_MANTISSA_BITS + XSUM_EXP_BIAS - e;
 
-        auto pair = twosum(x, y);
-        hi = pair.first;
-        lo = pair.second;
+    ivalue *= static_cast<int64_t>(1) << more;
+    int j = i - 1;
+    int64_t lower = m_smallAccumulator.chunk[j];
+    if (more >= XSUM_LOW_MANTISSA_BITS) {
+        more -= XSUM_LOW_MANTISSA_BITS;
+        ivalue += lower << more;
+        j -= 1;
+        lower = j < 0 ? 0 : m_smallAccumulator.chunk[j];
+    }
+    ivalue += lower >> (XSUM_LOW_MANTISSA_BITS - more);
+    lower &= (static_cast<int64_t>(1) << (XSUM_LOW_MANTISSA_BITS - more)) - 1;
 
-        if (lo)
+    bool shouldRoundAwayFromZero = false;
+    if (0 <= ivalue) {
+        intv = 0;
+        if (!(ivalue & 2)) {
+            // this is not required,
+            // but removing the branch would change the logic
+            // leave it as it is
+            shouldRoundAwayFromZero = false;
+        } else if ((ivalue & 1))
+            shouldRoundAwayFromZero = true;
+        else if ((ivalue & 4))
+            shouldRoundAwayFromZero = true;
+        else {
+            if (!lower) {
+                while (j > 0) {
+                    j -= 1;
+                    if (m_smallAccumulator.chunk[j]) {
+                        lower = 1;
+                        break;
+                    }
+                }
+            }
+            if (lower)
+                shouldRoundAwayFromZero = true;
+        }
+    } else {
+        if (!((-ivalue) & (static_cast<int64_t>(1) << (XSUM_MANTISSA_BITS + 2)))) {
+            int pos = (int64_t)1 << (XSUM_LOW_MANTISSA_BITS - 1 - more);
+            ivalue *= 2;
+            if (lower & pos) {
+                ivalue += 1;
+                lower &= ~pos;
+            }
+            e -= 1;
+        }
+
+        intv = XSUM_SIGN_MASK;
+        ivalue = -ivalue;
+        if ((ivalue & 3) == 3)
+            shouldRoundAwayFromZero = true;
+        if (!lower) {
+            while (j > 0) {
+                j -= 1;
+                if (m_smallAccumulator.chunk[j]) {
+                    lower = 1;
+                    break;
+                }
+            }
+        }
+        if (!lower)
+            shouldRoundAwayFromZero = true;
+    }
+
+    if (shouldRoundAwayFromZero) {
+        ivalue += 4;
+        if (ivalue & (static_cast<int64_t>(1) << (XSUM_MANTISSA_BITS + 3))) {
+            ivalue >>= 1;
+            e += 1;
+        }
+    }
+
+    ivalue >>= 2;
+    e += (i << XSUM_LOW_EXP_BITS) - XSUM_EXP_BIAS - XSUM_MANTISSA_BITS;
+    if (e >= XSUM_EXP_MASK) {
+        intv |= static_cast<int64_t>(XSUM_EXP_MASK) << XSUM_MANTISSA_BITS;
+        return std::bit_cast<double>(intv);
+    }
+    intv += (static_cast<int64_t>(e) << XSUM_MANTISSA_BITS) + (ivalue & XSUM_MANTISSA_MASK);
+    return std::bit_cast<double>(intv);
+}
+
+/*
+ADD AN INF OR NAN TO A SMALL ACCUMULATOR. This only changes the flags,
+not the chunks in the accumulator, which retains the sum of the finite
+terms (which is perhaps sometimes useful to access, though no function
+to do so is defined at present). A nan with larger payload (seen as a
+52-bit unsigned integer) takes precedence, with the sign of the nan always
+being positive. This ensures that the order of summing nan values doesn't
+matter.
+*/
+void PreciseSum::xsumSmallAddInfNan(int64_t ivalue)
+{
+    const int64_t mantissa = ivalue & XSUM_MANTISSA_MASK;
+    if (!mantissa) {
+        if (!m_smallAccumulator.inf)
+            m_smallAccumulator.inf = ivalue;
+        else if (m_smallAccumulator.inf != ivalue) {
+            double fltv = std::bit_cast<double>(ivalue);
+            fltv = fltv - fltv;
+            m_smallAccumulator.inf = std::bit_cast<int64_t>(fltv);
+        }
+    } else {
+        if ((m_smallAccumulator.nan & XSUM_MANTISSA_MASK) <= mantissa)
+            m_smallAccumulator.nan = ivalue & ~XSUM_SIGN_MASK;
+    }
+}
+
+/*
+ADD ONE NUMBER TO A SMALL ACCUMULATOR ASSUMING NO CARRY PROPAGATION REQ'D.
+This function is declared INLINE regardless of the setting of INLINE_SMALL
+and for good performance it must be inlined by the compiler (otherwise the
+procedure call overhead will result in substantial inefficiency).
+*/
+inline void PreciseSum::xsumAdd1NoCarry(double value)
+{
+    const int64_t ivalue = std::bit_cast<int64_t>(value);
+    int_fast16_t exp = (ivalue >> XSUM_MANTISSA_BITS) & XSUM_EXP_MASK;
+    int64_t mantissa = ivalue & XSUM_MANTISSA_MASK;
+    const int_fast16_t highExp = exp >> XSUM_LOW_EXP_BITS;
+    int_fast16_t lowExp = exp & XSUM_LOW_EXP_MASK;
+
+    if (!exp) {
+        if (!mantissa)
+            return;
+        exp = lowExp = 1;
+    } else if (exp == XSUM_EXP_MASK) {
+        xsumSmallAddInfNan(ivalue);
+        return;
+    } else
+        mantissa |= static_cast<int64_t>(1) << XSUM_MANTISSA_BITS;
+
+    const std::array<int64_t, 2> splitMantissa {
+        static_cast<int64_t>((static_cast<uint64_t>(mantissa) << lowExp) & XSUM_LOW_MANTISSA_MASK),
+        mantissa >> (XSUM_LOW_MANTISSA_BITS - lowExp)
+    };
+
+    if (ivalue < 0) {
+        m_smallAccumulator.chunk[highExp] -= splitMantissa[0];
+        m_smallAccumulator.chunk[highExp + 1] -= splitMantissa[1];
+    } else {
+        m_smallAccumulator.chunk[highExp] += splitMantissa[0];
+        m_smallAccumulator.chunk[highExp + 1] += splitMantissa[1];
+    }
+}
+
+/*
+PROPAGATE CARRIES TO NEXT CHUNK IN A SMALL ACCUMULATOR. Needs to
+be called often enough that accumulated carries don't overflow out
+the top, as indicated by m_smallAccumulator.addsUntilPropagate.  
+Returns the index of the uppermost non-zero chunk (0 if number is zero).
+
+After carry propagation, the uppermost non-zero chunk will indicate
+the sign of the number, and will not be -1 (all 1s). It will be in
+the range -2^XSUM_LOW_MANTISSA_BITS to 2^XSUM_LOW_MANTISSA_BITS - 1.
+Lower chunks will be non-negative, and in the range from 0 up to
+2^XSUM_LOW_MANTISSA_BITS - 1.
+*/
+int PreciseSum::xsumCarryPropagate()
+{
+    int u = XSUM_SCHUNKS - 1;
+    while (0 <= u && !m_smallAccumulator.chunk[u]) {
+        if (!u) {
+            m_smallAccumulator.addsUntilPropagate = XSUM_SMALL_CARRY_TERMS - 1;
+            return 0;
+        }
+        --u;
+    }
+
+    int i = 0;
+    int uix = -1;
+    do {
+        int64_t c;
+        int64_t clow;
+        int64_t chigh;
+        do {
+            c = m_smallAccumulator.chunk[i];
+            if (c)
+                break;
+            i += 1;
+        } while (i <= u);
+
+        if (i > u)
             break;
+
+        chigh = c >> XSUM_LOW_MANTISSA_BITS;
+        if (!chigh) {
+            uix = i;
+            i += 1;
+            continue;
+        }
+
+        if (u == i) {
+            if (chigh == -1) {
+                uix = i;
+                break;
+            }
+            u = i + 1;
+        }
+
+        clow = c & XSUM_LOW_MANTISSA_MASK;
+        if (clow)
+            uix = i;
+
+        m_smallAccumulator.chunk[i] = clow;
+        if (i + 1 >= XSUM_SCHUNKS) {
+            xsumSmallAddInfNan((static_cast<int64_t>(XSUM_EXP_MASK) << XSUM_MANTISSA_BITS) | XSUM_MANTISSA_MASK);
+            u = i;
+        } else
+            m_smallAccumulator.chunk[i + 1] += chigh;
+        i += 1;
+    } while (i <= u);
+
+    if (uix < 0) {
+        uix = 0;
+        m_smallAccumulator.addsUntilPropagate = XSUM_SMALL_CARRY_TERMS - 1;
+        return uix;
     }
 
-    // handle rounding
-    // when the roundoff error is exactly half of the ULP for the result, we need to check one more partial to know which way to round
-    if (n >= 0 && ((lo < 0 && m_partials[n] < 0) || (lo > 0 && m_partials[n] > 0))) {
-        double y = lo * 2;
-        double x = hi + y;
-        double yr = x - hi;
-        if (y == yr)
-            hi = x;
+    while (m_smallAccumulator.chunk[uix] == -1 && uix > 0) {
+        m_smallAccumulator.chunk[uix - 1] += static_cast<int64_t>(-1) * (static_cast<int64_t>(1) << XSUM_LOW_MANTISSA_BITS);
+        m_smallAccumulator.chunk[uix] = 0;
+        uix -= 1;
     }
+    m_smallAccumulator.addsUntilPropagate = XSUM_SMALL_CARRY_TERMS - 1;
+    return uix;
+}
 
-    return hi;
+/*
+Increment m_sizeCount and check positive value every time when value is added.
+This is needed to return -0 (negative zero) if applicable.
+*/
+ALWAYS_INLINE void PreciseSum::incrementWhenValueAdded(double value)
+{
+    m_sizeCount++;
+    m_hasPosNumber = m_hasPosNumber || !std::signbit(value);
 }
 
 } // namespace WTF


### PR DESCRIPTION
#### 2682d2ab17a40851f7e6bcff35126e810b0646fd
<pre>
[JSC] Switch from Shewchuk’s Algorithm to xsum Algorithm to Optimize `Math.sumPrecise`
<a href="https://bugs.webkit.org/show_bug.cgi?id=293158">https://bugs.webkit.org/show_bug.cgi?id=293158</a>

Reviewed by Yusuke Suzuki.

Previously, Shewchuk&apos;s algorithm was used [1], but it became slow with large arrays.
Improving the performance of Math.sumPrecise is important because it may be used in
scientific calculations, charting, and statistical analysis of large data sets,
where both high precision and fast speed are essential.
This patch switches to Radford M. Neal&apos;s xsum algorithm [2],
which improves the performance of Math.sumPrecise.
The original implementation is in C [3]; a C++ translation was referenced for integration [4].

                                TipOfTree              Patched                Ratio
math-sumPrecise-10              3.4638+-0.0681         2.6122+-0.0922         1.2338x faster
math-sumPrecise-100             27.2897+-0.115         17.9712+-0.0483        1.5185x faster
math-sumPrecise-1000            283.2722+-4.3743       171.4865+-2.4889       1.6518x faster
math-sumPrecise-10000           2922.8715+-9.1500      1709.5876+-4.2845      1.7096x faster

[1]: <a href="https://github.com/WebKit/WebKit/commit/f49d6a41fb8d93f9c7e6758d87a06a9eea3e9698">https://github.com/WebKit/WebKit/commit/f49d6a41fb8d93f9c7e6758d87a06a9eea3e9698</a>
[2]: <a href="https://arxiv.org/abs/1505.05571">https://arxiv.org/abs/1505.05571</a>
[3]: <a href="https://gitlab.com/radfordneal/xsum">https://gitlab.com/radfordneal/xsum</a>
[4]: <a href="https://github.com/Gumichocopengin8/xsum.cpp">https://github.com/Gumichocopengin8/xsum.cpp</a>

* JSTests/microbenchmarks/math-sumPrecise-10.js: Added.
* JSTests/microbenchmarks/math-sumPrecise-100.js: Added.
* JSTests/microbenchmarks/math-sumPrecise-1000.js: Added.
* JSTests/microbenchmarks/math-sumPrecise-10000.js: Added.
* Source/WTF/wtf/PreciseSum.cpp:
(WTF::XsumSmallAccumulator::XsumSmallAccumulator):
(WTF::PreciseSum::PreciseSum):
(WTF::PreciseSum::addList):
(WTF::PreciseSum::add):
(WTF::PreciseSum::compute):
(WTF::PreciseSum::xsumSmallAddInfNan):
(WTF::PreciseSum::xsumAdd1NoCarry):
(WTF::PreciseSum::xsumCarryPropagate):
(WTF::PreciseSum::incrementWhenValueAdded):
(WTF::twosum): Deleted.
* Source/WTF/wtf/PreciseSum.h:

Canonical link: <a href="https://commits.webkit.org/295242@main">https://commits.webkit.org/295242@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4021da2cae8422231f852b94a32d2df8394566fa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104168 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/23872 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/14192 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/109364 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/54836 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/24240 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/32416 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79122 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107174 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/18830 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/93974 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59449 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/18642 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/12013 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/54196 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/96843 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/88349 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/12071 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/111750 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/102779 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/31324 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23096 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88145 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/31688 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/90162 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87805 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32690 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10442 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/25788 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16962 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/31253 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/36566 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/126413 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/31047 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34955 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/34383 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/32607 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->