### PR TITLE
REGRESSION (294368@main): Fixed elements in sticky containers are incorrectly positioned when scrolling

### DIFF
--- a/LayoutTests/compositing/ios/clip-nested-fixed-in-sticky-container-expected.html
+++ b/LayoutTests/compositing/ios/clip-nested-fixed-in-sticky-container-expected.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ContentInsetBackgroundFillEnabled=true showsScrollIndicators=false ] -->
+<html>
+<head>
+<meta name="viewport" content="width=device-width">
+<script src="../../resources/ui-helper.js"></script>
+<style>
+html, body {
+    margin: 0;
+}
+
+main {
+    position: sticky;
+    width: 100%;
+    height: 4000px;
+    box-sizing: border-box;
+}
+
+nav {
+    position: fixed;
+    width: 100%;
+    height: 60px;
+    top: 0;
+    background: tomato;
+}
+</style>
+<script>
+addEventListener("load", async () => {
+    window.testRunner?.waitUntilDone();
+    await UIHelper.setObscuredInsets(50, 0, 0, 0);
+    await UIHelper.ensurePresentationUpdate();
+    window.testRunner?.notifyDone();
+});
+</script>
+</head>
+<body>
+    <main>
+        <nav></nav>
+    </main>
+</body>
+</html>

--- a/LayoutTests/compositing/ios/clip-nested-fixed-in-sticky-container.html
+++ b/LayoutTests/compositing/ios/clip-nested-fixed-in-sticky-container.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ContentInsetBackgroundFillEnabled=true showsScrollIndicators=false ] -->
+<html>
+<head>
+<meta name="viewport" content="width=device-width">
+<script src="../../resources/ui-helper.js"></script>
+<style>
+html, body {
+    margin: 0;
+}
+
+main {
+    position: sticky;
+    width: 100%;
+    height: 4000px;
+    box-sizing: border-box;
+}
+
+nav {
+    position: fixed;
+    width: 100%;
+    height: 60px;
+    top: 0;
+    background: tomato;
+}
+</style>
+<script>
+addEventListener("load", async () => {
+    window.testRunner?.waitUntilDone();
+    await UIHelper.setObscuredInsets(50, 0, 0, 0);
+    await UIHelper.renderingUpdate();
+    await UIHelper.sendEventStream(new UIHelper.EventStreamBuilder()
+        .begin(150, 300)
+        .move(150, 100, 0.25)
+        .end()
+        .takeResult());
+    await UIHelper.waitForZoomingOrScrollingToEnd();
+    window.testRunner?.notifyDone();
+});
+</script>
+</head>
+<body>
+    <main>
+        <nav></nav>
+    </main>
+</body>
+</html>

--- a/Source/WebCore/page/scrolling/ScrollingConstraints.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingConstraints.cpp
@@ -107,7 +107,12 @@ FloatSize StickyPositionViewportConstraints::computeStickyOffset(const FloatRect
 FloatPoint StickyPositionViewportConstraints::anchorLayerPositionForConstrainingRect(const FloatRect& constrainingRect) const
 {
     FloatSize offset = computeStickyOffset(constrainingRect);
-    return (m_layerPositionAtLastLayout + m_anchorLayerOffsetAtLastLayout) + offset - m_stickyOffsetAtLastLayout;
+    return anchorLayerPositionAtLastLayout() + offset - m_stickyOffsetAtLastLayout;
+}
+
+FloatPoint StickyPositionViewportConstraints::anchorLayerPositionAtLastLayout() const
+{
+    return m_layerPositionAtLastLayout + m_anchorLayerOffsetAtLastLayout;
 }
 
 TextStream& operator<<(TextStream& ts, ScrollPositioningBehavior behavior)

--- a/Source/WebCore/page/scrolling/ScrollingConstraints.h
+++ b/Source/WebCore/page/scrolling/ScrollingConstraints.h
@@ -154,6 +154,7 @@ public:
     void setStickyOffsetAtLastLayout(FloatSize offset) { m_stickyOffsetAtLastLayout = offset; }
 
     WEBCORE_EXPORT FloatPoint anchorLayerPositionForConstrainingRect(const FloatRect& constrainingRect) const;
+    FloatPoint anchorLayerPositionAtLastLayout() const;
 
     float leftOffset() const { return m_leftOffset; }
     float rightOffset() const { return m_rightOffset; }

--- a/Source/WebCore/page/scrolling/ScrollingStateStickyNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingStateStickyNode.cpp
@@ -194,8 +194,7 @@ bool ScrollingStateStickyNode::hasViewportClippingLayer() const
 
 FloatSize ScrollingStateStickyNode::scrollDeltaSinceLastCommit(const LayoutRect& viewportRect) const
 {
-    auto layerPosition = hasViewportClippingLayer() ? computeClippingLayerPosition(viewportRect) : computeAnchorLayerPosition(viewportRect);
-    return layerPosition - m_constraints.layerPositionAtLastLayout();
+    return computeAnchorLayerPosition(viewportRect) - m_constraints.anchorLayerPositionAtLastLayout();
 }
 
 void ScrollingStateStickyNode::dumpProperties(TextStream& ts, OptionSet<ScrollingStateTreeAsTextBehavior> behavior) const

--- a/Source/WebCore/page/scrolling/ScrollingTreeStickyNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTreeStickyNode.cpp
@@ -132,8 +132,7 @@ FloatPoint ScrollingTreeStickyNode::computeAnchorLayerPosition() const
 
 FloatSize ScrollingTreeStickyNode::scrollDeltaSinceLastCommit() const
 {
-    auto layerPosition = hasViewportClippingLayer() ? computeClippingLayerPosition() : computeAnchorLayerPosition();
-    return layerPosition - m_constraints.layerPositionAtLastLayout();
+    return computeAnchorLayerPosition() - m_constraints.anchorLayerPositionAtLastLayout();
 }
 
 } // namespace WebCore


