### PR TITLE
WKDownload.originatingFrame should be opener when opener navigates opened page to a download

### DIFF
--- a/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h
+++ b/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h
@@ -73,6 +73,7 @@ enum class SDKAlignedBehavior {
     MinimizesLanguages,
     ModernCompabilityModeByDefault,
     MutationEventsDisabledByDefault,
+    NavigationActionSourceFrameNonNull,
     NoClientCertificateLookup,
     NoExpandoIndexedPropertiesOnWindow,
     NoMoviStarPlusCORSPreflightQuirk,

--- a/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.mm
+++ b/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.mm
@@ -238,6 +238,9 @@ static SDKAlignedBehaviors computeSDKAlignedBehaviors()
         disableBehavior(SDKAlignedBehavior::SupportGameControllerEventInteractionAPI);
     }
 
+    if (linkedBefore(dyld_2024_SU_F_os_versions, DYLD_IOS_VERSION_18_5, DYLD_MACOSX_VERSION_15_5))
+        disableBehavior(SDKAlignedBehavior::NavigationActionSourceFrameNonNull);
+
     disableAdditionalSDKAlignedBehaviors(behaviors);
 
     return behaviors;

--- a/Source/WTF/wtf/spi/darwin/dyldSPI.h
+++ b/Source/WTF/wtf/spi/darwin/dyldSPI.h
@@ -103,6 +103,10 @@ DECLARE_SYSTEM_HEADER
 #define DYLD_IOS_VERSION_18_0 0x00120000
 #endif
 
+#ifndef DYLD_IOS_VERSION_18_5
+#define DYLD_IOS_VERSION_18_5 0x00120500
+#endif
+
 #ifndef DYLD_MACOSX_VERSION_10_13
 #define DYLD_MACOSX_VERSION_10_13 0x000A0D00
 #endif
@@ -163,6 +167,10 @@ DECLARE_SYSTEM_HEADER
 #define DYLD_MACOSX_VERSION_15_0 0x000f0000
 #endif
 
+#ifndef DYLD_MACOSX_VERSION_15_5
+#define DYLD_MACOSX_VERSION_15_5 0x000f0500
+#endif
+
 #else
 
 typedef uint32_t dyld_platform_t;
