### PR TITLE
Validate SecurityOriginData when creating storage paths with it

### DIFF
--- a/Source/WebCore/Modules/indexeddb/IDBDatabaseIdentifier.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBDatabaseIdentifier.cpp
@@ -78,6 +78,16 @@ String IDBDatabaseIdentifier::databaseDirectoryRelativeToRoot(const ClientOrigin
     return FileSystem::pathByAppendingComponent(mainFrameDirectory, origin.clientOrigin.databaseIdentifier());
 }
 
+String IDBDatabaseIdentifier::optionalDatabaseDirectoryRelativeToRoot(const ClientOrigin& origin, const String& rootDirectory, ASCIILiteral versionString)
+{
+    auto topOriginURL = origin.topOrigin.toURL();
+    auto clientOriginURL = origin.clientOrigin.toURL();
+    if (!topOriginURL.isValid() || !clientOriginURL.isValid())
+        return { };
+
+    return databaseDirectoryRelativeToRoot(origin, rootDirectory, versionString);
+}
+
 #if !LOG_DISABLED
 String IDBDatabaseIdentifier::loggingString() const
 {

--- a/Source/WebCore/Modules/indexeddb/IDBDatabaseIdentifier.h
+++ b/Source/WebCore/Modules/indexeddb/IDBDatabaseIdentifier.h
@@ -70,6 +70,7 @@ public:
 
     String databaseDirectoryRelativeToRoot(const String& rootDirectory, ASCIILiteral versionString = "v1"_s) const;
     WEBCORE_EXPORT static String databaseDirectoryRelativeToRoot(const ClientOrigin&, const String& rootDirectory, ASCIILiteral versionString);
+    WEBCORE_EXPORT static String optionalDatabaseDirectoryRelativeToRoot(const ClientOrigin&, const String& rootDirectory, ASCIILiteral versionString);
 
 #if !LOG_DISABLED
     String loggingString() const;

--- a/Source/WebCore/page/SecurityOriginData.cpp
+++ b/Source/WebCore/page/SecurityOriginData.cpp
@@ -116,6 +116,15 @@ String SecurityOriginData::databaseIdentifier() const
     return makeString(protocol, separatorCharacter, FileSystem::encodeForFileName(host()), separatorCharacter, port().value_or(0));
 }
 
