### PR TITLE
Document.h doesn't need to include ContextDestructionObserverInlines.h

### DIFF
--- a/Source/WebCore/Modules/audiosession/DOMAudioSession.cpp
+++ b/Source/WebCore/Modules/audiosession/DOMAudioSession.cpp
@@ -29,10 +29,12 @@
 #if ENABLE(DOM_AUDIO_SESSION)
 
 #include "AudioSession.h"
+#include "ContextDestructionObserverInlines.h"
 #include "Document.h"
 #include "Event.h"
 #include "EventNames.h"
 #include "EventTargetInlines.h"
+#include "EventTargetInterfaces.h"
 #include "ExceptionOr.h"
 #include "Page.h"
 #include "PermissionsPolicy.h"
@@ -142,6 +144,16 @@ DOMAudioSession::State DOMAudioSession::state() const
     if (!m_state)
         m_state = computeAudioSessionState();
     return *m_state;
+}
+
+enum EventTargetInterfaceType DOMAudioSession::eventTargetInterface() const
+{
+    return EventTargetInterfaceType::DOMAudioSession;
+}
+
+ScriptExecutionContext* DOMAudioSession::scriptExecutionContext() const
+{
+    return ContextDestructionObserver::scriptExecutionContext();
 }
 
 void DOMAudioSession::stop()

--- a/Source/WebCore/Modules/audiosession/DOMAudioSession.h
+++ b/Source/WebCore/Modules/audiosession/DOMAudioSession.h
@@ -29,8 +29,8 @@
 
 #include "ActiveDOMObject.h"
 #include "AudioSession.h"
+#include "ContextDestructionObserver.h"
 #include "EventTarget.h"
-#include "EventTargetInterfaces.h"
 #include <wtf/RefCounted.h>
 #include <wtf/TZoneMallocInlines.h>
 
@@ -63,8 +63,8 @@ private:
     explicit DOMAudioSession(ScriptExecutionContext*);
 
     // EventTarget
-    enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::DOMAudioSession; }
-    ScriptExecutionContext* scriptExecutionContext() const final { return ContextDestructionObserver::scriptExecutionContext(); }
+    EventTargetInterfaceType eventTargetInterface() const final;
+    ScriptExecutionContext* scriptExecutionContext() const final;
     void refEventTarget() final { ref(); }
     void derefEventTarget() final { deref(); }
 

--- a/Source/WebCore/Modules/entriesapi/DOMFileSystem.cpp
+++ b/Source/WebCore/Modules/entriesapi/DOMFileSystem.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "DOMFileSystem.h"
 
+#include "ContextDestructionObserverInlines.h"
 #include "ExceptionOr.h"
 #include "File.h"
 #include "FileSystemDirectoryEntry.h"

--- a/Source/WebCore/Modules/gamepad/GamepadHapticActuator.cpp
+++ b/Source/WebCore/Modules/gamepad/GamepadHapticActuator.cpp
@@ -28,6 +28,7 @@
 #if ENABLE(GAMEPAD)
 #include "GamepadHapticActuator.h"
 
+#include "ContextDestructionObserverInlines.h"
 #include "Document.h"
 #include "EventLoop.h"
 #include "Gamepad.h"

--- a/Source/WebCore/Modules/geolocation/Geolocation.cpp
+++ b/Source/WebCore/Modules/geolocation/Geolocation.cpp
@@ -276,6 +276,11 @@ void Geolocation::resetAllGeolocationPermission()
         startRequest(watcher.get());
 }
 
