### PR TITLE
[css-anchor-position-1] Make anchors shadow-DOM-scoped

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7637,7 +7637,6 @@ imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-update-003
 imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-update-007.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-anchor-position/position-area-inline-container.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-anchor-position/position-area-scroll-adjust.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-anchor-position/position-anchor-002.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-anchor-position/position-try-switch-to-fixed-anchor.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-anchor-position/position-visibility-add-no-overflow.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-anchor-position/position-visibility-anchors-visible-with-position.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-name-in-shadow-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-name-in-shadow-002-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Anchor names in different tree scopes should not be confused assert_equals: expected 0 but got 200
+PASS Anchor names in different tree scopes should not be confused
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-name-in-shadow-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-name-in-shadow-expected.txt
@@ -1,4 +1,4 @@
 
 PASS anchor-name should not leak out of a shadow tree
-FAIL anchor() in shadow tree should not match host anchor-name assert_equals: #anchored is positioned using fallback expected 37 but got 8
+PASS anchor() in shadow tree should not match host anchor-name
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-transition-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-transition-002-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Transition with anchor names defined in different tree scopes assert_equals: expected 250 but got 400
+PASS Transition with anchor names defined in different tree scopes
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-transition-003-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-transition-003-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Transition with anchor names defined in three different tree scopes assert_equals: expected 300 but got 400
+PASS Transition with anchor names defined in three different tree scopes
 

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2730,10 +2730,12 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
 
     style/AnchorPositionEvaluator.h
     style/PseudoElementIdentifier.h
+    style/ResolvedScopedName.h
     style/ScopedName.h
     style/StyleChange.h
     style/StyleInterpolationClient.h
     style/StyleScope.h
+    style/StyleScopeIdentifier.h
     style/StyleScopeOrdinal.h
     style/StyleUpdate.h
     style/StyleValidity.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -3117,6 +3117,7 @@ style/PageRuleCollector.cpp
 style/PropertyAllowlist.cpp
 style/PropertyCascade.cpp
 style/PseudoClassChangeInvalidation.cpp
+style/ResolvedScopedName.cpp
 style/RuleData.cpp
 style/RuleFeature.cpp
 style/RuleSet.cpp

--- a/Source/WebCore/style/AnchorPositionEvaluator.h
+++ b/Source/WebCore/style/AnchorPositionEvaluator.h
@@ -28,6 +28,7 @@
 #include "EventTarget.h"
 #include "LayoutUnit.h"
 #include "PositionTryOrder.h"
+#include "ResolvedScopedName.h"
 #include "ScopedName.h"
 #include "WritingMode.h"
 #include <wtf/HashMap.h>
@@ -60,17 +61,17 @@ enum class AnchorPositionResolutionStage : uint8_t {
     Positioned,
 };
 
-using AnchorElements = HashMap<AtomString, WeakPtr<Element, WeakPtrImplWithEventTargetData>>;
+using AnchorElements = HashMap<ResolvedScopedName, WeakPtr<Element, WeakPtrImplWithEventTargetData>>;
 
 struct AnchorPositionedState {
     WTF_MAKE_TZONE_ALLOCATED(AnchorPositionedState);
 public:
     AnchorElements anchorElements;
-    UncheckedKeyHashSet<AtomString> anchorNames;
+    UncheckedKeyHashSet<ResolvedScopedName> anchorNames;
     AnchorPositionResolutionStage stage;
 };
 
-using AnchorsForAnchorName = HashMap<AtomString, Vector<SingleThreadWeakRef<const RenderBoxModelObject>>>;
+using AnchorsForAnchorName = HashMap<ResolvedScopedName, Vector<SingleThreadWeakRef<const RenderBoxModelObject>>>;
 
 // https://drafts.csswg.org/css-anchor-position-1/#typedef-anchor-size
 enum class AnchorSizeDimension : uint8_t {
@@ -116,7 +117,7 @@ public:
     static bool isDefaultAnchorInvisibleOrClippedByInterveningBoxes(const RenderBox& anchoredBox);
 
 private:
-    static AnchorElements findAnchorsForAnchorPositionedElement(const Element&, const UncheckedKeyHashSet<AtomString>& anchorNames, const AnchorsForAnchorName&);
+    static AnchorElements findAnchorsForAnchorPositionedElement(const Element&, const UncheckedKeyHashSet<ResolvedScopedName>& anchorNames, const AnchorsForAnchorName&);
 };
 
 } // namespace Style

