### PR TITLE
[JSC]ASSERTION FAILED: cell->isObject() in DFG when AbstractInterpreter handles GetGlobalObject

### DIFF
--- a/JSTests/stress/dfg-get-global-object-should-use-object-edge.js
+++ b/JSTests/stress/dfg-get-global-object-should-use-object-edge.js
@@ -1,0 +1,12 @@
+//@ runDefault("--validateOptions=true", "--thresholdForJITSoon=10", "--thresholdForJITAfterWarmUp=10", "--thresholdForOptimizeAfterWarmUp=100", "--thresholdForOptimizeAfterLongWarmUp=100", "--thresholdForOptimizeSoon=100", "--thresholdForFTLOptimizeAfterWarmUp=1000", "--thresholdForFTLOptimizeSoon=1000", "--validateBCE=true", "--useConcurrentJIT=0")
+
+function opt(arg) {
+    try {
+        arg.test({ test: "padEnd" });
+    } catch (e) { }
+    arg.test(/123/);
+}
+
+for (let i = 0; i < 50; i++) {
+    opt({ test: opt });
+}

--- a/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
@@ -2115,9 +2115,13 @@ private:
         case SkipScope:
         case GetScope:
         case GetGetter:
-        case GetSetter:
-        case GetGlobalObject: {
+        case GetSetter: {
             fixEdge<KnownCellUse>(node->child1());
+            break;
+        }
+
+        case GetGlobalObject: {
+            fixEdge<ObjectUse>(node->child1());
             break;
         }
 

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -7966,9 +7966,15 @@ void SpeculativeJIT::compileGetGlobalObject(Node* node)
 {
     SpeculateCellOperand object(this, node->child1());
     GPRTemporary result(this);
-    emitLoadStructure(vm(), object.gpr(), result.gpr());
-    loadPtr(Address(result.gpr(), Structure::globalObjectOffset()), result.gpr());
-    cellResult(result.gpr(), node);
+
+    GPRReg objectGPR = object.gpr();
+    GPRReg resultGPR = result.gpr();
+
+    speculateObject(node->child1(), objectGPR);
+
+    emitLoadStructure(vm(), objectGPR, resultGPR);
+    loadPtr(Address(resultGPR, Structure::globalObjectOffset()), resultGPR);
+    cellResult(resultGPR, node);
 }
 
 void SpeculativeJIT::compileGetGlobalThis(Node* node)

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -11749,7 +11749,7 @@ IGNORE_CLANG_WARNINGS_END
 
     void compileGetGlobalObject()
     {
-        LValue structure = loadStructure(lowCell(m_node->child1()));
+        LValue structure = loadStructure(lowObject(m_node->child1()));
         setJSValue(m_out.loadPtr(structure, m_heaps.Structure_globalObject));
     }
 

--- a/Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp
+++ b/Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp
@@ -584,6 +584,7 @@ void MockRealtimeVideoSource::drawText(GraphicsContext& context)
     string = makeString("Size: "_s, size.width(), " x "_s, size.height());
     context.drawText(drawingState.statsFont(), TextRun(StringView(string)), statsLocation);
 
+    String deviceString;
     if (mockCamera()) {
         statsLocation.move(0, drawingState.statsFontSize());
         string = makeString("Preset size: "_s, captureSize.width(), " x "_s, captureSize.height());
@@ -607,13 +608,18 @@ void MockRealtimeVideoSource::drawText(GraphicsContext& context)
             camera = "Unknown"_s;
             break;
         }
-        string = makeString("Camera: "_s, camera);
-        statsLocation.move(0, drawingState.statsFontSize());
-        context.drawText(drawingState.statsFont(), TextRun(string), statsLocation);
-    } else if (!name().isNull()) {
-        statsLocation.move(0, drawingState.statsFontSize());
-        context.drawText(drawingState.statsFont(), TextRun { name() }, statsLocation);
-    }
+        deviceString = makeString("Camera: "_s, camera);
+    } else if (mockDisplay())
+        deviceString = "Display capture"_s;
+    else if (mockScreen())
+        deviceString = "Screen capture"_s;
+    else if (mockWindow())
+        deviceString = "Window capture"_s;
+    else
+        deviceString = "Unknown capture"_s;
+
+    statsLocation.move(0, drawingState.statsFontSize());
+    context.drawText(drawingState.statsFont(), TextRun(string), statsLocation);
 
     FloatPoint bipBopLocation(captureSize.width() * .6, captureSize.height() * .6);
     unsigned frameMod = m_frameNumber % 60;

--- a/Source/WebCore/rendering/RenderLayer.h
+++ b/Source/WebCore/rendering/RenderLayer.h
@@ -1489,8 +1489,7 @@ inline void RenderLayer::setIsHiddenByOverflowTruncation(bool isHidden)
     if (m_isHiddenByOverflowTruncation == isHidden)
         return;
     m_isHiddenByOverflowTruncation = isHidden;
-    m_visibleContentStatusDirty = true;
-    setNeedsPositionUpdate();
+    dirtyVisibleContentStatus();
 }
 
 #if ASSERT_ENABLED
@@ -1535,4 +1534,3 @@ void showPaintOrderTree(const WebCore::RenderLayer*);
 void showPaintOrderTree(const WebCore::RenderObject*);
 void showLayerPositionTree(const WebCore::RenderLayer* root, const WebCore::RenderLayer* mark = nullptr);
 #endif
-

