### PR TITLE
MediaRecorderPrivateEncoder shouldn't use lock on audio thread.

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
@@ -113,7 +113,6 @@ platform/graphics/angle/GraphicsContextGLANGLE.cpp
 platform/graphics/ca/PlatformCALayer.h
 platform/graphics/ca/TileController.cpp
 platform/graphics/mac/LegacyDisplayRefreshMonitorMac.h
-platform/mediarecorder/MediaRecorderPrivateEncoder.h
 platform/mediastream/libwebrtc/LibWebRTCDav1dDecoder.cpp
 platform/mediastream/mac/CoreAudioSharedUnit.h
 platform/network/cocoa/CredentialCocoa.h

--- a/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateEncoder.cpp
+++ b/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateEncoder.cpp
@@ -291,7 +291,8 @@ void MediaRecorderPrivateEncoder::appendAudioSampleBuffer(const PlatformAudioDat
         m_currentStreamDescription = toCAAudioStreamDescription(description);
         addRingBuffer(description);
         m_currentAudioSampleCount = 0;
-    }
+    } else
+        clearRingBuffersIfPossible();
 
     auto currentAudioTime = m_currentAudioTime;
     m_lastEnqueuedAudioTimeUs = m_currentAudioTime.toMicroseconds();
@@ -309,10 +310,14 @@ void MediaRecorderPrivateEncoder::appendAudioSampleBuffer(const PlatformAudioDat
     m_currentAudioSampleCount += sampleCount;
 }
 
