### PR TITLE
Add XSLT layout test

### DIFF
--- a/LayoutTests/fast/xsl/generate-id-distinct-elements-unique-value-expected.txt
+++ b/LayoutTests/fast/xsl/generate-id-distinct-elements-unique-value-expected.txt
@@ -1,0 +1,7 @@
+Verify that generate-id() does not return the same value for different nodes.
+
+1 and 2 have distinct IDs as expected: PASSED
+
+1 and 3 have distinct IDs as expected: PASSED
+
+2 and 3 have distinct IDs as expected: PASSED

--- a/LayoutTests/fast/xsl/generate-id-distinct-elements-unique-value.xml
+++ b/LayoutTests/fast/xsl/generate-id-distinct-elements-unique-value.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="generate-id-distinct-elements-unique-value.xsl"?>
+<root>
+  <value>1</value>
+  <value>2</value>
+  <value>3</value>
+</root>

--- a/LayoutTests/fast/xsl/generate-id-distinct-elements-unique-value.xsl
+++ b/LayoutTests/fast/xsl/generate-id-distinct-elements-unique-value.xsl
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" />
+  <xsl:template match="root">
+    <html><body>
+    <script>
+      if (testRunner) {
+        testRunner.dumpAsText();
+      }
+    </script>
+    <p>
+      Verify that generate-id() does not return the same value for different
+      nodes.
+    </p>
+    <xsl:for-each select="/root/value">
+      <xsl:variable name="current-node" select="." />
+      <xsl:for-each select="./following-sibling::*">
+        <xsl:variable name="subsequent-node" select="." />
+        <xsl:variable name="first-id" select="generate-id($current-node)" />
+        <xsl:variable name="second-id" select="generate-id($subsequent-node)" />
+        <p>
+          <xsl:value-of select="$current-node" /> and <xsl:value-of select="$subsequent-node" />
+          <xsl:choose>
+            <xsl:when test="$first-id != $second-id"> have distinct IDs as expected: PASSED</xsl:when>
+            <xsl:otherwise> have matching IDs but are distinct nodes (got <xsl:value-of select="$first-id" /> and <xsl:value-of select="$second-id" />): FAILED</xsl:otherwise>
+          </xsl:choose>
+        </p>
+      </xsl:for-each>
+    </xsl:for-each>
+    </body></html>
+  </xsl:template>
+</xsl:stylesheet>

--- a/LayoutTests/fast/xsl/generate-id-multiple-calls-same-value-expected.txt
+++ b/LayoutTests/fast/xsl/generate-id-multiple-calls-same-value-expected.txt
@@ -1,0 +1,7 @@
+Verify that generate-id() returns the same value each time it is called for a given node in the current document in the current transform.
+
+Value 1 IDs matched as expected: PASSED
+
+Value 2 IDs matched as expected: PASSED
+
+Value 3 IDs matched as expected: PASSED

--- a/LayoutTests/fast/xsl/generate-id-multiple-calls-same-value.xml
+++ b/LayoutTests/fast/xsl/generate-id-multiple-calls-same-value.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="generate-id-multiple-calls-same-value.xsl"?>
+<root>
+  <value>1</value>
+  <value>2</value>
+  <value>3</value>
+</root>

--- a/LayoutTests/fast/xsl/generate-id-multiple-calls-same-value.xsl
+++ b/LayoutTests/fast/xsl/generate-id-multiple-calls-same-value.xsl
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" />
+  <xsl:template match="root">
+    <html><body>
+    <script>
+      if (testRunner) {
+        testRunner.dumpAsText();
+      }
+    </script>
+    <p>
+      Verify that generate-id() returns the same value each time it is called
+      for a given node in the current document in the current transform.
+    </p>
+    <xsl:for-each select="/root/value">
+      <p>Value <xsl:value-of select="."/> IDs
+        <xsl:variable name="first" select="generate-id()" />
+        <xsl:variable name="second" select="generate-id()" />
+        <xsl:choose>
+          <xsl:when test="$first = $second">matched as expected: PASSED</xsl:when>
+          <xsl:otherwise>didn't match (got <xsl:value-of select="$first" /> and <xsl:value-of select="$second" />): FAILED</xsl:otherwise>
+        </xsl:choose>
+      </p>
+    </xsl:for-each>
+    </body></html>
+  </xsl:template>
+</xsl:stylesheet>


### PR DESCRIPTION
#### e7dc5db65bb2b42123bb4f0623e552cc56642fd9
<pre>
Add XSLT layout test
<a href="https://bugs.webkit.org/show_bug.cgi?id=293409">https://bugs.webkit.org/show_bug.cgi?id=293409</a>
<a href="https://rdar.apple.com/problem/151826889">rdar://problem/151826889</a>

Reviewed by David Kilzer.

Adding new test to ensure correct behavior, these were picked up from
<a href="https://source.chromium.org/chromium/chromium/src/+/e28eca57032ef5291631b2461d3a21628adec856">https://source.chromium.org/chromium/chromium/src/+/e28eca57032ef5291631b2461d3a21628adec856</a>

* LayoutTests/fast/xsl/generate-id-distinct-elements-unique-value-expected.txt: Added.
* LayoutTests/fast/xsl/generate-id-distinct-elements-unique-value.xml: Added.
* LayoutTests/fast/xsl/generate-id-distinct-elements-unique-value.xsl: Added.
* LayoutTests/fast/xsl/generate-id-multiple-calls-same-value-expected.txt: Added.
* LayoutTests/fast/xsl/generate-id-multiple-calls-same-value.xml: Added.
* LayoutTests/fast/xsl/generate-id-multiple-calls-same-value.xsl: Added.

Canonical link: <a href="https://commits.webkit.org/295355@main">https://commits.webkit.org/295355@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/63dc1be0fbcac7624ee130438adc76fd4edc2d89

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104717 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24429 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/14851 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/109931 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/55391 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/24820 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/32975 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79517 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107723 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19304 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94512 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59824 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/19071 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/12588 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/54766 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/88768 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/12636 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/112326 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/31882 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23452 "Found 1 new test failure: workers/sab/growable-shared-array-buffer-serialization.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88598 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32246 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/90740 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88221 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33111 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10886 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/27195 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17005 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/31807 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/31599 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/34940 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33158 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->