+Document* Geolocation::document() const
+{
+    return downcast<Document>(scriptExecutionContext());
+}
+
 void Geolocation::stop()
 {
     RefPtr page = this->page();

--- a/Source/WebCore/Modules/geolocation/Geolocation.h
+++ b/Source/WebCore/Modules/geolocation/Geolocation.h
@@ -29,6 +29,7 @@
 #if ENABLE(GEOLOCATION)
 
 #include "ActiveDOMObject.h"
+#include "ContextDestructionObserver.h"
 #include "Document.h"
 #include "GeolocationPosition.h"
 #include "GeolocationPositionError.h"
@@ -64,7 +65,7 @@ public:
     WEBCORE_EXPORT ~Geolocation();
 
     WEBCORE_EXPORT void resetAllGeolocationPermission();
-    Document* document() const { return downcast<Document>(scriptExecutionContext()); }
+    Document* document() const;
 
     void getCurrentPosition(Ref<PositionCallback>&&, RefPtr<PositionErrorCallback>&&, PositionOptions&&);
     int watchPosition(Ref<PositionCallback>&&, RefPtr<PositionErrorCallback>&&, PositionOptions&&);

--- a/Source/WebCore/Modules/mediastream/CanvasCaptureMediaStreamTrack.cpp
+++ b/Source/WebCore/Modules/mediastream/CanvasCaptureMediaStreamTrack.cpp
@@ -27,6 +27,7 @@
 
 #if ENABLE(MEDIA_STREAM)
 
+#include "ContextDestructionObserverInlines.h"
 #include "GraphicsContext.h"
 #include "HTMLCanvasElement.h"
 #include "VideoFrame.h"

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerDataChannelHandler.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerDataChannelHandler.cpp
@@ -22,6 +22,7 @@
 
 #if USE(GSTREAMER_WEBRTC)
 
+#include "ContextDestructionObserverInlines.h"
 #include "EventNames.h"
 #include "GStreamerWebRTCUtils.h"
 #include "RTCDataChannel.h"

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpSenderTransformBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpSenderTransformBackend.cpp
@@ -22,6 +22,7 @@
 
 #if ENABLE(WEB_RTC) && USE(GSTREAMER_WEBRTC)
 
+#include "ContextDestructionObserverInlines.h"
 #include "NotImplemented.h"
 #include <wtf/TZoneMallocInlines.h>
 

--- a/Source/WebCore/Modules/speech/SpeechSynthesisUtterance.cpp
+++ b/Source/WebCore/Modules/speech/SpeechSynthesisUtterance.cpp
@@ -31,6 +31,7 @@
 #include "ContextDestructionObserverInlines.h"
 #include "EventNames.h"
 #include "EventTargetInlines.h"
+#include "EventTargetInterfaces.h"
 #include "SpeechSynthesisErrorEvent.h"
 #include "SpeechSynthesisEvent.h"
 #include <wtf/TZoneMallocInlines.h>
@@ -132,6 +133,15 @@ bool SpeechSynthesisUtterance::virtualHasPendingActivity() const
     return m_activityCountForEventDispatch && hasEventListeners();
 }
 
+ScriptExecutionContext* SpeechSynthesisUtterance::scriptExecutionContext() const
+{
+    return ActiveDOMObject::scriptExecutionContext();
+}
+
+EventTargetInterfaceType SpeechSynthesisUtterance::eventTargetInterface() const
+{
+    return EventTargetInterfaceType::SpeechSynthesisUtterance;
+}
 
 } // namespace WebCore
 

--- a/Source/WebCore/Modules/speech/SpeechSynthesisUtterance.h
+++ b/Source/WebCore/Modules/speech/SpeechSynthesisUtterance.h
@@ -28,8 +28,8 @@
 #if ENABLE(SPEECH_SYNTHESIS)
 
 #include "ActiveDOMObject.h"
+#include "ContextDestructionObserver.h"
 #include "EventTarget.h"
-#include "EventTargetInterfaces.h"
 #include "PlatformSpeechSynthesisUtterance.h"
 #include "SpeechSynthesisErrorCode.h"
 #include "SpeechSynthesisVoice.h"
@@ -90,8 +90,8 @@ private:
     bool virtualHasPendingActivity() const final;
 
     // EventTarget
