### PR TITLE
[Page color sampling] Refactor fixed container edge sampling so that we keep track of state on all rect edges

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
@@ -110,7 +110,6 @@ platform/graphics/ImageBufferContextSwitcher.h
 platform/graphics/StringTruncator.cpp
 platform/graphics/angle/ANGLEUtilities.cpp
 platform/graphics/angle/GraphicsContextGLANGLE.cpp
-platform/graphics/ca/GraphicsLayerCA.cpp
 platform/graphics/ca/PlatformCALayer.h
 platform/graphics/ca/TileController.cpp
 platform/graphics/mac/LegacyDisplayRefreshMonitorMac.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2276,6 +2276,7 @@ platform/EventTrackingRegions.cpp
 platform/FileChooser.cpp
 platform/FileMonitor.cpp
 platform/FileStream.cpp
+platform/FixedContainerEdges.cpp
 platform/FrameRateMonitor.cpp
 platform/KeyboardScroll.cpp
 platform/KeyboardScrollingAnimator.cpp

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -222,6 +222,7 @@ struct ApplePayAMSUIRequest;
 struct AttributedString;
 struct CharacterRange;
 struct ClientOrigin;
+struct FixedContainerEdges;
 struct NavigationAPIMethodTracker;
 struct ProcessSyncData;
 struct SimpleRange;
@@ -237,6 +238,7 @@ using SharedStringHash = uint32_t;
 
 enum class ActivityState : uint16_t;
 enum class AdvancedPrivacyProtections : uint16_t;
+enum class BoxSideFlag : uint8_t;
 enum class CanWrap : bool;
 enum class ContentSecurityPolicyModeForExtension : uint8_t;
 enum class DidWrap : bool;
@@ -906,8 +908,9 @@ public:
     WEBCORE_EXPORT Color pageExtendedBackgroundColor() const;
     WEBCORE_EXPORT Color sampledPageTopColor() const;
 
-    void setLastTopFixedContainerColor(Color&& color) { m_lastTopFixedContainerColor = WTFMove(color); }
-    Color lastTopFixedContainerColor() const { return m_lastTopFixedContainerColor; }
+    WEBCORE_EXPORT void updateFixedContainerEdges(OptionSet<BoxSideFlag>);
+    const FixedContainerEdges& fixedContainerEdges() const { return m_fixedContainerEdges; }
+    Color lastTopFixedContainerColor() const;
 
 #if ENABLE(WEB_PAGE_SPATIAL_BACKDROP)
     WEBCORE_EXPORT std::optional<SpatialBackdropSource> spatialBackdropSource() const;
@@ -1706,7 +1709,7 @@ private:
 
     Color m_underPageBackgroundColorOverride;
     std::optional<Color> m_sampledPageTopColor;
-    Color m_lastTopFixedContainerColor;
+    UniqueRef<FixedContainerEdges> m_fixedContainerEdges;
 
     const bool m_httpsUpgradeEnabled { true };
     mutable Markable<MediaSessionGroupIdentifier> m_mediaSessionGroupIdentifier;

--- a/Source/WebCore/platform/FixedContainerEdges.cpp
+++ b/Source/WebCore/platform/FixedContainerEdges.cpp
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "config.h"
+#include "FixedContainerEdges.h"
+
+#include <wtf/TZoneMallocInlines.h>
+
+namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(FixedContainerEdges);
+
+bool FixedContainerEdges::hasFixedEdge(BoxSide side) const
+{
+    return WTF::visit(WTF::makeVisitor([&](PredominantColorType type) {
+        return type != PredominantColorType::None;
+    }, [&](const Color&) {
+        return true;
+    }), colors.at(side));
+}
+
+Color FixedContainerEdges::predominantColor(BoxSide side) const
+{
+    return WTF::visit(WTF::makeVisitor([&](PredominantColorType) -> Color {
+        return { };
+    }, [&](const Color& color) {
+        return color;
+    }), colors.at(side));
+}
+
+} // namespace WebCore

--- a/Source/WebCore/platform/FixedContainerEdges.h
+++ b/Source/WebCore/platform/FixedContainerEdges.h
@@ -35,28 +35,29 @@ enum class PredominantColorType : uint8_t {
     Multiple,
 };
 
