### PR TITLE
browser.test.runTests should move onto the next test if an assertion fails

### DIFF
--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITestCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITestCocoa.mm
@@ -152,15 +152,15 @@ void WebExtensionAPITest::log(JSContextRef context, JSValue *value)
 
 void WebExtensionAPITest::fail(JSContextRef context, NSString *message)
 {
-    assertTrue(context, false, message);
+    assertTrue(context, false, message, nil);
 }
 
 void WebExtensionAPITest::succeed(JSContextRef context, NSString *message)
 {
-    assertTrue(context, true, message);
+    assertTrue(context, true, message, nil);
 }
 
-void WebExtensionAPITest::assertTrue(JSContextRef context, bool actualValue, NSString *message)
+void WebExtensionAPITest::assertTrue(JSContextRef context, bool actualValue, NSString *message, NSString **outExceptionString)
 {
     auto location = scriptLocation(context);
 
@@ -172,17 +172,17 @@ void WebExtensionAPITest::assertTrue(JSContextRef context, bool actualValue, NSS
     if (!webExtensionControllerProxy)
         return;
 
-    recordAssertionIfNeeded(actualValue, message);
+    recordAssertionIfNeeded(actualValue, message, location, outExceptionString);
 
     WebProcess::singleton().send(Messages::WebExtensionController::TestResult(actualValue, message, location.first, location.second), webExtensionControllerProxy->identifier());
 }
 
-void WebExtensionAPITest::assertFalse(JSContextRef context, bool actualValue, NSString *message)
+void WebExtensionAPITest::assertFalse(JSContextRef context, bool actualValue, NSString *message, NSString **outExceptionString)
 {
-    assertTrue(context, !actualValue, message);
+    assertTrue(context, !actualValue, message, outExceptionString);
 }
 
-void WebExtensionAPITest::assertDeepEq(JSContextRef context, JSValue *actualValue, JSValue *expectedValue, NSString *message)
+void WebExtensionAPITest::assertDeepEq(JSContextRef context, JSValue *actualValue, JSValue *expectedValue, NSString *message, NSString **outExceptionString)
 {
     NSString *expectedJSONValue = debugString(expectedValue);
     NSString *actualJSONValue = debugString(actualValue);
@@ -202,7 +202,7 @@ void WebExtensionAPITest::assertDeepEq(JSContextRef context, JSValue *actualValu
     if (!webExtensionControllerProxy)
         return;
 
-    recordAssertionIfNeeded(deepEqual, message);
+    recordAssertionIfNeeded(deepEqual, message, location, outExceptionString);
 
     WebProcess::singleton().send(Messages::WebExtensionController::TestEqual(deepEqual, expectedJSONValue, actualJSONValue, message, location.first, location.second), webExtensionControllerProxy->identifier());
 }
@@ -216,7 +216,7 @@ static NSString *combineMessages(NSString *messageOne, NSString *messageTwo)
     return messageTwo;
 }
 
-void WebExtensionAPITest::assertEquals(JSContextRef context, bool result, NSString *expectedString, NSString *actualString, NSString *message)
+void WebExtensionAPITest::assertEquals(JSContextRef context, bool result, NSString *expectedString, NSString *actualString, NSString *message, NSString **outExceptionString)
 {
     auto location = scriptLocation(context);
 
@@ -228,12 +228,12 @@ void WebExtensionAPITest::assertEquals(JSContextRef context, bool result, NSStri
     if (!webExtensionControllerProxy)
         return;
 
-    recordAssertionIfNeeded(result, message);
+    recordAssertionIfNeeded(result, message, location, outExceptionString);
 
     WebProcess::singleton().send(Messages::WebExtensionController::TestEqual(result, expectedString, actualString, message, location.first, location.second), webExtensionControllerProxy->identifier());
 }
 
-void WebExtensionAPITest::assertEq(JSContextRef context, JSValue *actualValue, JSValue *expectedValue, NSString *message)
+void WebExtensionAPITest::assertEq(JSContextRef context, JSValue *actualValue, JSValue *expectedValue, NSString *message, NSString **outExceptionString)
 {
     NSString *expectedJSONValue = debugString(expectedValue);
     NSString *actualJSONValue = debugString(actualValue);
@@ -242,14 +242,16 @@ void WebExtensionAPITest::assertEq(JSContextRef context, JSValue *actualValue, J
     if (!strictEqual && [expectedJSONValue isEqualToString:actualJSONValue])
         actualJSONValue = [actualJSONValue stringByAppendingString:@" (different)"];
 
-    assertEquals(context, strictEqual, expectedJSONValue, actualJSONValue, message);
+    assertEquals(context, strictEqual, expectedJSONValue, actualJSONValue, message, outExceptionString);
 }
 
 JSValue *WebExtensionAPITest::assertRejects(JSContextRef context, JSValue *promise, JSValue *expectedError, NSString *message)
 {
     __block JSValue *resolveCallback;
+    __block JSValue *rejectCallback;
     JSValue *resultPromise = [JSValue valueWithNewPromiseInContext:promise.context fromExecutor:^(JSValue *resolve, JSValue *reject) {
         resolveCallback = resolve;
+        rejectCallback = reject;
     }];
 
     // Wrap in a native promise for consistency.
@@ -257,27 +259,27 @@ JSValue *WebExtensionAPITest::assertRejects(JSContextRef context, JSValue *promi
 
     [promise _awaitThenableResolutionWithCompletionHandler:^(JSValue *result, JSValue *error) {
         if (result || !error) {
-            assertEquals(context, false, expectedError ? debugString(expectedError) : @"(any error)", result ? debugString(result) : @"(no error)", combineMessages(message, @"Promise did not reject with an error"));
-            [resolveCallback callWithArguments:nil];
+            assertEquals(context, false, expectedError ? debugString(expectedError) : @"(any error)", result ? debugString(result) : @"(no error)", combineMessages(message, @"Promise did not reject with an error"), nil);
+            [rejectCallback callWithArguments:nil];
             return;
         }
 
         JSValue *errorMessageValue = error.isObject && [error hasProperty:@"message"] ? error[@"message"] : error;
 
         if (!expectedError) {
-            assertEquals(context, true, @"(any error)", debugString(errorMessageValue), combineMessages(message, @"Promise rejected with an error"));
+            assertEquals(context, true, @"(any error)", debugString(errorMessageValue), combineMessages(message, @"Promise rejected with an error"), nil);
             [resolveCallback callWithArguments:nil];
             return;
         }
 
         if (expectedError._isRegularExpression) {
             JSValue *testResult = [expectedError invokeMethod:@"test" withArguments:@[ errorMessageValue ]];
-            assertEquals(context, testResult.toBool, debugString(expectedError), debugString(errorMessageValue), combineMessages(message, @"Promise rejected with an error that didn't match the regular expression"));
+            assertEquals(context, testResult.toBool, debugString(expectedError), debugString(errorMessageValue), combineMessages(message, @"Promise rejected with an error that didn't match the regular expression"), nil);
             [resolveCallback callWithArguments:nil];
             return;
         }
 
-        assertEquals(context, [expectedError isEqualWithTypeCoercionToObject:errorMessageValue], debugString(expectedError), debugString(errorMessageValue), combineMessages(message, @"Promise rejected with an error that didn't equal"));
+        assertEquals(context, [expectedError isEqualWithTypeCoercionToObject:errorMessageValue], debugString(expectedError), debugString(errorMessageValue), combineMessages(message, @"Promise rejected with an error that didn't equal"), nil);
         [resolveCallback callWithArguments:nil];
     }];
 
@@ -310,13 +312,13 @@ JSValue *WebExtensionAPITest::assertResolves(JSContextRef context, JSValue *prom
     return resultPromise;
 }
 
-void WebExtensionAPITest::assertThrows(JSContextRef context, JSValue *function, JSValue *expectedError, NSString *message)
+void WebExtensionAPITest::assertThrows(JSContextRef context, JSValue *function, JSValue *expectedError, NSString *message, NSString **outExceptionString)
 {
     [function callWithArguments:@[ ]];
 
     JSValue *exceptionValue = function.context.exception;
     if (!exceptionValue) {
-        assertEquals(context, false, expectedError ? debugString(expectedError) : @"(any exception)", @"(no exception)", combineMessages(message, @"Function did not throw an exception"));
+        assertEquals(context, false, expectedError ? debugString(expectedError) : @"(any exception)", @"(no exception)", combineMessages(message, @"Function did not throw an exception"), outExceptionString);
         return;
     }
 
@@ -326,17 +328,17 @@ void WebExtensionAPITest::assertThrows(JSContextRef context, JSValue *function, 
     function.context.exception = nil;
 
     if (!expectedError) {
-        assertEquals(context, true, @"(any exception)", debugString(exceptionMessageValue), combineMessages(message, @"Function threw an exception"));
+        assertEquals(context, true, @"(any exception)", debugString(exceptionMessageValue), combineMessages(message, @"Function threw an exception"), outExceptionString);
         return;
     }
 
     if (expectedError._isRegularExpression) {
         JSValue *testResult = [expectedError invokeMethod:@"test" withArguments:@[ exceptionMessageValue ]];
-        assertEquals(context, testResult.toBool, debugString(expectedError), debugString(exceptionMessageValue), combineMessages(message, @"Function threw an exception that didn't match the regular expression"));
+        assertEquals(context, testResult.toBool, debugString(expectedError), debugString(exceptionMessageValue), combineMessages(message, @"Function threw an exception that didn't match the regular expression"), outExceptionString);
         return;
     }
 
-    assertEquals(context, [expectedError isEqualWithTypeCoercionToObject:exceptionMessageValue], debugString(expectedError), debugString(exceptionMessageValue), combineMessages(message, @"Function threw an exception that didn't equal"));
+    assertEquals(context, [expectedError isEqualWithTypeCoercionToObject:exceptionMessageValue], debugString(expectedError), debugString(exceptionMessageValue), combineMessages(message, @"Function threw an exception that didn't equal"), outExceptionString);
 }
 
 JSValue *WebExtensionAPITest::assertSafe(JSContextRef context, JSValue *function, NSString *message)
@@ -457,6 +459,9 @@ void WebExtensionAPITest::startNextTest()
 
         m_hitAssertion = false;
 
+        // Clear the exception since it was caught.
+        test.testFunction.get().context.exception = nil;
+
         if (!m_testQueue.isEmpty())
             startNextTest();
         else
@@ -469,6 +474,24 @@ void WebExtensionAPITest::startNextTest()
         }];
     } else
         testComplete(result, test.testFunction.get().context.exception);
+}
+
+void WebExtensionAPITest::recordAssertionIfNeeded(bool result, const String& message, std::pair<String, unsigned> location, NSString **outExceptionString)
+
+{
+    if (!m_runningTest || (m_runningTest && result))
+        return;
+
+    m_hitAssertion = true;
+    m_assertionMessage = message;
+
+    if (!outExceptionString)
+        return;
+
+    auto *locationString = [NSString stringWithFormat:@"%@:%u", location.first.createNSString().get(), location.second];
+    *outExceptionString = message.isNull()
+        ? [NSString stringWithFormat:@"Assertion Failed: %@", locationString]
+        : [NSString stringWithFormat:@"Assertion Failed: %@. %@", message.createNSString().get(), locationString];
 }
 
 void WebExtensionContextProxy::dispatchTestMessageEvent(const String& message, const String& argumentJSON, WebExtensionContentWorldType contentWorldType)

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPITest.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPITest.h
@@ -56,16 +56,16 @@ public:
     void fail(JSContextRef, NSString *message);
     void succeed(JSContextRef, NSString *message);
 
-    void assertTrue(JSContextRef, bool testValue, NSString *message);
-    void assertFalse(JSContextRef, bool testValue, NSString *message);
+    void assertTrue(JSContextRef, bool testValue, NSString *message, NSString **outExceptionString);
+    void assertFalse(JSContextRef, bool testValue, NSString *message, NSString **outExceptionString);
 
-    void assertDeepEq(JSContextRef, JSValue *actualValue, JSValue *expectedValue, NSString *message);
-    void assertEq(JSContextRef, JSValue *actualValue, JSValue *expectedValue, NSString *message);
+    void assertDeepEq(JSContextRef, JSValue *actualValue, JSValue *expectedValue, NSString *message, NSString **outExceptionString);
+    void assertEq(JSContextRef, JSValue *actualValue, JSValue *expectedValue, NSString *message, NSString **outExceptionString);
 
     JSValue *assertRejects(JSContextRef, JSValue *promise, JSValue *expectedError, NSString *message);
     JSValue *assertResolves(JSContextRef, JSValue *promise, NSString *message);
 
-    void assertThrows(JSContextRef, JSValue *function, JSValue *expectedError, NSString *message);
+    void assertThrows(JSContextRef, JSValue *function, JSValue *expectedError, NSString *message, NSString **outExceptionString);
     JSValue *assertSafe(JSContextRef, JSValue *function, NSString *message);
 
     JSValue *assertSafeResolve(JSContextRef, JSValue *function, NSString *message);
@@ -91,15 +91,9 @@ private:
     String m_assertionMessage;
 
     JSValue *addTest(JSContextRef, JSValue *testFunction, String callingAPIName);
-    void assertEquals(JSContextRef, bool result, NSString *expectedString, NSString *actualString, NSString *message);
+    void assertEquals(JSContextRef, bool result, NSString *expectedString, NSString *actualString, NSString *message, NSString **outExceptionString);
     void startNextTest();
-    void recordAssertionIfNeeded(bool result, const String& message)
-    {
-        if (m_runningTest && !result) {
-            m_hitAssertion = true;
-            m_assertionMessage = message;
-        }
-    }
+    void recordAssertionIfNeeded(bool result, const String& message, std::pair<String, unsigned> location, NSString **outExceptionString);
 #endif
 };
 

--- a/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPITest.idl
+++ b/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPITest.idl
@@ -56,16 +56,16 @@
     [NeedsScriptContext] void succeed([Optional] DOMString message);
 
     // Asserts the test value is `true`.
-    [NeedsScriptContext] void assertTrue(boolean actualValue, [Optional] DOMString message);
+    [RaisesException, NeedsScriptContext] void assertTrue(boolean actualValue, [Optional] DOMString message);
 
     // Asserts the test value is `false`.
-    [NeedsScriptContext] void assertFalse(boolean actualValue, [Optional] DOMString message);
+    [RaisesException, NeedsScriptContext] void assertFalse(boolean actualValue, [Optional] DOMString message);
 
     // Asserts the test value is deeply equal to the expected value.
-    [NeedsScriptContext] void assertDeepEq([ValuesAllowed] any actualValue, [ValuesAllowed] any expectedValue, [Optional] DOMString message);
+    [RaisesException, NeedsScriptContext] void assertDeepEq([ValuesAllowed] any actualValue, [ValuesAllowed] any expectedValue, [Optional] DOMString message);
 
     // Asserts the test value is equal to the expected value.
-    [NeedsScriptContext] void assertEq([ValuesAllowed] any actualValue, [ValuesAllowed] any expectedValue, [Optional] DOMString message);
+    [RaisesException, NeedsScriptContext] void assertEq([ValuesAllowed] any actualValue, [ValuesAllowed] any expectedValue, [Optional] DOMString message);
 
     // Asserts the promise is rejected.
     [NeedsScriptContext, ProcessArgumentsLeftToRight] any assertRejects(any promise, [Optional, ValuesAllowed] any expectedError, [Optional] DOMString message);
@@ -74,7 +74,7 @@
     [NeedsScriptContext] any assertResolves(any promise, [Optional] DOMString message);
 
     // Asserts the function throws an exception.
-    [NeedsScriptContext, ProcessArgumentsLeftToRight] void assertThrows(any function, [Optional, ValuesAllowed] any expectedError, [Optional] DOMString message);
+    [RaisesException, NeedsScriptContext, ProcessArgumentsLeftToRight] void assertThrows(any function, [Optional, ValuesAllowed] any expectedError, [Optional] DOMString message);
 
     // Asserts the function does not throw an exception.
     [NeedsScriptContext] any assertSafe(any function, [Optional] DOMString message);


### PR DESCRIPTION
#### 7dc1ce0a8e8a58ffe0c41fa433c86044edf7e4a5
<pre>
browser.test.runTests should move onto the next test if an assertion fails
<a href="https://bugs.webkit.org/show_bug.cgi?id=293404">https://bugs.webkit.org/show_bug.cgi?id=293404</a>
<a href="https://rdar.apple.com/150778809">rdar://150778809</a>

Reviewed by Timothy Hatcher.

If we&apos;re running a test via browser.test.runTests, throw an exception if a test assertion
fails to force the test to stop running.

* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITestCocoa.mm:
(WebKit::WebExtensionAPITest::fail):
(WebKit::WebExtensionAPITest::succeed):
(WebKit::WebExtensionAPITest::assertTrue):
(WebKit::WebExtensionAPITest::assertFalse):
(WebKit::WebExtensionAPITest::assertDeepEq):
(WebKit::WebExtensionAPITest::assertEquals):
(WebKit::WebExtensionAPITest::assertEq):
Modify these methods to raise an exception.

(WebKit::WebExtensionAPITest::assertRejects):
Drive by fix: Call the rejectCallback if the promise resolves for assertRejects.

(WebKit::WebExtensionAPITest::assertThrows):
(WebKit::WebExtensionAPITest::startNextTest):
(WebKit::WebExtensionAPITest::recordAssertionIfNeeded):

* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPITest.h:
(WebKit::WebExtensionAPITest::recordAssertionIfNeeded): Deleted.

* Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPITest.idl:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPITest.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPITest, RunTestsVerifyFailedTestAborts)):

Canonical link: <a href="https://commits.webkit.org/295926@main">https://commits.webkit.org/295926@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/068e5b6d96ab525243dbbe5f1c23a6fcd48e5dae

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/106601 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/26352 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/16749 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/111809 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/57197 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/108640 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/27022 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34854 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/111809 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/57197 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/109605 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/21435 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/96191 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/111809 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/20887 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/14297 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/56643 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/90774 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/14327 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/114670 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33739 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/24875 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/114670 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/34103 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/92421 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/114670 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/34643 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/12454 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/29366 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17269 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/33664 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/39077 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/33410 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/36763 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/35009 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->