### PR TITLE
NSData created by dataWithUserTypedString causes a crash when MALLOC_HEAP_BREAKDOWN is turned on

### DIFF
--- a/Source/WTF/wtf/cocoa/NSURLExtras.mm
+++ b/Source/WTF/wtf/cocoa/NSURLExtras.mm
@@ -198,7 +198,7 @@ static RetainPtr<NSData> dataWithUserTypedString(NSString *string)
     
     auto outBytesSpan = outBytes.releaseBuffer().leakSpan();
     return adoptNS([[NSData alloc] initWithBytesNoCopy:outBytesSpan.data() length:outBytesSpan.size() deallocator:^(void* bytes, NSUInteger) {
-        FastMalloc::free(bytes);
+        VectorBufferMalloc::free(bytes);
     }]); // adopts outBytes
 }
 


### PR DESCRIPTION
#### 4fbe97d9d0c4dc427ddcf7084b224ba3ee0ad6b8
<pre>
NSData created by dataWithUserTypedString causes a crash when MALLOC_HEAP_BREAKDOWN is turned on
<a href="https://bugs.webkit.org/show_bug.cgi?id=293369">https://bugs.webkit.org/show_bug.cgi?id=293369</a>
<a href="https://rdar.apple.com/151776839">rdar://151776839</a>

Reviewed by Mark Lam and Darin Adler.

The function has been changed some 6 months ago to use a Vector&lt;char&gt; to allocate and populate the
memory buffer, instead of a raw malloc and pointer operations. The buffer is then extracted from the
vector and registered to be freed using FastMalloc::free(). This assumes that the buffer was
initially allocated by FastMalloc. The assumption doesn&apos;t hold when MALLOC_HEAP_BREAKDOWN is on and
vector buffers are allocated by VectorBufferMalloc. FastMalloc::free() in that case sees the pointer
as misaligned and crashes. This happens on startup in both Safari and MiniBrowser.

The patch changes the deallocator logic to use VectorBufferMalloc::free(), which automatically
uses the allocator appropriate for the current MALLOC_HEAP_BREAKDOWN setting.

Canonical link: <a href="https://commits.webkit.org/295226@main">https://commits.webkit.org/295226@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2f9c2c44ccb521a08e87a6ad431e1de3c27ba208

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104474 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24184 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/14601 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/109681 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/55145 "Built successfully") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/24589 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/32728 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79327 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107480 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19110 "Unexpected infrastructure issue, retrying build") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94292 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59654 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/18898 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/12364 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/54514 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/97153 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/88598 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/12422 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/112066 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/103089 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/31635 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/23300 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88368 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/31999 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/90525 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88034 "Found 100 new API test failures: /WebKitGTK/TestInspector:/webkit/WebKitWebInspector/custom-container-destroyed, /TestWebKit:WebKit.GeolocationTransitionToHighAccuracy, /WebKitGTK/TestUIClient:/webkit/WebKitWebView/file-chooser-request, /TestWebKit:WebKit.PreventEmptyUserAgent, /TestWebKit:WebKit.PageLoadTwiceAndReload, /WebKitGTK/TestOptionMenu:/webkit/WebKitWebView/option-menu-groups, /WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/invalid-sequence, /WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/simple, /WebKitGTK/TestUIClient:/webkit/WebKitWebView/display-usermedia-permission-request, /WebKitGTK/TestUIClient:/webkit/WebKitWebView/usermedia-enumeratedevices-permission-check ... (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22418 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32932 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/26112 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/31562 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/36902 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/127353 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/31354 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/127353 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/34693 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/32914 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->