### PR TITLE
Rename UserGestureIndicator::IsPropagatedFrom to ShouldPropagateToMicroTask

### DIFF
--- a/Source/WebCore/Modules/fetch/FetchBodyConsumer.cpp
+++ b/Source/WebCore/Modules/fetch/FetchBodyConsumer.cpp
@@ -500,7 +500,7 @@ void FetchBodyConsumer::loadingSucceeded(const String& contentType)
         if (!m_userGestureToken || m_userGestureToken->hasExpired(UserGestureToken::maximumIntervalForUserGestureForwardingForFetch()) || !m_userGestureToken->processingUserGesture())
             resolve(m_consumePromise.releaseNonNull(), contentType, nullptr, nullptr);
         else {
-            UserGestureIndicator gestureIndicator(m_userGestureToken, UserGestureToken::GestureScope::MediaOnly, UserGestureToken::IsPropagatedFromFetch::Yes);
+            UserGestureIndicator gestureIndicator(m_userGestureToken, UserGestureToken::GestureScope::MediaOnly, UserGestureToken::ShouldPropagateToMicroTask::Yes);
             resolve(m_consumePromise.releaseNonNull(), contentType, nullptr, nullptr);
         }
     }

--- a/Source/WebCore/Modules/fetch/WindowOrWorkerGlobalScopeFetch.cpp
+++ b/Source/WebCore/Modules/fetch/WindowOrWorkerGlobalScopeFetch.cpp
@@ -67,7 +67,7 @@ static void doFetch(ScriptExecutionContext& scope, FetchRequest::Info&& input, F
                 promise.settle(WTFMove(result));
                 return;
             }
-            UserGestureIndicator gestureIndicator(userGestureToken, UserGestureToken::GestureScope::MediaOnly, UserGestureToken::IsPropagatedFromFetch::Yes);
+            UserGestureIndicator gestureIndicator(userGestureToken, UserGestureToken::GestureScope::MediaOnly, UserGestureToken::ShouldPropagateToMicroTask::Yes);
             promise.settle(WTFMove(result));
         });
     }, cachedResourceRequestInitiatorTypes().fetch);

--- a/Source/WebCore/Modules/mediastream/MediaDevices.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaDevices.cpp
@@ -446,7 +446,7 @@ void MediaDevices::enumerateDevices(EnumerateDevicesPromise&& promise)
 
         std::optional<UserGestureIndicator> gestureIndicator;
         if (userGestureToken)
-            gestureIndicator.emplace(userGestureToken, UserGestureToken::GestureScope::MediaOnly, UserGestureToken::IsPropagatedFromFetch::Yes);
+            gestureIndicator.emplace(userGestureToken, UserGestureToken::GestureScope::MediaOnly, UserGestureToken::ShouldPropagateToMicroTask::Yes);
 
         protectedThis->exposeDevices(WTFMove(newDevices), WTFMove(deviceIDHashSalts), WTFMove(promise));
     });

