### PR TITLE
Run GetUserMediaWithWebThread with WebThread enabled in DEBUG

### DIFF
--- a/Source/WTF/wtf/CallbackAggregator.h
+++ b/Source/WTF/wtf/CallbackAggregator.h
@@ -40,7 +40,7 @@ public:
 
     ~CallbackAggregatorOnThread()
     {
-        ASSERT(m_wasConstructedOnMainThread == isMainThread());
+        ASSERT(m_wasConstructedOnMainThread == isMainThread() || m_wasConstructedOnMainRunLoop == isMainRunLoop());
         if (m_callback)
             m_callback();
     }
@@ -50,6 +50,7 @@ private:
         : m_callback(WTFMove(callback))
 #if ASSERT_ENABLED
         , m_wasConstructedOnMainThread(isMainThread())
+        , m_wasConstructedOnMainRunLoop(isMainRunLoop())
 #endif
     {
     }
@@ -57,6 +58,7 @@ private:
     CompletionHandler<void()> m_callback;
 #if ASSERT_ENABLED
     bool m_wasConstructedOnMainThread;
+    bool m_wasConstructedOnMainRunLoop;
 #endif
 };
 

--- a/Source/WTF/wtf/RefCounted.h
+++ b/Source/WTF/wtf/RefCounted.h
@@ -92,6 +92,7 @@ protected:
         : m_refCount(1)
 #if ASSERT_ENABLED
         , m_isOwnedByMainThread(isMainThread())
+        , m_isOwnedByMainRunLoop(isMainRunLoop())
 #endif
     {
     }
@@ -111,12 +112,13 @@ protected:
         if (m_refCount == 1) {
             // Likely an ownership transfer across threads that may be safe.
             m_isOwnedByMainThread = isMainThread();
+            m_isOwnedByMainRunLoop = isMainRunLoop();
         } else if (areThreadingChecksEnabledGlobally && m_areThreadingChecksEnabled) {
             // If you hit this assertion, it means that the RefCounted object was ref/deref'd
             // from both the main thread and another in a way that is likely concurrent and unsafe.
             // Derive from ThreadSafeRefCounted and make sure the destructor is safe on threads
             // that call deref, or ref/deref from a single thread.
-            ASSERT_WITH_MESSAGE(m_isOwnedByMainThread == isMainThread(), "Unsafe to ref/deref from different threads");
+            ASSERT_WITH_MESSAGE(m_isOwnedByMainThread == isMainThread() || m_isOwnedByMainRunLoop == isMainRunLoop(), "Unsafe to ref/deref from different threads");
         }
 #endif
     }
@@ -160,6 +162,7 @@ private:
     mutable unsigned m_refCount;
 #if ASSERT_ENABLED
     mutable bool m_isOwnedByMainThread;
+    mutable bool m_isOwnedByMainRunLoop;
     bool m_areThreadingChecksEnabled { true };
 #endif
     WTF_EXPORT_PRIVATE static bool areThreadingChecksEnabledGlobally;

--- a/Source/WTF/wtf/SizeLimits.cpp
+++ b/Source/WTF/wtf/SizeLimits.cpp
@@ -47,6 +47,7 @@ struct SameSizeAsRefCounted {
     bool c;
     bool d;
     bool e;
+    bool f;
     // The debug version may get bigger.
 };
 #else