@@ -197,6 +205,7 @@ typedef struct {
 #define DYLD_IOS_VERSION_17_2 0x00110200
 #define DYLD_IOS_VERSION_17_4 0x00110400
 #define DYLD_IOS_VERSION_18_0 0x00120000
+#define DYLD_IOS_VERSION_18_5 0x00120500
 
 #define DYLD_MACOSX_VERSION_10_10 0x000A0A00
 #define DYLD_MACOSX_VERSION_10_11 0x000A0B00
@@ -218,6 +227,7 @@ typedef struct {
 #define DYLD_MACOSX_VERSION_14_2 0x000e0200
 #define DYLD_MACOSX_VERSION_14_4 0x000e0400
 #define DYLD_MACOSX_VERSION_15_0 0x000f0000
+#define DYLD_MACOSX_VERSION_15_5 0x000f0500
 
 #endif
 
@@ -313,6 +323,10 @@ WTF_EXTERN_C_BEGIN
 
 #ifndef dyld_fall_2024_os_versions
 #define dyld_fall_2024_os_versions ({ (dyld_build_version_t) { 0, 0 }; })
+#endif
+
+#ifndef dyld_2024_SU_F_os_versions
+#define dyld_2024_SU_F_os_versions ({ (dyld_build_version_t) { 0, 0 }; })
 #endif
 
 uint32_t dyld_get_program_sdk_version();

--- a/Source/WebKit/Shared/FrameInfoData.h
+++ b/Source/WebKit/Shared/FrameInfoData.h
@@ -38,6 +38,8 @@ namespace WebKit {
 enum class FrameType : bool { Local, Remote };
 
 struct FrameInfoData {
+    WTF_MAKE_STRUCT_FAST_ALLOCATED;
+
     bool isMainFrame { false };
     FrameType frameType { FrameType::Local };
     WebCore::ResourceRequest request;

--- a/Source/WebKit/Shared/LoadParameters.h
+++ b/Source/WebKit/Shared/LoadParameters.h
@@ -25,13 +25,13 @@
 
 #pragma once
 
+#include "FrameInfoData.h"
 #include "NetworkResourceLoadIdentifier.h"
 #include "PolicyDecision.h"
 #include "SandboxExtension.h"
 #include "UserData.h"
 #include "WebsitePoliciesData.h"
 #include <WebCore/AdvancedPrivacyProtections.h>
-#include <WebCore/FrameIdentifier.h>
 #include <WebCore/FrameLoaderTypes.h>
 #include <WebCore/NavigationIdentifier.h>
 #include <WebCore/OwnerPermissionsPolicyData.h>
@@ -68,6 +68,7 @@ struct LoadParameters {
     String provisionalLoadErrorURLString;
 
     std::optional<WebsitePoliciesData> websitePolicies;
+    std::optional<FrameInfoData> originatingFrame;
 
     WebCore::ShouldOpenExternalURLsPolicy shouldOpenExternalURLsPolicy { WebCore::ShouldOpenExternalURLsPolicy::ShouldNotAllow };
     WebCore::ShouldTreatAsContinuingLoad shouldTreatAsContinuingLoad { WebCore::ShouldTreatAsContinuingLoad::No };

--- a/Source/WebKit/Shared/LoadParameters.serialization.in
+++ b/Source/WebKit/Shared/LoadParameters.serialization.in
@@ -37,6 +37,7 @@ enum class WebCore::LockBackForwardList : bool;
     String unreachableURLString;
     String provisionalLoadErrorURLString;
     std::optional<WebKit::WebsitePoliciesData> websitePolicies;
+    std::optional<WebKit::FrameInfoData> originatingFrame;
     WebCore::ShouldOpenExternalURLsPolicy shouldOpenExternalURLsPolicy;
     WebCore::ShouldTreatAsContinuingLoad shouldTreatAsContinuingLoad;
     WebKit::UserData userData;

--- a/Source/WebKit/Sources.txt
+++ b/Source/WebKit/Sources.txt
@@ -484,6 +484,7 @@ UIProcess/API/APIInspectorConfiguration.cpp
 UIProcess/API/APIInspectorExtension.cpp
 UIProcess/API/APINavigation.cpp
 UIProcess/API/APINavigationData.cpp
+UIProcess/API/APINavigationResponse.cpp
 UIProcess/API/APIPageConfiguration.cpp
 UIProcess/API/APIProcessPoolConfiguration.cpp
 UIProcess/API/APIOpenPanelParameters.cpp

--- a/Source/WebKit/UIProcess/API/APINavigationResponse.h
+++ b/Source/WebKit/UIProcess/API/APINavigationResponse.h
@@ -33,6 +33,7 @@
 namespace API {
 
 class FrameInfo;
+class Navigation;
 
 class NavigationResponse final : public ObjectImpl<Object::Type::NavigationResponse> {
 public:
@@ -40,30 +41,29 @@ public:
     {
         return adoptRef(*new NavigationResponse(std::forward<Args>(args)...));
     }
+    ~NavigationResponse();
 
     FrameInfo& frame() { return m_frame.get(); }
     Ref<FrameInfo> protectedFrame() { return m_frame.get(); }
 
     const WebCore::ResourceRequest& request() const { return m_request; }
     const WebCore::ResourceResponse& response() const { return m_response; }
+    FrameInfo* navigationInitiatingFrame();
+    Navigation* navigation() { return m_navigation.get(); }
 
     bool canShowMIMEType() const { return m_canShowMIMEType; }
     const WTF::String& downloadAttribute() const { return m_downloadAttribute; }
 
 private:
-    NavigationResponse(API::FrameInfo& frame, const WebCore::ResourceRequest& request, const WebCore::ResourceResponse& response, bool canShowMIMEType, WTF::String&& downloadAttribute)
-        : m_frame(frame)
-        , m_request(request)
-        , m_response(response)
-        , m_canShowMIMEType(canShowMIMEType)
-        , m_downloadAttribute(WTFMove(downloadAttribute)) { }
+    NavigationResponse(API::FrameInfo&, const WebCore::ResourceRequest&, const WebCore::ResourceResponse&, bool canShowMIMEType, WTF::String&& downloadAttribute, Navigation*);
 
-    Ref<FrameInfo> m_frame;
-
+    const Ref<FrameInfo> m_frame;
     WebCore::ResourceRequest m_request;
     WebCore::ResourceResponse m_response;
     bool m_canShowMIMEType;
     WTF::String m_downloadAttribute;
+    const RefPtr<Navigation> m_navigation;
+    RefPtr<FrameInfo> m_sourceFrame;
 };
 
 } // namespace API

--- a/Source/WebKit/UIProcess/API/Cocoa/WKFrameInfo.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKFrameInfo.mm
@@ -60,7 +60,7 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
 
 - (NSURLRequest *)request
 {
-    return _frameInfo->request().nsURLRequest(WebCore::HTTPBodyUpdatePolicy::DoNotUpdateHTTPBody);
+    return _frameInfo->request().nsURLRequest(WebCore::HTTPBodyUpdatePolicy::DoNotUpdateHTTPBody) ?: [NSURLRequest requestWithURL:adoptNS([[NSURL alloc] initWithString:@""]).get()];
 }
 
 - (WKSecurityOrigin *)securityOrigin

--- a/Source/WebKit/UIProcess/API/Cocoa/WKNavigation.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKNavigation.mm
@@ -28,6 +28,9 @@
 #import "WKWebpagePreferencesInternal.h"
 
 #import "APINavigation.h"
+#import "FrameInfoData.h"
+#import "WKFrameInfoInternal.h"
+#import "WebFrameProxy.h"
 #import <WebCore/WebCoreObjCExtras.h>
 #import <wtf/AlignedStorage.h>
 
@@ -55,6 +58,15 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
 - (BOOL)_isUserInitiated
 {
     return _navigation->wasUserInitiated();
+}
+
+- (WKFrameInfo *)_initiatingFrame
+{
+    auto& frameInfo = _navigation->originatingFrameInfo();
+    if (!frameInfo)
+        return nil;
+    RefPtr frame = WebKit::WebFrameProxy::webFrame(frameInfo->frameID);
+    return wrapper(API::FrameInfo::create(WebKit::FrameInfoData { *frameInfo }, frame ? frame->page() : nullptr)).autorelease();
 }
 
 #if PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/UIProcess/API/Cocoa/WKNavigationPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKNavigationPrivate.h
@@ -25,7 +25,12 @@
 
 #import <WebKit/WKNavigation.h>
 
+@class WKNavigationAction;
+@class WKFrameInfo;
+
 @interface WKNavigation (WKPrivate)
 @property (nonatomic, readonly, copy) NSURLRequest *_request;
+@property (nonatomic, readonly, copy) WKFrameInfo *_initiatingFrame WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 @property (nonatomic, readonly, getter=_isUserInitiated) BOOL _userInitiated;
+
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/WKNavigationResponse.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKNavigationResponse.mm
@@ -27,6 +27,7 @@
 #import "WKNavigationResponseInternal.h"
 
 #import "WKFrameInfoInternal.h"
+#import "WKNavigationInternal.h"
 #import <WebCore/WebCoreObjCExtras.h>
 
 @implementation WKNavigationResponse
@@ -78,6 +79,16 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
 {
     // FIXME: This RefPtr should not be necessary. Remove it once clang static analyzer is fixed.
     return wrapper(RefPtr { _navigationResponse.get() }->protectedFrame().get());
+}
+
+- (WKFrameInfo *)_navigationInitiatingFrame
+{
+    return wrapper(_navigationResponse->navigationInitiatingFrame());
+}
+
+- (WKNavigation *)_navigation
+{
+    return wrapper(_navigationResponse->navigation());
 }
 
 - (NSURLRequest *)_request

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2758,6 +2758,8 @@ private:
     bool shouldForceForegroundPriorityForClientNavigation() const;
 
     bool canCreateFrame(WebCore::FrameIdentifier) const;
+    Ref<WebPageProxy> downloadOriginatingPage(const API::Navigation*);
+    Ref<WebPageProxy> navigationOriginatingPage(const FrameInfoData&);
 
     RefPtr<API::Navigation> goToBackForwardItem(WebBackForwardListFrameItem&, WebCore::FrameLoadType);
 

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -8666,6 +8666,7 @@
 		FA9AFA692B2254F600953DC5 /* APIArray.serialization.in */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = APIArray.serialization.in; sourceTree = "<group>"; };
 		FA9CD6332A01B21700EA5CAC /* NetworkOriginAccessPatterns.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = NetworkOriginAccessPatterns.cpp; sourceTree = "<group>"; };
 		FA9CD6342A01B21700EA5CAC /* NetworkOriginAccessPatterns.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NetworkOriginAccessPatterns.h; sourceTree = "<group>"; };
+		FA9D60A32DDFE0E400D94208 /* APINavigationResponse.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = APINavigationResponse.cpp; sourceTree = "<group>"; };
 		FAA4E2FE2A1575A3003F5E50 /* WebFrameLoaderClient.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebFrameLoaderClient.cpp; sourceTree = "<group>"; };
 		FAA4E2FF2A1575A4003F5E50 /* WebFrameLoaderClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebFrameLoaderClient.h; sourceTree = "<group>"; };
 		FAB751D12BACB65D00AC26DB /* APIPageConfigurationCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = APIPageConfigurationCocoa.mm; sourceTree = "<group>"; };
@@ -15006,6 +15007,7 @@
 				2DD9EB2C1A6F012500BB1267 /* APINavigationClient.h */,
 				BCF69FA11176D01400471A52 /* APINavigationData.cpp */,
 				BCF69FA01176D01400471A52 /* APINavigationData.h */,
+				FA9D60A32DDFE0E400D94208 /* APINavigationResponse.cpp */,
 				2DF9EEED1A786EAD00B6CFBE /* APINavigationResponse.h */,
 				7A1E2A841EEFE88A0037A0E0 /* APINotificationProvider.h */,
 				BC857FB412B830E600EDEB2E /* APIOpenPanelParameters.cpp */,

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -2137,6 +2137,9 @@ void WebPage::loadRequest(LoadParameters&& loadParameters)
 
     platformDidReceiveLoadParameters(loadParameters);
 
+    if (loadParameters.originatingFrame && !loadParameters.frameIdentifier)
+        m_mainFrameNavigationInitiator = makeUnique<FrameInfoData>(*loadParameters.originatingFrame);
+
     // Initate the load in WebCore.
     ASSERT(localFrame->document());
     FrameLoadRequest frameLoadRequest { *localFrame, WTFMove(loadParameters.request) };
@@ -10421,6 +10424,11 @@ bool WebPage::shouldDisableModelLoadDelaysForTesting() const
     return m_page && m_page->shouldDisableModelLoadDelaysForTesting();
 }
 #endif
+
+std::unique_ptr<FrameInfoData> WebPage::takeMainFrameNavigationInitiator()
+{
+    return std::exchange(m_mainFrameNavigationInitiator, nullptr);
+}
 
 } // namespace WebKit
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -2004,6 +2004,8 @@ public:
     bool shouldDisableModelLoadDelaysForTesting() const;
 #endif
 
+    std::unique_ptr<FrameInfoData> takeMainFrameNavigationInitiator();
+
 private:
     WebPage(WebCore::PageIdentifier, WebPageCreationParameters&&);
 
@@ -3083,6 +3085,7 @@ private:
 #endif
 
     std::unique_ptr<WebCore::NowPlayingMetadataObserver> m_nowPlayingMetadataObserver;
+    std::unique_ptr<FrameInfoData> m_mainFrameNavigationInitiator;
 
     mutable RefPtr<Logger> m_logger;
 };

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/Download.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/Download.mm
@@ -34,6 +34,7 @@
 #import "TestLegacyDownloadDelegate.h"
 #import "TestNavigationDelegate.h"
 #import "TestProtocol.h"
+#import "TestUIDelegate.h"
 #import "TestWKWebView.h"
 #import <Foundation/NSURLResponse.h>
 #import <WebKit/WKDownload.h>
@@ -3217,6 +3218,83 @@ TEST(WKDownload, DestinationFileAlreadyExists)
     [webView setNavigationDelegate:navigationDelegate.get()];
     [webView loadRequest:server.request()];
     Util::run(&failed);
+}
+
+TEST(WKDownload, OriginatingFrameWhenConvertingNavigationInNewWindow)
+{
+    HTTPServer server { {
+        { "/example"_s, { "hi"_s } },
+        { "/download"_s, { "hi"_s } }
+    }, HTTPServer::Protocol::HttpsProxy };
+
+    auto configuration = server.httpsProxyConfiguration();
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration]);
+    auto navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    [navigationDelegate allowAnyTLSCertificate];
+    [webView setNavigationDelegate:navigationDelegate.get()];
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/example"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    RetainPtr<WKFrameInfo> openerMainFrame = [webView mainFrame].info;
+
+    auto uiDelegate = adoptNS([TestUIDelegate new]);
+    [webView setUIDelegate:uiDelegate.get()];
+    __block RetainPtr<WKWebView> openedWebView;
+    uiDelegate.get().createWebViewWithConfiguration = ^WKWebView *(WKWebViewConfiguration *configuration, WKNavigationAction *, WKWindowFeatures *) {
+        openedWebView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration]);
+        [openedWebView setNavigationDelegate:navigationDelegate.get()];
+        return openedWebView.get();
+    };
+
+    auto frameInfoShouldBeEqual = ^(WKFrameInfo *a, WKFrameInfo *b) {
+        EXPECT_EQ(a.isMainFrame, b.isMainFrame);
+        EXPECT_WK_STREQ(a.request.URL.absoluteString, b.request.URL.absoluteString);
+        EXPECT_WK_STREQ(a.securityOrigin.protocol, b.securityOrigin.protocol);
+        EXPECT_WK_STREQ(a.securityOrigin.host, b.securityOrigin.host);
+        EXPECT_EQ(a.securityOrigin.port, b.securityOrigin.port);
+        EXPECT_EQ(a.webView, b.webView);
+    };
+
+    __block bool checkedDownload { false };
+    auto tryOpenerInitiatedDownloads = ^{
+        checkedDownload = false;
+        [webView evaluateJavaScript:@"a = document.createElement('a'); a.href = 'https://webkit.org/download'; a.target = '_blank'; document.body.appendChild(a); a.click()" completionHandler:nil];
+        Util::run(&checkedDownload);
+
+        checkedDownload = false;
+        [webView evaluateJavaScript:@"w = window.open('https://webkit.org/download')" completionHandler:nil];
+        Util::run(&checkedDownload);
+
+        checkedDownload = false;
+        [webView evaluateJavaScript:@"w.location.href = 'https://apple.com/download'" completionHandler:nil];
+        Util::run(&checkedDownload);
+    };
+
+    navigationDelegate.get().decidePolicyForNavigationAction = ^(WKNavigationAction *action, void (^completionHandler)(WKNavigationActionPolicy)) {
+        frameInfoShouldBeEqual(action.sourceFrame, openerMainFrame.get());
+        completionHandler(WKNavigationActionPolicyAllow);
+    };
+    navigationDelegate.get().decidePolicyForNavigationResponse = ^(WKNavigationResponse *response, void (^completionHandler)(WKNavigationResponsePolicy)) {
+        frameInfoShouldBeEqual(response._navigationInitiatingFrame, openerMainFrame.get());
+        completionHandler(WKNavigationResponsePolicyDownload);
+    };
+    navigationDelegate.get().navigationResponseDidBecomeDownload = ^(WKNavigationResponse *response, WKDownload *download) {
+        frameInfoShouldBeEqual(response._navigationInitiatingFrame, openerMainFrame.get());
+        frameInfoShouldBeEqual(download.originatingFrame, openerMainFrame.get());
+        checkedDownload = true;
+    };
+    tryOpenerInitiatedDownloads();
+
+    navigationDelegate.get().decidePolicyForNavigationAction = ^(WKNavigationAction *action, void (^completionHandler)(WKNavigationActionPolicy)) {
+        frameInfoShouldBeEqual(action.sourceFrame, openerMainFrame.get());
+        completionHandler(WKNavigationActionPolicyDownload);
+    };
+    navigationDelegate.get().navigationActionDidBecomeDownload = ^(WKNavigationAction *action, WKDownload *download) {
+        frameInfoShouldBeEqual(action.sourceFrame, openerMainFrame.get());
+        frameInfoShouldBeEqual(download.originatingFrame, openerMainFrame.get());
+        checkedDownload = true;
+    };
+    tryOpenerInitiatedDownloads();
 }
 
 }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/SOAuthorizationTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/SOAuthorizationTests.mm
