### PR TITLE
NEW-TEST(290386@main): [ Debug ] TestWebKitAPI.WKWebsiteDataStore.RemoveDataWaitUntilWebProcessesExit (api-test) is a flaky failure

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebsiteDatastore.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebsiteDatastore.mm
@@ -168,8 +168,7 @@ self.addEventListener('install', (event) => {
 });
 )SWRESOURCE"_s;
 
-// Fixme rdar://145508632 https://bugs.webkit.org/show_bug.cgi?id=288408
-TEST(WKWebsiteDataStore, DISABLED_RemoveDataWaitUntilWebProcessesExit)
+TEST(WKWebsiteDataStore, RemoveDataWaitUntilWebProcessesExit)
 {
     readyToContinue = false;
     [[WKWebsiteDataStore defaultDataStore] removeDataOfTypes:[WKWebsiteDataStore _allWebsiteDataTypesIncludingPrivate] modifiedSince:[NSDate distantPast] completionHandler:^() {
@@ -211,6 +210,10 @@ TEST(WKWebsiteDataStore, DISABLED_RemoveDataWaitUntilWebProcessesExit)
     readyToContinue = false;
     [[configuration websiteDataStore] fetchDataRecordsOfTypes:[WKWebsiteDataStore _allWebsiteDataTypesIncludingPrivate] completionHandler:^(NSArray<WKWebsiteDataRecord *> *dataRecords) {
         EXPECT_EQ(dataRecords.count, 0u);
+        for (WKWebsiteDataRecord* record in dataRecords) {
+            for (NSString *type in record.dataTypes)
+                NSLog(@"Unexpected record with type: [%@]", type);
+        }
         readyToContinue = true;
     }];
     TestWebKitAPI::Util::run(&readyToContinue);


### PR DESCRIPTION
#### 514b03caa6175a9dc7f45f4a92c001b51aa15318
<pre>
NEW-TEST(290386@main): [ Debug ] TestWebKitAPI.WKWebsiteDataStore.RemoveDataWaitUntilWebProcessesExit (api-test) is a flaky failure
<a href="https://rdar.apple.com/145508632">rdar://145508632</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=288408">https://bugs.webkit.org/show_bug.cgi?id=288408</a>

Reviewed by Per Arne Vollan.

The test fails as network process crashes on assertion failure in ConnectionToMachService::sendWithReply. This patch
converts the debug assertion to error log in the case of connection interruption, which can happen when daemon is
temporarily unavailable.

This patch also adds some log to the test so that if it fails later, we will know which data type to look at.

* Source/WebKit/Platform/IPC/cocoa/DaemonConnectionCocoa.mm:
(WebKit::Daemon::ConnectionToMachService&lt;Traits&gt;::initializeConnectionIfNeeded const):
(WebKit::Daemon::ConnectionToMachService&lt;Traits&gt;::sendWithReply const):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebsiteDatastore.mm:
(TestWebKitAPI::(WKWebsiteDataStore, RemoveDataWaitUntilWebProcessesExit)):
(TestWebKitAPI::(WKWebsiteDataStore, DISABLED_RemoveDataWaitUntilWebProcessesExit)): Deleted.

Canonical link: <a href="https://commits.webkit.org/295279@main">https://commits.webkit.org/295279@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9b38cd56311266b5d8922ec4c69a6d245fedca9a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104528 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24238 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/14656 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/109736 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/55199 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/106568 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/24622 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/32782 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79360 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107534 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19153 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94337 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59686 "Passed tests") | 
| | [💥 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/18929 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/12410 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/54569 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/88635 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/12466 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/112122 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/31689 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23335 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88404 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32053 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/90570 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88073 "Found 100 new API test failures: /WebKitGTK/TestInspector:/webkit/WebKitWebInspector/custom-container-destroyed, /TestWebKit:WebKit.GeolocationTransitionToHighAccuracy, /WebKitGTK/TestUIClient:/webkit/WebKitWebView/file-chooser-request, /TestWebKit:WebKit.PreventEmptyUserAgent, /TestWebKit:WebKit.PageLoadTwiceAndReload, /WebKitGTK/TestOptionMenu:/webkit/WebKitWebView/option-menu-groups, /WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/invalid-sequence, /WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/simple, /WebKitGTK/TestUIClient:/webkit/WebKitWebView/display-usermedia-permission-request, /WebKitGTK/TestUIClient:/webkit/WebKitWebView/usermedia-enumeratedevices-permission-check ... (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22458 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32973 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10744 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/27006 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/31616 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/36956 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/31408 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/34747 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/32968 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->