### PR TITLE
Web Inspector: enable Timeline recordings in Workers by default

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Base/Setting.js
+++ b/Source/WebInspectorUI/UserInterface/Base/Setting.js
@@ -243,7 +243,6 @@ WI.settings = {
     experimentalShowCaseSensitiveAutocomplete: new WI.Setting("experimental-show-case-sensitive-auto-complete", false),
     experimentalLimitSourceCodeHighlighting: new WI.Setting("engineering-limit-source-code-highlighting", false),
     experimentalUseFuzzyMatchingForCSSCodeCompletion: new WI.Setting("experimental-use-fuzzy-matching-for-css-code-completion", true),
-    experimentalEnableWorkerTimelineRecording: new WI.Setting("experimental-worker-timeline-recording", false),
     experimentalVirtualizeSourcesNavigationSidebarTreeOutline: new WI.Setting("experimental-virtualize-sources-navigation-sidebar-tree-outline", false),
 
     // Protocol

--- a/Source/WebInspectorUI/UserInterface/Models/HeapAllocationsInstrument.js
+++ b/Source/WebInspectorUI/UserInterface/Models/HeapAllocationsInstrument.js
@@ -45,11 +45,8 @@ WI.HeapAllocationsInstrument = class HeapAllocationsInstrument extends WI.Instru
         // FIXME: Include a periodic snapshot interval option for this instrument.
 
         if (!initiatedByBackend) {
-            for (let target of WI.targets) {
-                if (target.type === WI.TargetType.Worker && !WI.settings.experimentalEnableWorkerTimelineRecording.value)
-                    continue;
+            for (let target of WI.targets)
                 target.HeapAgent.startTracking();
-            }
         }
 
         // Periodic snapshots.
@@ -60,11 +57,8 @@ WI.HeapAllocationsInstrument = class HeapAllocationsInstrument extends WI.Instru
     stopInstrumentation(initiatedByBackend)
     {
         if (!initiatedByBackend) {
-            for (let target of WI.targets) {
-                if (target.type === WI.TargetType.Worker && !WI.settings.experimentalEnableWorkerTimelineRecording.value)
-                    continue;
+            for (let target of WI.targets)
                 target.HeapAgent.stopTracking();
-            }
         }
 
         window.clearInterval(this._snapshotIntervalIdentifier);

--- a/Source/WebInspectorUI/UserInterface/Models/Instrument.js
+++ b/Source/WebInspectorUI/UserInterface/Models/Instrument.js
@@ -67,8 +67,6 @@ WI.Instrument = class Instrument
             return;
 
         for (let target of WI.targets) {
-            if (target.type === WI.TargetType.Worker && !WI.settings.experimentalEnableWorkerTimelineRecording.value)
-                continue;
             // COMPATIBILITY (iOS X.Y, macOS X.Y): `Timeline.start` did not exist yet for Worker targets.
             if (target.hasDomain("Timeline"))
                 target.TimelineAgent.start();
@@ -88,8 +86,6 @@ WI.Instrument = class Instrument
             return;
 
         for (let target of WI.targets) {
-            if (target.type === WI.TargetType.Worker && !WI.settings.experimentalEnableWorkerTimelineRecording.value)
-                continue;
             // COMPATIBILITY (iOS X.Y, macOS X.Y): `Timeline.stop` did not exist yet for Worker targets.
             if (target.hasDomain("Timeline"))
                 target.TimelineAgent.stop();

--- a/Source/WebInspectorUI/UserInterface/Models/ScriptInstrument.js
+++ b/Source/WebInspectorUI/UserInterface/Models/ScriptInstrument.js
@@ -39,8 +39,6 @@ WI.ScriptInstrument = class ScriptInstrument extends WI.Instrument
 
         if (!initiatedByBackend) {
             for (let target of WI.targets) {
-                if (target.type === WI.TargetType.Worker && !WI.settings.experimentalEnableWorkerTimelineRecording.value)
-                    continue;
                 // COMPATIBILITY (iOS X.Y, macOS X.Y): `ScriptProfiler.startTracking` did not exist yet in Worker targets.
                 if (target.hasDomain("ScriptProfiler"))
                     target.ScriptProfilerAgent.startTracking(includeSamples);
@@ -52,8 +50,6 @@ WI.ScriptInstrument = class ScriptInstrument extends WI.Instrument
     {
         if (!initiatedByBackend) {
             for (let target of WI.targets) {
-                if (target.type === WI.TargetType.Worker && !WI.settings.experimentalEnableWorkerTimelineRecording.value)
-                    continue;
                 // COMPATIBILITY (iOS X.Y, macOS X.Y): `ScriptProfiler.stopTracking` did not exist yet for Worker targets.
                 if (target.hasDomain("ScriptProfiler"))
                     target.ScriptProfilerAgent.stopTracking();

--- a/Source/WebInspectorUI/UserInterface/Models/TimelineRecording.js
+++ b/Source/WebInspectorUI/UserInterface/Models/TimelineRecording.js
@@ -422,17 +422,15 @@ WI.TimelineRecording = class TimelineRecording extends WI.Object
 
     updateCallingContextTrees(target, stackTraces, sampleDurations)
     {
-        if (target === WI.mainTarget || WI.settings.experimentalEnableWorkerTimelineRecording.value) {
-            let exportDataSamples = this._exportDataSamplesForTarget.getOrInitialize(target, () => {
-                return {
-                    target: target.exportData(),
-                    stackTraces: [],
-                    durations: [],
-                };
-            });
-            exportDataSamples.stackTraces.pushAll(stackTraces);
-            exportDataSamples.durations.pushAll(sampleDurations);
-        }
+        let exportDataSamples = this._exportDataSamplesForTarget.getOrInitialize(target, () => {
+            return {
+                target: target.exportData(),
+                stackTraces: [],
+                durations: [],
+            };
+        });
+        exportDataSamples.stackTraces.pushAll(stackTraces);
+        exportDataSamples.durations.pushAll(sampleDurations);
 
         let scriptTimeline = this._timelines.get(WI.TimelineRecord.Type.Script);
         console.assert(scriptTimeline, this._timelines);

--- a/Source/WebInspectorUI/UserInterface/Views/SettingsTabContentView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/SettingsTabContentView.js
@@ -438,14 +438,6 @@ WI.SettingsTabContentView = class SettingsTabContentView extends WI.TabContentVi
 
         experimentalSettingsView.addSeparator();
 
-        let hasTimelineDomain = InspectorBackend.hasDomain("Timeline");
-        if (hasTimelineDomain) {
-            let timelinesGroup = experimentalSettingsView.addGroup(WI.UIString("Timelines:", "Timelines: @ Experimental Settings", "Category label for experimental settings related to the Timelines Tab."));
-            timelinesGroup.addSetting(WI.settings.experimentalEnableWorkerTimelineRecording, WI.UIString("Enable recording in Workers", "Label for checkbox that controls whether timeline recordings can capture activity in Worker contexts."));
-        }
-
-        experimentalSettingsView.addSeparator();
-
         let diagnosticsGroup = experimentalSettingsView.addGroup(WI.UIString("Diagnostics:", "Diagnostics: @ Experimental Settings", "Category label for experimental settings related to Web Inspector diagnostics."));
         diagnosticsGroup.addSetting(WI.settings.experimentalAllowInspectingInspector, WI.UIString("Allow Inspecting Web Inspector", "Allow Inspecting Web Inspector @ Experimental Settings", "Label for setting that allows the user to inspect the Web Inspector user interface."));
         experimentalSettingsView.addSeparator();
@@ -481,9 +473,6 @@ WI.SettingsTabContentView = class SettingsTabContentView extends WI.TabContentVi
         listenForChange(WI.settings.experimentalLimitSourceCodeHighlighting);
         listenForChange(WI.settings.experimentalUseFuzzyMatchingForCSSCodeCompletion);
         listenForChange(WI.settings.experimentalVirtualizeSourcesNavigationSidebarTreeOutline);
-
-        if (hasTimelineDomain)
-            listenForChange(WI.settings.experimentalEnableWorkerTimelineRecording);
 
         this._createReferenceLink(experimentalSettingsView);
 


### PR DESCRIPTION
#### 2b4a37f38452a2edfba7b3715eeb60ce036b7396
<pre>
Web Inspector: enable Timeline recordings in Workers by default
<a href="https://bugs.webkit.org/show_bug.cgi?id=293315">https://bugs.webkit.org/show_bug.cgi?id=293315</a>
&lt;<a href="https://rdar.apple.com/problem/151721737">rdar://problem/151721737</a>&gt;

Reviewed by BJ Burg.

* Source/WebInspectorUI/UserInterface/Base/Setting.js:
* Source/WebInspectorUI/UserInterface/Models/HeapAllocationsInstrument.js:
(WI.HeapAllocationsInstrument.prototype.startInstrumentation):
(WI.HeapAllocationsInstrument.prototype.stopInstrumentation):
* Source/WebInspectorUI/UserInterface/Models/Instrument.js:
(WI.Instrument.startLegacyTimelineAgent):
(WI.Instrument.stopLegacyTimelineAgent):
* Source/WebInspectorUI/UserInterface/Models/ScriptInstrument.js:
(WI.ScriptInstrument.prototype.startInstrumentation):
(WI.ScriptInstrument.prototype.stopInstrumentation):
* Source/WebInspectorUI/UserInterface/Models/TimelineRecording.js:
(WI.TimelineRecording.prototype.updateCallingContextTrees):
* Source/WebInspectorUI/UserInterface/Views/SettingsTabContentView.js:
(WI.SettingsTabContentView.prototype._createExperimentalSettingsView):

Canonical link: <a href="https://commits.webkit.org/295485@main">https://commits.webkit.org/295485@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bcaa1cc6fda44148d1ae4130d7fa3d2d353052a6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105236 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24948 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15373 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110449 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/55895 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/25378 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33492 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79927 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/55895 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108242 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19786 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94986 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60234 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/19541 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13060 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55290 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/89242 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13104 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/113040 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32396 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/23865 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89003 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32760 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91202 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/88639 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22604 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33535 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11323 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/27804 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32319 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/37732 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/32100 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/35444 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33666 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->