### PR TITLE
[GTK] GTK3 build fixes due to missing guard and headers

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1708,6 +1708,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     page/FrameSnapshotting.h
     page/FrameTree.h
     page/FrameView.h
+    page/GetComposedRangesOptions.h
     page/GlobalFrameIdentifier.h
     page/GlobalWindowIdentifier.h
     page/HandleUserInputEventResult.h

--- a/Source/WebKit/UIProcess/Automation/glib/BidiBrowserAgentGlib.cpp
+++ b/Source/WebKit/UIProcess/Automation/glib/BidiBrowserAgentGlib.cpp
@@ -29,7 +29,9 @@
 #if ENABLE(WEBDRIVER_BIDI)
 
 #include "BidiUserContext.h"
+#if ENABLE(2022_GLIB_API)
 #include "WebKitNetworkSession.h"
+#endif
 #include "WebKitWebContextPrivate.h"
 #include "WebKitWebsiteDataManagerPrivate.h"
 


### PR DESCRIPTION
#### 150fa103a89ef4095e520ddd3ebc5b7d050dc5aa
<pre>
[GTK] GTK3 build fixes due to missing guard and headers
<a href="https://bugs.webkit.org/show_bug.cgi?id=293412">https://bugs.webkit.org/show_bug.cgi?id=293412</a>

Reviewed by Adrian Perez de Castro.

294087@main added a new WebCore generated file GetComposedRangesOptions
that&apos;s used by DOMSelection which in turn is used by the GTK InjectedBundle
code in Source/WebKit.

And 293942@main added a new WebDriver class that used the 2022 API
WebKitNetworkSession but was missing the proper guard.

While this commit makes the GTK3 build past these errors, there are a
few more build failures related to 295196@main removing some fields from
DOMSelection that are used by the old WebKitDOMDOMSelection class. These
can be fixed in a follow-up commit.

* Source/WebCore/Headers.cmake: Add new GetComposedRangesOption header.
* Source/WebKit/UIProcess/Automation/glib/BidiBrowserAgentGlib.cpp:
  Guard WebKitNetworkSession with proper 2022 API check.

Canonical link: <a href="https://commits.webkit.org/295341@main">https://commits.webkit.org/295341@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2097c5536e156e61b46254ca373aaf8dc7859fa2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104582 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24292 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/14710 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/109793 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/55253 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/106622 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/24678 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/32837 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79410 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107588 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19189 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94387 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59722 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/18969 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/12462 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/54626 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/88668 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/12514 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/112183 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/31743 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23365 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88494 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32107 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/90621 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88113 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22501 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33016 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10785 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/27060 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/31670 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/37011 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/31462 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/34801 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33022 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->