### PR TITLE
[GStreamer][MSE] Support playing videos of less than 1 sec with libav decoders

### DIFF
--- a/LayoutTests/media/media-source/media-source-shortmediastall-expected.txt
+++ b/LayoutTests/media/media-source/media-source-shortmediastall-expected.txt
@@ -1,0 +1,24 @@
+
+RUN(source = new MediaSource())
+RUN(video.src = URL.createObjectURL(source))
+EVENT(sourceopen)
+RUN(sourceBuffer = source.addSourceBuffer(loader.type()))
+RUN(sourceBuffer.appendBuffer(loader.initSegment()))
+EVENT(update)
+RUN(sourceBuffer.appendBuffer(loader.mediaSegment(0)))
+EVENT(update)
+RUN(sourceBuffer.appendBuffer(loader.mediaSegment(1)))
+EVENT(update)
+RUN(video.play())
+EVENT(playing)
+EVENT(waiting)
+EXPECTED (video.currentTime >= '2') OK
+RUN(sourceBuffer.appendBuffer(loader.mediaSegment(2)))
+EVENT(update)
+RUN(sourceBuffer.appendBuffer(loader.mediaSegment(3)))
+EVENT(update)
+RUN(source.endOfStream())
+EVENT(ended)
+EXPECTED (video.currentTime >= '4') OK
+END OF TEST
+

--- a/LayoutTests/media/media-source/media-source-shortmediastall.html
+++ b/LayoutTests/media/media-source/media-source-shortmediastall.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>MSE playback of short media is completely processed until a stall, then able to continue.</title>
+    <meta name="timeout" content="long">
+    <script src="../../media/media-source/media-source-loader.js"></script>
+    <script src="../../media/video-test.js"></script>
+    <script src="../utilities.js"></script>
+    <script>
+
+    var source;
+    var sourceBuffer;
+    var index;
+    var loader;
+    var currentTimeWhenStalling;
+
+    function loaderPromise(loader) {
+        return new Promise((resolve, reject) => {
+            loader.onload = resolve;
+            loader.onerror = reject;
+        });
+    }
+
+    async function init() {
+        findMediaElement();
+
+        loader = new MediaSourceLoader('content/test-fragmented-video-manifest.json');
+        await loaderPromise(loader);
+        video.disableRemotePlayback = true;
+        video.muted = true;
+        run('source = new MediaSource()');
+        run('video.src = URL.createObjectURL(source)');
+        await waitFor(source, 'sourceopen');
+        run('sourceBuffer = source.addSourceBuffer(loader.type())');
+        run('sourceBuffer.appendBuffer(loader.initSegment())');
+        await waitFor(sourceBuffer, 'update');
+        run('sourceBuffer.appendBuffer(loader.mediaSegment(0))');
+        await waitFor(sourceBuffer, 'update');
+        run('sourceBuffer.appendBuffer(loader.mediaSegment(1))');
+        await waitFor(sourceBuffer, 'update');
+        run('video.play()');
+        await waitFor(video, 'playing');
+        await Promise.all([
+            testExpectedEventuallySilent('video.currentTime', 2, '>='),
+            waitFor(video, 'waiting')
+        ]);
+        // We support a small difference to account for inaccuracies acused by lack of edit list support,
+        // which is something we explicitly don't want to test here.
+        // See also:
+        // https://bugs.webkit.org/show_bug.cgi?id=270622
+        // https://bugs.webkit.org/show_bug.cgi?id=231019
+        testExpected('video.currentTime', 2, '>=');
+        currentTimeWhenStalling = video.currentTime;
+        
+        await sleepFor(500);
+
+        // Provide more video to check that the video unstalls and reaches the end.
+        run('sourceBuffer.appendBuffer(loader.mediaSegment(2))');
+        await waitFor(sourceBuffer, 'update');
+        run('sourceBuffer.appendBuffer(loader.mediaSegment(3))');
+        await waitFor(sourceBuffer, 'update');
+        run('source.endOfStream()')
+        await waitFor(video, 'ended');
+        testExpected('video.currentTime', 4, '>=');
+
+        endTest();
+    };
+    </script>
+</head>
+<body onload="init()">
+    <video playsinline></video>
+</body>
+</html>

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
@@ -262,7 +262,7 @@ private:
 void connectSimpleBusMessageCallback(GstElement*, Function<void(GstMessage*)>&& = [](GstMessage*) { });
 void disconnectSimpleBusMessageCallback(GstElement*);
 
-enum class GstVideoDecoderPlatform { ImxVPU, Video4Linux, OpenMAX };
+enum class GstVideoDecoderPlatform { ImxVPU, Video4Linux, OpenMAX, LibAv };
 
 bool isGStreamerPluginAvailable(ASCIILiteral name);
 bool gstElementFactoryEquals(GstElement*, ASCIILiteral name);

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -1598,9 +1598,32 @@ MediaTime MediaPlayerPrivateGStreamer::playbackPosition() const
     // Cached position is marked as non valid here but we might fail to get a new one so initializing to this as "educated guess".
     MediaTime playbackPosition = m_cachedPosition;
 