-    ScriptExecutionContext* scriptExecutionContext() const final { return ActiveDOMObject::scriptExecutionContext(); }
-    enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::SpeechSynthesisUtterance; }
+    ScriptExecutionContext* scriptExecutionContext() const final;
+    EventTargetInterfaceType eventTargetInterface() const final;
     void refEventTarget() final { ref(); }
     void derefEventTarget() final { deref(); }
 

--- a/Source/WebCore/Modules/storage/StorageManager.cpp
+++ b/Source/WebCore/Modules/storage/StorageManager.cpp
@@ -27,6 +27,7 @@
 #include "StorageManager.h"
 
 #include "ClientOrigin.h"
+#include "ContextDestructionObserverInlines.h"
 #include "Document.h"
 #include "ExceptionOr.h"
 #include "FileSystemDirectoryHandle.h"

--- a/Source/WebCore/Modules/webxr/WebXRFrame.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRFrame.cpp
@@ -28,6 +28,7 @@
 
 #if ENABLE(WEBXR)
 
+#include "ContextDestructionObserverInlines.h"
 #include "ExceptionOr.h"
 #include "WebXRBoundedReferenceSpace.h"
 #include "WebXRJointPose.h"

--- a/Source/WebCore/Modules/webxr/WebXRLayer.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRLayer.cpp
@@ -43,6 +43,11 @@ WebXRLayer::WebXRLayer(ScriptExecutionContext* context)
 
 WebXRLayer::~WebXRLayer() = default;
 
+ScriptExecutionContext* WebXRLayer::scriptExecutionContext() const
+{
+    return ContextDestructionObserver::scriptExecutionContext();
+}
+
 } // namespace WebCore
 
 #endif // ENABLE(WEBXR)

--- a/Source/WebCore/Modules/webxr/WebXRLayer.h
+++ b/Source/WebCore/Modules/webxr/WebXRLayer.h
@@ -53,7 +53,7 @@ protected:
     explicit WebXRLayer(ScriptExecutionContext*);
 
     // EventTarget
-    ScriptExecutionContext* scriptExecutionContext() const final { return ContextDestructionObserver::scriptExecutionContext(); }
+    ScriptExecutionContext* scriptExecutionContext() const final;
 
 private:
     // EventTarget

--- a/Source/WebCore/Modules/webxr/WebXROpaqueFramebufferCocoa.cpp
+++ b/Source/WebCore/Modules/webxr/WebXROpaqueFramebufferCocoa.cpp
@@ -28,6 +28,7 @@
 
 #if ENABLE(WEBXR) && PLATFORM(COCOA)
 
+#include "ContextDestructionObserverInlines.h"
 #include "GraphicsContextGLCocoa.h"
 #include "IntSize.h"
 #include "Logging.h"

--- a/Source/WebCore/Modules/webxr/WebXRSession.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRSession.cpp
@@ -29,6 +29,7 @@
 
 #if ENABLE(WEBXR)
 
+#include "ContextDestructionObserverInlines.h"
 #include "Document.h"
 #include "EventNames.h"
 #include "JSDOMPromiseDeferred.h"
@@ -428,6 +429,11 @@ void WebXRSession::didCompleteShutdown()
     // 7. Queue a task that fires an XRSessionEvent named end on session.
     auto event = XRSessionEvent::create(eventNames().endEvent, { RefPtr { this } });
     queueTaskToDispatchEvent(*this, TaskSource::WebXR, WTFMove(event));
+}
+
+ScriptExecutionContext* WebXRSession::scriptExecutionContext() const
+{
+    return ActiveDOMObject::scriptExecutionContext();
 }
 
 // https://immersive-web.github.io/webxr/#dom-xrsession-end

--- a/Source/WebCore/Modules/webxr/WebXRSession.h
+++ b/Source/WebCore/Modules/webxr/WebXRSession.h
@@ -98,7 +98,7 @@ public:
     void applicationWillEnterForeground() { m_shouldServiceRequestVideoFrameCallbacks = false; }
 
     // EventTarget.
