### PR TITLE
[Grid] Crash in copyUsedTrackSizesForSubgrid with subgrid and line name list.

### DIFF
--- a/LayoutTests/fast/css-grid-layout/subgrid-with-line-name-list-crash-expected.txt
+++ b/LayoutTests/fast/css-grid-layout/subgrid-with-line-name-list-crash-expected.txt
@@ -1,0 +1,2 @@
+Test passes if it does not CRASH.
+

--- a/LayoutTests/fast/css-grid-layout/subgrid-with-line-name-list-crash.html
+++ b/LayoutTests/fast/css-grid-layout/subgrid-with-line-name-list-crash.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<script>
+if (window.testRunner)
+  testRunner.dumpAsText();
+</script>
+<body>
+Test passes if it does not CRASH.
+<div style="display: grid; min-width: max-content;">
+  <div style="display: grid; grid-template-columns: subgrid [a] [b] [c]">
+    <div></div>
+  </div>
+  <div></div>
+  <div style="display: grid;" id="subgrid">
+    <div id="remove"></div>
+  </div>
+</div>
+</body>
+<script>
+document.body.offsetHeight;
+
+let subgrid = document.getElementById("subgrid");
+let remove = document.getElementById("remove");
+subgrid.removeChild(remove);
+
+subgrid.style["grid-template-columns"] = "subgrid [a] [b] [c]";
+subgrid.style["grid-template-areas"] = '"a"';
+
+document.body.offsetHeight;
+</script>
+</html>

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -409,14 +409,16 @@ void RenderBox::styleDidChange(StyleDifference diff, const RenderStyle* oldStyle
     }
 }
 
-static bool gridStyleHasNotChanged(const RenderStyle& style, const RenderStyle* oldStyle)
+static bool hasEquivalentGridPositioningStyle(const RenderStyle& style, const RenderStyle& oldStyle)
 {
-    return (oldStyle->gridItemColumnStart() == style.gridItemColumnStart()
-        && oldStyle->gridItemColumnEnd() == style.gridItemColumnEnd()
-        && oldStyle->gridItemRowStart() == style.gridItemRowStart()
-        && oldStyle->gridItemRowEnd() == style.gridItemRowEnd()
-        && oldStyle->order() == style.order()
-        && oldStyle->hasOutOfFlowPosition() == style.hasOutOfFlowPosition());
+    return (oldStyle.gridItemColumnStart() == style.gridItemColumnStart()
+        && oldStyle.gridItemColumnEnd() == style.gridItemColumnEnd()
+        && oldStyle.gridItemRowStart() == style.gridItemRowStart()
+        && oldStyle.gridItemRowEnd() == style.gridItemRowEnd()
+        && oldStyle.order() == style.order()
+        && oldStyle.hasOutOfFlowPosition() == style.hasOutOfFlowPosition())
+        && (oldStyle.gridSubgridColumns() == style.gridSubgridColumns() || style.orderedNamedGridColumnLines().map.isEmpty())
+        && (oldStyle.gridSubgridRows() == style.gridSubgridRows() || style.orderedNamedGridRowLines().map.isEmpty());
 }
 
 void RenderBox::updateGridPositionAfterStyleChange(const RenderStyle& style, const RenderStyle* oldStyle)
@@ -429,7 +431,7 @@ void RenderBox::updateGridPositionAfterStyleChange(const RenderStyle& style, con
 
     // Positioned items don't participate on the layout of the grid,
     // so we don't need to mark the grid as dirty if they change positions.
-    if ((oldStyle->hasOutOfFlowPosition() && style.hasOutOfFlowPosition()) || gridStyleHasNotChanged(style, oldStyle))
+    if ((oldStyle->hasOutOfFlowPosition() && style.hasOutOfFlowPosition()) || hasEquivalentGridPositioningStyle(style, *oldStyle))
         return;
 
     // It should be possible to not dirty the grid in some cases (like moving an


### PR DESCRIPTION
#### 228b9ba219831e5d4d359d589fe33bf184362b75
<pre>
[Grid] Crash in copyUsedTrackSizesForSubgrid with subgrid and line name list.
<a href="https://bugs.webkit.org/show_bug.cgi?id=293392">https://bugs.webkit.org/show_bug.cgi?id=293392</a>
<a href="https://rdar.apple.com/149687269">rdar://149687269</a>

Reviewed by Matt Woodrow.

When a grid item becomes a subgrid with a line name list
(e.g. subgrid [a] [b] [c]) this can end up affecting the positioning of
the subgrid in the parent grid. This is because the line names become
the number of tracks the subgrid will span in the parent grid if it has
an automatic span based on the other grid placement properties.

In some scenarios, such as the testcase explained below, this can cause us to
use a stale position from the subgrid because we fail to perform item
placement in the parent with the new span for the subgrid. To fix this
we need to treat this case as any other change to a grid item&apos;s
placement property as that is what it basically is. We do this in
RenderBox::styleDidChange -&gt; RenderBox::updateGridPositionAfterStyleChange.

* LayoutTests/fast/css-grid-layout/subgrid-with-line-name-list-crash-expected.txt: Added.
* LayoutTests/fast/css-grid-layout/subgrid-with-line-name-list-crash.html: Added.
After the initial layout:
1.) Remove a child from the subgrid
- This causes us to setNeedsItemPlacement on the parent, which is a
  normal grid at this point.
2.) Change aforementioned grid to a subgrid.
- Since we already setNeedsItemPlacement on the now subgrid we avoid
  setting the bit again which also avoids setNeedsItemPlacement on the
  parent.
3.) Compute the intrinsic logical widths of the parent grid because of
min-width: max-content.
- This ends up performing item placement on the subgrid but the
  placement on the parent during this step uses a temporary grid
  separate from the one being used during layout.
4.) Perform layout of the parent grid. This skips item placement (it was
never set) and causes us to use the old position of the subgrid.

Canonical link: <a href="https://commits.webkit.org/295262@main">https://commits.webkit.org/295262@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d95c7417013a1eaf8ab67f362bf2b9798da54230

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104553 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24263 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/14681 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/109762 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/55224 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/106593 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/24649 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/32807 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79376 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107559 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19169 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94363 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59701 "Passed tests") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/104031 "Build is in progress. Recent messages:") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/18946 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/12437 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/54596 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/88650 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/12490 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/112151 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/31714 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23348 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88473 "Passed tests") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/104108 "Build is in progress. Recent messages:") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32078 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/90597 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88091 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22444 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32990 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10765 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/27031 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/31641 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/36981 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/31433 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/34772 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/32993 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->