### PR TITLE
Segfault calling local variable after await and garbage collection

### DIFF
--- a/JSTests/stress/async-function-parsing-idempotent.js
+++ b/JSTests/stress/async-function-parsing-idempotent.js
@@ -1,0 +1,23 @@
+//@ slow!
+//@ runDefault("--useJIT=0", "--watchdog=6000", "--watchdog-exception-ok")
+if (typeof fullGC === "undefined") globalThis.fullGC = () => Bun.gc(true);
+if (typeof print === "undefined") globalThis.print = console.log;
+async function initializeFileImporter() {
+  for (let i = 1; i <= 50000; i++) {
+    await new Promise(resolve => resolve());
+    fullGC();
+  }
+}
+
+async function main() {
+  const addToLog = () => {};
+
+  if (false) {
+    addToLog(await foo(bar => ({ bar })));
+  } else {
+    await initializeFileImporter();
+    addToLog();
+  }
+}
+
+main().catch(e => print(e));


### PR DESCRIPTION
#### 25fa411b1ea6e1248b80c72881eb73dbc5af4c76
<pre>
Segfault calling local variable after await and garbage collection
<a href="https://bugs.webkit.org/show_bug.cgi?id=292875">https://bugs.webkit.org/show_bug.cgi?id=292875</a>
<a href="https://rdar.apple.com/151185009">rdar://151185009</a>

Reviewed by Yijia Huang.

When JIT is disabled, we have some memory reduction feature which
attempt to destroy UnlinkedCodeBlock when it is not used so much.
If we found that it is used later, we reparse the same function and
restore the UnlinkedCodeBlock with the bytecode.

Our generator is using bytecode&apos;s offset for suspend / resume, so
bytecode&apos;s idempotentness is very important (we are already handling
things with Debugger-enabled reparsing case FYI). But our parser had a
bug that we parse function parameters before saving parser state. This
is wrong since we may have different ParserState depending on whether
we parse / not-parse the inner function (we can skip if it is parsed
once).

This patch fixes the place saving parser state (it should be just after
tryLoadCachedFunction).

* JSTests/stress/async-function-parsing-idempotent.js: Added.
(async initializeFileImporter):
(async main):
* Source/JavaScriptCore/parser/Parser.cpp:
(JSC::Parser&lt;LexerType&gt;::parseFunctionInfo):

Canonical link: <a href="https://commits.webkit.org/295257@main">https://commits.webkit.org/295257@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6604e4b0ea56cae7a0cfc76f31e20bb2d758dc4b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104570 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24280 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/14698 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/109781 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/55241 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/24666 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/32824 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79390 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107576 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19182 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94375 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59715 "Passed tests") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/18961 "Build is in progress. Recent messages:") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/12450 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/54613 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/97249 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/88663 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/12502 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/112171 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/103185 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/31731 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/23361 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/88486 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32095 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/90609 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88104 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33004 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10776 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/27048 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16968 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/31658 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/36999 "Built successfully") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/127466 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/31450 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/127466 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/34789 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33010 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->