--- a/Source/WTF/wtf/ThreadAssertions.h
+++ b/Source/WTF/wtf/ThreadAssertions.h
@@ -33,6 +33,13 @@ namespace WTF {
 
 class ThreadLikeAssertion;
 WTF_EXPORT_PRIVATE bool isMainThread();
+WTF_EXPORT_PRIVATE bool isMainRunLoop();
+
+struct MainRunLoopLike {
+    constexpr operator uint32_t() const { return -4; }
+};
+inline constexpr MainRunLoopLike mainRunLoopLike;
+
 
 struct MainThreadLike {
     constexpr operator uint32_t() const { return -3; }
@@ -92,6 +99,10 @@ public:
         : ThreadLikeAssertion(static_cast<uint32_t>(a))
     {
     }
+    constexpr ThreadLikeAssertion(MainRunLoopLike a)
+        : ThreadLikeAssertion(static_cast<uint32_t>(a))
+    {
+    }
     ThreadLikeAssertion(CurrentThreadLike = currentThreadLike);
     ThreadLikeAssertion(ThreadLikeAssertion&&);
     ~ThreadLikeAssertion() { assertIsCurrent(*this); }
@@ -113,7 +124,7 @@ private:
 inline ThreadLikeAssertion::ThreadLikeAssertion(CurrentThreadLike)
 {
 #if ASSERT_ENABLED
-    m_uid = isMainThread() ? mainThreadLike : ThreadLike::currentSequence();
+    m_uid = isMainRunLoop() ? mainRunLoopLike : (isMainThread() ? mainThreadLike : ThreadLike::currentSequence());
 #endif
 }
 
@@ -149,6 +160,8 @@ inline bool ThreadLikeAssertion::isCurrent() const
         return true;
     if (m_uid == mainThreadLike)
         return isMainThread();
+    if (m_uid == mainRunLoopLike)
+        return isMainRunLoop() || isMainThread();
     return ThreadLike::currentSequence() == m_uid;
 #else
     return true;

--- a/Source/WTF/wtf/ThreadSafeRefCounted.h
+++ b/Source/WTF/wtf/ThreadSafeRefCounted.h
@@ -107,12 +107,13 @@ private:
     // Match the layout of RefCounted, which has flag bits for threading checks.
     UNUSED_MEMBER_VARIABLE bool m_unused1;
     UNUSED_MEMBER_VARIABLE bool m_unused2;
+    UNUSED_MEMBER_VARIABLE bool m_unused3;
 #endif
 
 #if CHECK_THREAD_SAFE_REF_COUNTED_LIFECYCLE
     mutable std::atomic<bool> m_deletionHasBegun { false };
     // Match the layout of RefCounted.
-    UNUSED_MEMBER_VARIABLE bool m_unused3;
+    UNUSED_MEMBER_VARIABLE bool m_unused4;
 #endif
 };
 

--- a/Source/WTF/wtf/WeakPtr.h
+++ b/Source/WTF/wtf/WeakPtr.h
@@ -169,7 +169,8 @@ private:
         return !m_impl
             || !m_shouldEnableAssertions
             || (m_impl->wasConstructedOnMainThread() && Thread::mayBeGCThread())
-            || m_impl->wasConstructedOnMainThread() == isMainThread();
+            || m_impl->wasConstructedOnMainThread() == isMainThread()
+            || m_impl->wasConstructedOnMainRunLoop() == isMainRunLoop();
     }
 #endif
 

--- a/Source/WTF/wtf/WeakPtrFactory.h
+++ b/Source/WTF/wtf/WeakPtrFactory.h
@@ -51,15 +51,25 @@ public:
     WeakPtrFactory()
 #if ASSERT_ENABLED
         : m_wasConstructedOnMainThread(isMainThread())
+        , m_wasConstructedOnMainRunLoop(isMainRunLoop())
 #endif
     {
     }
+
+#if ASSERT_ENABLED
+    bool checkConstructionConsistency() const
+    {
+        return (m_wasConstructedOnMainThread == isMainThread()) || (m_wasConstructedOnMainRunLoop == isMainRunLoop());
+    }
+#endif
 
     void prepareForUseOnlyOnNonMainThread()
     {
 #if ASSERT_ENABLED
         ASSERT(m_wasConstructedOnMainThread);
+        ASSERT(m_wasConstructedOnMainRunLoop);
         m_wasConstructedOnMainThread = false;
+        m_wasConstructedOnMainRunLoop = false;
 #endif
     }
 
@@ -79,7 +89,7 @@ public:
         if (m_impl)
             return;
 
-        ASSERT(m_wasConstructedOnMainThread == isMainThread());
+        ASSERT(checkConstructionConsistency());
 
         static_assert(std::is_final_v<WeakPtrImpl>);
         m_impl = adoptRef(*new WeakPtrImpl(const_cast<T*>(&object)));