-    if (GST_CLOCK_TIME_IS_VALID(gstreamerPosition))
+    if (GST_CLOCK_TIME_IS_VALID(gstreamerPosition)) {
         playbackPosition = MediaTime(gstreamerPosition, GST_SECOND);
-    else if (m_canFallBackToLastFinishedSeekPosition)
+        // As of currently (GStreamer 1.16) avdec_* elements don't start a task (thread) in their srcpads, so
+        // decoded frames are only propagated downstream when an encoded frame or EOS event is fed
+        // to the sinkpad.
+        // This may cause the presentation time that reaches the sink to not match the end time of
+        // a buffered range that doesn't correspond to an end of stream.
+        // This code attempts to detect and mitigate that condition by sending an event that drains the
+        // decoder if playback has not progressed for a given time.
+        // Ideally, the avdec elements would be improved to use a thread in their srcpads so that decoded
+        // frames are available as soon as they're decoded, as is the case with v4l2 decoder elements.
+        if (isMediaSource() && m_videoDecoderPlatform == GstVideoDecoderPlatform::LibAv) {
+            if (playbackPosition == m_cachedPosition && m_lastStalledPosition.isInvalid()) {
+                auto* playerPrivateMSE = reinterpret_cast<MediaPlayerPrivateGStreamerMSE*>(const_cast<MediaPlayerPrivateGStreamer*>(this));
+                if (!paused() && playerPrivateMSE->hasFutureTime(m_cachedPosition)) {
+                    m_lastStalledPosition = playbackPosition;
+                    // Apparently, the player got stuck. Let's force the emission of as many decoded frames as possible with an still frame event.
+                    GRefPtr<GstEvent> stillFrameEvent = adoptGRef(gst_video_event_new_still_frame(TRUE));
+                    gst_element_send_event(GST_ELEMENT(playerPrivateMSE->webKitMediaSrc()), stillFrameEvent.leakRef());
+                    GST_DEBUG_OBJECT(pipeline(), "The player seems stuck at %s. Sent still frame event to force emission of the last decoded frames",
+                        playbackPosition.toString().utf8().data());
+                }
+            } else if (m_lastStalledPosition.isValid() && m_lastStalledPosition != playbackPosition)
+                m_lastStalledPosition = MediaTime::invalidTime();
+        }
+    } else if (m_canFallBackToLastFinishedSeekPosition)
         playbackPosition = m_seekTarget.time;
 
     setCachedPosition(playbackPosition);
@@ -3456,11 +3479,14 @@ void MediaPlayerPrivateGStreamer::configureVideoDecoder(GstElement* decoder)
         m_videoDecoderPlatform = GstVideoDecoderPlatform::ImxVPU;
     else if (nameView.startsWith("omx"_s))
         m_videoDecoderPlatform = GstVideoDecoderPlatform::OpenMAX;
-    else if (gstElementMatchesFactoryAndHasProperty(decoder, "avdec*"_s, "max-threads"_s)) {
-        // Set the decoder maximum number of threads to a low, fixed value, not depending on the
-        // platform. This also helps with processing metrics gathering. When using the default value
-        // the decoder introduces artificial processing latency reflecting the maximum number of threads.
-        g_object_set(decoder, "max-threads", 2, nullptr);
+    else if (nameView.startsWith("avdec"_s)) {
+        m_videoDecoderPlatform = GstVideoDecoderPlatform::LibAv;
+        if (gstObjectHasProperty(decoder, "max-threads"_s)) {
+            // Set the decoder maximum number of threads to a low, fixed value, not depending on the
+            // platform. This also helps with processing metrics gathering. When using the default value
+            // the decoder introduces artificial processing latency reflecting the maximum number of threads.
+            g_object_set(decoder, "max-threads", 2, nullptr);
+        }
     }
 
     if (gstObjectHasProperty(decoder, "max-errors"_s))

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
@@ -364,6 +364,8 @@ protected:
     mutable MediaTime m_cachedPosition;
     mutable bool m_isCachedPositionValid { false };
     mutable MediaTime m_cachedDuration;
+    // Libav workaround: Used to avoid sending too many still frame events to unstall the libav video decoder.
+    mutable MediaTime m_lastStalledPosition { MediaTime::invalidTime() };
     bool m_canFallBackToLastFinishedSeekPosition { false };
     bool m_isChangingRate { false };
     bool m_didDownloadFinish { false };

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
@@ -445,6 +445,11 @@ bool MediaPlayerPrivateGStreamerMSE::isTimeBuffered(const MediaTime &time) const
     return result;
 }
 
