### PR TITLE
Temporal: Make ExactTime::difference() return an InternalDuration

### DIFF
--- a/JSTests/stress/temporal-instant.js
+++ b/JSTests/stress/temporal-instant.js
@@ -427,3 +427,19 @@ const maxValue = new Temporal.Instant(86400_0000_0000_000_000_000n);
         shouldThrow(() => epoch.subtract({ [unit]: -Number.MAX_VALUE }), RangeError);
     });
 }
+
+// since() and until()
+{
+    const earlier = Temporal.Instant.from("1976-11-18T15:23:30.123456789Z");
+    const later = Temporal.Instant.from("2019-10-29T10:46:38.271986102Z");
+    const diff = later.since(earlier);
+    shouldBe(diff.nanoseconds, 313);
+    shouldBe(diff.microseconds, 529);
+    shouldBe(diff.milliseconds, 148);
+    shouldBe(diff.seconds, 1355167388);
+    const diff1 = earlier.until(later);
+    shouldBe(diff1.nanoseconds, diff.nanoseconds);
+    shouldBe(diff1.microseconds, diff.microseconds);
+    shouldBe(diff1.milliseconds, diff.milliseconds);
+    shouldBe(diff1.seconds, diff.seconds);
+}

--- a/JSTests/test262/expectations.yaml
+++ b/JSTests/test262/expectations.yaml
@@ -262,48 +262,9 @@ test/built-ins/Temporal/Duration/prototype/total/throws-if-target-nanoseconds-ou
 test/built-ins/Temporal/Duration/prototype/total/total-of-each-unit-relativeto.js:
   default: "TypeError: undefined is not a constructor (evaluating 'new Temporal.ZonedDateTime(63072000_000_000_000n /* = 1972-01-01T00Z */, \"UTC\")')"
   strict mode: "TypeError: undefined is not a constructor (evaluating 'new Temporal.ZonedDateTime(63072000_000_000_000n /* = 1972-01-01T00Z */, \"UTC\")')"
-test/built-ins/Temporal/Instant/prototype/since/add-subtract.js:
-  default: 'Test262Error: equals method'
-  strict mode: 'Test262Error: equals method'
-test/built-ins/Temporal/Instant/prototype/since/largestunit.js:
-  default: 'Test262Error: does not include higher units than necessary (largest unit unspecified): nanoseconds result Expected SameValue(«40», «101») to be true'
-  strict mode: 'Test262Error: does not include higher units than necessary (largest unit unspecified): nanoseconds result Expected SameValue(«40», «101») to be true'
 test/built-ins/Temporal/Instant/prototype/since/order-of-operations.js:
   default: 'Test262Error: Actual [get other.toString, call other.toString, get options.smallestUnit, get options.smallestUnit.toString, call options.smallestUnit.toString, get options.largestUnit, get options.largestUnit.toString, call options.largestUnit.toString, get options.roundingMode, get options.roundingMode.toString, call options.roundingMode.toString, get options.roundingIncrement, get options.roundingIncrement.valueOf, call options.roundingIncrement.valueOf] and expected [get other.toString, call other.toString, get options.largestUnit, get options.largestUnit.toString, call options.largestUnit.toString, get options.roundingIncrement, get options.roundingIncrement.valueOf, call options.roundingIncrement.valueOf, get options.roundingMode, get options.roundingMode.toString, call options.roundingMode.toString, get options.smallestUnit, get options.smallestUnit.toString, call options.smallestUnit.toString] should have the same contents. order of operations'
   strict mode: 'Test262Error: Actual [get other.toString, call other.toString, get options.smallestUnit, get options.smallestUnit.toString, call options.smallestUnit.toString, get options.largestUnit, get options.largestUnit.toString, call options.largestUnit.toString, get options.roundingMode, get options.roundingMode.toString, call options.roundingMode.toString, get options.roundingIncrement, get options.roundingIncrement.valueOf, call options.roundingIncrement.valueOf] and expected [get other.toString, call other.toString, get options.largestUnit, get options.largestUnit.toString, call options.largestUnit.toString, get options.roundingIncrement, get options.roundingIncrement.valueOf, call options.roundingIncrement.valueOf, get options.roundingMode, get options.roundingMode.toString, call options.roundingMode.toString, get options.smallestUnit, get options.smallestUnit.toString, call options.smallestUnit.toString] should have the same contents. order of operations'