@@ -542,7 +542,7 @@ TEST(SOAuthorizationRedirect, InterceptionDoNotHandle)
 
     [webView loadRequest:[NSURLRequest requestWithURL:testURL.get()]];
     Util::run(&authorizationPerformed);
-    checkAuthorizationOptions(false, emptyString(), 0);
+    checkAuthorizationOptions(false, "null"_s, 0);
     EXPECT_TRUE(policyForAppSSOPerformed);
 
     [gDelegate authorizationDidNotHandle:gAuthorization];
@@ -564,7 +564,7 @@ TEST(SOAuthorizationRedirect, InterceptionCancel)
 
     [webView loadRequest:[NSURLRequest requestWithURL:testURL.get()]];
     Util::run(&authorizationPerformed);
-    checkAuthorizationOptions(false, emptyString(), 0);
+    checkAuthorizationOptions(false, "null"_s, 0);
     EXPECT_TRUE(policyForAppSSOPerformed);
 
     [gDelegate authorizationDidCancel:gAuthorization];
@@ -587,7 +587,7 @@ TEST(SOAuthorizationRedirect, InterceptionCompleteWithoutData)
 
     [webView loadRequest:[NSURLRequest requestWithURL:testURL.get()]];
     Util::run(&authorizationPerformed);
-    checkAuthorizationOptions(false, emptyString(), 0);
+    checkAuthorizationOptions(false, "null"_s, 0);
     EXPECT_TRUE(policyForAppSSOPerformed);
 
     [gDelegate authorizationDidComplete:gAuthorization];
