### PR TITLE
css/css-view-transitions/fractional-* fails due to not pixel snapping view transition renderers.

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7080,16 +7080,9 @@ imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/navigate-
 # -- View Transitions -- #
 # Reftest failures:
 imported/w3c/web-platform-tests/css/css-view-transitions/content-with-clip-root.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-view-transitions/fractional-box-new.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-view-transitions/fractional-box-old.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-view-transitions/fractional-box-with-overflow-children-old.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-view-transitions/fractional-box-with-shadow-new.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-view-transitions/fractional-box-with-shadow-old.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-view-transitions/inline-with-offset-from-containing-block.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-view-transitions/span-with-overflowing-text.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-view-transitions/fractional-box-with-overflow-children-new.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-view-transitions/new-content-captures-different-size.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-view-transitions/fractional-translation-from-position.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-view-transitions/paint-holding-in-iframe.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-view-transitions/auto-name-get-animations.html [ Failure ]
 imported/w3c/web-platform-tests/css/css-view-transitions/fractional-translation-from-transform.html [ ImageOnlyFailure ]

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -1387,6 +1387,10 @@ imported/w3c/web-platform-tests/css/css-view-transitions/navigation/hide-before-
 imported/w3c/web-platform-tests/css/css-view-transitions/navigation/pageswap-push-from-click.html [ Failure ]
 
 imported/w3c/web-platform-tests/css/css-view-transitions/snapshot-containing-block-static-iframe.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/css/css-view-transitions/fractional-box-old.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/css/css-view-transitions/fractional-box-with-shadow-old.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/css/css-view-transitions/inline-child-with-filter.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/css/css-view-transitions/inline-child-with-composited-filter.html [ ImageOnlyFailure ]
 
 # Needs special fuzziness on iOS.
 imported/w3c/web-platform-tests/css/css-view-transitions/rotated-cat-off-top-edge.html [ ImageOnlyFailure ]

--- a/Source/WebCore/dom/ViewTransition.h
+++ b/Source/WebCore/dom/ViewTransition.h
@@ -68,19 +68,22 @@ enum class ViewTransitionPhase : uint8_t {
 struct CapturedElement {
     WTF_MAKE_TZONE_ALLOCATED(CapturedElement);
 public:
+    struct State {
+        LayoutRect overflowRect;
+        LayoutPoint layerToLayoutOffset;
+        LayoutSize size;
+        LayoutSize subpixelOffset;
+        RefPtr<MutableStyleProperties> properties;
+        bool intersectsViewport { false };
+    };
+
     // std::nullopt represents an non-capturable element.
     // nullptr represents an absent snapshot on an capturable element.
     std::optional<RefPtr<ImageBuffer>> oldImage;
-    LayoutRect oldOverflowRect;
-    LayoutPoint oldLayerToLayoutOffset;
-    LayoutSize oldSize;
-    RefPtr<MutableStyleProperties> oldProperties;
-    bool initiallyIntersectsViewport { false };
+    State oldState;
 
     WeakStyleable newElement;
-    LayoutRect newOverflowRect;
-    LayoutSize newSize;
-    RefPtr<MutableStyleProperties> newProperties;
+    State newState;
 
     Vector<AtomString> classList;
     RefPtr<MutableStyleProperties> groupStyleProperties;
@@ -209,7 +212,7 @@ private:
     ViewTransition(Document&, RefPtr<ViewTransitionUpdateCallback>&&, Vector<AtomString>&&);
     ViewTransition(Document&, Vector<AtomString>&&);
 
-    Ref<MutableStyleProperties> copyElementBaseProperties(RenderLayerModelObject&, LayoutSize&, LayoutRect& overflowRect, bool& intersectsViewport);
+    void copyElementBaseProperties(RenderLayerModelObject&, CapturedElement::State&);
     bool updatePropertiesForGroupPseudo(CapturedElement&, const AtomString&);
 
     // Setup view transition sub-algorithms.

--- a/Source/WebCore/platform/graphics/transforms/TransformationMatrix.h
+++ b/Source/WebCore/platform/graphics/transforms/TransformationMatrix.h
@@ -297,7 +297,7 @@ public:
     TransformationMatrix& skewY(double angle) { return skew(0, angle); }
 
     TransformationMatrix& applyPerspective(double p);
-    bool hasPerspective() const { return m_matrix[2][3] != 0.0f; }
+    bool hasPerspective() const { return m_matrix[0][3] != 0.0f || m_matrix[1][3] != 0.0f || m_matrix[2][3] != 0.0f || m_matrix[3][3] != 1.0f; }
 
     // Returns a transformation that maps a rect to a rect.
     WEBCORE_EXPORT static TransformationMatrix rectToRect(const FloatRect&, const FloatRect&);

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -6840,6 +6840,9 @@ static void outputPaintOrderTreeRecursive(TextStream& stream, const WebCore::Ren
 
             stream << "}"_s;
         }
+
+        if (backing.subpixelOffsetFromRenderer() != WebCore::LayoutSize())
+            stream << " (subpixel offset "_s << backing.subpixelOffsetFromRenderer() << ")"_s;
     }
     stream << " "_s << layer.name();
     stream.nextLine();

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -1553,7 +1553,7 @@ void RenderLayerBacking::updateGeometry(const RenderLayer* compositedAncestor)
         if (RefPtr activeViewTransition = renderer().document().activeViewTransition()) {
             if (CheckedPtr viewTransitionCapture = activeViewTransition->viewTransitionNewPseudoForCapturedElement(renderer())) {
                 ComputedOffsets computedOffsets(m_owningLayer, compositedAncestor, viewTransitionCapture->captureOverflowRect(), { }, { });
-                parentGraphicsLayerRect = { { computedOffsets.fromParentGraphicsLayer().width(), computedOffsets.fromParentGraphicsLayer().height() }, viewTransitionCapture->captureOverflowRect().size() };
+                parentGraphicsLayerRect = LayoutRect(snapRectToDevicePixelsIfNeeded(LayoutRect(toLayoutPoint(computedOffsets.fromParentGraphicsLayer()), viewTransitionCapture->captureOverflowRect().size()), renderer()));
             }
         }
     }

