### PR TITLE
Allow RealtimeMediaSource audio sample observers to allocate buffers before observing audio samples

### DIFF
--- a/Source/WebCore/platform/mediastream/RealtimeMediaSource.h
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSource.h
@@ -230,6 +230,8 @@ public:
     bool echoCancellation() const { return m_echoCancellation; }
     void setEchoCancellation(bool);
 
+    virtual const AudioStreamDescription* audioStreamDescription() const;
+
     virtual const RealtimeMediaSourceCapabilities& capabilities() = 0;
     virtual const RealtimeMediaSourceSettings& settings() = 0;
 
@@ -501,6 +503,11 @@ inline void RealtimeMediaSource::setCanUseIOSurface()
     m_canUseIOSurface = true;
 }
 #endif
+
+inline const AudioStreamDescription* RealtimeMediaSource::audioStreamDescription() const
+{
+    return nullptr;
+}
 
 } // namespace WebCore
 

--- a/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.cpp
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.cpp
@@ -379,6 +379,13 @@ void CoreAudioCaptureSource::echoCancellationChanged()
     configurationChanged();
 }
 
+const AudioStreamDescription* CoreAudioCaptureSource::audioStreamDescription() const
+{
+    if (!CoreAudioSharedUnit::singleton().microphoneProcFormat())
+        return nullptr;
+    return &CoreAudioSharedUnit::singleton().microphoneProcFormat().value();
+}
+
 } // namespace WebCore
 
 #endif // ENABLE(MEDIA_STREAM)

--- a/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.h
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.h
@@ -88,6 +88,7 @@ private:
 #endif
 
     std::optional<Vector<int>> discreteSampleRates() const final { return { { 8000, 16000, 32000, 44100, 48000, 96000 } }; }
+    const AudioStreamDescription* audioStreamDescription() const final;
 
     const RealtimeMediaSourceCapabilities& capabilities() final;
     const RealtimeMediaSourceSettings& settings() final;

--- a/Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.h
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.h
@@ -129,6 +129,8 @@ public:
     WEBCORE_EXPORT void setMuteStatusChangedCallback(Function<void(bool)>&&);
     void handleMuteStatusChangedNotification(bool);
 
+    const std::optional<CAAudioStreamDescription>& microphoneProcFormat() const { return m_microphoneProcFormat; }
+
 private:
     CoreAudioSharedUnit();
 

--- a/Source/WebCore/platform/mediastream/mac/RealtimeOutgoingAudioSourceCocoa.h
+++ b/Source/WebCore/platform/mediastream/mac/RealtimeOutgoingAudioSourceCocoa.h
@@ -62,6 +62,7 @@ private:
     bool hasBufferedEnoughData() final;
     void sourceUpdated() final;
 
+    void updateSampleConverter(const AudioStreamDescription&);
     void pullAudioData();
 
     Ref<AudioSampleDataSource> m_sampleConverter;

--- a/Source/WebKit/WebProcess/cocoa/RemoteCaptureSampleManager.cpp
+++ b/Source/WebKit/WebProcess/cocoa/RemoteCaptureSampleManager.cpp
@@ -244,6 +244,7 @@ void RemoteCaptureSampleManager::RemoteAudio::setStorage(ConsumerSharedCARingBuf
     m_startTime = mediaTime;
     m_frameChunkSize = frameChunkSize;
     m_buffer = makeUnique<WebAudioBufferList>(description, m_frameChunkSize);
+    m_source->setDescription(description);
     startThread();
 }
 

--- a/Source/WebKit/WebProcess/cocoa/RemoteRealtimeAudioSource.cpp
+++ b/Source/WebKit/WebProcess/cocoa/RemoteRealtimeAudioSource.cpp
@@ -64,6 +64,19 @@ void RemoteRealtimeAudioSource::setIsInBackground(bool value)
     connection().send(Messages::UserMediaCaptureManagerProxy::SetIsInBackground { identifier(), value }, 0);
 }
 
+void RemoteRealtimeAudioSource::setDescription(const WebCore::CAAudioStreamDescription& description)
+{
+    m_description = description;
+}
+
+const WebCore::AudioStreamDescription* RemoteRealtimeAudioSource::audioStreamDescription() const
+{
+    if (!m_description)
+        return nullptr;
+
+    return &m_description.value();
+}
+
 }
 
 #endif