--- a/Source/WebKit/UIProcess/ios/WKVideoView.mm
+++ b/Source/WebKit/UIProcess/ios/WKVideoView.mm
@@ -27,8 +27,11 @@
 #include "WKVideoView.h"
 
 #if PLATFORM(IOS_FAMILY)
+
+#include <wtf/RetainPtr.h>
+
 @implementation WKVideoView {
-    WebAVPlayerLayerView* _playerView;
+    RetainPtr<WebAVPlayerLayerView> _playerView;
 }
 
 + (Class)layerClass
@@ -50,7 +53,7 @@
 
 - (CALayer *)playerLayer
 {
-    return _playerView.layer;
+    return _playerView.get().layer;
 }
 
 - (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event


### PR DESCRIPTION
#### 2a545562709ac7a6faea5de5f7902314f9feefcf
<pre>
[JSC]ASSERTION FAILED: cell-&gt;isObject() in DFG when AbstractInterpreter handles GetGlobalObject
<a href="https://bugs.webkit.org/show_bug.cgi?id=290834">https://bugs.webkit.org/show_bug.cgi?id=290834</a>
<a href="https://rdar.apple.com/148314529">rdar://148314529</a>

Reviewed by Keith Miller and Yijia Huang.

GetGlobalObject should only accept objects. Thus use ObjectUse edge.

* JSTests/stress/dfg-get-global-object-should-use-object-edge.js: Added.
(opt):
* Source/JavaScriptCore/dfg/DFGFixupPhase.cpp:
(JSC::DFG::FixupPhase::fixupNode):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileGetGlobalObject):

Originally-landed-as: 289651.384@safari-7621-branch (f4178b4dac13). <a href="https://rdar.apple.com/151713501">rdar://151713501</a>
Canonical link: <a href="https://commits.webkit.org/295287@main">https://commits.webkit.org/295287@main</a>
</pre>
----------------------------------------------------------------------
#### e6f52e99cdc6ed8ff2804d7745d6fbfd7808eb20
<pre>
WKVideoView needs to retain its player layer view
<a href="https://rdar.apple.com/92156864">rdar://92156864</a>

Reviewed by Jer Noble.

WKVideoView needs to retain its player layer view as there is no guarantee that the later will remain valid as long as the former.

* Source/WebKit/UIProcess/ios/WKVideoView.mm:
(-[WKVideoView playerLayer]):

Originally-landed-as: 289651.369@safari-7621-branch (3a0ca74e73d3). <a href="https://rdar.apple.com/151713625">rdar://151713625</a>
Canonical link: <a href="https://commits.webkit.org/295286@main">https://commits.webkit.org/295286@main</a>
</pre>
----------------------------------------------------------------------
#### adc161c58c5ab243b40ce1e11cef32abea4a09e0
<pre>
Fix heap-uaf in computeCompositingRequirements
<a href="https://bugs.webkit.org/show_bug.cgi?id=287908">https://bugs.webkit.org/show_bug.cgi?id=287908</a>
&lt;<a href="https://rdar.apple.com/144404223">rdar://144404223</a>&gt;

Reviewed by Matt Woodrow.

This issue was caused by us clearing the backing store of a layers
positive z-order lists while recursing through the layer tree. More
specifically, we need to make sure to dirty all ancestor layers when
content visibility changes, before we start traversing the tree, and
this was not being done for ancestor layers in
`setIsHiddenByOverflowTruncation`.

Change this function to let all ancestor layers know that they have a
descendant with a dirty content visibility status, which will allow us
to get the tree into the proper state when calling
`updateDescendantDependentFlags` on the root layer and having no dirty
flags in the tree following this.

* Source/WebCore/rendering/RenderLayer.h:
(WebCore::RenderLayer::setIsHiddenByOverflowTruncation):

Originally-landed-as: 289651.364@safari-7621-branch (fe7b8569d152). <a href="https://rdar.apple.com/151713755">rdar://151713755</a>
Canonical link: <a href="https://commits.webkit.org/295285@main">https://commits.webkit.org/295285@main</a>
</pre>
----------------------------------------------------------------------
#### 49dc08fbc054b0597bfeb758becde174e8cda2e9
<pre>
com.apple.WebKit.GPU.Development heap-use-after-free crash at com.apple.WebCore:  WebCore::RealtimeMediaSource::~RealtimeMediaSource
<a href="https://rdar.apple.com/147695781">rdar://147695781</a>

Reviewed by Chris Dumez.

We cannot reference a String created from main thread on a background thread.
Instead of using the source&apos;s name, we create the string to draw based on the mock capture type.

Covered by existing tests.

* Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp:
(WebCore::MockRealtimeVideoSource::drawText):

Originally-landed-as: 289651.310@safari-7621-branch (e97da24c96fe). <a href="https://rdar.apple.com/151708397">rdar://151708397</a>
Canonical link: <a href="https://commits.webkit.org/295284@main">https://commits.webkit.org/295284@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/31063ed7146c579bafe527591da98b33049dd159

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104518 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24228 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/14646 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/109726 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/55189 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/106558 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/24612 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/32772 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79355 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107524 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19143 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94329 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59681 "Passed tests") | 
| | [💥 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/18920 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/12402 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/54559 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/97197 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/88625 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/12459 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/112111 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/103133 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/31679 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23327 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88397 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32043 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/90562 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88065 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32962 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10738 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/27004 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16976 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/31606 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/36946 "Built successfully") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/127414 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/31398 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/127414 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/34737 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/32958 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->