+String SecurityOriginData::optionalDatabaseIdentifier() const
+{
+    auto url = toURL();
+    if (!url.isValid())
+        return { };
+
+    return databaseIdentifier();
+}
+
 std::optional<SecurityOriginData> SecurityOriginData::fromDatabaseIdentifier(StringView databaseIdentifier)
 {
     // Make sure there's a first separator

--- a/Source/WebCore/page/SecurityOriginData.h
+++ b/Source/WebCore/page/SecurityOriginData.h
@@ -125,6 +125,7 @@ public:
     // Serialize the security origin to a string that could be used as part of
     // file names. This format should be used in storage APIs only.
     WEBCORE_EXPORT String databaseIdentifier() const;
+    WEBCORE_EXPORT String optionalDatabaseIdentifier() const;
     WEBCORE_EXPORT static std::optional<SecurityOriginData> fromDatabaseIdentifier(StringView);
 
     bool isNull() const

--- a/Source/WebKit/NetworkProcess/storage/IDBStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/IDBStorageManager.cpp
@@ -125,8 +125,14 @@ String IDBStorageManager::idbStorageOriginDirectory(const String& rootDirectory,
     if (rootDirectory.isEmpty())
         return emptyString();
 
-    auto originDirectory = WebCore::IDBDatabaseIdentifier::databaseDirectoryRelativeToRoot(origin, rootDirectory, "v1"_s);
-    auto oldOriginDirectory = WebCore::IDBDatabaseIdentifier::databaseDirectoryRelativeToRoot(origin, rootDirectory, "v0"_s);
+    auto originDirectory = WebCore::IDBDatabaseIdentifier::optionalDatabaseDirectoryRelativeToRoot(origin, rootDirectory, "v1"_s);
+    if (originDirectory.isEmpty())
+        return emptyString();
+
+    auto oldOriginDirectory = WebCore::IDBDatabaseIdentifier::optionalDatabaseDirectoryRelativeToRoot(origin, rootDirectory, "v0"_s);
+    if (oldOriginDirectory.isEmpty())
+        return emptyString();
+
     migrateOriginDataImpl(oldOriginDirectory, originDirectory, [](const String& name) {
         return WebCore::SQLiteFileSystem::computeHashForFileName(WebCore::IDBServer::SQLiteIDBBackingStore::decodeDatabaseName(name));
     });

--- a/Source/WebKit/NetworkProcess/storage/LocalStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/LocalStorageManager.cpp
@@ -59,7 +59,11 @@ static std::optional<WebCore::SecurityOriginData> fileNameToOrigin(const String&
 
 static String originToFileName(const WebCore::ClientOrigin& origin)
 {
-    return makeString(origin.clientOrigin.databaseIdentifier(), ".localstorage"_s);
+    auto databaseIdentifier = origin.clientOrigin.optionalDatabaseIdentifier();
+    if (databaseIdentifier.isEmpty())
+        return { };
+
+    return makeString(databaseIdentifier, ".localstorage"_s);
 }
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(LocalStorageManager);
@@ -83,7 +87,11 @@ String LocalStorageManager::localStorageFilePath(const String& directory, const 
     if (directory.isEmpty())
         return emptyString();
 
-    return FileSystem::pathByAppendingComponent(directory, originToFileName(origin));
+    auto fileName = originToFileName(origin);
+    if (fileName.isEmpty())
+        return emptyString();
+
+    return FileSystem::pathByAppendingComponent(directory, fileName);
 }
 
 String LocalStorageManager::localStorageFilePath(const String& directory)


### PR DESCRIPTION
#### 8d04125bac35a6ad03dcba49e807abcab0829b50
<pre>
Validate SecurityOriginData when creating storage paths with it
<a href="https://rdar.apple.com/145635733">rdar://145635733</a>

Reviewed by Per Arne Vollan.

IDBStorageManager and LocalStorageManager use ClientOrigin included in IPC message sent by web content process to
create file paths (NetworkStorageManager::originStorageManager() can be invoked when handling IPC messages).
Specifically, IDBDatabaseIdentifier::databaseDirectoryRelativeToRoot() and SecurityOriginData::databaseIdentifier() are
used to construct the paths. As web content process cannot be trusted, the origin should be validated. This patch adds
SecurityOriginData::optionalDatabaseIdentifier() and IDBDatabaseIdentifier::optionalDatabaseDirectoryRelativeToRoot(),
which validate origin and return null string if validation fails. By adopting this, IDBStorageManager and
LocalStorageManager will get empty storage paths and will not perform operations on disk.

* Source/WebCore/Modules/indexeddb/IDBDatabaseIdentifier.cpp:
(WebCore::IDBDatabaseIdentifier::optionalDatabaseDirectoryRelativeToRoot):
* Source/WebCore/Modules/indexeddb/IDBDatabaseIdentifier.h:
* Source/WebCore/page/SecurityOriginData.cpp:
(WebCore::SecurityOriginData::optionalDatabaseIdentifier const):
* Source/WebCore/page/SecurityOriginData.h:
* Source/WebKit/NetworkProcess/storage/IDBStorageManager.cpp:
(WebKit::IDBStorageManager::idbStorageOriginDirectory):
* Source/WebKit/NetworkProcess/storage/LocalStorageManager.cpp:
(WebKit::originToFileName):
(WebKit::LocalStorageManager::localStorageFilePath):

Originally-landed-as: 289651.238@safari-7621-branch (652e27ab58f4). <a href="https://rdar.apple.com/151708061">rdar://151708061</a>
Canonical link: <a href="https://commits.webkit.org/295299@main">https://commits.webkit.org/295299@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d03f638bbd10145fedc5102d0353b8ef1bfe60e8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104697 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/131/builds/24409 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/14831 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/109911 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/55371 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/106737 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/24800 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/123/builds/32955 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/109911 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/55371 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107703 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/130/builds/24800 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/94494 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/109911 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/130/builds/24800 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/12569 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/54746 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/130/builds/24800 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/12619 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/112306 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/31862 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/123/builds/32955 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/112306 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/32226 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/90723 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/112306 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/10875 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/27175 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16987 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/31787 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/37139 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/31579 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/34920 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/33138 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->