@@ -118,6 +128,7 @@ private:
     mutable RefPtr<WeakPtrImpl> m_impl;
 #if ASSERT_ENABLED
     bool m_wasConstructedOnMainThread;
+    bool m_wasConstructedOnMainRunLoop;
 #endif
 };
 
@@ -133,9 +144,17 @@ public:
     WeakPtrFactoryWithBitField()
 #if ASSERT_ENABLED
         : m_wasConstructedOnMainThread(isMainThread())
+        , m_wasConstructedOnMainRunLoop(isMainRunLoop())
 #endif
     {
     }
+
+#if ASSERT_ENABLED
+    bool checkConstructionConsistency() const
+    {
+        return (m_wasConstructedOnMainThread == isMainThread()) || (m_wasConstructedOnMainRunLoop == isMainRunLoop());
+    }
+#endif
 
     ~WeakPtrFactoryWithBitField()
     {
@@ -153,7 +172,7 @@ public:
         if (m_impl.pointer())
             return;
 
-        ASSERT(m_wasConstructedOnMainThread == isMainThread());
+        ASSERT(checkConstructionConsistency());
 
         static_assert(std::is_final_v<WeakPtrImpl>);
         m_impl.setPointer(adoptRef(*new WeakPtrImpl(const_cast<T*>(&object))));
@@ -199,6 +218,7 @@ private:
     mutable CompactRefPtrTuple<WeakPtrImpl, uint16_t> m_impl;
 #if ASSERT_ENABLED
     bool m_wasConstructedOnMainThread;
+    bool m_wasConstructedOnMainRunLoop;
 #endif
 };
 

--- a/Source/WTF/wtf/WeakPtrImpl.h
+++ b/Source/WTF/wtf/WeakPtrImpl.h
@@ -53,6 +53,7 @@ public:
 
 #if ASSERT_ENABLED
     bool wasConstructedOnMainThread() const { return m_wasConstructedOnMainThread; }
+    bool wasConstructedOnMainRunLoop() const { return m_wasConstructedOnMainRunLoop; }
 #endif
 
     template<typename T>
@@ -60,6 +61,7 @@ public:
         : m_ptr(static_cast<typename T::WeakValueType*>(ptr))
 #if ASSERT_ENABLED
         , m_wasConstructedOnMainThread(isMainThread())
+        , m_wasConstructedOnMainRunLoop(isMainRunLoop())
 #endif
     {
     }
@@ -68,6 +70,7 @@ private:
     void* m_ptr;
 #if ASSERT_ENABLED
     bool m_wasConstructedOnMainThread;
+    bool m_wasConstructedOnMainRunLoop;
 #endif
 };
 
@@ -99,6 +102,7 @@ public:
 
 #if ASSERT_ENABLED
     bool wasConstructedOnMainThread() const { return m_wasConstructedOnMainThread; }
+    bool wasConstructedOnMainRunLoop() const { return m_wasConstructedOnMainRunLoop; }
 #endif
 
     template<typename T>
@@ -106,6 +110,7 @@ public:
         : m_ptr(static_cast<typename T::WeakValueType*>(ptr))
 #if ASSERT_ENABLED
         , m_wasConstructedOnMainThread(isMainThread())
+        , m_wasConstructedOnMainRunLoop(isMainRunLoop())
 #endif
     {
     }
@@ -127,6 +132,7 @@ private:
     void* m_ptr;
 #if ASSERT_ENABLED
     bool m_wasConstructedOnMainThread;
+    bool m_wasConstructedOnMainRunLoop;
 #endif
 };
 

--- a/Source/WTF/wtf/WeakRef.h
+++ b/Source/WTF/wtf/WeakRef.h
@@ -129,7 +129,8 @@ private:
         return !m_impl
             || !m_shouldEnableAssertions
             || (m_impl->wasConstructedOnMainThread() && Thread::mayBeGCThread())
