### PR TITLE
[ARMv7] Fix build and add headers for clangd.

### DIFF
--- a/Source/JavaScriptCore/assembler/ARM64Assembler.h
+++ b/Source/JavaScriptCore/assembler/ARM64Assembler.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if ENABLE(ASSEMBLER) && CPU(ARM64)
 
 #include "ARM64Registers.h"

--- a/Source/JavaScriptCore/assembler/ARM64EAssembler.h
+++ b/Source/JavaScriptCore/assembler/ARM64EAssembler.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if ENABLE(ASSEMBLER) && CPU(ARM64E)
 
 #include "ARM64Assembler.h"

--- a/Source/JavaScriptCore/assembler/ARMv7Assembler.h
+++ b/Source/JavaScriptCore/assembler/ARMv7Assembler.h
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if ENABLE(ASSEMBLER) && CPU(ARM_THUMB2)
 
 #include "AssemblerBuffer.h"

--- a/Source/JavaScriptCore/assembler/AllowMacroScratchRegisterUsage.h
+++ b/Source/JavaScriptCore/assembler/AllowMacroScratchRegisterUsage.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if ENABLE(ASSEMBLER)
 
 #include "MacroAssembler.h"

--- a/Source/JavaScriptCore/assembler/AllowMacroScratchRegisterUsageIf.h
+++ b/Source/JavaScriptCore/assembler/AllowMacroScratchRegisterUsageIf.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if ENABLE(ASSEMBLER)
 
 #include "MacroAssembler.h"

--- a/Source/JavaScriptCore/assembler/AssemblerBuffer.h
+++ b/Source/JavaScriptCore/assembler/AssemblerBuffer.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if ENABLE(ASSEMBLER)
 
 #include "ExecutableAllocator.h"

