### PR TITLE
RegExp with the v flag should correctly handle nested inverted character classes

### DIFF
--- a/JSTests/stress/regexp-vflag-property-of-strings.js
+++ b/JSTests/stress/regexp-vflag-property-of-strings.js
@@ -1,6 +1,8 @@
 // With verbose set to false, this test is successful if there is no output.  Set verbose to true to see expected matches.
 let verbose = false;
 
+let errors = 0;
+
 function arrayToString(arr)
 {
     let str = '';
@@ -30,7 +32,7 @@ function objectToString(obj)
 
         firstEntry = false;
     }
-    
+
     return "{ " + str + " }";
 }
 
@@ -139,23 +141,33 @@ function testRegExp(re, str, exp, groups)
     if (result) {
         if (verbose)
             print(re.toString() + ".exec(" + dumpValue(str) + "), passed ", dumpValue(exp));
-    } else
+    } else {
         print(re.toString() + ".exec(" + dumpValue(str) + "), FAILED test #" + testNumber + ", Expected ", dumpValue(exp), " got ", dumpValue(actual));
+        errors++;
+    }
 }
 
 function testRegExpSyntaxError(reString, flags, expError)
 {
     testNumber++;
 
+
     try {
         let re = new RegExp(reString, flags);
-        print("FAILED test #" + testNumber + ", Expected /" + reString + "/" + flags + " to throw \"" + expError);
+        print("FAILED test #" + testNumber + ", Expected /" + reString + "/" + flags + " to throw \"" + expError + "\", but it didn't");
+        errors++;
     } catch (e) {
         if (e != expError)
             print("FAILED test #" + testNumber + ", Expected /" + reString + "/" + flags + " to throw \"" + expError + "\" got \"" + e + "\"");
         else if (verbose)
             print("/" + reString + "/" + flags + " passed, it threw \"" + expError + "\" as expected");
     }
+}
+
+function printErrors()
+{
+    if (errors)
+        throw "Test had " + errors + " errors";
 }
 
 // Test 1
