### PR TITLE
Web Inspector: REGRESSION(?): Timelines: Call Trees of Page target sometimes aren't shown

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Controllers/TimelineManager.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/TimelineManager.js
@@ -683,6 +683,7 @@ WI.TimelineManager = class TimelineManager extends WI.Object
                 // Once we eliminate ProfileNodeTreeElements and ProfileNodeDataGridNodes.
                 // <https://webkit.org/b/154973> Web Inspector: Timelines UI redesign: Remove TimelineSidebarPanel
                 let topDownCallingContextTree = scriptTimeline.callingContextTree(target, WI.CallingContextTree.Type.TopDown);
+                console.assert(topDownCallingContextTree, scriptTimeline);
                 for (let i = 0; i < scriptProfilerRecords.length; ++i) {
                     let record = scriptProfilerRecords[i];
                     record.profilePayload = topDownCallingContextTree.toCPUProfilePayload(record.startTime, record.endTime);

--- a/Source/WebInspectorUI/UserInterface/Models/ScriptTimeline.js
+++ b/Source/WebInspectorUI/UserInterface/Models/ScriptTimeline.js
@@ -48,12 +48,14 @@ WI.ScriptTimeline = class ScriptTimeline extends WI.Timeline
         super.reset(suppressEvents);
     }
 
+    refresh()
+    {
+        this.dispatchEventToListeners(WI.Timeline.Event.Refresh);
+    }
+
     callingContextTree(target, type)
     {
-        let callingContextTrees = this._callingContextTreesForTarget.get(target);
-        if (!callingContextTrees)
-            return new WI.CallingContextTree(WI.assumingMainTarget(), type);
-        return callingContextTrees[type];
+        return this._callingContextTreesForTarget.get(target)?.[type] || null;
     }
 
     updateCallingContextTrees(target, stackTraces, sampleDurations)
@@ -80,5 +82,6 @@ WI.ScriptTimeline = class ScriptTimeline extends WI.Timeline
 };
 
 WI.ScriptTimeline.Event = {
+    Refreshed: "script-timeline-refreshed",
     TargetAdded: "script-timeline-target-added",
 };

--- a/Source/WebInspectorUI/UserInterface/Models/Timeline.js
+++ b/Source/WebInspectorUI/UserInterface/Models/Timeline.js
@@ -94,11 +94,6 @@ WI.Timeline = class Timeline extends WI.Object
         cookie[WI.Timeline.TimelineTypeCookieKey] = this._type;
     }
 
