### PR TITLE
[WebGPU] Add and use HAVE(...) macros for Metal family support instead of using WebGPU enablement macro

### DIFF
--- a/Source/WebGPU/WebGPU/Device.mm
+++ b/Source/WebGPU/WebGPU/Device.mm
@@ -254,33 +254,35 @@ Ref<Device> Device::create(id<MTLDevice> device, String&& deviceLabel, HardwareC
 
 static uint32_t computeMaxCountForDevice(id<MTLDevice> device)
 {
-    size_t result = 200 * MB;
-#if ENABLE(WEBGPU_BY_DEFAULT)
+#if HAVE(METAL_FAMILY_9)
     if ([device supportsFamily:MTLGPUFamilyApple9])
-        result = 300 * MB;
-    else if ([device supportsFamily:MTLGPUFamilyApple8])
-        result = 275 * MB;
-    else
+        return 300 * MB;
+#endif
+#if HAVE(METAL_FAMILY_8)
+    if ([device supportsFamily:MTLGPUFamilyApple8])
+        return 275 * MB;
 #endif
     if ([device supportsFamily:MTLGPUFamilyApple7])
-        result = 250 * MB;
-    else if ([device supportsFamily:MTLGPUFamilyApple6])
-        result = 225 * MB;
-    else if ([device supportsFamily:MTLGPUFamilyApple5])
-        result = 200 * MB;
-    else if ([device supportsFamily:MTLGPUFamilyApple4])
-        result = 200 * MB;
-    else if ([device supportsFamily:MTLGPUFamilyMac2])
-        result = 300 * MB;
+        return 250 * MB;
+    if ([device supportsFamily:MTLGPUFamilyApple6])
+        return 225 * MB;
+    if ([device supportsFamily:MTLGPUFamilyApple5])
+        return 200 * MB;
+    if ([device supportsFamily:MTLGPUFamilyApple4])
+        return 200 * MB;
+    if ([device supportsFamily:MTLGPUFamilyMac2])
+        return 300 * MB;
 
-    return result;
+    return 200 * MB;
 }
 
 static uint32_t computeAppleGPUFamily(id<MTLDevice> device)
 {
-#if ENABLE(WEBGPU_BY_DEFAULT)
+#if HAVE(METAL_FAMILY_9)
     if ([device supportsFamily:MTLGPUFamilyApple9])
         return 9;
+#endif
+#if HAVE(METAL_FAMILY_8)
     if ([device supportsFamily:MTLGPUFamilyApple8])
         return 8;
 #endif


### PR DESCRIPTION
#### 5d3ed13c04269a42c08b856b30172a2f0fc1dddc
<pre>
[WebGPU] Add and use HAVE(...) macros for Metal family support instead of using WebGPU enablement macro
<a href="https://bugs.webkit.org/show_bug.cgi?id=293302">https://bugs.webkit.org/show_bug.cgi?id=293302</a>
radar://151704028

Reviewed by David Kilzer.

Use seperate macro for family 8 and 9 support for test bots.

* Source/WebGPU/WebGPU/Device.mm:
(WebGPU::computeMaxCountForDevice):
(WebGPU::computeAppleGPUFamily):

Canonical link: <a href="https://commits.webkit.org/295176@main">https://commits.webkit.org/295176@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7ec6e4dffb4c490293670e875668e048e1103a42

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104290 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/23994 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/14405 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/109490 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/54958 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/24366 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/32541 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79201 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107296 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/18934 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94115 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59529 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/18738 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/54318 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/88439 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/12241 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/111872 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/31447 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/23172 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88225 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/31811 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/90355 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87888 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22382 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32783 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10550 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/25915 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/31375 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/36690 "Failed to build and analyze WebKit") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/31169 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/34505 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/32729 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->