### PR TITLE
[JSC] Accept `Unknown`/`Zzzz` in RegExp properties `Script` and `Script_Extensions`

### DIFF
--- a/JSTests/stress/regexp-property-escape-script-unknown.js
+++ b/JSTests/stress/regexp-property-escape-script-unknown.js
@@ -1,0 +1,19 @@
+function shouldBe(a, b) {
+    if (a !== b)
+        throw new Error(`Expected ${b} but got ${a}`);
+}
+
+const unknownChar = "\uE000";
+const knownChar = "A";
+
+shouldBe(/\p{Script=Unknown}/u.test(unknownChar), true);
+shouldBe(/\p{Script=Unknown}/u.test(knownChar), false);
+
+shouldBe(/\p{Script=Zzzz}/u.test(unknownChar), true);
+shouldBe(/\p{Script=Zzzz}/u.test(knownChar), false);
+
+shouldBe(/\p{Script_Extensions=Unknown}/u.test(unknownChar), true);
+shouldBe(/\p{Script_Extensions=Unknown}/u.test(knownChar), false);
+
+shouldBe(/\p{Script_Extensions=Zzzz}/u.test(unknownChar), true);
+shouldBe(/\p{Script_Extensions=Zzzz}/u.test(knownChar), false);

--- a/JSTests/test262/expectations.yaml
+++ b/JSTests/test262/expectations.yaml
@@ -76,9 +76,6 @@ test/built-ins/Proxy/construct/return-not-object-throws-undefined-realm.js:
 test/built-ins/Proxy/construct/trap-is-not-callable-realm.js:
   default: 'Test262Error: Expected a TypeError but got a different error constructor with the same name'
   strict mode: 'Test262Error: Expected a TypeError but got a different error constructor with the same name'
-test/built-ins/RegExp/property-escapes/special-property-value-Script_Extensions-Unknown.js:
-  default: 'SyntaxError: Invalid regular expression: invalid property expression'
-  strict mode: 'SyntaxError: Invalid regular expression: invalid property expression'
 test/built-ins/Temporal/Duration/compare/compare-no-precision-loss.js:
   default: 'Test262Error: Expected SameValue(«0», «0») to be false'
   strict mode: 'Test262Error: Expected SameValue(«0», «0») to be false'

--- a/Source/JavaScriptCore/yarr/generateYarrUnicodePropertyTables.py
+++ b/Source/JavaScriptCore/yarr/generateYarrUnicodePropertyTables.py
@@ -779,6 +779,8 @@ class Scripts:
             else:
                 self.unknownScript.addRange(lastAssignedCodePoint + 1, MaxUnicode)
 
+        self.scriptsByName["Unknown"] = self.unknownScript
+
         self.scriptsParsed = True
 
     def parseScriptExtensionsFile(self, file):


### PR DESCRIPTION
#### 69a8e21779b891c85dd094c292d9d7701310bfe2
<pre>
[JSC] Accept `Unknown`/`Zzzz` in RegExp properties `Script` and `Script_Extensions`
<a href="https://bugs.webkit.org/show_bug.cgi?id=293200">https://bugs.webkit.org/show_bug.cgi?id=293200</a>

Reviewed by Yusuke Suzuki.

Unicode TR 24[1][2] say the `Script` and `Script_Extensions` properties
must accept `Unknown` (alias `Zzzz`). But JSC currently rejects these escapes.

this patch adds support.

[1] <a href="https://www.unicode.org/reports/tr24/#Special_Explicit">https://www.unicode.org/reports/tr24/#Special_Explicit</a>
[2] <a href="https://www.unicode.org/reports/tr24/#Script_Extensions_Def">https://www.unicode.org/reports/tr24/#Script_Extensions_Def</a>

related test262 change: <a href="https://github.com/tc39/test262/pull/4473">https://github.com/tc39/test262/pull/4473</a>

* JSTests/stress/regexp-property-escape-script-unknown.js: Added.
(shouldBe):
* JSTests/test262/expectations.yaml:
* Source/JavaScriptCore/yarr/generateYarrUnicodePropertyTables.py:
(Scripts.parseScriptsFile):

Canonical link: <a href="https://commits.webkit.org/295253@main">https://commits.webkit.org/295253@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7860352d986d58b298490d97cd58945c26ff3023

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104051 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/23755 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/14075 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/109247 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/54718 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/24120 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/32299 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79042 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107057 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/18732 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/93856 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59371 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/18530 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/11906 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/54079 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/96726 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/88254 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/11964 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/111632 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/102662 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/31207 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23001 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88055 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/31571 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/90055 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87712 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22436 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32595 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10342 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/25644 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/31136 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/36448 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/126295 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/30929 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34929 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/34266 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/32490 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->