### PR TITLE
Add a tool to create a CSV file from safer C++ expectations

### DIFF
--- a/Tools/Scripts/create-csv-from-safer-cpp-expectations
+++ b/Tools/Scripts/create-csv-from-safer-cpp-expectations
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+# Copyright (C) 2024-2025 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import argparse
+import os
+import sys
+
+from webkitpy.safer_cpp.checkers import Checker
+
+
+def parser():
+    parser = argparse.ArgumentParser(
+        description='Create a CSV file from safer CPP expectations',
+        epilog='Example: create-csv-from-safer-cpp-expectations -p WebKit')
+
+    parser.add_argument(
+        '--project', '-p',
+        choices=Checker.projects(),
+        required=True,
+        help='Specify which project expectations you want to update'
+    )
+
+    parser.add_argument(
+        '--output-file', '-o',
+        help='Specify the output file path'
+    )
+
+    return parser.parse_args()
+
+
+def load_expectations(file_map, checker, project):
+    with open(checker.expectations_path(project)) as expectations_file:
+        for line in expectations_file:
+            line = line.strip()
+            file_map.setdefault(line, set())
+            file_map[line].add(checker.name())
+
+
+def main():
+    args = parser()
+
+    project = args.project
+    file_map = {}
+
+    output_file = open(args.output_file, 'w') if args.output_file else sys.stdout
+
+    checker_list = []
+    for checker in Checker.enumerate():
+        load_expectations(file_map, checker, args.project)
+        checker_list.append(checker.name())
+    print(','.join([''] + checker_list), file=output_file)
+
+    for file_name in sorted(list(file_map)):
+        checker_set = file_map[file_name]
+        row = [file_name]
+        for checker_type in checker_list:
+            row.append('Has Failures' if checker_type in checker_set else '')
+        print(','.join(row), file=output_file)
+
+
+if __name__ == '__main__':
+    main()

--- a/Tools/Scripts/webkitpy/safer_cpp/__init__.py
+++ b/Tools/Scripts/webkitpy/safer_cpp/__init__.py
@@ -1,0 +1,1 @@
+# Required for Python to search this directory for module files

--- a/Tools/Scripts/webkitpy/safer_cpp/checkers.py
+++ b/Tools/Scripts/webkitpy/safer_cpp/checkers.py
@@ -1,0 +1,75 @@
+# Copyright (C) 2019-2020 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+# 3.  Neither the name of Apple Inc. ("Apple") nor the names of
+#     its contributors may be used to endorse or promote products derived
+#     from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE AND ITS CONTRIBUTORS "AS IS" AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+# THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import os
+
+
+EXPECTATIONS_PATH = '../../../../../Source/{project}/SaferCPPExpectations/{checker}Expectations'
+PROJECTS = ['JavaScriptCore', 'WebCore', 'WebDriver', 'WebGPU', 'WebInspectorUI', 'WebKit', 'WebKitLegacy', 'WTF']
+
+
+class Checker(object):
+    def __init__(self, name, description):
+        self._name = name
+        self._description = description
+
+    def name(self):
+        return self._name
+
+    def description(self):
+        return self._description
+
+    def expectations_path(self, project_name):
+        path = os.path.join(__file__, EXPECTATIONS_PATH.format(project=project_name, checker=self.name()))
+        assert(project_name in PROJECTS)
+        return os.path.abspath(path)
+
+    @classmethod
+    def enumerate(cls):
+        return sorted(CHECKERS, key=lambda checker: checker.name())
+
+    @classmethod
+    def projects(cls):
+        return sorted(PROJECTS)
+
+
+CHECKERS = [
+    Checker('ForwardDeclChecker', 'Forward declared member or local variable or parameter'),
+    Checker('MemoryUnsafeCastChecker', 'Unsafe cast'),
+    Checker('NoUncheckedPtrMemberChecker', 'Member variable is a raw-pointer/reference to checked-pointer capable type'),
+    Checker('NoUncountedMemberChecker', 'Member variable is a raw-pointer/reference to reference-countable type'),
+    Checker('NoUnretainedMemberChecker', 'Member variable is a raw-pointer/reference to retainable type'),
+    Checker('RefCntblBaseVirtualDtor', 'Reference-countable base class doesn\'t have virtual destructor'),
+    Checker('RetainPtrCtorAdoptChecker', 'Correct use of RetainPtr, adoptNS, and adoptCF'),
+    Checker('UncheckedCallArgsChecker', 'Unchecked call argument for a raw pointer/reference parameter'),
+    Checker('UncheckedLocalVarsChecker', 'Unchecked raw pointer or reference not provably backed by checked variable'),
+    Checker('UncountedCallArgsChecker', 'Uncounted call argument for a raw pointer/reference parameter'),
+    Checker('UncountedLambdaCapturesChecker', 'Lambda capture of uncounted or unchecked variable'),
+    Checker('UncountedLocalVarsChecker', 'Uncounted raw pointer or reference not provably backed by ref-counted variable'),
+    Checker('UnretainedCallArgsChecker', 'Unretained call argument for a raw pointer/reference parameter'),
+    Checker('UnretainedLambdaCapturesChecker', 'Lambda capture of unretained variables'),
+    Checker('UnretainedLocalVarsChecker', 'Unretained raw pointer or reference not provably backed by a RetainPtr'),
+]


### PR DESCRIPTION
#### 6a7f7f6777890036cdec949a9586ec0cdc5aeb55
<pre>
Add a tool to create a CSV file from safer C++ expectations
<a href="https://bugs.webkit.org/show_bug.cgi?id=293250">https://bugs.webkit.org/show_bug.cgi?id=293250</a>

Reviewed by Brianna Fan.

Add a new script to create a CSV file by aggregating safer C++ expectation files.

This PR also adds webkitpy.safer_cpp.checkers to share more code across safer C++ scripts.

* Tools/Scripts/create-csv-from-safer-cpp-expectations: Added.
(parser): Added. Constructs argparser.
(load_expectations): Added. Loads a single expectation file.
(main): Added.
* Tools/Scripts/webkitpy/safer_cpp/__init__.py: Added.
* Tools/Scripts/webkitpy/safer_cpp/checkers.py: Added.
(Checker): Added.
(Checker.__init__): Added.
(Checker.name): Added.
(Checker.description): Added.
(Checker.expectations_path): Added. Returns the path to given project&apos;s expectation file.
(Checker.enumerate): Added. Lists all the checkers in the order.
(Checker.projects): Added. Lists all the WebKit projects with expectation files.
(CHECKERS): Added.

Canonical link: <a href="https://commits.webkit.org/295132@main">https://commits.webkit.org/295132@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1f5a53720b6f53d908073b9b4493c93ebc649ab1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104169 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/23873 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/14193 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/109365 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/54837 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/106209 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/24241 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/32417 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/109365 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107175 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/18831 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/93977 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/109365 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/103645 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/18643 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/12015 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/54197 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/88350 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/12073 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/111751 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/31325 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/23097 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/88143 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/31689 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/90164 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/87803 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/32691 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/10444 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/25789 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16912 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/31254 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/31048 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/34384 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/32608 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->