### PR TITLE
AX: Shrink size of AXTextRun from 56 bytes to 40 bytes and AXTextRuns from 32 to 24 bytes by replacing Vector with FixedVector for member variables

### DIFF
--- a/Source/WebCore/accessibility/AXTextRun.h
+++ b/Source/WebCore/accessibility/AXTextRun.h
@@ -31,6 +31,7 @@
 #include "TextAffinity.h"
 #include "TextFlags.h"
 #include <CoreText/CTFont.h>
+#include <wtf/FixedVector.h>
 #include <wtf/text/MakeString.h>
 #include <wtf/text/TextStream.h>
 
@@ -75,18 +76,18 @@ struct AXTextRun {
     // "Delta"
     // which we combine into |text|: "Charlie Delta"
     // This Vector would then have values: [[2, 10], [11, 16]]
-    Vector<std::array<uint16_t, 2>> textRunDomOffsets;
+    FixedVector<std::array<uint16_t, 2>> textRunDomOffsets;
 
     // An array the size of the run, where each value is the width/advance of each character in the run (in the direction
     // of the writing mode: horizontal or vertical).
-    Vector<uint16_t> characterAdvances;
+    FixedVector<uint16_t> characterAdvances;
 
     float lineHeight;
 
     // The distance between the RenderText's position and the start of the text run (useful for things that are not left-aligned, like `text-align: center`).
     float distanceFromBoundsInDirection;
 
-    AXTextRun(size_t lineIndex, String&& text, Vector<std::array<uint16_t, 2>>&& domOffsets, Vector<uint16_t> characterAdvances, float lineHeight, float distanceFromBoundsInDirection)
+    AXTextRun(size_t lineIndex, String&& text, Vector<std::array<uint16_t, 2>>&& domOffsets, Vector<uint16_t>&& characterAdvances, float lineHeight, float distanceFromBoundsInDirection)
         : lineIndex(lineIndex)
         , text(WTFMove(text))
         , textRunDomOffsets(WTFMove(domOffsets))
@@ -100,8 +101,8 @@ struct AXTextRun {
         AXTextRunLineID lineID = { containingBlock, lineIndex };
         return makeString(lineID.debugDescription(), ": |"_s, makeStringByReplacingAll(text, '\n', "{newline}"_s), "|(len "_s, text.length(), ")"_s);
     }
-    const Vector<std::array<uint16_t, 2>>& domOffsets() const { return textRunDomOffsets; }
-    const Vector<uint16_t>& advances() const { return characterAdvances; }
+    const FixedVector<std::array<uint16_t, 2>>& domOffsets() const { return textRunDomOffsets; }
+    const FixedVector<uint16_t>& advances() const { return characterAdvances; }
 
     // Convenience methods for TextUnit movement.
     bool startsWithLineBreak() const { return text.startsWith('\n'); }
@@ -114,7 +115,7 @@ struct AXTextRuns {
     // containing blocks, meaning they are rendered on different lines.
     // Do not de-reference. Use for comparison purposes only.
     void* containingBlock { nullptr };
-    Vector<AXTextRun> runs;
+    FixedVector<AXTextRun> runs;
     bool containsOnlyASCII { true };
 
     AXTextRuns() = default;


### PR DESCRIPTION
#### 101166eb27a3be7d91f7cfda207aeddf4adb75de
<pre>
AX: Shrink size of AXTextRun from 56 bytes to 40 bytes and AXTextRuns from 32 to 24 bytes by replacing Vector with FixedVector for member variables
<a href="https://bugs.webkit.org/show_bug.cgi?id=293463">https://bugs.webkit.org/show_bug.cgi?id=293463</a>
<a href="https://rdar.apple.com/151889539">rdar://151889539</a>

Reviewed by Joshua Hoffman.

FixedVector is 8 bytes smaller than Vector, with the restriction being that it cannot be modified after being constructed.
The benefit is worth the restriction, since these are treated as immutable once cached in the isolated tree.

We did modify AXTextRun::characterAdvances after setting it in AccessibilityRenderObject::textRuns, so this commit re-orders
the code to avoid needing to do that.

This presumably saves ~7.9mb of memory on <a href="http://html.spec.whatwg.org">http://html.spec.whatwg.org</a> (based on math alone, not actual `heap measurements`).

318911 instances of AXTextRuns * 8 bytes saved = 2.55mb
334589 instances of AXTextRun * 16 bytes saved = 5.35mb

* Source/WebCore/accessibility/AXTextRun.h:
(WebCore::AXTextRun::AXTextRun):
(WebCore::AXTextRun::domOffsets const):
(WebCore::AXTextRun::advances const):
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::AccessibilityRenderObject::textRuns):

Canonical link: <a href="https://commits.webkit.org/295337@main">https://commits.webkit.org/295337@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d24217cd0bc74c9ab54d420b2cebc99e9b2fea04

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104764 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24476 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/14898 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/109978 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/55438 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/106804 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/24867 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33022 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79544 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107770 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19334 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94541 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59851 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/19093 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/12618 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/54818 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/88791 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/12665 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/112380 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/31929 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23477 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88626 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32293 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/90767 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88250 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22499 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33140 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10906 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/27242 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/31854 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/37208 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/31646 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/34987 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33205 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->