### PR TITLE
[JSC] Add `AsyncDisposableStack` constructor from Explicit Resource Management Proposal

### DIFF
--- a/JSTests/stress/async-disposable-stack-constructor.js
+++ b/JSTests/stress/async-disposable-stack-constructor.js
@@ -1,0 +1,25 @@
+//@ requireOptions("--useExplicitResourceManagement=1")
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`expected ${expected} but got ${actual}`);
+}
+
+function shouldThrow(func, errorType, message) {
+    let error;
+    try {
+        func();
+    } catch (e) {
+        error = e;
+    }
+    if (!(error instanceof errorType))
+        throw new Error(`Expected ${errorType.name}!`);
+    if (message !== undefined)
+        shouldBe(String(error), message);
+}
+
+shouldBe(typeof DisposableStack, "function");
+shouldBe(Object.getPrototypeOf(DisposableStack.prototype), Object.prototype);
+shouldBe(new DisposableStack() instanceof Object, true);
+shouldBe(new DisposableStack() instanceof DisposableStack, true);
+shouldThrow(() => { DisposableStack(); }, TypeError);

--- a/JSTests/test262/config.yaml
+++ b/JSTests/test262/config.yaml
@@ -48,7 +48,7 @@ skip:
     - test/staging/sm/Temporal
     # Explicit Resource Management
     - test/staging/explicit-resource-management
-    - test/built-ins/AsyncDisposableStack
+    - test/built-ins/AsyncDisposableStack/prototype
     - test/language/statements/using
     - test/language/statements/await-using
   files:

--- a/Source/JavaScriptCore/CMakeLists.txt
+++ b/Source/JavaScriptCore/CMakeLists.txt
@@ -933,6 +933,9 @@ set(JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS
     runtime/ArrayStorage.h
     runtime/ArrayStorageInlines.h
     runtime/AssertInvariants.h
+    runtime/AsyncDisposableStackConstructor.h
+    runtime/AsyncDisposableStackPrototype.h
+    runtime/AsyncDisposableStackPrototypeInlines.h
     runtime/AsyncIteratorPrototype.h
     runtime/AuxiliaryBarrier.h
     runtime/AuxiliaryBarrierInlines.h
@@ -1056,6 +1059,8 @@ set(JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS
     runtime/JSArrayBufferView.h
     runtime/JSArrayBufferViewInlines.h
     runtime/JSArrayIterator.h
+    runtime/JSAsyncDisposableStack.h
+    runtime/JSAsyncDisposableStackInlines.h
     runtime/JSAsyncFromSyncIterator.h
     runtime/JSBigInt.h
     runtime/JSBoundFunction.h

--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -1446,6 +1446,11 @@
 		8CCBF05F2C804E8500EEC20B /* WrapForValidIteratorPrototypeInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = 8CCBF05E2C804E8500EEC20B /* WrapForValidIteratorPrototypeInlines.h */; };
 		8CCBF0622C804EAF00EEC20B /* JSWrapForValidIterator.h in Headers */ = {isa = PBXBuildFile; fileRef = 8CCBF0612C804EAF00EEC20B /* JSWrapForValidIterator.h */; };
 		8CCBF0642C804EB600EEC20B /* JSWrapForValidIteratorInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = 8CCBF0632C804EB600EEC20B /* JSWrapForValidIteratorInlines.h */; };
