### PR TITLE
[WPE] WPE Platform: mouse event button should be uninitialized for motion events

### DIFF
--- a/Source/WebKit/Shared/wpe/WebEventFactoryWPE.cpp
+++ b/Source/WebKit/Shared/wpe/WebEventFactoryWPE.cpp
@@ -74,17 +74,6 @@ static WebMouseEventButton buttonForWPEButton(guint button)
     return WebMouseEventButton::None;
 }
 
-static WebMouseEventButton buttonFromWPEModifiers(WPEModifiers modifiers)
-{
-    if (modifiers & WPE_MODIFIER_POINTER_BUTTON1)
-        return WebMouseEventButton::Left;
-    if (modifiers & WPE_MODIFIER_POINTER_BUTTON2)
-        return WebMouseEventButton::Middle;
-    if (modifiers & WPE_MODIFIER_POINTER_BUTTON3)
-        return WebMouseEventButton::Right;
-    return WebMouseEventButton::None;
-}
-
 static FloatPoint movementDeltaFromEvent(WPEEvent* event)
 {
     double x, y;
@@ -148,7 +137,6 @@ WebMouseEvent WebEventFactory::createWebMouseEvent(WPEEvent* event)
     case WPE_EVENT_POINTER_ENTER:
     case WPE_EVENT_POINTER_LEAVE:
         type = WebEventType::MouseMove;
-        button = buttonFromWPEModifiers(modifiers);
         movementDelta = movementDeltaFromEvent(event);
         break;
     default:


### PR DESCRIPTION
#### 7a1e26764e9f2006bccad59260b29a390e4a5f97
<pre>
[WPE] WPE Platform: mouse event button should be uninitialized for motion events
<a href="https://bugs.webkit.org/show_bug.cgi?id=293351">https://bugs.webkit.org/show_bug.cgi?id=293351</a>

Reviewed by Alejandro G. Castro.

Canonical link: <a href="https://commits.webkit.org/295201@main">https://commits.webkit.org/295201@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d8e0ad12caa2b0dd7883f861df66d5a98f997e49

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104415 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24119 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/14535 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/109618 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/55083 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/24500 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/32666 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/79282 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107421 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/19050 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/94231 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59612 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/18852 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/54445 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/88537 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/12358 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/112001 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/31572 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/23255 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/88320 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/31936 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/90475 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/87988 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32884 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10650 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/26042 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16946 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/31500 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/36825 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/31294 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/34630 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/32854 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->