### PR TITLE
Align CommandEvent with specification

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/button-event-dispatch-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/button-event-dispatch-expected.txt
@@ -1,23 +1,23 @@
 
 
-FAIL event dispatches on click with addEventListener assert_equals: composed expected false but got true
-FAIL event dispatches on click with oncommand property assert_equals: composed expected false but got true
-FAIL setting custom command property to --foo (must include dash) sets event command assert_equals: composed expected false but got true
-FAIL setting custom command attribute to --foo (must include dash) sets event command assert_equals: composed expected false but got true
-FAIL setting custom command property to --foo- (must include dash) sets event command assert_equals: composed expected false but got true
-FAIL setting custom command attribute to --foo- (must include dash) sets event command assert_equals: composed expected false but got true
-FAIL setting custom command property to --cAsE-cArRiEs (must include dash) sets event command assert_equals: composed expected false but got true
-FAIL setting custom command attribute to --cAsE-cArRiEs (must include dash) sets event command assert_equals: composed expected false but got true
-FAIL setting custom command property to -- (must include dash) sets event command assert_equals: composed expected false but got true
-FAIL setting custom command attribute to -- (must include dash) sets event command assert_equals: composed expected false but got true
-FAIL setting custom command property to --a- (must include dash) sets event command assert_equals: composed expected false but got true
-FAIL setting custom command attribute to --a- (must include dash) sets event command assert_equals: composed expected false but got true
-FAIL setting custom command property to --a-b (must include dash) sets event command assert_equals: composed expected false but got true
-FAIL setting custom command attribute to --a-b (must include dash) sets event command assert_equals: composed expected false but got true
-FAIL setting custom command property to --- (must include dash) sets event command assert_equals: composed expected false but got true
-FAIL setting custom command attribute to --- (must include dash) sets event command assert_equals: composed expected false but got true
-FAIL setting custom command property to --show-picker (must include dash) sets event command assert_equals: composed expected false but got true
-FAIL setting custom command attribute to --show-picker (must include dash) sets event command assert_equals: composed expected false but got true
+PASS event dispatches on click with addEventListener
+PASS event dispatches on click with oncommand property
+PASS setting custom command property to --foo (must include dash) sets event command
+PASS setting custom command attribute to --foo (must include dash) sets event command
+PASS setting custom command property to --foo- (must include dash) sets event command
+PASS setting custom command attribute to --foo- (must include dash) sets event command
+PASS setting custom command property to --cAsE-cArRiEs (must include dash) sets event command
+PASS setting custom command attribute to --cAsE-cArRiEs (must include dash) sets event command
+PASS setting custom command property to -- (must include dash) sets event command
+PASS setting custom command attribute to -- (must include dash) sets event command
+PASS setting custom command property to --a- (must include dash) sets event command
+PASS setting custom command attribute to --a- (must include dash) sets event command
+PASS setting custom command property to --a-b (must include dash) sets event command
+PASS setting custom command attribute to --a-b (must include dash) sets event command
+PASS setting custom command property to --- (must include dash) sets event command
+PASS setting custom command attribute to --- (must include dash) sets event command
+PASS setting custom command property to --show-picker (must include dash) sets event command
+PASS setting custom command attribute to --show-picker (must include dash) sets event command
 PASS setting custom command property to -foo (no dash) did not dispatch an event
 PASS setting custom command attribute to -foo (no dash) did not dispatch an event
 PASS setting custom command property to -foo- (no dash) did not dispatch an event
@@ -35,7 +35,7 @@ PASS event does not dispatch on input[type=button]
 PASS event does not dispatch if invoker is disabled
 PASS event does NOT dispatch if button is form associated, with implicit type
 PASS event does NOT dispatch if button is form associated, with explicit type=invalid
-FAIL event dispatches if button is form associated, with explicit type=button assert_equals: composed expected false but got true
+PASS event dispatches if button is form associated, with explicit type=button
 PASS event does NOT dispatch if button is form associated, with explicit type=submit
 PASS event does NOT dispatch if button is form associated, with explicit type=reset
 PASS event dispatches if invokee is non-HTML Element

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/event-dispatch-shadow-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/event-dispatch-shadow-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL cross shadow CommandEvent retargets source to host element null is not an object (evaluating 'document.body.append')
+PASS cross shadow CommandEvent retargets source to host element
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/event-dispatch-shadow.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/event-dispatch-shadow.html
@@ -5,7 +5,7 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="resources/invoker-utils.js"></script>
-
+<body>
 <script>
   test(function (t) {
     const host = document.createElement("div");
@@ -35,3 +35,4 @@
     assert_equals(eventSource, host, "source is host");
   }, "cross shadow CommandEvent retargets source to host element");
 </script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/source-attribute-retargeting.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/source-attribute-retargeting.tentative-expected.txt
@@ -3,8 +3,6 @@ popover 3show popover 3
 FAIL CommandEvent.source and ToggleEvent.source should be retargeted during and after event dispatch. assert_equals: beforetoggle.source during capture. expected (object) Element node <div id="host">
 
 </div> but got (undefined) undefined
-FAIL CommandEvent.source should be retargeted when manually dispatched with composed set to true. assert_equals: host2: event.source after dispatch. expected Element node <div id="host2">
-
-</div> but got Element node <div id="source">source</div>
+PASS CommandEvent.source should be retargeted when manually dispatched with composed set to true.
 FAIL CommandEvent.source and ToggleEvent.source should not be set to null after dispatch without ShadowDOM. assert_equals: beforetoggle.source should be the invoker button after dispatch. expected (object) Element node <button id="button3" commandfor="popover3" command="show-... but got (undefined) undefined
 

--- a/Source/WebCore/dom/CommandEvent.cpp
+++ b/Source/WebCore/dom/CommandEvent.cpp
@@ -72,7 +72,10 @@ RefPtr<Element> CommandEvent::source() const
         Ref node = treeScope->retargetToScope(*m_source.get());
         return &downcast<Element>(node).get();
     }
-    return m_source;
+
+    Ref treeScope = m_source->treeScope().documentScope();
+    Ref node = treeScope->retargetToScope(*m_source.get());
+    return &downcast<Element>(node).get();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/html/HTMLButtonElement.cpp
+++ b/Source/WebCore/html/HTMLButtonElement.cpp
@@ -219,7 +219,6 @@ void HTMLButtonElement::handleCommand()
     CommandEvent::Init init;
     init.bubbles = false;
     init.cancelable = true;
-    init.composed = true;
     init.source = this;
     init.command = commandRaw.isNull() ? emptyAtom() : commandRaw;
 


### PR DESCRIPTION
#### b4411b6bfe9ea3df804425609c4f002f04971c07
<pre>
Align CommandEvent with specification
<a href="https://bugs.webkit.org/show_bug.cgi?id=292368">https://bugs.webkit.org/show_bug.cgi?id=292368</a>

Reviewed by Tim Nguyen.

CommandEvent is no longer composed.

Also fix the retargeting behaviour to not leak shadow dom contents, in case event.currentTarget is null.

Canonical link: <a href="https://commits.webkit.org/298956@main">https://commits.webkit.org/298956@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/03b26083421a2aaf2acc6f2fcb8fda2a4e088ac0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/117215 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/36882 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/27489 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/123313 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/69195 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/119090 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/37581 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/45472 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89002 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/43641 "An unexpected error occured. Recent messages:Printed configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/120148 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29913 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105098 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69451 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28971 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/23211 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/66987 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99310 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23384 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/126435 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/44112 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33137 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97625 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/44468 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101324 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97416 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24821 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42765 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20691 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/40462 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/43985 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/49649 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/43441 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/46786 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/45137 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->