-    ScriptExecutionContext* scriptExecutionContext() const final { return ActiveDOMObject::scriptExecutionContext(); }
+    ScriptExecutionContext* scriptExecutionContext() const final;
 
     ExceptionOr<void> end(EndPromise&&);
     bool ended() const { return m_ended; }

--- a/Source/WebCore/Modules/webxr/WebXRSpace.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRSpace.cpp
@@ -66,6 +66,11 @@ std::optional<bool> WebXRSpace::isPositionEmulated() const
     return xrSession->isPositionEmulated();
 }
 
+ScriptExecutionContext* WebXRSpace::scriptExecutionContext() const
+{
+    return ContextDestructionObserver::scriptExecutionContext();
+}
+
 WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(WebXRViewerSpace);
 
 WebXRViewerSpace::WebXRViewerSpace(Document& document, WebXRSession& session)

--- a/Source/WebCore/Modules/webxr/WebXRSpace.h
+++ b/Source/WebCore/Modules/webxr/WebXRSpace.h
@@ -62,7 +62,7 @@ protected:
     const WebXRRigidTransform& originOffset() const { return m_originOffset.get(); }
 
     // EventTarget
-    ScriptExecutionContext* scriptExecutionContext() const final { return ContextDestructionObserver::scriptExecutionContext(); }
+    ScriptExecutionContext* scriptExecutionContext() const final;
 
 private:
     // EventTarget

--- a/Source/WebCore/Modules/webxr/XRInputSourceEvent.cpp
+++ b/Source/WebCore/Modules/webxr/XRInputSourceEvent.cpp
@@ -28,6 +28,7 @@
 
 #if ENABLE(WEBXR)
 
+#include "ContextDestructionObserverInlines.h"
 #include "WebXRFrame.h"
 #include "WebXRInputSource.h"
 #include <wtf/TZoneMallocInlines.h>

--- a/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
+++ b/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
@@ -5270,6 +5270,7 @@ sub GenerateImplementation
 
     if (NeedsImplementationClass($interface) && !$interface->extendedAttributes->{CustomHeapSnapshot}) {
         AddToImplIncludes("<JavaScriptCore/HeapAnalyzer.h>");
+        AddToImplIncludes("ContextDestructionObserverInlines.h");
         AddToImplIncludes("ScriptExecutionContext.h");
         AddToImplIncludes("<wtf/URL.h>");
         AddToImplIncludes("<wtf/text/MakeString.h>");

--- a/Source/WebCore/dom/ContextDestructionObserver.cpp
+++ b/Source/WebCore/dom/ContextDestructionObserver.cpp
@@ -61,9 +61,4 @@ void ContextDestructionObserver::contextDestroyed()
     m_scriptExecutionContext = nullptr;
 }
 
-RefPtr<ScriptExecutionContext> ContextDestructionObserver::protectedScriptExecutionContext() const
-{
-    return m_scriptExecutionContext.get();
-}
-
 } // namespace WebCore

--- a/Source/WebCore/dom/ContextDestructionObserver.h
+++ b/Source/WebCore/dom/ContextDestructionObserver.h
@@ -37,8 +37,8 @@ class ContextDestructionObserver {
 public:
     WEBCORE_EXPORT virtual void contextDestroyed();
 
-    ScriptExecutionContext* scriptExecutionContext() const; // Defined in ContextDestructionObserverInlines.h.
-    RefPtr<ScriptExecutionContext> protectedScriptExecutionContext() const;
+    inline ScriptExecutionContext* scriptExecutionContext() const; // Defined in ContextDestructionObserverInlines.h.
+    inline RefPtr<ScriptExecutionContext> protectedScriptExecutionContext() const; // Defined in ContextDestructionObserverInlines.h.
 
 protected:
     WEBCORE_EXPORT explicit ContextDestructionObserver(ScriptExecutionContext*);

--- a/Source/WebCore/dom/ContextDestructionObserverInlines.h
+++ b/Source/WebCore/dom/ContextDestructionObserverInlines.h
@@ -35,4 +35,9 @@ inline ScriptExecutionContext* ContextDestructionObserver::scriptExecutionContex
     return m_scriptExecutionContext.get();
 }
 
