### PR TITLE
Unreviewed, reverting 294973@main (ac36e134cce1)

### DIFF
--- a/Source/JavaScriptCore/llint/InPlaceInterpreter.asm
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter.asm
@@ -49,11 +49,17 @@
 # - PC: (Program Counter) IPInt's program counter. This records the interpreter's position in Wasm bytecode.
 # - MC: (Metadata Counter) IPInt's metadata pointer. This records the corresponding position in generated metadata.
 # - WI: (Wasm Instance) pointer to the current JSWebAssemblyInstance object. This is used for accessing
-#       function-specific data (callee-save).
+#       function-specific data.
 # - PL: (Pointer to Locals) pointer to the address of local 0 in the current function. This is used for accessing
 #       locals quickly.
-# - MB: (Memory Base) pointer to the current Wasm memory base address (callee-save).
-# - BC: (Bounds Check) the size of the current Wasm memory region, for bounds checking (callee-save).
+# - MB: (Memory Base) pointer to the current Wasm memory base address.
+# - BC: (Bounds Check) the size of the current Wasm memory region, for bounds checking.
+#
+# Additionally, there are a few registers that are optionally supported for optimization:
+# - IB: (Instruction Base) pointer to the address of the `unreachable` (0x00) label, removing the need to reload
+#       this address at every dispatch.
+# - HR: (Hoist Register) used for hoisting the load of the next opcode in Wasm instructions with low register
+#       pressure, helping reduce the impact of load misses.
 #
 # Finally, we provide four "sc" (safe for call) registers which are guaranteed to not overlap with argument
 # registers (sc0, sc1, sc2, sc3)
@@ -65,6 +71,9 @@ if ARM64 or ARM64E
     const PL = t6
     const MB = csr3
     const BC = csr4
+
+    const IB = t7
+    const HR = t3
 
     const sc0 = ws0
     const sc1 = ws1
@@ -78,6 +87,9 @@ elsif X86_64
     const MB = csr3
     const BC = csr4
 
+    const IB = t7
+    const HR = t3
+
     const sc0 = ws0
     const sc1 = ws1
     const sc2 = csr3
@@ -89,6 +101,9 @@ elsif RISCV64
     const PL = csr10
     const MB = csr3
     const BC = csr4
+
+    const IB = invalidGPR
+    const HR = invalidGPR
 
     const sc0 = ws0
     const sc1 = ws1
@@ -102,6 +117,9 @@ elsif ARMv7
     const MB = invalidGPR
     const BC = invalidGPR
 
+    const IB = invalidGPR
+    const HR = invalidGPR
+
     const sc0 = t4
     const sc1 = t5
     const sc2 = csr0
@@ -113,6 +131,9 @@ else
     const PL = invalidGPR
     const MB = invalidGPR
     const BC = invalidGPR
+
+    const IB = invalidGPR
+    const HR = invalidGPR
 
     const sc0 = invalidGPR
     const sc1 = invalidGPR
@@ -151,6 +172,30 @@ const UnboxedWasmCalleeStackSlot = CallerFrame - constexpr Wasm::numberOfIPIntCa
 const IPIntCalleeSaveSpaceAsVirtualRegisters = constexpr Wasm::numberOfIPIntCalleeSaveRegisters + constexpr Wasm::numberOfIPIntInternalRegisters
 const IPIntCalleeSaveSpaceStackAligned = (IPIntCalleeSaveSpaceAsVirtualRegisters * SlotSize + StackAlignment - 1) & ~StackAlignmentMask
 const IPIntCalleeSaveSpaceStackAligned = 2*IPIntCalleeSaveSpaceStackAligned
+
+# ---------------------------
+# 1.2: Optional optimizations
+# ---------------------------
+
+macro IfIPIntUsesIB(m)
+    if ARM64 or ARM64E or X86_64
+        m()
+    end
+end
+
+macro IfIPIntUsesHR(m, m2)
+    if ARM64 or ARM64E
+        m()
+    else
+        m2()
+    end
+end
+
+macro HoistNextOpcode(offset)
+    IfIPIntUsesHR(macro()
+        loadb offset[PC], HR
+    end, macro() end)
+end
 
 ##############################
 # 2. Core interpreter macros #