--- a/Source/JavaScriptCore/assembler/DisallowMacroScratchRegisterUsage.h
+++ b/Source/JavaScriptCore/assembler/DisallowMacroScratchRegisterUsage.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if ENABLE(ASSEMBLER)
 
 namespace JSC {

--- a/Source/JavaScriptCore/assembler/JITOperationList.h
+++ b/Source/JavaScriptCore/assembler/JITOperationList.h
@@ -28,6 +28,7 @@
 #include "Options.h"
 #include <wtf/HashMap.h>
 #include <wtf/NeverDestroyed.h>
+#include <wtf/Platform.h>
 #include <wtf/PtrTag.h>
 
 namespace JSC {

--- a/Source/JavaScriptCore/assembler/JITOperationValidation.h
+++ b/Source/JavaScriptCore/assembler/JITOperationValidation.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if ENABLE(JIT_CAGE)
 #include <WebKitAdditions/JITCageAdditions.h>
 #else // ENABLE(JIT_CAGE)

--- a/Source/JavaScriptCore/assembler/LinkBuffer.h
+++ b/Source/JavaScriptCore/assembler/LinkBuffer.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if ENABLE(ASSEMBLER)
 
 #define DUMP_LINK_STATISTICS 0

--- a/Source/JavaScriptCore/assembler/MacroAssembler.h
+++ b/Source/JavaScriptCore/assembler/MacroAssembler.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <wtf/Compiler.h>
+#include <wtf/Platform.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 

--- a/Source/JavaScriptCore/assembler/MacroAssemblerARM64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerARM64.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if ENABLE(ASSEMBLER) && CPU(ARM64)
 
 #include "ARM64Assembler.h"

--- a/Source/JavaScriptCore/assembler/MacroAssemblerARM64E.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerARM64E.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if ENABLE(ASSEMBLER) && CPU(ARM64E)
 
 #include "DisallowMacroScratchRegisterUsage.h"

--- a/Source/JavaScriptCore/assembler/MacroAssemblerARMv7.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerARMv7.h
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if ENABLE(ASSEMBLER) && CPU(ARM_THUMB2)
 
 #include <initializer_list>

--- a/Source/JavaScriptCore/assembler/MacroAssemblerRISCV64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerRISCV64.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if ENABLE(ASSEMBLER) && CPU(RISCV64)
 
 #include "AbstractMacroAssembler.h"

--- a/Source/JavaScriptCore/assembler/PerfLog.h
+++ b/Source/JavaScriptCore/assembler/PerfLog.h
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if ENABLE(ASSEMBLER)
 
 #include "LinkBuffer.h"

--- a/Source/JavaScriptCore/assembler/ProbeFrame.h
+++ b/Source/JavaScriptCore/assembler/ProbeFrame.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if ENABLE(ASSEMBLER)
 
 #include "CallFrame.h"

--- a/Source/JavaScriptCore/assembler/RISCV64Assembler.h
+++ b/Source/JavaScriptCore/assembler/RISCV64Assembler.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if ENABLE(ASSEMBLER) && CPU(RISCV64)
 
 #include "AssemblerBuffer.h"

--- a/Source/JavaScriptCore/assembler/X86Assembler.h
+++ b/Source/JavaScriptCore/assembler/X86Assembler.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if ENABLE(ASSEMBLER) && CPU(X86_64)
 
 #include "AssemblerBuffer.h"

--- a/Source/JavaScriptCore/b3/B3ArgumentRegValue.h
+++ b/Source/JavaScriptCore/b3/B3ArgumentRegValue.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if ENABLE(B3_JIT)
 
 #include "B3Value.h"

--- a/Source/JavaScriptCore/b3/B3AtomicValue.h
+++ b/Source/JavaScriptCore/b3/B3AtomicValue.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if ENABLE(B3_JIT)
 
 #include "B3MemoryValue.h"

--- a/Source/JavaScriptCore/b3/B3BackwardsCFG.h
+++ b/Source/JavaScriptCore/b3/B3BackwardsCFG.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if ENABLE(B3_JIT)
 
 #include "B3CFG.h"

--- a/Source/JavaScriptCore/b3/B3BackwardsDominators.h
+++ b/Source/JavaScriptCore/b3/B3BackwardsDominators.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if ENABLE(B3_JIT)
 
 #include "B3BackwardsCFG.h"

--- a/Source/JavaScriptCore/b3/B3Bank.h
+++ b/Source/JavaScriptCore/b3/B3Bank.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if ENABLE(B3_JIT)
 
 #include "B3Type.h"

--- a/Source/JavaScriptCore/b3/B3BasicBlock.h
+++ b/Source/JavaScriptCore/b3/B3BasicBlock.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if ENABLE(B3_JIT)
 
 #include "B3FrequentedBlock.h"

--- a/Source/JavaScriptCore/llint/InPlaceInterpreter32_64.asm
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter32_64.asm
@@ -224,9 +224,9 @@ macro ipintEntry()
     # Allocate space for locals and rethrow values
     loadi Wasm::IPIntCallee::m_localSizeToAlloc[ws0], argumINTTmp
     loadi Wasm::IPIntCallee::m_numRethrowSlotsToAlloc[ws0], argumINTEnd
-    mulq LocalSize, argumINTEnd
+    mulp LocalSize, argumINTEnd
     mulp LocalSize, argumINTTmp
-    subq argumINTEnd, sp
+    subp argumINTEnd, sp
     move sp, argumINTEnd
     subp argumINTTmp, sp
     move sp, argumINTDsp


### PR DESCRIPTION
#### c9b017789ac2044413f6dfc1559558f9730354ed
<pre>
[ARMv7] Fix build and add headers for clangd.
<a href="https://bugs.webkit.org/show_bug.cgi?id=293435">https://bugs.webkit.org/show_bug.cgi?id=293435</a>

Unreviewed build fix.

We quickly fix up a missing instruction on 32-bit so that the build can continue;
These headers are useful to get clangd working again, so I am throwing them in too.

Canonical link: <a href="https://commits.webkit.org/295306@main">https://commits.webkit.org/295306@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/292ec1a20537d2affc027f3194f42e2c3e6267f2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104663 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24375 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/14796 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/109877 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/55337 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/24766 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/32921 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79491 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107669 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19269 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94470 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59797 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/19037 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/12544 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/54710 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/97344 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/88736 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/12596 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/112269 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/103281 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/31828 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/23426 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88574 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32192 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/90698 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88189 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22473 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33084 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/10858 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/27141 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/31753 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/37103 "Built successfully") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/127559 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/31545 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/127559 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/34886 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33104 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->