### PR TITLE
WebContent Process capture thread can become de-prioritized; leading to underruns

### DIFF
--- a/Source/WTF/wtf/Threading.h
+++ b/Source/WTF/wtf/Threading.h
@@ -210,6 +210,7 @@ public:
     WTF_EXPORT_PRIVATE static void setCurrentThreadIsUserInitiated(int relativePriority = 0);
     WTF_EXPORT_PRIVATE static QOS currentThreadQOS();
     WTF_EXPORT_PRIVATE static bool currentThreadIsRealtime();
+    bool isRealtime() const { return m_isRealtime; }
 
 #if HAVE(QOS_CLASSES)
     WTF_EXPORT_PRIVATE static void setGlobalMaxQOSClass(qos_class_t);

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2057,6 +2057,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/audio/PlatformMediaSessionManager.h
     platform/audio/PlatformRawAudioData.h
     platform/audio/PushPullFIFO.h
+    platform/audio/RealtimeAudioThread.h
     platform/audio/SharedAudioDestination.h
 
     platform/calc/CalculationCategory.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2400,6 +2400,7 @@ platform/audio/PlatformMediaSessionInterface.cpp
 platform/audio/PlatformMediaSessionManager.cpp
 platform/audio/PlatformRawAudioData.cpp
 platform/audio/PushPullFIFO.cpp
+platform/audio/RealtimeAudioThread.cpp
 platform/audio/Reverb.cpp
 platform/audio/ReverbAccumulationBuffer.cpp
 platform/audio/ReverbConvolver.cpp

--- a/Source/WebCore/platform/audio/RealtimeAudioThread.cpp
+++ b/Source/WebCore/platform/audio/RealtimeAudioThread.cpp
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "RealtimeAudioThread.h"
+
+#include <wtf/MonotonicTime.h>
+
+namespace WebCore {
+
+static constexpr uint8_t s_maximumConcurrentRealtimeThreads { 3 };
+
+Ref<Thread> createMaybeRealtimeAudioThread(ASCIILiteral threadName, Function<void()>&& entryPoint, Seconds rawRenderingQuantumDuration)
+{
+    // Create a thread with Realtime scheduling, so that this thread does not become deprioritized
+    // during heavy loads. Realtime threads have a runtime cost, so ensure no more than three realtime
+    // audio threads can be created simultaneously.
+    // FIXME: Coalesce these threads to allow a single realtime thread to service every audio instance.
+
+    bool shouldCreateRealtimeThread = [] {
+        Locker threadLocker { Thread::allThreadsLock() };
+        uint8_t numberOfRealtimeThreads = 0;
+        for (RefPtr thread : Thread::allThreads()) {
+            if (thread && thread->isRealtime())
+                ++numberOfRealtimeThreads;
+        }
+
+        return numberOfRealtimeThreads < s_maximumConcurrentRealtimeThreads;
+    }();
+
+    auto schedulingPolicy = shouldCreateRealtimeThread ? Thread::SchedulingPolicy::Realtime : Thread::SchedulingPolicy::Other;
+
+    auto thread = Thread::create(threadName, WTFMove(entryPoint), ThreadType::Audio, Thread::QOS::UserInteractive, schedulingPolicy);
+
+#if HAVE(THREAD_TIME_CONSTRAINTS)
+    if (shouldCreateRealtimeThread) {
+        // Add thread time constraints to allow the system to ensure contiguous scheduling for this thread
+        auto renderingQuantumDuration = MonotonicTime::fromRawSeconds(rawRenderingQuantumDuration.seconds());
+        auto renderingTimeConstraint = MonotonicTime::fromRawSeconds(rawRenderingQuantumDuration.seconds() * 2);
+        thread->setThreadTimeConstraints(renderingQuantumDuration, renderingQuantumDuration, renderingTimeConstraint, true);
+    }
+#else
+    UNUSED_PARAM(rawRenderingQuantumDuration);
+#endif
+
+    // Roughly match the priority of the Audio IO thread in the GPU process.
+    thread->changePriority(60);
+
+    return thread;
+}
+
+}

--- a/Source/WebCore/platform/audio/RealtimeAudioThread.h
+++ b/Source/WebCore/platform/audio/RealtimeAudioThread.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/Threading.h>
+
+namespace WebCore {
+
+WEBCORE_EXPORT Ref<Thread> createMaybeRealtimeAudioThread(ASCIILiteral threadName, Function<void()>&&, Seconds renderingQuantumDuration);
+
+}

--- a/Source/WebCore/platform/audio/cocoa/AudioEncoderCocoa.cpp
+++ b/Source/WebCore/platform/audio/cocoa/AudioEncoderCocoa.cpp
@@ -32,6 +32,7 @@
 #include "AudioSampleBufferConverter.h"
 #include "AudioSampleFormat.h"
 #include "CAAudioStreamDescription.h"