@@ -609,7 +609,7 @@ TEST(SOAuthorizationRedirect, InterceptionUnexpectedCompletion)
 
     [webView loadRequest:[NSURLRequest requestWithURL:testURL.get()]];
     Util::run(&authorizationPerformed);
-    checkAuthorizationOptions(false, emptyString(), 0);
+    checkAuthorizationOptions(false, "null"_s, 0);
     EXPECT_TRUE(policyForAppSSOPerformed);
 
     [gDelegate authorization:gAuthorization didCompleteWithHTTPAuthorizationHeaders:adoptNS([[NSDictionary alloc] init]).get()];
@@ -632,7 +632,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceed1)
 
     [webView loadRequest:[NSURLRequest requestWithURL:testURL.get()]];
     Util::run(&authorizationPerformed);
-    checkAuthorizationOptions(false, emptyString(), 0);
+    checkAuthorizationOptions(false, "null"_s, 0);
     EXPECT_FALSE(policyForAppSSOPerformed); // The delegate isn't registered, so this won't be set.
 #if PLATFORM(MAC) || PLATFORM(IOS)
     EXPECT_TRUE(gAuthorization.enableEmbeddedAuthorizationViewController);
@@ -685,7 +685,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceed2)
 #endif
     Util::run(&authorizationPerformed);
 #if PLATFORM(MAC)
