### PR TITLE
ResourceResponseData::proxyName is not properly isolated copied

### DIFF
--- a/LayoutTests/http/tests/security/access-cssstylesheet-after-removing-from-document-expected.txt
+++ b/LayoutTests/http/tests/security/access-cssstylesheet-after-removing-from-document-expected.txt
@@ -1,0 +1,33 @@
+Tests accessing CSSStyleSheet after removing from the document
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS () => stylesheet.cssRules did not throw exception.
+PASS () => stylesheet.insertRule('#element2 { margin: 10px; }') did not throw exception.
+PASS () => stylesheet.deleteRule(0) did not throw exception.
+PASS () => stylesheet.cssRules threw exception SecurityError: Not allowed to access cross-origin stylesheet.
+PASS () => stylesheet.insertRule('body { margin: 10px; } ') threw exception SecurityError: Not allowed to insert rule into cross-origin stylesheet.
+PASS () => stylesheet.deleteRule(0) threw exception SecurityError: Not allowed to delete rule from cross-origin stylesheet.
+PASS () => stylesheet.cssRules did not throw exception.
+PASS () => stylesheet.insertRule('#element2 { margin: 10px; }') did not throw exception.
+PASS () => stylesheet.deleteRule(0) did not throw exception.
+PASS () => stylesheet.cssRules did not throw exception.
+PASS () => stylesheet.insertRule('#element2 { margin: 10px; }') did not throw exception.
+PASS () => stylesheet.deleteRule(0) did not throw exception.
+PASS () => stylesheet.cssRules threw exception SecurityError: Not allowed to access cross-origin stylesheet.
+PASS () => stylesheet.insertRule('body { margin: 10px; } ') threw exception SecurityError: Not allowed to insert rule into cross-origin stylesheet.
+PASS () => stylesheet.deleteRule(0) threw exception SecurityError: Not allowed to delete rule from cross-origin stylesheet.
+PASS () => stylesheet.cssRules threw exception SecurityError: Not allowed to access cross-origin stylesheet.
+PASS () => stylesheet.insertRule('body { margin: 10px; } ') threw exception SecurityError: Not allowed to insert rule into cross-origin stylesheet.
+PASS () => stylesheet.deleteRule(0) threw exception SecurityError: Not allowed to delete rule from cross-origin stylesheet.
+PASS () => stylesheet.cssRules did not throw exception.
+PASS () => stylesheet.insertRule('#element2 { margin: 10px; }') did not throw exception.
+PASS () => stylesheet.deleteRule(0) did not throw exception.
+PASS () => stylesheet.cssRules threw exception SecurityError: Not allowed to access cross-origin stylesheet.
+PASS () => stylesheet.insertRule('body { margin: 10px; } ') threw exception SecurityError: Not allowed to insert rule into cross-origin stylesheet.
+PASS () => stylesheet.deleteRule(0) threw exception SecurityError: Not allowed to delete rule from cross-origin stylesheet.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/security/access-cssstylesheet-after-removing-from-document.html
+++ b/LayoutTests/http/tests/security/access-cssstylesheet-after-removing-from-document.html
@@ -1,0 +1,93 @@
+<!DOCTYPE html>
+
+<head>
+
+<title>Accessing CSSStyleSheet after removing from document</title>
+<script src="/resources/js-test-pre.js"></script>
+
+<!--
+    Explicitly use <link> here instead of dynamically creating <link> elements
+    in JavaScript, so they're loaded before the JavaScript runs.
+-->
+
+<!-- Inline style -->
+<style id="local-style">#element { margin: 10px; }</style>
+
+<!-- Same origin -->
+<link class="test-stylesheet"
+      rel="stylesheet"
+      href="/security/resources/cssStyle.css"
+      data-accessible="true">
+
+<!-- Cross origin, no CORS -->
+<link class="test-stylesheet"
+      rel="stylesheet"
+      href="http://localhost:8000/security/resources/cssStyle.css"
+      data-accessible="false">
+
+<!-- Cross origin, CORS succeeds -->
+<link class="test-stylesheet"
+      rel="stylesheet"
+      href="http://localhost:8000/security/resources/xorigincss1-allow-star.py"
+      crossorigin=""
+      data-accessible="true">
+
+<!-- Same origin -> same origin -->
+<link class="test-stylesheet"
+      rel="stylesheet"
+      href="/resources/redirect.py?url=http://127.0.0.1:8000/security/resources/cssStyle.css"
+      data-accessible="true">
+
+<!-- Same origin -> cross origin, no CORS -->
+<link class="test-stylesheet"
+      rel="stylesheet"
+      href="/resources/redirect.py?url=http://localhost:8000/security/resources/cssStyle.css"
+      data-accessible="false">
+
+<!-- Cross origin -> same origin, no CORS -->
+<link class="test-stylesheet"
+      rel="stylesheet"
+      href="http://localhost:8000/resources/redirect.py?url=http://127.0.0.1:8000/security/resources/cssStyle.css"
+      data-accessible="false">
+
+<!-- Cross origin -> same origin, CORS succeeds -->
+<link class="test-stylesheet"
+      rel="stylesheet"
+      href="http://localhost:8000/security/resources/redirect-allow-star.py?url=http://127.0.0.1:8000/security/resources/xorigincss1-allow-star.py"
+      crossorigin=""
+      data-accessible="true">
+
+<!-- Same origin -> cross origin -> same origin -->
+<link class="test-stylesheet"
+      rel="stylesheet"
+      href="http://127.0.0.1:8000/resources/redirect.py?url=http://localhost:8000/resources/redirect.py?url=http://127.0.0.1:8000/security/resources/cssStyle.css"
+      data-accessible="false">
+
+</head>
+
+<body>
+
+<script>
+    description("Tests accessing CSSStyleSheet after removing from the document");
+
+    const link_elements = Array.from(document.getElementsByClassName("test-stylesheet"));
+    for (const element of link_elements) {
+        const stylesheet = element.sheet;
+
+        window.document.head.removeChild(element);
+
+        if (element.dataset.accessible === "true") {
+            shouldNotThrow(() => stylesheet.cssRules);
+            shouldNotThrow(() => stylesheet.insertRule('#element2 { margin: 10px; }'));
+            shouldNotThrow(() => stylesheet.deleteRule(0));
+        } else {
+            shouldThrowErrorName(() => stylesheet.cssRules, "SecurityError");
+            shouldThrowErrorName(() => stylesheet.insertRule('body { margin: 10px; } '), "SecurityError");
+            shouldThrowErrorName(() => stylesheet.deleteRule(0), "SecurityError");
+        }
+    }
+</script>
+
+<script src="/resources/js-test-post.js"></script>
+
+</body>

