### PR TITLE
[Swift in WebKit] Use swift-format to format _WebKit_SwiftUI code

### DIFF
--- a/.swift-format
+++ b/.swift-format
@@ -1,0 +1,79 @@
+{
+  "fileScopedDeclarationPrivacy" : {
+    "accessLevel" : "private"
+  },
+  "indentConditionalCompilationBlocks" : false,
+  "indentSwitchCaseLabels" : false,
+  "indentation" : {
+    "spaces" : 4
+  },
+  "lineBreakAroundMultilineExpressionChainComponents" : true,
+  "lineBreakBeforeControlFlowKeywords" : false,
+  "lineBreakBeforeEachArgument" : true,
+  "lineBreakBeforeEachGenericRequirement" : false,
+  "lineBreakBetweenDeclarationAttributes" : true,
+  "lineLength" : 140,
+  "maximumBlankLines" : 1,
+  "multiElementCollectionTrailingCommas" : true,
+  "noAssignmentInExpressions" : {
+    "allowedFunctions" : [
+      "XCTAssertNoThrow"
+    ]
+  },
+  "prioritizeKeepingFunctionOutputTogether" : true,
+  "reflowMultilineStringLiterals" : {
+    "never" : {
+
+    }
+  },
+  "respectsExistingLineBreaks" : true,
+  "rules" : {
+    "AllPublicDeclarationsHaveDocumentation" : true,
+    "AlwaysUseLiteralForEmptyCollectionInit" : true,
+    "AlwaysUseLowerCamelCase" : true,
+    "AmbiguousTrailingClosureOverload" : true,
+    "AvoidRetroactiveConformances" : true,
+    "BeginDocumentationCommentWithOneLineSummary" : true,
+    "DoNotUseSemicolons" : true,
+    "DontRepeatTypeInStaticProperties" : true,
+    "FileScopedDeclarationPrivacy" : true,
+    "FullyIndirectEnum" : true,
+    "GroupNumericLiterals" : true,
+    "IdentifiersMustBeASCII" : true,
+    "NeverForceUnwrap" : true,
+    "NeverUseForceTry" : true,
+    "NeverUseImplicitlyUnwrappedOptionals" : true,
+    "NoAccessLevelOnExtensionDeclaration" : true,
+    "NoAssignmentInExpressions" : true,
+    "NoBlockComments" : true,
+    "NoCasesWithOnlyFallthrough" : true,
+    "NoEmptyLinesOpeningClosingBraces" : true,
+    "NoEmptyTrailingClosureParentheses" : true,
+    "NoLabelsInCasePatterns" : true,
+    "NoLeadingUnderscores" : true,
+    "NoParensAroundConditions" : true,
+    "NoPlaygroundLiterals" : true,
+    "NoVoidReturnOnFunctionSignature" : true,
+    "OmitExplicitReturns" : true,
+    "OneCasePerLine" : true,
+    "OneVariableDeclarationPerLine" : true,
+    "OnlyOneTrailingClosureArgument" : true,
+    "OrderedImports" : true,
+    "ReplaceForEachWithForLoop" : true,
+    "ReturnVoidInsteadOfEmptyTuple" : true,
+    "TypeNamesShouldBeCapitalized" : true,
+    "UseEarlyExits" : true,
+    "UseExplicitNilCheckInConditions" : true,
+    "UseLetInEveryBoundCaseVariable" : true,
+    "UseShorthandTypeNames" : true,
+    "UseSingleLinePropertyGetter" : true,
+    "UseSynthesizedInitializer" : true,
+    "UseTripleSlashForDocumentationComments" : true,
+    "UseWhereClausesInForLoops" : true,
+    "ValidateDocumentationComments" : true
+  },
+  "spacesAroundRangeFormationOperators" : false,
+  "spacesBeforeEndOfLineComments" : 1,
+  "tabWidth" : 4,
+  "version" : 1
+}

