### PR TITLE
[GStreamer] Add gstElementLockAndSetState() helper

### DIFF
--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp
@@ -361,12 +361,11 @@ void GStreamerMediaEndpoint::disposeElementChain(GstElement* element)
     auto pad = adoptGRef(gst_element_get_static_pad(element, "sink"));
     auto peer = adoptGRef(gst_pad_get_peer(pad.get()));
 
-    gst_element_set_locked_state(m_pipeline.get(), TRUE);
+    gstElementLockAndSetState(element, GST_STATE_NULL);
+
     gst_pad_unlink(peer.get(), pad.get());
     gst_bin_remove(GST_BIN_CAST(m_pipeline.get()), element);
     gst_element_release_request_pad(m_webrtcBin.get(), peer.get());
-    gst_element_set_state(element, GST_STATE_NULL);
-    gst_element_set_locked_state(m_pipeline.get(), FALSE);
 }
 
 bool GStreamerMediaEndpoint::setConfiguration(MediaEndpointConfiguration& configuration)

--- a/Source/WebCore/platform/audio/gstreamer/AudioSourceProviderGStreamer.cpp
+++ b/Source/WebCore/platform/audio/gstreamer/AudioSourceProviderGStreamer.cpp
@@ -306,15 +306,12 @@ void AudioSourceProviderGStreamer::setClient(WeakPtr<AudioSourceProviderClient>&
         auto teeSrcPad = adoptGRef(gst_pad_get_peer(queueSinkPad.get()));
 
         GST_DEBUG("Cleaning up audio deinterleave chain");
-        gst_element_set_locked_state(m_audioSinkBin.get(), true);
-
-        gst_element_set_state(audioQueue.get(), GST_STATE_NULL);
-        gst_element_set_state(audioConvert.get(), GST_STATE_NULL);
-        gst_element_set_state(audioResample.get(), GST_STATE_NULL);
-        gst_element_set_state(capsFilter.get(), GST_STATE_NULL);
-        gst_element_set_state(deInterleave.get(), GST_STATE_NULL);
+        gstElementLockAndSetState(audioQueue.get(), GST_STATE_NULL);
+        gstElementLockAndSetState(audioConvert.get(), GST_STATE_NULL);
+        gstElementLockAndSetState(audioResample.get(), GST_STATE_NULL);
+        gstElementLockAndSetState(capsFilter.get(), GST_STATE_NULL);
+        gstElementLockAndSetState(deInterleave.get(), GST_STATE_NULL);
         gst_element_unlink_many(audioTee.get(), audioQueue.get(), audioConvert.get(), audioResample.get(), capsFilter.get(), deInterleave.get(), nullptr);
-        gst_element_set_locked_state(m_audioSinkBin.get(), false);
         gst_bin_remove_many(GST_BIN_CAST(m_audioSinkBin.get()), audioQueue.get(), audioConvert.get(), audioResample.get(), capsFilter.get(), deInterleave.get(), nullptr);
         gst_element_release_request_pad(audioTee.get(), teeSrcPad.get());
     }

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerAudioMixer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerAudioMixer.cpp
@@ -133,10 +133,8 @@ void GStreamerAudioMixer::unregisterProducer(const GRefPtr<GstPad>& mixerPad)
     auto interaudioSrc = adoptGRef(gst_pad_get_parent_element(srcPad.get()));
     GST_LOG_OBJECT(m_pipeline.get(), "interaudiosrc: %" GST_PTR_FORMAT, interaudioSrc.get());
 
-    gst_element_set_locked_state(interaudioSrc.get(), true);
-    gst_element_set_state(interaudioSrc.get(), GST_STATE_NULL);
-    gst_element_set_state(bin.get(), GST_STATE_NULL);
-
+    gstElementLockAndSetState(interaudioSrc.get(), GST_STATE_NULL);
+    gstElementLockAndSetState(bin.get(), GST_STATE_NULL);
     gst_pad_unlink(peer.get(), mixerPad.get());
     gst_element_unlink(interaudioSrc.get(), bin.get());
 

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
@@ -1959,6 +1959,21 @@ bool setGstElementGLContext(GstElement* element, ASCIILiteral contextType)
 }
 #endif
 