--- a/LayoutTests/http/tests/security/access-imported-cssstylesheet-after-removing-from-document-expected.txt
+++ b/LayoutTests/http/tests/security/access-imported-cssstylesheet-after-removing-from-document-expected.txt
@@ -1,0 +1,24 @@
+Tests accessing @import-ed CSSStyleSheet after
+
+PASS () => stylesheet.cssRules did not throw exception.
+PASS () => stylesheet.insertRule('#element2 { margin: 10px; }') did not throw exception.
+PASS () => stylesheet.deleteRule(0) did not throw exception.
+PASS () => stylesheet.cssRules threw exception SecurityError: Not allowed to access cross-origin stylesheet.
+PASS () => stylesheet.insertRule('body { margin: 10px; } ') threw exception SecurityError: Not allowed to insert rule into cross-origin stylesheet.
+PASS () => stylesheet.deleteRule(0) threw exception SecurityError: Not allowed to delete rule from cross-origin stylesheet.
+PASS () => stylesheet.cssRules did not throw exception.
+PASS () => stylesheet.insertRule('#element2 { margin: 10px; }') did not throw exception.
+PASS () => stylesheet.deleteRule(0) did not throw exception.
+PASS () => stylesheet.cssRules threw exception SecurityError: Not allowed to access cross-origin stylesheet.
+PASS () => stylesheet.insertRule('body { margin: 10px; } ') threw exception SecurityError: Not allowed to insert rule into cross-origin stylesheet.
+PASS () => stylesheet.deleteRule(0) threw exception SecurityError: Not allowed to delete rule from cross-origin stylesheet.
+PASS () => stylesheet.cssRules threw exception SecurityError: Not allowed to access cross-origin stylesheet.
+PASS () => stylesheet.insertRule('body { margin: 10px; } ') threw exception SecurityError: Not allowed to insert rule into cross-origin stylesheet.
+PASS () => stylesheet.deleteRule(0) threw exception SecurityError: Not allowed to delete rule from cross-origin stylesheet.
+PASS () => stylesheet.cssRules threw exception SecurityError: Not allowed to access cross-origin stylesheet.
+PASS () => stylesheet.insertRule('body { margin: 10px; } ') threw exception SecurityError: Not allowed to insert rule into cross-origin stylesheet.
+PASS () => stylesheet.deleteRule(0) threw exception SecurityError: Not allowed to delete rule from cross-origin stylesheet.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/security/access-imported-cssstylesheet-after-removing-from-document.html
+++ b/LayoutTests/http/tests/security/access-imported-cssstylesheet-after-removing-from-document.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+
+<head>
+
+<title>Accessing @import-ed CSSStyleSheet after removing from document</title>
+<script src="/resources/js-test-pre.js"></script>
+
+<style id="local-style">
+    /* Rule 0: same origin */
+    @import url('/security/resources/cssStyle.css');
+
+    /* Rule 1: cross origin */
+    @import url('http://localhost:8000/security/resources/cssStyle.css');
+
+    /* Rule 3: same origin -> same origin */
+    @import url('/resources/redirect.py?url=http://127.0.0.1:8000/security/resources/cssStyle.css');
+
+    /* Rule 4: same origin -> cross origin */
+    @import url('/resources/redirect.py?url=http://localhost:8000/security/resources/cssStyle.css');
+
+    /* Rule 5: cross origin -> same origin */
+    @import url('http://localhost:8000/resources/redirect.py?url=http://127.0.0.1:8000/security/resources/cssStyle.css');
+
+    /* Rule 6: same origin -> cross origin -> same origin */
+    @import url('http://127.0.0.1:8000/resources/redirect.py?url=http://localhost:8000/resources/redirect.py?url=http://127.0.0.1:8000/security/resources/cssStyle.css');
+</style>
+
+</head>
+
+<body>
+
+<script>
+    description("Tests accessing @import-ed CSSStyleSheet after <style> is removed from the document");
+
+    let local_style = document.getElementById("local-style");
+    let local_stylesheet = local_style.sheet;
+
+    // Remove the styles from the document
+    window.document.head.removeChild(local_style);
+
+    function check_accessible(stylesheet) {
+        shouldNotThrow(() => stylesheet.cssRules);
+        shouldNotThrow(() => stylesheet.insertRule('#element2 { margin: 10px; }'));
+        shouldNotThrow(() => stylesheet.deleteRule(0));
+    }
+
+    function check_inaccessible(stylesheet) {
+        shouldThrowErrorName(() => stylesheet.cssRules, "SecurityError");
+        shouldThrowErrorName(() => stylesheet.insertRule('body { margin: 10px; } '), "SecurityError");
+        shouldThrowErrorName(() => stylesheet.deleteRule(0), "SecurityError");
+    }
+
+    check_accessible(local_stylesheet.rules[0].styleSheet);
+    check_inaccessible(local_stylesheet.rules[1].styleSheet);
+    check_accessible(local_stylesheet.rules[2].styleSheet);
+    check_inaccessible(local_stylesheet.rules[3].styleSheet);
+    check_inaccessible(local_stylesheet.rules[4].styleSheet);
+    check_inaccessible(local_stylesheet.rules[5].styleSheet);
+</script>
+
+<script src="/resources/js-test-post.js"></script>
+
+</body>
+

