### PR TITLE
Remove unused parameter to RemoteLegacyCDMProxy.CreateSession

### DIFF
--- a/Source/WebKit/GPUProcess/media/RemoteLegacyCDMProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteLegacyCDMProxy.cpp
@@ -59,7 +59,7 @@ void RemoteLegacyCDMProxy::supportsMIMEType(const String& mimeType, SupportsMIME
     callback(protectedCDM()->supportsMIMEType(mimeType));
 }
 
-void RemoteLegacyCDMProxy::createSession(const String& keySystem, uint64_t logIdentifier, CreateSessionCallback&& callback)
+void RemoteLegacyCDMProxy::createSession(uint64_t logIdentifier, CreateSessionCallback&& callback)
 {
     RefPtr factory = m_factory.get();
     if (!factory) {

--- a/Source/WebKit/GPUProcess/media/RemoteLegacyCDMProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteLegacyCDMProxy.h
@@ -65,7 +65,7 @@ private:
     using SupportsMIMETypeCallback = CompletionHandler<void(bool)>;
     void supportsMIMEType(const String&, SupportsMIMETypeCallback&&);
     using CreateSessionCallback = CompletionHandler<void(std::optional<RemoteLegacyCDMSessionIdentifier>&&)>;
-    void createSession(const String&, uint64_t, CreateSessionCallback&&);
+    void createSession(uint64_t, CreateSessionCallback&&);
     void setPlayerId(std::optional<WebCore::MediaPlayerIdentifier> playerId) { m_playerId = playerId; }
 
     // LegacyCDMClient

--- a/Source/WebKit/GPUProcess/media/RemoteLegacyCDMProxy.messages.in
+++ b/Source/WebKit/GPUProcess/media/RemoteLegacyCDMProxy.messages.in
@@ -30,7 +30,7 @@
 ]
 messages -> RemoteLegacyCDMProxy {
     SupportsMIMEType(String mimeType) -> (bool supports) Synchronous
-    CreateSession(String mediaKeysStorageDirectory, uint64_t logIdentifier) -> (std::optional<WebKit::RemoteLegacyCDMSessionIdentifier> identifier) Synchronous
+    CreateSession(uint64_t logIdentifier) -> (std::optional<WebKit::RemoteLegacyCDMSessionIdentifier> identifier) Synchronous
     SetPlayerId(std::optional<WebCore::MediaPlayerIdentifier> playerId)
 }
 

--- a/Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDM.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDM.cpp
@@ -62,15 +62,13 @@ bool RemoteLegacyCDM::supportsMIMEType(const String& mimeType) const
 
 RefPtr<WebCore::LegacyCDMSession> RemoteLegacyCDM::createSession(WebCore::LegacyCDMSessionClient& client)
 {
-    String storageDirectory = client.mediaKeysStorageDirectory();
-
     uint64_t logIdentifier { 0 };
 #if !RELEASE_LOG_DISABLED
     logIdentifier = reinterpret_cast<uint64_t>(client.logIdentifier());
 #endif
 
     Ref factory = m_factory.get();
-    auto sendResult = factory->gpuProcessConnection().protectedConnection()->sendSync(Messages::RemoteLegacyCDMProxy::CreateSession(storageDirectory, logIdentifier), m_identifier);
+    auto sendResult = factory->gpuProcessConnection().protectedConnection()->sendSync(Messages::RemoteLegacyCDMProxy::CreateSession(logIdentifier), m_identifier);
     auto [identifier] = sendResult.takeReplyOr(std::nullopt);
     if (!identifier)
         return nullptr;


### PR DESCRIPTION
#### f3d3e234a2482c5787bfb190362ff7c5697c7e8b
<pre>
Remove unused parameter to RemoteLegacyCDMProxy.CreateSession
<a href="https://bugs.webkit.org/show_bug.cgi?id=293347">https://bugs.webkit.org/show_bug.cgi?id=293347</a>

Reviewed by Sihui Liu.

* Source/WebKit/GPUProcess/media/RemoteLegacyCDMProxy.cpp:
(WebKit::RemoteLegacyCDMProxy::createSession):
* Source/WebKit/GPUProcess/media/RemoteLegacyCDMProxy.h:
* Source/WebKit/GPUProcess/media/RemoteLegacyCDMProxy.messages.in:
* Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDM.cpp:
(WebKit::RemoteLegacyCDM::createSession):

Canonical link: <a href="https://commits.webkit.org/295280@main">https://commits.webkit.org/295280@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e2217d032f91dbb3f31c844366d2fe08502d1ec2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104406 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24110 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/14526 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/109608 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/55074 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/24489 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/32657 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79273 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107412 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19040 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94222 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59603 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/18846 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/54436 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/88530 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/12349 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/111992 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/31563 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23251 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88312 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/31927 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/90466 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87979 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22457 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32875 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10641 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/26031 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/31491 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/36816 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/31285 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/34621 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/32845 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->