### PR TITLE
[Declarative Web Push] Relocate 'app_badge' entry from the 'notification' dictionary to the top level JSON

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm
@@ -2175,40 +2175,40 @@ static constexpr ASCIILiteral json8 = R"JSONRESOURCE(
 static constexpr ASCIILiteral json9 = R"JSONRESOURCE(
 {
     "web_push": 8030,
+    "app_badge": "",
     "notification": {
         "navigate": "https://example.com/",
-        "title": "Hello world!",
-        "app_badge": ""
+        "title": "Hello world!"
     }
 }
 )JSONRESOURCE"_s;
 static constexpr ASCIILiteral json10 = R"JSONRESOURCE(
 {
     "web_push": 8030,
+    "app_badge": -1,
     "notification": {
         "navigate": "https://example.com/",
-        "title": "Hello world!",
-        "app_badge": -1
+        "title": "Hello world!"
     }
 }
 )JSONRESOURCE"_s;
 static constexpr ASCIILiteral json11 = R"JSONRESOURCE(
 {
     "web_push": 8030,
+    "app_badge": { },
     "notification": {
         "navigate": "https://example.com/",
-        "title": "Hello world!",
-        "app_badge": { }
+        "title": "Hello world!"
     }
 }
 )JSONRESOURCE"_s;
 static constexpr ASCIILiteral json12 = R"JSONRESOURCE(
 {
     "web_push": 8030,
+    "app_badge": 10,
     "notification": {
         "navigate": "https://example.com/",
-        "title": "Hello world!",
-        "app_badge": 10
+        "title": "Hello world!"
     }
 }
 )JSONRESOURCE"_s;
@@ -2405,30 +2405,30 @@ static constexpr ASCIILiteral json31 = R"JSONRESOURCE(
 static constexpr ASCIILiteral json32 = R"JSONRESOURCE(
 {
     "web_push": 8030,
+    "app_badge": "20",
     "notification": {
         "navigate": "https://example.com/",
-        "title": "Hello world!",
-        "app_badge": "20"
+        "title": "Hello world!"
     }
 }
 )JSONRESOURCE"_s;
 static constexpr ASCIILiteral json33 = R"JSONRESOURCE(
 {
     "web_push": 8030,
+    "app_badge": "8031",
     "notification": {
         "navigate": "https://example.com/",
-        "title": "Hello world!",
-        "app_badge": "8031"
+        "title": "Hello world!"
     }
 }
 )JSONRESOURCE"_s;
 static constexpr ASCIILiteral json34 = R"JSONRESOURCE(
 {
     "web_push": 8030,
+    "app_badge": "18446744073709551616",
     "notification": {
         "navigate": "https://example.com/",
-        "title": "Hello world!",
-        "app_badge": "18446744073709551616"
+        "title": "Hello world!"
     }
 }
 )JSONRESOURCE"_s;
