### PR TITLE
[Page color sampling] Extended top color should remain stable while scrolling

### DIFF
--- a/LayoutTests/fast/page-color-sampling/color-sampling-fixed-popup-expected.txt
+++ b/LayoutTests/fast/page-color-sampling/color-sampling-fixed-popup-expected.txt
@@ -1,0 +1,12 @@
+PASS edgeColorsBeforeUnparenting.top is "rgb(100, 100, 100)"
+PASS edgeColorsBeforeUnparenting.left is "rgb(100, 100, 100)"
+PASS edgeColorsBeforeUnparenting.right is "rgb(100, 100, 100)"
+PASS edgeColorsBeforeUnparenting.bottom is "rgb(100, 100, 100)"
+PASS edgeColorsAfterUnparenting.top is null
+PASS edgeColorsAfterUnparenting.left is null
+PASS edgeColorsAfterUnparenting.right is null
+PASS edgeColorsAfterUnparenting.bottom is null
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/page-color-sampling/color-sampling-fixed-popup.html
+++ b/LayoutTests/fast/page-color-sampling/color-sampling-fixed-popup.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true pageTopColorSamplingEnabled=true useFlexibleViewport=true ] -->
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <style>
+        body, html {
+            width: 100%;
+            height: 100%;
+            margin: 0;
+            font-family: system-ui;
+        }
+
+        .popup {
+            position: fixed;
+            top: 0;
+            bottom: 0;
+            left: 0;
+            right: 0;
+        }
+
+        .popup-content {
+            background: rgb(100, 100, 100);
+            width: 100%;
+            height: 100%;
+        }
+    </style>
+    <script src="../../resources/js-test.js"></script>
+    <script src="../../resources/ui-helper.js"></script>
+    <script>
+    jsTestIsAsync = true;
+
+    addEventListener("load", async () => {
+        await UIHelper.setObscuredInsets(50, 50, 50, 50);
+        await UIHelper.ensurePresentationUpdate();
+        edgeColorsBeforeUnparenting = await UIHelper.fixedContainerEdgeColors();
+        shouldBeEqualToString("edgeColorsBeforeUnparenting.top", "rgb(100, 100, 100)");
+        shouldBeEqualToString("edgeColorsBeforeUnparenting.left", "rgb(100, 100, 100)");
+        shouldBeEqualToString("edgeColorsBeforeUnparenting.right", "rgb(100, 100, 100)");
+        shouldBeEqualToString("edgeColorsBeforeUnparenting.bottom", "rgb(100, 100, 100)");
+
+        document.querySelector(".popup").remove();
+        edgeColorsAfterUnparenting = await UIHelper.fixedContainerEdgeColors();
+        shouldBeNull("edgeColorsAfterUnparenting.top");
+        shouldBeNull("edgeColorsAfterUnparenting.left");
+        shouldBeNull("edgeColorsAfterUnparenting.right");
+        shouldBeNull("edgeColorsAfterUnparenting.bottom");
+
+        finishJSTest();
+    });
+    </script>
+</head>
+<body>
+<div class="popup">
+    <div class="popup-content"></div>
+</div>
+<div class="tall"></div>
+</body>
+</html>

--- a/LayoutTests/fast/page-color-sampling/color-sampling-ignores-non-fixed-content-expected.txt
+++ b/LayoutTests/fast/page-color-sampling/color-sampling-ignores-non-fixed-content-expected.txt
@@ -1,5 +1,5 @@
 PASS colorBeforeFading.top is "rgba(255, 100, 0, 0.8)"
-PASS colorAfterFading.top is null
+PASS colorAfterFading.top is "rgba(255, 100, 0, 0.8)"
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/page-color-sampling/color-sampling-ignores-non-fixed-content.html
+++ b/LayoutTests/fast/page-color-sampling/color-sampling-ignores-non-fixed-content.html
@@ -48,7 +48,7 @@
         colorAfterFading = await UIHelper.fixedContainerEdgeColors();
 
         shouldBeEqualToString("colorBeforeFading.top", "rgba(255, 100, 0, 0.8)");
