### PR TITLE
[JSC] Tweak FTL inlining non-codegen-nodes list and MakeRope MovHints

### DIFF
--- a/Source/JavaScriptCore/dfg/DFGGraph.cpp
+++ b/Source/JavaScriptCore/dfg/DFGGraph.cpp
@@ -702,9 +702,7 @@ void Graph::dethread()
 {
     if (m_form == LoadStore || m_form == SSA)
         return;
-    
-    dataLogLnIf(logCompilationChanges(), "Dethreading DFG graph.");
-    
+
     for (BlockIndex blockIndex = m_blocks.size(); blockIndex--;) {
         BasicBlock* block = m_blocks[blockIndex].get();
         if (!block)

--- a/Source/JavaScriptCore/dfg/DFGMayExit.cpp
+++ b/Source/JavaScriptCore/dfg/DFGMayExit.cpp
@@ -347,6 +347,11 @@ ExitMode mayExitImpl(Graph& graph, Node* node, StateType& state)
         }
         break;
 
+    case MakeRope: {
+        result = ExitsForExceptions;
+        break;
+    }
+
     case StringReplaceString: {
         if (node->child3().useKind() == StringUse) {
             result = ExitsForExceptions;

--- a/Source/JavaScriptCore/dfg/DFGMovHintRemovalPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGMovHintRemovalPhase.cpp
@@ -81,16 +81,59 @@ private:
         Epoch currentEpoch = Epoch::first();
 
         m_state.fill(Epoch());
-        m_graph.forAllLiveInBytecode(
-            block->terminal()->origin.forExit,
-            [&] (Operand reg) {
-                m_state.operand(reg) = currentEpoch;
-            });
+
+        // This is a heuristic. We found cases that BB ends with Jump, and successor no longer have liveness for locals.
+        // However, at the end of the current BB, it is alive and we failed to kill that MovHint while we do not have exits.
+        // This is a work-around for that case, we chase only one successor and collect a bit more precise liveness information.
+        if (block->terminal()->isJump()) {
+            auto* successor = block->successor(0);
+
+            m_graph.forAllLiveInBytecode(
+                successor->terminal()->origin.forExit,
+                [&] (Operand reg) {
+                    m_state.operand(reg) = currentEpoch;
+                });
+
+            // Assume that blocks after we exit.
+            currentEpoch.bump();
+
+            for (unsigned nodeIndex = successor->size(); nodeIndex--;) {
+                Node* node = successor->at(nodeIndex);
+
+                if (node->op() == MovHint)
+                    m_state.operand(node->unlinkedOperand()) = Epoch();
+
+                if (mayExit(m_graph, node) != DoesNotExit)
+                    currentEpoch.bump();
+
+                Node* before = block->terminal();
+                if (nodeIndex)
+                    before = successor->at(nodeIndex - 1);
+
+                forAllKilledOperands(
+                    m_graph, before, node,
+                    [&] (Operand operand) {
+                        // This function is a bit sloppy - it might claim to kill a local even if
+                        // it's still live after. We need to protect against that.
+                        if (!!m_state.operand(operand))
+                            return;
+
+                        dataLogLnIf(DFGMovHintRemovalPhaseInternal::verbose, "    Killed operand at ", node, ": ", operand);
+                        m_state.operand(operand) = currentEpoch;
+                    });
+            }
+        } else {
+            m_graph.forAllLiveInBytecode(
+                block->terminal()->origin.forExit,
+                [&] (Operand reg) {
+                    m_state.operand(reg) = currentEpoch;
+                });
+
+            // Assume that blocks after we exit.
+            currentEpoch.bump();
+        }
 
         dataLogLnIf(DFGMovHintRemovalPhaseInternal::verbose, "    Locals at ", block->terminal()->origin.forExit, ": ", m_state);
-
-        // Assume that blocks after we exit.
-        currentEpoch.bump();
 
         for (unsigned nodeIndex = block->size(); nodeIndex--;) {
             Node* node = block->at(nodeIndex);

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -735,9 +735,11 @@ private:
         switch (m_node->op()) {
         case DFG::Upsilon:
             compileUpsilon();
+            codeGenerationResult = CodeGenerationResult::NotGenerated;
             break;
         case DFG::Phi:
             compilePhi();
+            codeGenerationResult = CodeGenerationResult::NotGenerated;
             break;
         case ExtractFromTuple:
             compileExtractFromTuple();
@@ -1872,6 +1874,7 @@ private:
 
         case LoopHint: {
             compileLoopHint();
+            codeGenerationResult = CodeGenerationResult::NotGenerated;
             break;
         }
 


### PR DESCRIPTION
#### f1fa4f744f36e153998175109c5c68b86c69c778
<pre>
[JSC] Tweak FTL inlining non-codegen-nodes list and MakeRope MovHints
<a href="https://bugs.webkit.org/show_bug.cgi?id=293243">https://bugs.webkit.org/show_bug.cgi?id=293243</a>
<a href="https://rdar.apple.com/151634076">rdar://151634076</a>

Reviewed by Yijia Huang.

This patch changes,

1. list of FTL non-codegen nodes. Upsilon / Phi are more control-flow
   graph shape related, and ultimately it is unrelated to the function&apos;s
   cost. This patch removes them from the codegen node list. We also
   remove LoopHint since it is not generating a code.
2. MakeRope should say ExitsForExceptions instead of Exits since only
   exception is OOM error.
3. We found that MovHint removal phase is suboptimal in some cases where
   we jump to the other BasicBlock and that has ZombieHint. This happens
   when FTL is inlining calls with polymorphic variants. We work-around
   this issue by getting a bit more precise liveness information by
   iterating the successor basic block. This is just a heuristic.

* Source/JavaScriptCore/dfg/DFGGraph.cpp:
(JSC::DFG::Graph::dethread):
* Source/JavaScriptCore/dfg/DFGMayExit.cpp:
* Source/JavaScriptCore/dfg/DFGMovHintRemovalPhase.cpp:
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileNode):

Canonical link: <a href="https://commits.webkit.org/295122@main">https://commits.webkit.org/295122@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9d08957188a7688db289c33416554e2f7fb09d77

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104135 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/23839 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/14159 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/109331 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/54803 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/24207 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/32383 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/79109 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107141 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/18806 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/93943 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/59436 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/18613 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/11983 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/54163 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/96810 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/88327 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/12039 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/111717 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/102746 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/31291 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Debug-WK2-Tests-EWS "Waiting to run tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/88119 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/31655 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/90130 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87779 "Found 1 new API test failure: /WebKitGTK/TestCookieManager:/webkit/WebKitCookieManager/persistent-storage (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32665 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10416 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/25755 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16908 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/31220 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/36533 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/126380 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/31014 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34949 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/34350 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/32574 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->