### PR TITLE
[WASM GC] Remove superfluous and instruction from ref.i31 implementations

### DIFF
--- a/JSTests/wasm/gc/i31.js
+++ b/JSTests/wasm/gc/i31.js
@@ -27,6 +27,17 @@ function testI31New() {
     "WebAssembly.Module doesn't validate: ref.i31 value to type F32 expected I32, in function at index 0 (evaluating 'new WebAssembly.Module(binary)')"
   )
 
+  assert.throws(
+    () => instantiate(`
+      (module
+        (func (export "f") (result i32)
+          (ref.i31 (i64.const 42)))
+      )
+    `),
+    WebAssembly.CompileError,
+    "WebAssembly.Module doesn't validate: ref.i31 value to type I64 expected I32, in function at index 0 (evaluating 'new WebAssembly.Module(binary)')"
+  )
+
   // Use i31 in global and also export to JS via global.
   {
     let m = instantiate(`
@@ -36,8 +47,10 @@ function testI31New() {
           (global.set 0 (ref.i31 (i32.const 42))))
       )
     `);
-    m.exports.f();
-    assert.eq(m.exports.g.value, 42);
+    for (let i = 0; i < testLoopCount; i++) {
+      m.exports.f();
+      assert.eq(m.exports.g.value, 42);
+    }
   }
 
   // Test export to JS.
@@ -48,7 +61,8 @@ function testI31New() {
           (ref.i31 (i32.const 42)))
       )
     `);
-    assert.eq(m.exports.f(), 42);
+    for (let i = 0; i < testLoopCount; i++)
+      assert.eq(m.exports.f(), 42);
   }
 
   // Export to JS via import.
@@ -61,7 +75,8 @@ function testI31New() {
       )`,
       { m: { f: (i31) => assert.eq(i31, 42) } }
     );
-    m.exports.g();
+    for (let i = 0; i < testLoopCount; i++)
+      m.exports.g();
   }
 }
 
@@ -83,7 +98,8 @@ function testI31Get() {
           (i31.get_u (ref.i31 (i32.const 42))))
       )
     `);
-    assert.eq(m.exports.f(), 42);
+    for (let i = 0; i < testLoopCount; i++)
+      assert.eq(m.exports.f(), 42);
   }
 
   {
@@ -93,7 +109,8 @@ function testI31Get() {
           (i31.get_s (ref.i31 (i32.const 0x4000_0000))))
       )
     `);
-    assert.eq(m.exports.f(), -0x40000000);
+    for (let i = 0; i < testLoopCount; i++)
+      assert.eq(m.exports.f(), -0x40000000);
   }
 
   {
@@ -103,7 +120,8 @@ function testI31Get() {
            (i31.get_u (ref.i31 (i32.const 0x4000_0000))))
        )
     `);
-    assert.eq(m.exports.f(), 0x40000000);
+    for (let i = 0; i < testLoopCount; i++)
+      assert.eq(m.exports.f(), 0x40000000);
   }
 
   {
@@ -113,7 +131,8 @@ function testI31Get() {
           (i31.get_s (ref.i31 (i32.const 0xaaaa_aaaa))))
       )
     `);
-    assert.eq(m.exports.f(), 0x2aaaaaaa);
+    for (let i = 0; i < testLoopCount; i++)
+      assert.eq(m.exports.f(), 0x2aaaaaaa);
   }
 
   {
@@ -123,7 +142,8 @@ function testI31Get() {
           (i31.get_u (ref.i31 (i32.const 0xaaaa_aaaa))))
       )
     `);
-    assert.eq(m.exports.f(), 0x2aaaaaaa);
+    for (let i = 0; i < testLoopCount; i++)
+      assert.eq(m.exports.f(), 0x2aaaaaaa);
   }
 
   {
@@ -133,7 +153,8 @@ function testI31Get() {
           (i31.get_s (ref.i31 (i32.const -1))))
       )
     `);