@@ -2475,97 +2475,97 @@ static constexpr ASCIILiteral json38 = R"JSONRESOURCE(
 static constexpr ASCIILiteral json39 = R"JSONRESOURCE(
 {
     "web_push": 8030,
+    "app_badge": "12",
     "notification": {
         "navigate": "https://example.com/",
         "title": "Hello world!",
-        "mutable": true,
-        "app_badge": "12"
+        "mutable": true
     }
 }
 )JSONRESOURCE"_s;
 static constexpr ASCIILiteral json40 = R"JSONRESOURCE(
 {
     "web_push": 8030,
+    "app_badge": "12",
     "notification": {
         "navigate": "https://example.com/",
         "title": "Hello world!",
         "mutable": true,
-        "tag": "title Gotcha!",
-        "app_badge": "12"
+        "tag": "title Gotcha!"
     }
 }
 )JSONRESOURCE"_s;
 static constexpr ASCIILiteral json41 = R"JSONRESOURCE(
 {
     "web_push": 8030,
+    "app_badge": "12",
     "notification": {
         "navigate": "https://example.com/",
         "title": "Hello world!",
         "mutable": true,
-        "tag": "badge 1024",
-        "app_badge": "12"
+        "tag": "badge 1024"
     }
 }
 )JSONRESOURCE"_s;
 static constexpr ASCIILiteral json42 = R"JSONRESOURCE(
 {
     "web_push": 8030,
+    "app_badge": "12",
     "notification": {
         "navigate": "https://example.com/",
         "title": "Hello world!",
         "mutable": true,
-        "tag": "titleandbadge ThisRules 4096",
-        "app_badge": "12"
+        "tag": "titleandbadge ThisRules 4096"
     }
 }
 )JSONRESOURCE"_s;
 static constexpr ASCIILiteral json43 = R"JSONRESOURCE(
 {
     "web_push": 8030,
+    "app_badge": "12",
     "notification": {
         "navigate": "https://example.com/",
         "title": "Test the data object",
         "mutable": true,
         "tag": "datatotitle",
-        "data": "Raw string",
-        "app_badge": "12"
+        "data": "Raw string"
     }
 }
 )JSONRESOURCE"_s;
 static constexpr ASCIILiteral json44 = R"JSONRESOURCE(
 {
     "web_push": 8030,
+    "app_badge": "12",
     "notification": {
         "navigate": "https://example.com/",
         "title": "Test the data object",
         "mutable": true,
         "tag": "datatotitle",
-        "data": { "key": "value" },
-        "app_badge": "12"
+        "data": { "key": "value" }
     }
 }
 )JSONRESOURCE"_s;
 static constexpr ASCIILiteral json45 = R"JSONRESOURCE(
 {
     "web_push": 8030,
+    "app_badge": "12",
     "notification": {
         "navigate": "https://example.com/",
         "title": "Test a default action URL override",
         "mutable": true,
-        "tag": "defaultactionurl https://webkit.org/",
-        "app_badge": "12"
+        "tag": "defaultactionurl https://webkit.org/"
     }
 }
 )JSONRESOURCE"_s;
 static constexpr ASCIILiteral json46 = R"JSONRESOURCE(
 {
     "web_push": 8030,
+    "app_badge": "12",
     "notification": {
         "navigate": "https://example.com/",
         "title": "Test a missing default action URL override",
         "mutable": true,
-        "tag": "emptydefaultactionurl",
-        "app_badge": "12"
+        "tag": "emptydefaultactionurl"
     }
 }
 )JSONRESOURCE"_s;


### PR DESCRIPTION
#### ba6683f729d8e80dc523b89d1afaacfb8a333664
<pre>
[Declarative Web Push] Relocate &apos;app_badge&apos; entry from the &apos;notification&apos; dictionary to the top level JSON
<a href="https://rdar.apple.com/151867990">rdar://151867990</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=293457">https://bugs.webkit.org/show_bug.cgi?id=293457</a>

Reviewed by Ben Nham.

During standards work, we moved `app_badge` from inside the `notification` dictionary up to the top-level JSON
for the declarative Web Push message.

We forgot to update the implementation to reflect.

That&apos;s what this patch does.

* Source/WebCore/Modules/notifications/NotificationJSONParser.cpp:
(WebCore::NotificationJSONParser::parseNotificationPayload):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm:

Canonical link: <a href="https://commits.webkit.org/295319@main">https://commits.webkit.org/295319@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aaf40e00fef12a769b873b475f88270d311be861

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104733 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24445 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/14867 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/109947 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/55407 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/106773 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/24836 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/32991 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79527 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/55407 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107739 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19308 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94519 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59834 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/19076 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/12596 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/54785 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/88772 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/12643 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/112344 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/31898 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/23460 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88607 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32262 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/90745 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88231 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33118 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/10890 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/27211 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16994 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/31823 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/37176 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/31615 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/34956 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33174 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->