### PR TITLE
Rename Vector::remove(index) to Vector::removeAt(index)

### DIFF
--- a/Source/JavaScriptCore/b3/B3BlockInsertionSet.cpp
+++ b/Source/JavaScriptCore/b3/B3BlockInsertionSet.cpp
@@ -64,7 +64,7 @@ BasicBlock* BlockInsertionSet::splitForward(
 
     // Remove everything prior to 'valueIndex' from 'block', since those things are now in the
     // new block.
-    block->m_values.remove(0, valueIndex);
+    block->m_values.removeAt(0, valueIndex);
 
     // This is being used in a forward loop over 'block'. Update the index of the loop so that
     // it can continue to the next block.

--- a/Source/JavaScriptCore/b3/air/AirOptimizePairedLoadStore.cpp
+++ b/Source/JavaScriptCore/b3/air/AirOptimizePairedLoadStore.cpp
@@ -290,7 +290,7 @@ bool optimizePairedLoadStore(Code& code)
                     if ((inst.args[1].base() == Tmp(CCallHelpers::stackPointerRegister) || inst.args[1].base() == Tmp(CCallHelpers::framePointerRegister)) && !inst.kind.spill)
                         continue;
                     if (tryStorePair(code, block, index, inst)) {
-                        block->insts().remove(index);
+                        block->insts().removeAt(index);
                         changed = true;
                     }
                     continue;

--- a/Source/JavaScriptCore/bytecode/BytecodeRewriter.cpp
+++ b/Source/JavaScriptCore/bytecode/BytecodeRewriter.cpp
@@ -40,7 +40,7 @@ void BytecodeRewriter::applyModification()
     for (size_t insertionIndex = m_insertions.size(); insertionIndex--;) {
         Insertion& insertion = m_insertions[insertionIndex];
         if (insertion.type == Insertion::Type::Remove)
-            m_writer.m_instructions.remove(insertion.index.bytecodeOffset, insertion.length());
+            m_writer.m_instructions.removeAt(insertion.index.bytecodeOffset, insertion.length());
         else {
             if (insertion.includeBranch == IncludeBranch::Yes) {
                 int finalOffset = insertion.index.bytecodeOffset + calculateDifference(m_insertions.begin(), m_insertions.begin() + insertionIndex);

--- a/Source/JavaScriptCore/bytecode/CodeBlock.cpp
+++ b/Source/JavaScriptCore/bytecode/CodeBlock.cpp
@@ -2135,7 +2135,7 @@ void CodeBlock::removeExceptionHandlerForCallSite(DisposableCallSiteIndex callSi
     for (size_t i = 0; i < exceptionHandlers.size(); ++i) {
         HandlerInfo& handler = exceptionHandlers[i];
         if (handler.start <= index && handler.end > index) {
-            exceptionHandlers.remove(i);
+            exceptionHandlers.removeAt(i);
             return;
         }
     }

--- a/Source/JavaScriptCore/inspector/JSGlobalObjectConsoleClient.cpp
+++ b/Source/JavaScriptCore/inspector/JSGlobalObjectConsoleClient.cpp
@@ -126,7 +126,7 @@ void JSGlobalObjectConsoleClient::profileEnd(JSC::JSGlobalObject*, const String&
     // Otherwise, match the title of the profile to stop.
     for (ptrdiff_t i = m_profiles.size() - 1; i >= 0; --i) {
         if (title.isEmpty() || m_profiles[i] == title) {
-            m_profiles.remove(i);
+            m_profiles.removeAt(i);
             if (m_profiles.isEmpty())
                 stopConsoleProfile();
             return;

--- a/Source/JavaScriptCore/inspector/agents/InspectorConsoleAgent.cpp
+++ b/Source/JavaScriptCore/inspector/agents/InspectorConsoleAgent.cpp
@@ -264,7 +264,7 @@ void InspectorConsoleAgent::addConsoleMessage(std::unique_ptr<ConsoleMessage> co
         m_consoleMessages.append(WTFMove(consoleMessage));
         if (m_consoleMessages.size() >= maximumConsoleMessages) {
             m_expiredConsoleMessageCount += expireConsoleMessagesStep;
-            m_consoleMessages.remove(0, expireConsoleMessagesStep);
+            m_consoleMessages.removeAt(0, expireConsoleMessagesStep);
         }
     }
 }

--- a/Source/JavaScriptCore/inspector/remote/socket/RemoteInspectorMessageParser.cpp
+++ b/Source/JavaScriptCore/inspector/remote/socket/RemoteInspectorMessageParser.cpp
@@ -100,7 +100,7 @@ bool MessageParser::parse()
 
         m_listener(WTFMove(dataBuffer));
 
-        m_buffer.remove(0, messageSize);
+        m_buffer.removeAt(0, messageSize);
     }
 
     return true;

--- a/Source/JavaScriptCore/inspector/remote/socket/RemoteInspectorSocketEndpoint.cpp
+++ b/Source/JavaScriptCore/inspector/remote/socket/RemoteInspectorSocketEndpoint.cpp
@@ -318,7 +318,7 @@ void RemoteInspectorSocketEndpoint::sendIfEnabled(ConnectionID id)
             }
 
             if (size > 0)
-                buffer.remove(0, size);
+                buffer.removeAt(0, size);
         }
 
         Socket::markWaitingWritable(connection->poll);

--- a/Source/JavaScriptCore/runtime/BasicBlockLocation.cpp
+++ b/Source/JavaScriptCore/runtime/BasicBlockLocation.cpp
@@ -67,7 +67,7 @@ Vector<std::pair<int, int>> BasicBlockLocation::getExecutedRanges() const
         }
         result.append(Gap(nextRangeStart, minGap.first - 1));
         nextRangeStart = minGap.second + 1;
-        gaps.remove(minIdx);
+        gaps.removeAt(minIdx);
     }
 
     result.append(Gap(nextRangeStart, m_endOffset));

--- a/Source/JavaScriptCore/runtime/NarrowingNumberPredictionFuzzerAgent.cpp
+++ b/Source/JavaScriptCore/runtime/NarrowingNumberPredictionFuzzerAgent.cpp
@@ -59,7 +59,7 @@ SpeculatedType NarrowingNumberPredictionFuzzerAgent::getPrediction(CodeBlock* co
     for (unsigned i = 0; i < numberOfTypesToKeep; i++) {
         unsigned indexOfTypeToKeep = m_random.getUint32(numberTypesThatCouldBePartOfSpeculation.size());
         mergeSpeculation(generated, numberTypesThatCouldBePartOfSpeculation[indexOfTypeToKeep]);
-        numberTypesThatCouldBePartOfSpeculation.remove(indexOfTypeToKeep);
+        numberTypesThatCouldBePartOfSpeculation.removeAt(indexOfTypeToKeep);
     }
 
     if (Options::dumpFuzzerAgentPredictions())

--- a/Source/JavaScriptCore/runtime/WideningNumberPredictionFuzzerAgent.cpp
+++ b/Source/JavaScriptCore/runtime/WideningNumberPredictionFuzzerAgent.cpp
@@ -62,7 +62,7 @@ SpeculatedType WideningNumberPredictionFuzzerAgent::getPrediction(CodeBlock* cod
     for (unsigned i = 0; i < numberOfTypesToAdd; i++) {
         unsigned indexOfNewType = m_random.getUint32(numberTypesNotIncludedInSpeculation.size());
         mergeSpeculation(generated, numberTypesNotIncludedInSpeculation[indexOfNewType]);
-        numberTypesNotIncludedInSpeculation.remove(indexOfNewType);
+        numberTypesNotIncludedInSpeculation.removeAt(indexOfNewType);
     }
 
     if (Options::dumpFuzzerAgentPredictions())

--- a/Source/JavaScriptCore/wasm/WasmStreamingParser.cpp
+++ b/Source/JavaScriptCore/wasm/WasmStreamingParser.cpp
@@ -231,7 +231,7 @@ auto StreamingParser::consume(std::span<const uint8_t> bytes, size_t& offsetInBy
 
     if (m_remaining.size() > requiredSize) {
         auto result = m_remaining.subvector(0, requiredSize);
-        m_remaining.remove(0, requiredSize);
+        m_remaining.removeAt(0, requiredSize);
         m_nextOffset += requiredSize;
         return result;
     }
@@ -278,7 +278,7 @@ auto StreamingParser::consumeVarUInt32(std::span<const uint8_t> bytes, size_t& o
     if (!WTF::LEBDecoder::decodeUInt32(m_remaining, offset, result))
         return makeUnexpected(State::FatalError);
     size_t consumedSize = offset;
-    m_remaining.remove(0, consumedSize);
+    m_remaining.removeAt(0, consumedSize);
     m_nextOffset += consumedSize;
     return result;
 }

--- a/Source/JavaScriptCore/yarr/YarrInterpreter.cpp
+++ b/Source/JavaScriptCore/yarr/YarrInterpreter.cpp
@@ -2480,7 +2480,7 @@ public:
         unsigned frameLocation = m_bodyDisjunction->terms[beginTerm].frameLocation;
 
         if (!m_bodyDisjunction->terms[beginTerm].alternative.next)
-            m_bodyDisjunction->terms.remove(beginTerm);
+            m_bodyDisjunction->terms.removeAt(beginTerm);
         else {
             while (m_bodyDisjunction->terms[beginTerm].alternative.next) {
                 beginTerm += m_bodyDisjunction->terms[beginTerm].alternative.next;

--- a/Source/JavaScriptCore/yarr/YarrJIT.cpp
+++ b/Source/JavaScriptCore/yarr/YarrJIT.cpp
@@ -2211,7 +2211,7 @@ class YarrGenerator final : public YarrJITInfo {
         // This assertion also checks that firstCharTermIndex is correct
         ASSERT(foundFirstCharTerm);
         if (firstCharTermIndex)
-            opList.remove(0, firstCharTermIndex);
+            opList.removeAt(0, firstCharTermIndex);
 
         if (have16BitCharacter && (m_charSize == CharSize::Char8)) {
             // Have a 16 bit pattern character and an 8 bit string - short circuit

--- a/Source/JavaScriptCore/yarr/YarrPattern.cpp
+++ b/Source/JavaScriptCore/yarr/YarrPattern.cpp
@@ -507,10 +507,10 @@ private:
                 if (val == 1) {
                     char32_t lo = ch;
                     char32_t hi = ch + 1;
-                    matches.remove(pos + index);
+                    matches.removeAt(pos + index);
                     if (pos + index > 0 && matches[pos + index - 1] == ch - 1) {
                         lo = ch - 1;
-                        matches.remove(pos + index - 1);
+                        matches.removeAt(pos + index - 1);
                     }
                     addSortedRange(isASCII(ch) ? m_ranges : m_rangesUnicode, lo, hi);
                     return;
@@ -520,10 +520,10 @@ private:
                 if (val == -1) {
                     char32_t lo = ch - 1;
                     char32_t hi = ch;
-                    matches.remove(pos + index);
+                    matches.removeAt(pos + index);
                     if (pos + index + 1 < matches.size() && matches[pos + index + 1] == ch + 1) {
                         hi = ch + 1;
-                        matches.remove(pos + index + 1);
+                        matches.removeAt(pos + index + 1);
                     }
                     addSortedRange(isASCII(ch) ? m_ranges : m_rangesUnicode, lo, hi);
                     return;
@@ -599,7 +599,7 @@ private:
             if (ranges[next].begin <= (ranges[index].end + 1)) {
                 // the next entry now overlaps / concatenates with this one.
                 ranges[index].end = std::max(ranges[index].end, ranges[next].end);
-                ranges.remove(next);
+                ranges.removeAt(next);
             } else
                 break;
         }
@@ -1002,7 +1002,7 @@ private:
 
                     if (matchesIndex < matches.size() && matches[matchesIndex] == ranges[rangesIndex].begin - 1) {
                         ranges[rangesIndex].begin = matches[matchesIndex];
-                        matches.remove(matchesIndex);
+                        matches.removeAt(matchesIndex);
                     }
                 }
 
@@ -1017,7 +1017,7 @@ private:
 
                     if (matches[matchesIndex] == ranges[rangesIndex].end + 1) {
                         ranges[rangesIndex].end = matches[matchesIndex];
-                        matches.remove(matchesIndex);
+                        matches.removeAt(matchesIndex);
 
                         mergeRangesFrom(ranges, rangesIndex);
                     } else
@@ -1029,7 +1029,7 @@ private:
                 for (auto rangesIndex = ranges.size() - 1; rangesIndex > 0; rangesIndex--) {
                     if (ranges[rangesIndex].begin == ranges[rangesIndex - 1].end + 1) {
                         ranges[rangesIndex - 1].end = ranges[rangesIndex].end;
-                        ranges.remove(rangesIndex);
+                        ranges.removeAt(rangesIndex);
                     }
                 }
             }
@@ -2132,10 +2132,10 @@ public:
 
             if (!containsCapturingTerms(alternative, firstExpressionTerm, endIndex)) {
                 for (termIndex = terms.size() - 1; termIndex >= endIndex; --termIndex)
-                    terms.remove(termIndex);
+                    terms.removeAt(termIndex);
 
                 for (termIndex = firstExpressionTerm; termIndex > 0; --termIndex)
-                    terms.remove(termIndex - 1);
+                    terms.removeAt(termIndex - 1);
 
                 terms.append(PatternTerm(startsWithBOL, endsWithEOL, m_flags));
                 

--- a/Source/WTF/wtf/URLParser.cpp
+++ b/Source/WTF/wtf/URLParser.cpp
@@ -863,7 +863,7 @@ void URLParser::copyURLPartsUntil(const URL& base, URLPart part, const CodePoint
             && m_asciiBuffer[pathStart] == '/'
             && m_asciiBuffer[pathStart + 1] == '.'
             && m_asciiBuffer[pathStart + 2] == '/') {
-            m_asciiBuffer.remove(pathStart + 1, 2);
+            m_asciiBuffer.removeAt(pathStart + 1, 2);
             m_url.m_pathAfterLastSlash = std::max(2u, m_url.m_pathAfterLastSlash) - 2;
             m_url.m_pathEnd = std::max(2u, m_url.m_pathEnd) - 2;
             m_url.m_queryEnd = std::max(2u, m_url.m_queryEnd) - 2;

--- a/Source/WTF/wtf/Vector.h
+++ b/Source/WTF/wtf/Vector.h
@@ -935,8 +935,8 @@ public:
     template<typename U> void insert(size_t position, U&&);
     template<typename U, size_t c, typename OH, size_t m, typename M> void insertVector(size_t position, const Vector<U, c, OH, m, M>&);
 
-    void remove(size_t position);
-    void remove(size_t position, size_t length);
+    void removeAt(size_t position);
+    void removeAt(size_t position, size_t length);
     bool removeFirst(const auto&);
     bool removeFirstMatching(NOESCAPE const Invocable<bool(T&)> auto&, size_t startIndex = 0);
     bool removeLast(const auto&);
@@ -1699,13 +1699,13 @@ inline void Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::ins
 }
 
 template<typename T, size_t inlineCapacity, typename OverflowHandler, size_t minCapacity, typename Malloc>
-inline void Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::remove(size_t position)
+inline void Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::removeAt(size_t position)
 {
-    remove(position, 1);
+    removeAt(position, 1);
 }
 
 template<typename T, size_t inlineCapacity, typename OverflowHandler, size_t minCapacity, typename Malloc>
-inline void Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::remove(size_t position, size_t length)
+inline void Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::removeAt(size_t position, size_t length)
 {
     auto beginSpot = mutableSpan().subspan(position);
     T* endSpot = beginSpot.subspan(length).data();
@@ -1728,7 +1728,7 @@ inline bool Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::rem
 {
     for (size_t i = startIndex; i < size(); ++i) {
         if (matches(at(i))) {
-            remove(i);
+            removeAt(i);
             return true;
         }
     }
@@ -1754,7 +1754,7 @@ inline bool Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::rem
 {
     for (size_t i = std::min(startIndex + 1, size()); i > 0; --i) {
         if (matches(at(i - 1))) {
-            remove(i - 1);
+            removeAt(i - 1);
             return true;
         }
     }

--- a/Source/WTF/wtf/text/TextBreakIterator.h
+++ b/Source/WTF/wtf/text/TextBreakIterator.h
@@ -160,7 +160,7 @@ private:
         if (iter == m_unused.end())
             return TextBreakIterator(string, priorContext, mode, contentAnalysis, locale);
         auto result = WTFMove(*iter);
-        m_unused.remove(iter - m_unused.begin());
+        m_unused.removeAt(iter - m_unused.begin());
         result.setText(string, priorContext);
         return result;
     }
@@ -170,7 +170,7 @@ private:
         ASSERT(isMainThread());
         m_unused.append(WTFMove(iterator));
         if (m_unused.size() > capacity)
-            m_unused.remove(0);
+            m_unused.removeAt(0);
     }
 
     TextBreakIteratorCache() = default;

--- a/Source/WebCore/Modules/airplay/WebMediaSessionManager.cpp
+++ b/Source/WebCore/Modules/airplay/WebMediaSessionManager.cpp
@@ -229,7 +229,7 @@ void WebMediaSessionManager::removePlaybackTargetPickerClient(WebMediaSessionMan
 
     ALWAYS_LOG_MEDIASESSIONMANAGER(__func__, m_clientState[index].get());
 
-    m_clientState.remove(index);
+    m_clientState.removeAt(index);
     scheduleDelayedTask({ ConfigurationTaskFlags::TargetMonitoringConfiguration, ConfigurationTaskFlags::TargetClientsConfiguration });
 }
 
@@ -241,7 +241,7 @@ void WebMediaSessionManager::removeAllPlaybackTargetPickerClients(WebMediaSessio
     for (size_t i = m_clientState.size(); i > 0; --i) {
         if (&m_clientState[i - 1]->client == &client) {
             ALWAYS_LOG_MEDIASESSIONMANAGER(__func__, m_clientState[i - 1].get());
-            m_clientState.remove(i - 1);
+            m_clientState.removeAt(i - 1);
         }
     }
     scheduleDelayedTask({ ConfigurationTaskFlags::TargetMonitoringConfiguration, ConfigurationTaskFlags::TargetClientsConfiguration });

--- a/Source/WebCore/Modules/encryptedmedia/NavigatorEME.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/NavigatorEME.cpp
@@ -135,7 +135,7 @@ static void tryNextSupportedConfiguration(Document& document, RefPtr<CDM>&& impl
         // 6.3.2. Let supported configuration be the result of executing the Get Supported Configuration
         //        algorithm on implementation, candidate configuration, and origin.
         MediaKeySystemConfiguration candidateConfiguration = WTFMove(supportedConfigurations.first());
-        supportedConfigurations.remove(0);
+        supportedConfigurations.removeAt(0);
 
         CDM::SupportedConfigurationCallback callback = [&document, implementation = implementation, supportedConfigurations = WTFMove(supportedConfigurations), promise, logger = WTFMove(logger), identifier = WTFMove(identifier)] (std::optional<MediaKeySystemConfiguration> supportedConfiguration) mutable {
             // 6.3.3. If supported configuration is not NotSupported, run the following steps:

--- a/Source/WebCore/Modules/highlight/Highlight.cpp
+++ b/Source/WebCore/Modules/highlight/Highlight.cpp
@@ -93,7 +93,7 @@ bool Highlight::addToSetLike(AbstractRange& range)
     }
     // Move to last since SetLike is an ordered set.
     m_highlightRanges.append(WTFMove(m_highlightRanges[index]));
-    m_highlightRanges.remove(index);
+    m_highlightRanges.removeAt(index);
     return false;
 }
 

--- a/Source/WebCore/Modules/mediasource/SourceBufferList.cpp
+++ b/Source/WebCore/Modules/mediasource/SourceBufferList.cpp
@@ -84,7 +84,7 @@ void SourceBufferList::remove(SourceBuffer& buffer)
     size_t index = m_list.find(Ref { buffer });
     if (index == notFound)
         return;
-    m_list.remove(index);
+    m_list.removeAt(index);
     scheduleEvent(eventNames().removesourcebufferEvent);
 }
 

--- a/Source/WebCore/Modules/mediastream/PeerConnectionBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/PeerConnectionBackend.cpp
@@ -134,7 +134,7 @@ public:
         if (!m_clients.contains(identifier))
             return;
 
-        m_clients.remove(identifier);
+        m_clients.removeFirst(identifier);
         if (m_clients.isEmpty())
             m_logFile = nullptr;
     }

--- a/Source/WebCore/Modules/webaudio/AudioParamTimeline.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioParamTimeline.cpp
@@ -211,7 +211,7 @@ void AudioParamTimeline::cancelScheduledValues(Seconds cancelTime)
     // Remove all events starting at cancelTime.
     for (unsigned i = 0; i < m_events.size(); ++i) {
         if (isAfter(m_events[i], cancelTime)) {
-            m_events.remove(i, m_events.size() - i);
+            m_events.removeAt(i, m_events.size() - i);
             break;
         }
     }
@@ -325,7 +325,7 @@ ExceptionOr<void> AudioParamTimeline::cancelAndHoldAtTime(Seconds cancelTime)
 
 void AudioParamTimeline::removeCancelledEvents(size_t firstEventToRemove)
 {
-    m_events.remove(firstEventToRemove, m_events.size() - firstEventToRemove);
+    m_events.removeAt(firstEventToRemove, m_events.size() - firstEventToRemove);
 }
 
 void AudioParamTimeline::removeOldEvents(size_t eventCount)
@@ -335,7 +335,7 @@ void AudioParamTimeline::removeOldEvents(size_t eventCount)
         return;
 
     // Always leave at least one event in the list.
-    m_events.remove(0, std::min(eventCount, m_events.size() - 1));
+    m_events.removeAt(0, std::min(eventCount, m_events.size() - 1));
 }
 
 std::optional<float> AudioParamTimeline::valueForContextTime(BaseAudioContext& context, float defaultValue, float minValue, float maxValue)

--- a/Source/WebCore/Modules/webaudio/BaseAudioContext.cpp
+++ b/Source/WebCore/Modules/webaudio/BaseAudioContext.cpp
@@ -669,7 +669,7 @@ void BaseAudioContext::updateTailProcessingNodes()
         // for disableOutputsForFinishedTailProcessingNodes() to process later on the main thread.
         ASSERT(!m_finishedTailProcessingNodes.contains(node));
         m_finishedTailProcessingNodes.append(WTFMove(node));
-        m_tailProcessingNodes.remove(i - 1);
+        m_tailProcessingNodes.removeAt(i - 1);
     }
 
     if (m_finishedTailProcessingNodes.isEmpty() || m_disableOutputsForTailProcessingScheduled)

--- a/Source/WebCore/Modules/webxr/WebXRInputSourceArray.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRInputSourceArray.cpp
@@ -193,7 +193,7 @@ void WebXRInputSourceArray::handleAddedOrUpdatedInputSources(double timestamp, c
             else
                 removedWithInputEvents.append(input);
             inputEvents.appendVector(sourceInputEvents);
-            m_inputSources.remove(index);
+            m_inputSources.removeAt(index);
 
             auto newInputSource = WebXRInputSource::create(*document, m_session, timestamp, inputSource);
             added.append(newInputSource);

--- a/Source/WebCore/accessibility/AccessibilityScrollView.cpp
+++ b/Source/WebCore/accessibility/AccessibilityScrollView.cpp
@@ -182,7 +182,7 @@ void AccessibilityScrollView::removeChildScrollbar(AccessibilityObject* scrollba
     });
     if (position != notFound) {
         m_children[position]->detachFromParent();
-        m_children.remove(position);
+        m_children.removeAt(position);
         resetChildrenIndexInParent();
 
         if (CheckedPtr cache = axObjectCache())

--- a/Source/WebCore/accessibility/atspi/AccessibilityAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AccessibilityAtspi.cpp
@@ -326,7 +326,7 @@ void AccessibilityAtspi::unregisterRoot(AccessibilityRootAtspi& rootObject)
         auto& pendingRootRegistration = m_pendingRootRegistrations[i];
         if (pendingRootRegistration.root.ptr() == &rootObject) {
             pendingRootRegistration.completionHandler({ });
-            m_pendingRootRegistrations.remove(i);
+            m_pendingRootRegistrations.removeAt(i);
             return;
         }
     }

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
@@ -997,7 +997,7 @@ void AXIsolatedTree::updateChildren(AccessibilityObject& axObject, ResolveNodeCh
         size_t index = oldChildrenIDs.find(newChildrenIDs[i]);
         if (index != notFound) {
             // Prevent deletion of this object below by removing it from oldChildrenIDs.
-            oldChildrenIDs.remove(index);
+            oldChildrenIDs.removeAt(index);
 
             // Propagate any subtree updates downwards for this already-existing child.
             if (auto* liveChild = dynamicDowncast<AccessibilityObject>(newChildren[i].get()); liveChild && liveChild->hasDirtySubtree())

--- a/Source/WebCore/accessibility/mac/AXObjectCacheMac.mm
+++ b/Source/WebCore/accessibility/mac/AXObjectCacheMac.mm
@@ -837,7 +837,7 @@ void AXObjectCache::addSortedObject(AccessibilityObject& object, PreSortedObject
                 // The object we found doesn't match up with what we expected at sortedList[i].
                 // Otherwise, we can repair sortedList outside the loop. Start by removing the element
                 // at [i] and all remaining ones.
-                sortedList.remove(i, sortedList.size() - 1 - i);
+                sortedList.removeAt(i, sortedList.size() - 1 - i);
                 sortedList.appendIfNotContains(result->objectID());
                 start = result;
                 break;
@@ -845,7 +845,7 @@ void AXObjectCache::addSortedObject(AccessibilityObject& object, PreSortedObject
         } else {
             // There are no remaining objects of the expected type, so anything remaining in sortedList
             // must be outdated.
-            sortedList.remove(i, sortedList.size() - 1 - i);
+            sortedList.removeAt(i, sortedList.size() - 1 - i);
             // If we didn't end up with the passed in object in our list, something probably went wrong,
             // or the tree is in an incorrect state.
             ASSERT(sortedList.contains(object.objectID()));

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -696,7 +696,7 @@ static inline ExceptionOr<void> processPropertyIndexedKeyframes(JSGlobalObject& 
         }
         // Since we've processed this keyframe, we can remove it and keep i the same
         // so that we process the next keyframe in the next loop iteration.
-        parsedKeyframes.remove(i);
+        parsedKeyframes.removeAt(i);
     }
 
     // 5. Let offsets be a sequence of nullable double values assigned based on the type of the “offset” member of the property-indexed keyframe as follows:

--- a/Source/WebCore/animation/StyleOriginatedTimelinesController.cpp
+++ b/Source/WebCore/animation/StyleOriginatedTimelinesController.cpp
@@ -314,7 +314,7 @@ void StyleOriginatedTimelinesController::unregisterNamedTimeline(const AtomStrin
     // Make sure to remove the named timeline from our name-to-timelines map first,
     // such that re-syncing any CSS Animation previously registered with it resolves
     // their `animation-timeline` properly.
-    timelines.remove(i);
+    timelines.removeAt(i);
 
     for (Ref animation : timeline->relevantAnimations()) {
         if (RefPtr cssAnimation = dynamicDowncast<CSSAnimation>(animation)) {
@@ -486,8 +486,7 @@ void StyleOriginatedTimelinesController::unregisterNamedTimelinesAssociatedWithE
             auto& timeline = timelines[i];
             if (originatingElement(timeline) == styleable) {
                 m_removedTimelines.add(timeline.get());
-                timelines.remove(i);
-                i--;
+                timelines.removeAt(i--);
             }
         }
         if (timelines.isEmpty())

--- a/Source/WebCore/contentextensions/DFABytecodeCompiler.cpp
+++ b/Source/WebCore/contentextensions/DFABytecodeCompiler.cpp
@@ -304,7 +304,7 @@ DFABytecodeCompiler::JumpTable DFABytecodeCompiler::extractJumpTable(Vector<DFAB
         return range.destination;
     });
 
-    ranges.remove(firstRange, size);
+    ranges.removeAt(firstRange, size);
 
     return jumpTable;
 }

--- a/Source/WebCore/contentextensions/DFACombiner.cpp
+++ b/Source/WebCore/contentextensions/DFACombiner.cpp
@@ -192,7 +192,7 @@ void DFACombiner::combineDFAs(unsigned minimumSize, NOESCAPE const Function<void
     for (unsigned i = m_dfas.size(); i--;) {
         if (m_dfas[i].graphSize() > minimumSize) {
             handler(WTFMove(m_dfas[i]));
-            m_dfas.remove(i);
+            m_dfas.removeAt(i);
         }
     }
 

--- a/Source/WebCore/contentextensions/URLFilterParser.cpp
+++ b/Source/WebCore/contentextensions/URLFilterParser.cpp
@@ -334,7 +334,7 @@ private:
             bool isAfterDotStar = false;
             while (termIndex < m_sunkTerms.size()) {
                 if (isAfterDotStar && m_sunkTerms[termIndex].isKnownToMatchAnyString()) {
-                    m_sunkTerms.remove(termIndex);
+                    m_sunkTerms.removeAt(termIndex);
                     continue;
                 }
                 isAfterDotStar = false;

--- a/Source/WebCore/crypto/keys/CryptoKeyRSA.cpp
+++ b/Source/WebCore/crypto/keys/CryptoKeyRSA.cpp
@@ -48,7 +48,7 @@ RefPtr<CryptoKeyRSA> CryptoKeyRSA::importJwk(CryptoAlgorithmIdentifier algorithm
         return nullptr;
     // Per RFC 7518 Section 6.3.1.1: https://tools.ietf.org/html/rfc7518#section-6.3.1.1
     if (!modulus->isEmpty() && !modulus->at(0))
-        modulus->remove(0);
+        modulus->removeAt(0);
     auto exponent = base64URLDecode(keyData.e);
     if (!exponent)
         return nullptr;

--- a/Source/WebCore/css/CSSFontFaceSet.cpp
+++ b/Source/WebCore/css/CSSFontFaceSet.cpp
@@ -237,7 +237,7 @@ void CSSFontFaceSet::removeFromFacesLookupTable(const CSSFontFace& face, const C
     for (size_t i = 0; i < iterator->value.size(); ++i) {
         if (iterator->value[i].ptr() == &face) {
             found = true;
-            iterator->value.remove(i);
+            iterator->value.removeAt(i);
             break;
         }
     }
@@ -269,7 +269,7 @@ void CSSFontFaceSet::remove(const CSSFontFace& face)
             if (i < m_facesPartitionIndex)
                 --m_facesPartitionIndex;
             Ref { m_faces[i] }->removeClient(*this);
-            m_faces.remove(i);
+            m_faces.removeAt(i);
             if (face.status() == CSSFontFace::Status::Loading || face.status() == CSSFontFace::Status::TimedOut)
                 decrementActiveCount();
             return;

--- a/Source/WebCore/css/CSSGroupingRule.cpp
+++ b/Source/WebCore/css/CSSGroupingRule.cpp
@@ -133,7 +133,7 @@ ExceptionOr<void> CSSGroupingRule::deleteRule(unsigned index)
 
     if (m_childRuleCSSOMWrappers[index])
         m_childRuleCSSOMWrappers[index]->setParentRule(nullptr);
-    m_childRuleCSSOMWrappers.remove(index);
+    m_childRuleCSSOMWrappers.removeAt(index);
 
     return { };
 }

--- a/Source/WebCore/css/CSSKeyframesRule.cpp
+++ b/Source/WebCore/css/CSSKeyframesRule.cpp
@@ -75,7 +75,7 @@ void StyleRuleKeyframes::wrapperAppendKeyframe(Ref<StyleRuleKeyframe>&& keyframe
 
 void StyleRuleKeyframes::wrapperRemoveKeyframe(unsigned index)
 {
-    m_keyframes.remove(index);
+    m_keyframes.removeAt(index);
 }
 
 std::optional<size_t> StyleRuleKeyframes::findKeyframeIndex(const String& key) const
@@ -153,7 +153,7 @@ void CSSKeyframesRule::deleteRule(const String& s)
 
     if (m_childRuleCSSOMWrappers[*i])
         m_childRuleCSSOMWrappers[*i]->setParentRule(nullptr);
-    m_childRuleCSSOMWrappers.remove(*i);
+    m_childRuleCSSOMWrappers.removeAt(*i);
 }
 
 CSSKeyframeRule* CSSKeyframesRule::findRule(const String& s)

--- a/Source/WebCore/css/CSSStyleRule.cpp
+++ b/Source/WebCore/css/CSSStyleRule.cpp
@@ -279,11 +279,11 @@ ExceptionOr<void> CSSStyleRule::deleteRule(unsigned index)
     auto& rules = downcast<StyleRuleWithNesting>(m_styleRule.get()).nestedRules();
     
     CSSStyleSheet::RuleMutationScope mutationScope(this);
-    rules.remove(index);
+    rules.removeAt(index);
 
     if (m_childRuleCSSOMWrappers[index])
         m_childRuleCSSOMWrappers[index]->setParentRule(nullptr);
-    m_childRuleCSSOMWrappers.remove(index);
+    m_childRuleCSSOMWrappers.removeAt(index);
 
     return { };
 }

--- a/Source/WebCore/css/CSSStyleSheet.cpp
+++ b/Source/WebCore/css/CSSStyleSheet.cpp
@@ -386,7 +386,7 @@ ExceptionOr<void> CSSStyleSheet::deleteRule(unsigned index)
     if (!m_childRuleCSSOMWrappers.isEmpty()) {
         if (m_childRuleCSSOMWrappers[index])
             m_childRuleCSSOMWrappers[index]->setParentStyleSheet(nullptr);
-        m_childRuleCSSOMWrappers.remove(index);
+        m_childRuleCSSOMWrappers.removeAt(index);
     }
 
     return { };

--- a/Source/WebCore/css/MediaList.cpp
+++ b/Source/WebCore/css/MediaList.cpp
@@ -113,7 +113,7 @@ ExceptionOr<void> MediaList::deleteMedium(const String& value)
     auto queries = mediaQueries();
     for (unsigned i = 0; i < queries.size(); ++i) {
         if (item(i) == valueToRemove) {
-            queries.remove(i);
+            queries.removeAt(i);
             setMediaQueries(WTFMove(queries));
             return { };
         }

--- a/Source/WebCore/css/MutableStyleProperties.cpp
+++ b/Source/WebCore/css/MutableStyleProperties.cpp
@@ -117,7 +117,7 @@ bool MutableStyleProperties::removePropertyAtIndex(int index, String* returnText
 
     // A more efficient removal strategy would involve marking entries as empty
     // and sweeping them when the vector grows too big.
-    m_propertyVector.remove(index);
+    m_propertyVector.removeAt(index);
     return true;
 }
 
@@ -226,7 +226,7 @@ bool MutableStyleProperties::setProperty(const CSSProperty& property, CSSPropert
             *toReplace = property;
             return true;
         }
-        m_propertyVector.remove(toReplace - m_propertyVector.begin());
+        m_propertyVector.removeAt(toReplace - m_propertyVector.begin());
     }
     m_propertyVector.append(property);
     return true;

--- a/Source/WebCore/css/StyleRule.cpp
+++ b/Source/WebCore/css/StyleRule.cpp
@@ -518,7 +518,7 @@ void StyleRuleGroup::wrapperInsertRule(unsigned index, Ref<StyleRuleBase>&& rule
 
 void StyleRuleGroup::wrapperRemoveRule(unsigned index)
 {
-    m_childRules.remove(index);
+    m_childRules.removeAt(index);
 }
 
 String StyleRuleGroup::debugDescription() const

--- a/Source/WebCore/css/StyleSheetContents.cpp
+++ b/Source/WebCore/css/StyleSheetContents.cpp
@@ -351,7 +351,7 @@ bool StyleSheetContents::wrapperDeleteRule(unsigned index)
 
     unsigned childVectorIndex = index;
     if (childVectorIndex < m_layerRulesBeforeImportRules.size()) {
-        m_layerRulesBeforeImportRules.remove(childVectorIndex);
+        m_layerRulesBeforeImportRules.removeAt(childVectorIndex);
         return true;
     }
     childVectorIndex -= m_layerRulesBeforeImportRules.size();
@@ -359,7 +359,7 @@ bool StyleSheetContents::wrapperDeleteRule(unsigned index)
     if (childVectorIndex < m_importRules.size()) {
         m_importRules[childVectorIndex]->cancelLoad();
         m_importRules[childVectorIndex]->clearParentStyleSheet();
-        m_importRules.remove(childVectorIndex);
+        m_importRules.removeAt(childVectorIndex);
         return true;
     }
     childVectorIndex -= m_importRules.size();
@@ -368,12 +368,12 @@ bool StyleSheetContents::wrapperDeleteRule(unsigned index)
         // Deleting @namespace rule when list contains anything other than @import or @namespace rules is not allowed.
         if (!m_childRules.isEmpty())
             return false;
-        m_namespaceRules.remove(childVectorIndex);
+        m_namespaceRules.removeAt(childVectorIndex);
         return true;
     }
     childVectorIndex -= m_namespaceRules.size();
 
-    m_childRules.remove(childVectorIndex);
+    m_childRules.removeAt(childVectorIndex);
     return true;
 }
 

--- a/Source/WebCore/css/parser/CSSParser.cpp
+++ b/Source/WebCore/css/parser/CSSParser.cpp
@@ -201,7 +201,7 @@ bool CSSParser::parseDeclarationList(MutableStyleProperties& declaration, const 
     filterProperties(IsImportant::Yes, parser.topContext().m_parsedProperties, results, unusedEntries, seenProperties, seenCustomProperties);
     filterProperties(IsImportant::No, parser.topContext().m_parsedProperties, results, unusedEntries, seenProperties, seenCustomProperties);
     if (unusedEntries)
-        results.remove(0, unusedEntries);
+        results.removeAt(0, unusedEntries);
     return declaration.addParsedProperties(results);
 }
 

--- a/Source/WebCore/css/typedom/CSSNumericValue.cpp
+++ b/Source/WebCore/css/typedom/CSSNumericValue.cpp
@@ -432,7 +432,7 @@ ExceptionOr<Ref<CSSMathSum>> CSSNumericValue::toSum(FixedVector<String>&& units)
             auto value = downcast<CSSUnitValue>(values[i]);
             if (auto convertedValue = value->convertTo(parsedUnit)) {
                 temp->setValue(temp->value() + convertedValue->value());
-                values.remove(i);
+                values.removeAt(i);
             } else
                 ++i;
         }

--- a/Source/WebCore/cssjit/RegisterAllocator.h
+++ b/Source/WebCore/cssjit/RegisterAllocator.h
@@ -130,7 +130,7 @@ public:
         ASSERT(m_allocatedRegisters.contains(registerID));
         // Most allocation/deallocation happen in stack-like order. In the common case, this
         // just removes the last item.
-        m_allocatedRegisters.remove(m_allocatedRegisters.reverseFind(registerID));
+        m_allocatedRegisters.removeLast(registerID);
         for (auto unallocatedRegister : m_registers)
             RELEASE_ASSERT(unallocatedRegister != registerID);
         m_registers.append(registerID);

--- a/Source/WebCore/dom/DataTransferItemList.cpp
+++ b/Source/WebCore/dom/DataTransferItemList.cpp
@@ -118,7 +118,7 @@ ExceptionOr<void> DataTransferItemList::remove(unsigned index)
     if (!removedItem->isFile())
         dataTransfer->pasteboard().clear(removedItem->type());
     removedItem->clearListAndPutIntoDisabledMode();
-    items.remove(index);
+    items.removeAt(index);
     if (removedItem->isFile())
         dataTransfer->updateFileList(protectedScriptExecutionContext().get());
 
@@ -172,7 +172,7 @@ static void removeStringItemOfLowercasedType(Vector<Ref<DataTransferItem>>& item
     if (index == notFound)
         return;
     items[index]->clearListAndPutIntoDisabledMode();
-    items.remove(index);
+    items.removeAt(index);
 }
 
 void DataTransferItemList::didClearStringData(const String& type)

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -1260,7 +1260,7 @@ void Document::addResultForSelectorAll(ContainerNode& context, const String& sel
     });
     auto& entries = result.iterator->value->entries;
     if (entries.size() >= QuerySelectorAllResults::maxSize)
-        entries.remove(weakRandomNumber<uint32_t>() % entries.size());
+        entries.removeAt(weakRandomNumber<uint32_t>() % entries.size());
     entries.append({ selectorString, nodeList, classNameToMatch });
 }
 
@@ -1292,7 +1292,7 @@ void Document::invalidateQuerySelectorAllResultsForClassAttributeChange(Node& st
         while (index < entries.size()) {
             auto& entry = entries[index];
             if (!entry.classNameToMatch.isNull() && oldClasses.contains(entry.classNameToMatch) != newClasses.contains(entry.classNameToMatch))
-                entries.remove(index);
+                entries.removeAt(index);
             else
                 ++index;
         }

--- a/Source/WebCore/dom/DocumentMarkerController.cpp
+++ b/Source/WebCore/dom/DocumentMarkerController.cpp
@@ -348,8 +348,8 @@ void DocumentMarkerController::addMarker(Node& node, DocumentMarker&& newMarker)
                 break;
             if (canMergeMarkers(marker, toInsert) && marker.endOffset() >= toInsert.startOffset()) {
                 toInsert.setStartOffset(marker.startOffset());
-                list->remove(i);
-                numMarkers--;
+                list->removeAt(i);
+                --numMarkers;
                 break;
             }
         }
@@ -362,7 +362,7 @@ void DocumentMarkerController::addMarker(Node& node, DocumentMarker&& newMarker)
             if (marker.startOffset() > toInsert.endOffset())
                 break;
             if (canMergeMarkers(marker, toInsert)) {
-                list->remove(j);
+                list->removeAt(j);
                 if (toInsert.endOffset() <= marker.endOffset()) {
                     toInsert.setEndOffset(marker.endOffset());
                     break;
@@ -466,7 +466,7 @@ void DocumentMarkerController::removeMarkers(Node& node, OffsetRange range, Opti
         needRepaint = true;
 
         DocumentMarker copiedMarker = marker;
-        list->remove(i);
+        list->removeAt(i);
         if (overlapRule == RemovePartiallyOverlappingMarker::Yes)
             continue;
 
@@ -712,7 +712,7 @@ OptionSet<DocumentMarkerType> DocumentMarkerController::removeMarkersFromList(Ma
             }
 
             // pitch the old marker
-            list->remove(i);
+            list->removeAt(i);
             needsRepainting = true;
             // i now is the index of the next marker
         }
@@ -777,7 +777,7 @@ void DocumentMarkerController::shiftMarkers(Node& node, unsigned startOffset, in
 
 #if PLATFORM(IOS_FAMILY)
             if (targetStartOffset >= node.length() || targetEndOffset <= 0) {
-                list->remove(i);
+                list->removeAt(i);
                 continue;
             }
 #endif
@@ -790,7 +790,7 @@ void DocumentMarkerController::shiftMarkers(Node& node, unsigned startOffset, in
         // FIXME: No obvious reason this should be iOS-specific. Remove the #if at some point.
         else if (marker.endOffset() > startOffset) {
             if (targetEndOffset <= marker.startOffset()) {
-                list->remove(i);
+                list->removeAt(i);
                 continue;
             }
             marker.setEndOffset(std::min(targetEndOffset, node.length()));

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -3842,7 +3842,7 @@ void Element::removeAttributeInternal(unsigned index, InSynchronizationOfLazyAtt
         detachAttrNodeFromElementWithValue(attrNode.get(), elementData.attributeAt(index).value());
 
     if (inSynchronizationOfLazyAttribute == InSynchronizationOfLazyAttribute::Yes) {
-        elementData.removeAttribute(index);
+        elementData.removeAttributeAt(index);
         return;
     }
 
@@ -3850,7 +3850,7 @@ void Element::removeAttributeInternal(unsigned index, InSynchronizationOfLazyAtt
     willModifyAttribute(name, valueBeingRemoved, nullAtom());
     {
         Style::AttributeChangeInvalidation styleInvalidation(*this, name, valueBeingRemoved, nullAtom());
-        elementData.removeAttribute(index);
+        elementData.removeAttributeAt(index);
     }
 
     didRemoveAttribute(name, valueBeingRemoved);

--- a/Source/WebCore/dom/ElementData.h
+++ b/Source/WebCore/dom/ElementData.h
@@ -170,7 +170,7 @@ public:
 
     // These functions do no error/duplicate checking.
     void addAttribute(const QualifiedName&, const AtomString&);
-    void removeAttribute(unsigned index);
+    void removeAttributeAt(unsigned index);
 
     Attribute& attributeAt(unsigned index);
     Attribute* findAttributeByName(const QualifiedName&);
@@ -283,9 +283,9 @@ inline void UniqueElementData::addAttribute(const QualifiedName& attributeName, 
     m_attributeVector.append(Attribute(attributeName, value));
 }
 
-inline void UniqueElementData::removeAttribute(unsigned index)
+inline void UniqueElementData::removeAttributeAt(unsigned index)
 {
-    m_attributeVector.remove(index);
+    m_attributeVector.removeAt(index);
 }
 
 inline Attribute& UniqueElementData::attributeAt(unsigned index)

--- a/Source/WebCore/dom/EventListenerMap.cpp
+++ b/Source/WebCore/dom/EventListenerMap.cpp
@@ -139,7 +139,7 @@ static bool removeListenerFromVector(EventListenerVector& listeners, EventListen
         return false;
 
     listeners[indexOfRemovedListener]->markAsRemoved();
-    listeners.remove(indexOfRemovedListener);
+    listeners.removeAt(indexOfRemovedListener);
     return true;
 }
 
@@ -152,7 +152,7 @@ bool EventListenerMap::remove(const AtomString& eventType, EventListener& listen
         if (m_entries[i].first == eventType) {
             bool wasRemoved = removeListenerFromVector(m_entries[i].second, listener, useCapture);
             if (m_entries[i].second.isEmpty())
-                m_entries.remove(i);
+                m_entries.removeAt(i);
             return wasRemoved;
         }
     }
@@ -191,7 +191,7 @@ void EventListenerMap::removeFirstEventListenerCreatedFromMarkup(const AtomStrin
         if (m_entries[i].first == eventType) {
             removeFirstListenerCreatedFromMarkup(m_entries[i].second);
             if (m_entries[i].second.isEmpty())
-                m_entries.remove(i);
+                m_entries.removeAt(i);
             return;
         }
     }

--- a/Source/WebCore/dom/ScriptRunner.cpp
+++ b/Source/WebCore/dom/ScriptRunner.cpp
@@ -140,7 +140,7 @@ void ScriptRunner::timerFired()
     for (; numInOrderScriptsToExecute < m_scriptsToExecuteInOrder.size() && m_scriptsToExecuteInOrder[numInOrderScriptsToExecute]->isLoaded(); ++numInOrderScriptsToExecute)
         scripts.append(m_scriptsToExecuteInOrder[numInOrderScriptsToExecute].ptr());
     if (numInOrderScriptsToExecute)
-        m_scriptsToExecuteInOrder.remove(0, numInOrderScriptsToExecute);
+        m_scriptsToExecuteInOrder.removeAt(0, numInOrderScriptsToExecute);
 
     for (auto& currentScript : scripts) {
         RefPtr script = WTFMove(currentScript);

--- a/Source/WebCore/editing/AlternativeTextController.cpp
+++ b/Source/WebCore/editing/AlternativeTextController.cpp
@@ -316,7 +316,7 @@ void AlternativeTextController::timerFired()
             break;
         }
         String topSuggestion = suggestions.first();
-        suggestions.remove(0);
+        suggestions.removeAt(0);
         m_isActive = true;
         auto boundingBox = rootViewRectForRange(*m_rangeWithAlternative);
         if (!boundingBox.isEmpty()) {

--- a/Source/WebCore/editing/ios/DictationCommandIOS.cpp
+++ b/Source/WebCore/editing/ios/DictationCommandIOS.cpp
@@ -60,7 +60,7 @@ void DictationCommandIOS::doApply()
 
         if (interpretations.size() > 1) {
             auto alternatives = interpretations;
-            alternatives.remove(0);
+            alternatives.removeAt(0);
             addMarker(*endingSelection().toNormalizedRange(), DocumentMarkerType::DictationPhraseWithAlternatives, WTFMove(alternatives));
         }
 

--- a/Source/WebCore/editing/ios/EditorIOS.mm
+++ b/Source/WebCore/editing/ios/EditorIOS.mm
@@ -218,7 +218,7 @@ void Editor::setDictationPhrasesAsChildOfElement(const Vector<Vector<String>>& d
         auto dictationPhraseLength = interpretations[0].length();
         if (interpretations.size() > 1) {
             auto alternatives = interpretations;
-            alternatives.remove(0);
+            alternatives.removeAt(0);
             addMarker(*textNode, previousDictationPhraseStart, dictationPhraseLength, DocumentMarkerType::DictationPhraseWithAlternatives, WTFMove(alternatives));
         }
         previousDictationPhraseStart += dictationPhraseLength;

--- a/Source/WebCore/html/DOMTokenList.cpp
+++ b/Source/WebCore/html/DOMTokenList.cpp
@@ -176,9 +176,9 @@ static inline void replaceInOrderedSet(Vector<AtomString, 1>& tokens, size_t tok
 
     if (newTokenIndex > tokenIndex) {
         tokens[tokenIndex] = newToken;
-        tokens.remove(newTokenIndex);
+        tokens.removeAt(newTokenIndex);
     } else
-        tokens.remove(tokenIndex);
+        tokens.removeAt(tokenIndex);
 }
 
 // https://dom.spec.whatwg.org/#dom-domtokenlist-replace

--- a/Source/WebCore/html/HTMLFormElement.cpp
+++ b/Source/WebCore/html/HTMLFormElement.cpp
@@ -606,7 +606,7 @@ void HTMLFormElement::unregisterFormListedElement(FormListedElement& element)
     if (index < m_listedElementsAfterIndex)
         --m_listedElementsAfterIndex;
     removeFromPastNamesMap(element);
-    m_listedElements.remove(index);
+    m_listedElements.removeAt(index);
 
     if (auto* nodeLists = this->nodeLists())
         nodeLists->invalidateCaches();

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -2710,7 +2710,7 @@ void HTMLMediaElement::textTrackRemoveCue(TextTrack&, TextTrackCue& cue)
     size_t index = m_cueData->currentlyActiveCues.find(interval);
     if (index != notFound) {
         cue.setIsActive(false);
-        m_cueData->currentlyActiveCues.remove(index);
+        m_cueData->currentlyActiveCues.removeAt(index);
     }
 
     cue.removeDisplayTree();

--- a/Source/WebCore/html/HTMLVideoElement.cpp
+++ b/Source/WebCore/html/HTMLVideoElement.cpp
@@ -711,7 +711,7 @@ void HTMLVideoElement::cancelVideoFrameCallback(unsigned identifier)
     index = m_videoFrameRequests.findIf([identifier](auto& request) { return request->identifier == identifier; });
     if (index == notFound)
         return;
-    m_videoFrameRequests.remove(index);
+    m_videoFrameRequests.removeAt(index);
 
     if (m_videoFrameRequests.isEmpty()) {
         if (RefPtr player = this->player())

--- a/Source/WebCore/html/MediaController.cpp
+++ b/Source/WebCore/html/MediaController.cpp
@@ -114,7 +114,7 @@ void MediaController::addMediaElement(HTMLMediaElement& element)
 void MediaController::removeMediaElement(HTMLMediaElement& element)
 {
     ASSERT(m_mediaElements.contains(&element));
-    m_mediaElements.remove(m_mediaElements.find(&element));
+    m_mediaElements.removeFirst(&element);
 }
 
 Ref<TimeRanges> MediaController::buffered() const

--- a/Source/WebCore/html/parser/HTMLFormattingElementList.cpp
+++ b/Source/WebCore/html/parser/HTMLFormattingElementList.cpp
@@ -100,7 +100,7 @@ void HTMLFormattingElementList::remove(Element& element)
 {
     size_t index = m_entries.reverseFind(&element);
     if (index != notFound)
-        m_entries.remove(index);
+        m_entries.removeAt(index);
 }
 
 void HTMLFormattingElementList::removeUpdatingBookmark(Element& element, Bookmark& bookmark)
@@ -109,7 +109,7 @@ void HTMLFormattingElementList::removeUpdatingBookmark(Element& element, Bookmar
     if (index != notFound) {
         size_t bookmarkIndex = &bookmark.mark() - &first();
         RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(bookmarkIndex <= size());
-        m_entries.remove(index);
+        m_entries.removeAt(index);
         // Removing an element from the list can change the position of the bookmarked
         // item. Update the address pointed by the bookmark, when needed.
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN

--- a/Source/WebCore/html/track/TextTrackCueList.cpp
+++ b/Source/WebCore/html/track/TextTrackCueList.cpp
@@ -116,7 +116,7 @@ void TextTrackCueList::add(Ref<TextTrackCue>&& cue)
 void TextTrackCueList::remove(TextTrackCue& cue)
 {
     ASSERT_SORTED(m_vector);
-    m_vector.remove(cueIndex(cue));
+    m_vector.removeAt(cueIndex(cue));
     ASSERT_SORTED(m_vector);
 }
 

--- a/Source/WebCore/html/track/TextTrackList.cpp
+++ b/Source/WebCore/html/track/TextTrackList.cpp
@@ -231,7 +231,7 @@ void TextTrackList::remove(TrackBase& track, bool scheduleEvent)
         track.clearTrackList();
 
     Ref<TrackBase> trackRef = *(*tracks)[index];
-    tracks->remove(index);
+    tracks->removeAt(index);
 
     if (scheduleEvent)
         scheduleRemoveTrackEvent(WTFMove(trackRef));

--- a/Source/WebCore/html/track/TrackListBase.cpp
+++ b/Source/WebCore/html/track/TrackListBase.cpp
@@ -92,7 +92,7 @@ void TrackListBase::remove(TrackBase& track, bool scheduleEvent)
 
     Ref<TrackBase> trackRef = *m_inbandTracks[index];
 
-    m_inbandTracks.remove(index);
+    m_inbandTracks.removeAt(index);
 
     if (scheduleEvent)
         scheduleRemoveTrackEvent(WTFMove(trackRef));

--- a/Source/WebCore/html/track/VTTRegionList.cpp
+++ b/Source/WebCore/html/track/VTTRegionList.cpp
@@ -59,7 +59,7 @@ void VTTRegionList::remove(VTTRegion& region)
 {
     for (unsigned i = 0, size = m_vector.size(); i < size; ++i) {
         if (m_vector[i].ptr() == &region) {
-            m_vector.remove(i);
+            m_vector.removeAt(i);
             return;
         }
     }

--- a/Source/WebCore/inspector/agents/InspectorTimelineAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorTimelineAgent.cpp
@@ -247,7 +247,7 @@ void InspectorTimelineAgent::stopFromConsole(const String& title)
         auto recordTitle = record.data->getString("title"_s);
         if (title.isEmpty() || recordTitle == title) {
             didCompleteRecordEntry(record);
-            m_pendingConsoleProfileRecords.remove(i);
+            m_pendingConsoleProfileRecords.removeAt(i);
 
             if (!m_trackingFromFrontend && m_pendingConsoleProfileRecords.isEmpty())
                 stopProgrammaticCapture();

--- a/Source/WebCore/layout/formattingContexts/inline/InlineContentCache.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineContentCache.h
@@ -114,7 +114,7 @@ inline void InlineContentCache::InlineItems::set(InlineItemList&& inlineItemList
 
 inline void InlineContentCache::InlineItems::replace(size_t insertionPosition, InlineItemList&& inlineItemList, ContentAttributes contentAttributes, IsPopulatedFromCache isPopulatedFromCache)
 {
-    m_inlineItemList.remove(insertionPosition, m_inlineItemList.size() - insertionPosition);
+    m_inlineItemList.removeAt(insertionPosition, m_inlineItemList.size() - insertionPosition);
     m_inlineItemList.appendVector(WTFMove(inlineItemList));
     m_contentAttributes = contentAttributes;
     if (isPopulatedFromCache == IsPopulatedFromCache::No)

--- a/Source/WebCore/layout/formattingContexts/inline/InlineItemsBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineItemsBuilder.cpp
@@ -837,7 +837,7 @@ bool InlineItemsBuilder::buildInlineItemListForTextFromBreakingPositionsCache(co
             ASSERT_NOT_REACHED();
             if (inlineItemList.size() > intialSize) {
                 // Revert.
-                !intialSize ? inlineItemList.clear() : inlineItemList.remove(intialSize, inlineItemList.size() - intialSize);
+                !intialSize ? inlineItemList.clear() : inlineItemList.removeAt(intialSize, inlineItemList.size() - intialSize);
             }
             return false;
         }

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLine.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLine.cpp
@@ -166,7 +166,7 @@ void Line::handleOverflowingNonBreakingSpace(TrailingContentAction trailingConte
         }
 
         removedOrCollapsedContentWidth += run.logicalWidth();
-        m_runs.remove(index);
+        m_runs.removeAt(index);
     }
     m_contentLogicalWidth -= removedOrCollapsedContentWidth;
 }
@@ -187,7 +187,7 @@ const Box* Line::removeOverflowingOutOfFlowContent()
     if (!lastTrailingOutOfFlowItemIndex)
         return { };
     auto* lastTrailingOpaqueBox = &m_runs[*lastTrailingOutOfFlowItemIndex].layoutBox();
-    m_runs.remove(*lastTrailingOutOfFlowItemIndex, m_runs.size() - *lastTrailingOutOfFlowItemIndex);
+    m_runs.removeAt(*lastTrailingOutOfFlowItemIndex, m_runs.size() - *lastTrailingOutOfFlowItemIndex);
     ASSERT(!m_runs.isEmpty());
     return lastTrailingOpaqueBox;
 }
@@ -716,7 +716,7 @@ InlineLayoutUnit Line::TrimmableTrailingContent::remove()
     if (!trimmableRun.textContent()->length) {
         // This trimmable run is fully collapsed now (e.g. <div><img>    <span></span></div>).
         // We don't need to keep it around anymore.
-        m_runs.remove(*m_firstTrimmableRunIndex);
+        m_runs.removeAt(*m_firstTrimmableRunIndex);
     }
     reset();
     return trimmedWidth;

--- a/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContent.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContent.cpp
@@ -55,8 +55,8 @@ void Content::insert(Content&& newContent, size_t lineIndex, size_t boxIndex)
 
 void Content::remove(size_t firstLineIndex, size_t numberOfLines, size_t firstBoxIndex, size_t numberOfBoxes)
 {
-    lines.remove(firstLineIndex, numberOfLines);
-    boxes.remove(firstBoxIndex, numberOfBoxes);
+    lines.removeAt(firstLineIndex, numberOfLines);
+    boxes.removeAt(firstBoxIndex, numberOfBoxes);
 }
 
 }

--- a/Source/WebCore/loader/archive/cf/LegacyWebArchive.cpp
+++ b/Source/WebCore/loader/archive/cf/LegacyWebArchive.cpp
@@ -660,7 +660,7 @@ static UncheckedKeyHashMap<Ref<CSSStyleSheet>, String> addSubresourcesForCSSStyl
                 auto fileName = FileSystem::lastComponentOfPathIgnoringTrailingSlash(subresources[index]->relativeFilePath());
                 uniqueFileNames.remove(fileName);
                 uniqueSubresources.remove(url.string());
-                subresources.remove(index);
+                subresources.removeAt(index);
             }
 
             auto extension = MIMETypeRegistry::preferredExtensionForMIMEType(cssContentTypeAtom());

--- a/Source/WebCore/page/EventSource.cpp
+++ b/Source/WebCore/page/EventSource.cpp
@@ -349,7 +349,7 @@ void EventSource::parseEventStream()
     if (position == size)
         m_receiveBuffer.clear();
     else if (position)
-        m_receiveBuffer.remove(0, position);
+        m_receiveBuffer.removeAt(0, position);
 }
 
 void EventSource::parseEventStreamLine(unsigned position, std::optional<unsigned> fieldLength, unsigned lineLength)

--- a/Source/WebCore/page/Navigation.cpp
+++ b/Source/WebCore/page/Navigation.cpp
@@ -692,7 +692,7 @@ void Navigation::updateForReactivation(Vector<Ref<HistoryItem>>& newHistoryItems
             auto& entry = oldEntries.at(entryIndex);
             if (entry->associatedHistoryItem() == item) {
                 newEntry = entry.ptr();
-                oldEntries.remove(entryIndex);
+                oldEntries.removeAt(entryIndex);
                 break;
             }
         }

--- a/Source/WebCore/page/UserContentController.cpp
+++ b/Source/WebCore/page/UserContentController.cpp
@@ -84,7 +84,7 @@ void UserContentController::removeUserScript(DOMWrapperWorld& world, const URL& 
     auto scripts = it->value.get();
     for (int i = scripts->size() - 1; i >= 0; --i) {
         if (scripts->at(i)->url() == url)
-            scripts->remove(i);
+            scripts->removeAt(i);
     }
 
     if (scripts->isEmpty())
@@ -116,7 +116,7 @@ void UserContentController::removeUserStyleSheet(DOMWrapperWorld& world, const U
     bool sheetsChanged = false;
     for (int i = stylesheets.size() - 1; i >= 0; --i) {
         if (stylesheets[i]->url() == url) {
-            stylesheets.remove(i);
+            stylesheets.removeAt(i);
             sheetsChanged = true;
         }
     }

--- a/Source/WebCore/page/scrolling/ScrollingStateTree.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingStateTree.cpp
@@ -438,7 +438,7 @@ void ScrollingStateTree::removeNodeAndAllDescendants(ScrollingStateNode& node)
             return child.ptr() == &node;
         });
         if (index != notFound)
-            children.remove(index);
+            children.removeAt(index);
         else
             ASSERT_NOT_REACHED();
     }

--- a/Source/WebCore/page/scrolling/ScrollingTreeNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTreeNode.cpp
@@ -67,7 +67,7 @@ void ScrollingTreeNode::removeChild(ScrollingTreeNode& node)
     // The index will be notFound if the node to remove is a deeper-than-1-level descendant or
     // if node is the root state node.
     if (index != notFound) {
-        m_children.remove(index);
+        m_children.removeAt(index);
         return;
     }
 

--- a/Source/WebCore/platform/PasteboardCustomData.cpp
+++ b/Source/WebCore/platform/PasteboardCustomData.cpp
@@ -158,7 +158,7 @@ PasteboardCustomData::Entry& PasteboardCustomData::addOrMoveEntryToEnd(const Str
     });
     auto entry = index == notFound ? Entry(type) : m_data[index];
     if (index != notFound)
-        m_data.remove(index);
+        m_data.removeAt(index);
     m_data.append(WTFMove(entry));
     return m_data.last();
 }

--- a/Source/WebCore/platform/animation/AnimationList.h
+++ b/Source/WebCore/platform/animation/AnimationList.h
@@ -45,7 +45,7 @@ public:
     bool isEmpty() const { return m_animations.isEmpty(); }
     
     void resize(size_t n) { m_animations.resize(n); }
-    void remove(size_t i) { m_animations.remove(i); }
+    void removeAt(size_t i) { m_animations.removeAt(i); }
     void append(Ref<Animation>&& animation) { m_animations.append(WTFMove(animation)); }
 
     Animation& animation(size_t i) LIFETIME_BOUND { return m_animations[i].get(); }

--- a/Source/WebCore/platform/audio/PlatformMediaSessionManager.cpp
+++ b/Source/WebCore/platform/audio/PlatformMediaSessionManager.cpp
@@ -244,7 +244,7 @@ void PlatformMediaSessionManager::removeSession(PlatformMediaSessionInterface& s
     if (index == notFound)
         return;
 
-    m_sessions.remove(index);
+    m_sessions.removeAt(index);
 
     if (hasNoSession() && !activeAudioSessionRequired())
         maybeDeactivateAudioSession();
@@ -338,7 +338,7 @@ void PlatformMediaSessionManager::sessionWillEndPlayback(PlatformMediaSessionInt
     // last playing session, and re-inserting that pausing session at the
     // lastPlayingSessionIndex effectively places the pausing session immediately
     // after the last playing session.
-    m_sessions.remove(pausingSessionIndex);
+    m_sessions.removeAt(pausingSessionIndex);
     m_sessions.insert(lastPlayingSessionIndex, session);
 
     ALWAYS_LOG(LOGIDENTIFIER, "session moved from index ", pausingSessionIndex, " to ", lastPlayingSessionIndex);
@@ -372,7 +372,7 @@ void PlatformMediaSessionManager::setCurrentSession(PlatformMediaSessionInterfac
     if (!index || index == notFound)
         return;
 
-    m_sessions.remove(index);
+    m_sessions.removeAt(index);
     m_sessions.insert(0, session);
     
     ALWAYS_LOG(LOGIDENTIFIER, "session moved from index ", index, " to 0");

--- a/Source/WebCore/platform/graphics/FontTaggedSettings.h
+++ b/Source/WebCore/platform/graphics/FontTaggedSettings.h
@@ -134,7 +134,7 @@ void FontTaggedSettings<T>::insert(FontTaggedSetting<T>&& feature)
         if (m_list[i].tag() < feature.tag())
             continue;
         if (m_list[i].tag() == feature.tag())
-            m_list.remove(i);
+            m_list.removeAt(i);
         break;
     }
     m_list.insert(i, WTFMove(feature));

--- a/Source/WebCore/platform/graphics/GlyphBuffer.h
+++ b/Source/WebCore/platform/graphics/GlyphBuffer.h
@@ -118,11 +118,11 @@ public:
 
     void remove(unsigned location, unsigned length)
     {
-        m_fonts.remove(location, length);
-        m_glyphs.remove(location, length);
-        m_advances.remove(location, length);
-        m_origins.remove(location, length);
-        m_offsetsInString.remove(location, length);
+        m_fonts.removeAt(location, length);
+        m_glyphs.removeAt(location, length);
+        m_advances.removeAt(location, length);
+        m_origins.removeAt(location, length);
+        m_offsetsInString.removeAt(location, length);
     }
 
     void deleteGlyphWithoutAffectingSize(unsigned index)

--- a/Source/WebCore/platform/graphics/MediaSourcePrivate.cpp
+++ b/Source/WebCore/platform/graphics/MediaSourcePrivate.cpp
@@ -119,7 +119,7 @@ void MediaSourcePrivate::removeSourceBuffer(SourceBufferPrivate& sourceBuffer)
 
     size_t pos = m_activeSourceBuffers.find(&sourceBuffer);
     if (pos != notFound) {
-        m_activeSourceBuffers.remove(pos);
+        m_activeSourceBuffers.removeAt(pos);
         notifyActiveSourceBuffersChanged();
     }
     m_sourceBuffers.removeFirst(&sourceBuffer);
@@ -139,7 +139,7 @@ void MediaSourcePrivate::sourceBufferPrivateDidChangeActiveState(SourceBufferPri
     if (active || position == notFound)
         return;
 
-    m_activeSourceBuffers.remove(position);
+    m_activeSourceBuffers.removeAt(position);
     notifyActiveSourceBuffersChanged();
 }
 

--- a/Source/WebCore/platform/graphics/PlatformTimeRanges.cpp
+++ b/Source/WebCore/platform/graphics/PlatformTimeRanges.cpp
@@ -232,7 +232,7 @@ void PlatformTimeRanges::add(const MediaTime& start, const MediaTime& end, AddTi
         if (addedRange.isOverlappingRange(m_ranges[overlappingArcIndex]) || addedRange.isContiguousWithRange(m_ranges[overlappingArcIndex])) {
             // We need to merge the addedRange and that range.
             addedRange = addedRange.unionWithOverlappingOrContiguousRange(m_ranges[overlappingArcIndex]);
-            m_ranges.remove(overlappingArcIndex);
+            m_ranges.removeAt(overlappingArcIndex);
             overlappingArcIndex--;
         } else {
             // Check the case for which there is no more to do

--- a/Source/WebCore/platform/graphics/WOFFFileFormat.cpp
+++ b/Source/WebCore/platform/graphics/WOFFFileFormat.cpp
@@ -119,7 +119,7 @@ public:
             return false;
         if (offset + n > m_vector.size())
             m_vector.grow(offset + n);
-        m_vector.remove(offset, n);
+        m_vector.removeAt(offset, n);
         m_vector.insertSpan(offset, unsafeMakeSpan(static_cast<const uint8_t*>(data), n));
         return true;
     }

--- a/Source/WebCore/platform/graphics/avfoundation/InbandTextTrackPrivateAVF.cpp
+++ b/Source/WebCore/platform/graphics/avfoundation/InbandTextTrackPrivateAVF.cpp
@@ -569,7 +569,7 @@ void InbandTextTrackPrivateAVF::processVTTSample(CMSampleBufferRef sampleBuffer,
             });
         }
 
-        m_sampleInputBuffer.remove(0, (size_t)boxLength);
+        m_sampleInputBuffer.removeAt(0, (size_t)boxLength);
     }
 }
 

--- a/Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.cpp
+++ b/Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.cpp
@@ -783,7 +783,7 @@ void MediaPlayerPrivateAVFoundation::processNewAndRemovedTextTracks(const Vector
             }
             if (player)
                 player->removeTextTrack(Ref { *m_textTracks[i] });
-            m_textTracks.remove(i);
+            m_textTracks.removeAt(i);
         }
     }
 

--- a/Source/WebCore/platform/graphics/avfoundation/WebAVSampleBufferListener.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/WebAVSampleBufferListener.mm
@@ -143,7 +143,7 @@ static bool isSampleBufferVideoRenderer(id object)
 
     [renderer removeObserver:self forKeyPath:errorKeyPath];
     [renderer removeObserver:self forKeyPath:outputObscuredDueToInsufficientExternalProtectionKeyPath];
-    _videoRenderers.remove(_videoRenderers.find(renderer));
+    _videoRenderers.removeFirst(renderer);
 
     [NSNotificationCenter.defaultCenter removeObserver:self name:AVSampleBufferDisplayLayerFailedToDecodeNotification object:renderer];
     [NSNotificationCenter.defaultCenter removeObserver:self name:AVSampleBufferVideoRendererDidFailToDecodeNotification object:renderer];
@@ -174,7 +174,7 @@ static bool isSampleBufferVideoRenderer(id object)
     [renderer removeObserver:self forKeyPath:errorKeyPath];
     [NSNotificationCenter.defaultCenter removeObserver:self name:AVSampleBufferAudioRendererWasFlushedAutomaticallyNotification object:renderer];
 
-    _audioRenderers.remove(_audioRenderers.find(renderer));
+    _audioRenderers.removeFirst(renderer);
 }
 
 - (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void*)context

--- a/Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm
@@ -1235,7 +1235,7 @@ void CDMInstanceSessionFairPlayStreamingAVFObjC::didProvideRequests(Vector<Retai
     auto initDataType = initTypeForRequest(requests.first().get());
     if (initDataType != InitDataRegistry::cencName()) {
         didProvideRequest(requests.first().get());
-        requests.remove(0);
+        requests.removeAt(0);
 
         for (auto& request : requests)
             m_pendingRequests.append({ initDataType, { WTFMove(request) } });
@@ -1498,7 +1498,7 @@ void CDMInstanceSessionFairPlayStreamingAVFObjC::nextRequest()
         return;
 
     Request nextRequest = WTFMove(m_pendingRequests.first());
-    m_pendingRequests.remove(0);
+    m_pendingRequests.removeAt(0);
 
     if (nextRequest.requests.isEmpty())
         return;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionMediaSourceAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionMediaSourceAVFObjC.mm
@@ -102,7 +102,7 @@ void CDMSessionMediaSourceAVFObjC::removeSourceBuffer(SourceBufferPrivateAVFObjC
     ASSERT(sourceBuffer);
 
     sourceBuffer->unregisterForErrorNotifications(this);
-    m_sourceBuffers.remove(m_sourceBuffers.find(sourceBuffer));
+    m_sourceBuffers.removeFirst(sourceBuffer);
 }
 
 String CDMSessionMediaSourceAVFObjC::storagePath() const

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
@@ -3150,7 +3150,7 @@ void MediaPlayerPrivateAVFoundationObjC::processMediaSelectionOptions()
             }
 
             if ([currentOption isEqual:option]) {
-                removedTextTracks.remove(i - 1);
+                removedTextTracks.removeAt(i - 1);
                 newTrack = false;
                 break;
             }

--- a/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm
@@ -817,7 +817,7 @@ void SourceBufferPrivateAVFObjC::registerForErrorNotifications(SourceBufferPriva
 void SourceBufferPrivateAVFObjC::unregisterForErrorNotifications(SourceBufferPrivateAVFObjCErrorClient* client)
 {
     ASSERT(m_errorClients.contains(client));
-    m_errorClients.remove(m_errorClients.find(client));
+    m_errorClients.removeFirst(client);
 }
 
 void SourceBufferPrivateAVFObjC::videoRendererDidReceiveError(WebSampleBufferVideoRendering *renderer, NSError *error)

--- a/Source/WebCore/platform/graphics/ca/LayerPool.cpp
+++ b/Source/WebCore/platform/graphics/ca/LayerPool.cpp
@@ -69,7 +69,7 @@ LayerPool::LayerList& LayerPool::listOfLayersWithSize(const IntSize& size, Acces
         it = m_reuseLists.add(size, LayerList()).iterator;
         m_sizesInPruneOrder.append(size);
     } else if (accessType == MarkAsUsed) {
-        m_sizesInPruneOrder.remove(m_sizesInPruneOrder.reverseFind(size));
+        m_sizesInPruneOrder.removeLast(size);
         m_sizesInPruneOrder.append(size);
     }
     return it->value;
@@ -130,7 +130,7 @@ void LayerPool::pruneTimerFired()
         LayerList& oldestReuseList = it->value;
         if (oldestReuseList.isEmpty()) {
             m_reuseLists.remove(sizeToDrop);
-            m_sizesInPruneOrder.remove(0);
+            m_sizesInPruneOrder.removeAt(0);
             continue;
         }
 

--- a/Source/WebCore/platform/graphics/cg/IOSurfacePool.cpp
+++ b/Source/WebCore/platform/graphics/cg/IOSurfacePool.cpp
@@ -113,7 +113,7 @@ void IOSurfacePool::didRemoveSurface(IOSurface& surface, bool inUse)
 
 void IOSurfacePool::didUseSurfaceOfSize(IntSize size)
 {
-    m_sizesInPruneOrder.remove(m_sizesInPruneOrder.reverseFind(size));
+    m_sizesInPruneOrder.removeLast(size);
     m_sizesInPruneOrder.append(size);
 }
 
@@ -210,7 +210,7 @@ void IOSurfacePool::insertSurfaceIntoPool(std::unique_ptr<IOSurface> surface)
     auto insertedTuple = m_cachedSurfaces.add(surfaceSize, CachedSurfaceQueue());
     insertedTuple.iterator->value.prepend(WTFMove(surface));
     if (!insertedTuple.isNewEntry)
-        m_sizesInPruneOrder.remove(m_sizesInPruneOrder.reverseFind(surfaceSize));
+        m_sizesInPruneOrder.removeLast(surfaceSize);
     m_sizesInPruneOrder.append(surfaceSize);
 
     scheduleCollectionTimer();
@@ -247,7 +247,7 @@ void IOSurfacePool::tryEvictOldestCachedSurface()
 
     if (surfaceQueueIter->value.isEmpty()) {
         m_cachedSurfaces.remove(surfaceQueueIter);
-        m_sizesInPruneOrder.remove(0);
+        m_sizesInPruneOrder.removeAt(0);
     }
 }
 

--- a/Source/WebCore/platform/graphics/filters/software/FEMorphologySoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FEMorphologySoftwareApplier.cpp
@@ -98,7 +98,7 @@ void FEMorphologySoftwareApplier::applyPlatformGeneric(const PaintingData& paint
                 extrema.append(columnExtremum(srcPixelBuffer, x + radiusX, yRadiusStart, yRadiusEnd, width, paintingData.type));
 
             if (x > radiusX)
-                extrema.remove(0);
+                extrema.removeAt(0);
 
             unsigned& destPixel = reinterpretCastSpanStartTo<unsigned>(dstPixelBuffer->bytes().subspan(pixelArrayIndex(x, y, width)));
             destPixel = makePixelValueFromColorComponents(kernelExtremum(extrema, paintingData.type)).value;

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.cpp
@@ -1284,7 +1284,7 @@ void TextureMapperLayer::removeFromParent()
     if (m_parent) {
         size_t index = m_parent->m_children.find(this);
         ASSERT(index != notFound);
-        m_parent->m_children.remove(index);
+        m_parent->m_children.removeAt(index);
 #if ENABLE(DAMAGE_TRACKING)
         if (m_parent->canInferDamage()) {
             collectDamageFromLayerAboutToBeRemoved(*this);

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperTiledBackingStore.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperTiledBackingStore.cpp
@@ -116,7 +116,7 @@ void TextureMapperTiledBackingStore::createOrDestroyTilesIfNeeded(const FloatSiz
 
             // A tile that we want to add already exists, no need to add or remove it.
             existsAlready = true;
-            tileRectsToAdd.remove(j);
+            tileRectsToAdd.removeAt(j);
             break;
         }
 
@@ -150,7 +150,7 @@ void TextureMapperTiledBackingStore::createOrDestroyTilesIfNeeded(const FloatSiz
     for (auto& index : tileIndicesToRemove) {
         if (m_tiles.size() <= TileEraseThreshold)
             break;
-        m_tiles.remove(index);
+        m_tiles.removeAt(index);
     }
 }
 

--- a/Source/WebCore/platform/ios/LegacyTileLayerPool.mm
+++ b/Source/WebCore/platform/ios/LegacyTileLayerPool.mm
@@ -64,7 +64,7 @@ LegacyTileLayerPool::LayerList& LegacyTileLayerPool::listOfLayersWithSize(const 
         it = m_reuseLists.add(size, LayerList()).iterator;
         m_sizesInPruneOrder.append(size);
     } else if (accessType == MarkAsUsed) {
-        m_sizesInPruneOrder.remove(m_sizesInPruneOrder.reverseFind(size));
+        m_sizesInPruneOrder.removeLast(size);
         m_sizesInPruneOrder.append(size);
     }
     return it->value;
@@ -144,7 +144,7 @@ void LegacyTileLayerPool::prune()
         LayerList& oldestReuseList = m_reuseLists.find(sizeToDrop)->value;
         if (oldestReuseList.isEmpty()) {
             m_reuseLists.remove(sizeToDrop);
-            m_sizesInPruneOrder.remove(0);
+            m_sizesInPruneOrder.removeAt(0);
             continue;
         }
 #if LOG_TILING

--- a/Source/WebCore/platform/mediastream/mac/ScreenCaptureKitSharingSessionManager.mm
+++ b/Source/WebCore/platform/mediastream/mac/ScreenCaptureKitSharingSessionManager.mm
@@ -391,7 +391,7 @@ void ScreenCaptureKitSharingSessionManager::contentSharingPickerUpdatedFilterFor
     auto activeSource = m_activeSources[index];
     if (!activeSource->observer()) {
         RELEASE_LOG_ERROR(WebRTC, "ScreenCaptureKitSharingSessionManager::contentFilterWasUpdated - null session observer!");
-        m_activeSources.remove(index);
+        m_activeSources.removeAt(index);
         return;
     }
 
@@ -596,7 +596,7 @@ void ScreenCaptureKitSharingSessionManager::cleanupSessionSource(ScreenCaptureSe
         return;
     }
 
-    m_activeSources.remove(index);
+    m_activeSources.removeAt(index);
 
     if (!promptingInProgress())
         cancelPicking();

--- a/Source/WebCore/platform/mock/TimerEventBasedMock.h
+++ b/Source/WebCore/platform/mock/TimerEventBasedMock.h
@@ -48,8 +48,7 @@ class TimerEventBasedMock {
 public:
     void removeEvent(TimerEvent& event)
     {
-        size_t pos = m_timerEvents.find(&event);
-        m_timerEvents.remove(pos);
+        m_timerEvents.removeFirst(&event);
     }
 
 protected:

--- a/Source/WebCore/platform/mock/mediasource/MockSourceBufferPrivate.cpp
+++ b/Source/WebCore/platform/mock/mediasource/MockSourceBufferPrivate.cpp
@@ -163,7 +163,7 @@ Ref<MediaPromise> MockSourceBufferPrivate::appendInternal(Ref<SharedBuffer>&& da
             m_inputBuffer.clear();
             return MediaPromise::createAndReject(PlatformMediaError::ParsingError);
         }
-        m_inputBuffer.remove(0, boxLength);
+        m_inputBuffer.removeAt(0, boxLength);
     }
 
     return MediaPromise::createAndResolve();

--- a/Source/WebCore/platform/network/curl/CurlMultipartHandle.cpp
+++ b/Source/WebCore/platform/network/curl/CurlMultipartHandle.cpp
@@ -135,7 +135,7 @@ bool CurlMultipartHandle::processContent()
             m_client->didReceiveDataFromMultipart({ m_buffer.data(), result.dataEnd });
 
         if (result.processed)
-            m_buffer.remove(0, result.processed);
+            m_buffer.removeAt(0, result.processed);
 
         if (!result.hasBoundary || result.hasCloseDelimiter) {
             if (m_didCompleteMessage) {
@@ -312,7 +312,7 @@ CurlMultipartHandle::ParseHeadersResult CurlMultipartHandle::parseHeadersIfPossi
         m_headers.append(makeString(name, ": "_s, value, "\r\n"_s));
     }
 
-    m_buffer.remove(0, end - contentStartPtr);
+    m_buffer.removeAt(0, end - contentStartPtr);
     return ParseHeadersResult::Success;
 }
 

--- a/Source/WebCore/platform/network/curl/CurlRequest.cpp
+++ b/Source/WebCore/platform/network/curl/CurlRequest.cpp
@@ -518,7 +518,7 @@ int CurlRequest::didReceiveDebugInfo(curl_infotype type, std::span<const char> d
         auto headerFields = requestHeader.split("\r\n"_s);
         // Remove the request line
         if (headerFields.size())
-            headerFields.remove(0);
+            headerFields.removeAt(0);
 
         m_requestHeaderSize = requestHeader.length();
 

--- a/Source/WebCore/platform/network/curl/CurlStream.cpp
+++ b/Source/WebCore/platform/network/curl/CurlStream.cpp
@@ -174,7 +174,7 @@ void CurlStream::tryToSend()
     m_sendBufferOffset += bytesSent;
 
     if (m_sendBufferOffset >= length) {
-        m_sendBuffers.remove(0);
+        m_sendBuffers.removeAt(0);
         m_sendBufferOffset = 0;
     }
 

--- a/Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp
+++ b/Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp
@@ -249,7 +249,7 @@ LayoutUnit GridTrackSizingAlgorithm::computeTrackBasedSize() const
         if (m_renderGrid->shouldCheckExplicitIntrinsicInnerLogicalSize(m_direction) && m_renderGrid->autoRepeatType(m_direction) == AutoRepeatType::Fit) {
             auto allTracks = tracks(m_direction);
             auto autoRepeatTracksRange = m_renderGrid->autoRepeatTracksRange(m_direction);
-            allTracks.remove(autoRepeatTracksRange.begin(), autoRepeatTracksRange.distance());
+            allTracks.removeAt(autoRepeatTracksRange.begin(), autoRepeatTracksRange.distance());
             return allTracks;
         }
         return tracks(m_direction);

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -2541,7 +2541,7 @@ void RenderElement::adjustComputedFontSizesOnBlocks(float size, float visibleWid
     // which has fixed height but its content overflows intentionally.
     for (CheckedPtr descendant = traverseNext(this, includeNonFixedHeight, currentDepth, newFixedDepth); descendant; descendant = descendant->traverseNext(this, includeNonFixedHeight, currentDepth, newFixedDepth)) {
         while (depthStack.size() > 0 && currentDepth <= depthStack[depthStack.size() - 1])
-            depthStack.remove(depthStack.size() - 1);
+            depthStack.removeAt(depthStack.size() - 1);
         if (newFixedDepth)
             depthStack.append(newFixedDepth);
 
@@ -2571,7 +2571,7 @@ void RenderElement::resetTextAutosizing()
 
     for (CheckedPtr descendant = traverseNext(this, includeNonFixedHeight, currentDepth, newFixedDepth); descendant; descendant = descendant->traverseNext(this, includeNonFixedHeight, currentDepth, newFixedDepth)) {
         while (depthStack.size() > 0 && currentDepth <= depthStack[depthStack.size() - 1])
-            depthStack.remove(depthStack.size() - 1);
+            depthStack.removeAt(depthStack.size() - 1);
         if (newFixedDepth)
             depthStack.append(newFixedDepth);
 

--- a/Source/WebCore/style/values/images/StyleGradient.cpp
+++ b/Source/WebCore/style/values/images/StyleGradient.cpp
@@ -470,7 +470,7 @@ template<typename GradientAdapter, typename StyleGradient> GradientColorStops co
         // Check if everything coincides or the midpoint is exactly in the middle.
         // If so, ignore the midpoint.
         if (offset - offset1 == offset2 - offset) {
-            stops.remove(x);
+            stops.removeAt(x);
             continue;
         }
 
@@ -512,7 +512,7 @@ template<typename GradientAdapter, typename StyleGradient> GradientColorStops co
             newStops[y].color = interpolateColors(styleGradient.parameters.colorInterpolationMethod.method, color1, 1.0f - multiplier, color2, multiplier);
         }
 
-        stops.remove(x);
+        stops.removeAt(x);
         stops.insertSpan(x, std::span { newStops });
         x += 9;
     }

--- a/Source/WebCore/svg/properties/SVGList.h
+++ b/Source/WebCore/svg/properties/SVGList.h
@@ -88,7 +88,7 @@ public:
         if (index > numberOfItems())
             index = numberOfItems();
 
-        auto item = insert(index, WTFMove(newItem));
+        auto item = insertAt(index, WTFMove(newItem));
         commitChange();
         return item;
     }
@@ -100,7 +100,7 @@ public:
             return result.releaseException();
         ASSERT(result.releaseReturnValue());
 
-        auto item = replace(index, WTFMove(newItem));
+        auto item = replaceAt(index, WTFMove(newItem));
         commitChange();
         return item;
     }
@@ -112,7 +112,7 @@ public:
             return result.releaseException();
         ASSERT(result.releaseReturnValue());
 
-        auto item = remove(index);
+        auto item = removeAt(index);
         commitChange();
         return item;
     }
@@ -194,9 +194,9 @@ protected:
 
     virtual void detachItems() { }
     virtual ItemType at(unsigned index) const = 0;
-    virtual ItemType insert(unsigned index, ItemType&&) = 0;
-    virtual ItemType replace(unsigned index, ItemType&&) = 0;
-    virtual ItemType remove(unsigned index) = 0;
+    virtual ItemType insertAt(unsigned index, ItemType&&) = 0;
+    virtual ItemType replaceAt(unsigned index, ItemType&&) = 0;
+    virtual ItemType removeAt(unsigned index) = 0;
     virtual ItemType append(ItemType&&) = 0;
 
     Vector<ItemType> m_items;

--- a/Source/WebCore/svg/properties/SVGPrimitiveList.h
+++ b/Source/WebCore/svg/properties/SVGPrimitiveList.h
@@ -43,25 +43,25 @@ protected:
         return m_items.at(index);
     }
 
-    PropertyType insert(unsigned index, PropertyType&& newItem) override
+    PropertyType insertAt(unsigned index, PropertyType&& newItem) override
     {
         ASSERT(index <= size());
         m_items.insert(index, WTFMove(newItem));
         return at(index);
     }
 
-    PropertyType replace(unsigned index, PropertyType&& newItem) override
+    PropertyType replaceAt(unsigned index, PropertyType&& newItem) override
     {
         ASSERT(index < size());
         m_items.at(index) = WTFMove(newItem);
         return at(index);
     }
 
-    PropertyType remove(unsigned index) override
+    PropertyType removeAt(unsigned index) override
     {
         ASSERT(index < size());
         PropertyType item = at(index);
-        m_items.remove(index);
+        m_items.removeAt(index);
         return item;
     }
 

--- a/Source/WebCore/svg/properties/SVGPropertyList.h
+++ b/Source/WebCore/svg/properties/SVGPropertyList.h
@@ -74,7 +74,7 @@ protected:
         return m_items.at(index).copyRef();
     }
 
-    Ref<PropertyType> insert(unsigned index, Ref<PropertyType>&& newItem) override
+    Ref<PropertyType> insertAt(unsigned index, Ref<PropertyType>&& newItem) override
     {
         ASSERT(index <= size());
 
@@ -89,7 +89,7 @@ protected:
         return at(index);
     }
 
-    Ref<PropertyType> replace(unsigned index, Ref<PropertyType>&& newItem) override
+    Ref<PropertyType> replaceAt(unsigned index, Ref<PropertyType>&& newItem) override
     {
         ASSERT(index < size());
         Ref<PropertyType>& item = m_items[index];
@@ -109,14 +109,14 @@ protected:
         return at(index);
     }
 
-    Ref<PropertyType> remove(unsigned index) override
+    Ref<PropertyType> removeAt(unsigned index) override
     {
         ASSERT(index < size());
         Ref<PropertyType> item = at(index);
 
         // Spec: Detach item.
         item->detach();
-        m_items.remove(index);
+        m_items.removeAt(index);
         return item;
     }
 

--- a/Source/WebCore/svg/properties/SVGValuePropertyList.h
+++ b/Source/WebCore/svg/properties/SVGValuePropertyList.h
@@ -63,12 +63,12 @@ public:
 
         // Remove existing items.
         while (size() > newSize)
-            remove(size() - 1);
+            removeAt(size() - 1);
     }
 
 protected:
     using Base::append;
-    using Base::remove;
+    using Base::removeAt;
 
     // Base and default constructor. Do not use "using Base::Base" because of Windows and GTK ports.
     SVGValuePropertyList(SVGPropertyOwner* owner = nullptr, SVGPropertyAccess access = SVGPropertyAccess::ReadWrite)

--- a/Source/WebCore/workers/WorkerAnimationController.cpp
+++ b/Source/WebCore/workers/WorkerAnimationController.cpp
@@ -103,7 +103,7 @@ void WorkerAnimationController::cancelAnimationFrame(CallbackId callbackId)
         auto& callback = m_animationCallbacks[i];
         if (callback->m_id == callbackId) {
             callback->m_firedOrCancelled = true;
-            m_animationCallbacks.remove(i);
+            m_animationCallbacks.removeAt(i);
             InspectorInstrumentation::didCancelAnimationFrame(m_workerGlobalScope, callbackId);
             return;
         }

--- a/Source/WebDriver/socket/HTTPParser.cpp
+++ b/Source/WebDriver/socket/HTTPParser.cpp
@@ -133,7 +133,7 @@ bool HTTPParser::readLine(String& line)
     if (line.isNull())
         LOG_ERROR("Client error: invalid encoding in HTTP header.");
 
-    m_buffer.remove(0, position + 2);
+    m_buffer.removeAt(0, position + 2);
     return true;
 }
 

--- a/Source/WebGPU/WGSL/WGSLShaderModule.h
+++ b/Source/WebGPU/WGSL/WGSLShaderModule.h
@@ -221,7 +221,7 @@ public:
         auto& vector = const_cast<Vector<T, size>&>(constVector);
         vector.insert(position, std::forward<T>(value));
         m_replacements.append([&vector, position]() {
-            vector.remove(position);
+            vector.removeAt(position);
         });
     }
 
@@ -231,7 +231,7 @@ public:
         auto& vector = const_cast<Vector<T, size>&>(constVector);
         vector.insertVector(position, value);
         m_replacements.append([&vector, position, length = value.size()]() {
-            vector.remove(position, length);
+            vector.removeAt(position, length);
         });
     }
 
@@ -243,7 +243,7 @@ public:
         m_replacements.append([&vector, position, entry]() mutable {
             vector.insert(position, entry);
         });
-        vector.remove(position);
+        vector.removeAt(position);
     }
 
     template<typename T, size_t size>

--- a/Source/WebGPU/WebGPU/RenderBundleEncoder.mm
+++ b/Source/WebGPU/WebGPU/RenderBundleEncoder.mm
@@ -961,7 +961,7 @@ void RenderBundleEncoder::endCurrentICB()
         recordedCommands.clear();
         m_icbDescriptor.commandTypes = 0;
     } else
-        recordedCommands.remove(0, lastIndexOfRecordedCommand);
+        recordedCommands.removeAt(0, lastIndexOfRecordedCommand);
 
     m_recordedCommands = std::exchange(recordedCommands, { });
     m_currentCommandIndex = commandCount - completedDraws;

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
@@ -1408,7 +1408,7 @@ void NetworkConnectionToWebProcess::stopTrackingResourceLoad(WebCore::ResourceLo
         return;
 
     m_networkActivityTrackers[itemIndex].networkActivity.complete(code);
-    m_networkActivityTrackers.remove(itemIndex);
+    m_networkActivityTrackers.removeAt(itemIndex);
 }
 
 void NetworkConnectionToWebProcess::stopAllNetworkActivityTracking()

--- a/Source/WebKit/NetworkProcess/cocoa/LaunchServicesDatabaseObserver.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/LaunchServicesDatabaseObserver.mm
@@ -126,7 +126,7 @@ void LaunchServicesDatabaseObserver::handleEvent(xpc_connection_t connection, xp
         Locker locker { m_connectionsLock };
         for (size_t i = 0; i < m_connections.size(); i++) {
             if (m_connections[i].get() == connection) {
-                m_connections.remove(i);
+                m_connections.removeAt(i);
                 break;
             }
         }

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageManager.cpp
@@ -339,7 +339,7 @@ void CacheStorageManager::removeCache(WebCore::DOMCacheIdentifier cacheIdentifie
 
     makeDirty();
     m_removedCaches.set(cacheIdentifier, WTFMove(m_caches[index]));
-    m_caches.remove(index);
+    m_caches.removeAt(index);
     return callback(true);
 }
 
@@ -452,7 +452,7 @@ void CacheStorageManager::dereference(IPC::Connection::UniqueID connection, WebC
     if (index == notFound)
         return;
 
-    refConnections.remove(index);
+    refConnections.removeAt(index);
     if (!refConnections.isEmpty())
         return;
 

--- a/Source/WebKit/Shared/API/c/WKMutableArray.cpp
+++ b/Source/WebKit/Shared/API/c/WKMutableArray.cpp
@@ -46,6 +46,6 @@ void WKArrayAppendItem(WKMutableArrayRef arrayRef, WKTypeRef itemRef)
 
 void WKArrayRemoveItemAtIndex(WKMutableArrayRef arrayRef, size_t index)
 {
-    WebKit::toImpl(arrayRef)->elements().remove(index);
+    WebKit::toImpl(arrayRef)->elements().removeAt(index);
 }
 

--- a/Source/WebKit/UIProcess/UserMediaPermissionRequestProxy.cpp
+++ b/Source/WebKit/UIProcess/UserMediaPermissionRequestProxy.cpp
@@ -81,7 +81,7 @@ static inline void setDeviceAsFirst(Vector<CaptureDevice>& devices, const String
         auto device = devices[index];
         ASSERT(device.enabled());
 
-        devices.remove(index);
+        devices.removeAt(index);
         devices.insert(0, WTFMove(device));
     }
 }

--- a/Source/WebKit/UIProcess/WebAuthentication/Mock/MockCcidService.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Mock/MockCcidService.mm
@@ -94,7 +94,7 @@ RetainPtr<NSData> MockCcidService::nextReply()
         return nil;
 
     auto result = adoptNS([[NSData alloc] initWithBase64EncodedString:m_configuration.ccid->payloadBase64[0].createNSString().get() options:NSDataBase64DecodingIgnoreUnknownCharacters]);
-    m_configuration.ccid->payloadBase64.remove(0);
+    m_configuration.ccid->payloadBase64.removeAt(0);
     return result;
 }
 

--- a/Source/WebKit/UIProcess/WebAuthentication/Mock/MockHidConnection.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/Mock/MockHidConnection.cpp
@@ -151,7 +151,7 @@ void MockHidConnection::parseRequest()
             auto payload = m_requestMessage->getMessagePayload();
             ASSERT(payload.size());
             auto cmd = static_cast<CtapRequestCommand>(payload[0]);
-            payload.remove(0);
+            payload.removeAt(0);
             auto requestMap = CBORReader::read(payload);
             ASSERT(requestMap || cmd == CtapRequestCommand::kAuthenticatorGetNextAssertion);
 
@@ -258,7 +258,7 @@ void MockHidConnection::feedReports()
         else {
             ASSERT(!m_configuration.hid->payloadBase64.isEmpty());
             auto payload = base64Decode(m_configuration.hid->payloadBase64[0]);
-            m_configuration.hid->payloadBase64.remove(0);
+            m_configuration.hid->payloadBase64.removeAt(0);
             if (!m_configuration.hid->isU2f)
                 message = FidoHidMessage::create(m_currentChannel, FidoHidDeviceCommand::kCbor, WTFMove(*payload));
             else

--- a/Source/WebKit/UIProcess/WebAuthentication/Mock/MockNfcService.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Mock/MockNfcService.mm
@@ -201,7 +201,7 @@ NSData* MockNfcService::transceive()
         return nil;
 
     auto result = adoptNS([[NSData alloc] initWithBase64EncodedString:m_configuration.nfc->payloadBase64[0].createNSString().get() options:NSDataBase64DecodingIgnoreUnknownCharacters]);
-    m_configuration.nfc->payloadBase64.remove(0);
+    m_configuration.nfc->payloadBase64.removeAt(0);
     return result.autorelease();
 }
 

--- a/Source/WebKit/UIProcess/WebAuthentication/Virtual/VirtualHidConnection.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/Virtual/VirtualHidConnection.cpp
@@ -155,7 +155,7 @@ void VirtualHidConnection::parseRequest()
         auto payload = m_requestMessage->getMessagePayload();
         ASSERT(payload.size());
         auto cmd = static_cast<CtapRequestCommand>(payload[0]);
-        payload.remove(0);
+        payload.removeAt(0);
         auto requestMap = CBORReader::read(payload);
         ASSERT(requestMap || cmd == CtapRequestCommand::kAuthenticatorGetNextAssertion);
         if (cmd == CtapRequestCommand::kAuthenticatorMakeCredential) {

--- a/Source/WebKit/UIProcess/WebBackForwardList.cpp
+++ b/Source/WebKit/UIProcess/WebBackForwardList.cpp
@@ -135,7 +135,7 @@ void WebBackForwardList::addItem(Ref<WebBackForwardListItem>&& newItem)
         if (m_entries.size() >= DefaultCapacity && (*m_currentIndex)) {
             didRemoveItem(m_entries[0]);
             removedItems.append(WTFMove(m_entries[0]));
-            m_entries.remove(0);
+            m_entries.removeAt(0);
 
             if (m_entries.isEmpty())
                 m_currentIndex = std::nullopt;
@@ -241,7 +241,7 @@ void WebBackForwardList::goToItem(WebBackForwardListItem& item)
     Vector<Ref<WebBackForwardListItem>> removedItems;
     if (!shouldKeepCurrentItem) {
         removedItems.append(currentItem.copyRef());
-        m_entries.remove(*m_currentIndex);
+        m_entries.removeAt(*m_currentIndex);
         targetIndex = notFound;
         for (size_t i = 0; i < m_entries.size(); ++i) {
             if (m_entries[i].ptr() == &item) {

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -3319,7 +3319,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
     for (int index = _pendingPositionInformationHandlers.size() - 1; index >= 0; --index) {
         if (!_pendingPositionInformationHandlers[index])
-            _pendingPositionInformationHandlers.remove(index);
+            _pendingPositionInformationHandlers.removeAt(index);
     }
 }
 
@@ -7687,7 +7687,7 @@ static UITextAutocapitalizationType toUITextAutocapitalize(WebCore::Autocapitali
         return;
     }
 
-    _keyWebEventHandlers.remove(indexOfHandlerToCall);
+    _keyWebEventHandlers.removeAt(indexOfHandlerToCall);
     handler(event, eventWasHandled);
 }
 

--- a/Source/WebKit/WPEPlatform/wpe/WPECursorTheme.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPECursorTheme.cpp
@@ -100,7 +100,7 @@ std::unique_ptr<CursorTheme> CursorTheme::create(const char* name, uint32_t size
             if (!path) {
                 // If there's no cursors path, use the first inherited theme.
                 path = WTFMove(inheritedThemes[0]);
-                inheritedThemes.remove(0);
+                inheritedThemes.removeAt(0);
             }
 
             return makeUnique<CursorTheme>(WTFMove(path), size, WTFMove(inheritedThemes));

--- a/Source/WebKit/WPEPlatform/wpe/atk/WPEApplicationAccessibleAtk.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/atk/WPEApplicationAccessibleAtk.cpp
@@ -115,7 +115,7 @@ void wpeApplicationAccessibleAtkToplevelDestroyed(WPEApplicationAccessibleAtk* a
     if (index == notFound)
         return;
 
-    accessible->priv->toplevels.remove(index);
+    accessible->priv->toplevels.removeAt(index);
     g_signal_emit_by_name(accessible, "children-changed::remove", index, toplevelAccessible, nullptr);
     atk_object_set_parent(toplevelAccessible, nullptr);
 }

--- a/Source/WebKit/WPEPlatform/wpe/wayland/WPEDisplayWayland.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/WPEDisplayWayland.cpp
@@ -271,7 +271,7 @@ const struct wl_registry_listener registryListener = {
         });
         if (index != notFound) {
             auto screen = priv->screens[index];
-            priv->screens.remove(index);
+            priv->screens.removeAt(index);
             wpe_display_screen_removed(WPE_DISPLAY(display), screen.get());
         }
     },

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.mm
@@ -400,7 +400,7 @@ void PlatformCALayerRemote::removeSublayer(PlatformCALayerRemote* layer)
 {
     size_t childIndex = m_children.find(layer);
     if (childIndex != notFound)
-        m_children.remove(childIndex);
+        m_children.removeAt(childIndex);
     layer->m_superlayer = nullptr;
     m_properties.notePropertiesChanged(LayerChange::ChildrenChanged);
 }
@@ -471,7 +471,7 @@ void PlatformCALayerRemote::adoptSublayers(PlatformCALayer& source)
         for (const auto& layer : *customLayers) {
             size_t layerIndex = layersToMove.find(layer);
             if (layerIndex != notFound)
-                layersToMove.remove(layerIndex);
+                layersToMove.removeAt(layerIndex);
         }
     }
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -9269,7 +9269,7 @@ void WebPage::requestTextRecognition(Element& element, TextRecognitionOptions&& 
         for (auto& completionHandler : protectedPage->m_elementsPendingTextRecognition[matchIndex].second)
             completionHandler(imageOverlayHost.copyRef());
 
-        protectedPage->m_elementsPendingTextRecognition.remove(matchIndex);
+        protectedPage->m_elementsPendingTextRecognition.removeAt(matchIndex);
     });
 }
 

--- a/Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.cpp
+++ b/Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.cpp
@@ -545,7 +545,7 @@ void AcceleratedSurfaceDMABuf::SwapChain::releaseTarget(uint64_t targetID, UnixF
     if (index != notFound) {
         m_lockedTargets[index]->setReleaseFenceFD(WTFMove(releaseFence));
         m_freeTargets.insert(0, WTFMove(m_lockedTargets[index]));
-        m_lockedTargets.remove(index);
+        m_lockedTargets.removeAt(index);
     }
 }
 

--- a/Source/WebKitLegacy/mac/History/BackForwardList.mm
+++ b/Source/WebKitLegacy/mac/History/BackForwardList.mm
@@ -66,7 +66,7 @@ void BackForwardList::addItem(Ref<HistoryItem>&& newItem)
     // (or even if we are, if we only want 1 entry).
     if (m_entries.size() == m_capacity && (m_current || m_capacity == 1)) {
         Ref<HistoryItem> item = WTFMove(m_entries[0]);
-        m_entries.remove(0);
+        m_entries.removeAt(0);
         m_entryHash.remove(item.ptr());
         BackForwardCache::singleton().remove(item);
         --m_current;
@@ -240,7 +240,7 @@ void BackForwardList::removeItem(HistoryItem& item)
 {
     for (unsigned i = 0; i < m_entries.size(); ++i) {
         if (m_entries[i].ptr() == &item) {
-            m_entries.remove(i);
+            m_entries.removeAt(i);
             m_entryHash.remove(&item);
             if (m_current == NoCurrentItemIndex || m_current < i)
                 break;

--- a/Source/WebKitLegacy/mac/WebView/WebHTMLRepresentation.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebHTMLRepresentation.mm
@@ -389,7 +389,7 @@ static RegularExpression* regExpForLabels(NSArray *labels)
         if (cacheHit != NSNotFound) {
             // remove from old spot
             [regExpLabels.get() removeObjectAtIndex:cacheHit];
-            regExps.get().remove(cacheHit);
+            regExps.get().removeAt(cacheHit);
         }
         // add to start
         [regExpLabels.get() insertObject:labels atIndex:0];

--- a/Source/WebKitLegacy/mac/WebView/WebView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebView.mm
@@ -8898,7 +8898,7 @@ FORWARD(toggleUnderline)
 
     if (!_private->fullscreenControllersExiting.isEmpty()) {
         auto controller = _private->fullscreenControllersExiting.first();
-        _private->fullscreenControllersExiting.remove(0);
+        _private->fullscreenControllersExiting.removeAt(0);
 
         [controller exitFullscreen];
         return;

--- a/Tools/TestWebKitAPI/Tests/WTF/JSONValue.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/JSONValue.cpp
@@ -357,7 +357,7 @@ TEST(JSONObject, Basic)
         auto position = keys.find(it->key);
         EXPECT_NE(position, notFound);
         EXPECT_TRUE(it == object->find(keys[position]));
-        keys.remove(position);
+        keys.removeAt(position);
     }
     EXPECT_TRUE(keys.isEmpty());
 

--- a/Tools/TestWebKitAPI/Tests/WTF/WeakPtr.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/WeakPtr.cpp
@@ -1315,7 +1315,7 @@ TEST(WTF_WeakPtr, WeakHashMapRemoveIterator)
     }
     while (!objects.isEmpty()) {
         auto it = weakHashMap.find(*objects.last());
-        objects.remove(0);
+        objects.removeAt(0);
         weakHashMap.remove(it);
         weakHashMap.checkConsistency();
     }
@@ -2175,7 +2175,7 @@ TEST(WTF_WeakPtr, WeakListHashSetRemoveIterator)
     }
     for (unsigned i = 0; i < 13; ++i) {
         auto it = weakListHashSet.find(*objects[0]);
-        objects.remove(0);
+        objects.removeAt(0);
         weakListHashSet.remove(it);
         weakListHashSet.checkConsistency();
         unsigned j = 0;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm
@@ -184,7 +184,7 @@ static bool frameTreesMatch(_WKFrameTreeNode *actualRoot, ExpectedFrameTree&& ex
         });
         if (index == WTF::notFound)
             return false;
-        expectedRoot.children.remove(index);
+        expectedRoot.children.removeAt(index);
     }
     return expectedRoot.children.isEmpty();
 }
@@ -200,7 +200,7 @@ static bool frameTreesMatch(NSSet<_WKFrameTreeNode *> *actualFrameTrees, Vector<
         });
         if (index == WTF::notFound)
             return false;
-        expectedFrameTrees.remove(index);
+        expectedFrameTrees.removeAt(index);
     }
     return expectedFrameTrees.isEmpty();
 }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKContentExtensionStore.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKContentExtensionStore.mm
@@ -1225,7 +1225,7 @@ TEST_F(WKContentRuleListStoreTest, Redirect)
     for (size_t i = 0; i < expectedRequestedURLs.size(); i++)
         EXPECT_WK_STREQ(expectedRequestedURLs[i], [[urls objectAtIndex:i] absoluteString]);
 
-    expectedRequestedURLs.remove(0);
+    expectedRequestedURLs.removeAt(0);
     expectedRequestedURLs[1] = "testscheme://testhost:123/2.txt"_s;
     checkURLs(urlsFromCallback, expectedRequestedURLs);
 }

--- a/Tools/TestWebKitAPI/cocoa/HTTPServer.mm
+++ b/Tools/TestWebKitAPI/cocoa/HTTPServer.mm
@@ -570,7 +570,7 @@ void H2::Connection::receive(CompletionHandler<void(Frame&&)>&& completionHandle
             return;
         }
         ASSERT(!memcmp(m_receiveBuffer.data(), "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n", clientConnectionPrefaceLength));
-        m_receiveBuffer.remove(0, clientConnectionPrefaceLength);
+        m_receiveBuffer.removeAt(0, clientConnectionPrefaceLength);
         m_expectClientConnectionPreface = false;
         return receive(WTFMove(completionHandler));
     }
