### PR TITLE
Fix Container Query for Shadow DOM to pass WPTs

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/container-for-shadow-dom-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/container-for-shadow-dom-expected.txt
@@ -1,16 +1,16 @@
 
 PASS Match container in outer tree
-FAIL Match container in walking flat tree ancestors assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
+PASS Match container in walking flat tree ancestors
 PASS Match container in ::slotted selector's originating element tree
 PASS Match container in outer tree for :host
-FAIL Match container in ::part selector's originating element tree assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
+PASS Match container in ::part selector's originating element tree
 FAIL Match container for ::before in ::slotted selector's originating element tree assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
 PASS Match container in outer tree for :host::before
-FAIL Match container for ::before in ::part selector's originating element tree assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
-FAIL Match container for ::part selector's originating element tree for exportparts assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
+PASS Match container for ::before in ::part selector's originating element tree
+PASS Match container for ::part selector's originating element tree for exportparts
 PASS Match container for slot light tree child fallback
-FAIL Should not match container inside shadow tree for ::part() assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
-FAIL A :host::part rule should match containers in the originating element tree assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
+PASS Should not match container inside shadow tree for ::part()
+PASS A :host::part rule should match containers in the originating element tree
 PASS Container name set inside a shadow tree should not match query using ::part on the outside
 PASS Container name set with a ::part should match query inside the shadow tree
 PASS Container name set inside a shadow tree should match query for a ::slotted() rule inside the tree

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/style-container-for-shadow-dom-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/style-container-for-shadow-dom-expected.txt
@@ -1,14 +1,14 @@
 
 PASS Match container in outer tree
-FAIL Match container in the shadow tree for a host child in the host child's tree scope assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
+PASS Match container in the shadow tree for a host child in the host child's tree scope
 PASS Match <slot> as a container for ::slotted element
 PASS Match container in outer tree for :host
-FAIL Match ::part's parent in the shadow tree as the container for ::part assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
+PASS Match ::part's parent in the shadow tree as the container for ::part
 FAIL Match ::slotted as a container for its ::before assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
 PASS Match container in outer tree for :host::before
 FAIL Match the ::part as a container for ::before on ::part elements assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
-FAIL Match container for ::part selector in inner shadow tree for exportparts assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
+PASS Match container for ::part selector in inner shadow tree for exportparts
 PASS Match container for slot light tree child fallback
-FAIL Should match parent container inside shadow tree for ::part() assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
-FAIL A :host::part rule matching a container in the shadow tree assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
+PASS Should match parent container inside shadow tree for ::part()
+PASS A :host::part rule matching a container in the shadow tree
 

--- a/Source/WebCore/style/ContainerQueryEvaluator.cpp
+++ b/Source/WebCore/style/ContainerQueryEvaluator.cpp
@@ -154,16 +154,18 @@ const Element* ContainerQueryEvaluator::selectContainer(OptionSet<CQ::Axis> requ
     };
 
     auto findOriginatingElement = [&]() -> const Element* {
-        // ::part() selectors can query its originating host, but not internal query containers inside the shadow tree.
-        if (selectionMode == SelectionMode::PartPseudoElement) {
-            if (scopeOrdinal <= ScopeOrdinal::ContainingHost)
-                return hostForScopeOrdinal(element, scopeOrdinal);
-            ASSERT(scopeOrdinal == ScopeOrdinal::Element);
-            return element.shadowHost();
-        }
+        // ::part() selectors query the composed tree
+        if (selectionMode == SelectionMode::PartPseudoElement)
+            return element.assignedSlot();
+
         // ::slotted() selectors can query containers inside the shadow tree, including the slot itself.
         if (scopeOrdinal >= ScopeOrdinal::FirstSlot && scopeOrdinal <= ScopeOrdinal::SlotLimit)
             return assignedSlotForScopeOrdinal(element, scopeOrdinal);
+
+        // Unnamed queries query the composed tree, while named queries do not.
+        if (scopeOrdinal == ScopeOrdinal::Element && element.assignedSlot() && name.isEmpty())
+            return element.assignedSlot();
+
         return nullptr;
     };
 


### PR DESCRIPTION
#### a20439aa1afd56e3b8e0f4af7c899ac98237fa3d
<pre>
Fix Container Query for Shadow DOM to pass WPTs

<a href="https://bugs.webkit.org/show_bug.cgi?id=289868">https://bugs.webkit.org/show_bug.cgi?id=289868</a>

Reviewed by Antti Koivisto.

Container Queries should resolve against the composed
tree in most cases (except for named container queries).

The WPTs already exist for this specification, so
this change is merely getting the WPTs to pass and
updating the expected output.

* LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/container-for-shadow-dom-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/style-container-for-shadow-dom-expected.txt:
* Source/WebCore/style/ContainerQueryEvaluator.cpp:
(WebCore::Style::ContainerQueryEvaluator::selectContainer):

Canonical link: <a href="https://commits.webkit.org/296080@main">https://commits.webkit.org/296080@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/82eefecaf66fffcd29e2a8808003f1dbdb6d91ac

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104211 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/23915 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/14243 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/109411 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/54879 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/106251 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/24283 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/32460 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79149 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107217 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/18866 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94016 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59476 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/18685 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/12052 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/54239 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/88379 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/12111 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/111793 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/31367 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23123 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88170 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/31731 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/90203 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87831 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23008 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32723 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10472 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/25831 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/31296 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/36609 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/31090 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/34426 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/32650 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->