### PR TITLE
[text-wrap][word-spacing] upstream test to WPT.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/white-space/reference/text-wrap-balance-word-spacing-001-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/white-space/reference/text-wrap-balance-word-spacing-001-ref.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>CSS Text level 4 Test: text-wrap-style should account for word-spacing</title>
+    <link rel="author" title="Yulun Wu">
+    <link rel="help" href="https://www.w3.org/TR/css-text-4/#word-spacing-property">
+    <link rel="help" href="https://www.w3.org/TR/css-text-4/#text-wrap-style">
+    <link rel="stylesheet" type="text/css" href="/fonts/ahem.css"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <style>
+      body {
+        font-family: "Ahem";
+        font-size: 12px;
+        width: 500px;
+      }
+      .spacing-10 {
+        word-spacing: 10px;
+      }
+      .spacing-30 {
+        word-spacing: 30px;
+      }
+      .balance-first-line-spacing-30::first-line {
+        word-spacing: 30px;
+      }
+      .img1 {
+        background-color: green;
+        width: 20px;
+        height: 10px;
+      }
+      .img2 {
+        background-color: green;
+        width: 20px;
+        height: 10px;
+        margin-left: 30px;
+        margin-right: 30px;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="spacing-10">This passes if this div is one line </div>
+    <div class="spacing-30">This passes if this<br> div has the exact<br> correct breaking points</div>
+    <div class="spacing-30">This passes if this div has<br> the exact correct breaking<br> points</div>
+    <div class="balance-first-line-spacing-30">This passes if this div<br> has the exact correct breaking points</div>
+    <div>test<img class="img1">test <img class="img2"> test</div>
+  </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/white-space/text-wrap-balance-word-spacing-001-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/white-space/text-wrap-balance-word-spacing-001-expected.html
@@ -2,8 +2,12 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
+    <title>CSS Text level 4 Test: text-wrap-style should account for word-spacing</title>
+    <link rel="author" title="Yulun Wu">
+    <link rel="help" href="https://www.w3.org/TR/css-text-4/#word-spacing-property">
+    <link rel="help" href="https://www.w3.org/TR/css-text-4/#text-wrap-style">
+    <link rel="stylesheet" type="text/css" href="/fonts/ahem.css"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Document</title>
     <style>
       body {
         font-family: "Ahem";

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/white-space/text-wrap-balance-word-spacing-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/white-space/text-wrap-balance-word-spacing-001.html
@@ -2,8 +2,13 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
+    <title>CSS Text level 4 Test: text-wrap-style should account for word-spacing</title>
+    <link rel="author" title="Yulun Wu">
+    <link rel="help" href="https://www.w3.org/TR/css-text-4/#word-spacing-property">
+    <link rel="help" href="https://www.w3.org/TR/css-text-4/#text-wrap-style">
+    <link rel="match" href="reference/text-wrap-balance-word-spacing-001-ref.html">
+    <link rel="stylesheet" type="text/css" href="/fonts/ahem.css"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Document</title>
     <style>
       body {
         font-family: "Ahem";
@@ -12,17 +17,17 @@
       }
       .spacing-10-balance {
         word-spacing: 10px;
-        text-wrap: balance;
+        text-wrap-style: balance;
       }
       .spacing-30-balance {
         word-spacing: 30px;
-        text-wrap: balance;
+        text-wrap-style: balance;
       }
       .spacing-30 {
         word-spacing: 30px;
       }
       .balance-first-line-spacing-30 {
-        text-wrap: balance;
+        text-wrap-style: balance;
       }
       .balance-first-line-spacing-30::first-line {
         word-spacing: 30px;


### PR DESCRIPTION
#### 58679693e157e59d8b6a42d19d8a31d3542cc2de
<pre>
[text-wrap][word-spacing] upstream test to WPT.
<a href="https://bugs.webkit.org/show_bug.cgi?id=293311">https://bugs.webkit.org/show_bug.cgi?id=293311</a>
&lt;<a href="https://rdar.apple.com/151644293">rdar://151644293</a>&gt;

Reviewed by Tim Nguyen.

This PR upstreams a test verifying that text-wrap correctly handles
explicit word-spacing to become a web platform test.

Combined changes:
* LayoutTests/imported/w3c/web-platform-tests/css/css-text/white-space/reference/text-wrap-balance-word-spacing-001-ref.html: Copied from LayoutTests/fast/css3-text/css3-text-wrap/text-wrap-balance-word-spacing-expected.html.
* LayoutTests/imported/w3c/web-platform-tests/css/css-text/white-space/text-wrap-balance-word-spacing-001-expected.html: Renamed from LayoutTests/fast/css3-text/css3-text-wrap/text-wrap-balance-word-spacing-expected.html.
* LayoutTests/imported/w3c/web-platform-tests/css/css-text/white-space/text-wrap-balance-word-spacing-001.html: Renamed from LayoutTests/fast/css3-text/css3-text-wrap/text-wrap-balance-word-spacing.html.

Canonical link: <a href="https://commits.webkit.org/295272@main">https://commits.webkit.org/295272@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3cb1e449c1ee1680a0efdf8a321af145844945b7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104509 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24219 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/14637 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/109717 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/55180 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/24603 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/32763 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79350 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107515 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19137 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94322 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59676 "Passed tests") | 
| | [💥 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/18916 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/12395 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/54550 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/88620 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/12452 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/112102 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/31670 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23320 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88391 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32034 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/90555 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88058 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22450 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32960 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10733 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/26986 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/31597 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/31389 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/34728 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/32949 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->