### PR DESCRIPTION
#### 6977b801a5f6f803deb27f3e179a42964dd5647c
<pre>
REGRESSION (294368@main): Fixed elements in sticky containers are incorrectly positioned when scrolling
<a href="https://bugs.webkit.org/show_bug.cgi?id=293258">https://bugs.webkit.org/show_bug.cgi?id=293258</a>
<a href="https://rdar.apple.com/151649175">rdar://151649175</a>

Reviewed by Abrar Rahman Protyasha.

When viewport clipping is enabled, nesting viewport-constrained children inside sticky ancestors
may cause the viewport-constrained children to visually &quot;lag behind&quot; while scrolling. While the
logic to compute post-layout clipping and anchor layer positions for the child is correct, the
corresponding logic to reposition viewport-relative layers when scrolling (in scrolling state and
tree nodes) is broken, which causes the anchor layer of the fixed/sticky child to get stuck in the
same absolute position instead of moving along with the viewport rect.

This happens because we overcompensate for the sticky ancestor&apos;s `scrollDeltaSinceLastCommit`, which
(before the viewport clipping changes) just returned how far the anchor layer has moved since the
last layout. In the case where the sticky ancestor isn&apos;t constrained to the viewport yet (and
therefore scrolls normally with the rest of the document), the anchor layer hasn&apos;t moved at all, and
so the `scrollDeltaSinceLastCommit` should be empty.

With viewport clipping enabled, this now computes how far the clipping layer has moved since the
last layout, which — in this case of a sticky-but-non-viewport-constrained container — will be non-
zero, since the viewport clipping layer always needs to track the viewport rect.

Since `Scrolling{State|Tree}StickyNode::scrollDeltaSinceLastCommit` is only used to adjust the
positions of child viewport-constrained elements nested inside of sticky ancestors, the latter (new)
behavior is incorrect because these child elements are inserted under the ancestor&apos;s anchor layer
(not the interstitial viewport clipping layer); in other words, when adjusting the child element&apos;s
layer position to account for the sticky ancestor, we need to adjust for both the anchor and
clipping layers (not just the clipping layer).

To fix this, we fix `Scrolling{State|Tree}StickyNode::scrollDeltaSinceLastCommit` so that it returns
the delta between the current (computed) anchor layer position, and the anchor layer position after
the last layout (both relative to the parent layer).

* LayoutTests/compositing/ios/clip-nested-fixed-in-sticky-container-expected.html: Added.
* LayoutTests/compositing/ios/clip-nested-fixed-in-sticky-container.html: Added.

Add a layout test to exercise the change by scrolling down in a webpage with a fixed `nav` docked to
the top of the viewport, inside a sticky `main` element; verify that this produces the same result
as if we didn&apos;t scroll at all.

* Source/WebCore/page/scrolling/ScrollingConstraints.cpp:
(WebCore::StickyPositionViewportConstraints::anchorLayerPositionForConstrainingRect const):
(WebCore::StickyPositionViewportConstraints::anchorLayerPositionAtLastLayout const):

Add a helper method to return the anchor layer position, relative to the sticky element&apos;s parent. In
the case where the viewport clipping layer is present, `m_layerPositionAtLastLayout` represents the
clipping layer&apos;s position, and `m_anchorLayerOffsetAtLastLayout` is the offset of the anchor layer
within the clipping layer. In the case where viewport clipping is disabled for this layer,
`m_layerPositionAtLastLayout` already represents the anchor layer position, and
`m_anchorLayerOffsetAtLastLayout` is always empty, since it represents the offset of the anchor
layer relative to itself.

* Source/WebCore/page/scrolling/ScrollingConstraints.h:
* Source/WebCore/page/scrolling/ScrollingStateStickyNode.cpp:
(WebCore::ScrollingStateStickyNode::scrollDeltaSinceLastCommit const):

See description above for more details.

* Source/WebCore/page/scrolling/ScrollingTreeStickyNode.cpp:
(WebCore::ScrollingTreeStickyNode::scrollDeltaSinceLastCommit const):

Canonical link: <a href="https://commits.webkit.org/295143@main">https://commits.webkit.org/295143@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/788f50364640a8603379f0776b3db1d4b6ba477a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104185 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/23889 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/14210 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/109383 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/54853 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/106225 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/24257 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/32433 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79132 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107191 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/18846 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/93985 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59459 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/18654 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/12024 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/54213 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/88360 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/12082 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/111767 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/31341 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23104 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88150 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/31705 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/90173 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87809 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22359 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32703 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10450 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/25805 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/31270 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/36583 "Failed to build and analyze WebKit") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/31064 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/34400 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/32624 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->