### PR TITLE
[JSC] Careful optimization of eval

### DIFF
--- a/Source/JavaScriptCore/bytecode/CodeBlock.h
+++ b/Source/JavaScriptCore/bytecode/CodeBlock.h
@@ -551,7 +551,9 @@ public:
 
     FunctionExecutable* functionDecl(int index) { return m_functionDecls[index].get(); }
     int numberOfFunctionDecls() { return m_functionDecls.size(); }
+    std::span<const WriteBarrier<FunctionExecutable>> functionDecls() { return m_functionDecls.span(); }
     FunctionExecutable* functionExpr(int index) { return m_functionExprs[index].get(); }
+    std::span<const WriteBarrier<FunctionExecutable>> functionExprs() { return m_functionExprs.span(); }
     
     const BitVector& bitVector(size_t i) { return m_unlinkedCode->bitVector(i); }
 

--- a/Source/JavaScriptCore/bytecode/UnlinkedCodeBlock.h
+++ b/Source/JavaScriptCore/bytecode/UnlinkedCodeBlock.h
@@ -245,8 +245,10 @@ public:
 
     UnlinkedFunctionExecutable* functionDecl(int index) { return m_functionDecls[index].get(); }
     size_t numberOfFunctionDecls() { return m_functionDecls.size(); }
+    std::span<const WriteBarrier<UnlinkedFunctionExecutable>> functionDecls() const { return m_functionDecls.span(); }
     UnlinkedFunctionExecutable* functionExpr(int index) { return m_functionExprs[index].get(); }
     size_t numberOfFunctionExprs() { return m_functionExprs.size(); }
+    std::span<const WriteBarrier<UnlinkedFunctionExecutable>> functionExprs() const { return m_functionExprs.span(); }
 
     // Exception handling support
     size_t numberOfExceptionHandlers() const { return m_rareData ? m_rareData->m_exceptionHandlers.size() : 0; }

--- a/Source/JavaScriptCore/bytecode/UnlinkedEvalCodeBlock.h
+++ b/Source/JavaScriptCore/bytecode/UnlinkedEvalCodeBlock.h
@@ -54,6 +54,7 @@ public:
 
     const Identifier& variable(unsigned index) { return m_variables[index]; }
     unsigned numVariables() { return m_variables.size(); }
+    std::span<const Identifier> variables() const { return m_variables.span(); }
     void adoptVariables(Vector<Identifier, 0, UnsafeVectorOverflow>&& variables)
     {
         ASSERT(m_variables.isEmpty());
@@ -62,6 +63,7 @@ public:
 
     const Identifier& functionHoistingCandidate(unsigned index) { return m_functionHoistingCandidates[index]; }
     unsigned numFunctionHoistingCandidates() { return m_functionHoistingCandidates.size(); }
+    std::span<const Identifier> functionHoistingCandidates() const { return m_functionHoistingCandidates.span(); }
     void adoptFunctionHoistingCandidates(Vector<Identifier, 0, UnsafeVectorOverflow>&& functionHoistingCandidates)
     {
         ASSERT(m_functionHoistingCandidates.isEmpty());

--- a/Source/JavaScriptCore/runtime/EvalExecutable.h
+++ b/Source/JavaScriptCore/runtime/EvalExecutable.h
@@ -64,8 +64,13 @@ public:
     DECLARE_INFO;
 
     unsigned numVariables() { return unlinkedCodeBlock()->numVariables(); }
+    std::span<const Identifier> variables() const { return unlinkedCodeBlock()->variables(); }
+
     unsigned numFunctionHoistingCandidates() { return unlinkedCodeBlock()->numFunctionHoistingCandidates(); }
+    std::span<const Identifier> functionHoistingCandidates() const { return unlinkedCodeBlock()->functionHoistingCandidates(); }
+
     unsigned numTopLevelFunctionDecls() { return unlinkedCodeBlock()->numberOfFunctionDecls(); }
+    std::span<const WriteBarrier<UnlinkedFunctionExecutable>> topLevelFunctionDecls() const { return unlinkedCodeBlock()->functionDecls(); }
     bool allowDirectEvalCache() const { return unlinkedCodeBlock()->allowDirectEvalCache(); }
     NeedsClassFieldInitializer needsClassFieldInitializer() const { return static_cast<NeedsClassFieldInitializer>(m_needsClassFieldInitializer); }
     PrivateBrandRequirement privateBrandRequirement() const { return static_cast<PrivateBrandRequirement>(m_privateBrandRequirement); }


### PR DESCRIPTION
#### d2420b690182fc40009f2049e0930d06f9b5b4ea
<pre>
[JSC] Careful optimization of eval
<a href="https://bugs.webkit.org/show_bug.cgi?id=293474">https://bugs.webkit.org/show_bug.cgi?id=293474</a>
<a href="https://rdar.apple.com/151902736">rdar://151902736</a>

Reviewed by Yijia Huang.

This patch carefully restructures executeEval code.

1. Avoid doing some unnecessary things when we do not need to
   instantiate any variables.
2. Use vmEntryToJavaScriptWith0Arguments if necessary.
3. Use ensureStillAliveHere to keep JITCode alive instead of ref-ing.
   This ThreadSafeRefCount turned out super costly.

* Source/JavaScriptCore/bytecode/CodeBlock.h:
(JSC::CodeBlock::functionDecls):
(JSC::CodeBlock::functionExprs):
* Source/JavaScriptCore/bytecode/UnlinkedCodeBlock.h:
(JSC::UnlinkedCodeBlock::functionDecls const):
(JSC::UnlinkedCodeBlock::functionExprs const):
* Source/JavaScriptCore/bytecode/UnlinkedEvalCodeBlock.h:
* Source/JavaScriptCore/interpreter/Interpreter.cpp:
(JSC::Interpreter::executeEval):
* Source/JavaScriptCore/runtime/EvalExecutable.h:
(JSC::EvalExecutable::variables const):
(JSC::EvalExecutable::functionHoistingCandidates const):
(JSC::EvalExecutable::topLevelFunctionDecls const):

Canonical link: <a href="https://commits.webkit.org/295349@main">https://commits.webkit.org/295349@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/46829d6b8c478d3135fb82f61cc60d2f2beae8e2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104790 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24502 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/14924 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110004 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/55464 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/24900 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33048 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79568 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107796 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19359 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94571 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59875 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/19116 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/12648 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/54846 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/97471 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/88814 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/12695 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/112411 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/103408 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/31955 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23494 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88648 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32319 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/90797 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88275 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33165 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10928 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/27268 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17002 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/31880 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/37234 "Built successfully") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/127687 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/31672 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/127687 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35013 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33231 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->