### PR TITLE
[CSS] Fix incorrect nestedContext with CSSOM insertRule()

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/at-scope-relative-syntax-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/at-scope-relative-syntax-expected.txt
@@ -4,7 +4,7 @@ PASS > .foo in .nest,@scope created by string valid
 PASS > .foo in @scope,.nest,@media screen created by string valid
 PASS > .foo in .nest,@scope,@media screen created by string valid
 PASS > .foo in @scope,.nest created by insertRule valid
-FAIL > .foo in .nest,@scope created by insertRule valid assert_equals: expected "> .foo" but got "& > .foo"
+PASS > .foo in .nest,@scope created by insertRule valid
 PASS > .foo in @scope,.nest,@media screen created by insertRule valid
 PASS > .foo in .nest,@scope,@media screen created by insertRule valid
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-nesting-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-nesting-expected.txt
@@ -19,7 +19,7 @@ PASS Scoped nested group rule
 PASS Scoped nested within another scope
 PASS Implicit (prelude-less) @scope as a nested group rule
 PASS Insert a nested style rule within @scope, &
-FAIL Insert a nested style rule within @scope, :scope assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
+PASS Insert a nested style rule within @scope, :scope
 FAIL Insert a CSSNestedDeclarations rule directly in top-level @scope The string did not match the expected pattern.
 PASS Mutating selectorText on outer style rule causes correct inner specificity
 


### PR DESCRIPTION
#### 72f431e71d4c849bb458aa7048e2cdf505d35a42
<pre>
[CSS] Fix incorrect nestedContext with CSSOM insertRule()
<a href="https://bugs.webkit.org/show_bug.cgi?id=293228">https://bugs.webkit.org/show_bug.cgi?id=293228</a>
<a href="https://rdar.apple.com/151604764">rdar://151604764</a>

Reviewed by Anne van Kesteren.

We need to consider the current rule + its ancestors to find the correct nestedContext,
and not only the ancestors.

* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/at-scope-relative-syntax-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-nesting-expected.txt:
* Source/WebCore/css/CSSGroupingRule.cpp:
(WebCore::CSSGroupingRule::insertRule):

Canonical link: <a href="https://commits.webkit.org/295109@main">https://commits.webkit.org/295109@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/10d10dc3c3c1c8fecf19d14f73a5dfbd6e0cffd8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104092 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/23796 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/14116 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/109288 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/54760 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/106132 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/24164 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/32340 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79079 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107098 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/18769 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/93899 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59406 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/18573 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/11943 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/54120 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/88292 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/12001 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/111674 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/31248 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23039 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88089 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/31612 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/90092 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87748 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22341 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32630 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10378 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/25705 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/31177 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/36489 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/30971 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/34307 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/32531 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->