-    checkAuthorizationOptions(false, emptyString(), 0);
+    checkAuthorizationOptions(false, "null"_s, 0);
 #elif PLATFORM(IOS) || PLATFORM(VISION)
     checkAuthorizationOptions(true, "null"_s, 0);
 #endif
@@ -719,7 +719,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceed3)
     Util::run(&authorizationPerformed);
     EXPECT_TRUE(gAuthorization.enableEmbeddedAuthorizationViewController);
 #if PLATFORM(MAC)
-    checkAuthorizationOptions(false, emptyString(), 0);
+    checkAuthorizationOptions(false, "null"_s, 0);
 #elif PLATFORM(IOS) || PLATFORM(VISION)
     checkAuthorizationOptions(true, "null"_s, 0);
 #endif
@@ -748,7 +748,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceed4)
 
     [webView loadRequest:[NSURLRequest requestWithURL:testURL.get()]];
     Util::run(&authorizationPerformed);
-    checkAuthorizationOptions(false, emptyString(), 0);
+    checkAuthorizationOptions(false, "null"_s, 0);
     EXPECT_TRUE(policyForAppSSOPerformed);
 
     RetainPtr<NSURL> redirectURL = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
@@ -775,7 +775,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceedWithOtherHttpStatusCode)
 
     [webView loadRequest:[NSURLRequest requestWithURL:testURL.get()]];
     Util::run(&authorizationPerformed);