--- a/LayoutTests/http/tests/security/cannot-read-cssrules-redirect-expected.txt
+++ b/LayoutTests/http/tests/security/cannot-read-cssrules-redirect-expected.txt
@@ -6,10 +6,8 @@ Test begins.
 exception thrown for cssRules: SecurityError: Not allowed to access cross-origin stylesheet
 exception thrown for rules: SecurityError: Not allowed to access cross-origin stylesheet
 == Cross-Origin to Same-Origin, no-cors mode ==
-cssRules: [object CSSRuleList]
-cssRules length: 1
-rules: [object CSSRuleList]
-rules length: 1
+exception thrown for cssRules: SecurityError: Not allowed to access cross-origin stylesheet
+exception thrown for rules: SecurityError: Not allowed to access cross-origin stylesheet
 == Same-Origin to Same-Origin, cors mode ==
 cssRules: [object CSSRuleList]
 cssRules length: 1

--- a/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/fetch-request-css-cross-origin.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/fetch-request-css-cross-origin.https-expected.txt
@@ -1,6 +1,6 @@
 
 PASS setup global state
 PASS MIME checking of CSS resources fetched via service worker when Content-Type is not set.
-FAIL Same-origin policy for access to CSS resources fetched via service worker promise_test: Unhandled rejection with value: object "SecurityError: Not allowed to access cross-origin stylesheet"
+PASS Same-origin policy for access to CSS resources fetched via service worker
 PASS cleanup global state
 