@@ -590,7 +590,7 @@ void H2::Connection::receive(CompletionHandler<void(Frame&&)>&& completionHandle
                 + (static_cast<uint32_t>(m_receiveBuffer[8]) << 0);
             Vector<uint8_t> payload;
             payload.append(m_receiveBuffer.subspan(frameHeaderLength, payloadLength));
-            m_receiveBuffer.remove(0, frameHeaderLength + payloadLength);
+            m_receiveBuffer.removeAt(0, frameHeaderLength + payloadLength);
             return completionHandler(Frame(type, flags, streamID, WTFMove(payload)));
         }
     }

--- a/Tools/TestWebKitAPI/glib/WebKitGLib/TestMain.cpp
+++ b/Tools/TestWebKitAPI/glib/WebKitGLib/TestMain.cpp
@@ -72,14 +72,14 @@ static void removeNonEmptyDirectory(const char* directoryPath)
 
 static void dbusConnectionClosed(GDBusConnection* connection)
 {
-    auto it = Test::s_dbusConnections.find(connection);
-    g_assert(it != notFound);
+    auto index = Test::s_dbusConnections.find(connection);
+    g_assert(index != notFound);
 
     for (auto it : Test::s_dbusConnectionPageMap) {
         if (it.value == connection)
             it.value = nullptr;
     }
-    Test::s_dbusConnections.remove(it);
+    Test::s_dbusConnections.removeAt(index);
 }
 
 static gboolean dbusServerConnection(GDBusServer* server, GDBusConnection* connection)