-void MediaRecorderPrivateEncoder::audioSamplesDescriptionChanged(const AudioStreamBasicDescription& description)
+void MediaRecorderPrivateEncoder::audioSamplesDescriptionChanged(const AudioStreamBasicDescription& description, InProcessCARingBuffer* newRingBuffer, size_t ringBufferId)
 {
     assertIsCurrent(queueSingleton());
 
+    if (!newRingBuffer) {
+        m_hadError = true;
+        return;
+    }
     if (!m_originalOutputDescription) {
         if (m_audioCodec != kAudioFormatLinearPCM) {
             AudioStreamBasicDescription outputDescription = { };
@@ -350,42 +355,39 @@ void MediaRecorderPrivateEncoder::audioSamplesDescriptionChanged(const AudioStre
         return;
     }
 
-    updateCurrentRingBufferIfNeeded();
+    m_currentRingBuffer = newRingBuffer;
+    m_currentRingBufferId = ringBufferId;
 }
 
 void MediaRecorderPrivateEncoder::addRingBuffer(const AudioStreamDescription& description)
 {
     auto asbd = *std::get<const AudioStreamBasicDescription*>(description.platformDescription().description);
-    Locker locker { m_ringBuffersLock };
-    m_ringBuffers.append(InProcessCARingBuffer::allocate(asbd, description.sampleRate() * 2)); // allocate 2s of buffer.
-    queueSingleton().dispatch([weakThis = ThreadSafeWeakPtr { *this }, description = asbd] {
+    m_ringBuffers.append(std::make_pair(InProcessCARingBuffer::allocate(asbd, description.sampleRate() * 2), ++m_lastRingBufferId)); // allocate 2s of buffer.
+    queueSingleton().dispatch([weakThis = ThreadSafeWeakPtr { *this }, description = asbd, newRingBuffer = m_ringBuffers.last().first.get(), lastRingBufferId = m_lastRingBufferId] {
         if (RefPtr protectedThis = weakThis.get())
-            protectedThis->audioSamplesDescriptionChanged(description);
+            protectedThis->audioSamplesDescriptionChanged(description, newRingBuffer, lastRingBufferId);
     });
 }
 
 void MediaRecorderPrivateEncoder::writeDataToRingBuffer(AudioBufferList* list, size_t sampleCount, size_t totalSampleCount)
 {
-    Locker locker { m_ringBuffersLock };
-    if (m_ringBuffers.isEmpty() || !m_ringBuffers.last())
+    ASSERT(!m_ringBuffers.isEmpty());
+    if (!m_ringBuffers.last().first)
         return;
-    m_ringBuffers.last()->store(list, sampleCount, totalSampleCount);
+    m_ringBuffers.last().first->store(list, sampleCount, totalSampleCount);
 }
 
-void MediaRecorderPrivateEncoder::updateCurrentRingBufferIfNeeded()
+void MediaRecorderPrivateEncoder::clearRingBuffersIfPossible()
 {
-    assertIsCurrent(queueSingleton());
-
-    Locker locker { m_ringBuffersLock };
-    if (m_currentRingBuffer) {
-        ASSERT(m_ringBuffers.size() > 1);
-        m_ringBuffers.removeFirst();
-    }
-    m_currentRingBuffer = m_ringBuffers.first().get();
-    if (!m_currentRingBuffer) {
-        RELEASE_LOG_ERROR(MediaStream, "MediaRecorderPrivateEncoder::audioSamplesDescriptionChanged: out of memory error occurred");
-        m_hadError = true;
-    }
+    if (m_ringBuffers.size() == 1)
+        return;
+    size_t currentRingBufferId = m_currentRingBufferId;
+    while (m_ringBuffers.size() > 1) {
+        if (m_ringBuffers.first().second < currentRingBufferId)
+            m_ringBuffers.removeFirst();
+        else
+            break;
+    };
 }
 
 void MediaRecorderPrivateEncoder::audioSamplesAvailable(const MediaTime& time, size_t sampleCount, size_t totalSampleCount)
@@ -884,11 +886,6 @@ void MediaRecorderPrivateEncoder::stopRecording()
         assertIsCurrent(queueSingleton());
 
         m_isPaused = false;
-
-        {
-            Locker locker { m_ringBuffersLock };
-            m_ringBuffers.clear();
-        }
 
         RefPtr converter = audioConverter();
         if (!converter)


### PR DESCRIPTION
#### 61d17594f7e3620871c08ea2b55a49008951acdd
<pre>
MediaRecorderPrivateEncoder shouldn&apos;t use lock on audio thread.
<a href="https://bugs.webkit.org/show_bug.cgi?id=293174">https://bugs.webkit.org/show_bug.cgi?id=293174</a>
<a href="https://rdar.apple.com/151516146">rdar://151516146</a>

Reviewed by Youenn Fablet.

Make access to the ringbuffers lockless.
Whenever the audio format changes, we have to create a new ringbuffer.
We now send the new ringbuffer to the queue alongside an Id to be able
to determine when the old ringbuffer is no longer in use and can be safely
removed from the dequeue, doing it all on the audio thread.
The lock was a low contention one, being only ever taken on the audio thread.
The only time it would be taken on the workqueue was if the audio format changed.

There&apos;s still a memory allocation required whenever the audio format change
(including on the first sample received).

Covered by existing tests, no change in observable behaviour

Canonical link: <a href="https://commits.webkit.org/295090@main">https://commits.webkit.org/295090@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bd80c39200fe122d1539bf8a721ff7893228b68b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104079 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/23783 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/14103 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/109275 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/54747 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/106119 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/24150 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/32327 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79067 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107085 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/18756 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/93887 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59394 "Found 1 new API test failure: /WPE/TestCookieManager:/webkit/WebKitCookieManager/persistent-storage (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/18562 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/11933 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/54107 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/88279 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/11991 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/111661 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/31235 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23028 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88078 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/31599 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/90082 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87735 "Found 99 new API test failures: /WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/invalid-sequence, /WebKitGTK/TestDownloads:/webkit/Downloads/blob-download, /WebKitGTK/TestUIClient:/webkit/WebKitWebView/mouse-target, /TestWebKit:WebKit.UserMediaBasic, /WebKitGTK/TestWebProcessExtensions:/webkit/WebKitWebProcessExtension/dom-input-element-is-user-edited, /WebKitGTK/TestDownloads:/webkit/Downloads/contex-menu-download-actions, /WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/cancel-sequence, /WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/is-playing-audio, /WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/page-visibility, /WebKitGTK/TestOptionMenu:/webkit/WebKitWebView/option-menu-select ... (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22329 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32615 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10368 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/25683 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/31164 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/36476 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/30958 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/34294 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/32518 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->