### PR TITLE
Make deprecated CSSOM JS bindings check a settings flag

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -2392,6 +2392,20 @@ DefaultTextEncodingName:
     WebCore:
       default: '{ }'
 
+DeprecatedCSSOMValuesInJavaScriptDisabled:
+  type: bool
+  status: testable
+  category: css
+  humanReadableName: "Disable deprecated CSSOM values in JavaScript"
+  humanReadableDescription: "Disable deprecated CSSOM values in JavaScript"
+  defaultValue:
+    WebKitLegacy:
+      default: true
+    WebKit:
+      default: WebKit::defaultDeprecatedCSSOMValuesInJavaScriptDisabled()
+    WebCore:
+      default: true
+
 DeprecationReportingEnabled:
   type: bool
   status: testable

--- a/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
+++ b/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
@@ -123,6 +123,7 @@ namespace WebCore {
     macro(ContactsManager) \
     macro(ContentVisibilityAutoStateChangeEvent) \
     macro(ConvolverNode) \
+    macro(Counter) \
     macro(CreateHTMLCallback) \
     macro(CreateScriptCallback) \
     macro(CreateScriptURLCallback) \
@@ -131,15 +132,15 @@ namespace WebCore {
     macro(CryptoKey) \
     macro(CSPViolationReportBody) \
     macro(CSSAnimation) \
-    macro(CSSCounterStyleRule) \
     macro(CSSColor) \
     macro(CSSColorValue) \
+    macro(CSSCounterStyleRule) \
     macro(CSSHSL) \
     macro(CSSHWB) \
     macro(CSSImageValue) \
     macro(CSSKeywordValue) \
-    macro(CSSLCH) \
     macro(CSSLab) \
+    macro(CSSLCH) \
     macro(CSSMathClamp) \
     macro(CSSMathInvert) \
     macro(CSSMathMax) \
@@ -151,12 +152,13 @@ namespace WebCore {
     macro(CSSMatrixComponent) \
     macro(CSSNumericArray) \
     macro(CSSNumericValue) \
-    macro(CSSOKLCH) \
     macro(CSSOKLab) \
+    macro(CSSOKLCH) \
     macro(CSSPaintSize) \
     macro(CSSPerspective) \
     macro(CSSPositionTryDescriptors) \
     macro(CSSPositionTryRule) \
+    macro(CSSPrimitiveValue) \
     macro(CSSRGB) \
     macro(CSSRotate) \
     macro(CSSScale) \
@@ -172,6 +174,8 @@ namespace WebCore {
     macro(CSSTranslate) \
     macro(CSSUnitValue) \
     macro(CSSUnparsedValue) \
+    macro(CSSValue) \
+    macro(CSSValueList) \
     macro(CSSVariableReferenceValue) \
     macro(CSSViewTransitionRule) \
     macro(CommandEvent) \
@@ -374,11 +378,13 @@ namespace WebCore {
     macro(PushSubscription) \
     macro(PushSubscriptionChangeEvent) \
     macro(PushSubscriptionOptions) \
+    macro(Rect) \
     macro(Report) \
     macro(ReportBody) \
     macro(ReportingObserver) \
     macro(ResizeObserver) \
     macro(ResizeObserverEntry) \
+    macro(RGBColor) \
     macro(RTCCertificate) \
     macro(RTCDTMFSender) \
     macro(RTCDTMFToneChangeEvent) \

--- a/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
+++ b/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
@@ -2132,6 +2132,7 @@ sub NeedsRuntimeCheck
         || $context->extendedAttributes->{EnabledForContext}
         || $context->extendedAttributes->{EnabledForWorld}
         || $context->extendedAttributes->{EnabledBySetting}
+        || $context->extendedAttributes->{DisabledBySetting}
         || $context->extendedAttributes->{EnabledByQuirk}
         || $context->extendedAttributes->{DisabledByQuirk}
         || $context->extendedAttributes->{SecureContext};
@@ -4297,6 +4298,32 @@ sub GenerateRuntimeEnableConditionalString
                     push(@orconjuncts, "downcast<Document>(jsCast<JSDOMGlobalObject*>(" . $globalObjectPtr . ")->scriptExecutionContext())->settingsValues()." . ToMethodName($orflag));
                 } else {
                     push(@orconjuncts, "jsCast<JSDOMGlobalObject*>(" . $globalObjectPtr . ")->scriptExecutionContext()->settingsValues()." . ToMethodName($orflag));
+                }
+            }
+            my $result = join(" || ", @orconjuncts);
+            $result = "($result)" if @orconjuncts > 1;
+            push(@conjuncts, $result);
+        }
+    }
+
+    if ($context->extendedAttributes->{DisabledBySetting}) {
+        assert("Must specify value for DisabledBySetting.") if $context->extendedAttributes->{DisabledBySetting} eq "VALUE_IS_MISSING";
+
+        my @flags = split(/&/, $context->extendedAttributes->{DisabledBySetting});
+        my $exposedToWindowOnly = $interface->extendedAttributes->{Exposed} && $interface->extendedAttributes->{Exposed} eq "Window";
+        AddToImplIncludes($exposedToWindowOnly ? "DocumentInlines.h" : "ScriptExecutionContext.h");
+        AddToImplIncludes("Settings.h");
+        foreach my $flag (@flags) {
+            my @orflags = split(/\|/, $flag);
+            my @orconjuncts;
+            foreach my $orflag (@orflags) {
+                if ($interface->type->name eq "DOMWindow") {
+                    push(@orconjuncts, "(!scriptExecutionContext || !scriptExecutionContext->settingsValues()." . ToMethodName($orflag) . ')');
+                } elsif ($exposedToWindowOnly) {
+                    # FIXME: This downcast<Document> doesn't seem necessary.
+                    push(@orconjuncts, "!downcast<Document>(jsCast<JSDOMGlobalObject*>(" . $globalObjectPtr . ")->scriptExecutionContext())->settingsValues()." . ToMethodName($orflag));
+                } else {
+                    push(@orconjuncts, "!jsCast<JSDOMGlobalObject*>(" . $globalObjectPtr . ")->scriptExecutionContext()->settingsValues()." . ToMethodName($orflag));
                 }
             }
             my $result = join(" || ", @orconjuncts);
@@ -8184,6 +8211,13 @@ sub GenerateConstructorDefinition
              if ($operation->extendedAttributes->{EnabledBySetting}) {
                  my $runtimeEnableConditionalString = GenerateRuntimeEnableConditionalString($interface, $operation, "lexicalGlobalObject");
                  push(@$outputArray, "    if (!${runtimeEnableConditionalString}) {\n");
+                 push(@$outputArray, "        throwTypeError(lexicalGlobalObject, throwScope, \"Illegal constructor\"_s);\n");
+                 push(@$outputArray, "        return JSValue::encode(jsNull());\n");
+                 push(@$outputArray, "    }\n");
+             }
+             if ($operation->extendedAttributes->{DisabledBySetting}) {
+                 my $runtimeEnableConditionalString = GenerateRuntimeEnableConditionalString($interface, $operation, "lexicalGlobalObject");
+                 push(@$outputArray, "    if (${runtimeEnableConditionalString}) {\n");
                  push(@$outputArray, "        throwTypeError(lexicalGlobalObject, throwScope, \"Illegal constructor\"_s);\n");
                  push(@$outputArray, "        return JSValue::encode(jsNull());\n");
                  push(@$outputArray, "    }\n");

--- a/Source/WebCore/bindings/scripts/IDLAttributes.json
+++ b/Source/WebCore/bindings/scripts/IDLAttributes.json
@@ -157,6 +157,11 @@
             "values": ["*"],
             "supportsConjunction": true
         },
+        "DisabledBySetting": {
+            "contextsAllowed": ["interface", "namespace", "dictionary", "enum", "attribute", "operation", "constant", "dictionary-member", "includes"],
+            "values": ["*"],
+            "supportsConjunction": true
+        },
         "DoNotCheckConstants": {
             "contextsAllowed": ["interface"]
         },

--- a/Source/WebCore/bindings/scripts/preprocess-idls.pl
+++ b/Source/WebCore/bindings/scripts/preprocess-idls.pl
@@ -514,7 +514,7 @@ sub GenerateConstructorAttributes
     my @extendedAttributesList;
     foreach my $attributeName (sort keys %{$extendedAttributes}) {
       next unless ($attributeName eq "Conditional" || $attributeName eq "EnabledByDeprecatedGlobalSetting" || $attributeName eq "EnabledForWorld"
-        || $attributeName eq "EnabledBySetting" || $attributeName eq "SecureContext" || $attributeName eq "PrivateIdentifier"
+        || $attributeName eq "DisabledBySetting" || $attributeName eq "EnabledBySetting" || $attributeName eq "SecureContext" || $attributeName eq "PrivateIdentifier"
         || $attributeName eq "PublicIdentifier" || $attributeName eq "DisabledByQuirk" || $attributeName eq "EnabledByQuirk"
         || $attributeName eq "EnabledForContext") || $attributeName eq "LegacyFactoryFunctionEnabledBySetting";
       my $extendedAttribute = $attributeName;

--- a/Source/WebCore/css/CSSStyleDeclaration.idl
+++ b/Source/WebCore/css/CSSStyleDeclaration.idl
@@ -42,5 +42,5 @@ typedef USVString CSSOMString;
     readonly attribute CSSRule? parentRule;
 
     // Non-standard.
-    DeprecatedCSSOMValue? getPropertyCSSValue(DOMString propertyName);
+    [DisabledBySetting=DeprecatedCSSOMValuesInJavaScriptDisabled] DeprecatedCSSOMValue? getPropertyCSSValue(DOMString propertyName);
 };

--- a/Source/WebCore/css/DeprecatedCSSOMCounter.idl
+++ b/Source/WebCore/css/DeprecatedCSSOMCounter.idl
@@ -19,6 +19,7 @@
 
 [
     ExportToWrappedFunction,
+    DisabledBySetting=DeprecatedCSSOMValuesInJavaScriptDisabled,
     InterfaceName=Counter,
     Exposed=Window
 ] interface DeprecatedCSSOMCounter {

--- a/Source/WebCore/css/DeprecatedCSSOMPrimitiveValue.idl
+++ b/Source/WebCore/css/DeprecatedCSSOMPrimitiveValue.idl
@@ -18,6 +18,7 @@
  */
 
 [
+    DisabledBySetting=DeprecatedCSSOMValuesInJavaScriptDisabled,
     InterfaceName=CSSPrimitiveValue,
     Exposed=Window
 ] interface DeprecatedCSSOMPrimitiveValue : DeprecatedCSSOMValue {

--- a/Source/WebCore/css/DeprecatedCSSOMRGBColor.idl
+++ b/Source/WebCore/css/DeprecatedCSSOMRGBColor.idl
@@ -20,6 +20,7 @@
 
 [
     ExportToWrappedFunction,
+    DisabledBySetting=DeprecatedCSSOMValuesInJavaScriptDisabled,
     InterfaceName=RGBColor,
     Exposed=Window
 ] interface DeprecatedCSSOMRGBColor {

--- a/Source/WebCore/css/DeprecatedCSSOMRect.idl
+++ b/Source/WebCore/css/DeprecatedCSSOMRect.idl
@@ -19,6 +19,7 @@
 
 [
     ExportToWrappedFunction,
+    DisabledBySetting=DeprecatedCSSOMValuesInJavaScriptDisabled,
     InterfaceName=Rect,
     Exposed=Window
 ] interface DeprecatedCSSOMRect {

--- a/Source/WebCore/css/DeprecatedCSSOMValue.idl
+++ b/Source/WebCore/css/DeprecatedCSSOMValue.idl
@@ -21,6 +21,7 @@
 [
     CustomIsReachable,
     CustomToJSObject,
+    DisabledBySetting=DeprecatedCSSOMValuesInJavaScriptDisabled,
     ExportToWrappedFunction,
     InterfaceName=CSSValue,
     Exposed=Window

--- a/Source/WebCore/css/DeprecatedCSSOMValueList.idl
+++ b/Source/WebCore/css/DeprecatedCSSOMValueList.idl
@@ -25,10 +25,10 @@
 
 // Introduced in DOM Level 2:
 [
+    DisabledBySetting=DeprecatedCSSOMValuesInJavaScriptDisabled,
     InterfaceName=CSSValueList,
     Exposed=Window
 ] interface DeprecatedCSSOMValueList : DeprecatedCSSOMValue {
     readonly attribute unsigned long length;
     getter DeprecatedCSSOMValue item(unsigned long index);
 };
-

--- a/Source/WebKit/Shared/WebPreferencesDefaultValues.cpp
+++ b/Source/WebKit/Shared/WebPreferencesDefaultValues.cpp
@@ -427,4 +427,15 @@ bool defaultContentInsetBackgroundFillEnabled()
 }
 #endif
 
+bool defaultDeprecatedCSSOMValuesInJavaScriptDisabled()
+{
+#if PLATFORM(IOS_FAMILY)
+    return !WTF::IOSApplication::isMobileMail();
+#elif PLATFORM(MAC)
+    return !WTF::MacApplication::isAppleMail();
+#else
+    return true;
+#endif
+}
+
 } // namespace WebKit

--- a/Source/WebKit/Shared/WebPreferencesDefaultValues.h
+++ b/Source/WebKit/Shared/WebPreferencesDefaultValues.h
@@ -208,4 +208,6 @@ bool defaultMutationEventsEnabled();
 
 bool defaultTrustedTypesEnabled();
 
+bool defaultDeprecatedCSSOMValuesInJavaScriptDisabled();
+
 } // namespace WebKit


### PR DESCRIPTION
#### 146cd2dca59ad8ef961991468b4f053dcce1e023
<pre>
Make deprecated CSSOM JS bindings check a settings flag
<a href="https://bugs.webkit.org/show_bug.cgi?id=293307">https://bugs.webkit.org/show_bug.cgi?id=293307</a>

Reviewed by NOBODY (OOPS!).

WIP FOR BOTS

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/bindings/js/WebCoreBuiltinNames.h:
* Source/WebCore/bindings/scripts/CodeGeneratorJS.pm:
* Source/WebCore/bindings/scripts/IDLAttributes.json:
* Source/WebCore/bindings/scripts/preprocess-idls.pl:
* Source/WebCore/css/CSSStyleDeclaration.idl:
* Source/WebCore/css/DeprecatedCSSOMCounter.idl:
* Source/WebCore/css/DeprecatedCSSOMPrimitiveValue.idl:
* Source/WebCore/css/DeprecatedCSSOMRGBColor.idl:
* Source/WebCore/css/DeprecatedCSSOMRect.idl:
* Source/WebCore/css/DeprecatedCSSOMValue.idl:
* Source/WebCore/css/DeprecatedCSSOMValueList.idl:
* Source/WebKit/Shared/WebPreferencesDefaultValues.cpp:
* Source/WebKit/Shared/WebPreferencesDefaultValues.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/146cd2dca59ad8ef961991468b4f053dcce1e023

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104330 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24034 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/14448 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/109531 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/54998 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/106370 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/24474 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/32581 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79230 "Found 128 new test failures: animations/animation-direction-alternate-reverse.html animations/animation-direction-reverse-fill-mode.html animations/animation-direction-reverse-hardware-opacity.html animations/animation-direction-reverse-non-hardware.html animations/animation-direction-reverse-timing-functions.html animations/animation-direction.html animations/calc-animation-test.html animations/change-keyframes.html animations/change-one-anim.html animations/duplicated-keyframes-name.html ... (failure)") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107336 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19025 "1 failures") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94147 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59560 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/18833 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/12220 "1 failures") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/54358 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/97005 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/88518 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/12275 "Too many flaky failures: animations/animation-border-overflow.html, animations/animation-direction-alternate-reverse.html, animations/animation-direction-reverse-fill-mode.html, animations/animation-direction-reverse-hardware-opacity.html, animations/animation-direction-reverse-non-hardware.html, animations/animation-direction-reverse-timing-functions.html, animations/animation-direction.html, animations/calc-animation-test.html, animations/change-keyframes.html, animations/duplicated-keyframes-name.html, animations/fill-forwards-end-state.html, animations/fill-mode-forwards-zero-duration.html, animations/fill-mode-reverse.html, animations/font-variations/font-stretch.html, animations/font-variations/font-weight.html, animations/generic-from-to.html, animations/import.html, animations/keyframe-multiple-timing-functions-transform.html, animations/keyframe-timing-functions.html, animations/keyframe-timing-functions2.html, animations/keyframes-comma-separated.html, animations/keyframes-dynamic.html, animations/keyframes-infinite-iterations.html, animations/keyframes-invalid-keys.html, animations/keyframes-out-of-order.html, animations/keyframes.html, animations/longhand-timing-function.html, animations/missing-from-to.html, animations/missing-keyframe-properties-repeating.html, animations/missing-keyframe-properties-timing-function.html, animations/missing-keyframe-properties.html, animations/multiple-animations-timing-function.html, animations/multiple-animations.html, animations/multiple-keyframes.html, animations/negative-delay.html, animations/simultaneous-start-left.html, animations/spring-computed-style.html, animations/spring-function.html, animations/spring-parsing.html, animations/stacking-context-unchanged-while-running.html, animations/text-decoration-thickness.html, animations/text-underline-offset.html, animations/timing-functions.html, animations/top-left-percent-interpolation.html, animations/unanimated-style.html, animations/unprefixed-keyframes.html, animations/unprefixed-properties.html, animations/unprefixed-shorthand.html, animations/width-using-ems.html, compositing/animation/animated-composited-inside-hidden.html, css3/calc/transitions.html, css3/color-filters/color-filter-exposed-if-disabled.html, css3/color-filters/color-filter-exposed-if-enabled.html, css3/filters/backdrop/backdropfilter-property-computed-style.html, css3/filters/backdrop/backdropfilter-property-parsing.html, css3/filters/unprefixed.html, css3/font-variant-parsing.html, fast/css-grid-layout/grid-simplified-layout-positioned.html, fast/css/CSSPrimitiveValue-exceptions.html, fast/css/CSSPrimitiveValue-font-family-primitiveType.html, fast/css/CSSPrimitiveValue-modern-length.html, fast/css/CSSStyleDeclaration-parameters.html, fast/css/counters/getCounterValue.html, fast/css/cursor-image-cssvalue.html, fast/css/custom-properties/rule-property-get-css-value.html, fast/css/font-systemFontID-parsing.html, fast/css/getComputedStyle/computed-style-font.html, fast/css/getComputedStyle/getComputedStyle-background-position.html, fast/css/getComputedStyle/getComputedStyle-background-shorthand.html, fast/css/getComputedStyle/getComputedStyle-background-size.html, fast/css/getComputedStyle/getComputedStyle-border-color-shorthand.html, fast/css/getComputedStyle/getComputedStyle-border-image-slice.html, fast/css/getComputedStyle/getComputedStyle-border-image.html, fast/css/getComputedStyle/getComputedStyle-border-radius-shorthand.html, fast/css/getComputedStyle/getComputedStyle-border-shorthand.html, fast/css/getComputedStyle/getComputedStyle-border-spacing.html, fast/css/getComputedStyle/getComputedStyle-border-style-shorthand.html, fast/css/getComputedStyle/getComputedStyle-border-width.html, fast/css/getComputedStyle/getComputedStyle-borderRadius.html, fast/css/getComputedStyle/getComputedStyle-column-rule.html, fast/css/getComputedStyle/getComputedStyle-list-style-shorthand.html, fast/css/getComputedStyle/getComputedStyle-margin-shorthand.html, fast/css/getComputedStyle/getComputedStyle-outline-offset.html, fast/css/getComputedStyle/getComputedStyle-outline-shorthand.html, fast/css/getComputedStyle/getComputedStyle-padding-shorthand.html, fast/css/getComputedStyle/getComputedStyle-text-decoration.html, fast/css/getComputedStyle/getComputedStyle-webkit-columns-shorthand.html, fast/css/getFloatValueForUnit.html, fast/css/image-rendering-parsing.html, fast/css/image-set-parsing.html, fast/css/image-value-type.html, fast/css/prefixed-unprefixed-variant-style-declaration.html, fast/css/style-enumerate-properties.html, fast/css/value-list-out-of-bounds-crash.html, fast/css3-text/css3-text-decoration/getComputedStyle/getComputedStyle-text-decoration-shorthand-ordering.html, fast/css3-text/css3-text-decoration/getComputedStyle/getComputedStyle-text-decoration-shorthand.html, fast/css3-text/css3-text-decoration/text-decoration-skip/text-decoration-skip-roundtrip.html, fast/css3-text/font-synthesis-parse.html, fast/dom/StyleSheet/gc-inline-style-cssvalues.html, fast/dom/Window/get-set-properties.html, fast/dom/Window/window-lookup-precedence.html, fast/dom/collection-iterators.html, fast/dom/constants.html, fast/dom/css-RGBValue.html, fast/dom/dom-constructors.html, fast/dom/global-constructors.html, fast/dom/setPrimitiveValue-exceptions.html, fast/dom/setPrimitiveValue.html, fast/repaint/inline-box-with-self-paint-layer.html, fast/shapes/shape-outside-floats/shape-outside-floats-image-002.html, fast/shapes/shape-outside-floats/shape-outside-shape-image-threshold-animation.html, fast/shapes/shape-outside-floats/shape-outside-shape-margin-animation.html, fast/transforms/listbox-zoom.html, http/tests/security/cross-frame-access-put.html, http/tests/security/cross-origin-css-primitive.html, imported/w3c/web-platform-tests/css/cssom/historical.html, imported/w3c/web-platform-tests/editing/other/delete-in-child-of-html.tentative.html?designMode=on&method=backspace, imported/w3c/web-platform-tests/editing/other/delete-in-child-of-html.tentative.html?designMode=on&method=forwarddelete, imported/w3c/web-platform-tests/editing/other/typing-around-link-element-at-collapsed-selection.tentative.html?target=DesignMode&child=b, imported/w3c/web-platform-tests/fetch/http-cache/invalidate.any.worker.html, imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/svg-script-href.tentative.html, imported/w3c/web-platform-tests/preload/preload-with-type.html, imported/w3c/web-platform-tests/webcodecs/video-encoder-h26x-annexb.https.any.html?h265_annexb_hardware, imported/w3c/web-platform-tests/webcodecs/video-encoder-h26x-annexb.https.any.html?h265_annexb_software, imported/w3c/web-platform-tests/webcodecs/video-encoder-h26x-annexb.https.any.worker.html?h265_annexb_hardware, imported/w3c/web-platform-tests/webcodecs/video-encoder-h26x-annexb.https.any.worker.html?h265_annexb_software, transforms/2d/transform-value-types.html, transitions/blendmode-transitions.html, transitions/lengthsize-transition-to-from-auto.html, transitions/shape-outside-transitions.html, transitions/svg-layout-transition.html, transitions/svg-transitions.html, transitions/transition-in-delay-phase.html, transitions/transition-on-element-with-content.html, transitions/transition-to-from-auto.html, transitions/transition-to-from-undefined.html, transitions/visited-link-color.html, transitions/zero-duration-in-list.html, transitions/zero-duration-with-non-zero-delay-start.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/111913 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/102941 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/31487 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23194 "Too many flaky failures: animations/animation-border-overflow.html, animations/animation-direction-alternate-reverse.html, animations/animation-direction-reverse-fill-mode.html, animations/animation-direction-reverse-hardware-opacity.html, animations/animation-direction-reverse-non-hardware.html, animations/animation-direction-reverse-timing-functions.html, animations/animation-direction.html, animations/calc-animation-test.html, animations/change-keyframes.html, animations/duplicated-keyframes-name.html, animations/fill-forwards-end-state.html, animations/fill-mode-forwards-zero-duration.html, animations/fill-mode-reverse.html, animations/font-variations/font-stretch.html, animations/font-variations/font-weight.html, animations/generic-from-to.html, animations/import.html, animations/keyframe-multiple-timing-functions-transform.html, animations/keyframe-timing-functions.html, animations/keyframe-timing-functions2.html, animations/keyframes-comma-separated.html, animations/keyframes-dynamic.html, animations/keyframes-infinite-iterations.html, animations/keyframes-invalid-keys.html, animations/keyframes-out-of-order.html, animations/keyframes.html, animations/longhand-timing-function.html, animations/missing-from-to.html, animations/missing-keyframe-properties-repeating.html, animations/missing-keyframe-properties-timing-function.html, animations/missing-keyframe-properties.html, animations/multiple-animations-timing-function.html, animations/multiple-animations.html, animations/multiple-keyframes.html, animations/negative-delay.html, animations/simultaneous-start-left.html, animations/spring-computed-style.html, animations/spring-function.html, animations/spring-parsing.html, animations/stacking-context-unchanged-while-running.html, animations/text-decoration-thickness.html, animations/text-underline-offset.html, animations/timing-functions.html, animations/top-left-percent-interpolation.html, animations/unanimated-style.html, animations/unprefixed-keyframes.html, animations/unprefixed-properties.html, animations/unprefixed-shorthand.html, animations/width-using-ems.html, compositing/animation/animated-composited-inside-hidden.html, css3/calc/transitions.html, css3/color-filters/color-filter-exposed-if-disabled.html, css3/color-filters/color-filter-exposed-if-enabled.html, css3/filters/backdrop/backdropfilter-property-computed-style.html, css3/filters/backdrop/backdropfilter-property-parsing.html, css3/filters/unprefixed.html, css3/font-variant-parsing.html, fast/css/CSSPrimitiveValue-exceptions.html, fast/css/CSSPrimitiveValue-font-family-primitiveType.html, fast/css/CSSPrimitiveValue-modern-length.html, fast/css/CSSStyleDeclaration-parameters.html, fast/css/counters/getCounterValue.html, fast/css/cursor-image-cssvalue.html, fast/css/custom-properties/rule-property-get-css-value.html, fast/css/font-systemFontID-parsing.html, fast/css/getComputedStyle/computed-style-font.html, fast/css/getComputedStyle/getComputedStyle-background-position.html, fast/css/getComputedStyle/getComputedStyle-background-shorthand.html, fast/css/getComputedStyle/getComputedStyle-background-size.html, fast/css/getComputedStyle/getComputedStyle-border-color-shorthand.html, fast/css/getComputedStyle/getComputedStyle-border-image-slice.html, fast/css/getComputedStyle/getComputedStyle-border-image.html, fast/css/getComputedStyle/getComputedStyle-border-radius-shorthand.html, fast/css/getComputedStyle/getComputedStyle-border-shorthand.html, fast/css/getComputedStyle/getComputedStyle-border-spacing.html, fast/css/getComputedStyle/getComputedStyle-border-style-shorthand.html, fast/css/getComputedStyle/getComputedStyle-border-width.html, fast/css/getComputedStyle/getComputedStyle-borderRadius.html, fast/css/getComputedStyle/getComputedStyle-column-rule.html, fast/css/getComputedStyle/getComputedStyle-list-style-shorthand.html, fast/css/getComputedStyle/getComputedStyle-margin-shorthand.html, fast/css/getComputedStyle/getComputedStyle-outline-offset.html, fast/css/getComputedStyle/getComputedStyle-outline-shorthand.html, fast/css/getComputedStyle/getComputedStyle-padding-shorthand.html, fast/css/getComputedStyle/getComputedStyle-text-decoration.html, fast/css/getComputedStyle/getComputedStyle-webkit-columns-shorthand.html, fast/css/getFloatValueForUnit.html, fast/css/image-rendering-parsing.html, fast/css/image-set-parsing.html, fast/css/image-value-type.html, fast/css/prefixed-unprefixed-variant-style-declaration.html, fast/css/style-enumerate-properties.html, fast/css/value-list-out-of-bounds-crash.html, fast/css3-text/css3-text-decoration/getComputedStyle/getComputedStyle-text-decoration-shorthand-ordering.html, fast/css3-text/css3-text-decoration/getComputedStyle/getComputedStyle-text-decoration-shorthand.html, fast/css3-text/css3-text-decoration/text-decoration-skip/text-decoration-skip-roundtrip.html, fast/css3-text/font-synthesis-parse.html, fast/dom/StyleSheet/gc-inline-style-cssvalues.html, fast/dom/Window/get-set-properties.html, fast/dom/Window/window-lookup-precedence.html, fast/dom/collection-iterators.html, fast/dom/constants.html, fast/dom/css-RGBValue.html, fast/dom/dom-constructors.html, fast/dom/global-constructors.html, fast/dom/setPrimitiveValue-exceptions.html, fast/dom/setPrimitiveValue.html, fast/shapes/shape-outside-floats/shape-outside-shape-image-threshold-animation.html, fast/shapes/shape-outside-floats/shape-outside-shape-margin-animation.html, fast/transforms/listbox-zoom.html, http/tests/security/cross-frame-access-put.html, http/tests/security/cross-origin-css-primitive.html, http/wpt/background-fetch/background-fetch-pause-resume.window.html, http/wpt/service-workers/navigate-iframes-window-client.https.html, imported/w3c/web-platform-tests/css/cssom/historical.html, imported/w3c/web-platform-tests/editing/other/typing-around-link-element-at-non-collapsed-selection.tentative.html?target=DesignMode&parent=b, imported/w3c/web-platform-tests/editing/run/justifycenter.html?4001-5000, imported/w3c/web-platform-tests/requestidlecallback/deadline-max-rAF-dynamic.html, inspector/canvas/recording-2d-frameCount.html, scrollingcoordinator/mac/latching/horizontal-overflow-back-swipe-overscroll-behavior.html, scrollingcoordinator/mac/latching/horizontal-overflow-back-swipe.html, transforms/2d/transform-value-types.html, transitions/blendmode-transitions.html, transitions/lengthsize-transition-to-from-auto.html, transitions/shape-outside-transitions.html, transitions/svg-layout-transition.html, transitions/svg-transitions.html, transitions/transition-in-delay-phase.html, transitions/transition-on-element-with-content.html, transitions/transition-to-from-auto.html, transitions/transition-to-from-undefined.html, transitions/visited-link-color.html, transitions/zero-duration-in-list.html, transitions/zero-duration-with-non-zero-delay-start.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88254 "Found 130 new test failures: animations/animation-border-overflow.html animations/animation-direction-alternate-reverse.html animations/animation-direction-reverse-fill-mode.html animations/animation-direction-reverse-hardware-opacity.html animations/animation-direction-reverse-non-hardware.html animations/animation-direction-reverse-timing-functions.html animations/animation-direction.html animations/calc-animation-test.html animations/change-keyframes.html animations/change-one-anim.html ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/31851 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/90391 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87918 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32817 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10586 "Too many flaky failures: animations/animation-border-overflow.html, animations/animation-direction-alternate-reverse.html, animations/animation-direction-reverse-fill-mode.html, animations/animation-direction-reverse-hardware-opacity.html, animations/animation-direction-reverse-non-hardware.html, animations/animation-direction-reverse-timing-functions.html, animations/animation-direction.html, animations/calc-animation-test.html, animations/change-keyframes.html, animations/duplicated-keyframes-name.html, animations/fill-forwards-end-state.html, animations/fill-mode-forwards-zero-duration.html, animations/fill-mode-reverse.html, animations/font-variations/font-stretch.html, animations/font-variations/font-weight.html, animations/generic-from-to.html, animations/import.html, animations/keyframe-multiple-timing-functions-transform.html, animations/keyframe-timing-functions.html, animations/keyframe-timing-functions2.html, animations/keyframes-comma-separated.html, animations/keyframes-dynamic.html, animations/keyframes-infinite-iterations.html, animations/keyframes-invalid-keys.html, animations/keyframes-out-of-order.html, animations/keyframes.html, animations/longhand-timing-function.html, animations/missing-from-to.html, animations/missing-keyframe-properties-repeating.html, animations/missing-keyframe-properties-timing-function.html, animations/missing-keyframe-properties.html, animations/multiple-animations-timing-function.html, animations/multiple-animations.html, animations/multiple-keyframes.html, animations/negative-delay.html, animations/simultaneous-start-left.html, animations/spring-computed-style.html, animations/spring-function.html, animations/spring-parsing.html, animations/stacking-context-unchanged-while-running.html, animations/text-decoration-thickness.html, animations/text-underline-offset.html, animations/timing-functions.html, animations/top-left-percent-interpolation.html, animations/unanimated-style.html, animations/unprefixed-keyframes.html, animations/unprefixed-properties.html, animations/unprefixed-shorthand.html, animations/width-using-ems.html, compositing/animation/animated-composited-inside-hidden.html, compositing/shared-backing/backing-sharing-compositing-change.html, compositing/z-order/rebuild-sibling-of-layer-with-foreground-layer.html, css3/calc/transitions.html, css3/color-filters/color-filter-exposed-if-disabled.html, css3/color-filters/color-filter-exposed-if-enabled.html, css3/filters/backdrop/backdropfilter-property-computed-style.html, css3/filters/backdrop/backdropfilter-property-parsing.html, css3/filters/unprefixed.html, css3/font-variant-parsing.html, fast/css/CSSPrimitiveValue-exceptions.html, fast/css/CSSPrimitiveValue-font-family-primitiveType.html, fast/css/CSSPrimitiveValue-modern-length.html, fast/css/CSSStyleDeclaration-parameters.html, fast/css/counters/getCounterValue.html, fast/css/cursor-image-cssvalue.html, fast/css/custom-properties/rule-property-get-css-value.html, fast/css/font-systemFontID-parsing.html, fast/css/getComputedStyle/computed-style-font.html, fast/css/getComputedStyle/getComputedStyle-background-position.html, fast/css/getComputedStyle/getComputedStyle-background-shorthand.html, fast/css/getComputedStyle/getComputedStyle-background-size.html, fast/css/getComputedStyle/getComputedStyle-border-color-shorthand.html, fast/css/getComputedStyle/getComputedStyle-border-image-slice.html, fast/css/getComputedStyle/getComputedStyle-border-image.html, fast/css/getComputedStyle/getComputedStyle-border-radius-shorthand.html, fast/css/getComputedStyle/getComputedStyle-border-shorthand.html, fast/css/getComputedStyle/getComputedStyle-border-spacing.html, fast/css/getComputedStyle/getComputedStyle-border-style-shorthand.html, fast/css/getComputedStyle/getComputedStyle-border-width.html, fast/css/getComputedStyle/getComputedStyle-borderRadius.html, fast/css/getComputedStyle/getComputedStyle-column-rule.html, fast/css/getComputedStyle/getComputedStyle-list-style-shorthand.html, fast/css/getComputedStyle/getComputedStyle-margin-shorthand.html, fast/css/getComputedStyle/getComputedStyle-outline-offset.html, fast/css/getComputedStyle/getComputedStyle-outline-shorthand.html, fast/css/getComputedStyle/getComputedStyle-padding-shorthand.html, fast/css/getComputedStyle/getComputedStyle-text-decoration.html, fast/css/getComputedStyle/getComputedStyle-webkit-columns-shorthand.html, fast/css/getFloatValueForUnit.html, fast/css/image-rendering-parsing.html, fast/css/image-set-parsing.html, fast/css/image-value-type.html, fast/css/prefixed-unprefixed-variant-style-declaration.html, fast/css/style-enumerate-properties.html, fast/css/value-list-out-of-bounds-crash.html, fast/css/view-transitions-hide-under-page-background-color.html, fast/css3-text/css3-text-decoration/getComputedStyle/getComputedStyle-text-decoration-shorthand-ordering.html, fast/css3-text/css3-text-decoration/getComputedStyle/getComputedStyle-text-decoration-shorthand.html, fast/css3-text/css3-text-decoration/text-decoration-skip/text-decoration-skip-roundtrip.html, fast/css3-text/font-synthesis-parse.html, fast/dom/StyleSheet/gc-inline-style-cssvalues.html, fast/dom/Window/get-set-properties.html, fast/dom/Window/window-lookup-precedence.html, fast/dom/collection-iterators.html, fast/dom/constants.html, fast/dom/css-RGBValue.html, fast/dom/dom-constructors.html, fast/dom/global-constructors.html, fast/dom/setPrimitiveValue-exceptions.html, fast/dom/setPrimitiveValue.html, fast/shapes/shape-outside-floats/shape-outside-shape-image-threshold-animation.html, fast/shapes/shape-outside-floats/shape-outside-shape-margin-animation.html, fast/transforms/listbox-zoom.html, http/tests/security/cross-frame-access-put.html, http/tests/security/cross-origin-css-primitive.html, imported/w3c/web-platform-tests/css/css-conditional/container-queries/canvas-as-container-001.html, imported/w3c/web-platform-tests/css/cssom/historical.html, imported/w3c/web-platform-tests/html/canvas/offscreen/pixel-manipulation/2d.imageData.create2.zero.html, imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/reporting-to-document-reporting-endpoint.https.window.html, imported/w3c/web-platform-tests/wasm/jsapi/memory/to-fixed-length-buffer.any.worker.html, swipe/basic-cached-back-swipe.html, transforms/2d/transform-value-types.html, transitions/blendmode-transitions.html, transitions/lengthsize-transition-to-from-auto.html, transitions/shape-outside-transitions.html, transitions/svg-layout-transition.html, transitions/svg-transitions.html, transitions/transition-in-delay-phase.html, transitions/transition-on-element-with-content.html, transitions/transition-to-from-auto.html, transitions/transition-to-from-undefined.html, transitions/visited-link-color.html, transitions/zero-duration-in-list.html, transitions/zero-duration-with-non-zero-delay-start.html, webgl/2.0.y/conformance2/sync/sync-webgl-specific.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/25955 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/31415 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/36740 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/127165 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/31209 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34965 "Found 1 new JSC stress test failure: wasm.yaml/wasm/gc/ref-i31-eq.js.wasm-eager (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/34545 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/32769 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->