### PR TITLE
Underruns in WebContent Process audio thread lead to extra latency

### DIFF
--- a/Source/WebKit/GPUProcess/media/RemoteAudioDestinationManager.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioDestinationManager.cpp
@@ -39,6 +39,7 @@
 #if PLATFORM(COCOA)
 #include "SharedCARingBuffer.h"
 #include <WebCore/AudioOutputUnitAdaptor.h>
+#include <WebCore/AudioSampleBufferList.h>
 #include <WebCore/CAAudioStreamDescription.h>
 #include <WebCore/CARingBuffer.h>
 #include <WebCore/WebAudioBufferList.h>
@@ -186,14 +187,15 @@ private:
         ASSERT(!isMainRunLoop());
 
         OSStatus status = -1;
-        if (!m_ringBuffer)
+        if (!m_ringBuffer || !ioData)
             return status;
 
-        if (m_ringBuffer->fetchIfHasEnoughData(ioData, numberOfFrames, m_startFrame)) {
-            m_startFrame += numberOfFrames;
+        if (m_ringBuffer->fetchIfHasEnoughData(ioData, numberOfFrames, m_startFrame))
             status = noErr;
-        }
+        else
+            WebCore::AudioSampleBufferList::zeroABL(*ioData, numberOfFrames);
 
+        m_startFrame += numberOfFrames;
         incrementTotalFrameCount(numberOfFrames);
         m_renderSemaphore.signal();
 


### PR DESCRIPTION
#### c8397c355c6d71ea18a397c23b583560eb44f753
<pre>
Underruns in WebContent Process audio thread lead to extra latency
<a href="https://rdar.apple.com/151701056">rdar://151701056</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=293296">https://bugs.webkit.org/show_bug.cgi?id=293296</a>

Reviewed by Jean-Yves Avenard.

If a stall or hang occurs on the audio thread in the WebContent process, it may not produce
enough samples for reading by the GPU process, leading to an underrun when rendering Web Audio.
When this occurs, the GPU process will render silence until data exists at point in the
ring buffer where the stall occurred. So, if the WebContent process hangs for 100ms and then
recovers, the GPU process will continue reading from the point in the ring buffer where the
stall began, and will render 100ms in the past upon recovery, adding 100ms of latency to the
output.

Instead, the GPU process should just advance the ring buffer read head when an overflow occurs.
The WebContent process _should_ eventually recover if the hang was temporary. If the Web Audio
graph is too complicated to process in the timeslice available, it may fall further and further
behind, but the behavior will be that no audio is ever output, which is arguably a better
user experience than having 128 samples randomly render surrounded by long periods of silence.

* Source/WebKit/GPUProcess/media/RemoteAudioDestinationManager.cpp:

Canonical link: <a href="https://commits.webkit.org/295323@main">https://commits.webkit.org/295323@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cdd97f79b9ff03c051b331a8ee9196a9ad67727c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104719 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24431 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/14853 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/109933 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/55393 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/24822 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/32977 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79523 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107725 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19301 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94513 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59830 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/19068 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/54768 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/88765 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/12637 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/112328 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/31884 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/23453 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88599 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32248 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/90741 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88222 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22488 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33110 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10887 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/27197 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/31809 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/37162 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/31601 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/34942 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33160 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->