### PR TITLE
Prune leaf PlatformCA layers from the CoreAnimation tree when possible

### DIFF
--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
@@ -2148,6 +2148,44 @@ void GraphicsLayerCA::commitLayerChangesBeforeSublayers(CommitState& commitState
 {
     SetForScope committingChangesChange(m_isCommittingChanges, true);
 
+    // zakr: intial list of layers that can be pruned and removed (need to refine it and add better animation checks)
+    // For now, must be a leaf, not intersecting the coverage rect, and not currently running a transform animation.
+    // ideas:
+    // - add a "safe area" around the viewport for non visible tiles/layers that likely will enter the viewport soon,
+    // so we dont have too much churn from pruning and unpruning layers.
+    // - dont prune layers that have video or media.
+    // - we might be introducing some extra work when we have to prune then unprune some layers again and again, so
+    // we can probably be a lot smarter about pruning layers (like maybe only if we're dealing with >1k layers etc,
+    // or this layer has been eligible for pruning for the past 10 flushes)
+    bool isLeafLayer = children().isEmpty();
+    bool shouldBePruned = isLeafLayer && !m_intersectsCoverageRect && !isRunningTransformAnimation();
+
+    if (shouldBePruned != m_isPrunedFromCATree) {
+        m_isPrunedFromCATree = shouldBePruned;
+        layerChanged = true;
+
+        if (m_isPrunedFromCATree) {
+            RefPtr<PlatformCALayer> platformLayerToRemove = layerForSuperlayer();
+            if (platformLayerToRemove && platformLayerToRemove->superlayer())
+                platformLayerToRemove->removeFromSuperlayer();
+
+            if (m_layer)
+                m_layer->setBackingStoreAttached(false);
+
+        } else { // unprune the layer, mark all the flags as dirty so all the updated properties are correct when we add it back to the CA tree
+            noteLayerPropertyChanged(GeometryChanged | TransformChanged | ChildrenTransformChanged
+                | Preserves3DChanged | MasksToBoundsChanged | DrawsContentChanged
+                | BackgroundColorChanged | ContentsOpaqueChanged | BackfaceVisibilityChanged
+                | OpacityChanged | FiltersChanged | BackdropFiltersChanged | BlendModeChanged
+                | ShapeChanged | ContentsRectsChanged | ContentsScaleChanged | ContentsVisibilityChanged
+                | DebugIndicatorsChanged
+                , DontScheduleFlush); // need to refine this list more
+        }
+
+        if (parent())
+            downcast<GraphicsLayerCA>(*parent()).noteLayerPropertyChanged(ChildrenChanged, DontScheduleFlush);
+    }
+
     if (!m_uncommittedChanges) {
         // Ensure that we cap layer depth in commitLayerChangesAfterSublayers().
         if (commitState.treeDepth > cMaxLayerTreeDepth)
@@ -2406,8 +2444,13 @@ void GraphicsLayerCA::updateSublayerList(bool maxLayerDepthReached)
     };
 
     auto appendLayersFromChildren = [&](PlatformCALayerList& list) {
-        for (Ref child : children())
-            list.append(downcast<GraphicsLayerCA>(child)->layerForSuperlayer());
+        for (Ref childGraphicsLayer : children()) {
+            Ref childCA = downcast<GraphicsLayerCA>(childGraphicsLayer.get());
+            if (!childCA->m_isPrunedFromCATree) {
+                if (PlatformCALayer* platformLayerOfChild = childCA->layerForSuperlayer())
+                    list.append(platformLayerOfChild);
+            }
+        }
     };
 
     auto appendDebugLayers = [&](PlatformCALayerList& list) {
@@ -3000,6 +3043,8 @@ void GraphicsLayerCA::updateCoverage(const CommitState& commitState)
         || !allowsBackingStoreDetaching()
         || commitState.ancestorWithTransformAnimationIntersectsCoverageRect // FIXME: Compute backing exactly for descendants of animating layers.
         || (isRunningTransformAnimation() && !animationExtent()); // Create backing if we don't know the animation extent.
+    if (m_isPrunedFromCATree)
+        requiresBacking = false; // if we've pruned this layer, we definitely dont need a backing store.
 
 #if !LOG_DISABLED
     if (requiresBacking) {
@@ -5022,6 +5067,9 @@ void GraphicsLayerCA::propagateLayerChangeToReplicas(ScheduleFlushOrNot schedule
 
 RefPtr<PlatformCALayer> GraphicsLayerCA::fetchCloneLayers(GraphicsLayer* replicaRoot, ReplicaState& replicaState, CloneLevel cloneLevel)
 {
+    if (m_isPrunedFromCATree)
+        return nullptr;
+
     RefPtr<PlatformCALayer> primaryLayer;
     RefPtr<PlatformCALayer> structuralLayer;
     RefPtr<PlatformCALayer> contentsLayer;

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h
@@ -731,6 +731,8 @@ private:
     FloatSize m_sizeAtLastCoverageRectUpdate;
     FloatSize m_pixelAlignmentOffset;
 
+    bool m_isPrunedFromCATree { false };
+
     Color m_contentsSolidColor;
 
     TileCoverage m_tileCoverage;


### PR DESCRIPTION
#### 838a7b514b2c0dfc445c24f82adc63ce29721063
<pre>
Prune leaf PlatformCA layers from the CoreAnimation tree when possible
<a href="https://bugs.webkit.org/show_bug.cgi?id=293218">https://bugs.webkit.org/show_bug.cgi?id=293218</a>
<a href="https://rdar.apple.com/151592961">rdar://151592961</a>

Reviewed by NOBODY (OOPS!).

WIP

In some scenarios, similar to when we detach backing stores for some layers,
we can get away with removing some platform layers from the CA tree.

Some situations where this can be done:
- off screen leaf layers that aren&apos;t involved in complex 3D transformations or animations
- any layer that we have decided doesn&apos;t need a backing store is generally safe to prune from the tree

We should remove these from the tree and not commit them to CoreAnimation whenever possible.

Local testing shows a big drop in number of layers we&apos;re committing to CoreAnimation.

* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp:
(WebCore::GraphicsLayerCA::commitLayerChangesBeforeSublayers):
(WebCore::GraphicsLayerCA::updateSublayerList):
(WebCore::GraphicsLayerCA::ensureStructuralLayer):
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/838a7b514b2c0dfc445c24f82adc63ce29721063

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121617 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41314 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31973 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/128113 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/73707 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/67a821e1-3bc3-45c5-8454-9a1f643c885f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/123493 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/42025 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49905 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92403 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61459 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4063ff35-6bf0-4d62-ac37-fca081fda236) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124569 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33543 "Found 2 new test failures: compositing/backing/animate-into-view-with-descendant.html compositing/backing/transform-transition-from-outside-view.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108928 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73062 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b07f07f7-83b2-414d-a176-94e40d6c3d04) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32557 "Found 1 new test failure: imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/custom-property.html (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/27098 "Found 4 new test failures: compositing/backing/animate-into-view-with-descendant.html compositing/backing/transform-transition-from-outside-view.html fast/scrolling/anchor-overscroll-fixed.html imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-fixed-scroll.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71650 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/103039 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27290 "Found 23 new test failures: compositing/backing/animate-into-view-with-descendant.html compositing/backing/transform-transition-from-outside-view.html css1/basic/comments.html fast/css/view-transitions-scrolling-position-fixed.html http/tests/site-isolation/page-zoom.html http/tests/site-isolation/text-zoom.html imported/blink/compositing/overflow/body-switch-composited-scrolling.html imported/blink/fast/overflow/scroll-html-hidden-body.html imported/w3c/web-platform-tests/css/compositing/root-element-filter.html imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-escape-scroller-004.html ... (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130918 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48551 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36940 "Found 60 new test failures: accessibility/mac/media-query-values-change.html accessibility/mac/menu-item-values.html accessibility/menu-item-crash.html accessibility/visible-character-range-basic.html animations/3d/transform-perspective.html animations/fill-mode-forwards2.html compositing/backing/animate-into-view-with-descendant.html compositing/backing/backing-store-attachment-animating-outside-viewport.html compositing/backing/backing-store-attachment-scroll.html compositing/backing/transform-transition-from-outside-view.html ... (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100978 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48923 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105145 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100867 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46268 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24363 "Found 23 new test failures: compositing/backing/animate-into-view-with-descendant.html compositing/backing/transform-transition-from-outside-view.html css1/basic/comments.html fast/css/view-transitions-scrolling-position-fixed.html http/tests/site-isolation/page-zoom.html http/tests/site-isolation/text-zoom.html imported/blink/compositing/overflow/body-switch-composited-scrolling.html imported/blink/fast/overflow/scroll-html-hidden-body.html imported/w3c/web-platform-tests/css/compositing/root-element-filter.html imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-escape-scroller-004.html ... (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/45252 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48408 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/54128 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47879 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/51228 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49562 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->