### PR TITLE
PDFDocumentImage::drawPDFPage() need not change the current NSGraphicsContext

### DIFF
--- a/Source/WebCore/platform/graphics/mac/PDFDocumentImageMac.mm
+++ b/Source/WebCore/platform/graphics/mac/PDFDocumentImageMac.mm
@@ -28,7 +28,7 @@
 
 #if USE(PDFKIT_FOR_PDFDOCUMENTIMAGE)
 
-#import "LocalCurrentGraphicsContext.h"
+#import "GraphicsContextStateSaver.h"
 #import "SharedBuffer.h"
 #import <Quartz/Quartz.h>
 #import <objc/objc-class.h>
@@ -66,18 +66,14 @@ unsigned PDFDocumentImage::pageCount() const
 
 void PDFDocumentImage::drawPDFPage(GraphicsContext& context)
 {
-    LocalCurrentGraphicsContext localCurrentContext(context);
+    GraphicsContextStateSaver stateSaver { context };
 
-    // These states can be mutated by PDFKit but are not saved
-    // on the context's state stack. (<rdar://problem/14951759&35738181>)
-    bool allowsSmoothing = CGContextGetAllowsFontSmoothing(context.platformContext());
-    bool allowsSubpixelQuantization = CGContextGetAllowsFontSubpixelQuantization(context.platformContext());
+    // This state can be mutated by PDFKit but is not saved
+    // on the context's state stack. (<rdar://35738181>)
     bool allowsSubpixelPositioning = CGContextGetAllowsFontSubpixelPositioning(context.platformContext());
 
     [[m_document pageAtIndex:0] drawWithBox:kPDFDisplayBoxCropBox toContext:context.platformContext()];
 
-    CGContextSetAllowsFontSmoothing(context.platformContext(), allowsSmoothing);
-    CGContextSetAllowsFontSubpixelQuantization(context.platformContext(), allowsSubpixelQuantization);
     CGContextSetAllowsFontSubpixelPositioning(context.platformContext(), allowsSubpixelPositioning);
 }
 


### PR DESCRIPTION
#### 788945e084abf91faae2abaa485b37b99561394c
<pre>
PDFDocumentImage::drawPDFPage() need not change the current NSGraphicsContext
<a href="https://bugs.webkit.org/show_bug.cgi?id=293397">https://bugs.webkit.org/show_bug.cgi?id=293397</a>
<a href="https://rdar.apple.com/151815335">rdar://151815335</a>

Reviewed by Sammy Gill.

Following 295232@main, PDFKit is now provided with a CGContext to draw
a page to. This patch drops our use of the LocalCurrentGraphicsContext
scope setter since there is no longer a need to override the current
NSGraphicsContext.

Also, as a drive-by fix, remove some manual CGContext state management
as a workaround to (now resolved) PDFKit bugs.

* Source/WebCore/platform/graphics/mac/PDFDocumentImageMac.mm:
(WebCore::PDFDocumentImage::drawPDFPage):

Canonical link: <a href="https://commits.webkit.org/295263@main">https://commits.webkit.org/295263@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/08e88d6af260ff182de16a40a73d77b9eabafb93

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104543 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24253 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/14671 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/109752 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/55214 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/106583 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/24638 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/32797 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79369 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107549 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19163 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94361 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59695 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/18939 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/12435 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/54585 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/88644 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/12488 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/112140 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/31704 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23345 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88420 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32068 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/90595 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88083 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22445 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32981 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10763 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/27021 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/31631 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/36971 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/31423 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/34762 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/32983 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->