-test/built-ins/Temporal/Instant/prototype/since/round-cross-unit-boundary.js:
-  default: 'Test262Error: -1:59 balances to -2 hours: hours result: Expected SameValue(«-1», «-2») to be true'
-  strict mode: 'Test262Error: -1:59 balances to -2 hours: hours result: Expected SameValue(«-1», «-2») to be true'
-test/built-ins/Temporal/Instant/prototype/since/rounding-increments.js:
-  default: 'Test262Error: nanoseconds result Expected SameValue(«128», «0») to be true'
-  strict mode: 'Test262Error: nanoseconds result Expected SameValue(«128», «0») to be true'
-test/built-ins/Temporal/Instant/prototype/since/roundingmode-ceil.js:
-  default: 'Test262Error: rounds to milliseconds (roundingMode = ceil, positive case): nanoseconds result Expected SameValue(«936», «0») to be true'
-  strict mode: 'Test262Error: rounds to milliseconds (roundingMode = ceil, positive case): nanoseconds result Expected SameValue(«936», «0») to be true'
-test/built-ins/Temporal/Instant/prototype/since/roundingmode-expand.js:
-  default: 'Test262Error: rounds to hours (rounding mode = expand, negative case): hours result: Expected SameValue(«-376435», «-376436») to be true'
-  strict mode: 'Test262Error: rounds to hours (rounding mode = expand, negative case): hours result: Expected SameValue(«-376435», «-376436») to be true'
-test/built-ins/Temporal/Instant/prototype/since/roundingmode-floor.js:
-  default: 'Test262Error: rounds to milliseconds (rounding mode = floor, negative case): nanoseconds result Expected SameValue(«-936», «0») to be true'
-  strict mode: 'Test262Error: rounds to milliseconds (rounding mode = floor, negative case): nanoseconds result Expected SameValue(«-936», «0») to be true'
-test/built-ins/Temporal/Instant/prototype/since/roundingmode-halfCeil.js:
-  default: 'Test262Error: rounds to milliseconds (roundingMode = halfCeil, positive case): nanoseconds result Expected SameValue(«936», «0») to be true'
-  strict mode: 'Test262Error: rounds to milliseconds (roundingMode = halfCeil, positive case): nanoseconds result Expected SameValue(«936», «0») to be true'
-test/built-ins/Temporal/Instant/prototype/since/roundingmode-halfEven.js:
-  default: 'Test262Error: rounds to milliseconds (roundingMode = halfEven, positive case): nanoseconds result Expected SameValue(«936», «0») to be true'
-  strict mode: 'Test262Error: rounds to milliseconds (roundingMode = halfEven, positive case): nanoseconds result Expected SameValue(«936», «0») to be true'
-test/built-ins/Temporal/Instant/prototype/since/roundingmode-halfExpand.js:
-  default: 'Test262Error: rounds to milliseconds (roundingMode = halfExpand, positive case): nanoseconds result Expected SameValue(«936», «0») to be true'
-  strict mode: 'Test262Error: rounds to milliseconds (roundingMode = halfExpand, positive case): nanoseconds result Expected SameValue(«936», «0») to be true'
-test/built-ins/Temporal/Instant/prototype/since/roundingmode-halfFloor.js:
-  default: 'Test262Error: rounds to milliseconds (roundingMode = halfFloor, positive case): nanoseconds result Expected SameValue(«936», «0») to be true'
-  strict mode: 'Test262Error: rounds to milliseconds (roundingMode = halfFloor, positive case): nanoseconds result Expected SameValue(«936», «0») to be true'
-test/built-ins/Temporal/Instant/prototype/since/roundingmode-halfTrunc.js:
-  default: 'Test262Error: rounds to milliseconds (roundingMode = halfTrunc, positive case): nanoseconds result Expected SameValue(«936», «0») to be true'
-  strict mode: 'Test262Error: rounds to milliseconds (roundingMode = halfTrunc, positive case): nanoseconds result Expected SameValue(«936», «0») to be true'
-test/built-ins/Temporal/Instant/prototype/since/roundingmode-trunc.js:
-  default: 'Test262Error: rounds to hours (rounding mode = trunc, negative case): hours result: Expected SameValue(«-376436», «-376435») to be true'
-  strict mode: 'Test262Error: rounds to hours (rounding mode = trunc, negative case): hours result: Expected SameValue(«-376436», «-376435») to be true'
 test/built-ins/Temporal/Instant/prototype/toString/order-of-operations.js:
   default: 'Error: FIXME: Temporal.Instant.toString({timeZone}) not implemented yet'
   strict mode: 'Error: FIXME: Temporal.Instant.toString({timeZone}) not implemented yet'
