### PR TITLE
[WPE] Add wp_presentation_feedback handling and forward data into sysprof

### DIFF
--- a/Source/WebKit/WPEPlatform/wpe/wayland/CMakeLists.txt
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/CMakeLists.txt
@@ -19,10 +19,16 @@ set(WPEPlatformWayland_SOURCES
     ${WPEPlatform_DERIVED_SOURCES_DIR}/wpe/wayland/linux-explicit-synchronization-unstable-v1-protocol.c
     ${WPEPlatform_DERIVED_SOURCES_DIR}/wpe/wayland/text-input-unstable-v1-protocol.c
     ${WPEPlatform_DERIVED_SOURCES_DIR}/wpe/wayland/text-input-unstable-v3-protocol.c
-    ${WPEPlatform_DERIVED_SOURCES_DIR}/wpe/wayland/xdg-shell-protocol.c
     ${WPEPlatform_DERIVED_SOURCES_DIR}/wpe/wayland/pointer-constraints-unstable-v1-protocol.c
     ${WPEPlatform_DERIVED_SOURCES_DIR}/wpe/wayland/relative-pointer-unstable-v1-protocol.c
+    ${WPEPlatform_DERIVED_SOURCES_DIR}/wpe/wayland/xdg-shell-protocol.c
 )
+
+if (USE_SYSPROF_CAPTURE)
+    list(APPEND WPEPlatformWayland_SOURCES
+        ${WPEPlatform_DERIVED_SOURCES_DIR}/wpe/wayland/presentation-time-protocol.c
+    )
+endif ()
 
 set(WPEPlatformWayland_INSTALLED_HEADERS
     ${WEBKIT_DIR}/WPEPlatform/wpe/wayland/wpe-wayland.h
@@ -128,6 +134,21 @@ add_custom_command(
     MAIN_DEPENDENCY ${WAYLAND_PROTOCOLS_DATADIR}/unstable/pointer-constraints/pointer-constraints-unstable-v1.xml
     COMMAND ${WAYLAND_SCANNER} client-header ${WAYLAND_PROTOCOLS_DATADIR}/unstable/pointer-constraints/pointer-constraints-unstable-v1.xml ${WPEPlatform_DERIVED_SOURCES_DIR}/wpe/wayland/pointer-constraints-unstable-v1-client-protocol.h
     VERBATIM)
+
+if (USE_SYSPROF_CAPTURE)
+    add_custom_command(
+        OUTPUT ${WPEPlatform_DERIVED_SOURCES_DIR}/wpe/wayland/presentation-time-protocol.c
+        MAIN_DEPENDENCY ${WAYLAND_PROTOCOLS_DATADIR}/stable/presentation-time/presentation-time.xml
+        DEPENDS ${WPEPlatform_DERIVED_SOURCES_DIR}/wpe/wayland/presentation-time-client-protocol.h
+        COMMAND ${WAYLAND_SCANNER} private-code ${WAYLAND_PROTOCOLS_DATADIR}/stable/presentation-time/presentation-time.xml ${WPEPlatform_DERIVED_SOURCES_DIR}/wpe/wayland/presentation-time-protocol.c
+        VERBATIM)
+
+    add_custom_command(
+        OUTPUT ${WPEPlatform_DERIVED_SOURCES_DIR}/wpe/wayland/presentation-time-client-protocol.h
+        MAIN_DEPENDENCY ${WAYLAND_PROTOCOLS_DATADIR}/stable/presentation-time/presentation-time.xml
+        COMMAND ${WAYLAND_SCANNER} client-header ${WAYLAND_PROTOCOLS_DATADIR}/stable/presentation-time/presentation-time.xml ${WPEPlatform_DERIVED_SOURCES_DIR}/wpe/wayland/presentation-time-client-protocol.h
+        VERBATIM)
+endif ()
 
 add_custom_command(
     OUTPUT ${WPEPlatform_DERIVED_SOURCES_DIR}/wpe/wayland/relative-pointer-unstable-v1-protocol.c

--- a/Source/WebKit/WPEPlatform/wpe/wayland/WPEDisplayWaylandPrivate.h
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/WPEDisplayWaylandPrivate.h
@@ -41,3 +41,4 @@ struct zwp_text_input_v1* wpeDisplayWaylandGetTextInputV1(WPEDisplayWayland*);
 struct zwp_text_input_v3* wpeDisplayWaylandGetTextInputV3(WPEDisplayWayland*);
 struct zwp_pointer_constraints_v1* wpeDisplayWaylandGetPointerConstraints(WPEDisplayWayland*);
 struct zwp_relative_pointer_manager_v1* wpeDisplayWaylandGetRelativePointerManager(WPEDisplayWayland*);
+struct wp_presentation* wpeDisplayWaylandGetPresentation(WPEDisplayWayland*);


### PR DESCRIPTION
#### 31a6f52402f8ffbb840b3d1d1d81dc0194c69923
<pre>
[WPE] Add wp_presentation_feedback handling and forward data into sysprof
<a href="https://bugs.webkit.org/show_bug.cgi?id=293343">https://bugs.webkit.org/show_bug.cgi?id=293343</a>

Reviewed by Carlos Garcia Campos.

Implement Wayland wp_presentation_feedback protocol handling and
intercept sync_output / presented / discarded events. Those events can
be used to verify how long it took from frame generation to presentation
on screen, and get post-display statistics on latency / frame drops etc.

We only collect those information when sysprof tracing is active to
avoid any overhead if we don&apos;t need it.

* Source/WebKit/WPEPlatform/wpe/wayland/CMakeLists.txt:
* Source/WebKit/WPEPlatform/wpe/wayland/WPEDisplayWayland.cpp:
(wpeDisplayWaylandConstructed):
(wpeDisplayWaylandDispose):
(wpeDisplayWaylandGetPresentation):
(wpe_display_wayland_class_init):
* Source/WebKit/WPEPlatform/wpe/wayland/WPEDisplayWaylandPrivate.h:
* Source/WebKit/WPEPlatform/wpe/wayland/WPEViewWayland.cpp:
(wpeViewWaylandDispose):
(PresentationFeedbackStatistics::~PresentationFeedbackStatistics):
(PresentationFeedbackStatistics::beginFrame):
(PresentationFeedbackStatistics::presentedFrame):
(PresentationFeedbackStatistics::discardedFrame):
(PresentationFeedbackStatistics::calculateAverageLatency const):
(wpeViewWaylandRenderBuffer): Deleted.

Canonical link: <a href="https://commits.webkit.org/297679@main">https://commits.webkit.org/297679@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/edaf177a3cb53f48d930c268d6c48f9e46541dd3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/112537 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/32269 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/22747 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/118735 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/62991 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/32921 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/40832 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/85650 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/36273 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/115484 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26276 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101249 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65952 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/25575 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/62495 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/95667 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/19455 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/121957 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/39611 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/29506 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/94517 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/39993 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97481 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94257 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24059 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39374 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17179 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/35699 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/39499 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/44987 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39136 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/42471 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/40877 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->