--- a/Source/WebCore/style/ResolvedScopedName.cpp
+++ b/Source/WebCore/style/ResolvedScopedName.cpp
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "ResolvedScopedName.h"
+
+#include "ScopedName.h"
+#include "StyleScope.h"
+
+namespace WebCore::Style {
+
+ResolvedScopedName::ResolvedScopedName(AtomString name, ScopeIdentifier scopeIdentifier)
+    : m_name(name)
+    , m_scopeIdentifier(scopeIdentifier)
+{
+}
+
+ResolvedScopedName ResolvedScopedName::createFromScopedName(const Element& element, const ScopedName& scopedName)
+{
+    CheckedPtr scope = Scope::forOrdinal(element, scopedName.scopeOrdinal);
+    ASSERT(scope);
+
+    return ResolvedScopedName { scopedName.name, scope->identifier() };
+}
+
+} // namespace WebCore::Style

--- a/Source/WebCore/style/ResolvedScopedName.h
+++ b/Source/WebCore/style/ResolvedScopedName.h
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "StyleScopeIdentifier.h"
+#include <wtf/Forward.h>
+#include <wtf/text/AtomString.h>
+
+namespace WebCore {
+
+class Element;
+
+namespace Style {
+
+class Scope;
+
+struct ScopedName;
+
+// A ScopedName that has been resolved to determine which specific scope it belongs to.
+class ResolvedScopedName {
+    WTF_MAKE_FAST_ALLOCATED;
+public:
+    ResolvedScopedName(AtomString, ScopeIdentifier);
+
+    // Creates a ResolvedScopedName from a ScopedName by resolving the scope ordinal
+    // into the concrete Style::Scope object.
+    static ResolvedScopedName createFromScopedName(const Element&, const ScopedName&);
+
+    AtomString name() const { return m_name; }
+    ScopeIdentifier scopeIdentifier() const { return m_scopeIdentifier; }
+
+    friend bool operator==(const ResolvedScopedName& lhs, const ResolvedScopedName& rhs) = default;
+
+private:
+    AtomString m_name;
+    ScopeIdentifier m_scopeIdentifier;
+};
+
+inline void add(Hasher& hasher, const ResolvedScopedName& name)
+{
+    add(hasher, name.name(), name.scopeIdentifier());
+}
+
+} // namespace Style
+
+} // namespace WebCore
+
+namespace WTF {
+
+template <>
+struct DefaultHash<WebCore::Style::ResolvedScopedName> {
+    static unsigned hash(const WebCore::Style::ResolvedScopedName& name) { return computeHash(name); }
+    static bool equal(const WebCore::Style::ResolvedScopedName& a, const WebCore::Style::ResolvedScopedName& b) { return a == b; }
+    static constexpr bool safeToCompareToEmptyOrDeleted = true;
+};
+
+template<>
+struct HashTraits<WebCore::Style::ResolvedScopedName> : GenericHashTraits<WebCore::Style::ResolvedScopedName> {
+    static const bool emptyValueIsZero = true;
+
+    static WebCore::Style::ResolvedScopedName emptyValue()
+    {
+        return { WTF::nullAtom(), HashTraits<WebCore::Style::ScopeIdentifier>::emptyValue() };
+    }
+
+    static void constructDeletedValue(WebCore::Style::ResolvedScopedName& slot)
+    {
+        new (NotNull, std::addressof(slot)) WebCore::Style::ResolvedScopedName { HashTableDeletedValue, HashTableDeletedValue };
+    }
+
+    static bool isDeletedValue(const WebCore::Style::ResolvedScopedName& value)
+    {
+        return value.name().isHashTableDeletedValue() && value.scopeIdentifier().isHashTableDeletedValue();
+    }
+};
+
+} // namespace WTF

--- a/Source/WebCore/style/StyleScope.cpp
+++ b/Source/WebCore/style/StyleScope.cpp
@@ -252,6 +252,11 @@ Scope* Scope::forOrdinal(Element& element, ScopeOrdinal ordinal)
     return slot ? &forNode(*slot) : nullptr;
 }
 
