### PR TITLE
ASAN_ILL | WebCore::MediaController::updateReadyState; WebCore::MediaController::play; WebCore::jsMediaControllerPrototypeFunction_play

### DIFF
--- a/LayoutTests/media/media-controller-pause-crash-expected.txt
+++ b/LayoutTests/media/media-controller-pause-crash-expected.txt
@@ -1,0 +1,1 @@
+PASS if no crash.

--- a/LayoutTests/media/media-controller-pause-crash.html
+++ b/LayoutTests/media/media-controller-pause-crash.html
@@ -1,0 +1,7 @@
+<script>
+(async => {
+  testRunner?.dumpAsText();
+  let m = new MediaController(); m.pause();
+})();
+</script>
+PASS if no crash.

--- a/Source/WebCore/html/MediaController.cpp
+++ b/Source/WebCore/html/MediaController.cpp
@@ -396,7 +396,9 @@ void MediaController::updateReadyState()
     // Otherwise, let it have the lowest value of the readyState IDL attributes of all of its
     // mediagroup elements.
     ReadyState oldReadyState = m_readyState;
-    ReadyState newReadyState = std::ranges::min(readyStates).value_or(HAVE_NOTHING);
+    ReadyState newReadyState = HAVE_NOTHING;
+    if (std::ranges::distance(readyStates) > 0)
+        newReadyState = std::ranges::min(readyStates).value_or(HAVE_NOTHING);
     if (newReadyState == oldReadyState)
         return;
 


### PR DESCRIPTION
#### 3d08aa15054681bd4f0b18438c1963e1417cfc67
<pre>
ASAN_ILL | WebCore::MediaController::updateReadyState; WebCore::MediaController::play; WebCore::jsMediaControllerPrototypeFunction_play
<a href="https://bugs.webkit.org/show_bug.cgi?id=293019">https://bugs.webkit.org/show_bug.cgi?id=293019</a>
<a href="https://rdar.apple.com/151306323">rdar://151306323</a>

Reviewed by Ryosuke Niwa.

The usage of std::ranges::min has undefined behaviour on empty ranges:
<a href="https://en.cppreference.com/w/cpp/algorithm/ranges/min">https://en.cppreference.com/w/cpp/algorithm/ranges/min</a>

To fix this avoid calling it for an empty range.

* LayoutTests/media/media-controller-pause-crash-expected.txt: Added.
* LayoutTests/media/media-controller-pause-crash.html: Added.
* Source/WebCore/html/MediaController.cpp:
(WebCore::MediaController::updateReadyState):

Canonical link: <a href="https://commits.webkit.org/295222@main">https://commits.webkit.org/295222@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bf8dd77f102cdf0ba25510b7035fe3e6b1c9d94a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104466 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24175 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/14593 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/109673 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/55137 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/106506 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/24557 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/32720 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79322 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107472 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19099 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94287 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59648 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/18888 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/12359 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/54505 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/88589 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/12417 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/112058 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/31627 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/23297 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/88362 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/31991 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/90520 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88027 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22415 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32924 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10700 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/26102 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/31554 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/36886 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/31346 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/34685 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/32906 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->