-using FixedContainerEdge = Variant<WebCore::PredominantColorType, WebCore::Color>;
+using FixedContainerEdge = Variant<PredominantColorType, Color>;
 
 struct FixedContainerEdges {
+    WTF_MAKE_TZONE_ALLOCATED(FixedContainerEdges);
+public:
     RectEdges<FixedContainerEdge> colors { PredominantColorType::None, PredominantColorType::None, PredominantColorType::None, PredominantColorType::None };
 
-    bool hasFixedEdge(BoxSide side) const
+    FixedContainerEdges() = default;
+    FixedContainerEdges(const FixedContainerEdges&) = default;
+    FixedContainerEdges(RectEdges<FixedContainerEdge>&& edgeColors)
+        : colors { WTFMove(edgeColors) }
     {
-        return WTF::visit(WTF::makeVisitor([&](PredominantColorType type) {
-            return type != PredominantColorType::None;
-        }, [&](const Color&) {
-            return true;
-        }), colors.at(side));
     }
 
-    Color predominantColor(BoxSide side) const
+    FixedContainerEdges(FixedContainerEdges&& other)
+        : colors { WTFMove(other.colors) }
     {
-        return WTF::visit(WTF::makeVisitor([&](PredominantColorType) -> Color {
-            return { };
-        }, [&](const Color& color) {
-            return color;
-        }), colors.at(side));
     }
+
+    FixedContainerEdges& operator=(const FixedContainerEdges&) = default;
+
+    WEBCORE_EXPORT bool hasFixedEdge(BoxSide) const;
+    WEBCORE_EXPORT Color predominantColor(BoxSide) const;
 
     bool operator==(const FixedContainerEdges&) const = default;
 };

--- a/Source/WebCore/platform/audio/gstreamer/PlatformRawAudioDataGStreamer.cpp
+++ b/Source/WebCore/platform/audio/gstreamer/PlatformRawAudioDataGStreamer.cpp
@@ -27,6 +27,7 @@
 #include "MediaSampleGStreamer.h"
 #include "SharedBuffer.h"
 #include "WebCodecsAudioDataAlgorithms.h"
+#include <wtf/glib/GUniquePtr.h>
 
 GST_DEBUG_CATEGORY(webkit_audio_data_debug);
 #define GST_CAT_DEFAULT webkit_audio_data_debug

--- a/Source/WebCore/platform/graphics/NativeImage.cpp
+++ b/Source/WebCore/platform/graphics/NativeImage.cpp
@@ -26,6 +26,11 @@
 #include "config.h"
 #include "NativeImage.h"
 
+#include "FloatRect.h"
+#include "GraphicsContext.h"
+#include "ImageBuffer.h"
+#include "RenderingMode.h"
+
 #if USE(SKIA)
 #include "GLFence.h"
 #endif

--- a/Source/WebCore/platform/graphics/gstreamer/TrackPrivateBaseGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/TrackPrivateBaseGStreamer.cpp
@@ -32,6 +32,7 @@
 #include "GStreamerCommon.h"
 #include "TrackPrivateBase.h"
 #include <gst/tag/tag.h>
+#include <wtf/glib/GUniquePtr.h>
 #include <wtf/text/CString.h>
 #include <wtf/text/StringCommon.h>
 #include <wtf/text/StringToIntegerConversion.h>

--- a/Source/WebCore/platform/graphics/gstreamer/mse/GStreamerMediaDescription.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/GStreamerMediaDescription.cpp
@@ -23,6 +23,7 @@
 #include "GStreamerCommon.h"
 
 #include <gst/pbutils/pbutils.h>
+#include <wtf/glib/GUniquePtr.h>
 #include <wtf/text/MakeString.h>
 
 #if ENABLE(VIDEO) && USE(GSTREAMER) && ENABLE(MEDIA_SOURCE)

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.h
@@ -259,7 +259,7 @@ public:
 #endif
 
     const std::optional<WebCore::FixedContainerEdges>& fixedContainerEdges() const { return m_fixedContainerEdges; }