-        shouldBeNull("colorAfterFading.top");
+        shouldBeEqualToString("colorAfterFading.top", "rgba(255, 100, 0, 0.8)");
         finishJSTest();
     });
     </script>

--- a/LayoutTests/fast/page-color-sampling/color-sampling-in-position-sticky-expected.txt
+++ b/LayoutTests/fast/page-color-sampling/color-sampling-in-position-sticky-expected.txt
@@ -2,7 +2,7 @@ PASS colorsBeforeScrolling.top is "rgb(250, 60, 0)"
 PASS colorsBeforeScrolling.left is null
 PASS colorsBeforeScrolling.right is null
 PASS colorsBeforeScrolling.bottom is null
-PASS colorsAfterScrolling.top is null
+PASS colorsAfterScrolling.top is "rgb(250, 60, 0)"
 PASS colorsAfterScrolling.left is null
 PASS colorsAfterScrolling.right is null
 PASS colorsAfterScrolling.bottom is null

--- a/LayoutTests/fast/page-color-sampling/color-sampling-in-position-sticky.html
+++ b/LayoutTests/fast/page-color-sampling/color-sampling-in-position-sticky.html
@@ -63,7 +63,7 @@
         await UIHelper.ensurePresentationUpdate();
 
         colorsAfterScrolling = await UIHelper.fixedContainerEdgeColors();
-        shouldBeNull("colorsAfterScrolling.top");
+        shouldBeEqualToString("colorsAfterScrolling.top", "rgb(250, 60, 0)");
         shouldBeNull("colorsAfterScrolling.left");
         shouldBeNull("colorsAfterScrolling.right");
         shouldBeNull("colorsAfterScrolling.bottom");

--- a/Source/WebCore/page/LocalFrameView.h
+++ b/Source/WebCore/page/LocalFrameView.h
@@ -364,7 +364,7 @@ public:
     // and adjusting for page scale.
     LayoutPoint scrollPositionForFixedPosition() const;
 
-    WEBCORE_EXPORT FixedContainerEdges fixedContainerEdges(BoxSideSet) const;
+    WEBCORE_EXPORT std::pair<FixedContainerEdges, WeakElementEdges> fixedContainerEdges(BoxSideSet) const;
     
     // Static function can be called from another thread.
     WEBCORE_EXPORT static LayoutPoint scrollPositionForFixedPosition(const LayoutRect& visibleContentRect, const LayoutSize& totalContentsSize, const LayoutPoint& scrollPosition, const LayoutPoint& scrollOrigin, float frameScaleFactor, bool fixedElementsLayoutRelativeToFrame, ScrollBehaviorForFixedElements, int headerHeight, int footerHeight);

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -238,6 +238,7 @@ using SharedStringHash = uint32_t;
 
 enum class ActivityState : uint16_t;
 enum class AdvancedPrivacyProtections : uint16_t;
+enum class BoxSide : uint8_t;
 enum class BoxSideFlag : uint8_t;
 enum class CanWrap : bool;
 enum class ContentSecurityPolicyModeForExtension : uint8_t;
@@ -354,6 +355,7 @@ constexpr auto allRenderingUpdateSteps = updateRenderingSteps | OptionSet<Render
 #endif
 };
 
