### PR TITLE
Make use of webkitpy.safer_cpp.checkers in update-safer-cpp-expectations

### DIFF
--- a/Tools/Scripts/update-safer-cpp-expectations
+++ b/Tools/Scripts/update-safer-cpp-expectations
@@ -24,23 +24,20 @@
 import os
 import argparse
 
-EXPECTATIONS_PATH = '../../Source/{project}/SaferCPPExpectations/{checker_type}Expectations'
-CHECKERS = ['ForwardDeclChecker', 'MemoryUnsafeCastChecker', 'NoUncountedMemberChecker', 'NoUncheckedPtrMemberChecker', 'NoUnretainedMemberChecker', 'RefCntblBaseVirtualDtor', 'RetainPtrCtorAdoptChecker',
-    'UncheckedCallArgsChecker', 'UncheckedLocalVarsChecker', 'UncountedCallArgsChecker', 'UncountedLambdaCapturesChecker', 'UncountedLocalVarsChecker', 'UnretainedCallArgsChecker',
-    'UnretainedLambdaCapturesChecker', 'UnretainedLocalVarsChecker']
-PROJECTS = ['JavaScriptCore', 'WebCore', 'WebDriver', 'WebGPU', 'WebInspectorUI', 'WebKit', 'WebKitLegacy', 'WTF']
+from webkitpy.safer_cpp.checkers import Checker
 
 
 def parser():
     parser = argparse.ArgumentParser(description='Automated tooling for updating safer CPP expectations', epilog='Example: update-safer-cpp-expectations -p WebKit --RefCntblBaseVirtualDtor platform/Scrollbar.h --UncountedCallArgsChecker platform/ScrollAnimator.h')
 
     checkers_group = parser.add_argument_group('checker arguments', 'List files to update for each checker')