+		8CF21B8B2DD9D64F00355A6C /* AsyncDisposableStackConstructor.h in Headers */ = {isa = PBXBuildFile; fileRef = 8CF21B8A2DD9D64F00355A6C /* AsyncDisposableStackConstructor.h */; };
+		8CF21B8E2DD9D65A00355A6C /* AsyncDisposableStackPrototype.h in Headers */ = {isa = PBXBuildFile; fileRef = 8CF21B8D2DD9D65A00355A6C /* AsyncDisposableStackPrototype.h */; };
+		8CF21B902DD9D66000355A6C /* AsyncDisposableStackPrototypeInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = 8CF21B8F2DD9D66000355A6C /* AsyncDisposableStackPrototypeInlines.h */; };
+		8CF21B932DD9D68A00355A6C /* JSAsyncDisposableStack.h in Headers */ = {isa = PBXBuildFile; fileRef = 8CF21B922DD9D68A00355A6C /* JSAsyncDisposableStack.h */; };
+		8CF21B952DD9D69000355A6C /* JSAsyncDisposableStackInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = 8CF21B942DD9D69000355A6C /* JSAsyncDisposableStackInlines.h */; };
 		90213E3E123A40C200D422F3 /* MemoryStatistics.h in Headers */ = {isa = PBXBuildFile; fileRef = 90213E3C123A40C200D422F3 /* MemoryStatistics.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		9064337DD4B0402BAF34A592 /* JSScriptFetcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 6BA93C9590484C5BAD9316EA /* JSScriptFetcher.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		91278D5521DEB82600B57184 /* InspectorAuditAgent.h in Headers */ = {isa = PBXBuildFile; fileRef = 91278D5321DEB82500B57184 /* InspectorAuditAgent.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -4830,6 +4835,14 @@
 		8CCBF0632C804EB600EEC20B /* JSWrapForValidIteratorInlines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSWrapForValidIteratorInlines.h; sourceTree = "<group>"; };
 		8CCBF0652C804ED800EEC20B /* WrapForValidIteratorPrototype.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = WrapForValidIteratorPrototype.js; sourceTree = "<group>"; };
 		8CCBF0662C804EE900EEC20B /* JSIteratorConstructor.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = JSIteratorConstructor.js; sourceTree = "<group>"; };
+		8CF21B892DD9D64800355A6C /* AsyncDisposableStackConstructor.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = AsyncDisposableStackConstructor.cpp; sourceTree = "<group>"; };
+		8CF21B8A2DD9D64F00355A6C /* AsyncDisposableStackConstructor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AsyncDisposableStackConstructor.h; sourceTree = "<group>"; };
+		8CF21B8C2DD9D65500355A6C /* AsyncDisposableStackPrototype.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = AsyncDisposableStackPrototype.cpp; sourceTree = "<group>"; };
+		8CF21B8D2DD9D65A00355A6C /* AsyncDisposableStackPrototype.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AsyncDisposableStackPrototype.h; sourceTree = "<group>"; };
+		8CF21B8F2DD9D66000355A6C /* AsyncDisposableStackPrototypeInlines.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AsyncDisposableStackPrototypeInlines.h; sourceTree = "<group>"; };
+		8CF21B912DD9D68300355A6C /* JSAsyncDisposableStack.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = JSAsyncDisposableStack.cpp; sourceTree = "<group>"; };
+		8CF21B922DD9D68A00355A6C /* JSAsyncDisposableStack.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = JSAsyncDisposableStack.h; sourceTree = "<group>"; };
+		8CF21B942DD9D69000355A6C /* JSAsyncDisposableStackInlines.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = JSAsyncDisposableStackInlines.h; sourceTree = "<group>"; };
 		90213E3B123A40C200D422F3 /* MemoryStatistics.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MemoryStatistics.cpp; sourceTree = "<group>"; };
 		90213E3C123A40C200D422F3 /* MemoryStatistics.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MemoryStatistics.h; sourceTree = "<group>"; };
 		91278D5221DEB82400B57184 /* InspectorAuditAgent.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = InspectorAuditAgent.cpp; sourceTree = "<group>"; };
@@ -7999,6 +8012,11 @@
 				FE1D6D7023625AB0007A5C26 /* ArrayStorageInlines.h */,
 				FE265F1F2C02D39100997B07 /* AssertInvariants.cpp */,
 				FE265F1E2C02D39100997B07 /* AssertInvariants.h */,
+				8CF21B892DD9D64800355A6C /* AsyncDisposableStackConstructor.cpp */,
+				8CF21B8A2DD9D64F00355A6C /* AsyncDisposableStackConstructor.h */,
+				8CF21B8C2DD9D65500355A6C /* AsyncDisposableStackPrototype.cpp */,
+				8CF21B8D2DD9D65A00355A6C /* AsyncDisposableStackPrototype.h */,
+				8CF21B8F2DD9D66000355A6C /* AsyncDisposableStackPrototypeInlines.h */,
 				8B6016F31F3E3CC000F9DE6A /* AsyncFromSyncIteratorPrototype.cpp */,
 				8B6016F41F3E3CC000F9DE6A /* AsyncFromSyncIteratorPrototype.h */,
 				276B385A2A71D0B500252F4E /* AsyncFromSyncIteratorPrototypeInlines.h */,
@@ -8373,6 +8391,9 @@
 				539FB8B91C99DA7C00940FA1 /* JSArrayInlines.h */,
 				539DD7F323C1BBA900905F13 /* JSArrayIterator.cpp */,
 				539DD7F423C1BBA900905F13 /* JSArrayIterator.h */,
+				8CF21B912DD9D68300355A6C /* JSAsyncDisposableStack.cpp */,
+				8CF21B922DD9D68A00355A6C /* JSAsyncDisposableStack.h */,
+				8CF21B942DD9D69000355A6C /* JSAsyncDisposableStackInlines.h */,
 				8CB955C92C8AF8D000282DA2 /* JSAsyncFromSyncIterator.cpp */,
 				8CB955CA2C8AF8E100282DA2 /* JSAsyncFromSyncIterator.h */,
 				8CB955CC2C8AF8F500282DA2 /* JSAsyncFromSyncIteratorInlines.h */,
@@ -10353,6 +10374,9 @@
 				6B767E7B26791F270017F8D1 /* AssemblyHelpersSpoolers.h in Headers */,
 				FE265F202C02D39100997B07 /* AssertInvariants.h in Headers */,
 				A784A26111D16622005776AC /* ASTBuilder.h in Headers */,
+				8CF21B8B2DD9D64F00355A6C /* AsyncDisposableStackConstructor.h in Headers */,
+				8CF21B8E2DD9D65A00355A6C /* AsyncDisposableStackPrototype.h in Headers */,
+				8CF21B902DD9D66000355A6C /* AsyncDisposableStackPrototypeInlines.h in Headers */,
 				8B6016F61F3E3CC000F9DE6A /* AsyncFromSyncIteratorPrototype.h in Headers */,
 				276B38692A71D0B600252F4E /* AsyncFromSyncIteratorPrototypeInlines.h in Headers */,
 				5B70CFE21DB69E6600EC23F9 /* AsyncFunctionConstructor.h in Headers */,
@@ -11240,6 +11264,8 @@
 				0F2B66EA17B6B5AB00A7AE3F /* JSArrayBufferViewInlines.h in Headers */,
 				539FB8BA1C99DA7C00940FA1 /* JSArrayInlines.h in Headers */,
 				539DD7F523C1BBB500905F13 /* JSArrayIterator.h in Headers */,
+				8CF21B932DD9D68A00355A6C /* JSAsyncDisposableStack.h in Headers */,
+				8CF21B952DD9D69000355A6C /* JSAsyncDisposableStackInlines.h in Headers */,
 				8CB955CB2C8AF8E100282DA2 /* JSAsyncFromSyncIterator.h in Headers */,
 				8CB955CD2C8AF8F500282DA2 /* JSAsyncFromSyncIteratorInlines.h in Headers */,
 				5B70CFDE1DB69E6600EC23F9 /* JSAsyncFunction.h in Headers */,

--- a/Source/JavaScriptCore/Sources.txt
+++ b/Source/JavaScriptCore/Sources.txt
@@ -738,6 +738,8 @@ runtime/ArrayConventions.cpp
 runtime/ArrayIteratorPrototype.cpp
 runtime/ArrayPrototype.cpp
 runtime/AssertInvariants.cpp
+runtime/AsyncDisposableStackConstructor.cpp
+runtime/AsyncDisposableStackPrototype.cpp
 runtime/AsyncFromSyncIteratorPrototype.cpp
 runtime/AsyncGeneratorFunctionConstructor.cpp
 runtime/AsyncGeneratorFunctionPrototype.cpp
@@ -877,6 +879,7 @@ runtime/JSArrayBuffer.cpp
 runtime/JSArrayBufferConstructor.cpp
 runtime/JSArrayBufferPrototype.cpp
 runtime/JSArrayBufferView.cpp
+runtime/JSAsyncDisposableStack.cpp
 runtime/JSAsyncFunction.cpp
 runtime/JSAsyncFromSyncIterator.cpp
 runtime/JSAsyncGenerator.cpp

--- a/Source/JavaScriptCore/heap/Heap.h
+++ b/Source/JavaScriptCore/heap/Heap.h
@@ -300,6 +300,7 @@ class Heap;
     v(asyncFromSyncIteratorSpace, cellHeapCellType, JSAsyncFromSyncIterator) \
     v(regExpStringIteratorSpace, cellHeapCellType, JSRegExpStringIterator) \
     v(disposableStackSpace, cellHeapCellType, JSDisposableStack) \
+    v(asyncDisposableStackSpace, cellHeapCellType, JSAsyncDisposableStack) \
     \
     FOR_EACH_JSC_WEBASSEMBLY_DYNAMIC_ISO_SUBSPACE(v)
 

--- a/Source/JavaScriptCore/heap/HeapSubspaceTypes.h
+++ b/Source/JavaScriptCore/heap/HeapSubspaceTypes.h
@@ -55,6 +55,7 @@
 #include "JSArray.h"
 #include "JSArrayBuffer.h"
 #include "JSArrayIterator.h"
+#include "JSAsyncDisposableStack.h"
 #include "JSAsyncFromSyncIterator.h"
 #include "JSAsyncGenerator.h"
 #include "JSBigInt.h"

--- a/Source/JavaScriptCore/runtime/AsyncDisposableStackConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/AsyncDisposableStackConstructor.cpp
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2025 Sosuke Suzuki <aosukeke@gmail.com>.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "AsyncDisposableStackConstructor.h"
+
+#include "AbstractSlotVisitor.h"
+#include "BuiltinNames.h"
+#include "GetterSetter.h"
+#include "JSAsyncDisposableStack.h"
+#include "JSCInlines.h"
+#include "AsyncDisposableStackPrototype.h"
+#include "SlotVisitor.h"
+
+namespace JSC {
+
+const ClassInfo AsyncDisposableStackConstructor::s_info = { "Function"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(AsyncDisposableStackConstructor) };
+
+Structure* AsyncDisposableStackConstructor::createStructure(VM& vm, JSGlobalObject* globalObject, JSValue prototype)
+{
+    return Structure::create(vm, globalObject, prototype, TypeInfo(InternalFunctionType, StructureFlags), info());
+}
+
+AsyncDisposableStackConstructor* AsyncDisposableStackConstructor::create(VM& vm, JSGlobalObject* globalObject, Structure* structure, AsyncDisposableStackPrototype* disposableStackPrototype)
+{
+    AsyncDisposableStackConstructor* constructor = new (NotNull, allocateCell<AsyncDisposableStackConstructor>(vm)) AsyncDisposableStackConstructor(vm, structure);
+    constructor->finishCreation(vm, globalObject, disposableStackPrototype);
+    return constructor;
+}
+
+void AsyncDisposableStackConstructor::finishCreation(VM& vm, JSGlobalObject*, AsyncDisposableStackPrototype* prototype)
+{
+    Base::finishCreation(vm, 0, vm.propertyNames->AsyncDisposableStack.string(), PropertyAdditionMode::WithoutStructureTransition);
+    putDirectWithoutTransition(vm, vm.propertyNames->prototype, prototype, static_cast<unsigned>(PropertyAttribute::DontEnum | PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly));
+}
+
+template<typename Visitor>
+void AsyncDisposableStackConstructor::visitChildrenImpl(JSCell* cell, Visitor& visitor)
+{
+    auto* thisObject = jsCast<AsyncDisposableStackConstructor*>(cell);
+    ASSERT_GC_OBJECT_INHERITS(thisObject, info());
+    Base::visitChildren(thisObject, visitor);
+}
+
+DEFINE_VISIT_CHILDREN(AsyncDisposableStackConstructor);
+
+static JSC_DECLARE_HOST_FUNCTION(callAsyncDisposableStack);
+static JSC_DECLARE_HOST_FUNCTION(constructAsyncDisposableStack);
+
+AsyncDisposableStackConstructor::AsyncDisposableStackConstructor(VM& vm, Structure* structure)
+    : Base(vm, structure, callAsyncDisposableStack, constructAsyncDisposableStack)
+{
+}
+
+JSC_DEFINE_HOST_FUNCTION(callAsyncDisposableStack, (JSGlobalObject* globalObject, CallFrame*))
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    return JSValue::encode(throwConstructorCannotBeCalledAsFunctionTypeError(globalObject, scope, "AsyncDisposableStack"_s));
+}
+
+JSC_DEFINE_HOST_FUNCTION(constructAsyncDisposableStack, (JSGlobalObject* globalObject, CallFrame* callFrame))
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    JSObject* newTarget = asObject(callFrame->newTarget());
+    Structure* asyncDisposableStackStructure = JSC_GET_DERIVED_STRUCTURE(vm, asyncDisposableStackStructure, newTarget, callFrame->jsCallee());
+    RETURN_IF_EXCEPTION(scope, { });
+
+    auto* asyncDisposableStack = JSAsyncDisposableStack::create(vm, asyncDisposableStackStructure);
+    auto* capabilityArray = constructEmptyArray(globalObject, nullptr);
+    if (!capabilityArray) [[unlikely]]
+        RETURN_IF_EXCEPTION(scope, { });
+    asyncDisposableStack->internalField(JSAsyncDisposableStack::Field::Capability).set(vm, asyncDisposableStack, capabilityArray);
+
+    RELEASE_AND_RETURN(scope, JSValue::encode(asyncDisposableStack));
+}
+
+} // namespace JSC