-    assert.eq(m.exports.f(), -1);
+    for (let i = 0; i < testLoopCount; i++)
+      assert.eq(m.exports.f(), -1);
   }
 
   {
@@ -143,7 +164,8 @@ function testI31Get() {
           (i31.get_u (ref.i31 (i32.const -1))))
       )
     `);
-    assert.eq(m.exports.f(), 0x7fffffff);
+    for (let i = 0; i < testLoopCount; i++)
+      assert.eq(m.exports.f(), 0x7fffffff);
   }
 
   {
@@ -153,10 +175,12 @@ function testI31Get() {
           (i31.get_u (ref.i31 (local.get $arg))))
       )
     `);
-    assert.eq(m.exports.f(0x7fffffff), 0x7fffffff);
-    assert.eq(m.exports.f(0x2aaaaaaa), 0x2aaaaaaa);
-    assert.eq(m.exports.f(0x40000000), 0x40000000);
-    assert.eq(m.exports.f(42), 42);
+    for (let i = 0; i < testLoopCount; i++) {
+      assert.eq(m.exports.f(0x7fffffff), 0x7fffffff);
+      assert.eq(m.exports.f(0x2aaaaaaa), 0x2aaaaaaa);
+      assert.eq(m.exports.f(0x40000000), 0x40000000);
+      assert.eq(m.exports.f(42), 42);
+    }
   }
 
   {
@@ -166,10 +190,12 @@ function testI31Get() {
           (i31.get_s (ref.i31 (local.get $arg))))
       )
     `);
-    assert.eq(m.exports.f(0x7fffffff), -1);
-    assert.eq(m.exports.f(0x2aaaaaaa), 0x2aaaaaaa);
-    assert.eq(m.exports.f(0x40000000), -0x40000000);
-    assert.eq(m.exports.f(42), 42);
+    for (let i = 0; i < testLoopCount; i++) {
+      assert.eq(m.exports.f(0x7fffffff), -1);
+      assert.eq(m.exports.f(0x2aaaaaaa), 0x2aaaaaaa);
+      assert.eq(m.exports.f(0x40000000), -0x40000000);
+      assert.eq(m.exports.f(42), 42);
+    }
   }
 
   assert.throws(
@@ -246,7 +272,8 @@ function testI31JS() {
         (global (export "g") (mut i31ref) (ref.null i31))
       )
     `);
-    m.exports.g.value = 42;
+    for (let i = 0; i < testLoopCount; i++)
+      m.exports.g.value = 42;
   }
 }
 
