### PR TITLE
[ iOS ] 9x TestWebKitAPI.DownloadProgress* (api-tests) are constant timeouts

### DIFF
--- a/Source/WebKit/NetworkProcess/Downloads/cocoa/DownloadCocoa.mm
+++ b/Source/WebKit/NetworkProcess/Downloads/cocoa/DownloadCocoa.mm
@@ -121,16 +121,18 @@ void Download::platformCancelNetworkLoad(CompletionHandler<void(std::span<const 
 void Download::platformDestroyDownload()
 {
 #if HAVE(MODERN_DOWNLOADPROGRESS)
-    m_bookmarkURL = nil;
-    [m_progress cancel];
-#else
+    if (enableModernDownloadProgress()) {
+        m_bookmarkURL = nil;
+        [m_progress cancel];
+        return;
+    }
+#endif
     if (m_progress)
 #if HAVE(NSPROGRESS_PUBLISHING_SPI)
         [m_progress _unpublish];
 #else
         [m_progress unpublish];
 #endif // HAVE(NSPROGRESS_PUBLISHING_SPI)
-#endif // HAVE(MODERN_DOWNLOADPROGRESS)
 }
 
 #if HAVE(MODERN_DOWNLOADPROGRESS)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/DownloadProgress.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/DownloadProgress.mm
@@ -399,12 +399,7 @@ static void* progressObservingContext = &progressObservingContext;
 // End-to-end test of subscribing to progress on a successful download. The client
 // should be able to receive an NSProgress that is updated as the download makes
 // progress, and the NSProgress should be unpublished when the download finishes.
-// FIXME rdar://145103161
-#if PLATFORM(IOS) && (__IPHONE_OS_VERSION_MIN_REQUIRED > 180000) && !defined(NDEBUG)
-TEST(DownloadProgress, DISABLED_BasicSubscriptionAndProgressUpdates)
-#else
 TEST(DownloadProgress, BasicSubscriptionAndProgressUpdates)
-#endif
 {
     auto testRunner = adoptNS([[DownloadProgressTestRunner alloc] init]);
 
@@ -428,12 +423,7 @@ TEST(DownloadProgress, BasicSubscriptionAndProgressUpdates)
 }
 
 // Similar test as before, but initiating the download before receiving its response.
-// FIXME rdar://145103161
-#if PLATFORM(IOS) && (__IPHONE_OS_VERSION_MIN_REQUIRED > 180000) && !defined(NDEBUG)
-TEST(DownloadProgress, DISABLED_StartDownloadFromNavigationAction)
-#else
 TEST(DownloadProgress, StartDownloadFromNavigationAction)
-#endif
 {
     auto testRunner = adoptNS([[DownloadProgressTestRunner alloc] init]);
 
@@ -449,12 +439,7 @@ TEST(DownloadProgress, StartDownloadFromNavigationAction)
 }
 
 // If the download is canceled, the progress should be unpublished.
-// FIXME rdar://145103161
-#if PLATFORM(IOS) && (__IPHONE_OS_VERSION_MIN_REQUIRED > 180000) && !defined(NDEBUG)
-TEST(DownloadProgress, DISABLED_LoseProgressWhenDownloadIsCanceled)
-#else
 TEST(DownloadProgress, LoseProgressWhenDownloadIsCanceled)
-#endif
 {
     auto testRunner = adoptNS([[DownloadProgressTestRunner alloc] init]);
 
@@ -470,12 +455,7 @@ TEST(DownloadProgress, LoseProgressWhenDownloadIsCanceled)
 }
 
 // If the download fails, the progress should be unpublished.
-// FIXME rdar://145103161
-#if PLATFORM(IOS) && (__IPHONE_OS_VERSION_MIN_REQUIRED > 180000) && !defined(NDEBUG)
-TEST(DownloadProgress, DISABLED_LoseProgressWhenDownloadFails)
-#else
 TEST(DownloadProgress, LoseProgressWhenDownloadFails)
-#endif
 {
     auto testRunner = adoptNS([[DownloadProgressTestRunner alloc] init]);
 
@@ -491,12 +471,7 @@ TEST(DownloadProgress, LoseProgressWhenDownloadFails)
 }
 
 // Canceling the progress should cancel the download.
-// FIXME rdar://145103161
-#if PLATFORM(IOS) && (__IPHONE_OS_VERSION_MIN_REQUIRED > 180000) && !defined(NDEBUG)
-TEST(DownloadProgress, DISABLED_CancelDownloadWhenProgressIsCanceled)
-#else
 TEST(DownloadProgress, CancelDownloadWhenProgressIsCanceled)
-#endif
 {
     auto testRunner = adoptNS([[DownloadProgressTestRunner alloc] init]);
 
@@ -526,12 +501,7 @@ TEST(DownloadProgress, PublishProgressAfterDownloadFinished)
 }
 
 // Test the behavior of a download of unknown length.
-// FIXME rdar://145103161
-#if PLATFORM(IOS) && (__IPHONE_OS_VERSION_MIN_REQUIRED > 180000) && !defined(NDEBUG)
-TEST(DownloadProgress, DISABLED_IndeterminateDownloadSize)
-#else
 TEST(DownloadProgress, IndeterminateDownloadSize)
-#endif
 {
     auto testRunner = adoptNS([[DownloadProgressTestRunner alloc] init]);
 
@@ -553,12 +523,7 @@ TEST(DownloadProgress, IndeterminateDownloadSize)
 }
 
 // Test the behavior when a download continues returning data beyond its expected length.
-// FIXME rdar://145103161
-#if PLATFORM(IOS) && (__IPHONE_OS_VERSION_MIN_REQUIRED > 180000) && !defined(NDEBUG)
-TEST(DownloadProgress, DISABLED_ExtraData)
-#else
 TEST(DownloadProgress, ExtraData)
-#endif
 {
     auto testRunner = adoptNS([[DownloadProgressTestRunner alloc] init]);
 
@@ -578,12 +543,7 @@ TEST(DownloadProgress, ExtraData)
 }
 
 // Clients should be able to publish progress on a download that has already started.
-// FIXME rdar://145103161
-#if PLATFORM(IOS) && (__IPHONE_OS_VERSION_MIN_REQUIRED > 180000) && !defined(NDEBUG)
-TEST(DownloadProgress, DISABLED_PublishProgressOnPartialDownload)
-#else
 TEST(DownloadProgress, PublishProgressOnPartialDownload)
-#endif
 {
     auto testRunner = adoptNS([[DownloadProgressTestRunner alloc] init]);
 
@@ -608,12 +568,7 @@ TEST(DownloadProgress, PublishProgressOnPartialDownload)
     [testRunner.get() tearDown];
 }
 
-// FIXME rdar://145103161
-#if PLATFORM(IOS) && (__IPHONE_OS_VERSION_MIN_REQUIRED > 180000) && !defined(NDEBUG)
-TEST(DownloadProgress, DISABLED_ProgressExtendedAttributeSetAfterPartialDownloadStops)
-#else
 TEST(DownloadProgress, ProgressExtendedAttributeSetAfterPartialDownloadStops)
-#endif
 {
     auto testRunner = adoptNS([[DownloadProgressTestRunner alloc] init]);
 


### PR DESCRIPTION
#### 16642e4b5679ba598bb8f840f186ac31da954057
<pre>
[ iOS ] 9x TestWebKitAPI.DownloadProgress* (api-tests) are constant timeouts
<a href="https://bugs.webkit.org/show_bug.cgi?id=293206">https://bugs.webkit.org/show_bug.cgi?id=293206</a>
<a href="https://rdar.apple.com/145103161">rdar://145103161</a>

Reviewed by Ryosuke Niwa.

In the simulator, Modern Download progress is not enabled, and we need to call NSProgress unpublish
in Download::platformDestroyDownload.

* Source/WebKit/NetworkProcess/Downloads/cocoa/DownloadCocoa.mm:
(WebKit::Download::platformDestroyDownload):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/DownloadProgress.mm:
(TEST(DownloadProgress, BasicSubscriptionAndProgressUpdates)):
(TEST(DownloadProgress, StartDownloadFromNavigationAction)):
(TEST(DownloadProgress, LoseProgressWhenDownloadIsCanceled)):
(TEST(DownloadProgress, LoseProgressWhenDownloadFails)):
(TEST(DownloadProgress, CancelDownloadWhenProgressIsCanceled)):
(TEST(DownloadProgress, IndeterminateDownloadSize)):
(TEST(DownloadProgress, ExtraData)):
(TEST(DownloadProgress, PublishProgressOnPartialDownload)):
(TEST(DownloadProgress, ProgressExtendedAttributeSetAfterPartialDownloadStops)):

Canonical link: <a href="https://commits.webkit.org/295104@main">https://commits.webkit.org/295104@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a8066991a514208aebd36f07e26e068bcdef4bf3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104056 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/23760 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/14080 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/109252 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/54723 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/106096 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/24127 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/32304 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79048 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107062 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/18737 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/93860 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59376 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/18538 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/11910 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/54084 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/88259 "Found 1 new API test failure: TestWebKitAPI.CARingBufferTest.FetchTimeBoundsConsistent (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/11968 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/111639 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/31212 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23005 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88061 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/31576 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/90059 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87718 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32598 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10346 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/25654 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16902 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/31141 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/36453 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/30934 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/34271 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/32495 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->