### PR TITLE
ComplexTextControllerCoreText: Adopt more CheckedRef for data members

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/NoUncheckedPtrMemberCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/NoUncheckedPtrMemberCheckerExpectations
@@ -51,7 +51,6 @@ platform/OrientationNotifier.h
 platform/ScrollAnimator.h
 platform/Scrollbar.h
 platform/ScrollbarsController.h
-platform/graphics/ComplexTextController.h
 platform/graphics/TextBoxIterator.h
 platform/graphics/ca/TileCoverageMap.h
 platform/ios/WebAVPlayerController.h

--- a/Source/WebCore/platform/graphics/ComplexTextController.h
+++ b/Source/WebCore/platform/graphics/ComplexTextController.h
@@ -201,8 +201,8 @@ private:
 
     SingleThreadWeakHashSet<const Font>* m_fallbackFonts { nullptr };
 
-    const FontCascade& m_fontCascade;
-    const TextRun& m_run;
+    CheckedRef<const FontCascade> m_fontCascade;
+    CheckedRef<const TextRun> m_run;
 
     unsigned m_currentCharacter { 0 };
     unsigned m_end { 0 };

--- a/Source/WebCore/platform/graphics/harfbuzz/ComplexTextControllerHarfBuzz.cpp
+++ b/Source/WebCore/platform/graphics/harfbuzz/ComplexTextControllerHarfBuzz.cpp
@@ -312,7 +312,7 @@ void ComplexTextController::collectComplexTextRunsForCharacters(std::span<const 
 {
     if (!font) {
         // Create a run of missing glyphs from the primary font.
-        m_complexTextRuns.append(ComplexTextRun::create(m_fontCascade.primaryFont(), characters, stringLocation, 0, characters.size(), m_run.ltr()));
+        m_complexTextRuns.append(ComplexTextRun::create(m_fontCascade->primaryFont(), characters, stringLocation, 0, characters.size(), m_run->ltr()));
         return;
     }
 
@@ -371,12 +371,12 @@ void ComplexTextController::collectComplexTextRunsForCharacters(std::span<const 
         hb_buffer_set_script(buffer.get(), findScriptForVerticalGlyphSubstitution(face.get()));
 
     for (unsigned i = 0; i < runCount; ++i) {
-        auto& run = runList[m_run.rtl() ? runCount - i - 1 : i];
+        auto& run = runList[m_run->rtl() ? runCount - i - 1 : i];
 
         if (fontPlatformData.orientation() != FontOrientation::Vertical)
             hb_buffer_set_script(buffer.get(), hb_icu_script_to_script(run.script));
-        if (!m_mayUseNaturalWritingDirection || m_run.directionalOverride())
-            hb_buffer_set_direction(buffer.get(), m_run.rtl() ? HB_DIRECTION_RTL : HB_DIRECTION_LTR);
+        if (!m_mayUseNaturalWritingDirection || m_run->directionalOverride())
+            hb_buffer_set_direction(buffer.get(), m_run->rtl() ? HB_DIRECTION_RTL : HB_DIRECTION_LTR);
         else {
             // Leaving direction to HarfBuzz to guess is *really* bad, but will do for now.
             hb_buffer_guess_segment_properties(buffer.get());

--- a/Source/WebCore/platform/graphics/skia/ComplexTextControllerSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/ComplexTextControllerSkia.cpp
@@ -155,7 +155,7 @@ void ComplexTextController::collectComplexTextRunsForCharacters(std::span<const 
 {
     if (!font) {
         // Create a run of missing glyphs from the primary font.
-        m_complexTextRuns.append(ComplexTextRun::create(m_fontCascade.primaryFont(), characters, stringLocation, 0, characters.size(), m_run.ltr()));
+        m_complexTextRuns.append(ComplexTextRun::create(m_fontCascade->primaryFont(), characters, stringLocation, 0, characters.size(), m_run->ltr()));
         return;
     }
 
@@ -183,7 +183,7 @@ void ComplexTextController::collectComplexTextRunsForCharacters(std::span<const 
     const hb_feature_t* featuresData = features.isEmpty() ? nullptr : features.data();
     unsigned featuresSize = features.size();
     Vector<hb_feature_t> featuresWithKerning;
-    if (!m_fontCascade.enableKerning()) {
+    if (!m_fontCascade->enableKerning()) {
         featuresWithKerning.reserveInitialCapacity(featuresSize + 1);
         featuresWithKerning.append({ HB_TAG('k', 'e', 'r', 'n'), 0, 0, static_cast<unsigned>(-1) });
         featuresWithKerning.appendVector(features);
@@ -198,17 +198,17 @@ void ComplexTextController::collectComplexTextRunsForCharacters(std::span<const 
     // According to <https://datatracker.ietf.org/doc/html/rfc5646#section-2.1>
     // "the language tags described in this document are sequences of characters
     // from the US-ASCII [ISO646] repertoire.".
-    auto language = hb_language_from_string(m_fontCascade.fontDescription().computedLocale().string().ascii().data(), -1);
+    auto language = hb_language_from_string(m_fontCascade->fontDescription().computedLocale().string().ascii().data(), -1);
 
     for (unsigned i = 0; i < runCount; ++i) {
         hb_buffer_set_language(buffer.get(), language);
 
-        auto& run = runList[m_run.rtl() ? runCount - i - 1 : i];
+        auto& run = runList[m_run->rtl() ? runCount - i - 1 : i];
 
         hb_buffer_set_script(buffer.get(), hb_icu_script_to_script(run.script));
 
-        if (!m_mayUseNaturalWritingDirection || m_run.directionalOverride())
-            hb_buffer_set_direction(buffer.get(), m_run.rtl() ? HB_DIRECTION_RTL : HB_DIRECTION_LTR);
+        if (!m_mayUseNaturalWritingDirection || m_run->directionalOverride())
+            hb_buffer_set_direction(buffer.get(), m_run->rtl() ? HB_DIRECTION_RTL : HB_DIRECTION_LTR);
         else
             hb_buffer_set_direction(buffer.get(), hb_script_get_horizontal_direction(hb_icu_script_to_script(run.script)));
 

--- a/Source/WebCore/platform/graphics/win/ComplexTextControllerUniscribe.cpp
+++ b/Source/WebCore/platform/graphics/win/ComplexTextControllerUniscribe.cpp
@@ -172,7 +172,7 @@ void ComplexTextController::collectComplexTextRunsForCharacters(std::span<const 
 {
     if (!font) {
         // Create a run of missing glyphs from the primary font.
-        m_complexTextRuns.append(ComplexTextRun::create(m_fontCascade.primaryFont(), cp, stringLocation, 0, cp.size(), m_run.ltr()));
+        m_complexTextRuns.append(ComplexTextRun::create(m_fontCascade->primaryFont(), cp, stringLocation, 0, cp.size(), m_run->ltr()));
         return;
     }
 
@@ -183,9 +183,9 @@ void ComplexTextController::collectComplexTextRunsForCharacters(std::span<const 
         SCRIPT_STATE state { };
         control.fMergeNeutralItems = true;
         // Set up the correct direction for the run.
-        state.uBidiLevel = m_run.rtl();
+        state.uBidiLevel = m_run->rtl();
         // Lock the correct directional override.
-        state.fOverrideDirection = m_run.directionalOverride();
+        state.fOverrideDirection = m_run->directionalOverride();
 
         // ScriptItemize may write (cMaxItems + 1) SCRIPT_ITEM.
         HRESULT hr = ScriptItemize(wcharFrom(cp.data()), cp.size(), items.size() - 1, &control, &state, items.data(), &numItems);


### PR DESCRIPTION
#### 86a071e0c2879b8fbabf814c1cdaaaa71576ece2
<pre>
ComplexTextControllerCoreText: Adopt more CheckedRef for data members
<a href="https://bugs.webkit.org/show_bug.cgi?id=293396">https://bugs.webkit.org/show_bug.cgi?id=293396</a>
<a href="https://rdar.apple.com/problem/151814464">rdar://problem/151814464</a>

Reviewed by Chris Dumez.

* Source/WebCore/SaferCPPExpectations/NoUncheckedPtrMemberCheckerExpectations:
* Source/WebCore/platform/graphics/ComplexTextController.cpp:
(WebCore::ComplexTextController::computeExpansionOpportunity):
(WebCore::ComplexTextController::enclosingGlyphBoundsForTextRun):
* Source/WebCore/platform/graphics/ComplexTextController.h:
* Source/WebCore/platform/graphics/coretext/ComplexTextControllerCoreText.mm:
(WebCore::ComplexTextController::collectComplexTextRunsForCharacters):
* Source/WebCore/platform/graphics/harfbuzz/ComplexTextControllerHarfBuzz.cpp:
(WebCore::ComplexTextController::collectComplexTextRunsForCharacters):
* Source/WebCore/platform/graphics/skia/ComplexTextControllerSkia.cpp:
(WebCore::ComplexTextController::collectComplexTextRunsForCharacters):
* Source/WebCore/platform/graphics/win/ComplexTextControllerUniscribe.cpp:
(WebCore::ComplexTextController::collectComplexTextRunsForCharacters):

Canonical link: <a href="https://commits.webkit.org/295290@main">https://commits.webkit.org/295290@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5ef7ef58e5946a41594a1ead4e8091684335ba05

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104551 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24261 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/14679 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/109760 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/55222 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/106591 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/24646 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/32805 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79375 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107557 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19165 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94358 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59700 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/18947 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/12432 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/54594 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/88646 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/12485 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/112148 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/31712 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23347 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88471 "Found 1 new test failure: imported/w3c/web-platform-tests/service-workers/service-worker/redirected-response.https.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32076 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/90592 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88089 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22464 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32989 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10760 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/27029 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/31639 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/36979 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/31431 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/34770 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/32991 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->