### PR TITLE
AX: Make AXCoreObject ref-counting non-threadsafe, improving performance

### DIFF
--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -559,6 +559,7 @@ accessibility/AXRemoteFrame.cpp
 accessibility/AXSearchManager.cpp
 accessibility/AXTextMarker.cpp
 accessibility/AXTextRun.cpp
+accessibility/AXTreeStore.cpp
 accessibility/AccessibilityARIAGridCell.cpp
 accessibility/AccessibilityARIAGridRow.cpp
 accessibility/AccessibilityARIATable.cpp

--- a/Source/WebCore/accessibility/AXCoreObject.cpp
+++ b/Source/WebCore/accessibility/AXCoreObject.cpp
@@ -1190,10 +1190,19 @@ unsigned AXCoreObject::headingLevel() const
             return level;
     }
 
-    unsigned tagLevel = headingTagLevel();
-    if (tagLevel > 0)
-        return tagLevel;
-
+    auto elementName = this->elementName();
+    if (elementName == ElementName::HTML_h1)
+        return 1;
+    if (elementName == ElementName::HTML_h2)
+        return 2;
+    if (elementName == ElementName::HTML_h3)
+        return 3;
+    if (elementName == ElementName::HTML_h4)
+        return 4;
+    if (elementName == ElementName::HTML_h5)
+        return 5;
+    if (elementName == ElementName::HTML_h6)
+        return 6;
     return 0;
 }
 

--- a/Source/WebCore/accessibility/AXCoreObject.h
+++ b/Source/WebCore/accessibility/AXCoreObject.h
@@ -792,7 +792,7 @@ enum class TextEmissionBehavior : uint8_t {
     DoubleNewline
 };
 
