### PR TITLE
[GTK][WPE] Simplify the web view creation in GLib API tests

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestAuthentication.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestAuthentication.cpp
@@ -45,12 +45,12 @@ public:
 
     AuthenticationTest()
     {
-        g_signal_connect(m_webView, "authenticate", G_CALLBACK(runAuthenticationCallback), this);
+        g_signal_connect(m_webView.get(), "authenticate", G_CALLBACK(runAuthenticationCallback), this);
     }
 
     ~AuthenticationTest()
     {
-        g_signal_handlers_disconnect_matched(m_webView, G_SIGNAL_MATCH_DATA, 0, 0, 0, 0, this);
+        g_signal_handlers_disconnect_matched(m_webView.get(), G_SIGNAL_MATCH_DATA, 0, 0, 0, 0, this);
     }
 
     static int authenticationRetries;
@@ -166,7 +166,7 @@ static void testWebViewAuthenticationLoadCancelled(AuthenticationTest* test, gco
 {
     test->loadURI(kServer->getURIForPath("/auth-test.html").data());
     test->waitForAuthenticationRequest();
-    webkit_web_view_stop_loading(test->m_webView);
+    webkit_web_view_stop_loading(test->webView());
     // Expect empty page.
     test->waitUntilLoadFinished();
 
@@ -203,7 +203,7 @@ static void testWebViewAuthenticationFailure(AuthenticationTest* test, gconstpoi
     g_assert_cmpint(test->m_loadEvents[0], ==, LoadTrackingTest::ProvisionalLoadStarted);
     g_assert_cmpint(test->m_loadEvents[1], ==, LoadTrackingTest::LoadCommitted);
     g_assert_cmpint(test->m_loadEvents[2], ==, LoadTrackingTest::LoadFinished);
-    g_assert_cmpstr(webkit_web_view_get_title(test->m_webView), ==, authExpectedFailureTitle);
+    g_assert_cmpstr(webkit_web_view_get_title(test->webView()), ==, authExpectedFailureTitle);
     g_assert_false(test->m_authenticationCancelledReceived);
     g_assert_false(test->m_authenticationSucceededReceived);
 }
@@ -221,7 +221,7 @@ static void testWebViewAuthenticationNoCredential(AuthenticationTest* test, gcon
     g_assert_cmpint(test->m_loadEvents[0], ==, LoadTrackingTest::ProvisionalLoadStarted);
     g_assert_cmpint(test->m_loadEvents[1], ==, LoadTrackingTest::LoadCommitted);
     g_assert_cmpint(test->m_loadEvents[2], ==, LoadTrackingTest::LoadFinished);
-    g_assert_cmpstr(webkit_web_view_get_title(test->m_webView), ==, authExpectedFailureTitle);
+    g_assert_cmpstr(webkit_web_view_get_title(test->webView()), ==, authExpectedFailureTitle);
     g_assert_false(test->m_authenticationCancelledReceived);
     g_assert_false(test->m_authenticationSucceededReceived);
 }
@@ -255,12 +255,12 @@ static void testWebViewAuthenticationStorage(AuthenticationTest* test, gconstpoi
 #endif
 
 #if ENABLE(2022_GLIB_API)
-    auto* networkSession = webkit_web_view_get_network_session(test->m_webView);
+    auto* networkSession = webkit_web_view_get_network_session(test->webView());
     g_assert_true(webkit_network_session_get_persistent_credential_storage_enabled(networkSession));
     webkit_network_session_set_persistent_credential_storage_enabled(networkSession, FALSE);
     g_assert_false(webkit_network_session_get_persistent_credential_storage_enabled(networkSession));
 #else
-    auto* websiteDataManager = webkit_web_view_get_website_data_manager(test->m_webView);
+    auto* websiteDataManager = webkit_web_view_get_website_data_manager(test->webView());
     g_assert_true(webkit_website_data_manager_get_persistent_credential_storage_enabled(websiteDataManager));
     webkit_website_data_manager_set_persistent_credential_storage_enabled(websiteDataManager, FALSE);
     g_assert_false(webkit_website_data_manager_get_persistent_credential_storage_enabled(websiteDataManager));
@@ -308,7 +308,7 @@ static void testWebViewAuthenticationSuccess(AuthenticationTest* test, gconstpoi
     g_assert_cmpint(test->m_loadEvents[0], ==, LoadTrackingTest::ProvisionalLoadStarted);
     g_assert_cmpint(test->m_loadEvents[1], ==, LoadTrackingTest::LoadCommitted);
     g_assert_cmpint(test->m_loadEvents[2], ==, LoadTrackingTest::LoadFinished);
-    g_assert_cmpstr(webkit_web_view_get_title(test->m_webView), ==, authExpectedSuccessTitle);
+    g_assert_cmpstr(webkit_web_view_get_title(test->webView()), ==, authExpectedSuccessTitle);
     g_assert_false(test->m_authenticationCancelledReceived);
     g_assert_true(test->m_authenticationSucceededReceived);
 
@@ -322,7 +322,7 @@ static void testWebViewAuthenticationSuccess(AuthenticationTest* test, gconstpoi
     g_assert_cmpint(test->m_loadEvents[0], ==, LoadTrackingTest::ProvisionalLoadStarted);
     g_assert_cmpint(test->m_loadEvents[1], ==, LoadTrackingTest::LoadCommitted);
     g_assert_cmpint(test->m_loadEvents[2], ==, LoadTrackingTest::LoadFinished);
-    g_assert_cmpstr(webkit_web_view_get_title(test->m_webView), ==, authExpectedSuccessTitle);
+    g_assert_cmpstr(webkit_web_view_get_title(test->webView()), ==, authExpectedSuccessTitle);
     g_assert_false(test->m_authenticationCancelledReceived);
     g_assert_true(test->m_authenticationSucceededReceived);
 }
@@ -340,7 +340,7 @@ static void testWebViewAuthenticationEmptyRealm(AuthenticationTest* test, gconst
     g_assert_cmpint(test->m_loadEvents[0], ==, LoadTrackingTest::ProvisionalLoadStarted);
     g_assert_cmpint(test->m_loadEvents[1], ==, LoadTrackingTest::LoadCommitted);
     g_assert_cmpint(test->m_loadEvents[2], ==, LoadTrackingTest::LoadFinished);
-    g_assert_cmpstr(webkit_web_view_get_title(test->m_webView), ==, authExpectedSuccessTitle);
+    g_assert_cmpstr(webkit_web_view_get_title(test->webView()), ==, authExpectedSuccessTitle);
     g_assert_false(test->m_authenticationCancelledReceived);
     g_assert_true(test->m_authenticationSucceededReceived);
 }

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestAutomationSession.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestAutomationSession.cpp
@@ -337,7 +337,7 @@ static void testAutomationSessionRequestSession(AutomationTest* test, gconstpoin
     g_assert_false(test->createTopLevelBrowsingContext(nullptr));
 
     // Will also fail if the web view is not controlled by automation.
-    auto webView = Test::adoptView(Test::createWebView(test->m_webContext.get()));
+    auto webView = test->createWebView();
     g_assert_false(webkit_web_view_is_controlled_by_automation(webView.get()));
     g_assert_false(test->createTopLevelBrowsingContext(webView.get()));
 #if ENABLE(2022_GLIB_API)
@@ -345,13 +345,7 @@ static void testAutomationSessionRequestSession(AutomationTest* test, gconstpoin
 #endif
 
     // And will work with a proper web view.
-    webView = Test::adoptView(g_object_new(WEBKIT_TYPE_WEB_VIEW,
-#if PLATFORM(WPE)
-        "backend", Test::createWebViewBackend(),
-#endif
-        "web-context", test->m_webContext.get(),
-        "is-controlled-by-automation", TRUE,
-        nullptr));
+    webView = test->createWebView("is-controlled-by-automation", TRUE, nullptr);
     g_assert_true(webkit_web_view_is_controlled_by_automation(webView.get()));
     g_assert_cmpuint(webkit_web_view_get_automation_presentation_type(webView.get()), ==, WEBKIT_AUTOMATION_BROWSING_CONTEXT_PRESENTATION_WINDOW);
 #if ENABLE(2022_GLIB_API)
@@ -359,17 +353,13 @@ static void testAutomationSessionRequestSession(AutomationTest* test, gconstpoin
 #endif
     g_assert_true(test->createTopLevelBrowsingContext(webView.get()));
 
-    auto newWebViewInWindow = Test::adoptView(g_object_new(WEBKIT_TYPE_WEB_VIEW,
-#if PLATFORM(WPE)
-        "backend", Test::createWebViewBackend(),
-#endif
-        "web-context", test->m_webContext.get(),
+    auto newWebViewInWindow = test->createWebView(
+        "is-controlled-by-automation", TRUE,
 #if ENABLE(2022_GLIB_API)
         // Check also here that network session property is ignored when is-controlled-by-automation is true.
         "network-session", test->m_networkSession.get(),
 #endif
-        "is-controlled-by-automation", TRUE,
-        nullptr));
+        nullptr);
     g_assert_true(webkit_web_view_is_controlled_by_automation(newWebViewInWindow.get()));
     g_assert_cmpuint(webkit_web_view_get_automation_presentation_type(newWebViewInWindow.get()), ==, WEBKIT_AUTOMATION_BROWSING_CONTEXT_PRESENTATION_WINDOW);
 #if ENABLE(2022_GLIB_API)
@@ -377,14 +367,10 @@ static void testAutomationSessionRequestSession(AutomationTest* test, gconstpoin
 #endif
     g_assert_true(test->createNewWindow(newWebViewInWindow.get()));
 
-    auto newWebViewInTab = Test::adoptView(g_object_new(WEBKIT_TYPE_WEB_VIEW,
-#if PLATFORM(WPE)
-        "backend", Test::createWebViewBackend(),
-#endif
-        "web-context", test->m_webContext.get(),
+    auto newWebViewInTab = test->createWebView(
         "is-controlled-by-automation", TRUE,
         "automation-presentation-type", WEBKIT_AUTOMATION_BROWSING_CONTEXT_PRESENTATION_TAB,
-        nullptr));
+        nullptr);
     g_assert_true(webkit_web_view_is_controlled_by_automation(newWebViewInTab.get()));
     g_assert_cmpuint(webkit_web_view_get_automation_presentation_type(newWebViewInTab.get()), ==, WEBKIT_AUTOMATION_BROWSING_CONTEXT_PRESENTATION_TAB);
     g_assert_true(test->createNewTab(newWebViewInTab.get()));

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestBackForwardList.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestBackForwardList.cpp
@@ -121,7 +121,7 @@ public:
     }
 
     BackForwardListTest()
-        : m_list(webkit_web_view_get_back_forward_list(m_webView))
+        : m_list(webkit_web_view_get_back_forward_list(m_webView.get()))
         , m_changedFlags(0)
         , m_hasChanged(false)
         , m_expectedRemovedItems(0)
@@ -159,8 +159,8 @@ static void testBackForwardListNavigation(BackForwardListTest* test, gconstpoint
 {
     WebKitBackForwardListItem* items[1];
 
-    g_assert_false(webkit_web_view_can_go_back(test->m_webView));
-    g_assert_false(webkit_web_view_can_go_forward(test->m_webView));
+    g_assert_false(webkit_web_view_can_go_back(test->webView()));
+    g_assert_false(webkit_web_view_can_go_forward(test->webView()));
 
     g_assert_cmpuint(webkit_back_forward_list_get_length(test->m_list), ==, 0);
     g_assert_null(webkit_back_forward_list_get_current_item(test->m_list));
@@ -176,8 +176,8 @@ static void testBackForwardListNavigation(BackForwardListTest* test, gconstpoint
     test->waitUntilLoadFinished();
     test->waitUntilTitleChanged();
 
-    g_assert_false(webkit_web_view_can_go_back(test->m_webView));
-    g_assert_false(webkit_web_view_can_go_forward(test->m_webView));
+    g_assert_false(webkit_web_view_can_go_back(test->webView()));
+    g_assert_false(webkit_web_view_can_go_forward(test->webView()));
 
     g_assert_cmpuint(webkit_back_forward_list_get_length(test->m_list), ==, 1);
     WebKitBackForwardListItem* itemPage1 = webkit_back_forward_list_get_current_item(test->m_list);
@@ -194,8 +194,8 @@ static void testBackForwardListNavigation(BackForwardListTest* test, gconstpoint
     test->waitUntilLoadFinished();
     test->waitUntilTitleChanged();
 
-    g_assert_true(webkit_web_view_can_go_back(test->m_webView));
-    g_assert_false(webkit_web_view_can_go_forward(test->m_webView));
+    g_assert_true(webkit_web_view_can_go_back(test->webView()));
+    g_assert_false(webkit_web_view_can_go_forward(test->webView()));
 
     g_assert_cmpuint(webkit_back_forward_list_get_length(test->m_list), ==, 2);
     WebKitBackForwardListItem* itemPage2 = webkit_back_forward_list_get_current_item(test->m_list);
@@ -211,8 +211,8 @@ static void testBackForwardListNavigation(BackForwardListTest* test, gconstpoint
     test->goBack();
     test->waitUntilLoadFinished();
 
-    g_assert_false(webkit_web_view_can_go_back(test->m_webView));
-    g_assert_true(webkit_web_view_can_go_forward(test->m_webView));
+    g_assert_false(webkit_web_view_can_go_back(test->webView()));
+    g_assert_true(webkit_web_view_can_go_forward(test->webView()));
 
     g_assert_cmpuint(webkit_back_forward_list_get_length(test->m_list), ==, 2);
     g_assert_true(itemPage1 == webkit_back_forward_list_get_current_item(test->m_list));
@@ -228,8 +228,8 @@ static void testBackForwardListNavigation(BackForwardListTest* test, gconstpoint
     test->goForward();
     test->waitUntilLoadFinished();
 
-    g_assert_true(webkit_web_view_can_go_back(test->m_webView));
-    g_assert_false(webkit_web_view_can_go_forward(test->m_webView));
+    g_assert_true(webkit_web_view_can_go_back(test->webView()));
+    g_assert_false(webkit_web_view_can_go_forward(test->webView()));
 
     g_assert_cmpuint(webkit_back_forward_list_get_length(test->m_list), ==, 2);
     g_assert_true(itemPage2 == webkit_back_forward_list_get_current_item(test->m_list));
@@ -271,9 +271,9 @@ static void testBackForwardListLimitAndCache(BackForwardListTest* test, gconstpo
 
 static void testWebKitWebViewSessionState(BackForwardListTest* test, gconstpointer)
 {
-    WebKitWebViewSessionState* state = webkit_web_view_get_session_state(test->m_webView);
+    WebKitWebViewSessionState* state = webkit_web_view_get_session_state(test->webView());
     g_assert_nonnull(state);
-    auto view = Test::adoptView(Test::createWebView());
+    auto view = test->createWebView();
     WebKitBackForwardList* bfList = webkit_web_view_get_back_forward_list(view.get());
     g_assert_cmpuint(webkit_back_forward_list_get_length(bfList), ==, 0);
     webkit_web_view_restore_session_state(view.get(), state);
@@ -282,7 +282,7 @@ static void testWebKitWebViewSessionState(BackForwardListTest* test, gconstpoint
     g_assert_nonnull(data);
     state = webkit_web_view_session_state_new(data.get());
     g_assert_nonnull(state);
-    view = Test::adoptView(Test::createWebView());
+    view = test->createWebView();
     bfList = webkit_web_view_get_back_forward_list(view.get());
     g_assert_cmpuint(webkit_back_forward_list_get_length(bfList), ==, 0);
     webkit_web_view_restore_session_state(view.get(), state);
@@ -308,7 +308,7 @@ static void testWebKitWebViewSessionState(BackForwardListTest* test, gconstpoint
     test->goBack();
     test->waitUntilLoadFinished();
 
-    state = webkit_web_view_get_session_state(test->m_webView);
+    state = webkit_web_view_get_session_state(test->webView());
     g_assert_nonnull(state);
 
     g_assert_cmpuint(webkit_back_forward_list_get_length(bfList), ==, 0);
@@ -325,7 +325,7 @@ static void testWebKitWebViewSessionState(BackForwardListTest* test, gconstpoint
     state = webkit_web_view_session_state_new(data.get());
     g_assert_nonnull(state);
 
-    view = Test::adoptView(Test::createWebView());
+    view = test->createWebView();
     bfList = webkit_web_view_get_back_forward_list(view.get());
     g_assert_cmpuint(webkit_back_forward_list_get_length(bfList), ==, 0);
     webkit_web_view_restore_session_state(view.get(), state);
@@ -349,12 +349,12 @@ static void testWebKitWebViewSessionStateWithFormData(BackForwardListTest* test,
     test->loadURI(htmlURL.get());
     test->waitUntilLoadFinished();
 
-    webkit_web_view_evaluate_javascript(test->m_webView, "submitForm();", -1, nullptr, nullptr, nullptr, nullptr, nullptr);
+    webkit_web_view_evaluate_javascript(test->webView(), "submitForm();", -1, nullptr, nullptr, nullptr, nullptr, nullptr);
     test->waitUntilLoadFinished();
 
-    WebKitWebViewSessionState* state = webkit_web_view_get_session_state(test->m_webView);
+    WebKitWebViewSessionState* state = webkit_web_view_get_session_state(test->webView());
     g_assert_nonnull(state);
-    auto view = Test::adoptView(Test::createWebView());
+    auto view = test->createWebView();
     WebKitBackForwardList* bfList = webkit_web_view_get_back_forward_list(view.get());
     g_assert_cmpuint(webkit_back_forward_list_get_length(bfList), ==, 0);
     webkit_web_view_restore_session_state(view.get(), state);
@@ -363,7 +363,7 @@ static void testWebKitWebViewSessionStateWithFormData(BackForwardListTest* test,
     g_assert_nonnull(data);
     state = webkit_web_view_session_state_new(data.get());
     g_assert_nonnull(state);
-    view = Test::adoptView(Test::createWebView());
+    view = test->createWebView();
     bfList = webkit_web_view_get_back_forward_list(view.get());
     g_assert_cmpuint(webkit_back_forward_list_get_length(bfList), ==, 0);
     webkit_web_view_restore_session_state(view.get(), state);
@@ -381,7 +381,7 @@ static void testWebKitWebViewNavigationAfterSessionRestore(BackForwardListTest* 
 {
     // This test checks that a normal load after a session restore with a BackForard list having
     // forward items doesn't produce any runtime critical warning. See https://bugs.webkit.org/show_bug.cgi?id=153233.
-    auto view = Test::adoptView(Test::createWebView());
+    auto view = test->createWebView();
     g_signal_connect(view.get(), "load-changed", G_CALLBACK(viewLoadChanged), test->m_mainLoop);
 
     webkit_web_view_load_uri(view.get(), kServer->getURIForPath("/Page1").data());
@@ -394,7 +394,7 @@ static void testWebKitWebViewNavigationAfterSessionRestore(BackForwardListTest* 
     g_main_loop_run(test->m_mainLoop);
 
     WebKitWebViewSessionState* state = webkit_web_view_get_session_state(view.get());
-    webkit_web_view_restore_session_state(test->m_webView, state);
+    webkit_web_view_restore_session_state(test->webView(), state);
     webkit_web_view_session_state_unref(state);
 
     // A normal load after a session restore should remove the forward list, add the new item and update the current one.

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestCookieManager.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestCookieManager.cpp
@@ -777,17 +777,13 @@ static void testCookieManagerEphemeral(CookieManagerTest* test, gconstpointer)
 #if ENABLE(2022_GLIB_API)
     GRefPtr<WebKitNetworkSession> ephemeralSession = adoptGRef(webkit_network_session_new_ephemeral());
 #endif
-    auto webView = Test::adoptView(g_object_new(WEBKIT_TYPE_WEB_VIEW,
-#if PLATFORM(WPE)
-        "backend", Test::createWebViewBackend(),
-#endif
-        "web-context", webkit_web_view_get_context(test->m_webView),
+    auto webView = test->createWebView(
 #if ENABLE(2022_GLIB_API)
         "network-session", ephemeralSession.get(),
 #else
         "is-ephemeral", TRUE,
 #endif
-        nullptr));
+        nullptr);
 #if ENABLE(2022_GLIB_API)
     g_assert_true(webkit_web_view_get_network_session(webView.get()) == ephemeralSession.get());
 #else
@@ -813,7 +809,7 @@ static void testCookieManagerEphemeral(CookieManagerTest* test, gconstpointer)
 #if ENABLE(2022_GLIB_API)
     auto* cookieManager = webkit_network_session_get_cookie_manager(ephemeralSession.get());
 #else
-    g_assert_true(viewDataManager != webkit_web_context_get_website_data_manager(webkit_web_view_get_context(test->m_webView)));
+    g_assert_true(viewDataManager != webkit_web_context_get_website_data_manager(webkit_web_view_get_context(test->webView())));
     auto* cookieManager = webkit_website_data_manager_get_cookie_manager(viewDataManager);
 #endif
     g_assert_true(WEBKIT_IS_COOKIE_MANAGER(cookieManager));

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestGeolocationManager.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestGeolocationManager.cpp
@@ -72,7 +72,7 @@ public:
         assertObjectIsDeletedWhenTestFinishes(G_OBJECT(m_manager));
         g_signal_connect(m_manager, "start", G_CALLBACK(startCallback), this);
         g_signal_connect(m_manager, "stop", G_CALLBACK(stopCallback), this);
-        g_signal_connect(m_webView, "permission-request", G_CALLBACK(permissionRequested), this);
+        g_signal_connect(m_webView.get(), "permission-request", G_CALLBACK(permissionRequested), this);
     }
 
     ~GeolocationTest()
@@ -81,7 +81,7 @@ public:
             webkit_geolocation_position_free(m_checkPosition);
 
         g_signal_handlers_disconnect_matched(m_manager, G_SIGNAL_MATCH_DATA, 0, 0, nullptr, nullptr, this);
-        g_signal_handlers_disconnect_matched(m_webView, G_SIGNAL_MATCH_DATA, 0, 0, nullptr, nullptr, this);
+        g_signal_handlers_disconnect_matched(m_webView.get(), G_SIGNAL_MATCH_DATA, 0, 0, nullptr, nullptr, this);
     }
 
     void start()

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestInputMethodContext.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestInputMethodContext.cpp
@@ -273,15 +273,15 @@ public:
     {
         WebViewTest::showInWindow();
 #if PLATFORM(GTK)
-        auto* defaultContext = webkit_web_view_get_input_method_context(m_webView);
+        auto* defaultContext = webkit_web_view_get_input_method_context(m_webView.get());
         g_assert_true(WEBKIT_IS_INPUT_METHOD_CONTEXT(defaultContext));
         assertObjectIsDeletedWhenTestFinishes(G_OBJECT(defaultContext));
 #elif PLATFORM(WPE)
-        g_assert_null(webkit_web_view_get_input_method_context(m_webView));
+        g_assert_null(webkit_web_view_get_input_method_context(m_webView.get()));
 #endif
         assertObjectIsDeletedWhenTestFinishes(G_OBJECT(m_context.get()));
-        webkit_web_view_set_input_method_context(m_webView, WEBKIT_INPUT_METHOD_CONTEXT(m_context.get()));
-        g_assert_true(webkit_web_view_get_input_method_context(m_webView) == WEBKIT_INPUT_METHOD_CONTEXT(m_context.get()));
+        webkit_web_view_set_input_method_context(m_webView.get(), WEBKIT_INPUT_METHOD_CONTEXT(m_context.get()));
+        g_assert_true(webkit_web_view_get_input_method_context(m_webView.get()) == WEBKIT_INPUT_METHOD_CONTEXT(m_context.get()));
 
 #if !ENABLE(2022_GLIB_API)
         webkit_user_content_manager_register_script_message_handler(m_userContentManager.get(), "imEvent");

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestNetworkProcessMemoryPressure.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestNetworkProcessMemoryPressure.cpp
@@ -78,7 +78,7 @@ public:
 
     void waitUntilLoadFailed()
     {
-        g_signal_connect(m_webView, "load-failed", G_CALLBACK(MemoryPressureTest::loadFailedCallback), this);
+        g_signal_connect(m_webView.get(), "load-failed", G_CALLBACK(MemoryPressureTest::loadFailedCallback), this);
         g_main_loop_run(m_mainLoop);
     }
 };

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestOptionMenu.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestOptionMenu.cpp
@@ -34,12 +34,12 @@ public:
 
     OptionMenuTest()
     {
-        g_signal_connect(m_webView, "show-option-menu", G_CALLBACK(showOptionMenuCallback), this);
+        g_signal_connect(m_webView.get(), "show-option-menu", G_CALLBACK(showOptionMenuCallback), this);
     }
 
     ~OptionMenuTest()
     {
-        g_signal_handlers_disconnect_matched(m_webView, G_SIGNAL_MATCH_DATA, 0, 0, 0, 0, this);
+        g_signal_handlers_disconnect_matched(m_webView.get(), G_SIGNAL_MATCH_DATA, 0, 0, 0, 0, this);
         if (m_menu)
             close();
     }
@@ -59,7 +59,7 @@ public:
 #endif
         PlatformRectangle* rect, OptionMenuTest* test)
     {
-        g_assert_true(test->m_webView == webView);
+        g_assert_true(test->webView() == webView);
         g_assert_nonnull(rect);
         g_assert_true(WEBKIT_IS_OPTION_MENU(menu));
 #if PLATFORM(GTK) && !USE(GTK4)

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitFindController.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitFindController.cpp
@@ -29,7 +29,7 @@ public:
     MAKE_GLIB_TEST_FIXTURE(FindControllerTest);
 
     FindControllerTest()
-        : m_findController(webkit_web_view_get_find_controller(m_webView))
+        : m_findController(webkit_web_view_get_find_controller(m_webView.get()))
         , m_runFindUntilCompletion(false)
     {
         assertObjectIsDeletedWhenTestFinishes(G_OBJECT(m_findController.get()));
@@ -63,7 +63,7 @@ public:
 #if PLATFORM(GTK)
     cairo_surface_t* takeSnapshotAndWaitUntilReady()
     {
-        webkit_web_view_get_snapshot(m_webView, WEBKIT_SNAPSHOT_REGION_FULL_DOCUMENT, WEBKIT_SNAPSHOT_OPTIONS_NONE, nullptr, [](GObject* source, GAsyncResult* result, gpointer userData) {
+        webkit_web_view_get_snapshot(m_webView.get(), WEBKIT_SNAPSHOT_REGION_FULL_DOCUMENT, WEBKIT_SNAPSHOT_OPTIONS_NONE, nullptr, [](GObject* source, GAsyncResult* result, gpointer userData) {
             auto& test = *static_cast<FindControllerTest*>(userData);
 #if USE(GTK4)
             if (GRefPtr<GdkTexture> snapshot = adoptGRef(webkit_web_view_get_snapshot_finish(WEBKIT_WEB_VIEW(source), result, nullptr))) {
@@ -302,9 +302,9 @@ static void testFindControllerHide(FindControllerTest* test, gconstpointer)
     g_assert_nonnull(highlightSurface);
     g_assert_false(Test::cairoSurfacesEqual(originalSurface, highlightSurface));
 
-    WebKitFindController* findController = webkit_web_view_get_find_controller(test->m_webView);
+    WebKitFindController* findController = webkit_web_view_get_find_controller(test->webView());
     webkit_find_controller_search_finish(findController);
-    webkit_web_view_execute_editing_command(test->m_webView, "Unselect");
+    webkit_web_view_execute_editing_command(test->webView(), "Unselect");
 
     auto* unhighlightSurface = test->takeSnapshotAndWaitUntilReady();
     g_assert_nonnull(unhighlightSurface);
@@ -318,8 +318,8 @@ static void testFindControllerHide(FindControllerTest* test, gconstpointer)
 
 static void testFindControllerInstance(FindControllerTest* test, gconstpointer)
 {
-    WebKitFindController* findController1 = webkit_web_view_get_find_controller(test->m_webView);
-    WebKitFindController* findController2 = webkit_web_view_get_find_controller(test->m_webView);
+    WebKitFindController* findController1 = webkit_web_view_get_find_controller(test->webView());
+    WebKitFindController* findController2 = webkit_web_view_get_find_controller(test->webView());
 
     g_assert_true(findController1 == findController2);
 }
@@ -329,10 +329,10 @@ static void testFindControllerGetters(FindControllerTest* test, gconstpointer)
     const char* searchText = "testing";
     guint maxMatchCount = 1;
     guint32 findOptions = WEBKIT_FIND_OPTIONS_WRAP_AROUND | WEBKIT_FIND_OPTIONS_AT_WORD_STARTS;
-    WebKitFindController* findController = webkit_web_view_get_find_controller(test->m_webView);
+    WebKitFindController* findController = webkit_web_view_get_find_controller(test->webView());
 
     webkit_find_controller_search(findController, searchText, findOptions, maxMatchCount);
-    g_assert_true(webkit_find_controller_get_web_view(findController) == test->m_webView);
+    g_assert_true(webkit_find_controller_get_web_view(findController) == test->webView());
     g_assert_cmpstr(webkit_find_controller_get_search_text(findController), ==, searchText);
     g_assert_cmpuint(webkit_find_controller_get_max_match_count(findController), ==, maxMatchCount);
     g_assert_cmpuint(webkit_find_controller_get_options(findController), ==, findOptions);

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitNetworkSession.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitNetworkSession.cpp
@@ -49,16 +49,10 @@ static void testNetworkSessionEphemeral(Test* test, gconstpointer)
     g_assert_true(WEBKIT_IS_WEBSITE_DATA_MANAGER(manager));
     g_assert_false(webkit_website_data_manager_is_ephemeral(manager));
 
-    auto webView = Test::adoptView(Test::createWebView());
+    auto webView = test->createWebView("network-session", nullptr, nullptr);
     g_assert_true(webkit_web_view_get_network_session(webView.get()) == webkit_network_session_get_default());
 
-    webView = Test::adoptView(g_object_new(WEBKIT_TYPE_WEB_VIEW,
-#if PLATFORM(WPE)
-        "backend", Test::createWebViewBackend(),
-#endif
-        "web-context", test->m_webContext.get(),
-        "network-session", test->m_networkSession.get(),
-        nullptr));
+    webView = test->createWebView();
     g_assert_true(webkit_web_view_get_network_session(webView.get()) == test->m_networkSession.get());
 
     GRefPtr<WebKitNetworkSession> session = adoptGRef(webkit_network_session_new_ephemeral());
@@ -68,13 +62,7 @@ static void testNetworkSessionEphemeral(Test* test, gconstpointer)
     g_assert_true(webkit_website_data_manager_is_ephemeral(manager));
     g_assert_true(webkit_web_view_get_network_session(webView.get()) != session.get());
 
-    webView = Test::adoptView(g_object_new(WEBKIT_TYPE_WEB_VIEW,
-#if PLATFORM(WPE)
-        "backend", Test::createWebViewBackend(),
-#endif
-        "web-context", test->m_webContext.get(),
-        "network-session", session.get(),
-        nullptr));
+    webView = test->createWebView("network-session", session.get(), nullptr);
     g_assert_true(webkit_web_view_get_network_session(webView.get()) == session.get());
 }
 
@@ -200,13 +188,7 @@ static void testNetworkSessionProxySettings(ProxyTest* test, gconstpointer)
     GRefPtr<WebKitNetworkSession> ephemeralSession = adoptGRef(webkit_network_session_new_ephemeral());
     webkit_network_session_set_proxy_settings(ephemeralSession.get(), WEBKIT_NETWORK_PROXY_MODE_CUSTOM, settings);
     webkit_network_proxy_settings_free(settings);
-    auto webView = Test::adoptView(g_object_new(WEBKIT_TYPE_WEB_VIEW,
-#if PLATFORM(WPE)
-        "backend", Test::createWebViewBackend(),
-#endif
-        "web-context", test->m_webContext.get(),
-        "network-session", ephemeralSession.get(),
-        nullptr));
+    auto webView = test->createWebView("network-session", ephemeralSession.get(), nullptr);
     g_assert_true(webkit_web_view_get_network_session(webView.get()) == ephemeralSession.get());
 
     g_signal_connect(webView.get(), "load-changed", G_CALLBACK(ephemeralViewloadChanged), test);

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitPolicyClient.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitPolicyClient.cpp
@@ -113,7 +113,7 @@ public:
     PolicyClientTest()
         : LoadTrackingTest()
     {
-        g_signal_connect(m_webView, "decide-policy", G_CALLBACK(decidePolicyCallback), this);
+        g_signal_connect(m_webView.get(), "decide-policy", G_CALLBACK(decidePolicyCallback), this);
 #if !ENABLE(2022_GLIB_API)
         webkit_user_content_manager_register_script_message_handler(m_userContentManager.get(), "testHandler");
 #else
@@ -229,7 +229,7 @@ static void testResponsePolicy(PolicyClientTest* test, gconstpointer)
     WebKitURIResponse* response = webkit_response_policy_decision_get_response(decision);
     g_assert_true(WEBKIT_IS_URI_RESPONSE(response));
     ASSERT_CMP_CSTRING(webkit_uri_response_get_uri(response), ==, kServer->getURIForPath("/"));
-    g_assert_cmpint(webkit_web_view_can_show_mime_type(test->m_webView, webkit_uri_response_get_mime_type(response)), ==,
+    g_assert_cmpint(webkit_web_view_can_show_mime_type(test->webView(), webkit_uri_response_get_mime_type(response)), ==,
         webkit_response_policy_decision_is_mime_type_supported(decision));
     g_assert_true(webkit_response_policy_decision_is_main_frame_main_resource(decision));
 
@@ -276,13 +276,13 @@ static void testNewWindowPolicy(PolicyClientTest* test, gconstpointer)
         "    </script>"
         "</body></html>";
     test->m_policyDecisionTypeFilter = WEBKIT_POLICY_DECISION_TYPE_NEW_WINDOW_ACTION;
-    webkit_settings_set_javascript_can_open_windows_automatically(webkit_web_view_get_settings(test->m_webView), TRUE);
+    webkit_settings_set_javascript_can_open_windows_automatically(webkit_web_view_get_settings(test->webView()), TRUE);
 
     CreateCallbackData data;
     data.triedToOpenWindow = false;
     data.mainLoop = test->m_mainLoop;
 
-    g_signal_connect(test->m_webView, "create", G_CALLBACK(createCallback), &data);
+    g_signal_connect(test->webView(), "create", G_CALLBACK(createCallback), &data);
     test->m_policyDecisionResponse = PolicyClientTest::Use;
     test->loadHtml(windowOpeningHTML, "http://webkitgtk.org/");
     test->wait(1);

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitSettings.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitSettings.cpp
@@ -582,7 +582,7 @@ static void testWebKitSettingsUserAgent(WebViewTest* test, gconstpointer)
 {
     GRefPtr<WebKitSettings> settings = adoptGRef(webkit_settings_new());
     CString defaultUserAgent = webkit_settings_get_user_agent(settings.get());
-    webkit_web_view_set_settings(test->m_webView, settings.get());
+    webkit_web_view_set_settings(test->webView(), settings.get());
 
     g_assert_nonnull(g_strstr_len(defaultUserAgent.data(), -1, "AppleWebKit"));
     g_assert_nonnull(g_strstr_len(defaultUserAgent.data(), -1, "Safari"));
@@ -619,7 +619,7 @@ static void testWebKitSettingsUserAgent(WebViewTest* test, gconstpointer)
 
 static void testWebKitSettingsJavaScriptMarkup(WebViewTest* test, gconstpointer)
 {
-    webkit_settings_set_enable_javascript_markup(webkit_web_view_get_settings(test->m_webView), FALSE);
+    webkit_settings_set_enable_javascript_markup(webkit_web_view_get_settings(test->webView()), FALSE);
     static const char* html =
         "<html>"
         " <head>"
@@ -634,12 +634,12 @@ static void testWebKitSettingsJavaScriptMarkup(WebViewTest* test, gconstpointer)
     test->loadHtml(html, nullptr);
     test->waitUntilTitleChanged();
 
-    g_assert_cmpstr(webkit_web_view_get_title(test->m_webView), ==, "No JavaScript allowed");
+    g_assert_cmpstr(webkit_web_view_get_title(test->webView()), ==, "No JavaScript allowed");
     auto* jsResult = test->runJavaScriptAndWaitUntilFinished("document.getElementsByTagName('script').length", nullptr);
     g_assert(jsResult);
     g_assert_cmpfloat(WebViewTest::javascriptResultToNumber(jsResult), ==, 0);
 
-    webkit_settings_set_enable_javascript_markup(webkit_web_view_get_settings(test->m_webView), TRUE);
+    webkit_settings_set_enable_javascript_markup(webkit_web_view_get_settings(test->webView()), TRUE);
 }
 
 #if USE(SOUP2)

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitUserContentManager.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitUserContentManager.cpp
@@ -68,10 +68,10 @@ static void testWebViewNewWithUserContentManager(Test* test, gconstpointer)
 {
     GRefPtr<WebKitUserContentManager> userContentManager1 = adoptGRef(webkit_user_content_manager_new());
     test->assertObjectIsDeletedWhenTestFinishes(G_OBJECT(userContentManager1.get()));
-    auto webView1 = Test::adoptView(Test::createWebView(userContentManager1.get()));
+    auto webView1 = test->createWebView("user-content-manager", userContentManager1.get(), nullptr);
     g_assert_true(webkit_web_view_get_user_content_manager(webView1.get()) == userContentManager1.get());
 
-    auto webView2 = Test::adoptView(Test::createWebView());
+    auto webView2 = test->createWebView();
     g_assert_true(webkit_web_view_get_user_content_manager(webView2.get()) != userContentManager1.get());
 }
 
@@ -330,7 +330,7 @@ public:
     {
         GUniquePtr<char> javascriptSnippet(g_strdup_printf("window.webkit.messageHandlers.%s.postMessage(%s);", handlerName, javascriptValueAsText));
         m_waitForScriptRun = true;
-        webkit_web_view_evaluate_javascript(m_webView, javascriptSnippet.get(), -1, worldName, nullptr, nullptr, reinterpret_cast<GAsyncReadyCallback>(runJavaScriptFinished), this);
+        webkit_web_view_evaluate_javascript(m_webView.get(), javascriptSnippet.get(), -1, worldName, nullptr, nullptr, reinterpret_cast<GAsyncReadyCallback>(runJavaScriptFinished), this);
         return waitUntilMessageReceived(handlerName);
     }
 
@@ -382,7 +382,7 @@ public:
         GUniquePtr<char> javascriptSnippet(g_strdup_printf("var p = window.webkit.messageHandlers.%s.postMessage(%s); await p; return p;", handlerName, javascriptValueAsText));
         m_waitForScriptRun = true;
 
-        webkit_web_view_call_async_javascript_function(m_webView, javascriptSnippet.get(), -1, nullptr, worldName, nullptr, nullptr, reinterpret_cast<GAsyncReadyCallback>(runAsyncJavaScriptFinished), this);
+        webkit_web_view_call_async_javascript_function(m_webView.get(), javascriptSnippet.get(), -1, nullptr, worldName, nullptr, nullptr, reinterpret_cast<GAsyncReadyCallback>(runAsyncJavaScriptFinished), this);
 
         return waitUntilPromiseResolved(handlerName, error);
     }

--- a/Tools/TestWebKitAPI/Tests/WebKitGtk/TestContextMenu.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGtk/TestContextMenu.cpp
@@ -84,13 +84,13 @@ public:
         , m_menuPositionY(0)
         , m_expectedEventType(GDK_BUTTON_PRESS)
     {
-        g_signal_connect(m_webView, "context-menu", G_CALLBACK(contextMenuCallback), this);
-        g_signal_connect(m_webView, "context-menu-dismissed", G_CALLBACK(contextMenuDismissedCallback), this);
+        g_signal_connect(m_webView.get(), "context-menu", G_CALLBACK(contextMenuCallback), this);
+        g_signal_connect(m_webView.get(), "context-menu-dismissed", G_CALLBACK(contextMenuDismissedCallback), this);
     }
 
     ~ContextMenuTest()
     {
-        g_signal_handlers_disconnect_matched(m_webView, G_SIGNAL_MATCH_DATA, 0, 0, 0, 0, this);
+        g_signal_handlers_disconnect_matched(m_webView.get(), G_SIGNAL_MATCH_DATA, 0, 0, 0, 0, this);
     }
 
     virtual bool contextMenu(WebKitContextMenu*, GdkEvent*, WebKitHitTestResult*) = 0;
@@ -114,7 +114,7 @@ public:
             if (!GTK_IS_MENU(child))
                 continue;
 
-            if (gtk_menu_get_attach_widget(GTK_MENU(child)) == GTK_WIDGET(m_webView))
+            if (gtk_menu_get_attach_widget(GTK_MENU(child)) == GTK_WIDGET(m_webView.get()))
                 return child;
 #endif // USE(GTK4)
         }
@@ -471,7 +471,7 @@ public:
             g_assert_not_reached();
         }
 
-        if (webkit_settings_get_enable_developer_extras(webkit_web_view_get_settings(m_webView))) {
+        if (webkit_settings_get_enable_developer_extras(webkit_web_view_get_settings(m_webView.get()))) {
             iter = checkCurrentItemIsSeparatorAndGetNext(iter);
             iter = checkCurrentItemIsStockActionAndGetNext(iter, WEBKIT_CONTEXT_MENU_ACTION_INSPECT_ELEMENT, Visible | Enabled);
         }
@@ -534,7 +534,7 @@ static void testContextMenuDefaultMenu(ContextMenuDefaultTest* test, gconstpoint
 
     // Enable developer extras now, so that inspector element
     // will be shown in the default context menu.
-    webkit_settings_set_enable_developer_extras(webkit_web_view_get_settings(test->m_webView), TRUE);
+    webkit_settings_set_enable_developer_extras(webkit_web_view_get_settings(test->webView()), TRUE);
 
     // Context menu for image link.
     test->m_expectedMenuType = ContextMenuDefaultTest::LinkImage;

--- a/Tools/TestWebKitAPI/Tests/WebKitGtk/TestDOMDOMWindow.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGtk/TestDOMDOMWindow.cpp
@@ -102,7 +102,7 @@ static void testWebKitDOMDOMWindowSignals(WebViewTest* test, gconstpointer)
 
     GVariantBuilder builder;
     g_variant_builder_init(&builder, G_VARIANT_TYPE_VARDICT);
-    g_variant_builder_add(&builder, "{sv}", "pageID", g_variant_new_uint64(webkit_web_view_get_page_id(status.test->m_webView)));
+    g_variant_builder_add(&builder, "{sv}", "pageID", g_variant_new_uint64(webkit_web_view_get_page_id(status.test->webView())));
     status.testRunner->runTestAndWait("WebKitDOMDOMWindow", "signals", g_variant_builder_end(&builder));
     g_assert_true(status.testRunner->getTestResult());
 }
@@ -120,7 +120,7 @@ static void testWebKitDOMDOMWindowDispatchEvent(WebViewTest* test, gconstpointer
 
     GVariantBuilder builder;
     g_variant_builder_init(&builder, G_VARIANT_TYPE_VARDICT);
-    g_variant_builder_add(&builder, "{sv}", "pageID", g_variant_new_uint64(webkit_web_view_get_page_id(status.test->m_webView)));
+    g_variant_builder_add(&builder, "{sv}", "pageID", g_variant_new_uint64(webkit_web_view_get_page_id(status.test->webView())));
     status.testRunner->runTestAndWait("WebKitDOMDOMWindow", "dispatch-event", g_variant_builder_end(&builder));
     g_assert_true(status.testRunner->getTestResult());
 }
@@ -137,7 +137,7 @@ static void testWebKitDOMDOMWindowGetComputedStyle(WebViewTest* test, gconstpoin
 
     GVariantBuilder builder;
     g_variant_builder_init(&builder, G_VARIANT_TYPE_VARDICT);
-    g_variant_builder_add(&builder, "{sv}", "pageID", g_variant_new_uint64(webkit_web_view_get_page_id(status.test->m_webView)));
+    g_variant_builder_add(&builder, "{sv}", "pageID", g_variant_new_uint64(webkit_web_view_get_page_id(status.test->webView())));
     g_assert_true(status.testRunner->runTest("WebKitDOMDOMWindow", "get-computed-style", g_variant_builder_end(&builder)));
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebKitGtk/TestInspector.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGtk/TestInspector.cpp
@@ -62,9 +62,9 @@ public:
 
     InspectorTest()
         : WebViewTest()
-        , m_inspector(webkit_web_view_get_inspector(m_webView))
+        , m_inspector(webkit_web_view_get_inspector(m_webView.get()))
     {
-        webkit_settings_set_enable_developer_extras(webkit_web_view_get_settings(m_webView), TRUE);
+        webkit_settings_set_enable_developer_extras(webkit_web_view_get_settings(m_webView.get()), TRUE);
         assertObjectIsDeletedWhenTestFinishes(G_OBJECT(m_inspector));
         g_signal_connect(m_inspector, "open-window", G_CALLBACK(openWindowCallback), this);
         g_signal_connect(m_inspector, "bring-to-front", G_CALLBACK(bringToFrontCallback), this);
@@ -285,22 +285,22 @@ public:
 
         GtkWidget* pane;
 #if USE(GTK4)
-        if (gtk_window_get_child(GTK_WINDOW(m_parentWindow)) == GTK_WIDGET(m_webView)) {
-            GRefPtr<WebKitWebView> inspectedView = m_webView;
+        if (gtk_window_get_child(GTK_WINDOW(m_parentWindow)) == GTK_WIDGET(m_webView.get())) {
+            GRefPtr<WebKitWebView> inspectedView = m_webView.get();
             gtk_window_set_child(GTK_WINDOW(m_parentWindow), nullptr);
             pane = gtk_paned_new(GTK_ORIENTATION_VERTICAL);
-            gtk_paned_set_start_child(GTK_PANED(pane), GTK_WIDGET(m_webView));
+            gtk_paned_set_start_child(GTK_PANED(pane), GTK_WIDGET(m_webView.get()));
             gtk_window_set_child(GTK_WINDOW(m_parentWindow), pane);
         } else
             pane = gtk_window_get_child(GTK_WINDOW(m_parentWindow));
         gtk_paned_set_position(GTK_PANED(pane), webkit_web_inspector_get_attached_height(m_inspector));
         gtk_paned_set_end_child(GTK_PANED(pane), GTK_WIDGET(inspectorView.get()));
 #else
-        if (gtk_bin_get_child(GTK_BIN(m_parentWindow)) == GTK_WIDGET(m_webView)) {
-            GRefPtr<WebKitWebView> inspectedView = m_webView;
-            gtk_container_remove(GTK_CONTAINER(m_parentWindow), GTK_WIDGET(m_webView));
+        if (gtk_bin_get_child(GTK_BIN(m_parentWindow)) == GTK_WIDGET(m_webView.get())) {
+            GRefPtr<WebKitWebView> inspectedView = m_webView.get();
+            gtk_container_remove(GTK_CONTAINER(m_parentWindow), GTK_WIDGET(m_webView.get()));
             pane = gtk_paned_new(GTK_ORIENTATION_VERTICAL);
-            gtk_paned_add1(GTK_PANED(pane), GTK_WIDGET(m_webView));
+            gtk_paned_add1(GTK_PANED(pane), GTK_WIDGET(m_webView.get()));
             gtk_container_add(GTK_CONTAINER(m_parentWindow), pane);
             gtk_widget_show_all(pane);
         } else

--- a/Tools/TestWebKitAPI/Tests/WebKitGtk/TestInspectorServer.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGtk/TestInspectorServer.cpp
@@ -133,7 +133,7 @@ public:
             const char* mainResourceData = this->mainResourceData(mainResourceDataSize);
             g_assert_nonnull(mainResourceData);
             if (g_strrstr_len(mainResourceData, mainResourceDataSize, "No targets found")) {
-                webkit_web_view_reload(m_webView);
+                webkit_web_view_reload(m_webView.get());
                 waitUntilLoadFinished();
                 continue;
             }

--- a/Tools/TestWebKitAPI/Tests/WebKitGtk/TestWebKitAccessibility.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGtk/TestWebKitAccessibility.cpp
@@ -2394,7 +2394,7 @@ static void testDocumentLoadEvents(AccessibilityTest* test, gconstpointer)
     events = { };
 
     test->startEventMonitor(std::nullopt, { "document:", "object:state-changed:busy" });
-    webkit_web_view_reload(test->m_webView);
+    webkit_web_view_reload(test->webView());
     test->waitUntilLoadFinished();
     events = test->stopEventMonitor(4);
     g_assert_cmpuint(events.size(), ==, 4);

--- a/Tools/TestWebKitAPI/glib/WebKitGLib/LoadTrackingTest.cpp
+++ b/Tools/TestWebKitAPI/glib/WebKitGLib/LoadTrackingTest.cpp
@@ -113,17 +113,17 @@ LoadTrackingTest::LoadTrackingTest()
     : m_runLoadUntilCompletion(false)
     , m_loadFailed(false)
 {
-    g_signal_connect(m_webView, "load-changed", G_CALLBACK(loadChangedCallback), this);
-    g_signal_connect(m_webView, "load-failed", G_CALLBACK(loadFailedCallback), this);
-    g_signal_connect(m_webView, "load-failed-with-tls-errors", G_CALLBACK(loadFailedWithTLSErrorsCallback), this);
-    g_signal_connect(m_webView, "notify::estimated-load-progress", G_CALLBACK(estimatedProgressChangedCallback), this);
+    g_signal_connect(m_webView.get(), "load-changed", G_CALLBACK(loadChangedCallback), this);
+    g_signal_connect(m_webView.get(), "load-failed", G_CALLBACK(loadFailedCallback), this);
+    g_signal_connect(m_webView.get(), "load-failed-with-tls-errors", G_CALLBACK(loadFailedWithTLSErrorsCallback), this);
+    g_signal_connect(m_webView.get(), "notify::estimated-load-progress", G_CALLBACK(estimatedProgressChangedCallback), this);
 
-    g_assert_null(webkit_web_view_get_uri(m_webView));
+    g_assert_null(webkit_web_view_get_uri(m_webView.get()));
 }
 
 LoadTrackingTest::~LoadTrackingTest()
 {
-    g_signal_handlers_disconnect_matched(m_webView, G_SIGNAL_MATCH_DATA, 0, 0, 0, 0, this);
+    g_signal_handlers_disconnect_matched(m_webView.get(), G_SIGNAL_MATCH_DATA, 0, 0, 0, 0, this);
 }
 
 void LoadTrackingTest::waitUntilLoadFinished()
@@ -173,7 +173,7 @@ bool LoadTrackingTest::loadFailedWithTLSErrors(const gchar* /*failingURI*/, GTls
 
 void LoadTrackingTest::estimatedProgressChanged()
 {
-    double progress = webkit_web_view_get_estimated_load_progress(m_webView);
+    double progress = webkit_web_view_get_estimated_load_progress(m_webView.get());
     g_assert_cmpfloat(m_estimatedProgress, <, progress);
     m_estimatedProgress = progress;
 }
@@ -211,7 +211,7 @@ void LoadTrackingTest::loadRequest(WebKitURIRequest* request)
 void LoadTrackingTest::reload()
 {
     reset();
-    webkit_web_view_reload(m_webView);
+    webkit_web_view_reload(m_webView.get());
 }
 
 void LoadTrackingTest::goBack()

--- a/Tools/TestWebKitAPI/glib/WebKitGLib/WebViewTest.cpp
+++ b/Tools/TestWebKitAPI/glib/WebKitGLib/WebViewTest.cpp
@@ -39,37 +39,31 @@ WebViewTest::WebViewTest()
 WebViewTest::~WebViewTest()
 {
     platformDestroy();
-    s_dbusConnectionPageMap.remove(webkit_web_view_get_page_id(m_webView));
+    s_dbusConnectionPageMap.remove(webkit_web_view_get_page_id(m_webView.get()));
 
-    g_object_unref(m_webView);
     g_main_loop_unref(m_mainLoop);
 }
 
 void WebViewTest::initializeWebView()
 {
-    g_assert_null(m_webView);
+    g_assert_null(m_webView.get());
 
 #if ENABLE(2022_GLIB_API)
     GRefPtr<WebKitNetworkSession> networkSession = shouldCreateEphemeralWebView ? adoptGRef(webkit_network_session_new_ephemeral()) : m_networkSession;
 #endif
 
-    m_webView = WEBKIT_WEB_VIEW(g_object_new(WEBKIT_TYPE_WEB_VIEW,
-#if PLATFORM(WPE)
-        "backend", Test::createWebViewBackend(),
-#endif
-        "web-context", m_webContext.get(),
+    m_webView = createWebView(
         "user-content-manager", m_userContentManager.get(),
 #if ENABLE(2022_GLIB_API)
         "network-session", networkSession.get(),
 #else
         "is-ephemeral", shouldCreateEphemeralWebView,
 #endif
-        nullptr));
+        nullptr);
 
-    platformInitializeWebView();
-    assertObjectIsDeletedWhenTestFinishes(G_OBJECT(m_webView));
+    assertObjectIsDeletedWhenTestFinishes(G_OBJECT(m_webView.get()));
 
-    g_signal_connect(m_webView, "web-process-terminated", G_CALLBACK(WebViewTest::webProcessTerminated), this);
+    g_signal_connect(m_webView.get(), "web-process-terminated", G_CALLBACK(WebViewTest::webProcessTerminated), this);
 }
 
 gboolean WebViewTest::webProcessTerminated(WebKitWebView*, WebKitWebProcessTerminationReason, WebViewTest* test)
@@ -85,9 +79,9 @@ gboolean WebViewTest::webProcessTerminated(WebKitWebView*, WebKitWebProcessTermi
 void WebViewTest::loadURI(const char* uri)
 {
     m_activeURI = uri;
-    webkit_web_view_load_uri(m_webView, uri);
-    g_assert_true(webkit_web_view_is_loading(m_webView));
-    g_assert_cmpstr(webkit_web_view_get_uri(m_webView), ==, m_activeURI.data());
+    webkit_web_view_load_uri(m_webView.get(), uri);
+    g_assert_true(webkit_web_view_is_loading(m_webView.get()));
+    g_assert_cmpstr(webkit_web_view_get_uri(m_webView.get()), ==, m_activeURI.data());
 }
 
 void WebViewTest::loadHtml(const char* html, const char* baseURI, WebKitWebView* webView)
@@ -98,7 +92,7 @@ void WebViewTest::loadHtml(const char* html, const char* baseURI, WebKitWebView*
         m_activeURI = baseURI;
 
     if (!webView)
-        webView = m_webView;
+        webView = m_webView.get();
 
     webkit_web_view_load_html(webView, html, baseURI);
     g_assert_true(webkit_web_view_is_loading(webView));
@@ -108,9 +102,9 @@ void WebViewTest::loadHtml(const char* html, const char* baseURI, WebKitWebView*
 void WebViewTest::loadPlainText(const char* plainText)
 {
     m_activeURI = "about:blank";
-    webkit_web_view_load_plain_text(m_webView, plainText);
-    g_assert_true(webkit_web_view_is_loading(m_webView));
-    g_assert_cmpstr(webkit_web_view_get_uri(m_webView), ==, m_activeURI.data());
+    webkit_web_view_load_plain_text(m_webView.get(), plainText);
+    g_assert_true(webkit_web_view_is_loading(m_webView.get()));
+    g_assert_cmpstr(webkit_web_view_get_uri(m_webView.get()), ==, m_activeURI.data());
 }
 
 void WebViewTest::loadBytes(GBytes* bytes, const char* mimeType, const char* encoding, const char* baseURI)
@@ -119,67 +113,67 @@ void WebViewTest::loadBytes(GBytes* bytes, const char* mimeType, const char* enc
         m_activeURI = "about:blank";
     else
         m_activeURI = baseURI;
-    webkit_web_view_load_bytes(m_webView, bytes, mimeType, encoding, baseURI);
-    g_assert_true(webkit_web_view_is_loading(m_webView));
-    g_assert_cmpstr(webkit_web_view_get_uri(m_webView), ==, m_activeURI.data());
+    webkit_web_view_load_bytes(m_webView.get(), bytes, mimeType, encoding, baseURI);
+    g_assert_true(webkit_web_view_is_loading(m_webView.get()));
+    g_assert_cmpstr(webkit_web_view_get_uri(m_webView.get()), ==, m_activeURI.data());
 }
 
 void WebViewTest::loadRequest(WebKitURIRequest* request)
 {
     m_activeURI = webkit_uri_request_get_uri(request);
-    webkit_web_view_load_request(m_webView, request);
-    g_assert_true(webkit_web_view_is_loading(m_webView));
-    g_assert_cmpstr(webkit_web_view_get_uri(m_webView), ==, m_activeURI.data());
+    webkit_web_view_load_request(m_webView.get(), request);
+    g_assert_true(webkit_web_view_is_loading(m_webView.get()));
+    g_assert_cmpstr(webkit_web_view_get_uri(m_webView.get()), ==, m_activeURI.data());
 }
 
 void WebViewTest::loadAlternateHTML(const char* html, const char* contentURI, const char* baseURI)
 {
     m_activeURI = contentURI;
-    webkit_web_view_load_alternate_html(m_webView, html, contentURI, baseURI);
-    g_assert_true(webkit_web_view_is_loading(m_webView));
-    g_assert_cmpstr(webkit_web_view_get_uri(m_webView), ==, m_activeURI.data());
+    webkit_web_view_load_alternate_html(m_webView.get(), html, contentURI, baseURI);
+    g_assert_true(webkit_web_view_is_loading(m_webView.get()));
+    g_assert_cmpstr(webkit_web_view_get_uri(m_webView.get()), ==, m_activeURI.data());
 }
 
 void WebViewTest::goBack()
 {
-    bool canGoBack = webkit_web_view_can_go_back(m_webView);
+    bool canGoBack = webkit_web_view_can_go_back(m_webView.get());
     if (canGoBack) {
-        WebKitBackForwardList* list = webkit_web_view_get_back_forward_list(m_webView);
+        WebKitBackForwardList* list = webkit_web_view_get_back_forward_list(m_webView.get());
         WebKitBackForwardListItem* item = webkit_back_forward_list_get_nth_item(list, -1);
         m_activeURI = webkit_back_forward_list_item_get_original_uri(item);
     }
 
     // Call go_back even when can_go_back returns FALSE to check nothing happens.
-    webkit_web_view_go_back(m_webView);
+    webkit_web_view_go_back(m_webView.get());
     if (canGoBack) {
-        g_assert_true(webkit_web_view_is_loading(m_webView));
-        g_assert_cmpstr(webkit_web_view_get_uri(m_webView), ==, m_activeURI.data());
+        g_assert_true(webkit_web_view_is_loading(m_webView.get()));
+        g_assert_cmpstr(webkit_web_view_get_uri(m_webView.get()), ==, m_activeURI.data());
     }
 }
 
 void WebViewTest::goForward()
 {
-    bool canGoForward = webkit_web_view_can_go_forward(m_webView);
+    bool canGoForward = webkit_web_view_can_go_forward(m_webView.get());
     if (canGoForward) {
-        WebKitBackForwardList* list = webkit_web_view_get_back_forward_list(m_webView);
+        WebKitBackForwardList* list = webkit_web_view_get_back_forward_list(m_webView.get());
         WebKitBackForwardListItem* item = webkit_back_forward_list_get_nth_item(list, 1);
         m_activeURI = webkit_back_forward_list_item_get_original_uri(item);
     }
 
     // Call go_forward even when can_go_forward returns FALSE to check nothing happens.
-    webkit_web_view_go_forward(m_webView);
+    webkit_web_view_go_forward(m_webView.get());
     if (canGoForward) {
-        g_assert_true(webkit_web_view_is_loading(m_webView));
-        g_assert_cmpstr(webkit_web_view_get_uri(m_webView), ==, m_activeURI.data());
+        g_assert_true(webkit_web_view_is_loading(m_webView.get()));
+        g_assert_cmpstr(webkit_web_view_get_uri(m_webView.get()), ==, m_activeURI.data());
     }
 }
 
 void WebViewTest::goToBackForwardListItem(WebKitBackForwardListItem* item)
 {
     m_activeURI = webkit_back_forward_list_item_get_original_uri(item);
-    webkit_web_view_go_to_back_forward_list_item(m_webView, item);
-    g_assert_true(webkit_web_view_is_loading(m_webView));
-    g_assert_cmpstr(webkit_web_view_get_uri(m_webView), ==, m_activeURI.data());
+    webkit_web_view_go_to_back_forward_list_item(m_webView.get(), item);
+    g_assert_true(webkit_web_view_is_loading(m_webView.get()));
+    g_assert_cmpstr(webkit_web_view_get_uri(m_webView.get()), ==, m_activeURI.data());
 }
 
 void WebViewTest::quitMainLoop()
@@ -207,7 +201,7 @@ static void loadChanged(WebKitWebView* webView, WebKitLoadEvent loadEvent, WebVi
 void WebViewTest::waitUntilLoadFinished(WebKitWebView* webView)
 {
     if (!webView)
-        webView = m_webView;
+        webView = m_webView.get();
     g_signal_connect(webView, "load-changed", G_CALLBACK(loadChanged), this);
     g_main_loop_run(m_mainLoop);
 }
@@ -223,11 +217,11 @@ static void titleChanged(WebKitWebView* webView, GParamSpec*, WebViewTest* test)
 
 void WebViewTest::waitUntilTitleChangedTo(const char* expectedTitle)
 {
-    if (expectedTitle && !g_strcmp0(expectedTitle, webkit_web_view_get_title(m_webView)))
+    if (expectedTitle && !g_strcmp0(expectedTitle, webkit_web_view_get_title(m_webView.get())))
         return;
 
     m_expectedTitle = expectedTitle;
-    g_signal_connect(m_webView, "notify::title", G_CALLBACK(titleChanged), this);
+    g_signal_connect(m_webView.get(), "notify::title", G_CALLBACK(titleChanged), this);
     g_main_loop_run(m_mainLoop);
     m_expectedTitle = CString();
 }
@@ -245,23 +239,23 @@ static void isWebProcessResponsiveChanged(WebKitWebView* webView, GParamSpec*, W
 
 void WebViewTest::waitUntilIsWebProcessResponsiveChanged()
 {
-    g_signal_connect(m_webView, "notify::is-web-process-responsive", G_CALLBACK(isWebProcessResponsiveChanged), this);
+    g_signal_connect(m_webView.get(), "notify::is-web-process-responsive", G_CALLBACK(isWebProcessResponsiveChanged), this);
     g_main_loop_run(m_mainLoop);
 }
 
 void WebViewTest::selectAll()
 {
-    webkit_web_view_execute_editing_command(m_webView, "SelectAll");
+    webkit_web_view_execute_editing_command(m_webView.get(), "SelectAll");
 }
 
 bool WebViewTest::isEditable()
 {
-    return webkit_web_view_is_editable(m_webView);
+    return webkit_web_view_is_editable(m_webView.get());
 }
 
 void WebViewTest::setEditable(bool editable)
 {
-    webkit_web_view_set_editable(m_webView, editable);
+    webkit_web_view_set_editable(m_webView.get(), editable);
 }
 
 void WebViewTest::assertFileIsCreated(const char *filename)
@@ -315,7 +309,7 @@ const char* WebViewTest::mainResourceData(size_t& mainResourceDataSize)
 {
     m_resourceDataSize = 0;
     m_resourceData.reset();
-    WebKitWebResource* resource = webkit_web_view_get_main_resource(m_webView);
+    WebKitWebResource* resource = webkit_web_view_get_main_resource(m_webView.get());
     g_assert_nonnull(resource);
 
     webkit_web_resource_get_data(resource, 0, resourceGetDataCallback, this);
@@ -333,7 +327,7 @@ static void runJavaScriptReadyCallback(GObject* object, GAsyncResult* result, We
 
 static void runAsyncJavaScriptFunctionInWorldReadyCallback(GObject*, GAsyncResult* result, WebViewTest* test)
 {
-    test->m_javascriptResult = adoptGRef(webkit_web_view_call_async_javascript_function_finish(test->m_webView, result, test->m_javascriptError));
+    test->m_javascriptResult = adoptGRef(webkit_web_view_call_async_javascript_function_finish(test->webView(), result, test->m_javascriptError));
     g_main_loop_quit(test->m_mainLoop);
 }
 
@@ -341,7 +335,7 @@ JSCValue* WebViewTest::runJavaScriptAndWaitUntilFinished(const char* javascript,
 {
     m_javascriptResult = nullptr;
     m_javascriptError = error;
-    webkit_web_view_evaluate_javascript(m_webView, javascript, length, nullptr, nullptr, nullptr, reinterpret_cast<GAsyncReadyCallback>(runJavaScriptReadyCallback), this);
+    webkit_web_view_evaluate_javascript(m_webView.get(), javascript, length, nullptr, nullptr, nullptr, reinterpret_cast<GAsyncReadyCallback>(runJavaScriptReadyCallback), this);
     g_main_loop_run(m_mainLoop);
     return m_javascriptResult.get();
 }
@@ -351,7 +345,7 @@ JSCValue* WebViewTest::runJavaScriptAndWaitUntilFinished(const char* javascript,
     m_javascriptResult = nullptr;
     m_javascriptError = error;
     if (!webView)
-        webView = m_webView;
+        webView = m_webView.get();
     webkit_web_view_evaluate_javascript(webView, javascript, -1, nullptr, nullptr, nullptr, reinterpret_cast<GAsyncReadyCallback>(runJavaScriptReadyCallback), this);
     g_main_loop_run(m_mainLoop);
     return m_javascriptResult.get();
@@ -369,7 +363,7 @@ JSCValue* WebViewTest::runJavaScriptFromGResourceAndWaitUntilFinished(const char
     GUniquePtr<char> sourceURI(g_strdup_printf("resource://%s", resource));
 
     m_javascriptError = error;
-    webkit_web_view_evaluate_javascript(m_webView, reinterpret_cast<const char*>(script), length, nullptr, sourceURI.get(), nullptr, reinterpret_cast<GAsyncReadyCallback>(runJavaScriptReadyCallback), this);
+    webkit_web_view_evaluate_javascript(m_webView.get(), reinterpret_cast<const char*>(script), length, nullptr, sourceURI.get(), nullptr, reinterpret_cast<GAsyncReadyCallback>(runJavaScriptReadyCallback), this);
     g_main_loop_run(m_mainLoop);
     return m_javascriptResult.get();
 }
@@ -378,7 +372,7 @@ JSCValue* WebViewTest::runJavaScriptInWorldAndWaitUntilFinished(const char* java
 {
     m_javascriptResult = nullptr;
     m_javascriptError = error;
-    webkit_web_view_evaluate_javascript(m_webView, javascript, -1, world, sourceURI, nullptr, reinterpret_cast<GAsyncReadyCallback>(runJavaScriptReadyCallback), this);
+    webkit_web_view_evaluate_javascript(m_webView.get(), javascript, -1, world, sourceURI, nullptr, reinterpret_cast<GAsyncReadyCallback>(runJavaScriptReadyCallback), this);
     g_main_loop_run(m_mainLoop);
     return m_javascriptResult.get();
 }
@@ -387,7 +381,7 @@ JSCValue* WebViewTest::runAsyncJavaScriptFunctionInWorldAndWaitUntilFinished(con
 {
     m_javascriptResult = nullptr;
     m_javascriptError = error;
-    webkit_web_view_call_async_javascript_function(m_webView, body, -1, arguments, world, nullptr, nullptr, reinterpret_cast<GAsyncReadyCallback>(runAsyncJavaScriptFunctionInWorldReadyCallback), this);
+    webkit_web_view_call_async_javascript_function(m_webView.get(), body, -1, arguments, world, nullptr, nullptr, reinterpret_cast<GAsyncReadyCallback>(runAsyncJavaScriptFunctionInWorldReadyCallback), this);
     g_main_loop_run(m_mainLoop);
     return m_javascriptResult.get();
 }
@@ -396,14 +390,14 @@ JSCValue* WebViewTest::runJavaScriptWithoutForcedUserGesturesAndWaitUntilFinishe
 {
     m_javascriptResult = nullptr;
     m_javascriptError = error;
-    webkitWebViewRunJavascriptWithoutForcedUserGestures(m_webView, javascript, nullptr, reinterpret_cast<GAsyncReadyCallback>(runJavaScriptReadyCallback), this);
+    webkitWebViewRunJavascriptWithoutForcedUserGestures(m_webView.get(), javascript, nullptr, reinterpret_cast<GAsyncReadyCallback>(runJavaScriptReadyCallback), this);
     g_main_loop_run(m_mainLoop);
     return m_javascriptResult.get();
 }
 
 void WebViewTest::runJavaScriptAndWait(const char* javascript)
 {
-    webkit_web_view_evaluate_javascript(m_webView, javascript, -1, nullptr, nullptr, nullptr, nullptr, nullptr);
+    webkit_web_view_evaluate_javascript(m_webView.get(), javascript, -1, nullptr, nullptr, nullptr, nullptr, nullptr);
     g_main_loop_run(m_mainLoop);
 }
 
@@ -500,16 +494,16 @@ GRefPtr<GDBusProxy> WebViewTest::extensionProxy()
     GDBusConnection* connection = nullptr;
 
     // If nothing has been loaded yet, load about:blank to force the web process to be spawned.
-    if (!webkit_web_view_get_uri(m_webView)) {
+    if (!webkit_web_view_get_uri(m_webView.get())) {
         loadURI("about:blank");
         waitUntilLoadFinished();
 
-        connection = s_dbusConnectionPageMap.get(webkit_web_view_get_page_id(m_webView));
+        connection = s_dbusConnectionPageMap.get(webkit_web_view_get_page_id(m_webView.get()));
         if (!connection) {
             // Wait for page created signal.
             g_idle_add([](gpointer userData) -> gboolean {
                 auto* test = static_cast<WebViewTest*>(userData);
-                if (!s_dbusConnectionPageMap.get(webkit_web_view_get_page_id(test->m_webView)))
+                if (!s_dbusConnectionPageMap.get(webkit_web_view_get_page_id(test->webView())))
                     return TRUE;
 
                 test->quitMainLoop();
@@ -517,10 +511,10 @@ GRefPtr<GDBusProxy> WebViewTest::extensionProxy()
             }, this);
             g_main_loop_run(m_mainLoop);
             // FIXME: we can cache this once we can monitor the page id on the web view.
-            connection = s_dbusConnectionPageMap.get(webkit_web_view_get_page_id(m_webView));
+            connection = s_dbusConnectionPageMap.get(webkit_web_view_get_page_id(m_webView.get()));
         }
     } else
-        connection = s_dbusConnectionPageMap.get(webkit_web_view_get_page_id(m_webView));
+        connection = s_dbusConnectionPageMap.get(webkit_web_view_get_page_id(m_webView.get()));
 
     return adoptGRef(g_dbus_proxy_new_sync(connection, static_cast<GDBusProxyFlags>(G_DBUS_PROXY_FLAGS_DO_NOT_LOAD_PROPERTIES | G_DBUS_PROXY_FLAGS_DO_NOT_CONNECT_SIGNALS),
         nullptr, nullptr, "/org/webkit/gtk/WebProcessExtensionTest", "org.webkit.gtk.WebProcessExtensionTest", nullptr, nullptr));

--- a/Tools/TestWebKitAPI/glib/WebKitGLib/WebViewTest.h
+++ b/Tools/TestWebKitAPI/glib/WebKitGLib/WebViewTest.h
@@ -32,8 +32,8 @@ public:
     static bool shouldInitializeWebViewInConstructor;
     static bool shouldCreateEphemeralWebView;
     void initializeWebView();
+    WebKitWebView* webView() const { return m_webView.get(); }
 
-    void platformInitializeWebView();
     void platformDestroy();
 
     virtual void loadURI(const char* uri);
@@ -111,7 +111,7 @@ public:
     GRefPtr<GDBusProxy> extensionProxy();
 
     GRefPtr<WebKitUserContentManager> m_userContentManager;
-    WebKitWebView* m_webView { nullptr };
+    GRefPtr<WebKitWebView> m_webView;
     GMainLoop* m_mainLoop;
     CString m_activeURI;
     CString m_expectedTitle;

--- a/Tools/TestWebKitAPI/glib/WebKitGLib/gtk/WebViewTestGtk.cpp
+++ b/Tools/TestWebKitAPI/glib/WebKitGLib/gtk/WebViewTestGtk.cpp
@@ -37,13 +37,6 @@ void WebViewTest::platformDestroy()
 #endif
 }
 
-void WebViewTest::platformInitializeWebView()
-{
-    g_assert_true(WEBKIT_WEB_VIEW(m_webView));
-    g_assert_true(g_object_is_floating(m_webView));
-    g_object_ref_sink(m_webView);
-}
-
 void WebViewTest::quitMainLoopAfterProcessingPendingEvents()
 {
     while (g_main_context_pending(nullptr))
@@ -54,17 +47,17 @@ void WebViewTest::quitMainLoopAfterProcessingPendingEvents()
 void WebViewTest::resizeView(int width, int height)
 {
     GtkAllocation allocation;
-    gtk_widget_get_allocation(GTK_WIDGET(m_webView), &allocation);
+    gtk_widget_get_allocation(GTK_WIDGET(m_webView.get()), &allocation);
     if (width != -1)
         allocation.width = width;
     if (height != -1)
         allocation.height = height;
-    gtk_widget_size_allocate(GTK_WIDGET(m_webView), &allocation);
+    gtk_widget_size_allocate(GTK_WIDGET(m_webView.get()), &allocation);
 }
 
 void WebViewTest::hideView()
 {
-    gtk_widget_hide(GTK_WIDGET(m_webView));
+    gtk_widget_hide(GTK_WIDGET(m_webView.get()));
 }
 
 void WebViewTest::showInWindow(int width, int height)
@@ -72,11 +65,11 @@ void WebViewTest::showInWindow(int width, int height)
     g_assert_null(m_parentWindow);
 #if USE(GTK4)
     m_parentWindow = gtk_window_new();
-    gtk_window_set_child(GTK_WINDOW(m_parentWindow), GTK_WIDGET(m_webView));
+    gtk_window_set_child(GTK_WINDOW(m_parentWindow), GTK_WIDGET(m_webView.get()));
 #else
     m_parentWindow = gtk_window_new(GTK_WINDOW_TOPLEVEL);
-    gtk_container_add(GTK_CONTAINER(m_parentWindow), GTK_WIDGET(m_webView));
-    gtk_widget_show(GTK_WIDGET(m_webView));
+    gtk_container_add(GTK_CONTAINER(m_parentWindow), GTK_WIDGET(m_webView.get()));
+    gtk_widget_show(GTK_WIDGET(m_webView.get()));
 #endif
 
     if (width && height)
@@ -91,18 +84,18 @@ void WebViewTest::showInWindow(int width, int height)
 void WebViewTest::mouseMoveTo(int x, int y, unsigned mouseModifiers)
 {
     g_assert_nonnull(m_parentWindow);
-    webkitWebViewBaseSynthesizeMouseEvent(WEBKIT_WEB_VIEW_BASE(m_webView), MouseEventType::Motion, 0, 0, x, y, mouseModifiers, 0);
+    webkitWebViewBaseSynthesizeMouseEvent(WEBKIT_WEB_VIEW_BASE(m_webView.get()), MouseEventType::Motion, 0, 0, x, y, mouseModifiers, 0);
 }
 
 void WebViewTest::clickMouseButton(int x, int y, unsigned button, unsigned mouseModifiers)
 {
-    webkitWebViewBaseSynthesizeMouseEvent(WEBKIT_WEB_VIEW_BASE(m_webView), MouseEventType::Press, button, 1 << (8 + button - 1), x, y, mouseModifiers, 1);
-    webkitWebViewBaseSynthesizeMouseEvent(WEBKIT_WEB_VIEW_BASE(m_webView), MouseEventType::Release, button, 0, x, y, mouseModifiers, 0);
+    webkitWebViewBaseSynthesizeMouseEvent(WEBKIT_WEB_VIEW_BASE(m_webView.get()), MouseEventType::Press, button, 1 << (8 + button - 1), x, y, mouseModifiers, 1);
+    webkitWebViewBaseSynthesizeMouseEvent(WEBKIT_WEB_VIEW_BASE(m_webView.get()), MouseEventType::Release, button, 0, x, y, mouseModifiers, 0);
 }
 
 void WebViewTest::emitPopupMenuSignal()
 {
-    GtkWidget* viewWidget = GTK_WIDGET(m_webView);
+    GtkWidget* viewWidget = GTK_WIDGET(m_webView.get());
     g_assert_true(gtk_widget_get_realized(viewWidget));
 
     gboolean handled;
@@ -112,5 +105,5 @@ void WebViewTest::emitPopupMenuSignal()
 void WebViewTest::keyStroke(unsigned keyVal, unsigned keyModifiers)
 {
     g_assert_nonnull(m_parentWindow);
-    webkitWebViewBaseSynthesizeKeyEvent(WEBKIT_WEB_VIEW_BASE(m_webView), KeyEventType::Insert, keyVal, keyModifiers, ShouldTranslateKeyboardState::No);
+    webkitWebViewBaseSynthesizeKeyEvent(WEBKIT_WEB_VIEW_BASE(m_webView.get()), KeyEventType::Insert, keyVal, keyModifiers, ShouldTranslateKeyboardState::No);
 }

--- a/Tools/TestWebKitAPI/glib/WebKitGLib/wpe/WebViewTestWPE.cpp
+++ b/Tools/TestWebKitAPI/glib/WebKitGLib/wpe/WebViewTestWPE.cpp
@@ -26,10 +26,6 @@ void WebViewTest::platformDestroy()
 {
 }
 
-void WebViewTest::platformInitializeWebView()
-{
-}
-
 void WebViewTest::quitMainLoopAfterProcessingPendingEvents()
 {
     // FIXME: implement if needed.
@@ -43,13 +39,13 @@ void WebViewTest::resizeView(int width, int height)
 
 void WebViewTest::showInWindow(int, int)
 {
-    auto* backend = webkit_web_view_backend_get_wpe_backend(webkit_web_view_get_backend(m_webView));
+    auto* backend = webkit_web_view_backend_get_wpe_backend(webkit_web_view_get_backend(m_webView.get()));
     wpe_view_backend_add_activity_state(backend, wpe_view_activity_state_visible | wpe_view_activity_state_in_window | wpe_view_activity_state_focused);
 }
 
 void WebViewTest::hideView()
 {
-    auto* backend = webkit_web_view_backend_get_wpe_backend(webkit_web_view_get_backend(m_webView));
+    auto* backend = webkit_web_view_backend_get_wpe_backend(webkit_web_view_get_backend(m_webView.get()));
     wpe_view_backend_remove_activity_state(backend, wpe_view_activity_state_visible | wpe_view_activity_state_focused);
 }
 
@@ -60,7 +56,7 @@ void WebViewTest::mouseMoveTo(int x, int y, unsigned mouseModifiers)
 
 void WebViewTest::clickMouseButton(int x, int y, unsigned button, unsigned mouseModifiers)
 {
-    auto* backend = webkit_web_view_backend_get_wpe_backend(webkit_web_view_get_backend(m_webView));
+    auto* backend = webkit_web_view_backend_get_wpe_backend(webkit_web_view_get_backend(m_webView.get()));
     struct wpe_input_pointer_event event { wpe_input_pointer_event_type_button, 0, x, y, button, 1, mouseModifiers };
     wpe_view_backend_dispatch_pointer_event(backend, &event);
     event.state = 0;
@@ -69,7 +65,7 @@ void WebViewTest::clickMouseButton(int x, int y, unsigned button, unsigned mouse
 
 void WebViewTest::keyStroke(unsigned keyVal, unsigned keyModifiers)
 {
-    auto* backend = webkit_web_view_backend_get_wpe_backend(webkit_web_view_get_backend(m_webView));
+    auto* backend = webkit_web_view_backend_get_wpe_backend(webkit_web_view_get_backend(m_webView.get()));
     struct wpe_input_xkb_keymap_entry* entries;
     uint32_t entriesCount;
     wpe_input_xkb_context_get_entries_for_key_code(wpe_input_xkb_context_get_default(), keyVal, &entries, &entriesCount);


### PR DESCRIPTION
#### 0895e14042e419cc3000ac8810c9ed235d9a9430
<pre>
[GTK][WPE] Simplify the web view creation in GLib API tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=293480">https://bugs.webkit.org/show_bug.cgi?id=293480</a>

Reviewed by Adrian Perez de Castro.

Remove all createWebView static functions and add a non-static one that
receives construct parameters and automatically sets the web-context and
network-session when not provided. In the case of WPE it always sets the
backend too. This function returns a GRefPtr so we no longer need the
adoptView() function. This simplifies the web view creation in tests and
will easily allow to add support for running API tests with new WPE API.

Canonical link: <a href="https://commits.webkit.org/295332@main">https://commits.webkit.org/295332@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0a9d62c5c4ac857c3fdc09361a720981f5d542d2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104808 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24521 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/14942 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110023 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/55482 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/106848 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/24919 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33066 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/79581 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/55482 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107814 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19371 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/94590 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59888 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/12667 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/54865 "Built successfully") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/12714 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/112432 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/31973 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/23507 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/88660 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32337 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/90816 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88287 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33178 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/10947 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/27286 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16998 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/31898 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/31690 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/35031 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/33249 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->