### PR TITLE
Reland [WebAuthn] Implement batching for checking excludeCredentials

### DIFF
--- a/LayoutTests/http/wpt/webauthn/public-key-credential-create-failure-hid.https-expected.txt
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-create-failure-hid.https-expected.txt
@@ -7,4 +7,5 @@ PASS PublicKeyCredential's [[create]] with mixed options in a mock hid authentic
 PASS PublicKeyCredential's [[create]] with mixed options in a mock hid authenticator. 2
 PASS PublicKeyCredential's [[create]] with InvalidStateError in a mock hid authenticator.
 PASS PublicKeyCredential's [[create]] with full key store.
+PASS PublicKeyCredential's [[create]] with InvalidStateError due to excluded credentials in a mock hid authenticator using batching.
 

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-create-failure-hid.https.html
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-create-failure-hid.https.html
@@ -160,7 +160,7 @@
         return promiseRejects(t, "InvalidStateError", navigator.credentials.create(options), "At least one credential matches an entry of the excludeCredentials list in the authenticator.");
     }, "PublicKeyCredential's [[create]] with InvalidStateError in a mock hid authenticator.");
 
-        promise_test(function(t) {
+    promise_test(function(t) {
         const options = {
             publicKey: {
                 rp: {
@@ -182,4 +182,38 @@
             internals.setMockWebAuthenticationConfiguration({ hid: { stage: "request", subStage: "msg", error: "malicious-payload", payloadBase64: [testCreateMessageFullKeyStoreBase64] } });
         return promiseRejects(t, "NotAllowedError", navigator.credentials.create(options), "Operation timed out.");
     }, "PublicKeyCredential's [[create]] with full key store.");
+
+    promise_test(function(t) {
+        const config = { hid: { stage: "request", subStage: "msg", error: "malicious-payload", payloadBase64: [testCtapErrCredentialExcludedOnlyResponseBase64] } };
+
+        const options = {
+            publicKey: {
+                rp: {
+                    name: "example.com"
+                },
+                user: {
+                    name: "John Appleseed",
+                    id: asciiToUint8Array("123456"),
+                    displayName: "John",
+                },
+                challenge: asciiToUint8Array("123456"),
+                pubKeyCredParams: [{ type: "public-key", alg: -7 }],
+                excludeCredentials: [],
+            }
+        };
+        const numCredentials = 5;
+
+        for (let i = 0; i < numCredentials; i++) {
+            if (i == 0)
+                config.hid.payloadBase64.unshift(testAssertionMessageBase64); // Passes assertion, therefore excluded credential present
+            else
+                config.hid.payloadBase64.unshift("Lg=="); // no match
+            options.publicKey.excludeCredentials.push({ type: "public-key", id: generateID(i) });
+        }
+
+        if (window.internals)
+            internals.setMockWebAuthenticationConfiguration(config);
+        return promiseRejects(t, "InvalidStateError", navigator.credentials.create(options), "At least one credential matches an entry of the excludeCredentials list in the authenticator.");
+    }, "PublicKeyCredential's [[create]] with InvalidStateError due to excluded credentials in a mock hid authenticator using batching.");
+
 </script>

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-create-success-hid.https-expected.txt
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-create-success-hid.https-expected.txt
@@ -19,4 +19,6 @@ PASS PublicKeyCredential's [[create]] with indirect attestation in a mock hid au
 PASS PublicKeyCredential's [[create]] with googleLegacyAppidSupport extension in a mock hid authenticator.
 PASS PublicKeyCredential's [[create]] with googleLegacyAppidSupport and appid extensions in a mock hid authenticator.
 PASS PublicKeyCredential's [[create]] with authenticatorSelection { 'cross-platform', 'preferred' } in a mock hid authenticator with a full key store.
+PASS PublicKeyCredential's [[create]] with many excludedCredentials necessitating batching in a mock hid authenticator.
+PASS PublicKeyCredential's [[create]] with many excludedCredentials necessitating batching in a mock hid authenticator. 2
 

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-create-success-hid.https.html
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-create-success-hid.https.html
@@ -489,4 +489,68 @@
             checkCtapMakeCredentialResult(credential);
         });
     }, "PublicKeyCredential's [[create]] with authenticatorSelection { 'cross-platform', 'preferred' } in a mock hid authenticator with a full key store.");
+
+    promise_test(t => {
+        let config = { hid: { stage: "request", subStage: "msg", error: "success", payloadBase64: [testCreationMessageBase64] } };
+        let options = {
+            publicKey: {
+                rp: {
+                    name: "localhost",
+                },
+                user: {
+                    name: "John Appleseed",
+                    id: Base64URL.parse(testUserhandleBase64),
+                    displayName: "Appleseed",
+                },
+                challenge: Base64URL.parse("MTIzNDU2"),
+                pubKeyCredParams: [{ type: "public-key", alg: -7 }],
+                timeout: 1000,
+                excludeCredentials: []
+            }
+        };
+        const numCredentials = 20;
+
+        for (let i = 0; i < numCredentials; i++) {
+            options.publicKey.excludeCredentials.push({ type: "public-key", id: generateID(i) });
+            config.hid.payloadBase64.unshift("Lg==");
+        }
+
+        if (window.internals)
+            internals.setMockWebAuthenticationConfiguration(config);
+        return navigator.credentials.create(options).then(credential => {
+            checkCtapMakeCredentialResult(credential, true, ["usb"]);
+        });
+    }, "PublicKeyCredential's [[create]] with many excludedCredentials necessitating batching in a mock hid authenticator.");
+
+    promise_test(t => {
+        let config = { hid: { maxCredentialCountInList: 5, stage: "request", subStage: "msg", error: "success", payloadBase64: [testCreationMessageBase64] } };
+        let options = {
+            publicKey: {
+                rp: {
+                    name: "localhost",
+                },
+                user: {
+                    name: "John Appleseed",
+                    id: Base64URL.parse(testUserhandleBase64),
+                    displayName: "Appleseed",
+                },
+                challenge: Base64URL.parse("MTIzNDU2"),
+                pubKeyCredParams: [{ type: "public-key", alg: -7 }],
+                timeout: 1000,
+                excludeCredentials: []
+            }
+        };
+        const numCredentials = 20;
+
+        for (let i = 0; i < numCredentials; i++)
+            options.publicKey.excludeCredentials.push({ type: "public-key", id: generateID(i) });
+        for (let i = 0; i < Math.ceil(numCredentials/config.hid.maxCredentialCountInList); i++)
+            config.hid.payloadBase64.unshift("Lg==");
+
+        if (window.internals)
+            internals.setMockWebAuthenticationConfiguration(config);
+        return navigator.credentials.create(options).then(credential => {
+            checkCtapMakeCredentialResult(credential, true, ["usb"]);
+        });
+    }, "PublicKeyCredential's [[create]] with many excludedCredentials necessitating batching in a mock hid authenticator. 2");
 </script>

--- a/LayoutTests/http/wpt/webauthn/resources/util.js
+++ b/LayoutTests/http/wpt/webauthn/resources/util.js
@@ -279,6 +279,15 @@ function concatenateBuffers(buffer1, buffer2)
     return tmp.buffer;
 }
 
