### PR TITLE
Accessing properties of HTMLFormControlElement is slow before accessing "elements" property

### DIFF
--- a/Source/WebCore/html/HTMLFormElement.h
+++ b/Source/WebCore/html/HTMLFormElement.h
@@ -179,6 +179,7 @@ private:
     WeakHashSet<HTMLElement, WeakPtrImplWithEventTargetData> m_invalidFormControls;
     WeakPtr<FormSubmission> m_plannedFormSubmission;
     std::unique_ptr<DOMTokenList> m_relList;
+    RefPtr<HTMLFormControlsCollection> m_controlsCollection;
 
     unsigned m_listedElementsBeforeIndex { 0 };
     unsigned m_listedElementsAfterIndex { 0 };


### PR DESCRIPTION
#### 143eb3cdb9d7c172ddbb3146617ec15aa8507ce9
<pre>
Accessing properties of HTMLFormControlElement is slow before accessing &quot;elements&quot; property
<a href="https://bugs.webkit.org/show_bug.cgi?id=293335">https://bugs.webkit.org/show_bug.cgi?id=293335</a>

Reviewed by Chris Dumez.

The bug was caused by HTMLFormControlsCollection getting repeatedly constructed to do the named
item lookup for every property access. Cache the collection in HTMLFormElement so that we don&apos;t
re-create HTMLFormControlsCollection repeatedly in this case.

No new tests since while this could be tested using a performance test, it doesn&apos;t seem like
worth the cost of introducing a new performance test for this.

* Source/WebCore/html/HTMLFormElement.cpp:
(WebCore::HTMLFormElement::removedFromAncestor): Clear the cache when this element is getting
disconnected from a document to break the retain cycle between a back Ref to this element in
the collection and this cache.
(WebCore::HTMLFormElement::elements): Cache the collection if this element is connected. If we
always cache (regardless of connectedness), we can end up leaking this collection &amp; element as
the collection has a back Ref to this element.
* Source/WebCore/html/HTMLFormElement.h:

Canonical link: <a href="https://commits.webkit.org/295315@main">https://commits.webkit.org/295315@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5a3e486426aa7b0f08056d3c26d0bd1f5f6cb48d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104660 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24372 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/14793 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/109874 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/55334 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/106700 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/24763 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/32918 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79483 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107666 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19268 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94457 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59812 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/19036 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/12531 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/54707 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/88735 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/12584 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/112283 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/31825 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23423 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88573 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32189 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/90685 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88188 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33080 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10850 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/27138 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16993 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/31750 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/37100 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/31542 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/34883 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33101 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->