--- a/Source/WebCore/bindings/js/JSDOMWindowBase.cpp
+++ b/Source/WebCore/bindings/js/JSDOMWindowBase.cpp
@@ -265,7 +265,7 @@ public:
     {
         auto runnability = currentRunnability();
         if (runnability == JSC::QueuedTask::Result::Executed) {
-            UserGestureIndicator gestureIndicator(m_userGestureToken.ptr(), UserGestureToken::GestureScope::MediaOnly, UserGestureToken::IsPropagatedFromFetch::Yes);
+            UserGestureIndicator gestureIndicator(m_userGestureToken.ptr(), UserGestureToken::GestureScope::MediaOnly, UserGestureToken::ShouldPropagateToMicroTask::Yes);
             JSExecState::runTask(task.globalObject(), task);
         }
         return runnability;
@@ -291,7 +291,7 @@ void JSDOMWindowBase::queueMicrotaskToEventLoop(JSGlobalObject& object, QueuedTa
     auto& eventLoop = objectScriptExecutionContext->eventLoop();
     // Propagating media only user gesture for Fetch API's promise chain.
     auto userGestureToken = UserGestureIndicator::currentUserGesture();
-    if (userGestureToken && (!userGestureToken->isPropagatedFromFetch() || !objectScriptExecutionContext->settingsValues().userGesturePromisePropagationEnabled))
+    if (userGestureToken && (!userGestureToken->shouldPropagateToMicroTask() || !objectScriptExecutionContext->settingsValues().userGesturePromisePropagationEnabled))
         userGestureToken = nullptr;
 
     if (!userGestureToken)

--- a/Source/WebCore/dom/UserGestureIndicator.cpp
+++ b/Source/WebCore/dom/UserGestureIndicator.cpp
@@ -151,7 +151,7 @@ UserGestureIndicator::UserGestureIndicator(std::optional<IsProcessingUserGesture
     }
 }
 
-UserGestureIndicator::UserGestureIndicator(RefPtr<UserGestureToken> token, UserGestureToken::GestureScope scope, UserGestureToken::IsPropagatedFromFetch isPropagatedFromFetch)
+UserGestureIndicator::UserGestureIndicator(RefPtr<UserGestureToken> token, UserGestureToken::GestureScope scope, UserGestureToken::ShouldPropagateToMicroTask shouldPropagateToMicroTask)
 {
     // Silently ignore UserGestureIndicators on non main threads.
     if (!isMainThread())
@@ -162,7 +162,7 @@ UserGestureIndicator::UserGestureIndicator(RefPtr<UserGestureToken> token, UserG
 
     if (token) {
         token->setScope(scope);
-        token->setIsPropagatedFromFetch(isPropagatedFromFetch);
+        token->setShouldPropagateToMicroTask(shouldPropagateToMicroTask);
         currentToken() = token;
     }
 }
@@ -175,7 +175,7 @@ UserGestureIndicator::~UserGestureIndicator()
     if (auto token = currentToken()) {
         token->resetDOMPasteAccess();
         token->resetScope();
-        token->resetIsPropagatedFromFetch();
+        token->resetShouldPropagateToMicroTask();
     }
 
     currentToken() = m_previousToken;

--- a/Source/WebCore/dom/UserGestureIndicator.h
+++ b/Source/WebCore/dom/UserGestureIndicator.h
@@ -90,10 +90,10 @@ public:
     void resetScope() { m_scope = GestureScope::All; }
 
     // Expand the following methods if more propagation sources are added later.
-    enum class IsPropagatedFromFetch : bool { No, Yes };
-    void setIsPropagatedFromFetch(IsPropagatedFromFetch is) { m_isPropagatedFromFetch = is; }
-    void resetIsPropagatedFromFetch() { m_isPropagatedFromFetch = IsPropagatedFromFetch::No; }
-    bool isPropagatedFromFetch() const { return m_isPropagatedFromFetch == IsPropagatedFromFetch::Yes; }
+    enum class ShouldPropagateToMicroTask : bool { No, Yes };
+    void setShouldPropagateToMicroTask(ShouldPropagateToMicroTask is) { m_shouldPropagateToMicroTask = is; }
+    void resetShouldPropagateToMicroTask() { m_shouldPropagateToMicroTask = ShouldPropagateToMicroTask::No; }
+    bool shouldPropagateToMicroTask() const { return m_shouldPropagateToMicroTask == ShouldPropagateToMicroTask::Yes; }
 
     bool hasExpired(Seconds expirationInterval) const
     {
@@ -121,7 +121,7 @@ private:
     DOMPasteAccessPolicy m_domPasteAccessPolicy { DOMPasteAccessPolicy::NotRequestedYet };
     GestureScope m_scope { GestureScope::All };
     MonotonicTime m_startTime { MonotonicTime::now() };
-    IsPropagatedFromFetch m_isPropagatedFromFetch { IsPropagatedFromFetch::No };
+    ShouldPropagateToMicroTask m_shouldPropagateToMicroTask { ShouldPropagateToMicroTask::No };
     std::optional<WTF::UUID> m_authorizationToken;
 };
 
@@ -137,7 +137,7 @@ public:
     // If a document is provided, its last known user gesture timestamp is updated.
     enum class ProcessInteractionStyle { Immediate, Delayed, Never };
     WEBCORE_EXPORT explicit UserGestureIndicator(std::optional<IsProcessingUserGesture>, Document* = nullptr, UserGestureType = UserGestureType::ActivationTriggering, ProcessInteractionStyle = ProcessInteractionStyle::Immediate, std::optional<WTF::UUID> authorizationToken = std::nullopt, CanRequestDOMPaste = CanRequestDOMPaste::Yes);
-    WEBCORE_EXPORT explicit UserGestureIndicator(RefPtr<UserGestureToken>, UserGestureToken::GestureScope = UserGestureToken::GestureScope::All, UserGestureToken::IsPropagatedFromFetch = UserGestureToken::IsPropagatedFromFetch::No);
+    WEBCORE_EXPORT explicit UserGestureIndicator(RefPtr<UserGestureToken>, UserGestureToken::GestureScope = UserGestureToken::GestureScope::All, UserGestureToken::ShouldPropagateToMicroTask = UserGestureToken::ShouldPropagateToMicroTask::No);
     WEBCORE_EXPORT ~UserGestureIndicator();
 
     WEBCORE_EXPORT std::optional<WTF::UUID> authorizationToken() const;


### PR DESCRIPTION
#### 3b3b0c89901f3dd2ff2272bf37a993e677977195
<pre>
Rename UserGestureIndicator::IsPropagatedFrom to ShouldPropagateToMicroTask
<a href="https://bugs.webkit.org/show_bug.cgi?id=293229">https://bugs.webkit.org/show_bug.cgi?id=293229</a>
<a href="https://rdar.apple.com/151605220">rdar://151605220</a>

Reviewed by Jean-Yves Avenard.

Propagation may not be specific to fetch and does not tell what it does.
Renaming to express that the token does not get cleared on next synchronous microtask instead.

* Source/WebCore/Modules/fetch/FetchBodyConsumer.cpp:
(WebCore::FetchBodyConsumer::loadingSucceeded):
* Source/WebCore/Modules/fetch/WindowOrWorkerGlobalScopeFetch.cpp:
(WebCore::doFetch):
* Source/WebCore/bindings/js/JSDOMWindowBase.cpp:
(WebCore::JSDOMWindowBase::queueMicrotaskToEventLoop):
* Source/WebCore/dom/UserGestureIndicator.cpp:
(WebCore::UserGestureIndicator::UserGestureIndicator):
(WebCore::UserGestureIndicator::~UserGestureIndicator):
* Source/WebCore/dom/UserGestureIndicator.h:
(WebCore::UserGestureToken::setShouldPropagateToMicroTask):
(WebCore::UserGestureToken::resetShouldPropagateToMicroTask):
(WebCore::UserGestureToken::shouldPropagateToMicroTask const):
(WebCore::UserGestureToken::setIsPropagatedFromFetch): Deleted.
(WebCore::UserGestureToken::resetIsPropagatedFromFetch): Deleted.
(WebCore::UserGestureToken::isPropagatedFromFetch const): Deleted.

Canonical link: <a href="https://commits.webkit.org/295266@main">https://commits.webkit.org/295266@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/08c71b00c13a722515d856fe60b1c14f846dfc66

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104390 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24094 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/14510 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/109592 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/55058 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/106430 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/24471 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/32641 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79259 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107396 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19023 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94208 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59589 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/18831 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/12283 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/54420 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/88516 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/12335 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/111976 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/31547 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23239 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88299 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/31911 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/90452 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87965 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22447 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32863 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10628 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/26015 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/31475 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/36800 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/31269 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/34605 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/32829 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->