### PR TITLE
[JSC] Remove Unused Flag

### DIFF
--- a/LayoutTests/js/dom/resizable-array-buffer-serialization.html
+++ b/LayoutTests/js/dom/resizable-array-buffer-serialization.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML><!-- webkit-test-runner [ jscOptions=--useResizableArrayBuffer=true,--useSharedArrayBuffer=true ] -->
+<!DOCTYPE HTML><!-- webkit-test-runner [ jscOptions=--useSharedArrayBuffer=true ] -->
 <html>
 <head>
 <title>Resizable ArrayBuffers serialization</title>

--- a/LayoutTests/js/dom/resizable-array-buffer-should-be-rejected-by-default.html
+++ b/LayoutTests/js/dom/resizable-array-buffer-should-be-rejected-by-default.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML><!-- webkit-test-runner [ jscOptions=--useResizableArrayBuffer=true,--useSharedArrayBuffer=true ] -->
+<!DOCTYPE HTML><!-- webkit-test-runner [ jscOptions=--useSharedArrayBuffer=true ] -->
 <html>
 <head>
 <title>Resizable ArrayBuffers</title>

--- a/LayoutTests/js/dom/resizable-array-buffer-view-serialization-out-of-bounds-explicit-length.html
+++ b/LayoutTests/js/dom/resizable-array-buffer-view-serialization-out-of-bounds-explicit-length.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML><!-- webkit-test-runner [ jscOptions=--useResizableArrayBuffer=true,--useSharedArrayBuffer=true ] -->
+<!DOCTYPE HTML><!-- webkit-test-runner [ jscOptions=--useSharedArrayBuffer=true ] -->
 <html>
 <head>
 <title>Resizable ArrayBuffers serialization</title>

--- a/LayoutTests/js/dom/resizable-array-buffer-view-serialization-out-of-bounds.html
+++ b/LayoutTests/js/dom/resizable-array-buffer-view-serialization-out-of-bounds.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML><!-- webkit-test-runner [ jscOptions=--useResizableArrayBuffer=true,--useSharedArrayBuffer=true ] -->
+<!DOCTYPE HTML><!-- webkit-test-runner [ jscOptions=--useSharedArrayBuffer=true ] -->
 <html>
 <head>
 <title>Resizable ArrayBuffers serialization</title>

--- a/LayoutTests/js/dom/resizable-array-buffer-view-serialization.html
+++ b/LayoutTests/js/dom/resizable-array-buffer-view-serialization.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML><!-- webkit-test-runner [ jscOptions=--useResizableArrayBuffer=true,--useSharedArrayBuffer=true ] -->
+<!DOCTYPE HTML><!-- webkit-test-runner [ jscOptions=--useSharedArrayBuffer=true ] -->
 <html>
 <head>
 <title>Resizable ArrayBuffers serialization</title>

--- a/LayoutTests/js/dom/resizable-data-view-serialization-out-of-bounds-explicit-length.html
+++ b/LayoutTests/js/dom/resizable-data-view-serialization-out-of-bounds-explicit-length.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML><!-- webkit-test-runner [ jscOptions=--useResizableArrayBuffer=true,--useSharedArrayBuffer=true ] -->
+<!DOCTYPE HTML><!-- webkit-test-runner [ jscOptions=--useSharedArrayBuffer=true ] -->
 <html>
 <head>
 <title>Resizable ArrayBuffers serialization</title>

--- a/LayoutTests/js/dom/resizable-data-view-serialization-out-of-bounds.html
+++ b/LayoutTests/js/dom/resizable-data-view-serialization-out-of-bounds.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML><!-- webkit-test-runner [ jscOptions=--useResizableArrayBuffer=true,--useSharedArrayBuffer=true ] -->
+<!DOCTYPE HTML><!-- webkit-test-runner [ jscOptions=--useSharedArrayBuffer=true ] -->
 <html>
 <head>
 <title>Resizable ArrayBuffers serialization</title>

--- a/LayoutTests/js/structuredClone/structured-clone-of-ResizableSharedArrayBuffer.html
+++ b/LayoutTests/js/structuredClone/structured-clone-of-ResizableSharedArrayBuffer.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML><!-- webkit-test-runner [ jscOptions=--useResizableArrayBuffer=true,--useSharedArrayBuffer=true ] -->
+<!DOCTYPE HTML><!-- webkit-test-runner [ jscOptions=--useSharedArrayBuffer=true ] -->
 <body>
     <script>
 

