### PR TITLE
Remove references to WEBKIT_LIBRARIES on Windows

### DIFF
--- a/Tools/Scripts/run-javascriptcore-tests
+++ b/Tools/Scripts/run-javascriptcore-tests
@@ -635,9 +635,7 @@ if ($coverage) {
 }
 
 my $productDir = jscProductDir();
-if (isWindows()) {
-    setupWindowsWebKitEnvironment();
-} else {
+if (!isWindows()) {
     $ENV{DYLD_FRAMEWORK_PATH} = $productDir;
 }
 $ENV{JSCTEST_timeout} = 120 unless $ENV{JSCTEST_timeout}; # Set a 120 second timeout on all jsc tests (if environment variable not defined already).

--- a/Tools/Scripts/run-jsc
+++ b/Tools/Scripts/run-jsc
@@ -61,7 +61,6 @@ if ($debugger) {
 }
 
 if (isWindows()) {
-    setupWindowsWebKitEnvironment();
     print STDERR "Running $count time(s): $jsc\n";
 } else {
     $ENV{"DYLD_FRAMEWORK_PATH"} = $dyld;

--- a/Tools/Scripts/test-webkitperl
+++ b/Tools/Scripts/test-webkitperl
@@ -63,11 +63,6 @@ if (shouldUseFlatpak()) {
 my $sourceRootDir = File::Spec->catfile($FindBin::Bin, "../..");
 chdir($sourceRootDir);
 
-# WEBKIT_LIBRARIES is needed to run some tests on Windows
-if (isAnyWindows() && !defined $ENV{WEBKIT_LIBRARIES}) {
-    $ENV{WEBKIT_LIBRARIES} = File::Spec->catfile($sourceRootDir, "WebKitLibraries", "win");
-}
-
 # Relative to root
 my $pattern = "Tools/Scripts/webkitperl/*_unittest/*.pl";
 

--- a/Tools/Scripts/webkitdirs.pm
+++ b/Tools/Scripts/webkitdirs.pm
@@ -182,7 +182,6 @@ BEGIN {
        &setXcodeSDK
        &setupMacWebKitEnvironment
        &setupUnixWebKitEnvironment
-       &setupWindowsWebKitEnvironment
        &sharedCommandLineOptions
        &sharedCommandLineOptionsUsage
        &shouldBuild32Bit
@@ -2338,7 +2337,6 @@ sub setupCygwinEnv()
 
     print "Building results into: ", baseProductDir(), "\n";
     print "WEBKIT_OUTPUTDIR is set to: ", $ENV{"WEBKIT_OUTPUTDIR"}, "\n";
-    print "WEBKIT_LIBRARIES is set to: ", $ENV{"WEBKIT_LIBRARIES"}, "\n";
 
     # We will actually use MSBuild to build WebKit, but we need to find the Visual Studio install (above) to make
     # sure we use the right options.
@@ -3160,17 +3158,6 @@ sub setupUnixWebKitEnvironment($)
     my ($productDir) = @_;
 
     $ENV{TEST_RUNNER_INJECTED_BUNDLE_FILENAME} = File::Spec->catfile($productDir, "lib", "libTestRunnerInjectedBundle.so");
-}
-
-sub setupWindowsWebKitEnvironment()
-{
-    my $lib;
-    if ($ENV{WEBKIT_LIBRARIES}) {
-        $lib = File::Spec->catfile($ENV{WEBKIT_LIBRARIES}, 'bin');
-    } else  {
-        $lib = File::Spec->catfile(sourceDir(), 'WebKitLibraries', 'win', 'bin');
-    }
-    $ENV{PATH} = $lib . ';' . $ENV{PATH};
 }
 
 sub setupIOSWebKitEnvironment($)

--- a/Tools/Scripts/webkitpy/port/win.py
+++ b/Tools/Scripts/webkitpy/port/win.py
@@ -125,17 +125,11 @@ class WinPort(ApplePort):
             'SYSTEMROOT',
             'TEMP',
             'TMP',
-            'WEBKIT_LIBRARIES',
         ]
         for variable in variables_to_copy:
             self._copy_value_from_environ_if_set(env, variable)
         if 'WEBKIT_TESTFONTS' not in env:
             env['WEBKIT_TESTFONTS'] = self.path_from_webkit_base('Tools', 'WebKitTestRunner', 'fonts')
-        if 'WEBKIT_LIBRARIES' in env:
-            lib = self._filesystem.join(env['WEBKIT_LIBRARIES'], 'bin')
-        else:
-            lib = self.path_from_webkit_base('WebKitLibraries', 'win', 'bin')
-        env['PATH'] = lib + ';' + env['PATH']
         env['PYTHONUTF8'] = '1'
         env['XML_CATALOG_FILES'] = ''  # work around missing /etc/catalog <rdar://problem/4292995>
         return env


### PR DESCRIPTION
#### 0dc438e2e2ef0344b96394956ee23514883a4242
<pre>
Remove references to WEBKIT_LIBRARIES on Windows
<a href="https://bugs.webkit.org/show_bug.cgi?id=293192">https://bugs.webkit.org/show_bug.cgi?id=293192</a>

Reviewed by Yusuke Suzuki.

There is no more need for the WEBKIT_LIBRARIES environment variable on
Windows.

* Tools/Scripts/run-javascriptcore-tests:
* Tools/Scripts/run-jsc:
* Tools/Scripts/test-webkitperl:
* Tools/Scripts/webkitdirs.pm:
(setupCygwinEnv):
(setupWindowsWebKitEnvironment): Deleted.
* Tools/Scripts/webkitpy/port/win.py:
(WinPort.setup_environ_for_server):

Canonical link: <a href="https://commits.webkit.org/295077@main">https://commits.webkit.org/295077@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/84096d83d0e06465540aa54d95cab08804d799fb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104008 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/23712 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/14032 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/109204 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/54675 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/106048 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/24071 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/32256 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79008 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107014 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/18695 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/93820 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59336 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/103484 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/18487 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/11871 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/54036 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/96683 "Built successfully and passed tests") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/88215 "Found 1 new API test failure: TestWebKitAPI.CARingBufferTest.FetchTimeBoundsConsistent (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/11929 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/111588 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/102619 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/31164 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/22966 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88022 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/31528 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/90020 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87678 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22321 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32563 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10307 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/25571 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/31093 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/126252 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/30886 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34917 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/34223 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/32447 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->