+#include "Logging.h"
 #include "MediaSampleAVFObjC.h"
 #include "MediaUtilities.h"
 #include "PlatformRawAudioDataCocoa.h"

--- a/Source/WebCore/platform/audio/cocoa/WebAudioBufferList.cpp
+++ b/Source/WebCore/platform/audio/cocoa/WebAudioBufferList.cpp
@@ -27,6 +27,7 @@
 #include "WebAudioBufferList.h"
 
 #include "CAAudioStreamDescription.h"
+#include "Logging.h"
 #include <wtf/CheckedArithmetic.h>
 #include <wtf/IndexedRange.h>
 #include <wtf/StdLibExtras.h>

--- a/Source/WebCore/platform/graphics/GraphicsContextGLImageExtractor.h
+++ b/Source/WebCore/platform/graphics/GraphicsContextGLImageExtractor.h
@@ -28,6 +28,7 @@
 #if ENABLE(WEBGL)
 
 #include "GraphicsContextGL.h"
+#include "PlatformImage.h"
 #include <wtf/MallocSpan.h>
 
 namespace WebCore {

--- a/Source/WebCore/platform/graphics/cg/GradientRendererCG.h
+++ b/Source/WebCore/platform/graphics/cg/GradientRendererCG.h
@@ -27,6 +27,7 @@
 
 #include "ColorComponents.h"
 #include "ColorInterpolationMethod.h"
+#include "DestinationColorSpace.h"
 #include <CoreGraphics/CoreGraphics.h>
 #include <wtf/RetainPtr.h>
 #include <wtf/ThreadSafeRefCounted.h>

--- a/Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.cpp
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.cpp
@@ -33,6 +33,7 @@
 #include "IOSurface.h"
 #include "IOSurfacePool.h"
 #include "IntRect.h"
+#include "NativeImage.h"
 #include "PixelBuffer.h"
 #include <CoreGraphics/CoreGraphics.h>
 #include <pal/cg/CoreGraphicsSoftLink.h>

--- a/Source/WebCore/platform/graphics/filters/FilterRenderingMode.cpp
+++ b/Source/WebCore/platform/graphics/filters/FilterRenderingMode.cpp
@@ -25,6 +25,7 @@
 
 #include "config.h"
 #include "FilterRenderingMode.h"
+#include <wtf/text/TextStream.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/platform/graphics/gbm/MemoryMappedGPUBuffer.cpp
+++ b/Source/WebCore/platform/graphics/gbm/MemoryMappedGPUBuffer.cpp
@@ -34,6 +34,7 @@
 #include "Logging.h"
 #include "PlatformDisplay.h"
 #include <epoxy/egl.h>
+#include <fcntl.h>
 #include <linux/dma-buf.h>
 #include <sys/ioctl.h>
 #include <wtf/SafeStrerror.h>

--- a/Source/WebCore/platform/mediastream/mac/RealtimeIncomingAudioSourceCocoa.h
+++ b/Source/WebCore/platform/mediastream/mac/RealtimeIncomingAudioSourceCocoa.h
@@ -31,6 +31,7 @@
 
 #include "CAAudioStreamDescription.h"
 #include "RealtimeIncomingAudioSource.h"
+#include "Timer.h"
 #include "WebAudioBufferList.h"
 #include <CoreAudio/CoreAudioTypes.h>
 

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioDestinationProxy.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioDestinationProxy.h
@@ -35,7 +35,6 @@
 #include <WebCore/AudioIOCallback.h>
 #include <wtf/CrossThreadQueue.h>
 #include <wtf/MediaTime.h>
-#include <wtf/Threading.h>
 
 #if PLATFORM(COCOA)
 #include "SharedCARingBuffer.h"
@@ -109,7 +108,6 @@ private:
     RefPtr<WebCore::SharedMemory> m_frameCount;
     uint32_t m_lastFrameCount { 0 };
     std::atomic<bool> m_shouldStopThread { false };
-    bool m_isRealtimeThread { false };
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/cocoa/RemoteCaptureSampleManager.cpp
+++ b/Source/WebKit/WebProcess/cocoa/RemoteCaptureSampleManager.cpp
@@ -35,6 +35,7 @@
 #include "WebProcess.h"
 #include <WebCore/CVUtilities.h>
 #include <WebCore/NativeImage.h>
+#include <WebCore/RealtimeAudioThread.h>
 #include <WebCore/VideoFrameCV.h>
 #include <WebCore/WebAudioBufferList.h>
 #include <wtf/TZoneMallocInlines.h>
@@ -240,7 +241,8 @@ void RemoteCaptureSampleManager::RemoteAudio::startThread()
             m_source->remoteAudioSamplesAvailable(currentTime, *m_buffer, *m_description, m_frameChunkSize);
         } while (!m_shouldStopThread);
     };
