### PR TITLE
[macOS] Add vector-based version of scroll corner image

### DIFF
--- a/Source/WebCore/page/FrameView.cpp
+++ b/Source/WebCore/page/FrameView.cpp
@@ -181,6 +181,16 @@ bool FrameView::scrollAnimatorEnabled() const
     return false;
 }
 
+#if ENABLE(VECTOR_BASED_CONTROLS_ON_MAC)
+bool FrameView::vectorBasedControlsEnabled() const
+{
+    if (RefPtr page = frame().page())
+        return page->settings().vectorBasedControlsOnMacEnabled();
+
+    return false;
+}
+#endif
+
 IntRect FrameView::convertFromRendererToContainingView(const RenderElement* renderer, const IntRect& rendererRect) const
 {
     IntRect rect = snappedIntRect(enclosingLayoutRect(renderer->localToAbsoluteQuad(FloatRect(rendererRect)).boundingBox()));

--- a/Source/WebCore/page/FrameView.h
+++ b/Source/WebCore/page/FrameView.h
@@ -105,6 +105,9 @@ private:
     ScrollableArea* enclosingScrollableArea() const final;
 
     bool scrollAnimatorEnabled() const final;
+#if ENABLE(VECTOR_BASED_CONTROLS_ON_MAC)
+    bool vectorBasedControlsEnabled() const final;
+#endif
 };
 
 }

--- a/Source/WebCore/platform/ScrollableArea.h
+++ b/Source/WebCore/platform/ScrollableArea.h
@@ -436,6 +436,10 @@ public:
     virtual IntSize totalScrollbarSpace() const { return { }; }
     virtual int insetForLeftScrollbarSpace() const { return 0; }
 
+#if ENABLE(VECTOR_BASED_CONTROLS_ON_MAC)
+    virtual bool vectorBasedControlsEnabled() const { return false; }
+#endif
+
 protected:
     WEBCORE_EXPORT ScrollableArea();
     WEBCORE_EXPORT virtual ~ScrollableArea();

--- a/Source/WebCore/platform/mac/ScrollbarThemeMac.mm
+++ b/Source/WebCore/platform/mac/ScrollbarThemeMac.mm
@@ -50,6 +50,10 @@
 #import <wtf/SetForScope.h>
 #import <wtf/StdLibExtras.h>
 
+#if USE(APPLE_INTERNAL_SDK) && __has_include(<WebKitAdditions/ScrollbarThemeMacAdditions.mm>)
+#import <WebKitAdditions/ScrollbarThemeMacAdditions.mm>
+#endif
+
 // FIXME: There are repainting problems due to Aqua scroll bar buttons' visual overflow.
 
 namespace WebCore {
@@ -571,6 +575,10 @@ void ScrollbarThemeMac::paintScrollCorner(ScrollableArea& area, GraphicsContext&
     // Keep this in sync with ScrollAnimatorMac's effectiveAppearanceForScrollerImp:.
     LocalDefaultSystemAppearance localAppearance(area.useDarkAppearanceForScrollbars());
 
+#if ENABLE(VECTOR_BASED_CONTROLS_ON_MAC)
+    if (paintScrollCornerForVectorBasedControls(area, context, cornerRect))
+        return;
+#endif
     context.drawSystemImage(ScrollbarTrackCornerSystemImageMac::create(), cornerRect);
 }
 

--- a/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
+++ b/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
@@ -2037,4 +2037,12 @@ void RenderLayerScrollableArea::scrollbarWidthChanged(ScrollbarWidth width)
     availableContentSizeChanged(AvailableSizeChangeReason::ScrollbarsChanged);
 }
 
+#if ENABLE(VECTOR_BASED_CONTROLS_ON_MAC)
+bool RenderLayerScrollableArea::vectorBasedControlsEnabled() const
+{
+    return m_layer.page().settings().vectorBasedControlsOnMacEnabled();
+}
+#endif
+
+
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderLayerScrollableArea.h
+++ b/Source/WebCore/rendering/RenderLayerScrollableArea.h
@@ -273,6 +273,10 @@ public:
 
     void scrollbarWidthChanged(ScrollbarWidth) override;
 
+#if ENABLE(VECTOR_BASED_CONTROLS_ON_MAC)
+    bool vectorBasedControlsEnabled() const override;
+#endif
+
 private:
     bool hasHorizontalOverflow() const;
     bool hasVerticalOverflow() const;

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
@@ -394,6 +394,9 @@ protected:
     WebCore::IntRect scrollCornerRect() const final;
     WebCore::ScrollableArea* enclosingScrollableArea() const final;
     bool scrollAnimatorEnabled() const final { return true; }
+#if ENABLE(VECTOR_BASED_CONTROLS_ON_MAC)
+    bool vectorBasedControlsEnabled() const final;
+#endif
     bool isScrollableOrRubberbandable() final { return true; }
     bool hasScrollableOrRubberbandableAncestor() final { return true; }
     WebCore::IntRect scrollableAreaBoundingBox(bool* = nullptr) const final;

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
@@ -788,6 +788,16 @@ ScrollableArea* PDFPluginBase::enclosingScrollableArea() const
     return enclosingScrollableLayer->scrollableArea();
 }
 
+#if ENABLE(VECTOR_BASED_CONTROLS_ON_MAC)
+bool PDFPluginBase::vectorBasedControlsEnabled() const
+{
+    if (RefPtr page = this->page())
+        return page->settings().vectorBasedControlsOnMacEnabled();
+
+    return false;
+}
+#endif
+
 IntRect PDFPluginBase::scrollableAreaBoundingBox(bool*) const
 {
     return m_view->frameRect();


### PR DESCRIPTION
#### 5d9d7517cbdfc851465bce2a943fbdf904dae25d
<pre>
[macOS] Add vector-based version of scroll corner image
<a href="https://bugs.webkit.org/show_bug.cgi?id=293104">https://bugs.webkit.org/show_bug.cgi?id=293104</a>
<a href="https://rdar.apple.com/151644998">rdar://151644998</a>

Reviewed by Aditya Keerthi.

Paint a vector-based version of the scroll corner image
when vector-based controls for Mac are enabled.

* Source/WebCore/page/FrameView.cpp:
(WebCore::FrameView::vectorBasedControlsEnabled const):
* Source/WebCore/page/FrameView.h:
* Source/WebCore/platform/ScrollableArea.h:
(WebCore::ScrollableArea::vectorBasedControlsEnabled const):
* Source/WebCore/platform/mac/ScrollbarThemeMac.mm:
(WebCore::ScrollbarThemeMac::paintScrollCorner):
* Source/WebCore/rendering/RenderLayerScrollableArea.cpp:
(WebCore::RenderLayerScrollableArea::vectorBasedControlsEnabled const):
* Source/WebCore/rendering/RenderLayerScrollableArea.h:
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h:
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm:
(WebKit::PDFPluginBase::vectorBasedControlsEnabled const):

Canonical link: <a href="https://commits.webkit.org/295519@main">https://commits.webkit.org/295519@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/66fffa2fc3671a3a4be576ed4b033212888eecb2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104191 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/23895 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/14217 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/109389 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/54859 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/106231 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/24318 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/32439 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79137 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107197 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/18895 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/93999 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59464 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/18705 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/12036 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/54219 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/88404 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/12094 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/111773 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/31347 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23111 "Passed tests") | [⏳ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/GTK-WK2-Tests-EWS "Waiting to run tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/31711 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/90185 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87813 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22631 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32711 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10460 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/25811 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/31276 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/37199 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/31070 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/34406 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/32630 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->