--- a/Source/WebCore/css/CSSImportRule.cpp
+++ b/Source/WebCore/css/CSSImportRule.cpp
@@ -26,6 +26,7 @@
 #include "CSSMarkup.h"
 #include "CSSSerializationContext.h"
 #include "CSSStyleSheet.h"
+#include "CachedCSSStyleSheet.h"
 #include "MediaList.h"
 #include "MediaQueryParser.h"
 #include "StyleRuleImport.h"
@@ -121,8 +122,13 @@ CSSStyleSheet* CSSImportRule::styleSheet() const
 { 
     if (!m_importRule.get().styleSheet())
         return nullptr;
+
+    std::optional<bool> isOriginClean;
+    if (const auto* cachedSheet = m_importRule->cachedCSSStyleSheet())
+        isOriginClean = cachedSheet->isCORSSameOrigin();
+
     if (!m_styleSheetCSSOMWrapper)
-        m_styleSheetCSSOMWrapper = CSSStyleSheet::create(*m_importRule.get().styleSheet(), const_cast<CSSImportRule*>(this));
+        m_styleSheetCSSOMWrapper = CSSStyleSheet::create(*m_importRule.get().styleSheet(), const_cast<CSSImportRule*>(this), isOriginClean);
     return m_styleSheetCSSOMWrapper.get(); 
 }
 

--- a/Source/WebCore/css/CSSStyleSheet.h
+++ b/Source/WebCore/css/CSSStyleSheet.h
@@ -64,7 +64,7 @@ public:
         Variant<RefPtr<MediaList>, String> media { emptyString() };
         bool disabled { false };
     };
-    static Ref<CSSStyleSheet> create(Ref<StyleSheetContents>&&, CSSImportRule* ownerRule = 0);
+    static Ref<CSSStyleSheet> create(Ref<StyleSheetContents>&&, CSSImportRule* ownerRule = nullptr, std::optional<bool>isOriginClean = std::nullopt);
     static Ref<CSSStyleSheet> create(Ref<StyleSheetContents>&&, Node& ownerNode, const std::optional<bool>& isOriginClean = std::nullopt);
     static Ref<CSSStyleSheet> createInline(Ref<StyleSheetContents>&&, Element& owner, const TextPosition& startPosition);
     static ExceptionOr<Ref<CSSStyleSheet>> create(Document&, Init&&);
@@ -164,7 +164,7 @@ public:
     bool isDetached() const;
 
 private:
-    CSSStyleSheet(Ref<StyleSheetContents>&&, CSSImportRule* ownerRule);
+    CSSStyleSheet(Ref<StyleSheetContents>&&, CSSImportRule* ownerRule, std::optional<bool> isOriginClean);
     CSSStyleSheet(Ref<StyleSheetContents>&&, Node* ownerNode, const TextPosition& startPosition, bool isInlineStylesheet);
     CSSStyleSheet(Ref<StyleSheetContents>&&, Node& ownerNode, const TextPosition& startPosition, bool isInlineStylesheet, const std::optional<bool>&);
     CSSStyleSheet(Ref<StyleSheetContents>&&, Document&, Init&&);

