### PR TITLE
[CoreIPC][Networking] MemoryObjectStoreCursor::iterate should invalidate `m_iterator` too when invalidating `m_currentPositionKey`

### DIFF
--- a/Source/WebCore/Modules/indexeddb/server/MemoryObjectStoreCursor.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/MemoryObjectStoreCursor.cpp
@@ -330,12 +330,14 @@ void MemoryObjectStoreCursor::iterate(const IDBKeyData& key, const IDBKeyData& p
     Ref objectStore = m_objectStore.get();
     if (!objectStore->orderedKeys()) {
         m_currentPositionKey = { };
+        m_iterator = std::nullopt;
         outData = { };
         return;
     }
 
     if (key.isValid() && !info().range().containsKey(key)) {
         m_currentPositionKey = { };
+        m_iterator = std::nullopt;
         outData = { };
         return;
     }


### PR DESCRIPTION
#### 65e790f57dc0d5b879926faa2628d5cc76ca66ce
<pre>
[CoreIPC][Networking] MemoryObjectStoreCursor::iterate should invalidate `m_iterator` too when invalidating `m_currentPositionKey`
<a href="https://bugs.webkit.org/show_bug.cgi?id=289111">https://bugs.webkit.org/show_bug.cgi?id=289111</a>
<a href="https://rdar.apple.com/143027372">rdar://143027372</a>

Reviewed by Sihui Liu.

`m_currentPositionKey` must always be in sync with `m_iterator`. As in, it must always be
equal to the key that `m_iterator` is currently pointing to. It follows that when invalidating
`m_currentPositiionKey` in MemoryObjectStoreCursor::iterate(), we must invalidate `m_iterator`
as well.

* Source/WebCore/Modules/indexeddb/server/MemoryObjectStoreCursor.cpp:
(WebCore::IDBServer::MemoryObjectStoreCursor::iterate):

Originally-landed-as: 289651.236@safari-7621-branch (16f37eee4c63). <a href="https://rdar.apple.com/151648221">rdar://151648221</a>
Canonical link: <a href="https://commits.webkit.org/295300@main">https://commits.webkit.org/295300@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2259dd1479ede4c566e9203d6179323a6e082cd8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104699 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/131/builds/24411 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/14833 "Failed to checkout and rebase branch from PR 45789") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/109913 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/55373 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/106739 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/24802 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/123/builds/32957 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/109913 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/55373 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107705 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/130/builds/24802 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/138/builds/14833 "Failed to checkout and rebase branch from PR 45789") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/109913 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/130/builds/24802 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/138/builds/14833 "Failed to checkout and rebase branch from PR 45789") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/54748 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/130/builds/24802 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/138/builds/14833 "Failed to checkout and rebase branch from PR 45789") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/112308 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/31864 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/123/builds/32957 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/112308 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/32228 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/138/builds/14833 "Failed to checkout and rebase branch from PR 45789") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/112308 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/138/builds/14833 "Failed to checkout and rebase branch from PR 45789") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/27177 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16988 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/31789 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/37141 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/31581 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/34922 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/33140 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->