### PR TITLE
TrackBuffer.decodeQueue() shouldn't be a public method.

### DIFF
--- a/Source/WebCore/platform/graphics/TrackBuffer.h
+++ b/Source/WebCore/platform/graphics/TrackBuffer.h
@@ -48,49 +48,52 @@ class TrackBuffer final
 public:
     static UniqueRef<TrackBuffer> create(RefPtr<MediaDescription>&&);
     static UniqueRef<TrackBuffer> create(RefPtr<MediaDescription>&&, const MediaTime&);
-    
+
     MediaTime maximumBufferedTime() const;
     void addBufferedRange(const MediaTime& start, const MediaTime& end, AddTimeRangeOption = AddTimeRangeOption::None);
     void addSample(MediaSample&);
-    
+
     bool updateMinimumUpcomingPresentationTime();
-    
+
     bool reenqueueMediaForTime(const MediaTime&, const MediaTime& timeFudgeFactor, bool isEnded = false);
     MediaTime findSeekTimeForTargetTime(const MediaTime& targetTime, const MediaTime& negativeThreshold, const MediaTime& positiveThreshold);
     int64_t removeCodedFrames(const MediaTime& start, const MediaTime& end, const MediaTime& currentTime);
     PlatformTimeRanges removeSamples(const DecodeOrderSampleMap::MapType&, ASCIILiteral);
     int64_t codedFramesIntervalSize(const MediaTime& start, const MediaTime& end);
 
+    RefPtr<MediaSample> nextSample();
+    size_t remainingSamples() const { return decodeQueue().size(); }
+
     void resetTimestampOffset();
     void reset();
     void clearSamples();
-    
+
     const MediaTime& lastDecodeTimestamp() const { return m_lastDecodeTimestamp; }
     void setLastDecodeTimestamp(MediaTime timestamp) { m_lastDecodeTimestamp = WTFMove(timestamp); }
-    
+
     const MediaTime& greatestFrameDuration() const { return m_greatestFrameDuration; }
     void setGreatestFrameDuration(MediaTime duration) { m_greatestFrameDuration = WTFMove(duration); }
     const MediaTime& lastFrameDuration() const { return m_lastFrameDuration; }
     void setLastFrameDuration(MediaTime duration) { m_lastFrameDuration = WTFMove(duration); }
-    
+
     const MediaTime& highestPresentationTimestamp() const { return m_highestPresentationTimestamp; }
     void setHighestPresentationTimestamp(MediaTime timestamp) { m_highestPresentationTimestamp = WTFMove(timestamp); }
-    
+
     const MediaTime& highestEnqueuedPresentationTime() const { return m_highestEnqueuedPresentationTime; }
     void setHighestEnqueuedPresentationTime(MediaTime timestamp) { m_highestEnqueuedPresentationTime = WTFMove(timestamp); }
     const MediaTime& minimumEnqueuedPresentationTime() const { return m_minimumEnqueuedPresentationTime; }
     void setMinimumEnqueuedPresentationTime(MediaTime timestamp) { m_minimumEnqueuedPresentationTime = WTFMove(timestamp); }
-    
+
     const DecodeOrderSampleMap::KeyType& lastEnqueuedDecodeKey() const { return m_lastEnqueuedDecodeKey; }
     void setLastEnqueuedDecodeKey(DecodeOrderSampleMap::KeyType key) { m_lastEnqueuedDecodeKey = WTFMove(key); }
-    
+
     const MediaTime& enqueueDiscontinuityBoundary() const { return m_enqueueDiscontinuityBoundary; }
     void setEnqueueDiscontinuityBoundary(MediaTime boundary) { m_enqueueDiscontinuityBoundary = WTFMove(boundary); }
-    
+
     const MediaTime& roundedTimestampOffset() const { return m_roundedTimestampOffset; }
     void setRoundedTimestampOffset(MediaTime offset) { m_roundedTimestampOffset = WTFMove(offset); }
     void setRoundedTimestampOffset(const MediaTime&, uint32_t, const MediaTime&);
-    
+
     uint32_t lastFrameTimescale() const { return m_lastFrameTimescale; }
     void setLastFrameTimescale(uint32_t timescale) { m_lastFrameTimescale = timescale; }
     bool needRandomAccessFlag() const { return m_needRandomAccessFlag; }
@@ -101,15 +104,13 @@ public:
     void setNeedsReenqueueing(bool flag) { m_needsReenqueueing = flag; }
     bool needsMinimumUpcomingPresentationTimeUpdating() const { return m_needsMinimumUpcomingPresentationTimeUpdating; }
     void setNeedsMinimumUpcomingPresentationTimeUpdating(bool flag) { m_needsMinimumUpcomingPresentationTimeUpdating = flag; }