--- a/LayoutTests/workers/sab/growable-shared-array-buffer-serialization.html
+++ b/LayoutTests/workers/sab/growable-shared-array-buffer-serialization.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML><!-- webkit-test-runner [ jscOptions=--useResizableArrayBuffer=true,--useSharedArrayBuffer=true ] -->
+<!DOCTYPE HTML><!-- webkit-test-runner [ jscOptions=--useSharedArrayBuffer=true ] -->
 <html>
 <head>
 <title>Growable SharedArrayBuffers should be serializable</title>

--- a/LayoutTests/workers/sab/growable-shared-array-buffer-view-serialization-explicit-length.html
+++ b/LayoutTests/workers/sab/growable-shared-array-buffer-view-serialization-explicit-length.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML><!-- webkit-test-runner [ jscOptions=--useResizableArrayBuffer=true,--useSharedArrayBuffer=true ] -->
+<!DOCTYPE HTML><!-- webkit-test-runner [ jscOptions=--useSharedArrayBuffer=true ] -->
 <html>
 <head>
 <title>Growable SharedArrayBuffers typed array should be serializable explicit length</title>

--- a/LayoutTests/workers/sab/growable-shared-array-buffer-view-serialization.html
+++ b/LayoutTests/workers/sab/growable-shared-array-buffer-view-serialization.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML><!-- webkit-test-runner [ jscOptions=--useResizableArrayBuffer=true,--useSharedArrayBuffer=true ] -->
+<!DOCTYPE HTML><!-- webkit-test-runner [ jscOptions=--useSharedArrayBuffer=true ] -->
 <html>
 <head>
 <title>Growable SharedArrayBuffers typed array should be serializable</title>

--- a/LayoutTests/workers/sab/postMessage-clones-growable.html
+++ b/LayoutTests/workers/sab/postMessage-clones-growable.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML><!-- webkit-test-runner [ jscOptions=--useResizableArrayBuffer=true,--useSharedArrayBuffer=true ] -->
+<!DOCTYPE HTML><!-- webkit-test-runner [ jscOptions=--useSharedArrayBuffer=true ] -->
 <html>
 <head>
 <script src="../../resources/js-test.js"></script>


### PR DESCRIPTION
#### 2b6804d0992cc9e39027dece9ebc5e144f91015b
<pre>
[JSC] Remove Unused Flag
<a href="https://bugs.webkit.org/show_bug.cgi?id=293162">https://bugs.webkit.org/show_bug.cgi?id=293162</a>

Reviewed by Yusuke Suzuki.

Remove unused useSharedArrayBuffer flag from LayoutTests

* LayoutTests/js/dom/resizable-array-buffer-serialization.html:
* LayoutTests/js/dom/resizable-array-buffer-should-be-rejected-by-default.html:
* LayoutTests/js/dom/resizable-array-buffer-view-serialization-out-of-bounds-explicit-length.html:
* LayoutTests/js/dom/resizable-array-buffer-view-serialization-out-of-bounds.html:
* LayoutTests/js/dom/resizable-array-buffer-view-serialization.html:
* LayoutTests/js/dom/resizable-data-view-serialization-out-of-bounds-explicit-length.html:
* LayoutTests/js/dom/resizable-data-view-serialization-out-of-bounds.html:
* LayoutTests/js/structuredClone/structured-clone-of-ResizableSharedArrayBuffer.html:
* LayoutTests/workers/sab/growable-shared-array-buffer-serialization.html:
* LayoutTests/workers/sab/growable-shared-array-buffer-view-serialization-explicit-length.html:
* LayoutTests/workers/sab/growable-shared-array-buffer-view-serialization.html:
* LayoutTests/workers/sab/postMessage-clones-growable.html:

Canonical link: <a href="https://commits.webkit.org/295054@main">https://commits.webkit.org/295054@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b370f538a7ac37dd73416f5b5457d1e99ad6383b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/103909 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/23612 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/13933 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/109102 "Built successfully") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/54570 "") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/23967 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/32157 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78934 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/54570 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/106915 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/18605 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/93733 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59262 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/18401 "Found unexpected failure with change (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/11784 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/53937 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/96584 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/88155 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/11843 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/111489 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/102520 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/31065 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/22897 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/87943 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/31428 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/89934 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87597 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32484 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10221 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/25431 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16875 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/30994 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/126153 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/30787 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34909 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/34124 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/32348 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->