--- a/Source/JavaScriptCore/runtime/AsyncDisposableStackConstructor.h
+++ b/Source/JavaScriptCore/runtime/AsyncDisposableStackConstructor.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2025 Sosuke Suzuki <aosukeke@gmail.com>.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "InternalFunction.h"
+
+namespace JSC {
+
+class AsyncDisposableStackPrototype;
+
+class AsyncDisposableStackConstructor final : public InternalFunction {
+public:
+    typedef InternalFunction Base;
+
+    static Structure* createStructure(VM&, JSGlobalObject*, JSValue);
+    static AsyncDisposableStackConstructor* create(VM&, JSGlobalObject*, Structure*, AsyncDisposableStackPrototype*);
+
+    DECLARE_INFO;
+    DECLARE_VISIT_CHILDREN;
+private:
+    AsyncDisposableStackConstructor(VM&, Structure*);
+
+    void finishCreation(VM&, JSGlobalObject*, AsyncDisposableStackPrototype*);
+};
+STATIC_ASSERT_ISO_SUBSPACE_SHARABLE(AsyncDisposableStackConstructor, InternalFunction);
+
+} // namespace JSC

--- a/Source/JavaScriptCore/runtime/AsyncDisposableStackPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/AsyncDisposableStackPrototype.cpp
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2025 Sosuke Suzuki <aosukeke@gmail.com>.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "AsyncDisposableStackPrototype.h"
+
+#include "BuiltinNames.h"
+#include "InterpreterInlines.h"
+#include "JSCBuiltins.h"
+#include "JSCInlines.h"
+#include "VMEntryScopeInlines.h"
+
+namespace JSC {
+
+const ClassInfo AsyncDisposableStackPrototype::s_info = { "AsyncDisposableStack"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(AsyncDisposableStackPrototype) };
+
+void AsyncDisposableStackPrototype::finishCreation(VM& vm, JSGlobalObject*)
+{
+    Base::finishCreation(vm);
+    ASSERT(inherits(info()));
+}
+
+} // namespace JSC

