### PR TITLE
Remove SelectionAPIForShadowDOMEnabled preference

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -6588,20 +6588,6 @@ SelectTrailingWhitespaceEnabled:
     WebCore:
       default: false
 
-SelectionAPIForShadowDOMEnabled:
-  type: bool
-  status: stable
-  category: dom
-  humanReadableName: "Selection API for shadow DOM"
-  humanReadableDescription: "Enable selection API for shadow DOM"
-  defaultValue:
-    WebKit:
-      default: true
-    WebKitLegacy:
-      default: true
-    WebCore:
-      default: true
-
 SelectionFlippingEnabled:
   type: bool
   status: embedder

--- a/Source/WebCore/page/DOMSelection.cpp
+++ b/Source/WebCore/page/DOMSelection.cpp
@@ -236,7 +236,7 @@ ExceptionOr<void> DOMSelection::collapse(Node* node, unsigned offset)
         }
         if (auto result = Range::checkNodeOffsetPair(*node, offset); result.hasException())
             return result.releaseException();
-        if (!(frame->settings().selectionAPIForShadowDOMEnabled() && node->isConnected() && frame->document() == &node->document())
+        if (!(node->isConnected() && frame->document() == &node->document())
             && &node->rootNode() != frame->document())
             return { };
     } else {
@@ -300,13 +300,8 @@ ExceptionOr<void> DOMSelection::setBaseAndExtent(Node* baseNode, unsigned baseOf
         if (auto result = Range::checkNodeOffsetPair(*extentNode, extentOffset); result.hasException())
             return result.releaseException();
         Ref document = *frame->document();
-        if (frame->settings().selectionAPIForShadowDOMEnabled()) {
-            if (!document->isShadowIncludingInclusiveAncestorOf(baseNode) || !document->isShadowIncludingInclusiveAncestorOf(extentNode))
-                return { };
-        } else {
-            if (!document->contains(*baseNode) || !document->contains(*extentNode))
-                return { };
-        }
+        if (!document->isShadowIncludingInclusiveAncestorOf(baseNode) || !document->isShadowIncludingInclusiveAncestorOf(extentNode))
+            return { };
     } else {
         if (!isValidForPosition(baseNode) || !isValidForPosition(extentNode))
             return { };
@@ -380,8 +375,7 @@ ExceptionOr<void> DOMSelection::extend(Node& node, unsigned offset)
         return Exception { ExceptionCode::InvalidStateError, "extend() requires a Range to be added to the Selection"_s };
 
     if (frame->settings().liveRangeSelectionEnabled()) {
-        if (!(frame->settings().selectionAPIForShadowDOMEnabled() && node.isConnected() && frame->document() == &node.document())
-            && &node.rootNode() != frame->document())
+        if (!(node.isConnected() && frame->document() == &node.document()) && &node.rootNode() != frame->document())
             return { };
         if (auto result = Range::checkNodeOffsetPair(node, offset); result.hasException())
             return result.releaseException();

--- a/Source/WebCore/page/DOMSelection.idl
+++ b/Source/WebCore/page/DOMSelection.idl
@@ -42,14 +42,14 @@
     readonly attribute unsigned long rangeCount;
 
     readonly attribute DOMString type;
-    [EnabledBySetting=SelectionAPIForShadowDOMEnabled] readonly attribute DOMString direction;
+    readonly attribute DOMString direction;
 
     Range getRangeAt(unsigned long index);
     undefined addRange(Range range);
     [EnabledBySetting=LiveRangeSelectionEnabled] undefined removeRange(Range range);
     undefined removeAllRanges();
 
-    [EnabledBySetting=SelectionAPIForShadowDOMEnabled] sequence<StaticRange> getComposedRanges(optional (ShadowRoot or GetComposedRangesOptions) options, ShadowRoot... shadowRoots);
+    sequence<StaticRange> getComposedRanges(optional (ShadowRoot or GetComposedRangesOptions) options, ShadowRoot... shadowRoots);
 
     undefined empty();
 


### PR DESCRIPTION
#### 45f9055b17aa13e82460112a630f90ea7c795df6
<pre>
Remove SelectionAPIForShadowDOMEnabled preference
<a href="https://bugs.webkit.org/show_bug.cgi?id=293219">https://bugs.webkit.org/show_bug.cgi?id=293219</a>

Reviewed by Ryosuke Niwa.

It&apos;s been enabled on main for two years. As of 263033@main.

Canonical link: <a href="https://commits.webkit.org/295102@main">https://commits.webkit.org/295102@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/15300958a219b0adb64a2ff5fd88c68314ec9aaf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104077 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/23781 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/14101 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/109273 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/54745 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/106117 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/24148 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/32325 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79072 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107083 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/18755 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/93884 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59399 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/18557 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/11930 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/54105 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/96752 "Built successfully and passed tests") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/88278 "Found 1 new API test failure: TestWebKitAPI.CARingBufferTest.FetchTimeBoundsConsistent (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/11988 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/111659 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/102688 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/31233 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23025 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88081 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/31597 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/90079 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87738 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32617 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10366 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/25679 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16900 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/31162 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/36474 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/126321 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/30956 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34934 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/34292 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/32516 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->