-    void setFixedContainerEdges(WebCore::FixedContainerEdges&& edges) { m_fixedContainerEdges = { WTFMove(edges) }; }
+    void setFixedContainerEdges(const WebCore::FixedContainerEdges& edges) { m_fixedContainerEdges = edges; }
 
 private:
     friend struct IPC::ArgumentCoder<RemoteLayerTreeTransaction, void>;

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -4964,9 +4964,8 @@ void WebPage::willCommitLayerTree(RemoteLayerTreeTransaction& layerTransaction, 
     layerTransaction.setPageExtendedBackgroundColor(page->pageExtendedBackgroundColor());
     layerTransaction.setSampledPageTopColor(page->sampledPageTopColor());
     if (std::exchange(m_needsFixedContainerEdgesUpdate, false)) {
-        auto fixedContainerEdges = frameView->fixedContainerEdges(sidesRequiringFixedContainerEdges());
-        protectedCorePage()->setLastTopFixedContainerColor(fixedContainerEdges.predominantColor(BoxSide::Top));
-        layerTransaction.setFixedContainerEdges(WTFMove(fixedContainerEdges));
+        page->updateFixedContainerEdges(sidesRequiringFixedContainerEdges());
+        layerTransaction.setFixedContainerEdges(page->fixedContainerEdges());
     }
 
     layerTransaction.setBaseLayoutViewportSize(frameView->baseLayoutViewportSize());


### PR DESCRIPTION
#### fa24f4dd4063c526c78440b381fce8baee934a5e
<pre>
[Page color sampling] Refactor fixed container edge sampling so that we keep track of state on all rect edges
<a href="https://bugs.webkit.org/show_bug.cgi?id=293165">https://bugs.webkit.org/show_bug.cgi?id=293165</a>

Reviewed by Abrar Rahman Protyasha.

Part 1 of refactoring the fixed container edge sampling heuristic to be more stable — this adds a
member to `Page` to store the last `FixedContainerEdges` state. Instead of computing this and
sending it along in the remote layer tree transaction, we now call `updateFixedContainerEdges` and
send along the current state.

* Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/page/Page.cpp:
(WebCore::Page::didCommitLoad):
(WebCore::Page::updateFixedContainerEdges):
(WebCore::Page::lastTopFixedContainerColor const):
* Source/WebCore/page/Page.h:

Replace `m_lastTopFixedContainerColor` (which only keeps track of the last predominant color on the
top edge) with `m_fixedContainerEdges`, which keeps track of all sampled edges. Note that this is a
`UniqueRef`, in order to avoid including `FixedContainerEdges.h` in `Page.h`.

(WebCore::Page::fixedContainerEdges const):
(WebCore::Page::setLastTopFixedContainerColor): Deleted.
(WebCore::Page::lastTopFixedContainerColor const): Deleted.
* Source/WebCore/platform/FixedContainerEdges.cpp: Copied from Source/WebCore/platform/FixedContainerEdges.h.

Add an implementation file for `FixedContainerEdges` so that it can contain the
`WTF_MAKE_TZONE_ALLOCATED_IMPL`. Also move a couple of inline method definitions to the source file,
to make the header somewhat more readable.

(WebCore::FixedContainerEdges::hasFixedEdge const):
(WebCore::FixedContainerEdges::predominantColor const):
* Source/WebCore/platform/FixedContainerEdges.h:
(WebCore::FixedContainerEdges::FixedContainerEdges):
(WebCore::FixedContainerEdges::hasFixedEdge const): Deleted.
(WebCore::FixedContainerEdges::predominantColor const): Deleted.
* Source/WebCore/platform/audio/gstreamer/PlatformRawAudioDataGStreamer.cpp:
* Source/WebCore/platform/graphics/NativeImage.cpp:
* Source/WebCore/platform/graphics/gstreamer/TrackPrivateBaseGStreamer.cpp:
* Source/WebCore/platform/graphics/gstreamer/mse/GStreamerMediaDescription.cpp:

Unified source build fixes (include missing headers).

* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.h:
(WebKit::RemoteLayerTreeTransaction::setFixedContainerEdges):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::willCommitLayerTree):

Canonical link: <a href="https://commits.webkit.org/295058@main">https://commits.webkit.org/295058@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3c22b1f06c693a8355c403b4af9bc725da1dc0b5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/103976 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/23679 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/14000 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/109171 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/54640 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/106016 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/24038 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/32224 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78986 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/106982 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/18667 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/93794 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59314 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/18457 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/11845 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/54004 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/88196 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/11903 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/111556 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/31132 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/22940 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/87998 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/31496 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/89994 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87655 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22306 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32539 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10281 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/25522 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/31061 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/36371 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/30854 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/34191 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/32415 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->