### PR TITLE
[Refactor] Make AudioBus::create() return a Ref

### DIFF
--- a/Source/WebCore/Modules/webaudio/AudioParam.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioParam.cpp
@@ -59,7 +59,7 @@ AudioParam::AudioParam(BaseAudioContext& context, const String& name, float defa
     , m_automationRate(automationRate)
     , m_automationRateMode(automationRateMode)
     , m_smoothedValue(defaultValue)
-    , m_summingBus(AudioBus::create(1, AudioUtilities::renderQuantumSize, false).releaseNonNull())
+    , m_summingBus(AudioBus::create(1, AudioUtilities::renderQuantumSize, false))
 #if !RELEASE_LOG_DISABLED
     , m_logger(context.logger())
     , m_logIdentifier(context.nextAudioParameterLogIdentifier())

--- a/Source/WebCore/Modules/webaudio/ConvolverNode.cpp
+++ b/Source/WebCore/Modules/webaudio/ConvolverNode.cpp
@@ -141,7 +141,7 @@ ExceptionOr<void> ConvolverNode::setBufferForBindings(RefPtr<AudioBuffer>&& buff
 
     // Create the reverb with the given impulse response.
     bool useBackgroundThreads = !context().isOfflineContext();
-    auto reverb = makeUnique<Reverb>(bufferBus.get(), AudioUtilities::renderQuantumSize, MaxFFTSize, useBackgroundThreads, m_normalize);
+    auto reverb = makeUnique<Reverb>(bufferBus.ptr(), AudioUtilities::renderQuantumSize, MaxFFTSize, useBackgroundThreads, m_normalize);
 
     {
         // The context must be locked since changing the buffer can re-configure the number of channels that are output.

--- a/Source/WebCore/platform/audio/AudioBus.h
+++ b/Source/WebCore/platform/audio/AudioBus.h
@@ -67,7 +67,7 @@ public:
     // allocate indicates whether or not to initially have the AudioChannels created with managed storage.
     // Normal usage is to pass true here, in which case the AudioChannels will memory-manage their own storage.
     // If allocate is false then setChannelMemory() has to be called later on for each channel before the AudioBus is useable...
-    WEBCORE_EXPORT static RefPtr<AudioBus> create(unsigned numberOfChannels, size_t length, bool allocate = true);
+    WEBCORE_EXPORT static Ref<AudioBus> create(unsigned numberOfChannels, size_t length, bool allocate = true);
 
     // Tells the given channel to use an externally allocated buffer.
     WEBCORE_EXPORT void setChannelMemory(unsigned channelIndex, std::span<float> storage);

--- a/Source/WebCore/platform/audio/AudioDestinationResampler.cpp
+++ b/Source/WebCore/platform/audio/AudioDestinationResampler.cpp
@@ -40,8 +40,8 @@ constexpr size_t fifoSize = 96 * AudioUtilities::renderQuantumSize;
 
 AudioDestinationResampler::AudioDestinationResampler(const CreationOptions& options, float outputSampleRate)
     : AudioDestination(options)
-    , m_outputBus(AudioBus::create(options.numberOfOutputChannels, AudioUtilities::renderQuantumSize, false).releaseNonNull())
-    , m_renderBus(AudioBus::create(options.numberOfOutputChannels, AudioUtilities::renderQuantumSize).releaseNonNull())
+    , m_outputBus { AudioBus::create(options.numberOfOutputChannels, AudioUtilities::renderQuantumSize, false) }
+    , m_renderBus { AudioBus::create(options.numberOfOutputChannels, AudioUtilities::renderQuantumSize) }
     , m_fifo(options.numberOfOutputChannels, fifoSize)
 {
     if (options.sampleRate != outputSampleRate) {

--- a/Source/WebCore/platform/audio/SharedAudioDestination.cpp
+++ b/Source/WebCore/platform/audio/SharedAudioDestination.cpp
@@ -141,7 +141,7 @@ SharedAudioDestinationAdapter::SharedAudioDestinationAdapter(const CreationOptio
         , options.sceneIdentifier.isNull() ? emptyString() : options.sceneIdentifier
 #endif
         }) }
-    , m_workBus { AudioBus::create(options.numberOfOutputChannels, AudioUtilities::renderQuantumSize).releaseNonNull() }
+    , m_workBus { AudioBus::create(options.numberOfOutputChannels, AudioUtilities::renderQuantumSize) }
     , m_ensureFunction { WTFMove(ensureFunction) }
 {
 }

--- a/Source/WebCore/platform/audio/gstreamer/AudioFileReaderGStreamer.cpp
+++ b/Source/WebCore/platform/audio/gstreamer/AudioFileReaderGStreamer.cpp
@@ -459,7 +459,7 @@ RefPtr<AudioBus> AudioFileReader::createBus(float sampleRate, bool mixToMono)
     m_buffers.clear();
 
     if (mixToMono)
-        return AudioBus::createByMixingToMono(audioBus.get());
+        return AudioBus::createByMixingToMono(audioBus.ptr());
     return audioBus;
 }
 


### PR DESCRIPTION
#### 18e1389a07ca83ca6e1dc7013b82cc1546b60ae4
<pre>
[Refactor] Make AudioBus::create() return a Ref
<a href="https://bugs.webkit.org/show_bug.cgi?id=293395">https://bugs.webkit.org/show_bug.cgi?id=293395</a>
<a href="https://rdar.apple.com/problem/151814836">rdar://problem/151814836</a>

Reviewed by Jean-Yves Avenard.

`AudioBus::create()` currently returns a RefPtr because of assertion that the `numberOfChannels`
parameter is not greater than a constant maximum value. However, that maximum is only necessary
because a stack variable in `copyWithGainFrom()` is created with that maximum channel size.
That stack variable is unnecessary if the looping algorithm is slightly modified.

Whats worse, a number of callers of `AudioBus::create()` convert the RefPtr to a Ref via
`releaseNonNull()` without checking whether the return value is null, which is a potential
null dereference waiting to happen.

Remove the concept of `MaxBusChannels`, and change the return type of `AudioBus::create()`
to a Ref.

* Source/WebCore/Modules/webaudio/AudioParam.cpp:
(WebCore::AudioParam::AudioParam):
* Source/WebCore/Modules/webaudio/ConvolverNode.cpp:
(WebCore::ConvolverNode::setBufferForBindings):
* Source/WebCore/platform/audio/AudioBus.cpp:
(WebCore::AudioBus::create):
(WebCore::AudioBus::copyFromRange):
(WebCore::AudioBus::copyWithGainFrom):
* Source/WebCore/platform/audio/AudioBus.h:
* Source/WebCore/platform/audio/AudioDestinationResampler.cpp:
(WebCore::AudioDestinationResampler::AudioDestinationResampler):
* Source/WebCore/platform/audio/SharedAudioDestination.cpp:
* Source/WebCore/platform/audio/gstreamer/AudioFileReaderGStreamer.cpp:
(WebCore::AudioFileReader::createBus):

Canonical link: <a href="https://commits.webkit.org/295322@main">https://commits.webkit.org/295322@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7a240353f58091e636ea85d2488f36f6a37b3518

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104723 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24435 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/14857 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/109937 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/55397 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/106763 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/24826 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/32981 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79521 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107729 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19303 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94515 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59828 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/19070 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/12592 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/54773 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/88767 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/12639 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/112332 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/31888 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/23455 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88604 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32252 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/90743 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88228 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22487 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33112 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10888 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/27201 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/31813 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/37166 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/31605 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/34946 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33164 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->