-    
+
     const SampleMap& samples() const { return m_samples; }
     SampleMap& samples() { return m_samples; }
-    const DecodeOrderSampleMap::MapType& decodeQueue() const { return m_decodeQueue; }
-    DecodeOrderSampleMap::MapType& decodeQueue() { return m_decodeQueue; }
     const RefPtr<MediaDescription>& description() const { return m_description; }
     const PlatformTimeRanges& buffered() const { return m_buffered; }
     PlatformTimeRanges& buffered() { return m_buffered; }
-    
+
 #if !RELEASE_LOG_DISABLED
     void setLogger(const Logger&, uint64_t);
     const Logger& logger() const final { ASSERT(m_logger); return *m_logger.get(); }
@@ -117,38 +118,41 @@ public:
     ASCIILiteral logClassName() const final { return "TrackBuffer"_s; }
     WTFLogChannel& logChannel() const final;
 #endif
-    
+
 private:
     friend UniqueRef<TrackBuffer> WTF::makeUniqueRefWithoutFastMallocCheck<TrackBuffer>(RefPtr<WebCore::MediaDescription>&&, const WTF::MediaTime&);
     TrackBuffer(RefPtr<MediaDescription>&&, const MediaTime&);
-    
+
+    const DecodeOrderSampleMap::MapType& decodeQueue() const { return m_decodeQueue; }
+    DecodeOrderSampleMap::MapType& decodeQueue() { return m_decodeQueue; }
+
     SampleMap m_samples;
     DecodeOrderSampleMap::MapType m_decodeQueue;
     RefPtr<MediaDescription> m_description;
     PlatformTimeRanges m_buffered;
-    
+
     MediaTime m_lastDecodeTimestamp { MediaTime::invalidTime() };
-    
+
     MediaTime m_greatestFrameDuration { MediaTime::invalidTime() };
     MediaTime m_lastFrameDuration { MediaTime::invalidTime() };
-    
+
     MediaTime m_highestPresentationTimestamp { MediaTime::invalidTime() };
-    
+
     MediaTime m_highestEnqueuedPresentationTime { MediaTime::invalidTime() };
     MediaTime m_minimumEnqueuedPresentationTime { MediaTime::invalidTime() };
-    
+
     DecodeOrderSampleMap::KeyType m_lastEnqueuedDecodeKey { MediaTime::invalidTime(), MediaTime::invalidTime() };
-    
+
     MediaTime m_enqueueDiscontinuityBoundary;
     MediaTime m_discontinuityTolerance;
-    
+
     MediaTime m_roundedTimestampOffset { MediaTime::invalidTime() };
-    
+
 #if !RELEASE_LOG_DISABLED
     RefPtr<const Logger> m_logger;
     uint64_t m_logIdentifier { 0 };
 #endif
-    
+
     uint32_t m_lastFrameTimescale { 0 };
     bool m_needRandomAccessFlag { true };
     bool m_enabled { false };


### PR DESCRIPTION
#### 0c01b830e20090c83cef7692e6236ff4b1171ed2
<pre>
TrackBuffer.decodeQueue() shouldn&apos;t be a public method.
<a href="https://bugs.webkit.org/show_bug.cgi?id=293459">https://bugs.webkit.org/show_bug.cgi?id=293459</a>
<a href="https://rdar.apple.com/151887171">rdar://151887171</a>

Reviewed by Youenn Fablet.

We move the whole logic to add a new sample to the TrackBuffer in the TrackBuffer class instead.
Similarly, we move the logic to retrieve the next frame to be enqueued for decoding in the TrackBuffer.

This allows for some simplification and removal of duplicated code.
It will also allows to make the tracking of the next minimumUpcomingSampleTime
dynamic required for a follow-up change.

* Source/WebCore/platform/graphics/TrackBuffer.cpp:
(WebCore::TrackBuffer::addSample): addSample now handles adding the sample to the global sample map and the decode queue.
(WebCore::TrackBuffer::nextSample): Method added.

Canonical link: <a href="https://commits.webkit.org/295339@main">https://commits.webkit.org/295339@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1966e0b7b2a2a75b4eb5b8ace07f27ce722b794b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104792 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24505 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/14926 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110006 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/55466 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/106832 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/24902 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33050 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79570 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107798 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19360 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94573 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59877 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/19117 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/12650 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/54848 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/88815 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/12697 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/112413 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/31957 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23496 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88649 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32321 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/90799 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88276 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22500 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33166 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10930 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/27270 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/31882 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/37236 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/31674 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35015 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33233 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->