-    checkAuthorizationOptions(false, emptyString(), 0);
+    checkAuthorizationOptions(false, "null"_s, 0);
     EXPECT_TRUE(policyForAppSSOPerformed);
 
     RetainPtr<NSURL> redirectURL = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
@@ -1049,7 +1049,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceedWithCookie)
 
     [webView loadRequest:[NSURLRequest requestWithURL:testURL.get()]];
     Util::run(&authorizationPerformed);
-    checkAuthorizationOptions(false, emptyString(), 0);
+    checkAuthorizationOptions(false, "null"_s, 0);
     EXPECT_TRUE(policyForAppSSOPerformed);
 
     RetainPtr<NSURL> redirectURL = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
@@ -1083,7 +1083,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceedWithCookies)
 
     [webView loadRequest:[NSURLRequest requestWithURL:testURL.get()]];
     Util::run(&authorizationPerformed);
-    checkAuthorizationOptions(false, emptyString(), 0);
+    checkAuthorizationOptions(false, "null"_s, 0);
     EXPECT_TRUE(policyForAppSSOPerformed);
 
     RetainPtr<NSURL> redirectURL = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
@@ -1123,7 +1123,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceedWithRedirectionAndCookie)
 #endif
     Util::run(&authorizationPerformed);
 #if PLATFORM(MAC)
