### PR TITLE
Remove all calls to deprecated NSImage setScalesWhenResized

### DIFF
--- a/Source/WebKitLegacy/mac/Misc/WebNSImageExtras.m
+++ b/Source/WebKitLegacy/mac/Misc/WebNSImageExtras.m
@@ -53,9 +53,6 @@
     
     if(resizeDelta > 0.0){
         NSSize newSize = NSMakeSize((originalSize.width * resizeDelta), (originalSize.height * resizeDelta));
-ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-        [self setScalesWhenResized:YES];
-ALLOW_DEPRECATED_DECLARATIONS_END
         [self setSize:newSize];
     }
 }

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.mm
@@ -2028,12 +2028,8 @@ static NSImage *webGetNSImage(WebCore::Image* image, NSSize size)
     NSImage* nsImage = image->adapter().nsImage();
     if (!nsImage)
         return nil;
-    if (!NSEqualSizes([nsImage size], size)) {
-ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-        [nsImage setScalesWhenResized:YES];
-ALLOW_DEPRECATED_DECLARATIONS_END
+    if (!NSEqualSizes([nsImage size], size))
         [nsImage setSize:size];
-    }
     return nsImage;
 }
 #endif // !PLATFORM(IOS_FAMILY)

--- a/Tools/TestWebKitAPI/Tests/mac/WebViewIconLoading.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/WebViewIconLoading.mm
@@ -63,9 +63,6 @@ static NSImage *imageFromData(NSData *data)
 {
     auto image = adoptNS([[NSImage alloc] initWithData:data]);
 
-ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    [image setScalesWhenResized:YES];
-ALLOW_DEPRECATED_DECLARATIONS_END
     [image setSize:NSMakeSize(16, 16)];
 
     return image.autorelease();


### PR DESCRIPTION
#### 04842bc8c6862d866322643210e793aaddcd1238
<pre>
Remove all calls to deprecated NSImage setScalesWhenResized
<a href="https://bugs.webkit.org/show_bug.cgi?id=293240">https://bugs.webkit.org/show_bug.cgi?id=293240</a>
<a href="https://rdar.apple.com/151628981">rdar://151628981</a>

Reviewed by Wenson Hsieh.

I removed on use of the deprecated `setScalesWhenResized:` call in Bug 293071.
I failed to search the codebase for other instances, and missed several others.

We should remove them, too.

* Source/WebKitLegacy/mac/Misc/WebNSImageExtras.m:
(-[NSImage _web_scaleToMaxSize:]):
* Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.mm:
(webGetNSImage):
* Tools/TestWebKitAPI/Tests/mac/WebViewIconLoading.mm:
(imageFromData):

Canonical link: <a href="https://commits.webkit.org/295233@main">https://commits.webkit.org/295233@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f4c56efd0693f94a5bbeff12ba61375e6d22f8b6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104127 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/23831 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/14151 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/109323 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/54795 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/106167 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/24199 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/32375 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79103 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107133 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/18800 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/93938 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59430 "Found 1 new API test failure: /WPE/TestSSL:/webkit/WebKitWebView/ephemeral-tls-errors (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/18631 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/11978 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/54155 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/88323 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/12035 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/111709 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/31283 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23070 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88114 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/31647 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/90126 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87774 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32658 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10412 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/25747 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16958 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/31212 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/36525 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/31006 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/34342 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/32566 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->