### PR TITLE
Remove HyperlinkAuditingEnabled preference

### DIFF
--- a/LayoutTests/http/tests/app-privacy-report/app-attribution-ping-load.html
+++ b/LayoutTests/http/tests/app-privacy-report/app-attribution-ping-load.html
@@ -7,7 +7,6 @@
 if (window.testRunner && window.internals) {
     testRunner.dumpAsText();
     testRunner.setStatisticsShouldDowngradeReferrer(false, function () { });
-    internals.settings.setHyperlinkAuditingEnabled(true);
     testRunner.waitUntilDone();
 }
 

--- a/LayoutTests/http/tests/app-privacy-report/user-attribution-ping-load.html
+++ b/LayoutTests/http/tests/app-privacy-report/user-attribution-ping-load.html
@@ -7,7 +7,6 @@
 if (window.testRunner && window.internals) {
     testRunner.dumpAsText();
     testRunner.setStatisticsShouldDowngradeReferrer(false, function () { });
-    internals.settings.setHyperlinkAuditingEnabled(true);
     testRunner.waitUntilDone();
 }
 

--- a/LayoutTests/http/tests/contentextensions/block-cookies-in-ping.html
+++ b/LayoutTests/http/tests/contentextensions/block-cookies-in-ping.html
@@ -3,7 +3,6 @@
 if (window.testRunner && window.internals) {
     testRunner.dumpAsText();
     testRunner.dumpChildFramesAsText();
-    internals.settings.setHyperlinkAuditingEnabled(true);
     testRunner.waitUntilDone();
 }
 

--- a/LayoutTests/http/tests/contentextensions/block-ping-resource-type-ping.html
+++ b/LayoutTests/http/tests/contentextensions/block-ping-resource-type-ping.html
@@ -3,7 +3,6 @@
 if (window.testRunner && window.internals) {
     testRunner.dumpAsText();
     testRunner.dumpChildFramesAsText();
-    internals.settings.setHyperlinkAuditingEnabled(true);
     testRunner.waitUntilDone();
 }
 

--- a/LayoutTests/http/tests/contentextensions/block-ping-resource-type-raw.html
+++ b/LayoutTests/http/tests/contentextensions/block-ping-resource-type-raw.html
@@ -3,7 +3,6 @@
 if (window.testRunner && window.internals) {
     testRunner.dumpAsText();
     testRunner.dumpChildFramesAsText();
-    internals.settings.setHyperlinkAuditingEnabled(true);
     testRunner.waitUntilDone();
 }
 

--- a/LayoutTests/http/tests/contentextensions/block-ping.html
+++ b/LayoutTests/http/tests/contentextensions/block-ping.html
@@ -3,7 +3,6 @@
 if (window.testRunner && window.internals) {
     testRunner.dumpAsText();
     testRunner.dumpChildFramesAsText();
-    internals.settings.setHyperlinkAuditingEnabled(true);
     testRunner.waitUntilDone();
 }
 

--- a/LayoutTests/http/tests/contentextensions/hide-on-ping-with-ping-that-redirects.html
+++ b/LayoutTests/http/tests/contentextensions/hide-on-ping-with-ping-that-redirects.html
@@ -3,7 +3,6 @@
 if (window.testRunner && window.internals) {
     testRunner.dumpAsText();
     testRunner.dumpChildFramesAsText();
-    internals.settings.setHyperlinkAuditingEnabled(true);
     testRunner.waitUntilDone();
 }
 

--- a/LayoutTests/http/tests/contentextensions/hide-on-ping.html
+++ b/LayoutTests/http/tests/contentextensions/hide-on-ping.html
@@ -3,7 +3,6 @@
 if (window.testRunner && window.internals) {
     testRunner.dumpAsText();
     testRunner.dumpChildFramesAsText();
-    internals.settings.setHyperlinkAuditingEnabled(true);
     testRunner.waitUntilDone();
 }
 

--- a/LayoutTests/http/tests/inspector/network/ping-type.html
+++ b/LayoutTests/http/tests/inspector/network/ping-type.html
@@ -4,9 +4,6 @@
 <meta charset="utf-8">
 <script src="../resources/inspector-test.js"></script>
 <script>
