### PR TITLE
[WPE] Extract common logic from EventSenderProxyClientWPE touch event handling

### DIFF
--- a/Tools/WebKitTestRunner/wpe/EventSenderProxyClientWPE.h
+++ b/Tools/WebKitTestRunner/wpe/EventSenderProxyClientWPE.h
@@ -67,6 +67,10 @@ private:
         int y { 0 };
     };
 
+    struct TouchPointContext;
+
+    std::function<bool(TouchPoint&)> pointProcessor(const TouchPointContext&);
+
     Vector<TouchPoint> m_touchPoints;
     unsigned m_touchModifiers { 0 };
 #endif // ENABLE(TOUCH_EVENTS)


### PR DESCRIPTION
#### c826c720a335b5bb60a01b4d1adbc0bf472d4b34
<pre>
[WPE] Extract common logic from EventSenderProxyClientWPE touch event handling
<a href="https://bugs.webkit.org/show_bug.cgi?id=293352">https://bugs.webkit.org/show_bug.cgi?id=293352</a>

Reviewed by Adrian Perez de Castro.

Extract the common logic from touchStart, touchMove, touchEnd and
touchCancel into a lambda-generating function. As these 4 methods
transverse the m_touchPoints, they can all invoke the lambda on each
point: two in a range-based for loop, two in removeAllMatching.

The return value in the lambda is ignored in the range-based case, and
used by removeAllMatching in the other, and a context structure is used
to keep all arguments together.

* Tools/WebKitTestRunner/wpe/EventSenderProxyClientWPE.cpp:
(WTR::std::function&lt;bool):
(WTR::EventSenderProxyClientWPE::touchStart):
(WTR::EventSenderProxyClientWPE::touchMove):
(WTR::EventSenderProxyClientWPE::touchEnd):
(WTR::EventSenderProxyClientWPE::touchCancel):
* Tools/WebKitTestRunner/wpe/EventSenderProxyClientWPE.h:

Canonical link: <a href="https://commits.webkit.org/298280@main">https://commits.webkit.org/298280@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/67f5eba6d3049bedf9cac1f715b5ea9e4e1c3a76

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/114992 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/34708 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/25189 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121112 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/65643 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/116881 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/35353 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/43269 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87378 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42200 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/117940 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28170 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103238 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/67774 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27342 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/21357 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/64764 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97551 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21474 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/124302 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/41965 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31369 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96179 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42337 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99428 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/95964 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24420 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41160 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19000 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/37985 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/41840 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41384 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/44701 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43122 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->