### PR TITLE
Include layer clones in backingStoreMemoryEstimate

### DIFF
--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
@@ -5254,16 +5254,21 @@ double GraphicsLayerCA::backingStoreMemoryEstimate() const
         return 0;
 
     // contentsLayer is given to us, so we don't really know anything about its contents.
-    // FIXME: ignores layer clones.
-    
-    if (TiledBacking* tiledBacking = this->tiledBacking())
-        return tiledBacking->retainedTileBackingStoreMemory();
+    double memoryEstimate = 0;
 
-    if (!backingStoreAttached())
-        return 0;
+    if (TiledBacking* tiledBacking = this->tiledBacking()) {
+        memoryEstimate += tiledBacking->retainedTileBackingStoreMemory();
+    } else if (backingStoreAttached()) {
+        Ref layer = *m_layer;
+        memoryEstimate += layer->backingStoreBytesPerPixel() * size().width() * layer->contentsScale() * size().height() * layer->contentsScale();
+    }
 
-    Ref layer = *m_layer;
-    return layer->backingStoreBytesPerPixel() * size().width() * layer->contentsScale() * size().height() * layer->contentsScale();
+    // Note: Clones share the same backing store contents with the original layer (they don't
+    // have separate backing stores), so we don't count their memory separately to avoid double-counting.
+    // The clones copy contents from the original layer via copyContentsFromLayer() when the original
+    // layer updates, but this is just sharing references to the same underlying backing store.
+
+    return memoryEstimate;
 }
 
 Vector<std::pair<String, double>> GraphicsLayerCA::acceleratedAnimationsForTesting(const Settings& settings) const


### PR DESCRIPTION
#### 4376e117672607dc57fb8f13d209b003b0277564
<pre>
Include layer clones in backingStoreMemoryEstimate
<a href="https://bugs.webkit.org/show_bug.cgi?id=293217">https://bugs.webkit.org/show_bug.cgi?id=293217</a>
<a href="https://rdar.apple.com/151591592">rdar://151591592</a>

Reviewed by NOBODY (OOPS!).

We should include the layer clones backingStore memory in the estimate
in the same way that we calculate it for the main layer. We only
need to include primaryLayerClones since those are the only ones
that can have backing stores attached.

* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp:
(WebCore::GraphicsLayerCA::ensureStructuralLayer):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4376e117672607dc57fb8f13d209b003b0277564

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/119084 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/38765 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/29416 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/125300 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/71147 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/41854799-9ea2-4fa7-8e8f-634790fc22b6) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/120962 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/39461 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/47347 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/90417 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/59861 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c26ded5c-d66c-4f8b-83d4-9bfead27e13c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/122037 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31458 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106755 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70878 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/88588835-88f5-4a3f-9aca-624b0ea152f4) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/30520 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/24871 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/68951 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100905 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25054 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/128325 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/45991 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/34754 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/99036 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/46358 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102972 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98816 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/44273 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/22275 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/42570 "Hash 4376e117 for PR 45574 does not build (failure)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/45861 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/51541 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/45328 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/48674 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/47013 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->