### PR TITLE
Make NetworkSession::networkStorageSession() return a smart pointer

### DIFF
--- a/Source/WebCore/platform/network/NetworkStorageSession.cpp
+++ b/Source/WebCore/platform/network/NetworkStorageSession.cpp
@@ -96,11 +96,6 @@ void NetworkStorageSession::setTrackingPreventionDebugLoggingEnabled(bool enable
     m_isTrackingPreventionDebugLoggingEnabled = enabled;
 }
 
-bool NetworkStorageSession::trackingPreventionDebugLoggingEnabled() const
-{
-    return m_isTrackingPreventionDebugLoggingEnabled;
-}
-
 bool NetworkStorageSession::shouldBlockThirdPartyCookies(const RegistrableDomain& registrableDomain) const
 {
     if (!m_isTrackingPreventionEnabled || registrableDomain.isEmpty())

--- a/Source/WebCore/platform/network/NetworkStorageSession.h
+++ b/Source/WebCore/platform/network/NetworkStorageSession.h
@@ -239,7 +239,7 @@ public:
     WEBCORE_EXPORT void setTrackingPreventionEnabled(bool);
     WEBCORE_EXPORT bool trackingPreventionEnabled() const;
     WEBCORE_EXPORT void setTrackingPreventionDebugLoggingEnabled(bool);
-    WEBCORE_EXPORT bool trackingPreventionDebugLoggingEnabled() const;
+    bool trackingPreventionDebugLoggingEnabled() const { return m_isTrackingPreventionDebugLoggingEnabled; }
     WEBCORE_EXPORT ThirdPartyCookieBlockingDecision thirdPartyCookieBlockingDecisionForRequest(const ResourceRequest&, std::optional<FrameIdentifier>, std::optional<PageIdentifier>, ShouldRelaxThirdPartyCookieBlocking) const;
     ThirdPartyCookieBlockingDecision thirdPartyCookieBlockingDecisionForRequest(const URL& firstPartyForCookies, const URL& resource, std::optional<FrameIdentifier>, std::optional<PageIdentifier>, ShouldRelaxThirdPartyCookieBlocking) const;
     WEBCORE_EXPORT bool shouldBlockCookies(const ResourceRequest&, std::optional<FrameIdentifier>, std::optional<PageIdentifier>, ShouldRelaxThirdPartyCookieBlocking) const;

--- a/Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.cpp
+++ b/Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.cpp
@@ -605,7 +605,7 @@ void ResourceLoadStatisticsStore::updateClientSideCookiesAgeCap()
 
     RunLoop::protectedMain()->dispatch([store = Ref { m_store.get() }, seconds = capTime] () {
         if (auto* networkSession = store->networkSession()) {
-            if (auto* storageSession = networkSession->networkStorageSession())
+            if (CheckedPtr storageSession = networkSession->networkStorageSession())
                 storageSession->setAgeCapForClientSideCookies(seconds);
         }
     });
@@ -1795,7 +1795,7 @@ void ResourceLoadStatisticsStore::grantStorageAccess(SubFrameDomain&& subFrameDo
         CanRequestStorageAccessWithoutUserInteraction canRequestStorageAccessWithoutUserInteraction { CanRequestStorageAccessWithoutUserInteraction::No };
 
         if (auto* networkSession = store->networkSession()) {
-            if (auto* storageSession = networkSession->networkStorageSession()) {
+            if (CheckedPtr storageSession = networkSession->networkStorageSession()) {
                 additionalDomainGrants = storageSession->storageAccessQuirkForDomainPair(subFrameDomain, topFrameDomain);
                 canRequestStorageAccessWithoutUserInteraction = storageSession->canRequestStorageAccessForLoginOrCompatibilityPurposesWithoutPriorUserInteraction(subFrameDomain, topFrameDomain) ? CanRequestStorageAccessWithoutUserInteraction::Yes : CanRequestStorageAccessWithoutUserInteraction::No;
             }

--- a/Source/WebKit/NetworkProcess/NetworkSession.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkSession.cpp
@@ -110,6 +110,11 @@ NetworkStorageSession* NetworkSession::networkStorageSession() const
     return storageSession;
 }
 
+CheckedPtr<NetworkStorageSession> NetworkSession::checkedNetworkStorageSession() const
+{
+    return networkStorageSession();
+}
+
 static Ref<PCM::ManagerInterface> managerOrProxy(NetworkSession& networkSession, NetworkProcess& networkProcess, const NetworkSessionCreationParameters& parameters)
 {
     if (!parameters.pcmMachServiceName.isEmpty() && !networkSession.sessionID().isEphemeral())

--- a/Source/WebKit/NetworkProcess/NetworkSession.h
+++ b/Source/WebKit/NetworkProcess/NetworkSession.h
@@ -125,6 +125,7 @@ public:
     NetworkProcess& networkProcess() { return m_networkProcess; }
     Ref<NetworkProcess> protectedNetworkProcess();
     WebCore::NetworkStorageSession* networkStorageSession() const;
+    CheckedPtr<WebCore::NetworkStorageSession> checkedNetworkStorageSession() const;
 
     void registerNetworkDataTask(NetworkDataTask&);
     void unregisterNetworkDataTask(NetworkDataTask&);
@@ -187,7 +188,6 @@ public:
 
     NetworkCache::Cache* cache() { return m_cache.get(); }
 
-    PrefetchCache& prefetchCache() { return m_prefetchCache; }
     CheckedRef<PrefetchCache> checkedPrefetchCache();
     void clearPrefetchCache() { m_prefetchCache.clear(); }
 

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
@@ -1636,7 +1636,7 @@ SessionWrapper& NetworkSessionCocoa::sessionWrapperForTask(std::optional<WebPage
     if (isParentProcessAFullWebBrowser(networkProcess()))
         shouldBeConsideredAppBound = NavigatingToAppBoundDomain::No;
 
-    if (auto* storageSession = networkStorageSession()) {
+    if (CheckedPtr storageSession = networkStorageSession()) {
         auto firstParty = WebCore::RegistrableDomain(request.firstPartyForCookies());
         if (storageSession->shouldBlockThirdPartyCookiesButKeepFirstPartyCookiesFor(firstParty))
             return protectedSessionSetForPage(webPageProxyID)->isolatedSession(storedCredentialsPolicy, firstParty, shouldBeConsideredAppBound, *this);

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkTaskCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkTaskCocoa.mm
@@ -301,7 +301,7 @@ void NetworkTaskCocoa::unblockCookies()
     if (!m_hasBeenSetToUseStatelessCookieStorage)
         return;
 
-    if (auto* storageSession = m_networkSession->networkStorageSession()) {
+    if (CheckedPtr storageSession = m_networkSession->networkStorageSession()) {
         [task() _setExplicitCookieStorage:[storageSession->nsCookieStorage() _cookieStorage]];
         m_hasBeenSetToUseStatelessCookieStorage = false;
     }

--- a/Source/WebKit/NetworkProcess/cocoa/WebSocketTaskCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/WebSocketTaskCocoa.mm
@@ -60,7 +60,7 @@ WebSocketTask::WebSocketTask(NetworkSocketChannel& channel, WebPageProxyIdentifi
         m_topOrigin = clientOrigin.topOrigin;
 
     bool shouldBlockCookies = storedCredentialsPolicy == WebCore::StoredCredentialsPolicy::EphemeralStateless;
-    if (auto* networkStorageSession = networkSession() ? networkSession()->networkStorageSession() : nullptr) {
+    if (CheckedPtr networkStorageSession = networkSession() ? networkSession()->networkStorageSession() : nullptr) {
         if (!shouldBlockCookies)
             shouldBlockCookies = networkStorageSession->shouldBlockCookies(request, frameID, pageID, shouldRelaxThirdPartyCookieBlocking());
     }

--- a/Source/WebKit/NetworkProcess/curl/NetworkSessionCurl.cpp
+++ b/Source/WebKit/NetworkProcess/curl/NetworkSessionCurl.cpp
@@ -62,7 +62,7 @@ NetworkSessionCurl::~NetworkSessionCurl()
 
 void NetworkSessionCurl::clearAlternativeServices(WallTime)
 {
-    if (auto* storageSession = networkStorageSession())
+    if (CheckedPtr storageSession = networkStorageSession())
         storageSession->clearAlternativeServices();
 }
 

--- a/Source/WebKit/NetworkProcess/curl/WebSocketTaskCurl.cpp
+++ b/Source/WebKit/NetworkProcess/curl/WebSocketTaskCurl.cpp
@@ -129,7 +129,7 @@ void WebSocketTask::didOpen(WebCore::CurlStreamID)
     CString cookieHeader;
 
     if (m_request.allowCookies()) {
-        if (auto* storageSession = networkSession() ? networkSession()->networkStorageSession() : nullptr) {
+        if (CheckedPtr storageSession = networkSession() ? networkSession()->networkStorageSession() : nullptr) {
             auto includeSecureCookies = m_request.url().protocolIs("wss"_s) ? WebCore::IncludeSecureCookies::Yes : WebCore::IncludeSecureCookies::No;
             auto cookieHeaderField = storageSession->cookieRequestHeaderFieldValue(m_request.firstPartyForCookies(), WebCore::SameSiteInfo::create(m_request), m_request.url(), std::nullopt, std::nullopt, includeSecureCookies, WebCore::ApplyTrackingPrevention::Yes, WebCore::ShouldRelaxThirdPartyCookieBlocking::No).first;
             if (!cookieHeaderField.isEmpty())
@@ -311,7 +311,7 @@ Expected<bool, String> WebSocketTask::validateOpeningHandshake()
 
     auto serverSetCookie = m_handshake->serverSetCookie();
     if (!serverSetCookie.isEmpty()) {
-        if (auto* storageSession = networkSession() ? networkSession()->networkStorageSession() : nullptr)
+        if (CheckedPtr storageSession = networkSession() ? networkSession()->networkStorageSession() : nullptr)
             storageSession->setCookiesFromHTTPResponse(m_request.firstPartyForCookies(), m_request.url(), serverSetCookie);
     }
 

--- a/Source/WebKit/NetworkProcess/soup/NetworkSessionSoup.cpp
+++ b/Source/WebKit/NetworkProcess/soup/NetworkSessionSoup.cpp
@@ -47,7 +47,7 @@ NetworkSessionSoup::NetworkSessionSoup(NetworkProcess& networkProcess, const Net
     , m_networkSession(makeUnique<SoupNetworkSession>(m_sessionID))
     , m_persistentCredentialStorageEnabled(parameters.persistentCredentialStorageEnabled)
 {
-    auto* storageSession = networkStorageSession();
+    CheckedPtr storageSession = networkStorageSession();
     ASSERT(storageSession);
 
     storageSession->setCookieAcceptPolicy(parameters.cookieAcceptPolicy);
@@ -75,7 +75,7 @@ SoupSession* NetworkSessionSoup::soupSession() const
 
 void NetworkSessionSoup::setCookiePersistentStorage(const String& storagePath, SoupCookiePersistentStorageType storageType)
 {
-    auto* storageSession = networkStorageSession();
+    CheckedPtr storageSession = networkStorageSession();
     if (!storageSession)
         return;
 
@@ -139,7 +139,7 @@ std::unique_ptr<WebSocketTask> NetworkSessionSoup::createWebSocketTask(WebPagePr
 #endif
     }
 
-    bool shouldBlockCookies = networkStorageSession()->shouldBlockCookies(request, frameID, pageID, networkProcess().shouldRelaxThirdPartyCookieBlockingForPage(webPageProxyID));
+    bool shouldBlockCookies = checkedNetworkStorageSession()->shouldBlockCookies(request, frameID, pageID, networkProcess().shouldRelaxThirdPartyCookieBlockingForPage(webPageProxyID));
     if (shouldBlockCookies)
         soup_message_disable_feature(soupMessage.get(), SOUP_TYPE_COOKIE_JAR);
 

--- a/Source/WebKit/NetworkProcess/soup/WebSocketTaskSoup.cpp
+++ b/Source/WebKit/NetworkProcess/soup/WebSocketTaskSoup.cpp
@@ -86,13 +86,13 @@ WebSocketTask::WebSocketTask(NetworkSocketChannel& channel, const WebCore::Resou
     {
         // No need to subscribe to the "request-certificate" signal, just set the client certificate upfront.
         auto protectionSpace = WebCore::AuthenticationChallenge::protectionSpaceForClientCertificate(WebCore::soupURIToURL(soup_message_get_uri(msg)));
-        auto certificate = channel.session()->networkStorageSession()->credentialStorage().get(m_request.cachePartition(), protectionSpace).certificate();
+        auto certificate = channel.session()->checkedNetworkStorageSession()->credentialStorage().get(m_request.cachePartition(), protectionSpace).certificate();
         soup_message_set_tls_client_certificate(msg, certificate);
     }
 
     g_signal_connect(msg, "request-certificate-password", G_CALLBACK(+[](SoupMessage* msg, GTlsPassword* tlsPassword, WebSocketTask* task) -> gboolean {
         auto protectionSpace = WebCore::AuthenticationChallenge::protectionSpaceForClientCertificatePassword(WebCore::soupURIToURL(soup_message_get_uri(msg)), tlsPassword);
-        auto password = task->protectedChannel()->session()->networkStorageSession()->credentialStorage().get(task->m_request.cachePartition(), protectionSpace).password().utf8();
+        auto password = task->protectedChannel()->session()->checkedNetworkStorageSession()->credentialStorage().get(task->m_request.cachePartition(), protectionSpace).password().utf8();
         g_tls_password_set_value(tlsPassword, reinterpret_cast<const unsigned char*>(password.data()), password.length());
         soup_message_tls_client_certificate_password_request_complete(msg);
         return TRUE;

--- a/Source/WebKit/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
@@ -13,8 +13,6 @@ NetworkProcess/ServiceWorker/WebSWServerToContextConnection.cpp
 NetworkProcess/SharedWorker/WebSharedWorkerServerConnection.cpp
 NetworkProcess/cocoa/NetworkDataTaskCocoa.mm
 NetworkProcess/cocoa/NetworkSessionCocoa.mm
-NetworkProcess/cocoa/NetworkTaskCocoa.mm
-NetworkProcess/cocoa/WebSocketTaskCocoa.mm
 NetworkProcess/storage/NetworkStorageManager.cpp
 Platform/IPC/ArgumentCoders.h
 Shared/RemoteLayerTree/RemoteLayerBackingStoreCollection.mm


### PR DESCRIPTION
#### 801233ee219a83bd730929c59616d09536f607d1
<pre>
Make NetworkSession::networkStorageSession() return a smart pointer
<a href="https://bugs.webkit.org/show_bug.cgi?id=293423">https://bugs.webkit.org/show_bug.cgi?id=293423</a>

Reviewed by Chris Dumez.

Make NetworkSession::networkStorageSession() return a smart pointer.

* Source/WebCore/platform/network/NetworkStorageSession.cpp:
(WebCore::NetworkStorageSession::trackingPreventionDebugLoggingEnabled const): Deleted.
* Source/WebCore/platform/network/NetworkStorageSession.h:
(WebCore::NetworkStorageSession::trackingPreventionDebugLoggingEnabled const):
* Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.cpp:
(WebKit::ResourceLoadStatisticsStore::updateClientSideCookiesAgeCap):
(WebKit::ResourceLoadStatisticsStore::grantStorageAccess):
* Source/WebKit/NetworkProcess/NetworkSession.cpp:
(WebKit::NetworkSession::checkedNetworkStorageSession const):
* Source/WebKit/NetworkProcess/NetworkSession.h:
(WebKit::NetworkSession::prefetchCache): Deleted.
* Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm:
(WebKit::NetworkDataTaskCocoa::NetworkDataTaskCocoa):
(WebKit::NetworkDataTaskCocoa::willPerformHTTPRedirection):
(WebKit::NetworkDataTaskCocoa::tryPasswordBasedAuthentication):
* Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm:
(WebKit::NetworkSessionCocoa::sessionWrapperForTask):
* Source/WebKit/NetworkProcess/cocoa/NetworkTaskCocoa.mm:
(WebKit::NetworkTaskCocoa::unblockCookies):
* Source/WebKit/NetworkProcess/cocoa/WebSocketTaskCocoa.mm:
(WebKit::WebSocketTask::WebSocketTask):
* Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.cpp:
(WebKit::NetworkDataTaskCurl::NetworkDataTaskCurl):
(WebKit::NetworkDataTaskCurl::willPerformHTTPRedirection):
(WebKit::NetworkDataTaskCurl::tryHttpAuthentication):
(WebKit::NetworkDataTaskCurl::appendCookieHeader):
(WebKit::NetworkDataTaskCurl::shouldBlockCookies):
* Source/WebKit/NetworkProcess/curl/NetworkSessionCurl.cpp:
(WebKit::NetworkSessionCurl::clearAlternativeServices):
* Source/WebKit/NetworkProcess/curl/WebSocketTaskCurl.cpp:
(WebKit::WebSocketTask::didOpen):
(WebKit::WebSocketTask::validateOpeningHandshake):
* Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp:
(WebKit::NetworkDataTaskSoup::NetworkDataTaskSoup):
(WebKit::NetworkDataTaskSoup::authenticate):
(WebKit::NetworkDataTaskSoup::continueAuthenticate):
(WebKit::NetworkDataTaskSoup::continueHTTPRedirection):
(WebKit::NetworkDataTaskSoup::didGetHeaders):
* Source/WebKit/NetworkProcess/soup/NetworkSessionSoup.cpp:
(WebKit::NetworkSessionSoup::NetworkSessionSoup):
(WebKit::NetworkSessionSoup::setCookiePersistentStorage):
(WebKit::NetworkSessionSoup::createWebSocketTask):
* Source/WebKit/NetworkProcess/soup/WebSocketTaskSoup.cpp:
(WebKit::WebSocketTask::WebSocketTask):
* Source/WebKit/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations:

Canonical link: <a href="https://commits.webkit.org/295997@main">https://commits.webkit.org/295997@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/24488687ac33c9aec3250c3d4923e54c817dc496

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/106891 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/26612 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/17009 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/112099 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/57462 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/108898 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/27280 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/35113 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/81171 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/109863 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/21663 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/96431 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/61512 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/21106 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/14540 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/56911 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/91004 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/14567 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/115082 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33998 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/25088 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/90230 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/34364 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/92662 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89941 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22945 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34864 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/12677 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/29702 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/33922 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/39366 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/33669 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/37022 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/35291 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->