-            || m_impl->wasConstructedOnMainThread() == isMainThread();
+            || m_impl->wasConstructedOnMainThread() == isMainThread()
+            || m_impl->wasConstructedOnMainRunLoop() == isMainRunLoop();
     }
 #endif
 

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp
@@ -1373,6 +1373,12 @@ void RealtimeMediaSource::setFrameRate(double rate)
     notifySettingsDidChangeObservers(RealtimeMediaSourceSettings::Flag::FrameRate);
 }
 
+void RealtimeMediaSource::initializeFrameRate(double rate)
+{
+    ASSERT(!isProducingData() && !m_hasStartedProducingData);
+    m_frameRate = rate;
+}
+
 void RealtimeMediaSource::setZoom(double zoom)
 {
     if (m_zoom == zoom)
@@ -1404,6 +1410,12 @@ void RealtimeMediaSource::setFacingMode(VideoFacingMode mode)
 
     m_facingMode = mode;
     notifySettingsDidChangeObservers(RealtimeMediaSourceSettings::Flag::FacingMode);
+}
+
+void RealtimeMediaSource::initializeFacingMode(VideoFacingMode facingMode)
+{
+    ASSERT(!isProducingData() && !m_hasStartedProducingData);
+    m_facingMode = facingMode;
 }
 
 void RealtimeMediaSource::setWhiteBalanceMode(MeteringMode mode)

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSource.h
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSource.h
@@ -364,6 +364,9 @@ protected:
 
     bool hasSeveralVideoFrameObserversWithAdaptors() const { return m_videoFrameObserversWithAdaptors > 1; }
 
+    void initializeFrameRate(double);
+    void initializeFacingMode(VideoFacingMode);
+
     OwnerCallback m_registerOwnerCallback;
 
 private:

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSourceCenter.cpp
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSourceCenter.cpp
@@ -52,7 +52,7 @@ static const Seconds deviceChangeDebounceTimerInterval { 200_ms };
 
 RealtimeMediaSourceCenter& RealtimeMediaSourceCenter::singleton()
 {
-    ASSERT(isMainThread());
+    ASSERT(isMainRunLoop());
     static NeverDestroyed<RealtimeMediaSourceCenter> center;
     return center;
 }
