### PR TITLE
For-In can return duplicate keys in JSC

### DIFF
--- a/JSTests/stress/property-enumeration-object-with-indexed-property-and-string-prototype.js
+++ b/JSTests/stress/property-enumeration-object-with-indexed-property-and-string-prototype.js
@@ -1,0 +1,32 @@
+function assert(actual, expected) {
+    if (actual.length !== expected.length)
+        throw new Error(`Length mismatch: got [${actual}], expected [${expected}]`);
+
+    for (let i = 0; i < expected.length; i++) {
+        if (actual[i] !== expected[i])
+            throw new Error(`Mismatch at index ${i}: got "${actual[i]}", expected "${expected[i]}"`);
+    }
+}
+
+function getKey(x) {
+    var arr = [];
+    for (var i in x) {
+        arr.push(i);
+    }
+    return arr;
+}
+
+function opt() {
+    var x = new String("ab");
+    function B() {
+        this[0] = 4;
+        this.bar = 77;
+    }
+    B.prototype = x;
+    var y = new B();
+    return getKey(y);
+}
+
+for (let i = 0; i < testLoopCount; i++) {
+    assert(opt(), ['0', 'bar', '1']);
+}

--- a/Source/JavaScriptCore/runtime/StringObjectInlines.h
+++ b/Source/JavaScriptCore/runtime/StringObjectInlines.h
@@ -26,7 +26,7 @@ namespace JSC {
 
 Structure* StringObject::createStructure(VM& vm, JSGlobalObject* globalObject, JSValue prototype)
 {
-    return Structure::create(vm, globalObject, prototype, TypeInfo(StringObjectType, StructureFlags), info());
+    return Structure::create(vm, globalObject, prototype, TypeInfo(StringObjectType, StructureFlags), info(), MayHaveIndexedAccessors);
 }
 
 } // namespace JSC


### PR DESCRIPTION
#### 0a1e72158c24c5ab5212961e2e4115f57c26b9c5
<pre>
For-In can return duplicate keys in JSC
<a href="https://bugs.webkit.org/show_bug.cgi?id=291997">https://bugs.webkit.org/show_bug.cgi?id=291997</a>
<a href="https://rdar.apple.com/150420842">rdar://150420842</a>

Reviewed by Yusuke Suzuki.

When an object has a StringObject as its prototype, indexed properties may
be intercepted dynamically via string index behavior. However, the StringObject&apos;s
structure was not marked with MayHaveIndexedAccessors, allowing fast indexed
enumeration to proceed incorrectly.

This caused JSPropertyNameEnumerator to enter IndexedMode and emit indexed
property names (e.g., &quot;0&quot;) without considering that the prototype also exposes
them. As a result, duplicate property names could appear during for...in enumeration.

To fix this, we mark the StringObject&apos;s structure with MayHaveIndexedAccessors.
This ensures holesMustForwardToPrototype() returns true, which disables fast
indexed enumeration and prevents duplicate keys.

* JSTests/stress/property-enumeration-object-with-indexed-property-and-string-prototype.js: Added.
(assert):
(opt.B):
(opt):
* Source/JavaScriptCore/runtime/StringObjectInlines.h:
(JSC::StringObject::createStructure):

Canonical link: <a href="https://commits.webkit.org/295350@main">https://commits.webkit.org/295350@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b8a7ad3514da862ec65700eac789d61394e8cb2f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104789 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24501 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/14923 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110003 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/55463 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/24899 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33047 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79566 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107795 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19357 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94572 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59873 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/19114 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/12649 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/54845 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/97470 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/88812 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/12696 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/112410 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/103407 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/31954 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23493 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88647 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32318 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/90798 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88274 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22503 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33161 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10929 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/27267 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/31879 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/37233 "Built successfully") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/127686 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/31671 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/127686 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35012 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33230 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->