### PR TITLE
[WPE] Guard WPE gamepad sources by ENABLE(GAMEPAD) define

### DIFF
--- a/Source/WebCore/platform/gamepad/libwpe/GamepadLibWPE.cpp
+++ b/Source/WebCore/platform/gamepad/libwpe/GamepadLibWPE.cpp
@@ -27,7 +27,9 @@
 #include "config.h"
 #include "GamepadLibWPE.h"
 
-#if ENABLE(GAMEPAD) && USE(LIBWPE) && WPE_CHECK_VERSION(1, 13, 90)
+#if ENABLE(GAMEPAD) && USE(LIBWPE)
+
+#if WPE_CHECK_VERSION(1, 13, 90)
 
 #include "GamepadProviderLibWPE.h"
 
@@ -85,4 +87,6 @@ void GamepadLibWPE::absoluteAxisChanged(unsigned axis, double value)
 
 } // namespace WebCore
 
-#endif // ENABLE(GAMEPAD) && USE(LIBWPE) && WPE_CHECK_VERSION(1, 13, 90)
+#endif // WPE_CHECK_VERSION(1, 13, 90)
+
+#endif // ENABLE(GAMEPAD) && USE(LIBWPE)

--- a/Source/WebCore/platform/gamepad/libwpe/GamepadProviderLibWPE.cpp
+++ b/Source/WebCore/platform/gamepad/libwpe/GamepadProviderLibWPE.cpp
@@ -27,7 +27,9 @@
 #include "config.h"
 #include "GamepadProviderLibWPE.h"
 
-#if ENABLE(GAMEPAD) && USE(LIBWPE) && WPE_CHECK_VERSION(1, 13, 90)
+#if ENABLE(GAMEPAD) && USE(LIBWPE)
+
+#if WPE_CHECK_VERSION(1, 13, 90)
 
 #include "GamepadLibWPE.h"
 #include "GamepadProviderClient.h"
@@ -234,4 +236,5 @@ void GamepadProviderLibWPE::stopEffects(unsigned, const String&, CompletionHandl
 
 } // namespace WebCore
 
+#endif // ENABLE(GAMEPAD) && USE(LIBWPE) && WPE_CHECK_VERSION(1, 13, 90)
 #endif // ENABLE(GAMEPAD) && USE(LIBWPE) && WPE_CHECK_VERSION(1, 13, 90)

--- a/Source/WebKit/UIProcess/Gamepad/wpe/GamepadProviderWPE.cpp
+++ b/Source/WebKit/UIProcess/Gamepad/wpe/GamepadProviderWPE.cpp
@@ -26,7 +26,7 @@
 #include "config.h"
 #include "GamepadProviderWPE.h"
 
-#if ENABLE(WPE_PLATFORM)
+#if ENABLE(GAMEPAD) && ENABLE(WPE_PLATFORM)
 #include "PlatformGamepadWPE.h"
 #include <WebCore/GamepadProviderClient.h>
 #include <WebCore/NotImplemented.h>
@@ -181,4 +181,4 @@ void GamepadProviderWPE::notifyInput(PlatformGamepadWPE& gamepad, ShouldMakeGame
 
 } // namespace WebKit
 
-#endif // ENABLE(WPE_PLATFORM)
+#endif // ENABLE(GAMEPAD) && ENABLE(WPE_PLATFORM)

--- a/Source/WebKit/UIProcess/Gamepad/wpe/GamepadProviderWPE.h
+++ b/Source/WebKit/UIProcess/Gamepad/wpe/GamepadProviderWPE.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#if ENABLE(WPE_PLATFORM)
+#if ENABLE(GAMEPAD) && ENABLE(WPE_PLATFORM)
 #include <WebCore/GamepadProvider.h>
 #include <wtf/HashMap.h>
 #include <wtf/RunLoop.h>
@@ -79,4 +79,4 @@ private:
 
 } // namespace WebKit
 
-#endif // ENABLE(WPE_PLATFORM)
+#endif // ENABLE(GAMEPAD) && ENABLE(WPE_PLATFORM)

--- a/Source/WebKit/UIProcess/Gamepad/wpe/PlatformGamepadWPE.cpp
+++ b/Source/WebKit/UIProcess/Gamepad/wpe/PlatformGamepadWPE.cpp
@@ -26,7 +26,7 @@
 #include "config.h"
 #include "PlatformGamepadWPE.h"
 
-#if ENABLE(WPE_PLATFORM)
+#if ENABLE(GAMEPAD) && ENABLE(WPE_PLATFORM)
 #include <wpe/wpe-platform.h>
 
 namespace WebKit {
@@ -78,4 +78,4 @@ void PlatformGamepadWPE::axisEvent(size_t axis, double value)
 
 } // namespace WebKit
 
-#endif // ENABLE(WPE_PLATFORM)
+#endif // ENABLE(GAMEPAD) && ENABLE(WPE_PLATFORM)

--- a/Source/WebKit/UIProcess/Gamepad/wpe/PlatformGamepadWPE.h
+++ b/Source/WebKit/UIProcess/Gamepad/wpe/PlatformGamepadWPE.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#if ENABLE(WPE_PLATFORM)
+#if ENABLE(GAMEPAD) && ENABLE(WPE_PLATFORM)
 #include <WebCore/PlatformGamepad.h>
 #include <wtf/glib/GRefPtr.h>
 
@@ -52,4 +52,4 @@ private:
 
 } // namespace WebKit
 
-#endif // ENABLE(WPE_PLATFORM)
+#endif // ENABLE(GAMEPAD) && ENABLE(WPE_PLATFORM)


### PR DESCRIPTION
#### 6b8cc6776c839f8ab226819a192f06bb5483eaa3
<pre>
[WPE] Guard WPE gamepad sources by ENABLE(GAMEPAD) define
<a href="https://bugs.webkit.org/show_bug.cgi?id=293419">https://bugs.webkit.org/show_bug.cgi?id=293419</a>

Reviewed by Carlos Garcia Campos.

* Fix build when GAMEPAD feature is disabled
* Wrap WPE platform gamepad files with ENABLE(GAMEPAD) checks
* Separate WPE_CHECK_VERSION check to avoid macro undefined error

This change is related to <a href="https://commits.webkit.org/295094@main">https://commits.webkit.org/295094@main</a>

* Source/WebCore/platform/gamepad/libwpe/GamepadLibWPE.cpp:
* Source/WebCore/platform/gamepad/libwpe/GamepadProviderLibWPE.cpp:
* Source/WebKit/UIProcess/Gamepad/wpe/GamepadProviderWPE.cpp:
* Source/WebKit/UIProcess/Gamepad/wpe/GamepadProviderWPE.h:
* Source/WebKit/UIProcess/Gamepad/wpe/PlatformGamepadWPE.cpp:
* Source/WebKit/UIProcess/Gamepad/wpe/PlatformGamepadWPE.h:

Canonical link: <a href="https://commits.webkit.org/295273@main">https://commits.webkit.org/295273@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8149cd6b10cd2b3b017ada978ca29f0b2348c57e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104610 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24320 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/14738 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/109822 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/55281 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/106650 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/24707 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/32865 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79437 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107616 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19217 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94414 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59749 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/18998 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/12488 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/54654 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/88704 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/12540 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/112213 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/31771 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/23388 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88521 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32135 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/90647 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88140 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22452 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33042 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10811 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/27088 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/31698 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/37040 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/31491 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/34829 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33050 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->