### PR TITLE
Introduce MainRunLoopNeverDestroyed for use in WebKit/

### DIFF
--- a/Source/WTF/wtf/NeverDestroyed.h
+++ b/Source/WTF/wtf/NeverDestroyed.h
@@ -57,6 +57,13 @@ struct MainThreadAccessTraits {
     }
 };
 
+struct MainRunLoopAccessTraits {
+    static void assertAccess()
+    {
+        ASSERT(isMainRunLoop());
+    }
+};
+
 template<typename T, typename AccessTraits> class NeverDestroyed {
     WTF_MAKE_NONCOPYABLE(NeverDestroyed);
     WTF_FORBID_HEAP_ALLOCATION;
@@ -181,14 +188,18 @@ private:
 template<typename T> NeverDestroyed(T) -> NeverDestroyed<T>;
 
 template<typename T> using MainThreadNeverDestroyed = NeverDestroyed<T, MainThreadAccessTraits>;
-
 template<typename T> using MainThreadLazyNeverDestroyed = LazyNeverDestroyed<T, MainThreadAccessTraits>;
+template<typename T> using MainRunLoopNeverDestroyed = NeverDestroyed<T, MainRunLoopAccessTraits>;
+template<typename T> using MainRunLoopLazyNeverDestroyed = LazyNeverDestroyed<T, MainRunLoopAccessTraits>;
 
 } // namespace WTF;
 
 using WTF::LazyNeverDestroyed;
 using WTF::NeverDestroyed;
+using WTF::MainRunLoopNeverDestroyed;
+using WTF::MainRunLoopLazyNeverDestroyed;
 using WTF::MainThreadNeverDestroyed;
 using WTF::MainThreadLazyNeverDestroyed;
 using WTF::AnyThreadsAccessTraits;
+using WTF::MainRunLoopAccessTraits;
 using WTF::MainThreadAccessTraits;

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
@@ -85,7 +85,7 @@ static constexpr Seconds originLastModificationTimeUpdateInterval = 30_s;
 // FIXME: Remove this if rdar://104754030 is fixed.
 static HashMap<String, ThreadSafeWeakPtr<NetworkStorageManager>>& activePaths()
 {
-    static MainThreadNeverDestroyed<HashMap<String, ThreadSafeWeakPtr<NetworkStorageManager>>> pathToManagerMap;
+    static MainRunLoopNeverDestroyed<HashMap<String, ThreadSafeWeakPtr<NetworkStorageManager>>> pathToManagerMap;
     return pathToManagerMap;
 }
 

