### PR TITLE
[HDR] Avoid colorSpace transformation and double caching when sharing an image with GPUProcess

### DIFF
--- a/LayoutTests/fast/images/hdr-background-image.html
+++ b/LayoutTests/fast/images/hdr-background-image.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html>
-<meta name="fuzzy" content="maxDifference=0-14; totalPixels=0-80000" />
+<meta name="fuzzy" content="maxDifference=0-68; totalPixels=0-80000" />
 <style>
     .container {
         width: 200px;

--- a/LayoutTests/fast/images/hdr-basic-image-dynamic-range-limit.html
+++ b/LayoutTests/fast/images/hdr-basic-image-dynamic-range-limit.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html>
-<meta name="fuzzy" content="maxDifference=0-6; totalPixels=0-40000" />
+<meta name="fuzzy" content="maxDifference=0-68; totalPixels=0-80000" />
 <style>
     .image-box {
         width: 200px;

--- a/LayoutTests/fast/images/hdr-basic-image.html
+++ b/LayoutTests/fast/images/hdr-basic-image.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html>
-<meta name="fuzzy" content="maxDifference=0-6; totalPixels=0-80000" />
+<meta name="fuzzy" content="maxDifference=0-68; totalPixels=0-80000" />
 <style>
     .image-box {
         width: 200px;

--- a/LayoutTests/fast/images/hdr-border-image.html
+++ b/LayoutTests/fast/images/hdr-border-image.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html>
-<meta name="fuzzy" content="maxDifference=0-6; totalPixels=0-40000" />
+<meta name="fuzzy" content="maxDifference=0-68; totalPixels=0-40000" />
 <style>
     .container {
         width: 200px;

--- a/LayoutTests/fast/images/hdr-image-layer-sdr-dynamic-range-limit.html
+++ b/LayoutTests/fast/images/hdr-image-layer-sdr-dynamic-range-limit.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html>
-<meta name="fuzzy" content="maxDifference=0-14; totalPixels=0-80000" />
+<meta name="fuzzy" content="maxDifference=0-68; totalPixels=0-80000" />
 <style>
     .image-box {
         width: 200px;

--- a/LayoutTests/fast/images/hdr-pseudo-before-image.html
+++ b/LayoutTests/fast/images/hdr-pseudo-before-image.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html>
-<meta name="fuzzy" content="maxDifference=0-14; totalPixels=0-80000" />
+<meta name="fuzzy" content="maxDifference=0-68; totalPixels=0-80000" />
 <style>
     .container {
         width: 200px;

--- a/LayoutTests/fast/images/hdr-svg-inline-image.html
+++ b/LayoutTests/fast/images/hdr-svg-inline-image.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html>
-<meta name="fuzzy" content="maxDifference=0-6; totalPixels=0-40000" />
+<meta name="fuzzy" content="maxDifference=0-68; totalPixels=0-40000" />
 <style>
     .image-box {
         width: 200px;

--- a/LayoutTests/platform/ios/compositing/hdr/hdr-basic-image-dynamic-range-limit-expected.txt
+++ b/LayoutTests/platform/ios/compositing/hdr/hdr-basic-image-dynamic-range-limit-expected.txt
@@ -16,6 +16,7 @@
                 (GraphicsLayer
                   (bounds 200.00 200.00)
                   (drawsContent 1)
+                  (drawsHDRContent 1)
                 )
               )
             )

--- a/LayoutTests/platform/mac-wk2/compositing/hdr/hdr-basic-image-dynamic-range-limit-expected.txt
+++ b/LayoutTests/platform/mac-wk2/compositing/hdr/hdr-basic-image-dynamic-range-limit-expected.txt
@@ -16,6 +16,7 @@
                 (GraphicsLayer
                   (bounds 200.00 200.00)
                   (drawsContent 1)
+                  (drawsHDRContent 1)
                 )
               )
             )

--- a/Source/WebCore/platform/graphics/DestinationColorSpace.cpp
+++ b/Source/WebCore/platform/graphics/DestinationColorSpace.cpp
@@ -159,6 +159,17 @@ std::optional<DestinationColorSpace> DestinationColorSpace::asRGB() const
 #endif
 }
 
+std::optional<DestinationColorSpace> DestinationColorSpace::asExtended() const
+{
+    if (usesExtendedRange())
+        return *this;
+#if USE(CG)
+    if (RetainPtr colorSpace = adoptCF(CGColorSpaceCreateExtended(platformColorSpace())))
+        return DestinationColorSpace(WTFMove(colorSpace));
+#endif
+    return std::nullopt;
+}
+
 bool DestinationColorSpace::supportsOutput() const
 {
 #if USE(CG)

--- a/Source/WebCore/platform/graphics/DestinationColorSpace.h
+++ b/Source/WebCore/platform/graphics/DestinationColorSpace.h
@@ -63,6 +63,7 @@ public:
     PlatformColorSpace serializableColorSpace() const { return m_platformColorSpace; }
 
     WEBCORE_EXPORT std::optional<DestinationColorSpace> asRGB() const;
+    WEBCORE_EXPORT std::optional<DestinationColorSpace> asExtended() const;
 
     WEBCORE_EXPORT bool supportsOutput() const;
 

--- a/Source/WebCore/platform/graphics/ShareableBitmap.cpp
+++ b/Source/WebCore/platform/graphics/ShareableBitmap.cpp
@@ -36,9 +36,10 @@ namespace WebCore {
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER_AND_EXPORT(ShareableBitmap, WTF_INTERNAL);
 DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(ShareableBitmap);
 
-ShareableBitmapConfiguration::ShareableBitmapConfiguration(const IntSize& size, std::optional<DestinationColorSpace> colorSpace, bool isOpaque)
+ShareableBitmapConfiguration::ShareableBitmapConfiguration(const IntSize& size, std::optional<DestinationColorSpace> colorSpace, Headroom headroom, bool isOpaque)
     : m_size(size)
     , m_colorSpace(validateColorSpace(colorSpace))
+    , m_headroom(headroom)
     , m_isOpaque(isOpaque)
     , m_bytesPerPixel(calculateBytesPerPixel(this->colorSpace()))
     , m_bytesPerRow(calculateBytesPerRow(size, this->colorSpace()))
@@ -52,13 +53,14 @@ ShareableBitmapConfiguration::ShareableBitmapConfiguration(const IntSize& size, 
     ASSERT(!m_size.isEmpty());
 }
 
-ShareableBitmapConfiguration::ShareableBitmapConfiguration(const IntSize& size, std::optional<DestinationColorSpace> colorSpace, bool isOpaque, unsigned bytesPerPixel, unsigned bytesPerRow
+ShareableBitmapConfiguration::ShareableBitmapConfiguration(const IntSize& size, std::optional<DestinationColorSpace> colorSpace, Headroom headroom, bool isOpaque, unsigned bytesPerPixel, unsigned bytesPerRow
 #if USE(CG)
     , CGBitmapInfo bitmapInfo
 #endif
 )
     : m_size(size)
     , m_colorSpace(colorSpace)
+    , m_headroom(headroom)
     , m_isOpaque(isOpaque)
     , m_bytesPerPixel(bytesPerPixel)
     , m_bytesPerRow(bytesPerRow)

--- a/Source/WebCore/platform/graphics/ShareableBitmap.h
+++ b/Source/WebCore/platform/graphics/ShareableBitmap.h
@@ -27,6 +27,7 @@
 
 #include "CopyImageOptions.h"
 #include "DestinationColorSpace.h"
+#include "ImageTypes.h"
 #include "IntRect.h"
 #include "PlatformImage.h"
 #include "SharedMemory.h"
@@ -50,8 +51,8 @@ class ShareableBitmapConfiguration {
 public:
     ShareableBitmapConfiguration() = default;
 
-    WEBCORE_EXPORT ShareableBitmapConfiguration(const IntSize&, std::optional<DestinationColorSpace> = std::nullopt, bool isOpaque = false);
-    WEBCORE_EXPORT ShareableBitmapConfiguration(const IntSize&, std::optional<DestinationColorSpace>, bool isOpaque, unsigned bytesPerPixel, unsigned bytesPerRow
+    WEBCORE_EXPORT ShareableBitmapConfiguration(const IntSize&, std::optional<DestinationColorSpace> = std::nullopt, Headroom = Headroom::None, bool isOpaque = false);
+    WEBCORE_EXPORT ShareableBitmapConfiguration(const IntSize&, std::optional<DestinationColorSpace>, Headroom, bool isOpaque, unsigned bytesPerPixel, unsigned bytesPerRow
 #if USE(CG)
         , CGBitmapInfo
 #endif
@@ -63,6 +64,7 @@ public:
     IntSize size() const { return m_size; }
     const DestinationColorSpace& colorSpace() const { return m_colorSpace ? *m_colorSpace : DestinationColorSpace::SRGB(); }
     PlatformColorSpaceValue platformColorSpace() const { return colorSpace().platformColorSpace(); }
+    Headroom headroom() const { return m_headroom; }
     bool isOpaque() const { return m_isOpaque; }
 
     unsigned bytesPerPixel() const { ASSERT(!m_bytesPerPixel.hasOverflowed()); return m_bytesPerPixel; }
@@ -90,6 +92,7 @@ private:
 
     IntSize m_size;
     std::optional<DestinationColorSpace> m_colorSpace;
+    Headroom m_headroom { Headroom::None };
     bool m_isOpaque { false };
 
     CheckedUint32 m_bytesPerPixel;

--- a/Source/WebCore/platform/graphics/cg/NativeImageCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/NativeImageCG.cpp
@@ -121,13 +121,6 @@ void NativeImage::draw(GraphicsContext& context, const FloatRect& destinationRec
     }
 #endif
 
-#if !HAVE(FIX_FOR_RADAR_147007029)
-    if (options.dynamicRangeLimit() == PlatformDynamicRangeLimit::standard()) {
-        drawWithToneMapping(context, destinationRect, sourceRect, options);
-        return;
-    }
-#endif
-
     context.drawNativeImageInternal(*this, destinationRect, sourceRect, options);
 }
 

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -5936,8 +5936,6 @@ static bool hasVisibleBoxDecorationsOrBackground(const RenderElement& renderer)
 static bool rendererHasHDRContent(const RenderElement& renderer)
 {
     auto& style = renderer.style();
-    if (style.dynamicRangeLimit() == Style::DynamicRangeLimit(CSS::Keyword::Standard { }))
-        return false;
 
     if (CheckedPtr imageRenderer = dynamicDowncast<RenderImage>(renderer)) {
         if (auto* cachedImage = imageRenderer->cachedImage()) {

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -8542,6 +8542,7 @@ header: <WebCore/ShareableBitmap.h>
 [CustomHeader] class WebCore::ShareableBitmapConfiguration {
     [Validator='m_size->width() >= 0 && m_size->height() >= 0'] WebCore::IntSize m_size;
     std::optional<WebCore::DestinationColorSpace> m_colorSpace;
+    WebCore::Headroom m_headroom;
     bool m_isOpaque;
     unsigned bytesPerPixel();
     unsigned bytesPerRow();

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.cpp
@@ -105,11 +105,9 @@ void RemoteResourceCacheProxy::recordNativeImageUse(NativeImage& image, const De
 
     handle->takeOwnershipOfMemory(MemoryLedger::Graphics);
 
-    // FIXME: Remove the double backends for HDR images when the tonemapping can be applied in GPUProcess. <https://webkit.org/b/292679>
-    if (newBackend && !image.hasHDRContent()) {
-        // Replace the contents of the original NativeImage to save memory.
+    // Replace the contents of the original NativeImage to save memory.
+    if (newBackend)
         image.replaceBackend(makeUniqueRefFromNonNullUniquePtr(WTFMove(newBackend)));
-    }
 
     // Tell the GPU process to cache this resource.
     m_remoteRenderingBackendProxy->cacheNativeImage(WTFMove(*handle), identifier);

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.mm
@@ -298,8 +298,15 @@ DestinationColorSpace PlatformCALayerRemote::displayColorSpace() const
     if (auto displayColorSpace = contentsFormatExtendedColorSpace(contentsFormat()))
         return displayColorSpace.value();
 #else
-    if (auto displayColorSpace = m_context ? m_context->displayColorSpace() : std::nullopt)
+    if (auto displayColorSpace = m_context ? m_context->displayColorSpace() : std::nullopt) {
+#if ENABLE(PIXEL_FORMAT_RGBA16F)
+        if (contentsFormat() == ContentsFormat::RGBA16F) {
+            if (auto extendedDisplayColorSpace = displayColorSpace->asExtended())
+                return extendedDisplayColorSpace.value();
+        }
+#endif
         return displayColorSpace.value();
+    }
 #endif
 
     return DestinationColorSpace::SRGB();


### PR DESCRIPTION
#### 1cfbc06323c83c1436ab9208965a2665fc93ff73
<pre>
[HDR] Avoid colorSpace transformation and double caching when sharing an image with GPUProcess
<a href="https://bugs.webkit.org/show_bug.cgi?id=293450">https://bugs.webkit.org/show_bug.cgi?id=293450</a>
<a href="https://rdar.apple.com/151876825">rdar://151876825</a>

Reviewed by Simon Fraser.

Currently ShareableBitmap shares an image with GPUProcess by drawing it to a
SharedMemory only if its colorSpace is not sRGB. Otherwise it uses the data
provider to copy the pixels to a SharedMemory. In addition to the SharedMemory,
the image metadata which is stored in ShareableBitmapConfiguration, GPUProcess
can construct the original image.

Also NativeImage::draw() does the tone-mapping to SDR in WebProcess before
sharing the image with GPUProcess. It does this by drawing the image to an SDR
unaccelerated ImageBuffer. But this forces RemoteResourceCacheProxy to double
cache the image: one copy for the SDR and the other copy for the HDR.

These two steps can be avoided if
(1) the data provider approach is used for any colorSpace.
(2) the system tone-mapping APIs are used to tone-map the HDR image to SDR.
(3) the extended display ColorSpace is used for HDR layers.

* LayoutTests/fast/images/hdr-background-image.html:
* LayoutTests/fast/images/hdr-basic-image-dynamic-range-limit.html:
* LayoutTests/fast/images/hdr-basic-image.html:
* LayoutTests/fast/images/hdr-border-image.html:
* LayoutTests/fast/images/hdr-image-layer-sdr-dynamic-range-limit.html:
* LayoutTests/fast/images/hdr-pseudo-before-image.html:
* LayoutTests/fast/images/hdr-svg-inline-image.html:
The pixel tolerance in the ref test has to be increased due to using the
extended display ColorSpace for HDR layers. This should be revisited if
the system behavior changes.

* LayoutTests/platform/ios/compositing/hdr/hdr-basic-image-dynamic-range-limit-expected.txt:
* LayoutTests/platform/mac-wk2/compositing/hdr/hdr-basic-image-dynamic-range-limit-expected.txt:
HDR images with &quot;dynamic-range-limit: standard;&quot; have to be drawn to
HDR layers. Tone-mapping functions will be used to get the SDR images.

* Source/WebCore/platform/graphics/DestinationColorSpace.cpp:
(WebCore::DestinationColorSpace::asExtended const):
* Source/WebCore/platform/graphics/DestinationColorSpace.h:
* Source/WebCore/platform/graphics/ShareableBitmap.cpp:
(WebCore::ShareableBitmapConfiguration::ShareableBitmapConfiguration):
* Source/WebCore/platform/graphics/ShareableBitmap.h:
(WebCore::ShareableBitmapConfiguration::headroom const):
* Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp:
(WebCore::setCGDynamicRangeLimitForImage):
(WebCore::GraphicsContextCG::drawNativeImageInternal):
* Source/WebCore/platform/graphics/cg/NativeImageCG.cpp:
(WebCore::NativeImage::draw):
* Source/WebCore/platform/graphics/cg/ShareableBitmapCG.mm:
(WebCore::ShareableBitmapConfiguration::ShareableBitmapConfiguration):
(WebCore::ShareableBitmap::createFromImagePixels):
(WebCore::ShareableBitmap::createCGImage const):
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::calculateClipRects const):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.cpp:
(WebKit::RemoteResourceCacheProxy::recordNativeImageUse):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.mm:
(WebKit::PlatformCALayerRemote::displayColorSpace const):

Canonical link: <a href="https://commits.webkit.org/295899@main">https://commits.webkit.org/295899@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/85e9de1278385f5b117816987e1a66b9e2d6d5dd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/106473 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/26222 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/16620 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/111675 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/57069 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/108512 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/26889 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34725 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80864 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/109477 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/21322 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/96082 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/61194 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/20787 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/14183 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/56510 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/90667 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/14218 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/114535 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33611 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24780 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89935 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33975 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/92313 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89642 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22877 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34535 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/12355 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/29220 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/33536 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/38948 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/33282 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/36635 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34880 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->