--- a/Source/WebCore/dom/ProcessingInstruction.cpp
+++ b/Source/WebCore/dom/ProcessingInstruction.cpp
@@ -190,11 +190,13 @@ void ProcessingInstruction::setCSSStyleSheet(const String& href, const URL& base
         return;
     }
 
+    ASSERT(sheet);
+
     Ref document = this->document();
     ASSERT(m_isCSS);
     CSSParserContext parserContext(document, baseURL, charset);
 
-    Ref cssSheet = CSSStyleSheet::create(StyleSheetContents::create(href, parserContext), *this);
+    Ref cssSheet = CSSStyleSheet::create(StyleSheetContents::create(href, parserContext), *this, sheet->isCORSSameOrigin());
     cssSheet->setDisabled(m_alternate);
     cssSheet->setTitle(m_title);
     cssSheet->setMediaQueries(MQ::MediaQueryParser::parse(m_media, MediaQueryParserContext(document)));

--- a/Source/WebCore/html/HTMLLinkElement.cpp
+++ b/Source/WebCore/html/HTMLLinkElement.cpp
@@ -579,17 +579,12 @@ void HTMLLinkElement::finishParsingChildren()
 
 void HTMLLinkElement::initializeStyleSheet(Ref<StyleSheetContents>&& styleSheet, const CachedCSSStyleSheet& cachedStyleSheet, MediaQueryParserContext context)
 {
-    // FIXME: originClean should be turned to false except if fetch mode is CORS.
-    std::optional<bool> originClean;
-    if (cachedStyleSheet.options().mode == FetchOptions::Mode::Cors)
-        originClean = cachedStyleSheet.isCORSSameOrigin();
-
     if (m_sheet) {
         ASSERT(m_sheet->ownerNode() == this);
         m_sheet->clearOwnerNode();
     }
 
-    m_sheet = CSSStyleSheet::create(WTFMove(styleSheet), *this, originClean);
+    m_sheet = CSSStyleSheet::create(WTFMove(styleSheet), *this, cachedStyleSheet.isCORSSameOrigin());
     m_sheet->setMediaQueries(MQ::MediaQueryParser::parse(m_media, context));
     if (!isInShadowTree())
         m_sheet->setTitle(title());

--- a/Source/WebCore/platform/network/ResourceResponseBase.cpp
+++ b/Source/WebCore/platform/network/ResourceResponseBase.cpp
@@ -112,7 +112,7 @@ ResourceResponseData ResourceResponseData::isolatedCopy() const
     result.isRedirected = isRedirected;
     result.usedLegacyTLS = usedLegacyTLS;
     result.wasPrivateRelayed = wasPrivateRelayed;
-    result.proxyName = proxyName;
+    result.proxyName = proxyName.isolatedCopy();
     result.isRangeRequested = isRangeRequested;
     if (certificateInfo)
         result.certificateInfo = certificateInfo->isolatedCopy();
@@ -139,7 +139,7 @@ ResourceResponseData ResourceResponseBase::crossThreadData() const
     data.isRedirected = m_isRedirected;
     data.usedLegacyTLS = m_usedLegacyTLS;
     data.wasPrivateRelayed = m_wasPrivateRelayed;
-    data.proxyName = m_proxyName;
+    data.proxyName = m_proxyName.isolatedCopy();
     data.isRangeRequested = m_isRangeRequested;
     if (m_certificateInfo)
         data.certificateInfo = m_certificateInfo->isolatedCopy();
@@ -171,7 +171,7 @@ ResourceResponse ResourceResponseBase::fromCrossThreadData(CrossThreadData&& dat
     response.m_isRedirected = data.isRedirected;
     response.m_usedLegacyTLS =  data.usedLegacyTLS;
     response.m_wasPrivateRelayed = data.wasPrivateRelayed;
-    response.m_proxyName = data.proxyName;
+    response.m_proxyName = WTFMove(data.proxyName);
     response.m_isRangeRequested = data.isRangeRequested;
     response.m_certificateInfo = WTFMove(data.certificateInfo);
 

--- a/Source/WebCore/platform/network/ResourceResponseBase.h
+++ b/Source/WebCore/platform/network/ResourceResponseBase.h
@@ -146,8 +146,8 @@ public:
     void setUsedLegacyTLS(UsedLegacyTLS used) { m_usedLegacyTLS = used; }
     bool wasPrivateRelayed() const { return m_wasPrivateRelayed == WasPrivateRelayed::Yes; }
     void setWasPrivateRelayed(WasPrivateRelayed privateRelayed) { m_wasPrivateRelayed = privateRelayed; }
-    void setProxyName(String&& proxyName) { m_proxyName = proxyName; }
-    String proxyName() const { return m_proxyName; }
+    void setProxyName(String&& proxyName) { m_proxyName = WTFMove(proxyName); }
+    const String& proxyName() const { return m_proxyName; }
 
     // These functions return parsed values of the corresponding response headers.
     WEBCORE_EXPORT bool cacheControlContainsNoCache() const;
@@ -266,7 +266,7 @@ protected:
     unsigned m_initLevel : 3; // Controlled by ResourceResponse.
     mutable UsedLegacyTLS m_usedLegacyTLS : bitWidthOfUsedLegacyTLS { UsedLegacyTLS::No };
     mutable WasPrivateRelayed m_wasPrivateRelayed : bitWidthOfWasPrivateRelayed { WasPrivateRelayed::No };
-    String m_proxyName { };
+    String m_proxyName;
 
 private:
     friend struct WTF::Persistence::Coder<ResourceResponse>;


### PR DESCRIPTION
#### 1d88cd372a58384f14f98fb95b5d5c83a4fd4c22
<pre>
ResourceResponseData::proxyName is not properly isolated copied
<a href="https://bugs.webkit.org/show_bug.cgi?id=291646">https://bugs.webkit.org/show_bug.cgi?id=291646</a>
<a href="https://rdar.apple.com/148182167">rdar://148182167</a>

Reviewed by Chris Dumez.

In existing implementation, ResourceResponseData::proxyName is not isolated copied or moved correctly at the places it
is supposed to be, and this can be the cause of increasing crashes we saw in recent builds. Credits to Chris who found
the issue.

* Source/WebCore/platform/network/ResourceResponseBase.cpp:
(WebCore::ResourceResponseData::isolatedCopy const):
(WebCore::ResourceResponseBase::crossThreadData const):
(WebCore::ResourceResponseBase::fromCrossThreadData):
* Source/WebCore/platform/network/ResourceResponseBase.h:
(WebCore::ResourceResponseBase::setProxyName):
(WebCore::ResourceResponseBase::proxyName const):

Originally-landed-as: cdd407b46a54. <a href="https://rdar.apple.com/151714620">rdar://151714620</a>
Canonical link: <a href="https://commits.webkit.org/295343@main">https://commits.webkit.org/295343@main</a>
</pre>
----------------------------------------------------------------------
#### 647e80ac22b36756d0b194b3f0526fae8f62447a
<pre>
Tighten up cross-site access to CSSStyleSheet
<a href="https://rdar.apple.com/148513087">rdar://148513087</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=290992">https://bugs.webkit.org/show_bug.cgi?id=290992</a>

Reviewed by Youenn Fablet.

CSSStyleSheet::canAccessRules() gates access to rules within
CSSStyleSheet, depending on whether the JS code and stylesheet comes
from the same origin.

bool CSSStyleSheet::canAccessRules() const
{
    if (m_isOriginClean)                      // (1)
        return m_isOriginClean.value();

    URL baseURL = m_contents-&gt;baseURL();      // (2)
    if (baseURL.isEmpty())
        return true;
    Document* document = ownerDocument();     // (3)
    if (!document)
        return true;                          // (4)
    return document-&gt;protectedSecurityOrigin()-&gt;canRequest(baseURL, OriginAccessPatternsForWebProcess::singleton()); // (5)
}

If CSSStyleSheet is constructed with an explicit same-origin flag, (which
indicates the origin status of the JS code and stylesheet), that flag is
used (1). Otherwise, it manually checks the origin:

* get the base URL of the stylesheet (2)
* get the document owner of the CSSStyleSheet
  (also the document that the JS code is in) (3)
* check whether the JS code and the stylesheet is same-origin (5)

There&apos;s a bug at (4) - it grants access if the CSSStyleSheet doesn&apos;t
belong to a Document. Malicious JS code can manipulate a cross-origin
CSSStyleSheet into this state:

* If the CSSStyleSheet comes from HTMLLinkElement.sheet (&lt;link rel=&quot;stylesheet&quot;&gt;)
  or HTMLStyleElement.sheet (&lt;style&gt;), remove the &lt;link&gt; or &lt;style&gt; element
  from the document e.g using Node.removeChild
* If it comes from CSSImportRule.styleSheet (@import), remove the
  stylesheet containing the @import rule from the document

Following the removal, ownerDocument() returns nullptr, and access is
granted. Fix this by changing (4) to return false instead.

Unfortunately, many places in the codebase construct CSSStyleSheet
without supplying the same-origin flag, instead relying on the
fallback check. For those cases, this change introduces a regression
where if a same-origin stylesheet is created without the same-origin
flag, then is removed from the document, the fallback check will
incorrectly deny access. Fix this by hunting down places that
construct CSSStyleSheet and supply the flag if possible.

Also fix CSSStyleSheet.{insert,delete}Rule to always check with
canAccessRules() before allowing insertion/deletion.

* LayoutTests/http/tests/security/access-cssstylesheet-after-removing-from-document-expected.txt: Added.
* LayoutTests/http/tests/security/access-cssstylesheet-after-removing-from-document.html: Added.
* LayoutTests/http/tests/security/access-imported-cssstylesheet-after-removing-from-document-expected.txt: Added.
* LayoutTests/http/tests/security/access-imported-cssstylesheet-after-removing-from-document.html: Added.
* LayoutTests/http/tests/security/cannot-read-cssrules-redirect-expected.txt:
    - Adjust expectation. This now matches Chrome&apos;s output.

* LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/fetch-request-css-cross-origin.https-expected.txt:
* Source/WebCore/css/CSSImportRule.cpp:
(WebCore::CSSImportRule::styleSheet const):
    - Supply same-origin flag when creating CSSStyleSheet if possible.

* Source/WebCore/css/CSSStyleSheet.cpp:
(WebCore::CSSStyleSheet::create):
    - Make ::create for @import rules take an optional same-origin flag.

(WebCore::CSSStyleSheet::createInline):
    - Take an optional same-origin flag.

(WebCore::CSSStyleSheet::canAccessRules const):
    - Deny access if the CSSStyleSheet does not belong to a Document.

(WebCore::CSSStyleSheet::insertRule):
    - Deny access if not allowed (using canAccessRules())

(WebCore::CSSStyleSheet::deleteRule):
    - Deny access if not allowed (using canAccessRules())

* Source/WebCore/css/CSSStyleSheet.h:
* Source/WebCore/dom/ProcessingInstruction.cpp:
(WebCore::ProcessingInstruction::setCSSStyleSheet):
    - Supply same-origin flag when creating CSSStyleSheet.

* Source/WebCore/html/HTMLLinkElement.cpp:
(WebCore::HTMLLinkElement::initializeStyleSheet):
    - Always set the origin clean flag, regardless whether the fetch
      request is CORS or not.

Originally-landed-as: be53cebfe0d9. <a href="https://rdar.apple.com/151714711">rdar://151714711</a>
Canonical link: <a href="https://commits.webkit.org/295342@main">https://commits.webkit.org/295342@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/04e1bcb2dfc5d5ebab9e7a6930dcd2fa23968f7d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104529 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24239 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/14657 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/109737 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/55200 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/106569 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/24623 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/32783 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79363 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107535 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19149 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94341 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59689 "Passed tests") | 
| | [💥 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/18926 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/12414 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/54588 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/88631 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/12470 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/112123 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/31690 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23336 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88408 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32054 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/90574 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88078 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32974 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10748 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/27007 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17000 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/31617 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/37145 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/31409 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/34748 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/32969 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->