### PR TITLE
Unreviewed, try to fix the Mac Catalyst build

### DIFF
--- a/Source/WebCore/PAL/pal/spi/ios/UIKitSPI.h
+++ b/Source/WebCore/PAL/pal/spi/ios/UIKitSPI.h
@@ -33,6 +33,8 @@ WTF_EXTERN_C_BEGIN
 typedef struct __GSKeyboard* GSKeyboardRef;
 WTF_EXTERN_C_END
 
+#import <UIKit/UIKit.h>
+
 #if USE(APPLE_INTERNAL_SDK)
 
 #import <Foundation/NSGeometry.h>
@@ -59,10 +61,7 @@ WTF_EXTERN_C_END
 - (CGFloat)_iOSMacScale;
 @end
 
-
 #else // USE(APPLE_INTERNAL_SDK)
-
-#import <UIKit/UIKit.h>
 
 #if ENABLE(DRAG_SUPPORT)
 #import <UIKit/NSItemProvider+UIKitAdditions.h>


### PR DESCRIPTION
#### 5584d6ed33e038555ea89d301a610a6b042f4c3d
<pre>
Unreviewed, try to fix the Mac Catalyst build
<a href="https://rdar.apple.com/151519087">rdar://151519087</a>

Reviewed by Chris Dumez.

Speculative fix for a build failure in <a href="https://rdar.apple.com/151519087">rdar://151519087</a> — make sure that the declaration of
`UIDocumentInteractionController` is pulled in when importing `UIKitSPI.h` in WebCore. From the
build failure, it seems the return type of `allocUIDocumentInteractionControllerInstance()` is
treated as an `id` instead of `UIDocumentInteractionController *`, due to the soft-linked class
being only a forward declaration.

```
&lt;redacted&gt;/Source/WebCore/rendering/ios/RenderThemeIOS.mm:1244:36: error: &apos;setName:&apos; is unavailable: not available on macCatalyst
 1244 |     [documentInteractionController setName:fileName.isEmpty() ? title.createNSString().get() : fileName.createNSString().get()];
      |                                    ^
In file included from &lt;redacted&gt;/DerivedSources/WebCore/unified-sources/UnifiedSource55-mm.mm:2:
In file included from &lt;redacted&gt;/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm:84:
In file included from PAL/pal/ios/UIKitSoftLink.h:30:
In file included from PAL/pal/spi/ios/UIKitSPI.h:44:

…

&lt;redacted&gt;.h:23:28: note: property &apos;name&apos; is declared unavailable here
   23 | @property (copy) NSString* name API_AVAILABLE(macos(10.13)) API_UNAVAILABLE(ios, tvos, watchos);
```

To (maybe) fix this, we pull `#import &lt;UIKit/UIKit.h&gt;` out to the start of `UIKitSPI.h` to ensure
that all public headers (which includes the declaration of `UIDocumentInteractionController`) get
pulled in when compiling `RenderThemeIOS.mm` (and anything else that imports PAL&apos;s `UIKitSPI.h`).

* Source/WebCore/PAL/pal/spi/ios/UIKitSPI.h:

Canonical link: <a href="https://commits.webkit.org/295067@main">https://commits.webkit.org/295067@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9f37d65c11513b300c8e1c209bb165b6698dd6f5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104010 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/23714 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/14034 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/109206 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/54677 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/106050 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/24073 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/32258 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79011 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107016 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/18699 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/93823 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59339 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/18491 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/11874 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/54038 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/88218 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/11932 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/111590 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/31166 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/22970 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/88024 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/31530 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/90023 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87680 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/22311 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32567 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10310 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/25578 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16882 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/31095 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/36407 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/30888 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/34225 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/32449 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->