### PR TITLE
Reduce the amount of duplicated set*() methods in wtf/JSONValues

### DIFF
--- a/Source/JavaScriptCore/inspector/InspectorBackendDispatcher.cpp
+++ b/Source/JavaScriptCore/inspector/InspectorBackendDispatcher.cpp
@@ -216,7 +216,7 @@ void BackendDispatcher::sendResponse(long requestId, Ref<JSON::Object>&& result,
     // if no error occurred during an invocation, but we do not include it at all.
     Ref<JSON::Object> responseMessage = JSON::Object::create();
     responseMessage->setObject("result"_s, WTFMove(result));
-    responseMessage->setInteger("id"_s, requestId);
+    responseMessage->setPrimitive("id"_s, requestId);
     m_frontendRouter->sendResponse(responseMessage->toJSONString());
 }
 
@@ -247,20 +247,20 @@ void BackendDispatcher::sendPendingErrors()
         ASSERT_ARG(errorCode, errorCodes[errorCode]);
 
         Ref<JSON::Object> error = JSON::Object::create();
-        error->setInteger("code"_s, errorCodes[errorCode]);
+        error->setPrimitive("code"_s, errorCodes[errorCode]);
         error->setString("message"_s, errorMessage);
         payload->pushObject(WTFMove(error));
     }
 
     Ref<JSON::Object> topLevelError = JSON::Object::create();
-    topLevelError->setInteger("code"_s, errorCodes[errorCode]);
+    topLevelError->setPrimitive("code"_s, errorCodes[errorCode]);
     topLevelError->setString("message"_s, errorMessage);
     topLevelError->setArray("data"_s, WTFMove(payload));
 
     Ref<JSON::Object> message = JSON::Object::create();
     message->setObject("error"_s, WTFMove(topLevelError));
     if (m_currentRequestId)