--- a/Source/JavaScriptCore/runtime/AsyncDisposableStackPrototype.h
+++ b/Source/JavaScriptCore/runtime/AsyncDisposableStackPrototype.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2025 Sosuke Suzuki <aosukeke@gmail.com>.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "JSObject.h"
+
+namespace JSC {
+
+class AsyncDisposableStackPrototype final : public JSNonFinalObject {
+public:
+    using Base = JSNonFinalObject;
+
+    static constexpr unsigned StructureFlags = Base::StructureFlags;
+
+    template<typename CellType, SubspaceAccess>
+    static GCClient::IsoSubspace* subspaceFor(VM& vm)
+    {
+        STATIC_ASSERT_ISO_SUBSPACE_SHARABLE(AsyncDisposableStackPrototype, Base);
+        return &vm.plainObjectSpace();
+    }
+
+    static AsyncDisposableStackPrototype* create(VM& vm, JSGlobalObject* globalObject, Structure* structure)
+    {
+        AsyncDisposableStackPrototype* prototype = new (NotNull, allocateCell<AsyncDisposableStackPrototype>(vm)) AsyncDisposableStackPrototype(vm, structure);
+        prototype->finishCreation(vm, globalObject);
+        return prototype;
+    }
+
+    DECLARE_INFO;
+
+    inline static Structure* createStructure(VM&, JSGlobalObject*, JSValue);
+
+private:
+    AsyncDisposableStackPrototype(VM& vm, Structure* structure)
+        : Base(vm, structure)
+    {
+    }
+    void finishCreation(VM&, JSGlobalObject*);
+};
+
+} // namespace JSC