-    checkAuthorizationOptions(false, emptyString(), 0);
+    checkAuthorizationOptions(false, "null"_s, 0);
 #elif PLATFORM(IOS) || PLATFORM(VISION)
     checkAuthorizationOptions(true, "null"_s, 0);
 #endif
@@ -1156,7 +1156,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceedWithDifferentOrigin)
 
     [webView loadRequest:[NSURLRequest requestWithURL:testURL.get()]];
     Util::run(&authorizationPerformed);
-    checkAuthorizationOptions(false, emptyString(), 0);
+    checkAuthorizationOptions(false, "null"_s, 0);
     EXPECT_TRUE(policyForAppSSOPerformed);
 
     URL redirectURL { "https://www.example.com"_str };
@@ -1187,7 +1187,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceedWithWaitingSession)
     // Should activate the session.
     [webView addToTestWindow];
     Util::run(&authorizationPerformed);
-    checkAuthorizationOptions(false, emptyString(), 0);
+    checkAuthorizationOptions(false, "null"_s, 0);
     EXPECT_TRUE(policyForAppSSOPerformed);
 
     RetainPtr<NSURL> redirectURL = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
@@ -1243,7 +1243,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceedWithActiveSessionDidMoveWindow)
 
     [webView loadRequest:[NSURLRequest requestWithURL:testURL.get()]];
     Util::run(&authorizationPerformed);
-    checkAuthorizationOptions(false, emptyString(), 0);
+    checkAuthorizationOptions(false, "null"_s, 0);
     EXPECT_TRUE(policyForAppSSOPerformed);
 
     // Should be a no op.
@@ -1276,7 +1276,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceedTwice)
         policyForAppSSOPerformed = false;
         [webView loadRequest:[NSURLRequest requestWithURL:testURL.get()]];
         Util::run(&authorizationPerformed);
-        checkAuthorizationOptions(false, emptyString(), 0);
+        checkAuthorizationOptions(false, i ? "file://"_s : "null"_s, 0);
         EXPECT_TRUE(policyForAppSSOPerformed);
 
         navigationCompleted = false;
@@ -1305,7 +1305,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceedSuppressActiveSession)
 
     [webView loadRequest:[NSURLRequest requestWithURL:testURL.get()]];
     Util::run(&authorizationPerformed);
-    checkAuthorizationOptions(false, emptyString(), 0);
+    checkAuthorizationOptions(false, "null"_s, 0);
     EXPECT_TRUE(policyForAppSSOPerformed);
 
     // Suppress the last active session.
@@ -1314,7 +1314,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceedSuppressActiveSession)
     [webView loadRequest:[NSURLRequest requestWithURL:testURL.get()]];
     Util::run(&authorizationCancelled);
     Util::run(&authorizationPerformed);
-    checkAuthorizationOptions(false, emptyString(), 0);
+    checkAuthorizationOptions(false, "null"_s, 0);
     EXPECT_TRUE(policyForAppSSOPerformed);
 
     RetainPtr<NSURL> redirectURL = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
@@ -1356,7 +1356,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceedSuppressWaitingSession)
     // Activate the last session.
     [webView addToTestWindow];
     Util::run(&authorizationPerformed);
-    checkAuthorizationOptions(false, emptyString(), 0);
+    checkAuthorizationOptions(false, "null"_s, 0);
     EXPECT_TRUE(policyForAppSSOPerformed);
 
     RetainPtr<NSURL> redirectURL = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
@@ -1392,7 +1392,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceedSAML)
 
     [webView loadRequest:request.get()];
     Util::run(&authorizationPerformed);
-    checkAuthorizationOptions(false, emptyString(), 0);
+    checkAuthorizationOptions(false, "null"_s, 0);
     EXPECT_TRUE(policyForAppSSOPerformed);
 
     // Pass a HTTP 200 response with a html to mimic a SAML response.
@@ -1528,7 +1528,7 @@ TEST(SOAuthorizationRedirect, SOAuthorizationLoadPolicyAllowAsync)
 
     [webView loadRequest:[NSURLRequest requestWithURL:testURL.get()]];
     Util::run(&authorizationPerformed);
-    checkAuthorizationOptions(false, ""_s, 0);
+    checkAuthorizationOptions(false, "null"_s, 0);
     EXPECT_TRUE(policyForAppSSOPerformed);
 
     RetainPtr<NSURL> redirectURL = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];


