### PR TITLE
AX: Password field notifications should be spaced out in time at fixed intervals.

### DIFF
--- a/LayoutTests/accessibility/password-notifications-timing-expected.txt
+++ b/LayoutTests/accessibility/password-notifications-timing-expected.txt
@@ -1,0 +1,12 @@
+This test ensures that password notifications are spaced out in time in no less than a prefixed interval.
+
+Field value length: 9
+PASS: elapsed >= interval === true
+PASS: elapsed >= interval === true
+PASS: elapsed >= interval === true
+Field value length: 12
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/password-notifications-timing.html
+++ b/LayoutTests/accessibility/password-notifications-timing.html
@@ -1,0 +1,56 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../resources/accessibility-helper.js"></script>
+<script src="../resources/js-test.js"></script>
+<script src="../resources/ui-helper.js"></script>
+</head>
+<body>
+
+<input type="password" id="password-field">
+
+<script>
+var output = "This test ensures that password notifications are spaced out in time in no less than a prefixed interval.\n\n";
+
+var notificationsCount = 0;
+var lastNotificationTime = Date.now();
+var interval = 25; // Notifications shouldn't come in less than 25 milliseconds.
+function notificationCallback(notification) {
+    if (notification != "AXValueChanged")
+        return;
+
+    now = Date.now();
+    elapsed = now - lastNotificationTime;
+    lastNotificationTime = now;
+    output += expect("elapsed >= interval", "true");
+
+    ++notificationsCount;
+}
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+    document.getElementById("password-field").focus();
+    var field = accessibilityController.accessibleElementById("password-field");
+    field.addNotificationListener(notificationCallback);
+
+    var value = field.stringValue;
+    var valueLength = value.length;
+    output += `Field value length: ${valueLength}\n`;
+    setTimeout(async () => {
+        UIHelper.typeCharacter("a");
+        UIHelper.typeCharacter("b");
+        UIHelper.typeCharacter("c");
+
+        await waitFor(() => {
+            return notificationsCount == 3 && field.stringValue.length == valueLength + 3;
+        });
+        value = field.stringValue;
+        output += `Field value length: ${value.length}\n`;
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -680,6 +680,7 @@ accessibility/opacity-0-bounding-box.html [ Skip ]
 accessibility/clip-path-bounding-box.html [ Skip ]
 
 accessibility/dynamic-content-visibility.html [ Skip ]
+accessibility/password-notifications-timing.html [ Skip ]
 
 # AXObjectCache::announce not implemented.
 accessibility/announcement-notification.html [ Skip ]

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -2414,6 +2414,9 @@ imported/w3c/web-platform-tests/svg/pservers/reftests/meshgradient-complex-001.s
 # webkit.org/b/290848 : AX: accessibility/mac/line-boundary-at-br.html asserts on Debug
 [ Debug ] accessibility/mac/line-boundary-at-br.html [ Skip ]
 
+# Timing is different in debug, thus skip.
+[ Debug ] accessibility/password-notifications-timing.html [ Skip ]
+
 # The color input only has a swatch overlay on macOS
 fast/forms/color/input-color-swatch-overlay-appearance.html [ Pass ]
 

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -147,9 +147,16 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(AXObjectCache);
 using namespace HTMLNames;
 
 #if PLATFORM(COCOA)
-// Post value change notifications for password fields or elements contained in password fields at a 40hz interval to thwart analysis of typing cadence
+
+// Post notifications for secure fields or elements contained in secure fields at a 40hz interval to thwart analysis of typing cadence.
 static const Seconds accessibilityPasswordValueChangeNotificationInterval { 25_ms };
-#endif
+
+static bool isSecureFieldOrContainedBySecureField(AccessibilityObject& object)
+{
+    return object.isSecureField() || object.isContainedBySecureField();
+}
+
+#endif // PLATFORM(COCOA)
 
 static bool rendererNeedsDeferredUpdate(const RenderObject& renderer)
 {
@@ -1761,6 +1768,12 @@ void AXObjectCache::postNotification(AccessibilityObject* object, Document* docu
     if (!object)
         return;
 
+#if PLATFORM(COCOA)
+    if (notification == AXNotification::ValueChanged
+        && enqueuePasswordNotification(*object, { }))
+        return;
+#endif
+
     m_notificationsToPost.append(std::make_pair(Ref { *object }, notification));
     if (!m_notificationPostTimer.isActive())
         m_notificationPostTimer.startOneShot(0_s);
@@ -1773,6 +1786,12 @@ void AXObjectCache::postNotification(AccessibilityObject& object, AXNotification
     ASSERT(isMainThread());
 
     stopCachingComputedObjectAttributes();
+
+#if PLATFORM(COCOA)
+    if (notification == AXNotification::ValueChanged
+        && enqueuePasswordNotification(object, { }))
+        return;
+#endif
 
     m_notificationsToPost.append(std::make_pair(Ref { object }, notification));
     if (!m_notificationPostTimer.isActive())
@@ -2352,13 +2371,6 @@ void AXObjectCache::setIsSynchronizingSelection(bool isSynchronizing)
     m_isSynchronizingSelection = isSynchronizing;
 }
 
-#if PLATFORM(COCOA)
-static bool isSecureFieldOrContainedBySecureField(AccessibilityObject& object)
-{
-    return object.isSecureField() || object.isContainedBySecureField();
-}
-#endif
-
 void AXObjectCache::postTextStateChangeNotification(Node* node, const AXTextStateChangeIntent& intent, const VisibleSelection& selection)
 {
     if (!node)
@@ -2571,60 +2583,50 @@ bool AXObjectCache::enqueuePasswordNotification(AccessibilityObject& object, AXT
 
     m_passwordNotifications.append({ *observableObject, secureContext(*observableObject, context) });
     if (!m_passwordNotificationTimer.isActive())
-        m_passwordNotificationTimer.startOneShot(accessibilityPasswordValueChangeNotificationInterval);
+        m_passwordNotificationTimer.startRepeating(accessibilityPasswordValueChangeNotificationInterval);
 
     return true;
 }
 
 void AXObjectCache::passwordNotificationTimerFired()
 {
-    m_passwordNotificationTimer.stop();
+    if (m_passwordNotifications.isEmpty()) {
+        m_passwordNotificationTimer.stop();
+        return;
+    }
 
-    // In tests, posting notifications has a tendency to immediately queue up other notifications, which can lead to unexpected behavior
-    // when the notification list is cleared at the end. Instead copy this list at the start.
-    auto passwordNotifications = std::exchange(m_passwordNotifications, { });
-
+    auto notification = m_passwordNotifications.takeFirst();
+    auto& context = notification.second;
+    switch (context.intent.type) {
+    case AXTextStateChangeTypeEdit:
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
-    Vector<std::pair<Ref<AccessibilityObject>, AXNotification>> notifications;
-    for (const auto& note : passwordNotifications) {
-        switch (note.second.intent.type) {
-        case AXTextStateChangeTypeEdit:
-            notifications.append({ note.first, AXNotification::ValueChanged });
-            break;
-        case AXTextStateChangeTypeSelectionMove:
-        case AXTextStateChangeTypeSelectionExtend:
-        case AXTextStateChangeTypeSelectionBoundary:
-            notifications.append({ note.first, AXNotification::SelectedTextChanged });
-            break;
-        case AXTextStateChangeTypeUnknown:
-            break;
-        };
-    }
-    updateIsolatedTree(notifications);
-#endif // ENABLE(ACCESSIBILITY_ISOLATED_TREE)
-
-    for (const auto& note : passwordNotifications) {
-        auto& context = note.second;
-        switch (context.intent.type) {
-        case AXTextStateChangeTypeEdit:
-            if (context.intent.editType == AXTextEditTypeReplace) {
-                postTextReplacementPlatformNotification(note.first.ptr(),
-                    AXTextEditTypeDelete, context.deletedText, AXTextEditTypeInsert, context.insertedText, context.selection.start());
-            } else {
-                postTextStateChangePlatformNotification(note.first.ptr(),
-                    context.intent.editType, context.insertedText, context.selection.start());
-            }
-            break;
-        case AXTextStateChangeTypeSelectionMove:
-        case AXTextStateChangeTypeSelectionExtend:
-        case AXTextStateChangeTypeSelectionBoundary:
-            postTextSelectionChangePlatformNotification(note.first.ptr(),
-                context.intent, context.selection);
-            break;
-        case AXTextStateChangeTypeUnknown:
-            break;
-        };
-    }
+        updateIsolatedTree(notification.first, AXNotification::ValueChanged);
+#endif
+        if (context.intent.editType == AXTextEditTypeReplace) {
+            postTextReplacementPlatformNotification(notification.first.ptr(),
+                AXTextEditTypeDelete, context.deletedText, AXTextEditTypeInsert, context.insertedText, context.selection.start());
+        } else {
+            postTextStateChangePlatformNotification(notification.first.ptr(),
+                context.intent.editType, context.insertedText, context.selection.start());
+        }
+        break;
+    case AXTextStateChangeTypeSelectionMove:
+    case AXTextStateChangeTypeSelectionExtend:
+    case AXTextStateChangeTypeSelectionBoundary:
+#if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
+        updateIsolatedTree(notification.first, AXNotification::SelectedTextChanged);
+#endif
+        postTextSelectionChangePlatformNotification(notification.first.ptr(),
+            context.intent, context.selection);
+        break;
+    case AXTextStateChangeTypeUnknown:
+        // No additional context, fallback to a ValueChanged notification.
+#if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
+        updateIsolatedTree(notification.first, AXNotification::ValueChanged);
+#endif
+        postPlatformNotification(notification.first, AXNotification::ValueChanged);
+        break;
+    };
 }
 
 #endif // PLATFORM(COCOA)

--- a/Source/WebCore/accessibility/AXObjectCache.h
+++ b/Source/WebCore/accessibility/AXObjectCache.h
@@ -37,6 +37,7 @@
 #include "VisibleUnits.h"
 #include <limits.h>
 #include <wtf/Compiler.h>
+#include <wtf/Deque.h>
 #include <wtf/HashMap.h>
 #include <wtf/HashSet.h>
 #include <wtf/ListHashSet.h>
@@ -868,7 +869,7 @@ private:
 
 #if PLATFORM(COCOA)
     Timer m_passwordNotificationTimer;
-    Vector<std::pair<Ref<AccessibilityObject>, AXTextChangeContext>> m_passwordNotifications;
+    Deque<std::pair<Ref<AccessibilityObject>, AXTextChangeContext>> m_passwordNotifications;
 #endif
 
     Timer m_liveRegionChangedPostTimer;


### PR DESCRIPTION
#### 73cfeec8eddd592db34c7df8c14ed25555889f98
<pre>
AX: Password field notifications should be spaced out in time at fixed intervals.
<a href="https://bugs.webkit.org/show_bug.cgi?id=293298">https://bugs.webkit.org/show_bug.cgi?id=293298</a>
&lt;<a href="https://rdar.apple.com/problem/151703251">rdar://problem/151703251</a>&gt;

Reviewed by Tyler Wilcock.

At the moment, password field notifications are fired on a one-shot timer, similarly to any other notification. With this change, they are fired at least at a fixed interval which is the desired behavior to avoid any cadence analysis.

* LayoutTests/accessibility/password-notifications-timing-expected.txt: Added.
* LayoutTests/accessibility/password-notifications-timing.html: Added.
* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/mac/TestExpectations:
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::isSecureFieldOrContainedBySecureField):
(WebCore::AXObjectCache::postNotification):
(WebCore::AXObjectCache::enqueuePasswordNotification):
(WebCore::AXObjectCache::passwordNotificationTimerFired):
* Source/WebCore/accessibility/AXObjectCache.h:

Canonical link: <a href="https://commits.webkit.org/295318@main">https://commits.webkit.org/295318@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1f2ed9c65ba08409020824704b79a08ad58770ca

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104618 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24328 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/14746 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/109830 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/55289 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/106658 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/24717 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/32873 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79445 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107624 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19226 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94419 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59757 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/19012 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/12493 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/54662 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/88709 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/12545 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/112221 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/31779 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23402 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88530 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32143 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/90652 "Exiting early after 10 failures. 121 tests run. 1 flakes") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88149 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22483 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33047 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10816 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/27096 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/31706 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/37048 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/31499 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/34837 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33058 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->