@@ -176,19 +176,19 @@ String RealtimeMediaSourceCenter::hashStringWithSalt(const String& id, const Str
 
 void RealtimeMediaSourceCenter::addDevicesChangedObserver(RealtimeMediaSourceCenterObserver& observer)
 {
-    ASSERT(isMainThread());
+    ASSERT(isMainRunLoop());
     m_observers.add(observer);
 }
 
 void RealtimeMediaSourceCenter::removeDevicesChangedObserver(RealtimeMediaSourceCenterObserver& observer)
 {
-    ASSERT(isMainThread());
+    ASSERT(isMainRunLoop());
     m_observers.remove(observer);
 }
 
 void RealtimeMediaSourceCenter::captureDevicesChanged()
 {
-    ASSERT(isMainThread());
+    ASSERT(isMainRunLoop());
 
 #if USE(GSTREAMER)
     triggerDevicesChangedObservers();

--- a/Source/WebCore/platform/mediastream/mac/BaseAudioSharedUnit.cpp
+++ b/Source/WebCore/platform/mediastream/mac/BaseAudioSharedUnit.cpp
@@ -53,7 +53,7 @@ BaseAudioSharedUnit::~BaseAudioSharedUnit()
 
 void BaseAudioSharedUnit::addClient(CoreAudioCaptureSource& client)
 {
-    ASSERT(isMainThread());
+    ASSERT(isMainRunLoop());
     m_clients.add(client);
     Locker locker { m_audioThreadClientsLock };
     m_audioThreadClients = m_clients.weakValues();
@@ -61,7 +61,7 @@ void BaseAudioSharedUnit::addClient(CoreAudioCaptureSource& client)
 
 void BaseAudioSharedUnit::removeClient(CoreAudioCaptureSource& client)
 {
-    ASSERT(isMainThread());
+    ASSERT(isMainRunLoop());
     m_clients.remove(client);
     {
         Locker locker { m_audioThreadClientsLock };
@@ -74,7 +74,7 @@ void BaseAudioSharedUnit::removeClient(CoreAudioCaptureSource& client)
 
 void BaseAudioSharedUnit::clearClients()
 {
-    ASSERT(isMainThread());
+    ASSERT(isMainRunLoop());
     m_clients.clear();
     Locker locker { m_audioThreadClientsLock };
     m_audioThreadClients.clear();
@@ -82,7 +82,7 @@ void BaseAudioSharedUnit::clearClients()
 
 void BaseAudioSharedUnit::forEachClient(NOESCAPE const Function<void(CoreAudioCaptureSource&)>& apply) const
 {
-    ASSERT(isMainThread());
+    ASSERT(isMainRunLoop());
     m_clients.forEach(apply);
 }
 
@@ -90,7 +90,7 @@ const static OSStatus lowPriorityError1 = 560557684;
 const static OSStatus lowPriorityError2 = 561017449;
 void BaseAudioSharedUnit::startProducingData()
 {
-    ASSERT(isMainThread());
+    ASSERT(isMainRunLoop());
     ASSERT(m_isAllowedToStart);
 
     if (m_suspended)
@@ -221,7 +221,7 @@ void BaseAudioSharedUnit::captureFailed()
 
 void BaseAudioSharedUnit::stopProducingData()
 {
-    ASSERT(isMainThread());
+    ASSERT(isMainRunLoop());
     ASSERT(m_producingCount);
 #if PLATFORM(MAC)
     if (!m_suspended) {
@@ -269,7 +269,7 @@ void BaseAudioSharedUnit::stopRunning()
 
 void BaseAudioSharedUnit::reconfigure()
 {
-    ASSERT(isMainThread());
+    ASSERT(isMainRunLoop());
     if (m_suspended) {
         m_needsReconfiguration = true;
         return;
@@ -279,7 +279,7 @@ void BaseAudioSharedUnit::reconfigure()
 
 OSStatus BaseAudioSharedUnit::resume()
 {
-    ASSERT(isMainThread());
+    ASSERT(isMainRunLoop());
     if (!m_suspended)
         return 0;
 
@@ -312,7 +312,7 @@ OSStatus BaseAudioSharedUnit::resume()
 
 OSStatus BaseAudioSharedUnit::suspend()
 {
-    ASSERT(isMainThread());
+    ASSERT(isMainRunLoop());
 
     RELEASE_LOG_INFO(WebRTC, "BaseAudioSharedUnit::suspend");
 

--- a/Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.cpp
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.cpp
@@ -408,7 +408,7 @@ int CoreAudioSharedUnit::actualSampleRate() const
 
 OSStatus CoreAudioSharedUnit::configureMicrophoneProc(int sampleRate)
 {
-    ASSERT(isMainThread());
+    ASSERT(isMainRunLoop());
 
     AURenderCallbackStruct callback = { microphoneCallback, this };
     if (auto err = m_ioUnit->set(kAudioOutputUnitProperty_SetInputCallback, kAudioUnitScope_Global, inputBus, &callback, sizeof(callback))) {
@@ -445,7 +445,7 @@ OSStatus CoreAudioSharedUnit::configureMicrophoneProc(int sampleRate)
 
 OSStatus CoreAudioSharedUnit::configureSpeakerProc(int sampleRate)
 {
-    ASSERT(isMainThread());
+    ASSERT(isMainRunLoop());
 
     AURenderCallbackStruct callback = { speakerCallback, this };
     if (auto err = m_ioUnit->set(kAudioUnitProperty_SetRenderCallback, kAudioUnitScope_Input, outputBus, &callback, sizeof(callback))) {
@@ -599,7 +599,7 @@ void CoreAudioSharedUnit::delaySamples(Seconds seconds)
 
 OSStatus CoreAudioSharedUnit::reconfigureAudioUnit()
 {
-    ASSERT(isMainThread());
+    ASSERT(isMainRunLoop());
     if (!hasAudioUnit())
         return 0;
 
@@ -634,7 +634,7 @@ OSStatus CoreAudioSharedUnit::reconfigureAudioUnit()
 
 OSStatus CoreAudioSharedUnit::startInternal()
 {
-    ASSERT(isMainThread());
+    ASSERT(isMainRunLoop());
 
     setIsProducingMicrophoneSamples(true);
 
@@ -801,7 +801,7 @@ void CoreAudioSharedUnit::verifyIsCapturing()
 
 void CoreAudioSharedUnit::stopInternal()
 {
-    ASSERT(isMainThread());
+    ASSERT(isMainRunLoop());
 
     if (m_verifyCapturingTimer)
         m_verifyCapturingTimer->stop();
@@ -828,7 +828,7 @@ void CoreAudioSharedUnit::stopInternal()
 
 void CoreAudioSharedUnit::registerSpeakerSamplesProducer(CoreAudioSpeakerSamplesProducer& producer)
 {
-    ASSERT(isMainThread());
+    ASSERT(isMainRunLoop());
 
     setIsRenderingAudio(true);
 
@@ -847,7 +847,7 @@ void CoreAudioSharedUnit::registerSpeakerSamplesProducer(CoreAudioSpeakerSamples
 
 void CoreAudioSharedUnit::unregisterSpeakerSamplesProducer(CoreAudioSpeakerSamplesProducer& producer)
 {
-    ASSERT(isMainThread());
+    ASSERT(isMainRunLoop());
 
     {
         Locker locker { m_speakerSamplesProducerLock };

--- a/Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp
+++ b/Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp
@@ -164,8 +164,8 @@ MockRealtimeVideoSource::MockRealtimeVideoSource(String&& deviceID, AtomString&&
     }
 
     auto& properties = std::get<MockCameraProperties>(m_device.properties);
-    setFrameRate(properties.defaultFrameRate);
-    setFacingMode(properties.facingMode);
+    initializeFrameRate(properties.defaultFrameRate);
+    initializeFacingMode(properties.facingMode);
     m_fillColor = properties.fillColor;
 }
 

--- a/Tools/TestWebKitAPI/Tests/WTF/WeakPtr.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/WeakPtr.cpp
@@ -3201,6 +3201,7 @@ public:
 
 #if ASSERT_ENABLED
     bool wasConstructedOnMainThread() const { return true; }
+    bool wasConstructedOnMainRunLoop() const { return true; }
 #endif
 
     void resetDidUpdateRefCount() { m_didUpdateRefCount = false; }

--- a/Tools/TestWebKitAPI/Tests/WebKit/GetUserMedia.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/GetUserMedia.mm
@@ -2063,28 +2063,43 @@ TEST(WebKit2, getUserMediaWithDeviceChangeWebPage)
 #if PLATFORM(IOS_FAMILY) && !PLATFORM(MACCATALYST)
 TEST(WebKit, GetUserMediaWithWebThread)
 {
-#if defined(NDEBUG)
-    // We only enable web thread in release builds as our main thread assertions are not handling well web thread existence
-    [WebView enableWebThread];
-#endif
-
     auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    auto messageHandler = adoptNS([[GUMMessageHandler alloc] init]);
+    [[configuration.get() userContentController] addScriptMessageHandler:messageHandler.get() name:@"gum"];
+
     auto processPoolConfig = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
     initializeMediaCaptureConfiguration(configuration.get());
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get() processPoolConfiguration:processPoolConfig.get()]);
     auto delegate = adoptNS([[UserMediaCaptureUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
 
+#if !defined(NDEBUG)
+    // FIXME: We should capture video as well once we resolve ScreenSleepDisabler assertion.
+    [delegate setVideoDecision:WKPermissionDecisionDeny];
+    [WebView enableWebThread];
+#endif
+
     [webView _setMediaCaptureReportingDelayForTesting:0];
 
     [webView loadTestPageNamed:@"getUserMedia"];
+    [delegate waitUntilPrompted];
+
+    [WebView enableWebThread];
+
+#if defined(NDEBUG)
     EXPECT_TRUE(waitUntilCaptureState(webView.get(), _WKMediaCaptureStateDeprecatedActiveCamera));
+    [webView stringByEvaluatingJavaScript:@"stop()"];
+    EXPECT_TRUE(waitUntilCaptureState(webView.get(), _WKMediaCaptureStateDeprecatedNone));
+#endif
+
+    done = false;
+    [webView stringByEvaluatingJavaScript:@"captureAudio(true)"];
+    TestWebKitAPI::Util::run(&done);
+
+    EXPECT_TRUE(waitUntilCaptureState(webView.get(), _WKMediaCaptureStateDeprecatedActiveMicrophone));
 
     [webView stringByEvaluatingJavaScript:@"stop()"];
     EXPECT_TRUE(waitUntilCaptureState(webView.get(), _WKMediaCaptureStateDeprecatedNone));
-
-    [webView stringByEvaluatingJavaScript:@"captureAudio()"];
-    EXPECT_TRUE(waitUntilCaptureState(webView.get(), _WKMediaCaptureStateDeprecatedActiveMicrophone));
 }
 #endif // PLATFORM(IOS_FAMILY) && !PLATFORM(MACCATALYST)
 


### PR DESCRIPTION
#### f35a59ec63f1d3a60c3b1b6aaabf2f6374e98ef9
<pre>
Run GetUserMediaWithWebThread with WebThread enabled in DEBUG
<a href="https://bugs.webkit.org/show_bug.cgi?id=293379">https://bugs.webkit.org/show_bug.cgi?id=293379</a>

Reviewed by NOBODY (OOPS!).

We soften the thread assertions so that if object is constructed in the main run loop, it can also be destroyed/unrefed in the main run loop.
We change some isMainThread asserts to isMainRunLoop since they are related to capture code that only runs in WK2.
We update the API test to capture audio in DEBUG (but not video due to an assertion in SleepDisabler).

* Source/WTF/wtf/CallbackAggregator.h:
(WTF::CallbackAggregatorOnThread::~CallbackAggregatorOnThread):
(WTF::CallbackAggregatorOnThread::CallbackAggregatorOnThread):
* Source/WTF/wtf/RefCounted.h:
(WTF::RefCountedBase::RefCountedBase):
(WTF::RefCountedBase::applyRefDerefThreadingCheck const):
* Source/WTF/wtf/SizeLimits.cpp:
* Source/WTF/wtf/ThreadAssertions.h:
(WTF::MainRunLoopLike::operator uint32_t const):
(WTF::ThreadLikeAssertion::ThreadLikeAssertion):
(WTF::ThreadLikeAssertion::isCurrent const):
* Source/WTF/wtf/ThreadSafeRefCounted.h:
* Source/WTF/wtf/WeakPtr.h:
(WTF::WeakPtr::canSafelyBeUsed const):
* Source/WTF/wtf/WeakPtrFactory.h:
(WTF::WeakPtrFactory::WeakPtrFactory):
(WTF::WeakPtrFactory::checkConstructionConsistency const):
(WTF::WeakPtrFactory::prepareForUseOnlyOnNonMainThread):
(WTF::WeakPtrFactory::initializeIfNeeded const):
(WTF::WeakPtrFactoryWithBitField::WeakPtrFactoryWithBitField):
(WTF::WeakPtrFactoryWithBitField::checkConstructionConsistency const):
(WTF::WeakPtrFactoryWithBitField::initializeIfNeeded const):
* Source/WTF/wtf/WeakPtrImpl.h:
(WTF::WeakPtrImplBase::wasConstructedOnMainRunLoop const):
(WTF::WeakPtrImplBase::WeakPtrImplBase):
(WTF::WeakPtrImplBaseSingleThread::wasConstructedOnMainRunLoop const):
(WTF::WeakPtrImplBaseSingleThread::WeakPtrImplBaseSingleThread):
* Source/WTF/wtf/WeakRef.h:
(WTF::WeakRef::canSafelyBeUsed const):
* Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp:
(WebCore::RealtimeMediaSource::initializeFrameRate):
(WebCore::RealtimeMediaSource::initializeFacingMode):
* Source/WebCore/platform/mediastream/RealtimeMediaSource.h:
* Source/WebCore/platform/mediastream/RealtimeMediaSourceCenter.cpp:
(WebCore::RealtimeMediaSourceCenter::singleton):
(WebCore::RealtimeMediaSourceCenter::addDevicesChangedObserver):
(WebCore::RealtimeMediaSourceCenter::removeDevicesChangedObserver):
(WebCore::RealtimeMediaSourceCenter::captureDevicesChanged):
* Source/WebCore/platform/mediastream/mac/BaseAudioSharedUnit.cpp:
(WebCore::BaseAudioSharedUnit::addClient):
(WebCore::BaseAudioSharedUnit::removeClient):
(WebCore::BaseAudioSharedUnit::clearClients):
(WebCore::BaseAudioSharedUnit::forEachClient const):
(WebCore::BaseAudioSharedUnit::startProducingData):
(WebCore::BaseAudioSharedUnit::stopProducingData):
(WebCore::BaseAudioSharedUnit::reconfigure):
(WebCore::BaseAudioSharedUnit::resume):
(WebCore::BaseAudioSharedUnit::suspend):
* Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.cpp:
(WebCore::CoreAudioSharedUnit::configureMicrophoneProc):
(WebCore::CoreAudioSharedUnit::configureSpeakerProc):
(WebCore::CoreAudioSharedUnit::reconfigureAudioUnit):
(WebCore::CoreAudioSharedUnit::startInternal):
(WebCore::CoreAudioSharedUnit::stopInternal):
(WebCore::CoreAudioSharedUnit::registerSpeakerSamplesProducer):
(WebCore::CoreAudioSharedUnit::unregisterSpeakerSamplesProducer):
* Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp:
* Tools/TestWebKitAPI/Tests/WTF/WeakPtr.cpp:
* Tools/TestWebKitAPI/Tests/WebKit/GetUserMedia.mm:
(TestWebKitAPI::(WebKit, GetUserMediaWithWebThread)):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4a5d7fb153a3c61cf8670e4b223372e7e8cf9a36

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104590 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24300 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/14718 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/109802 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/55261 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/106630 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/24687 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/32845 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79421 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107596 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19198 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94395 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59733 "Found 50 new API test failures: /WPE/TestWebsiteData:beforeAll, /WPE/TestInputMethodContext:beforeAll, /WPE/TestWebKitURIUtilities:beforeAll, /TestJSC:/jsc/json, /WPE/TestWebKitUserContentManager:beforeAll, /TestJSC:/jsc/weak-value, /WPE/TestUIClient:beforeAll, /WPE/TestOptionMenu:beforeAll, /TestJSC:/jsc/promises, /WPE/TestWebKitUserContentFilterStore:beforeAll ... (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/18982 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/12470 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/54634 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/97269 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/88677 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/12522 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/112192 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/103205 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/31751 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23373 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88506 "Failure limit exceed. At least found 495 new test failures: accessibility/ARIA-reflection.html accessibility/accessibility-crash-focused-element-change.html accessibility/accessibility-crash-setattribute.html accessibility/accessibility-crash-with-dynamic-inline-content.html accessibility/accessibility-node-memory-management.html accessibility/accessibility-node-reparent.html accessibility/accessibility-object-detached.html accessibility/accessibility-object-update-during-style-resolution-crash.html accessibility/activation-of-input-field-inside-other-element.html accessibility/active-descendant-changes-result-in-focus-changes.html ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32115 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/90629 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88125 "Found 115 new API test failures: /TestWebKit:WebKit.GeolocationTransitionToHighAccuracy, /TestJavaScriptCore:Inspector.ConsoleMessageJSONValueBasicMessage, /WebKitGTK/TestWebsiteData:beforeAll, /WebKitGTK/TestWebKitWebExtensionMatchPattern:beforeAll, /TestWebKit:WebKit.PreventEmptyUserAgent, /WebKitGTK/TestWebKitFindController:beforeAll, /WebKitGTK/TestWebProcessExtensions:beforeAll, /TestWebKit:WebKit.PageLoadTwiceAndReload, /TestJSC:/jsc/json, /WebKitGTK/TestInputMethodContext:beforeAll ... (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33023 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10793 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/27068 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/31678 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/37020 "Built successfully") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/127486 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled JSC (cancelled)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/31471 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/127486 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled JSC (cancelled)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/34809 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33030 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->