-    m_thread = Thread::create("RemoteCaptureSampleManager::RemoteAudio thread"_s, WTFMove(threadLoop), ThreadType::Audio, Thread::QOS::UserInteractive);
+
+    m_thread = WebCore::createMaybeRealtimeAudioThread("RemoteCaptureSampleManager::RemoteAudio thread"_s, WTFMove(threadLoop), Seconds { m_frameChunkSize / m_description->sampleRate() });
 }
 
 void RemoteCaptureSampleManager::RemoteAudio::setStorage(ConsumerSharedCARingBuffer::Handle&& handle, const WebCore::CAAudioStreamDescription& description, IPC::Semaphore&& semaphore, const MediaTime& mediaTime, size_t frameChunkSize)


### PR DESCRIPTION
#### ada13b119831c938d4a5fbbd5c502c3d3ae6c667
<pre>
WebContent Process capture thread can become de-prioritized; leading to underruns
<a href="https://bugs.webkit.org/show_bug.cgi?id=293295">https://bugs.webkit.org/show_bug.cgi?id=293295</a>
<a href="https://rdar.apple.com/problem/151699897">rdar://problem/151699897</a>

Reviewed by Youenn Fablet.

The Audio IO thread in the GPU process is running at a realtime scheduling priority,
reading samples from a shared ring buffer for Web Audio, and storing samples into a
shared ring buffer for microphone capture. While the matching thread storing samples
for Web Audio in the Web Content process (owned by RemoteAudioDestinationManager) is
also running at a realtime priority, the matching thread reading microphone samples
from the shared ring buffer is running at a normal thread priority. This allows the
kernel to deprioritize and preempt that thread, which can lead to dropped microphone
samples when used as an input to Web Audio.

For now, the limit to the number of concurrent realtime audio threads is 3. Given
that its relatively unlikely to have three capture sessions running simultaneously
this is likely good enough, and in the future, we can and should coalesce all of
of these threads into a single audio thread.

* Source/WTF/wtf/Threading.h:
* Source/WebKit/GPUProcess/media/RemoteAudioDestinationManager.cpp:
* Source/WebKit/WebProcess/cocoa/RemoteCaptureSampleManager.cpp:
(WebKit::RemoteCaptureSampleManager::RemoteAudio::stopThread):
(WebKit::RemoteCaptureSampleManager::RemoteAudio::startThread):
* Source/WebKit/WebProcess/cocoa/RemoteCaptureSampleManager.h:

Canonical link: <a href="https://commits.webkit.org/295769@main">https://commits.webkit.org/295769@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/db00d048774d3cbbfc87ef4d3799441e5d684cc2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105963 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25713 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/16107 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/111160 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/56560 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/108003 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/26353 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34216 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80495 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108968 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/20778 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95630 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60815 "Found 142 new API test failures: /WPE/TestUIClient:/webkit/WebKitWebView/query-permission-requests, /WPE/TestWebsiteData:/webkit/WebKitWebsiteData/deviceidhashsalt, /WPE/TestLoaderClient:/webkit/WebKitWebView/load-twice-and-reload, /WPE/TestCookieManager:/webkit/WebKitCookieManager/ephemeral, /WPE/TestWebKitWebView:/webkit/WebKitWebView/is-playing-audio, /WPE/TestConsoleMessage:/webkit/WebKitConsoleMessage/network-error, /WPE/TestWebsiteData:/webkit/WebKitWebsiteData/configuration, /WPE/TestCookieManager:/webkit/WebKitCookieManager/delete-cookies, /WPE/TestWebKitWebView:/webkit/WebKitWebView/terminate-unresponsive-web-process, /WPE/TestSSL:/webkit/WebKitWebView/insecure-content ... (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/20394 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13727 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55998 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/98603 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/90159 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13763 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/114012 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/104581 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33102 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24424 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89576 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33466 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91858 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89256 "Found 101 new API test failures: /TestWebKit:WebKit.PageLoadDidChangeLocationWithinPage, /TestWebKit:WebKit.AboutBlankLoad, /TestWebKit:WebKit.PreventEmptyUserAgent, /TestWebKit:WebKit.PrivateBrowsingPushStateNoHistoryCallback, /WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/content-type, /WebKitGTK/TestUIClient:/webkit/WebKitWebView/pointer-lock-permission-request, /TestWebKit:WebKit.HitTestResultNodeHandle, /TestWebKit:WebKit2TextFieldBeginAndEditEditingTest.TextFieldDidBeginShouldNotBeDispatchedForAlreadyFocusedField, /TestWebKit:WebKit.Find, /WebKitGTK/TestWebProcessExtensions:/webkit/WebKitWebProcessExtension/dom-input-element-is-user-edited ... (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22774 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34116 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11931 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/28641 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/33027 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/38438 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/128893 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32773 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/35163 "Found 1 new JSC stress test failure: wasm.yaml/wasm/gc/ref-i31-eq.js.default-wasm (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/36122 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34371 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->