@@ -304,18 +349,18 @@ macro operationCall(fn)
     if ARM64 or ARM64E
         push PL, ws0
     elsif X86_64
-        push PL
-        # preserve 16 byte alignment.
-        subq MachineRegisterSize, sp
+        push PL, IB
     end
     fn()
     if ARM64 or ARM64E
         pop ws0, PL
     elsif X86_64
-        addq MachineRegisterSize, sp
-        pop PL
+        pop IB, PL
     end
     pop MC, PC
+    if ARM64 or ARM64E
+        pcrtoaddr _ipint_unreachable, IB
+    end
 end
 
 macro operationCallMayThrow(fn)
@@ -326,9 +371,7 @@ macro operationCallMayThrow(fn)
     if ARM64 or ARM64E
         push PL, ws0
     elsif X86_64
-        push PL
-        # preserve 16 byte alignment.
-        subq MachineRegisterSize, sp
+        push PL, IB
     end
     fn()
     bpneq r1, (constexpr JSC::IPInt::SlowPathExceptionTag), .continuation
@@ -338,10 +381,12 @@ macro operationCallMayThrow(fn)
     if ARM64 or ARM64E
         pop ws0, PL
     elsif X86_64
-        addq MachineRegisterSize, sp
-        pop PL
+        pop IB, PL
     end
     pop MC, PC
+    if ARM64 or ARM64E
+        pcrtoaddr _ipint_unreachable, IB
+    end
 end
 
 # Exception handling
@@ -528,6 +573,13 @@ if WEBASSEMBLY and (ARM64 or ARM64E or X86_64 or ARMv7)
     # OSR Check
     ipintPrologueOSR(5)
 
+    IfIPIntUsesIB(macro ()
+if ARM64 or ARM64E
+        pcrtoaddr _ipint_unreachable, IB
+elsif X86_64
+        leap (_ipint_unreachable - _ipint_entry_relativePCBase)[PL], IB
+end
+    end)
     move sp, PL
 
     loadp Wasm::IPIntCallee::m_bytecode[ws0], PC
@@ -569,6 +621,9 @@ if ARMv7
 end
 
     loadp CodeBlock[cfr], wasmInstance
+    if ARM64 or ARM64E
+        pcrtoaddr _ipint_unreachable, IB
+    end
     loadp Wasm::IPIntCallee::m_bytecode[ws0], t1
     addp t1, PC
     loadp Wasm::IPIntCallee::m_metadata[ws0], t1
@@ -606,6 +661,10 @@ global _ipint_catch_entry
 _ipint_catch_entry:
 if WEBASSEMBLY and (ARM64 or ARM64E or X86_64)
     ipintCatchCommon()
+if X86_64
+    initPCRelative(ipint_catch_entry, IB)
+    leap (_ipint_unreachable - _ipint_catch_entry_relativePCBase)[IB], IB
+end
 
     move cfr, a1
     move sp, a2
@@ -623,6 +682,10 @@ global _ipint_catch_all_entry
 _ipint_catch_all_entry:
 if WEBASSEMBLY and (ARM64 or ARM64E or X86_64)
     ipintCatchCommon()
+if X86_64
+    initPCRelative(ipint_catch_all_entry, IB)
+    leap (_ipint_unreachable - _ipint_catch_all_entry_relativePCBase)[IB], IB
+end
 
     move cfr, a1
     move 0, a2
@@ -640,6 +703,10 @@ global _ipint_table_catch_entry
 _ipint_table_catch_entry:
 if WEBASSEMBLY and (ARM64 or ARM64E or X86_64 or ARMv7)
     ipintCatchCommon()
+if X86_64
+    initPCRelative(ipint_table_catch_entry, IB)
+    leap (_ipint_unreachable - _ipint_table_catch_entry_relativePCBase)[IB], IB
+end
 
     # push arguments but no ref: sp in a2, call normal operation
 