--- a/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.h
+++ b/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.h
@@ -101,7 +101,7 @@ class ListDataController : public ListDataControllerBase {
 public:
     static DerivedType& sharedSingleton()
     {
-        static MainThreadNeverDestroyed<DerivedType> sharedInstance;
+        static MainRunLoopNeverDestroyed<DerivedType> sharedInstance;
         return sharedInstance.get();
     }
 
@@ -117,7 +117,7 @@ public:
     const BackingDataType& cachedListData() const { return m_cachedListData; }
 
 protected:
-    friend class NeverDestroyed<DerivedType, MainThreadAccessTraits>;
+    friend class NeverDestroyed<DerivedType, MainRunLoopAccessTraits>;
 
     void setCachedListData(BackingDataType&& data)
     {
@@ -170,7 +170,7 @@ public:
     RestrictedOpenerType lookup(const WebCore::RegistrableDomain&) const;
 
 private:
-    friend class NeverDestroyed<RestrictedOpenerDomainsController, MainThreadAccessTraits>;
+    friend class NeverDestroyed<RestrictedOpenerDomainsController, MainRunLoopAccessTraits>;
     RestrictedOpenerDomainsController();
     void scheduleNextUpdate(ContinuousApproximateTime);
     void update();
@@ -188,7 +188,7 @@ public:
     void getSource(CompletionHandler<void(String&&)>&&);
 
 private:
-    friend class NeverDestroyed<ResourceMonitorURLsController, MainThreadAccessTraits>;
+    friend class NeverDestroyed<ResourceMonitorURLsController, MainRunLoopAccessTraits>;
     ResourceMonitorURLsController() = default;
 };
 

--- a/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.mm
+++ b/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.mm
@@ -266,7 +266,7 @@ void StorageAccessPromptQuirkController::updateList(CompletionHandler<void()>&& 
         return;
     }
 
-    static MainThreadNeverDestroyed<Vector<CompletionHandler<void()>, 1>> lookupCompletionHandlers;
+    static MainRunLoopNeverDestroyed<Vector<CompletionHandler<void()>, 1>> lookupCompletionHandlers;
     lookupCompletionHandlers->append(WTFMove(completionHandler));
     if (lookupCompletionHandlers->size() > 1)
         return;
@@ -308,7 +308,7 @@ void StorageAccessUserAgentStringQuirkController::updateList(CompletionHandler<v
         return;
     }
 
-    static MainThreadNeverDestroyed<Vector<CompletionHandler<void()>, 1>> lookupCompletionHandlers;
+    static MainRunLoopNeverDestroyed<Vector<CompletionHandler<void()>, 1>> lookupCompletionHandlers;
     lookupCompletionHandlers->append(WTFMove(completionHandler));
     if (lookupCompletionHandlers->size() > 1)
         return;
@@ -334,7 +334,7 @@ void StorageAccessUserAgentStringQuirkController::updateList(CompletionHandler<v
 
 RestrictedOpenerDomainsController& RestrictedOpenerDomainsController::shared()
 {
-    static MainThreadNeverDestroyed<RestrictedOpenerDomainsController> sharedInstance;
+    static MainRunLoopNeverDestroyed<RestrictedOpenerDomainsController> sharedInstance;
     return sharedInstance.get();
 }
 
@@ -408,7 +408,7 @@ RestrictedOpenerType RestrictedOpenerDomainsController::lookup(const WebCore::Re
 
 ResourceMonitorURLsController& ResourceMonitorURLsController::singleton()
 {
-    static MainThreadNeverDestroyed<ResourceMonitorURLsController> sharedInstance;
+    static MainRunLoopNeverDestroyed<ResourceMonitorURLsController> sharedInstance;
     return sharedInstance.get();
 }
 
@@ -420,7 +420,7 @@ void ResourceMonitorURLsController::prepare(CompletionHandler<void(WKContentRule
         return;
     }
 
-    static MainThreadNeverDestroyed<Vector<CompletionHandler<void(WKContentRuleList*, bool)>, 1>> lookupCompletionHandlers;
+    static MainRunLoopNeverDestroyed<Vector<CompletionHandler<void(WKContentRuleList*, bool)>, 1>> lookupCompletionHandlers;
     lookupCompletionHandlers->append(WTFMove(completionHandler));
     if (lookupCompletionHandlers->size() > 1)
         return;
@@ -444,7 +444,7 @@ void ResourceMonitorURLsController::getSource(CompletionHandler<void(String&&)>&
         return;
     }
 
-    static MainThreadNeverDestroyed<Vector<CompletionHandler<void(NSString *)>, 1>> lookupCompletionHandlers;
+    static MainRunLoopNeverDestroyed<Vector<CompletionHandler<void(NSString *)>, 1>> lookupCompletionHandlers;
     lookupCompletionHandlers->append(WTFMove(completionHandler));
     if (lookupCompletionHandlers->size() > 1)
         return;

--- a/Source/WebKit/Shared/API/APISerializedScriptValue.cpp
+++ b/Source/WebKit/Shared/API/APISerializedScriptValue.cpp
@@ -43,7 +43,7 @@ class SharedJSContextWK {
 public:
     static SharedJSContextWK& singleton()
     {
-        static MainThreadNeverDestroyed<SharedJSContextWK> sharedContext;
+        static MainRunLoopNeverDestroyed<SharedJSContextWK> sharedContext;
         return sharedContext.get();
     }
 
@@ -87,7 +87,7 @@ public:
     }
 
 private:
-    friend class NeverDestroyed<SharedJSContextWK, MainThreadAccessTraits>;
+    friend class NeverDestroyed<SharedJSContextWK, MainRunLoopAccessTraits>;
 
     SharedJSContextWK()
         : m_timer(RunLoop::main(), this, &SharedJSContextWK::releaseContextIfNecessary)

--- a/Source/WebKit/Shared/WebBackForwardListFrameItem.cpp
+++ b/Source/WebKit/Shared/WebBackForwardListFrameItem.cpp
@@ -58,7 +58,7 @@ WebBackForwardListFrameItem::~WebBackForwardListFrameItem()
 
 HashMap<std::pair<BackForwardFrameItemIdentifier, BackForwardItemIdentifier>, WeakRef<WebBackForwardListFrameItem>>& WebBackForwardListFrameItem::allItems()
 {
-    static MainThreadNeverDestroyed<HashMap<std::pair<BackForwardFrameItemIdentifier, BackForwardItemIdentifier>, WeakRef<WebBackForwardListFrameItem>>> items;
+    static MainRunLoopNeverDestroyed<HashMap<std::pair<BackForwardFrameItemIdentifier, BackForwardItemIdentifier>, WeakRef<WebBackForwardListFrameItem>>> items;
     return items;
 }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/APISerializedScriptValueCocoa.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/APISerializedScriptValueCocoa.mm
@@ -46,7 +46,7 @@ public:
     {
         ASSERT(isInWebProcess());
 
-        static MainThreadNeverDestroyed<SharedJSContext> sharedContext;
+        static MainRunLoopNeverDestroyed<SharedJSContext> sharedContext;
         return sharedContext.get();
     }
 
@@ -90,7 +90,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     }
 
 private:
-    friend class NeverDestroyed<SharedJSContext, MainThreadAccessTraits>;
+    friend class NeverDestroyed<SharedJSContext, MainRunLoopAccessTraits>;
 
     SharedJSContext()
         : m_timer(RunLoop::main(), this, &SharedJSContext::releaseContextIfNecessary)

--- a/Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp
@@ -66,7 +66,7 @@ namespace WebKit {
 
 static HashMap<IPC::Connection::UniqueID, WeakPtr<AuxiliaryProcessProxy>>& connectionToProcessMap()
 {
-    static MainThreadNeverDestroyed<HashMap<IPC::Connection::UniqueID, WeakPtr<AuxiliaryProcessProxy>>> map;
+    static MainRunLoopNeverDestroyed<HashMap<IPC::Connection::UniqueID, WeakPtr<AuxiliaryProcessProxy>>> map;
     return map.get();
 }
 

--- a/Source/WebKit/UIProcess/Extensions/WebExtension.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtension.cpp
@@ -1588,7 +1588,7 @@ void WebExtension::populateSidePanelProperties(const JSON::Object& sidePanelObje
 
 const WebExtension::PermissionsSet& WebExtension::supportedPermissions()
 {
-    static MainThreadNeverDestroyed<PermissionsSet> permissions = std::initializer_list<String> { WebExtensionPermission::activeTab(), WebExtensionPermission::alarms(), WebExtensionPermission::clipboardWrite(),
+    static MainRunLoopNeverDestroyed<PermissionsSet> permissions = std::initializer_list<String> { WebExtensionPermission::activeTab(), WebExtensionPermission::alarms(), WebExtensionPermission::clipboardWrite(),
         WebExtensionPermission::contextMenus(), WebExtensionPermission::cookies(), WebExtensionPermission::declarativeNetRequest(), WebExtensionPermission::declarativeNetRequestFeedback(),
         WebExtensionPermission::declarativeNetRequestWithHostAccess(), WebExtensionPermission::menus(), WebExtensionPermission::nativeMessaging(), WebExtensionPermission::notifications(), WebExtensionPermission::scripting(),
         WebExtensionPermission::storage(), WebExtensionPermission::tabs(), WebExtensionPermission::unlimitedStorage(), WebExtensionPermission::webNavigation(), WebExtensionPermission::webRequest(),

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionController.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionController.cpp
@@ -45,7 +45,7 @@ constexpr auto freshlyCreatedTimeout = 5_s;
 
 static HashMap<WebExtensionControllerIdentifier, WeakPtr<WebExtensionController>>& webExtensionControllers()
 {
-    static MainThreadNeverDestroyed<HashMap<WebExtensionControllerIdentifier, WeakPtr<WebExtensionController>>> controllers;
+    static MainRunLoopNeverDestroyed<HashMap<WebExtensionControllerIdentifier, WeakPtr<WebExtensionController>>> controllers;
     return controllers;
 }
 

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionMatchPattern.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionMatchPattern.cpp
@@ -49,19 +49,19 @@ static constexpr ASCIILiteral allHostsAndSchemesPattern = "*://*/*"_s;
 
 WebExtensionMatchPattern::URLSchemeSet& WebExtensionMatchPattern::extensionSchemes()
 {
-    static MainThreadNeverDestroyed<URLSchemeSet> schemes = std::initializer_list<String> { "webkit-extension"_s };
+    static MainRunLoopNeverDestroyed<URLSchemeSet> schemes = std::initializer_list<String> { "webkit-extension"_s };
     return schemes;
 }
 
 WebExtensionMatchPattern::URLSchemeSet& WebExtensionMatchPattern::validSchemes()
 {
-    static MainThreadNeverDestroyed<URLSchemeSet> schemes = std::initializer_list<String> { "*"_s, "http"_s, "https"_s, "file"_s, "ftp"_s, "webkit-extension"_s };
+    static MainRunLoopNeverDestroyed<URLSchemeSet> schemes = std::initializer_list<String> { "*"_s, "http"_s, "https"_s, "file"_s, "ftp"_s, "webkit-extension"_s };
     return schemes;
 }
 
 WebExtensionMatchPattern::URLSchemeSet& WebExtensionMatchPattern::supportedSchemes()
 {
-    static MainThreadNeverDestroyed<URLSchemeSet> schemes = std::initializer_list<String> { "*"_s, "http"_s, "https"_s, "webkit-extension"_s };
+    static MainRunLoopNeverDestroyed<URLSchemeSet> schemes = std::initializer_list<String> { "*"_s, "http"_s, "https"_s, "webkit-extension"_s };
     return schemes;
 }
 
@@ -87,7 +87,7 @@ bool WebExtensionMatchPattern::patternsMatchPattern(const MatchPatternSet& match
 
 static HashMap<String, RefPtr<WebExtensionMatchPattern>>& patternCache()
 {
-    static MainThreadNeverDestroyed<HashMap<String, RefPtr<WebExtensionMatchPattern>>> cache;
+    static MainRunLoopNeverDestroyed<HashMap<String, RefPtr<WebExtensionMatchPattern>>> cache;
     return cache;
 }
 

--- a/Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp
@@ -107,7 +107,7 @@ static WeakPtr<GPUProcessProxy>& singleton()
 
 static RefPtr<GPUProcessProxy>& keptAliveGPUProcessProxy()
 {
-    static MainThreadNeverDestroyed<RefPtr<GPUProcessProxy>> keptAliveGPUProcessProxy;
+    static MainRunLoopNeverDestroyed<RefPtr<GPUProcessProxy>> keptAliveGPUProcessProxy;
     return keptAliveGPUProcessProxy.get();
 }
 

--- a/Source/WebKit/UIProcess/Notifications/ServiceWorkerNotificationHandler.cpp
+++ b/Source/WebKit/UIProcess/Notifications/ServiceWorkerNotificationHandler.cpp
@@ -37,7 +37,7 @@ namespace WebKit {
 
 ServiceWorkerNotificationHandler& ServiceWorkerNotificationHandler::singleton()
 {
-    static MainThreadNeverDestroyed<Ref<ServiceWorkerNotificationHandler>> handler = adoptRef(*new ServiceWorkerNotificationHandler);
+    static MainRunLoopNeverDestroyed<Ref<ServiceWorkerNotificationHandler>> handler = adoptRef(*new ServiceWorkerNotificationHandler);
     return handler.get();
 }
 

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticatorCoordinatorProxy.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticatorCoordinatorProxy.mm
@@ -482,7 +482,7 @@ RetainPtr<NSArray> WebAuthenticatorCoordinatorProxy::requestsForAssertion(const 
 
 WeakPtr<WebAuthenticatorCoordinatorProxy>& WebAuthenticatorCoordinatorProxy::activeConditionalMediationProxy()
 {
-    static MainThreadNeverDestroyed<WeakPtr<WebAuthenticatorCoordinatorProxy>> proxy;
+    static MainRunLoopNeverDestroyed<WeakPtr<WebAuthenticatorCoordinatorProxy>> proxy;
     return proxy.get();
 }
 

--- a/Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm
+++ b/Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm
@@ -91,7 +91,7 @@ static std::atomic<bool> keyExists = false;
 #if ENABLE(MANAGED_DOMAINS)
 static WorkQueue& managedDomainQueueSingleton()
 {
-    static MainThreadNeverDestroyed<Ref<WorkQueue>> queue = WorkQueue::create("com.apple.WebKit.ManagedDomains"_s);
+    static MainRunLoopNeverDestroyed<Ref<WorkQueue>> queue = WorkQueue::create("com.apple.WebKit.ManagedDomains"_s);
     return queue.get();
 }
 static std::atomic<bool> hasInitializedManagedDomains = false;

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
@@ -120,7 +120,7 @@ void WebsiteDataStore::allowWebsiteDataRecordsForAllOrigins()
 
 static HashMap<String, PAL::SessionID>& activeGeneralStorageDirectories()
 {
-    static MainThreadNeverDestroyed<HashMap<String, PAL::SessionID>> directoryToSessionMap;
+    static MainRunLoopNeverDestroyed<HashMap<String, PAL::SessionID>> directoryToSessionMap;
     return directoryToSessionMap;
 }
 
@@ -138,7 +138,7 @@ static String computeMediaKeyFile(const String& mediaKeyDirectory)
 
 WorkQueue& WebsiteDataStore::websiteDataStoreIOQueueSingleton()
 {
-    static MainThreadNeverDestroyed<Ref<WorkQueue>> queue = WorkQueue::create("com.apple.WebKit.WebsiteDataStoreIO"_s);
+    static MainRunLoopNeverDestroyed<Ref<WorkQueue>> queue = WorkQueue::create("com.apple.WebKit.WebsiteDataStoreIO"_s);
     return queue.get();
 }
 

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIPortCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIPortCocoa.mm
@@ -49,7 +49,7 @@ using PortChannelPortMap = HashMap<WebExtensionPortChannelIdentifier, HashSet<We
 
 static PortChannelPortMap& webExtensionPorts()
 {
-    static MainThreadNeverDestroyed<PortChannelPortMap> ports;
+    static MainRunLoopNeverDestroyed<PortChannelPortMap> ports;
     return ports;
 }
 

--- a/Source/WebKit/WebProcess/Extensions/Cocoa/WebExtensionContextProxyCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/Cocoa/WebExtensionContextProxyCocoa.mm
@@ -50,7 +50,7 @@ namespace WebKit {
 
 static HashMap<WebExtensionContextIdentifier, WeakPtr<WebExtensionContextProxy>>& webExtensionContextProxies()
 {
-    static MainThreadNeverDestroyed<HashMap<WebExtensionContextIdentifier, WeakPtr<WebExtensionContextProxy>>> contexts;
+    static MainRunLoopNeverDestroyed<HashMap<WebExtensionContextIdentifier, WeakPtr<WebExtensionContextProxy>>> contexts;
     return contexts;
 }
 

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionControllerProxy.cpp
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionControllerProxy.cpp
@@ -43,7 +43,7 @@ using namespace WebCore;
 
 static HashMap<WebExtensionControllerIdentifier, WeakPtr<WebExtensionControllerProxy>>& webExtensionControllerProxies()
 {
-    static MainThreadNeverDestroyed<HashMap<WebExtensionControllerIdentifier, WeakPtr<WebExtensionControllerProxy>>> controllers;
+    static MainRunLoopNeverDestroyed<HashMap<WebExtensionControllerIdentifier, WeakPtr<WebExtensionControllerProxy>>> controllers;
     return controllers;
 }
 

--- a/Source/WebKit/WebProcess/Plugins/WebPluginInfoProvider.cpp
+++ b/Source/WebKit/WebProcess/Plugins/WebPluginInfoProvider.cpp
@@ -37,7 +37,7 @@ namespace WebKit {
 
 WebPluginInfoProvider& WebPluginInfoProvider::singleton()
 {
-    static MainThreadNeverDestroyed<Ref<WebPluginInfoProvider>> pluginInfoProvider = adoptRef(*new WebPluginInfoProvider);
+    static MainRunLoopNeverDestroyed<Ref<WebPluginInfoProvider>> pluginInfoProvider = adoptRef(*new WebPluginInfoProvider);
     return pluginInfoProvider.get();
 }
 

--- a/Tools/Scripts/webkitpy/style/checkers/cpp.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp.py
@@ -2856,6 +2856,51 @@ def check_ismainthread(filename, clean_lines, line_number, file_state, error):
     error(line_number, 'runtime/ismainthread', 4, "Use 'isMainRunLoop()' instead of 'isMainThread()' in Source/WebKit.")
 
 
+def check_mainthreadneverdestroyed(filename, clean_lines, line_number, file_state, error):
+    """Looks for use of 'MainThreadNeverDestroyed' which should be replaced with 'MainRunLoopNeverDestroyed'.
+
+    Args:
+      filename: The current file cpp_style is running over.
+      clean_lines: A CleansedLines instance containing the file.
+      line_number: The number of the line to check.
+      file_state: A _FileState instance which maintains information about
+                  the state of things in the file.
+      error: The function to call with any errors found.
+    """
+
+    if not _is_webkit2_file(filename):
+        return
+
+    line = clean_lines.elided[line_number]  # Get rid of comments and strings.
+    using_mainthreadneverdestroyed = search(r'\bMainThreadNeverDestroyed<', line)
+    if not using_mainthreadneverdestroyed:
+        return
+
+    error(line_number, 'runtime/mainthreadneverdestroyed', 4, "Use 'MainRunLoopNeverDestroyed' instead of 'MainThreadNeverDestroyed' in Source/WebKit.")
+
+
+def check_mainthreadlazyneverdestroyed(filename, clean_lines, line_number, file_state, error):
+    """Looks for use of 'MainThreadLazyNeverDestroyed' which should be replaced with 'MainRunLoopLazyNeverDestroyed'.
+
+    Args:
+      filename: The current file cpp_style is running over.
+      clean_lines: A CleansedLines instance containing the file.
+      line_number: The number of the line to check.
+      file_state: A _FileState instance which maintains information about
+                  the state of things in the file.
+      error: The function to call with any errors found.
+    """
+
+    if not _is_webkit2_file(filename):
+        return
+
+    line = clean_lines.elided[line_number]  # Get rid of comments and strings.
+    using_mainthreadlazyneverdestroyed = search(r'\bMainThreadLazyNeverDestroyed<', line)
+    if not using_mainthreadlazyneverdestroyed:
+        return
+
+    error(line_number, 'runtime/mainthreadlazyneverdestroyed', 4, "Use 'MainRunLoopLazyNeverDestroyed' instead of 'MainThreadLazyNeverDestroyed' in Source/WebKit.")
+
 def check_wtf_make_unique(clean_lines, line_number, file_state, error):
     """Looks for use of 'std::make_unique<>' which should be replaced with 'WTF::makeUnique<>'.
 
@@ -4765,6 +4810,8 @@ def process_line(filename, file_extension,
     check_os_version_checks(filename, clean_lines, line, error)
     check_callonmainthread(filename, clean_lines, line, file_state, error)
     check_ismainthread(filename, clean_lines, line, file_state, error)
+    check_mainthreadneverdestroyed(filename, clean_lines, line, file_state, error)
+    check_mainthreadlazyneverdestroyed(filename, clean_lines, line, file_state, error)
 
 
 class _InlineASMState(object):
@@ -4897,6 +4944,8 @@ class CppChecker(object):
         'runtime/leaky_pattern',
         'runtime/lock_guard',
         'runtime/log',
+        'runtime/mainthreadlazyneverdestroyed',
+        'runtime/mainthreadneverdestroyed',
         'runtime/max_min_macros',
         'runtime/memset',
         'runtime/once_flag',


### PR DESCRIPTION
#### e97db92ef913fc05a2601a51084c341c394121c2
<pre>
Introduce MainRunLoopNeverDestroyed for use in WebKit/
<a href="https://bugs.webkit.org/show_bug.cgi?id=293293">https://bugs.webkit.org/show_bug.cgi?id=293293</a>

Reviewed by Yusuke Suzuki.

Introduce MainRunLoopNeverDestroyed for use in WebKit/. We were using MainThreadNeverDestroyed
which is not safe in the UIProcess when an app is using both WK2 and WK1 on iOS with a
WebThread.

Canonical link: <a href="https://commits.webkit.org/295167@main">https://commits.webkit.org/295167@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/385a626e62e0b7ec90c588a5fe307abb987fed4f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104265 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/23969 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/14363 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/109465 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/54933 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/106305 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/24340 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/32515 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79188 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107271 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/18916 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94091 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59516 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/103743 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/18719 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/12152 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/54293 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/96940 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/88421 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/12212 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/111847 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/102876 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/31421 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23158 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88211 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/31786 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/90321 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87874 "Found 100 new API test failures: /WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/invalid-sequence, /WebKitGTK/TestDownloads:/webkit/Downloads/blob-download, /WebKitGTK/TestUIClient:/webkit/WebKitWebView/mouse-target, /TestWebKit:WebKit.UserMediaBasic, /WebKitGTK/TestWebProcessExtensions:/webkit/WebKitWebProcessExtension/dom-input-element-is-user-edited, /WebKitGTK/TestDownloads:/webkit/Downloads/contex-menu-download-actions, /WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/cancel-sequence, /WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/is-playing-audio, /WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/page-visibility, /WebKitGTK/TestOptionMenu:/webkit/WebKitWebView/option-menu-select ... (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22374 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32767 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10528 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/25890 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/31350 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/36663 "Built successfully") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/126521 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/31144 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/126521 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/34480 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/32704 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->