### PR TITLE
Expose a default system speaker device

### DIFF
--- a/LayoutTests/fast/mediastream/enumerate-speaker.html
+++ b/LayoutTests/fast/mediastream/enumerate-speaker.html
@@ -35,6 +35,22 @@
         if (!window.internals)
             return;
 
+        let firstSpeaker;
+        let secondSpeaker;
+        for (let device of devices) {
+            if (device.kind === "audiooutput") {
+                if (!firstSpeaker)
+                    firstSpeaker = device;
+                else if (!secondSpeaker)
+                    secondSpeaker = device;
+                else
+                    break;
+            }
+        }
+        assert_equals(firstSpeaker.deviceId, "default", "default speaker deviceId");
+        assert_equals(firstSpeaker.groupId, secondSpeaker.groupId, "default speaker groupId");
+        assert_true(firstSpeaker.label.startsWith("Default - "), "default speaker label");
+
         const mic1 = deviceFromLabel(devices, "Mock audio device 1");
         const mic2 = deviceFromLabel(devices, "Mock audio device 2");
         const speaker1 = deviceFromLabel(devices, "Mock speaker device 1");

--- a/LayoutTests/http/tests/media/media-stream/enumerate-devices-source-id.html
+++ b/LayoutTests/http/tests/media/media-stream/enumerate-devices-source-id.html
@@ -35,8 +35,8 @@
                 if (originInfo[device.deviceId] != device.kind)
                     testFailed(`: duplicate device IDs for ${device.kind} and ${originInfo[device.deviceId]} in ${origin}/${self.origin}`);
 
-                if (Object.keys(originInfo).length > 8)
-                    testFailed(`: more than seven unique device IDs in ${origin}/${self.origin}`);
+                if (Object.keys(originInfo).length > 9)
+                    testFailed(`: more than eight unique device IDs in ${origin}/${self.origin}`);
             }
 
             let eventCount = 0;

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -2724,6 +2724,19 @@ ExposeCaptureDevicesAfterCaptureEnabled:
     WebCore:
       default: false
 
+ExposeDefaultSpeakerAsSpecificDeviceEnabled:
+  type: bool
+  status: internal
+  category: media
+  humanReadableName: "Expose the system default speaker as a specific device"
+  humanReadableDescription: "Expose the system default speaker as a specific device"
+  condition: ENABLE(MEDIA_STREAM)
+  defaultValue:
+    WebKit:
+      default: true
+    WebCore:
+      default: true
+
 ExposeSpeakersEnabled:
   type: bool
   status: internal

--- a/Source/WebCore/Modules/mediastream/MediaDevices.h
+++ b/Source/WebCore/Modules/mediastream/MediaDevices.h
@@ -94,7 +94,7 @@ public:
     void enumerateDevices(EnumerateDevicesPromise&&);
     MediaTrackSupportedConstraints getSupportedConstraints();
 
-    String deviceIdToPersistentId(const String& deviceId) const { return m_audioOutputDeviceIdToPersistentId.get(deviceId); }
+    String deviceIdToPersistentId(const String&) const;
 
     void willStartMediaCapture(bool microphone, bool camera);
 

--- a/Source/WebCore/platform/LocalizedStrings.cpp
+++ b/Source/WebCore/platform/LocalizedStrings.cpp
@@ -617,6 +617,13 @@ String searchMenuClearRecentSearchesText()
 
 #endif // !PLATFORM(IOS_FAMILY)
 
+#if ENABLE(MEDIA_STREAM)
+String defaultSystemSpeakerLabel()
+{
+    return WEB_UI_STRING("Default", "label for the default system speaker");
+}
+#endif
+
 String AXWebAreaText()
 {
     return WEB_UI_STRING("HTML content", "accessibility role description for web area");

--- a/Source/WebCore/platform/LocalizedStrings.h
+++ b/Source/WebCore/platform/LocalizedStrings.h
@@ -208,6 +208,10 @@ namespace WebCore {
     String searchMenuClearRecentSearchesText();
 #endif
 
+#if ENABLE(MEDIA_STREAM)
+    String defaultSystemSpeakerLabel();
+#endif
+
     String AXWebAreaText();
     String AXLinkText();
     String AXListMarkerText();


### PR DESCRIPTION
#### 9e0323c7869de9670c8edafaea6e35f5b3e91136
<pre>
Expose a default system speaker device
<a href="https://rdar.apple.com/151761469">rdar://151761469</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=293349">https://bugs.webkit.org/show_bug.cgi?id=293349</a>

Reviewed by Eric Carlson.

As can be seen in websites like Webex, providing an explicit system default speaker device is useful to users.
That way, users can explicitly select to follow the system default speaker.
We use &quot;default&quot; as the deviceId and concatenate &quot;Default - &quot; with the actual default speaker name.
This heuristic is the same as Chrome&apos;s approach.

Manually tested on Webex and covered by updated layout test.

* LayoutTests/fast/mediastream/enumerate-speaker.html:
* LayoutTests/http/tests/media/media-stream/enumerate-devices-source-id.html:
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/Modules/mediastream/MediaDevices.cpp:
(WebCore::MediaDevices::deviceIdToPersistentId const):
(WebCore::createDefaultSpeakerAsSpecificDevice):
(WebCore::MediaDevices::exposeDevices):
* Source/WebCore/Modules/mediastream/MediaDevices.h:
* Source/WebCore/platform/LocalizedStrings.cpp:
(WebCore::defaultSystemSpeakerLabel):
* Source/WebCore/platform/LocalizedStrings.h:

Canonical link: <a href="https://commits.webkit.org/295206@main">https://commits.webkit.org/295206@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1e153c723894ec66e40c86eb8a532187a1ac085f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104429 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24133 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/14549 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/109632 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/55097 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/106469 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/24516 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/32680 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/79296 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107435 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19067 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94247 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59626 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/18867 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/12322 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/54459 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/97114 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/88552 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/12390 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/112015 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/103040 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/31586 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/23273 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88334 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/31950 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/90490 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88003 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22400 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32899 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/10674 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/26061 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/31514 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/36853 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/127303 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/31308 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/127303 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/34644 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/32868 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->