--- a/Source/JavaScriptCore/runtime/AsyncDisposableStackPrototypeInlines.h
+++ b/Source/JavaScriptCore/runtime/AsyncDisposableStackPrototypeInlines.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2025 Sosuke Suzuki <aosukeke@gmail.com>.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "AsyncDisposableStackPrototype.h"
+
+namespace JSC {
+
+inline Structure* AsyncDisposableStackPrototype::createStructure(VM& vm, JSGlobalObject* globalObject, JSValue prototype)
+{
+    return Structure::create(vm, globalObject, prototype, TypeInfo(ObjectType, StructureFlags), info());
+}
+
+} // namespace JSC

--- a/Source/JavaScriptCore/runtime/ClonedArguments.h
+++ b/Source/JavaScriptCore/runtime/ClonedArguments.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "ArgumentsMode.h"
+#include "CommonIdentifiers.h"
 #include "JSObject.h"
 
 namespace JSC {

--- a/Source/JavaScriptCore/runtime/CommonIdentifiers.h
+++ b/Source/JavaScriptCore/runtime/CommonIdentifiers.h
@@ -325,6 +325,7 @@
     macro(dispose) \
     macro(use) \
     macro(move) \
+    macro(AsyncDisposableStack)
 
 #define JSC_COMMON_IDENTIFIERS_EACH_PRIVATE_FIELD(macro) \
     macro(constructor)

--- a/Source/JavaScriptCore/runtime/JSAsyncDisposableStack.cpp
+++ b/Source/JavaScriptCore/runtime/JSAsyncDisposableStack.cpp
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2025 Sosuke Suzuki <aosukeke@gmail.com>.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "JSAsyncDisposableStack.h"
+
+#include "JSCInlines.h"
+#include "JSInternalFieldObjectImplInlines.h"
+
+namespace JSC {
+
+const ClassInfo JSAsyncDisposableStack::s_info = { "AsyncDisposableStack"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSAsyncDisposableStack) };
+
+JSAsyncDisposableStack* JSAsyncDisposableStack::create(VM& vm, Structure* structure)
+{
+    JSAsyncDisposableStack* asyncDisposableStack = new (NotNull, allocateCell<JSAsyncDisposableStack>(vm)) JSAsyncDisposableStack(vm, structure);
+    asyncDisposableStack->finishCreation(vm);
+    return asyncDisposableStack;
+}
+
+void JSAsyncDisposableStack::finishCreation(VM& vm)
+{
+    Base::finishCreation(vm);
+    auto values = initialValues();
+    ASSERT(values.size() == numberOfInternalFields);
+    internalField(Field::State).set(vm, this, values[0]);
+    internalField(Field::Capability).set(vm, this, values[1]);
+}
+
+template<typename Visitor>
+void JSAsyncDisposableStack::visitChildrenImpl(JSCell* cell, Visitor& visitor)
+{
+    auto* thisObject = jsCast<JSAsyncDisposableStack*>(cell);
+    ASSERT_GC_OBJECT_INHERITS(thisObject, info());
+    Base::visitChildren(thisObject, visitor);
+}
+
+DEFINE_VISIT_CHILDREN(JSAsyncDisposableStack);
+
+} // namespace JSC