+inline RefPtr<ScriptExecutionContext> ContextDestructionObserver::protectedScriptExecutionContext() const
+{
+    return m_scriptExecutionContext.get();
+}
+
 } // namespace WebCore

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -30,7 +30,7 @@
 #include "AsyncNodeDeletionQueue.h"
 #include "Color.h"
 #include "ContainerNode.h"
-#include "ContextDestructionObserverInlines.h"
+#include "ContextDestructionObserver.h"
 #include "DocumentClasses.h"
 #include "DocumentEnums.h"
 #include "DocumentEventTiming.h"

--- a/Source/WebCore/fileapi/NetworkSendQueue.cpp
+++ b/Source/WebCore/fileapi/NetworkSendQueue.cpp
@@ -27,6 +27,7 @@
 #include "NetworkSendQueue.h"
 
 #include "BlobLoader.h"
+#include "ContextDestructionObserverInlines.h"
 #include "ScriptExecutionContext.h"
 
 namespace WebCore {

--- a/Source/WebCore/html/CustomPaintCanvas.cpp
+++ b/Source/WebCore/html/CustomPaintCanvas.cpp
@@ -28,6 +28,7 @@
 
 #include "BitmapImage.h"
 #include "CanvasRenderingContext.h"
+#include "ContextDestructionObserverInlines.h"
 #include "ImageBitmap.h"
 #include "PaintRenderingContext2D.h"
 #include "ScriptExecutionContext.h"
@@ -102,6 +103,11 @@ std::unique_ptr<CSSParserContext> CustomPaintCanvas::createCSSParserContext() co
 {
     // FIXME: Rather than using a default CSSParserContext, there should be one exposed via ScriptExecutionContext.
     return makeUnique<CSSParserContext>(HTMLStandardMode);
+}
+
+ScriptExecutionContext* CustomPaintCanvas::canvasBaseScriptExecutionContext() const
+{
+    return ContextDestructionObserver::scriptExecutionContext();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/html/CustomPaintCanvas.h
+++ b/Source/WebCore/html/CustomPaintCanvas.h
@@ -76,7 +76,7 @@ public:
 private:
     CustomPaintCanvas(ScriptExecutionContext&, unsigned width, unsigned height);
 
-    ScriptExecutionContext* canvasBaseScriptExecutionContext() const final { return ContextDestructionObserver::scriptExecutionContext(); }
+    ScriptExecutionContext* canvasBaseScriptExecutionContext() const final;
 
     std::unique_ptr<PaintRenderingContext2D> m_context;
     mutable RefPtr<Image> m_copiedImage;

--- a/Source/WebCore/html/canvas/EXTDisjointTimerQuery.cpp
+++ b/Source/WebCore/html/canvas/EXTDisjointTimerQuery.cpp
@@ -29,6 +29,7 @@
 
 #include "EXTDisjointTimerQuery.h"
 
+#include "ContextDestructionObserverInlines.h"
 #include "EventLoop.h"
 #include "ScriptExecutionContext.h"
 #include "WebGLRenderingContext.h"

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioRTPPacketizer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioRTPPacketizer.cpp
@@ -22,6 +22,7 @@
 
 #if USE(GSTREAMER_WEBRTC)
 
+#include "ContextDestructionObserverInlines.h"
 #include "GStreamerCommon.h"
 #include "GStreamerRegistryScanner.h"
 #include <gst/rtp/rtp.h>

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerMockDeviceProvider.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerMockDeviceProvider.cpp
@@ -23,6 +23,7 @@
 
 #if ENABLE(MEDIA_STREAM) && USE(GSTREAMER)
 
+#include "ContextDestructionObserverInlines.h"
 #include "GStreamerMockDevice.h"
 #include "GUniquePtrGStreamer.h"
 #include "MockRealtimeMediaSourceCenter.h"

--- a/Source/WebCore/platform/mediastream/gstreamer/MockDisplayCaptureSourceGStreamer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/MockDisplayCaptureSourceGStreamer.cpp
@@ -22,9 +22,10 @@
  */
 
 #include "config.h"
+#include "MockDisplayCaptureSourceGStreamer.h"
 
 #if ENABLE(MEDIA_STREAM) && USE(GSTREAMER)
-#include "MockDisplayCaptureSourceGStreamer.h"
+#include "ContextDestructionObserverInlines.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingAudioSourceGStreamer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingAudioSourceGStreamer.cpp
@@ -22,6 +22,7 @@
 
 #if USE(GSTREAMER_WEBRTC)
 
+#include "ContextDestructionObserverInlines.h"
 #include "GStreamerAudioRTPPacketizer.h"
 #include "GStreamerCommon.h"
 #include "GStreamerMediaStreamSource.h"

--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingVideoSourceGStreamer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingVideoSourceGStreamer.cpp
@@ -21,7 +21,7 @@
 #include "RealtimeOutgoingVideoSourceGStreamer.h"
 
 #if USE(GSTREAMER_WEBRTC)
-
+#include "ContextDestructionObserverInlines.h"
 #include "GStreamerCommon.h"
 #include "GStreamerMediaStreamSource.h"
 #include "GStreamerRegistryScanner.h"

--- a/Source/WebCore/testing/WebXRTest.cpp
+++ b/Source/WebCore/testing/WebXRTest.cpp
@@ -28,6 +28,7 @@
 
 #if ENABLE(WEBXR)
 
+#include "ContextDestructionObserverInlines.h"
 #include "JSDOMPromiseDeferred.h"
 #include "JSWebFakeXRDevice.h"
 #include "JSXRReferenceSpaceType.h"

--- a/Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.cpp
@@ -39,6 +39,7 @@
 #include "WebProcessProxy.h"
 #include "WebsiteDataStore.h"
 #include <WebCore/CaptureDeviceWithCapabilities.h>
+#include <WebCore/ContextDestructionObserverInlines.h>
 #include <WebCore/MediaConstraintType.h>
 #include <WebCore/MediaConstraints.h>
 #include <WebCore/MockRealtimeMediaSourceCenter.h>

--- a/Source/WebKit/UIProcess/glib/UserMediaPermissionRequestManagerProxyGLib.cpp
+++ b/Source/WebKit/UIProcess/glib/UserMediaPermissionRequestManagerProxyGLib.cpp
@@ -23,6 +23,7 @@
 #include "WebPageProxy.h"
 #include "WebProcessProxy.h"
 #include <WebCore/CaptureDeviceWithCapabilities.h>
+#include <WebCore/ContextDestructionObserverInlines.h>
 #include <WebCore/MediaConstraintType.h>
 #include <WebCore/UserMediaRequest.h>
 


### PR DESCRIPTION
#### 1371865b7df5413956adb15a7eae6a81ecd2e859
<pre>
Document.h doesn&apos;t need to include ContextDestructionObserverInlines.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=293277">https://bugs.webkit.org/show_bug.cgi?id=293277</a>

Reviewed by Chris Dumez.

Include ContextDestructionObserver.h instead of ContextDestructionObserverInlines.h

GTK+ build fix is based on Diego Pino Garcia&apos;s patch.

* Source/WebCore/Modules/audiosession/DOMAudioSession.cpp:
(WebCore::DOMAudioSession::eventTargetInterface const):
(WebCore::DOMAudioSession::scriptExecutionContext const):
* Source/WebCore/Modules/audiosession/DOMAudioSession.h:
* Source/WebCore/Modules/entriesapi/DOMFileSystem.cpp:
* Source/WebCore/Modules/gamepad/GamepadHapticActuator.cpp:
* Source/WebCore/Modules/geolocation/Geolocation.cpp:
(WebCore::Geolocation::document const):
* Source/WebCore/Modules/geolocation/Geolocation.h:
* Source/WebCore/Modules/mediastream/CanvasCaptureMediaStreamTrack.cpp:
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerDataChannelHandler.cpp:
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpSenderTransformBackend.cpp:
* Source/WebCore/Modules/speech/SpeechSynthesisUtterance.cpp:
(WebCore::SpeechSynthesisUtterance::scriptExecutionContext const):
(WebCore::SpeechSynthesisUtterance::eventTargetInterface const):
* Source/WebCore/Modules/speech/SpeechSynthesisUtterance.h:
* Source/WebCore/Modules/storage/StorageManager.cpp:
* Source/WebCore/Modules/webxr/WebXRFrame.cpp:
* Source/WebCore/Modules/webxr/WebXRLayer.cpp:
(WebCore::WebXRLayer::scriptExecutionContext const):
* Source/WebCore/Modules/webxr/WebXRLayer.h:
* Source/WebCore/Modules/webxr/WebXROpaqueFramebufferCocoa.cpp:
* Source/WebCore/Modules/webxr/WebXRSession.cpp:
(WebCore::WebXRSession::scriptExecutionContext const):
* Source/WebCore/Modules/webxr/WebXRSession.h:
* Source/WebCore/Modules/webxr/WebXRSpace.cpp:
(WebCore::WebXRSpace::scriptExecutionContext const):
* Source/WebCore/Modules/webxr/WebXRSpace.h:
* Source/WebCore/Modules/webxr/XRInputSourceEvent.cpp:
* Source/WebCore/bindings/scripts/CodeGeneratorJS.pm:
(GenerateImplementation):
* Source/WebCore/dom/ContextDestructionObserver.cpp:
(WebCore::ContextDestructionObserver::protectedScriptExecutionContext const): Deleted.
* Source/WebCore/dom/ContextDestructionObserver.h:
* Source/WebCore/dom/ContextDestructionObserverInlines.h:
(WebCore::ContextDestructionObserver::protectedScriptExecutionContext const):
* Source/WebCore/dom/Document.h:
* Source/WebCore/fileapi/NetworkSendQueue.cpp:
* Source/WebCore/html/CustomPaintCanvas.cpp:
(WebCore::CustomPaintCanvas::canvasBaseScriptExecutionContext const):
* Source/WebCore/html/CustomPaintCanvas.h:
* Source/WebCore/html/canvas/EXTDisjointTimerQuery.cpp:
* Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioRTPPacketizer.cpp:
* Source/WebCore/platform/mediastream/gstreamer/GStreamerMockDeviceProvider.cpp:
* Source/WebCore/platform/mediastream/gstreamer/MockDisplayCaptureSourceGStreamer.cpp:
* Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingAudioSourceGStreamer.cpp:
* Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingVideoSourceGStreamer.cpp:
* Source/WebCore/testing/WebXRTest.cpp:
* Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.cpp:
* Source/WebKit/UIProcess/glib/UserMediaPermissionRequestManagerProxyGLib.cpp:

Canonical link: <a href="https://commits.webkit.org/295353@main">https://commits.webkit.org/295353@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6d1c4d199b4bcba5ace6fb1c690d81d99bef1acb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104837 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24550 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/14971 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110052 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/55511 "Built successfully") 
| [❌ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/106877 "Found 86 Binding test failures: JSTestPluginInterface.cpp, JSTestNode.cpp, JSTestCEReactions.cpp, JSTestStringifierReadWriteAttribute.cpp, JSTestNamedDeleterNoIdentifier.cpp, JSTestIndexedSetterThrowingException.cpp, JSTestNamedAndIndexedSetterWithIdentifier.cpp, JSTestDefaultToJSONFilteredByExposed.cpp, JSTestEventTarget.cpp, JSShadowRealmGlobalScope.cpp, JSTestStringifierOperationImplementedAs.cpp, JSTestOverloadedConstructorsWithSequence.cpp, JSTestCallTracer.cpp, JSTestNamedSetterWithIndexedGetter.cpp, JSTestInterface.cpp, JSSharedWorkerGlobalScope.cpp, JSTestCEReactionsStringifier.cpp, JSTestPromiseRejectionEvent.cpp, JSTestScheduledAction.cpp, JSTestStringifierOperationNamedToString.cpp, JSTestNamedSetterWithLegacyUnforgeableProperties.cpp, JSTestOverloadedConstructors.cpp, JSTestSetLikeWithOverriddenOperations.cpp, JSTestSetLike.cpp, JSTestLegacyOverrideBuiltIns.cpp, JSTestIndexedSetterWithIdentifier.cpp, JSServiceWorkerGlobalScope.cpp, JSTestConditionallyReadWrite.cpp, JSTestNamedGetterWithIdentifier.cpp, JSExposedStar.cpp, JSTestMapLike.cpp, JSTestNamedDeleterThrowingException.cpp, JSTestNamedGetterCallWith.cpp, JSWorkletGlobalScope.cpp, JSTestDefaultToJSON.cpp, JSTestGenerateAddOpaqueRoot.cpp, JSTestSerializedScriptValueInterface.cpp, JSTestObj.cpp, JSTestIndexedSetterNoIdentifier.cpp, JSTestStringifier.cpp, JSTestInterfaceLeadingUnderscore.cpp, JSTestReadOnlyMapLike.cpp, JSTestEnabledBySetting.cpp, JSTestGlobalObject.cpp, JSTestNamedAndIndexedSetterNoIdentifier.cpp, JSTestReportExtraMemoryCost.cpp, JSTestException.cpp, JSTestStringifierReadOnlyAttribute.cpp, JSTestIterable.cpp, JSTestNamedSetterThrowingException.cpp, JSTestOperationConditional.cpp, JSTestReadOnlySetLike.cpp, JSTestClassWithJSBuiltinConstructor.cpp, JSTestDomainSecurity.cpp, JSTestDefaultToJSONIndirectInheritance.cpp, JSTestDelegateToSharedSyntheticAttribute.cpp, JSTestLegacyFactoryFunction.cpp, JSTestDOMJIT.cpp, JSTestNamedSetterWithLegacyUnforgeablePropertiesAndLegacyOverrideBuiltIns.cpp, JSTestNamedDeleterWithIdentifier.cpp, JSTestNamedSetterWithLegacyOverrideBuiltIns.cpp, JSDOMWindow.cpp, JSTestGenerateIsReachable.cpp, JSTestNamedSetterNoIdentifier.cpp, JSPaintWorkletGlobalScope.cpp, JSTestNamedAndIndexedSetterThrowingException.cpp, JSTestMapLikeWithOverriddenOperations.cpp, JSTestNamedSetterWithIndexedGetterAndSetter.cpp, JSTestTypedefs.cpp, JSTestEnabledForContext.cpp, JSWorkerGlobalScope.cpp, JSExposedToWorkerAndWindow.cpp, JSDedicatedWorkerGlobalScope.cpp, JSTestDefaultToJSONInheritFinal.cpp, JSTestLegacyNoInterfaceObject.cpp, JSTestNamedSetterWithIdentifier.cpp, JSTestNamedDeleterWithIndexedGetter.cpp, JSTestAsyncIterable.cpp, JSTestStringifierAnonymousOperation.cpp, JSTestNamedGetterNoIdentifier.cpp, JSTestStringifierNamedOperation.cpp, JSTestAsyncKeyValueIterable.cpp, JSTestTaggedWrapper.cpp, JSTestEventConstructor.cpp, JSTestConditionalIncludes.cpp, JSTestDefaultToJSONInherit.cpp") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/24950 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33095 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79607 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107843 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19402 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94614 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59914 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/19149 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/12691 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/54894 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/88848 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/12738 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/112469 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32002 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/23526 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88686 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32366 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/90840 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88313 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33204 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10969 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/27316 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17004 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/31927 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/37281 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/31719 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35060 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33278 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->