--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -507,7 +507,7 @@ void TestController::closeOtherPage(WKPageRef page, PlatformWebView* view)
     WKPageClose(page);
     auto index = m_auxiliaryWebViews.findIf([view](auto& auxiliaryWebView) { return auxiliaryWebView.ptr() == view; });
     if (index != notFound)
-        m_auxiliaryWebViews.remove(index);
+        m_auxiliaryWebViews.removeAt(index);
 }
 
 WKPageRef TestController::createOtherPage(WKPageRef, WKPageConfigurationRef configuration, WKNavigationActionRef navigationAction, WKWindowFeaturesRef windowFeatures, const void *clientInfo)


### PR DESCRIPTION
#### f30d291d969e9ec3ffe4bd4e402f47e81c4ab2da
<pre>
Rename Vector::remove(index) to Vector::removeAt(index)
<a href="https://bugs.webkit.org/show_bug.cgi?id=293362">https://bugs.webkit.org/show_bug.cgi?id=293362</a>

Reviewed by Anne van Kesteren and Ryosuke Niwa.

Rename Vector::remove(index) to Vector::removeAt(index) to reduce confusion
and avoid bugs such as <a href="https://commits.webkit.org/294832@main.">https://commits.webkit.org/294832@main.</a>

Also apply the same rename to API in SVGList.h and AnimationList.h since
it was similar.

Canonical link: <a href="https://commits.webkit.org/295281@main">https://commits.webkit.org/295281@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9483bb1ff87aa9d0a3ff7fdf9e56a7a73ae033ce

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104638 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24348 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/14766 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/109850 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/55309 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/106678 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/24737 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/32893 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/79469 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107644 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/19255 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94447 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59774 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/19024 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/12517 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/54682 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/97321 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/88723 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/12574 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/112241 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/103253 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/31799 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/23411 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/88553 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32163 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/90675 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88164 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/22460 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33069 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/10842 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/27116 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16973 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/31726 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/37068 "Built successfully") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/127534 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/31519 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/127534 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/34857 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33078 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->