--- a/Source/JavaScriptCore/runtime/JSAsyncDisposableStack.h
+++ b/Source/JavaScriptCore/runtime/JSAsyncDisposableStack.h
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2025 Sosuke Suzuki <aosukeke@gmail.com>.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "JSInternalFieldObjectImpl.h"
+
+namespace JSC {
+
+const static uint8_t JSAsyncDisposableStackNumberOfInternalFields = 2;
+
+class JSAsyncDisposableStack final : public JSInternalFieldObjectImpl<JSAsyncDisposableStackNumberOfInternalFields> {
+
+public:
+    using Base = JSInternalFieldObjectImpl<JSAsyncDisposableStackNumberOfInternalFields>;
+
+    DECLARE_EXPORT_INFO;
+
+    enum class State : int32_t {
+        Pending = 0,
+        Disposed
+    };
+
+    enum class Field : uint8_t {
+        State = 0,
+        Capability,
+    };
+    static_assert(numberOfInternalFields == JSAsyncDisposableStackNumberOfInternalFields);
+
+    static std::array<JSValue, numberOfInternalFields> initialValues()
+    {
+        return { {
+            jsNumber(static_cast<int32_t>(State::Pending)),
+            jsNull(),
+        } };
+    }
+
+    const WriteBarrier<Unknown>& internalField(Field field) const { return Base::internalField(static_cast<uint32_t>(field)); }
+    WriteBarrier<Unknown>& internalField(Field field) { return Base::internalField(static_cast<uint32_t>(field)); }
+
+    template<typename CellType, SubspaceAccess mode>
+    static GCClient::IsoSubspace* subspaceFor(VM& vm)
+    {
+        return vm.asyncDisposableStackSpace<mode>();
+    }
+
+    inline static Structure* createStructure(VM&, JSGlobalObject*, JSValue);
+
+    static JSAsyncDisposableStack* createWithInitialValues(VM&);
+    static JSAsyncDisposableStack* create(VM&, Structure*);
+
+private:
+    JSAsyncDisposableStack(VM& vm, Structure* structure)
+        : Base(vm, structure)
+    {
+    }
+
+    void finishCreation(VM&);
+    DECLARE_VISIT_CHILDREN;
+};
+
+STATIC_ASSERT_IS_TRIVIALLY_DESTRUCTIBLE(JSAsyncDisposableStack);
+
+}

--- a/Source/JavaScriptCore/runtime/JSAsyncDisposableStackInlines.h
+++ b/Source/JavaScriptCore/runtime/JSAsyncDisposableStackInlines.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2025 Sosuke Suzuki <aosukeke@gmail.com>.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "JSAsyncDisposableStack.h"
+
+namespace JSC {
+
+inline Structure* JSAsyncDisposableStack::createStructure(VM& vm, JSGlobalObject* globalObject, JSValue prototype)
+{
+    return Structure::create(vm, globalObject, prototype, TypeInfo(AsyncDisposableStackType, StructureFlags), info());
+}
+
+} // namespace JSC

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -38,6 +38,9 @@
 #include "ArrayConstructorInlines.h"
 #include "ArrayIteratorPrototypeInlines.h"
 #include "ArrayPrototypeInlines.h"
+#include "AsyncDisposableStackConstructor.h"
+#include "AsyncDisposableStackPrototype.h"
+#include "AsyncDisposableStackPrototypeInlines.h"
 #include "AsyncFromSyncIteratorPrototypeInlines.h"
 #include "AsyncFunctionConstructorInlines.h"
 #include "AsyncFunctionPrototypeInlines.h"
@@ -116,6 +119,8 @@
 #include "JSArrayBufferConstructor.h"
 #include "JSArrayBufferPrototype.h"
 #include "JSArrayIterator.h"
+#include "JSAsyncDisposableStack.h"
+#include "JSAsyncDisposableStackInlines.h"
 #include "JSAsyncFromSyncIterator.h"
 #include "JSAsyncFromSyncIteratorInlines.h"
 #include "JSAsyncFunctionInlines.h"
@@ -1158,6 +1163,12 @@ void JSGlobalObject::init(VM& vm)
             init.setStructure(JSDisposableStack::createStructure(init.vm, init.global, init.prototype));
             init.setConstructor(DisposableStackConstructor::create(init.vm, init.global, DisposableStackConstructor::createStructure(init.vm, init.global, init.global->m_functionPrototype.get()), jsCast<DisposableStackPrototype*>(init.prototype)));
         });
+    m_asyncDisposableStackStructure.initLater(
+        [] (LazyClassStructure::Initializer& init) -> void {
+            init.setPrototype(AsyncDisposableStackPrototype::create(init.vm, init.global, AsyncDisposableStackPrototype::createStructure(init.vm, init.global, init.global->m_objectPrototype.get())));
+            init.setStructure(JSAsyncDisposableStack::createStructure(init.vm, init.global, init.prototype));
+            init.setConstructor(AsyncDisposableStackConstructor::create(init.vm, init.global, AsyncDisposableStackConstructor::createStructure(init.vm, init.global, init.global->m_functionPrototype.get()), jsCast<AsyncDisposableStackPrototype*>(init.prototype)));
+        });
 
     m_iteratorPrototype.set(vm, this, JSIteratorPrototype::create(vm, this, JSIteratorPrototype::createStructure(vm, this, m_objectPrototype.get())));
 
