### PR TITLE
On speaker device change, web application should be allowed to change of speaker without user gesture

### DIFF
--- a/LayoutTests/http/wpt/audio-output/setSinkId.https-expected.txt
+++ b/LayoutTests/http/wpt/audio-output/setSinkId.https-expected.txt
@@ -1,4 +1,5 @@
 
 PASS setSinkId requires user gesture
 PASS setSinkId and sinkId
+PASS setSinkid can be called close to a devicechange event
 

--- a/LayoutTests/http/wpt/audio-output/setSinkId.https.html
+++ b/LayoutTests/http/wpt/audio-output/setSinkId.https.html
@@ -20,7 +20,6 @@ promise_test(t => {
     return promise_rejects_dom(t, "NotAllowedError", audio.setSinkId(""));
 }, "setSinkId requires user gesture");
 
-
 promise_test(async t => {
     await navigator.mediaDevices.getUserMedia({ audio : true });
     const list = await navigator.mediaDevices.enumerateDevices();
@@ -33,4 +32,24 @@ promise_test(async t => {
     await promise;
     assert_equals(audio.sinkId, outputDevicesList[0].deviceId);
 }, "setSinkId and sinkId");
+
+promise_test(async t => {
+    if (!window.internals)
+        return;
+    internals.settings.setSpeakerSelectionRequiresUserGesture(true);
+    t.add_cleanup(() => { internals.settings.setSpeakerSelectionRequiresUserGesture(false); });
+
+    await navigator.mediaDevices.getUserMedia({ audio: true, video: true });
+    await new Promise(resolve => setTimeout(resolve, 500));
+
+    window.testRunner.addMockMicrophoneDevice('NewMicrophone', 'new microphone', { });
+    await new Promise(resolve => navigator.mediaDevices.ondevicechange = resolve);
+
+    const list = await navigator.mediaDevices.enumerateDevices();
+    const outputDevicesList = list.filter(({kind}) => kind == "audiooutput");
+    assert_not_equals(outputDevicesList.length, 0, "media device list includes at least one audio output device");
+
+    return audio.setSinkId(outputDevicesList[0].deviceId);
+}, "setSinkid can be called close to a devicechange event");
+
 </script>

--- a/Source/WebCore/Modules/mediastream/MediaDevices.h
+++ b/Source/WebCore/Modules/mediastream/MediaDevices.h
@@ -126,6 +126,9 @@ private:
     };
     bool computeUserGesturePriviledge(GestureAllowedRequest);
 
+    enum class UserActivation : bool { No, Yes };
+    void queueTaskForDeviceChangeEvent(UserActivation);
+
     RunLoop::Timer m_scheduledEventTimer;
     Markable<UserMediaClient::DeviceChangeObserverToken> m_deviceChangeToken;
     const EventNames& m_eventNames; // Need to cache this so we can use it from GC threads.

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -3787,6 +3787,7 @@ void HTMLMediaElement::setAudioOutputDevice(String&& deviceId, DOMPromiseDeferre
     }
 
     if (!document().processingUserGestureForMedia() && document().settings().speakerSelectionRequiresUserGesture()) {
+        ERROR_LOG(LOGIDENTIFIER, "rejecting promise as a user gesture is required");
         promise.reject(Exception { ExceptionCode::NotAllowedError, "A user gesture is required"_s });
         return;
     }


### PR DESCRIPTION
#### 8aa00d2e6fd1ab4ec8d9cc7f6174d839be9c750e
<pre>
On speaker device change, web application should be allowed to change of speaker without user gesture
<a href="https://bugs.webkit.org/show_bug.cgi?id=293222">https://bugs.webkit.org/show_bug.cgi?id=293222</a>
<a href="https://rdar.apple.com/149246873">rdar://149246873</a>

Reviewed by Eric Carlson.

<a href="https://w3c.github.io/mediacapture-output/">https://w3c.github.io/mediacapture-output/</a> is not mandating a user gesture to call setSinkId.
WebKit implementation mandates this which may cause isses on existing websites such as Webex.

One issue is when a speaker is added or removed. In that case, the website might want to automatically switch.
We allow this by adding a user gesture token to the devicechange event and allow propagation of this user gesture through enumerateDevices.

* LayoutTests/http/wpt/audio-output/setSinkId.https-expected.txt:
* LayoutTests/http/wpt/audio-output/setSinkId.https.html:
* Source/WebCore/Modules/mediastream/MediaDevices.cpp:
(WebCore::MediaDevices::enumerateDevices):
(WebCore::MediaDevices::scheduledEventTimerFired):
(WebCore::MediaDevices::willStartMediaCapture):
(WebCore::MediaDevices::queueTaskForDeviceChangeEvent):
* Source/WebCore/Modules/mediastream/MediaDevices.h:
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::setAudioOutputDevice):

Canonical link: <a href="https://commits.webkit.org/295152@main">https://commits.webkit.org/295152@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9da076e2ba7d085c7773e1955d785800d3b09a6f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104091 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/23795 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/14115 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/109287 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/54759 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/106131 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/24163 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/32339 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79080 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107097 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/18770 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/93900 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59407 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/18574 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/11944 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/54119 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/88387 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/12002 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/111673 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/31247 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23038 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88090 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/31611 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/90093 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87747 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22364 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32629 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10379 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/25704 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/31176 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/36488 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/30970 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/34306 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/32530 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->