### PR TITLE
[GTK][WPE] Share the implementation of wallTimeForEventTime()

### DIFF
--- a/Source/WebCore/platform/gtk/GtkUtilities.cpp
+++ b/Source/WebCore/platform/gtk/GtkUtilities.cpp
@@ -121,25 +121,6 @@ unsigned widgetKeyvalToKeycode(GtkWidget* widget, unsigned keyval)
     return keycode;
 }
 
-template<>
-WallTime wallTimeForEvent(const GdkEvent* event)
-{
-    // This works if and only if the X server or Wayland compositor happens to
-    // be using CLOCK_MONOTONIC for its monotonic time, and so long as
-    // g_get_monotonic_time() continues to do so as well, and so long as
-    // MonotonicTime continues to use g_get_monotonic_time().
-#if USE(GTK4)
-    if (!event)
-        return WallTime::now();
-    auto time = gdk_event_get_time(const_cast<GdkEvent*>(event));
-#else
-    auto time = gdk_event_get_time(event);
-#endif
-    if (time == GDK_CURRENT_TIME)
-        return WallTime::now();
-    return MonotonicTime::fromRawSeconds(time / 1000.).approximateWallTime();
-}
-
 unsigned stateModifierForGdkButton(unsigned button)
 {
     return 1 << (8 + button - 1);

--- a/Source/WebCore/platform/gtk/GtkUtilities.h
+++ b/Source/WebCore/platform/gtk/GtkUtilities.h
@@ -21,7 +21,6 @@
 #include "DragActions.h"
 #include <gtk/gtk.h>
 #include <wtf/MonotonicTime.h>
-#include <wtf/WallTime.h>
 #include <wtf/text/CString.h>
 #include <wtf/text/WTFString.h>
 
@@ -34,18 +33,6 @@ bool widgetIsOnscreenToplevelWindow(GtkWidget*);
 IntPoint widgetRootCoords(GtkWidget*, int, int);
 void widgetDevicePosition(GtkWidget*, GdkDevice*, double*, double*, GdkModifierType*);
 unsigned widgetKeyvalToKeycode(GtkWidget*, unsigned);
-
-template<typename GdkEventType>
-WallTime wallTimeForEvent(const GdkEventType* event)
-{
-    const auto eventTime = gdk_event_get_time(reinterpret_cast<GdkEvent*>(const_cast<GdkEventType*>(event)));
-    if (eventTime == GDK_CURRENT_TIME)
-        return WallTime::now();
-    return MonotonicTime::fromRawSeconds(eventTime / 1000.).approximateWallTime();
-}
-
-template<>
-WallTime wallTimeForEvent(const GdkEvent*);
 
 WEBCORE_EXPORT unsigned stateModifierForGdkButton(unsigned button);
 

--- a/Source/WebKit/Shared/WebEventConversion.cpp
+++ b/Source/WebKit/Shared/WebEventConversion.cpp
@@ -519,4 +519,24 @@ WebCore::PlatformGestureEvent platform(const WebGestureEvent& webEvent)
 }
 #endif
 
+#if PLATFORM(GTK) || PLATFORM(WPE) || USE(LIBWPE)
+WallTime wallTimeForEventTimeInMilliseconds(uint64_t timestamp)
+{
+    if (!timestamp)
+        return WallTime::now();
+
+    // GTK and WPE events provide a timestamp as uint32_t, which is too small for full millisecond timestamps since
+    // the epoch. They are expected to be just timestamps with monotonic behavior to be compared among themselves,
+    // not against WallTime-like measurements. Thus the need to define a reference origin based on the first event
+    // received.
+    static WallTime firstEventWallTime;
+    static uint64_t firstEventTimestamp = 0;
+    if (!firstEventTimestamp) {
+        firstEventTimestamp = timestamp;
+        firstEventWallTime = WallTime::now();
+    }
+    return firstEventWallTime + Seconds::fromMilliseconds(timestamp - firstEventTimestamp);
+}
+#endif
+
 } // namespace WebKit

--- a/Source/WebKit/Shared/WebEventConversion.h
+++ b/Source/WebKit/Shared/WebEventConversion.h
@@ -82,4 +82,8 @@ WebEventType kit(WebCore::PlatformEvent::Type);
 OptionSet<WebCore::PlatformEvent::Modifier> platform(OptionSet<WebEventModifier>);
 OptionSet<WebKit::WebEventModifier> kit(OptionSet<WebCore::PlatformEvent::Modifier>);
 
+#if PLATFORM(GTK) || PLATFORM(WPE) || USE(LIBWPE)
+WallTime wallTimeForEventTimeInMilliseconds(uint64_t);
+#endif
+
 } // namespace WebKit

--- a/Source/WebKit/Shared/wpe/WebEventFactoryWPE.cpp
+++ b/Source/WebKit/Shared/wpe/WebEventFactoryWPE.cpp
@@ -27,6 +27,7 @@
 #include "WebEventFactory.h"
 
 #if ENABLE(WPE_PLATFORM)
+#include "WebEventConversion.h"
 #include <WebCore/FloatPoint.h>
 #include <WebCore/Scrollbar.h>
 #include <wpe/wpe-platform.h>
@@ -42,7 +43,7 @@ static WallTime wallTimeForEvent(WPEEvent* event)
     auto time = wpe_event_get_time(event);
     if (!time)
         return WallTime::now();
-    return MonotonicTime::fromRawSeconds(time / 1000.).approximateWallTime();
+    return wallTimeForEventTimeInMilliseconds(time);
 }
 
 static OptionSet<WebEventModifier> modifiersFromWPEModifiers(WPEModifiers wpeModifiers)


### PR DESCRIPTION
#### a8ebf9965c252edce2e1352576a3fe730e377bf3
<pre>
[GTK][WPE] Share the implementation of wallTimeForEventTime()
<a href="https://bugs.webkit.org/show_bug.cgi?id=293414">https://bugs.webkit.org/show_bug.cgi?id=293414</a>

Reviewed by Adrian Perez de Castro.

The libwpe implementation deals with rounding issues due to timestamp
being a 32 bit unsigned, so we can use that one for GTK and WPE platform
API too.

Canonical link: <a href="https://commits.webkit.org/295264@main">https://commits.webkit.org/295264@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2252693be95f0d190517c89b417949d798f1a064

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104596 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24306 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/14724 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/109808 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/55267 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/106636 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/24693 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/32851 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79424 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107602 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19204 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94400 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59736 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/18988 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/12475 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/54640 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/88682 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/12527 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/112198 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/31757 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/23378 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88507 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32121 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/90634 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88126 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33029 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10798 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/27074 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16969 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/31684 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/37026 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/31477 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/34815 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33036 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->