### PR TITLE
Fix ODR violation of WebCore::ScrollView class

### DIFF
--- a/Source/WebCore/platform/ScrollView.h
+++ b/Source/WebCore/platform/ScrollView.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2004-2025 Apple Inc. All rights reserved.
  * Copyright (C) 2009 Holger Hans Peter Freyther
  *
  * Redistribution and use in source and binary forms, with or without
@@ -37,24 +37,25 @@
 #include <wtf/WeakPtr.h>
 
 #if PLATFORM(IOS_FAMILY)
-
-OBJC_CLASS WAKScrollView;
-OBJC_CLASS WAKView;
-
 #ifndef NSScrollView
 #define NSScrollView WAKScrollView
 #endif
-
 #ifndef NSView
 #define NSView WAKView
 #endif
-
 #endif // PLATFORM(IOS_FAMILY)
 
-#if PLATFORM(COCOA) && defined __OBJC__
-@class NSScrollView;
+#if PLATFORM(COCOA)
+OBJC_CLASS NSScrollView;
+OBJC_CLASS NSView;
+
+#ifdef __OBJC__
 @protocol WebCoreFrameScrollView;
+#define PlatformScrollView NSScrollView<WebCoreFrameScrollView>
+#else
+#define PlatformScrollView NSScrollView
 #endif
+#endif // PLATFORM(COCOA)
 
 namespace WebCore {
 
@@ -447,12 +448,12 @@ protected:
 
     virtual void didFinishProhibitingScrollingWhenChangingContentSize() = 0;
 
-#if PLATFORM(COCOA) && defined __OBJC__
+#if PLATFORM(COCOA)
 public:
     WEBCORE_EXPORT NSView* documentView() const;
 
 private:
-    NSScrollView<WebCoreFrameScrollView>* scrollView() const;
+    PlatformScrollView* scrollView() const;
 #endif
 
 private:


### PR DESCRIPTION
#### 6dc33bb6223de0f12008ca96bc29b2a8ce10b473
<pre>
Fix ODR violation of WebCore::ScrollView class
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=293194">https://bugs.webkit.org/show_bug.cgi?id=293194</a>&gt;
&lt;<a href="https://rdar.apple.com/151537420">rdar://151537420</a>&gt;

Reviewed by Sihui Liu.

* Source/WebCore/platform/ScrollView.h:
- Move OBJC_CLASS definitions from PLATFORM(IOS_FAMILY) to
  PLATFORM(COCOA).
- Introduce PlatformScrollView macro for C++ vs ObjC++ sources.
(WebCore::ScrollView::documentView() const):
(WebCore::ScrollView::scrollView() const):
- Remove defined(__OBJC__) requirement when declaring class so the
  definition is the same in C++ and ObjC++.

Canonical link: <a href="https://commits.webkit.org/295073@main">https://commits.webkit.org/295073@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a48d0ceb84cd1bd3f2c7f16aa7c4ba75ebb7370d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104015 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/23719 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/14039 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/109211 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/54682 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/106055 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/24079 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/32263 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79014 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107021 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/18703 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/93826 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59342 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/18496 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/11877 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/54043 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/88222 "Found 1 new API test failure: TestWebKitAPI.CARingBufferTest.FetchTimeBoundsConsistent (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/11935 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/111596 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/31171 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/22972 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88028 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/31535 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/90026 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87684 "Found 100 new API test failures: /WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/invalid-sequence, /WebKitGTK/TestDownloads:/webkit/Downloads/blob-download, /WebKitGTK/TestUIClient:/webkit/WebKitWebView/mouse-target, /TestWebKit:WebKit.UserMediaBasic, /WebKitGTK/TestWebProcessExtensions:/webkit/WebKitWebProcessExtension/dom-input-element-is-user-edited, /WebKitGTK/TestDownloads:/webkit/Downloads/contex-menu-download-actions, /WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/cancel-sequence, /WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/is-playing-audio, /WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/page-visibility, /WebKitGTK/TestOptionMenu:/webkit/WebKitWebView/option-menu-select ... (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32571 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10313 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/25589 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16888 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/31100 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/36412 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/30893 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/34230 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/32454 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->