### PR TITLE
[GTK] add webkit_web_context_get_process_ids helper

### DIFF
--- a/Source/WebKit/UIProcess/API/glib/WebKitWebContext.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebContext.cpp
@@ -1942,6 +1942,29 @@ void webkit_web_context_send_message_to_all_extensions(WebKitWebContext* context
         process->send(Messages::WebProcess::SendMessageToWebProcessExtension(webkitUserMessageGetMessage(message)), 0);
 }
 
+/**
+ * webkit_web_context_get_process_ids:
+ * @context: the #WebKitWebContext
+ * @result: a #GList
+ *
+ * Get the process IDs for the @context.
+ *
+ * Returns: the @result #GList with the process ids appended.
+ *
+ * Since: 2.49.2
+ */
+GList* webkit_web_context_get_process_ids(WebKitWebContext* context, GList* result)
+{
+    g_return_val_if_fail(WEBKIT_IS_WEB_CONTEXT(context), result);
+
+    for (Ref process : context->priv->processPool->processes()) {
+        if (auto pid = process->processID())
+            result = g_list_append(result, GINT_TO_POINTER(pid));
+    }
+
+    return result;
+}
+
 #if PLATFORM(GTK) && !USE(GTK4)
 /**
  * webkit_web_context_set_use_system_appearance_for_scrollbars:

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebContext.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebContext.h.in
@@ -413,6 +413,10 @@ WEBKIT_API void
 webkit_web_context_send_message_to_all_extensions   (WebKitWebContext              *context,
                                                      WebKitUserMessage             *message);
 
+WEBKIT_API GList *
+webkit_web_context_get_process_ids                  (WebKitWebContext              *context,
+                                                     GList                         *result);
+
 #if PLATFORM(GTK) && !USE(GTK4)
 WEBKIT_DEPRECATED void
 webkit_web_context_set_use_system_appearance_for_scrollbars (WebKitWebContext      *context,

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebsiteDataManager.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebsiteDataManager.cpp
@@ -1369,6 +1369,30 @@ gboolean webkit_website_data_manager_clear_finish(WebKitWebsiteDataManager* mana
 }
 
 /**
+ * webkit_website_data_manager_get_process_ids:
+ * @manager: a #WebKitWebsiteDataManager
+ * @result: a #GList
+ *
+ * Get the process IDs for the @manager.
+ *
+ * Returns: the @result #GList with the process ids appended.
+ *
+ * Since: 2.49.2
+ */
+GList* webkit_website_data_manager_get_process_ids(WebKitWebsiteDataManager* manager, GList* result)
+{
+    g_return_val_if_fail(WEBKIT_IS_WEBSITE_DATA_MANAGER(manager), result);
+
+    if (manager->priv->websiteDataStore) {
+        const auto& networkProcess = manager->priv->websiteDataStore->networkProcess();
+        if (auto pid = networkProcess.processID())
+            result = g_list_append(result, GINT_TO_POINTER(pid));
+    }
+
+    return result;
+}
+
+/**
  * WebKitITPFirstParty: (ref-func webkit_itp_first_party_ref) (unref-func webkit_itp_first_party_unref)
  *
  * Describes a first party origin.

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebsiteDataManager.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebsiteDataManager.h.in
@@ -193,6 +193,10 @@ webkit_website_data_manager_clear_finish                               (WebKitWe
                                                                         GAsyncResult             *result,
                                                                         GError                  **error);
 
+WEBKIT_API GList *
+webkit_website_data_manager_get_process_ids                            (WebKitWebsiteDataManager *manager,
+                                                                        GList                    *result);
+
 #if !ENABLE(2022_GLIB_API)
 WEBKIT_API void
 webkit_website_data_manager_set_memory_pressure_settings               (WebKitMemoryPressureSettings *settings);


### PR DESCRIPTION
https://bugs.webkit.org/show_bug.cgi?id=293292

Reviewed by NOBODY (OOPS!).

----

This PR will probably need more work, if any interest, then let me know what exactly I have to add/change to this PR.

Usage:
```c
GList *process_ids = g_list_append(NULL, GINT_TO_POINTER(getpid()));

WebKitWebContext *web_context = webkit_web_view_get_context(web_view);
process_ids = webkit_web_context_get_process_ids(web_context, process_ids);

WebKitNetworkSession *network_session = webkit_web_view_get_network_session(web_view);
WebKitWebsiteDataManager *web_manager = webkit_network_session_get_website_data_manager(network_session);
process_ids = webkit_website_data_manager_get_process_ids(web_manager, process_ids);
```

----


<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2c240796a58d0f17c3056ce8b1db127b4b9cbb13

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104264 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/23968 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/14362 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/109464 "Hash 2c240796 for PR 45644 does not build (failure)") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/54932 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/24339 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/32514 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/109464 "Hash 2c240796 for PR 45644 does not build (failure)") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107270 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/18915 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94090 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/109464 "Hash 2c240796 for PR 45644 does not build (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/18721 "Passed tests") | | [❌ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/54292 "Failed to compile WebKit") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/88420 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/12211 "Passed tests") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/111846 "Failed to compile WebKit") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/31420 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23157 "Found 1 new test failure: js/JSON-stringify-exposes-array-indices-as-strings.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/111846 "Failed to compile WebKit") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/31785 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/90320 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/111846 "Failed to compile WebKit") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32766 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10527 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/25887 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/31349 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/36662 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/31143 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/34479 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/32703 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->