--- a/Source/WebKit/_WebKit_SwiftUI/API/View+WebViewModifiers.swift
+++ b/Source/WebKit/_WebKit_SwiftUI/API/View+WebViewModifiers.swift
@@ -53,7 +53,7 @@ extension View {
     @available(WK_IOS_TBA, WK_MAC_TBA, WK_XROS_TBA, *)
     @available(watchOS, unavailable)
     @available(tvOS, unavailable)
-    public nonisolated func webViewTextSelection<S>(_ selectability: S) -> some View where S : TextSelectability {
+    public nonisolated func webViewTextSelection<S>(_ selectability: S) -> some View where S: TextSelectability {
         environment(\.webViewTextSelection, S.allowsSelection)
     }
 
@@ -75,17 +75,19 @@ extension View {
     @available(visionOS, unavailable)
     @available(watchOS, unavailable)
     @available(tvOS, unavailable)
-    public nonisolated func webViewContextMenu(@ViewBuilder menu: @MainActor @escaping (WebView.ActivatedElementInfo) -> some View) -> some View {
-#if os(macOS)
+    public nonisolated func webViewContextMenu(
+        @ViewBuilder menu: @MainActor @escaping (WebView.ActivatedElementInfo) -> some View
+    ) -> some View {
+        #if os(macOS)
         let context = ContextMenuContext { info in
             let menuView = menu(info)
             return NSHostingMenu(rootView: menuView)
         }
 
         return environment(\.webViewContextMenuContext, context)
-#else
+        #else
         return self
-#endif
+        #endif
     }
 
     /// Specifies the visibility of the webpage's natural background color within this view.
@@ -116,7 +118,7 @@ extension View {
         for type: T.Type,
         of transform: @escaping (ScrollGeometry) -> T,
         action: @escaping (T, T) -> Void
-    ) -> some View where T : Hashable {
+    ) -> some View where T: Hashable {
         let change = OnScrollGeometryChangeContext {
             AnyHashable(transform($0))
         } action: {

--- a/Source/WebKit/_WebKit_SwiftUI/API/WebPage+SwiftUI.swift
+++ b/Source/WebKit/_WebKit_SwiftUI/API/WebPage+SwiftUI.swift
@@ -33,11 +33,11 @@ extension WebPage {
     public var themeColor: Color? {
         self.backingProperty(\.themeColor, backedBy: \.themeColor) { backingValue in
             // The themeColor property is a UIColor/NSColor in WKWebView.
-#if canImport(UIKit)
+            #if canImport(UIKit)
             return backingValue.map(Color.init(uiColor:))
-#else
+            #else
             return backingValue.map(Color.init(nsColor:))
-#endif
+            #endif
         }
     }
 
@@ -51,10 +51,10 @@ extension WebPage {
     public func snapshot(_ configuration: WKSnapshotConfiguration = .init()) async throws -> Image? {
         let cocoaImage = try await backingWebView.takeSnapshot(configuration: configuration)
 
-#if canImport(UIKit)
+        #if canImport(UIKit)
         return Image(uiImage: cocoaImage)
-#else
+        #else
         return Image(nsImage: cocoaImage)
-#endif
+        #endif
     }
 }

--- a/Source/WebKit/_WebKit_SwiftUI/API/WebView.swift
+++ b/Source/WebKit/_WebKit_SwiftUI/API/WebView.swift
@@ -197,14 +197,14 @@ extension WebView {
 
         var webPage: WebPage {
             switch self {
-            case let .state(state, _): state.wrappedValue
-            case let .webPage(webPage): webPage
+            case .state(let state, _): state.wrappedValue
+            case .webPage(let webPage): webPage
             }
         }
 
         var url: URL? {
             switch self {
-            case let .state(_, url): url
+            case .state(_, let url): url
             case .webPage: nil
             }
         }

--- a/Source/WebKit/_WebKit_SwiftUI/CrossImportOverlay.swift
+++ b/Source/WebKit/_WebKit_SwiftUI/CrossImportOverlay.swift
@@ -21,6 +21,6 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+import SwiftUI
 // This is a cross-import overlay of WebKit. Do not remove this @_exported import:
 @_exported import WebKit
-import SwiftUI

--- a/Source/WebKit/_WebKit_SwiftUI/Implementation/CocoaWebViewAdapter.swift
+++ b/Source/WebKit/_WebKit_SwiftUI/Implementation/CocoaWebViewAdapter.swift
@@ -32,8 +32,7 @@ typealias CocoaView = NSView
 
 @MainActor
 class CocoaWebViewAdapter: CocoaView, PlatformTextSearching {
-
-#if os(iOS)
+    #if os(iOS)
     var extrinsicSafeAreaInsets: EdgeInsets? = nil {
         didSet {
             guard oldValue != extrinsicSafeAreaInsets else {
@@ -56,54 +55,59 @@ class CocoaWebViewAdapter: CocoaView, PlatformTextSearching {
             rightSafeArea = extrinsicSafeAreaInsets.leading
         }
 
-        return UIEdgeInsets(top: extrinsicSafeAreaInsets.top, left: leftSafeArea, bottom: extrinsicSafeAreaInsets.bottom, right: rightSafeArea)
+        return UIEdgeInsets(
+            top: extrinsicSafeAreaInsets.top,
+            left: leftSafeArea,
+            bottom: extrinsicSafeAreaInsets.bottom,
+            right: rightSafeArea
+        )
     }
-#endif
+    #endif
 
     // MARK: PlatformTextSearching conformance
 
-#if os(macOS)
+    #if os(macOS)
     typealias FindInteraction = NSTextFinderAdapter
-#else
+    #else
     typealias FindInteraction = UIFindInteractionAdapter
-#endif
+    #endif
 
     var isFindNavigatorVisible: Bool {
-#if os(macOS)
+        #if os(macOS)
         isFindBarVisible
-#else
+        #else
         webView?.findInteraction?.isFindNavigatorVisible ?? false
-#endif
+        #endif
     }
 
     lazy var findInteraction: FindInteraction? = {
-#if os(macOS)
+        #if os(macOS)
         let interaction = NSTextFinder()
         interaction.isIncrementalSearchingEnabled = true
         interaction.incrementalSearchingShouldDimContentView = false
         interaction.client = webView
         interaction.findBarContainer = self
-#else
+        #else
         guard let interaction = webView?.findInteraction else {
             return nil
         }
-#endif
+        #endif
 
         return .init(wrapped: interaction)
     }()
 
-#if os(macOS)
+    #if os(macOS)
     var isFindBarVisible: Bool = false {
         didSet {
             guard oldValue != isFindBarVisible else {
                 return
             }
 
-#if canImport(SwiftUI, _version: "7.0.57")
+            #if canImport(SwiftUI, _version: "7.0.57")
             if let isPresented = findContext?.isPresented {
                 isPresented.wrappedValue = isFindBarVisible
             }
-#endif
+            #endif
 
             if isFindBarVisible {
                 findBarDidBecomeVisible()
@@ -114,17 +118,17 @@ class CocoaWebViewAdapter: CocoaView, PlatformTextSearching {
     }
 
     var findBarView: CocoaView? = nil
-#endif
+    #endif
 
     // MARK: Find-in-Page support
 
-#if canImport(SwiftUI, _version: "7.0.57")
+    #if canImport(SwiftUI, _version: "7.0.57")
     var findContext: FindContext?
-#endif
+    #endif
 
     var scrollPosition: ScrollPositionContext?
 
-#if os(macOS)
+    #if os(macOS)
     // This is called by the Find menu items in the Menu Bar
     @objc(performFindPanelAction:)
     func performFindPanelAction(_ sender: Any!) {
@@ -184,12 +188,17 @@ class CocoaWebViewAdapter: CocoaView, PlatformTextSearching {
             webView.window?.makeFirstResponder(webView)
         }
     }
-#endif
+    #endif
 
     // MARK: Scroll Geometry
 
     var onScrollGeometryChange: OnScrollGeometryChangeContext?
-    private var currentScrollGeometry = ScrollGeometry(contentOffset: .zero, contentSize: .zero, contentInsets: .init(), containerSize: .zero)
+    private var currentScrollGeometry = ScrollGeometry(
+        contentOffset: .zero,
+        contentSize: .zero,
+        contentInsets: .init(),
+        containerSize: .zero
+    )
 
     // MARK: Constraints
 
@@ -248,9 +257,9 @@ class CocoaWebViewAdapter: CocoaView, PlatformTextSearching {
             activateConstraints()
 
             webView.delegate = self
-#if os(macOS)
+            #if os(macOS)
             findInteraction?.wrapped.client = webView
-#endif
+            #endif
         }
     }
 }
@@ -267,31 +276,31 @@ extension CocoaWebViewAdapter: @preconcurrency NSTextFinderBarContainer {
 #endif
 
 extension CocoaWebViewAdapter: WebPageWebView.Delegate {
-#if os(iOS)
+    #if os(iOS)
     func findInteraction(_ interaction: UIFindInteraction, didBegin session: UIFindSession) {
-#if canImport(SwiftUI, _version: "7.0.57")
+        #if canImport(SwiftUI, _version: "7.0.57")
         if let isPresented = findContext?.isPresented {
             isPresented.wrappedValue = true
         }
-#endif
+        #endif
     }
 
     func findInteraction(_ interaction: UIFindInteraction, didEnd session: UIFindSession) {
-#if canImport(SwiftUI, _version: "7.0.57")
+        #if canImport(SwiftUI, _version: "7.0.57")
         if let isPresented = findContext?.isPresented {
             isPresented.wrappedValue = false
         }
-#endif
+        #endif
     }
 
     func supportsTextReplacement() -> Bool {
-#if canImport(SwiftUI, _version: "7.0.57")
+        #if canImport(SwiftUI, _version: "7.0.57")
         findContext?.supportsReplace ?? false
-#else
+        #else
         false
-#endif
+        #endif
     }
-#endif // os(iOS)
+    #endif // os(iOS)
 
     func geometryDidChange(_ geometry: WKScrollGeometryAdapter) {
         let newScrollGeometry = ScrollGeometry(geometry)

--- a/Source/WebKit/_WebKit_SwiftUI/Implementation/Foundation+Extras.swift
+++ b/Source/WebKit/_WebKit_SwiftUI/Implementation/Foundation+Extras.swift
@@ -35,11 +35,12 @@ func onNextMainRunLoop(do body: @escaping @MainActor () -> Void) {
 
 extension NSDirectionalRectEdge {
     init(_ edge: Edge) {
-        self = switch edge {
-        case .top: .top
-        case .leading: .leading
-        case .bottom: .bottom
-        case .trailing: .trailing
-        }
+        self =
+            switch edge {
+            case .top: .top
+            case .leading: .leading
+            case .bottom: .bottom
+            case .trailing: .trailing
+            }
     }
 }

--- a/Source/WebKit/_WebKit_SwiftUI/Implementation/PlatformTextSearching.swift
+++ b/Source/WebKit/_WebKit_SwiftUI/Implementation/PlatformTextSearching.swift
@@ -63,7 +63,7 @@ struct NSTextFinderAdapter: PlatformFindInteraction {
 @MainActor
 struct UIFindInteractionAdapter: PlatformFindInteraction {
     let wrapped: UIFindInteraction
-    
+
     func presentFindNavigator(showingReplace: Bool) {
         wrapped.presentFindNavigator(showingReplace: showingReplace)
     }

--- a/Source/WebKit/_WebKit_SwiftUI/Implementation/SwiftUI+Extras.swift
+++ b/Source/WebKit/_WebKit_SwiftUI/Implementation/SwiftUI+Extras.swift
@@ -25,20 +25,25 @@ public import SwiftUI
 @_spi(CrossImportOverlay) public import WebKit
 
 extension EdgeInsets {
-#if canImport(UIKit)
+    #if canImport(UIKit)
     init(_ edgeInsets: UIEdgeInsets) {
         self = EdgeInsets(top: edgeInsets.top, leading: edgeInsets.left, bottom: edgeInsets.bottom, trailing: edgeInsets.right)
     }
-#else
+    #else
     init(_ edgeInsets: NSEdgeInsets) {
         self = EdgeInsets(top: edgeInsets.top, leading: edgeInsets.left, bottom: edgeInsets.bottom, trailing: edgeInsets.right)
     }
-#endif
+    #endif
 }
 
 extension ScrollGeometry {
     init(_ geometry: WKScrollGeometryAdapter) {
-        self = ScrollGeometry(contentOffset: geometry.contentOffset, contentSize: geometry.contentSize, contentInsets: EdgeInsets(geometry.contentInsets), containerSize: geometry.containerSize)
+        self = ScrollGeometry(
+            contentOffset: geometry.contentOffset,
+            contentSize: geometry.contentSize,
+            contentInsets: EdgeInsets(geometry.contentInsets),
+            containerSize: geometry.containerSize
+        )
     }
 }
 
@@ -49,29 +54,31 @@ extension Transaction {
 }
 
 extension EventModifiers {
-#if canImport(UIKit)
+    #if canImport(UIKit)
     init(_ wrapped: UIKeyModifierFlags) {
-        self = switch wrapped {
-        case .alphaShift: .capsLock
-        case .command: .command
-        case .control: .control
-        case .numericPad: .numericPad
-        case .alternate: .option
-        case .shift: .shift
-        default: []
-        }
+        self =
+            switch wrapped {
+            case .alphaShift: .capsLock
+            case .command: .command
+            case .control: .control
+            case .numericPad: .numericPad
+            case .alternate: .option
+            case .shift: .shift
+            default: []
+            }
     }
-#else
+    #else
     init(_ wrapped: NSEvent.ModifierFlags) {
-        self = switch wrapped {
-        case .capsLock: .capsLock
-        case .command: .command
-        case .control: .control
-        case .numericPad: .numericPad
-        case .option: .option
-        case .shift: .shift
-        default: []
-        }
+        self =
+            switch wrapped {
+            case .capsLock: .capsLock
+            case .command: .command
+            case .control: .control
+            case .numericPad: .numericPad
+            case .option: .option
+            case .shift: .shift
+            default: []
+            }
     }
-#endif
+    #endif
 }

--- a/Source/WebKit/_WebKit_SwiftUI/Implementation/ViewModifierContexts.swift
+++ b/Source/WebKit/_WebKit_SwiftUI/Implementation/ViewModifierContexts.swift
@@ -25,9 +25,9 @@ internal import SwiftUI
 @_spi(Private) internal import WebKit
 
 struct ContextMenuContext {
-#if os(macOS)
+    #if os(macOS)
     let menu: @MainActor (WebView.ActivatedElementInfo) -> NSMenu
-#endif
+    #endif
 }
 
 struct OnScrollGeometryChangeContext {

--- a/Source/WebKit/_WebKit_SwiftUI/Implementation/WebViewRepresentable.swift
+++ b/Source/WebKit/_WebKit_SwiftUI/Implementation/WebViewRepresentable.swift
@@ -38,9 +38,9 @@ struct WebViewRepresentable {
 
         let parent = CocoaWebViewAdapter()
         parent.webView = page.backingWebView
-#if os(iOS)
+        #if os(iOS)
         parent.extrinsicSafeAreaInsets = safeAreaInsets
-#endif
+        #endif
         page.isBoundToWebView = true
 
         return parent
@@ -50,9 +50,9 @@ struct WebViewRepresentable {
         let webView = page.backingWebView
         let environment = context.environment
 
-#if os(iOS)
+        #if os(iOS)
         platformView.extrinsicSafeAreaInsets = safeAreaInsets
-#endif
+        #endif
         platformView.webView = webView
 
         webView.allowsBackForwardNavigationGestures = environment.webViewAllowsBackForwardNavigationGestures.value != .disabled
@@ -61,21 +61,23 @@ struct WebViewRepresentable {
 
         let isOpaque = environment.webViewContentBackground != .hidden
 
-#if os(macOS)
+        #if os(macOS)
         if webView._drawsBackground != isOpaque {
             webView._drawsBackground = isOpaque
         }
-#else
+        #else
         if webView.isOpaque != isOpaque {
             webView.isOpaque = isOpaque
         }
-#endif
+        #endif
 
         if let scrollInputBehavior = environment.webViewScrollInputBehaviorContext {
             webView.configureScrollInputBehavior(scrollInputBehavior.behavior, for: scrollInputBehavior.input)
         }
 
-        if EquatableScrollBounceBehavior(environment.verticalScrollBounceBehavior) == .always || EquatableScrollBounceBehavior(environment.verticalScrollBounceBehavior) == .automatic {
+        if EquatableScrollBounceBehavior(environment.verticalScrollBounceBehavior) == .always
+            || EquatableScrollBounceBehavior(environment.verticalScrollBounceBehavior) == .automatic
+        {
             webView.alwaysBounceVertical = true
             webView.bouncesVertically = true
         } else if EquatableScrollBounceBehavior(environment.verticalScrollBounceBehavior) == .basedOnSize {
@@ -83,7 +85,9 @@ struct WebViewRepresentable {
             webView.bouncesVertically = true
         }
 
-        if EquatableScrollBounceBehavior(environment.horizontalScrollBounceBehavior) == .always || EquatableScrollBounceBehavior(environment.horizontalScrollBounceBehavior) == .automatic {
+        if EquatableScrollBounceBehavior(environment.horizontalScrollBounceBehavior) == .always
+            || EquatableScrollBounceBehavior(environment.horizontalScrollBounceBehavior) == .automatic
+        {
             webView.alwaysBounceHorizontal = true
             webView.bouncesHorizontally = true
         } else if EquatableScrollBounceBehavior(environment.horizontalScrollBounceBehavior) == .basedOnSize {
@@ -98,7 +102,7 @@ struct WebViewRepresentable {
 
         context.coordinator.update(platformView, configuration: self, context: context)
 
-#if os(macOS) && !targetEnvironment(macCatalyst)
+        #if os(macOS) && !targetEnvironment(macCatalyst)
         if let menu = environment.webViewContextMenuContext?.menu {
             page.setMenuBuilder {
                 menu(.init(linkURL: $0.linkURL))
@@ -106,7 +110,7 @@ struct WebViewRepresentable {
         } else {
             page.setMenuBuilder(nil)
         }
-#endif
+        #endif
     }
 
     func makeCoordinator() -> WebViewCoordinator {
@@ -123,7 +127,7 @@ struct WebViewRepresentable {
         //
         // Rounding down is needed to ensure that the view is never bigger than the requested size, otherwise miscellaneous UI
         // issues manifest.
-        return CGSize(width: width.rounded(.down), height: height.rounded(.down));
+        return CGSize(width: width.rounded(.down), height: height.rounded(.down))
     }
 
     static func dismantlePlatformView(_ platformView: CocoaWebViewAdapter, coordinator: WebViewCoordinator) {
@@ -142,9 +146,9 @@ final class WebViewCoordinator {
     func update(_ view: CocoaWebViewAdapter, configuration: WebViewRepresentable, context: WebViewRepresentable.Context) {
         self.configuration = configuration
 
-#if canImport(SwiftUI, _version: "7.0.57")
+        #if canImport(SwiftUI, _version: "7.0.57")
         updateFindInteraction(view, context: context)
-#endif
+        #endif
         updateScrollPosition(view, context: context)
     }
 
@@ -178,7 +182,7 @@ final class WebViewCoordinator {
         }
     }
 
-#if canImport(SwiftUI, _version: "7.0.57")
+    #if canImport(SwiftUI, _version: "7.0.57")
     private func updateFindInteraction(_ view: CocoaWebViewAdapter, context: WebViewRepresentable.Context) {
         guard let webView = view.webView else {
             return
@@ -189,9 +193,9 @@ final class WebViewCoordinator {
         let findContext = environment.findContext
         view.findContext = findContext
 
-#if os(iOS)
+        #if os(iOS)
         webView.isFindInteractionEnabled = findContext != nil
-#endif
+        #endif
 
         guard let findInteraction = view.findInteraction else {
             return
@@ -210,7 +214,7 @@ final class WebViewCoordinator {
             }
         }
     }
-#endif // canImport(SwiftUI, _version: "7.0.57")
+    #endif // canImport(SwiftUI, _version: "7.0.57")
 }
 
 #if canImport(UIKit)


### PR DESCRIPTION
#### 0bb7cc8732d6e88c23c7ceee4879b73146619ea1
<pre>
[Swift in WebKit] Use swift-format to format _WebKit_SwiftUI code
<a href="https://bugs.webkit.org/show_bug.cgi?id=293475">https://bugs.webkit.org/show_bug.cgi?id=293475</a>
<a href="https://rdar.apple.com/151908352">rdar://151908352</a>

Reviewed by Abrar Rahman Protyasha.

Having formatted and linted code is paramount to ensuring a maintainable, readable, consistent, and safe codebase.
The best time to have introduced a Swift formatter and linter was before any Swift was introduced in WebKit. But
the second best time is now.

Work towards this goal by adding a `.swift-format` file and formatting the `_WebKit_SwiftUI` code which is a reasonably
small change.

Subsequent PRs will:

1. Lint _WebKit_SwiftUI code
2. Format WebKit code
3. Lint WebKit code
4. Create an automated way to format/lint code and have it integrated with CI

* .swift-format: Added.

Add a configuration file for swift-format. The following formatting options are customized:

- indentConditionalCompilationBlocks: true -&gt; false
- indentation: 2 spaces -&gt; 4 spaces
- lineBreakAroundMultilineExpressionChainComponents: false -&gt; true
- lineBreakBeforeEachArgument: false -&gt; true
- lineBreakBetweenDeclarationAttributes: false -&gt; true
- lineLength: 100 -&gt; 140
- prioritizeKeepingFunctionOutputTogether: false -&gt; true
- tabWidth: 2 -&gt; 4
- spacesBeforeEndOfLineComments: 2 -&gt; 1

All rule options are set to `true` for maximal correctness and safety. If any of these prove to
be too restrictive, they may be reverted to their default values if needed.

* Source/WebKit/_WebKit_SwiftUI/API/View+WebViewModifiers.swift:
* Source/WebKit/_WebKit_SwiftUI/API/WebPage+SwiftUI.swift:
* Source/WebKit/_WebKit_SwiftUI/CrossImportOverlay.swift:
* Source/WebKit/_WebKit_SwiftUI/Implementation/CocoaWebViewAdapter.swift:
* Source/WebKit/_WebKit_SwiftUI/Implementation/Foundation+Extras.swift:
* Source/WebKit/_WebKit_SwiftUI/Implementation/PlatformTextSearching.swift:
* Source/WebKit/_WebKit_SwiftUI/Implementation/SwiftUI+Extras.swift:
* Source/WebKit/_WebKit_SwiftUI/Implementation/ViewModifierContexts.swift:
* Source/WebKit/_WebKit_SwiftUI/Implementation/WebViewRepresentable.swift:

Apply formatting.

Canonical link: <a href="https://commits.webkit.org/295406@main">https://commits.webkit.org/295406@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a62d1b6db523ba5af49d0a6e686759cae2923c47

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104996 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24710 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15132 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110213 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/55676 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/25118 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33254 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/79727 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108002 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19548 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94763 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60034 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/19292 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55053 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/89015 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/12886 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/112710 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32161 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/23665 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/88809 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32526 "Failed to checkout and rebase branch from PR 45819") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/90988 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88437 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/22543 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11115 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/27511 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17034 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32085 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/37457 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/31878 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35219 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33437 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->