@@ -313,42 +274,9 @@ test/built-ins/Temporal/Instant/prototype/toString/timezone-string-sub-minute-of
 test/built-ins/Temporal/Instant/prototype/toString/timezone-wrong-type.js:
   default: 'Test262Error: null does not convert to a valid ISO string Expected a TypeError but got a RangeError'
   strict mode: 'Test262Error: null does not convert to a valid ISO string Expected a TypeError but got a RangeError'
-test/built-ins/Temporal/Instant/prototype/until/add-subtract.js:
-  default: 'Test262Error: equals method'
-  strict mode: 'Test262Error: equals method'
 test/built-ins/Temporal/Instant/prototype/until/order-of-operations.js:
   default: 'Test262Error: Actual [get other.toString, call other.toString, get options.smallestUnit, get options.smallestUnit.toString, call options.smallestUnit.toString, get options.largestUnit, get options.largestUnit.toString, call options.largestUnit.toString, get options.roundingMode, get options.roundingMode.toString, call options.roundingMode.toString, get options.roundingIncrement, get options.roundingIncrement.valueOf, call options.roundingIncrement.valueOf] and expected [get other.toString, call other.toString, get options.largestUnit, get options.largestUnit.toString, call options.largestUnit.toString, get options.roundingIncrement, get options.roundingIncrement.valueOf, call options.roundingIncrement.valueOf, get options.roundingMode, get options.roundingMode.toString, call options.roundingMode.toString, get options.smallestUnit, get options.smallestUnit.toString, call options.smallestUnit.toString] should have the same contents. order of operations'
   strict mode: 'Test262Error: Actual [get other.toString, call other.toString, get options.smallestUnit, get options.smallestUnit.toString, call options.smallestUnit.toString, get options.largestUnit, get options.largestUnit.toString, call options.largestUnit.toString, get options.roundingMode, get options.roundingMode.toString, call options.roundingMode.toString, get options.roundingIncrement, get options.roundingIncrement.valueOf, call options.roundingIncrement.valueOf] and expected [get other.toString, call other.toString, get options.largestUnit, get options.largestUnit.toString, call options.largestUnit.toString, get options.roundingIncrement, get options.roundingIncrement.valueOf, call options.roundingIncrement.valueOf, get options.roundingMode, get options.roundingMode.toString, call options.roundingMode.toString, get options.smallestUnit, get options.smallestUnit.toString, call options.smallestUnit.toString] should have the same contents. order of operations'