-    refresh()
-    {
-        this.dispatchEventToListeners(WI.Timeline.Event.Refreshed);
-    }
-
     closestRecordTo(timestamp)
     {
         let lowerIndex = this._records.lowerBound(timestamp, (time, record) => time - record.endTime);
@@ -199,7 +194,6 @@ WI.Timeline.Event = {
     Reset: "timeline-reset",
     RecordAdded: "timeline-record-added",
     TimesUpdated: "timeline-times-updated",
-    Refreshed: "timeline-refreshed",
 };
 
 WI.Timeline.TimelineTypeCookieKey = "timeline-type";

--- a/Source/WebInspectorUI/UserInterface/Views/ScriptClusterTimelineView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/ScriptClusterTimelineView.js
@@ -227,7 +227,7 @@ WI.ScriptClusterTimelineView = class ScriptClusterTimelineView extends WI.Cluste
         this._pathComponentForTarget.set(target, this._createTargetPathComponent(target));
         this._sortTargetPathComponents();
 
-        console.assert(!this._contentViewsForTarget.has(target), target, this);
+        console.assert(target === this._displayedTarget || !this._contentViewsForTarget.has(target), target, this);
 
         if (!this._selectedTarget) {
             console.assert(this._pathComponentForTarget.size >= 1, this._pathComponentForTarget);

--- a/Source/WebInspectorUI/UserInterface/Views/ScriptDetailsTimelineView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/ScriptDetailsTimelineView.js
@@ -80,7 +80,7 @@ WI.ScriptDetailsTimelineView = class ScriptDetailsTimelineView extends WI.Timeli
         this.addSubview(this._dataGrid);
 
         this.representedObject.addEventListener(WI.Timeline.Event.RecordAdded, this._scriptTimelineRecordAdded, this);
-        this.representedObject.addEventListener(WI.Timeline.Event.Refreshed, this._scriptTimelineRecordRefreshed, this);
+        this.representedObject.addEventListener(WI.ScriptTimeline.Event.Refreshed, this._handleScriptTimelineRefreshed, this);
 
         this._pendingRecords = [];
 
@@ -95,7 +95,7 @@ WI.ScriptDetailsTimelineView = class ScriptDetailsTimelineView extends WI.Timeli
     closed()
     {
         this.representedObject.removeEventListener(WI.Timeline.Event.RecordAdded, this._scriptTimelineRecordAdded, this);
-        this.representedObject.removeEventListener(WI.Timeline.Event.Refreshed, this._scriptTimelineRecordRefreshed, this);
+        this.representedObject.removeEventListener(WI.ScriptTimeline.Event.Refreshed, this._handleScriptTimelineRefreshed, this);
 
         this._dataGrid.closed();
 
@@ -229,7 +229,7 @@ WI.ScriptDetailsTimelineView = class ScriptDetailsTimelineView extends WI.Timeli
         this._pendingRecords.push(scriptTimelineRecord);
     }
 
-    _scriptTimelineRecordRefreshed(event)
+    _handleScriptTimelineRefreshed(event)
     {
         this.needsLayout();
     }

--- a/Source/WebInspectorUI/UserInterface/Views/TimelineRecordingContentView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/TimelineRecordingContentView.js
@@ -745,8 +745,10 @@ WI.TimelineRecordingContentView = class TimelineRecordingContentView extends WI.
         this._lastUpdateTimestamp = NaN;
         this._startTimeNeedsReset = true;
 
-        this._recording.removeEventListener(WI.TimelineRecording.Event.TimesUpdated, this._recordingTimesUpdated, this);
-        this._waitingToResetCurrentTime = false;
+        if (this._waitingToResetCurrentTime) {
+            this._recording.removeEventListener(WI.TimelineRecording.Event.TimesUpdated, this._recordingTimesUpdated, this);
+            this._waitingToResetCurrentTime = false;
+        }
 
         this._timelineOverview.reset();
         this._overviewTimelineView.reset();


### PR DESCRIPTION
#### 404b97e5c7727ac33edefbeb7cfebb0573fa04d9
<pre>
Web Inspector: REGRESSION(?): Timelines: Call Trees of Page target sometimes aren&apos;t shown
<a href="https://bugs.webkit.org/show_bug.cgi?id=293469">https://bugs.webkit.org/show_bug.cgi?id=293469</a>

Reviewed by BJ Burg.

* Source/WebInspectorUI/UserInterface/Models/ScriptTimeline.js:
(WI.ScriptTimeline.prototype.refresh): Added.
(WI.ScriptTimeline.prototype.callingContextTree):
* Source/WebInspectorUI/UserInterface/Views/ScriptProfileTimelineView.js:
(WI.ScriptProfileTimelineView):
(WI.ScriptProfileTimelineView.prototype.closed):
(WI.ScriptProfileTimelineView.prototype._callingContextTreeForOrientation):
(WI.ScriptProfileTimelineView.prototype._handleScriptTimelineTargetAdded): Renamed from `_scriptTimelineRecordRefreshed`.
If the `WI.ScriptTimeline` doesn&apos;t have any `WI.Target`, it will instead use a temporary `WI.CallingContextTree` with the `WI.mainTarget`.
This means that `WI.ProfileView` created for it won&apos;t have any data `WI.ScriptTimeline.prototype.updateCallingContextTrees` won&apos;t affect it.
In this case, listen for `WI.ScriptTimeline.Event.TargetAdded` to see when the `WI.Target` is finally added to the `WI.ScriptTimeline` to recreate the above.
If the `WI.mainTarget` is never added to the `WI.ScriptTimeline` then it&apos;ll instead fallback to the first `WI.Target` added (see `WI.ScriptClusterTimelineView.prototype._handleTargetAdded`).

* Source/WebInspectorUI/UserInterface/Models/Timeline.js:
(WI.Timeline.prototype.refresh): Deleted.
* Source/WebInspectorUI/UserInterface/Views/ScriptDetailsTimelineView.js:
(WI.ScriptDetailsTimelineView):
(WI.ScriptDetailsTimelineView.prototype.closed):
(WI.ScriptDetailsTimelineView.prototype._handleScriptTimelineRefreshed): Renamed from `_scriptTimelineRecordRefreshed`.
Drive-by: move the dispatch of `WI.Timeline.Event.Refreshed` to the subclass `WI.ScriptTimeline` since that&apos;s where it&apos;s used.

* Source/WebInspectorUI/UserInterface/Views/ScriptClusterTimelineView.js:
(WI.ScriptClusterTimelineView.prototype._handleTargetAdded):
Drive-by: fix an incorrect assertion.

* Source/WebInspectorUI/UserInterface/Views/TimelineRecordingContentView.js:
(WI.TimelineRecordingContentView.prototype._recordingReset):
Drive-by: prevent an assertion failure.

* Source/WebInspectorUI/UserInterface/Controllers/TimelineManager.js:
(WI.TimelineManager.prototype.scriptProfilerTrackingCompleted):

Drive-by: add an extra assertion just in case.
Canonical link: <a href="https://commits.webkit.org/295373@main">https://commits.webkit.org/295373@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4f04f7fed4c2856cdb2b4bcfbc5f03a475674dc0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104775 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24487 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/14909 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/109989 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/55449 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/24880 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33033 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79554 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107781 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19345 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94558 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59861 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/19104 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/12635 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/54831 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/88801 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/12682 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/112393 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/31940 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23486 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88636 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32304 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/90784 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88260 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22517 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33149 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10922 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/27253 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/31865 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/37219 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/31657 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/34998 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33216 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->