### PR TITLE
[macOS] Color input components do not update to match their parent's used `appearance`

### DIFF
--- a/LayoutTests/fast/forms/color/color-input-appearance-none-inherited-expected.html
+++ b/LayoutTests/fast/forms/color/color-input-appearance-none-inherited-expected.html
@@ -1,0 +1,16 @@
+<style>
+
+input {
+    appearance: none;
+}
+
+input[type="color"]::-webkit-color-swatch-wrapper {
+    appearance: none;
+}
+
+input[type="color"]::-webkit-color-swatch {
+    appearance: none;
+}
+
+</style>
+<input type=color>

--- a/LayoutTests/fast/forms/color/color-input-appearance-none-inherited.html
+++ b/LayoutTests/fast/forms/color/color-input-appearance-none-inherited.html
@@ -1,0 +1,14 @@
+<input id="color" type=color>
+<script>
+
+if (window.testRunner)
+    testRunner.waitUntilDone();
+
+addEventListener("load", async () => {
+    color.style.appearance = "none";
+
+    if (window.testRunner)
+        testRunner.notifyDone();
+});
+
+</script>

--- a/LayoutTests/fast/forms/color/color-input-devolved-appearance-inherited-expected.html
+++ b/LayoutTests/fast/forms/color/color-input-devolved-appearance-inherited-expected.html
@@ -1,0 +1,16 @@
+<style>
+
+input {
+    border: 1px solid red;
+}
+
+input[type="color"]::-webkit-color-swatch-wrapper {
+    appearance: none;
+}
+
+input[type="color"]::-webkit-color-swatch {
+    appearance: none;
+}
+
+</style>
+<input type=color>

--- a/LayoutTests/fast/forms/color/color-input-devolved-appearance-inherited.html
+++ b/LayoutTests/fast/forms/color/color-input-devolved-appearance-inherited.html
@@ -1,0 +1,14 @@
+<input id="color" type=color>
+<script>
+
+if (window.testRunner)
+    testRunner.waitUntilDone();
+
+addEventListener("load", async () => {
+    color.style.border = "1px solid red";
+
+    if (window.testRunner)
+        testRunner.notifyDone();
+});
+
+</script>

--- a/LayoutTests/fast/forms/color/color-input-swatch-wrapper-appearance-none-inherited-expected.html
+++ b/LayoutTests/fast/forms/color/color-input-swatch-wrapper-appearance-none-inherited-expected.html
@@ -1,0 +1,12 @@
+<style>
+
+input[type="color"]::-webkit-color-swatch-wrapper {
+    appearance: none;
+}
+
+input[type="color"]::-webkit-color-swatch {
+    appearance: none;
+}
+
+</style>
+<input type=color>

--- a/LayoutTests/fast/forms/color/color-input-swatch-wrapper-appearance-none-inherited.html
+++ b/LayoutTests/fast/forms/color/color-input-swatch-wrapper-appearance-none-inherited.html
@@ -1,0 +1,17 @@
+<input id="color" type=color>
+<script>
+
+if (window.testRunner)
+    testRunner.waitUntilDone();
+
+addEventListener("load", async () => {
+    const sheet = new CSSStyleSheet();
+    sheet.insertRule('input[type="color"]::-webkit-color-swatch-wrapper { appearance: none; }');
+
+    document.adoptedStyleSheets = [...document.adoptedStyleSheets, sheet];
+
+    if (window.testRunner)
+        testRunner.notifyDone();
+});
+
+</script>

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -525,8 +525,16 @@ bool RenderStyle::descendantAffectingNonInheritedPropertiesEqual(const RenderSty
         || m_nonInheritedData->miscData.ptr() == other.m_nonInheritedData->miscData.ptr())
         return true;
 
-    return m_nonInheritedData->miscData->alignItems == other.m_nonInheritedData->miscData->alignItems
-        && m_nonInheritedData->miscData->justifyItems == other.m_nonInheritedData->miscData->justifyItems;
+    if (m_nonInheritedData->miscData->alignItems != other.m_nonInheritedData->miscData->alignItems)
+        return false;
+
+    if (m_nonInheritedData->miscData->justifyItems != other.m_nonInheritedData->miscData->justifyItems)
+        return false;
+
+    if (m_nonInheritedData->miscData->usedAppearance != other.m_nonInheritedData->miscData->usedAppearance)
+        return false;
+
+    return true;
 }
 
 bool RenderStyle::borderAndBackgroundEqual(const RenderStyle& other) const


### PR DESCRIPTION
#### 44c4b0052dab1b8e57ae2688263a971ef7a0b7ed
<pre>
[macOS] Color input components do not update to match their parent&apos;s used `appearance`
<a href="https://bugs.webkit.org/show_bug.cgi?id=293381">https://bugs.webkit.org/show_bug.cgi?id=293381</a>
<a href="https://rdar.apple.com/148625484">rdar://148625484</a>

Reviewed by Antti Koivisto, Wenson Hsieh, and Abrar Rahman Protyasha.

`appearance` is an implementation detail of the elements in the color input&apos;s
shadow tree. When the used appearance of color inputs is `none` (either
explicitly specified using `appearance`, or after devolution due to
border/background styling), the inner components should also have a used
`appearance` of `none`, to avoid mixing and matching native and primitive styles.

The behavior described above is already implemented by checking the parent style
during style adjustment. However, if the used `appearance` changes later on,
updates to the parent are not always reflected in the children.

Fix this by checking for used `appearance` in
`RenderStyle::descendantAffectingNonInheritedPropertiesEqual`. This ensures that
descendent styles will be recomputed if the parent&apos;s `appearance` changes,
including the children&apos;s `appearance.

* LayoutTests/fast/forms/color/color-input-appearance-none-inherited-expected.html: Added.
* LayoutTests/fast/forms/color/color-input-appearance-none-inherited.html: Added.
* LayoutTests/fast/forms/color/color-input-devolved-appearance-inherited-expected.html: Added.
* LayoutTests/fast/forms/color/color-input-devolved-appearance-inherited.html: Added.
* LayoutTests/fast/forms/color/color-input-swatch-wrapper-appearance-none-inherited-expected.html: Added.
* LayoutTests/fast/forms/color/color-input-swatch-wrapper-appearance-none-inherited.html: Added.
* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::RenderStyle::descendantAffectingNonInheritedPropertiesEqual const):

Restructure the logic to be like other `RenderStyle` comparisons.

Add the check for used `appearance`, as explained above.

Canonical link: <a href="https://commits.webkit.org/295282@main">https://commits.webkit.org/295282@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9e8b05fcc27ac312641d2172bd7cf91778741a33

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104588 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24298 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/14716 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/109800 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/55259 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/106628 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/24685 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/32843 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79418 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107594 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19197 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94393 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59730 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/18981 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/12468 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/54632 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/88676 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/12520 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/112190 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/31749 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23371 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88500 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32113 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/90627 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88120 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33022 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10791 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/27066 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16974 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/31676 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/37017 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/31468 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/34807 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33028 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->