### PR TITLE
Overflow crash in CDMInstanceSessionFairPlayStreamingAVFObjC::contentKeyForSample when indexing into m_keyStatuses

### DIFF
--- a/Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm
@@ -1790,13 +1790,12 @@ bool CDMInstanceSessionFairPlayStreamingAVFObjC::isLicenseTypeSupported(LicenseT
 AVContentKey *CDMInstanceSessionFairPlayStreamingAVFObjC::contentKeyForSample(const MediaSampleAVFObjC& sample)
 {
     auto& sampleKeyIDs = sample.keyIDs();
-    size_t keyStatusIndex = 0;
 
     for (auto& request : contentKeyRequests()) {
-        for (auto& keyID : CDMPrivateFairPlayStreaming::keyIDsForRequest(request.get())) {
-            if (!isPotentiallyUsableKeyStatus(m_keyStatuses[keyStatusIndex++].second))
-                continue;
+        if (!isPotentiallyUsableKeyStatus(requestStatusToCDMStatus([request status])))
+            continue;
 
+        for (auto& keyID : CDMPrivateFairPlayStreaming::keyIDsForRequest(request.get())) {
             if (!sampleKeyIDs.containsIf([&](auto& sampleKeyID) { return sampleKeyID.get() == keyID.get(); }))
                 continue;
 


### PR DESCRIPTION
#### da81bcac35cf42cbc638da427a84db3b3a795ac3
<pre>
Overflow crash in CDMInstanceSessionFairPlayStreamingAVFObjC::contentKeyForSample when indexing into m_keyStatuses
<a href="https://bugs.webkit.org/show_bug.cgi?id=293312">https://bugs.webkit.org/show_bug.cgi?id=293312</a>
<a href="https://rdar.apple.com/149617172">rdar://149617172</a>

Reviewed by Jer Noble.

CDMInstanceSessionFairPlayStreamingAVFObjC::contentKeyForSample() assumed that m_keyStatuses
represented a flattened array of statuses for each key ID in each request in m_requests. However,
this assumption is only true immediately after updateKeyStatuses() is called. If
contentKeyForSample() is called after a request is added to m_requests but before
updateKeyStatuses() is called, contentKeyForSample() will attempt to access an out-of-bounds index
in m_keyStatuses.

Rather than calling updateKeyStatuses() in contentKeyForSample(), resolved the bug by removing the
need to access m_keyStatuses in contentKeyForSample(). Instead of accessing m_keyStatuses, we can
simply check if each request&apos;s status is potentially usable prior to extracting its key IDs.

* Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm:
(WebCore::CDMInstanceSessionFairPlayStreamingAVFObjC::contentKeyForSample):

Canonical link: <a href="https://commits.webkit.org/295208@main">https://commits.webkit.org/295208@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ccd92526deb63f6b57160216534a43dba82796ef

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104312 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24016 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/14430 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/109513 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/54980 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/106352 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/24388 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/32563 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79215 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107318 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/18952 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94128 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59544 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/18754 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/12196 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/54340 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/88455 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/12254 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/111894 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/31469 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Debug-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88241 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/31833 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/90368 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87904 "Found 101 new API test failures: /WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/invalid-sequence, /WebKitGTK/TestDownloads:/webkit/Downloads/blob-download, /WebKitGTK/TestUIClient:/webkit/WebKitWebView/mouse-target, /TestWebKit:WebKit.UserMediaBasic, /WebKitGTK/TestWebProcessExtensions:/webkit/WebKitWebProcessExtension/dom-input-element-is-user-edited, /WebKitGTK/TestDownloads:/webkit/Downloads/contex-menu-download-actions, /WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/cancel-sequence, /WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/is-playing-audio, /WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/page-visibility, /WebKitGTK/TestOptionMenu:/webkit/WebKitWebView/option-menu-select ... (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22402 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32805 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10560 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/25937 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/31397 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/36713 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/31191 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/34527 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/32751 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->