### PR TITLE
AX: aria-expanded should be supported on WebCoreLink

### DIFF
--- a/LayoutTests/accessibility/aria-expanded-links-expected.txt
+++ b/LayoutTests/accessibility/aria-expanded-links-expected.txt
@@ -1,0 +1,11 @@
+This tests that aria-expanded works as expected on links.
+
+PASS: link.isAttributeSupported('AXExpanded') === true
+PASS: link.isExpanded === true
+Changing link expanded status to FALSE
+PASS: link.isExpanded === false
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+This is an expanded link.

--- a/LayoutTests/accessibility/aria-expanded-links.html
+++ b/LayoutTests/accessibility/aria-expanded-links.html
@@ -1,0 +1,34 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../resources/js-test.js"></script>
+<script src="../resources/accessibility-helper.js"></script>
+</head>
+<body>
+
+<a id="link" aria-expanded="true" href="#">This is an expanded link.</a>
+
+<script>
+var output = "This tests that aria-expanded works as expected on links.\n\n";
+
+var link;
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+    link = accessibilityController.accessibleElementById('link');
+    output += expect("link.isAttributeSupported('AXExpanded')", "true");
+    output += expect("link.isExpanded", "true");
+
+    output += "Changing link expanded status to FALSE\n";
+    document.getElementById("link").setAttribute("aria-expanded", "false");
+    setTimeout(async () => {
+        await waitFor(() => link.isExpanded == false);
+        output += expect("link.isExpanded", "false");
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+
+</body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -703,6 +703,9 @@ accessibility/dynamic-datetime-attribute.html [ Skip ]
 # AccessibilityUIElement::isAttributeSupported needs to be updated to handle AXSelectedRows.
 accessibility/aria-table-selection-support.html [ Skip ]
 
+# AccessibilityUIElement::isAttributeSupported doesn't handle AXExpanded.
+accessibility/aria-expanded-links.html [ Skip ]
+
 # AccessibilityUIElement::customContent is not implemented.
 accessibility/dynamic-aria-describedby-subtree.html [ Skip ]
 accessibility/dynamic-aria-describedby-text.html [ Skip ]

--- a/LayoutTests/platform/glib/accessibility/aria-expanded-supported-roles-expected.txt
+++ b/LayoutTests/platform/glib/accessibility/aria-expanded-supported-roles-expected.txt
@@ -5,6 +5,7 @@ AXRole: AXCheckBox is expanded
 AXRole: AXColumnHeader is expanded
 AXRole: AXComboBox is expanded
 AXRole: AXCell is expanded
+AXRole: AXLink is expanded
 AXRole: AXMenuItem is expanded
 AXRole: AXCheckMenuItem is expanded
 AXRole: AXRadioMenuItem is expanded

--- a/LayoutTests/platform/mac/accessibility/aria-expanded-supported-roles-expected.txt
+++ b/LayoutTests/platform/mac/accessibility/aria-expanded-supported-roles-expected.txt
@@ -5,6 +5,7 @@ AXRole: AXCheckBox is expanded
 AXRole: AXCell is expanded
 AXRole: AXComboBox is expanded
 AXRole: AXCell is expanded
+AXRole: AXLink is expanded
 AXRole: AXMenuItem is expanded
 AXRole: AXMenuItem is expanded
 AXRole: AXMenuItem is expanded

--- a/Source/WebCore/accessibility/AXCoreObject.cpp
+++ b/Source/WebCore/accessibility/AXCoreObject.cpp
@@ -40,7 +40,7 @@ namespace WebCore {
 bool AXCoreObject::isLink() const
 {
     auto role = roleValue();
-    return role == AccessibilityRole::Link || role == AccessibilityRole::WebCoreLink;
+    return role == AccessibilityRole::Link;
 }
 
 bool AXCoreObject::isList() const
@@ -144,7 +144,6 @@ bool AXCoreObject::isImplicitlyInteractive() const
     case AccessibilityRole::TextArea:
     case AccessibilityRole::TextField:
     case AccessibilityRole::ToggleButton:
-    case AccessibilityRole::WebCoreLink:
         return true;
     default:
         return false;

--- a/Source/WebCore/accessibility/AXCoreObject.h
+++ b/Source/WebCore/accessibility/AXCoreObject.h
@@ -262,7 +262,6 @@ enum class AccessibilityRole : uint8_t {
     Video,
     WebApplication,
     WebArea,
-    WebCoreLink,
 };
 
 using AccessibilityRoleSet = HashSet<AccessibilityRole, IntHash<AccessibilityRole>, WTF::StrongEnumHashTraits<AccessibilityRole>>;
@@ -536,8 +535,6 @@ ALWAYS_INLINE String accessibilityRoleToString(AccessibilityRole role)
         return "WebApplication"_s;
     case AccessibilityRole::WebArea:
         return "WebArea"_s;
-    case AccessibilityRole::WebCoreLink:
-        return "WebCoreLink"_s;
     }
     UNREACHABLE();
     return ""_s;

--- a/Source/WebCore/accessibility/AXSearchManager.cpp
+++ b/Source/WebCore/accessibility/AXSearchManager.cpp
@@ -114,7 +114,7 @@ bool AXSearchManager::matchForSearchKeyAtIndex(Ref<AXCoreObject> axObject, const
         bool isLink = axObject->isLink();
 #if PLATFORM(IOS_FAMILY)
         if (!isLink)
-            isLink = axObject->isDescendantOfRole(AccessibilityRole::WebCoreLink);
+            isLink = axObject->isDescendantOfRole(AccessibilityRole::Link);
 #endif
         return isLink;
     }

--- a/Source/WebCore/accessibility/AccessibilityImageMapLink.cpp
+++ b/Source/WebCore/accessibility/AccessibilityImageMapLink.cpp
@@ -66,7 +66,7 @@ AccessibilityRole AccessibilityImageMapLink::determineAccessibilityRole()
     if ((m_ariaRole = determineAriaRoleAttribute()) != AccessibilityRole::Unknown)
         return m_ariaRole;
 
-    return !url().isEmpty() ? AccessibilityRole::WebCoreLink : AccessibilityRole::Generic;
+    return !url().isEmpty() ? AccessibilityRole::Link : AccessibilityRole::Generic;
 }
 
 bool AccessibilityImageMapLink::computeIsIgnored() const

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
@@ -327,7 +327,7 @@ AccessibilityRole AccessibilityNodeObject::determineAccessibilityRoleFromNode(Tr
         return AccessibilityRole::Unknown;
 
     if (element->isLink())
-        return AccessibilityRole::WebCoreLink;
+        return AccessibilityRole::Link;
     if (RefPtr selectElement = dynamicDowncast<HTMLSelectElement>(*element))
         return selectElement->multiple() ? AccessibilityRole::ListBox : AccessibilityRole::PopUpButton;
     if (is<HTMLImageElement>(*element) && element->hasAttributeWithoutSynchronization(usemapAttr))

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -2296,7 +2296,6 @@ String AccessibilityObject::localizedActionVerb() const
     case AccessibilityRole::Switch:
         return isChecked() ? checkedCheckboxAction : uncheckedCheckboxAction;
     case AccessibilityRole::Link:
-    case AccessibilityRole::WebCoreLink:
         return linkAction;
     case AccessibilityRole::PopUpButton:
         return menuListAction;
@@ -2329,7 +2328,6 @@ String AccessibilityObject::actionVerb() const
     case AccessibilityRole::Switch:
         return isChecked() ? "uncheck"_s : "check"_s;
     case AccessibilityRole::Link:
-    case AccessibilityRole::WebCoreLink:
         return "jump"_s;
     case AccessibilityRole::PopUpButton:
     case AccessibilityRole::MenuListPopup:
@@ -2597,10 +2595,10 @@ static void initializeRoleMap()
         RoleEntry { "doc-acknowledgments"_s, AccessibilityRole::LandmarkDocRegion },
         RoleEntry { "doc-afterword"_s, AccessibilityRole::LandmarkDocRegion },
         RoleEntry { "doc-appendix"_s, AccessibilityRole::LandmarkDocRegion },
-        RoleEntry { "doc-backlink"_s, AccessibilityRole::WebCoreLink },
+        RoleEntry { "doc-backlink"_s, AccessibilityRole::Link },
         RoleEntry { "doc-biblioentry"_s, AccessibilityRole::ListItem },
         RoleEntry { "doc-bibliography"_s, AccessibilityRole::LandmarkDocRegion },
-        RoleEntry { "doc-biblioref"_s, AccessibilityRole::WebCoreLink },
+        RoleEntry { "doc-biblioref"_s, AccessibilityRole::Link },
         RoleEntry { "doc-chapter"_s, AccessibilityRole::LandmarkDocRegion },
         RoleEntry { "doc-colophon"_s, AccessibilityRole::TextGroup },
         RoleEntry { "doc-conclusion"_s, AccessibilityRole::LandmarkDocRegion },
@@ -2617,10 +2615,10 @@ static void initializeRoleMap()
         RoleEntry { "doc-footnote"_s, AccessibilityRole::Footnote },
         RoleEntry { "doc-foreword"_s, AccessibilityRole::LandmarkDocRegion },
         RoleEntry { "doc-glossary"_s, AccessibilityRole::LandmarkDocRegion },
-        RoleEntry { "doc-glossref"_s, AccessibilityRole::WebCoreLink },
+        RoleEntry { "doc-glossref"_s, AccessibilityRole::Link },
         RoleEntry { "doc-index"_s, AccessibilityRole::LandmarkNavigation },
         RoleEntry { "doc-introduction"_s, AccessibilityRole::LandmarkDocRegion },
-        RoleEntry { "doc-noteref"_s, AccessibilityRole::WebCoreLink },
+        RoleEntry { "doc-noteref"_s, AccessibilityRole::Link },
         RoleEntry { "doc-notice"_s, AccessibilityRole::DocumentNote },
         RoleEntry { "doc-pagebreak"_s, AccessibilityRole::Splitter },
         RoleEntry { "doc-pagelist"_s, AccessibilityRole::LandmarkNavigation },
@@ -2656,7 +2654,7 @@ static void initializeRoleMap()
         RoleEntry { "image"_s, AccessibilityRole::Image },
         RoleEntry { "img"_s, AccessibilityRole::Image },
         RoleEntry { "insertion"_s, AccessibilityRole::Insertion },
-        RoleEntry { "link"_s, AccessibilityRole::WebCoreLink },
+        RoleEntry { "link"_s, AccessibilityRole::Link },
         RoleEntry { "list"_s, AccessibilityRole::List },
         RoleEntry { "listitem"_s, AccessibilityRole::ListItem },
         RoleEntry { "listbox"_s, AccessibilityRole::ListBox },

--- a/Source/WebCore/accessibility/AccessibilityObject.h
+++ b/Source/WebCore/accessibility/AccessibilityObject.h
@@ -980,7 +980,7 @@ inline unsigned AccessibilityObject::getLengthForTextRange() const { return text
 inline bool AccessibilityObject::hasTextContent() const
 {
     return isStaticText()
-        || roleValue() == AccessibilityRole::WebCoreLink
+        || roleValue() == AccessibilityRole::Link
         || isTextControl() || isTabItem();
 }
 
@@ -988,7 +988,7 @@ inline bool AccessibilityObject::hasTextContent() const
 inline bool AccessibilityObject::hasAttributedText() const
 {
     return (isStaticText() && !isARIAStaticText())
-        || roleValue() == AccessibilityRole::WebCoreLink
+        || roleValue() == AccessibilityRole::Link
         || isTextControl() || isTabItem();
 }
 #endif

--- a/Source/WebCore/accessibility/AccessibilitySVGObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilitySVGObject.cpp
@@ -316,7 +316,7 @@ AccessibilityRole AccessibilitySVGObject::determineAccessibilityRole()
     if (m_renderer->isRenderSVGTSpan())
         return AccessibilityRole::SVGTSpan;
     if (is<SVGAElement>(element))
-        return AccessibilityRole::WebCoreLink;
+        return AccessibilityRole::Link;
 
     return AccessibilityRenderObject::determineAccessibilityRole();
 }

--- a/Source/WebCore/accessibility/atspi/AccessibilityAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AccessibilityAtspi.cpp
@@ -726,7 +726,6 @@ static constexpr std::pair<AccessibilityRole, RoleNameEntry> roleNames[] = {
     { AccessibilityRole::UserInterfaceTooltip, { "tool tip", N_("tool tip") } },
     { AccessibilityRole::Video, { "video", N_("video") } },
     { AccessibilityRole::WebArea, { "document web", N_("document web") } },
-    { AccessibilityRole::WebCoreLink, { "link", N_("link") } },
 };
 
 const char* AccessibilityAtspi::localizedRoleName(AccessibilityRole role)

--- a/Source/WebCore/accessibility/atspi/AccessibilityObjectAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AccessibilityObjectAtspi.cpp
@@ -53,7 +53,6 @@ static inline bool roleIsTextType(AccessibilityRole role)
         || role == AccessibilityRole::Generic
         || role == AccessibilityRole::Cell
         || role == AccessibilityRole::Link
-        || role == AccessibilityRole::WebCoreLink
         || role == AccessibilityRole::ListItem
         || role == AccessibilityRole::Pre
         || role == AccessibilityRole::GridCell
@@ -250,7 +249,6 @@ static Atspi::Role atspiRole(AccessibilityRole role)
     case AccessibilityRole::GridCell:
         return Atspi::Role::TableCell;
     case AccessibilityRole::Link:
-    case AccessibilityRole::WebCoreLink:
         return Atspi::Role::Link;
     case AccessibilityRole::ImageMap:
         return Atspi::Role::ImageMap;

--- a/Source/WebCore/accessibility/cocoa/AXCoreObjectCocoa.mm
+++ b/Source/WebCore/accessibility/cocoa/AXCoreObjectCocoa.mm
@@ -519,7 +519,6 @@ PlatformRoleMap createPlatformRoleMap()
         { AccessibilityRole::Link, NSAccessibilityLinkRole },
         { AccessibilityRole::Grid, NSAccessibilityTableRole },
         { AccessibilityRole::TreeGrid, NSAccessibilityTableRole },
-        { AccessibilityRole::WebCoreLink, NSAccessibilityLinkRole },
         { AccessibilityRole::ImageMap, NSAccessibilityImageMapRole },
         { AccessibilityRole::ListMarker, NSAccessibilityListMarkerRole },
         { AccessibilityRole::WebArea, NSAccessibilityWebAreaRole },

--- a/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
+++ b/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
@@ -670,7 +670,6 @@ static AccessibilityObjectWrapper *ancestorWithRole(const AXCoreObject& descenda
 
         switch (parentRole) {
         case AccessibilityRole::Link:
-        case AccessibilityRole::WebCoreLink:
             traits |= [self _axLinkTrait];
             if (parent->isVisitedLink())
                 traits |= [self _axVisitedTrait];
@@ -782,7 +781,6 @@ static AccessibilityObjectWrapper *ancestorWithRole(const AXCoreObject& descenda
     uint64_t traits = [self _axWebContentTrait];
     switch (role) {
     case AccessibilityRole::Link:
-    case AccessibilityRole::WebCoreLink:
         traits |= [self _axLinkTrait];
         if (self.axBackingObject->isVisitedLink())
             traits |= [self _axVisitedTrait];
@@ -936,7 +934,6 @@ static AccessibilityObjectWrapper *ancestorWithRole(const AXCoreObject& descenda
 
     // Links can sometimes be elements (when they only contain static text or don't contain anything).
     // They should not be elements when containing text and other types.
-    case AccessibilityRole::WebCoreLink:
     case AccessibilityRole::Link:
         // Links can sometimes be elements (when they only contain static text or don't contain anything).
         // They should not be elements when containing text and other types.
@@ -1771,7 +1768,7 @@ static void appendStringToResult(NSMutableString *result, NSString *string)
         return NO;
     
     AccessibilityRole role = self.axBackingObject->roleValue();
-    if (role != AccessibilityRole::Link && role != AccessibilityRole::WebCoreLink)
+    if (role != AccessibilityRole::Link)
         return NO;
     
     const auto& children = self.axBackingObject->unignoredChildren();

--- a/Source/WebCore/page/InteractionRegion.cpp
+++ b/Source/WebCore/page/InteractionRegion.cpp
@@ -160,7 +160,6 @@ static bool shouldAllowAccessibilityRoleAsPointerCursorReplacement(const Element
     case AccessibilityRole::Button:
     case AccessibilityRole::Checkbox:
     case AccessibilityRole::Link:
-    case AccessibilityRole::WebCoreLink:
     case AccessibilityRole::ListBoxOption:
     case AccessibilityRole::MenuItem:
     case AccessibilityRole::MenuItemCheckbox:


### PR DESCRIPTION
#### 1d055ce00488eb9b591129eb6a913175cd678f12
<pre>
AX: aria-expanded should be supported on WebCoreLink
<a href="https://bugs.webkit.org/show_bug.cgi?id=293452">https://bugs.webkit.org/show_bug.cgi?id=293452</a>
<a href="https://rdar.apple.com/141163086">rdar://141163086</a>

Reviewed by Chris Fleizach.

SupportsExpanded did not handle WebCoreLink, meaning that links wouldn&apos;t report their
expanded status to ATs. Per the spec, links are a valid role for aria-expanded, so
we should return true for all WebCoreLinks.

Since there is no meaningful difference between WebCoreLink and Link, this PR also
removes all references to WebCoreLink, and switches to using Link everywhere.

* LayoutTests/accessibility/aria-expanded-links-expected.txt: Added.
* LayoutTests/accessibility/aria-expanded-links.html: Added.
* LayoutTests/platform/glib/accessibility/aria-expanded-supported-roles-expected.txt:
* LayoutTests/platform/mac/accessibility/aria-expanded-supported-roles-expected.txt:
* Source/WebCore/accessibility/AXCoreObject.cpp:
(WebCore::AXCoreObject::isLink const):
(WebCore::AXCoreObject::isImplicitlyInteractive const):
* Source/WebCore/accessibility/AXCoreObject.h:
(WebCore::accessibilityRoleToString):
* Source/WebCore/accessibility/AXSearchManager.cpp:
(WebCore::AXSearchManager::matchForSearchKeyAtIndex):
* Source/WebCore/accessibility/AccessibilityImageMapLink.cpp:
(WebCore::AccessibilityImageMapLink::determineAccessibilityRole):
* Source/WebCore/accessibility/AccessibilityNodeObject.cpp:
(WebCore::AccessibilityNodeObject::determineAccessibilityRoleFromNode const):
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::localizedActionVerb const):
(WebCore::AccessibilityObject::actionVerb const):
(WebCore::initializeRoleMap):
* Source/WebCore/accessibility/AccessibilityObject.h:
(WebCore::AccessibilityObject::hasTextContent const):
(WebCore::AccessibilityObject::hasAttributedText const):
* Source/WebCore/accessibility/AccessibilitySVGObject.cpp:
(WebCore::AccessibilitySVGObject::determineAccessibilityRole):
* Source/WebCore/accessibility/atspi/AccessibilityAtspi.cpp:
* Source/WebCore/accessibility/atspi/AccessibilityObjectAtspi.cpp:
(WebCore::roleIsTextType):
(WebCore::atspiRole):
* Source/WebCore/accessibility/cocoa/AXCoreObjectCocoa.mm:
(WebCore::Accessibility::createPlatformRoleMap):
* Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm:
(-[WebAccessibilityObjectWrapper _accessibilityTraitsFromAncestors]):
(-[WebAccessibilityObjectWrapper accessibilityTraits]):
(-[WebAccessibilityObjectWrapper determineIsAccessibilityElement]):
(-[WebAccessibilityObjectWrapper containsUnnaturallySegmentedChildren]):
* Source/WebCore/page/InteractionRegion.cpp:
(WebCore::shouldAllowAccessibilityRoleAsPointerCursorReplacement):

Canonical link: <a href="https://commits.webkit.org/295356@main">https://commits.webkit.org/295356@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e4f5e25b6d078588f3d3c0cb341686d27f424e75

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104841 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24554 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/14975 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110056 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/55515 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/106881 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/24954 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33099 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79608 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107847 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19404 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94617 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59915 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/19151 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/12694 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/54898 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/88851 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/12741 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/112486 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32006 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/23529 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88689 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32370 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/90843 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88317 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22509 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33206 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10972 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/27320 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/31931 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/37285 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/31723 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35064 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33282 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->