### PR TITLE
Debug heap allocation profile call needs to be adjusted

### DIFF
--- a/Source/bmalloc/bmalloc/DebugHeap.cpp
+++ b/Source/bmalloc/bmalloc/DebugHeap.cpp
@@ -221,7 +221,7 @@ bool pas_debug_heap_is_enabled(pas_heap_config_kind kind)
 void* pas_debug_heap_malloc(size_t size)
 {
     auto debugHeap = DebugHeap::getExisting();
-    PAS_PROFILE(DEBUG_HEAP_ALLOCATION, debugHeap, size, 1, pas_non_compact_allocation_mode);
+    PAS_PROFILE(DEBUG_HEAP_ALLOCATION, debugHeap, size, 0, pas_non_compact_allocation_mode);
     return debugHeap->malloc(size, FailureAction::ReturnNull);
 }
 
@@ -242,7 +242,7 @@ void* pas_debug_heap_realloc(void* ptr, size_t size)
 void* pas_debug_heap_malloc_compact(size_t size)
 {
     auto debugHeap = DebugHeap::getExisting();
-    PAS_PROFILE(DEBUG_HEAP_ALLOCATION, debugHeap, size, 1, pas_always_compact_allocation_mode);
+    PAS_PROFILE(DEBUG_HEAP_ALLOCATION, debugHeap, size, 0, pas_always_compact_allocation_mode);
     return debugHeap->malloc(size, FailureAction::ReturnNull);
 }
 


### PR DESCRIPTION
#### 3192612d4898d0d8173b692b47b0d45a19bd485f
<pre>
Debug heap allocation profile call needs to be adjusted
<a href="https://bugs.webkit.org/show_bug.cgi?id=293401">https://bugs.webkit.org/show_bug.cgi?id=293401</a>
<a href="https://rdar.apple.com/151817410">rdar://151817410</a>

Reviewed by David Degazio.

The PAS_PROFILE macro in pas_debug_heap_malloc should use 0 instead of 1 to match the profile
expectations. The patch changes the macro to use the expected values.

* Source/bmalloc/bmalloc/DebugHeap.cpp:
(pas_debug_heap_malloc):
(pas_debug_heap_malloc_compact):

Canonical link: <a href="https://commits.webkit.org/295295@main">https://commits.webkit.org/295295@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f769ad5c1ebee7900eb574ebaea64031c050eaf2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104561 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24271 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/14689 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/109771 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/55232 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/24657 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/32815 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79383 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107567 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19175 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94370 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59708 "Found 1 new API test failure: /WPE/TestMultiprocess:/webkit/WebKitWebView/multiprocess-create-ready-close (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/18958 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/12444 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/54604 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/97240 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/88657 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/12497 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/112160 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/103176 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/31722 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23355 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88479 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32086 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/90604 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88097 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22468 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32996 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10771 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/27039 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/31649 "Built successfully") | | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/127457 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/31441 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/127457 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/34780 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33001 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->