-if (window.testRunner && window.internals)
-    internals.settings.setHyperlinkAuditingEnabled(true);
-
 async function clickElement(element) {
     let x = element.offsetLeft + 2;
     let y = element.offsetTop + 2;

--- a/LayoutTests/http/tests/navigation/ping-attribute/anchor-cookie.html
+++ b/LayoutTests/http/tests/navigation/ping-attribute/anchor-cookie.html
@@ -5,7 +5,6 @@
 <script>
 if (window.testRunner && window.internals) {
     testRunner.dumpAsText();
-    internals.settings.setHyperlinkAuditingEnabled(true);
     testRunner.waitUntilDone();
 }
 

--- a/LayoutTests/http/tests/navigation/ping-attribute/anchor-cross-origin-from-https-UpgradeMixedContent.html
+++ b/LayoutTests/http/tests/navigation/ping-attribute/anchor-cross-origin-from-https-UpgradeMixedContent.html
@@ -19,7 +19,6 @@ function test() {
     if (!testCalled) {
         if (window.testRunner && window.internals) {
             testRunner.dumpAsText();
-            internals.settings.setHyperlinkAuditingEnabled(true);
             testRunner.waitUntilDone();
         }
         testCalled = true;

--- a/LayoutTests/http/tests/navigation/ping-attribute/anchor-cross-origin-from-https.html
+++ b/LayoutTests/http/tests/navigation/ping-attribute/anchor-cross-origin-from-https.html
@@ -19,7 +19,6 @@ function test() {
     if (!testCalled) {
         if (window.testRunner && window.internals) {
             testRunner.dumpAsText();
-            internals.settings.setHyperlinkAuditingEnabled(true);
             testRunner.waitUntilDone();
         }
         testCalled = true;

--- a/LayoutTests/http/tests/navigation/ping-attribute/anchor-cross-origin.html
+++ b/LayoutTests/http/tests/navigation/ping-attribute/anchor-cross-origin.html
@@ -12,7 +12,6 @@ function test() {
         if (window.testRunner && window.internals) {
             testRunner.setStatisticsShouldDowngradeReferrer(false, function () { });
             testRunner.dumpAsText();
-            internals.settings.setHyperlinkAuditingEnabled(true);
             testRunner.waitUntilDone();
         }
         testCalled = true;

--- a/LayoutTests/http/tests/navigation/ping-attribute/anchor-ping-and-follow-redirect-when-sending-ping.html
+++ b/LayoutTests/http/tests/navigation/ping-attribute/anchor-ping-and-follow-redirect-when-sending-ping.html
@@ -5,7 +5,6 @@
 <script>
 if (window.testRunner && window.internals) {
     testRunner.dumpAsText();
-    internals.settings.setHyperlinkAuditingEnabled(true);
     testRunner.waitUntilDone();
 }
 

--- a/LayoutTests/http/tests/navigation/ping-attribute/anchor-same-origin.html
+++ b/LayoutTests/http/tests/navigation/ping-attribute/anchor-same-origin.html
@@ -11,7 +11,6 @@ function test() {
     if (!testCalled) {
         if (window.testRunner && window.internals) {
             testRunner.dumpAsText();
-            internals.settings.setHyperlinkAuditingEnabled(true);
             testRunner.waitUntilDone();
         }
         testCalled = true;

--- a/LayoutTests/http/tests/navigation/ping-attribute/area-cookie.html
+++ b/LayoutTests/http/tests/navigation/ping-attribute/area-cookie.html
@@ -5,7 +5,6 @@
 <script>
 if (window.testRunner && window.internals) {
     testRunner.dumpAsText();
-    internals.settings.setHyperlinkAuditingEnabled(true);
     testRunner.waitUntilDone();
 }
 

--- a/LayoutTests/http/tests/navigation/ping-attribute/area-cross-origin-from-https-UpgradeMixedContent.html
+++ b/LayoutTests/http/tests/navigation/ping-attribute/area-cross-origin-from-https-UpgradeMixedContent.html
@@ -5,7 +5,6 @@
 <script>
 if (window.testRunner && window.internals) {
     testRunner.dumpAsText();
-    internals.settings.setHyperlinkAuditingEnabled(true);
     testRunner.waitUntilDone();
 }
 

--- a/LayoutTests/http/tests/navigation/ping-attribute/area-cross-origin-from-https.html
+++ b/LayoutTests/http/tests/navigation/ping-attribute/area-cross-origin-from-https.html
@@ -5,7 +5,6 @@
 <script>
 if (window.testRunner && window.internals) {
     testRunner.dumpAsText();
-    internals.settings.setHyperlinkAuditingEnabled(true);
     testRunner.waitUntilDone();
 }
 

--- a/LayoutTests/http/tests/navigation/ping-attribute/area-cross-origin.html
+++ b/LayoutTests/http/tests/navigation/ping-attribute/area-cross-origin.html
@@ -6,7 +6,6 @@
 if (window.testRunner && window.internals) {
     testRunner.dumpAsText();
     testRunner.setStatisticsShouldDowngradeReferrer(false, function () { });
-    internals.settings.setHyperlinkAuditingEnabled(true);
     testRunner.waitUntilDone();
 }
 

--- a/LayoutTests/http/tests/navigation/ping-attribute/area-same-origin.html
+++ b/LayoutTests/http/tests/navigation/ping-attribute/area-same-origin.html
@@ -5,7 +5,6 @@
 <script>
 if (window.testRunner && window.internals) {
     testRunner.dumpAsText();
-    internals.settings.setHyperlinkAuditingEnabled(true);
     testRunner.waitUntilDone();
 }
 

--- a/LayoutTests/http/tests/navigation/ping-attribute/secure-anchor-cross-origin-UpgradeMixedContent.html
+++ b/LayoutTests/http/tests/navigation/ping-attribute/secure-anchor-cross-origin-UpgradeMixedContent.html
@@ -3,7 +3,6 @@
     if (window.testRunner && window.internals) {
         testRunner.setStatisticsShouldDowngradeReferrer(false, function () { });
         testRunner.dumpAsText();
-        internals.settings.setHyperlinkAuditingEnabled(true);
         testRunner.waitUntilDone();
     }
     let destination = new URL('resources/secure-anchor-cross-origin.html', window.location);

--- a/LayoutTests/http/tests/navigation/ping-attribute/secure-anchor-cross-origin.html
+++ b/LayoutTests/http/tests/navigation/ping-attribute/secure-anchor-cross-origin.html
@@ -3,7 +3,6 @@
     if (window.testRunner && window.internals) {
         testRunner.setStatisticsShouldDowngradeReferrer(false, function () { });
         testRunner.dumpAsText();
-        internals.settings.setHyperlinkAuditingEnabled(true);
         testRunner.waitUntilDone();
     }
     let destination = new URL('resources/secure-anchor-cross-origin.html', window.location);

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -3327,19 +3327,6 @@ HostedBlurMaterialInMediaControlsEnabled:
     WebCore:
       default: false
 
-HyperlinkAuditingEnabled:
-  type: bool
-  status: embedder
-  humanReadableName: "Hyperlink Auditing"
-  humanReadableDescription: "Enable Hyperlink Auditing"
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: false
-
 ICECandidateFilteringEnabled:
   type: bool
   status: internal

--- a/Source/WebCore/html/HTMLAnchorElement.cpp
+++ b/Source/WebCore/html/HTMLAnchorElement.cpp
@@ -339,9 +339,6 @@ void HTMLAnchorElement::sendPings(const URL& destinationURL)
     if (!document().frame())
         return;
 
-    if (!document().settings().hyperlinkAuditingEnabled())
-        return;
-
     const auto& pingValue = attributeWithoutSynchronization(pingAttr);
     if (pingValue.isNull())
         return;

--- a/Source/WebKit/UIProcess/API/C/WKPreferences.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKPreferences.cpp
@@ -184,16 +184,6 @@ bool WKPreferencesGetJavaScriptCanOpenWindowsAutomatically(WKPreferencesRef pref
     return toProtectedImpl(preferencesRef)->javaScriptCanOpenWindowsAutomatically();
 }
 
-void WKPreferencesSetHyperlinkAuditingEnabled(WKPreferencesRef preferencesRef, bool hyperlinkAuditingEnabled)
-{
-    toProtectedImpl(preferencesRef)->setHyperlinkAuditingEnabled(hyperlinkAuditingEnabled);
-}
-
-bool WKPreferencesGetHyperlinkAuditingEnabled(WKPreferencesRef preferencesRef)
-{
-    return toProtectedImpl(preferencesRef)->hyperlinkAuditingEnabled();
-}
-
 void WKPreferencesSetStandardFontFamily(WKPreferencesRef preferencesRef, WKStringRef family)
 {
     toProtectedImpl(preferencesRef)->setStandardFontFamily(toWTFString(family));
@@ -1712,6 +1702,15 @@ bool WKPreferencesGetRequestVideoFrameCallbackEnabled(WKPreferencesRef preferenc
 
 
 // The following are all deprecated and do nothing. They should be removed when possible.
+
+void WKPreferencesSetHyperlinkAuditingEnabled(WKPreferencesRef, bool)
+{
+}
+
+bool WKPreferencesGetHyperlinkAuditingEnabled(WKPreferencesRef)
+{
+    return true;
+}
 
 void WKPreferencesSetDNSPrefetchingEnabled(WKPreferencesRef, bool)
 {

--- a/Source/WebKit/UIProcess/API/C/WKPreferencesRef.h
+++ b/Source/WebKit/UIProcess/API/C/WKPreferencesRef.h
@@ -91,10 +91,6 @@ WK_EXPORT bool WKPreferencesGetDatabasesEnabled(WKPreferencesRef preferences);
 WK_EXPORT void WKPreferencesSetJavaScriptCanOpenWindowsAutomatically(WKPreferencesRef preferences, bool javaScriptCanOpenWindowsAutomatically);
 WK_EXPORT bool WKPreferencesGetJavaScriptCanOpenWindowsAutomatically(WKPreferencesRef preferences);
 
-// Defaults to true.
-WK_EXPORT void WKPreferencesSetHyperlinkAuditingEnabled(WKPreferencesRef preferences, bool hyperlinkAuditingEnabled);
-WK_EXPORT bool WKPreferencesGetHyperlinkAuditingEnabled(WKPreferencesRef preferences);
-
 WK_EXPORT void WKPreferencesSetStandardFontFamily(WKPreferencesRef preferencesRef, WKStringRef family);
 WK_EXPORT WKStringRef WKPreferencesCopyStandardFontFamily(WKPreferencesRef preferencesRef);
 
@@ -309,10 +305,12 @@ WK_EXPORT void WKPreferencesSetRequestVideoFrameCallbackEnabled(WKPreferencesRef
 
 // The following are all deprecated and do nothing. They should be removed when possible.
 
-WK_EXPORT void WKPreferencesSetDNSPrefetchingEnabled(WKPreferencesRef, bool);
-WK_EXPORT bool WKPreferencesGetDNSPrefetchingEnabled(WKPreferencesRef);
-WK_EXPORT bool WKPreferencesGetRestrictedHTTPResponseAccess(WKPreferencesRef);
-WK_EXPORT void WKPreferencesSetRestrictedHTTPResponseAccess(WKPreferencesRef, bool);
+WK_EXPORT void WKPreferencesSetHyperlinkAuditingEnabled(WKPreferencesRef, bool) WK_C_API_DEPRECATED;
+WK_EXPORT bool WKPreferencesGetHyperlinkAuditingEnabled(WKPreferencesRef) WK_C_API_DEPRECATED;
+WK_EXPORT void WKPreferencesSetDNSPrefetchingEnabled(WKPreferencesRef, bool) WK_C_API_DEPRECATED;
+WK_EXPORT bool WKPreferencesGetDNSPrefetchingEnabled(WKPreferencesRef) WK_C_API_DEPRECATED;
+WK_EXPORT bool WKPreferencesGetRestrictedHTTPResponseAccess(WKPreferencesRef) WK_C_API_DEPRECATED;
+WK_EXPORT void WKPreferencesSetRestrictedHTTPResponseAccess(WKPreferencesRef, bool) WK_C_API_DEPRECATED;
 WK_EXPORT void WKPreferencesSetOfflineWebApplicationCacheEnabled(WKPreferencesRef, bool) WK_C_API_DEPRECATED;
 WK_EXPORT bool WKPreferencesGetOfflineWebApplicationCacheEnabled(WKPreferencesRef) WK_C_API_DEPRECATED;
 WK_EXPORT void WKPreferencesSetXSSAuditorEnabled(WKPreferencesRef, bool) WK_C_API_DEPRECATED;

--- a/Source/WebKit/UIProcess/API/glib/WebKitSettings.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitSettings.cpp
@@ -824,14 +824,16 @@ static void webkit_settings_class_init(WebKitSettingsClass* klass)
      *
      * The hyperlink auditing specification is available at
      * http://www.whatwg.org/specs/web-apps/current-work/multipage/links.html#hyperlink-auditing.
+     *
+     * Deprecated: 2.50
      */
     sObjProperties[PROP_ENABLE_HYPERLINK_AUDITING] =
         g_param_spec_boolean(
             "enable-hyperlink-auditing",
             _("Enable hyperlink auditing"),
             _("Whether <a ping> should be able to send pings."),
-            FEATURE_DEFAULT(HyperlinkAuditingEnabled),
-            readWriteConstructParamFlags);
+            TRUE,
+            static_cast<GParamFlags>(readWriteConstructParamFlags | G_PARAM_DEPRECATED));
 
     /**
      * WebKitSettings:default-font-family:
@@ -2147,12 +2149,16 @@ void webkit_settings_set_javascript_can_open_windows_automatically(WebKitSetting
  * Get the #WebKitSettings:enable-hyperlink-auditing property.
  *
  * Returns: %TRUE If hyper link auditing is enabled or %FALSE otherwise.
+ *
+ * Deprecated: 2.50.
  */
 gboolean webkit_settings_get_enable_hyperlink_auditing(WebKitSettings* settings)
 {
     g_return_val_if_fail(WEBKIT_IS_SETTINGS(settings), FALSE);
 
-    return settings->priv->preferences->hyperlinkAuditingEnabled();
+    g_warning("webkit_settings_get_enable_hyperlink_auditing is deprecated and always returns FALSE.");
+
+    return FALSE;
 }
 
 /**
@@ -2161,18 +2167,15 @@ gboolean webkit_settings_get_enable_hyperlink_auditing(WebKitSettings* settings)
  * @enabled: Value to be set
  *
  * Set the #WebKitSettings:enable-hyperlink-auditing property.
+ *
+ * Deprecated: 2.50.
  */
 void webkit_settings_set_enable_hyperlink_auditing(WebKitSettings* settings, gboolean enabled)
 {
     g_return_if_fail(WEBKIT_IS_SETTINGS(settings));
 
-    WebKitSettingsPrivate* priv = settings->priv;
-    bool currentValue = priv->preferences->hyperlinkAuditingEnabled();
-    if (currentValue == enabled)
-        return;
-
-    priv->preferences->setHyperlinkAuditingEnabled(enabled);
-    g_object_notify_by_pspec(G_OBJECT(settings), sObjProperties[PROP_ENABLE_HYPERLINK_AUDITING]);
+    if (!enabled)
+        g_warning("webkit_settings_set_enable_hyperlink_auditing is deprecated and does nothing.");
 }
 
 /**

--- a/Source/WebKit/UIProcess/API/glib/WebKitSettings.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitSettings.h.in
@@ -176,10 +176,10 @@ WEBKIT_API void
 webkit_settings_set_javascript_can_open_windows_automatically  (WebKitSettings *settings,
                                                                 gboolean        enabled);
 
-WEBKIT_API gboolean
+WEBKIT_DEPRECATED gboolean
 webkit_settings_get_enable_hyperlink_auditing                  (WebKitSettings *settings);
 
-WEBKIT_API void
+WEBKIT_DEPRECATED void
 webkit_settings_set_enable_hyperlink_auditing                  (WebKitSettings *settings,
                                                                 gboolean        enabled);
 

--- a/Source/WebKitLegacy/mac/WebView/WebPreferenceKeysPrivate.h
+++ b/Source/WebKitLegacy/mac/WebView/WebPreferenceKeysPrivate.h
@@ -113,7 +113,6 @@
 #define WebKitSpatialNavigationEnabledPreferenceKey @"WebKitSpatialNavigationEnabled"
 #define WebKitFullScreenEnabledPreferenceKey @"WebKitFullScreenEnabled"
 #define WebKitAsynchronousSpellCheckingEnabledPreferenceKey @"WebKitAsynchronousSpellCheckingEnabled"
-#define WebKitHyperlinkAuditingEnabledPreferenceKey @"WebKitHyperlinkAuditingEnabled"
 #define WebKitAVFoundationEnabledKey @"WebKitAVFoundationEnabled"
 #define WebKitRequiresUserGestureForMediaPlaybackPreferenceKey @"WebKitMediaPlaybackRequiresUserGesture"
 #define WebKitRequiresUserGestureForVideoPlaybackPreferenceKey @"WebKitVideoPlaybackRequiresUserGesture"
@@ -250,6 +249,7 @@
 
 // The preference keys below this point are deprecated and have no effect. They should
 // be removed when it is considered safe to do so.
+#define WebKitHyperlinkAuditingEnabledPreferenceKey @"WebKitHyperlinkAuditingEnabled"
 #define WebKitCSSOMViewSmoothScrollingEnabledPreferenceKey @"WebKitCSSOMViewSmoothScrollingEnabled"
 #define WebKitDNSPrefetchingEnabledPreferenceKey @"WebKitDNSPrefetchingEnabled"
 #define WebKitLinkPreloadResponsiveImagesEnabledPreferenceKey @"WebKitLinkPreloadResponsiveImagesEnabled"

--- a/Source/WebKitLegacy/mac/WebView/WebPreferences.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebPreferences.mm
@@ -1812,16 +1812,6 @@ static RetainPtr<NSString>& classIBCreatorID()
     [self _setBoolValue:flag forKey:WebKitSpatialNavigationEnabledPreferenceKey];
 }
 
-- (BOOL)hyperlinkAuditingEnabled
-{
-    return [self _boolValueForKey:WebKitHyperlinkAuditingEnabledPreferenceKey];
-}
-
-- (void)setHyperlinkAuditingEnabled:(BOOL)flag
-{
-    [self _setBoolValue:flag forKey:WebKitHyperlinkAuditingEnabledPreferenceKey];
-}
-
 - (BOOL)usePreHTML5ParserQuirks
 {
     return [self _boolValueForKey:WebKitUsePreHTML5ParserQuirksKey];
@@ -2961,6 +2951,15 @@ static RetainPtr<NSString>& classIBCreatorID()
 
 // The preferences in this category are deprecated and have no effect. They should
 // be removed when it is considered safe to do so.
+
+- (BOOL)hyperlinkAuditingEnabled
+{
+    return YES;
+}
+
+- (void)setHyperlinkAuditingEnabled:(BOOL)flag
+{
+}
 
 - (BOOL)CSSOMViewSmoothScrollingEnabled
 {

--- a/Source/WebKitLegacy/mac/WebView/WebPreferencesPrivate.h
+++ b/Source/WebKitLegacy/mac/WebView/WebPreferencesPrivate.h
@@ -150,7 +150,6 @@ extern NSString *WebPreferencesCacheModelChangedInternalNotification WEBKIT_DEPR
 @property (nonatomic) BOOL webAudioEnabled;
 @property (nonatomic) BOOL webGLEnabled;
 @property (nonatomic, getter=forceLowPowerGPUForWebGL) BOOL forceWebGLUsesLowPower;
-@property (nonatomic) BOOL hyperlinkAuditingEnabled;
 @property (nonatomic) BOOL mediaPlaybackRequiresUserGesture; // Deprecated. Use videoPlaybackRequiresUserGesture and audioPlaybackRequiresUserGesture instead.
 @property (nonatomic) BOOL videoPlaybackRequiresUserGesture;
 @property (nonatomic) BOOL audioPlaybackRequiresUserGesture;
@@ -313,6 +312,7 @@ extern NSString *WebPreferencesCacheModelChangedInternalNotification WEBKIT_DEPR
 // The preferences in this category are deprecated and have no effect. They should
 // be removed when it is considered safe to do so.
 
+@property (nonatomic) BOOL hyperlinkAuditingEnabled;
 @property (nonatomic) BOOL CSSOMViewSmoothScrollingEnabled;
 @property (nonatomic, getter=isDNSPrefetchingEnabled) BOOL DNSPrefetchingEnabled;
 @property (nonatomic) BOOL linkPreloadResponsiveImagesEnabled;

--- a/Tools/MiniBrowser/playstation/WebContext.cpp
+++ b/Tools/MiniBrowser/playstation/WebContext.cpp
@@ -88,7 +88,6 @@ WebContext::WebContext()
 
     m_preferencesMaster = adoptWK(WKPreferencesCreate());
     WKPreferencesSetFullScreenEnabled(m_preferencesMaster.get(), true);
-    WKPreferencesSetDNSPrefetchingEnabled(m_preferencesMaster.get(), true);
     WKPreferencesSetNeedsSiteSpecificQuirks(m_preferencesMaster.get(), false);
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKPreferences.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKPreferences.cpp
@@ -82,7 +82,6 @@ TEST(WebKit, WKPreferencesDefaults)
     EXPECT_FALSE(WKPreferencesGetShouldPrintBackgrounds(preference));
     EXPECT_TRUE(WKPreferencesGetJavaScriptCanOpenWindowsAutomatically(preference));
 #endif
-    EXPECT_TRUE(WKPreferencesGetHyperlinkAuditingEnabled(preference));
     EXPECT_WK_STREQ(expectedStandardFontFamily, adoptWK(WKPreferencesCopyStandardFontFamily(preference)));
     EXPECT_WK_STREQ(expectedFixedFontFamily, adoptWK(WKPreferencesCopyFixedFontFamily(preference)));
     EXPECT_WK_STREQ(expectedSerifFontFamily, adoptWK(WKPreferencesCopySerifFontFamily(preference)));

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitSettings.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitSettings.cpp
@@ -89,11 +89,6 @@ static void testWebKitSettings(Test*, gconstpointer)
     webkit_settings_set_javascript_can_open_windows_automatically(settings, TRUE);
     g_assert_true(webkit_settings_get_javascript_can_open_windows_automatically(settings));
 
-    // By default hyper link auditing is enabled.
-    g_assert_true(webkit_settings_get_enable_hyperlink_auditing(settings));
-    webkit_settings_set_enable_hyperlink_auditing(settings, FALSE);
-    g_assert_false(webkit_settings_get_enable_hyperlink_auditing(settings));
-
     // Default font family is "sans-serif".
     g_assert_cmpstr(webkit_settings_get_default_font_family(settings), ==, "sans-serif");
     webkit_settings_set_default_font_family(settings, "monospace");


### PR DESCRIPTION
#### 6256f6805364ea18dfde7a36f65972ec45082848
<pre>
Remove HyperlinkAuditingEnabled preference
<a href="https://bugs.webkit.org/show_bug.cgi?id=293225">https://bugs.webkit.org/show_bug.cgi?id=293225</a>

Reviewed by Ryosuke Niwa.

This has been enabled on main for many years and is not useful enough
to keep around.

* Source/WebKit/UIProcess/API/C/WKPreferencesRef.h:

While here also mark DNSPrefetchingEnabled and
RestrictedHTTPResponseAccess as WK_C_API_DEPRECATED as this was missed
in their removal patches.

Canonical link: <a href="https://commits.webkit.org/295103@main">https://commits.webkit.org/295103@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2d09aa2af69b614b38fa500eecbc0c7586cd1bd4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104109 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/23813 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/14133 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/109305 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/54777 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/106149 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/24181 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/32357 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/109305 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/54777 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107115 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/18786 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/93920 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/109305 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/18593 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/11961 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/54137 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/96784 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/88309 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/12018 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/111691 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/102720 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/31265 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/23055 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/111691 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/31629 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/90109 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/111691 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/32646 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/10395 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/25728 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16901 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/31194 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/36506 "Built successfully") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/126354 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/30988 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/126354 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/34324 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/32548 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->