### PR TITLE
REGRESSION (294915@main): Can no longer enable log channels in debug builds

### DIFF
--- a/Source/WTF/wtf/LogChannels.cpp
+++ b/Source/WTF/wtf/LogChannels.cpp
@@ -61,14 +61,14 @@ void LogChannels::clearAllLogChannelsToAccumulate()
     m_logChannelsNeedInitialization = true;
 }
 
-void LogChannels::initializeLogChannelsIfNecessary(String&& logChannelString)
+void LogChannels::initializeLogChannelsIfNecessary(std::optional<String> logChannelString)
 {
-    if (!m_logChannelsNeedInitialization)
+    if (!m_logChannelsNeedInitialization && !logChannelString)
         return;
 
     m_logChannelsNeedInitialization = false;
 
-    String enabledChannelsString = !logChannelString.isEmpty() ? WTFMove(logChannelString) : logLevelString();
+    String enabledChannelsString = logChannelString ? logChannelString.value() : logLevelString();
     WTFInitializeLogChannelStatesFromString(m_logChannels.data(), m_logChannels.size(), enabledChannelsString.utf8().data());
 }
 

--- a/Source/WTF/wtf/LogChannels.h
+++ b/Source/WTF/wtf/LogChannels.h
@@ -42,7 +42,7 @@ public:
     WTF_EXPORT_PRIVATE bool isLogChannelEnabled(const String& name);
     WTF_EXPORT_PRIVATE void setLogChannelToAccumulate(const String& name);
     WTF_EXPORT_PRIVATE void clearAllLogChannelsToAccumulate();
-    WTF_EXPORT_PRIVATE void initializeLogChannelsIfNecessary(String&& = { });
+    WTF_EXPORT_PRIVATE void initializeLogChannelsIfNecessary(std::optional<String> = std::nullopt);
     WTF_EXPORT_PRIVATE WTFLogChannel* getLogChannel(const String& name);
 
 protected:

--- a/Source/WebKit/Shared/AuxiliaryProcess.cpp
+++ b/Source/WebKit/Shared/AuxiliaryProcess.cpp
@@ -240,9 +240,9 @@ void AuxiliaryProcess::shutDown()
 void AuxiliaryProcess::applyProcessCreationParameters(AuxiliaryProcessCreationParameters&& parameters)
 {
 #if !LOG_DISABLED || !RELEASE_LOG_DISABLED
-    WTF::logChannels().initializeLogChannelsIfNecessary(WTFMove(parameters.wtfLoggingChannels));
-    WebCore::logChannels().initializeLogChannelsIfNecessary(WTFMove(parameters.webCoreLoggingChannels));
-    WebKit::logChannels().initializeLogChannelsIfNecessary(WTFMove(parameters.webKitLoggingChannels));
+    WTF::logChannels().initializeLogChannelsIfNecessary(parameters.wtfLoggingChannels);
+    WebCore::logChannels().initializeLogChannelsIfNecessary(parameters.webCoreLoggingChannels);
+    WebKit::logChannels().initializeLogChannelsIfNecessary(parameters.webKitLoggingChannels);
 #endif
 #if PLATFORM(COCOA)
     SecureCoding::applyProcessCreationParameters(WTFMove(parameters));


### PR DESCRIPTION
#### 8a57bdea634b902c6fc749c9bc42fa7b55b40adc
<pre>
REGRESSION (294915@main): Can no longer enable log channels in debug builds
<a href="https://bugs.webkit.org/show_bug.cgi?id=293202">https://bugs.webkit.org/show_bug.cgi?id=293202</a>
<a href="https://rdar.apple.com/151564733">rdar://151564733</a>

Reviewed by Wenson Hsieh.

Revert the logging-related parts of 294915@main since they broke reading the
log channel string.

* Source/WTF/wtf/LogChannels.cpp:
(WTF::LogChannels::initializeLogChannelsIfNecessary):
* Source/WTF/wtf/LogChannels.h:
(WTF::LogChannels::initializeLogChannelsIfNecessary): Deleted.
* Source/WebKit/Shared/AuxiliaryProcess.cpp:
(WebKit::AuxiliaryProcess::applyProcessCreationParameters):

Canonical link: <a href="https://commits.webkit.org/295080@main">https://commits.webkit.org/295080@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/979f93e1319596d1ca4a9c8e78c757331e013a41

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104053 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/23757 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/14077 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/109249 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/54720 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/24123 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/32301 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79045 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107059 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/18735 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/93858 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59373 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/18535 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/11908 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/54081 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/96728 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/88257 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/11966 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/111634 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/102664 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/31209 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23003 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88057 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/31573 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/90057 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87714 "Found 101 new API test failures: /WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/invalid-sequence, /WebKitGTK/TestDownloads:/webkit/Downloads/blob-download, /WebKitGTK/TestUIClient:/webkit/WebKitWebView/mouse-target, /TestWebKit:WebKit.UserMediaBasic, /WebKitGTK/TestWebProcessExtensions:/webkit/WebKitWebProcessExtension/dom-input-element-is-user-edited, /WebKitGTK/TestDownloads:/webkit/Downloads/contex-menu-download-actions, /WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/cancel-sequence, /WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/is-playing-audio, /WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/page-visibility, /WebKitGTK/TestOptionMenu:/webkit/WebKitWebView/option-menu-select ... (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22323 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32597 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10344 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/25646 "Hash 979f93e1 for PR 45565 does not build (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/31138 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/36450 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/126297 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/30931 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34930 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/34268 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/32492 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->