-test/built-ins/Temporal/Instant/prototype/until/rounding-increments.js:
-  default: 'Test262Error: nanoseconds result Expected SameValue(«128», «0») to be true'
-  strict mode: 'Test262Error: nanoseconds result Expected SameValue(«128», «0») to be true'
-test/built-ins/Temporal/Instant/prototype/until/roundingmode-ceil.js:
-  default: 'Test262Error: rounds to milliseconds (roundingMode = ceil, positive case): nanoseconds result Expected SameValue(«936», «0») to be true'
-  strict mode: 'Test262Error: rounds to milliseconds (roundingMode = ceil, positive case): nanoseconds result Expected SameValue(«936», «0») to be true'
-test/built-ins/Temporal/Instant/prototype/until/roundingmode-expand.js:
-  default: 'Test262Error: rounds to hours (rounding mode = expand, negative case): hours result: Expected SameValue(«-376435», «-376436») to be true'
-  strict mode: 'Test262Error: rounds to hours (rounding mode = expand, negative case): hours result: Expected SameValue(«-376435», «-376436») to be true'
-test/built-ins/Temporal/Instant/prototype/until/roundingmode-floor.js:
-  default: 'Test262Error: rounds to milliseconds (rounding mode = floor, negative case): nanoseconds result Expected SameValue(«-936», «0») to be true'
-  strict mode: 'Test262Error: rounds to milliseconds (rounding mode = floor, negative case): nanoseconds result Expected SameValue(«-936», «0») to be true'
-test/built-ins/Temporal/Instant/prototype/until/roundingmode-halfCeil.js:
-  default: 'Test262Error: rounds to milliseconds (roundingMode = halfCeil, positive case): nanoseconds result Expected SameValue(«936», «0») to be true'
-  strict mode: 'Test262Error: rounds to milliseconds (roundingMode = halfCeil, positive case): nanoseconds result Expected SameValue(«936», «0») to be true'
-test/built-ins/Temporal/Instant/prototype/until/roundingmode-halfEven.js:
-  default: 'Test262Error: rounds to milliseconds (roundingMode = halfEven, positive case): nanoseconds result Expected SameValue(«936», «0») to be true'
-  strict mode: 'Test262Error: rounds to milliseconds (roundingMode = halfEven, positive case): nanoseconds result Expected SameValue(«936», «0») to be true'
-test/built-ins/Temporal/Instant/prototype/until/roundingmode-halfExpand.js:
-  default: 'Test262Error: rounds to milliseconds (roundingMode = halfExpand, positive case): nanoseconds result Expected SameValue(«936», «0») to be true'
-  strict mode: 'Test262Error: rounds to milliseconds (roundingMode = halfExpand, positive case): nanoseconds result Expected SameValue(«936», «0») to be true'
-test/built-ins/Temporal/Instant/prototype/until/roundingmode-halfFloor.js:
-  default: 'Test262Error: rounds to milliseconds (roundingMode = halfFloor, positive case): nanoseconds result Expected SameValue(«936», «0») to be true'
-  strict mode: 'Test262Error: rounds to milliseconds (roundingMode = halfFloor, positive case): nanoseconds result Expected SameValue(«936», «0») to be true'
-test/built-ins/Temporal/Instant/prototype/until/roundingmode-halfTrunc.js:
-  default: 'Test262Error: rounds to milliseconds (roundingMode = halfTrunc, positive case): nanoseconds result Expected SameValue(«936», «0») to be true'
-  strict mode: 'Test262Error: rounds to milliseconds (roundingMode = halfTrunc, positive case): nanoseconds result Expected SameValue(«936», «0») to be true'
-test/built-ins/Temporal/Instant/prototype/until/roundingmode-trunc.js:
-  default: 'Test262Error: rounds to hours (rounding mode = trunc, negative case): hours result: Expected SameValue(«-376436», «-376435») to be true'
-  strict mode: 'Test262Error: rounds to hours (rounding mode = trunc, negative case): hours result: Expected SameValue(«-376436», «-376435») to be true'
 test/built-ins/Temporal/PlainDate/argument-convert.js:
   default: 'Test262Error: calendar must be string in canonicalizeCalendarEra Expected SameValue(«"undefined"», «"string"») to be true'
   strict mode: 'Test262Error: calendar must be string in canonicalizeCalendarEra Expected SameValue(«"undefined"», «"string"») to be true'

--- a/Source/JavaScriptCore/runtime/ISO8601.h
+++ b/Source/JavaScriptCore/runtime/ISO8601.h
@@ -86,6 +86,8 @@ private:
     std::array<double, numberOfTemporalUnits> m_data { };
 };
 