+const Scope* Scope::forOrdinal(const Element& element, ScopeOrdinal ordinal)
+{
+    return forOrdinal(const_cast<Element&>(element), ordinal);
+}
+
 void Scope::setPreferredStylesheetSetName(const String& name)
 {
     if (m_preferredStylesheetSetName == name)

--- a/Source/WebCore/style/StyleScope.h
+++ b/Source/WebCore/style/StyleScope.h
@@ -29,12 +29,14 @@
 
 #include "AnchorPositionEvaluator.h"
 #include "LayoutSize.h"
+#include "StyleScopeIdentifier.h"
 #include "StyleScopeOrdinal.h"
 #include "Timer.h"
 #include <memory>
 #include <wtf/CheckedPtr.h>
 #include <wtf/HashMap.h>
 #include <wtf/HashSet.h>
+#include <wtf/Identified.h>
 #include <wtf/ListHashSet.h>
 #include <wtf/RefPtr.h>
 #include <wtf/TZoneMalloc.h>
@@ -71,7 +73,7 @@ class Resolver;
 class RuleSet;
 struct MatchResult;
 
-class Scope final : public CanMakeWeakPtr<Scope>, public CanMakeCheckedPtr<Scope> {
+class Scope final : public CanMakeWeakPtr<Scope>, public CanMakeCheckedPtr<Scope>, public Identified<ScopeIdentifier> {
     WTF_MAKE_TZONE_ALLOCATED(Scope);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(Scope);
 public:
@@ -147,6 +149,7 @@ public:
     static Scope& forNode(Node&);
     static const Scope& forNode(const Node&);
     static Scope* forOrdinal(Element&, ScopeOrdinal);
+    static const Scope* forOrdinal(const Element&, ScopeOrdinal);
 
     struct LayoutDependencyUpdateContext {
         UncheckedKeyHashSet<CheckedRef<const Element>> invalidatedContainers;

--- a/Source/WebCore/style/StyleScopeIdentifier.h
+++ b/Source/WebCore/style/StyleScopeIdentifier.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/ObjectIdentifier.h>
+
+namespace WebCore::Style {
+
+struct ScopeIdentifierType;
+using ScopeIdentifier = ObjectIdentifier<ScopeIdentifierType>;
+
+}


### PR DESCRIPTION
#### f205117295d5ce8eabd95aec9981b3fb1e439334
<pre>
[css-anchor-position-1] Make anchors shadow-DOM-scoped
<a href="https://rdar.apple.com/151797497">rdar://151797497</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=293382">https://bugs.webkit.org/show_bug.cgi?id=293382</a>

Reviewed by Antti Koivisto.

Right now, anchors are uniquely identified by their string identifier,
which is not enough since anchors are scoped to their shadow DOM tree.
This patch introduces ResolvedScopedName, which contains the same info
as a ScopedName, except the scope ordinal has been resolved to the
concrete Style::Scope object. ResolvedScopedName are then used
as unique identifier for anchor names. Code that uses AtomString
to identify anchors now uses ResolvedScopedName instead.

Combined changes:
* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-name-in-shadow-002-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-name-in-shadow-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-transition-002-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-transition-003-expected.txt:
* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/style/AnchorPositionEvaluator.cpp:
(WebCore::Style::AnchorPositionEvaluator::findAnchorForAnchorFunctionAndAttemptResolution):
(WebCore::Style::findLastAcceptableAnchorWithName):
(WebCore::Style::collectAnchorsForAnchorName):
(WebCore::Style::AnchorPositionEvaluator::findAnchorsForAnchorPositionedElement):
(WebCore::Style::AnchorPositionEvaluator::updateAnchorPositionedStateForLayoutTimePositioned):
* Source/WebCore/style/AnchorPositionEvaluator.h:
* Source/WebCore/style/ResolvedScopedName.cpp: Added.
(WebCore::Style::ResolvedScopedName::ResolvedScopedName):
(WebCore::Style::ResolvedScopedName::createFromScopedName):
* Source/WebCore/style/ResolvedScopedName.h: Added.
(WebCore::Style::ResolvedScopedName::name const):
(WebCore::Style::ResolvedScopedName::scopeIdentifier const):
(WebCore::Style::add):
(WTF::DefaultHash&lt;WebCore::Style::ResolvedScopedName&gt;::hash):
(WTF::DefaultHash&lt;WebCore::Style::ResolvedScopedName&gt;::equal):
(WTF::HashTraits&lt;WebCore::Style::ResolvedScopedName&gt;::emptyValue):
(WTF::HashTraits&lt;WebCore::Style::ResolvedScopedName&gt;::constructDeletedValue):
(WTF::HashTraits&lt;WebCore::Style::ResolvedScopedName&gt;::isDeletedValue):
* Source/WebCore/style/StyleScope.cpp:
(WebCore::Style::Scope::forOrdinal):
* Source/WebCore/style/StyleScope.h:
* Source/WebCore/style/StyleScopeIdentifier.h: Added.

Canonical link: <a href="https://commits.webkit.org/295465@main">https://commits.webkit.org/295465@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0478efadde1daeb73eb8472fe5800177ba2b170e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104915 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24629 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15049 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110131 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/55589 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/106956 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/25029 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33173 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79660 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107921 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19467 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94683 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59967 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/19218 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/12761 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/54972 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/88932 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/12807 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/112605 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32080 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23596 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88737 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32444 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/90909 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88368 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22591 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33262 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11036 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/27395 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32005 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/37430 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/31797 "Built successfully") | | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35138 "Build is in progress. Recent messages:OS: Sequoia (15.2), Xcode: 16.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33356 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->