### PR TITLE
Switch from deprecated `[PDFPage drawWithBox:]` to modern `[PDFPage drawWithBox:toContext:]`

### DIFF
--- a/Source/WebCore/platform/graphics/mac/PDFDocumentImageMac.mm
+++ b/Source/WebCore/platform/graphics/mac/PDFDocumentImageMac.mm
@@ -74,9 +74,7 @@ void PDFDocumentImage::drawPDFPage(GraphicsContext& context)
     bool allowsSubpixelQuantization = CGContextGetAllowsFontSubpixelQuantization(context.platformContext());
     bool allowsSubpixelPositioning = CGContextGetAllowsFontSubpixelPositioning(context.platformContext());
 
-ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    [[m_document pageAtIndex:0] drawWithBox:kPDFDisplayBoxCropBox];
-ALLOW_DEPRECATED_DECLARATIONS_END
+    [[m_document pageAtIndex:0] drawWithBox:kPDFDisplayBoxCropBox toContext:context.platformContext()];
 
     CGContextSetAllowsFontSmoothing(context.platformContext(), allowsSmoothing);
     CGContextSetAllowsFontSubpixelQuantization(context.platformContext(), allowsSubpixelQuantization);

--- a/Source/WebKit/UIProcess/mac/WKPrintingView.mm
+++ b/Source/WebKit/UIProcess/mac/WKPrintingView.mm
@@ -480,9 +480,8 @@ static RetainPtr<NSString> linkDestinationName(PDFDocument *document, PDFDestina
     CGContextTranslateCTM(context.get(), point.x, point.y);
     CGContextScaleCTM(context.get(), _totalScaleFactorForPrinting, -_totalScaleFactorForPrinting);
     CGContextTranslateCTM(context.get(), 0, -[pdfPage boundsForBox:kPDFDisplayBoxMediaBox].size.height);
-ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    [pdfPage drawWithBox:kPDFDisplayBoxMediaBox];
-ALLOW_DEPRECATED_DECLARATIONS_END
+
+    [pdfPage drawWithBox:kPDFDisplayBoxMediaBox toContext:context.get()];
 
     CGAffineTransform transform = CGContextGetCTM(context.get());
 


### PR DESCRIPTION
#### 86d17dda5f113cbfe9ae0c6f5b1d4561e6781872
<pre>
Switch from deprecated `[PDFPage drawWithBox:]` to modern `[PDFPage drawWithBox:toContext:]`
<a href="https://bugs.webkit.org/show_bug.cgi?id=293247">https://bugs.webkit.org/show_bug.cgi?id=293247</a>
<a href="https://rdar.apple.com/151640250">rdar://151640250</a>

Reviewed by Abrar Rahman Protyasha.

We already do this in most places in the modern PDF code, but two code paths
were still using the deprecated form. No detectable change in behavior, but
this change could reduce time spent by the PDF code needed to find the
correct context to use.

* Source/WebCore/platform/graphics/mac/PDFDocumentImageMac.mm:
(WebCore::PDFDocumentImage::drawPDFPage):
* Source/WebKit/UIProcess/mac/WKPrintingView.mm:
(-[WKPrintingView _drawPDFDocument:page:atPoint:]):

Canonical link: <a href="https://commits.webkit.org/295232@main">https://commits.webkit.org/295232@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e0ab8fc788f0892361c6055a2259de2dcedaa3f9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104148 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/23852 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/14172 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/109344 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/54816 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/106188 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/24220 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/32396 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79116 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107154 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/18820 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/93958 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59550 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/18630 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/11997 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/54176 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/88340 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/12053 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/111730 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/31304 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23203 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88129 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/31668 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/90144 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87789 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32676 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10429 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/25768 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16957 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/31233 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/36546 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/31027 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/34363 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/32587 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->