### PR TITLE
Digital Credentials: stop skipping tests

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7749,10 +7749,6 @@ webanimations/scroll-timeline-clamped-current-time-while-rubber-banding-ios.html
 
 webkit.org/b/287313 [ Debug ] fast/inline/list-marker-float-crash.html [ Skip ]
 
-# Digital Credentials API, not enabled yet
-http/wpt/identity/ [ Skip ]
-imported/w3c/web-platform-tests/digital-credentials/ [ Skip ]
-
 # macOS-only test.
 media/webkit-media-controls-not-visible-after-exiting-fullscreen.html [ Skip ]
 

--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/allow-attribute-with-get.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/allow-attribute-with-get.https-expected.txt
@@ -1,8 +1,9 @@
 
+
 PASS With Get: Policy to use: null, is cross-origin: false, is allowed by policy: true
 PASS With Get: Policy to use: null, is cross-origin: true, is allowed by policy: false
 PASS With Get: Policy to use: digital-credentials-get, is cross-origin: false, is allowed by policy: true
-PASS With Get: Policy to use: digital-credentials-get, is cross-origin: true, is allowed by policy: true
+FAIL With Get: Policy to use: digital-credentials-get, is cross-origin: true, is allowed by policy: true assert_true: <iframe allow="digital-credentials-get" src="https://127.0.0.1:9443/digital-credentials/support/iframe.html" data-expect-is-allowed="true"></iframe> - Digital credentials are not supported. expected true got false
 PASS With Get: Policy to use: digital-credentials-get *, is cross-origin: false, is allowed by policy: true
 PASS With Get: Policy to use: digital-credentials-get *, is cross-origin: true, is allowed by policy: true
 PASS With Get: Policy to use: digital-credentials-get 'none', is cross-origin: false, is allowed by policy: false

--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/allow-attribute-with-get.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/allow-attribute-with-get.https.html
@@ -105,10 +105,11 @@
                         const options = {
                             digital: {
                                 // Results in TypeError when allowed, NotAllowedError when disallowed
-                                requests: [],
+                                requests: [{ data: {}, protocol: "openid4vp" }],
                             },
                             mediation: "required",
                         };
+                        await test_driver.bless("User activation");
                         const { data } = await new Promise((resolve) => {
                             window.addEventListener("message", resolve, {
                                 once: true,

--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/get.tentative.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/get.tentative.https-expected.txt
@@ -1,5 +1,6 @@
 
 
+PASS Type conversion happens on the data member of the DigitalCredentialGetRequest object.
 PASS Calling navigator.credentials.get() without a digital member same origin.
 PASS navigator.credentials.get() API rejects if there are no credential request.
 PASS navigator.credentials.get() API rejects if there are no credential request for same-origin iframe.
@@ -7,7 +8,7 @@ PASS navigator.credentials.get() API rejects if there are no credential request 
 PASS navigator.credentials.get() promise is rejected if called with an aborted controller.
 PASS navigator.credentials.get() promise is rejected if called with an aborted controller in same-origin iframe.
 PASS navigator.credentials.get() promise is rejected if called with an aborted signal in cross-origin iframe.
-PASS navigator.credentials.get() promise is rejected if abort controller is aborted after call to get().
+FAIL navigator.credentials.get() promise is rejected if abort controller is aborted after call to get(). promise_rejects_dom: function "function() { throw e }" threw object "NotSupportedError: Digital credentials are not supported." that is not a DOMException AbortError: property "code" is equal to 9, expected 20
 FAIL navigator.credentials.get() promise is rejected if abort controller is aborted after call to get() in cross-origin iframe. assert_equals: expected "AbortError" but got "NotAllowedError"
 PASS Mediation is required to get a DigitalCredential.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/get.tentative.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/get.tentative.https.html
@@ -29,6 +29,27 @@
   });
 
   promise_test(async (t) => {
+    const invalidData = [null, undefined, "", 123, true, false];
+    for (const data of invalidData) {
+      const options = {
+        digital: {
+          requests: [
+            {
+              data,
+              protocol: "openid4vp",
+            },
+          ],
+        },
+      };
+      await promise_rejects_js(
+        t,
+        TypeError,
+        navigator.credentials.get(options)
+      );
+    }
+  }, "Type conversion happens on the data member of the DigitalCredentialGetRequest object.");
+
+  promise_test(async (t) => {
     iframeSameOrigin.focus();
     for (const global of [window, iframeSameOrigin.contentWindow]) {
       await promise_rejects_dom(
@@ -89,7 +110,11 @@
     for (const request of [undefined, []]) {
       const options = makeGetOptions(request);
       await test_driver.bless("user activation");
-      await promise_rejects_js(t, TypeError, navigator.credentials.get(options));
+      await promise_rejects_js(
+        t,
+        TypeError,
+        navigator.credentials.get(options)
+      );
     }
   }, "navigator.credentials.get() API rejects if there are no credential request.");
 
@@ -196,10 +221,14 @@
 
   promise_test(async (t) => {
     /** @type sequence<CredentialMediationRequirement> */
-    const disallowedMediations = [ "conditional", "optional", "silent"];
+    const disallowedMediations = ["conditional", "optional", "silent"];
     for (const mediation of disallowedMediations) {
       const options = makeGetOptions("default", mediation);
-      await promise_rejects_js(t, TypeError, navigator.credentials.get(options));
+      await promise_rejects_js(
+        t,
+        TypeError,
+        navigator.credentials.get(options)
+      );
     }
   }, "Mediation is required to get a DigitalCredential.");
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/non-fully-active.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/non-fully-active.https-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL non-fully active document behavior for CredentialsContainer promise_test: Unhandled rejection with value: object "TypeError: null is not an object (evaluating 'navigator.credentials.get')"
+PASS non-fully active document behavior for CredentialsContainer
 

--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/non-fully-active.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/non-fully-active.https.html
@@ -33,7 +33,7 @@
     controller.abort();
 
     // Steal all the needed references.
-    const navigator = iframe.contentWindow.navigator;
+    const { credentials } = iframe.contentWindow.navigator;
     const DOMExceptionCtor = iframe.contentWindow.DOMException;
 
     // No longer fully active.
@@ -44,7 +44,7 @@
       t,
       "InvalidStateError",
       DOMExceptionCtor,
-      navigator.credentials.get({ signal }),
+      credentials.get({ signal }),
       "Expected InvalidStateError for get() on non-fully-active document"
     );
 
@@ -53,7 +53,7 @@
       t,
       "InvalidStateError",
       DOMExceptionCtor,
-      navigator.credentials.create({ signal }),
+      credentials.create({ signal }),
       "Expected InvalidStateError for create() on non-fully-active document"
     );
 
@@ -62,7 +62,7 @@
       t,
       "InvalidStateError",
       DOMExceptionCtor,
-      navigator.credentials.preventSilentAccess(),
+      credentials.preventSilentAccess(),
       "Expected InvalidStateError for preventSilentAccess() on non-fully-active document"
     );
   }, "non-fully active document behavior for CredentialsContainer");

