### PR TITLE
Web Inspector: Adding Lizette to contributors.json

### DIFF
--- a/metadata/contributors.json
+++ b/metadata/contributors.json
@@ -5405,6 +5405,14 @@
    },
    {
       "emails" : [
+         "lhernandez28@apple.com",
+         "lizette4662@gmail.com"
+      ],
+      "github" : "liz4662",
+      "name" : "Lizette Hernandez"
+   },
+   {
+      "emails" : [
          "ltilve@igalia.com"
       ],
       "name" : "Lorenzo Tilve",


### PR DESCRIPTION
#### fcc4154a89cdda633d002d2ea940171219f1ea30
<pre>
Web Inspector: Adding Lizette to contributors.json
<a href="https://bugs.webkit.org/show_bug.cgi?id=293391">https://bugs.webkit.org/show_bug.cgi?id=293391</a>
<a href="https://rdar.apple.com/151810077">rdar://151810077</a>

Reviewed by BJ Burg.

Added name and information to contributors list.

* metadata/contributors.json:

Canonical link: <a href="https://commits.webkit.org/295752@main">https://commits.webkit.org/295752@main</a>
</pre>