@@ -1349,6 +1360,7 @@ capitalName ## Constructor* lowerName ## Constructor = featureFlag ? capitalName
     if (Options::useExplicitResourceManagement()) {
         putDirectWithoutTransition(vm, vm.propertyNames->SuppressedError, m_suppressedErrorStructure.constructor(this), static_cast<unsigned>(PropertyAttribute::DontEnum));
         putDirectWithoutTransition(vm, vm.propertyNames->DisposableStack, m_disposableStackStructure.constructor(this), static_cast<unsigned>(PropertyAttribute::DontEnum));
+        putDirectWithoutTransition(vm, vm.propertyNames->AsyncDisposableStack, m_asyncDisposableStackStructure.constructor(this), static_cast<unsigned>(PropertyAttribute::DontEnum));
     }
 
 #define PUT_CONSTRUCTOR_FOR_SIMPLE_TYPE(capitalName, lowerName, properName, instanceType, jsName, prototypeBase, featureFlag) \
@@ -2786,6 +2798,7 @@ void JSGlobalObject::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     thisObject->m_proxyRevokeStructure.visit(visitor);
     thisObject->m_sharedArrayBufferStructure.visit(visitor);
     thisObject->m_disposableStackStructure.visit(visitor);
+    thisObject->m_asyncDisposableStackStructure.visit(visitor);
 
     for (auto& property : thisObject->m_linkTimeConstants)
         property.visit(visitor);

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.h
@@ -399,6 +399,7 @@ public:
     LazyProperty<JSGlobalObject, Structure> m_proxyRevokeStructure;
     LazyClassStructure m_sharedArrayBufferStructure;
     LazyClassStructure m_disposableStackStructure;
+    LazyClassStructure m_asyncDisposableStackStructure;
 
 #define DEFINE_STORAGE_FOR_SIMPLE_TYPE_PROTOTYPE(capitalName, lowerName, properName, instanceType, jsName, prototypeBase, featureFlag) \
     WriteBarrier<capitalName ## Prototype> m_ ## lowerName ## Prototype;
@@ -929,6 +930,7 @@ public:
     Structure* callableProxyObjectStructure() const { return m_callableProxyObjectStructure.get(this); }
     Structure* proxyRevokeStructure() const { return m_proxyRevokeStructure.get(this); }
     Structure* disposableStackStructure() const { return m_disposableStackStructure.get(this); }
+    Structure* asyncDisposableStackStructure() const { return m_asyncDisposableStackStructure.get(this); }
     Structure* restParameterStructure() const { return arrayStructureForIndexingTypeDuringAllocation(ArrayWithContiguous); }
     Structure* originalRestParameterStructure() const { return originalArrayStructureForIndexingType(ArrayWithContiguous); }
 #if ENABLE(WEBASSEMBLY)

--- a/Source/JavaScriptCore/runtime/JSStringJoiner.h
+++ b/Source/JavaScriptCore/runtime/JSStringJoiner.h
@@ -28,6 +28,7 @@
 #include "ExceptionHelpers.h"
 #include "JSCJSValue.h"
 #include "JSGlobalObject.h"
+#include "JSString.h"
 
 namespace JSC {
 

--- a/Source/JavaScriptCore/runtime/JSType.cpp
+++ b/Source/JavaScriptCore/runtime/JSType.cpp
@@ -126,6 +126,7 @@ void printInternal(PrintStream& out, JSC::JSType type)
     CASE(JSRegExpStringIteratorType)
     CASE(JSAsyncFromSyncIteratorType)
     CASE(DisposableStackType)
+    CASE(AsyncDisposableStackType)
     }
 }
 