--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/support/iframe.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/support/iframe.html
@@ -27,8 +27,8 @@
       }
       data.options.signal = abortController.signal;
     }
-    if (data.needsActivation) {
-      await test_driver.bless("user activation", null, window);
+    if (data.needsActivation && !navigator.userActivation.isActive) {
+      await test_driver.bless("user activation");
     }
     let result;
     try {

--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/user-activation.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/user-activation.https-expected.txt
@@ -1,6 +1,6 @@
 
-FAIL navigator.credentials.get() calling the API without user activation should reject with NotAllowedError. promise_rejects_dom: function "function() { throw e }" threw object "TypeError: At least one request must present." that is not a DOMException NotAllowedError: property "code" is equal to undefined, expected 0
-FAIL navigator.credentials.get() consumes user activation. assert_false: User activation should be consumed after navigator.credentials.get(). expected false got true
-FAIL navigator.credentials.create() calling the API without user activation should reject with NotAllowedError. assert_false: User activation should not be active expected false got true
+PASS navigator.credentials.get() calling the API without user activation should reject with NotAllowedError.
+FAIL navigator.credentials.get() consumes user activation. promise_rejects_dom: function "function() { throw e }" threw object "NotSupportedError: Digital credentials are not supported." that is not a DOMException AbortError: property "code" is equal to 9, expected 20
+FAIL navigator.credentials.create() calling the API without user activation should reject with NotAllowedError. assert_unreached: Should have rejected: undefined Reached unreachable code
 FAIL navigator.credentials.create() consumes user activation. assert_unreached: Should have rejected: undefined Reached unreachable code
 

--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/user-activation.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/user-activation.https.html
@@ -14,7 +14,7 @@
       navigator.userActivation.isActive,
       "User activation should not be active"
     );
-    const options = makeGetOptions([]);
+    const options = makeGetOptions("openid4vp");
     await promise_rejects_dom(
       t,
       "NotAllowedError",
@@ -24,12 +24,17 @@
 
   promise_test(async (t) => {
     await test_driver.bless();
+    const abort = new AbortController();
+    const options = makeGetOptions("openid4vp");
+    options.signal = abort.signal;
     assert_true(
       navigator.userActivation.isActive,
       "User activation should be active after test_driver.bless()."
     );
-    const options = makeGetOptions([]);
-    await promise_rejects_js(t, TypeError, navigator.credentials.get(options));
+
+    const getPromise = navigator.credentials.get(options);
+    abort.abort();
+    await promise_rejects_dom(t, "AbortError", getPromise);
     assert_false(
       navigator.userActivation.isActive,
       "User activation should be consumed after navigator.credentials.get()."

--- a/LayoutTests/platform/gtk/TestExpectations
+++ b/LayoutTests/platform/gtk/TestExpectations
@@ -1998,3 +1998,7 @@ webkit.org/b/291636 svg/text/timeout-long-text-content.html [ Skip ]
 webkit.org/b/286580 http/tests/media/clearkey/clear-key-session-id.html [ Skip ]
 
 http/tests/iframe-memory-monitor/media-video-autoplay-in-frames.html [ Skip ]
+
+# The Digital Credentials API is not supported in GTK port
+http/wpt/identity/ [ Skip ]
+imported/w3c/web-platform-tests/digital-credentials/ [ Skip ]

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/digital-credentials/get.tentative.https-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/digital-credentials/get.tentative.https-expected.txt
@@ -1,6 +1,7 @@
 
 
-PASS Calling navigator.credentials.get() without an digital member same origin.
+PASS Type conversion happens on the data member of the DigitalCredentialGetRequest object.
+PASS Calling navigator.credentials.get() without a digital member same origin.
 PASS navigator.credentials.get() API rejects if there are no credential request.
 FAIL navigator.credentials.get() API rejects if there are no credential request for same-origin iframe. promise_rejects_js: function "function() { throw e }" threw object "NotAllowedError: The document is not focused." ("NotAllowedError") expected instance of function "function TypeError() {
     [native code]
@@ -9,7 +10,7 @@ PASS navigator.credentials.get() API rejects if there are no credential request 
 PASS navigator.credentials.get() promise is rejected if called with an aborted controller.
 PASS navigator.credentials.get() promise is rejected if called with an aborted controller in same-origin iframe.
 PASS navigator.credentials.get() promise is rejected if called with an aborted signal in cross-origin iframe.
-PASS navigator.credentials.get() promise is rejected if abort controller is aborted after call to get().
+FAIL navigator.credentials.get() promise is rejected if abort controller is aborted after call to get(). promise_rejects_dom: function "function() { throw e }" threw object "NotSupportedError: Digital credentials are not supported." that is not a DOMException AbortError: property "code" is equal to 9, expected 20
 FAIL navigator.credentials.get() promise is rejected if abort controller is aborted after call to get() in cross-origin iframe. assert_equals: expected "AbortError" but got "NotAllowedError"
 PASS Mediation is required to get a DigitalCredential.
 

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -110,6 +110,10 @@ imported/w3c/web-platform-tests/screen-orientation [ Skip ]
 # webkit.org/b/247981
 imported/w3c/web-platform-tests/fetch [ Skip ]
 
+# The Digital Credentials API is not supported in WebKit1.
+http/wpt/identity/ [ Skip ]
+imported/w3c/web-platform-tests/digital-credentials/ [ Skip ]
+
 # Shared & service workers are only implemented for WebKit2.
 http/tests/navigation/page-cache-shared-worker.html [ Skip ]
 http/tests/workers/shared [ Skip ]

--- a/LayoutTests/platform/visionos/TestExpectations
+++ b/LayoutTests/platform/visionos/TestExpectations
@@ -109,6 +109,10 @@ imported/w3c/web-platform-tests/webxr/hit-test [ Skip ]
 imported/w3c/web-platform-tests/webxr/layers [ Skip ]
 imported/w3c/web-platform-tests/webxr/light-estimation [ Skip ]
 
+# The Digital Credentials API is not supported on visionOS.
+http/wpt/identity/ [ Skip ]
+imported/w3c/web-platform-tests/digital-credentials/ [ Skip ]
+
 ### END OF Legitimate failures
 ###################################################################################################
 

--- a/LayoutTests/platform/wpe/TestExpectations
+++ b/LayoutTests/platform/wpe/TestExpectations
@@ -1747,3 +1747,7 @@ webkit.org/b/286580 http/tests/media/clearkey/clear-key-session-id.html [ Skip ]
 webkit.org/b/292841 fullscreen/exit-full-screen-video-crash.html [ Timeout ]
 
 http/tests/iframe-memory-monitor/media-video-autoplay-in-frames.html [ Skip ]
+
+# The Digital Credentials API is not supported on WPE port.
+http/wpt/identity/ [ Skip ]
+imported/w3c/web-platform-tests/digital-credentials/ [ Skip ]


### PR DESCRIPTION
#### d8b8d2dbc5f6f56ad97ab8c7d0b79f08ffd16af4
<pre>
Digital Credentials: stop skipping tests
<a href="https://rdar.apple.com/151585360">rdar://151585360</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=292851">https://bugs.webkit.org/show_bug.cgi?id=292851</a>

Reviewed by Ryosuke Niwa.

Stop skipping Digital Credentials API tests and resyncs WPT upstream to commit:

<a href="https://github.com/web-platform-tests/wpt/commit/0d7fb0a39aa73bf885ca2a5d0220dee77e2b8a55">https://github.com/web-platform-tests/wpt/commit/0d7fb0a39aa73bf885ca2a5d0220dee77e2b8a55</a>
Canonical link: <a href="https://commits.webkit.org/295384@main">https://commits.webkit.org/295384@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/624f3d560e76cf1f00880235f502a27f4942ab09

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104702 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24414 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/14836 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/109916 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/55376 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/24805 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/32960 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79510 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107708 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19294 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94498 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59817 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/19061 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/12573 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/54751 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/88757 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/12623 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/112311 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/31867 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23446 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88591 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32231 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/90727 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88209 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22525 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33100 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10877 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/27180 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/31792 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/31584 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/34925 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33143 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->