-        message->setInteger("id"_s, m_currentRequestId.value());
+        message->setPrimitive("id"_s, m_currentRequestId.value());
     else {
         // The 'null' value for an unknown id is specified in JSON-RPC 2.0, Section 5.
         message->setValue("id"_s, JSON::Value::null());

--- a/Source/JavaScriptCore/inspector/remote/socket/RemoteInspectorSocket.cpp
+++ b/Source/JavaScriptCore/inspector/remote/socket/RemoteInspectorSocket.cpp
@@ -127,8 +127,8 @@ TargetListing RemoteInspector::listingForInspectionTarget(const RemoteInspection
 
     targetListing->setString("name"_s, target.name());
     targetListing->setString("url"_s, target.url());
-    targetListing->setInteger("targetID"_s, target.targetIdentifier());
-    targetListing->setBoolean("hasLocalDebugger"_s, target.hasLocalDebugger());
+    targetListing->setPrimitive("targetID"_s, target.targetIdentifier());
+    targetListing->setPrimitive("hasLocalDebugger"_s, target.hasLocalDebugger());
     if (target.type() == RemoteInspectionTarget::Type::WebPage)
         targetListing->setString("type"_s, "web-page"_s);
     else if (target.type() == RemoteInspectionTarget::Type::Page)
@@ -146,8 +146,8 @@ TargetListing RemoteInspector::listingForAutomationTarget(const RemoteAutomation
     TargetListing targetListing = JSON::Object::create();
     targetListing->setString("type"_s, "automation"_s);
     targetListing->setString("name"_s, target.name());
-    targetListing->setInteger("targetID"_s, target.targetIdentifier());
-    targetListing->setBoolean("isPaired"_s, target.isPaired());
+    targetListing->setPrimitive("targetID"_s, target.targetIdentifier());
+    targetListing->setPrimitive("isPaired"_s, target.isPaired());
     return targetListing;
 }
 
@@ -165,8 +165,8 @@ void RemoteInspector::pushListingsNow()
     auto jsonEvent = JSON::Object::create();
     jsonEvent->setString("event"_s, "SetTargetList"_s);
     jsonEvent->setString("message"_s, targetListJSON->toJSONString());
-    jsonEvent->setInteger("connectionID"_s, m_clientConnection.value());
-    jsonEvent->setBoolean("remoteAutomationAllowed"_s, m_clientCapabilities && m_clientCapabilities->remoteAutomationAllowed);
+    jsonEvent->setPrimitive("connectionID"_s, m_clientConnection.value());
+    jsonEvent->setPrimitive("remoteAutomationAllowed"_s, m_clientCapabilities && m_clientCapabilities->remoteAutomationAllowed);
     sendWebInspectorEvent(jsonEvent->toJSONString());
 }
 
@@ -219,9 +219,9 @@ void RemoteInspector::sendMessageToRemote(TargetID targetIdentifier, const Strin
         return;
 
     auto sendMessageEvent = JSON::Object::create();
-    sendMessageEvent->setInteger("targetID"_s, targetIdentifier);
+    sendMessageEvent->setPrimitive("targetID"_s, targetIdentifier);
     sendMessageEvent->setString("event"_s, "SendMessageToFrontend"_s);
-    sendMessageEvent->setInteger("connectionID"_s, m_clientConnection.value());
+    sendMessageEvent->setPrimitive("connectionID"_s, m_clientConnection.value());
     sendMessageEvent->setString("message"_s, message);
     sendWebInspectorEvent(sendMessageEvent->toJSONString());
 }

--- a/Source/JavaScriptCore/inspector/scripts/codegen/cpp_generator.py
+++ b/Source/JavaScriptCore/inspector/scripts/codegen/cpp_generator.py
@@ -104,10 +104,16 @@ class CppGenerator(Generator):
 
         if isinstance(_type, PrimitiveType):
             if _type.raw_name() == 'number':
-                return 'setDouble'
+                return 'setPrimitive'
+            if _type.raw_name() == 'integer':
+                return 'setPrimitive'
+            if _type.raw_name() == 'string':
+                return 'setString'
+            if _type.raw_name() == 'boolean':
+                return 'setPrimitive'
             if _type.raw_name() == 'any':
                 return 'setValue'
-            return 'set' + ucfirst(_type.raw_name())
+            return 'setPrimitive'
 
         raise ValueError("unknown type")
 

--- a/Source/JavaScriptCore/inspector/scripts/codegen/objc_generator.py
+++ b/Source/JavaScriptCore/inspector/scripts/codegen/objc_generator.py
@@ -518,11 +518,11 @@ class ObjCGenerator(Generator):
         if (isinstance(_type, PrimitiveType)):
             raw_name = _type.raw_name()
             if raw_name == 'boolean':
-                return 'setBool'
+                return 'setPrimitive'
             if raw_name == 'integer':
-                return 'setInteger'
+                return 'setPrimitive'
             if raw_name == 'number':
-                return 'setDouble'
+                return 'setPrimitive'
             if raw_name == 'string':
                 return 'setString'
             if raw_name in ['any', 'object']:

--- a/Source/JavaScriptCore/profiler/ProfilerBytecode.cpp
+++ b/Source/JavaScriptCore/profiler/ProfilerBytecode.cpp
@@ -38,7 +38,7 @@ namespace JSC { namespace Profiler {
 Ref<JSON::Value> Bytecode::toJSON(Dumper& dumper) const
 {
     auto result = JSON::Object::create();
-    result->setDouble(dumper.keys().m_bytecodeIndex, m_bytecodeIndex);
+    result->setPrimitive(dumper.keys().m_bytecodeIndex, m_bytecodeIndex);
     result->setString(dumper.keys().m_opcode, String::fromUTF8(opcodeNames[m_opcodeID]));
     result->setString(dumper.keys().m_description, String::fromUTF8(m_description.span()));
     return result;

--- a/Source/JavaScriptCore/profiler/ProfilerBytecodes.cpp
+++ b/Source/JavaScriptCore/profiler/ProfilerBytecodes.cpp
@@ -57,7 +57,7 @@ Ref<JSON::Value> Bytecodes::toJSON(Dumper& dumper) const
 {
     auto result = JSON::Object::create();
 
-    result->setDouble(dumper.keys().m_bytecodesID, m_id);
+    result->setPrimitive(dumper.keys().m_bytecodesID, m_id);
     result->setString(dumper.keys().m_inferredName, String::fromUTF8(m_inferredName.span()));
     String sourceCode = String::fromUTF8(m_sourceCode.span());
     if (Options::abbreviateSourceCodeForProfiler()) {
@@ -67,7 +67,7 @@ Ref<JSON::Value> Bytecodes::toJSON(Dumper& dumper) const
     }
     result->setString(dumper.keys().m_sourceCode, WTFMove(sourceCode));
     result->setString(dumper.keys().m_hash, String::fromUTF8(toCString(m_hash).span()));
-    result->setDouble(dumper.keys().m_instructionCount, m_instructionCount);
+    result->setPrimitive(dumper.keys().m_instructionCount, m_instructionCount);
     addSequenceProperties(dumper, result.get());
 
     return result;

--- a/Source/JavaScriptCore/profiler/ProfilerCompilation.cpp
+++ b/Source/JavaScriptCore/profiler/ProfilerCompilation.cpp
@@ -114,7 +114,7 @@ void Compilation::dump(PrintStream& out) const
 Ref<JSON::Value> Compilation::toJSON(Dumper& dumper) const
 {
     auto result = JSON::Object::create();
-    result->setDouble(dumper.keys().m_bytecodesID, m_bytecodes->id());
+    result->setPrimitive(dumper.keys().m_bytecodesID, m_bytecodes->id());
     result->setString(dumper.keys().m_compilationKind, String::fromUTF8(toCString(m_kind).span()));
 
     auto profiledBytecodes = JSON::Array::create();
@@ -131,7 +131,7 @@ Ref<JSON::Value> Compilation::toJSON(Dumper& dumper) const
     for (const auto& [key, value] : m_counters) {
         auto counterEntry = JSON::Object::create();
         counterEntry->setValue(dumper.keys().m_origin, key.toJSON(dumper));
-        counterEntry->setDouble(dumper.keys().m_executionCount, value->count());
+        counterEntry->setPrimitive(dumper.keys().m_executionCount, value->count());
         counters->pushValue(WTFMove(counterEntry));
     }
     result->setValue(dumper.keys().m_counters, WTFMove(counters));
@@ -146,9 +146,9 @@ Ref<JSON::Value> Compilation::toJSON(Dumper& dumper) const
         exits->pushValue(m_osrExits[i].toJSON(dumper));
     result->setValue(dumper.keys().m_osrExits, WTFMove(exits));
 
-    result->setDouble(dumper.keys().m_numInlinedGetByIds, m_numInlinedGetByIds);
-    result->setDouble(dumper.keys().m_numInlinedPutByIds, m_numInlinedPutByIds);
-    result->setDouble(dumper.keys().m_numInlinedCalls, m_numInlinedCalls);
+    result->setPrimitive(dumper.keys().m_numInlinedGetByIds, m_numInlinedGetByIds);
+    result->setPrimitive(dumper.keys().m_numInlinedPutByIds, m_numInlinedPutByIds);
+    result->setPrimitive(dumper.keys().m_numInlinedCalls, m_numInlinedCalls);
     result->setString(dumper.keys().m_jettisonReason, String::fromUTF8(toCString(m_jettisonReason).span()));
     if (!m_additionalJettisonReason.isNull())
         result->setString(dumper.keys().m_additionalJettisonReason, String::fromUTF8(m_additionalJettisonReason.span()));

--- a/Source/JavaScriptCore/profiler/ProfilerEvent.cpp
+++ b/Source/JavaScriptCore/profiler/ProfilerEvent.cpp
@@ -49,8 +49,8 @@ Ref<JSON::Value> Event::toJSON(Dumper& dumper) const
 {
     auto result = JSON::Object::create();
 
-    result->setDouble(dumper.keys().m_time, m_time.secondsSinceEpoch().value());
-    result->setDouble(dumper.keys().m_bytecodesID, m_bytecodes->id());
+    result->setPrimitive(dumper.keys().m_time, m_time.secondsSinceEpoch().value());
+    result->setPrimitive(dumper.keys().m_bytecodesID, m_bytecodes->id());
     if (m_compilation)
         result->setString(dumper.keys().m_compilationUID, makeString(m_compilation->uid()));
     result->setString(dumper.keys().m_summary, String::fromUTF8(m_summary));

--- a/Source/JavaScriptCore/profiler/ProfilerOSRExit.cpp
+++ b/Source/JavaScriptCore/profiler/ProfilerOSRExit.cpp
@@ -46,11 +46,11 @@ OSRExit::~OSRExit() = default;
 Ref<JSON::Value> OSRExit::toJSON(Dumper& dumper) const
 {
     auto result = JSON::Object::create();
-    result->setDouble(dumper.keys().m_id, m_id);
+    result->setPrimitive(dumper.keys().m_id, m_id);
     result->setValue(dumper.keys().m_origin, m_origin.toJSON(dumper));
     result->setString(dumper.keys().m_exitKind, enumName(m_exitKind));
-    result->setBoolean(dumper.keys().m_isWatchpoint, !!m_isWatchpoint);
-    result->setDouble(dumper.keys().m_count, m_counter);
+    result->setPrimitive(dumper.keys().m_isWatchpoint, !!m_isWatchpoint);
+    result->setPrimitive(dumper.keys().m_count, m_counter);
     return result;
 }
 

--- a/Source/JavaScriptCore/profiler/ProfilerOrigin.cpp
+++ b/Source/JavaScriptCore/profiler/ProfilerOrigin.cpp
@@ -48,8 +48,8 @@ void Origin::dump(PrintStream& out) const
 Ref<JSON::Value> Origin::toJSON(Dumper& dumper) const
 {
     auto result = JSON::Object::create();
-    result->setDouble(dumper.keys().m_bytecodesID, m_bytecodes->id());
-    result->setDouble(dumper.keys().m_bytecodeIndex, m_bytecodeIndex.offset());
+    result->setPrimitive(dumper.keys().m_bytecodesID, m_bytecodes->id());
+    result->setPrimitive(dumper.keys().m_bytecodeIndex, m_bytecodeIndex.offset());
     return result;
 }
 

--- a/Source/JavaScriptCore/profiler/ProfilerProfiledBytecodes.cpp
+++ b/Source/JavaScriptCore/profiler/ProfilerProfiledBytecodes.cpp
@@ -43,7 +43,7 @@ ProfiledBytecodes::~ProfiledBytecodes() = default;
 Ref<JSON::Value> ProfiledBytecodes::toJSON(Dumper& dumper) const
 {
     auto result = JSON::Object::create();
-    result->setDouble(dumper.keys().m_bytecodesID, m_bytecodes->id());
+    result->setPrimitive(dumper.keys().m_bytecodesID, m_bytecodes->id());
     addSequenceProperties(dumper, result.get());
     return result;
 }

--- a/Source/JavaScriptCore/runtime/SamplingProfiler.cpp
+++ b/Source/JavaScriptCore/runtime/SamplingProfiler.cpp
@@ -1103,25 +1103,25 @@ Ref<JSON::Value> SamplingProfiler::stackTracesAsJSON()
             sources.add(sourceID, Ref { *provider });
 
         auto result = JSON::Object::create();
-        result->setDouble("sourceID"_s, sourceID);
+        result->setPrimitive("sourceID"_s, sourceID);
         result->setString("name"_s, stackFrame.displayName(m_vm));
         result->setString("location"_s, descriptionForLocation(stackFrame.semanticLocation, stackFrame.wasmCompilationMode, stackFrame.wasmOffset));
-        result->setDouble("line"_s, stackFrame.semanticLocation.lineColumn.line);
-        result->setDouble("column"_s, stackFrame.semanticLocation.lineColumn.column);
+        result->setPrimitive("line"_s, stackFrame.semanticLocation.lineColumn.line);
+        result->setPrimitive("column"_s, stackFrame.semanticLocation.lineColumn.column);
         result->setString("category"_s, tierName(stackFrame));
         uint32_t flags = 0;
         if (stackFrame.frameType == SamplingProfiler::FrameType::Executable && stackFrame.executable) {
             if (auto* executable = jsDynamicCast<FunctionExecutable*>(stackFrame.executable); executable && executable->isBuiltinFunction())
                 flags = 1;
         }
-        result->setDouble("flags"_s, flags);
+        result->setPrimitive("flags"_s, flags);
 
         if (std::optional<std::pair<StackFrame::CodeLocation, CodeBlock*>> machineLocation = stackFrame.machineLocation) {
             auto inliner = JSON::Object::create();
             inliner->setString("name"_s, String::fromUTF8(machineLocation->second->inferredName().span()));
             inliner->setString("location"_s, descriptionForLocation(machineLocation->first, std::nullopt, BytecodeIndex()));
-            inliner->setDouble("line"_s, machineLocation->first.lineColumn.line);
-            inliner->setDouble("column"_s, machineLocation->first.lineColumn.column);
+            inliner->setPrimitive("line"_s, machineLocation->first.lineColumn.line);
+            inliner->setPrimitive("column"_s, machineLocation->first.lineColumn.column);
             inliner->setString("category"_s, tierName(stackFrame));
             result->setValue("inliner"_s, WTFMove(inliner));
         }
@@ -1130,7 +1130,7 @@ Ref<JSON::Value> SamplingProfiler::stackTracesAsJSON()
 
     auto stackTraceAsJSON = [&](StackTrace& stackTrace) {
         auto result = JSON::Object::create();
-        result->setDouble("timestamp"_s, stackTrace.timestamp.secondsSinceEpoch().seconds());
+        result->setPrimitive("timestamp"_s, stackTrace.timestamp.secondsSinceEpoch().seconds());
         {
             auto frames = JSON::Array::create();
             for (StackFrame& stackFrame : stackTrace.frames)
@@ -1142,7 +1142,7 @@ Ref<JSON::Value> SamplingProfiler::stackTracesAsJSON()
 
     auto sourceAsJSON = [&](SourceProvider& provider) {
         auto result = JSON::Object::create();
-        result->setDouble("sourceID"_s, provider.asID());
+        result->setPrimitive("sourceID"_s, provider.asID());
         if (!provider.sourceURL().isEmpty())
             result->setString("url"_s, provider.sourceURL());
         if (!provider.sourceURLDirective().isEmpty())
@@ -1153,7 +1153,7 @@ Ref<JSON::Value> SamplingProfiler::stackTracesAsJSON()
     };
 
     auto result = JSON::Object::create();
-    result->setDouble("interval"_s, m_timingInterval.seconds());
+    result->setPrimitive("interval"_s, m_timingInterval.seconds());
     auto traces = JSON::Array::create();
     for (StackTrace& stackTrace : m_stackTraces)
         traces->pushValue(stackTraceAsJSON(stackTrace));

--- a/Source/WTF/wtf/JSONValues.cpp
+++ b/Source/WTF/wtf/JSONValues.cpp
@@ -496,21 +496,6 @@ Ref<Value> Value::null()
     return adoptRef(*new Value);
 }
 
-Ref<Value> Value::create(bool value)
-{
-    return adoptRef(*new Value(value));
-}
-
-Ref<Value> Value::create(int value)
-{
-    return adoptRef(*new Value(value));
-}
-
-Ref<Value> Value::create(double value)
-{
-    return adoptRef(*new Value(value));
-}
-
 Ref<Value> Value::create(const String& value)
 {
     return adoptRef(*new Value(value));

--- a/Source/WTF/wtf/JSONValues.h
+++ b/Source/WTF/wtf/JSONValues.h
@@ -78,9 +78,8 @@ public:
     }
 
     static Ref<Value> null();
-    static Ref<Value> create(bool);
-    static Ref<Value> create(int);
-    static Ref<Value> create(double);
+    template<class T>
+    static Ref<Value> create(T value) requires std::is_arithmetic_v<T>;
     static Ref<Value> create(const String&);
     template<class T>
     static Ref<Value> create(T) = delete;
@@ -173,6 +172,20 @@ private:
     } m_value;
 };
 
+template<class T>
+inline Ref<Value> Value::create(T value)
+    requires std::is_arithmetic_v<T> {
+    if constexpr (std::same_as<T, bool>) {
+        return adoptRef(*new Value(value));
+    } else if constexpr (std::is_integral_v<T>) {
+        if constexpr (sizeof(T) <= sizeof(int) && std::is_signed_v<T>)
+            return adoptRef(*new Value(static_cast<int>(value)));
+        else
+            return adoptRef(*new Value(static_cast<double>(value)));
+    } else if constexpr (std::is_floating_point_v<T>)
+        return adoptRef(*new Value(static_cast<double>(value)));
+}
+
 class ObjectBase : public Value {
 private:
     friend class Value;
@@ -186,10 +199,10 @@ public:
 protected:
     ~ObjectBase();
 
+    template<typename T>
+    void setPrimitive(const String& name, T&& value) requires std::is_arithmetic_v<std::remove_cvref_t<T>>;
+
     // FIXME: use templates to reduce the amount of duplicated set*() methods.
-    void setBoolean(const String& name, bool);
-    void setInteger(const String& name, int);
-    void setDouble(const String& name, double);
     void setString(const String& name, const String&);
     void setValue(const String& name, Ref<Value>&&);
     void setObject(const String& name, Ref<ObjectBase>&&);
@@ -240,9 +253,7 @@ public:
     static WTF_EXPORT_PRIVATE Ref<Object> create();
 
     // This class expected non-cyclic values, as we cannot serialize cycles in JSON.
-    using ObjectBase::setBoolean;
-    using ObjectBase::setInteger;
-    using ObjectBase::setDouble;
+    using ObjectBase::setPrimitive;
     using ObjectBase::setString;
     using ObjectBase::setValue;
     using ObjectBase::setObject;
@@ -336,19 +347,11 @@ inline ObjectBase::const_iterator ObjectBase::find(const String& name) const
     return m_map.find(name);
 }
 
-inline void ObjectBase::setBoolean(const String& name, bool value)
+template<typename T>
+inline void ObjectBase::setPrimitive(const String& name, T&& value)
+    requires std::is_arithmetic_v<std::remove_cvref_t<T>>
 {
-    setValue(name, Value::create(value));
-}
-
-inline void ObjectBase::setInteger(const String& name, int value)
-{
-    setValue(name, Value::create(value));
-}
-
-inline void ObjectBase::setDouble(const String& name, double value)
-{
-    setValue(name, Value::create(value));
+    setValue(name, Value::create(std::forward<T>(value)));
 }
 
 inline void ObjectBase::setString(const String& name, const String& value)

--- a/Source/WTF/wtf/MediaTime.cpp
+++ b/Source/WTF/wtf/MediaTime.cpp
@@ -548,12 +548,12 @@ Ref<JSON::Object> MediaTime::toJSONObject() const
     auto object = JSON::Object::create();
 
     if (hasDoubleValue()) {
-        object->setDouble("value"_s, toDouble());
+        object->setPrimitive("value"_s, toDouble());
         return object;
     }
 
     if (isInvalid())
-        object->setBoolean("invalid"_s, true);
+        object->setPrimitive("invalid"_s, true);
     else if (isIndefinite())
         object->setString("value"_s, "NaN"_s);
     else if (isPositiveInfinite())
@@ -561,11 +561,11 @@ Ref<JSON::Object> MediaTime::toJSONObject() const
     else if (isNegativeInfinite())
         object->setString("value"_s, "NEGATIVE_INFINITY"_s);
     else
-        object->setDouble("value"_s, toDouble());
+        object->setPrimitive("value"_s, toDouble());
 
-    object->setDouble("numerator"_s, static_cast<double>(m_timeValue));
-    object->setInteger("denominator"_s, m_timeScale);
-    object->setInteger("flags"_s, m_timeFlags);
+    object->setPrimitive("numerator"_s, static_cast<double>(m_timeValue));
+    object->setPrimitive("denominator"_s, m_timeScale);
+    object->setPrimitive("flags"_s, m_timeFlags);
 
     return object;
 }

--- a/Source/WTF/wtf/darwin/LibraryPathDiagnostics.mm
+++ b/Source/WTF/wtf/darwin/LibraryPathDiagnostics.mm
@@ -200,7 +200,7 @@ void LibraryPathDiagnosticsLogger::logDynamicLibraryInfo(const String& installNa
     libraryObject->setString("UUID"_s, uuidToString(uuid));
 
 #if HAVE(SHARED_REGION_SPI)
-    libraryObject->setBoolean("InSharedCache"_s, isAddressInSharedRegion(header));
+    libraryObject->setPrimitive("InSharedCache"_s, isAddressInSharedRegion(header));
 #endif
 
     logObject(std::initializer_list<String> { "Libraries"_s, installName }, WTFMove(libraryObject));

--- a/Source/WebCore/Modules/mediasession/MediaSession.cpp
+++ b/Source/WebCore/Modules/mediasession/MediaSession.cpp
@@ -582,9 +582,9 @@ String MediaPositionState::toJSONString() const
 {
     auto object = JSON::Object::create();
 
-    object->setDouble("duration"_s, duration);
-    object->setDouble("playbackRate"_s, playbackRate);
-    object->setDouble("position"_s, position);
+    object->setPrimitive("duration"_s, duration);
+    object->setPrimitive("playbackRate"_s, playbackRate);
+    object->setPrimitive("position"_s, position);
 
     return object->toJSONString();
 }

--- a/Source/WebCore/Modules/mediasource/VideoPlaybackQuality.cpp
+++ b/Source/WebCore/Modules/mediasource/VideoPlaybackQuality.cpp
@@ -52,12 +52,12 @@ Ref<JSON::Object> VideoPlaybackQuality::toJSONObject() const
 {
     Ref json = JSON::Object::create();
 
-    json->setDouble("creationTime"_s, m_creationTime);
-    json->setInteger("totalVideoFrames"_s, m_totalVideoFrames);
-    json->setInteger("droppedVideoFrames"_s, m_droppedVideoFrames);
-    json->setInteger("corruptedVideoFrames"_s, m_corruptedVideoFrames);
-    json->setInteger("displayCompositedVideoFrames"_s, m_displayCompositedVideoFrames);
-    json->setDouble("totalFrameDelay"_s, m_totalFrameDelay);
+    json->setPrimitive("creationTime"_s, m_creationTime);
+    json->setPrimitive("totalVideoFrames"_s, m_totalVideoFrames);
+    json->setPrimitive("droppedVideoFrames"_s, m_droppedVideoFrames);
+    json->setPrimitive("corruptedVideoFrames"_s, m_corruptedVideoFrames);
+    json->setPrimitive("displayCompositedVideoFrames"_s, m_displayCompositedVideoFrames);
+    json->setPrimitive("totalFrameDelay"_s, m_totalFrameDelay);
 
     return json;
 }

--- a/Source/WebCore/Modules/reporting/DeprecationReportBody.cpp
+++ b/Source/WebCore/Modules/reporting/DeprecationReportBody.cpp
@@ -67,8 +67,8 @@ Ref<FormData> DeprecationReportBody::createReportFormDataForViolation() const
     reportBody->setString("message"_s, m_message);
     if (!m_sourceFile.isNull()) {
         reportBody->setString("sourceFile"_s, m_sourceFile);
-        reportBody->setInteger("lineNumber"_s, m_lineNumber.value_or(0));
-        reportBody->setInteger("columnNumber"_s, m_columnNumber.value_or(0));
+        reportBody->setPrimitive("lineNumber"_s, m_lineNumber.value_or(0));
+        reportBody->setPrimitive("columnNumber"_s, m_columnNumber.value_or(0));
     }
 
     auto reportObject = JSON::Object::create();

--- a/Source/WebCore/Modules/reporting/Report.cpp
+++ b/Source/WebCore/Modules/reporting/Report.cpp
@@ -75,8 +75,8 @@ Ref<FormData> Report::createReportFormDataForViolation(const String& type, const
     reportObject->setString("user_agent"_s, userAgent);
     reportObject->setString("destination"_s, destination);
     reportObject->setString("type"_s, type);
-    reportObject->setInteger("age"_s, 0); // We currently do not delay sending the reports.
-    reportObject->setInteger("attempts"_s, 0);
+    reportObject->setPrimitive("age"_s, 0); // We currently do not delay sending the reports.
+    reportObject->setPrimitive("attempts"_s, 0);
     if (url.isValid())
         reportObject->setString("url"_s, url.string());
 

--- a/Source/WebCore/Modules/webauthn/WebAuthenticationUtils.cpp
+++ b/Source/WebCore/Modules/webauthn/WebAuthenticationUtils.cpp
@@ -169,7 +169,7 @@ Ref<ArrayBuffer> buildClientDataJson(ClientDataType type, const BufferSource& ch
     object->setString("origin"_s, origin.toRawString());
 
     if (scope != WebAuthn::Scope::SameOrigin)
-        object->setBoolean("crossOrigin"_s, scope != WebAuthn::Scope::SameOrigin);
+        object->setPrimitive("crossOrigin"_s, scope != WebAuthn::Scope::SameOrigin);
 
     if (!topOrigin.isNull())
         object->setString("topOrigin"_s, topOrigin);

--- a/Source/WebCore/Modules/webcodecs/VideoColorSpace.cpp
+++ b/Source/WebCore/Modules/webcodecs/VideoColorSpace.cpp
@@ -49,7 +49,7 @@ Ref<JSON::Object> VideoColorSpace::toJSON() const
     if (auto& matrix = this->matrix())
         json->setString("matrix"_s, convertEnumerationToString(*matrix));
     if (auto& fullRange = this->fullRange())
-        json->setBoolean("fullRange"_s, *fullRange);
+        json->setPrimitive("fullRange"_s, *fullRange);
 
     return json;
 }

--- a/Source/WebCore/html/track/AudioTrackConfiguration.cpp
+++ b/Source/WebCore/html/track/AudioTrackConfiguration.cpp
@@ -39,9 +39,9 @@ Ref<JSON::Object> AudioTrackConfiguration::toJSON() const
 {
     Ref json = JSON::Object::create();
     json->setString("codec"_s, codec());
-    json->setInteger("sampleRate"_s, sampleRate());
-    json->setInteger("numberOfChannels"_s, numberOfChannels());
-    json->setInteger("bitrate"_s, bitrate());
+    json->setPrimitive("sampleRate"_s, sampleRate());
+    json->setPrimitive("numberOfChannels"_s, numberOfChannels());
+    json->setPrimitive("bitrate"_s, bitrate());
     return json;
 }
 

--- a/Source/WebCore/html/track/TextTrackCue.cpp
+++ b/Source/WebCore/html/track/TextTrackCue.cpp
@@ -428,8 +428,8 @@ void TextTrackCue::toJSON(JSON::Object& value) const
     }
 
     value.setString("type"_s, type);
-    value.setDouble("startTime"_s, startTime());
-    value.setDouble("endTime"_s, endTime());
+    value.setPrimitive("startTime"_s, startTime());
+    value.setPrimitive("endTime"_s, endTime());
 }
 
 String TextTrackCue::toJSONString() const

--- a/Source/WebCore/html/track/TextTrackCueGeneric.cpp
+++ b/Source/WebCore/html/track/TextTrackCueGeneric.cpp
@@ -186,9 +186,9 @@ void TextTrackCueGeneric::toJSON(JSON::Object& object) const
     if (m_highlightColor.isValid())
         object.setString("highlightColor"_s, serializationForHTML(m_highlightColor));
     if (m_baseFontSizeRelativeToVideoHeight)
-        object.setDouble("relativeFontSize"_s, m_baseFontSizeRelativeToVideoHeight);
+        object.setPrimitive("relativeFontSize"_s, m_baseFontSizeRelativeToVideoHeight);
     if (m_fontSizeMultiplier)
-        object.setDouble("fontSizeMultiplier"_s, m_fontSizeMultiplier);
+        object.setPrimitive("fontSizeMultiplier"_s, m_fontSizeMultiplier);
     if (!m_fontName.isEmpty())
         object.setString("font"_s, m_fontName);
 }

--- a/Source/WebCore/html/track/VTTCue.cpp
+++ b/Source/WebCore/html/track/VTTCue.cpp
@@ -1403,16 +1403,16 @@ void VTTCue::toJSON(JSON::Object& object) const
 
     object.setString("text"_s, text());
     object.setString("vertical"_s, convertEnumerationToString(vertical()));
-    object.setBoolean("snapToLines"_s, snapToLines());
+    object.setPrimitive("snapToLines"_s, snapToLines());
     if (m_linePosition)
-        object.setDouble("line"_s, *m_linePosition);
+        object.setPrimitive("line"_s, *m_linePosition);
     else
         object.setString("line"_s, autoAtom());
     if (m_textPosition)
-        object.setDouble("position"_s, *m_textPosition);
+        object.setPrimitive("position"_s, *m_textPosition);
     else
         object.setString("position"_s, autoAtom());
-    object.setInteger("size"_s, m_cueSize);
+    object.setPrimitive("size"_s, m_cueSize);
     object.setString("align"_s, convertEnumerationToString(align()));
 }
 

--- a/Source/WebCore/html/track/VideoTrackConfiguration.cpp
+++ b/Source/WebCore/html/track/VideoTrackConfiguration.cpp
@@ -128,13 +128,13 @@ Ref<JSON::Object> VideoTrackConfiguration::toJSON() const
 {
     Ref json = JSON::Object::create();
     json->setString("codec"_s, codec());
-    json->setInteger("width"_s, width());
-    json->setInteger("height"_s, height());
+    json->setPrimitive("width"_s, width());
+    json->setPrimitive("height"_s, height());
     json->setObject("colorSpace"_s, colorSpace()->toJSON());
-    json->setDouble("framerate"_s, framerate());
-    json->setInteger("bitrate"_s, bitrate());
-    json->setBoolean("isSpatial"_s, !!spatialVideoMetadata());
-    json->setBoolean("isImmersive"_s, !!videoProjectionMetadata());
+    json->setPrimitive("framerate"_s, framerate());
+    json->setPrimitive("bitrate"_s, bitrate());
+    json->setPrimitive("isSpatial"_s, !!spatialVideoMetadata());
+    json->setPrimitive("isImmersive"_s, !!videoProjectionMetadata());
     return json;
 }
 

--- a/Source/WebCore/inspector/InspectorCanvas.cpp
+++ b/Source/WebCore/inspector/InspectorCanvas.cpp
@@ -469,10 +469,10 @@ std::optional<InspectorCanvasCallTracer::ProcessedArgument> InspectorCanvas::pro
         return WTF::switchOn(item,
             [](DOMPointInit point) -> Ref<JSON::Value> {
                 auto object = JSON::Object::create();
-                object->setDouble("x"_s, point.x);
-                object->setDouble("y"_s, point.y);
-                object->setDouble("z"_s, point.z);
-                object->setDouble("w"_s, point.w);
+                object->setPrimitive("x"_s, point.x);
+                object->setPrimitive("y"_s, point.y);
+                object->setPrimitive("z"_s, point.z);
+                object->setPrimitive("w"_s, point.w);
                 // FIXME We'd likely want to either create a new RecordingSwizzleType::DOMPointInit or RecordingSwizzleType::Object to avoid
                 // encoding the same data multiple times
                 return object;
@@ -1222,8 +1222,8 @@ Ref<Inspector::Protocol::Recording::InitialState> InspectorCanvas::buildInitialS
     auto initialStatePayload = Inspector::Protocol::Recording::InitialState::create().release();
 
     auto attributesPayload = JSON::Object::create();
-    attributesPayload->setInteger("width"_s, m_context->canvasBase().width());
-    attributesPayload->setInteger("height"_s, m_context->canvasBase().height());
+    attributesPayload->setPrimitive("width"_s, m_context->canvasBase().width());
+    attributesPayload->setPrimitive("height"_s, m_context->canvasBase().height());
 
     auto statesPayload = JSON::ArrayOf<JSON::Object>::create();
 
@@ -1234,16 +1234,16 @@ Ref<Inspector::Protocol::Recording::InitialState> InspectorCanvas::buildInitialS
             auto statePayload = JSON::Object::create();
 
             statePayload->setArray(stringIndexForKey("setTransform"_s), buildArrayForAffineTransform(state.transform));
-            statePayload->setDouble(stringIndexForKey("globalAlpha"_s), state.globalAlpha);
-            statePayload->setInteger(stringIndexForKey("globalCompositeOperation"_s), indexForData(state.globalCompositeOperationString()));
-            statePayload->setDouble(stringIndexForKey("lineWidth"_s), state.lineWidth);
-            statePayload->setInteger(stringIndexForKey("lineCap"_s), indexForData(convertEnumerationToString(state.canvasLineCap())));
-            statePayload->setInteger(stringIndexForKey("lineJoin"_s), indexForData(convertEnumerationToString(state.canvasLineJoin())));
-            statePayload->setDouble(stringIndexForKey("miterLimit"_s), state.miterLimit);
-            statePayload->setDouble(stringIndexForKey("shadowOffsetX"_s), state.shadowOffset.width());
-            statePayload->setDouble(stringIndexForKey("shadowOffsetY"_s), state.shadowOffset.height());
-            statePayload->setDouble(stringIndexForKey("shadowBlur"_s), state.shadowBlur);
-            statePayload->setInteger(stringIndexForKey("shadowColor"_s), indexForData(serializationForHTML(state.shadowColor)));
+            statePayload->setPrimitive(stringIndexForKey("globalAlpha"_s), state.globalAlpha);
+            statePayload->setPrimitive(stringIndexForKey("globalCompositeOperation"_s), indexForData(state.globalCompositeOperationString()));
+            statePayload->setPrimitive(stringIndexForKey("lineWidth"_s), state.lineWidth);
+            statePayload->setPrimitive(stringIndexForKey("lineCap"_s), indexForData(convertEnumerationToString(state.canvasLineCap())));
+            statePayload->setPrimitive(stringIndexForKey("lineJoin"_s), indexForData(convertEnumerationToString(state.canvasLineJoin())));
+            statePayload->setPrimitive(stringIndexForKey("miterLimit"_s), state.miterLimit);
+            statePayload->setPrimitive(stringIndexForKey("shadowOffsetX"_s), state.shadowOffset.width());
+            statePayload->setPrimitive(stringIndexForKey("shadowOffsetY"_s), state.shadowOffset.height());
+            statePayload->setPrimitive(stringIndexForKey("shadowBlur"_s), state.shadowBlur);
+            statePayload->setPrimitive(stringIndexForKey("shadowColor"_s), indexForData(serializationForHTML(state.shadowColor)));
 
             // The parameter to `setLineDash` is itself an array, so we need to wrap the parameters
             // list in an array to allow spreading.
@@ -1251,11 +1251,11 @@ Ref<Inspector::Protocol::Recording::InitialState> InspectorCanvas::buildInitialS
             setLineDash->addItem(buildArrayForVector(state.lineDash));
             statePayload->setArray(stringIndexForKey("setLineDash"_s), WTFMove(setLineDash));
 
-            statePayload->setDouble(stringIndexForKey("lineDashOffset"_s), state.lineDashOffset);
-            statePayload->setInteger(stringIndexForKey("font"_s), indexForData(state.fontString()));
-            statePayload->setInteger(stringIndexForKey("textAlign"_s), indexForData(convertEnumerationToString(state.canvasTextAlign())));
-            statePayload->setInteger(stringIndexForKey("textBaseline"_s), indexForData(convertEnumerationToString(state.canvasTextBaseline())));
-            statePayload->setInteger(stringIndexForKey("direction"_s), indexForData(convertEnumerationToString(state.direction)));
+            statePayload->setPrimitive(stringIndexForKey("lineDashOffset"_s), state.lineDashOffset);
+            statePayload->setPrimitive(stringIndexForKey("font"_s), indexForData(state.fontString()));
+            statePayload->setPrimitive(stringIndexForKey("textAlign"_s), indexForData(convertEnumerationToString(state.canvasTextAlign())));
+            statePayload->setPrimitive(stringIndexForKey("textBaseline"_s), indexForData(convertEnumerationToString(state.canvasTextBaseline())));
+            statePayload->setPrimitive(stringIndexForKey("direction"_s), indexForData(convertEnumerationToString(state.direction)));
 
             int strokeStyleIndex;
             if (auto canvasGradient = state.strokeStyle.canvasGradient())
@@ -1264,7 +1264,7 @@ Ref<Inspector::Protocol::Recording::InitialState> InspectorCanvas::buildInitialS
                 strokeStyleIndex = indexForData(canvasPattern);
             else
                 strokeStyleIndex = indexForData(state.strokeStyle.colorString());
-            statePayload->setInteger(stringIndexForKey("strokeStyle"_s), strokeStyleIndex);
+            statePayload->setPrimitive(stringIndexForKey("strokeStyle"_s), strokeStyleIndex);
 
             int fillStyleIndex;
             if (auto canvasGradient = state.fillStyle.canvasGradient())
@@ -1273,10 +1273,10 @@ Ref<Inspector::Protocol::Recording::InitialState> InspectorCanvas::buildInitialS
                 fillStyleIndex = indexForData(canvasPattern);
             else
                 fillStyleIndex = indexForData(state.fillStyle.colorString());
-            statePayload->setInteger(stringIndexForKey("fillStyle"_s), fillStyleIndex);
+            statePayload->setPrimitive(stringIndexForKey("fillStyle"_s), fillStyleIndex);
 
-            statePayload->setBoolean(stringIndexForKey("imageSmoothingEnabled"_s), state.imageSmoothingEnabled);
-            statePayload->setInteger(stringIndexForKey("imageSmoothingQuality"_s), indexForData(convertEnumerationToString(state.imageSmoothingQuality)));
+            statePayload->setPrimitive(stringIndexForKey("imageSmoothingEnabled"_s), state.imageSmoothingEnabled);
+            statePayload->setPrimitive(stringIndexForKey("imageSmoothingQuality"_s), indexForData(convertEnumerationToString(state.imageSmoothingQuality)));
 
             // FIXME: This is wrong: it will repeat the context's current path for every level in the stack, ignoring saved paths.
             auto setPath = JSON::ArrayOf<JSON::Value>::create();

--- a/Source/WebCore/inspector/TimelineRecordFactory.cpp
+++ b/Source/WebCore/inspector/TimelineRecordFactory.cpp
@@ -46,7 +46,7 @@ using namespace Inspector;
 Ref<JSON::Object> TimelineRecordFactory::createGenericRecord(double startTime, int maxCallStackDepth)
 {
     Ref<JSON::Object> record = JSON::Object::create();
-    record->setDouble("startTime"_s, startTime);
+    record->setPrimitive("startTime"_s, startTime);
 
     if (maxCallStackDepth) {
         Ref<ScriptCallStack> stackTrace = createScriptCallStack(JSExecState::currentState(), maxCallStackDepth);
@@ -67,8 +67,8 @@ Ref<JSON::Object> TimelineRecordFactory::createFunctionCallData(const String& sc
 {
     Ref<JSON::Object> data = JSON::Object::create();
     data->setString("scriptName"_s, scriptName);
-    data->setInteger("scriptLine"_s, scriptLine);
-    data->setInteger("scriptColumn"_s, scriptColumn);
+    data->setPrimitive("scriptLine"_s, scriptLine);
+    data->setPrimitive("scriptColumn"_s, scriptColumn);
     return data;
 }
 
@@ -82,8 +82,8 @@ Ref<JSON::Object> TimelineRecordFactory::createConsoleProfileData(const String& 
 Ref<JSON::Object> TimelineRecordFactory::createProbeSampleData(JSC::BreakpointActionID actionID, unsigned sampleId)
 {
     Ref<JSON::Object> data = JSON::Object::create();
-    data->setInteger("probeId"_s, actionID);
-    data->setInteger("sampleId"_s, sampleId);
+    data->setPrimitive("probeId"_s, actionID);
+    data->setPrimitive("sampleId"_s, sampleId);
     return data;
 }
 
@@ -97,16 +97,16 @@ Ref<JSON::Object> TimelineRecordFactory::createEventDispatchData(const Event& ev
 Ref<JSON::Object> TimelineRecordFactory::createGenericTimerData(int timerId)
 {
     Ref<JSON::Object> data = JSON::Object::create();
-    data->setInteger("timerId"_s, timerId);
+    data->setPrimitive("timerId"_s, timerId);
     return data;
 }
 
 Ref<JSON::Object> TimelineRecordFactory::createTimerInstallData(int timerId, Seconds timeout, bool singleShot)
 {
     Ref<JSON::Object> data = JSON::Object::create();
-    data->setInteger("timerId"_s, timerId);
-    data->setInteger("timeout"_s, (int)timeout.milliseconds());
-    data->setBoolean("singleShot"_s, singleShot);
+    data->setPrimitive("timerId"_s, timerId);
+    data->setPrimitive("timeout"_s, (int)timeout.milliseconds());
+    data->setPrimitive("singleShot"_s, singleShot);
     return data;
 }
 
@@ -114,8 +114,8 @@ Ref<JSON::Object> TimelineRecordFactory::createEvaluateScriptData(const String& 
 {
     Ref<JSON::Object> data = JSON::Object::create();
     data->setString("url"_s, url);
-    data->setInteger("lineNumber"_s, lineNumber);
-    data->setInteger("columnNumber"_s, columnNumber);
+    data->setPrimitive("lineNumber"_s, lineNumber);
+    data->setPrimitive("columnNumber"_s, columnNumber);
     return data;
 }
 
@@ -129,7 +129,7 @@ Ref<JSON::Object> TimelineRecordFactory::createTimeStampData(const String& messa
 Ref<JSON::Object> TimelineRecordFactory::createAnimationFrameData(int callbackId)
 {
     Ref<JSON::Object> data = JSON::Object::create();
-    data->setInteger("id"_s, callbackId);
+    data->setPrimitive("id"_s, callbackId);
     return data;
 }
 

--- a/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
@@ -274,7 +274,7 @@ public:
 
 #if ENABLE(FULLSCREEN_API)
         if (event.type() == eventNames().webkitfullscreenchangeEvent || event.type() == eventNames().fullscreenchangeEvent)
-            data->setBoolean("enabled"_s, !!node->document().fullscreen().fullscreenElement());
+            data->setPrimitive("enabled"_s, !!node->document().fullscreen().fullscreenElement());
 #endif // ENABLE(FULLSCREEN_API)
 
         auto timestamp = m_domAgent.m_environment.executionStopwatch().elapsedTime().seconds();

--- a/Source/WebCore/inspector/agents/InspectorDOMDebuggerAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorDOMDebuggerAgent.cpp
@@ -310,7 +310,7 @@ void InspectorDOMDebuggerAgent::willHandleEvent(ScriptExecutionContext& scriptEx
     if (domAgent) {
         int eventListenerId = domAgent->idForEventListener(*event.currentTarget(), event.type(), registeredEventListener.callback(), registeredEventListener.useCapture());
         if (eventListenerId)
-            eventData->setInteger("eventListenerId"_s, eventListenerId);
+            eventData->setPrimitive("eventListenerId"_s, eventListenerId);
     }
 
     m_debuggerAgent->schedulePauseForSpecialBreakpoint(*breakpoint, Inspector::DebuggerFrontendDispatcher::Reason::Listener, WTFMove(eventData));

--- a/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp
@@ -603,7 +603,7 @@ void InspectorNetworkAgent::didReceiveResponse(ResourceLoaderIdentifier identifi
             
             resourceResponse->setString("mimeType"_s, previousResourceData->mimeType());
             
-            resourceResponse->setInteger("status"_s, previousResourceData->httpStatusCode());
+            resourceResponse->setPrimitive("status"_s, previousResourceData->httpStatusCode());
             resourceResponse->setString("statusText"_s, previousResourceData->httpStatusText());
             
             resourceResponse->setString("source"_s, Inspector::Protocol::Helpers::getEnumConstantValue(Inspector::Protocol::Network::Response::Source::DiskCache));

--- a/Source/WebCore/inspector/agents/InspectorTimelineAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorTimelineAgent.cpp
@@ -285,7 +285,7 @@ void InspectorTimelineAgent::didDispatchEvent(bool defaultPrevented)
 
     auto& entry = m_recordStack.last();
     ASSERT(entry.type == TimelineRecordType::EventDispatch);
-    entry.data->setBoolean("defaultPrevented"_s, defaultPrevented);
+    entry.data->setPrimitive("defaultPrevented"_s, defaultPrevented);
 
     didCompleteCurrentRecord(TimelineRecordType::EventDispatch);
 }
@@ -601,7 +601,7 @@ void InspectorTimelineAgent::didCompleteRecordEntry(const TimelineRecordEntry& e
     entry.record->setObject("data"_s, entry.data.copyRef());
     if (entry.children)
         entry.record->setArray("children"_s, *entry.children);
-    entry.record->setDouble("endTime"_s, timestamp());
+    entry.record->setPrimitive("endTime"_s, timestamp());
     addRecordToTimeline(entry.record.copyRef(), entry.type);
 }
 

--- a/Source/WebCore/inspector/agents/page/PageDOMDebuggerAgent.cpp
+++ b/Source/WebCore/inspector/agents/page/PageDOMDebuggerAgent.cpp
@@ -198,7 +198,7 @@ void PageDOMDebuggerAgent::willInsertDOMNode(Node& parent)
     ASSERT(closestBreakpointOwner);
 
     auto pauseData = buildPauseDataForDOMBreakpoint(Inspector::Protocol::DOMDebugger::DOMBreakpointType::SubtreeModified, *closestBreakpointOwner);
-    pauseData->setBoolean("insertion"_s, true);
+    pauseData->setPrimitive("insertion"_s, true);
     // FIXME: <https://webkit.org/b/213499> Web Inspector: allow DOM nodes to be instrumented at any point, regardless of whether the main document has also been instrumented
     // Include the new child node ID so the frontend can show the node that's about to be inserted.
     m_debuggerAgent->breakProgram(Inspector::DebuggerFrontendDispatcher::Reason::DOM, WTFMove(pauseData), WTFMove(closestBreakpoint));
@@ -255,7 +255,7 @@ void PageDOMDebuggerAgent::willRemoveDOMNode(Node& node)
     if (auto* domAgent = m_instrumentingAgents.persistentDOMAgent()) {
         if (&node != closestBreakpointOwner) {
             if (auto targetNodeId = domAgent->pushNodeToFrontend(&node))
-                pauseData->setInteger("targetNodeId"_s, targetNodeId);
+                pauseData->setPrimitive("targetNodeId"_s, targetNodeId);
         }
     }
     m_debuggerAgent->breakProgram(Inspector::DebuggerFrontendDispatcher::Reason::DOM, WTFMove(pauseData), WTFMove(closestBreakpoint));
@@ -313,7 +313,7 @@ Ref<JSON::Object> PageDOMDebuggerAgent::buildPauseDataForDOMBreakpoint(Inspector
     pauseData->setString("type"_s, Inspector::Protocol::Helpers::getEnumConstantValue(breakpointType));
     if (auto* domAgent = m_instrumentingAgents.persistentDOMAgent()) {
         if (auto breakpointOwnerNodeId = domAgent->pushNodeToFrontend(&breakpointOwner))
-            pauseData->setInteger("nodeId"_s, breakpointOwnerNodeId);
+            pauseData->setPrimitive("nodeId"_s, breakpointOwnerNodeId);
     }
     return pauseData;
 }

--- a/Source/WebCore/loader/PrivateClickMeasurement.cpp
+++ b/Source/WebCore/loader/PrivateClickMeasurement.cpp
@@ -296,10 +296,10 @@ Ref<JSON::Object> PrivateClickMeasurement::attributionReportJSON() const
 
     reportDetails->setString("source_engagement_type"_s, "click"_s);
     reportDetails->setString("source_site"_s, m_sourceSite.registrableDomain.string());
-    reportDetails->setInteger("source_id"_s, m_sourceID);
+    reportDetails->setPrimitive("source_id"_s, m_sourceID);
     reportDetails->setString("attributed_on_site"_s, m_destinationSite.registrableDomain.string());
-    reportDetails->setInteger("trigger_data"_s, m_attributionTriggerData->data);
-    reportDetails->setInteger("version"_s, privateClickMeasurementVersion);
+    reportDetails->setPrimitive("trigger_data"_s, m_attributionTriggerData->data);
+    reportDetails->setPrimitive("version"_s, privateClickMeasurementVersion);
 
     // This token has been kept secret this far and cannot be linked to the unlinkable token.
     if (m_sourceSecretToken) {
@@ -377,7 +377,7 @@ Ref<JSON::Object> PrivateClickMeasurement::tokenSignatureJSON() const
     reportDetails->setString("source_nonce"_s, m_ephemeralSourceNonce->nonce);
     // This token can not be linked to the secret token.
     reportDetails->setString("source_unlinkable_token"_s, m_sourceUnlinkableToken.valueBase64URL);
-    reportDetails->setInteger("version"_s, privateClickMeasurementVersion);
+    reportDetails->setPrimitive("version"_s, privateClickMeasurementVersion);
     return reportDetails;
 }
 
@@ -394,7 +394,7 @@ Ref<JSON::Object> PCM::AttributionTriggerData::tokenSignatureJSON() const
     reportDetails->setString("destination_nonce"_s, ephemeralDestinationNonce->nonce);
     // This token can not be linked to the secret token.
     reportDetails->setString("destination_unlinkable_token"_s, destinationUnlinkableToken->valueBase64URL);
-    reportDetails->setInteger("version"_s, privateClickMeasurementVersion);
+    reportDetails->setPrimitive("version"_s, privateClickMeasurementVersion);
     return reportDetails;
 }
 

--- a/Source/WebCore/loader/SubresourceIntegrity.cpp
+++ b/Source/WebCore/loader/SubresourceIntegrity.cpp
@@ -177,8 +177,8 @@ static Ref<FormData> createReportFormData(const String& type, const URL& url, co
     reportObject->setString("user_agent"_s, userAgent);
     // The spec allows user agents to delay report sending, in order to reduce impact on the user and potential overhead. See https://www.w3.org/TR/reporting-1/#delivery
     // Currently we're not taking advantage of that, so setting the `age` to 0 to indicate immediate delivery.
-    reportObject->setInteger("age"_s, 0);
-    reportObject->setInteger("attempts"_s, 0);
+    reportObject->setPrimitive("age"_s, 0);
+    reportObject->setPrimitive("attempts"_s, 0);
     if (url.isValid())
         reportObject->setString("url"_s, url.strippedForUseAsReferrer().string);
 

--- a/Source/WebCore/page/csp/CSPViolationReportBody.cpp
+++ b/Source/WebCore/page/csp/CSPViolationReportBody.cpp
@@ -109,12 +109,12 @@ Ref<FormData> CSPViolationReportBody::createReportFormDataForViolation(bool uses
         cspReport->setString("effectiveDirective"_s, effectiveDirective());
         cspReport->setString("blockedURL"_s, blockedURL());
         cspReport->setString("originalPolicy"_s, originalPolicy());
-        cspReport->setInteger("statusCode"_s, statusCode());
+        cspReport->setPrimitive("statusCode"_s, statusCode());
         cspReport->setString("sample"_s, sample());
         if (!sourceFile().isNull()) {
             cspReport->setString("sourceFile"_s, sourceFile());
-            cspReport->setInteger("lineNumber"_s, lineNumber());
-            cspReport->setInteger("columnNumber"_s, columnNumber());
+            cspReport->setPrimitive("lineNumber"_s, lineNumber());
+            cspReport->setPrimitive("columnNumber"_s, columnNumber());
         }
     } else {
         cspReport->setString("document-uri"_s, documentURL());
@@ -123,11 +123,11 @@ Ref<FormData> CSPViolationReportBody::createReportFormDataForViolation(bool uses
         cspReport->setString("effective-directive"_s, effectiveDirective());
         cspReport->setString("original-policy"_s, originalPolicy());
         cspReport->setString("blocked-uri"_s, blockedURL());
-        cspReport->setInteger("status-code"_s, statusCode());
+        cspReport->setPrimitive("status-code"_s, statusCode());
         if (!sourceFile().isNull()) {
             cspReport->setString("source-file"_s, sourceFile());
-            cspReport->setInteger("line-number"_s, lineNumber());
-            cspReport->setInteger("column-number"_s, columnNumber());
+            cspReport->setPrimitive("line-number"_s, lineNumber());
+            cspReport->setPrimitive("column-number"_s, columnNumber());
         }
     }
 

--- a/Source/WebCore/platform/MediaSample.h
+++ b/Source/WebCore/platform/MediaSample.h
@@ -131,7 +131,7 @@ public:
         object->setObject("pts"_s, presentationTime().toJSONObject());
         object->setObject("dts"_s, decodeTime().toJSONObject());
         object->setObject("duration"_s, duration().toJSONObject());
-        object->setInteger("flags"_s, static_cast<unsigned>(flags()));
+        object->setPrimitive("flags"_s, static_cast<unsigned>(flags()));
         object->setObject("presentationSize"_s, presentationSize().toJSONObject());
 
         return object->toJSONString();

--- a/Source/WebCore/platform/encryptedmedia/CDMLogging.cpp
+++ b/Source/WebCore/platform/encryptedmedia/CDMLogging.cpp
@@ -55,8 +55,8 @@ static Ref<JSON::Object> toJSONObject(const CDMMediaCapability& capability)
 static Ref<JSON::Object> toJSONObject(const CDMRestrictions& restrictions)
 {
     auto object = JSON::Object::create();
-    object->setBoolean("distinctiveIdentifierDenied"_s, restrictions.distinctiveIdentifierDenied);
-    object->setBoolean("persistentStateDenied"_s, restrictions.persistentStateDenied);
+    object->setPrimitive("distinctiveIdentifierDenied"_s, restrictions.distinctiveIdentifierDenied);
+    object->setPrimitive("persistentStateDenied"_s, restrictions.persistentStateDenied);
     auto deniedSessionTypes = JSON::Array::create();
     for (auto type : restrictions.deniedSessionTypes)
         deniedSessionTypes->pushString(convertEnumerationToString(type));

--- a/Source/WebCore/platform/graphics/FloatPoint.cpp
+++ b/Source/WebCore/platform/graphics/FloatPoint.cpp
@@ -102,8 +102,8 @@ Ref<JSON::Object> FloatPoint::toJSONObject() const
 {
     auto object = JSON::Object::create();
 
-    object->setDouble("x"_s, m_x);
-    object->setDouble("y"_s, m_y);
+    object->setPrimitive("x"_s, m_x);
+    object->setPrimitive("y"_s, m_y);
 
     return object;
 }

--- a/Source/WebCore/platform/graphics/FloatSize.cpp
+++ b/Source/WebCore/platform/graphics/FloatSize.cpp
@@ -65,8 +65,8 @@ Ref<JSON::Object> FloatSize::toJSONObject() const
 {
     auto object = JSON::Object::create();
 
-    object->setDouble("width"_s, m_width);
-    object->setDouble("height"_s, m_height);
+    object->setPrimitive("width"_s, m_width);
+    object->setPrimitive("height"_s, m_height);
 
     return object;
 }

--- a/Source/WebCore/platform/graphics/InbandGenericCue.cpp
+++ b/Source/WebCore/platform/graphics/InbandGenericCue.cpp
@@ -44,9 +44,9 @@ String InbandGenericCue::toJSONString() const
     auto object = JSON::Object::create();
 
     object->setString("text"_s, m_cueData.m_content);
-    object->setInteger("identifier"_s, m_cueData.m_uniqueId->toUInt64());
-    object->setDouble("start"_s, m_cueData.m_startTime.toDouble());
-    object->setDouble("end"_s, m_cueData.m_endTime.toDouble());
+    object->setPrimitive("identifier"_s, m_cueData.m_uniqueId->toUInt64());
+    object->setPrimitive("start"_s, m_cueData.m_startTime.toDouble());
+    object->setPrimitive("end"_s, m_cueData.m_endTime.toDouble());
 
     ASCIILiteral status = ""_s;
     switch (m_cueData.m_status) {
@@ -66,13 +66,13 @@ String InbandGenericCue::toJSONString() const
         object->setString("id"_s, m_cueData.m_id);
 
     if (m_cueData.m_line > 0)
-        object->setDouble("line"_s, m_cueData.m_line);
+        object->setPrimitive("line"_s, m_cueData.m_line);
 
     if (m_cueData.m_size > 0)
-        object->setDouble("size"_s, m_cueData.m_size);
+        object->setPrimitive("size"_s, m_cueData.m_size);
 
     if (m_cueData.m_position > 0)
-        object->setDouble("position"_s, m_cueData.m_position);
+        object->setPrimitive("position"_s, m_cueData.m_position);
 
     if (m_cueData.m_positionAlign != GenericCueData::Alignment::None) {
         ASCIILiteral positionAlign = ""_s;
@@ -122,10 +122,10 @@ String InbandGenericCue::toJSONString() const
         object->setString("highlightColor"_s, serializationForHTML(m_cueData.m_highlightColor));
 
     if (m_cueData.m_baseFontSize)
-        object->setDouble("baseFontSize"_s, m_cueData.m_baseFontSize);
+        object->setPrimitive("baseFontSize"_s, m_cueData.m_baseFontSize);
 
     if (m_cueData.m_relativeFontSize)
-        object->setDouble("relativeFontSize"_s, m_cueData.m_relativeFontSize);
+        object->setPrimitive("relativeFontSize"_s, m_cueData.m_relativeFontSize);
 
     if (!m_cueData.m_fontName.isEmpty())
         object->setString("font"_s, m_cueData.m_fontName);

--- a/Source/WebCore/platform/graphics/IntSize.cpp
+++ b/Source/WebCore/platform/graphics/IntSize.cpp
@@ -55,8 +55,8 @@ Ref<JSON::Object> IntSize::toJSONObject() const
 {
     auto object = JSON::Object::create();
 
-    object->setDouble("width"_s, m_width);
-    object->setDouble("height"_s, m_height);
+    object->setPrimitive("width"_s, m_width);
+    object->setPrimitive("height"_s, m_height);
 
     return object;
 }

--- a/Source/WebCore/platform/graphics/iso/ISOVTTCue.cpp
+++ b/Source/WebCore/platform/graphics/iso/ISOVTTCue.cpp
@@ -134,8 +134,8 @@ String ISOWebVTTCue::toJSONString() const
     object->setString("originalStartTime"_s, encodeWithURLEscapeSequences(m_originalStartTime));
     object->setString("settings"_s, encodeWithURLEscapeSequences(m_settings));
 
-    object->setDouble("presentationTime"_s, m_presentationTime.toDouble());
-    object->setDouble("duration"_s, m_duration.toDouble());
+    object->setPrimitive("presentationTime"_s, m_presentationTime.toDouble());
+    object->setPrimitive("duration"_s, m_duration.toDouble());
 
     return object->toJSONString();
 }

--- a/Source/WebCore/platform/mediacapabilities/MediaCapabilitiesLogging.cpp
+++ b/Source/WebCore/platform/mediacapabilities/MediaCapabilitiesLogging.cpp
@@ -47,12 +47,12 @@ static Ref<JSON::Object> toJSONObject(const VideoConfiguration& configuration)
 {
     auto object = JSON::Object::create();
     object->setString("contentType"_s, configuration.contentType);
-    object->setInteger("width"_s, configuration.width);
-    object->setInteger("height"_s, configuration.height);
-    object->setInteger("bitrate"_s, static_cast<int>(configuration.bitrate));
-    object->setDouble("framerate"_s, configuration.framerate);
+    object->setPrimitive("width"_s, configuration.width);
+    object->setPrimitive("height"_s, configuration.height);
+    object->setPrimitive("bitrate"_s, static_cast<int>(configuration.bitrate));
+    object->setPrimitive("framerate"_s, configuration.framerate);
     if (configuration.alphaChannel)
-        object->setBoolean("alphaChannel"_s, configuration.alphaChannel.value());
+        object->setPrimitive("alphaChannel"_s, configuration.alphaChannel.value());
     if (configuration.colorGamut)
         object->setString("colorGamut"_s, convertEnumerationToString(configuration.colorGamut.value()));
     if (configuration.hdrMetadataType)
@@ -69,11 +69,11 @@ static Ref<JSON::Object> toJSONObject(const AudioConfiguration& configuration)
     if (!configuration.channels.isNull())
         object->setString("channels"_s, configuration.channels);
     if (configuration.bitrate)
-        object->setInteger("bitrate"_s, static_cast<int>(configuration.bitrate.value()));
+        object->setPrimitive("bitrate"_s, static_cast<int>(configuration.bitrate.value()));
     if (configuration.samplerate)
-        object->setDouble("samplerate"_s, configuration.samplerate.value());
+        object->setPrimitive("samplerate"_s, configuration.samplerate.value());
     if (configuration.spatialRendering)
-        object->setBoolean("spatialRendering"_s, configuration.spatialRendering.value());
+        object->setPrimitive("spatialRendering"_s, configuration.spatialRendering.value());
     return object;
 }
 
@@ -104,9 +104,9 @@ static Ref<JSON::Object> toJSONObject(const MediaEncodingConfiguration& configur
 static Ref<JSON::Object> toJSONObject(const MediaCapabilitiesInfo& info)
 {
     auto object = JSON::Object::create();
-    object->setBoolean("supported"_s, info.supported);
-    object->setBoolean("smooth"_s, info.smooth);
-    object->setBoolean("powerEfficient"_s, info.powerEfficient);
+    object->setPrimitive("supported"_s, info.supported);
+    object->setPrimitive("smooth"_s, info.smooth);
+    object->setPrimitive("powerEfficient"_s, info.powerEfficient);
     return object;
 }
 

--- a/Source/WebCore/platform/mediastream/RealtimeVideoCaptureSource.cpp
+++ b/Source/WebCore/platform/mediastream/RealtimeVideoCaptureSource.cpp
@@ -564,10 +564,10 @@ Ref<JSON::Object> SizeFrameRateAndZoom::toJSONObject() const
 {
     auto object = JSON::Object::create();
 
-    object->setDouble("width"_s, width ? width.value() : 0);
-    object->setDouble("height"_s, height ? height.value() : 0);
-    object->setDouble("frameRate"_s, frameRate ? frameRate.value() : 0);
-    object->setDouble("zoom"_s, zoom ? zoom.value() : 0);
+    object->setPrimitive("width"_s, width ? width.value() : 0);
+    object->setPrimitive("height"_s, height ? height.value() : 0);
+    object->setPrimitive("frameRate"_s, frameRate ? frameRate.value() : 0);
+    object->setPrimitive("zoom"_s, zoom ? zoom.value() : 0);
 
     return object;
 }

--- a/Source/WebDriver/Session.cpp
+++ b/Source/WebDriver/Session.cpp
@@ -179,9 +179,9 @@ void Session::getTimeouts(Function<void(CommandResult&&)>&& completionHandler)
     if (m_scriptTimeout == std::numeric_limits<double>::infinity())
         parameters->setValue("script"_s, JSON::Value::null());
     else
-        parameters->setDouble("script"_s, m_scriptTimeout);
-    parameters->setDouble("pageLoad"_s, m_pageLoadTimeout);
-    parameters->setDouble("implicit"_s, m_implicitWaitTimeout);
+        parameters->setPrimitive("script"_s, m_scriptTimeout);
+    parameters->setPrimitive("pageLoad"_s, m_pageLoadTimeout);
+    parameters->setPrimitive("implicit"_s, m_implicitWaitTimeout);
     completionHandler(CommandResult::success(WTFMove(parameters)));
 }
 
@@ -366,7 +366,7 @@ void Session::go(const String& url, Function<void(CommandResult&&)>&& completion
         auto parameters = JSON::Object::create();
         parameters->setString("handle"_s, m_toplevelBrowsingContext.value());
         parameters->setString("url"_s, url);
-        parameters->setDouble("pageLoadTimeout"_s, m_pageLoadTimeout);
+        parameters->setPrimitive("pageLoadTimeout"_s, m_pageLoadTimeout);
         if (auto pageLoadStrategy = pageLoadStrategyString())
             parameters->setString("pageLoadStrategy"_s, pageLoadStrategy.value());
         m_host->sendCommandToBackend("navigateBrowsingContext"_s, WTFMove(parameters), [this, protectedThis, completionHandler = WTFMove(completionHandler)](SessionHost::CommandResponse&& response) mutable {
@@ -431,7 +431,7 @@ void Session::back(Function<void(CommandResult&&)>&& completionHandler)
         }
         auto parameters = JSON::Object::create();
         parameters->setString("handle"_s, m_toplevelBrowsingContext.value());
-        parameters->setDouble("pageLoadTimeout"_s, m_pageLoadTimeout);
+        parameters->setPrimitive("pageLoadTimeout"_s, m_pageLoadTimeout);
         if (auto pageLoadStrategy = pageLoadStrategyString())
             parameters->setString("pageLoadStrategy"_s, pageLoadStrategy.value());
         m_host->sendCommandToBackend("goBackInBrowsingContext"_s, WTFMove(parameters), [this, protectedThis, completionHandler = WTFMove(completionHandler)](SessionHost::CommandResponse&& response) mutable {
@@ -458,7 +458,7 @@ void Session::forward(Function<void(CommandResult&&)>&& completionHandler)
         }
         auto parameters = JSON::Object::create();
         parameters->setString("handle"_s, m_toplevelBrowsingContext.value());
-        parameters->setDouble("pageLoadTimeout"_s, m_pageLoadTimeout);
+        parameters->setPrimitive("pageLoadTimeout"_s, m_pageLoadTimeout);
         if (auto pageLoadStrategy = pageLoadStrategyString())
             parameters->setString("pageLoadStrategy"_s, pageLoadStrategy.value());
         m_host->sendCommandToBackend("goForwardInBrowsingContext"_s, WTFMove(parameters), [this, protectedThis, completionHandler = WTFMove(completionHandler)](SessionHost::CommandResponse&& response) mutable {
@@ -485,7 +485,7 @@ void Session::refresh(Function<void(CommandResult&&)>&& completionHandler)
         }
         auto parameters = JSON::Object::create();
         parameters->setString("handle"_s, m_toplevelBrowsingContext.value());
-        parameters->setDouble("pageLoadTimeout"_s, m_pageLoadTimeout);
+        parameters->setPrimitive("pageLoadTimeout"_s, m_pageLoadTimeout);
         if (auto pageLoadStrategy = pageLoadStrategyString())
             parameters->setString("pageLoadStrategy"_s, pageLoadStrategy.value());
         m_host->sendCommandToBackend("reloadBrowsingContext"_s, WTFMove(parameters), [this, protectedThis, completionHandler = WTFMove(completionHandler)](SessionHost::CommandResponse&& response) mutable {
@@ -748,7 +748,7 @@ void Session::switchToFrame(RefPtr<JSON::Value>&& frameID, Function<void(Command
                 completionHandler(CommandResult::fail(CommandResult::ErrorCode::InvalidArgument));
                 return;
             }
-            parameters->setInteger("ordinal"_s, *frameIndex);
+            parameters->setPrimitive("ordinal"_s, *frameIndex);
         } else {
             String frameElementID = extractElementID(*frameID);
             ASSERT(!frameElementID.isEmpty());
@@ -858,10 +858,10 @@ void Session::getToplevelBrowsingContextRect(Function<void(CommandResult&&)>&& c
         }
 
         auto windowRect = JSON::Object::create();
-        windowRect->setDouble("x"_s, *x);
-        windowRect->setDouble("y"_s, *y);
-        windowRect->setDouble("width"_s, *width);
-        windowRect->setDouble("height"_s, *height);
+        windowRect->setPrimitive("x"_s, *x);
+        windowRect->setPrimitive("y"_s, *y);
+        windowRect->setPrimitive("width"_s, *width);
+        windowRect->setPrimitive("height"_s, *height);
         completionHandler(CommandResult::success(WTFMove(windowRect)));
     });
 }
@@ -899,14 +899,14 @@ void Session::setWindowRect(std::optional<double> x, std::optional<double> y, st
         parameters->setString("handle"_s, m_toplevelBrowsingContext.value());
         if (x && y) {
             auto windowOrigin = JSON::Object::create();
-            windowOrigin->setDouble("x"_s, x.value());
-            windowOrigin->setDouble("y"_s, y.value());
+            windowOrigin->setPrimitive("x"_s, x.value());
+            windowOrigin->setPrimitive("y"_s, y.value());
             parameters->setObject("origin"_s, WTFMove(windowOrigin));
         }
         if (width && height) {
             auto windowSize = JSON::Object::create();
-            windowSize->setDouble("width"_s, width.value());
-            windowSize->setDouble("height"_s, height.value());
+            windowSize->setPrimitive("width"_s, width.value());
+            windowSize->setPrimitive("height"_s, height.value());
             parameters->setObject("size"_s, WTFMove(windowSize));
         }
         m_host->sendCommandToBackend("setWindowFrameOfBrowsingContext"_s, WTFMove(parameters), [this, protectedThis, completionHandler = WTFMove(completionHandler)](SessionHost::CommandResponse&& response) mutable {
@@ -986,7 +986,7 @@ void Session::fullscreenWindow(Function<void(CommandResult&&)>&& completionHandl
         parameters->setString("browsingContextHandle"_s, m_toplevelBrowsingContext.value());
         parameters->setString("function"_s, StringImpl::createWithoutCopying(EnterFullscreenJavaScript));
         parameters->setArray("arguments"_s, JSON::Array::create());
-        parameters->setBoolean("expectsImplicitCallbackArgument"_s, true);
+        parameters->setPrimitive("expectsImplicitCallbackArgument"_s, true);
         m_host->sendCommandToBackend("evaluateJavaScriptFunction"_s, WTFMove(parameters), [this, protectedThis, completionHandler = WTFMove(completionHandler)](SessionHost::CommandResponse&& response) mutable {
             if (response.isError || !response.responseObject) {
                 completionHandler(CommandResult::fail(WTFMove(response.responseObject)));
@@ -1080,7 +1080,7 @@ void Session::computeElementLayout(const String& elementID, OptionSet<ElementLay
     parameters->setString("browsingContextHandle"_s, m_toplevelBrowsingContext.value());
     parameters->setString("frameHandle"_s, m_currentBrowsingContext.value_or(emptyString()));
     parameters->setString("nodeHandle"_s, elementID);
-    parameters->setBoolean("scrollIntoViewIfNeeded"_s, options.contains(ElementLayoutOption::ScrollIntoViewIfNeeded));
+    parameters->setPrimitive("scrollIntoViewIfNeeded"_s, options.contains(ElementLayoutOption::ScrollIntoViewIfNeeded));
     parameters->setString("coordinateSystem"_s, options.contains(ElementLayoutOption::UseViewportCoordinates) ? "LayoutViewport"_s : "Page"_s);
     m_host->sendCommandToBackend("computeElementLayout"_s, WTFMove(parameters), [protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](SessionHost::CommandResponse&& response) mutable {
         if (response.isError || !response.responseObject) {
@@ -1172,10 +1172,10 @@ void Session::findElements(const String& strategy, const String& selector, FindE
             parameters->setString("frameHandle"_s, m_currentBrowsingContext.value());
         parameters->setString("function"_s, StringImpl::createWithoutCopying(FindNodesJavaScript));
         parameters->setArray("arguments"_s, WTFMove(arguments));
-        parameters->setBoolean("expectsImplicitCallbackArgument"_s, true);
+        parameters->setPrimitive("expectsImplicitCallbackArgument"_s, true);
         // If there's an implicit wait, use one second more as callback timeout.
         if (m_implicitWaitTimeout)
-            parameters->setDouble("callbackTimeout"_s, m_implicitWaitTimeout + 1000);
+            parameters->setPrimitive("callbackTimeout"_s, m_implicitWaitTimeout + 1000);
 
         m_host->sendCommandToBackend("evaluateJavaScriptFunction"_s, WTFMove(parameters), [this, protectedThis, mode, isShadowRoot, completionHandler = WTFMove(completionHandler)](SessionHost::CommandResponse&& response) {
             if (response.isError || !response.responseObject) {
@@ -1488,10 +1488,10 @@ void Session::getElementRect(const String& elementID, Function<void(CommandResul
                 return;
             }
             auto rectObject = JSON::Object::create();
-            rectObject->setInteger("x"_s, rect.value().origin.x);
-            rectObject->setInteger("y"_s, rect.value().origin.y);
-            rectObject->setInteger("width"_s, rect.value().size.width);
-            rectObject->setInteger("height"_s, rect.value().size.height);
+            rectObject->setPrimitive("x"_s, rect.value().origin.x);
+            rectObject->setPrimitive("y"_s, rect.value().origin.y);
+            rectObject->setPrimitive("width"_s, rect.value().size.width);
+            rectObject->setPrimitive("height"_s, rect.value().size.height);
             completionHandler(CommandResult::success(WTFMove(rectObject)));
         });
     });
@@ -1797,7 +1797,7 @@ void Session::waitForNavigationToComplete(Function<void(CommandResult&&)>&& comp
     parameters->setString("browsingContextHandle"_s, m_toplevelBrowsingContext.value());
     if (m_currentBrowsingContext)
         parameters->setString("frameHandle"_s, m_currentBrowsingContext.value());
-    parameters->setDouble("pageLoadTimeout"_s, m_pageLoadTimeout);
+    parameters->setPrimitive("pageLoadTimeout"_s, m_pageLoadTimeout);
     if (auto pageLoadStrategy = pageLoadStrategyString())
         parameters->setString("pageLoadStrategy"_s, pageLoadStrategy.value());
     m_host->sendCommandToBackend("waitForNavigationToComplete"_s, WTFMove(parameters), [this, protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](SessionHost::CommandResponse&& response) {
@@ -2455,9 +2455,9 @@ void Session::executeScript(const String& script, RefPtr<JSON::Array>&& argument
         parameters->setString("function"_s, makeString("function(){\n"_s, script, "\n}"_s));
         parameters->setArray("arguments"_s, WTFMove(arguments));
         if (mode == ExecuteScriptMode::Async)
-            parameters->setBoolean("expectsImplicitCallbackArgument"_s, true);
+            parameters->setPrimitive("expectsImplicitCallbackArgument"_s, true);
         if (m_scriptTimeout != std::numeric_limits<double>::infinity())
-            parameters->setDouble("callbackTimeout"_s, m_scriptTimeout);
+            parameters->setPrimitive("callbackTimeout"_s, m_scriptTimeout);
         m_host->sendCommandToBackend("evaluateJavaScriptFunction"_s, WTFMove(parameters), [this, protectedThis, completionHandler = WTFMove(completionHandler)](SessionHost::CommandResponse&& response) mutable {
             if (response.isError || !response.responseObject) {
                 auto result = CommandResult::fail(WTFMove(response.responseObject));
@@ -2506,8 +2506,8 @@ void Session::performMouseInteraction(int x, int y, MouseButton button, MouseInt
     auto parameters = JSON::Object::create();
     parameters->setString("handle"_s, m_toplevelBrowsingContext.value());
     auto position = JSON::Object::create();
-    position->setInteger("x"_s, x);
-    position->setInteger("y"_s, y);
+    position->setPrimitive("x"_s, x);
+    position->setPrimitive("y"_s, y);
     parameters->setObject("position"_s, WTFMove(position));
     parameters->setString("button"_s, mouseButtonForAutomation(button));
     switch (interaction) {
@@ -2619,10 +2619,10 @@ static Ref<JSON::Object> builtAutomationCookie(const Session::Cookie& cookie)
     cookieObject->setString("value"_s, cookie.value);
     cookieObject->setString("path"_s, cookie.path.value_or("/"_s));
     cookieObject->setString("domain"_s, cookie.domain.value_or(emptyString()));
-    cookieObject->setBoolean("secure"_s, cookie.secure.value_or(false));
-    cookieObject->setBoolean("httpOnly"_s, cookie.httpOnly.value_or(false));
-    cookieObject->setBoolean("session"_s, !cookie.expiry);
-    cookieObject->setDouble("expires"_s, cookie.expiry.value_or(0));
+    cookieObject->setPrimitive("secure"_s, cookie.secure.value_or(false));
+    cookieObject->setPrimitive("httpOnly"_s, cookie.httpOnly.value_or(false));
+    cookieObject->setPrimitive("session"_s, !cookie.expiry);
+    cookieObject->setPrimitive("expires"_s, cookie.expiry.value_or(0));
     cookieObject->setString("sameSite"_s, cookie.sameSite.value_or("None"_s));
     return cookieObject;
 }
@@ -2637,11 +2637,11 @@ static Ref<JSON::Object> serializeCookie(const Session::Cookie& cookie)
     if (cookie.domain)
         cookieObject->setString("domain"_s, cookie.domain.value());
     if (cookie.secure)
-        cookieObject->setBoolean("secure"_s, cookie.secure.value());
+        cookieObject->setPrimitive("secure"_s, cookie.secure.value());
     if (cookie.httpOnly)
-        cookieObject->setBoolean("httpOnly"_s, cookie.httpOnly.value());
+        cookieObject->setPrimitive("httpOnly"_s, cookie.httpOnly.value());
     if (cookie.expiry)
-        cookieObject->setInteger("expiry"_s, cookie.expiry.value());
+        cookieObject->setPrimitive("expiry"_s, cookie.expiry.value());
     if (cookie.sameSite)
         cookieObject->setString("sameSite"_s, cookie.sameSite.value());
     return cookieObject;
@@ -2877,7 +2877,7 @@ void Session::performActions(Vector<Vector<Action>>&& actionsByTick, Function<vo
                 switch (action.type) {
                 case Action::Type::None:
                     if (action.duration)
-                        state->setDouble("duration"_s, action.duration.value());
+                        state->setPrimitive("duration"_s, action.duration.value());
                     break;
                 case Action::Type::Pointer: {
                     switch (action.subtype) {
@@ -2890,8 +2890,8 @@ void Session::performActions(Vector<Vector<Action>>&& actionsByTick, Function<vo
                     case Action::Subtype::PointerMove: {
                         state->setString("origin"_s, automationOriginType(action.origin->type));
                         auto location = JSON::Object::create();
-                        location->setInteger("x"_s, action.x.value());
-                        location->setInteger("y"_s, action.y.value());
+                        location->setPrimitive("x"_s, action.x.value());
+                        location->setPrimitive("y"_s, action.y.value());
                         state->setObject("location"_s, WTFMove(location));
                         if (action.origin->type == PointerOrigin::Type::Element)
                             state->setString("nodeHandle"_s, action.origin->elementID.value());
@@ -2899,7 +2899,7 @@ void Session::performActions(Vector<Vector<Action>>&& actionsByTick, Function<vo
                     }
                     case Action::Subtype::Pause:
                         if (action.duration)
-                            state->setDouble("duration"_s, action.duration.value());
+                            state->setPrimitive("duration"_s, action.duration.value());
                         break;
                     case Action::Subtype::PointerCancel:
                         currentState.pressedButton = std::nullopt;
@@ -2935,7 +2935,7 @@ void Session::performActions(Vector<Vector<Action>>&& actionsByTick, Function<vo
                     }
                     case Action::Subtype::Pause:
                         if (action.duration)
-                            state->setDouble("duration"_s, action.duration.value());
+                            state->setPrimitive("duration"_s, action.duration.value());
                         break;
                     case Action::Subtype::PointerUp:
                     case Action::Subtype::PointerDown:
@@ -2959,13 +2959,13 @@ void Session::performActions(Vector<Vector<Action>>&& actionsByTick, Function<vo
                     case Action::Subtype::Scroll: {
                         state->setString("origin"_s, automationOriginType(action.origin->type));
                         auto location = JSON::Object::create();
-                        location->setInteger("x"_s, action.x.value());
-                        location->setInteger("y"_s, action.y.value());
+                        location->setPrimitive("x"_s, action.x.value());
+                        location->setPrimitive("y"_s, action.y.value());
                         state->setObject("location"_s, WTFMove(location));
 
                         auto delta = JSON::Object::create();
-                        delta->setInteger("width"_s, action.deltaX.value());
-                        delta->setInteger("height"_s, action.deltaY.value());
+                        delta->setPrimitive("width"_s, action.deltaX.value());
+                        delta->setPrimitive("height"_s, action.deltaY.value());
                         state->setObject("delta"_s, WTFMove(delta));
 
                         if (action.origin->type == PointerOrigin::Type::Element)
@@ -2974,7 +2974,7 @@ void Session::performActions(Vector<Vector<Action>>&& actionsByTick, Function<vo
                     }
                     case Action::Subtype::Pause:
                         if (action.duration)
-                            state->setDouble("duration"_s, action.duration.value());
+                            state->setPrimitive("duration"_s, action.duration.value());
                         break;
                     case Action::Subtype::PointerUp:
                     case Action::Subtype::PointerDown:
@@ -3133,9 +3133,9 @@ void Session::takeScreenshot(std::optional<String> elementID, std::optional<bool
             parameters->setString("frameHandle"_s, m_currentBrowsingContext.value());
         if (elementID)
             parameters->setString("nodeHandle"_s, elementID.value());
-        parameters->setBoolean("clipToViewport"_s, true);
+        parameters->setPrimitive("clipToViewport"_s, true);
         if (scrollIntoView.value_or(false))
-            parameters->setBoolean("scrollIntoViewIfNeeded"_s, true);
+            parameters->setPrimitive("scrollIntoViewIfNeeded"_s, true);
         m_host->sendCommandToBackend("takeScreenshot"_s, WTFMove(parameters), [protectedThis, completionHandler = WTFMove(completionHandler)](SessionHost::CommandResponse&& response) mutable {
             if (response.isError || !response.responseObject) {
                 completionHandler(CommandResult::fail(WTFMove(response.responseObject)));

--- a/Source/WebDriver/WebDriverService.cpp
+++ b/Source/WebDriver/WebDriverService.cpp
@@ -794,7 +794,7 @@ RefPtr<JSON::Object> WebDriverService::validatedCapabilities(const JSON::Object&
             auto acceptInsecureCerts = it->value->asBoolean();
             if (!acceptInsecureCerts)
                 return nullptr;
-            result->setBoolean(it->key, *acceptInsecureCerts);
+            result->setPrimitive(it->key, *acceptInsecureCerts);
         } else if (it->key == "browserName"_s || it->key == "browserVersion"_s || it->key == "platformName"_s) {
             auto stringValue = it->value->asString();
             if (!stringValue)
@@ -814,7 +814,7 @@ RefPtr<JSON::Object> WebDriverService::validatedCapabilities(const JSON::Object&
             auto strictFileInteractability = it->value->asBoolean();
             if (!strictFileInteractability)
                 return nullptr;
-            result->setBoolean(it->key, *strictFileInteractability);
+            result->setPrimitive(it->key, *strictFileInteractability);
         } else if (it->key == "timeouts"_s) {
             auto timeouts = it->value->asObject();
             if (!timeouts || !deserializeTimeouts(*timeouts, IgnoreUnknownTimeout::No))
@@ -833,7 +833,7 @@ RefPtr<JSON::Object> WebDriverService::validatedCapabilities(const JSON::Object&
             auto webSocketURL = it->value->asBoolean();
             if (!webSocketURL)
                 return nullptr;
-            result->setBoolean(it->key, *webSocketURL);
+            result->setPrimitive(it->key, *webSocketURL);
         } else
             return nullptr;
     }
@@ -872,11 +872,11 @@ RefPtr<JSON::Object> WebDriverService::matchCapabilities(const JSON::Object& mer
     if (platformCapabilities.platformName)
         matchedCapabilities->setString("platformName"_s, platformCapabilities.platformName.value());
     if (platformCapabilities.acceptInsecureCerts)
-        matchedCapabilities->setBoolean("acceptInsecureCerts"_s, platformCapabilities.acceptInsecureCerts.value());
+        matchedCapabilities->setPrimitive("acceptInsecureCerts"_s, platformCapabilities.acceptInsecureCerts.value());
     if (platformCapabilities.strictFileInteractability)
-        matchedCapabilities->setBoolean("strictFileInteractability"_s, platformCapabilities.strictFileInteractability.value());
+        matchedCapabilities->setPrimitive("strictFileInteractability"_s, platformCapabilities.strictFileInteractability.value());
     if (platformCapabilities.setWindowRect)
-        matchedCapabilities->setBoolean("setWindowRect"_s, platformCapabilities.setWindowRect.value());
+        matchedCapabilities->setPrimitive("setWindowRect"_s, platformCapabilities.setWindowRect.value());
 
     auto end = mergedCapabilities.end();
     for (auto it = mergedCapabilities.begin(); it != end; ++it) {
@@ -1102,9 +1102,9 @@ void WebDriverService::createSession(Vector<Capabilities>&& capabilitiesList, Re
             capabilitiesObject->setString("browserName"_s, capabilities.browserName.value_or(emptyString()));
             capabilitiesObject->setString("browserVersion"_s, capabilities.browserVersion.value_or(emptyString()));
             capabilitiesObject->setString("platformName"_s, capabilities.platformName.value_or(emptyString()));
-            capabilitiesObject->setBoolean("acceptInsecureCerts"_s, capabilities.acceptInsecureCerts.value_or(false));
-            capabilitiesObject->setBoolean("strictFileInteractability"_s, capabilities.strictFileInteractability.value_or(false));
-            capabilitiesObject->setBoolean("setWindowRect"_s, capabilities.setWindowRect.value_or(true));
+            capabilitiesObject->setPrimitive("acceptInsecureCerts"_s, capabilities.acceptInsecureCerts.value_or(false));
+            capabilitiesObject->setPrimitive("strictFileInteractability"_s, capabilities.strictFileInteractability.value_or(false));
+            capabilitiesObject->setPrimitive("setWindowRect"_s, capabilities.setWindowRect.value_or(true));
             switch (capabilities.unhandledPromptBehavior.value_or(UnhandledPromptBehavior::DismissAndNotify)) {
             case UnhandledPromptBehavior::Dismiss:
                 capabilitiesObject->setString("unhandledPromptBehavior"_s, "dismiss"_s);
@@ -1139,9 +1139,9 @@ void WebDriverService::createSession(Vector<Capabilities>&& capabilitiesList, Re
             if (m_session->scriptTimeout() == std::numeric_limits<double>::infinity())
                 timeoutsObject->setValue("script"_s, JSON::Value::null());
             else
-                timeoutsObject->setDouble("script"_s, m_session->scriptTimeout());
-            timeoutsObject->setDouble("pageLoad"_s, m_session->pageLoadTimeout());
-            timeoutsObject->setDouble("implicit"_s, m_session->implicitWaitTimeout());
+                timeoutsObject->setPrimitive("script"_s, m_session->scriptTimeout());
+            timeoutsObject->setPrimitive("pageLoad"_s, m_session->pageLoadTimeout());
+            timeoutsObject->setPrimitive("implicit"_s, m_session->implicitWaitTimeout());
             capabilitiesObject->setObject("timeouts"_s, WTFMove(timeoutsObject));
 
 #if ENABLE(WEBDRIVER_BIDI)
@@ -1203,7 +1203,7 @@ void WebDriverService::status(RefPtr<JSON::Object>&&, Function<void (CommandResu
     // §8.3 Status
     // https://w3c.github.io/webdriver/webdriver-spec.html#status
     auto body = JSON::Object::create();
-    body->setBoolean("ready"_s, !m_session);
+    body->setPrimitive("ready"_s, !m_session);
     body->setString("message"_s, m_session ? "A session already exists"_s : "No sessions"_s);
     completionHandler(CommandResult::success(WTFMove(body)));
 }
@@ -2709,7 +2709,7 @@ void WebDriverService::bidiSessionStatus(unsigned id, RefPtr<JSON::Object>&&, Fu
 {
     auto result = JSON::Object::create();
     bool ready = !m_session;
-    result->setBoolean("ready"_s, ready);
+    result->setPrimitive("ready"_s, ready);
     if (ready)
         result->setString("message"_s, "Ready for new sessions"_s);
     else

--- a/Source/WebDriver/WebSocketServer.cpp
+++ b/Source/WebDriver/WebSocketServer.cpp
@@ -152,7 +152,7 @@ WebSocketMessageHandler::Message WebSocketMessageHandler::Message::fail(CommandR
     auto reply = JSON::Object::create();
 
     if (commandId)
-        reply->setInteger("id"_s, *commandId);
+        reply->setPrimitive("id"_s, *commandId);
 
     if (errorMessage)
         reply->setString("message"_s, *errorMessage);
@@ -167,7 +167,7 @@ WebSocketMessageHandler::Message WebSocketMessageHandler::Message::reply(const S
 {
     auto reply = JSON::Object::create();
     reply->setString("type"_s, type);
-    reply->setInteger("id"_s, id);
+    reply->setPrimitive("id"_s, id);
 
     if (auto resultObject = result->asObject())
         reply->setObject("result"_s, resultObject.releaseNonNull());
@@ -237,7 +237,7 @@ void WebSocketServer::sendErrorResponse(WebSocketMessageHandler::Connection conn
     errorObject->setString("error"_s, CommandResult::errorCodeToString(errorCode));
     errorObject->setString("message"_s, errorMessage);
     if (commandId)
-        errorObject->setInteger("id"_s, *commandId); // FIXME change to JSON::Value
+        errorObject->setPrimitive("id"_s, *commandId); // FIXME change to JSON::Value
     if (stacktrace)
         errorObject->setString("stacktrace"_s, *stacktrace);
 

--- a/Source/WebDriver/socket/SessionHostSocket.cpp
+++ b/Source/WebDriver/socket/SessionHostSocket.cpp
@@ -264,7 +264,7 @@ void SessionHost::startAutomationSession(Function<void (bool, std::optional<Stri
     m_sessionID = createVersion4UUIDString();
 
     auto capabilitiesObject = JSON::Object::create();
-    capabilitiesObject->setBoolean("acceptInsecureCerts"_s, m_capabilities.acceptInsecureCerts.value_or(false));
+    capabilitiesObject->setPrimitive("acceptInsecureCerts"_s, m_capabilities.acceptInsecureCerts.value_or(false));
 
     auto messageObject = JSON::Object::create();
     messageObject->setString("sessionID"_s, m_sessionID);
@@ -310,8 +310,8 @@ void SessionHost::setTargetList(uint64_t connectionID, Vector<Target>&& targetLi
 
     auto sendEvent = JSON::Object::create();
     sendEvent->setString("event"_s, "Setup"_s);
-    sendEvent->setInteger("connectionID"_s, m_connectionID);
-    sendEvent->setInteger("targetID"_s, m_target.id);
+    sendEvent->setPrimitive("connectionID"_s, m_connectionID);
+    sendEvent->setPrimitive("targetID"_s, m_target.id);
     sendWebInspectorEvent(sendEvent->toJSONString());
 
     auto startSessionCompletionHandler = std::exchange(m_startSessionCompletionHandler, nullptr);
@@ -322,8 +322,8 @@ void SessionHost::sendMessageToBackend(const String& message)
 {
     auto sendEvent = JSON::Object::create();
     sendEvent->setString("event"_s, "SendMessageToBackend"_s);
-    sendEvent->setInteger("connectionID"_s, m_connectionID);
-    sendEvent->setInteger("targetID"_s, m_target.id);
+    sendEvent->setPrimitive("connectionID"_s, m_connectionID);
+    sendEvent->setPrimitive("targetID"_s, m_target.id);
     sendEvent->setString("message"_s, message);
     sendWebInspectorEvent(sendEvent->toJSONString());
 }

--- a/Source/WebKit/UIProcess/Automation/WebDriverBidiProcessor.cpp
+++ b/Source/WebKit/UIProcess/Automation/WebDriverBidiProcessor.cpp
@@ -192,7 +192,7 @@ void WebDriverBidiProcessor::sendBidiMessage(const String& message)
             bidiErrorObj->setString("message"_s, internalMsg);
             bidiErrorObj->setString("error"_s, toBidiErrorCode(*codeField, internalMsg));
             if (auto commandId = msgObj->getInteger("id"_s))
-                bidiErrorObj->setInteger("id"_s, *commandId);
+                bidiErrorObj->setPrimitive("id"_s, *commandId);
 
             session->sendBidiMessage(bidiErrorObj->toJSONString());
             return;

--- a/Source/WebKit/UIProcess/Inspector/socket/RemoteInspectorClient.cpp
+++ b/Source/WebKit/UIProcess/Inspector/socket/RemoteInspectorClient.cpp
@@ -178,8 +178,8 @@ void RemoteInspectorClient::inspect(ConnectionID connectionID, TargetID targetID
 
     auto setupEvent = JSON::Object::create();
     setupEvent->setString("event"_s, "Setup"_s);
-    setupEvent->setInteger("connectionID"_s, connectionID);
-    setupEvent->setInteger("targetID"_s, targetID);
+    setupEvent->setPrimitive("connectionID"_s, connectionID);
+    setupEvent->setPrimitive("targetID"_s, targetID);
     sendWebInspectorEvent(setupEvent->toJSONString());
 
     addResult.iterator->value->initialize();
@@ -189,8 +189,8 @@ void RemoteInspectorClient::sendMessageToBackend(ConnectionID connectionID, Targ
 {
     auto backendEvent = JSON::Object::create();
     backendEvent->setString("event"_s, "SendMessageToBackend"_s);
-    backendEvent->setInteger("connectionID"_s, connectionID);
-    backendEvent->setInteger("targetID"_s, targetID);
+    backendEvent->setPrimitive("connectionID"_s, connectionID);
+    backendEvent->setPrimitive("targetID"_s, targetID);
     backendEvent->setString("message"_s, message);
     sendWebInspectorEvent(backendEvent->toJSONString());
 }
@@ -199,8 +199,8 @@ void RemoteInspectorClient::closeFromFrontend(ConnectionID connectionID, TargetI
 {
     auto closedEvent = JSON::Object::create();
     closedEvent->setString("event"_s, "FrontendDidClose"_s);
-    closedEvent->setInteger("connectionID"_s, connectionID);
-    closedEvent->setInteger("targetID"_s, targetID);
+    closedEvent->setPrimitive("connectionID"_s, connectionID);
+    closedEvent->setPrimitive("targetID"_s, targetID);
     sendWebInspectorEvent(closedEvent->toJSONString());
 
     m_inspectorProxyMap.remove(std::make_pair(connectionID, targetID));

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorUIExtensionController.cpp
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorUIExtensionController.cpp
@@ -229,7 +229,7 @@ void WebInspectorUIExtensionController::evaluateScriptForExtension(const Inspect
     if (contextSecurityOrigin)
         optionalArguments->setString("contextSecurityOrigin"_s, contextSecurityOrigin->string());
     if (useContentScriptContext)
-        optionalArguments->setBoolean("useContentScriptContext"_s, *useContentScriptContext);
+        optionalArguments->setPrimitive("useContentScriptContext"_s, *useContentScriptContext);
 
     Vector<Ref<JSON::Value>> arguments {
         JSON::Value::create(extensionID),
@@ -300,7 +300,7 @@ void WebInspectorUIExtensionController::reloadForExtension(const Inspector::Exte
 
     Ref<JSON::Object> optionalArguments = JSON::Object::create();
     if (ignoreCache)
-        optionalArguments->setBoolean("ignoreCache"_s, *ignoreCache);
+        optionalArguments->setPrimitive("ignoreCache"_s, *ignoreCache);
     if (userAgent)
         optionalArguments->setString("userAgent"_s, *userAgent);
     if (injectedScript)

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -645,9 +645,9 @@
 		A14FC58B1B89927100D107EB /* ContentFilteringPlugIn.mm in Sources */ = {isa = PBXBuildFile; fileRef = A14FC5891B89927100D107EB /* ContentFilteringPlugIn.mm */; };
 		A170E3AA2ABA7857009EA799 /* VectorCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = A170E3A22ABA7857009EA799 /* VectorCocoa.mm */; };
 		A17191AD2CD2DB090088944E /* WKWebViewLogging.mm in Sources */ = {isa = PBXBuildFile; fileRef = A17191AC2CD2DB090088944E /* WKWebViewLogging.mm */; };
-		A176D24B2D6D2A4E00C63915 /* GPUExtension.appex in Embed Extensions */ = {isa = PBXBuildFile; fileRef = A176D2472D6D295400C63915 /* GPUExtension.appex */; platformFilters = (ios, ); settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		A176D24C2D6D2A4E00C63915 /* NetworkingExtension.appex in Embed Extensions */ = {isa = PBXBuildFile; fileRef = A176D2482D6D295400C63915 /* NetworkingExtension.appex */; platformFilters = (ios, ); settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		A176D24D2D6D2A4E00C63915 /* WebContentExtension.appex in Embed Extensions */ = {isa = PBXBuildFile; fileRef = A176D2492D6D295400C63915 /* WebContentExtension.appex */; platformFilters = (ios, ); settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		A176D24B2D6D2A4E00C63915 /* GPUExtension.appex in Embed Extensions */ = {isa = PBXBuildFile; fileRef = A176D2472D6D295400C63915 /* GPUExtension.appex */; platformFilter = ios; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		A176D24C2D6D2A4E00C63915 /* NetworkingExtension.appex in Embed Extensions */ = {isa = PBXBuildFile; fileRef = A176D2482D6D295400C63915 /* NetworkingExtension.appex */; platformFilter = ios; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		A176D24D2D6D2A4E00C63915 /* WebContentExtension.appex in Embed Extensions */ = {isa = PBXBuildFile; fileRef = A176D2492D6D295400C63915 /* WebContentExtension.appex */; platformFilter = ios; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		A1798B7F22431D2B000764BD /* libWebCoreTestSupport.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = A1798B7E22431D2B000764BD /* libWebCoreTestSupport.dylib */; };
 		A1798B8522433647000764BD /* WebProcessPlugInWithInternals.mm in Sources */ = {isa = PBXBuildFile; fileRef = A1798B8422433647000764BD /* WebProcessPlugInWithInternals.mm */; };
 		A17991881E1C994E00A505ED /* SharedBuffer.mm in Sources */ = {isa = PBXBuildFile; fileRef = A17991861E1C994E00A505ED /* SharedBuffer.mm */; };

--- a/Tools/TestWebKitAPI/Tests/WTF/JSONValue.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/JSONValue.cpp
@@ -315,19 +315,19 @@ TEST(JSONObject, Basic)
     EXPECT_TRUE(value);
     EXPECT_TRUE(value->isNull());
 
-    object->setBoolean("boolean"_s, true);
+    object->setPrimitive("boolean"_s, true);
     EXPECT_EQ(object->size(), 2U);
     auto booleanValue = object->getBoolean("boolean"_s);
     EXPECT_TRUE(booleanValue);
     EXPECT_EQ(*booleanValue, true);
 
-    object->setInteger("integer"_s, 1);
+    object->setPrimitive("integer"_s, 1);
     EXPECT_EQ(object->size(), 3U);
     auto integerValue = object->getInteger("integer"_s);
     EXPECT_TRUE(integerValue);
     EXPECT_EQ(*integerValue, 1);
 
-    object->setDouble("double"_s, 1.5);
+    object->setPrimitive("double"_s, 1.5);
     EXPECT_EQ(object->size(), 4U);
     auto doubleValue = object->getDouble("double"_s);
     EXPECT_TRUE(doubleValue);
@@ -446,9 +446,9 @@ TEST(JSONValue, ToJSONString)
         EXPECT_EQ(object->toJSONString(), "{}"_s);
         object->setValue("null"_s, JSON::Value::null());
         EXPECT_EQ(object->toJSONString(), "{\"null\":null}"_s);
-        object->setBoolean("boolean"_s, true);
+        object->setPrimitive("boolean"_s, true);
         EXPECT_EQ(object->toJSONString(), "{\"null\":null,\"boolean\":true}"_s);
-        object->setDouble("double"_s, 1.5);
+        object->setPrimitive("double"_s, 1.5);
         EXPECT_EQ(object->toJSONString(), "{\"null\":null,\"boolean\":true,\"double\":1.5}"_s);
         object->setString("string"_s, "webkit"_s);
         EXPECT_EQ(object->toJSONString(), "{\"null\":null,\"boolean\":true,\"double\":1.5,\"string\":\"webkit\"}"_s);
@@ -456,7 +456,7 @@ TEST(JSONValue, ToJSONString)
         EXPECT_EQ(object->toJSONString(), "{\"null\":null,\"boolean\":true,\"double\":1.5,\"string\":\"webkit\",\"array\":[]}"_s);
         Ref<JSON::Object> subObject = JSON::Object::create();
         subObject->setString("foo"_s, "bar"_s);
-        subObject->setInteger("baz"_s, 25);
+        subObject->setPrimitive("baz"_s, 25);
         object->setObject("object"_s, WTFMove(subObject));
         EXPECT_EQ(object->toJSONString(), "{\"null\":null,\"boolean\":true,\"double\":1.5,\"string\":\"webkit\",\"array\":[],\"object\":{\"foo\":\"bar\",\"baz\":25}}"_s);
     }

--- a/Tools/WebKitTestRunner/gtk/UIScriptControllerGtk.cpp
+++ b/Tools/WebKitTestRunner/gtk/UIScriptControllerGtk.cpp
@@ -194,7 +194,7 @@ static Ref<JSON::Object> toJSONObject(GVariant* variant)
         else if (type && g_variant_type_equal(type, G_VARIANT_TYPE_STRING))
             jsonObject->setString(String::fromLatin1(key), String::fromLatin1(g_variant_get_string(value, nullptr)));
         else if (type && g_variant_type_equal(type, G_VARIANT_TYPE_DOUBLE))
-            jsonObject->setDouble(String::fromLatin1(key), g_variant_get_double(value));
+            jsonObject->setPrimitive(String::fromLatin1(key), g_variant_get_double(value));
     }
     return jsonObject;
 }


### PR DESCRIPTION
#### 45dfe7e93f4909cbb81486a66bc57034d1d4f3ff
<pre>
Reduce the amount of duplicated set*() methods in wtf/JSONValues
<a href="https://bugs.webkit.org/show_bug.cgi?id=293408">https://bugs.webkit.org/show_bug.cgi?id=293408</a>
<a href="https://rdar.apple.com/problem/151824473">rdar://problem/151824473</a>

Reviewed by NOBODY (OOPS!).

Use C++20&apos;s concepts to replace duplicate set method overloads.

* Source/JavaScriptCore/inspector/InspectorBackendDispatcher.cpp:
(Inspector::BackendDispatcher::sendResponse):
(Inspector::BackendDispatcher::sendPendingErrors):
* Source/JavaScriptCore/inspector/scripts/codegen/cpp_generator.py:
(CppGenerator.cpp_setter_method_for_type):
* Source/JavaScriptCore/inspector/scripts/codegen/objc_generator.py:
(ObjCGenerator.objc_setter_method_for_member_internal):
* Source/JavaScriptCore/profiler/ProfilerBytecode.cpp:
(JSC::Profiler::Bytecode::toJSON const):
* Source/JavaScriptCore/profiler/ProfilerBytecodes.cpp:
(JSC::Profiler::Bytecodes::toJSON const):
* Source/JavaScriptCore/profiler/ProfilerCompilation.cpp:
(JSC::Profiler::Compilation::toJSON const):
* Source/JavaScriptCore/profiler/ProfilerEvent.cpp:
(JSC::Profiler::Event::toJSON const):
* Source/JavaScriptCore/profiler/ProfilerOSRExit.cpp:
(JSC::Profiler::OSRExit::toJSON const):
* Source/JavaScriptCore/profiler/ProfilerOrigin.cpp:
(JSC::Profiler::Origin::toJSON const):
* Source/JavaScriptCore/profiler/ProfilerProfiledBytecodes.cpp:
(JSC::Profiler::ProfiledBytecodes::toJSON const):
* Source/JavaScriptCore/runtime/SamplingProfiler.cpp:
(JSC::SamplingProfiler::stackTracesAsJSON):
* Source/WTF/wtf/JSONValues.cpp:
* Source/WTF/wtf/JSONValues.h:
(WTF::JSONImpl::ObjectBase::setBoolean): Deleted.
(WTF::JSONImpl::ObjectBase::setInteger): Deleted.
(WTF::JSONImpl::ObjectBase::setDouble): Deleted.
* Source/WTF/wtf/MediaTime.cpp:
(WTF::MediaTime::toJSONObject const):
* Source/WTF/wtf/darwin/LibraryPathDiagnostics.mm:
(WTF::LibraryPathDiagnosticsLogger::logDynamicLibraryInfo):
* Source/WebCore/Modules/mediasession/MediaSession.cpp:
(WebCore::MediaPositionState::toJSONString const):
* Source/WebCore/Modules/mediasource/VideoPlaybackQuality.cpp:
(WebCore::VideoPlaybackQuality::toJSONObject const):
* Source/WebCore/Modules/reporting/DeprecationReportBody.cpp:
(WebCore::DeprecationReportBody::createReportFormDataForViolation const):
* Source/WebCore/Modules/reporting/Report.cpp:
(WebCore::Report::createReportFormDataForViolation):
* Source/WebCore/Modules/webauthn/WebAuthenticationUtils.cpp:
(WebCore::buildClientDataJson):
* Source/WebCore/Modules/webcodecs/VideoColorSpace.cpp:
(WebCore::VideoColorSpace::toJSON const):
* Source/WebCore/html/track/AudioTrackConfiguration.cpp:
(WebCore::AudioTrackConfiguration::toJSON const):
* Source/WebCore/html/track/TextTrackCue.cpp:
(WebCore::TextTrackCue::toJSON const):
* Source/WebCore/html/track/TextTrackCueGeneric.cpp:
(WebCore::TextTrackCueGeneric::toJSON const):
* Source/WebCore/html/track/VTTCue.cpp:
(WebCore::VTTCue::toJSON const):
* Source/WebCore/html/track/VideoTrackConfiguration.cpp:
(WebCore::VideoTrackConfiguration::toJSON const):
* Source/WebCore/inspector/InspectorCanvas.cpp:
(WebCore::InspectorCanvas::processArgument):
(WebCore::InspectorCanvas::buildInitialState):
* Source/WebCore/inspector/TimelineRecordFactory.cpp:
(WebCore::TimelineRecordFactory::createGenericRecord):
(WebCore::TimelineRecordFactory::createFunctionCallData):
(WebCore::TimelineRecordFactory::createProbeSampleData):
(WebCore::TimelineRecordFactory::createGenericTimerData):
(WebCore::TimelineRecordFactory::createTimerInstallData):
(WebCore::TimelineRecordFactory::createEvaluateScriptData):
(WebCore::TimelineRecordFactory::createAnimationFrameData):
* Source/WebCore/inspector/agents/InspectorDOMAgent.cpp:
* Source/WebCore/inspector/agents/InspectorDOMDebuggerAgent.cpp:
(WebCore::InspectorDOMDebuggerAgent::willHandleEvent):
* Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp:
(WebCore::InspectorNetworkAgent::didReceiveResponse):
* Source/WebCore/inspector/agents/InspectorTimelineAgent.cpp:
(WebCore::InspectorTimelineAgent::didDispatchEvent):
(WebCore::InspectorTimelineAgent::didCompleteRecordEntry):
* Source/WebCore/inspector/agents/page/PageDOMDebuggerAgent.cpp:
(WebCore::PageDOMDebuggerAgent::willInsertDOMNode):
(WebCore::PageDOMDebuggerAgent::willRemoveDOMNode):
(WebCore::PageDOMDebuggerAgent::buildPauseDataForDOMBreakpoint):
* Source/WebCore/loader/PrivateClickMeasurement.cpp:
(WebCore::PrivateClickMeasurement::attributionReportJSON const):
(WebCore::PrivateClickMeasurement::tokenSignatureJSON const):
(WebCore::PCM::AttributionTriggerData::tokenSignatureJSON const):
* Source/WebCore/loader/SubresourceIntegrity.cpp:
(WebCore::createReportFormData):
* Source/WebCore/page/csp/CSPViolationReportBody.cpp:
(WebCore::CSPViolationReportBody::createReportFormDataForViolation const):
* Source/WebCore/platform/MediaSample.h:
(WebCore::MediaSample::toJSONString const):
* Source/WebCore/platform/encryptedmedia/CDMLogging.cpp:
(WebCore::toJSONObject):
* Source/WebCore/platform/graphics/FloatPoint.cpp:
(WebCore::FloatPoint::toJSONObject const):
* Source/WebCore/platform/graphics/FloatSize.cpp:
(WebCore::FloatSize::toJSONObject const):
* Source/WebCore/platform/graphics/InbandGenericCue.cpp:
(WebCore::InbandGenericCue::toJSONString const):
* Source/WebCore/platform/graphics/IntSize.cpp:
(WebCore::IntSize::toJSONObject const):
* Source/WebCore/platform/graphics/iso/ISOVTTCue.cpp:
(WebCore::ISOWebVTTCue::toJSONString const):
* Source/WebCore/platform/mediacapabilities/MediaCapabilitiesLogging.cpp:
(WebCore::toJSONObject):
* Source/WebCore/platform/mediastream/RealtimeVideoCaptureSource.cpp:
(WebCore::SizeFrameRateAndZoom::toJSONObject const):
* Source/WebKit/UIProcess/Automation/WebDriverBidiProcessor.cpp:
(WebKit::WebDriverBidiProcessor::sendBidiMessage):
* Source/WebKit/WebProcess/Inspector/WebInspectorUIExtensionController.cpp:
(WebKit::WebInspectorUIExtensionController::evaluateScriptForExtension):
(WebKit::WebInspectorUIExtensionController::reloadForExtension):
* Tools/TestWebKitAPI/Tests/WTF/JSONValue.cpp:
(TestWebKitAPI::TEST(JSONObject, Basic)):
(TestWebKitAPI::TEST(JSONValue, ToJSONString)):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/45dfe7e93f4909cbb81486a66bc57034d1d4f3ff

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104849 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24562 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/14983 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110064 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/55523 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/106889 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/24962 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33107 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79627 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107855 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19411 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94625 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59934 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/19252 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/12702 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/54906 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/97530 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/88966 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/12749 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/112499 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/103467 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32014 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23534 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88691 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32378 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/90851 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88319 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33212 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10979 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/27328 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/31939 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/37294 "Built successfully") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/127746 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled JSC (cancelled)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/31731 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/127746 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled JSC (cancelled)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35072 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33290 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->