### PR TITLE
[WASM GC] Fix BBQJIT::addRefI31 on constant expression

### DIFF
--- a/JSTests/wasm/gc/ref-i31-eq.js
+++ b/JSTests/wasm/gc/ref-i31-eq.js
@@ -1,0 +1,33 @@
+import * as assert from "../assert.js";
+import { compile, instantiate } from "./wast-wrapper.js";
+
+const wat = `
+(module
+
+  (func (export "test")
+    (result i32)
+
+    (ref.eq
+      (call $getI31Ref (i32.const 0x40000000))
+      (call $getI31RefConst))
+  )
+
+  (func $getI31Ref
+    (param $v i32)
+    (result i31ref)
+
+    (ref.i31 (local.get $v))
+  )
+
+  (func $getI31RefConst
+    (result i31ref)
+
+    (ref.i31 (i32.const 0x40000000))
+  )
+)
+`;
+
+let instance = instantiate(wat);
+
+for (let i = 0; i < testLoopCount; i++)
+  assert.eq(instance.exports.test(), 1);

--- a/Source/JavaScriptCore/llint/InPlaceInterpreter64.asm
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter64.asm
@@ -3621,7 +3621,7 @@ ipintOp(_ref_i31, macro()
     lshifti 0x1, t0
     rshifti 0x1, t0
     orq TagNumber, t0
-    pushInt32(t0)
+    pushQuad(t0)
 
     advancePC(2)
     nextIPIntInstruction()

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp
@@ -1502,7 +1502,8 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::truncSaturated(Ext1OpType truncationOp,
 PartialResult WARN_UNUSED_RETURN BBQJIT::addRefI31(ExpressionType value, ExpressionType& result)
 {
     if (value.isConst()) {
-        result = Value::fromI64((((value.asI32() & 0x7fffffff) << 1) >> 1) | JSValue::NumberTag);
+        uint32_t lo32 = (value.asI32() << 1) >> 1;
+        result = Value::fromI64(lo32 | JSValue::NumberTag);
         LOG_INSTRUCTION("RefI31", value, RESULT(result));
         return { };
     }


### PR DESCRIPTION
#### 06e92c10a5725ff226b8ba6a00cc428614d781a0
<pre>
[WASM GC] Fix BBQJIT::addRefI31 on constant expression
<a href="https://bugs.webkit.org/show_bug.cgi?id=293207">https://bugs.webkit.org/show_bug.cgi?id=293207</a>
<a href="https://rdar.apple.com/151653787">rdar://151653787</a>

Reviewed by Yusuke Suzuki.

The constant evaluation path is constructing the final
i32.ref value incorrectly. The lhs of | is promoted to
signed 64-bits. So, when the constant had bit 30 set
(high bit of the i31), the sign was extended all the way
to 64 bits, rather than 32 bits.

This would not be noticible when doing i31.get_{u, s}
but is noticible when using the value as a ref, e.g. ref.eq.

Bonus: cleanup in InPlaceInterpreter64.asm is a no-op
but the value being pushed is the 64-bit ref, so use pushQuad().

Canonical link: <a href="https://commits.webkit.org/295271@main">https://commits.webkit.org/295271@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2b57edb168ddc7da2633c6b3f0de3ec735cb5e96

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104545 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24255 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/14673 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/109754 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/55216 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/24640 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/32799 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79371 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107551 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19160 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94353 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59697 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/18941 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/12425 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/54587 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/97224 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/88641 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/12480 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/112142 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/103160 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/31706 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23342 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88469 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32070 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/90584 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88085 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22449 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32982 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10755 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/27023 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/31633 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/36973 "Failed to build and analyze WebKit") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/127441 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/31425 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/127441 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/34764 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/32985 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->