### PR TITLE
css/css-view-transitions/(new|old)-content-with-overflow-zoomed.html fails because css zoom isn't applied correctly.

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7115,10 +7115,6 @@ imported/w3c/web-platform-tests/css/css-view-transitions/nested/ [ Skip ]
 # View transitions Level ? - scoped view-transitions
 imported/w3c/web-platform-tests/css/css-view-transitions/scoped/ [ Skip ]
 
-# Depends on overflow-clip-margin (unimplemented).
-imported/w3c/web-platform-tests/css/css-view-transitions/new-content-with-overflow-zoomed.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-view-transitions/old-content-with-overflow-zoomed.html [ ImageOnlyFailure ]
-
 # Depends on object-view-box (unimplemented).
 imported/w3c/web-platform-tests/css/css-view-transitions/old-content-with-object-view-box.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-view-transitions/object-view-box-new-image.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/content-with-overflow-zoomed-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/content-with-overflow-zoomed-ref.html
@@ -6,9 +6,7 @@
 .target {
   width: 80px;
   height: 80px;
-  contain: paint;
   background: blue;
-  overflow-clip-margin: 50px;
   view-transition-name: target;
   zoom: 1.5;
   border: 2px solid black;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/new-content-with-overflow-zoomed-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/new-content-with-overflow-zoomed-expected.html
@@ -6,9 +6,7 @@
 .target {
   width: 80px;
   height: 80px;
-  contain: paint;
   background: blue;
-  overflow-clip-margin: 50px;
   view-transition-name: target;
   zoom: 1.5;
   border: 2px solid black;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/new-content-with-overflow-zoomed.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/new-content-with-overflow-zoomed.html
@@ -9,9 +9,7 @@
 .target {
   width: 80px;
   height: 80px;
-  contain: paint;
   background: blue;
-  overflow-clip-margin: 50px;
   view-transition-name: target;
   zoom: 1.5;
 }

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/old-content-with-overflow-zoomed-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/old-content-with-overflow-zoomed-expected.html
@@ -6,9 +6,7 @@
 .target {
   width: 80px;
   height: 80px;
-  contain: paint;
   background: blue;
-  overflow-clip-margin: 50px;
   view-transition-name: target;
   zoom: 1.5;
   border: 2px solid black;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/old-content-with-overflow-zoomed.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/old-content-with-overflow-zoomed.html
@@ -9,9 +9,7 @@
 .target {
   width: 80px;
   height: 80px;
-  contain: paint;
   background: blue;
-  overflow-clip-margin: 50px;
   view-transition-name: target;
   zoom: 1.5;
 }


### PR DESCRIPTION
#### 8443d607cca0b34a661af9242646aec0b0a507a7
<pre>
css/css-view-transitions/(new|old)-content-with-overflow-zoomed.html fails because css zoom isn&apos;t applied correctly.
<a href="https://bugs.webkit.org/show_bug.cgi?id=293466">https://bugs.webkit.org/show_bug.cgi?id=293466</a>

Reviewed by Tim Nguyen.

Imports the test fix from <a href="https://github.com/web-platform-tests/wpt/commit/74fbdf6d5963d7f4330ac9826d30433a8c78f465">https://github.com/web-platform-tests/wpt/commit/74fbdf6d5963d7f4330ac9826d30433a8c78f465</a>

Removes the code that removed the zoom factors when converting to pixels, since we want to remain in the zoomed coordinate space.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/content-with-overflow-zoomed-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/new-content-with-overflow-zoomed-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/new-content-with-overflow-zoomed.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/old-content-with-overflow-zoomed-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/old-content-with-overflow-zoomed.html:
* Source/WebCore/dom/ViewTransition.cpp:
(WebCore::ViewTransition::copyElementBaseProperties):

Canonical link: <a href="https://commits.webkit.org/295428@main">https://commits.webkit.org/295428@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ce7aabf96a1743c0af18d28218e97161949458d2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105073 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24787 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15210 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110290 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/55754 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/107114 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/25205 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33331 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79798 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108079 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19630 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94838 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60105 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/19391 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/12913 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55130 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/89098 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/12958 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/112808 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32238 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23736 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88879 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32604 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91057 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88509 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22561 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33397 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11187 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/27636 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32162 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/37536 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/31955 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35296 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33514 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->