--- a/Source/WebCore/rendering/updating/RenderTreeUpdaterViewTransition.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeUpdaterViewTransition.cpp
@@ -158,7 +158,7 @@ static RenderPtr<RenderBox> createRendererIfNeeded(RenderElement& documentElemen
         RenderPtr<RenderViewTransitionCapture> rendererViewTransition = WebCore::createRenderer<RenderViewTransitionCapture>(RenderObject::Type::ViewTransitionCapture, document, RenderStyle::clone(*style));
         if (pseudoId == PseudoId::ViewTransitionOld)
             rendererViewTransition->setImage(capturedElement->oldImage.value_or(nullptr));
-        rendererViewTransition->setCapturedSize(capturedElement->oldSize, capturedElement->oldOverflowRect, capturedElement->oldLayerToLayoutOffset);
+        rendererViewTransition->setCapturedSize(capturedElement->oldState.size, capturedElement->oldState.overflowRect, capturedElement->oldState.layerToLayoutOffset);
         renderer = WTFMove(rendererViewTransition);
     } else
         renderer = WebCore::createRenderer<RenderBlockFlow>(RenderObject::Type::BlockFlow, document, RenderStyle::clone(*style));


### PR DESCRIPTION
#### 72ba48fd55e6120b28f47394c5ea63373cdd53ed
<pre>
css/css-view-transitions/fractional-* fails due to not pixel snapping view transition renderers.
<a href="https://bugs.webkit.org/show_bug.cgi?id=293273">https://bugs.webkit.org/show_bug.cgi?id=293273</a>
&lt;<a href="https://rdar.apple.com/151661047">rdar://151661047</a>&gt;

Reviewed by Simon Fraser.

Moves the duplicated state in CapturedElement into a separate struct, and use
that to simplify parameters of copyElementBaseProperties.

Compute and remove the fractional component of the view transition transform,
and pass it through to the snapshot rendering.

Snap the layer rects to pixels, so that the fractional component gets computed
and passed down the inner layer, as it does for non-VT rendering.

* LayoutTests/TestExpectations:
* LayoutTests/platform/ios/TestExpectations:
* Source/WebCore/dom/ViewTransition.cpp:
(WebCore::captureOverflowRect):
(WebCore::snapshotElementVisualOverflowClippedToViewport):
(WebCore::ViewTransition::captureOldState):
(WebCore::ViewTransition::updatePropertiesForGroupPseudo):
(WebCore::ViewTransition::captureNewState):
(WebCore::ViewTransition::setupDynamicStyleSheet):
(WebCore::snapTransformationTranslationToDevicePixels):
(WebCore::ViewTransition::copyElementBaseProperties):
(WebCore::ViewTransition::updatePseudoElementStylesRead):
(WebCore::ViewTransition::updatePseudoElementRenderers):
* Source/WebCore/dom/ViewTransition.h:
* Source/WebCore/platform/graphics/transforms/TransformationMatrix.h:
(WebCore::TransformationMatrix::hasPerspective const):
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::outputPaintOrderTreeRecursive):
(WebCore::RenderLayer::filtersForPainting const): Deleted.
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::updateGeometry):
* Source/WebCore/rendering/updating/RenderTreeUpdaterViewTransition.cpp:
(WebCore::createRendererIfNeeded):

Canonical link: <a href="https://commits.webkit.org/295401@main">https://commits.webkit.org/295401@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d3a4cd872d3554787aeead29b992040147536912

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104969 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24683 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15104 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110185 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/55648 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/107010 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/25089 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33227 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79704 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107975 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19519 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94735 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60011 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/19263 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/12813 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55026 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/88982 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/12859 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/112672 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32134 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23638 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/88785 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32499 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/90961 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88413 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22538 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33306 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11088 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/27466 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32058 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/37429 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/31851 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35192 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33410 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->