@@ -520,58 +532,105 @@ testRegExpSyntaxError("\\%", "u", "SyntaxError: Invalid regular expression: inva
 testRegExpSyntaxError("\\,", "u", "SyntaxError: Invalid regular expression: invalid escaped character for Unicode pattern");
 testRegExpSyntaxError("\\:", "u", "SyntaxError: Invalid regular expression: invalid escaped character for Unicode pattern");
 
-// Test 256
+// Test 261
 testRegExpSyntaxError("\\;", "u", "SyntaxError: Invalid regular expression: invalid escaped character for Unicode pattern");
 testRegExpSyntaxError("\\<", "u", "SyntaxError: Invalid regular expression: invalid escaped character for Unicode pattern");
 testRegExpSyntaxError("\\=", "u", "SyntaxError: Invalid regular expression: invalid escaped character for Unicode pattern");
 testRegExpSyntaxError("\\>", "u", "SyntaxError: Invalid regular expression: invalid escaped character for Unicode pattern");
 testRegExpSyntaxError("\\@", "u", "SyntaxError: Invalid regular expression: invalid escaped character for Unicode pattern");
 
-// Test 261
+// Test 266
 testRegExpSyntaxError("\\`", "u", "SyntaxError: Invalid regular expression: invalid escaped character for Unicode pattern");
 testRegExpSyntaxError("\\~", "u", "SyntaxError: Invalid regular expression: invalid escaped character for Unicode pattern");
 testRegExpSyntaxError("[\\&]", "u", "SyntaxError: Invalid regular expression: invalid escaped character for Unicode pattern");
 testRegExpSyntaxError("[\\!]", "u", "SyntaxError: Invalid regular expression: invalid escaped character for Unicode pattern");
 testRegExpSyntaxError("[\\#]", "u", "SyntaxError: Invalid regular expression: invalid escaped character for Unicode pattern");
 
-// Test 255
+// Test 260
 testRegExpSyntaxError("[\\%]", "u", "SyntaxError: Invalid regular expression: invalid escaped character for Unicode pattern");
 testRegExpSyntaxError("[\\,]", "u", "SyntaxError: Invalid regular expression: invalid escaped character for Unicode pattern");
 testRegExpSyntaxError("[\\:]", "u", "SyntaxError: Invalid regular expression: invalid escaped character for Unicode pattern");
 testRegExpSyntaxError("[\\;]", "u", "SyntaxError: Invalid regular expression: invalid escaped character for Unicode pattern");
 testRegExpSyntaxError("[\\<]", "u", "SyntaxError: Invalid regular expression: invalid escaped character for Unicode pattern");
 
-// Test 271
+// Test 276
 testRegExpSyntaxError("[\\=]", "u", "SyntaxError: Invalid regular expression: invalid escaped character for Unicode pattern");
 testRegExpSyntaxError("[\\>]", "u", "SyntaxError: Invalid regular expression: invalid escaped character for Unicode pattern");
 testRegExpSyntaxError("[\\@]", "u", "SyntaxError: Invalid regular expression: invalid escaped character for Unicode pattern");
 testRegExpSyntaxError("[\\`]", "u", "SyntaxError: Invalid regular expression: invalid escaped character for Unicode pattern");
 testRegExpSyntaxError("[\\~]", "u", "SyntaxError: Invalid regular expression: invalid escaped character for Unicode pattern");
 
-// Test 276
+// Test 281
 testRegExpSyntaxError("\\&", "v", "SyntaxError: Invalid regular expression: invalid escaped character for Unicode pattern");
 testRegExpSyntaxError("\\-", "v", "SyntaxError: Invalid regular expression: invalid escaped character for Unicode pattern");
 testRegExpSyntaxError("\\!", "v", "SyntaxError: Invalid regular expression: invalid escaped character for Unicode pattern");
 testRegExpSyntaxError("\\#", "v", "SyntaxError: Invalid regular expression: invalid escaped character for Unicode pattern");
 testRegExpSyntaxError("\\%", "v", "SyntaxError: Invalid regular expression: invalid escaped character for Unicode pattern");
 
-// Test 281
+// Test 286
 testRegExpSyntaxError("\\,", "v", "SyntaxError: Invalid regular expression: invalid escaped character for Unicode pattern");
 testRegExpSyntaxError("\\:", "v", "SyntaxError: Invalid regular expression: invalid escaped character for Unicode pattern");
 testRegExpSyntaxError("\\;", "v", "SyntaxError: Invalid regular expression: invalid escaped character for Unicode pattern");
 testRegExpSyntaxError("\\<", "v", "SyntaxError: Invalid regular expression: invalid escaped character for Unicode pattern");
 testRegExpSyntaxError("\\=", "v", "SyntaxError: Invalid regular expression: invalid escaped character for Unicode pattern");
 
-// Test 286
+// Test 291
 testRegExpSyntaxError("\\>", "v", "SyntaxError: Invalid regular expression: invalid escaped character for Unicode pattern");
 testRegExpSyntaxError("\\@", "v", "SyntaxError: Invalid regular expression: invalid escaped character for Unicode pattern");
 testRegExpSyntaxError("\\`", "v", "SyntaxError: Invalid regular expression: invalid escaped character for Unicode pattern");
 testRegExpSyntaxError("\\~", "v", "SyntaxError: Invalid regular expression: invalid escaped character for Unicode pattern");
 testRegExpSyntaxError("\\q{a}", "v", "SyntaxError: Invalid regular expression: invalid escaped character for Unicode pattern");
 
-// Test 291
+// Test 296
 testRegExp(/[\&\-\!\#\%\,\:\;\<\=\>\@\`\~]*/v, "&-!#%,:;<=>@`~", ["&-!#%,:;<=>@`~"]);
 testRegExp(/[\q{\&\-\!\#\%\,\:\;\<\=\>\@\`\~}X]*/v, "X&-!#%,:;<=>@`~X", ["X&-!#%,:;<=>@`~X"]);
 testRegExp(/[\q{}]/v, "", [""]);
 testRegExp(/[\q{\u{0095}|k}]/vi, "k", ["k"]);
 testRegExp(/[\q{\u{0095}|s}]/vi, "s", ["s"]);
+
+// Test 301
+testRegExp(/[f[^a-z]]/v, "f", ["f"]);
+testRegExp(/[f[^a-z]]/v, "a", null);
+testRegExp(/[f[^a-z]]/v, "2", ["2"]);
+
+// Test 304
+testRegExp(/[^f[^a-z]]/v, "f", null);
+testRegExp(/[^f[^a-z]]/v, "a", ["a"]);
+testRegExp(/[^f[^a-z]]/v, "2", null);
+
+// Test 307
+testRegExp(/[^f[a-z]]/v, "f", null);
+testRegExp(/[^f[a-z]]/v, "a", null);
+testRegExp(/[^f[a-z]]/v, "2", ["2"]);
+
+// Test 310
+testRegExp(/[^[^[^[^[^[^[^[^[^[^[^[^abc]]]]]]]]]]]]/v, "a", ["a"]);
+testRegExp(/[^[^[^[^[^[^[^[^[^[^[^[^abc]]]]]]]]]]]]/v, "d", null);
+
+testRegExp(/[^[^[^[^[^[^[^[^[^[^[^abc]]]]]]]]]]]/v, "a", null);
+testRegExp(/[^[^[^[^[^[^[^[^[^[^[^abc]]]]]]]]]]]/v, "d", ["d"]);
+
+// Test 314
+testRegExp(/[a\u{1813}[^\u{0250}-\u{3373}a]]/v, "\u{0250}", null);
+testRegExp(/[a\u{1813}[^\u{0250}-\u{3373}a]]/v, "\u{1813}", ["\u{1813}"]);
+testRegExp(/[a\u{1813}[^\u{0250}-\u{3373}a]]/v, "a", ["a"]);
+
+// Test 317
+testRegExpSyntaxError("[a-[^a-z]]", "v", "SyntaxError: Invalid regular expression: invalid class set character");
+
+// Test 318
+testRegExp(/[f[^[a-m][n-z]]]/v, "f", "f");
+testRegExp(/[f[^[a-m][n-z]]]/v, "a", null);
+testRegExp(/[f[^[a-m][n-z]]]/v, "2", "2");
+
+// Test 321
+testRegExp(/[f[^[a-z]&&[a-f]]]/v, "f", "f");
+testRegExp(/[f[^[a-z]&&[a-f]]]/v, "a", null);
+testRegExp(/[f[^[a-z]&&[a-f]]]/v, "g", "g");
+testRegExp(/[f[^[a-z]&&[a-f]]]/v, "2", "2");
+
+testRegExp(/[f[^[a-z]--[a-f]]]/v, "f", "f");
+testRegExp(/[f[^[a-z]--[a-f]]]/v, "a", "a");
+testRegExp(/[f[^[a-z]--[a-f]]]/v, "g", null);
+testRegExp(/[f[^[a-z]--[a-f]]]/v, "2", "2");
+

--- a/Source/JavaScriptCore/yarr/YarrSyntaxChecker.cpp
+++ b/Source/JavaScriptCore/yarr/YarrSyntaxChecker.cpp
@@ -45,8 +45,8 @@ public:
     void atomCharacterClassBuiltIn(BuiltInCharacterClassID, bool) { }
     void atomClassStringDisjunction(Vector<Vector<char32_t>>&) { }
     void atomCharacterClassSetOp(CharacterClassSetOp) { }
-    void atomCharacterClassPushNested() { }
-    void atomCharacterClassPopNested() { }
+    void atomCharacterClassPushNested(bool) { }
+    void atomCharacterClassPopNested(bool) { }
     void atomCharacterClassEnd() { }
     void atomParenthesesSubpatternBegin(bool = true, std::optional<String> = std::nullopt) { }
     void atomParentheticalAssertionBegin(bool, MatchDirection) { }

--- a/Source/WebCore/contentextensions/URLFilterParser.cpp
+++ b/Source/WebCore/contentextensions/URLFilterParser.cpp
@@ -216,12 +216,12 @@ public:
         // Nothing to do here.
     }
 
-    void atomCharacterClassPushNested()
+    void atomCharacterClassPushNested(bool)
     {
         // Nothing to do here.
     }
 
-    void atomCharacterClassPopNested()
+    void atomCharacterClassPopNested(bool)
     {
         // Nothing to do here.
     }


### PR DESCRIPTION
#### c07d637bf0207a1427d0f0b5d0d297e90fa90825
<pre>
RegExp with the v flag should correctly handle nested inverted character classes
<a href="https://bugs.webkit.org/show_bug.cgi?id=292429">https://bugs.webkit.org/show_bug.cgi?id=292429</a>
<a href="https://rdar.apple.com/151000852">rdar://151000852</a>

Reviewed by Michael Saboff.

Currently, we do not handle nested character classes correctly if
they are inverted. While the parser is able to work out the inner
character class needs to be inverted, this information isn&apos;t sent
to the pattern generator, meaning that it treats any nested class
as a non-inverted class. This leads to spec non-conformance. This
patch fixes that issue by adding functions to handle inversion of
a character class&apos;s matches and ranges, for ASCII and Unicode. In
the case of an inverted nested group, we invert its contents when
the closing `]` is reached.

This change also requires a small change to the parser, since its
state holds a cached character to check for potential ranges. The
cached character previously was not cleared when we read a nested
character class, meaning that its character would be processed as
part of the nested class. This would lead to bugs where character
classes would seem to ignore parts of their contents, due to that
character being cached and being treated as a part of the nested,
inverted character class.

* JSTests/stress/regexp-vflag-property-of-strings.js:
(objectToString):
(testRegExp):
(testRegExpSyntaxError):
(printErrors):
* Source/JavaScriptCore/yarr/YarrParser.h:
(JSC::Yarr::requires):
(JSC::Yarr::Parser::ClassSetParserDelegate::nestedClassBegin):
(JSC::Yarr::Parser::ClassSetParserDelegate::nestedClassEnd):
(JSC::Yarr::Parser::parseClassSet):
* Source/JavaScriptCore/yarr/YarrPattern.cpp:
(JSC::Yarr::CharacterClassConstructor::invertMatches):
(JSC::Yarr::CharacterClassConstructor::asciiInvert):
(JSC::Yarr::CharacterClassConstructor::unicodeInvert):
(JSC::Yarr::YarrPatternConstructor::atomCharacterClassPushNested):
(JSC::Yarr::YarrPatternConstructor::atomCharacterClassPopNested):
* Source/JavaScriptCore/yarr/YarrSyntaxChecker.cpp:
(JSC::Yarr::SyntaxChecker::atomCharacterClassPushNested):
(JSC::Yarr::SyntaxChecker::atomCharacterClassPopNested):
* Source/WebCore/contentextensions/URLFilterParser.cpp:
(WebCore::ContentExtensions::PatternParser::atomCharacterClassPushNested):
(WebCore::ContentExtensions::PatternParser::atomCharacterClassPopNested):

Canonical link: <a href="https://commits.webkit.org/295277@main">https://commits.webkit.org/295277@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ff1f236652397ae176a150ddc47e7e03c4e9a1f1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104546 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24256 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/14674 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/109755 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/55217 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/106586 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/24641 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/32800 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79370 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107552 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19161 "layout-tests (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94351 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59696 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/18936 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/12423 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/54589 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/97225 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/88642 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/12478 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/112143 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/103161 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/31707 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23343 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88447 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32071 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/90582 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88086 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22455 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32988 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10753 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/27024 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/31634 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/36974 "Built successfully") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/127442 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/31426 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/127442 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/34765 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/32986 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->