+GstStateChangeReturn gstElementLockAndSetState(GstElement* element, GstState state)
+{
+    auto parent = adoptGRef(gst_element_get_parent(element));
+    if (parent)
+        GST_STATE_LOCK(parent.get());
+
+    gst_element_set_locked_state(element, TRUE);
+    auto result = gst_element_set_state(element, state);
+    gst_element_set_locked_state(element, FALSE);
+
+    if (parent)
+        GST_STATE_UNLOCK(parent.get());
+    return result;
+}
+
 #undef GST_CAT_DEFAULT
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
@@ -356,6 +356,9 @@ WARN_UNUSED_RETURN GRefPtr<GstCaps> buildDMABufCaps();
 #if USE(GSTREAMER_GL)
 bool setGstElementGLContext(GstElement*, ASCIILiteral contextType);
 #endif
+
+GstStateChangeReturn gstElementLockAndSetState(GstElement*, GstState);
+
 } // namespace WebCore
 
 #ifndef GST_BUFFER_DTS_OR_PTS

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp
@@ -799,13 +799,8 @@ static void webkitMediaStreamSrcCleanup(WebKitMediaStreamSrc* self, const std::u
     GST_DEBUG_OBJECT(self, "Cleaning-up internal source element %" GST_PTR_FORMAT, appSrc);
     source->cleanUp();
 
-    {
-        auto locker = GstStateLocker(element);
-        gst_element_set_locked_state(appSrc, true);
-        gst_element_set_state(appSrc, GST_STATE_NULL);
-        gst_bin_remove(GST_BIN_CAST(self), appSrc);
-        gst_element_set_locked_state(appSrc, false);
-    }
+    gstElementLockAndSetState(appSrc, GST_STATE_NULL);
+    gst_bin_remove(GST_BIN_CAST(self), appSrc);
 
     auto pad = adoptGRef(gst_element_get_static_pad(element, source->padName().ascii().data()));
     if (auto proxyPad = adoptGRef(GST_PAD_CAST(gst_proxy_pad_get_internal(GST_PROXY_PAD(pad.get())))))

--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingMediaSourceGStreamer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingMediaSourceGStreamer.cpp
@@ -215,13 +215,9 @@ void RealtimeOutgoingMediaSourceGStreamer::stopOutgoingSource(StoppedCallback&& 
 
 void RealtimeOutgoingMediaSourceGStreamer::removeOutgoingSource()
 {
-    gst_element_set_locked_state(m_outgoingSource.get(), TRUE);
-
+    gstElementLockAndSetState(m_outgoingSource.get(), GST_STATE_NULL);
     gst_element_unlink(m_outgoingSource.get(), m_tee.get());
-
-    gst_element_set_state(m_outgoingSource.get(), GST_STATE_NULL);
     gst_bin_remove(GST_BIN_CAST(m_bin.get()), m_outgoingSource.get());
-    gst_element_set_locked_state(m_outgoingSource.get(), FALSE);
     m_outgoingSource.clear();
 }
 
@@ -683,11 +679,10 @@ void RealtimeOutgoingMediaSourceGStreamer::teardown()
             }
         }
 
-        gst_element_set_locked_state(m_bin.get(), TRUE);
-        gst_element_set_state(m_bin.get(), GST_STATE_NULL);
+        gstElementLockAndSetState(m_bin.get(), GST_STATE_NULL);
+
         if (auto pipeline = adoptGRef(gst_element_get_parent(m_bin.get())))
             gst_bin_remove(GST_BIN_CAST(pipeline.get()), m_bin.get());
-        gst_element_set_locked_state(m_bin.get(), FALSE);
 
         m_packetizers.clear();
 


### PR DESCRIPTION
#### 289e7faf0435c7776e169e35b2ce195cf73c2da5
<pre>
[GStreamer] Add gstElementLockAndSetState() helper
<a href="https://bugs.webkit.org/show_bug.cgi?id=293358">https://bugs.webkit.org/show_bug.cgi?id=293358</a>

Reviewed by Xabier Rodriguez-Calvar.

This new function can be used to set a GstElement state while keeping the state lock of the parent
held.

Canonical link: <a href="https://commits.webkit.org/295327@main">https://commits.webkit.org/295327@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/35fc4a866b447dd1aacbfc84d76bc07712581357

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104597 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24307 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/14725 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/109809 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/55268 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/106637 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/24694 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/32852 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79429 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107603 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19206 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94401 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59741 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/18989 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/12476 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/54641 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/88683 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/12528 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/112200 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/31758 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23379 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88509 "Found 1 new test failure: fast/css/view-transitions-nested-transparency-layers.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32122 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/90635 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88128 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22490 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33031 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10799 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/27075 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/31685 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/37027 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/31478 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/34816 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33037 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->