@@ -659,6 +726,10 @@ global _ipint_table_catch_ref_entry
 _ipint_table_catch_ref_entry:
 if WEBASSEMBLY and (ARM64 or ARM64E or X86_64 or ARMv7)
     ipintCatchCommon()
+if X86_64
+    initPCRelative(ipint_table_catch_ref_entry, IB)
+    leap (_ipint_unreachable - _ipint_table_catch_ref_entry_relativePCBase)[IB], IB
+end
 
     # push both arguments and ref
 
@@ -678,6 +749,10 @@ global _ipint_table_catch_all_entry
 _ipint_table_catch_all_entry:
 if WEBASSEMBLY and (ARM64 or ARM64E or X86_64 or ARMv7)
     ipintCatchCommon()
+if X86_64
+    initPCRelative(ipint_table_catch_all_entry, IB)
+    leap (_ipint_unreachable - _ipint_table_catch_all_entry_relativePCBase)[IB], IB
+end
 
     # do nothing: 0 in sp for no arguments, call normal operation
 
@@ -697,6 +772,10 @@ global _ipint_table_catch_allref_entry
 _ipint_table_catch_allref_entry:
 if WEBASSEMBLY and (ARM64 or ARM64E or X86_64 or ARMv7)
     ipintCatchCommon()
+if X86_64
+    initPCRelative(ipint_table_catch_allref_entry, IB)
+    leap (_ipint_unreachable - _ipint_table_catch_allref_entry_relativePCBase)[IB], IB
+end
 
     # push only the ref
 

