### PR TITLE
css/css-view-transitions/root-style-change-during-animation.html fails due to visibility:hidden not being respected on the VT pseudo.

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7086,7 +7086,6 @@ imported/w3c/web-platform-tests/css/css-view-transitions/fractional-box-with-ove
 imported/w3c/web-platform-tests/css/css-view-transitions/fractional-box-with-shadow-new.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-view-transitions/fractional-box-with-shadow-old.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-view-transitions/inline-with-offset-from-containing-block.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-view-transitions/root-style-change-during-animation.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-view-transitions/span-with-overflowing-text.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-view-transitions/fractional-box-with-overflow-children-new.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-view-transitions/new-content-captures-different-size.html [ ImageOnlyFailure ]

--- a/Source/WebCore/rendering/RenderViewTransitionCapture.cpp
+++ b/Source/WebCore/rendering/RenderViewTransitionCapture.cpp
@@ -112,6 +112,14 @@ void RenderViewTransitionCapture::updateFromStyle()
         setHasNonVisibleOverflow();
 }
 
+void RenderViewTransitionCapture::styleDidChange(StyleDifference diff, const RenderStyle* oldStyle)
+{
+    RenderReplaced::styleDidChange(diff, oldStyle);
+
+    if (oldStyle && oldStyle->usedVisibility() != style().usedVisibility() && hasLayer())
+        layer()->setNeedsCompositingLayerConnection();
+}
+
 LayoutPoint RenderViewTransitionCapture::captureContentInset() const
 {
     LayoutPoint location = m_localOverflowRect.location();

--- a/Source/WebCore/rendering/RenderViewTransitionCapture.h
+++ b/Source/WebCore/rendering/RenderViewTransitionCapture.h
@@ -43,6 +43,8 @@ public:
     void paintReplaced(PaintInfo&, const LayoutPoint& paintOffset) override;
     void intrinsicSizeChanged() override;
 
+    void styleDidChange(StyleDifference, const RenderStyle*) override;
+
     void layout() override;
 
     FloatSize scale() const { return m_scale; }


### PR DESCRIPTION
#### 4a3d6eaaf8bf27447381c59a928b3e2c143a7130
<pre>
css/css-view-transitions/root-style-change-during-animation.html fails due to visibility:hidden not being respected on the VT pseudo.
<a href="https://bugs.webkit.org/show_bug.cgi?id=293464">https://bugs.webkit.org/show_bug.cgi?id=293464</a>
&lt;<a href="https://rdar.apple.com/151891703">rdar://151891703</a>&gt;

Reviewed by Tim Nguyen.

Visibility:hidden for the ::view-transition-new pseudo is applied as part of
attaching compositing layers, so make sure this bit gets invalidated.

* LayoutTests/TestExpectations:
* Source/WebCore/rendering/RenderViewTransitionCapture.cpp:
(WebCore::RenderViewTransitionCapture::styleDidChange):
* Source/WebCore/rendering/RenderViewTransitionCapture.h:

Canonical link: <a href="https://commits.webkit.org/295386@main">https://commits.webkit.org/295386@main</a>
</pre>