+class InternalDuration;
+
 class ExactTime {
     WTF_MAKE_TZONE_ALLOCATED(ExactTime);
 public:
@@ -152,8 +154,8 @@ public:
     friend constexpr auto operator<=>(const ExactTime&, const ExactTime&) = default;
 
     std::optional<ExactTime> add(Duration) const;
-    Int128 difference(ExactTime other, unsigned increment, TemporalUnit, RoundingMode) const;
-    ExactTime round(unsigned increment, TemporalUnit, RoundingMode) const;
+    InternalDuration difference(JSGlobalObject*, ExactTime, unsigned, TemporalUnit, RoundingMode) const;
+    ExactTime round(JSGlobalObject*, unsigned, TemporalUnit, RoundingMode) const;
 
     static ExactTime now();
 
@@ -164,8 +166,6 @@ private:
             asStringImpl(builder, value / 10);
         builder.append(static_cast<LChar>(static_cast<unsigned>(value % 10) + '0'));
     }
-
-    static Int128 round(Int128 quantity, unsigned increment, TemporalUnit, RoundingMode);
 
     Int128 m_epochNanoseconds { };
 };
@@ -328,4 +328,12 @@ bool isDateTimeWithinLimits(int32_t year, uint8_t month, uint8_t day, unsigned h
 bool isYearWithinLimits(double year);
 
 } // namespace ISO8601
+
+static constexpr Int128 absInt128(const Int128& value)
+{
+    if (value < 0)
+        return -value;
+    return value;
+}
+
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/TemporalDuration.h
+++ b/Source/JavaScriptCore/runtime/TemporalDuration.h
@@ -72,6 +72,8 @@ public:
     static ISO8601::Duration fromDurationLike(JSGlobalObject*, JSObject*);
     static ISO8601::Duration toISO8601Duration(JSGlobalObject*, JSValue);
 
+    static ISO8601::Duration temporalDurationFromInternal(ISO8601::InternalDuration, TemporalUnit);
+
     static int sign(const ISO8601::Duration&);
     static double round(ISO8601::Duration&, double increment, TemporalUnit, RoundingMode);
     static std::optional<double> balance(ISO8601::Duration&, TemporalUnit largestUnit);

--- a/Source/JavaScriptCore/runtime/TemporalObject.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalObject.cpp
@@ -457,6 +457,33 @@ RoundingMode negateTemporalRoundingMode(RoundingMode roundingMode)
     }
 }
 
