### PR TITLE
[JSC] MovHintRemoval should track exit liveness

### DIFF
--- a/Source/JavaScriptCore/dfg/DFGOSRAvailabilityAnalysisPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOSRAvailabilityAnalysisPhase.cpp
@@ -72,16 +72,6 @@ public:
             dataLogLn("Tail: ", availabilityAtTail(block));
         };
 
-        auto dumpBytecodeLivenessAtHead = [&] (BasicBlock* block) {
-            dataLog("Live: ");
-            m_graph.forAllLiveInBytecode(
-                block->at(0)->origin.forExit,
-                [&] (Operand operand) {
-                    dataLog(operand, " ");
-                });
-            dataLogLn("");
-        };
-
         LocalOSRAvailabilityCalculator calculator(m_graph);
         bool changed;
         do {
@@ -113,17 +103,6 @@ public:
                     BasicBlock* successor = block->successor(successorIndex);
                     availabilityAtHead(successor).merge(calculator.m_availability);
                 }
-
-                for (unsigned successorIndex = block->numSuccessors(); successorIndex--;) {
-                    BasicBlock* successor = block->successor(successorIndex);
-                    availabilityAtHead(successor).pruneByLiveness(
-                        m_graph, successor->at(0)->origin.forExit);
-                    if (verbose) {
-                        dataLogLn("After pruning Block #", successor->index);
-                        dumpAvailability(successor);
-                        dumpBytecodeLivenessAtHead(successor);
-                    }
-                }
             }
         } while (changed);
 
@@ -134,7 +113,7 @@ public:
                 
                 for (unsigned nodeIndex = 0; nodeIndex < block->size(); ++nodeIndex) {
                     Node* node = block->at(nodeIndex);
-                    if (node->origin.exitOK) {
+                    if (mayExit(m_graph, node) != DoesNotExit) {
                         // If we're allowed to exit here, the heap must be in a state
                         // where exiting wouldn't crash. These particular fields are
                         // required for correctness because we use them during OSR exit


### PR DESCRIPTION
#### bea18247d1b998afb5b46c68fb9f5c5e7fdfb352
<pre>
[JSC] MovHintRemoval should track exit liveness
<a href="https://bugs.webkit.org/show_bug.cgi?id=293337">https://bugs.webkit.org/show_bug.cgi?id=293337</a>
<a href="https://rdar.apple.com/151740794">rdar://151740794</a>

Reviewed by Yijia Huang and Justin Michaud.

The current MovHintRemoval&apos;s analysis looks weird. We should just do liveness
analysis globally and use this information for MovHint removal.

1. &quot;Use&quot; is a node which may exit. When exit happens, we should keep all
   use of live locals at this bytecode exit location alive.
2. &quot;Def&quot; is MovHint. We kill the locals here.

And doing fixpoint analysis and using this information to remove
MovHint.

Also, pruning Availability in OSRAvailabilityAnalysisPhase via bytecode
liveness is wrong: they need to keep live nodes from DFG for example.

    0: PutHint @x, PROP(@y)
    1: OSR exit point #1 (here, loc0 is not alive)

    2: -- Pruning happens --

    3: MovHint @x, loc0
    4: OSR exit point #2 (here, loc0 is alive)

In this case pruning point will remove (0)&apos;s heap availability since @x is
not alive from bytecode at (1), but this is wrong as we need this in (4).
In this patch, we remove pruneByLiveness in DFGOSRAvailabilityAnalysisPhase.
This pruning should happen by the user of DFGOSRAvailabilityAnalysisPhase instead,
and it is already happening (see FTLLowerToB3&apos;s pruneByLiveness in exit
site, which is right. And ObjectAllocationSinking is pruning with
CombinedLiveness, this is right since it also accounts Node&apos;s liveness
in addition to bytecode&apos;s liveness.). Let&apos;s just make availability just
compute the availability for all things, and then we prune some of
unnecessary ones at each use of this information.

* Source/JavaScriptCore/dfg/DFGMovHintRemovalPhase.cpp:
* Source/JavaScriptCore/dfg/DFGOSRAvailabilityAnalysisPhase.cpp:
(JSC::DFG::OSRAvailabilityAnalysisPhase::run):

Canonical link: <a href="https://commits.webkit.org/295369@main">https://commits.webkit.org/295369@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/28d150de0297d21297fe8250803ac326d8c26f6f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104853 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24566 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/14987 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110068 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/55527 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/24966 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33111 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79615 "Found 1 new test failure: imported/w3c/web-platform-tests/html/semantics/forms/constraints/infinite_backtracking.html (failure)") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107859 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19415 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94628 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59922 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/19162 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/12705 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/54910 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/97534 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/88861 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/12752 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/112514 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/103471 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32018 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23537 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88696 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32382 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/90854 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88324 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33217 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10982 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/27332 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17017 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/31943 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/37298 "Built successfully") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/127750 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/31735 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/127750 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35076 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33294 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->