-    for checker in CHECKERS:
-        checkers_group.add_argument(f'--{checker}', type=str, nargs='+')
+    for checker in Checker.enumerate():
+        checker_name = checker.name()
+        checkers_group.add_argument(f'--{checker_name}', type=str, nargs='+')
 
     parser.add_argument(
         '--project', '-p',
-        choices=PROJECTS,
+        choices=Checker.projects(),
         help='Specify which project expectations you want to update'
     )
     parser.add_argument(
@@ -65,8 +62,8 @@ def parser():
     return parser.parse_args()
 
 
-def modify_expectations_for_checker_from_file(checker_type, unexpected_contents, project, add=False):
-    path_to_expectations = os.path.join(os.path.dirname(__file__), EXPECTATIONS_PATH.format(project=project, checker_type=checker_type))
+def modify_expectations_for_checker_from_file(checker, unexpected_contents, project, add=False):
+    path_to_expectations = checker.expectations_path(project)
     with open(path_to_expectations) as expectations_file:
         expectations = expectations_file.readlines()
         prev_len = len(expectations)
@@ -79,14 +76,14 @@ def modify_expectations_for_checker_from_file(checker_type, unexpected_contents,
                 try:
                     expectations.remove(line)
                 except ValueError:
-                    print(f'Error: {line.strip()} is not in {checker_type}Expectations!')
+                    print(f'Error: {line.strip()} is not in {os.path.relpath(path_to_expectations)}!')
             elif line not in expectations:
                 expectations.append(line)
             else:
-                print(f'Error: {line.strip()} is already in {checker_type}Expectations!\n')
+                print(f'Error: {line.strip()} is already in {os.path.relpath(path_to_expectations)}!\n')
     with open(path_to_expectations, 'w') as expectations_file:
         expectations_file.writelines(sorted(expectations))
-    print(f'Updated expectations for {checker_type}!')
+    print(f'Updated expectations for {checker.name()}!')
     if not add:
         print(f'Removed {prev_len - len(expectations)} fixed files.\n')
     else:
@@ -94,9 +91,9 @@ def modify_expectations_for_checker_from_file(checker_type, unexpected_contents,
 
 
 def update_expectations_from_file(unexpected_results, project, add=False):
-    filename = unexpected_results.split('/')[-1]
+    filename = os.path.basename(unexpected_results)
     if not project:
-        projects = [p for p in PROJECTS if p in filename]
+        projects = [p for p in Checker.projects() if p in filename]
         if projects:
             project = projects[0]
         else:
@@ -107,12 +104,13 @@ def update_expectations_from_file(unexpected_results, project, add=False):
         for line in unexpected_contents:
             if '=>' in line:
                 checker_type = line.split()[-1]
-                modify_expectations_for_checker_from_file(checker_type, unexpected_contents, project, add)
+                modify_expectations_for_checker_from_file(Checker.find_checker_by_name(checker_type), unexpected_contents, project, add)
     print(f'Please add any changes to your commit using `git add` and `git commit --amend`.')
 
 
-def modify_expectations_for_checker(checker_type, unexpected_contents, project, add=False):
-    path_to_expectations = os.path.join(os.path.dirname(__file__), EXPECTATIONS_PATH.format(project=project, checker_type=checker_type))
+def modify_expectations_for_checker(checker, unexpected_contents, project, add=False):
+    path_to_expectations = checker.expectations_path(project)
+    checker_name = checker.name()
     with open(path_to_expectations) as expectations_file:
         expectations = expectations_file.readlines()
         prev_len = len(expectations)
@@ -121,14 +119,14 @@ def modify_expectations_for_checker(checker_type, unexpected_contents, project, 
             try:
                 expectations.remove(f'{line}\n')
             except ValueError:
-                print(f'Error: {line} is not in {checker_type}Expectations!')
+                print(f'Error: {line} is not in {os.path.relpath(path_to_expectations)}!')
         elif line not in expectations:
             expectations.append(f'{line}\n')
         else:
-            print(f'Error: {line} is already in {checker_type}Expectations!\n')
+            print(f'Error: {line} is already in {os.path.relpath(path_to_expectations)}!\n')
     with open(path_to_expectations, 'w') as expectations_file:
         expectations_file.writelines(sorted(expectations))
-    print(f'Updated expectations for {checker_type}!')
+    print(f'Updated expectations for {checker_name}!')
     if not add:
         print(f'Removed {prev_len - len(expectations)} fixed files.\n')
     else:
@@ -140,10 +138,10 @@ def update_expectations(args, project, add=False):
         print(f'Could not find a project to update. Please pass in the --project argument.')
         return
     print(f"{'Adding' if add else 'Removing'} unexpected failures in {project}...\n")
-    for checker_type in CHECKERS:
-        files_per_checker = args[checker_type]
+    for checker in Checker.enumerate():
+        files_per_checker = args[checker.name()]
         if files_per_checker:
-            modify_expectations_for_checker(checker_type, files_per_checker, project, add)
+            modify_expectations_for_checker(checker, files_per_checker, project, add)
     print(f'Please add any changes to your commit using `git add` and `git commit --amend`.')
 
 
@@ -155,9 +153,9 @@ def is_expected_file(expected_file):
     print('This checks against local expectations. Ensure your checkout is up-to-date.\n')
     line = f'{expected_file}\n'
     issues = False
-    for project in PROJECTS:
-        for checker in CHECKERS:
-            path_to_expectations = os.path.join(os.path.dirname(__file__), EXPECTATIONS_PATH.format(project=project, checker_type=checker))
+    for project in Checker.projects():
+        for checker in Checker.enumerate():
+            path_to_expectations = checker.expectations_path(project)
             with open(path_to_expectations, 'r') as f:
                 expectations = f.read()
                 if line in expectations:

--- a/Tools/Scripts/webkitpy/safer_cpp/checkers.py
+++ b/Tools/Scripts/webkitpy/safer_cpp/checkers.py
@@ -48,6 +48,13 @@ class Checker(object):
         return os.path.abspath(path)
 
     @classmethod
+    def find_checker_by_name(cls, name):
+        for checker in cls.enumerate():
+            if checker.name() == name:
+                return checker
+        return None
+
+    @classmethod
     def find_checker_by_description(cls, description):
         for checker in cls.enumerate():
             if checker.description() == description:


### PR DESCRIPTION
#### 79f9c1a1ab4f8894f70e1a0eb7cd6e7ccece2618
<pre>
Make use of webkitpy.safer_cpp.checkers in update-safer-cpp-expectations
<a href="https://bugs.webkit.org/show_bug.cgi?id=293398">https://bugs.webkit.org/show_bug.cgi?id=293398</a>

Reviewed by Brianna Fan.

Replaced the hard-coded list of checkers and projects with the use of webkitpy.safer_cpp.checkers.

* Tools/Scripts/update-safer-cpp-expectations:
(parser):
(modify_expectations_for_checker_from_file):
(update_expectations_from_file):
(modify_expectations_for_checker):
(update_expectations):
(is_expected_file):
* Tools/Scripts/webkitpy/safer_cpp/checkers.py:
(Checker):
(Checker.find_checker_by_name):

Canonical link: <a href="https://commits.webkit.org/295247@main">https://commits.webkit.org/295247@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/65c44b810ee3c4f9397f306e821b6176f668832d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104549 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24259 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/14677 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/109758 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/55220 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/106589 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/24644 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/123/builds/32803 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/109758 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/55220 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107555 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/130/builds/24644 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/94356 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/109758 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/104027 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/130/builds/24644 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/12428 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/54592 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/130/builds/24644 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/12483 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/112146 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/31710 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/123/builds/32803 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/112146 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/32074 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/90587 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/112146 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/10758 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/27027 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16965 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/31637 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/31429 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/34768 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/32989 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->