+function generateID(nonce) {
+    let idBuffer = new Uint8Array(32);
+    for (let i = 0; i < 8; i++) {
+        idBuffer[i] = nonce % 256;
+        nonce = Math.floor(nonce / 256);
+    }
+    return idBuffer;
+}
+
 // Very dirty asn1 decoder. Just works.
 function extractRawSignature(asn1signature)
 {

--- a/Source/WebCore/Modules/webauthn/fido/AuthenticatorGetInfoResponse.cpp
+++ b/Source/WebCore/Modules/webauthn/fido/AuthenticatorGetInfoResponse.cpp
@@ -96,6 +96,17 @@ AuthenticatorGetInfoResponse& AuthenticatorGetInfoResponse::setMinPINLength(uint
     return *this;
 }
 
+AuthenticatorGetInfoResponse& AuthenticatorGetInfoResponse::setMaxCredentialCountInList(uint32_t maxCredentialCountInList)
+{
+    m_maxCredentialCountInList = maxCredentialCountInList;
+    return *this;
+}
+
+AuthenticatorGetInfoResponse& AuthenticatorGetInfoResponse::setMaxCredentialIDLength(uint32_t maxCredentialIDLength)
+{
+    m_maxCredentialIdLength = maxCredentialIDLength;
+    return *this;
+}
 
 Vector<uint8_t> encodeAsCBOR(const AuthenticatorGetInfoResponse& response)
 {
@@ -107,29 +118,35 @@ Vector<uint8_t> encodeAsCBOR(const AuthenticatorGetInfoResponse& response)
     for (const auto& version : response.versions())
         versionArray.append(toString(version));
     deviceInfoMap.emplace(CBORValue(1), CBORValue(WTFMove(versionArray)));
+    deviceInfoMap.emplace(CBORValue(kCtapAuthenticatorGetInfoVersionsKey), CBORValue(WTFMove(versionArray)));
 
     if (response.extensions())
-        deviceInfoMap.emplace(CBORValue(2), toArrayValue(*response.extensions()));
+        deviceInfoMap.emplace(CBORValue(kCtapAuthenticatorGetInfoExtensionsKey), toArrayValue(*response.extensions()));
 
-    deviceInfoMap.emplace(CBORValue(3), CBORValue(response.aaguid()));
-    deviceInfoMap.emplace(CBORValue(4), convertToCBOR(response.options()));
+    deviceInfoMap.emplace(CBORValue(kCtapAuthenticatorGetInfoAAGUIDKey), CBORValue(response.aaguid()));
+    deviceInfoMap.emplace(CBORValue(kCtapAuthenticatorGetInfoOptionsKey), convertToCBOR(response.options()));
 
     if (response.maxMsgSize())
-        deviceInfoMap.emplace(CBORValue(5), CBORValue(static_cast<int64_t>(*response.maxMsgSize())));
+        deviceInfoMap.emplace(CBORValue(kCtapAuthenticatorGetInfoMaxMsgSizeKey), CBORValue(static_cast<int64_t>(*response.maxMsgSize())));
 
     if (response.pinProtocol())
-        deviceInfoMap.emplace(CBORValue(6), toArrayValue(*response.pinProtocol()));
+        deviceInfoMap.emplace(CBORValue(kCtapAuthenticatorGetInfoPinUVAuthProtocolsKey), toArrayValue(*response.pinProtocol()));
     
     if (response.transports()) {
         auto transports = *response.transports();
-        deviceInfoMap.emplace(CBORValue(7), toArrayValue(transports.map(WebCore::toString)));
+        deviceInfoMap.emplace(CBORValue(kCtapAuthenticatorGetInfoTransportsKey), toArrayValue(transports.map(WebCore::toString)));
     }
 
     if (response.remainingDiscoverableCredentials())
-        deviceInfoMap.emplace(CBORValue(8), CBORValue(static_cast<int64_t>(*response.remainingDiscoverableCredentials())));
+        deviceInfoMap.emplace(CBORValue(kCtapAuthenticatorGetInfoRemainingDiscoverableCredentialsKey), CBORValue(static_cast<int64_t>(*response.remainingDiscoverableCredentials())));
 
     if (auto minPINLength = response.minPINLength())
-        deviceInfoMap.emplace(CBORValue(13), CBORValue(static_cast<int64_t>(*minPINLength)));
+        deviceInfoMap.emplace(CBORValue(kCtapAuthenticatorGetInfoMinPINLengthKey), CBORValue(static_cast<int64_t>(*minPINLength)));
+
+    if (response.maxCredentialCountInList())
+        deviceInfoMap.emplace(CBORValue(kCtapAuthenticatorGetInfoMaxCredentialCountInListKey), CBORValue(static_cast<int64_t>(*response.maxCredentialCountInList())));
+    if (response.maxCredentialIDLength())
+        deviceInfoMap.emplace(CBORValue(kCtapAuthenticatorGetInfoMaxCredentialIdLengthKey), CBORValue(static_cast<int64_t>(*response.maxCredentialIDLength())));
 
     auto encodedBytes = CBORWriter::write(CBORValue(WTFMove(deviceInfoMap)));
     ASSERT(encodedBytes);

--- a/Source/WebCore/Modules/webauthn/fido/AuthenticatorGetInfoResponse.h
+++ b/Source/WebCore/Modules/webauthn/fido/AuthenticatorGetInfoResponse.h
@@ -58,6 +58,8 @@ public:
     AuthenticatorGetInfoResponse& setRemainingDiscoverableCredentials(uint32_t);
     AuthenticatorGetInfoResponse& setMinPINLength(uint32_t);
 
+    AuthenticatorGetInfoResponse& setMaxCredentialCountInList(uint32_t);
+    AuthenticatorGetInfoResponse& setMaxCredentialIDLength(uint32_t);
 
     const StdSet<ProtocolVersion>& versions() const { return m_versions; }
     const Vector<uint8_t>& aaguid() const { return m_aaguid; }
@@ -70,12 +72,16 @@ public:
     const std::optional<Vector<WebCore::PublicKeyCredentialParameters>>& algorithms() const { return m_algorithms; }
     const std::optional<uint32_t>& remainingDiscoverableCredentials() const { return m_remainingDiscoverableCredentials; }
     const std::optional<uint32_t>& minPINLength() const { return m_minPINLength; }
+    const std::optional<uint32_t>& maxCredentialCountInList() const { return m_maxCredentialCountInList; }
+    const std::optional<uint32_t>& maxCredentialIDLength() const { return m_maxCredentialIdLength; }
 
 private:
     StdSet<ProtocolVersion> m_versions;
     Vector<uint8_t> m_aaguid;
     std::optional<uint32_t> m_maxMsgSize;
     std::optional<Vector<uint8_t>> m_pinProtocols;
+    std::optional<uint32_t> m_maxCredentialCountInList;
+    std::optional<uint32_t> m_maxCredentialIdLength;
     std::optional<Vector<String>> m_extensions;
     AuthenticatorSupportedOptions m_options;
     std::optional<Vector<WebCore::AuthenticatorTransport>> m_transports;

--- a/Source/WebCore/Modules/webauthn/fido/DeviceRequestConverter.cpp
+++ b/Source/WebCore/Modules/webauthn/fido/DeviceRequestConverter.cpp
@@ -35,6 +35,7 @@
 #include "CBORWriter.h"
 #include "Pin.h"
 #include "PublicKeyCredentialCreationOptions.h"
+#include "PublicKeyCredentialDescriptor.h"
 #include "PublicKeyCredentialRequestOptions.h"
 #include "PublicKeyCredentialRpEntity.h"
 #include "PublicKeyCredentialUserEntity.h"
@@ -118,14 +119,19 @@ static Vector<PublicKeyCredentialParameters> trimmedParameters(const Vector<Publ
     return parameters;
 }
 
-Vector<uint8_t> encodeMakeCredentialRequestAsCBOR(const Vector<uint8_t>& hash, const PublicKeyCredentialCreationOptions& options, UVAvailability uvCapability, AuthenticatorSupportedOptions::ResidentKeyAvailability residentKeyAvailability, const Vector<String>& authenticatorSupportedExtensions, std::optional<PinParameters> pin, const std::optional<Vector<WebCore::PublicKeyCredentialParameters>>& authenticatorSupportedParameters)
+Vector<uint8_t> encodeMakeCredentialRequestAsCBOR(const Vector<uint8_t>& hash, const PublicKeyCredentialCreationOptions& options, UVAvailability uvCapability, AuthenticatorSupportedOptions::ResidentKeyAvailability residentKeyAvailability, const Vector<String>& authenticatorSupportedExtensions, std::optional<PinParameters> pin, const std::optional<Vector<WebCore::PublicKeyCredentialParameters>>& authenticatorSupportedParameters, std::optional<Vector<PublicKeyCredentialDescriptor>>&& overrideExcludeCredentials)
 {
     CBORValue::MapValue cborMap;
     cborMap[CBORValue(1)] = CBORValue(hash);
     cborMap[CBORValue(2)] = convertRpEntityToCBOR(options.rp);
     cborMap[CBORValue(3)] = convertUserEntityToCBOR(options.user);
     cborMap[CBORValue(4)] = convertParametersToCBOR(trimmedParameters(options.pubKeyCredParams, authenticatorSupportedParameters));
-    if (!options.excludeCredentials.isEmpty()) {
+    if (overrideExcludeCredentials) {
+        CBORValue::ArrayValue excludeListArray;
+        for (const auto& descriptor : *overrideExcludeCredentials)
+            excludeListArray.append(convertDescriptorToCBOR(descriptor));
+        cborMap[CBORValue(5)] = CBORValue(WTFMove(excludeListArray));
+    } else if (!options.excludeCredentials.isEmpty()) {
         CBORValue::ArrayValue excludeListArray;
         for (const auto& descriptor : options.excludeCredentials)
             excludeListArray.append(convertDescriptorToCBOR(descriptor));
@@ -183,6 +189,35 @@ Vector<uint8_t> encodeMakeCredentialRequestAsCBOR(const Vector<uint8_t>& hash, c
     ASSERT(serializedParam);
 
     Vector<uint8_t> cborRequest({ static_cast<uint8_t>(CtapRequestCommand::kAuthenticatorMakeCredential) });
+    cborRequest.appendVector(*serializedParam);
+    return cborRequest;
+}
+
+Vector<uint8_t> encodeSilentGetAssertion(const String& rpId, const Vector<uint8_t>& hash, const Vector<PublicKeyCredentialDescriptor>& credentials, std::optional<PinParameters> pin)
+{
+    CBORValue::MapValue cborMap;
+    cborMap[CBORValue(kCtapGetAssertionRpIdKey)] = CBORValue(rpId);
+    cborMap[CBORValue(kCtapGetAssertionClientDataHashKey)] = CBORValue(hash);
+
+    CBORValue::ArrayValue allowListArray;
+    for (const auto& descriptor : credentials)
+        allowListArray.append(convertDescriptorToCBOR(descriptor));
+    cborMap[CBORValue(kCtapGetAssertionAllowListKey)] = CBORValue(WTFMove(allowListArray));
+
+    if (pin) {
+        ASSERT(pin->protocol >= 0);
+        cborMap[CBORValue(kCtapGetAssertionPinUvAuthParamKey)] = CBORValue(WTFMove(pin->auth));
+        cborMap[CBORValue(kCtapGetAssertionPinUvAuthProtocolKey)] = CBORValue(pin->protocol);
+    }
+
+    CBORValue::MapValue optionMap;
+    optionMap[CBORValue(kUserPresenceMapKey)] = CBORValue(false);
+    cborMap[CBORValue(kCtapGetAssertionRequestOptionsKey)] = CBORValue(WTFMove(optionMap));
+
+    auto serializedParam = CBORWriter::write(CBORValue(WTFMove(cborMap)));
+    ASSERT(serializedParam);
+
+    Vector<uint8_t> cborRequest({ static_cast<uint8_t>(CtapRequestCommand::kAuthenticatorGetAssertion) });
     cborRequest.appendVector(*serializedParam);
     return cborRequest;
 }

--- a/Source/WebCore/Modules/webauthn/fido/DeviceRequestConverter.h
+++ b/Source/WebCore/Modules/webauthn/fido/DeviceRequestConverter.h
@@ -38,6 +38,7 @@
 namespace WebCore {
 struct PublicKeyCredentialCreationOptions;
 struct PublicKeyCredentialRequestOptions;
+struct PublicKeyCredentialDescriptor;
 struct PublicKeyCredentialParameters;
 }
 
@@ -51,15 +52,15 @@ struct PinParameters {
 // Serializes MakeCredential request parameter into CBOR encoded map with
 // integer keys and CBOR encoded values as defined by the CTAP spec.
 // https://fidoalliance.org/specs/fido-v2.0-ps-20170927/fido-client-to-authenticator-protocol-v2.0-ps-20170927.html#authenticatorMakeCredential
-WEBCORE_EXPORT Vector<uint8_t> encodeMakeCredentialRequestAsCBOR(const Vector<uint8_t>& hash, const WebCore::PublicKeyCredentialCreationOptions&, AuthenticatorSupportedOptions::UserVerificationAvailability, AuthenticatorSupportedOptions::ResidentKeyAvailability, const Vector<String>& authenticatorSupportedExtensions, std::optional<PinParameters> = std::nullopt, const std::optional<Vector<WebCore::PublicKeyCredentialParameters>>& = std::nullopt);
+WEBCORE_EXPORT Vector<uint8_t> encodeMakeCredentialRequestAsCBOR(const Vector<uint8_t>& hash, const WebCore::PublicKeyCredentialCreationOptions&, AuthenticatorSupportedOptions::UserVerificationAvailability, AuthenticatorSupportedOptions::ResidentKeyAvailability, const Vector<String>& authenticatorSupportedExtensions, std::optional<PinParameters> = std::nullopt, const std::optional<Vector<WebCore::PublicKeyCredentialParameters>>& = std::nullopt, std::optional<Vector<WebCore::PublicKeyCredentialDescriptor>>&& = std::nullopt);
 
 // Serializes GetAssertion request parameter into CBOR encoded map with
 // integer keys and CBOR encoded values as defined by the CTAP spec.
 // https://fidoalliance.org/specs/fido-v2.0-ps-20170927/fido-client-to-authenticator-protocol-v2.0-ps-20170927.html#authenticatorGetAssertion
 WEBCORE_EXPORT Vector<uint8_t> encodeGetAssertionRequestAsCBOR(const Vector<uint8_t>& hash, const WebCore::PublicKeyCredentialRequestOptions&, AuthenticatorSupportedOptions::UserVerificationAvailability, const Vector<String>& authenticatorSupportedExtensions, std::optional<PinParameters> = std::nullopt);
 
-
 WEBCORE_EXPORT Vector<uint8_t> encodeBogusRequestForAuthenticatorSelection();
+WEBCORE_EXPORT Vector<uint8_t> encodeSilentGetAssertion(const String& rpId, const Vector<uint8_t>& hash, const Vector<WebCore::PublicKeyCredentialDescriptor>& credentials, std::optional<PinParameters> = std::nullopt);
 
 // Represents CTAP requests with empty parameters, including
 // AuthenticatorGetInfo, AuthenticatorReset and AuthenticatorGetNextAssertion commands.

--- a/Source/WebCore/Modules/webauthn/fido/DeviceResponseConverter.cpp
+++ b/Source/WebCore/Modules/webauthn/fido/DeviceResponseConverter.cpp
@@ -206,7 +206,7 @@ std::optional<AuthenticatorGetInfoResponse> readCTAPGetInfoResponse(const Vector
         return std::nullopt;
     const auto& responseMap = decodedMap->getMap();
 
-    auto it = responseMap.find(CBOR(1));
+    auto it = responseMap.find(CBOR(kCtapAuthenticatorGetInfoVersionsKey));
     if (it == responseMap.end() || !it->second.isArray())
         return std::nullopt;
     StdSet<ProtocolVersion> protocolVersions;
@@ -226,13 +226,13 @@ std::optional<AuthenticatorGetInfoResponse> readCTAPGetInfoResponse(const Vector
     if (protocolVersions.empty())
         return std::nullopt;
 
-    it = responseMap.find(CBOR(3));
+    it = responseMap.find(CBOR(kCtapAuthenticatorGetInfoAAGUIDKey));
     if (it == responseMap.end() || !it->second.isByteString() || it->second.getByteString().size() != aaguidLength)
         return std::nullopt;
 
     AuthenticatorGetInfoResponse response(WTFMove(protocolVersions), Vector<uint8_t>(it->second.getByteString()));
 
-    it = responseMap.find(CBOR(2));
+    it = responseMap.find(CBOR(kCtapAuthenticatorGetInfoExtensionsKey));
     if (it != responseMap.end()) {
         if (!it->second.isArray())
             return std::nullopt;
@@ -248,7 +248,7 @@ std::optional<AuthenticatorGetInfoResponse> readCTAPGetInfoResponse(const Vector
     }
 
     AuthenticatorSupportedOptions options;
-    it = responseMap.find(CBOR(4));
+    it = responseMap.find(CBOR(kCtapAuthenticatorGetInfoOptionsKey));
     if (it != responseMap.end()) {
         if (!it->second.isMap())
             return std::nullopt;
@@ -303,7 +303,7 @@ std::optional<AuthenticatorGetInfoResponse> readCTAPGetInfoResponse(const Vector
         response.setOptions(WTFMove(options));
     }
 
-    it = responseMap.find(CBOR(5));
+    it = responseMap.find(CBOR(kCtapAuthenticatorGetInfoMaxMsgSizeKey));
     if (it != responseMap.end()) {
         if (!it->second.isUnsigned())
             return std::nullopt;
@@ -311,7 +311,7 @@ std::optional<AuthenticatorGetInfoResponse> readCTAPGetInfoResponse(const Vector
         response.setMaxMsgSize(it->second.getUnsigned());
     }
 
-    it = responseMap.find(CBOR(6));
+    it = responseMap.find(CBOR(kCtapAuthenticatorGetInfoPinUVAuthProtocolsKey));
     if (it != responseMap.end()) {
         if (!it->second.isArray())
             return std::nullopt;
@@ -326,7 +326,22 @@ std::optional<AuthenticatorGetInfoResponse> readCTAPGetInfoResponse(const Vector
         response.setPinProtocols(WTFMove(supportedPinProtocols));
     }
 
-    it = responseMap.find(CBOR(9));
+    it = responseMap.find(CBOR(kCtapAuthenticatorGetInfoMaxCredentialCountInListKey));
+    if (it != responseMap.end()) {
+        if (!it->second.isUnsigned())
+            return std::nullopt;
+
+        response.setMaxCredentialCountInList(it->second.getUnsigned());
+    }
+    it = responseMap.find(CBOR(kCtapAuthenticatorGetInfoMaxCredentialIdLengthKey));
+    if (it != responseMap.end()) {
+        if (!it->second.isUnsigned())
+            return std::nullopt;
+
+        response.setMaxCredentialIDLength(it->second.getUnsigned());
+    }
+
+    it = responseMap.find(CBOR(kCtapAuthenticatorGetInfoTransportsKey));
     if (it != responseMap.end()) {
         if (!it->second.isArray())
             return std::nullopt;
@@ -342,14 +357,14 @@ std::optional<AuthenticatorGetInfoResponse> readCTAPGetInfoResponse(const Vector
         response.setTransports(WTFMove(transports));
     }
 
-    it = responseMap.find(CBOR(0x0D));
+    it = responseMap.find(CBOR(kCtapAuthenticatorGetInfoMinPINLengthKey));
     if (it != responseMap.end()) {
         if (!it->second.isUnsigned())
             return std::nullopt;
         response.setMinPINLength(it->second.getUnsigned());
     }
 
-    it = responseMap.find(CBOR(20));
+    it = responseMap.find(CBOR(kCtapAuthenticatorGetInfoRemainingDiscoverableCredentialsKey));
     if (it != responseMap.end()) {
         if (!it->second.isUnsigned())
             return std::nullopt;

--- a/Source/WebCore/Modules/webauthn/fido/FidoConstants.h
+++ b/Source/WebCore/Modules/webauthn/fido/FidoConstants.h
@@ -288,6 +288,28 @@ constexpr int64_t kCtapGetAssertionRequestOptionsKey = 5;
 constexpr int64_t kCtapGetAssertionPinUvAuthParamKey = 6;
 constexpr int64_t kCtapGetAssertionPinUvAuthProtocolKey = 7;
 
+constexpr int64_t kCtapAuthenticatorGetInfoVersionsKey = 0x01;
+constexpr int64_t kCtapAuthenticatorGetInfoExtensionsKey = 0x02;
+constexpr int64_t kCtapAuthenticatorGetInfoAAGUIDKey = 0x03;
+constexpr int64_t kCtapAuthenticatorGetInfoOptionsKey = 0x04;
+constexpr int64_t kCtapAuthenticatorGetInfoMaxMsgSizeKey = 0x05;
+constexpr int64_t kCtapAuthenticatorGetInfoPinUVAuthProtocolsKey = 0x06;
+constexpr int64_t kCtapAuthenticatorGetInfoMaxCredentialCountInListKey = 0x07;
+constexpr int64_t kCtapAuthenticatorGetInfoMaxCredentialIdLengthKey = 0x08;
+constexpr int64_t kCtapAuthenticatorGetInfoTransportsKey = 0x09;
+constexpr int64_t kCtapAuthenticatorGetInfoAlgorithmsKey = 0x0a;
+constexpr int64_t kCtapAuthenticatorGetInfoMaxSerializedLargeBlobArrayKey = 0x0b;
+constexpr int64_t kCtapAuthenticatorGetInfoForcePINChangeKey = 0x0c;
+constexpr int64_t kCtapAuthenticatorGetInfoMinPINLengthKey = 0x0d;
+constexpr int64_t kCtapAuthenticatorGetInfoFirmwareVersionKey = 0x0e;
+constexpr int64_t kCtapAuthenticatorGetInfoMaxCredBlobLengthKey = 0x0f;
+constexpr int64_t kCtapAuthenticatorGetInfoMaxRPIDsForSetMinPINLengthKey = 0x10;
+constexpr int64_t kCtapAuthenticatorGetInfoPreferredPlatformUvAttemptsKey = 0x11;
+constexpr int64_t kCtapAuthenticatorGetInfoUVModalitysKey = 0x12;
+constexpr int64_t kCtapAuthenticatorGetInfoCertificationsKey = 0x13;
+constexpr int64_t kCtapAuthenticatorGetInfoRemainingDiscoverableCredentialsKey = 0x14;
+constexpr int64_t kCtapAuthenticatorGetInfoVendorPrototypeConfigCommandsKey = 0x15;
+
 } // namespace fido
 
 #endif // ENABLE(WEB_AUTHN)

--- a/Source/WebCore/testing/MockWebAuthenticationConfiguration.h
+++ b/Source/WebCore/testing/MockWebAuthenticationConfiguration.h
@@ -90,6 +90,8 @@ struct MockWebAuthenticationConfiguration {
         bool expectCancel { false };
         bool supportClientPin { false };
         bool supportInternalUV { false };
+        long maxCredentialCountInList { 1 };
+        long maxCredentialIdLength { 64 };
     };
 
     struct NfcConfiguration {

--- a/Source/WebCore/testing/MockWebAuthenticationConfiguration.idl
+++ b/Source/WebCore/testing/MockWebAuthenticationConfiguration.idl
@@ -104,6 +104,8 @@
     boolean expectCancel = false;
     boolean supportClientPin = false;
     boolean supportInternalUV = false;
+    long maxCredentialCountInList = 1;
+    long maxCredentialIdLength = 64;
 };
 
 [

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -6516,6 +6516,8 @@ header: <WebCore/ISOVTTCue.h>
     bool expectCancel;
     bool supportClientPin;
     bool supportInternalUV;
+    long maxCredentialCountInList;
+    long maxCredentialIdLength;
 };
 
 [Nested] enum class WebCore::MockWebAuthenticationConfiguration::NfcError : uint8_t {

--- a/Source/WebKit/UIProcess/WebAuthentication/Mock/MockHidConnection.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/Mock/MockHidConnection.cpp
@@ -230,6 +230,8 @@ void MockHidConnection::feedReports()
             if (m_configuration.hid->supportInternalUV)
                 options.setUserVerificationAvailability(AuthenticatorSupportedOptions::UserVerificationAvailability::kSupportedAndConfigured);
             infoResponse.setOptions(WTFMove(options));
+            infoResponse.setMaxCredentialCountInList(m_configuration.hid->maxCredentialCountInList);
+            infoResponse.setMaxCredentialIDLength(m_configuration.hid->maxCredentialIdLength);
             infoData = encodeAsCBOR(infoResponse);
         }
         infoData.insert(0, static_cast<uint8_t>(CtapDeviceResponseCode::kSuccess)); // Prepend status code.

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.h
@@ -30,6 +30,7 @@
 #include "FidoAuthenticator.h"
 #include <WebCore/AuthenticatorGetInfoResponse.h>
 #include <WebCore/CryptoKeyEC.h>
+#include <WebCore/PublicKeyCredentialDescriptor.h>
 
 namespace fido {
 namespace pin {
@@ -54,6 +55,8 @@ private:
     void makeCredential() final;
     void continueMakeCredentialAfterResponseReceived(Vector<uint8_t>&&);
     void getAssertion() final;
+    void continueCheckExcludedCredentialsAfterResponseRecieved(Vector<uint8_t>&& data);
+    void continueMakeCredentialAfterCheckExcludedCredentials(bool includeCurrentBatch = false);
     void continueGetAssertionAfterResponseReceived(Vector<uint8_t>&&);
     void continueGetNextAssertionAfterResponseReceived(Vector<uint8_t>&&);
 
@@ -81,7 +84,9 @@ private:
     bool m_isDowngraded { false };
     bool m_isKeyStoreFull { false };
     size_t m_remainingAssertionResponses { 0 };
+    size_t m_currentBatch { 0 };
     Vector<Ref<WebCore::AuthenticatorAssertionResponse>> m_assertionResponses;
+    Vector<Vector<WebCore::PublicKeyCredentialDescriptor>> m_batches;
     Vector<uint8_t> m_pinAuth;
 };
 


### PR DESCRIPTION
#### aa15739bf97edf4cf9a5df5468613e062e296ed1
<pre>
Reland [WebAuthn] Implement batching for checking excludeCredentials
<a href="https://rdar.apple.com/151644306">rdar://151644306</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=293252">https://bugs.webkit.org/show_bug.cgi?id=293252</a>

Reviewed by Brent Fulgham.

This change starts to implement checking the excludeCredential list in batches as
supported by the authenticator during a makeCredential. This is accomplished by using
smaller, up=0, get requests to detect if a credential is present on the authenticator.

Then if a credential is detected, only that credential may be included with the actual
makeCredential request to get the proper error code back from the authenticator. If none
matched, we don&apos;t need to include a excludeCredentials list to the authenticator since
we already know those credentials aren&apos;t present.

This patch only implements this logic for makeCredential, getAssertion will be done in
another patch.

Added layout tests to test matching exclude list with batching, non-matching exclude list with
batching, and a security key that supports batches greater than 1.

This patch also includes improved behavior on security keys that by policy always require
user verification. This is implemented by setting a pin when required or passing along
the pin auth information with the silent requests. This fixes an issue that arose the last
time we landed the allowCredentials flavor of this patch.

* LayoutTests/http/wpt/webauthn/public-key-credential-create-failure-hid.https-expected.txt:
* LayoutTests/http/wpt/webauthn/public-key-credential-create-failure-hid.https.html:
* LayoutTests/http/wpt/webauthn/public-key-credential-create-success-hid.https-expected.txt:
* LayoutTests/http/wpt/webauthn/public-key-credential-create-success-hid.https.html:
* LayoutTests/http/wpt/webauthn/resources/util.js:
* Source/WebCore/Modules/webauthn/fido/AuthenticatorGetInfoResponse.cpp:
(fido::AuthenticatorGetInfoResponse::setMaxCredentialCountInList):
(fido::AuthenticatorGetInfoResponse::setMaxCredentialIDLength):
(fido::encodeAsCBOR):
* Source/WebCore/Modules/webauthn/fido/AuthenticatorGetInfoResponse.h:
* Source/WebCore/Modules/webauthn/fido/DeviceRequestConverter.cpp:
(fido::encodeMakeCredentialRequestAsCBOR):
(fido::encodeSilentGetAssertion):
* Source/WebCore/Modules/webauthn/fido/DeviceRequestConverter.h:
* Source/WebCore/Modules/webauthn/fido/DeviceResponseConverter.cpp:
(fido::readCTAPGetInfoResponse):
* Source/WebCore/Modules/webauthn/fido/FidoConstants.h:
* Source/WebCore/testing/MockWebAuthenticationConfiguration.h:
* Source/WebCore/testing/MockWebAuthenticationConfiguration.idl:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/WebAuthentication/Mock/MockHidConnection.cpp:
(WebKit::MockHidConnection::feedReports):
* Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.cpp:
(WebKit::CtapAuthenticator::makeCredential):
(WebKit::CtapAuthenticator::continueCheckExcludedCredentialsAfterResponseRecieved):
(WebKit::CtapAuthenticator::continueMakeCredentialAfterCheckExcludedCredentials):
* Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.h:

Canonical link: <a href="https://commits.webkit.org/295506@main">https://commits.webkit.org/295506@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eb5d56515d81589fb3d3cb26294b741007ae7301

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105266 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24978 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15403 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110477 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/55921 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/107307 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/25410 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33521 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79956 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108272 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19817 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95013 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60262 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/19571 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13087 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55320 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/89271 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13131 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/113084 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32424 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23887 "Found 1 new test failure: imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/track-webvtt-align-text-line-position.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89029 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32788 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91229 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88667 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22615 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33562 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11349 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/27847 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32348 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/37760 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32126 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35470 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33695 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->