### PR TITLE
Convert export-w3c-test-changes to use webkitscmpy/webkitbugspy

### DIFF
--- a/Tools/Scripts/webkitpy/tool/commands/upload_unittest.py
+++ b/Tools/Scripts/webkitpy/tool/commands/upload_unittest.py
@@ -146,6 +146,7 @@ Obsoleting 2 old patches on bug 50000
 MOCK reassign_bug: bug_id=50000, assignee=None
 MOCK add_patch_to_bug: bug_id=50000, description=MOCK description, mark_for_review=True, mark_for_commit_queue=False, mark_for_landing=False
 MOCK: user.open_url: http://example.com/50000
+Checking for WPT changes
 """
         with wmocks.local.Git(self.path):
             self.assert_execute_outputs(Upload(), [50000], options=options, expected_logs=expected_logs)
@@ -171,6 +172,7 @@ Obsoleting 2 old patches on bug 50000
 MOCK reassign_bug: bug_id=50000, assignee=None
 MOCK add_patch_to_bug: bug_id=50000, description=[fast-cq] MOCK description, mark_for_review=True, mark_for_commit_queue=False, mark_for_landing=False
 MOCK: user.open_url: http://example.com/50000
+Checking for WPT changes
 """
         with wmocks.local.Git(self.path):
             self.assert_execute_outputs(Upload(), [50000], options=options, expected_logs=expected_logs)
@@ -197,6 +199,7 @@ MOCK reassign_bug: bug_id=50000, assignee=None
 MOCK add_patch_to_bug: bug_id=50000, description=MOCK description, mark_for_review=False, mark_for_commit_queue=False, mark_for_landing=False
 MOCK: user.open_url: http://example.com/50000
 MOCK: submit_to_ews: 10001
+Checking for WPT changes
 """
         with wmocks.local.Git(self.path):
             self.assert_execute_outputs(Upload(), [50000], options=options, expected_logs=expected_logs)
@@ -285,6 +288,7 @@ Obsoleting 2 old patches on bug 50000
 MOCK reassign_bug: bug_id=50000, assignee=None
 MOCK add_patch_to_bug: bug_id=50000, description=MOCK description, mark_for_review=True, mark_for_commit_queue=False, mark_for_landing=False
 MOCK: user.open_url: http://example.com/50000
+Checking for WPT changes
 """
         with wmocks.local.Git(self.path):
             self.assert_execute_outputs(Upload(), [50000], options=options, expected_logs=expected_logs)


### PR DESCRIPTION
#### 56c33b4b15944cd3010ed1da9e6c3f2dbfdcce7a
<pre>
Convert export-w3c-test-changes to use webkitscmpy/webkitbugspy
<a href="https://rdar.apple.com/110276747">rdar://110276747</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=257728">https://bugs.webkit.org/show_bug.cgi?id=257728</a>

Reviewed by Sam Sneddon.

Move all git operations to the webkitscmpy.local.Git class instead of webkitpy.

* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/git.py:
    - Add mocks for `git apply&apos; and `git commit -m`.

* Tools/Scripts/webkitpy/tool/commands/upload_unittest.py:
   - Add new logging to tests

* Tools/Scripts/webkitpy/w3c/test_exporter.py:
(WebPlatformTestExporter.__init__):
(WebPlatformTestExporter.username):
(WebPlatformTestExporter._wpt_fork_push_url):
(WebPlatformTestExporter._init_wpt_remote):
(WebPlatformTestExporter):
(WebPlatformTestExporter._run_wpt_git):
(WebPlatformTestExporter.has_wpt_changes):
(WebPlatformTestExporter._ensure_wpt_repository):
(WebPlatformTestExporter._ensure_new_branch_name):
(WebPlatformTestExporter.clean):
(WebPlatformTestExporter.create_branch_with_patch):
(WebPlatformTestExporter.set_up_wpt_fork):
(WebPlatformTestExporter.push_to_wpt_fork):
(WebPlatformTestExporter.make_pull_request):
(WebPlatformTestExporter.create_wpt_pull_request):
(WebPlatformTestExporter.delete_local_branch):
(WebPlatformTestExporter.do_export):
(parse_args): Remove unused arguments.

(main):
(WebPlatformTestExporter.token): Deleted.
(WebPlatformTestExporter._github): Deleted.
(WebPlatformTestExporter._git): Deleted.
(WebPlatformTestExporter._prompt_for_token): Deleted.
(WebPlatformTestExporter._prompt_for_username): Deleted.
(WebPlatformTestExporter._ensure_username_and_token): Deleted.
(WebPlatformTestExporter._validate_and_save_token): Deleted.
(WebPlatformTestExporter._fetch_wpt_repository): Deleted.
(WebPlatformTestExporter.create_upload_remote_if_needed): Deleted.

* Tools/Scripts/webkitpy/w3c/test_exporter_unittest.py:
(TestExporterTest):
(TestExporterTest.MockGit):
(TestExporterTest.MockGit.__init__):
(TestExporterTest.test_export):
(TestExporterTest.test_export_with_specific_branch):
(TestExporterTest.test_export_no_clean):
(TestExporterTest.test_export_interactive_mode):
(TestExporterTest.test_export_invalid_token):
(TestExporterTest.test_export_wrong_token):
(TestExporterTest.test_has_wpt_changes):
(TestExporterTest.test_has_no_wpt_changes_for_no_diff):
(TestExporterTest.test_ignore_changes_to_expected_file):
(test_ignore_changes_to_expected_mismatch_file):
(test_ignore_changes_to_w3c_import_log):
(TestExporterTest.MockGit.clone): Deleted.
(TestExporterTest.MockGit.fetch): Deleted.
(TestExporterTest.MockGit.checkout): Deleted.
(TestExporterTest.MockGit.reset_hard): Deleted.
(TestExporterTest.MockGit.push): Deleted.
(TestExporterTest.MockGit.delete_branch): Deleted.
(TestExporterTest.MockGit.checkout_new_branch): Deleted.
(TestExporterTest.MockGit.apply_mail_patch): Deleted.
(TestExporterTest.MockGit.commit): Deleted.
(TestExporterTest.MockGit.remote): Deleted.
(TestExporterTest.MockGit.local_config): Deleted.
(TestExporterTest.MockGit.branch_ref_exists): Deleted.

Canonical link: <a href="https://commits.webkit.org/296936@main">https://commits.webkit.org/296936@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d4d84d1c79b10cc9b2f5a147738c57de58d5dfe1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/110042 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/29701 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/20133 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/116064 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/60290 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/112005 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/30379 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/38288 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/83661 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/60290 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112990 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/24224 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/99099 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/64104 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/109474 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/23593 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/17241 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/59860 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/93597 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/17290 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/118855 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/37082 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/27489 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/92632 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/109538 "Passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/37454 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/95367 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/92458 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37443 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/15182 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/32964 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17754 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36976 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/36638 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39978 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/38347 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->