+using WeakElementEdges = RectEdges<WeakPtr<Element, WeakPtrImplWithEventTargetData>>;
 
 class Page : public RefCountedAndCanMakeWeakPtr<Page>, public Supplementable<Page> {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(Page, WEBCORE_EXPORT);
@@ -909,8 +911,8 @@ public:
     WEBCORE_EXPORT Color sampledPageTopColor() const;
 
     WEBCORE_EXPORT void updateFixedContainerEdges(OptionSet<BoxSideFlag>);
-    const FixedContainerEdges& fixedContainerEdges() const { return m_fixedContainerEdges; }
     Color lastTopFixedContainerColor() const;
+    const FixedContainerEdges& fixedContainerEdges() const { return m_fixedContainerEdgesAndElements.first; }
 
 #if ENABLE(WEB_PAGE_SPATIAL_BACKDROP)
     WEBCORE_EXPORT std::optional<SpatialBackdropSource> spatialBackdropSource() const;
@@ -1709,7 +1711,7 @@ private:
 
     Color m_underPageBackgroundColorOverride;
     std::optional<Color> m_sampledPageTopColor;
-    UniqueRef<FixedContainerEdges> m_fixedContainerEdges;
+    std::pair<UniqueRef<FixedContainerEdges>, WeakElementEdges> m_fixedContainerEdgesAndElements;
 
     const bool m_httpsUpgradeEnabled { true };
     mutable Markable<MediaSessionGroupIdentifier> m_mediaSessionGroupIdentifier;


### PR DESCRIPTION
#### d7a1e8219fecc4cdd17d2d530357402a6b6480a2
<pre>
[Page color sampling] Extended top color should remain stable while scrolling
<a href="https://bugs.webkit.org/show_bug.cgi?id=293209">https://bugs.webkit.org/show_bug.cgi?id=293209</a>
<a href="https://rdar.apple.com/151422381">rdar://151422381</a>

Reviewed by Abrar Rahman Protyasha.

Fine-tune the page color sampling/fixed color extension heuristic again, to maintain stability for
sampled viewport-constrained containers, even if those containers are no longer present along the
edges of the viewport.

* LayoutTests/fast/page-color-sampling/color-sampling-fixed-popup-expected.txt: Added.
* LayoutTests/fast/page-color-sampling/color-sampling-fixed-popup.html: Added.

Add a layout test to verify that the sampled colors reset after removing an element that covers the
entire viewport.

* LayoutTests/fast/page-color-sampling/color-sampling-ignores-non-fixed-content-expected.txt:
* LayoutTests/fast/page-color-sampling/color-sampling-ignores-non-fixed-content.html:
* LayoutTests/fast/page-color-sampling/color-sampling-in-position-sticky-expected.txt:
* LayoutTests/fast/page-color-sampling/color-sampling-in-position-sticky.html:

Rebaseline a couple of existing tests to reflect the fact that the sampled fixed color now lingers
around, even if the sampled element no longer intersects with the edge of the viewport.

* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::fixedContainerEdges const):
* Source/WebCore/page/LocalFrameView.h:
* Source/WebCore/page/Page.cpp:
(WebCore::m_fixedContainerEdgesAndElements):

Turn this into a pair of fixed container edges (i.e. color sampling results per edge) and `WeakPtr`
to an Element, per edge. See `fixedContainerEdges` below.

(WebCore::Page::didCommitLoad):
(WebCore::Page::updateFixedContainerEdges):
(WebCore::Page::lastTopFixedContainerColor const):
* Source/WebCore/page/Page.h:
(WebCore::Page::fixedContainerEdges const):

In the case where color sampling finds no fixed edge but the previous color sampling result found a
fixed edge, carry over the previous result as long as the viewport-constrained container element
hit-tested by the previous result is still in the DOM and rendered.

Canonical link: <a href="https://commits.webkit.org/295099@main">https://commits.webkit.org/295099@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4460baee80b5a3ed903ed0de00a402f913dbd747

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104065 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/23769 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/14089 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/109261 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/54732 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/106105 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/24136 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/32313 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79054 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107071 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/18744 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/93869 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59382 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/18545 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/11918 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/54093 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/88267 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/11976 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/111647 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/31221 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23013 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88065 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/31585 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/90067 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87722 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22335 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32604 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10354 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/25665 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/31150 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/36462 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/30944 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/34280 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/32504 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->