+// https://tc39.es/proposal-temporal/#sec-applyunsignedroundingmode
+// ApplyUnsignedRoundingMode ( x, r1, r2, unsignedRoundingMode )
+double applyUnsignedRoundingMode(double x, double r1, double r2, UnsignedRoundingMode unsignedRoundingMode)
+{
+    if (x == r1)
+        return r1;
+    ASSERT(r1 < x && x < r2);
+    if (unsignedRoundingMode == UnsignedRoundingMode::Zero)
+        return r1;
+    if (unsignedRoundingMode == UnsignedRoundingMode::Infinity)
+        return r2;
+    double d1 = x - r1;
+    double d2 = r2 - x;
+    if (d1 < d2)
+        return r1;
+    if (d2 < d1)
+        return r2;
+    ASSERT(d1 == d2);
+    if (unsignedRoundingMode == UnsignedRoundingMode::HalfZero)
+        return r1;
+    if (unsignedRoundingMode == UnsignedRoundingMode::HalfInfinity)
+        return r2;
+    ASSERT(unsignedRoundingMode == UnsignedRoundingMode::HalfEven);
+    auto cardinality = std::fmod(r1 / (r2 - r1), 2);
+    return !cardinality ? r1 : r2;
+}
+
 void formatSecondsStringFraction(StringBuilder& builder, unsigned fraction, std::tuple<Precision, unsigned> precision)
 {
     auto [precisionType, precisionValue] = precision;
@@ -600,55 +627,77 @@ double roundNumberToIncrement(double x, double increment, RoundingMode mode)
 
 // RoundNumberToIncrementAsIfPositive ( x, increment, roundingMode )
 // https://tc39.es/proposal-temporal/#sec-temporal-roundnumbertoincrementasifpositive
-Int128 roundNumberToIncrement(Int128 x, Int128 increment, RoundingMode mode)
+Int128 roundNumberToIncrementAsIfPositive(Int128 x, Int128 increment, RoundingMode roundingMode)
 {
-    ASSERT(increment);
-
-    if (increment == 1)
-        return x;
-
+    // The following code follows the polyfill rather than the spec, because we don't have float128.
+    // ApplyUnsignedRoundingMode is inlined here to mirror the polyfill's implementation of it,
+    // which has a different type than in the spec.
+    // See https://github.com/tc39/proposal-temporal/blob/main/polyfill/lib/ecmascript.mjs#L4056
     Int128 quotient = x / increment;
     Int128 remainder = x % increment;
-    if (!remainder)
-        return x;
-
-    bool sign = remainder < 0;
-    switch (mode) {
-    case RoundingMode::Ceil:
-    case RoundingMode::Expand:
-        if (!sign)
-            quotient++;
-        break;
-    case RoundingMode::Floor:
-    case RoundingMode::Trunc:
-        if (sign)
-            quotient--;
-        break;
-    case RoundingMode::HalfCeil:
-    case RoundingMode::HalfExpand:
-        // "half toward infinity"
-        if (!sign && remainder * 2 >= increment)
-            quotient++;
-        else if (sign && -remainder * 2 > increment)
-            quotient--;
-        break;
-    case RoundingMode::HalfFloor:
-    case RoundingMode::HalfTrunc:
-        // "half toward zero"
-        if (!sign && remainder * 2 > increment)
-            quotient++;
-        else if (sign && -remainder * 2 >= increment)
-            quotient--;
-        break;
-    case RoundingMode::HalfEven:
-        // "half toward even multiple of increment"
-        if (!sign && (remainder * 2 > increment || (remainder * 2 == increment && quotient % 2 == 1)))
-            quotient++;
-        else if (sign && (-remainder * 2 > increment || (-remainder * 2 == increment && -quotient % 2 == 1)))
-            quotient--;
-        break;
+    auto unsignedRoundingMode = getUnsignedRoundingMode(roundingMode, false);
+    auto r1 = quotient;
+    auto r2 = quotient + 1;
+    if (x < 0) {
+        r1 = quotient - 1;
+        r2 = quotient;
     }
-    return quotient * increment;
+    auto doubleRemainder = absInt128(remainder * 2);
+    auto even = r1 % 2;
+    if (quotient * increment == x)
+        return x;
+    if (unsignedRoundingMode == UnsignedRoundingMode::Zero)
+        return r1 * increment;
+    if (unsignedRoundingMode == UnsignedRoundingMode::Infinity)
+        return r2 * increment;
+    if (doubleRemainder < increment)
+        return r1 * increment;
+    if (doubleRemainder > increment)
+        return r2 * increment;
+    if (unsignedRoundingMode == UnsignedRoundingMode::HalfZero)
+        return r1 * increment;
+    if (unsignedRoundingMode == UnsignedRoundingMode::HalfInfinity)
+        return r2 * increment;
+    return !even ? r1 * increment : r2 * increment;
+}
+
+// There are two different versions of this method due to the lack
+// of float128. The names are different (roundNumberToIncrementInt128() and
+// roundNumberToIncrement()) to avoid confusion in the presence of
+// implicit casts.
+// https://tc39.es/proposal-temporal/#sec-temporal-roundnumbertoincrement
+Int128 roundNumberToIncrementInt128(Int128 x, Int128 increment, RoundingMode mode)
+{
+    // This follows the polyfill code rather than the spec, in order to work around
+    // being unable to apply floating-point division in x / increment.
+    // See https://github.com/tc39/proposal-temporal/blob/main/polyfill/lib/ecmascript.mjs#L4043
+    Int128 quotient = x / increment;
+    Int128 remainder = x % increment;
+    bool isNegative = x < 0;
+    Int128 r1 = absInt128(quotient);
+    Int128 r2 = r1 + 1;
+    Int128 even = r1 % 2;
+    auto unsignedRoundingMode = getUnsignedRoundingMode(mode, isNegative);
+    Int128 rounded = 0;
+    if (absInt128(x) == r1 * increment)
+        rounded = r1;
+    else if (unsignedRoundingMode == UnsignedRoundingMode::Zero)
+        rounded = r1;
+    else if (unsignedRoundingMode == UnsignedRoundingMode::Infinity)
+        rounded = r2;
+    else if (absInt128(remainder * 2) < increment)
+        rounded = r1;
+    else if (absInt128(remainder * 2) > increment)
+        rounded = r2;
+    else if (unsignedRoundingMode == UnsignedRoundingMode::HalfZero)
+        rounded = r1;
+    else if (unsignedRoundingMode == UnsignedRoundingMode::HalfInfinity)
+        rounded = r2;
+    else
+        rounded = !even ? r1 : r2;
+    if (isNegative)
+        rounded = -rounded;
+    return rounded * increment;
 }
 
 TemporalOverflow toTemporalOverflow(JSGlobalObject* globalObject, JSObject* options)


### PR DESCRIPTION
#### 4927ce289367605b71e2599379961f52ccb31b4c
<pre>
Temporal: Make ExactTime::difference() return an InternalDuration

<a href="https://bugs.webkit.org/show_bug.cgi?id=223166">https://bugs.webkit.org/show_bug.cgi?id=223166</a>

Reviewed by Keith Miller.

TemporalInstant::difference() now calls ExactTime::difference(),
then converts the result back to a Duration.

This enables some of the tests for TemporalInstant/p/since and
TemporalInstant/p/until that previously failed.

As part of this change, implement ExactTime::round() according to the
spec.

* JSTests/stress/temporal-instant.js:
* JSTests/test262/expectations.yaml:
* Source/JavaScriptCore/runtime/ISO8601.cpp:
(JSC::ISO8601::roundTemporalInstant):
(JSC::ISO8601::validateTemporalRoundingIncrement):
(JSC::ISO8601::ExactTime::round const):
(JSC::ISO8601::roundTimeDurationToIncrement):
(JSC::ISO8601::roundTimeDuration):
(JSC::ISO8601::ExactTime::difference const):
(JSC::ISO8601::absInt128): Deleted.
(JSC::ISO8601::ExactTime::round): Deleted.
* Source/JavaScriptCore/runtime/ISO8601.h:
(JSC::ISO8601::ExactTime::absInt128):
* Source/JavaScriptCore/runtime/TemporalDuration.cpp:
(JSC::TemporalDuration::temporalDurationFromInternal):
* Source/JavaScriptCore/runtime/TemporalDuration.h:
* Source/JavaScriptCore/runtime/TemporalInstant.cpp:
* Source/JavaScriptCore/runtime/TemporalObject.cpp:
(JSC::applyUnsignedRoundingMode):
(JSC::roundNumberToIncrementAsIfPositive):
(JSC::roundNumberToIncrementInt128):
* Source/JavaScriptCore/runtime/TemporalObject.h:
(JSC::lengthInNanoseconds):
(JSC::getUnsignedRoundingMode):

Canonical link: <a href="https://commits.webkit.org/299050@main">https://commits.webkit.org/299050@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0622f719a5b32108ca1553ad3b5db6986fad9b70

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/117587 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37264 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/27889 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/123699 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/69594 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/37957 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/45847 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89235 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/45041 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/120539 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30211 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105428 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/69737 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29273 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/23544 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/67368 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/109697 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99627 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23726 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/126812 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/116096 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/44490 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33469 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97900 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/44848 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101657 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97688 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24870 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43059 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21013 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/40848 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44361 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/50036 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/144794 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/43819 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/37262 "Found 1 new JSC binary failure: testapi, Found 20047 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Array/array_slice.js.default, ChakraCore.yaml/ChakraCore/test/Array/array_sort2.js.default, ChakraCore.yaml/ChakraCore/test/Array/push2.js.default, ChakraCore.yaml/ChakraCore/test/Array/reverse1.js.default, ChakraCore.yaml/ChakraCore/test/Array/toLocaleString.js.default, ChakraCore.yaml/ChakraCore/test/Bugs/blue_1086262.js.default, ChakraCore.yaml/ChakraCore/test/Bugs/bug215238.shrua-2.js.default, ChakraCore.yaml/ChakraCore/test/ControlFlow/forInPrimitive.js.default, ChakraCore.yaml/ChakraCore/test/Date/date_cache_bug.js.default, ChakraCore.yaml/ChakraCore/test/Error/CallNonFunction.js.default ... (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/47167 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/45511 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->