### PR TITLE
[scroll-animations] Presence of an animation with a custom property breaks font-size that depends on rem

### DIFF
--- a/LayoutTests/fast/css/animation-resolution-rem-unit-expected.html
+++ b/LayoutTests/fast/css/animation-resolution-rem-unit-expected.html
@@ -1,0 +1,8 @@
+<style>
+.test {
+    font-size: 1rem;
+}
+</style>
+<div class="test">
+This should be small.
+</div>

--- a/LayoutTests/fast/css/animation-resolution-rem-unit.html
+++ b/LayoutTests/fast/css/animation-resolution-rem-unit.html
@@ -1,0 +1,26 @@
+<style>
+html {
+    --rem: 1rem;
+}
+
+body {
+    font-size: 6em;
+    timeline-scope: --foo;
+}
+
+.test {
+    font-size: var(--rem);
+
+    animation: --test;
+    animation-timeline: --foo;
+}
+
+@keyframes --test {
+    0% {
+        --foo: unused;
+    }
+}
+</style>
+<div class="test">
+This should be small.
+</div>

--- a/Source/WebCore/style/StyleTreeResolver.h
+++ b/Source/WebCore/style/StyleTreeResolver.h
@@ -164,6 +164,7 @@ private:
     const Parent* boxGeneratingParent() const;
     const RenderStyle* parentBoxStyle() const;
     const RenderStyle* parentBoxStyleForPseudoElement(const ElementUpdate&) const;
+    const RenderStyle* documentElementStyle() const;
 
     LayoutInterleavingAction updateAnchorPositioningState(Element&, const RenderStyle*, OptionSet<Change>);
 
@@ -184,7 +185,7 @@ private:
     bool hasResolvedAnchorPosition(const Element&) const;
 
     CheckedRef<Document> m_document;
-    std::unique_ptr<RenderStyle> m_documentElementStyle;
+    std::unique_ptr<RenderStyle> m_computedDocumentElementStyle;
 
     Vector<Ref<Scope>, 4> m_scopeStack;
     Vector<Parent, 32> m_parentStack;


### PR DESCRIPTION
#### c7d5be16b5839e276fbceb011d099b338e4c4a80
<pre>
[scroll-animations] Presence of an animation with a custom property breaks font-size that depends on rem
<a href="https://bugs.webkit.org/show_bug.cgi?id=289992">https://bugs.webkit.org/show_bug.cgi?id=289992</a>
<a href="https://rdar.apple.com/147872254">rdar://147872254</a>

Reviewed by Antoine Quint.

For certain animation related style computations we use Style::Builder directly from TreeResolver.
In this direct use we fail to initialize the root element style paramater the same way it is done
when invoked by Style::Resolver and this may result in different resolution of values (like rem unit)
that depends on it.

* LayoutTests/fast/css/animation-resolution-rem-unit-expected.html: Added.
* LayoutTests/fast/css/animation-resolution-rem-unit.html: Added.
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::makeResolutionContext):
(WebCore::Style::TreeResolver::makeResolutionContextForPseudoElement):
(WebCore::Style::TreeResolver::makeResolutionContextForInheritedFirstLine):
(WebCore::Style::TreeResolver::documentElementStyle const):

Get the document element style from the document element if we don&apos;t have a local
copy of the style.

(WebCore::Style::TreeResolver::resolveComposedTree):
(WebCore::Style::TreeResolver::existingStyle):
* Source/WebCore/style/StyleTreeResolver.h:

Rename the field for clarity.

Canonical link: <a href="https://commits.webkit.org/295395@main">https://commits.webkit.org/295395@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f82a5a915d8d880fda3ba44d9d383abda4e7bc54

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104253 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/23957 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/14341 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/109453 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/54921 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/106293 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/24327 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/32503 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79182 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107259 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/18905 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94081 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59510 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/18712 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/12136 "Found 1 new test failure: imported/w3c/web-platform-tests/cookies/schemeful-same-site/schemeful-websockets.sub.tentative.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/54281 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/88414 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/12197 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/111835 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/31409 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23150 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88203 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Passed layout tests; 53 flakes 93 failures; Uploaded test results; 26 flakes 61 failures; Compiled WebKit; 3 flakes 61 failures; Running analyze-layout-tests-results") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/31774 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/90299 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87866 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22532 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32756 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10518 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/25875 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/31338 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/36651 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/31132 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/34468 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/32692 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->