### PR TITLE
[Refactor] AudioSourceProvider should take a AudioBus&

### DIFF
--- a/Source/WebCore/Modules/webaudio/MediaElementAudioSourceNode.h
+++ b/Source/WebCore/Modules/webaudio/MediaElementAudioSourceNode.h
@@ -60,7 +60,7 @@ public:
 
 private:
     MediaElementAudioSourceNode(BaseAudioContext&, Ref<HTMLMediaElement>&&);
-    void provideInput(AudioBus*, size_t framesToProcess);
+    void provideInput(AudioBus&, size_t framesToProcess);
 
     double tailTime() const override { return 0; }
     double latencyTime() const override { return 0; }

--- a/Source/WebCore/Modules/webaudio/MediaStreamAudioSourceNode.h
+++ b/Source/WebCore/Modules/webaudio/MediaStreamAudioSourceNode.h
@@ -56,7 +56,7 @@ private:
     // AudioSourceProviderClient
     void setFormat(size_t numberOfChannels, float sampleRate) final;
 
-    void provideInput(AudioBus*, size_t framesToProcess);
+    void provideInput(AudioBus&, size_t framesToProcess);
 
     double tailTime() const override { return 0; }
     double latencyTime() const override { return 0; }

--- a/Source/WebCore/platform/audio/AudioBus.cpp
+++ b/Source/WebCore/platform/audio/AudioBus.cpp
@@ -45,7 +45,7 @@ constexpr unsigned MaxBusChannels = 32;
 
 RefPtr<AudioBus> AudioBus::create(unsigned numberOfChannels, size_t length, bool allocate)
 {
-    ASSERT(numberOfChannels <= MaxBusChannels);
+    RELEASE_ASSERT(numberOfChannels <= MaxBusChannels);
     if (numberOfChannels > MaxBusChannels)
         return nullptr;
 

--- a/Source/WebCore/platform/audio/AudioDestinationResampler.cpp
+++ b/Source/WebCore/platform/audio/AudioDestinationResampler.cpp
@@ -46,9 +46,9 @@ AudioDestinationResampler::AudioDestinationResampler(const CreationOptions& opti
 {
     if (options.sampleRate != outputSampleRate) {
         double scaleFactor = static_cast<double>(options.sampleRate) / outputSampleRate;
-        m_resampler = makeUnique<MultiChannelResampler>(scaleFactor, options.numberOfOutputChannels, AudioUtilities::renderQuantumSize, [this](AudioBus* bus, size_t framesToProcess) {
+        m_resampler = makeUnique<MultiChannelResampler>(scaleFactor, options.numberOfOutputChannels, AudioUtilities::renderQuantumSize, [this](AudioBus& bus, size_t framesToProcess) {
             ASSERT_UNUSED(framesToProcess, framesToProcess == AudioUtilities::renderQuantumSize);
-            callRenderCallback(nullptr, bus, AudioUtilities::renderQuantumSize, m_outputTimestamp);
+            callRenderCallback(nullptr, &bus, AudioUtilities::renderQuantumSize, m_outputTimestamp);
         });
     }
 }

--- a/Source/WebCore/platform/audio/AudioResampler.cpp
+++ b/Source/WebCore/platform/audio/AudioResampler.cpp
@@ -83,6 +83,9 @@ void AudioResampler::process(AudioSourceProvider* provider, AudioBus* destinatio
         return;
 
     RefPtr sourceBus = m_sourceBus;
+    if (!sourceBus)
+        return;
+
     // Setup the source bus.
     for (unsigned i = 0; i < numberOfChannels; ++i) {
         // Figure out how many frames we need to get from the provider, and a pointer to the buffer.
@@ -96,7 +99,7 @@ void AudioResampler::process(AudioSourceProvider* provider, AudioBus* destinatio
     }
 
     // Ask the provider to supply the desired number of source frames.
-    provider->provideInput(sourceBus.get(), sourceBus->length());
+    provider->provideInput(*sourceBus, sourceBus->length());
 
     // Now that we have the source data, resample each channel into the destination bus.
     // FIXME: optimize for the common stereo case where it's faster to process both left/right channels in the same inner loop.

--- a/Source/WebCore/platform/audio/AudioSourceProvider.h
+++ b/Source/WebCore/platform/audio/AudioSourceProvider.h
@@ -39,7 +39,7 @@ class AudioSourceProviderClient;
 class AudioSourceProvider {
 public:
     // provideInput() gets called repeatedly to render time-slices of a continuous audio stream.
-    virtual void provideInput(AudioBus* bus, size_t framesToProcess) = 0;
+    virtual void provideInput(AudioBus&, size_t framesToProcess) = 0;
 
     // If a client is set, we call it back when the audio format is available or changes.
     virtual void setClient(WeakPtr<AudioSourceProviderClient>&&) { };

--- a/Source/WebCore/platform/audio/MultiChannelResampler.h
+++ b/Source/WebCore/platform/audio/MultiChannelResampler.h
@@ -43,7 +43,7 @@ class MultiChannelResampler final {
     WTF_MAKE_TZONE_ALLOCATED(MultiChannelResampler);
 public:   
     // requestFrames constrols the size of the buffer in frames when provideInput is called.
-    MultiChannelResampler(double scaleFactor, unsigned numberOfChannels, unsigned requestFrames, Function<void(AudioBus*, size_t framesToProcess)>&& provideInput);
+    MultiChannelResampler(double scaleFactor, unsigned numberOfChannels, unsigned requestFrames, Function<void(AudioBus&, size_t framesToProcess)>&& provideInput);
     ~MultiChannelResampler();
 
     void process(AudioBus* destination, size_t framesToProcess);
@@ -60,7 +60,7 @@ private:
     
     unsigned m_numberOfChannels;
     size_t m_outputFramesReady { 0 };
-    Function<void(AudioBus*, size_t framesToProcess)> m_provideInput;
+    Function<void(AudioBus&, size_t framesToProcess)> m_provideInput;
     const RefPtr<AudioBus> m_multiChannelBus;
 };
 

--- a/Source/WebCore/platform/audio/gstreamer/AudioSourceProviderGStreamer.cpp
+++ b/Source/WebCore/platform/audio/gstreamer/AudioSourceProviderGStreamer.cpp
@@ -66,22 +66,22 @@ static void onGStreamerDeinterleavePadRemovedCallback(GstElement*, GstPad* pad, 
     provider->handleRemovedDeinterleavePad(pad);
 }
 
-static void copyGStreamerBuffersToAudioChannel(GstAdapter* adapter, AudioBus* bus , int channelNumber, size_t framesToProcess)
+static void copyGStreamerBuffersToAudioChannel(GstAdapter* adapter, AudioBus& bus , int channelNumber, size_t framesToProcess)
 {
     auto available = gst_adapter_available(adapter);
     if (!available) {
         GST_TRACE("Adapter empty, silencing bus");
-        bus->zero();
+        bus.zero();
         return;
     }
 
     GST_TRACE("%zu samples available for channel %d (%zu frames requested)", available, channelNumber, framesToProcess);
     size_t bytes = framesToProcess * sizeof(float);
     if (available >= bytes) {
-        gst_adapter_copy(adapter, bus->channel(channelNumber)->mutableData(), 0, bytes);
+        gst_adapter_copy(adapter, bus.channel(channelNumber)->mutableData(), 0, bytes);
         gst_adapter_flush(adapter, bytes);
     } else
-        bus->zero();
+        bus.zero();
 }
 
 AudioSourceProviderGStreamer::AudioSourceProviderGStreamer()
@@ -229,7 +229,7 @@ void AudioSourceProviderGStreamer::configureAudioBin(GstElement* audioBin, GstEl
     gst_element_link_pads_full(audioResample2, "src", audioSink, "sink", GST_PAD_LINK_CHECK_NOTHING);
 }
 
-void AudioSourceProviderGStreamer::provideInput(AudioBus* bus, size_t framesToProcess)
+void AudioSourceProviderGStreamer::provideInput(AudioBus& bus, size_t framesToProcess)
 {
     GST_TRACE("Fetching buffers from adapters");
     if (!m_adapterLock.tryLock())

--- a/Source/WebCore/platform/audio/gstreamer/AudioSourceProviderGStreamer.h
+++ b/Source/WebCore/platform/audio/gstreamer/AudioSourceProviderGStreamer.h
@@ -57,7 +57,7 @@ public:
 
     void configureAudioBin(GstElement* audioBin, GstElement* audioSink);
 
-    void provideInput(AudioBus*, size_t framesToProcess) override;
+    void provideInput(AudioBus&, size_t framesToProcess) override;
     void setClient(WeakPtr<AudioSourceProviderClient>&&) override;
     const AudioSourceProviderClient* client() const { return m_client.get(); }
 

--- a/Source/WebCore/platform/graphics/avfoundation/AudioSourceProviderAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/AudioSourceProviderAVFObjC.h
@@ -76,7 +76,7 @@ private:
     void createMixIfNeeded();
 
     // AudioSourceProvider
-    void provideInput(AudioBus*, size_t framesToProcess) override;
+    void provideInput(AudioBus&, size_t framesToProcess) override;
     void setClient(WeakPtr<AudioSourceProviderClient>&&) override;
     bool isHandlingAVPlayer() const final { return true; }
 

--- a/Source/WebCore/platform/mediastream/mac/WebAudioSourceProviderCocoa.h
+++ b/Source/WebCore/platform/mediastream/mac/WebAudioSourceProviderCocoa.h
@@ -70,7 +70,7 @@ private:
 #endif
 
     // AudioSourceProvider
-    void provideInput(AudioBus*, size_t) final;
+    void provideInput(AudioBus&, size_t) final;
     void setClient(WeakPtr<AudioSourceProviderClient>&&) final;
 
     void prepare(const AudioStreamBasicDescription&);

--- a/Source/WebCore/platform/mediastream/mac/WebAudioSourceProviderCocoa.mm
+++ b/Source/WebCore/platform/mediastream/mac/WebAudioSourceProviderCocoa.mm
@@ -62,30 +62,30 @@ void WebAudioSourceProviderCocoa::setClient(WeakPtr<AudioSourceProviderClient>&&
     hasNewClient(m_client.get());
 }
 
-void WebAudioSourceProviderCocoa::provideInput(AudioBus* bus, size_t framesToProcess)
+void WebAudioSourceProviderCocoa::provideInput(AudioBus& bus, size_t framesToProcess)
 {
     if (!m_lock.tryLock()) {
-        bus->zero();
+        bus.zero();
         return;
     }
     Locker locker { AdoptLock, m_lock };
     if (!m_dataSource || !m_audioBufferList) {
-        bus->zero();
+        bus.zero();
         return;
     }
 
     if (m_writeCount <= m_readCount) {
-        bus->zero();
+        bus.zero();
         return;
     }
 
-    if (bus->numberOfChannels() < m_audioBufferList->bufferCount()) {
-        bus->zero();
+    if (bus.numberOfChannels() < m_audioBufferList->bufferCount()) {
+        bus.zero();
         return;
     }
 
-    for (unsigned i = 0; i < bus->numberOfChannels(); ++i) {
-        auto& channel = *bus->channel(i);
+    for (unsigned i = 0; i < bus.numberOfChannels(); ++i) {
+        auto& channel = *bus.channel(i);
         if (i >= m_audioBufferList->bufferCount()) {
             channel.zero();
             continue;
@@ -96,7 +96,7 @@ void WebAudioSourceProviderCocoa::provideInput(AudioBus* bus, size_t framesToPro
         buffer->mDataByteSize = channel.length() * sizeof(float);
     }
 
-    ASSERT(framesToProcess <= bus->length());
+    ASSERT(framesToProcess <= bus.length());
     m_dataSource->pullSamples(*m_audioBufferList->list(), framesToProcess, m_readCount, 0, AudioSampleDataSource::Copy);
     m_readCount += framesToProcess;
 }


### PR DESCRIPTION
#### 994737b91096860fd0be093458e1cbcf644a3123
<pre>
[Refactor] AudioSourceProvider should take a AudioBus&amp;
<a href="https://bugs.webkit.org/show_bug.cgi?id=293299">https://bugs.webkit.org/show_bug.cgi?id=293299</a>
<a href="https://rdar.apple.com/problem/151704088">rdar://problem/151704088</a>

Reviewed by Jean-Yves Avenard.

* Source/WebCore/Modules/webaudio/MediaElementAudioSourceNode.cpp:
(WebCore::MediaElementAudioSourceNode::provideInput):
(WebCore::MediaElementAudioSourceNode::process):
* Source/WebCore/Modules/webaudio/MediaElementAudioSourceNode.h:
* Source/WebCore/Modules/webaudio/MediaStreamAudioSourceNode.cpp:
(WebCore::MediaStreamAudioSourceNode::provideInput):
(WebCore::MediaStreamAudioSourceNode::process):
* Source/WebCore/Modules/webaudio/MediaStreamAudioSourceNode.h:
* Source/WebCore/platform/audio/AudioBus.cpp:
(WebCore::AudioBus::create):
* Source/WebCore/platform/audio/AudioDestinationResampler.cpp:
(WebCore::AudioDestinationResampler::AudioDestinationResampler):
* Source/WebCore/platform/audio/AudioResampler.cpp:
(WebCore::AudioResampler::process):
* Source/WebCore/platform/audio/AudioSourceProvider.h:
* Source/WebCore/platform/audio/MultiChannelResampler.cpp:
(WebCore::MultiChannelResampler::MultiChannelResampler):
(WebCore::MultiChannelResampler::provideInputForChannel):
* Source/WebCore/platform/audio/MultiChannelResampler.h:
* Source/WebCore/platform/graphics/avfoundation/AudioSourceProviderAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/AudioSourceProviderAVFObjC.mm:
(WebCore::AudioSourceProviderAVFObjC::provideInput):
* Source/WebCore/platform/mediastream/mac/WebAudioSourceProviderCocoa.h:
* Source/WebCore/platform/mediastream/mac/WebAudioSourceProviderCocoa.mm:
(WebCore::WebAudioSourceProviderCocoa::provideInput):

Canonical link: <a href="https://commits.webkit.org/295223@main">https://commits.webkit.org/295223@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5c46ac0341e123f1da561c4e674b84d358d93fe3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104455 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24164 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/14582 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/109662 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/55126 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/106495 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/24546 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/32709 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79317 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107461 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19089 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94269 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59643 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/18881 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/12341 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/54492 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/88581 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/12399 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/112047 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/31616 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/23290 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88356 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/31980 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/90502 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88022 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22416 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32915 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10684 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/26091 "Hash 5c46ac03 for PR 45667 does not build (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/31543 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/36875 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/31335 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/34674 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/32895 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->