### PR TITLE
[JSC] JSWebAssemblyException should be a derived class from ErrorInstance

### DIFF
--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyException.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyException.cpp
@@ -49,7 +49,7 @@ Structure* JSWebAssemblyException::createStructure(VM& vm, JSGlobalObject* globa
 }
 
 JSWebAssemblyException::JSWebAssemblyException(VM& vm, Structure* structure, Ref<const Wasm::Tag>&& tag, FixedVector<uint64_t>&& payload)
-    : Base(vm, structure)
+    : Base(vm, structure, ErrorType::Error)
     , m_tag(WTFMove(tag))
     , m_payload(WTFMove(payload))
 {
@@ -57,7 +57,7 @@ JSWebAssemblyException::JSWebAssemblyException(VM& vm, Structure* structure, Ref
 
 void JSWebAssemblyException::finishCreation(VM& vm)
 {
-    Base::finishCreation(vm);
+    Base::finishCreation(vm, String(), JSValue());
     ASSERT(inherits(info()));
     vm.heap.reportExtraMemoryAllocated(this, payload().byteSize());
 }

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyException.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyException.h
@@ -28,15 +28,15 @@
 
 #if ENABLE(WEBASSEMBLY)
 
+#include "ErrorInstance.h"
 #include "JSObject.h"
 #include "WasmTag.h"
 
 namespace JSC {
 
-class JSWebAssemblyException final : public JSNonFinalObject {
+class JSWebAssemblyException final : public ErrorInstance {
 public:
-    using Base = JSNonFinalObject;
-    static constexpr DestructionMode needsDestruction = NeedsDestruction;
+    using Base = ErrorInstance;
     using Payload = FixedVector<uint64_t>;
 
     static void destroy(JSCell*);


### PR DESCRIPTION
#### 552ce57784f136079dc1d17c2a0d23b906336f68
<pre>
[JSC] JSWebAssemblyException should be a derived class from ErrorInstance
<a href="https://bugs.webkit.org/show_bug.cgi?id=293417">https://bugs.webkit.org/show_bug.cgi?id=293417</a>
<a href="https://rdar.apple.com/151840996">rdar://151840996</a>

Reviewed by NOBODY (OOPS!).

As it is using ErrorInstanceType, it should be a derived class from
ErrorInstance. JSType should reflect our type hierarchy.

* Source/JavaScriptCore/wasm/js/JSWebAssemblyException.cpp:
(JSC::JSWebAssemblyException::JSWebAssemblyException):
(JSC::JSWebAssemblyException::finishCreation):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyException.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/552ce57784f136079dc1d17c2a0d23b906336f68

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104604 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24314 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/14732 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/109816 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/55275 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/24701 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/32859 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79430 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107610 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19212 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94407 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59742 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/19004 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/12482 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/54648 "Built successfully") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/97283 "Found 13 new JSC stress test failures: wasm.yaml/wasm/v8/regress/regress-8094.js.default-wasm, wasm.yaml/wasm/v8/regress/regress-8094.js.wasm-aggressive-inline, wasm.yaml/wasm/v8/regress/regress-8094.js.wasm-bbq, wasm.yaml/wasm/v8/regress/regress-8094.js.wasm-bbq-no-consts, wasm.yaml/wasm/v8/regress/regress-8094.js.wasm-collect-continuously, wasm.yaml/wasm/v8/regress/regress-8094.js.wasm-eager, wasm.yaml/wasm/v8/regress/regress-8094.js.wasm-eager-jettison, wasm.yaml/wasm/v8/regress/regress-8094.js.wasm-graph-reg-alloc, wasm.yaml/wasm/v8/regress/regress-8094.js.wasm-no-cjit, wasm.yaml/wasm/v8/regress/regress-8094.js.wasm-no-wasm-jit ... (failure)") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/88703 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/12534 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/112207 "Built successfully") | 
| [❌ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/103219 "Found 13 new JSC stress test failures: wasm.yaml/wasm/v8/regress/regress-8094.js.default-wasm, wasm.yaml/wasm/v8/regress/regress-8094.js.wasm-aggressive-inline, wasm.yaml/wasm/v8/regress/regress-8094.js.wasm-bbq, wasm.yaml/wasm/v8/regress/regress-8094.js.wasm-bbq-no-consts, wasm.yaml/wasm/v8/regress/regress-8094.js.wasm-collect-continuously, wasm.yaml/wasm/v8/regress/regress-8094.js.wasm-eager, wasm.yaml/wasm/v8/regress/regress-8094.js.wasm-eager-jettison, wasm.yaml/wasm/v8/regress/regress-8094.js.wasm-graph-reg-alloc, wasm.yaml/wasm/v8/regress/regress-8094.js.wasm-no-cjit, wasm.yaml/wasm/v8/regress/regress-8094.js.wasm-no-wasm-jit ... (failure)") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/31765 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23384 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88516 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32129 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/90641 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88135 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33035 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10805 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/27082 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/31692 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/37034 "Built successfully") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/127500 "Build was cancelled. Recent messages:Printed configuration; Running apply-patch; Failed to checkout and rebase branch from PR 45758") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/31485 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/127500 "Build was cancelled. Recent messages:Printed configuration; Running apply-patch; Failed to checkout and rebase branch from PR 45758") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/34823 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33044 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->