### PR TITLE
[Content Filtering] Make ParentalControlsContentFilter::finishedAddingData wait for decision

### DIFF
--- a/Source/WebCore/loader/ContentFilter.cpp
+++ b/Source/WebCore/loader/ContentFilter.cpp
@@ -249,27 +249,29 @@ bool ContentFilter::continueAfterNotifyFinished(CachedResource& resource)
 }
 
 template <typename Function>
-inline void ContentFilter::forEachContentFilterUntilBlocked(Function&& function)
+void ContentFilter::forEachContentFilterUntilBlocked(Function&& getData)
 {
-    bool allFiltersAllowedLoad { true };
-    for (auto& contentFilter : m_contentFilters) {
-        if (!contentFilter->needsMoreData()) {
-            ASSERT(!contentFilter->didBlockData());
+    unsigned allowedCount = 0;
+    for (Ref contentFilter : m_contentFilters) {
+        if (contentFilter->needsMoreData())
+            getData(contentFilter.get());
+
+        // Still need more data for decision.
+        if (contentFilter->needsMoreData())
+            continue;
+
+        if (!contentFilter->didBlockData()) {
+            ++allowedCount;
             continue;
         }
 
-        function(contentFilter.get());
-
-        if (contentFilter->didBlockData()) {
-            ASSERT(!m_blockingContentFilter);
-            m_blockingContentFilter = contentFilter.get();
-            didDecide(State::Blocked);
-            return;
-        } else if (contentFilter->needsMoreData())
-            allFiltersAllowedLoad = false;
+        ASSERT(!m_blockingContentFilter.get());
+        m_blockingContentFilter = contentFilter.get();
+        didDecide(State::Blocked);
+        return;
     }
 
-    if (allFiltersAllowedLoad)
+    if (m_contentFilters.size() == allowedCount)
         didDecide(State::Allowed);
 }
 
@@ -286,7 +288,9 @@ void ContentFilter::didDecide(State state)
         return;
 
     Ref client = m_client.get();
-    m_blockedError = client->contentFilterDidBlock(m_blockingContentFilter->unblockHandler(), m_blockingContentFilter->unblockRequestDeniedScript());
+    RefPtr blockingContentFilter = m_blockingContentFilter.get();
+    ASSERT(blockingContentFilter);
+    m_blockedError = client->contentFilterDidBlock(blockingContentFilter->unblockHandler(), blockingContentFilter->unblockRequestDeniedScript());
     client->cancelMainResourceLoadForContentFilter(m_blockedError);
 }
 
@@ -348,7 +352,9 @@ void ContentFilter::handleProvisionalLoadFailure(const ResourceError& error)
 {
     ASSERT(willHandleProvisionalLoadFailure(error));
 
-    RefPtr replacementData { m_blockingContentFilter->replacementData() };
+    RefPtr blockingContentFilter = m_blockingContentFilter.get();
+    ASSERT(blockingContentFilter);
+    RefPtr replacementData { blockingContentFilter->replacementData() };
     ResourceResponse response { URL(), "text/html"_s, static_cast<long long>(replacementData->size()), "UTF-8"_s };
     SubstituteData substituteData { WTFMove(replacementData), URL { error.failingURL() }, WTFMove(response), SubstituteData::SessionHistoryVisibility::Hidden };
     SetForScope loadingBlockedPage { m_isLoadingBlockedPage, true };

--- a/Source/WebCore/loader/ContentFilter.h
+++ b/Source/WebCore/loader/ContentFilter.h
@@ -90,12 +90,12 @@ private:
     using State = PlatformContentFilter::State;
 
     struct Type {
-        Function<UniqueRef<PlatformContentFilter>(const PlatformContentFilter::FilterParameters&)> create;
+        Function<Ref<PlatformContentFilter>(const PlatformContentFilter::FilterParameters&)> create;
     };
     template <typename T> static Type type();
     WEBCORE_EXPORT static Vector<Type>& types();
 
-    using Container = Vector<UniqueRef<PlatformContentFilter>>;
+    using Container = Vector<Ref<PlatformContentFilter>>;
     friend std::unique_ptr<ContentFilter> std::make_unique<ContentFilter>(Container&&, ContentFilterClient&);
     ContentFilter(Container&&, ContentFilterClient&);
 
@@ -116,7 +116,7 @@ private:
     };
     Vector<ResourceDataItem> m_buffers;
     CachedResourceHandle<CachedRawResource> m_mainResource;
-    WeakPtr<const PlatformContentFilter> m_blockingContentFilter;
+    ThreadSafeWeakPtr<const PlatformContentFilter> m_blockingContentFilter;
     State m_state { State::Stopped };
     ResourceError m_blockedError;
     bool m_isLoadingBlockedPage { false };

--- a/Source/WebCore/platform/PlatformContentFilter.h
+++ b/Source/WebCore/platform/PlatformContentFilter.h
@@ -30,6 +30,7 @@
 #include <wtf/CheckedPtr.h>
 #include <wtf/Ref.h>
 #include <wtf/TZoneMallocInlines.h>
+#include <wtf/ThreadSafeWeakPtr.h>
 #include <wtf/WeakPtr.h>
 #include <wtf/text/WTFString.h>
 
@@ -50,9 +51,8 @@ class ResourceRequest;
 class ResourceResponse;
 class SharedBuffer;
 
-class PlatformContentFilter : public CanMakeWeakPtr<PlatformContentFilter>, public CanMakeCheckedPtr<PlatformContentFilter> {
+class PlatformContentFilter : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<PlatformContentFilter> {
     WTF_MAKE_TZONE_ALLOCATED_INLINE(PlatformContentFilter);
-    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(PlatformContentFilter);
     WTF_MAKE_NONCOPYABLE(PlatformContentFilter);
 
 public:

--- a/Source/WebCore/platform/cocoa/NetworkExtensionContentFilter.h
+++ b/Source/WebCore/platform/cocoa/NetworkExtensionContentFilter.h
@@ -44,10 +44,9 @@ namespace WebCore {
 
 class NetworkExtensionContentFilter final : public PlatformContentFilter {
     WTF_MAKE_TZONE_ALLOCATED(NetworkExtensionContentFilter);
-    friend UniqueRef<NetworkExtensionContentFilter> WTF::makeUniqueRefWithoutFastMallocCheck<NetworkExtensionContentFilter>();
 
 public:
-    static UniqueRef<NetworkExtensionContentFilter> create(const PlatformContentFilter::FilterParameters&);
+    static Ref<NetworkExtensionContentFilter> create(const PlatformContentFilter::FilterParameters&);
 
     void willSendRequest(ResourceRequest&, const ResourceResponse&) override;
     void responseReceived(const ResourceResponse&) override;

--- a/Source/WebCore/platform/cocoa/NetworkExtensionContentFilter.mm
+++ b/Source/WebCore/platform/cocoa/NetworkExtensionContentFilter.mm
@@ -56,9 +56,9 @@ bool NetworkExtensionContentFilter::enabled()
     return isRequired();
 }
 
-UniqueRef<NetworkExtensionContentFilter> NetworkExtensionContentFilter::create(const PlatformContentFilter::FilterParameters&)
+Ref<NetworkExtensionContentFilter> NetworkExtensionContentFilter::create(const PlatformContentFilter::FilterParameters&)
 {
-    return makeUniqueRef<NetworkExtensionContentFilter>();
+    return adoptRef(*new NetworkExtensionContentFilter);
 }
 
 void NetworkExtensionContentFilter::initialize(const URL* url)

--- a/Source/WebCore/platform/cocoa/ParentalControlsContentFilter.h
+++ b/Source/WebCore/platform/cocoa/ParentalControlsContentFilter.h
@@ -40,10 +40,9 @@ class ParentalControlsURLFilter;
 
 class ParentalControlsContentFilter final : public PlatformContentFilter {
     WTF_MAKE_TZONE_ALLOCATED(ParentalControlsContentFilter);
-    friend UniqueRef<ParentalControlsContentFilter> WTF::makeUniqueRefWithoutFastMallocCheck<ParentalControlsContentFilter>(const PlatformContentFilter::FilterParameters&);
 
 public:
-    static UniqueRef<ParentalControlsContentFilter> create(const PlatformContentFilter::FilterParameters&);
+    static Ref<ParentalControlsContentFilter> create(const PlatformContentFilter::FilterParameters&);
 
     void willSendRequest(ResourceRequest&, const ResourceResponse&) override { }
     void responseReceived(const ResourceResponse&) override;
@@ -60,8 +59,8 @@ private:
 
     void updateFilterState();
 #if HAVE(WEBCONTENTRESTRICTIONS)
-    void updateFilterState(PlatformContentFilter::State, NSData *);
-    void enableURLFilter();
+    void didReceiveAllowDecisionOnQueue(bool isAllowed, NSData *);
+    void updateFilterStateOnMain();
 #endif
 
     RetainPtr<WebFilterEvaluator> m_webFilterEvaluator;
@@ -70,6 +69,10 @@ private:
 #if HAVE(WEBCONTENTRESTRICTIONS)
     bool m_usesWebContentRestrictions { false };
     std::optional<URL> m_evaluatedURL;
+    Lock m_resultLock;
+    Condition m_resultCondition;
+    std::optional<bool> m_isAllowdByWebContentRestrictions WTF_GUARDED_BY_LOCK(m_resultLock);
+    RetainPtr<NSData> m_webContentRestrictionsReplacementData WTF_GUARDED_BY_LOCK(m_resultLock);
 #endif
 #if HAVE(WEBCONTENTRESTRICTIONS_PATH_SPI)
     String m_webContentRestrictionsConfigurationPath;

--- a/Source/WebCore/platform/cocoa/ParentalControlsContentFilter.mm
+++ b/Source/WebCore/platform/cocoa/ParentalControlsContentFilter.mm
@@ -36,6 +36,7 @@
 #import <pal/spi/cocoa/WebFilterEvaluatorSPI.h>
 #import <wtf/SoftLinking.h>
 #import <wtf/TZoneMallocInlines.h>
+#import <wtf/WorkQueue.h>
 #import <wtf/cocoa/SpanCocoa.h>
 
 #if HAVE(WEBCONTENTRESTRICTIONS)
@@ -53,6 +54,16 @@ SOFT_LINK_CLASS_OPTIONAL(WebContentAnalysis, WebFilterEvaluator);
 namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(ParentalControlsContentFilter);
+
+#if HAVE(WEBCONTENTRESTRICTIONS)
+
+static WorkQueue& globalQueue()
+{
+    static MainThreadNeverDestroyed<Ref<WorkQueue>> queue = WorkQueue::create("ParentalControlsContentFilter queue"_s);
+    return queue.get();
+}
+
+#endif
 
 bool ParentalControlsContentFilter::enabled() const
 {
@@ -76,9 +87,9 @@ bool ParentalControlsContentFilter::enabled() const
 #endif
 }
 
-UniqueRef<ParentalControlsContentFilter> ParentalControlsContentFilter::create(const PlatformContentFilter::FilterParameters& params)
+Ref<ParentalControlsContentFilter> ParentalControlsContentFilter::create(const PlatformContentFilter::FilterParameters& params)
 {
-    return makeUniqueRef<ParentalControlsContentFilter>(params);
+    return adoptRef(*new ParentalControlsContentFilter(params));
 }
 
 ParentalControlsContentFilter::ParentalControlsContentFilter(const PlatformContentFilter::FilterParameters& params)
@@ -117,10 +128,10 @@ void ParentalControlsContentFilter::responseReceived(const ResourceResponse& res
 #else
         auto& filter = ParentalControlsURLFilter::singleton();
 #endif
-        filter.isURLAllowed(*m_evaluatedURL, [weakThis = WeakPtr { *this }](bool isAllowed, auto replacementData) {
-            if (CheckedPtr checkedThis = weakThis.get())
-                checkedThis->updateFilterState(isAllowed ? State::Allowed : State::Blocked, replacementData);
-        });
+        filter.isURLAllowedWithQueue(*m_evaluatedURL, [weakThis = ThreadSafeWeakPtr { *this }](bool isAllowed, auto replacementData) {
+            if (RefPtr protectedThis = weakThis.get())
+                protectedThis->didReceiveAllowDecisionOnQueue(isAllowed, replacementData);
+        }, globalQueue());
         return;
     }
 #endif
@@ -158,8 +169,19 @@ void ParentalControlsContentFilter::addData(const SharedBuffer& data)
 void ParentalControlsContentFilter::finishedAddingData()
 {
 #if HAVE(WEBCONTENTRESTRICTIONS)
-    if (m_usesWebContentRestrictions)
+    if (m_usesWebContentRestrictions) {
+        if (m_state != State::Filtering)
+            return;
+
+        // Callers expect state is ready after finishing adding data.
+        Locker resultLocker { m_resultLock };
+        while (!m_isAllowdByWebContentRestrictions)
+            m_resultCondition.wait(m_resultLock);
+
+        m_state = *m_isAllowdByWebContentRestrictions ? State::Allowed : State::Blocked;
+        m_replacementData = std::exchange(m_webContentRestrictionsReplacementData, nullptr);
         return;
+    }
 #endif
 
 #if HAVE(WEBCONTENTANALYSIS_FRAMEWORK)
@@ -216,10 +238,32 @@ void ParentalControlsContentFilter::updateFilterState()
 
 #if HAVE(WEBCONTENTRESTRICTIONS)
 
-void ParentalControlsContentFilter::updateFilterState(State state, NSData *replacementData)
+void ParentalControlsContentFilter::didReceiveAllowDecisionOnQueue(bool isAllowed, NSData *replacementData)
 {
-    m_state = state;
-    m_replacementData = replacementData;
+    RELEASE_ASSERT(!isMainThread());
+
+    Locker resultLocker { m_resultLock };
+    ASSERT(!m_isAllowdByWebContentRestrictions);
+    m_isAllowdByWebContentRestrictions = isAllowed;
+    m_webContentRestrictionsReplacementData = replacementData;
+    m_resultCondition.notifyOne();
+    callOnMainRunLoop([weakThis = ThreadSafeWeakPtr { *this }]() {
+        if (RefPtr protectedThis = weakThis.get())
+            protectedThis->updateFilterStateOnMain();
+    });
+}
+
+void ParentalControlsContentFilter::updateFilterStateOnMain()
+{
+    ASSERT(isMainThread());
+
+    if (m_state != State::Filtering)
+        return;
+
+    Locker resultLocker { m_resultLock };
+    ASSERT(m_isAllowdByWebContentRestrictions);
+    m_state = *m_isAllowdByWebContentRestrictions ? State::Allowed : State::Blocked;
+    m_replacementData = std::exchange(m_webContentRestrictionsReplacementData, nullptr);
 }
 
 #endif

--- a/Source/WebCore/platform/cocoa/ParentalControlsURLFilter.h
+++ b/Source/WebCore/platform/cocoa/ParentalControlsURLFilter.h
@@ -29,6 +29,10 @@
 
 OBJC_CLASS WCRBrowserEngineClient;
 
+namespace WTF {
+class WorkQueue;
+}
+
 namespace WebCore {
 
 class ParentalControlsURLFilter {
@@ -42,7 +46,7 @@ public:
 
     void resetIsEnabled();
     bool isEnabled() const;
-    void isURLAllowed(const URL&, CompletionHandler<void(bool, NSData *)>&&);
+    void isURLAllowedWithQueue(const URL&, CompletionHandler<void(bool, NSData *)>&&, WTF::WorkQueue& completionHandlerQueue);
     void allowURL(const URL&, CompletionHandler<void(bool)>&&);
 
 private:

--- a/Source/WebCore/testing/MockContentFilter.cpp
+++ b/Source/WebCore/testing/MockContentFilter.cpp
@@ -61,9 +61,9 @@ bool MockContentFilter::enabled()
     return enabled;
 }
 
-UniqueRef<MockContentFilter> MockContentFilter::create(const PlatformContentFilter::FilterParameters&)
+Ref<MockContentFilter> MockContentFilter::create(const PlatformContentFilter::FilterParameters&)
 {
-    return makeUniqueRef<MockContentFilter>();
+    return adoptRef(*new MockContentFilter);
 }
 
 void MockContentFilter::willSendRequest(ResourceRequest& request, const ResourceResponse& redirectResponse)

--- a/Source/WebCore/testing/MockContentFilter.h
+++ b/Source/WebCore/testing/MockContentFilter.h
@@ -34,11 +34,10 @@ namespace WebCore {
 
 class MockContentFilter final : public PlatformContentFilter {
     WTF_MAKE_TZONE_ALLOCATED(MockContentFilter);
-    friend UniqueRef<MockContentFilter> WTF::makeUniqueRefWithoutFastMallocCheck<MockContentFilter>();
 
 public:
     static void ensureInstalled();
-    static UniqueRef<MockContentFilter> create(const PlatformContentFilter::FilterParameters&);
+    static Ref<MockContentFilter> create(const PlatformContentFilter::FilterParameters&);
 
     void willSendRequest(ResourceRequest&, const ResourceResponse&) override;
     void responseReceived(const ResourceResponse&) override;


### PR DESCRIPTION
#### 9526692b2b36a704effe3cfc21fc4658f771528c
<pre>
[Content Filtering] Make ParentalControlsContentFilter::finishedAddingData wait for decision
<a href="https://bugs.webkit.org/show_bug.cgi?id=293403">https://bugs.webkit.org/show_bug.cgi?id=293403</a>
<a href="https://rdar.apple.com/145777952">rdar://145777952</a>

Reviewed by Per Arne Vollan.

Re-land 294563@main with fixes for two issues:
1. ParentalControlsContentFilter::didReceiveAllowDecisionOnQueue() does not wake up main thread after decision is
available. This is fixed by adding notifyOne() to the function.
2. ContentFilter::forEachContentFilterUntilBlocked() does not update state to blocked if a PlatformContentFilter makes
decision to block before getting more data (from invoking the function). This is fixed by adjusting the logic to try
getting more data for PlatformContentFilter first, and then updating ContentFilter&apos;s state based on the decision (if
the decision is available).

* Source/WebCore/loader/ContentFilter.cpp:
(WebCore::ContentFilter::forEachContentFilterUntilBlocked):
(WebCore::ContentFilter::didDecide):
(WebCore::ContentFilter::handleProvisionalLoadFailure):
* Source/WebCore/loader/ContentFilter.h:
* Source/WebCore/platform/PlatformContentFilter.h:
* Source/WebCore/platform/cocoa/NetworkExtensionContentFilter.h:
* Source/WebCore/platform/cocoa/NetworkExtensionContentFilter.mm:
(WebCore::NetworkExtensionContentFilter::create):
* Source/WebCore/platform/cocoa/ParentalControlsContentFilter.h:
* Source/WebCore/platform/cocoa/ParentalControlsContentFilter.mm:
(WebCore::globalQueue):
(WebCore::ParentalControlsContentFilter::create):
(WebCore::ParentalControlsContentFilter::responseReceived):
(WebCore::ParentalControlsContentFilter::finishedAddingData):
(WebCore::ParentalControlsContentFilter::didReceiveAllowDecisionOnQueue):
(WebCore::ParentalControlsContentFilter::updateFilterStateOnMain):
* Source/WebCore/platform/cocoa/ParentalControlsURLFilter.h:
* Source/WebCore/platform/cocoa/ParentalControlsURLFilter.mm:
(WebCore::ParentalControlsURLFilter::isURLAllowedWithQueue):
(WebCore::ParentalControlsURLFilter::isURLAllowed): Deleted.
* Source/WebCore/testing/MockContentFilter.cpp:
(WebCore::MockContentFilter::create):
* Source/WebCore/testing/MockContentFilter.h:

Canonical link: <a href="https://commits.webkit.org/295283@main">https://commits.webkit.org/295283@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2f4e3246a1ab7adddfa31b063e2f690c6168adcd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104558 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24268 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/14686 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/109767 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/55229 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/106598 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/24654 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/32812 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79380 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107564 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/19258 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94365 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59705 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/18948 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/12439 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/54601 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/88651 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/12492 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/112157 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/31719 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23351 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88476 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32083 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/90599 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88094 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22462 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32993 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10767 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/27036 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/31646 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/36986 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/31438 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/34777 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/32998 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->