--- a/Source/JavaScriptCore/runtime/JSType.h
+++ b/Source/JavaScriptCore/runtime/JSType.h
@@ -112,6 +112,7 @@ namespace JSC {
     macro(WithScopeType, SpecObjectOther) \
     /* End JSScope types. */ \
     \
+    macro(AsyncDisposableStackType, SpecObjectOther) \
     macro(DisposableStackType, SpecObjectOther) \
     macro(ModuleNamespaceObjectType, SpecObjectOther) \
     macro(ShadowRealmType, SpecObjectOther) \

--- a/Source/JavaScriptCore/runtime/PageCount.h
+++ b/Source/JavaScriptCore/runtime/PageCount.h
@@ -27,6 +27,7 @@
 
 #include <algorithm>
 #include <limits.h>
+#include <wtf/MathExtras.h>
 
 namespace WTF {
 class PrintStream;

--- a/Source/JavaScriptCore/runtime/ProxyObject.cpp
+++ b/Source/JavaScriptCore/runtime/ProxyObject.cpp
@@ -26,11 +26,12 @@
 #include "config.h"
 #include "ProxyObject.h"
 
-#include <algorithm>
+#include "GetterSetter.h"
 #include "JSCInlines.h"
 #include "JSInternalFieldObjectImplInlines.h"
 #include "ObjectConstructor.h"
 #include "VMInlines.h"
+#include <algorithm>
 #include <wtf/NoTailCalls.h>
 #include <wtf/text/MakeString.h>
 

--- a/Source/JavaScriptCore/runtime/RegExpConstructor.h
+++ b/Source/JavaScriptCore/runtime/RegExpConstructor.h
@@ -20,6 +20,7 @@
 
 #pragma once
 
+#include "CommonIdentifiers.h"
 #include "InternalFunction.h"
 #include "RegExp.h"
 #include "RegExpCachedResult.h"


### PR DESCRIPTION
#### 852d9c1f1d614b0e2a6ded32836886712718695c
<pre>
[JSC] Add `AsyncDisposableStack` constructor from Explicit Resource Management Proposal
<a href="https://bugs.webkit.org/show_bug.cgi?id=293196">https://bugs.webkit.org/show_bug.cgi?id=293196</a>

Reviewed by Yusuke Suzuki.

This patch implements `AsyncDisposableStack` constructor[1] from Explicit
Resource Management Proposal[2].

[1]: <a href="https://tc39.es/proposal-explicit-resource-management/#sec-asyncdisposablestack">https://tc39.es/proposal-explicit-resource-management/#sec-asyncdisposablestack</a>
[2]: <a href="https://github.com/tc39/proposal-explicit-resource-management">https://github.com/tc39/proposal-explicit-resource-management</a>

* JSTests/stress/async-disposable-stack-constructor.js: Added.
(shouldBe):
(shouldThrow):
* JSTests/test262/config.yaml:
* Source/JavaScriptCore/CMakeLists.txt:
* Source/JavaScriptCore/Sources.txt:
* Source/JavaScriptCore/heap/Heap.h:
* Source/JavaScriptCore/heap/HeapSubspaceTypes.h:
* Source/JavaScriptCore/runtime/AsyncDisposableStackConstructor.cpp: Added.
(JSC::AsyncDisposableStackConstructor::createStructure):
(JSC::AsyncDisposableStackConstructor::create):
(JSC::AsyncDisposableStackConstructor::finishCreation):
(JSC::AsyncDisposableStackConstructor::visitChildrenImpl):
(JSC::AsyncDisposableStackConstructor::AsyncDisposableStackConstructor):
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/AsyncDisposableStackConstructor.h: Added.
* Source/JavaScriptCore/runtime/AsyncDisposableStackPrototype.cpp: Added.
(JSC::AsyncDisposableStackPrototype::finishCreation):
* Source/JavaScriptCore/runtime/AsyncDisposableStackPrototype.h: Added.
* Source/JavaScriptCore/runtime/AsyncDisposableStackPrototypeInlines.h: Added.
(JSC::AsyncDisposableStackPrototype::createStructure):
* Source/JavaScriptCore/runtime/ClonedArguments.h:
* Source/JavaScriptCore/runtime/CommonIdentifiers.h:
* Source/JavaScriptCore/runtime/JSAsyncDisposableStack.cpp: Added.
(JSC::JSAsyncDisposableStack::create):
(JSC::JSAsyncDisposableStack::finishCreation):
(JSC::JSAsyncDisposableStack::visitChildrenImpl):
* Source/JavaScriptCore/runtime/JSAsyncDisposableStack.h: Added.
* Source/JavaScriptCore/runtime/JSAsyncDisposableStackInlines.h: Added.
(JSC::JSAsyncDisposableStack::createStructure):
* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
(JSC::JSGlobalObject::init):
(JSC::JSGlobalObject::visitChildrenImpl):
* Source/JavaScriptCore/runtime/JSGlobalObject.h:
(JSC::JSGlobalObject::asyncDisposableStackStructure const):
* Source/JavaScriptCore/runtime/JSStringJoiner.h:
* Source/JavaScriptCore/runtime/JSType.cpp:
(WTF::printInternal):
* Source/JavaScriptCore/runtime/JSType.h:
* Source/JavaScriptCore/runtime/PageCount.h:
* Source/JavaScriptCore/runtime/RegExpConstructor.h:

Canonical link: <a href="https://commits.webkit.org/295523@main">https://commits.webkit.org/295523@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/de8de81ca20af9dac2514e0dcb2e527970db5e6a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105291 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25003 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15428 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110502 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/55946 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/25439 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33546 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79982 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108297 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19842 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95038 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60288 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/19597 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13111 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55345 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/97965 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/89298 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13155 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/113127 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/103909 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32450 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23912 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89057 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32813 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91253 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88695 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22635 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33585 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11373 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/27876 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32373 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/37785 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/128213 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32151 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/35050 "Found 2 new JSC stress test failures: wasm.yaml/wasm/gc/ref-i31-eq.js.default-wasm, wasm.yaml/wasm/gc/ref-i31-eq.js.wasm-eager-jettison (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35495 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33720 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->