@@ -260,8 +287,11 @@ function testI31Table() {
         (func (export "get") (param i32) (result i32)
           (i31.get_s (table.get (local.get 0)))))
     `);
-    m.exports.set(3);
-    assert.eq(m.exports.get(3), 42);
+    for (let i = 0; i < testLoopCount; i++) {
+      m.exports.set(3);
+      assert.eq(m.exports.get(3), 42);
+      m.exports.set(0);
+    }
     assert.throws(() => m.exports.get(2), WebAssembly.RuntimeError, "i31.get_<sx> to a null");
   }
 
@@ -305,10 +335,12 @@ function testI31Table() {
       TypeError,
       "Argument value did not match the reference type"
     );
-    m.exports.t.set(0, 3);
-    assert.eq(m.exports.t.get(0), 3);
-    m.exports.t.set(0, null);
-    assert.eq(m.exports.t.get(0), null);
+    for (let i = 0; i < testLoopCount; i++) {
+      m.exports.t.set(0, 3);
+      assert.eq(m.exports.t.get(0), 3);
+      m.exports.t.set(0, null);
+      assert.eq(m.exports.t.get(0), null);
+    }
   }
 }
 

--- a/Source/JavaScriptCore/llint/InPlaceInterpreter64.asm
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter64.asm
@@ -3617,7 +3617,6 @@ end)
 
 ipintOp(_ref_i31, macro()
     popInt32(t0, t1)
-    andq 0x7fffffff, t0
     lshifti 0x1, t0
     rshifti 0x1, t0
     orq TagNumber, t0

--- a/Source/JavaScriptCore/llint/WebAssembly64.asm
+++ b/Source/JavaScriptCore/llint/WebAssembly64.asm
@@ -1292,7 +1292,6 @@ end
 
 wasmOp(ref_i31, WasmRefI31, macro(ctx)
     mloadi(ctx, m_value, t0)
-    andq 0x7fffffff, t0
     lshifti 0x1, t0
     rshifti 0x1, t0
     orq TagNumber, t0

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp
@@ -1516,7 +1516,6 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addRefI31(ExpressionType value, Express
 
     LOG_INSTRUCTION("RefI31", value, RESULT(result));
 
-    m_jit.and32(TrustedImm32(0x7fffffff), initialValue.asGPR(), resultLocation.asGPR());
     m_jit.lshift32(TrustedImm32(1), resultLocation.asGPR());
     m_jit.rshift32(TrustedImm32(1), resultLocation.asGPR());
     m_jit.or64(TrustedImm64(JSValue::NumberTag), resultLocation.asGPR());

--- a/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
@@ -3009,8 +3009,8 @@ auto OMGIRGenerator::truncSaturated(Ext1OpType op, ExpressionType argVar, Expres
 
 auto OMGIRGenerator::addRefI31(ExpressionType value, ExpressionType& result) -> PartialResult
 {
-    Value* masked = m_currentBlock->appendNew<Value>(m_proc, B3::BitAnd, origin(), get(value), constant(Int32, 0x7fffffff));
-    Value* shiftLeft = m_currentBlock->appendNew<Value>(m_proc, B3::Shl, origin(), masked, constant(Int32, 0x1));
+    ASSERT(value->type().kind() == Int32);
+    Value* shiftLeft = m_currentBlock->appendNew<Value>(m_proc, B3::Shl, origin(), get(value), constant(Int32, 0x1));
     Value* shiftRight = m_currentBlock->appendNew<Value>(m_proc, B3::SShr, origin(), shiftLeft, constant(Int32, 0x1));
     Value* extended = m_currentBlock->appendNew<Value>(m_proc, B3::ZExt32, origin(), shiftRight);
     result = push(m_currentBlock->appendNew<Value>(m_proc, B3::BitOr, origin(), extended, constant(Int64, JSValue::NumberTag)));


### PR DESCRIPTION
#### 3c5b128f95fbed72e636f4ca332a026e40a416d7
<pre>
[WASM GC] Remove superfluous and instruction from ref.i31 implementations
<a href="https://bugs.webkit.org/show_bug.cgi?id=293430">https://bugs.webkit.org/show_bug.cgi?id=293430</a>
<a href="https://rdar.apple.com/151858273">rdar://151858273</a>

Reviewed by Yusuke Suzuki.

The subsequent 32-bit left then right shift will shift away
bit 31, so there&apos;s no need to mask it first.

* JSTests/wasm/gc/i31.js:
 - Add a type check failure test case for i64 as input to ref.i31
 - Update this test so it exercises OMG

Canonical link: <a href="https://commits.webkit.org/295314@main">https://commits.webkit.org/295314@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cb58476474ff26537931adadb8c6e8552c2050a4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104738 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/131/builds/24450 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/14872 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/109952 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/55412 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/24841 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/32996 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/109952 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/55412 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107744 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/19310 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94521 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/109952 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/19078 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/12598 "Passed tests") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/54791 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/97419 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/88774 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/12645 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/112349 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/103356 "Built successfully and passed tests") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/31903 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/23461 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/88608 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32267 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/90747 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/88232 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22479 "Built successfully and passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33120 "Build is in progress. Recent messages:") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/10892 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/27216 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/31828 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/37181 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/127635 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/31620 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/127635 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/34961 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/33179 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->