### PR TITLE
Use CGStyle-based filters for saturate() and hue-rotate() - dropped frames on fakecake.org

### DIFF
--- a/LayoutTests/css3/filters/effect-blur-hw.html
+++ b/LayoutTests/css3/filters/effect-blur-hw.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <meta name="fuzzy" content="maxDifference=0-54; totalPixels=0-61800">
+    <meta name="fuzzy" content="maxDifference=0-99; totalPixels=0-61800">
     <link rel="stylesheet" href="resources/filter-helpers.css">
     <style>
         img {

--- a/LayoutTests/css3/filters/effect-brightness-hw.html
+++ b/LayoutTests/css3/filters/effect-brightness-hw.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <meta name="fuzzy" content="maxDifference=0-100; totalPixels=0-41000">
+    <meta name="fuzzy" content="maxDifference=0-186; totalPixels=0-41100">
     <link rel="stylesheet" href="resources/filter-helpers.css">
     <style>
         img {

--- a/LayoutTests/css3/filters/effect-combined.html
+++ b/LayoutTests/css3/filters/effect-combined.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <meta name="fuzzy" content="maxDifference=0-20; totalPixels=0-600" />
+    <meta name="fuzzy" content="maxDifference=0-20; totalPixels=0-26400" />
     <link rel="stylesheet" href="resources/filter-helpers.css">
     <script src="resources/filter-helpers.js"></script>
 </head>

--- a/LayoutTests/css3/filters/effect-grayscale-hw.html
+++ b/LayoutTests/css3/filters/effect-grayscale-hw.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <meta name="fuzzy" content="maxDifference=0-54; totalPixels=0-33000">
+    <meta name="fuzzy" content="maxDifference=0-99; totalPixels=0-33050">
     <link rel="stylesheet" href="resources/filter-helpers.css">
     <style>
         img {

--- a/LayoutTests/css3/filters/effect-hue-rotate-hw.html
+++ b/LayoutTests/css3/filters/effect-hue-rotate-hw.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <meta name="fuzzy" content="maxDifference=0-68; totalPixels=0-22400">
+    <meta name="fuzzy" content="maxDifference=0-123; totalPixels=0-22400">
     <link rel="stylesheet" href="resources/filter-helpers.css">
     <style>
         img {

--- a/LayoutTests/css3/filters/effect-hue-rotate.html
+++ b/LayoutTests/css3/filters/effect-hue-rotate.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <meta name="fuzzy" content="maxDifference=0-48; totalPixels=0-2500">
+    <meta name="fuzzy" content="maxDifference=0-48; totalPixels=0-55700">
     <link rel="stylesheet" href="resources/filter-helpers.css">
     <script src="resources/filter-helpers.js"></script>
 </head>

--- a/LayoutTests/css3/filters/effect-invert-hw.html
+++ b/LayoutTests/css3/filters/effect-invert-hw.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <meta name="fuzzy" content="maxDifference=0-54; totalPixels=0-40300" />
+    <meta name="fuzzy" content="maxDifference=0-99; totalPixels=0-40410" />
     <link rel="stylesheet" href="resources/filter-helpers.css">
     <style>
         img {

--- a/LayoutTests/css3/filters/effect-opacity-hw.html
+++ b/LayoutTests/css3/filters/effect-opacity-hw.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <meta name="fuzzy" content="maxDifference=0-54; totalPixels=0-29200">
+    <meta name="fuzzy" content="maxDifference=0-99; totalPixels=0-29200">
     <link rel="stylesheet" href="resources/filter-helpers.css">
     <style>
         img {

--- a/LayoutTests/css3/filters/effect-saturate.html
+++ b/LayoutTests/css3/filters/effect-saturate.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <meta name="fuzzy" content="maxDifference=0-48; totalPixels=0-2500">
+    <meta name="fuzzy" content="maxDifference=0-48; totalPixels=0-33200">
     <link rel="stylesheet" href="resources/filter-helpers.css">
     <script src="resources/filter-helpers.js"></script>
 </head>

--- a/LayoutTests/css3/filters/effect-sepia-hw.html
+++ b/LayoutTests/css3/filters/effect-sepia-hw.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <meta name="fuzzy" content="maxDifference=0-54; totalPixels=0-36800">
+    <meta name="fuzzy" content="maxDifference=0-99; totalPixels=0-36800">
     <link rel="stylesheet" href="resources/filter-helpers.css">
     <style>
         img {

--- a/LayoutTests/css3/filters/invalid-reference-filter-in-chain.html
+++ b/LayoutTests/css3/filters/invalid-reference-filter-in-chain.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<meta name="fuzzy" content="maxDifference=1; totalPixels=25600" />
+<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-40000" />
 <html>
 <head>
 <style>

--- a/LayoutTests/css3/filters/resources/filter-helpers.css
+++ b/LayoutTests/css3/filters/resources/filter-helpers.css
@@ -1,5 +1,6 @@
 img {
     margin: 10px;
+    image-rendering: crisp-edges;
 }
 
 svg {

--- a/LayoutTests/fast/filter-image/filter-image.html
+++ b/LayoutTests/fast/filter-image/filter-image.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-5000" />
+<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-7500" />
 <style>
 div {
     width: 50px;

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2611,6 +2611,7 @@ platform/graphics/filters/FilterFunction.cpp
 platform/graphics/filters/FilterImage.cpp
 platform/graphics/filters/FilterOperation.cpp
 platform/graphics/filters/FilterOperations.cpp
+platform/graphics/filters/FilterRenderingMode.cpp
 platform/graphics/filters/FilterResults.cpp
 platform/graphics/filters/PointLightSource.cpp
 platform/graphics/filters/SourceAlpha.cpp

--- a/Source/WebCore/platform/graphics/GraphicsStyle.h
+++ b/Source/WebCore/platform/graphics/GraphicsStyle.h
@@ -66,7 +66,7 @@ struct GraphicsGaussianBlur {
 };
 
 struct GraphicsColorMatrix {
-    std::array<float, 20> values;
+    std::array<float, 20> values; // Really a ColorMatrix<5, 4>.
 
     friend bool operator==(const GraphicsColorMatrix&, const GraphicsColorMatrix&) = default;
 };

--- a/Source/WebCore/platform/graphics/filters/FilterRenderingMode.cpp
+++ b/Source/WebCore/platform/graphics/filters/FilterRenderingMode.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc.  All rights reserved.
+ * Copyright (C) 2025 Apple Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,24 +23,21 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
-
-#include <wtf/OptionSet.h>
+#include "config.h"
+#include "FilterRenderingMode.h"
 
 namespace WebCore {
 
-enum class FilterRenderingMode : uint8_t {
-    Software        = 1 << 0,
-    Accelerated     = 1 << 1,
-    GraphicsContext = 1 << 2
-};
+TextStream& operator<<(TextStream& ts, FilterRenderingMode mode)
+{
+    switch (mode) {
+    case FilterRenderingMode::Software: ts << "Software"; break;
+    case FilterRenderingMode::Accelerated: ts << "Accelerated"; break;
+    case FilterRenderingMode::GraphicsContext: ts << "GraphicsContext"; break;
+    }
 
-constexpr OptionSet<FilterRenderingMode> allFilterRenderingModes = {
-    FilterRenderingMode::Software,
-    FilterRenderingMode::Accelerated,
-    FilterRenderingMode::GraphicsContext
-};
+    return ts;
+}
 
-WTF::TextStream& operator<<(WTF::TextStream&, FilterRenderingMode);
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.cpp
@@ -35,6 +35,7 @@
 #include "GLContext.h"
 #include "ImageBuffer.h"
 #include "IntRect.h"
+#include "NativeImage.h"
 #include "NotImplemented.h"
 #include "PlatformDisplay.h"
 #include "ProcessCapabilities.h"

--- a/Source/WebCore/platform/gtk/DragImageGtk.cpp
+++ b/Source/WebCore/platform/gtk/DragImageGtk.cpp
@@ -21,6 +21,7 @@
 
 #include "Element.h"
 #include "Image.h"
+#include "NativeImage.h"
 #include "TextFlags.h"
 #include "TextIndicator.h"
 #include <cairo.h>

--- a/Source/WebCore/rendering/CSSFilter.cpp
+++ b/Source/WebCore/rendering/CSSFilter.cpp
@@ -59,9 +59,10 @@ RefPtr<CSSFilter> CSSFilter::create(RenderElement& renderer, const FilterOperati
         return nullptr;
     }
 
-    LOG_WITH_STREAM(Filters, stream << "CSSFilter::create built filter " << filter.get() << " for " << operations);
-
     filter->setFilterRenderingModes(preferredFilterRenderingModes);
+
+    LOG_WITH_STREAM(Filters, stream << "CSSFilter::create built filter " << filter.get() << " for " << operations << " supported rendering mode(s) " << filter->filterRenderingModes());
+
     return filter;
 }
 


### PR DESCRIPTION
#### e664737f1d2f8c6567134999415c930933336cd1
<pre>
Use CGStyle-based filters for saturate() and hue-rotate() - dropped frames on fakecake.org
<a href="https://bugs.webkit.org/show_bug.cgi?id=293212">https://bugs.webkit.org/show_bug.cgi?id=293212</a>
<a href="https://rdar.apple.com/148338705">rdar://148338705</a>

Reviewed by Sam Weinig.

The code in `FEColorMatrix::supportedFilterRenderingModes()` caused fallback to `FilterRenderingMode::Software`
for `hue-rotate()` and `saturate()` filters, because we didn&apos;t have code that converted these to a color matrix.
However, that code exists in ColorMatrix, so we can use it.

I attempted to have GraphicsColorMatrix own a ColorMatrix&lt;5, 4&gt;, but that isn&apos;t easily IPC-encodable. Instead,
add a `ColorMatrix` constructors that takes a span, and make the variadic constructor limited to numeric types.

* LayoutTests/css3/filters/effect-blur-hw.html:
* LayoutTests/css3/filters/effect-brightness-hw.html:
* LayoutTests/css3/filters/effect-combined.html:
* LayoutTests/css3/filters/effect-grayscale-hw.html:
* LayoutTests/css3/filters/effect-hue-rotate-hw.html:
* LayoutTests/css3/filters/effect-hue-rotate.html:
* LayoutTests/css3/filters/effect-invert-hw.html:
* LayoutTests/css3/filters/effect-opacity-hw.html:
* LayoutTests/css3/filters/effect-saturate.html:
* LayoutTests/css3/filters/effect-sepia-hw.html:
* LayoutTests/css3/filters/invalid-reference-filter-in-chain.html:
* LayoutTests/css3/filters/resources/filter-helpers.css: Use image-rendering: crisp-edges to reduce noise on iOS where images get scaled.
* LayoutTests/fast/filter-image/filter-image.html:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/graphics/ColorMatrix.h:
(WebCore::ColorMatrix::ColorMatrix):
(WebCore::ColorMatrix::data const):
(WebCore::to5x4Matrix):
* Source/WebCore/platform/graphics/GraphicsStyle.h:
* Source/WebCore/platform/graphics/filters/FEColorMatrix.cpp:
(WebCore::FEColorMatrix::supportedFilterRenderingModes const):
(WebCore::FEColorMatrix::createGraphicsStyle const):
* Source/WebCore/platform/graphics/filters/FilterRenderingMode.cpp: Copied from Source/WebCore/platform/graphics/filters/FilterRenderingMode.h.
(WebCore::operator&lt;&lt;): Make FilterRenderingMode streamable.
* Source/WebCore/platform/graphics/filters/FilterRenderingMode.h:
* Source/WebCore/rendering/CSSFilter.cpp:
(WebCore::CSSFilter::create): Log the rendering mode.

Canonical link: <a href="https://commits.webkit.org/295269@main">https://commits.webkit.org/295269@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/306eabae697c6133b3321f2dbc7a154496936f5f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104583 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24293 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/14711 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/109794 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/55254 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/106623 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/24679 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/32838 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79416 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107589 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19191 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94388 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59728 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/18971 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/12463 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/54627 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/88670 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/12515 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/112184 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/31744 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23367 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88495 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32108 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/90622 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88114 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22448 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33017 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10786 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/27061 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/31671 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/37012 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/31463 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/34802 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33023 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->