### PR TITLE
Remove obsolete app checks from shouldUseMouseGestureRecognizer

### DIFF
--- a/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h
+++ b/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h
@@ -94,7 +94,6 @@ enum class SDKAlignedBehavior {
     SnapshotAfterScreenUpdates,
     SupportsDeviceOrientationAndMotionPermissionAPI,
     SupportsInitConstructors,
-    SupportsiOSAppsOnMacOS,
     TimerThreadSafetyChecks,
     UIScrollViewDoesNotApplyKeyboardInsetsUnconditionally,
     UnprefixedPlaysInlineAttribute,
@@ -182,26 +181,17 @@ namespace IOSApplication {
 
 WTF_EXPORT_PRIVATE bool isAmazon();
 WTF_EXPORT_PRIVATE bool isAppleWebApp();
-WTF_EXPORT_PRIVATE bool isCrunchyroll();
 WTF_EXPORT_PRIVATE bool isDataActivation();
-WTF_EXPORT_PRIVATE bool isDoubleDown();
 WTF_EXPORT_PRIVATE bool isDumpRenderTree();
-WTF_EXPORT_PRIVATE bool isESPNFantasySports();
 WTF_EXPORT_PRIVATE bool isEssentialSkeleton();
-WTF_EXPORT_PRIVATE bool isFIFACompanion();
 WTF_EXPORT_PRIVATE bool isFeedly();
 WTF_EXPORT_PRIVATE bool isHimalaya();
 WTF_EXPORT_PRIVATE bool isHoYoLAB();
-WTF_EXPORT_PRIVATE bool isJWLibrary();
 WTF_EXPORT_PRIVATE bool isMailCompositionService();
 WTF_EXPORT_PRIVATE bool isMiniBrowser();
 WTF_EXPORT_PRIVATE bool isMobileMail();
 WTF_EXPORT_PRIVATE bool isMobileSafari();
 WTF_EXPORT_PRIVATE bool isNews();
-WTF_EXPORT_PRIVATE bool isNoggin();
-WTF_EXPORT_PRIVATE bool isOKCupid();
-WTF_EXPORT_PRIVATE bool isPaperIO();
-WTF_EXPORT_PRIVATE bool isPocketCity();
 WTF_EXPORT_PRIVATE bool isSafariViewService();
 WTF_EXPORT_PRIVATE bool isStocks();
 WTF_EXPORT_PRIVATE bool isWebBookmarksD();

--- a/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.mm
+++ b/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.mm
@@ -155,9 +155,6 @@ static SDKAlignedBehaviors computeSDKAlignedBehaviors()
         disableBehavior(SDKAlignedBehavior::NoPokerBrosBuiltInTagQuirk);
     }
 
-    if (linkedBefore(dyld_late_fall_2020_os_versions, DYLD_IOS_VERSION_14_2, DYLD_MACOSX_VERSION_10_16))
-        disableBehavior(SDKAlignedBehavior::SupportsiOSAppsOnMacOS);
-
     if (linkedBefore(dyld_spring_2021_os_versions, DYLD_IOS_VERSION_14_5, DYLD_MACOSX_VERSION_11_3)) {
         disableBehavior(SDKAlignedBehavior::DataURLFragmentRemoval);
         disableBehavior(SDKAlignedBehavior::HTMLDocumentSupportedPropertyNames);
@@ -545,64 +542,10 @@ bool IOSApplication::isFeedly()
     return isFeedly;
 }
 
-bool IOSApplication::isPocketCity()
-{
-    static bool isPocketCity = applicationBundleIsEqualTo("com.codebrewgames.pocketcity"_s);
-    return isPocketCity;
-}
-
 bool IOSApplication::isEssentialSkeleton()
 {
     static bool isEssentialSkeleton = applicationBundleIsEqualTo("com.3d4medical.EssentialSkeleton"_s);
     return isEssentialSkeleton;
-}
-
-bool IOSApplication::isESPNFantasySports()
-{
-    static bool isESPNFantasySports = applicationBundleIsEqualTo("com.espn.fantasyFootball"_s);
-    return isESPNFantasySports;
-}
-
-bool IOSApplication::isDoubleDown()
-{
-    static bool isDoubleDown = applicationBundleIsEqualTo("com.doubledowninteractive.DDCasino"_s);
-    return isDoubleDown;
-}
-
-bool IOSApplication::isFIFACompanion()
-{
-    static bool isFIFACompanion = applicationBundleIsEqualTo("com.ea.ios.fifaultimate"_s);
-    return isFIFACompanion;
-}
-
-bool IOSApplication::isNoggin()
-{
-    static bool isNoggin = applicationBundleIsEqualTo("com.mtvn.noggin"_s);
-    return isNoggin;
-}
-
-bool IOSApplication::isOKCupid()
-{
-    static bool isOKCupid = applicationBundleIsEqualTo("com.okcupid.app"_s);
-    return isOKCupid;
-}
-
-bool IOSApplication::isJWLibrary()
-{
-    static bool isJWLibrary = applicationBundleIsEqualTo("org.jw.jwlibrary"_s);
-    return isJWLibrary;
-}
-
-bool IOSApplication::isPaperIO()
-{
-    static bool isPaperIO = applicationBundleIsEqualTo("io.voodoo.paperio"_s);
-    return isPaperIO;
-}
-
-bool IOSApplication::isCrunchyroll()
-{
-    static bool isCrunchyroll = applicationBundleIsEqualTo("com.crunchyroll.iphone"_s);
-    return isCrunchyroll;
 }
 
 bool IOSApplication::isUNIQLOApp()

--- a/Source/WTF/wtf/spi/darwin/dyldSPI.h
+++ b/Source/WTF/wtf/spi/darwin/dyldSPI.h
@@ -63,10 +63,6 @@ DECLARE_SYSTEM_HEADER
 #define DYLD_IOS_VERSION_14_0 0x000E0000
 #endif
 
-#ifndef DYLD_IOS_VERSION_14_2
-#define DYLD_IOS_VERSION_14_2 0x000E0200
-#endif
-
 #ifndef DYLD_IOS_VERSION_14_5
 #define DYLD_IOS_VERSION_14_5 0x000E0500
 #endif
@@ -283,10 +279,6 @@ WTF_EXTERN_C_BEGIN
 
 #ifndef dyld_fall_2020_os_versions
 #define dyld_fall_2020_os_versions ({ (dyld_build_version_t) { 0, 0 }; })
-#endif
-
-#ifndef dyld_late_fall_2020_os_versions
-#define dyld_late_fall_2020_os_versions ({ (dyld_build_version_t) { 0, 0 }; })
 #endif
 
 #ifndef dyld_spring_2021_os_versions


### PR DESCRIPTION
#### cea182dea916491025be8eeab9a3223b0e3c4c1b
<pre>
Remove obsolete app checks from shouldUseMouseGestureRecognizer
<a href="https://bugs.webkit.org/show_bug.cgi?id=293353">https://bugs.webkit.org/show_bug.cgi?id=293353</a>
<a href="https://rdar.apple.com/151973434">rdar://151973434</a>

Reviewed by Wenson Hsieh.

The combination of linked-on-or-after, mandatory usage of newer SDKs,
and most of these apps getting active updates, enables us to simplify
our code.

This code was added back in 2020 in 222230@main and 228838@main.

Canonical link: <a href="https://commits.webkit.org/296512@main">https://commits.webkit.org/296512@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c19731ded8ca8c3b335a86f94ea53cb29e742aa0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108489 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28150 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18574 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/113698 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/58892 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/28839 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/36702 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82392 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111437 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22879 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97721 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62828 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22296 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/15859 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58417 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/101048 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92250 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15912 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/116819 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/107048 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35543 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26195 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91416 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/35916 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93995 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91217 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23286 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36113 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13876 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/31291 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35445 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/40980 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/131331 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35154 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/35631 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38506 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/36836 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->