### PR TITLE
Proactively stop the audio capture thread in WebProcess when audio track is stopped

### DIFF
--- a/LayoutTests/fast/mediastream/mediastreamtrack-audio-mute-expected.txt
+++ b/LayoutTests/fast/mediastream/mediastreamtrack-audio-mute-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Unmuting the audio track should properly restart capture
+

--- a/LayoutTests/fast/mediastream/mediastreamtrack-audio-mute.html
+++ b/LayoutTests/fast/mediastream/mediastreamtrack-audio-mute.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <script src="../../webrtc/routines.js"></script>
+    <script src="../../resources/testharness.js"></script>
+    <script src="../../resources/testharnessreport.js"></script>
+</head>
+<body>
+<script>
+var context = new AudioContext();
+promise_test(async (t) => {
+    const stream = await navigator.mediaDevices.getUserMedia({ audio : true });
+    const audioTrack = stream.getAudioTracks()[0];
+
+    assert_true(await doHumAnalysis(stream, true), "Heard hum from track");
+
+    navigator.mediaSession.setMicrophoneActive(false);
+    await new Promise(resolve => audioTrack.onmute = resolve);
+
+    assert_true(await doHumAnalysis(stream, false), "Do not hear hum from muted track");
+
+    if (!window.internals)
+        return;
+
+    internals.withUserGesture(() => {
+        navigator.mediaSession.setMicrophoneActive(true);
+    });
+
+    await new Promise(resolve => audioTrack.onunmute = resolve);
+
+    assert_true(await doHumAnalysis(stream, true), "Heard hum from muted track");
+}, "Unmuting the audio track should properly restart capture");
+</script>
+</body>
+</html>

--- a/Source/WebKit/WebProcess/cocoa/RemoteCaptureSampleManager.cpp
+++ b/Source/WebKit/WebProcess/cocoa/RemoteCaptureSampleManager.cpp
@@ -132,6 +132,17 @@ void RemoteCaptureSampleManager::removeSource(WebCore::RealtimeMediaSourceIdenti
     });
 }
 
+void RemoteCaptureSampleManager::audioSourceWillBeStopped(WebCore::RealtimeMediaSourceIdentifier identifier)
+{
+    ASSERT(WTF::isMainRunLoop());
+    m_queue->dispatch([this, protectedThis = Ref { *this }, identifier] {
+        auto iterator = m_audioSources.find(identifier);
+        if (iterator == m_audioSources.end())
+            return;
+        iterator->value->willBeStopped();
+    });
+}
+
 void RemoteCaptureSampleManager::didUpdateSourceConnection(IPC::Connection& connection)
 {
     ASSERT(WTF::isMainRunLoop());

--- a/Source/WebKit/WebProcess/cocoa/RemoteCaptureSampleManager.h
+++ b/Source/WebKit/WebProcess/cocoa/RemoteCaptureSampleManager.h
@@ -69,6 +69,7 @@ public:
     void addSource(Ref<RemoteRealtimeAudioSource>&&);
     void addSource(Ref<RemoteRealtimeVideoSource>&&);
     void removeSource(WebCore::RealtimeMediaSourceIdentifier);
+    void audioSourceWillBeStopped(WebCore::RealtimeMediaSourceIdentifier);
 
     void didUpdateSourceConnection(IPC::Connection&);
     void setVideoFrameObjectHeapProxy(RefPtr<RemoteVideoFrameObjectHeapProxy>&&);
@@ -93,6 +94,7 @@ private:
         ~RemoteAudio();
 
         void setStorage(ConsumerSharedCARingBuffer::Handle&&, const WebCore::CAAudioStreamDescription&, IPC::Semaphore&&, const MediaTime&, size_t frameChunkSize);
+        void willBeStopped() { stopThread(); }
 
     private:
         void stopThread();

--- a/Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSource.cpp
+++ b/Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSource.cpp
@@ -118,6 +118,13 @@ void RemoteRealtimeMediaSource::applyConstraintsSucceeded(WebCore::RealtimeMedia
     m_proxy.applyConstraintsSucceeded();
 }
 
+void RemoteRealtimeMediaSource::stopProducingData()
+{
+    if (isAudio())
+        m_manager->remoteCaptureSampleManager().audioSourceWillBeStopped(identifier());
+    m_proxy.stopProducingData();
+}
+
 void RemoteRealtimeMediaSource::didEnd()
 {
     if (m_proxy.isEnded())

--- a/Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSource.h
+++ b/Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSource.h
@@ -83,10 +83,10 @@ protected:
 private:
     // RealtimeMediaSource
     void startProducingData() final { m_proxy.startProducingData(*pageIdentifier()); }
-    void stopProducingData() final { m_proxy.stopProducingData(); }
     void endProducingData() final { m_proxy.endProducingData(); }
     bool isCaptureSource() const final { return true; }
     void applyConstraints(const WebCore::MediaConstraints&, ApplyConstraintsHandler&&) final;
+    void stopProducingData() final;
     void didEnd() final;
     void whenReady(CompletionHandler<void(WebCore::CaptureSourceError&&)>&& callback) final { m_proxy.whenReady(WTFMove(callback)); }
     WebCore::CaptureDevice::DeviceType deviceType() const final { return m_proxy.deviceType(); }


### PR DESCRIPTION
#### 8ff3d6d944068534316c9136a0c47b1432ade9bd
<pre>
Proactively stop the audio capture thread in WebProcess when audio track is stopped
<a href="https://rdar.apple.com/151908497">rdar://151908497</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=293477">https://bugs.webkit.org/show_bug.cgi?id=293477</a>

Reviewed by Jer Noble.

A page may be muted due to another page starting to capture.
If both pages are in the same process, it is important to stop the audio thread of the muted track as soon as possible.
This ensures that audio contexts or other microphone tracks can get access to the best audio thread configuration.

* LayoutTests/fast/mediastream/mediastreamtrack-audio-mute-expected.txt: Added.
* LayoutTests/fast/mediastream/mediastreamtrack-audio-mute.html: Added.
* Source/WebKit/WebProcess/cocoa/RemoteCaptureSampleManager.cpp:
(WebKit::RemoteCaptureSampleManager::removeSource):
(WebKit::RemoteCaptureSampleManager::audioSourceIsStopping):
* Source/WebKit/WebProcess/cocoa/RemoteCaptureSampleManager.h:
(WebKit::RemoteCaptureSampleManager::RemoteAudio::isStopping):
* Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSource.cpp:
(WebKit::RemoteRealtimeMediaSource::stopProducingData):
* Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSource.h:

Canonical link: <a href="https://commits.webkit.org/295410@main">https://commits.webkit.org/295410@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cd99518d3a60ed1219adb4478cd0febc6eeb2bbc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104834 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24547 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/14968 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110049 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/55508 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/24946 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33092 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79605 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107840 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19400 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94612 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59912 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/19148 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/12689 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/54891 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/88847 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/12736 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/112465 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/31999 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23525 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88684 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32363 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/90838 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88311 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22546 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33202 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10967 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/27313 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/31924 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/37278 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/31716 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35057 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33275 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->