+bool MediaPlayerPrivateGStreamerMSE::hasFutureTime(const MediaTime &time) const
+{
+    return m_mediaSourcePrivate && m_mediaSourcePrivate->hasFutureTime(time);
+}
+
 void MediaPlayerPrivateGStreamerMSE::durationChanged()
 {
     ASSERT(isMainThread());

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.h
@@ -96,6 +96,7 @@ public:
 #ifndef GST_DISABLE_GST_DEBUG
     void setShouldDisableSleep(bool) final;
 #endif
+    bool hasFutureTime(const MediaTime&) const;
 
 private:
     explicit MediaPlayerPrivateGStreamerMSE(MediaPlayer*);

--- a/Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.cpp
@@ -856,6 +856,22 @@ static gboolean webKitMediaSrcSendEvent(GstElement* element, GstEvent* eventTran
             source->priv->rate = rate.value();
         return forwardToAllPads ? wasEventHandledByAllStreams : wasEventHandledByAnyStream;
     }
+    case GST_EVENT_CUSTOM_DOWNSTREAM: {
+        if (gst_structure_has_name(gst_event_get_structure(event.get()), "GstEventStillFrame")) {
+            // Drain the video stream (and only that one, assuming there's only one).
+            WebKitMediaSrc* source = WEBKIT_MEDIA_SRC(element);
+            for (auto stream : source->priv->streams.values()) {
+                if (stream->track.get().type() == TrackPrivateBaseGStreamer::TrackType::Video) {
+                    GRefPtr<GstPad> sinkPeerPad = adoptGRef(gst_pad_get_peer(stream->pad.get()));
+                    stream->track->enqueueObject(adoptGRef(GST_MINI_OBJECT(event.leakRef())));
+                    return TRUE;
+                }
+            }
+            GST_DEBUG_OBJECT(element, "No video stream to send the still frame event to");
+            return FALSE;
+        }
+        [[fallthrough]];
+    }
     default:
         return GST_ELEMENT_CLASS(webkit_media_src_parent_class)->send_event(element, event.leakRef());
     }


### PR DESCRIPTION
#### bc7ce86c849cbc01c75e33c073e30e185b3455c8
<pre>
[GStreamer][MSE] Support playing videos of less than 1 sec with libav decoders
<a href="https://bugs.webkit.org/show_bug.cgi?id=293239">https://bugs.webkit.org/show_bug.cgi?id=293239</a>

Reviewed by NOBODY (OOPS!).

GStreamer video decoders based on libav are currently implemented in a
way that hoard one video frame per decoding thread. This not only means
more latency during continuous playback, but also on stalls (when no
more frames are supplied at the video decoder input). While problem has
been mitigated by reducing the max-threads to 2 [1], the behaviour still
causes problems in some tests with very short videos.

This commit checks that we&apos;re currently using the libav video decoder
and, if the video position hasn&apos;t moved but in theory should, emits a
still frame event to force the video decoder to emit all the video
frames at its source pad.

A layout test to check that the video decoder has emitted all the frames
when a stall happens has been added. This test explicitly doesn&apos;t check
the exact played timestamps, to not fail because of missing edit list
support, which skews the timestamps.

See also:
<a href="https://bugs.webkit.org/show_bug.cgi?id=270622">https://bugs.webkit.org/show_bug.cgi?id=270622</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=231019">https://bugs.webkit.org/show_bug.cgi?id=231019</a>

[1] <a href="https://github.com/WebKit/WebKit/commit/128e962baa61f49c78087a622eaecd08dc692ef6#diff-4376b854280205494dc9de0f08f985afd4d6584a7487c0a136adac2954c003cdR2831">https://github.com/WebKit/WebKit/commit/128e962baa61f49c78087a622eaecd08dc692ef6#diff-4376b854280205494dc9de0f08f985afd4d6584a7487c0a136adac2954c003cdR2831</a>

* LayoutTests/media/media-source/media-source-shortmediastall-expected.txt: Added.
* LayoutTests/media/media-source/media-source-shortmediastall.html: Added.
* Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h: Added the LibAv video decoding platform.
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::MediaPlayerPrivateGStreamer::playbackPosition const): Emit the still frame event if the video hasn&apos;t advanced but in theory should have, but only when using a libav decoder and when the player isn&apos;t stalled in the same timestamp as the last time (avoid redundant emission).
(WebCore::MediaPlayerPrivateGStreamer::configureVideoDecoder): Declare that we&apos;re using the LibAv video decoding platform when present.
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h: Added m_lastStalledPosition to store the timestamp where the player got last stalled. This is used to avoid redundant emission of the still frame event on consecutive stalls that are in fact for the the same timestamp.
* Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp:
(WebCore::MediaPlayerPrivateGStreamerMSE::hasFutureTime const): Expose MediaSourcePrivate::hasFutureTime() through the player private.
* Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.h: Add hasFutureTime().
* Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.cpp:
(webKitMediaSrcSendEvent): Forward the GstEventStillFrame custom downstream event to the first (and only, if present) video src pad, but enqueing it in the buffer/event queue in MediaSourceTrackGStreamer.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bc7ce86c849cbc01c75e33c073e30e185b3455c8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/111645 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/31312 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/21786 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/117680 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/61927 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/113607 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/32000 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/39897 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84823 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/35571 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/114592 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/25544 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/100482 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65264 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24880 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/18617 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/61512 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/94929 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/18685 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/120928 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/38698 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/28751 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93722 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/39076 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/96739 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93548 "Found 2 new API test failures: /WebKitGTK/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/new-window-policy, /WebKitGTK/TestWebProcessExtensions:/webkit/WebKitWebView/web-process-crashed (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38688 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/16481 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/34734 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/38587 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/44072 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/38250 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/41586 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/39952 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->