-class AXCoreObject : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<AXCoreObject> {
+class AXCoreObject : public RefCountedAndCanMakeWeakPtr<AXCoreObject> {
 public:
     virtual ~AXCoreObject() = default;
     String dbg(bool verbose = false) const { return dbgInternal(verbose, { }); }
@@ -1026,7 +1026,6 @@ public:
 
     unsigned blockquoteLevel() const;
     unsigned headingLevel() const;
-    virtual unsigned headingTagLevel() const = 0;
     virtual AccessibilityButtonState checkboxOrRadioValue() const = 0;
     virtual String valueDescription() const = 0;
     virtual float valueForRange() const = 0;
@@ -1256,7 +1255,6 @@ public:
     virtual Page* page() const = 0;
     virtual Document* document() const = 0;
     virtual LocalFrameView* documentFrameView() const = 0;
-    virtual ScrollView* scrollView() const = 0;
     // Should eliminate the need for exposing scrollView().
     AXCoreObject* axScrollView() const;
 
@@ -1566,6 +1564,10 @@ protected:
         : m_id(axID)
     { }
 
+    explicit AXCoreObject(AXID axID, AccessibilityRole role)
+        : m_role(role)
+        , m_id(axID)
+    { }
 
 private:
     virtual String dbgInternal(bool, OptionSet<AXDebugStringOption>) const = 0;

--- a/Source/WebCore/accessibility/AXObjectCache.h
+++ b/Source/WebCore/accessibility/AXObjectCache.h
@@ -664,9 +664,8 @@ public:
     WEBCORE_EXPORT static void initializeAXThreadIfNeeded();
 private:
     static bool clientSupportsIsolatedTree();
-    AXCoreObject* isolatedTreeRootObject();
     // Propagates the root of the isolated tree back into the Core and WebKit.
-    void setIsolatedTreeRoot(AXCoreObject*);
+    void setIsolatedTree(Ref<AXIsolatedTree>);
     void setIsolatedTreeFocusedObject(AccessibilityObject*);
     RefPtr<AXIsolatedTree> getOrCreateIsolatedTree();
     void buildIsolatedTree();
@@ -939,7 +938,7 @@ private:
     UncheckedKeyHashMap<AXID, AXRelations> m_recentlyRemovedRelations;
 
 #if USE(ATSPI)
-    ListHashSet<RefPtr<AXCoreObject>> m_deferredParentChangedList;
+    ListHashSet<RefPtr<AccessibilityObject>> m_deferredParentChangedList;
 #endif
 
 #if PLATFORM(MAC)

--- a/Source/WebCore/accessibility/AXSearchManager.cpp
+++ b/Source/WebCore/accessibility/AXSearchManager.cpp
@@ -242,6 +242,7 @@ static void appendChildrenToArray(Ref<AXCoreObject> object, bool isForward, RefP
         // We should only ever hit this case with a live object (not an isolated object), as it would require startObject to be ignored,
         // and we should never have created an isolated object from an ignored live object.
         // FIXME: This is not true for ENABLE(INCLUDE_IGNORED_IN_CORE_AX_TREE), fix this before shipping it.
+        // FIXME: We hit this ASSERT on google.com. https://bugs.webkit.org/show_bug.cgi?id=293263
         ASSERT(is<AccessibilityObject>(startObject));
         auto* newStartObject = dynamicDowncast<AccessibilityObject>(startObject.get());
         // Get the un-ignored sibling based on the search direction, and update the searchPosition.

--- a/Source/WebCore/accessibility/AXTreeStore.cpp
+++ b/Source/WebCore/accessibility/AXTreeStore.cpp
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "AXTreeStore.h"
+
+#include "AXIsolatedTree.h"
+
+namespace WebCore {
+
+#if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
+template<>
+void AXTreeStore<AXIsolatedTree>::applyPendingChangesForAllIsolatedTrees()
+{
+    ASSERT(!isMainThread());
+
+    Locker locker { AXTreeStore<AXIsolatedTree>::s_storeLock };
+    auto& map = AXTreeStore<AXIsolatedTree>::isolatedTreeMap();
+    for (const auto& axIDToTree : map) {
+        if (RefPtr tree = axIDToTree.value.get(); tree && !tree->willBeDestroyed()) {
+            // Only applyPendingChanges for trees that aren't about to be destroyed.
+            // When a tree is destroyed, it tries to remove itself from AXTreeStore,
+            // which requires taking s_storeLock, which we hold. This would cause a deadlock.
+            tree->applyPendingChanges();
+        }
+    }
+}
+#endif // ENABLE(ACCESSIBILITY_ISOLATED_TREE)
+
+} // namespace WebCore

--- a/Source/WebCore/accessibility/AXTreeStore.h
+++ b/Source/WebCore/accessibility/AXTreeStore.h
@@ -67,6 +67,7 @@ public:
     static WeakPtr<AXObjectCache> axObjectCacheForID(std::optional<AXID>);
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
     static RefPtr<AXIsolatedTree> isolatedTreeForID(std::optional<AXID>);
+    static void applyPendingChangesForAllIsolatedTrees();
 #endif
 
 protected:

--- a/Source/WebCore/accessibility/AccessibilityMenuList.cpp
+++ b/Source/WebCore/accessibility/AccessibilityMenuList.cpp
@@ -37,15 +37,17 @@ AccessibilityMenuList::AccessibilityMenuList(AXID axID, RenderMenuList& renderer
     : AccessibilityRenderObject(axID, renderer)
     , m_popup(downcast<AccessibilityMenuListPopup>(*cache.create(AccessibilityRole::MenuListPopup)))
 {
-    m_popup->setParent(this);
-
-    addChild(m_popup.get());
-    m_childrenInitialized = true;
 }
 
 Ref<AccessibilityMenuList> AccessibilityMenuList::create(AXID axID, RenderMenuList& renderer, AXObjectCache& cache)
 {
-    return adoptRef(*new AccessibilityMenuList(axID, renderer, cache));
+    Ref menuList = adoptRef(*new AccessibilityMenuList(axID, renderer, cache));
+    // We have to do this setup here and not in the constructor to avoid an
+    // adoptionIsRequired ASSERT in RefCounted.h.
+    menuList->m_popup->setParent(menuList.ptr());
+    menuList->addChild(menuList->m_popup.get());
+    menuList->m_childrenInitialized = true;
+    return menuList;
 }
 
 bool AccessibilityMenuList::press()
@@ -87,7 +89,7 @@ void AccessibilityMenuList::updateChildrenIfNecessary()
 
 void AccessibilityMenuList::addChildren()
 {
-    // This class sets its children once in the constructor, and should never
+    // This class sets its children once in the create function, and should never
     // have dirty or uninitialized children afterwards.
     ASSERT(m_childrenInitialized);
     ASSERT(!m_childrenDirty);

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
@@ -985,25 +985,6 @@ AXCoreObject::AccessibilityChildrenVector AccessibilityNodeObject::radioButtonGr
     return result;
 }
 
-unsigned AccessibilityNodeObject::headingTagLevel() const
-{
-    auto elementName = this->elementName();
-    if (elementName == ElementName::HTML_h1)
-        return 1;
-    if (elementName == ElementName::HTML_h2)
-        return 2;
-    if (elementName == ElementName::HTML_h3)
-        return 3;
-    if (elementName == ElementName::HTML_h4)
-        return 4;
-    if (elementName == ElementName::HTML_h5)
-        return 5;
-    if (elementName == ElementName::HTML_h6)
-        return 6;
-
-    return 0;
-}
-
 String AccessibilityNodeObject::valueDescription() const
 {
     if (!isRangeControl())

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.h
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.h
@@ -90,8 +90,6 @@ public:
     std::optional<AccessibilityOrientation> orientationFromARIA() const;
     std::optional<AccessibilityOrientation> explicitOrientation() const override { return orientationFromARIA(); }
 
-    unsigned headingTagLevel() const final;
-
     AccessibilityButtonState checkboxOrRadioValue() const final;
 
     URL url() const override;

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -700,6 +700,7 @@ void AccessibilityObject::insertChild(AccessibilityObject& child, unsigned index
     } else {
         // Table component child-parent relationships often don't line up properly, hence the need for methods
         // like parentTable() and parentRow(). Exclude them from this ASSERT.
+        // FIXME: We hit this ASSERT on gmail.com. https://bugs.webkit.org/show_bug.cgi?id=293264
         ASSERT(isTableComponent(child) || isTableComponent(*this) || child.parentObject() == this);
         insert(Ref { child }, index);
     }

--- a/Source/WebCore/accessibility/AccessibilityObject.h
+++ b/Source/WebCore/accessibility/AccessibilityObject.h
@@ -63,7 +63,7 @@ class ScrollableArea;
 
 enum class CommandType: uint8_t;
 
-class AccessibilityObject : public AXCoreObject, public CanMakeWeakPtr<AccessibilityObject> {
+class AccessibilityObject : public AXCoreObject {
 public:
     virtual ~AccessibilityObject();
 
@@ -258,7 +258,6 @@ public:
     bool isShowingValidationMessage() const;
     String validationMessage() const;
 
-    unsigned headingTagLevel() const override { return 0; }
     AccessibilityButtonState checkboxOrRadioValue() const override;
     String valueDescription() const override { return String(); }
     float valueForRange() const override { return 0.0f; }
@@ -490,7 +489,7 @@ public:
     RefPtr<LocalFrame> localMainFrame() const;
     Document* topDocument() const;
     RenderView* topRenderer() const;
-    ScrollView* scrollView() const override { return nullptr; }
+    virtual ScrollView* scrollView() const { return nullptr; }
     unsigned ariaLevel() const final;
     String language() const final;
     // 1-based, to match the aria-level spec.

--- a/Source/WebCore/accessibility/atspi/AXObjectCacheAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AXObjectCacheAtspi.cpp
@@ -44,7 +44,7 @@ void AXObjectCache::attachWrapper(AccessibilityObject& axObject)
 
 void AXObjectCache::platformPerformDeferredCacheUpdate()
 {
-    auto handleParentChanged = [&](const AXCoreObject& axObject) {
+    auto handleParentChanged = [&](const AccessibilityObject& axObject) {
         auto* wrapper = axObject.wrapper();
         if (!wrapper)
             return;

--- a/Source/WebCore/accessibility/atspi/AccessibilityObjectAtspi.h
+++ b/Source/WebCore/accessibility/atspi/AccessibilityObjectAtspi.h
@@ -35,6 +35,8 @@ typedef struct _GVariantBuilder GVariantBuilder;
 
 namespace WebCore {
 
+class AXCoreObject;
+
 using RelationMap = UncheckedKeyHashMap<Atspi::Relation, Vector<Ref<AccessibilityObjectAtspi>>, IntHash<Atspi::Relation>, WTF::StrongEnumHashTraits<Atspi::Relation>>;
 
 class AccessibilityObjectAtspi final : public RefCounted<AccessibilityObjectAtspi> {

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
@@ -51,22 +51,21 @@ namespace WebCore {
 
 using namespace HTMLNames;
 
-AXIsolatedObject::AXIsolatedObject(const Ref<AccessibilityObject>& axObject, AXIsolatedTree* tree)
-    : AXCoreObject(axObject->objectID())
-    , m_cachedTree(tree)
+AXIsolatedObject::AXIsolatedObject(IsolatedObjectData&& data)
+    : AXCoreObject(data.axID, data.role)
+    , m_childrenIDs(WTFMove(data.childrenIDs))
+    , m_properties(WTFMove(data.properties))
+    , m_tree(WTFMove(data.tree))
+    , m_parentID(data.parentID)
+    , m_propertyFlags(data.propertyFlags)
+    , m_getsGeometryFromChildren(data.getsGeometryFromChildren)
 {
-    ASSERT(isMainThread());
-
-    if (auto* axParent = axObject->parentInCoreTree())
-        m_parentID = axParent->objectID();
-    m_role = axObject->roleValue();
-
-    initializeProperties(axObject);
+    ASSERT(!isMainThread());
 }
 
-Ref<AXIsolatedObject> AXIsolatedObject::create(const Ref<AccessibilityObject>& object, AXIsolatedTree* tree)
+Ref<AXIsolatedObject> AXIsolatedObject::create(IsolatedObjectData&& data)
 {
-    return adoptRef(*new AXIsolatedObject(object, tree));
+    return adoptRef(*new AXIsolatedObject(WTFMove(data)));
 }
 
 AXIsolatedObject::~AXIsolatedObject()
@@ -96,531 +95,9 @@ String AXIsolatedObject::dbgInternal(bool verbose, OptionSet<AXDebugStringOption
     return result.toString();
 }
 
-void AXIsolatedObject::initializeProperties(const Ref<AccessibilityObject>& axObject)
+static bool isDefaultValue(AXProperty property, AXPropertyValueVariant& value)
 {
-    AXTRACE("AXIsolatedObject::initializeProperties"_s);
-    auto& object = axObject.get();
-
-    auto reserveCapacityAndCacheBaseProperties = [&] (unsigned sizeToReserve) {
-        if (sizeToReserve)
-            m_properties.reserveInitialCapacity(sizeToReserve);
-
-        // These properties are cached for all objects, ignored and unignored.
-        setProperty(AXProperty::HasClickHandler, object.hasClickHandler());
-        auto elementName = object.elementName();
-        if (elementName == ElementName::HTML_body)
-            setProperty(AXProperty::ElementName, ElementName::HTML_body);
-        else if (elementName == ElementName::HTML_h1)
-            setProperty(AXProperty::ElementName, ElementName::HTML_h1);
-        else if (elementName == ElementName::HTML_h2)
-            setProperty(AXProperty::ElementName, ElementName::HTML_h2);
-        else if (elementName == ElementName::HTML_h3)
-            setProperty(AXProperty::ElementName, ElementName::HTML_h3);
-        else if (elementName == ElementName::HTML_h4)
-            setProperty(AXProperty::ElementName, ElementName::HTML_h4);
-        else if (elementName == ElementName::HTML_h5)
-            setProperty(AXProperty::ElementName, ElementName::HTML_h5);
-        else if (elementName == ElementName::HTML_h6)
-            setProperty(AXProperty::ElementName, ElementName::HTML_h6);
-        else if (elementName == ElementName::HTML_th)
-            setProperty(AXProperty::ElementName, ElementName::HTML_th);
-#if ENABLE(AX_THREAD_TEXT_APIS)
-        else if (elementName == ElementName::HTML_mark)
-            setProperty(AXProperty::ElementName, ElementName::HTML_mark);
-        else if (elementName == ElementName::HTML_attachment)
-            setProperty(AXProperty::ElementName, ElementName::HTML_attachment);
-        else if (elementName == ElementName::HTML_thead)
-            setProperty(AXProperty::ElementName, ElementName::HTML_thead);
-        else if (elementName == ElementName::HTML_tbody)
-            setProperty(AXProperty::ElementName, ElementName::HTML_tbody);
-        else if (elementName == ElementName::HTML_tfoot)
-            setProperty(AXProperty::ElementName, ElementName::HTML_tfoot);
-        else if (elementName == ElementName::HTML_output)
-            setProperty(AXProperty::ElementName, ElementName::HTML_output);
-
-        setProperty(AXProperty::TextRuns, std::make_shared<AXTextRuns>(object.textRuns()));
-        setProperty(AXProperty::TextEmissionBehavior, object.textEmissionBehavior());
-        if (roleValue() == AccessibilityRole::ListMarker) {
-            setProperty(AXProperty::ListMarkerText, object.listMarkerText().isolatedCopy());
-            setProperty(AXProperty::ListMarkerLineID, object.listMarkerLineID());
-        }
-#endif // ENABLE(AX_THREAD_TEXT_APIS)
-
-        String language = object.language();
-        if (!language.isEmpty())
-            setProperty(AXProperty::Language, WTFMove(language).isolatedCopy());
-        setProperty(AXProperty::IsEnabled, object.isEnabled());
-        initializeBasePlatformProperties(axObject);
-    };
-
-    // Allocate a capacity based on the minimum properties an object has (based on measurements from a real webpage).
-    constexpr unsigned unignoredSizeToReserve = 2;
-#if ENABLE(INCLUDE_IGNORED_IN_CORE_AX_TREE)
-    if (object.includeIgnoredInCoreTree()) {
-        bool isIgnored = object.isIgnored();
-        setProperty(AXProperty::IsIgnored, isIgnored);
-        // Maintain full properties for objects meeting this criteria:
-        //   - Unconnected objects, which are involved in relations or outgoing notifications
-        //   - Static text. We sometimes ignore static text (e.g. because it descends from a text field),
-        //     but need full properties for proper text marker behavior.
-        // FIXME: We shouldn't cache all properties for empty / non-rendered text?
-        bool needsAllProperties = !isIgnored || tree()->isUnconnectedNode(axObject->objectID()) || is<RenderText>(axObject->renderer());
-        if (!needsAllProperties) {
-            // FIXME: If isIgnored, we should only cache a small subset of necessary properties, e.g. those used in the text marker APIs.
-            reserveCapacityAndCacheBaseProperties(0);
-            return;
-        }
-        reserveCapacityAndCacheBaseProperties(unignoredSizeToReserve);
-    }
-#else
-    reserveCapacityAndCacheBaseProperties(unignoredSizeToReserve);
-#endif // ENABLE(INCLUDE_IGNORED_IN_CORE_AX_TREE)
-
-    setProperty(AXProperty::IsAttachment, object.isAttachment());
-    setProperty(AXProperty::IsBusy, object.isBusy());
-    setProperty(AXProperty::IsExpanded, object.isExpanded());
-
-    // FIXME: Caching isSecureField would require caching an additional property (on top of input type), so for now, let's still cache this.
-    setProperty(AXProperty::IsSecureField, object.isSecureField());
-
-    setProperty(AXProperty::IsIndeterminate, object.isIndeterminate());
-    setProperty(AXProperty::IsInlineText, object.isInlineText());
-    setProperty(AXProperty::IsMultiSelectable, object.isMultiSelectable());
-    setProperty(AXProperty::IsRequired, object.isRequired());
-    setProperty(AXProperty::IsSelected, object.isSelected());
-    setProperty(AXProperty::IsVisited, object.isVisited());
-    setProperty(AXProperty::IsValueAutofillAvailable, object.isValueAutofillAvailable());
-    setProperty(AXProperty::ARIARoleDescription, object.ariaRoleDescription().isolatedCopy());
-    setProperty(AXProperty::SubrolePlatformString, object.subrolePlatformString().isolatedCopy());
-    setProperty(AXProperty::CanSetFocusAttribute, object.canSetFocusAttribute());
-    setProperty(AXProperty::CanSetValueAttribute, object.canSetValueAttribute());
-    setProperty(AXProperty::CanSetSelectedAttribute, object.canSetSelectedAttribute());
-    setProperty(AXProperty::ValueDescription, object.valueDescription().isolatedCopy());
-    setProperty(AXProperty::ValueForRange, object.valueForRange());
-    setProperty(AXProperty::MaxValueForRange, object.maxValueForRange());
-    setProperty(AXProperty::MinValueForRange, object.minValueForRange());
-    setProperty(AXProperty::SupportsARIAOwns, object.supportsARIAOwns());
-    setProperty(AXProperty::ExplicitPopupValue, object.explicitPopupValue().isolatedCopy());
-    setProperty(AXProperty::ExplicitInvalidStatus, object.explicitInvalidStatus().isolatedCopy());
-    setProperty(AXProperty::SupportsExpanded, object.supportsExpanded());
-    setProperty(AXProperty::SortDirection, static_cast<int>(object.sortDirection()));
-#if !LOG_DISABLED
-    // Eagerly cache ID when logging is enabled so that we can log isolated objects without constant deadlocks.
-    // Don't cache ID when logging is disabled because we don't expect non-test AX clients to actually request it.
-    setProperty(AXProperty::IdentifierAttribute, object.identifierAttribute().isolatedCopy());
-#endif
-    // FIXME: We never update AXProperty::SupportsDropping.
-    setProperty(AXProperty::SupportsDropping, object.supportsDropping());
-    setProperty(AXProperty::SupportsDragging, object.supportsDragging());
-    setProperty(AXProperty::IsGrabbed, object.isGrabbed());
-    setProperty(AXProperty::PlaceholderValue, object.placeholderValue().isolatedCopy());
-    setProperty(AXProperty::ValueAutofillButtonType, static_cast<int>(object.valueAutofillButtonType()));
-    setProperty(AXProperty::URL, std::make_shared<URL>(object.url().isolatedCopy()));
-    setProperty(AXProperty::AccessKey, object.accessKey().isolatedCopy());
-    setProperty(AXProperty::ExplicitAutoCompleteValue, object.explicitAutoCompleteValue().isolatedCopy());
-    setProperty(AXProperty::ColorValue, object.colorValue());
-    setOptionalProperty(AXProperty::ExplicitOrientation, object.explicitOrientation());
-    setProperty(AXProperty::ExplicitLiveRegionStatus, object.explicitLiveRegionStatus().isolatedCopy());
-    setProperty(AXProperty::ExplicitLiveRegionRelevant, object.explicitLiveRegionRelevant().isolatedCopy());
-    setProperty(AXProperty::LiveRegionAtomic, object.liveRegionAtomic());
-    setProperty(AXProperty::HasBoldFont, object.hasBoldFont());
-    setProperty(AXProperty::HasItalicFont, object.hasItalicFont());
-    setProperty(AXProperty::HasPlainText, object.hasPlainText());
-#if !ENABLE(AX_THREAD_TEXT_APIS)
-    setProperty(AXProperty::HasUnderline, object.hasUnderline());
-    setProperty(AXProperty::TextContentPrefixFromListMarker, object.textContentPrefixFromListMarker());
-#endif
-    setProperty(AXProperty::IsKeyboardFocusable, object.isKeyboardFocusable());
-    setProperty(AXProperty::BrailleRoleDescription, object.brailleRoleDescription().isolatedCopy());
-    setProperty(AXProperty::BrailleLabel, object.brailleLabel().isolatedCopy());
-    setProperty(AXProperty::IsNonLayerSVGObject, object.isNonLayerSVGObject());
-
-    // Only cache input types on things that are an input.
-    if (std::optional inputType = axObject->inputType())
-        setProperty(AXProperty::InputType, *inputType);
-
-    bool isWebArea = axObject->isWebArea();
-    bool isScrollArea = axObject->isScrollView();
-    if (isScrollArea && !axObject->parentObject()) {
-        // Eagerly cache the screen relative position for the root. AXIsolatedObject::screenRelativePosition()
-        // of non-root objects depend on the root object's screen relative position, so make sure it's there
-        // from the start. We keep this up-to-date via AXIsolatedTree::updateRootScreenRelativePosition().
-        setProperty(AXProperty::ScreenRelativePosition, axObject->screenRelativePosition());
-        // FIXME: We never update this property, e.g. when the iframe is moved in the hosting web content process.
-        setProperty(AXProperty::RemoteFrameOffset, object.remoteFrameOffset());
-    }
-
-    RefPtr geometryManager = tree()->geometryManager();
-    std::optional frame = geometryManager ? geometryManager->cachedRectForID(object.objectID()) : std::nullopt;
-    if (frame)
-        setProperty(AXProperty::RelativeFrame, WTFMove(*frame));
-    else if (isScrollArea || isWebArea || object.isScrollbar()) {
-        // The GeometryManager does not have a relative frame for ScrollViews, WebAreas, or scrollbars yet. We need to get it from the
-        // live object so that we don't need to hit the main thread in the case a request comes in while the whole isolated tree is being built.
-        setProperty(AXProperty::RelativeFrame, enclosingIntRect(object.relativeFrame()));
-    } else if (!object.renderer() && object.node() && is<AccessibilityNodeObject>(object)) {
-        // The frame of node-only AX objects is made up of their children.
-        m_getsGeometryFromChildren = true;
-    } else if (object.isMenuListPopup()) {
-        // AccessibilityMenuListPopup's elementRect is hardcoded to return an empty rect, so preserve that behavior.
-        setProperty(AXProperty::RelativeFrame, IntRect());
-    } else
-        setProperty(AXProperty::InitialFrameRect, object.frameRect());
-
-    if (object.supportsPath()) {
-        setProperty(AXProperty::SupportsPath, true);
-        setProperty(AXProperty::Path, std::make_shared<Path>(object.elementPath()));
-    }
-
-    if (object.supportsKeyShortcuts()) {
-        setProperty(AXProperty::SupportsKeyShortcuts, true);
-        setProperty(AXProperty::KeyShortcuts, object.keyShortcuts().isolatedCopy());
-    }
-
-    if (object.supportsCurrent()) {
-        setProperty(AXProperty::SupportsCurrent, true);
-        setProperty(AXProperty::CurrentState, static_cast<int>(object.currentState()));
-    }
-
-    if (object.supportsSetSize()) {
-        setProperty(AXProperty::SupportsSetSize, true);
-        setProperty(AXProperty::SetSize, object.setSize());
-    }
-
-    if (object.supportsPosInSet()) {
-        setProperty(AXProperty::SupportsPosInSet, true);
-        setProperty(AXProperty::PosInSet, object.posInSet());
-    }
-
-    if (object.supportsExpandedTextValue()) {
-        setProperty(AXProperty::SupportsExpandedTextValue, true);
-        setProperty(AXProperty::ExpandedTextValue, object.expandedTextValue().isolatedCopy());
-    }
-
-    if (object.supportsDatetimeAttribute()) {
-        setProperty(AXProperty::SupportsDatetimeAttribute, true);
-        setProperty(AXProperty::DatetimeAttributeValue, object.datetimeAttributeValue().isolatedCopy());
-    }
-
-    if (object.supportsCheckedState()) {
-        setProperty(AXProperty::SupportsCheckedState, true);
-        setProperty(AXProperty::IsChecked, object.isChecked());
-        setProperty(AXProperty::ButtonState, object.checkboxOrRadioValue());
-    }
-
-    if (object.isTable()) {
-        setProperty(AXProperty::IsTable, true);
-        setProperty(AXProperty::IsExposable, object.isExposable());
-        setObjectVectorProperty(AXProperty::Columns, object.columns());
-        setObjectVectorProperty(AXProperty::Rows, object.rows());
-        setObjectVectorProperty(AXProperty::Cells, object.cells());
-        setObjectVectorProperty(AXProperty::VisibleRows, object.visibleRows());
-        setProperty(AXProperty::AXColumnCount, object.axColumnCount());
-        setProperty(AXProperty::AXRowCount, object.axRowCount());
-        setProperty(AXProperty::CellSlots, object.cellSlots());
-    }
-
-    if (object.isExposedTableCell()) {
-        setProperty(AXProperty::IsExposedTableCell, true);
-        setProperty(AXProperty::ColumnIndexRange, object.columnIndexRange());
-        setProperty(AXProperty::RowIndexRange, object.rowIndexRange());
-        setOptionalProperty(AXProperty::AXColumnIndex, object.axColumnIndex());
-        setOptionalProperty(AXProperty::AXRowIndex, object.axRowIndex());
-        setProperty(AXProperty::IsColumnHeader, object.isColumnHeader());
-        setProperty(AXProperty::IsRowHeader, object.isRowHeader());
-        setProperty(AXProperty::CellScope, object.cellScope().isolatedCopy());
-    }
-
-    bool isTableRow = object.isTableRow();
-    if (object.isTableColumn())
-        setProperty(AXProperty::ColumnIndex, object.columnIndex());
-    else if (isTableRow) {
-        setProperty(AXProperty::IsTableRow, true);
-        setProperty(AXProperty::RowIndex, object.rowIndex());
-    }
-
-    if (object.isARIATreeGridRow()) {
-        setProperty(AXProperty::IsARIATreeGridRow, true);
-        setObjectVectorProperty(AXProperty::DisclosedRows, object.disclosedRows());
-        setObjectProperty(AXProperty::DisclosedByRow, object.disclosedByRow());
-    } else if (object.isAccessibilityARIAGridRowInstance())
-        setProperty(AXProperty::IsARIAGridRow, true);
-
-    bool isTreeItem = object.isTreeItem();
-    if (isTreeItem) {
-        setProperty(AXProperty::IsTreeItem, true);
-        setObjectVectorProperty(AXProperty::DisclosedRows, object.disclosedRows());
-    }
-
-    setProperty(AXProperty::IsTree, object.isTree());
-    if (object.isRadioButton()) {
-        setProperty(AXProperty::NameAttribute, object.nameAttribute().isolatedCopy());
-        // FIXME: This property doesn't get updated when a page changes dynamically.
-        setObjectVectorProperty(AXProperty::RadioButtonGroup, object.radioButtonGroup());
-    }
-
-    if (object.isImage())
-        setProperty(AXProperty::EmbeddedImageDescription, object.embeddedImageDescription().isolatedCopy());
-
-    // On macOS, we only advertise support for the visible children attribute for lists and listboxes.
-    if (object.isList() || object.isListBox())
-        setObjectVectorProperty(AXProperty::VisibleChildren, object.visibleChildren());
-
-    if (object.isDateTime()) {
-        setProperty(AXProperty::DateTimeValue, object.dateTimeValue().isolatedCopy());
-        setProperty(AXProperty::DateTimeComponentsType, object.dateTimeComponentsType());
-    }
-
-    if (object.isSpinButton()) {
-        setObjectProperty(AXProperty::DecrementButton, object.decrementButton());
-        setObjectProperty(AXProperty::IncrementButton, object.incrementButton());
-    }
-
-    if (object.isMathElement()) {
-        setProperty(AXProperty::IsMathElement, true);
-        setProperty(AXProperty::IsMathFraction, object.isMathFraction());
-        setProperty(AXProperty::IsMathFenced, object.isMathFenced());
-        setProperty(AXProperty::IsMathSubscriptSuperscript, object.isMathSubscriptSuperscript());
-        setProperty(AXProperty::IsMathRow, object.isMathRow());
-        setProperty(AXProperty::IsMathUnderOver, object.isMathUnderOver());
-        setProperty(AXProperty::IsMathTable, object.isMathTable());
-        setProperty(AXProperty::IsMathTableRow, object.isMathTableRow());
-        setProperty(AXProperty::IsMathTableCell, object.isMathTableCell());
-        setProperty(AXProperty::IsMathMultiscript, object.isMathMultiscript());
-        setProperty(AXProperty::IsMathToken, object.isMathToken());
-        setProperty(AXProperty::MathFencedOpenString, object.mathFencedOpenString().isolatedCopy());
-        setProperty(AXProperty::MathFencedCloseString, object.mathFencedCloseString().isolatedCopy());
-        setProperty(AXProperty::MathLineThickness, object.mathLineThickness());
-        setProperty(AXProperty::IsAnonymousMathOperator, object.isAnonymousMathOperator());
-
-        bool isMathRoot = object.isMathRoot();
-        setProperty(AXProperty::IsMathRoot, isMathRoot);
-        setProperty(AXProperty::IsMathSquareRoot, object.isMathSquareRoot());
-        if (isMathRoot) {
-            if (auto radicand = object.mathRadicand())
-                setObjectVectorProperty(AXProperty::MathRadicand, *radicand);
-
-            setObjectProperty(AXProperty::MathRootIndexObject, object.mathRootIndexObject());
-        }
-
-        setObjectProperty(AXProperty::MathUnderObject, object.mathUnderObject());
-        setObjectProperty(AXProperty::MathOverObject, object.mathOverObject());
-        setObjectProperty(AXProperty::MathNumeratorObject, object.mathNumeratorObject());
-        setObjectProperty(AXProperty::MathDenominatorObject, object.mathDenominatorObject());
-        setObjectProperty(AXProperty::MathBaseObject, object.mathBaseObject());
-        setObjectProperty(AXProperty::MathSubscriptObject, object.mathSubscriptObject());
-        setObjectProperty(AXProperty::MathSuperscriptObject, object.mathSuperscriptObject());
-        setMathscripts(AXProperty::MathPrescripts, object);
-        setMathscripts(AXProperty::MathPostscripts, object);
-    }
-
-    Vector<AccessibilityText> texts;
-    object.accessibilityText(texts);
-    auto axTextValue = texts.map([] (const auto& text) -> AccessibilityText {
-        return { text.text.isolatedCopy(), text.textSource };
-    });
-    setProperty(AXProperty::AccessibilityText, axTextValue);
-
-    if (isScrollArea) {
-        setObjectProperty(AXProperty::VerticalScrollBar, object.scrollBar(AccessibilityOrientation::Vertical));
-        setObjectProperty(AXProperty::HorizontalScrollBar, object.scrollBar(AccessibilityOrientation::Horizontal));
-        setProperty(AXProperty::HasRemoteFrameChild, object.hasRemoteFrameChild());
-    } else if (isWebArea && !tree()->isEmptyContentTree()) {
-        // We expose DocumentLinks only for the web area objects when the tree is not an empty content tree. This property is expensive and makes no sense in an empty content tree.
-        // FIXME: compute DocumentLinks on the AX thread instead of caching it.
-        setObjectVectorProperty(AXProperty::DocumentLinks, object.documentLinks());
-    }
-
-    if (object.isWidget()) {
-        if (object.isPlugin()) {
-            // Plugins are a subclass of widget, so we only need to cache IsPlugin, and we implicitly know
-            // this is also a widget (see AXIsolatedObject::isWidget).
-            setProperty(AXProperty::IsPlugin, true);
-        } else
-            setProperty(AXProperty::IsWidget, true);
-
-        setProperty(AXProperty::IsVisible, object.isVisible());
-    }
-
-    auto descriptor = object.title();
-    if (descriptor.length())
-        setProperty(AXProperty::Title, descriptor.isolatedCopy());
-
-    descriptor = object.description();
-    if (descriptor.length())
-        setProperty(AXProperty::Description, descriptor.isolatedCopy());
-
-    descriptor = object.extendedDescription();
-    if (descriptor.length())
-        setProperty(AXProperty::ExtendedDescription, descriptor.isolatedCopy());
-
-    if (object.isTextControl()) {
-        // FIXME: We don't keep this property up-to-date, and we can probably just compute it using
-        // AXIsolatedObject::selectedTextMarkerRange() (which does stay up-to-date).
-        setProperty(AXProperty::SelectedTextRange, object.selectedTextRange());
-
-        auto range = object.textInputMarkedTextMarkerRange();
-        if (auto characterRange = range.characterRange(); range && characterRange)
-            setProperty(AXProperty::TextInputMarkedTextMarkerRange, std::make_shared<AXIDAndCharacterRange>(AXIDAndCharacterRange(range.start().objectID(), *characterRange)));
-
-        setProperty(AXProperty::CanBeMultilineTextField, canBeMultilineTextField(object));
-    }
-
-    if (object.isHeading() || isTableRow || isTreeItem)
-        setProperty(AXProperty::ARIALevel, object.ariaLevel());
-
-    // These properties are only needed on the AXCoreObject interface due to their use in ATSPI,
-    // so only cache them for ATSPI.
-#if USE(ATSPI)
-    // We cache IsVisible on all platforms just for Widgets above. In ATSPI, this should be cached on all objects.
-    if (!object.isWidget())
-        setProperty(AXProperty::IsVisible, object.isVisible());
-
-    setProperty(AXProperty::ActionVerb, object.actionVerb().isolatedCopy());
-    setProperty(AXProperty::IsFieldset, object.isFieldset());
-    setProperty(AXProperty::IsPressed, object.isPressed());
-    setProperty(AXProperty::IsSelectedOptionActive, object.isSelectedOptionActive());
-    setProperty(AXProperty::LocalizedActionVerb, object.localizedActionVerb().isolatedCopy());
-#endif // USE(ATSPI)
-    setObjectProperty(AXProperty::InternalLinkElement, object.internalLinkElement());
-
-    initializePlatformProperties(axObject);
-
-    shrinkPropertiesAfterUpdates();
-}
-
-bool AXIsolatedObject::canBeMultilineTextField(AccessibilityObject& object)
-{
-    if (object.isNonNativeTextControl())
-        return !object.hasAttribute(aria_multilineAttr) || object.ariaIsMultiline();
-
-    auto* renderer = object.renderer();
-    if (renderer && renderer->isRenderTextControl())
-        return renderer->isRenderTextControlMultiLine();
-
-    // If we're not sure, return true, it means we can't use this as an optimization to avoid computing the line index.
-    return true;
-}
-
-AccessibilityObject* AXIsolatedObject::associatedAXObject() const
-{
-    ASSERT(isMainThread());
-
-    auto* axObjectCache = this->axObjectCache();
-    return axObjectCache ? axObjectCache->objectForID(objectID()) : nullptr;
-}
-
-void AXIsolatedObject::setMathscripts(AXProperty property, AccessibilityObject& object)
-{
-    AccessibilityMathMultiscriptPairs pairs;
-    if (property == AXProperty::MathPrescripts)
-        object.mathPrescripts(pairs);
-    else if (property == AXProperty::MathPostscripts)
-        object.mathPostscripts(pairs);
-    
-    size_t mathSize = pairs.size();
-    if (!mathSize)
-        return;
-
-    auto idPairs = pairs.map([](auto& mathPair) {
-        return std::pair { mathPair.first ? Markable { mathPair.first->objectID() } : std::nullopt, mathPair.second ? Markable { mathPair.second->objectID() } : std::nullopt };
-    });
-    setProperty(property, WTFMove(idPairs));
-}
-
-void AXIsolatedObject::setObjectProperty(AXProperty property, AXCoreObject* object)
-{
-    setProperty(property, object ? Markable { object->objectID() } : std::nullopt);
-}
-
-void AXIsolatedObject::setObjectVectorProperty(AXProperty property, const AccessibilityChildrenVector& objects)
-{
-    setProperty(property, axIDs(objects));
-}
-
-template<typename T>
-void AXIsolatedObject::setOptionalProperty(AXProperty property, const std::optional<T>& value)
-{
-    if (value)
-        setProperty(property, *value);
-}
-
-void AXIsolatedObject::setProperty(AXProperty property, AXPropertyValueVariant&& value)
-{
-    if (std::holds_alternative<bool>(value)) {
-        switch (property) {
-        case AXProperty::CanSetFocusAttribute:
-            setPropertyFlag(AXPropertyFlag::CanSetFocusAttribute, std::get<bool>(value));
-            return;
-        case AXProperty::CanSetSelectedAttribute:
-            setPropertyFlag(AXPropertyFlag::CanSetSelectedAttribute, std::get<bool>(value));
-            return;
-        case AXProperty::CanSetValueAttribute:
-            setPropertyFlag(AXPropertyFlag::CanSetValueAttribute, std::get<bool>(value));
-            return;
-        case AXProperty::HasBoldFont:
-            setPropertyFlag(AXPropertyFlag::HasBoldFont, std::get<bool>(value));
-            return;
-        case AXProperty::HasClickHandler:
-            setPropertyFlag(AXPropertyFlag::HasClickHandler, std::get<bool>(value));
-            return;
-        case AXProperty::HasItalicFont:
-            setPropertyFlag(AXPropertyFlag::HasItalicFont, std::get<bool>(value));
-            return;
-        case AXProperty::HasPlainText:
-            setPropertyFlag(AXPropertyFlag::HasPlainText, std::get<bool>(value));
-            return;
-        case AXProperty::IsEnabled:
-            setPropertyFlag(AXPropertyFlag::IsEnabled, std::get<bool>(value));
-            return;
-        case AXProperty::IsExposedTableCell:
-            setPropertyFlag(AXPropertyFlag::IsExposedTableCell, std::get<bool>(value));
-            return;
-        case AXProperty::IsGrabbed:
-            setPropertyFlag(AXPropertyFlag::IsGrabbed, std::get<bool>(value));
-            return;
-        case AXProperty::IsIgnored:
-            setPropertyFlag(AXPropertyFlag::IsIgnored, std::get<bool>(value));
-            return;
-        case AXProperty::IsInlineText:
-            setPropertyFlag(AXPropertyFlag::IsInlineText, std::get<bool>(value));
-            return;
-        case AXProperty::IsKeyboardFocusable:
-            setPropertyFlag(AXPropertyFlag::IsKeyboardFocusable, std::get<bool>(value));
-            return;
-        case AXProperty::IsNonLayerSVGObject:
-            setPropertyFlag(AXPropertyFlag::IsNonLayerSVGObject, std::get<bool>(value));
-            return;
-        case AXProperty::IsTableRow:
-            setPropertyFlag(AXPropertyFlag::IsTableRow, std::get<bool>(value));
-            return;
-        case AXProperty::IsVisited:
-            setPropertyFlag(AXPropertyFlag::IsVisited, std::get<bool>(value));
-            return;
-        case AXProperty::SupportsCheckedState:
-            setPropertyFlag(AXPropertyFlag::SupportsCheckedState, std::get<bool>(value));
-            return;
-        case AXProperty::SupportsDragging:
-            setPropertyFlag(AXPropertyFlag::SupportsDragging, std::get<bool>(value));
-            return;
-        case AXProperty::SupportsExpanded:
-            setPropertyFlag(AXPropertyFlag::SupportsExpanded, std::get<bool>(value));
-            return;
-        case AXProperty::SupportsPath:
-            setPropertyFlag(AXPropertyFlag::SupportsPath, std::get<bool>(value));
-            return;
-        case AXProperty::SupportsPosInSet:
-            setPropertyFlag(AXPropertyFlag::SupportsPosInSet, std::get<bool>(value));
-            return;
-        case AXProperty::SupportsSetSize:
-            setPropertyFlag(AXPropertyFlag::SupportsSetSize, std::get<bool>(value));
-            return;
-        default:
-            break;
-        }
-    }
-
-    bool isDefaultValue = WTF::switchOn(value,
+    return WTF::switchOn(value,
         [](std::nullptr_t&) { return true; },
         [](Markable<AXID> typedValue) { return !typedValue; },
         [&](String& typedValue) {
@@ -689,7 +166,56 @@ void AXIsolatedObject::setProperty(AXProperty property, AXPropertyValueVariant&&
             return false;
         }
     );
-    if (isDefaultValue)
+}
+
+AccessibilityObject* AXIsolatedObject::associatedAXObject() const
+{
+    // It is only safe to call this on an AXIsolatedObject when done via a synchronous call from the
+    // accessibility thread. Otherwise, |this| could be deleted by the secondary thread (who owns the
+    // lifetime of isolated objects) in the middle of this method.
+    ASSERT(isMainThread());
+
+    auto* axObjectCache = this->axObjectCache();
+    return axObjectCache ? axObjectCache->objectForID(objectID()) : nullptr;
+}
+
+void AXIsolatedObject::setMathscripts(AXProperty property, AccessibilityObject& object)
+{
+    AccessibilityMathMultiscriptPairs pairs;
+    if (property == AXProperty::MathPrescripts)
+        object.mathPrescripts(pairs);
+    else if (property == AXProperty::MathPostscripts)
+        object.mathPostscripts(pairs);
+
+    if (pairs.isEmpty())
+        return;
+
+    auto idPairs = pairs.map([](auto& mathPair) {
+        return std::pair { mathPair.first ? Markable { mathPair.first->objectID() } : std::nullopt, mathPair.second ? Markable { mathPair.second->objectID() } : std::nullopt };
+    });
+    setProperty(property, WTFMove(idPairs));
+}
+
+void AXIsolatedObject::setObjectProperty(AXProperty property, AXCoreObject* object)
+{
+    setProperty(property, object ? Markable { object->objectID() } : std::nullopt);
+}
+
+void AXIsolatedObject::setObjectVectorProperty(AXProperty property, const AccessibilityChildrenVector& objects)
+{
+    setProperty(property, axIDs(objects));
+}
+
+void AXIsolatedObject::setProperty(AXProperty property, AXPropertyValueVariant&& value)
+{
+    if (const bool* boolValue = std::get_if<bool>(&value)) {
+        if (std::optional propertyFlag = convertToPropertyFlag(property)) {
+            setPropertyFlag(*propertyFlag, *boolValue);
+            return;
+        }
+    }
+
+    if (isDefaultValue(property, value))
         removePropertyInVector(property);
     else
         setPropertyInVector(property, WTFMove(value));
@@ -1683,15 +1209,16 @@ bool AXIsolatedObject::insertText(const String& text)
 
     // Dispatch to the main thread without waiting since AXObject::insertText waits for the UI process that can be waiting resulting in a deadlock. That is the case when running LayoutTests.
     // The return value of insertText is not used, so not waiting does not result in any loss of functionality.
-    callOnMainThread([text = text.isolatedCopy(), this] () {
-        if (auto* axObject = associatedAXObject())
-            axObject->insertText(text);
+    performFunctionOnMainThread([text = text.isolatedCopy()] (auto* axObject) {
+        axObject->insertText(text);
     });
     return true;
 }
 
 bool AXIsolatedObject::press()
 {
+    ASSERT(isMainThread());
+
     if (auto* object = associatedAXObject())
         return object->press();
     return false;
@@ -2272,13 +1799,6 @@ LocalFrameView* AXIsolatedObject::documentFrameView() const
     return nullptr;
 }
 
-ScrollView* AXIsolatedObject::scrollView() const
-{
-    if (auto* object = associatedAXObject())
-        return object->scrollView();
-    return nullptr;
-}
-
 AXCoreObject::AccessibilityChildrenVector AXIsolatedObject::relatedObjects(AXRelation relation) const
 {
     if (auto relatedObjectIDs = tree()->relatedObjectIDsFor(*this, relation))
@@ -2333,27 +1853,6 @@ AXIsolatedObject* AXIsolatedObject::headerContainer()
             return downcast<AXIsolatedObject>(child.ptr());
     }
     return nullptr;
-}
-
-unsigned AXIsolatedObject::headingTagLevel() const
-{
-    auto name = elementName();
-    switch (name) {
-    case ElementName::HTML_h1:
-        return 1;
-    case ElementName::HTML_h2:
-        return 2;
-    case ElementName::HTML_h3:
-        return 3;
-    case ElementName::HTML_h4:
-        return 4;
-    case ElementName::HTML_h5:
-        return 5;
-    case ElementName::HTML_h6:
-        return 6;
-    default:
-        return 0;
-    }
 }
 
 #if !PLATFORM(MAC)

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
@@ -355,6 +355,38 @@ struct NodeUpdateOptions {
     }
 };
 
+void setPropertyIn(AXProperty, AXPropertyValueVariant&&, AXPropertyVector&, OptionSet<AXPropertyFlag>&);
+
+struct IsolatedObjectData {
+    Vector<AXID> childrenIDs;
+    AXPropertyVector properties;
+    Ref<AXIsolatedTree> tree;
+    Markable<AXID> parentID;
+    AXID axID;
+    AccessibilityRole role;
+    OptionSet<AXPropertyFlag> propertyFlags;
+    bool getsGeometryFromChildren;
+
+    IsolatedObjectData(Vector<AXID> childrenIDs, AXPropertyVector properties, Ref<AXIsolatedTree> tree, Markable<AXID> parentID, AXID axID, AccessibilityRole role, OptionSet<AXPropertyFlag> propertyFlags, bool getsGeometryFromChildren)
+        : childrenIDs(WTFMove(childrenIDs))
+        , properties(WTFMove(properties))
+        , tree(WTFMove(tree))
+        , parentID(parentID)
+        , axID(axID)
+        , role(role)
+        , propertyFlags(propertyFlags)
+        , getsGeometryFromChildren(getsGeometryFromChildren)
+    { }
+
+    void setProperty(AXProperty property, AXPropertyValueVariant&& value)
+    {
+        properties.removeFirstMatching([&property] (const auto& propertyAndValue) {
+            return propertyAndValue.first == property;
+        });
+        setPropertyIn(property, WTFMove(value), properties, propertyFlags);
+    }
+};
+
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(AXIsolatedTree);
 class AXIsolatedTree : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<AXIsolatedTree>
     , public AXTreeStore<AXIsolatedTree> {
@@ -368,6 +400,7 @@ public:
     static Ref<AXIsolatedTree> createEmpty(AXObjectCache&);
     constexpr bool isEmptyContentTree() const { return m_isEmptyContentTree; }
     virtual ~AXIsolatedTree();
+    bool willBeDestroyed();
 
     static void removeTreeForPageID(PageIdentifier);
 
@@ -376,7 +409,7 @@ public:
     AXObjectCache* axObjectCache() const;
     constexpr AXGeometryManager* geometryManager() const { return m_geometryManager.get(); }
 
-    AXIsolatedObject* rootNode() { return m_rootNode.get(); }
+    AXIsolatedObject* rootNode() { ASSERT(!isMainThread()); return m_rootNode.get(); }
     RefPtr<AXIsolatedObject> rootWebArea();
     std::optional<AXID> focusedNodeID();
     WEBCORE_EXPORT RefPtr<AXIsolatedObject> focusedNode();
@@ -457,9 +490,10 @@ public:
     // Both setPendingRootNodeLocked and setFocusedNodeID are called during the generation
     // of the IsolatedTree.
     // Focused node updates in AXObjectCache use setFocusNodeID.
-    void setPendingRootNodeLocked(AXIsolatedObject&) WTF_REQUIRES_LOCK(m_changeLogLock);
+    void setPendingRootNodeID(AXID);
+    void setPendingRootNodeIDLocked(AXID) WTF_REQUIRES_LOCK(m_changeLogLock);
     void setFocusedNodeID(std::optional<AXID>);
-    void applyPendingRootNode();
+    void applyPendingRootNodeLocked() WTF_REQUIRES_LOCK(m_changeLogLock);
 
     // Relationships between objects.
     std::optional<ListHashSet<AXID>> relatedObjectIDsFor(const AXIsolatedObject&, AXRelation);
@@ -470,8 +504,7 @@ public:
     AXCoreObject::AccessibilityChildrenVector sortedNonRootWebAreas();
 
     // Called on AX thread from WebAccessibilityObjectWrapper methods.
-    // During layout tests, it is called on the main thread.
-    void applyPendingChanges();
+    WEBCORE_EXPORT void applyPendingChanges();
 
     constexpr AXID treeID() const { return m_id; }
     constexpr ProcessID processID() const { return m_processID; }
@@ -514,22 +547,24 @@ private:
     constexpr bool isUpdatingSubtree() const { return m_rootOfSubtreeBeingUpdated; }
     constexpr void updatingSubtree(AccessibilityObject* axObject) { m_rootOfSubtreeBeingUpdated = axObject; }
 
-    enum class AttachWrapper : bool { OnMainThread, OnAXThread };
     struct NodeChange {
-        Ref<AXIsolatedObject> isolatedObject;
+        IsolatedObjectData data;
 #if PLATFORM(COCOA)
         RetainPtr<AccessibilityObjectWrapper> wrapper;
 #elif USE(ATSPI)
         RefPtr<AccessibilityObjectWrapper> wrapper;
 #endif
-        AttachWrapper attachWrapper { AttachWrapper::OnMainThread };
+        explicit NodeChange(IsolatedObjectData&& isolatedData, RetainPtr<AccessibilityObjectWrapper> wrapper)
+            : data(WTFMove(isolatedData))
+            , wrapper(WTFMove(wrapper))
+        { }
     };
 
     void updateChildren(AccessibilityObject&, ResolveNodeChanges = ResolveNodeChanges::Yes);
     void updateNode(AccessibilityObject&);
     void updateNodeProperties(AccessibilityObject&, const AXPropertySet&);
 
-    std::optional<NodeChange> nodeChangeForObject(Ref<AccessibilityObject>, AttachWrapper = AttachWrapper::OnMainThread);
+    std::optional<NodeChange> nodeChangeForObject(Ref<AccessibilityObject>);
     void collectNodeChangesForSubtree(AccessibilityObject&);
     bool isCollectingNodeChanges() const { return m_isCollectingNodeChanges; }
     void queueChange(const NodeChange&) WTF_REQUIRES_LOCK(m_changeLogLock);
@@ -567,8 +602,7 @@ private:
 
     // Only accessed on the main thread.
     // The key is the ID of the object that will be resolved into an m_pendingAppends NodeChange.
-    // The value is whether the wrapper should be attached on the main thread or the AX thread.
-    UncheckedKeyHashMap<AXID, AttachWrapper> m_unresolvedPendingAppends;
+    HashSet<AXID> m_unresolvedPendingAppends;
     // Only accessed on the main thread.
     // While performing tree updates, we append nodes to this list that are no longer connected
     // in the tree and should be removed. This list turns into m_pendingSubtreeRemovals when
@@ -591,7 +625,7 @@ private:
     RefPtr<AXIsolatedObject> m_rootNode;
 
     // Written to by main thread under lock, accessed and applied by AX thread.
-    RefPtr<AXIsolatedObject> m_pendingRootNode WTF_GUARDED_BY_LOCK(m_changeLogLock);
+    Markable<AXID> m_pendingRootNodeID WTF_GUARDED_BY_LOCK(m_changeLogLock);
     Vector<NodeChange> m_pendingAppends WTF_GUARDED_BY_LOCK(m_changeLogLock); // Nodes to be added to the tree and platform-wrapped.
     Vector<AXPropertyChange> m_pendingPropertyChanges WTF_GUARDED_BY_LOCK(m_changeLogLock);
     Vector<AXID> m_pendingSubtreeRemovals WTF_GUARDED_BY_LOCK(m_changeLogLock); // Nodes whose subtrees are to be removed from the tree.
@@ -625,6 +659,9 @@ private:
     // The key is the ID of the node being removed. The value is the ID of the parent in the core tree (if it exists).
     UncheckedKeyHashMap<AXID, std::optional<AXID>> m_needsNodeRemoval;
 };
+
+IsolatedObjectData createIsolatedObjectData(const Ref<AccessibilityObject>&, Ref<AXIsolatedTree>);
+std::optional<AXPropertyFlag> convertToPropertyFlag(AXProperty);
 
 inline AXObjectCache* AXIsolatedTree::axObjectCache() const
 {

--- a/Source/WebCore/accessibility/isolatedtree/mac/AXIsolatedObjectMac.mm
+++ b/Source/WebCore/accessibility/isolatedtree/mac/AXIsolatedObjectMac.mm
@@ -34,8 +34,12 @@
 
 namespace WebCore {
 
-void AXIsolatedObject::initializeBasePlatformProperties(const Ref<const AccessibilityObject>& object)
+void appendBasePlatformProperties(AXPropertyVector& properties, OptionSet<AXPropertyFlag>& propertyFlags, const Ref<AccessibilityObject>& object)
 {
+    auto setProperty = [&] (AXProperty property, AXPropertyValueVariant&& value) {
+        setPropertyIn(property, WTFMove(value), properties, propertyFlags);
+    };
+
     // These attributes are used to serve APIs on static text, but, we cache them on the highest-level ancestor
     // to avoid caching the same value multiple times.
     auto* parent = object->parentObject();
@@ -48,8 +52,12 @@ void AXIsolatedObject::initializeBasePlatformProperties(const Ref<const Accessib
         setProperty(AXProperty::TextColor, WTFMove(style.textColor));
 }
 
-void AXIsolatedObject::initializePlatformProperties(const Ref<const AccessibilityObject>& object)
+void appendPlatformProperties(AXPropertyVector& properties, OptionSet<AXPropertyFlag>& propertyFlags, const Ref<AccessibilityObject>& object)
 {
+    auto setProperty = [&] (AXProperty property, AXPropertyValueVariant&& value) {
+        setPropertyIn(property, WTFMove(value), properties, propertyFlags);
+    };
+
     setProperty(AXProperty::HasApplePDFAnnotationAttribute, object->hasApplePDFAnnotationAttribute());
     setProperty(AXProperty::SpeakAs, object->speakAs());
 #if ENABLE(AX_THREAD_TEXT_APIS)

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.h
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.h
@@ -63,9 +63,11 @@ RetainPtr<NSAttributedString> attributedStringCreate(Node&, StringView, const Si
     WeakPtr<WebCore::AccessibilityObject> m_axObject;
 
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
-    ThreadSafeWeakPtr<WebCore::AXIsolatedObject> m_isolatedObject;
-    // To be accessed only on the main thread.
-    bool m_isolatedObjectInitialized;
+    WeakPtr<WebCore::AXIsolatedObject> m_isolatedObject;
+    // FIXME: Is it possible for this to not be atomic, instead using the information we already have
+    // on the accessibility thread (or information we send from the main-thread, like a list of valid
+    // or invalid IDs)? https://bugs.webkit.org/show_bug.cgi?id=293262
+    std::atomic<bool> m_isolatedObjectInitialized;
 #endif
 
     Markable<WebCore::AXID> _identifier;

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
@@ -2371,7 +2371,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     AXTRACE("WebAccessibilityObjectWrapper _accessibilityShowContextMenu"_s);
     ASSERT(isMainThread());
 
-    RefPtr<AXCoreObject> backingObject = self.axBackingObject;
+    RefPtr<AccessibilityObject> backingObject = dynamicDowncast<AccessibilityObject>(self.axBackingObject);
     if (!backingObject) {
         AXLOG(makeString("No backingObject for wrapper "_s, hex(reinterpret_cast<uintptr_t>(self))));
         return;
@@ -3691,8 +3691,6 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
     return subarray;
 }
-
-
 @end
 
 #endif // PLATFORM(MAC)

--- a/Source/WebCore/loader/EmptyClients.cpp
+++ b/Source/WebCore/loader/EmptyClients.cpp
@@ -1094,7 +1094,7 @@ IntPoint EmptyFrameLoaderClient::accessibilityRemoteFrameOffset()
 }
 
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
-void EmptyFrameLoaderClient::setAXIsolatedTreeRoot(WebCore::AXCoreObject*)
+void EmptyFrameLoaderClient::setIsolatedTree(Ref<WebCore::AXIsolatedTree>&&)
 {
 }
 #endif

--- a/Source/WebCore/loader/EmptyFrameLoaderClient.h
+++ b/Source/WebCore/loader/EmptyFrameLoaderClient.h
@@ -179,7 +179,7 @@ private:
     RemoteAXObjectRef accessibilityRemoteObject() final;
     IntPoint accessibilityRemoteFrameOffset() final;
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
-    void setAXIsolatedTreeRoot(WebCore::AXCoreObject*) final;
+    void setIsolatedTree(Ref<WebCore::AXIsolatedTree>&&) final;
 #endif
     void willCacheResponse(DocumentLoader*, ResourceLoaderIdentifier, NSCachedURLResponse *, CompletionHandler<void(NSCachedURLResponse *)>&&) const final;
 #endif

--- a/Source/WebCore/loader/LocalFrameLoaderClient.h
+++ b/Source/WebCore/loader/LocalFrameLoaderClient.h
@@ -67,7 +67,7 @@ OBJC_CLASS NSView;
 
 namespace WebCore {
 
-class AXCoreObject;
+class AXIsolatedTree;
 class AuthenticationChallenge;
 class CachedFrame;
 class CachedResourceRequest;
@@ -290,7 +290,7 @@ public:
     virtual RemoteAXObjectRef accessibilityRemoteObject() = 0;
     virtual IntPoint accessibilityRemoteFrameOffset() = 0;
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
-    virtual void setAXIsolatedTreeRoot(AXCoreObject*) = 0;
+    virtual void setIsolatedTree(Ref<WebCore::AXIsolatedTree>&&) = 0;
 #endif
     virtual void willCacheResponse(DocumentLoader*, ResourceLoaderIdentifier, NSCachedURLResponse*, CompletionHandler<void(NSCachedURLResponse *)>&&) const = 0;
     virtual std::optional<double> dataDetectionReferenceDate() { return std::nullopt; }

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
@@ -1833,11 +1833,11 @@ RemoteAXObjectRef WebLocalFrameLoaderClient::accessibilityRemoteObject()
 }
 
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
-void WebLocalFrameLoaderClient::setAXIsolatedTreeRoot(WebCore::AXCoreObject* axObject)
+void WebLocalFrameLoaderClient::setIsolatedTree(Ref<WebCore::AXIsolatedTree>&& tree)
 {
     ASSERT(isMainRunLoop());
     if (RefPtr webPage = m_frame->page())
-        webPage->setAXIsolatedTreeRoot(axObject);
+        webPage->setIsolatedTree(WTFMove(tree));
 }
 #endif
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.h
@@ -237,7 +237,7 @@ private:
     RemoteAXObjectRef accessibilityRemoteObject() final;
     WebCore::IntPoint accessibilityRemoteFrameOffset() final;
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
-    void setAXIsolatedTreeRoot(WebCore::AXCoreObject*) final;
+    void setIsolatedTree(Ref<WebCore::AXIsolatedTree>&&) final;
 #endif
     void willCacheResponse(WebCore::DocumentLoader*, WebCore::ResourceLoaderIdentifier, NSCachedURLResponse*, CompletionHandler<void(NSCachedURLResponse *)>&&) const final;
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -167,7 +167,7 @@ class SharedBufferReference;
 
 namespace WebCore {
 
-class AXCoreObject;
+class AXIsolatedTree;
 class CachedPage;
 class CaptureDevice;
 class DocumentLoader;
@@ -1214,7 +1214,7 @@ public:
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
     void cacheAXPosition(const WebCore::FloatPoint&);
     void cacheAXSize(const WebCore::IntSize&);
-    void setAXIsolatedTreeRoot(WebCore::AXCoreObject*);
+    void setIsolatedTree(Ref<WebCore::AXIsolatedTree>&&);
 #endif
     NSObject *accessibilityObjectForMainFramePlugin();
     const WebCore::FloatPoint& accessibilityPosition() const { return m_accessibilityPosition; }

--- a/Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectBase.h
+++ b/Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectBase.h
@@ -37,7 +37,7 @@ class WebPage;
 }
 
 namespace WebCore {
-class AXCoreObject;
+class AXIsolatedTree;
 }
 
 @interface WKAccessibilityWebPageObjectBase : NSObject {
@@ -47,7 +47,7 @@ class AXCoreObject;
     Lock m_cacheLock;
     WebCore::FloatPoint m_position WTF_GUARDED_BY_LOCK(m_cacheLock);
     WebCore::IntSize m_size WTF_GUARDED_BY_LOCK(m_cacheLock);
-    ThreadSafeWeakPtr<WebCore::AXCoreObject> m_isolatedTreeRoot;
+    ThreadSafeWeakPtr<WebCore::AXIsolatedTree> m_isolatedTree;
 
     Lock m_windowLock;
     WeakObjCPtr<id> m_window;
@@ -66,7 +66,7 @@ class AXCoreObject;
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
 - (void)setPosition:(const WebCore::FloatPoint&)point;
 - (void)setSize:(const WebCore::IntSize&)size;
-- (void)setIsolatedTreeRoot:(NakedPtr<WebCore::AXCoreObject>)root;
+- (void)setIsolatedTree:(Ref<WebCore::AXIsolatedTree>&&)tree;
 - (void)setWindow:(id)window;
 #endif
 - (void)setRemoteParent:(id)parent;

--- a/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
@@ -520,9 +520,9 @@ void WebPage::cacheAXSize(const WebCore::IntSize& size)
     [m_mockAccessibilityElement setSize:size];
 }
 
-void WebPage::setAXIsolatedTreeRoot(WebCore::AXCoreObject* root)
+void WebPage::setIsolatedTree(Ref<WebCore::AXIsolatedTree>&& tree)
 {
-    [m_mockAccessibilityElement setIsolatedTreeRoot:root];
+    [m_mockAccessibilityElement setIsolatedTree:WTFMove(tree)];
 }
 #endif
 

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.h
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.h
@@ -221,7 +221,7 @@ private:
     RemoteAXObjectRef accessibilityRemoteObject() final { return 0; }
     WebCore::IntPoint accessibilityRemoteFrameOffset() final { return { }; }
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
-    void setAXIsolatedTreeRoot(WebCore::AXCoreObject*) final { }
+    void setIsolatedTree(Ref<WebCore::AXIsolatedTree>&&) final { }
 #endif
 
     RetainPtr<WebFramePolicyListener> setUpPolicyListener(WebCore::FramePolicyFunction&&, WebCore::PolicyAction defaultPolicy, NSURL *appLinkURL, NSURL* referrerURL);


### PR DESCRIPTION
#### 139e9a6d68c9f8638cee836da5d04690f8a9d323
<pre>
AX: Make AXCoreObject ref-counting non-threadsafe, improving performance
<a href="https://bugs.webkit.org/show_bug.cgi?id=293164">https://bugs.webkit.org/show_bug.cgi?id=293164</a>
<a href="https://rdar.apple.com/151499521">rdar://151499521</a>

Reviewed by Joshua Hoffman.

AXCoreObject ref-counting had to be threadsafe because prior to this commit, AXIsolatedObjects were built on the
main-thread (incurring numerous refs along the way), and then &quot;transferred&quot; to the accessibility thread. However, there
were other places we held refs or otherwise manipulated isolated objects on the main-thread, even after transferring them:

  - Attaching them to wrappers
  - Returning the root isolated tree node from the WKAccessibilityWebPageObjectBase
  - Some usages of associatedAXObject() and performFunctionOnMainThread (which is async) implicitly assumed the associated
    isolated object would stay alive for the lifetime of associatedAXObject() / the dispatched function, which can no
    longer be relied upon.

With this commit, instead of creating isolated objects on the main-thread, we instead create the data needed to populate
an isolated object, and send that plain-struct over. Then the accessibility thread can create the isolated object, and
thus be the only thing that ever refs and derefs these objects, in turn allowing us to safely make our ref-counting
non-threadsafe.

This required a host of associated changes:

  - Rather than storing the isolated tree root node on WKAccessibilityWebPageObjectBase, we instead store a thread-safe
    pointer to the isolated tree. AXIsolatedTree is still threadsafe ref-counted, so it&apos;s OK to use from either thread,
    and we can use it to get the root node when we know we&apos;re off the main-thread.

  - The AttachWrapper enum is removed. All isolated objects are now unconditionally attached on the accessibility thread.

  - WebAccessibilityObjectWrapperBase::m_isolatedObjectInitialized has become an atomic bool, as the secondary thread
    writes it when attaching an isolated object to a wrapper, and the main-thread reads it when destroying a main-thread
    object to know whether it should call NSAccessibilityUnregisterUniqueIdForUIElement. This probably should&apos;ve always
    been atomic, as it was possible to attach isolated objects to wrappers off the main-thread before this commit too.

  - Because all wrapper attachments happen off the main-thread now, there&apos;s nothing to kick off the first AXIsolatedTree::applyPendingChanges.
    Usually that happens when we get a backing object in the wrapper, and call updateObjectBackingStore. But until the
    first applyPendingChanges, there is no backingObject, so it&apos;s a classic chicken and egg problem. Solve this by adding
    AXTreeStore::applyPendingChangesForAllIsolatedTrees, and calling it whenever a wrapper is missing a backing object,
    as it may be there, just waiting to be attached.

This change has huge performance wins. On pages with slow VO-Right navigation (e.g. <a href="http://html.spec.whatwg.org)">http://html.spec.whatwg.org)</a>,
ref-counting took up ~40% of the samples, largely because threadsafe ref-counting is slow. It also means iOS no longer
unnecessarily pays the cost of threadsafe ref-counting that it didn&apos;t even use, since isolated tree mode is not enabled
for that platform.

* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
Add AXTreeStore.cpp.
* Source/WebCore/accessibility/AXCoreObject.cpp:
(WebCore::AXCoreObject::headingLevel const):
* Source/WebCore/accessibility/AXCoreObject.h:
(WebCore::AXCoreObject::AXCoreObject):
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::setIsolatedTree):
(WebCore::AXObjectCache::rootObjectForFrame):
(WebCore::AXObjectCache::isolatedTreeRootObject): Deleted.
(WebCore::AXObjectCache::setIsolatedTreeRoot): Deleted.
* Source/WebCore/accessibility/AXObjectCache.h:
* Source/WebCore/accessibility/AXSearchManager.cpp:
(WebCore::appendChildrenToArray):
* Source/WebCore/accessibility/AXTreeStore.h:
* Source/WebCore/accessibility/AccessibilityNodeObject.cpp:
(WebCore::AccessibilityNodeObject::headingTagLevel const): Deleted.
* Source/WebCore/accessibility/AccessibilityNodeObject.h:
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::insertChild):
* Source/WebCore/accessibility/AccessibilityObject.h:
(WebCore::AccessibilityObject::scrollView const):
* Source/WebCore/accessibility/atspi/AXObjectCacheAtspi.cpp:
(WebCore::AXObjectCache::platformPerformDeferredCacheUpdate):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp:
(WebCore::AXIsolatedObject::AXIsolatedObject):
(WebCore::AXIsolatedObject::create):
(WebCore::isDefaultValue):
(WebCore::AXIsolatedObject::associatedAXObject const):
(WebCore::AXIsolatedObject::setMathscripts):
(WebCore::AXIsolatedObject::setObjectProperty):
(WebCore::AXIsolatedObject::setObjectVectorProperty):
(WebCore::AXIsolatedObject::setProperty):
(WebCore::AXIsolatedObject::insertText):
(WebCore::AXIsolatedObject::press):
(WebCore::AXIsolatedObject::initializeProperties): Deleted.
(WebCore::AXIsolatedObject::canBeMultilineTextField): Deleted.
(WebCore::AXIsolatedObject::setOptionalProperty): Deleted.
(WebCore::AXIsolatedObject::scrollView const): Deleted.
(WebCore::AXIsolatedObject::headingTagLevel const): Deleted.
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h:
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp:
(WebCore::AXIsolatedTree::AXIsolatedTree):
(WebCore::AXIsolatedTree::createEmptyContent):
(WebCore::AXIsolatedTree::create):
(WebCore::AXIsolatedTree::applyPendingRootNodeLocked):
(WebCore::AXIsolatedTree::storeTree):
(WebCore::AXIsolatedTree::nodeChangeForObject):
(WebCore::AXIsolatedTree::queueChange):
(WebCore::AXIsolatedTree::addUnconnectedNode):
(WebCore::AXIsolatedTree::resolveAppends):
(WebCore::AXIsolatedTree::queueAppendsAndRemovals):
(WebCore::AXIsolatedTree::collectNodeChangesForSubtree):
(WebCore::AXIsolatedTree::updateNode):
(WebCore::AXIsolatedTree::updateChildren):
(WebCore::AXIsolatedTree::setPendingRootNodeID):
(WebCore::AXIsolatedTree::setPendingRootNodeIDLocked):
(WebCore::AXIsolatedTree::willBeDestroyed):
(WebCore::AXIsolatedTree::applyPendingChanges):
(WebCore::AXIsolatedTree::processQueuedNodeUpdates):
(WebCore::convertToPropertyFlag):
(WebCore::setPropertyIn):
(WebCore::shouldCacheElementName):
(WebCore::canBeMultilineTextField):
(WebCore::createIsolatedObjectData):
(WebCore::AXIsolatedTree::applyPendingRootNode): Deleted.
(WebCore::AXIsolatedTree::setPendingRootNodeLocked): Deleted.
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h:
(WebCore::IsolatedObjectData::IsolatedObjectData):
(WebCore::IsolatedObjectData::setProperty):
(WebCore::AXIsolatedTree::axObjectCacheID const):
(WebCore::AXIsolatedTree::rootNode):
(WebCore::AXIsolatedTree::NodeChange::NodeChange):
* Source/WebCore/accessibility/isolatedtree/mac/AXIsolatedObjectMac.mm:
(WebCore::appendBasePlatformProperties):
(WebCore::appendPlatformProperties):
(WebCore::AXIsolatedObject::initializeBasePlatformProperties): Deleted.
(WebCore::AXIsolatedObject::initializePlatformProperties): Deleted.
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.h:
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.mm:
(-[WebAccessibilityObjectWrapperBase attachIsolatedObject:]):
(-[WebAccessibilityObjectWrapperBase hasIsolatedObject]):
(-[WebAccessibilityObjectWrapperBase detachIsolatedObject:]):
(-[WebAccessibilityObjectWrapperBase updateObjectBackingStore]):
(-[WebAccessibilityObjectWrapperBase axBackingObject]):
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm:
(-[WebAccessibilityObjectWrapper _accessibilityShowContextMenu]):
(-[WebAccessibilityObjectWrapper _accessibilityChildrenFromIndex:maxCount:returnPlatformElements:]):
* Source/WebCore/loader/EmptyClients.cpp:
(WebCore::EmptyFrameLoaderClient::setIsolatedTree):
(WebCore::EmptyFrameLoaderClient::setAXIsolatedTreeRoot): Deleted.
* Source/WebCore/loader/EmptyFrameLoaderClient.h:
* Source/WebCore/loader/LocalFrameLoaderClient.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp:
(WebKit::WebLocalFrameLoaderClient::setIsolatedTree):
(WebKit::WebLocalFrameLoaderClient::setAXIsolatedTreeRoot): Deleted.
* Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.h:
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectBase.h:
* Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectBase.mm:
(-[WKAccessibilityWebPageObjectBase accessibilityRootObjectWrapper:]):
(-[WKAccessibilityWebPageObjectBase setIsolatedTree:]):
(-[WKAccessibilityWebPageObjectBase setIsolatedTreeRoot:]): Deleted.
* Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm:
(WebKit::WebPage::setIsolatedTree):
(WebKit::WebPage::setAXIsolatedTreeRoot): Deleted.
* Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.h:

Canonical link: <a href="https://commits.webkit.org/295174@main">https://commits.webkit.org/295174@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cc4630dad7701da345b20294d5656222a9a38c48

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104182 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/23886 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/14207 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/109380 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/54850 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/106222 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/24254 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/32430 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79128 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107188 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/18843 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/93995 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59455 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/18651 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/12033 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/54210 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/88358 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/12091 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/111764 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/31338 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23103 "Found 2 new test failures: http/tests/navigation/ping-attribute/cross-site-url-anchor-cookie-preexisting-cookie.html http/tests/navigation/ping-attribute/cross-site-url-anchor-cookie.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88149 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/31702 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/90182 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87808 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22379 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32702 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10457 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/25802 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/31267 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/36580 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/31061 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/34397 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/32621 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->