### PR TITLE
AX: AXTextMarker::partialOrderByTraversal is extremely slow on large webpages

### DIFF
--- a/LayoutTests/accessibility/mac/text-marker-ordering-expected.txt
+++ b/LayoutTests/accessibility/mac/text-marker-ordering-expected.txt
@@ -1,0 +1,11 @@
+This test ensures we order text marker pairs correctly in various scenarios.
+
+PASS: 'Foo[NEWLINE]bar' === 'Foo[NEWLINE]bar' === true
+PASS: 'Foo[NEWLINE]bar' === 'Foo[NEWLINE]bar' === true
+PASS: 'Foo bar' === 'Foo bar' === true
+PASS: 'Foo[NEWLINE]bar' === 'Foo[NEWLINE]bar' === true
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/mac/text-marker-ordering.html
+++ b/LayoutTests/accessibility/mac/text-marker-ordering.html
@@ -1,0 +1,82 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+
+<div id="wrapper">
+    <!-- First descends from second. -->
+    <div id="testcase1-second" role="group">
+    Foo
+        <div id="testcase1-first" role="group">bar</div>
+    </div>
+
+    <!-- Second descends from first. -->
+    <div id="testcase2-first" role="group">
+    Foo
+        <div id="testcase2-second" role="group">bar</div>
+    </div>
+
+    <!-- First and second share a parent. -->
+    <div id="testcase3" role="group">
+    Foo bar
+    </div>
+
+    <!-- First and second are multiple levels away from their shared ancestor. -->
+    <div role="group">
+        <div role="group">
+            <div id="testcase4-first" role="group">Foo</div>
+        </div>
+        <div role="group">
+            <div id="testcase4-second" role="group">bar</div>
+        </div>
+    </div>
+</div>
+
+
+<script>
+var output = "This test ensures we order text marker pairs correctly in various scenarios.\n\n";
+
+var element;
+function endTextMarker(id) {
+    element = accessibilityController.accessibleElementById(id);
+    return element.endTextMarkerForTextMarkerRange(element.textMarkerRangeForElement(element));
+}
+
+function startTextMarker(id) {
+    element = accessibilityController.accessibleElementById(id);
+    return element.startTextMarkerForTextMarkerRange(element.textMarkerRangeForElement(element));
+}
+
+var stringForMarkerRange;
+function verifyRangeEqualsString(startMarker, endMarker, expectedString) {
+    stringForMarkerRange = webArea.stringForTextMarkerRange(webArea.textMarkerRangeForUnorderedMarkers(startMarker, endMarker));
+    output += expect(`'${stringForMarkerRange.replace("\n", "[NEWLINE]")}' === '${expectedString.replace("\n", "[NEWLINE]")}'`, "true");
+}
+
+if (window.accessibilityController) {
+    var webArea = accessibilityController.rootElement.childAtIndex(0);
+    // The start and end markers are purposely swapped, such that if we implement ordering incorrectly, our range will be invalid.
+    // In this first example, the end marker of #testcase1-first is after "Bar" (the end of the whole range-string), but we set
+    // it to be the start marker. Meanwhile, #testcase1-second is the start of "Foo", the beginning of the range-string, but it's
+    // passed as the end marker.
+    verifyRangeEqualsString(endTextMarker("testcase1-first"), startTextMarker("testcase1-second"), "Foo\nbar");
+    verifyRangeEqualsString(endTextMarker("testcase2-second"), startTextMarker("testcase2-first"), "Foo\nbar");
+
+    element = accessibilityController.accessibleElementById("testcase3");
+    var markerRange = element.textMarkerRangeForElement(element);
+    var startMarker = element.startTextMarkerForTextMarkerRange(markerRange);
+    var endMarker = element.endTextMarkerForTextMarkerRange(markerRange);
+    verifyRangeEqualsString(endMarker, startMarker, "Foo bar");
+
+    verifyRangeEqualsString(endTextMarker("testcase4-second"), startTextMarker("testcase4-first"), "Foo\nbar");
+
+    document.getElementById("wrapper").style.visibility = "hidden";
+    debug(output);
+}
+</script>
+</body>
+</html>
+

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -953,6 +953,7 @@ accessibility/mac/lazy-spellchecking.html [ Skip ]
 accessibility/mac/spellcheck-with-voiceover.html [ Skip ]
 accessibility/text-marker/text-marker-range-with-unordered-markers.html
 accessibility/mac/line-boundary-at-br.html [ Skip ]
+accessibility/mac/text-marker-ordering.html [ Skip ]
 
 accessibility/aria-controlled-table-row-visibility.html [ Skip ]
 

--- a/Source/WebCore/accessibility/AXCoreObject.h
+++ b/Source/WebCore/accessibility/AXCoreObject.h
@@ -807,6 +807,8 @@ public:
     void detach(AccessibilityDetachmentType);
     virtual bool isDetached() const = 0;
 
+    std::partial_ordering partialOrder(const AXCoreObject&);
+
     typedef Vector<Ref<AXCoreObject>> AccessibilityChildrenVector;
 
     virtual bool isAccessibilityObject() const = 0;

--- a/Source/WebCore/accessibility/AXTextMarker.h
+++ b/Source/WebCore/accessibility/AXTextMarker.h
@@ -345,8 +345,6 @@ public:
     // the last marker on the entire webpage.
     AXTextMarker findLastBefore(std::optional<AXID>) const;
     AXTextMarker findLast() const { return findLastBefore(std::nullopt); }
