### PR TITLE
[GStreamer] Build with telemetry enabled and without EME enabled broken

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -4560,6 +4560,7 @@ String MediaPlayerPrivateGStreamer::codecForStreamId(TrackID streamId)
 #if ENABLE(MEDIA_TELEMETRY)
 MediaTelemetryReport::DrmType MediaPlayerPrivateGStreamer::getDrm() const
 {
+#if ENABLE(ENCRYPTED_MEDIA)
     if (!m_pipeline)
         return MediaTelemetryReport::DrmType::None;
 
@@ -4571,11 +4572,11 @@ MediaTelemetryReport::DrmType MediaPlayerPrivateGStreamer::getDrm() const
     if (!drmCdmInstanceStructure)
         return MediaTelemetryReport::DrmType::None;
 
-    const GValue* drmCdmInstanceVal = gst_structure_get_value(drmCdmInstanceStructure, "cdm-instance");
-    if (!drmCdmInstanceVal)
+    const GValue* drmCdmInstanceValue = gst_structure_get_value(drmCdmInstanceStructure, "cdm-instance");
+    if (!drmCdmInstanceValue)
         return MediaTelemetryReport::DrmType::None;
 
-    const CDMInstance* drmCdmInstance = static_cast<const CDMInstance*>(g_value_get_pointer(drmCdmInstanceVal));
+    const CDMInstance* drmCdmInstance = static_cast<const CDMInstance*>(g_value_get_pointer(drmCdmInstanceValue));
     if (!drmCdmInstance)
         return MediaTelemetryReport::DrmType::None;
 
@@ -4585,8 +4586,10 @@ MediaTelemetryReport::DrmType MediaPlayerPrivateGStreamer::getDrm() const
     if (GStreamerEMEUtilities::isWidevineKeySystem(keySystem))
         return MediaTelemetryReport::DrmType::Widevine;
     return MediaTelemetryReport::DrmType::Unknown;
+#endif // ENABLE(ENCRYPTED_MEDIA)
+    return MediaTelemetryReport::DrmType::None;
 }
-#endif
+#endif // ENABLE(MEDIA_TELEMETRY)
 
 #undef GST_CAT_DEFAULT
 


### PR DESCRIPTION
#### 2e50258066012d678006b2d382209a4af597fc59
<pre>
[GStreamer] Build with telemetry enabled and without EME enabled broken
<a href="https://bugs.webkit.org/show_bug.cgi?id=293178">https://bugs.webkit.org/show_bug.cgi?id=293178</a>

Reviewed by Xabier Rodriguez-Calvar.

Make sure the code depending on ENCRYPTED_MEDIA doesn&apos;t get compiled when that feature is disabled.

* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::MediaPlayerPrivateGStreamer::getDrm const):

Canonical link: <a href="https://commits.webkit.org/295098@main">https://commits.webkit.org/295098@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a0c446afffe53e735ca002d83553c0d883ddeb39

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/103962 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/23665 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/13986 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/109156 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/54625 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/106002 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/24024 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/32210 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78974 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/106968 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/18656 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/93784 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59302 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/18446 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/11835 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/53990 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/88189 "Found 1 new API test failure: TestWebKitAPI.CARingBufferTest.FetchTimeBoundsConsistent (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/11893 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/111542 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/31118 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/22930 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/87988 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/31482 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/89984 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87644 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22333 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32529 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10271 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/25499 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/31047 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/36357 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/30840 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/34177 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/32401 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->