### PR DESCRIPTION
#### c28b242bf3e686ec6989e05b23abd92f0512f1c1
<pre>
WKDownload.originatingFrame should be opener when opener navigates opened page to a download
<a href="https://bugs.webkit.org/show_bug.cgi?id=293460">https://bugs.webkit.org/show_bug.cgi?id=293460</a>

Reviewed by Brady Eidson.

This merges 289651.351@safari-7621-branch, 289651.419@safari-7621-branch, and 289651.461@safari-7621-branch
originally fixing <a href="https://rdar.apple.com/144600565">rdar://144600565</a>, <a href="https://rdar.apple.com/148793218">rdar://148793218</a>, and <a href="https://rdar.apple.com/149887382">rdar://149887382</a>, respectively.

* Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h:
* Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.mm:
(WTF::computeSDKAlignedBehaviors):
* Source/WTF/wtf/spi/darwin/dyldSPI.h:
* Source/WebKit/Shared/FrameInfoData.h:
* Source/WebKit/Shared/LoadParameters.h:
* Source/WebKit/Shared/LoadParameters.serialization.in:
* Source/WebKit/Sources.txt:
* Source/WebKit/UIProcess/API/APINavigationResponse.cpp: Copied from Source/WebKit/UIProcess/API/Cocoa/WKNavigation.mm.
(API::NavigationResponse::NavigationResponse):
(API::NavigationResponse::navigationInitiatingFrame):
* Source/WebKit/UIProcess/API/APINavigationResponse.h:
* Source/WebKit/UIProcess/API/Cocoa/WKFrameInfo.mm:
(-[WKFrameInfo request]):
* Source/WebKit/UIProcess/API/Cocoa/WKNavigation.mm:
(-[WKNavigation _initiatingFrame]):
* Source/WebKit/UIProcess/API/Cocoa/WKNavigationPrivate.h:
* Source/WebKit/UIProcess/API/Cocoa/WKNavigationResponse.mm:
(-[WKNavigationResponse _navigationInitiatingFrame]):
(-[WKNavigationResponse _navigation]):
* Source/WebKit/UIProcess/API/Cocoa/WKNavigationResponsePrivate.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::loadRequestWithNavigationShared):
(WebKit::WebPageProxy::downloadOriginatingPage):
(WebKit::WebPageProxy::navigationOriginatingPage):
(WebKit::WebPageProxy::receivedPolicyDecision):
(WebKit::WebPageProxy::receivedNavigationResponsePolicyDecision):
(WebKit::WebPageProxy::decidePolicyForNavigationAction):
(WebKit::WebPageProxy::decidePolicyForResponseShared):
(WebKit::WebPageProxy::createNewPage):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp:
(WebKit::WebFrameLoaderClient::navigationActionData const):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::loadRequest):
(WebKit::WebPage::takeMainFrameNavigationInitiator):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/DecidePolicyForNavigationAction.mm:
(TEST(WebKit, NavigationActionFrames)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/Download.mm:
(TestWebKitAPI::OriginatingFrameWhenConvertingNavigationInNewWindow)):

Canonical link: <a href="https://commits.webkit.org/295334@main">https://commits.webkit.org/295334@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3d6bf79de5ca9ddb1eebfde43772c407d0e60948

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104771 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24483 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/14905 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/109985 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/55445 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/106811 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/24874 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33029 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79553 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107777 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19342 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94554 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59860 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/19101 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/12631 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/54827 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/97452 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/88798 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/12678 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/112387 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/103389 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/31936 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23484 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88633 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32300 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/90780 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88257 "Found 102 new API test failures: /WebKitGTK/TestUIClient:/webkit/WebKitWebView/usermedia-enumeratedevices-permission-check, /TestWebKit:WebKit.ForceRepaint, /TestWebKit:WebKit.LoadAlternateHTMLStringWithNonDirectoryURL, /WebKitGTK/TestCookieManager:/webkit/WebKitCookieManager/persistent-storage, /WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/content-type, /WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/sequence, /TestWebKit:WebKit.PageLoadDidChangeLocationWithinPage, /TestWebKit:WebKit.OnDeviceChangeCrash, /WebKitGTK/TestGeolocationManager:/webkit/WebKitGeolocationManager/watch-position, /TestWebKit:WebKit.InjectedBundleInitializationUserDataCallbackWins ... (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33147 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10918 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/27249 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16999 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/31861 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/37215 "") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/127668 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/31653 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/127668 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/34994 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33212 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->