--- a/Source/WebKit/WebProcess/cocoa/RemoteRealtimeAudioSource.h
+++ b/Source/WebKit/WebProcess/cocoa/RemoteRealtimeAudioSource.h
@@ -28,6 +28,7 @@
 #if PLATFORM(COCOA) && ENABLE(MEDIA_STREAM)
 
 #include "RemoteRealtimeMediaSource.h"
+#include <WebCore/CAAudioStreamDescription.h>
 
 namespace WebKit {
 
@@ -37,11 +38,15 @@ public:
     ~RemoteRealtimeAudioSource();
 
     void remoteAudioSamplesAvailable(const WTF::MediaTime&, const WebCore::PlatformAudioData&, const WebCore::AudioStreamDescription&, size_t);
+    void setDescription(const WebCore::CAAudioStreamDescription&);
 
 private:
     RemoteRealtimeAudioSource(WebCore::RealtimeMediaSourceIdentifier, const WebCore::CaptureDevice&, const WebCore::MediaConstraints*, WebCore::MediaDeviceHashSalts&&, UserMediaCaptureManager&, bool shouldCaptureInGPUProcess, std::optional<WebCore::PageIdentifier>);
 
     void setIsInBackground(bool) final;
+    const WebCore::AudioStreamDescription* audioStreamDescription() const final;
+
+    std::optional<WebCore::CAAudioStreamDescription> m_description;
 };
 
 } // namespace WebKit


### PR DESCRIPTION
#### 6b7339d689be6671b117c4349133b96fe8b8e001
<pre>
Allow RealtimeMediaSource audio sample observers to allocate buffers before observing audio samples
<a href="https://rdar.apple.com/151596713">rdar://151596713</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=293220">https://bugs.webkit.org/show_bug.cgi?id=293220</a>

Reviewed by Jean-Yves Avenard.

Allow getting the audio sample description from the RealtimeMediaSource.
By default, RealtimeMediaSource will receive nullptr if it does not know this description.

Observers can get this description to preallocate audio buffers for processing.
This limits allocation in the audio thread to the case of a audio format change during observation.

We implement this for CoreAudioCaptureSource and make use of it in  RealtimeOutgoingAudioSourceCocoa and UserMediaCaptureManagerProxy.

Covered by existing tests.

* Source/WebCore/platform/mediastream/RealtimeMediaSource.h:
* Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.cpp:
(WebCore::CoreAudioCaptureSource::audioStreamDescription const):
* Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.h:
* Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.h:
* Source/WebCore/platform/mediastream/mac/RealtimeOutgoingAudioSourceCocoa.cpp:
(WebCore::RealtimeOutgoingAudioSourceCocoa::RealtimeOutgoingAudioSourceCocoa):
(WebCore::RealtimeOutgoingAudioSourceCocoa::updateSampleConverter):
(WebCore::RealtimeOutgoingAudioSourceCocoa::audioSamplesAvailable):
(WebCore::RealtimeOutgoingAudioSourceCocoa::pullAudioData):
(WebCore::RealtimeOutgoingAudioSourceCocoa::sourceUpdated):
* Source/WebCore/platform/mediastream/mac/RealtimeOutgoingAudioSourceCocoa.h:
* Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.cpp:
(WebKit::UserMediaCaptureManagerProxy::createMediaSourceForCaptureDeviceWithConstraints):
* Source/WebKit/WebProcess/cocoa/RemoteCaptureSampleManager.cpp:
(WebKit::RemoteCaptureSampleManager::RemoteAudio::setStorage):
* Source/WebKit/WebProcess/cocoa/RemoteRealtimeAudioSource.cpp:
(WebKit::RemoteRealtimeAudioSource::setDescription):
(WebKit::RemoteRealtimeAudioSource::audioStreamDescription const):
* Source/WebKit/WebProcess/cocoa/RemoteRealtimeAudioSource.h:

Canonical link: <a href="https://commits.webkit.org/295329@main">https://commits.webkit.org/295329@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/946635b27060a8186ad9a574ff3f365cc7063f1a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104256 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/23960 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/14349 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/109456 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/54924 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/106296 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/24586 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/32506 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79185 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107262 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19126 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94084 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59513 "Passed tests") | 
| | [💥 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/18907 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/12141 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/54284 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/88609 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/12202 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/111838 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/31412 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23243 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88207 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/31777 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/90310 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87870 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22492 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32760 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10521 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/25879 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/31341 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/36654 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/31135 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/34471 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/32695 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->