-    // Determines partial order by traversing forward and backwards to try the other marker.
-    std::partial_ordering partialOrderByTraversal(const AXTextMarker&) const;
     // The index of the line this text marker is on relative to the nearest editable ancestor (or start of the page if there are no editable ancestors).
     // Returns -1 if the line couldn't be computed (i.e. because `this` is invalid).
     int lineIndex() const;

--- a/Source/WebCore/accessibility/AccessibilityObject.h
+++ b/Source/WebCore/accessibility/AccessibilityObject.h
@@ -521,7 +521,7 @@ public:
 
     void updateRole();
     bool childrenInitialized() const { return m_childrenInitialized; }
-    const AccessibilityChildrenVector& children(bool updateChildrenIfNeeded = true) override;
+    const AccessibilityChildrenVector& children(bool updateChildrenIfNeeded = true) final;
     virtual void addChildren() { }
     enum class DescendIfIgnored : bool { No, Yes };
     void insertChild(AccessibilityObject&, unsigned, DescendIfIgnored = DescendIfIgnored::Yes);

--- a/Source/WebCore/accessibility/isolatedtree/mac/AXIsolatedObjectMac.mm
+++ b/Source/WebCore/accessibility/isolatedtree/mac/AXIsolatedObjectMac.mm
@@ -245,10 +245,11 @@ AXTextMarkerRange AXIsolatedObject::textMarkerRange() const
 
         auto thisMarker = AXTextMarker { *this, 0 };
         AXTextMarkerRange range { thisMarker, thisMarker };
-        auto endMarker = thisMarker.findLastBefore(stopObject ? std::optional { stopObject->objectID() } : std::nullopt);
+        auto startMarker = thisMarker.toTextRunMarker();
+        auto endMarker = startMarker.findLastBefore(stopObject ? std::optional { stopObject->objectID() } : std::nullopt);
         if (endMarker.isValid() && endMarker.isInTextRun()) {
             // One or more of our descendants have text, so let's form a range from the first and last text positions.
-            range = { thisMarker.toTextRunMarker(), WTFMove(endMarker) };
+            range = { WTFMove(startMarker), WTFMove(endMarker) };
         }
         return range;
     }


### PR DESCRIPTION
#### 9ca6a02d5b6ab91a124a8b4c11b837b42b3250a3
<pre>
AX: AXTextMarker::partialOrderByTraversal is extremely slow on large webpages
<a href="https://bugs.webkit.org/show_bug.cgi?id=293257">https://bugs.webkit.org/show_bug.cgi?id=293257</a>
<a href="https://rdar.apple.com/151648013">rdar://151648013</a>

Reviewed by Joshua Hoffman.

When holding VO-Right on html.spec.whatwg.org for 120 seconds, 48.6 seconds are spent in AXTextMarker::partialOrderByTraversal.
This commit replaces that function with a new one: AXTextMarker::partialOrderByAncestry. This function walks up and keeps
track of the ancestry for the |this| and |other| text markers. When we find a shared ancestor, we get the next-most
recent ancestor (which will be different for each), and determine what child-index it is in the shared ancestor. This
gets us the same information, much faster.

The old method took 48.6 seconds to process 1800 order-comparisons on html.spec.whatwg.org. The new one takes 4.4ms.

This is also faster in the case of simpler, more common webpages:

YouTube: 0.45ms vs 18.2ms for 237 comparisons
Wikipedia: 3.8ms vs. 18.7ms for 270 comparisons

Behavior covered by existing tests, and new test. I also did manual testing on html.spec.whatwg.org, YouTube, and Wikipedia where
I RELEASE_ASSERT&apos;d that the new function computed the same thing as the old one, and did not find any divergent cases.

* LayoutTests/accessibility/mac/text-marker-ordering-expected.txt: Added.
* LayoutTests/accessibility/mac/text-marker-ordering.html: Added.
* LayoutTests/platform/mac-wk1/TestExpectations:
* Source/WebCore/accessibility/AXCoreObject.cpp:
(WebCore::AXCoreObject::partialOrder):
* Source/WebCore/accessibility/AXCoreObject.h:
* Source/WebCore/accessibility/AXTextMarker.cpp:
(WebCore::operator&lt;=&gt;):
(WebCore::AXTextMarker::partialOrderByTraversal const): Deleted.
* Source/WebCore/accessibility/AXTextMarker.h:
(WebCore::AXTextMarker::findLast const):
* Source/WebCore/accessibility/AccessibilityObject.h:
* Source/WebCore/accessibility/isolatedtree/mac/AXIsolatedObjectMac.mm:
(WebCore::AXIsolatedObject::textMarkerRange const):

Canonical link: <a href="https://commits.webkit.org/295312@main">https://commits.webkit.org/295312@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7f0a0c6302e1f5e14bc2b7f8176c70b5f8fd5848

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104548 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24258 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/14676 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/109757 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/55219 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/106588 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/24643 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/32802 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79379 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107554 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94357 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59704 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/12431 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/54591 "Built successfully") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/12484 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/112145 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/31709 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23344 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88470 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32073 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/90591 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88088 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22480 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32986 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10759 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/27026 "Hash 7f0a0c63 for PR 45617 does not build (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/31636 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/36976 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/31428 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/34767 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/32988 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->