### PR TITLE
Quirk premierleague.com to fix fullscreen video position after return from PIP on iPad

### DIFF
--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -612,6 +612,18 @@ bool Quirks::needsYouTubeOverflowScrollQuirk() const
 #endif
 }
 
+// premierleague.com rdar://138050196
+bool Quirks::shouldInjectCSSInFullscreenForPremierLeague() const
+{
+#if PLATFORM(IOS_FAMILY) && ENABLE(FULLSCREEN_API)
+    QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
+
+    return m_quirksData.quirkIsEnabled(QuirksData::SiteSpecificQuirk::ShouldInjectCSSInFullscreenForPremierLeague);
+#else
+    return false;
+#endif
+}
+
 // amazon.com rdar://128962002
 bool Quirks::needsPrimeVideoUserSelectNoneQuirk() const
 {
@@ -3086,6 +3098,8 @@ static void handlePremierLeagueQuirks(QuirksData& quirksData, const URL& /* quir
         QuirksData::SiteSpecificQuirk::ShouldDispatchPlayPauseEventsOnResume,
         // premierleague.com: rdar://136791737
         QuirksData::SiteSpecificQuirk::ShouldAvoidStartingSelectionOnMouseDownOverPointerCursor,
+        // premierleague.com: rdar://138050196
+        QuirksData::SiteSpecificQuirk::ShouldInjectCSSInFullscreenForPremierLeague,
     });
 }
 

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -258,6 +258,8 @@ public:
 
     bool implicitMuteWhenVolumeSetToZero() const;
 
+    bool shouldInjectCSSInFullscreenForPremierLeague() const;
+
     bool needsZeroMaxTouchPointsQuirk() const;
     bool needsChromeMediaControlsPseudoElement() const;
 

--- a/Source/WebCore/page/QuirksData.h
+++ b/Source/WebCore/page/QuirksData.h
@@ -199,6 +199,7 @@ struct QuirksData {
         ShouldIgnoreViewportArgumentsToAvoidExcessiveZoomQuirk,
         ShouldIgnoreViewportArgumentsToAvoidEnlargedViewQuirk,
 #endif
+        ShouldInjectCSSInFullscreenForPremierLeague,
         ShouldLayOutAtMinimumWindowWidthWhenIgnoringScalingConstraintsQuirk,
 #if PLATFORM(IOS_FAMILY)
         ShouldNavigatorPluginsBeEmpty,

--- a/Source/WebCore/style/StyleAdjuster.cpp
+++ b/Source/WebCore/style/StyleAdjuster.cpp
@@ -1176,6 +1176,30 @@ void Adjuster::adjustForSiteSpecificQuirks(RenderStyle& style) const
 
     if (documentQuirks.needsInstagramResizingReelsQuirk(*m_element, style, m_parentStyle))
         style.setFlexGrow(1);
+
+    if (documentQuirks.shouldInjectCSSInFullscreenForPremierLeague()) {
+        if (m_element->hasAttribute("data-fullscreen"_s) && m_document->fullscreenIfExists()->isFullscreen()) {
+            style.setMaxWidth(100_css_percentage);
+            style.setMaxHeight(100_css_percentage);
+            style.setWidth(100_css_percentage);
+            style.setHeight(100_css_percentage);
+            style.setBackgroundColor({ WebCore::Color::black });
+
+            style.setMarginTop(0_css_px);
+            style.setMarginBottom(0_css_px);
+            style.setMarginLeft(0_css_px);
+            style.setMarginRight(0_css_px);
+
+            style.setPaddingTop(0_css_px);
+            style.setPaddingBottom(0_css_px);
+            style.setPaddingLeft(0_css_px);
+            style.setPaddingRight(0_css_px);
+
+            style.setPosition(PositionType::Fixed);
+            style.setTop(0_css_px);
+            style.setLeft(0_css_px);
+        }
+    }
 }
 
 void Adjuster::propagateToDocumentElementAndInitialContainingBlock(Update& update, const Document& document)


### PR DESCRIPTION
#### b83ad00cab384b8814f2e6b1c37cce8306ce1c8b
<pre>
Quirk premierleague.com to fix fullscreen video position after return from PIP on iPad
<a href="https://bugs.webkit.org/show_bug.cgi?id=293436">https://bugs.webkit.org/show_bug.cgi?id=293436</a>
<a href="https://rdar.apple.com/138050196">rdar://138050196</a>

Reviewed by NOBODY (OOPS!).

PremierLeague.com has a &lt;div&gt; around the &lt;video&gt; with an attribute called data-fullscreen.
This attribute controls the div&apos;s styling. When the user exits pip and the video transitions
back to fullscreen, the site does not set data-fullscreen to true, so their inline styling
is applied instead, and the video moves to the top of the viewport.

While waiting for the site to fix their bug, we can apply a quirk that corrects the css style
on the div.

* Source/WebCore/page/Quirks.cpp:
(WebCore::Quirks::shouldInjectCSSInFullscreenForPremierLeague const):
(WebCore::handlePremierLeagueQuirks):
* Source/WebCore/page/Quirks.h:
* Source/WebCore/page/QuirksData.h:
* Source/WebCore/style/StyleAdjuster.cpp:
(WebCore::Style::Adjuster::adjustForSiteSpecificQuirks const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b83ad00cab384b8814f2e6b1c37cce8306ce1c8b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140926 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13310 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/2562 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/149385 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/94014 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/142799 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14020 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/13462 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108164 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/78435 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143877 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10830 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/126136 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89066 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10427 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8003 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/9360 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119678 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2129 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/151890 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/12996 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/2387 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116365 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13011 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11353 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116704 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/12781 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/122812 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/68157 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13039 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/2219 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/12778 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/76740 "Built successfully") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/12977 "Hash b83ad00c for PR 45779 does not build (failure)") | | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/12822 "Hash b83ad00c for PR 45779 does not build (failure)") | | | | 
<!--EWS-Status-Bubble-End-->