### PR TITLE
[macOS] Reenable content inset fill views when top fixed color extension view is present

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -3051,6 +3051,7 @@ static WebCore::CocoaColor *sampledFixedPositionContentColor(const WebCore::Fixe
     RetainPtr oldTopColor = [self _sampledTopFixedPositionContentColor];
     RetainPtr newTopColor = sampledFixedPositionContentColor(edges, WebCore::BoxSide::Top);
     bool isTopColorChanging = oldTopColor != newTopColor || ![oldTopColor isEqual:newTopColor.get()];
+    bool isTopFixedEdgeChanging = isTopColorChanging || _fixedContainerEdges.hasFixedEdge(WebCore::BoxSide::Top) != edges.hasFixedEdge(WebCore::BoxSide::Top);
 
     if (isTopColorChanging)
         [self willChangeValueForKey:NSStringFromSelector(@selector(_sampledTopFixedPositionContentColor))];
@@ -3059,6 +3060,13 @@ static WebCore::CocoaColor *sampledFixedPositionContentColor(const WebCore::Fixe
 
 #if ENABLE(CONTENT_INSET_BACKGROUND_FILL)
     [self _updateFixedColorExtensionViews];
+#endif
+
+#if PLATFORM(MAC) && ENABLE(CONTENT_INSET_BACKGROUND_FILL)
+    if (isTopFixedEdgeChanging)
+        _impl->updateContentInsetFillViews();
+#else
+    UNUSED_VARIABLE(isTopFixedEdgeChanging);
 #endif
 
     if (isTopColorChanging)
@@ -3247,12 +3255,16 @@ static WebCore::CocoaColor *sampledFixedPositionContentColor(const WebCore::Fixe
 
 - (void)colorExtensionViewWillFadeOut:(WKColorExtensionView *)view
 {
+#if PLATFORM(IOS_FAMILY)
     [self _updateFixedColorExtensionEdges];
+#endif
 }
 
 - (void)colorExtensionViewDidFadeIn:(WKColorExtensionView *)view
 {
+#if PLATFORM(IOS_FAMILY)
     [self _updateFixedColorExtensionEdges];
+#endif
 }
 
 #endif // ENABLE(CONTENT_INSET_BACKGROUND_FILL)


### PR DESCRIPTION
#### a820d51be808daa7c3f816027cac109c19d0852b
<pre>
[macOS] Reenable content inset fill views when top fixed color extension view is present
<a href="https://bugs.webkit.org/show_bug.cgi?id=293454">https://bugs.webkit.org/show_bug.cgi?id=293454</a>
<a href="https://rdar.apple.com/151873760">rdar://151873760</a>

Reviewed by Abrar Rahman Protyasha.

Make some adjustments to avoid removing the content inset fill views when the top fixed color
extension view is present. See paired change for more details.

* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _updateFixedContainerEdges:]):
(-[WKWebView colorExtensionViewWillFadeOut:]):
(-[WKWebView colorExtensionViewDidFadeIn:]):

Canonical link: <a href="https://commits.webkit.org/295324@main">https://commits.webkit.org/295324@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/81af7344f1ca213084db98bd5389c6e1439a109c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104755 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24467 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/14889 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/109969 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/55429 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/24858 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33013 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79539 "Failure limit exceed. At least found 456 new test failures: http/wpt/2dcontext/imagebitmap/createImageBitmap-sizing.html http/wpt/2dcontext/imagebitmap/createImageBitmap.html http/wpt/2dcontext/imagebitmap/drawImage-ImageBitmap.html http/wpt/2dcontext/imagebitmap/nullptrcrash-when-gpu-process-times-out.html http/wpt/audio-output/setSinkId.https.html http/wpt/beacon/beacon-async-error-logging.html http/wpt/beacon/beacon-quota.html http/wpt/beacon/beacon-readablestream.html http/wpt/beacon/connect-src-beacon-blocked.sub.html http/wpt/beacon/connect-src-beacon-redirect-allowed.sub.html ... (failure)") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107761 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19323 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94537 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59846 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/19086 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/54808 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/88782 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/12661 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/112371 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/31920 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/23469 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88619 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32284 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/90763 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88242 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22489 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33133 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10903 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/27233 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/31845 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/37198 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/31637 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/34978 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33196 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->