--- a/Source/JavaScriptCore/llint/InPlaceInterpreter.cpp
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -39,32 +39,102 @@
 
 namespace JSC { namespace IPInt {
 
-#define VALIDATE_IPINT_OPCODE_FROM_BASE(dispatchBase, width, opcode, name) \
+#define VALIDATE_IPINT_OPCODE(opcode, name) \
 do { \
-    void* base = reinterpret_cast<void*>(dispatchBase); \
+    void* base = reinterpret_cast<void*>(ipint_unreachable_validate); \
     void* ptr = reinterpret_cast<void*>(ipint_ ## name ## _validate); \
     void* untaggedBase = CodePtr<CFunctionPtrTag>::fromTaggedPtr(base).template untaggedPtr<>(); \
     void* untaggedPtr = CodePtr<CFunctionPtrTag>::fromTaggedPtr(ptr).template untaggedPtr<>(); \
-    RELEASE_ASSERT_WITH_MESSAGE((char*)(untaggedPtr) - (char*)(untaggedBase) == opcode * width, #name); \
+    RELEASE_ASSERT_WITH_MESSAGE((char*)(untaggedPtr) - (char*)(untaggedBase) == opcode * 256, #name); \
 } while (false);
 
-#define VALIDATE_IPINT_OPCODE(opcode, name) VALIDATE_IPINT_OPCODE_FROM_BASE(ipint_unreachable_validate, 256, opcode, name)
-#define VALIDATE_IPINT_GC_OPCODE(opcode, name) VALIDATE_IPINT_OPCODE_FROM_BASE(ipint_struct_new_validate, 256, opcode, name)
-#define VALIDATE_IPINT_CONVERSION_OPCODE(opcode, name) VALIDATE_IPINT_OPCODE_FROM_BASE(ipint_i32_trunc_sat_f32_s_validate, 256, opcode, name)
-#define VALIDATE_IPINT_SIMD_OPCODE(opcode, name) VALIDATE_IPINT_OPCODE_FROM_BASE(ipint_simd_v128_load_mem_validate, 256, opcode, name)
-#define VALIDATE_IPINT_ATOMIC_OPCODE(opcode, name) VALIDATE_IPINT_OPCODE_FROM_BASE(ipint_memory_atomic_notify_validate, 256, opcode, name)
-#define VALIDATE_IPINT_ARGUMINT_OPCODE(opcode, name) VALIDATE_IPINT_OPCODE_FROM_BASE(ipint_argumINT_a0_validate, 64, opcode, name)
-#define VALIDATE_IPINT_SLOW_PATH(opcode, name) VALIDATE_IPINT_OPCODE_FROM_BASE(ipint_local_get_slow_path_validate, 256, opcode, name)
-#define VALIDATE_IPINT_MINT_CALL_OPCODE(opcode, name) VALIDATE_IPINT_OPCODE_FROM_BASE(ipint_mint_a0_validate, 64, opcode, name)
-#define VALIDATE_IPINT_MINT_RETURN_OPCODE(opcode, name) VALIDATE_IPINT_OPCODE_FROM_BASE(ipint_mint_r0_validate, 64, opcode, name)
-#define VALIDATE_IPINT_UINT_OPCODE(opcode, name) VALIDATE_IPINT_OPCODE_FROM_BASE(ipint_uint_r0_validate, 64, opcode, name)
+#define VALIDATE_IPINT_0xFB_OPCODE(opcode, name) \
+do { \
+    void* base = reinterpret_cast<void*>(ipint_struct_new_validate); \
+    void* ptr = reinterpret_cast<void*>(ipint_ ## name ## _validate); \
+    void* untaggedBase = CodePtr<CFunctionPtrTag>::fromTaggedPtr(base).template untaggedPtr<>(); \
+    void* untaggedPtr = CodePtr<CFunctionPtrTag>::fromTaggedPtr(ptr).template untaggedPtr<>(); \
+    RELEASE_ASSERT_WITH_MESSAGE((char*)(untaggedPtr) - (char*)(untaggedBase) == opcode * 256, #name); \
+} while (false);
+
+#define VALIDATE_IPINT_0xFC_OPCODE(opcode, name) \
+do { \
+    void* base = reinterpret_cast<void*>(ipint_i32_trunc_sat_f32_s_validate); \
+    void* ptr = reinterpret_cast<void*>(ipint_ ## name ## _validate); \
+    void* untaggedBase = CodePtr<CFunctionPtrTag>::fromTaggedPtr(base).template untaggedPtr<>(); \
+    void* untaggedPtr = CodePtr<CFunctionPtrTag>::fromTaggedPtr(ptr).template untaggedPtr<>(); \
+    RELEASE_ASSERT_WITH_MESSAGE((char*)(untaggedPtr) - (char*)(untaggedBase) == opcode * 256, #name); \
+} while (false);
+
+#define VALIDATE_IPINT_SIMD_OPCODE(opcode, name) \
+do { \
+    void* base = reinterpret_cast<void*>(ipint_simd_v128_load_mem_validate); \
+    void* ptr = reinterpret_cast<void*>(ipint_ ## name ## _validate); \
+    void* untaggedBase = CodePtr<CFunctionPtrTag>::fromTaggedPtr(base).template untaggedPtr<>(); \
+    void* untaggedPtr = CodePtr<CFunctionPtrTag>::fromTaggedPtr(ptr).template untaggedPtr<>(); \
+    RELEASE_ASSERT_WITH_MESSAGE((char*)(untaggedPtr) - (char*)(untaggedBase) == opcode * 256, #name); \
+} while (false);
+
+#define VALIDATE_IPINT_ATOMIC_OPCODE(opcode, name) \
+do { \
+    void* base = reinterpret_cast<void*>(ipint_memory_atomic_notify_validate); \
+    void* ptr = reinterpret_cast<void*>(ipint_ ## name ## _validate); \
+    void* untaggedBase = CodePtr<CFunctionPtrTag>::fromTaggedPtr(base).template untaggedPtr<>(); \
+    void* untaggedPtr = CodePtr<CFunctionPtrTag>::fromTaggedPtr(ptr).template untaggedPtr<>(); \
+    RELEASE_ASSERT_WITH_MESSAGE((char*)(untaggedPtr) - (char*)(untaggedBase) == opcode * 256, #name); \
+} while (false);
+
+#define VALIDATE_IPINT_ARGUMINT_OPCODE(opcode, name) \
+do { \
+    void* base = reinterpret_cast<void*>(ipint_argumINT_a0_validate); \
+    void* ptr = reinterpret_cast<void*>(ipint_ ## name ## _validate); \
+    void* untaggedBase = CodePtr<CFunctionPtrTag>::fromTaggedPtr(base).template untaggedPtr<>(); \
+    void* untaggedPtr = CodePtr<CFunctionPtrTag>::fromTaggedPtr(ptr).template untaggedPtr<>(); \
+    RELEASE_ASSERT_WITH_MESSAGE((char*)(untaggedPtr) - (char*)(untaggedBase) == opcode * 64, #name); \
+} while (false);
+
+#define VALIDATE_IPINT_SLOW_PATH(opcode, name) \
+do { \
+    void* base = reinterpret_cast<void*>(ipint_local_get_slow_path_validate); \
+    void* ptr = reinterpret_cast<void*>(ipint_ ## name ## _validate); \
+    void* untaggedBase = CodePtr<CFunctionPtrTag>::fromTaggedPtr(base).template untaggedPtr<>(); \
+    void* untaggedPtr = CodePtr<CFunctionPtrTag>::fromTaggedPtr(ptr).template untaggedPtr<>(); \
+    RELEASE_ASSERT_WITH_MESSAGE((char*)(untaggedPtr) - (char*)(untaggedBase) == opcode * 256, #name); \
+} while (false);
+
+#define VALIDATE_IPINT_MINT_CALL_OPCODE(opcode, name) \
+do { \
+    void* base = reinterpret_cast<void*>(ipint_mint_a0_validate); \
+    void* ptr = reinterpret_cast<void*>(ipint_ ## name ## _validate); \
+    void* untaggedBase = CodePtr<CFunctionPtrTag>::fromTaggedPtr(base).template untaggedPtr<>(); \
+    void* untaggedPtr = CodePtr<CFunctionPtrTag>::fromTaggedPtr(ptr).template untaggedPtr<>(); \
+    RELEASE_ASSERT_WITH_MESSAGE((char*)(untaggedPtr) - (char*)(untaggedBase) == opcode * 64, #name); \
+} while (false);
+
+#define VALIDATE_IPINT_MINT_RETURN_OPCODE(opcode, name) \
+do { \
+    void* base = reinterpret_cast<void*>(ipint_mint_r0_validate); \
+    void* ptr = reinterpret_cast<void*>(ipint_ ## name ## _validate); \
+    void* untaggedBase = CodePtr<CFunctionPtrTag>::fromTaggedPtr(base).template untaggedPtr<>(); \
+    void* untaggedPtr = CodePtr<CFunctionPtrTag>::fromTaggedPtr(ptr).template untaggedPtr<>(); \
+    RELEASE_ASSERT_WITH_MESSAGE((char*)(untaggedPtr) - (char*)(untaggedBase) == opcode * 64, #name); \
+} while (false);
+
+#define VALIDATE_IPINT_UINT_OPCODE(opcode, name) \
+do { \
+    void* base = reinterpret_cast<void*>(ipint_uint_r0_validate); \
+    void* ptr = reinterpret_cast<void*>(ipint_ ## name ## _validate); \
+    void* untaggedBase = CodePtr<CFunctionPtrTag>::fromTaggedPtr(base).template untaggedPtr<>(); \
+    void* untaggedPtr = CodePtr<CFunctionPtrTag>::fromTaggedPtr(ptr).template untaggedPtr<>(); \
+    RELEASE_ASSERT_WITH_MESSAGE((char*)(untaggedPtr) - (char*)(untaggedBase) == opcode * 64, #name); \
+} while (false);
 
 void initialize()
 {
 #if !ENABLE(C_LOOP) && ((CPU(ADDRESS64) && (CPU(ARM64) || CPU(X86_64))) || (CPU(ADDRESS32) && CPU(ARM_THUMB2)))
     FOR_EACH_IPINT_OPCODE(VALIDATE_IPINT_OPCODE);
-    FOR_EACH_IPINT_GC_OPCODE(VALIDATE_IPINT_GC_OPCODE);
-    FOR_EACH_IPINT_CONVERSION_OPCODE(VALIDATE_IPINT_CONVERSION_OPCODE);
+    FOR_EACH_IPINT_0xFB_OPCODE(VALIDATE_IPINT_0xFB_OPCODE);
+    FOR_EACH_IPINT_0xFC_TRUNC_OPCODE(VALIDATE_IPINT_0xFC_OPCODE);
     FOR_EACH_IPINT_SIMD_OPCODE(VALIDATE_IPINT_SIMD_OPCODE);
     FOR_EACH_IPINT_ATOMIC_OPCODE(VALIDATE_IPINT_ATOMIC_OPCODE);
 

--- a/Source/JavaScriptCore/llint/InPlaceInterpreter.h
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -38,12 +38,6 @@ extern "C" void SYSV_ABI ipint_table_catch_entry();
 extern "C" void SYSV_ABI ipint_table_catch_ref_entry();
 extern "C" void SYSV_ABI ipint_table_catch_all_entry();
 extern "C" void SYSV_ABI ipint_table_catch_allref_entry();
-
-extern "C" void SYSV_ABI ipint_dispatch_base() REFERENCED_FROM_ASM WTF_INTERNAL NO_REORDER;
-extern "C" void SYSV_ABI ipint_gc_dispatch_base() REFERENCED_FROM_ASM WTF_INTERNAL NO_REORDER;
-extern "C" void SYSV_ABI ipint_conversion_dispatch_base() REFERENCED_FROM_ASM WTF_INTERNAL NO_REORDER;
-extern "C" void SYSV_ABI ipint_simd_dispatch_base() REFERENCED_FROM_ASM WTF_INTERNAL NO_REORDER;
-extern "C" void SYSV_ABI ipint_atomic_dispatch_base() REFERENCED_FROM_ASM WTF_INTERNAL NO_REORDER;
 
 #define IPINT_VALIDATE_DEFINE_FUNCTION(opcode, name) \
     extern "C" void SYSV_ABI ipint_ ## name ## _validate() REFERENCED_FROM_ASM WTF_INTERNAL NO_REORDER;
@@ -300,13 +294,13 @@ extern "C" void SYSV_ABI ipint_atomic_dispatch_base() REFERENCED_FROM_ASM WTF_IN
     m(0xf8, reserved_0xf8) \
     m(0xf9, reserved_0xf9) \
     m(0xfa, reserved_0xfa) \
-    m(0xfb, gc_prefix) \
-    m(0xfc, conversion_prefix) \
-    m(0xfd, simd_prefix) \
-    m(0xfe, atomic_prefix) \
+    m(0xfb, fb_block) \
+    m(0xfc, fc_block) \
+    m(0xfd, simd) \
+    m(0xfe, atomic) \
     m(0xff, reserved_0xff)
 
-#define FOR_EACH_IPINT_GC_OPCODE(m) \
+#define FOR_EACH_IPINT_0xFB_OPCODE(m) \
     m(0x00, struct_new) \
     m(0x01, struct_new_default) \
     m(0x02, struct_get) \
@@ -339,7 +333,7 @@ extern "C" void SYSV_ABI ipint_atomic_dispatch_base() REFERENCED_FROM_ASM WTF_IN
     m(0x1d, i31_get_s) \
     m(0x1e, i31_get_u)
 
-#define FOR_EACH_IPINT_CONVERSION_OPCODE(m) \
+#define FOR_EACH_IPINT_0xFC_TRUNC_OPCODE(m) \
     m(0x00, i32_trunc_sat_f32_s) \
     m(0x01, i32_trunc_sat_f32_u) \
     m(0x02, i32_trunc_sat_f64_s) \
@@ -792,8 +786,8 @@ extern "C" void SYSV_ABI ipint_atomic_dispatch_base() REFERENCED_FROM_ASM WTF_IN
 
 #if !ENABLE(C_LOOP) && (CPU(ADDRESS64) && (CPU(ARM64) || CPU(X86_64)) || (CPU(ADDRESS32) && CPU(ARM_THUMB2)))
 FOR_EACH_IPINT_OPCODE(IPINT_VALIDATE_DEFINE_FUNCTION);
-FOR_EACH_IPINT_GC_OPCODE(IPINT_VALIDATE_DEFINE_FUNCTION);
-FOR_EACH_IPINT_CONVERSION_OPCODE(IPINT_VALIDATE_DEFINE_FUNCTION);
+FOR_EACH_IPINT_0xFB_OPCODE(IPINT_VALIDATE_DEFINE_FUNCTION);
+FOR_EACH_IPINT_0xFC_TRUNC_OPCODE(IPINT_VALIDATE_DEFINE_FUNCTION);
 FOR_EACH_IPINT_SIMD_OPCODE(IPINT_VALIDATE_DEFINE_FUNCTION);
 FOR_EACH_IPINT_ATOMIC_OPCODE(IPINT_VALIDATE_DEFINE_FUNCTION);
 FOR_EACH_IPINT_ARGUMINT_OPCODE(IPINT_VALIDATE_DEFINE_FUNCTION);

--- a/Source/JavaScriptCore/llint/LowLevelInterpreter.asm
+++ b/Source/JavaScriptCore/llint/LowLevelInterpreter.asm
@@ -1,4 +1,4 @@
-# Copyright (C) 2011-2025 Apple Inc. All rights reserved.
+# Copyright (C) 2011-2024 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/Source/JavaScriptCore/llint/LowLevelInterpreter.cpp
+++ b/Source/JavaScriptCore/llint/LowLevelInterpreter.cpp
@@ -111,7 +111,7 @@ using WebConfig::g_config;
 
 #define OFFLINE_ASM_OPCODE_LABEL(opcode) DEFINE_OPCODE(opcode) USE_LABEL(opcode); TRACE_OPCODE(opcode);
 
-#define OFFLINE_ASM_GLOBAL_LABEL(label)  .global label label: USE_LABEL(label);
+#define OFFLINE_ASM_GLOBAL_LABEL(label)  label: USE_LABEL(label);
 
 #if ENABLE(LABEL_TRACING)
 #define TRACE_LABEL(prefix, label) dataLog(#prefix, ": ", #label, "\n")


### PR DESCRIPTION
#### 00f733f3fff8e11f0c056d7b02f79835ca84ca29
<pre>
Unreviewed, reverting 294973@main (ac36e134cce1)
<a href="https://bugs.webkit.org/show_bug.cgi?id=293259">https://bugs.webkit.org/show_bug.cgi?id=293259</a>
<a href="https://rdar.apple.com/151647409">rdar://151647409</a>

This reverts because 36 wasm test are a consistent crash

Reverted change:

    Harden IPInt dispatch
    <a href="https://bugs.webkit.org/show_bug.cgi?id=292725">https://bugs.webkit.org/show_bug.cgi?id=292725</a>
    <a href="https://rdar.apple.com/150797746">rdar://150797746</a>
    294973@main (ac36e134cce1)

Canonical link: <a href="https://commits.webkit.org/295133@main">https://commits.webkit.org/295133@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/23a88d9503d54ff6dae846dd9ec628e583d92005

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104170 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/23874 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/14195 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/109367 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/54838 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/24242 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/123/builds/32418 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/109367 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/54838 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107176 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/130/builds/24242 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/93984 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/109367 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/130/builds/24242 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/12022 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/54198 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/96845 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/130/builds/24242 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/12080 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/111752 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/102781 "Built successfully and passed tests") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/31326 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/123/builds/32418 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/111752 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/31690 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/90171 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/111752 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/10449 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/25790 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16913 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/31255 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/36568 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/126415 "Built successfully") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/31049 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/34956 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/34385 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/32609 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->