### PR TITLE
Improve debug_ipint.py

### DIFF
--- a/Source/JavaScriptCore/llint/InPlaceInterpreter64.asm
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter64.asm
@@ -3167,6 +3167,9 @@ reservedOpcode(0xf8)
 reservedOpcode(0xf9)
 reservedOpcode(0xfa)
 
+# If the following four instructions are given more descriptive names,
+# the changes should be matched in IPINT_INSTRUCTIONS in Tools/lldb/debug_ipint.py
+
 ipintOp(_fb_block, macro()
     decodeLEBVarUInt32(1, t0, t1, t2, t3, t4)
     # Security guarantee: always less than 30 (0x00 -> 0x1e)

--- a/Tools/lldb/debug_ipint.py
+++ b/Tools/lldb/debug_ipint.py
@@ -27,45 +27,60 @@ elif ARCH == 'x64':
     MC_REG = 'r12'
     PL_REG = 'r10'
 
-# Read all instruction opcodes from InPlaceInterpreter64.asm
-
+# Instruction opcode symbols from InPlaceInterpreter64.asm, without the "ipint_" prefix.
+# The order should match the address space order.
 IPINT_INSTRUCTIONS = [
-    'unreachable', 'nop', 'block', 'loop', 'if', 'else', 'try', 'catch', 'throw',
-    'rethrow', 'throw_ref', 'end', 'br', 'br_if', 'br_table', 'return', 'call', 'call_indirect',
-    'return_call', 'return_call_indirect', 'call_ref', 'return_call_ref', 'delegate',
-    'catch_all', 'drop', 'select', 'select_t', 'try_table', 'local_get', 'local_set', 'local_tee',
-    'global_get', 'global_set', 'table_get', 'table_set', 'i32_load_mem', 'i64_load_mem',
-    'f32_load_mem', 'f64_load_mem', 'i32_load8s_mem', 'i32_load8u_mem', 'i32_load16s_mem',
-    'i32_load16u_mem', 'i64_load8s_mem', 'i64_load8u_mem', 'i64_load16s_mem',
-    'i64_load16u_mem', 'i64_load32s_mem', 'i64_load32u_mem', 'i32_store_mem',
-    'i64_store_mem', 'f32_store_mem', 'f64_store_mem', 'i32_store8_mem', 'i32_store16_mem',
-    'i64_store8_mem', 'i64_store16_mem', 'i64_store32_mem', 'memory_size', 'memory_grow',
-    'i32_const', 'i64_const', 'f32_const', 'f64_const', 'i32_eqz', 'i32_eq',
-    'i32_ne', 'i32_lt_s', 'i32_lt_u', 'i32_gt_s', 'i32_gt_u', 'i32_le_s',
-    'i32_le_u', 'i32_ge_s', 'i32_ge_u', 'i64_eqz', 'i64_eq', 'i64_ne', 'i64_lt_s',
-    'i64_lt_u', 'i64_gt_s', 'i64_gt_u', 'i64_le_s', 'i64_le_u', 'i64_ge_s',
-    'i64_ge_u', 'f32_eq', 'f32_ne', 'f32_lt', 'f32_gt', 'f32_le', 'f32_ge',
-    'f64_eq', 'f64_ne', 'f64_lt', 'f64_gt', 'f64_le', 'f64_ge', 'i32_clz',
-    'i32_ctz', 'i32_popcnt', 'i32_add', 'i32_sub', 'i32_mul', 'i32_div_s',
-    'i32_div_u', 'i32_rem_s', 'i32_rem_u', 'i32_and', 'i32_or', 'i32_xor',
-    'i32_shl', 'i32_shr_s', 'i32_shr_u', 'i32_rotl', 'i32_rotr', 'i64_clz',
-    'i64_ctz', 'i64_popcnt', 'i64_add', 'i64_sub', 'i64_mul', 'i64_div_s',
-    'i64_div_u', 'i64_rem_s', 'i64_rem_u', 'i64_and', 'i64_or', 'i64_xor',
-    'i64_shl', 'i64_shr_s', 'i64_shr_u', 'i64_rotl', 'i64_rotr', 'f32_abs',
-    'f32_neg', 'f32_ceil', 'f32_floor', 'f32_trunc', 'f32_nearest', 'f32_sqrt',
-    'f32_add', 'f32_sub', 'f32_mul', 'f32_div', 'f32_min', 'f32_max', 'f32_copysign',
-    'f64_abs', 'f64_neg', 'f64_ceil', 'f64_floor', 'f64_trunc', 'f64_nearest',
-    'f64_sqrt', 'f64_add', 'f64_sub', 'f64_mul', 'f64_div', 'f64_min', 'f64_max',
-    'f64_copysign', 'i32_wrap_i64', 'i32_trunc_f32_s', 'i32_trunc_f32_u',
-    'i32_trunc_f64_s', 'i32_trunc_f64_u', 'i64_extend_i32_s', 'i64_extend_i32_u',
-    'i64_trunc_f32_s', 'i64_trunc_f32_u', 'i64_trunc_f64_s', 'i64_trunc_f64_u',
-    'f32_convert_i32_s', 'f32_convert_i32_u', 'f32_convert_i64_s', 'f32_convert_i64_u',
-    'f32_demote_f64', 'f64_convert_i32_s', 'f64_convert_i32_u', 'f64_convert_i64_s',
-    'f64_convert_i64_u', 'f64_promote_f32', 'i32_reinterpret_f32', 'i64_reinterpret_f64',
-    'f32_reinterpret_i32', 'f64_reinterpret_i64', 'i32_extend8_s', 'i32_extend16_s',
-    'i64_extend8_s', 'i64_extend16_s', 'i64_extend32_s', 'ref_null_t', 'ref_is_null',
-    'ref_func', 'ref_eq', 'ref_as_non_null', 'br_on_null', 'br_on_non_null', 'fb_block',
-    'fc_block', 'simd', 'atomic', 'struct_new', 'struct_new_default', 'struct_get',
+    # 0x00
+    'unreachable', 'nop', 'block', 'loop', 'if', 'else', 'try', 'catch',
+    'throw', 'rethrow', 'throw_ref', 'end', 'br', 'br_if', 'br_table', 'return',
+    # 0x10
+    'call', 'call_indirect', 'return_call', 'return_call_indirect', 'call_ref', 'return_call_ref',
+    'delegate', 'catch_all', 'drop', 'select', 'select_t', 'try_table',
+    # 0x20
+    'local_get', 'local_set', 'local_tee', 'global_get', 'global_set', 'table_get', 'table_set',
+    'i32_load_mem', 'i64_load_mem', 'f32_load_mem', 'f64_load_mem', 'i32_load8s_mem', 'i32_load8u_mem', 'i32_load16s_mem', 'i32_load16u_mem',
+    # 0x30
+    'i64_load8s_mem', 'i64_load8u_mem', 'i64_load16s_mem', 'i64_load16u_mem', 'i64_load32s_mem', 'i64_load32u_mem', 'i32_store_mem', 'i64_store_mem',
+    'f32_store_mem', 'f64_store_mem', 'i32_store8_mem', 'i32_store16_mem', 'i64_store8_mem', 'i64_store16_mem', 'i64_store32_mem', 'memory_size',
+    # 0x40
+    'memory_grow', 'i32_const', 'i64_const', 'f32_const', 'f64_const', 'i32_eqz', 'i32_eq', 'i32_ne',
+    'i32_lt_s', 'i32_lt_u', 'i32_gt_s', 'i32_gt_u', 'i32_le_s', 'i32_le_u', 'i32_ge_s', 'i32_ge_u',
+    # 0x50
+    'i64_eqz', 'i64_eq', 'i64_ne', 'i64_lt_s', 'i64_lt_u', 'i64_gt_s', 'i64_gt_u', 'i64_le_s',
+    'i64_le_u', 'i64_ge_s', 'i64_ge_u', 'f32_eq', 'f32_ne', 'f32_lt', 'f32_gt', 'f32_le',
+    # 0x60
+    'f32_ge', 'f64_eq', 'f64_ne', 'f64_lt', 'f64_gt', 'f64_le', 'f64_ge', 'i32_clz',
+    'i32_ctz', 'i32_popcnt', 'i32_add', 'i32_sub', 'i32_mul', 'i32_div_s', 'i32_div_u', 'i32_rem_s',
+    # 0x70
+    'i32_rem_u', 'i32_and', 'i32_or', 'i32_xor', 'i32_shl', 'i32_shr_s', 'i32_shr_u', 'i32_rotl',
+    'i32_rotr', 'i64_clz', 'i64_ctz', 'i64_popcnt', 'i64_add', 'i64_sub', 'i64_mul', 'i64_div_s',
+    # 0x80
+    'i64_div_u', 'i64_rem_s', 'i64_rem_u', 'i64_and', 'i64_or', 'i64_xor', 'i64_shl', 'i64_shr_s',
+    'i64_shr_u', 'i64_rotl', 'i64_rotr', 'f32_abs', 'f32_neg', 'f32_ceil', 'f32_floor', 'f32_trunc',
+    # 0x90
+    'f32_nearest', 'f32_sqrt', 'f32_add', 'f32_sub', 'f32_mul', 'f32_div', 'f32_min', 'f32_max',
+    'f32_copysign', 'f64_abs', 'f64_neg', 'f64_ceil', 'f64_floor', 'f64_trunc', 'f64_nearest', 'f64_sqrt',
+    # 0xA0
+    'f64_add', 'f64_sub', 'f64_mul', 'f64_div', 'f64_min', 'f64_max', 'f64_copysign', 'i32_wrap_i64',
+    'i32_trunc_f32_s', 'i32_trunc_f32_u', 'i32_trunc_f64_s', 'i32_trunc_f64_u', 'i64_extend_i32_s', 'i64_extend_i32_u', 'i64_trunc_f32_s', 'i64_trunc_f32_u',
+    # 0xB0
+    'i64_trunc_f64_s', 'i64_trunc_f64_u', 'f32_convert_i32_s', 'f32_convert_i32_u', 'f32_convert_i64_s', 'f32_convert_i64_u', 'f32_demote_f64', 'f64_convert_i32_s',
+    'f64_convert_i32_u', 'f64_convert_i64_s', 'f64_convert_i64_u', 'f64_promote_f32', 'i32_reinterpret_f32', 'i64_reinterpret_f64', 'f32_reinterpret_i32', 'f64_reinterpret_i64',
+    # 0xC0
+    'i32_extend8_s', 'i32_extend16_s', 'i64_extend8_s', 'i64_extend16_s', 'i64_extend32_s',
+    # 0xD0
+    'ref_null_t', 'ref_is_null', 'ref_func', 'ref_eq', 'ref_as_non_null', 'br_on_null', 'br_on_non_null',
+    # 0xFB
+    # The four instructions starting with 0xFB are in transition. The names appearing below are their current
+    # names in InPlaceInterpreter64.asm.
+    'fb_block', 'fc_block', 'simd', 'atomic',
+    # There was an attempted PR that would change their names: https://bugs.webkit.org/show_bug.cgi?id=292725
+    # The PR has been reverted, but if it's reintroduced after fixes, the names above should be changed
+    # to the commented out names below:
+    # 'gc_prefix', 'conversion_prefix', 'simd_prefix', 'atomic_prefix',
+
+    # extended
+    'struct_new', 'struct_new_default', 'struct_get',
     'struct_get_s', 'struct_get_u', 'struct_set', 'array_new', 'array_new_default',
     'array_new_fixed', 'array_new_data', 'array_new_elem', 'array_get', 'array_get_s',
     'array_get_u', 'array_set', 'array_len', 'array_fill', 'array_copy',
@@ -108,48 +123,52 @@ breakpoints_enabled = []
 instruction_locs = []
 
 
-def print_value(mem, result, prefix=None):
+def extract_gprs(top_frame):
+    """Given the top frame of a stack, produce a dictionary mapping register names such as 'x29' to their values."""
+    regs = top_frame.GetRegisters()
+    gprs = {}
+    for reg in regs[0]:
+        gprs[reg.name] = int(reg.value[2:], 16)
+    return gprs
+
+
+def print_value(mem, output, prefix=None):
     raw = ' '.join(f'{x:02x}' for x in mem)
     i32 = struct.unpack('ixxxxxxxxxxxx', mem)[0]
     f32 = struct.unpack('fxxxxxxxxxxxx', mem)[0]
     i64 = struct.unpack('qxxxxxxxx', mem)[0]
     f64 = struct.unpack('dxxxxxxxx', mem)[0]
     interpretations = f'{DIM}i32:{RESET}{i32}  {DIM}f32:{RESET}{f32}  {DIM}i64{RESET}:{i64}  {DIM}f64{RESET}:{f64}'
-    print(f'{prefix}{CYAN}{raw}{RESET}  {interpretations}', file=result)
+    print(f'{prefix}{CYAN}{raw}{RESET}  {interpretations}', file=output)
 
 
-def print_stack(proc, frame, pl, result):
+def print_stack(proc, frame, pl, output, limit=100000):
     ptr = frame.sp
     slot_count = (pl - ptr) // 16
     slot_text = 'empty' if slot_count == 0 else '1 entry' if slot_count == 1 else f'{slot_count} entries'
 
-    print(f'Stack: {DIM}({slot_text}){RESET}', file=result)
+    print(f'Stack: {DIM}({slot_text}){RESET}', file=output)
     i = 0
-    while ptr != pl:
+    while ptr != pl and i < limit:
         error = lldb.SBError()
         mem = proc.ReadMemory(ptr, 16, error)
         if error.Success():
             mem = bytearray(mem)
-            print_value(mem, result, "  ")
+            print_value(mem, output, "  ")
         else:
-            print(f'{RED}can\'t read stack memory at address 0x{ptr:016x} :({RESET}', file=result)
+            print(f'{RED}can\'t read stack memory at address 0x{ptr:016x} :({RESET}', file=output)
             break
         ptr += 16
         i += 1
 
 
-def get_load_address(breakpoint):
-    for loc in breakpoint.locations:
-        if loc.IsResolved():
-            return loc.GetLoadAddress()
-    # if failed to find a proper resolved one, return something at least
-    return breakpoint.locations[0].GetLoadAddress()
-
-
-def get_instruction_addresses(target):
+def find_instruction_addresses(target):
     result = []
     for instr in IPINT_INSTRUCTIONS:
         contexts = target.FindSymbols(f'ipint_{instr}')
+        if contexts.GetSize() == 0:
+            print(f"ABORTING at ipint_{instr}")
+            return []
         addr = contexts[0].GetSymbol().GetStartAddress().GetLoadAddress(target)
         if addr == 0xffffffffffffffff:
             # unresolved, let's try again later
@@ -161,33 +180,29 @@ def get_instruction_addresses(target):
 def find_instruction(pc, target):
     global instruction_locs
     if not instruction_locs:
-        instruction_locs = get_instruction_addresses(target)
+        instruction_locs = find_instruction_addresses(target)
         if not instruction_locs:  # still empty, not resolved yet
             return -1
     return bisect.bisect(instruction_locs, pc) - 1
 
 
-def ipint_state(debugger, command, exe_ctx, result, internal_dict):
+def ipint_state(debugger, command, exe_ctx, output, internal_dict):
     target = debugger.GetSelectedTarget()
     proc = target.process
     thread = proc.GetSelectedThread()
     top_frame = thread.frame[0]
     this_frame = thread.GetSelectedFrame()
-    regs = top_frame.GetRegisters()
+    gprs = extract_gprs(top_frame)
 
-    print('--------------- IPInt state ---------------', file=result)
+    print('--------------- IPInt state ---------------', file=output)
 
     # current PC
-    pc = this_frame.pc
-    i = find_instruction(pc, target)
-    if i < 0:
-        print(f'Instruction = {RED}<none>{RESET} (not in IPInt)', file=result)
+    native_pc = this_frame.pc
+    instr_index = find_instruction(native_pc, target)
+    if instr_index < 0:
+        print(f'Instruction = {RED}<none>{RESET} (not in IPInt)', file=output)
     else:
-        print(f'Instruction = {BOLD}{IPINT_INSTRUCTIONS[i]}{RESET}', file=result)
-
-    gprs = {}
-    for reg in regs[0]:
-        gprs[reg.name] = int(reg.value[2:], 16)
+        print(f'Instruction = {BOLD}{IPINT_INSTRUCTIONS[instr_index]}{RESET}', file=output)
 
     # PC = x26
     pc = gprs[PC_REG]
@@ -202,7 +217,7 @@ def ipint_state(debugger, command, exe_ctx, result, internal_dict):
             pc_data = ' '.join(f'{x:02x}' for x in mem)
         else:
             pc_data = '???'
-        print(f'PC = 0x{pc:x} -> {CYAN}{pc_data}{RESET}', file=result)
+        print(f'PC = 0x{pc:x} -> {CYAN}{pc_data}{RESET}', file=output)
 
     if mc != 0:
         # preview 16 bytes of MC
@@ -213,31 +228,38 @@ def ipint_state(debugger, command, exe_ctx, result, internal_dict):
                 mc_data = ' '.join(f'{x:02x}' for x in mem)
             else:
                 mc_data = '???'
-        print(f'MC = 0x{mc:x} -> {CYAN}{mc_data}{RESET}', file=result)
+        print(f'MC = 0x{mc:x} -> {CYAN}{mc_data}{RESET}', file=output)
     else:
-        print('MC = {RED}<none>{RESET} (no metadata generated)', file=result)
+        print('MC = {RED}<none>{RESET} (no metadata generated)', file=output)
 
-    if i < 0:
-        print("Stack unknown: not in IPInt", file=result)
+    if instr_index < 0:
+        print("Stack unknown: not in IPInt", file=output)
     else:
-        print_stack(proc, this_frame, pl, result)
-    print('-------------------------------------------', file=result)
+        print_stack(proc, this_frame, pl, output)
+    print('-------------------------------------------', file=output)
 
 
-def ipint_stack(debugger, command, exec_ctx, result, internal_dict):
-    proc = debugger.GetTargetAtIndex(0).process
-    frame = proc.selected_thread.frame[0]
-    try:
-        print_stack(proc, frame, result, int(command))
-    except ValueError:
-        print('usage: ipint_stack <num_stack_entries>', file=result)
+def ipint_stack(debugger, command, exec_ctx, output, internal_dict):
+    proc = debugger.GetSelectedTarget().process
+    top_frame = proc.GetSelectedThread().frame[0]
+    gprs = extract_gprs(top_frame)
+    pl = gprs[PL_REG]
+    if not command:
+        limit = 100000
+    else:
+        try:
+            limit = int(command)
+        except ValueError:
+            print('usage: ipint_stack <num_stack_entries>', file=output)
+            return
+    print_stack(proc, top_frame, pl, output, limit)
 
 
-def ipint_local(debugger, command, exec_ctx, result, internal_dict):
+def ipint_local(debugger, command, exec_ctx, output, internal_dict):
     try:
         local_index = int(command)
     except ValueError:
-        print('usage: ipint_local <local_idx>', file=result)
+        print('usage: ipint_local <local_idx>', file=output)
         return
 
     proc = debugger.GetTargetAtIndex(0).process
@@ -254,12 +276,12 @@ def ipint_local(debugger, command, exec_ctx, result, internal_dict):
     mem = proc.ReadMemory(ptr, 16, error)
     if error.Success():
         mem = bytearray(mem)
-        print_value(mem, result)
+        print_value(mem, output)
     else:
-        print(f'can\'t read stack memory at address 0x{ptr:016x} (bad local index?)', file=result)
+        print(f'can\'t read stack memory at address 0x{ptr:016x} (bad local index?)', file=output)
 
 
-def ipint_continue_until(debugger, command, exec_ctx, result, internal_dict):
+def ipint_continue_until(debugger, command, exec_ctx, output, internal_dict):
     try:
         op_index = IPINT_INSTRUCTIONS.index(command)
         for i in range(len(IPINT_INSTRUCTIONS)):
@@ -271,42 +293,52 @@ def ipint_continue_until(debugger, command, exec_ctx, result, internal_dict):
         for i in range(len(IPINT_INSTRUCTIONS)):
             breakpoints[i].enabled = True
     except ValueError:
-        print(f'can\'t find operation {command}', file=result)
+        print(f'can\'t find operation {command}', file=output)
 
 
-def ipint_break_at(debugger, command, exec_ctx, result, internal_dict):
+def set_breakpoints_internal(debugger, initially_enable):
+    target = debugger.GetSelectedTarget()
+    for instr in IPINT_INSTRUCTIONS:
+        brk = target.BreakpointCreateByName(f'ipint_{instr}')
+        brk.SetCommandLineCommands(stop_commands)
+        brk.enabled = initially_enable
+        breakpoints.append(brk)
+
+
+def ipint_break_at(debugger, command, exec_ctx, output, internal_dict):
+    if not breakpoints:
+        set_breakpoints_internal(debugger, False)
     try:
         op_index = IPINT_INSTRUCTIONS.index(command)
         breakpoints[op_index].enabled = True
     except ValueError:
-        print(f'can\'t find operation {command}', file=result)
+        print(f'can\'t find operation {command}', file=output)
 
 
-def ipint_disable_all_breakpoints(debugger, command, exec_ctx, result, internal_dict):
+def ipint_disable_all_breakpoints(debugger, command, exec_ctx, output, internal_dict):
     for brk in breakpoints:
         brk.enabled = False
 
 
-def ipint_reenable_all_breakpoints(debugger, command, exec_ctx, result, internal_dict):
+def ipint_reenable_all_breakpoints(debugger, command, exec_ctx, output, internal_dict):
     for brk in breakpoints:
         brk.enabled = True
 
 
-def ipint_continue_on_all_breakpoints(debugger, command, exec_ctx, result, internal_dict):
+def ipint_continue_on_all_breakpoints(debugger, command, exec_ctx, output, internal_dict):
     for brk in breakpoints:
         brk.enabled = True
         brk.SetAutoContinue(True)
 
 
-def set_breakpoints(debugger, command, exe_ctx, result, internal_dict):
-    print("Initializing internal breakpoints...", file=result)
-    target = debugger.GetTargetAtIndex(0)
-
-    for instr in IPINT_INSTRUCTIONS:
-        brk = target.BreakpointCreateByName(f'ipint_{instr}')
-        brk.SetCommandLineCommands(stop_commands)
-        breakpoints.append(brk)
-    print("done!", file=result)
+def set_breakpoints(debugger, command, exe_ctx, output, internal_dict):
+    if not breakpoints:
+        print("Initializing internal breakpoints...", file=output)
+        set_breakpoints_internal(debugger, True)
+        print("done!", file=output)
+    else:
+        print("Breakpoints already set, enabling all", file=output)
+        ipint_reenable_all_breakpoints(debugger, command, exe_ctx, output, internal_dict)
 
 
 def __lldb_init_module(debugger, internal_dict):


### PR DESCRIPTION
#### db255dd395acdf767640ec368c7a6affb9dabc89
<pre>
Improve debug_ipint.py
<a href="https://bugs.webkit.org/show_bug.cgi?id=293443">https://bugs.webkit.org/show_bug.cgi?id=293443</a>
<a href="https://rdar.apple.com/151868845">rdar://151868845</a>

Reviewed by Daniel Liu.

This patch fixes some outstanding issues in debug_ipint.py, some introduced by an earlier set of
changes, some original:

    - ipint_break_at command
    - ipint_stack command

It also somewhat organizes the instruction symbol list and provides a tentative future change
(commented out) for the renaming of `fb_block` and 3 other instructions that was attempted
by <a href="https://bugs.webkit.org/show_bug.cgi?id=292725">https://bugs.webkit.org/show_bug.cgi?id=292725</a> but has been reverted for now.

* Source/JavaScriptCore/llint/InPlaceInterpreter64.asm:
* Tools/lldb/debug_ipint.py:
(extract_gprs):
(print_value):
(print_stack):
(find_instruction_addresses):
(find_instruction):
(ipint_state):
(ipint_stack):
(ipint_local):
(ipint_continue_until):
(set_breakpoints_internal):
(ipint_break_at):
(ipint_disable_all_breakpoints):
(ipint_reenable_all_breakpoints):
(ipint_continue_on_all_breakpoints):
(set_breakpoints):
(get_load_address): Deleted.
(get_instruction_addresses): Deleted.

Canonical link: <a href="https://commits.webkit.org/295340@main">https://commits.webkit.org/295340@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4bde8308f1262cd5bc06d563d0f55ef25ac2850e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104703 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24415 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/14837 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/109917 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/55377 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/106743 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/24806 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/32961 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79511 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107709 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19300 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94503 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59818 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/19067 "layout-tests (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/12578 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/54752 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/97384 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/88764 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/12628 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/112312 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/103321 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/31868 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23445 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88590 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32232 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/90732 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88208 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22498 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33102 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10881 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/27181 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/31793 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/37146 "Built successfully") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/127600 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/31585 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/127600 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/34926 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33144 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->