### PR TITLE
[Page color sampling] Sampled background colors should always be opaque

### DIFF
--- a/LayoutTests/fast/page-color-sampling/color-sampling-ignores-non-fixed-content-expected.txt
+++ b/LayoutTests/fast/page-color-sampling/color-sampling-ignores-non-fixed-content-expected.txt
@@ -1,5 +1,5 @@
-PASS colorBeforeFading.top is "rgba(255, 100, 0, 0.8)"
-PASS colorAfterFading.top is "rgba(255, 100, 0, 0.8)"
+PASS colorBeforeFading.top is "rgb(255, 100, 0)"
+PASS colorAfterFading.top is "rgb(255, 100, 0)"
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/page-color-sampling/color-sampling-ignores-non-fixed-content.html
+++ b/LayoutTests/fast/page-color-sampling/color-sampling-ignores-non-fixed-content.html
@@ -47,8 +47,8 @@
         await UIHelper.ensurePresentationUpdate();
         colorAfterFading = await UIHelper.fixedContainerEdgeColors();
 
-        shouldBeEqualToString("colorBeforeFading.top", "rgba(255, 100, 0, 0.8)");
-        shouldBeEqualToString("colorAfterFading.top", "rgba(255, 100, 0, 0.8)");
+        shouldBeEqualToString("colorBeforeFading.top", "rgb(255, 100, 0)");
+        shouldBeEqualToString("colorAfterFading.top", "rgb(255, 100, 0)");
         finishJSTest();
     });
     </script>

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -2247,7 +2247,7 @@ std::pair<FixedContainerEdges, WeakElementEdges> LocalFrameView::fixedContainerE
         }
 
         if (result.backgroundColor.isVisible()) {
-            edges.colors.setAt(side, WTFMove(result.backgroundColor));
+            edges.colors.setAt(side, result.backgroundColor.colorWithAlpha(1));
             continue;
         }
 

--- a/Source/WebCore/page/PageColorSampler.cpp
+++ b/Source/WebCore/page/PageColorSampler.cpp
@@ -340,7 +340,7 @@ Variant<PredominantColorType, Color> PageColorSampler::predominantColor(Page& pa
         if (!color.isVisible())
             continue;
 
-        colorDistribution.add(WTFMove(color));
+        colorDistribution.add(color.colorWithAlpha(1));
     }
 
     if (colorDistribution.isEmpty())


### PR DESCRIPTION
#### 984456c2bf6f58b68dc9427b6d352daa3cbe4987
<pre>
[Page color sampling] Sampled background colors should always be opaque
<a href="https://bugs.webkit.org/show_bug.cgi?id=293306">https://bugs.webkit.org/show_bug.cgi?id=293306</a>

Reviewed by Aditya Keerthi.

Force all sampled background colors to be fully opaque (alpha = 1), so that no content shows up from
behind the corresponding fixed position color extension views.

* LayoutTests/fast/page-color-sampling/color-sampling-ignores-non-fixed-content-expected.txt:
* LayoutTests/fast/page-color-sampling/color-sampling-ignores-non-fixed-content.html:

Rebaseline an existing layout test.

* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::fixedContainerEdges const):
* Source/WebCore/page/PageColorSampler.cpp:
(WebCore::PageColorSampler::predominantColor):

Canonical link: <a href="https://commits.webkit.org/295175@main">https://commits.webkit.org/295175@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/715999ac6968ca22e82e730debc2de0b894c597e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104303 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24007 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/14420 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/109504 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/54971 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/106343 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/24379 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/32554 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/79210 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/54971 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107309 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/18946 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94125 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59538 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/18744 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/12193 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/54331 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/88449 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/12251 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/111885 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/31460 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/23177 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88237 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/31824 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/90365 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87900 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22380 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32792 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10558 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/25928 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/31388 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/36703 "Built successfully") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/31182 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/34518 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/32742 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->