### PR TITLE
[GTK] Enable damage propagation to the UI process by default

### DIFF
--- a/LayoutTests/platform/glib/damage/basic-propagation-002.html
+++ b/LayoutTests/platform/glib/damage/basic-propagation-002.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html> <!-- webkit-test-runner [ UnifyDamagedRegions=false ] -->
 <html lang="en">
   <head>
     <link rel="stylesheet" href="./common.css">

--- a/LayoutTests/platform/glib/damage/common.js
+++ b/LayoutTests/platform/glib/damage/common.js
@@ -24,8 +24,6 @@ function setupTestCase(options = {}) {
 
         if (!window.internals) {
             failTest("FAIL: this test case requires internals");
-        } else if (window.internals.getCurrentDamagePropagation() != "Region") {
-            failTest("FAIL: this test case requires proper damage propagation");
         } else {
             try {
                 window.internals.getFrameDamageHistory();

--- a/LayoutTests/platform/glib/damage/layer-downsize-with-movement.html
+++ b/LayoutTests/platform/glib/damage/layer-downsize-with-movement.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html> <!-- webkit-test-runner [ UnifyDamagedRegions=false ] -->
 <html lang="en">
   <head>
     <link rel="stylesheet" href="./common.css">

--- a/LayoutTests/platform/glib/damage/layer-in-layer-movement.html
+++ b/LayoutTests/platform/glib/damage/layer-in-layer-movement.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html> <!-- webkit-test-runner [ UnifyDamagedRegions=false ] -->
 <html lang="en">
   <head>
     <link rel="stylesheet" href="./common.css">

--- a/LayoutTests/platform/glib/damage/layer-movement.html
+++ b/LayoutTests/platform/glib/damage/layer-movement.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html> <!-- webkit-test-runner [ UnifyDamagedRegions=false ] -->
 <html lang="en">
   <head>
     <link rel="stylesheet" href="./common.css">

--- a/LayoutTests/platform/glib/damage/layer-overlaps-with-opacity.html
+++ b/LayoutTests/platform/glib/damage/layer-overlaps-with-opacity.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html> <!-- webkit-test-runner [ UnifyDamagedRegions=false ] -->
 <html lang="en">
   <head>
     <link rel="stylesheet" href="./common.css">

--- a/LayoutTests/platform/glib/damage/layer-resize.html
+++ b/LayoutTests/platform/glib/damage/layer-resize.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html> <!-- webkit-test-runner [ UnifyDamagedRegions=false ] -->
 <html lang="en">
   <head>
     <link rel="stylesheet" href="./common.css">

--- a/LayoutTests/platform/glib/damage/non-accelerated-canvas-2d-fillRect.html
+++ b/LayoutTests/platform/glib/damage/non-accelerated-canvas-2d-fillRect.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html> <!-- webkit-test-runner [ UnifyDamagedRegions=false ] -->
 <html lang="en">
   <head>
     <link rel="stylesheet" href="./common.css">

--- a/LayoutTests/platform/glib/damage/non-accelerated-canvas-2d-resizing.html
+++ b/LayoutTests/platform/glib/damage/non-accelerated-canvas-2d-resizing.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html> <!-- webkit-test-runner [ UnifyDamagedRegions=false ] -->
 <html lang="en">
   <head>
     <link rel="stylesheet" href="./common.css">

--- a/LayoutTests/platform/glib/damage/transform-3d-rotate-3-axes.html
+++ b/LayoutTests/platform/glib/damage/transform-3d-rotate-3-axes.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html> <!-- webkit-test-runner [ UnifyDamagedRegions=false ] -->
 <html lang="en">
   <head>
     <link rel="stylesheet" href="./common.css">

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -5916,13 +5916,14 @@ PropagateDamagingInformation:
    category: dom
    humanReadableName: "Propagate Damaging Information"
    humanReadableDescription: "Propagate Damaging Information"
-   condition: USE(COORDINATED_GRAPHICS)
+   condition: ENABLE(DAMAGE_TRACKING)
    defaultValue:
-     WebCore:
-       default: false
      WebKitLegacy:
        default: false
      WebKit:
+       "PLATFORM(GTK)": true
+       default: false
+     WebCore:
        default: false
 
 PunchOutWhiteBackgroundsInDarkMode:
@@ -7721,13 +7722,14 @@ UnifyDamagedRegions:
    category: dom
    humanReadableName: "Unify Damaged Regions"
    humanReadableDescription: "Unify Damaged Regions"
-   condition: USE(COORDINATED_GRAPHICS)
+   condition: ENABLE(DAMAGE_TRACKING)
    defaultValue:
-     WebCore:
-       default: false
      WebKitLegacy:
        default: false
      WebKit:
+       "PLATFORM(GTK)": true
+       default: false
+     WebCore:
        default: false
 
 UpgradeKnownHostsToHTTPSEnabled:
@@ -7808,6 +7810,21 @@ UseCGDisplayListsForDOMRendering:
     WebKit:
       default: true
   sharedPreferenceForWebProcess: true
+
+UseDamagingInformationForCompositing:
+  type: bool
+  status: testable
+  category: dom
+  humanReadableName: "Use the Damaging Information to optimize compositing"
+  humanReadableDescription: "Use the Damaging Information to optimize compositing"
+  condition: ENABLE(DAMAGE_TRACKING)
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
 
 UseGPUProcessForCanvasRenderingEnabled:
   type: bool

--- a/Source/WebCore/platform/graphics/Damage.h
+++ b/Source/WebCore/platform/graphics/Damage.h
@@ -71,12 +71,6 @@ class Damage {
 public:
     using Rects = Vector<IntRect, 1>;
 
-    enum class Propagation : uint8_t {
-        None,
-        Region,
-        Unified,
-    };
-
     enum class Mode : uint8_t {
         Rectangles, // Tracks dirty regions as rectangles, only unifying when maximum is reached.
         BoundingBox, // Dirty region is always the minimum bounding box of all added rectangles.

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.h
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.h
@@ -119,7 +119,7 @@ public:
     void addChild(TextureMapperLayer*);
 
 #if ENABLE(DAMAGE_TRACKING)
-    void setDamagePropagation(bool enabled) { m_damagePropagation = enabled; }
+    void setDamagePropagationEnabled(bool enabled) { m_damagePropagationEnabled = enabled; }
     void setDamage(Damage&&);
     void collectDamage(TextureMapper&, Damage&);
 #endif
@@ -187,7 +187,6 @@ private:
     void collect3DRenderingContextLayers(Vector<TextureMapperLayer*>&);
 
 #if ENABLE(DAMAGE_TRACKING)
-    bool canInferDamage() const { return m_damagePropagation; }
     void collectDamageRecursive(TextureMapperPaintOptions&, Damage&);
     void collectDamageSelfAndChildren(TextureMapperPaintOptions&, Damage&);
     void collectDamageSelf(TextureMapperPaintOptions&, Damage&);
@@ -289,7 +288,7 @@ private:
     bool m_isReplica { false };
 
 #if ENABLE(DAMAGE_TRACKING)
-    bool m_damagePropagation { false };
+    bool m_damagePropagationEnabled { false };
     bool m_collectDamageDespiteBeingInvisible { false };
     std::optional<Damage> m_damageInLayerCoordinateSpace;
     std::optional<Damage> m_damageInGlobalCoordinateSpace;

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp
@@ -102,7 +102,7 @@ TextureMapperLayer& CoordinatedPlatformLayer::ensureTarget()
     if (!m_target) {
         m_target = makeUnique<TextureMapperLayer>();
 #if ENABLE(DAMAGE_TRACKING)
-        m_target->setDamagePropagation(m_damagePropagation);
+        m_target->setDamagePropagationEnabled(m_damagePropagationEnabled);
 #endif
     }
     return *m_target;

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h
@@ -97,8 +97,7 @@ public:
     void invalidateTarget();
 
 #if ENABLE(DAMAGE_TRACKING)
-    void setDamagePropagation(bool enabled) { m_damagePropagation = enabled; }
-    bool damagePropagation() const { return m_damagePropagation; }
+    void setDamagePropagationEnabled(bool enabled) { m_damagePropagationEnabled = enabled; }
 #endif
 
     void setPosition(FloatPoint&&);
@@ -246,7 +245,7 @@ private:
     bool m_needsTilesUpdate { false };
 
 #if ENABLE(DAMAGE_TRACKING)
-    bool m_damagePropagation { false };
+    bool m_damagePropagationEnabled { false };
 #endif
 
     Lock m_lock;

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -7869,23 +7869,6 @@ void Internals::setShouldSkipResourceMonitorThrottling(bool flag)
 #endif
 
 #if ENABLE(DAMAGE_TRACKING)
-std::optional<Internals::DamagePropagation> Internals::getCurrentDamagePropagation() const
-{
-    RefPtr document = contextDocument();
-    if (!document || !document->page())
-        return std::nullopt;
-
-    auto damagePropagation = ([](const Settings& settings) {
-        if (!settings.propagateDamagingInformation())
-            return Damage::Propagation::None;
-        if (settings.unifyDamagedRegions())
-            return Damage::Propagation::Unified;
-        return Damage::Propagation::Region;
-    })(document->page()->settings());
-
-    return damagePropagation;
-}
-
 ExceptionOr<Vector<Internals::FrameDamage>> Internals::getFrameDamageHistory() const
 {
     RefPtr document = contextDocument();

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -55,10 +55,6 @@
 #include "MediaUniqueIdentifier.h"
 #endif
 
-#if ENABLE(DAMAGE_TRACKING)
-#include "Damage.h"
-#endif
-
 #if USE(AUDIO_SESSION)
 #include "AudioSession.h"
 #endif
@@ -1570,13 +1566,11 @@ public:
 #endif
 
 #if ENABLE(DAMAGE_TRACKING)
-    using DamagePropagation = Damage::Propagation;
     struct FrameDamage {
         unsigned sequenceId { 0 };
         RefPtr<DOMRectReadOnly> bounds;
         Vector<Ref<DOMRectReadOnly>> rects;
     };
-    std::optional<DamagePropagation> getCurrentDamagePropagation() const;
     ExceptionOr<Vector<FrameDamage>> getFrameDamageHistory() const;
 #endif // ENABLE(DAMAGE_TRACKING)
 

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -470,12 +470,6 @@ enum ContentsFormat {
 #endif
 };
 
-[Conditional=DAMAGE_TRACKING] enum DamagePropagation {
-    "None",
-    "Region",
-    "Unified"
-};
-
 [
     Conditional=DAMAGE_TRACKING,
     ExportMacro=WEBCORE_TESTSUPPORT_EXPORT,
@@ -758,7 +752,6 @@ enum ContentsFormat {
     undefined setResourceCachingDisabledByWebInspector(boolean disabled);
     undefined lowerAllFrameMemoryMonitorLimits();
 
-    [Conditional=DAMAGE_TRACKING] DamagePropagation? getCurrentDamagePropagation();
     [Conditional=DAMAGE_TRACKING] sequence<FrameDamage> getFrameDamageHistory();
 
     // Flags for layerTreeAsText.

--- a/Source/WebKit/WebProcess/WebPage/AcceleratedSurface.h
+++ b/Source/WebKit/WebProcess/WebPage/AcceleratedSurface.h
@@ -63,8 +63,15 @@ public:
     virtual void didRenderFrame() { }
 
 #if ENABLE(DAMAGE_TRACKING)
-    virtual const std::optional<WebCore::Damage>& addDamage(WebCore::Damage&&) { return m_frameDamage; }
+    void setFrameDamage(WebCore::Damage&& damage)
+    {
+        if (!damage.isEmpty())
+            m_frameDamage = WTFMove(damage);
+        else
+            m_frameDamage = std::nullopt;
+    }
     const std::optional<WebCore::Damage>& frameDamage() const { return m_frameDamage; }
+    virtual const std::optional<WebCore::Damage>& frameDamageSinceLastUse() { return m_frameDamage; }
 #endif
 
     virtual void didCreateCompositingRunLoop(WTF::RunLoop&) { }

--- a/Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.cpp
+++ b/Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.cpp
@@ -690,13 +690,8 @@ void AcceleratedSurfaceDMABuf::didRenderFrame()
 }
 
 #if ENABLE(DAMAGE_TRACKING)
-const std::optional<WebCore::Damage>& AcceleratedSurfaceDMABuf::addDamage(WebCore::Damage&& damage)
+const std::optional<WebCore::Damage>& AcceleratedSurfaceDMABuf::frameDamageSinceLastUse()
 {
-    if (!damage.isEmpty())
-        m_frameDamage = WTFMove(damage);
-    else
-        m_frameDamage = std::nullopt;
-
     m_swapChain.addDamage(m_frameDamage);
     ASSERT(m_target);
     return m_target->damage();

--- a/Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.h
+++ b/Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.h
@@ -91,7 +91,7 @@ private:
     void didRenderFrame() override;
 
 #if ENABLE(DAMAGE_TRACKING)
-    const std::optional<WebCore::Damage>& addDamage(WebCore::Damage&&) override;
+    const std::optional<WebCore::Damage>& frameDamageSinceLastUse() override;
 #endif
 
     void didCreateCompositingRunLoop(WTF::RunLoop&) override;


### PR DESCRIPTION
#### a4128243147f4fe9d0a4daa1951b22100129dc3d
<pre>
[GTK] Enable damage propagation to the UI process by default
<a href="https://bugs.webkit.org/show_bug.cgi?id=293290">https://bugs.webkit.org/show_bug.cgi?id=293290</a>

Reviewed by Alejandro G. Castro.

We can enable damage tracking only to propagate the damage information
to the UI process, for now using a single unified rectangle. This patch
changes the default value of PropagateDamagingInformation and
UnifyDamagedRegions to true for the GTK port, and adds a new setting
UseDamagingInformationForCompositing, disabled by default, for using the
damage information to optimize the composition.
This patch removes the check to ensure tests are running with
UnifyDamagedRegions disabled, and sets the setting on each test that
actually requires it, since we might want to also test the behavior of
UnifyDamagedRegions.
The settings are now passed to the compositor as flags to simplify it
and several functions to enable/disable damage propagation have been
renamed to clarify what they do.
AcceleratedSurface::addDamage() has been split into two because we don&apos;t
want to set the damage on render targets when not using the damage
information for the composition.

Canonical link: <a href="https://commits.webkit.org/295437@main">https://commits.webkit.org/295437@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/abb207c62ec3233248df3d4e40fe0c5d6c2647fb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104806 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24519 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/14940 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110021 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/55480 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/106846 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/24917 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33064 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79584 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107812 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19373 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94588 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59891 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/19125 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/12665 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/54863 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/97487 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/88825 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/12712 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/112435 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/103424 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/31971 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23504 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88665 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32335 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/90814 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88314 "Found 1 new API test failure: /WebKitGTK/TestCookieManager:/webkit/WebKitCookieManager/replace-get-all-cookies (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33179 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10945 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/27284 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17042 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/31896 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/37250 "Built successfully") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/127703 "Build was cancelled. Recent messages:Printed configuration") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/31688 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/127703 "Build was cancelled. Recent messages:Printed configuration") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35029 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33247 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->