### PR TITLE
Add NetworkProcess::checkedNetworkSession()

### DIFF
--- a/Source/WebKit/NetworkProcess/Downloads/cocoa/DownloadCocoa.mm
+++ b/Source/WebKit/NetworkProcess/Downloads/cocoa/DownloadCocoa.mm
@@ -45,7 +45,7 @@ void Download::resume(std::span<const uint8_t> resumeData, const String& path, S
     if (RefPtr extension = m_sandboxExtension)
         extension->consume();
 
-    auto* networkSession = m_downloadManager->protectedClient()->networkSession(m_sessionID);
+    CheckedPtr networkSession = m_downloadManager->protectedClient()->networkSession(m_sessionID);
     if (!networkSession) {
         WTFLogAlways("Could not find network session with given session ID");
         return;

--- a/Source/WebKit/NetworkProcess/NetworkProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
@@ -395,7 +395,7 @@ void NetworkProcess::createNetworkConnectionToWebProcess(ProcessIdentifier ident
     for (auto pageID : parameters.pagesWithRelaxedThirdPartyCookieBlocking)
         m_pagesWithRelaxedThirdPartyCookieBlocking.add(pageID);
 
-    if (auto* session = networkSession(sessionID)) {
+    if (auto session = checkedNetworkSession(sessionID)) {
         Vector<WebCore::RegistrableDomain> allowedSites;
         auto iter = m_allowedFirstPartiesForCookies.find(identifier);
         if (iter != m_allowedFirstPartiesForCookies.end()) {
@@ -605,6 +605,11 @@ NetworkSession* NetworkProcess::networkSession(PAL::SessionID sessionID) const
     return m_networkSessions.get(sessionID);
 }
 
+CheckedPtr<NetworkSession> NetworkProcess::checkedNetworkSession(PAL::SessionID sessionID) const
+{
+    return networkSession(sessionID);
+}
+
 void NetworkProcess::setSession(PAL::SessionID sessionID, std::unique_ptr<NetworkSession>&& session)
 {
     ASSERT(RunLoop::isMain());
@@ -652,7 +657,7 @@ void NetworkProcess::ensureSessionWithDataStoreIdentifierRemoved(WTF::UUID ident
 
 void NetworkProcess::registrableDomainsWithLastAccessedTime(PAL::SessionID sessionID, CompletionHandler<void(std::optional<HashMap<RegistrableDomain, WallTime>>&&)>&& completionHandler)
 {
-    if (auto* session = networkSession(sessionID)) {
+    if (auto session = checkedNetworkSession(sessionID)) {
         if (auto* resourceLoadStatistics = session->resourceLoadStatistics()) {
             resourceLoadStatistics->registrableDomainsWithLastAccessedTime(WTFMove(completionHandler));
             return;
@@ -663,7 +668,7 @@ void NetworkProcess::registrableDomainsWithLastAccessedTime(PAL::SessionID sessi
 
 void NetworkProcess::registrableDomainsExemptFromWebsiteDataDeletion(PAL::SessionID sessionID, CompletionHandler<void(HashSet<RegistrableDomain>)>&& completionHandler)
 {
-    if (auto* session = networkSession(sessionID)) {
+    if (auto session = checkedNetworkSession(sessionID)) {
         if (auto* resourceLoadStatistics = session->resourceLoadStatistics()) {
             resourceLoadStatistics->registrableDomainsExemptFromWebsiteDataDeletion(WTFMove(completionHandler));
             return;
@@ -674,7 +679,7 @@ void NetworkProcess::registrableDomainsExemptFromWebsiteDataDeletion(PAL::Sessio
 
 void NetworkProcess::dumpResourceLoadStatistics(PAL::SessionID sessionID, CompletionHandler<void(String)>&& completionHandler)
 {
-    if (auto* session = networkSession(sessionID)) {
+    if (auto session = checkedNetworkSession(sessionID)) {
         if (auto* resourceLoadStatistics = session->resourceLoadStatistics())
             resourceLoadStatistics->dumpResourceLoadStatistics(WTFMove(completionHandler));
         else
@@ -694,7 +699,7 @@ void NetworkProcess::updatePrevalentDomainsToBlockCookiesFor(PAL::SessionID sess
 
 void NetworkProcess::isGrandfathered(PAL::SessionID sessionID, RegistrableDomain&& domain, CompletionHandler<void(bool)>&& completionHandler)
 {
-    if (auto* session = networkSession(sessionID)) {
+    if (auto session = checkedNetworkSession(sessionID)) {
         if (auto* resourceLoadStatistics = session->resourceLoadStatistics())
             resourceLoadStatistics->isGrandfathered(WTFMove(domain), WTFMove(completionHandler));
         else
@@ -707,7 +712,7 @@ void NetworkProcess::isGrandfathered(PAL::SessionID sessionID, RegistrableDomain
 
 void NetworkProcess::isPrevalentResource(PAL::SessionID sessionID, RegistrableDomain&& domain, CompletionHandler<void(bool)>&& completionHandler)
 {
-    if (auto* session = networkSession(sessionID)) {
+    if (auto session = checkedNetworkSession(sessionID)) {
         if (auto* resourceLoadStatistics = session->resourceLoadStatistics())
             resourceLoadStatistics->isPrevalentResource(WTFMove(domain), WTFMove(completionHandler));
         else
@@ -720,7 +725,7 @@ void NetworkProcess::isPrevalentResource(PAL::SessionID sessionID, RegistrableDo
 
 void NetworkProcess::isVeryPrevalentResource(PAL::SessionID sessionID, RegistrableDomain&& domain, CompletionHandler<void(bool)>&& completionHandler)
 {
-    if (auto* session = networkSession(sessionID)) {
+    if (auto session = checkedNetworkSession(sessionID)) {
         if (auto* resourceLoadStatistics = session->resourceLoadStatistics())
             resourceLoadStatistics->isVeryPrevalentResource(WTFMove(domain), WTFMove(completionHandler));
         else
@@ -733,7 +738,7 @@ void NetworkProcess::isVeryPrevalentResource(PAL::SessionID sessionID, Registrab
 
 void NetworkProcess::setGrandfathered(PAL::SessionID sessionID, RegistrableDomain&& domain, bool isGrandfathered, CompletionHandler<void()>&& completionHandler)
 {
-    if (auto* session = networkSession(sessionID)) {
+    if (auto session = checkedNetworkSession(sessionID)) {
         if (auto* resourceLoadStatistics = session->resourceLoadStatistics())
             resourceLoadStatistics->setGrandfathered(WTFMove(domain), isGrandfathered, WTFMove(completionHandler));
         else
@@ -746,7 +751,7 @@ void NetworkProcess::setGrandfathered(PAL::SessionID sessionID, RegistrableDomai
 
 void NetworkProcess::setPrevalentResource(PAL::SessionID sessionID, RegistrableDomain&& domain, CompletionHandler<void()>&& completionHandler)
 {
-    if (auto* session = networkSession(sessionID)) {
+    if (auto session = checkedNetworkSession(sessionID)) {
         if (auto* resourceLoadStatistics = session->resourceLoadStatistics())
             resourceLoadStatistics->setPrevalentResource(WTFMove(domain), WTFMove(completionHandler));
         else
@@ -759,7 +764,7 @@ void NetworkProcess::setPrevalentResource(PAL::SessionID sessionID, RegistrableD
 
 void NetworkProcess::setPrevalentResourceForDebugMode(PAL::SessionID sessionID, RegistrableDomain&& domain, CompletionHandler<void()>&& completionHandler)
 {
-    if (auto* session = networkSession(sessionID)) {
+    if (auto session = checkedNetworkSession(sessionID)) {
         if (auto* resourceLoadStatistics = session->resourceLoadStatistics())
             resourceLoadStatistics->setPrevalentResourceForDebugMode(WTFMove(domain), WTFMove(completionHandler));
         else
@@ -772,7 +777,7 @@ void NetworkProcess::setPrevalentResourceForDebugMode(PAL::SessionID sessionID, 
 
 void NetworkProcess::setVeryPrevalentResource(PAL::SessionID sessionID, RegistrableDomain&& domain, CompletionHandler<void()>&& completionHandler)
 {
-    if (auto* session = networkSession(sessionID)) {
+    if (auto session = checkedNetworkSession(sessionID)) {
         if (auto* resourceLoadStatistics = session->resourceLoadStatistics())
             resourceLoadStatistics->setVeryPrevalentResource(WTFMove(domain), WTFMove(completionHandler));
         else
@@ -785,7 +790,7 @@ void NetworkProcess::setVeryPrevalentResource(PAL::SessionID sessionID, Registra
 
 void NetworkProcess::clearPrevalentResource(PAL::SessionID sessionID, RegistrableDomain&& domain, CompletionHandler<void()>&& completionHandler)
 {
-    if (auto* session = networkSession(sessionID)) {
+    if (auto session = checkedNetworkSession(sessionID)) {
         if (auto* resourceLoadStatistics = session->resourceLoadStatistics())
             resourceLoadStatistics->clearPrevalentResource(WTFMove(domain), WTFMove(completionHandler));
         else
@@ -798,7 +803,7 @@ void NetworkProcess::clearPrevalentResource(PAL::SessionID sessionID, Registrabl
 
 void NetworkProcess::scheduleCookieBlockingUpdate(PAL::SessionID sessionID, CompletionHandler<void()>&& completionHandler)
 {
-    if (auto* session = networkSession(sessionID)) {
+    if (auto session = checkedNetworkSession(sessionID)) {
         if (auto* resourceLoadStatistics = session->resourceLoadStatistics())
             resourceLoadStatistics->scheduleCookieBlockingUpdate(WTFMove(completionHandler));
         else
@@ -811,7 +816,7 @@ void NetworkProcess::scheduleCookieBlockingUpdate(PAL::SessionID sessionID, Comp
 
 void NetworkProcess::scheduleClearInMemoryAndPersistent(PAL::SessionID sessionID, std::optional<WallTime> modifiedSince, ShouldGrandfatherStatistics shouldGrandfather, CompletionHandler<void()>&& completionHandler)
 {
-    if (auto* session = networkSession(sessionID)) {
+    if (auto session = checkedNetworkSession(sessionID)) {
         session->clearIsolatedSessions();
         if (auto* resourceLoadStatistics = session->resourceLoadStatistics()) {
             if (modifiedSince)
@@ -828,7 +833,7 @@ void NetworkProcess::scheduleClearInMemoryAndPersistent(PAL::SessionID sessionID
 
 void NetworkProcess::getResourceLoadStatisticsDataSummary(PAL::SessionID sessionID, CompletionHandler<void(Vector<ITPThirdPartyData>&&)>&& completionHandler)
 {
-    if (auto* session = networkSession(sessionID)) {
+    if (auto session = checkedNetworkSession(sessionID)) {
         if (auto* resourceLoadStatistics = session->resourceLoadStatistics())
             resourceLoadStatistics->aggregatedThirdPartyData(WTFMove(completionHandler));
         else
@@ -841,7 +846,7 @@ void NetworkProcess::getResourceLoadStatisticsDataSummary(PAL::SessionID session
 
 void NetworkProcess::resetParametersToDefaultValues(PAL::SessionID sessionID, CompletionHandler<void()>&& completionHandler)
 {
-    if (auto* session = networkSession(sessionID)) {
+    if (auto session = checkedNetworkSession(sessionID)) {
         session->resetFirstPartyDNSData();
         if (auto* resourceLoadStatistics = session->resourceLoadStatistics())
             resourceLoadStatistics->resetParametersToDefaultValues(WTFMove(completionHandler));
@@ -855,7 +860,7 @@ void NetworkProcess::resetParametersToDefaultValues(PAL::SessionID sessionID, Co
 
 void NetworkProcess::scheduleStatisticsAndDataRecordsProcessing(PAL::SessionID sessionID, CompletionHandler<void()>&& completionHandler)
 {
-    if (auto* session = networkSession(sessionID)) {
+    if (auto session = checkedNetworkSession(sessionID)) {
         if (auto* resourceLoadStatistics = session->resourceLoadStatistics())
             resourceLoadStatistics->scheduleStatisticsAndDataRecordsProcessing(WTFMove(completionHandler));
         else
@@ -868,7 +873,7 @@ void NetworkProcess::scheduleStatisticsAndDataRecordsProcessing(PAL::SessionID s
 
 void NetworkProcess::statisticsDatabaseHasAllTables(PAL::SessionID sessionID, CompletionHandler<void(bool)>&& completionHandler)
 {
-    if (auto* session = networkSession(sessionID)) {
+    if (auto session = checkedNetworkSession(sessionID)) {
         if (auto* resourceLoadStatistics = session->resourceLoadStatistics())
             resourceLoadStatistics->statisticsDatabaseHasAllTables(WTFMove(completionHandler));
         else
@@ -881,7 +886,7 @@ void NetworkProcess::statisticsDatabaseHasAllTables(PAL::SessionID sessionID, Co
 
 void NetworkProcess::setResourceLoadStatisticsTimeAdvanceForTesting(PAL::SessionID sessionID, Seconds time, CompletionHandler<void()>&& completionHandler)
 {
-    if (auto* session = networkSession(sessionID)) {
+    if (auto session = checkedNetworkSession(sessionID)) {
         if (auto* resourceLoadStatistics = session->resourceLoadStatistics())
             return resourceLoadStatistics->setTimeAdvanceForTesting(time, WTFMove(completionHandler));
     }
@@ -890,7 +895,7 @@ void NetworkProcess::setResourceLoadStatisticsTimeAdvanceForTesting(PAL::Session
 
 void NetworkProcess::setIsRunningResourceLoadStatisticsTest(PAL::SessionID sessionID, bool value, CompletionHandler<void()>&& completionHandler)
 {
-    if (auto* session = networkSession(sessionID)) {
+    if (auto session = checkedNetworkSession(sessionID)) {
         if (auto* resourceLoadStatistics = session->resourceLoadStatistics())
             resourceLoadStatistics->setIsRunningTest(value, WTFMove(completionHandler));
         else
@@ -903,7 +908,7 @@ void NetworkProcess::setIsRunningResourceLoadStatisticsTest(PAL::SessionID sessi
 
 void NetworkProcess::setSubframeUnderTopFrameDomain(PAL::SessionID sessionID, RegistrableDomain&& subFrameDomain, RegistrableDomain&& topFrameDomain, CompletionHandler<void()>&& completionHandler)
 {
-    if (auto* session = networkSession(sessionID)) {
+    if (auto session = checkedNetworkSession(sessionID)) {
         if (auto* resourceLoadStatistics = session->resourceLoadStatistics())
             resourceLoadStatistics->setSubframeUnderTopFrameDomain(WTFMove(subFrameDomain), WTFMove(topFrameDomain), WTFMove(completionHandler));
         else
@@ -916,7 +921,7 @@ void NetworkProcess::setSubframeUnderTopFrameDomain(PAL::SessionID sessionID, Re
 
 void NetworkProcess::isRegisteredAsRedirectingTo(PAL::SessionID sessionID, RegistrableDomain&& domainRedirectedFrom, RegistrableDomain&& domainRedirectedTo, CompletionHandler<void(bool)>&& completionHandler)
 {
-    if (auto* session = networkSession(sessionID)) {
+    if (auto session = checkedNetworkSession(sessionID)) {
         if (auto* resourceLoadStatistics = session->resourceLoadStatistics())
             resourceLoadStatistics->isRegisteredAsRedirectingTo(WTFMove(domainRedirectedFrom), WTFMove(domainRedirectedTo), WTFMove(completionHandler));
         else
@@ -929,7 +934,7 @@ void NetworkProcess::isRegisteredAsRedirectingTo(PAL::SessionID sessionID, Regis
 
 void NetworkProcess::isRegisteredAsSubFrameUnder(PAL::SessionID sessionID, RegistrableDomain&& subFrameDomain, RegistrableDomain&& topFrameDomain, CompletionHandler<void(bool)>&& completionHandler)
 {
-    if (auto* session = networkSession(sessionID)) {
+    if (auto session = checkedNetworkSession(sessionID)) {
         if (auto* resourceLoadStatistics = session->resourceLoadStatistics())
             resourceLoadStatistics->isRegisteredAsSubFrameUnder(WTFMove(subFrameDomain), WTFMove(topFrameDomain), WTFMove(completionHandler));
         else
@@ -942,7 +947,7 @@ void NetworkProcess::isRegisteredAsSubFrameUnder(PAL::SessionID sessionID, Regis
 
 void NetworkProcess::setSubresourceUnderTopFrameDomain(PAL::SessionID sessionID, RegistrableDomain&& subresourceDomain, RegistrableDomain&& topFrameDomain, CompletionHandler<void()>&& completionHandler)
 {
-    if (auto* session = networkSession(sessionID)) {
+    if (auto session = checkedNetworkSession(sessionID)) {
         if (auto* resourceLoadStatistics = session->resourceLoadStatistics())
             resourceLoadStatistics->setSubresourceUnderTopFrameDomain(WTFMove(subresourceDomain), WTFMove(topFrameDomain), WTFMove(completionHandler));
         else
@@ -955,7 +960,7 @@ void NetworkProcess::setSubresourceUnderTopFrameDomain(PAL::SessionID sessionID,
 
 void NetworkProcess::setSubresourceUniqueRedirectTo(PAL::SessionID sessionID, RegistrableDomain&& subresourceDomain, RegistrableDomain&& domainRedirectedTo, CompletionHandler<void()>&& completionHandler)
 {
-    if (auto* session = networkSession(sessionID)) {
+    if (auto session = checkedNetworkSession(sessionID)) {
         if (auto* resourceLoadStatistics = session->resourceLoadStatistics())
             resourceLoadStatistics->setSubresourceUniqueRedirectTo(WTFMove(subresourceDomain), WTFMove(domainRedirectedTo), WTFMove(completionHandler));
         else
@@ -968,7 +973,7 @@ void NetworkProcess::setSubresourceUniqueRedirectTo(PAL::SessionID sessionID, Re
 
 void NetworkProcess::setSubresourceUniqueRedirectFrom(PAL::SessionID sessionID, RegistrableDomain&& subresourceDomain, RegistrableDomain&& domainRedirectedFrom, CompletionHandler<void()>&& completionHandler)
 {
-    if (auto* session = networkSession(sessionID)) {
+    if (auto session = checkedNetworkSession(sessionID)) {
         if (auto* resourceLoadStatistics = session->resourceLoadStatistics())
             resourceLoadStatistics->setSubresourceUniqueRedirectFrom(WTFMove(subresourceDomain), WTFMove(domainRedirectedFrom), WTFMove(completionHandler));
         else
@@ -981,7 +986,7 @@ void NetworkProcess::setSubresourceUniqueRedirectFrom(PAL::SessionID sessionID, 
 
 void NetworkProcess::isRegisteredAsSubresourceUnder(PAL::SessionID sessionID, RegistrableDomain&& subresourceDomain, RegistrableDomain&& topFrameDomain, CompletionHandler<void(bool)>&& completionHandler)
 {
-    if (auto* session = networkSession(sessionID)) {
+    if (auto session = checkedNetworkSession(sessionID)) {
         if (auto* resourceLoadStatistics = session->resourceLoadStatistics())
             resourceLoadStatistics->isRegisteredAsSubresourceUnder(WTFMove(subresourceDomain), WTFMove(topFrameDomain), WTFMove(completionHandler));
         else
@@ -994,7 +999,7 @@ void NetworkProcess::isRegisteredAsSubresourceUnder(PAL::SessionID sessionID, Re
 
 void NetworkProcess::setTopFrameUniqueRedirectTo(PAL::SessionID sessionID, RegistrableDomain&& topFrameDomain, RegistrableDomain&& domainRedirectedTo, CompletionHandler<void()>&& completionHandler)
 {
-    if (auto* session = networkSession(sessionID)) {
+    if (auto session = checkedNetworkSession(sessionID)) {
         if (auto* resourceLoadStatistics = session->resourceLoadStatistics())
             resourceLoadStatistics->setTopFrameUniqueRedirectTo(WTFMove(topFrameDomain), WTFMove(domainRedirectedTo), WTFMove(completionHandler));
         else
@@ -1007,7 +1012,7 @@ void NetworkProcess::setTopFrameUniqueRedirectTo(PAL::SessionID sessionID, Regis
 
 void NetworkProcess::setTopFrameUniqueRedirectFrom(PAL::SessionID sessionID, RegistrableDomain&& topFrameDomain, RegistrableDomain&& domainRedirectedFrom, CompletionHandler<void()>&& completionHandler)
 {
-    if (auto* session = networkSession(sessionID)) {
+    if (auto session = checkedNetworkSession(sessionID)) {
         if (auto* resourceLoadStatistics = session->resourceLoadStatistics())
             resourceLoadStatistics->setTopFrameUniqueRedirectFrom(WTFMove(topFrameDomain), WTFMove(domainRedirectedFrom), WTFMove(completionHandler));
         else
@@ -1021,7 +1026,7 @@ void NetworkProcess::setTopFrameUniqueRedirectFrom(PAL::SessionID sessionID, Reg
     
 void NetworkProcess::setLastSeen(PAL::SessionID sessionID, RegistrableDomain&& domain, Seconds seconds, CompletionHandler<void()>&& completionHandler)
 {
-    if (auto* session = networkSession(sessionID)) {
+    if (auto session = checkedNetworkSession(sessionID)) {
         if (auto* resourceLoadStatistics = session->resourceLoadStatistics())
             resourceLoadStatistics->setLastSeen(WTFMove(domain), seconds, WTFMove(completionHandler));
         else
@@ -1034,7 +1039,7 @@ void NetworkProcess::setLastSeen(PAL::SessionID sessionID, RegistrableDomain&& d
 
 void NetworkProcess::domainIDExistsInDatabase(PAL::SessionID sessionID, int domainID, CompletionHandler<void(bool)>&& completionHandler)
 {
-    if (auto* session = networkSession(sessionID)) {
+    if (auto session = checkedNetworkSession(sessionID)) {
         if (auto* resourceLoadStatistics = session->resourceLoadStatistics())
             resourceLoadStatistics->domainIDExistsInDatabase(domainID, WTFMove(completionHandler));
         else
@@ -1047,7 +1052,7 @@ void NetworkProcess::domainIDExistsInDatabase(PAL::SessionID sessionID, int doma
 
 void NetworkProcess::mergeStatisticForTesting(PAL::SessionID sessionID, RegistrableDomain&& domain, RegistrableDomain&& topFrameDomain1, RegistrableDomain&& topFrameDomain2, Seconds lastSeen, bool hadUserInteraction, Seconds mostRecentUserInteraction, bool isGrandfathered, bool isPrevalent, bool isVeryPrevalent, uint64_t dataRecordsRemoved, CompletionHandler<void()>&& completionHandler)
 {
-    if (auto* session = networkSession(sessionID)) {
+    if (auto session = checkedNetworkSession(sessionID)) {
         if (auto* resourceLoadStatistics = session->resourceLoadStatistics())
             resourceLoadStatistics->mergeStatisticForTesting(WTFMove(domain), WTFMove(topFrameDomain1), WTFMove(topFrameDomain2), lastSeen, hadUserInteraction, mostRecentUserInteraction, isGrandfathered, isPrevalent, isVeryPrevalent, unsigned(dataRecordsRemoved), WTFMove(completionHandler));
         else
@@ -1060,7 +1065,7 @@ void NetworkProcess::mergeStatisticForTesting(PAL::SessionID sessionID, Registra
 
 void NetworkProcess::insertExpiredStatisticForTesting(PAL::SessionID sessionID, RegistrableDomain&& domain, uint64_t numberOfOperatingDaysPassed, bool hadUserInteraction, bool isScheduledForAllButCookieDataRemoval, bool isPrevalent, CompletionHandler<void()>&& completionHandler)
 {
-    if (auto* session = networkSession(sessionID)) {
+    if (auto session = checkedNetworkSession(sessionID)) {
         if (auto* resourceLoadStatistics = session->resourceLoadStatistics())
             resourceLoadStatistics->insertExpiredStatisticForTesting(WTFMove(domain), unsigned(numberOfOperatingDaysPassed), hadUserInteraction, isScheduledForAllButCookieDataRemoval, isPrevalent, WTFMove(completionHandler));
         else
@@ -1083,7 +1088,7 @@ void NetworkProcess::getAllStorageAccessEntries(PAL::SessionID sessionID, Comple
 
 void NetworkProcess::logFrameNavigation(PAL::SessionID sessionID, RegistrableDomain&& targetDomain, RegistrableDomain&& topFrameDomain, RegistrableDomain&& sourceDomain, bool isRedirect, bool isMainFrame, Seconds delayAfterMainFrameDocumentLoad, bool wasPotentiallyInitiatedByUser)
 {
-    if (auto* session = networkSession(sessionID)) {
+    if (auto session = checkedNetworkSession(sessionID)) {
         if (auto* resourceLoadStatistics = session->resourceLoadStatistics())
             resourceLoadStatistics->logFrameNavigation(WTFMove(targetDomain), WTFMove(topFrameDomain), WTFMove(sourceDomain), isRedirect, isMainFrame, delayAfterMainFrameDocumentLoad, wasPotentiallyInitiatedByUser);
     } else
@@ -1092,7 +1097,7 @@ void NetworkProcess::logFrameNavigation(PAL::SessionID sessionID, RegistrableDom
 
 void NetworkProcess::logUserInteraction(PAL::SessionID sessionID, RegistrableDomain&& domain, CompletionHandler<void()>&& completionHandler)
 {
-    if (auto* session = networkSession(sessionID)) {
+    if (auto session = checkedNetworkSession(sessionID)) {
         if (auto* resourceLoadStatistics = session->resourceLoadStatistics())
             resourceLoadStatistics->logUserInteraction(WTFMove(domain), WTFMove(completionHandler));
         else
@@ -1105,7 +1110,7 @@ void NetworkProcess::logUserInteraction(PAL::SessionID sessionID, RegistrableDom
 
 void NetworkProcess::hadUserInteraction(PAL::SessionID sessionID, RegistrableDomain&& domain, CompletionHandler<void(bool)>&& completionHandler)
 {
-    if (auto* session = networkSession(sessionID)) {
+    if (auto session = checkedNetworkSession(sessionID)) {
         if (auto* resourceLoadStatistics = session->resourceLoadStatistics())
             resourceLoadStatistics->hasHadUserInteraction(WTFMove(domain), WTFMove(completionHandler));
         else
@@ -1118,7 +1123,7 @@ void NetworkProcess::hadUserInteraction(PAL::SessionID sessionID, RegistrableDom
 
 void NetworkProcess::isRelationshipOnlyInDatabaseOnce(PAL::SessionID sessionID, RegistrableDomain&& subDomain, RegistrableDomain&& topDomain, CompletionHandler<void(bool)>&& completionHandler)
 {
-    if (auto* session = networkSession(sessionID)) {
+    if (auto session = checkedNetworkSession(sessionID)) {
         if (auto* resourceLoadStatistics = session->resourceLoadStatistics())
             resourceLoadStatistics->isRelationshipOnlyInDatabaseOnce(WTFMove(subDomain), WTFMove(topDomain), WTFMove(completionHandler));
         else
@@ -1131,7 +1136,7 @@ void NetworkProcess::isRelationshipOnlyInDatabaseOnce(PAL::SessionID sessionID, 
 
 void NetworkProcess::clearUserInteraction(PAL::SessionID sessionID, RegistrableDomain&& domain, CompletionHandler<void()>&& completionHandler)
 {
-    if (auto* session = networkSession(sessionID)) {
+    if (auto session = checkedNetworkSession(sessionID)) {
         if (auto* resourceLoadStatistics = session->resourceLoadStatistics())
             resourceLoadStatistics->clearUserInteraction(WTFMove(domain), WTFMove(completionHandler));
         else
@@ -1144,7 +1149,7 @@ void NetworkProcess::clearUserInteraction(PAL::SessionID sessionID, RegistrableD
 
 void NetworkProcess::hasLocalStorage(PAL::SessionID sessionID, const RegistrableDomain& domain, CompletionHandler<void(bool)>&& completionHandler)
 {
-    auto* session = networkSession(sessionID);
+    auto session = checkedNetworkSession(sessionID);
     if (!session)
         return completionHandler(false);
 
@@ -1167,7 +1172,7 @@ void NetworkProcess::setCacheMaxAgeCapForPrevalentResources(PAL::SessionID sessi
 
 void NetworkProcess::setGrandfatheringTime(PAL::SessionID sessionID, Seconds seconds, CompletionHandler<void()>&& completionHandler)
 {
-    if (auto* session = networkSession(sessionID)) {
+    if (auto session = checkedNetworkSession(sessionID)) {
         if (auto* resourceLoadStatistics = session->resourceLoadStatistics())
             resourceLoadStatistics->setGrandfatheringTime(seconds, WTFMove(completionHandler));
         else
@@ -1180,7 +1185,7 @@ void NetworkProcess::setGrandfatheringTime(PAL::SessionID sessionID, Seconds sec
 
 void NetworkProcess::setMaxStatisticsEntries(PAL::SessionID sessionID, uint64_t maximumEntryCount, CompletionHandler<void()>&& completionHandler)
 {
-    if (auto* session = networkSession(sessionID)) {
+    if (auto session = checkedNetworkSession(sessionID)) {
         if (auto* resourceLoadStatistics = session->resourceLoadStatistics())
             resourceLoadStatistics->setMaxStatisticsEntries(maximumEntryCount, WTFMove(completionHandler));
         else
@@ -1193,7 +1198,7 @@ void NetworkProcess::setMaxStatisticsEntries(PAL::SessionID sessionID, uint64_t 
 
 void NetworkProcess::setMinimumTimeBetweenDataRecordsRemoval(PAL::SessionID sessionID, Seconds seconds, CompletionHandler<void()>&& completionHandler)
 {
-    if (auto* session = networkSession(sessionID)) {
+    if (auto session = checkedNetworkSession(sessionID)) {
         if (auto* resourceLoadStatistics = session->resourceLoadStatistics())
             resourceLoadStatistics->setMinimumTimeBetweenDataRecordsRemoval(seconds, WTFMove(completionHandler));
         else
@@ -1206,7 +1211,7 @@ void NetworkProcess::setMinimumTimeBetweenDataRecordsRemoval(PAL::SessionID sess
 
 void NetworkProcess::setPruneEntriesDownTo(PAL::SessionID sessionID, uint64_t pruneTargetCount, CompletionHandler<void()>&& completionHandler)
 {
-    if (auto* session = networkSession(sessionID)) {
+    if (auto session = checkedNetworkSession(sessionID)) {
         if (auto* resourceLoadStatistics = session->resourceLoadStatistics())
             resourceLoadStatistics->setPruneEntriesDownTo(pruneTargetCount, WTFMove(completionHandler));
         else
@@ -1219,7 +1224,7 @@ void NetworkProcess::setPruneEntriesDownTo(PAL::SessionID sessionID, uint64_t pr
 
 void NetworkProcess::setTimeToLiveUserInteraction(PAL::SessionID sessionID, Seconds seconds, CompletionHandler<void()>&& completionHandler)
 {
-    if (auto* session = networkSession(sessionID)) {
+    if (auto session = checkedNetworkSession(sessionID)) {
         if (auto* resourceLoadStatistics = session->resourceLoadStatistics())
             resourceLoadStatistics->setTimeToLiveUserInteraction(seconds, WTFMove(completionHandler));
         else
@@ -1232,7 +1237,7 @@ void NetworkProcess::setTimeToLiveUserInteraction(PAL::SessionID sessionID, Seco
 
 void NetworkProcess::setShouldClassifyResourcesBeforeDataRecordsRemoval(PAL::SessionID sessionID, bool value, CompletionHandler<void()>&& completionHandler)
 {
-    if (auto* session = networkSession(sessionID)) {
+    if (auto session = checkedNetworkSession(sessionID)) {
         if (auto* resourceLoadStatistics = session->resourceLoadStatistics())
             resourceLoadStatistics->setShouldClassifyResourcesBeforeDataRecordsRemoval(value, WTFMove(completionHandler));
         else
@@ -1245,7 +1250,7 @@ void NetworkProcess::setShouldClassifyResourcesBeforeDataRecordsRemoval(PAL::Ses
 
 void NetworkProcess::setTrackingPreventionEnabled(PAL::SessionID sessionID, bool enabled)
 {
-    if (auto* session = networkSession(sessionID))
+    if (auto session = checkedNetworkSession(sessionID))
         session->setTrackingPreventionEnabled(enabled);
 }
 
@@ -1263,7 +1268,7 @@ void NetworkProcess::setResourceLoadStatisticsLogTestingEvent(bool enabled)
 
 void NetworkProcess::setResourceLoadStatisticsDebugMode(PAL::SessionID sessionID, bool debugMode, CompletionHandler<void()>&& completionHandler)
 {
-    if (auto* session = networkSession(sessionID)) {
+    if (auto session = checkedNetworkSession(sessionID)) {
         if (auto* resourceLoadStatistics = session->resourceLoadStatistics())
             resourceLoadStatistics->setResourceLoadStatisticsDebugMode(debugMode, WTFMove(completionHandler));
         else
@@ -1276,7 +1281,7 @@ void NetworkProcess::setResourceLoadStatisticsDebugMode(PAL::SessionID sessionID
 
 void NetworkProcess::isResourceLoadStatisticsEphemeral(PAL::SessionID sessionID, CompletionHandler<void(bool)>&& completionHandler) const
 {
-    if (auto* session = networkSession(sessionID)) {
+    if (auto session = checkedNetworkSession(sessionID)) {
         if (auto* resourceLoadStatistics = session->resourceLoadStatistics()) {
             completionHandler(resourceLoadStatistics->isEphemeral());
             return;
@@ -1312,7 +1317,7 @@ void NetworkProcess::didCommitCrossSiteLoadWithDataTransfer(PAL::SessionID sessi
         ASSERT_NOT_REACHED();
 
     if (navigationDataTransfer.contains(CrossSiteNavigationDataTransfer::Flag::DestinationLinkDecoration)) {
-        if (auto* session = networkSession(sessionID)) {
+        if (auto session = checkedNetworkSession(sessionID)) {
             if (auto* resourceLoadStatistics = session->resourceLoadStatistics())
                 resourceLoadStatistics->logCrossSiteLoadWithLinkDecoration(WTFMove(fromDomain), WTFMove(toDomain), didFilterKnownLinkDecoration, [] { });
         } else
@@ -1322,7 +1327,7 @@ void NetworkProcess::didCommitCrossSiteLoadWithDataTransfer(PAL::SessionID sessi
 
 void NetworkProcess::setCrossSiteLoadWithLinkDecorationForTesting(PAL::SessionID sessionID, RegistrableDomain&& fromDomain, RegistrableDomain&& toDomain, DidFilterKnownLinkDecoration didFilterKnownLinkDecoration, CompletionHandler<void()>&& completionHandler)
 {
-    if (auto* session = networkSession(sessionID)) {
+    if (auto session = checkedNetworkSession(sessionID)) {
         if (auto* resourceLoadStatistics = session->resourceLoadStatistics()) {
             resourceLoadStatistics->logCrossSiteLoadWithLinkDecoration(WTFMove(fromDomain), WTFMove(toDomain), didFilterKnownLinkDecoration, WTFMove(completionHandler));
             return;
@@ -1359,7 +1364,7 @@ void NetworkProcess::grantStorageAccessForTesting(PAL::SessionID sessionID, Vect
 void NetworkProcess::hasIsolatedSession(PAL::SessionID sessionID, const WebCore::RegistrableDomain& domain, CompletionHandler<void(bool)>&& completionHandler) const
 {
     bool result = false;
-    if (auto* session = networkSession(sessionID))
+    if (auto session = checkedNetworkSession(sessionID))
         result = session->hasIsolatedSession(domain);
     completionHandler(result);
 }
@@ -1367,7 +1372,7 @@ void NetworkProcess::hasIsolatedSession(PAL::SessionID sessionID, const WebCore:
 #if ENABLE(APP_BOUND_DOMAINS)
 void NetworkProcess::setAppBoundDomainsForResourceLoadStatistics(PAL::SessionID sessionID, HashSet<WebCore::RegistrableDomain>&& appBoundDomains, CompletionHandler<void()>&& completionHandler)
 {
-    if (auto* session = networkSession(sessionID)) {
+    if (auto session = checkedNetworkSession(sessionID)) {
         if (auto* resourceLoadStatistics = session->resourceLoadStatistics()) {
             resourceLoadStatistics->setAppBoundDomains(WTFMove(appBoundDomains), WTFMove(completionHandler));
             return;
@@ -1381,7 +1386,7 @@ void NetworkProcess::setAppBoundDomainsForResourceLoadStatistics(PAL::SessionID 
 #if ENABLE(MANAGED_DOMAINS)
 void NetworkProcess::setManagedDomainsForResourceLoadStatistics(PAL::SessionID sessionID, HashSet<WebCore::RegistrableDomain>&& managedDomains, CompletionHandler<void()>&& completionHandler)
 {
-    if (auto* session = networkSession(sessionID)) {
+    if (auto session = checkedNetworkSession(sessionID)) {
         RefPtr { supplement<WebCookieManager>() }->setHTTPCookieAcceptPolicy(sessionID, WebCore::HTTPCookieAcceptPolicy::AlwaysAccept, [session = WeakPtr { *session }, managedDomains = WTFMove(managedDomains), completionHandler = WTFMove(completionHandler)]() mutable {
             if (session) {
                 if (auto* resourceLoadStatistics = session->resourceLoadStatistics()) {
@@ -1408,7 +1413,7 @@ void NetworkProcess::setShouldDowngradeReferrerForTesting(bool enabled, Completi
 
 void NetworkProcess::setThirdPartyCookieBlockingMode(PAL::SessionID sessionID, WebCore::ThirdPartyCookieBlockingMode blockingMode, CompletionHandler<void()>&& completionHandler)
 {
-    if (auto* session = networkSession(sessionID))
+    if (auto session = checkedNetworkSession(sessionID))
         session->setThirdPartyCookieBlockingMode(blockingMode);
     else
         ASSERT_NOT_REACHED();
@@ -1417,7 +1422,7 @@ void NetworkProcess::setThirdPartyCookieBlockingMode(PAL::SessionID sessionID, W
 
 void NetworkProcess::setShouldEnbleSameSiteStrictEnforcementForTesting(PAL::SessionID sessionID, WebCore::SameSiteStrictEnforcementEnabled enabled, CompletionHandler<void()>&& completionHandler)
 {
-    if (auto* session = networkSession(sessionID))
+    if (auto session = checkedNetworkSession(sessionID))
         session->setShouldEnbleSameSiteStrictEnforcement(enabled);
     else
         ASSERT_NOT_REACHED();
@@ -1426,7 +1431,7 @@ void NetworkProcess::setShouldEnbleSameSiteStrictEnforcementForTesting(PAL::Sess
 
 void NetworkProcess::setFirstPartyWebsiteDataRemovalModeForTesting(PAL::SessionID sessionID, WebCore::FirstPartyWebsiteDataRemovalMode mode, CompletionHandler<void()>&& completionHandler)
 {
-    if (auto* session = networkSession(sessionID)) {
+    if (auto session = checkedNetworkSession(sessionID)) {
         if (auto* resourceLoadStatistics = session->resourceLoadStatistics())
             resourceLoadStatistics->setFirstPartyWebsiteDataRemovalMode(mode, WTFMove(completionHandler));
         else
@@ -1449,14 +1454,14 @@ void NetworkProcess::setToSameSiteStrictCookiesForTesting(PAL::SessionID session
 
 void NetworkProcess::setFirstPartyHostCNAMEDomainForTesting(PAL::SessionID sessionID, String&& firstPartyHost, WebCore::RegistrableDomain&& cnameDomain, CompletionHandler<void()>&& completionHandler)
 {
-    if (auto* session = networkSession(sessionID))
+    if (auto session = checkedNetworkSession(sessionID))
         session->setFirstPartyHostCNAMEDomain(WTFMove(firstPartyHost), WTFMove(cnameDomain));
     completionHandler();
 }
 
 void NetworkProcess::setThirdPartyCNAMEDomainForTesting(PAL::SessionID sessionID, WebCore::RegistrableDomain&& domain, CompletionHandler<void()>&& completionHandler)
 {
-    if (auto* session = networkSession(sessionID))
+    if (auto session = checkedNetworkSession(sessionID))
         session->setThirdPartyCNAMEDomainForTesting(WTFMove(domain));
     completionHandler();
 }
@@ -1498,20 +1503,20 @@ void NetworkProcess::notifyMediaStreamingActivity(bool activity)
 
 void NetworkProcess::setPrivateClickMeasurementDebugMode(PAL::SessionID sessionID, bool enabled)
 {
-    if (auto* session = networkSession(sessionID))
+    if (auto session = checkedNetworkSession(sessionID))
         session->setPrivateClickMeasurementDebugMode(enabled);
 }
 
 void NetworkProcess::setShouldSendPrivateTokenIPCForTesting(PAL::SessionID sessionID, bool enabled) const
 {
-    if (auto* session = networkSession(sessionID))
+    if (auto session = checkedNetworkSession(sessionID))
         session->setShouldSendPrivateTokenIPCForTesting(enabled);
 }
 
 #if HAVE(ALLOW_ONLY_PARTITIONED_COOKIES)
 void NetworkProcess::setOptInCookiePartitioningEnabled(PAL::SessionID sessionID, bool enabled) const
 {
-    if (auto* session = networkSession(sessionID))
+    if (auto session = checkedNetworkSession(sessionID))
         session->setOptInCookiePartitioningEnabled(enabled);
 }
 #endif
@@ -1600,7 +1605,7 @@ void NetworkProcess::fetchWebsiteData(PAL::SessionID sessionID, OptionSet<Websit
     };
 
     auto callbackAggregator = adoptRef(*new CallbackAggregator(WTFMove(completionHandler)));
-    auto* session = networkSession(sessionID);
+    auto session = checkedNetworkSession(sessionID);
 
     if (websiteDataTypes.contains(WebsiteDataType::Cookies)) {
         if (auto* networkStorageSession = storageSession(sessionID))
@@ -1711,7 +1716,7 @@ void NetworkProcess::deleteWebsiteDataImpl(PAL::SessionID sessionID, OptionSet<W
     });
 
     RELEASE_LOG(Storage, "NetworkProcess::deleteWebsiteDataImpl starts deleting data modified since %f for session %" PRIu64, modifiedSince.secondsSinceEpoch().value(), sessionID.toUInt64());
-    auto* session = networkSession(sessionID);
+    auto session = checkedNetworkSession(sessionID);
 
 #if PLATFORM(COCOA) || USE(SOUP)
     if (websiteDataTypes.contains(WebsiteDataType::HSTSCache))
@@ -1784,7 +1789,7 @@ void NetworkProcess::deleteWebsiteDataForOrigin(PAL::SessionID sessionID, Option
     });
     RELEASE_LOG(Storage, "NetworkProcess::deleteWebsiteDataForOrigin started to delete data for session %" PRIu64, sessionID.toUInt64());
 
-    auto* session = networkSession(sessionID);
+    auto session = checkedNetworkSession(sessionID);
     if (websiteDataTypes.contains(WebsiteDataType::Cookies)) {
         if (auto* networkStorageSession = storageSession(sessionID))
             networkStorageSession->deleteCookies(origin, [clearTasksHandler] { });
@@ -1823,7 +1828,7 @@ void NetworkProcess::deleteWebsiteDataForOrigins(PAL::SessionID sessionID, Optio
     });
 
     RELEASE_LOG(Storage, "NetworkProcess::deleteWebsiteDataForOrigins started to delete data for session %" PRIu64, sessionID.toUInt64());
-    auto* session = networkSession(sessionID);
+    auto session = checkedNetworkSession(sessionID);
 
     if (websiteDataTypes.contains(WebsiteDataType::Cookies)) {
         if (auto* networkStorageSession = storageSession(sessionID))
@@ -1931,7 +1936,7 @@ static Vector<WebCore::SecurityOriginData> filterForRegistrableDomains(const Has
 void NetworkProcess::deleteAndRestrictWebsiteDataForRegistrableDomains(PAL::SessionID sessionID, OptionSet<WebsiteDataType> websiteDataTypes, RegistrableDomainsToDeleteOrRestrictWebsiteDataFor&& domains, CompletionHandler<void(HashSet<RegistrableDomain>&&)>&& completionHandler)
 {
     RELEASE_LOG(Storage, "NetworkProcess::deleteAndRestrictWebsiteDataForRegistrableDomains started to delete and restrict data for session %" PRIu64 " with candidate domains - %zu domainsToDeleteAllCookiesFor, %zu domainsToDeleteAllButHttpOnlyCookiesFor, %zu domainsToDeleteAllScriptWrittenStorageFor", sessionID.toUInt64(), domains.domainsToDeleteAllCookiesFor.size(), domains.domainsToDeleteAllButHttpOnlyCookiesFor.size(), domains.domainsToDeleteAllScriptWrittenStorageFor.size());
-    auto* session = networkSession(sessionID);
+    auto session = checkedNetworkSession(sessionID);
 
     OptionSet<WebsiteDataFetchOption> fetchOptions = WebsiteDataFetchOption::DoNotCreateProcesses;
 
@@ -2091,7 +2096,7 @@ void NetworkProcess::deleteCookiesForTesting(PAL::SessionID sessionID, Registrab
 
 void NetworkProcess::registrableDomainsWithWebsiteData(PAL::SessionID sessionID, OptionSet<WebsiteDataType> websiteDataTypes, CompletionHandler<void(HashSet<RegistrableDomain>&&)>&& completionHandler)
 {
-    auto* session = networkSession(sessionID);
+    auto session = checkedNetworkSession(sessionID);
     struct CallbackAggregator final : public ThreadSafeRefCounted<CallbackAggregator> {
         explicit CallbackAggregator(CompletionHandler<void(HashSet<RegistrableDomain>&&)>&& completionHandler)
             : m_completionHandler(WTFMove(completionHandler))
@@ -2174,7 +2179,7 @@ void NetworkProcess::registrableDomainsWithWebsiteData(PAL::SessionID sessionID,
 
 void NetworkProcess::closeITPDatabase(PAL::SessionID sessionID, CompletionHandler<void()>&& completionHandler)
 {
-    if (auto* session = networkSession(sessionID)) {
+    if (auto session = checkedNetworkSession(sessionID)) {
         session->destroyResourceLoadStatistics(WTFMove(completionHandler));
         return;
     }
@@ -2262,7 +2267,7 @@ void NetworkProcess::dataTaskWithRequest(WebPageProxyIdentifier pageID, PAL::Ses
 
 void NetworkProcess::cancelDataTask(DataTaskIdentifier identifier, PAL::SessionID sessionID, CompletionHandler<void()>&& completionHandler)
 {
-    if (auto* session = networkSession(sessionID))
+    if (auto session = checkedNetworkSession(sessionID))
         session->cancelDataTask(identifier);
     completionHandler();
 }
@@ -2289,7 +2294,7 @@ void NetworkProcess::setCacheModel(CacheModel cacheModel)
 
 void NetworkProcess::allowTLSCertificateChainForLocalPCMTesting(PAL::SessionID sessionID, const WebCore::CertificateInfo& certificateInfo)
 {
-    if (auto* session = networkSession(sessionID))
+    if (auto session = checkedNetworkSession(sessionID))
         session->allowTLSCertificateChainForLocalPCMTesting(certificateInfo);
 }
 
@@ -2330,7 +2335,7 @@ void NetworkProcess::processWillSuspendImminentlyForTestingSync(CompletionHandle
 
 void NetworkProcess::terminateRemoteWorkerContextConnectionWhenPossible(RemoteWorkerType workerType, PAL::SessionID sessionID, const WebCore::RegistrableDomain& registrableDomain, WebCore::ProcessIdentifier processIdentifier)
 {
-    auto* session = networkSession(sessionID);
+    auto session = checkedNetworkSession(sessionID);
     if (!session)
         return;
 
@@ -2348,7 +2353,7 @@ void NetworkProcess::terminateRemoteWorkerContextConnectionWhenPossible(RemoteWo
 
 void NetworkProcess::runningOrTerminatingServiceWorkerCountForTesting(PAL::SessionID sessionID, CompletionHandler<void(unsigned)>&& completionHandler) const
 {
-    auto* session = networkSession(sessionID);
+    auto session = checkedNetworkSession(sessionID);
     if (!session)
         return completionHandler(0);
 
@@ -2445,7 +2450,7 @@ void NetworkProcess::syncLocalStorage(CompletionHandler<void()>&& completionHand
 
 void NetworkProcess::storeServiceWorkerRegistrations(PAL::SessionID sessionID, CompletionHandler<void()>&& completionHandler)
 {
-    auto* session = networkSession(sessionID);
+    auto session = checkedNetworkSession(sessionID);
     RefPtr server = session ? session->swServer() : nullptr;
     if (!server)
         return completionHandler();
@@ -2455,7 +2460,7 @@ void NetworkProcess::storeServiceWorkerRegistrations(PAL::SessionID sessionID, C
 
 void NetworkProcess::resetQuota(PAL::SessionID sessionID, CompletionHandler<void()>&& completionHandler)
 {
-    if (auto* session = networkSession(sessionID))
+    if (auto session = checkedNetworkSession(sessionID))
         return session->protectedStorageManager()->resetQuotaForTesting(WTFMove(completionHandler));
 
     completionHandler();
@@ -2463,7 +2468,7 @@ void NetworkProcess::resetQuota(PAL::SessionID sessionID, CompletionHandler<void
 
 void NetworkProcess::setOriginQuotaRatioEnabledForTesting(PAL::SessionID sessionID, bool enabled, CompletionHandler<void()>&& completionHandler)
 {
-    if (auto* session = networkSession(sessionID))
+    if (auto session = checkedNetworkSession(sessionID))
         return session->protectedStorageManager()->setOriginQuotaRatioEnabledForTesting(enabled, WTFMove(completionHandler));
 
     completionHandler();
@@ -2471,7 +2476,7 @@ void NetworkProcess::setOriginQuotaRatioEnabledForTesting(PAL::SessionID session
 
 void NetworkProcess::resetStoragePersistedState(PAL::SessionID sessionID, CompletionHandler<void()>&& completionHandler)
 {
-    if (auto* session = networkSession(sessionID))
+    if (auto session = checkedNetworkSession(sessionID))
         session->protectedStorageManager()->resetStoragePersistedState(WTFMove(completionHandler));
     else
         completionHandler();
@@ -2479,13 +2484,13 @@ void NetworkProcess::resetStoragePersistedState(PAL::SessionID sessionID, Comple
 
 void NetworkProcess::cloneSessionStorageForWebPage(PAL::SessionID sessionID, WebPageProxyIdentifier sourcePage, WebPageProxyIdentifier destinationPage)
 {
-    if (auto* session = networkSession(sessionID))
+    if (auto session = checkedNetworkSession(sessionID))
         session->protectedStorageManager()->cloneSessionStorageForWebPage(sourcePage, destinationPage);
 }
 
 void NetworkProcess::didIncreaseQuota(PAL::SessionID sessionID, ClientOrigin&& origin, QuotaIncreaseRequestIdentifier identifier, std::optional<uint64_t> newQuota)
 {
-    if (auto* session = networkSession(sessionID))
+    if (auto session = checkedNetworkSession(sessionID))
         session->protectedStorageManager()->didIncreaseQuota(WTFMove(origin), identifier, newQuota);
 }
 
@@ -2496,7 +2501,7 @@ void NetworkProcess::renameOriginInWebsiteData(PAL::SessionID sessionID, Securit
     if (oldOrigin.isNull() || newOrigin.isNull())
         return;
 
-    if (auto* session = networkSession(sessionID))
+    if (auto session = checkedNetworkSession(sessionID))
         session->protectedStorageManager()->moveData(dataTypes, WTFMove(oldOrigin), WTFMove(newOrigin), [aggregator] { });
 }
 
@@ -2507,7 +2512,7 @@ void NetworkProcess::websiteDataOriginDirectoryForTesting(PAL::SessionID session
         return;
     }
     
-    auto* session = networkSession(sessionID);
+    auto session = checkedNetworkSession(sessionID);
     if (!session)
         return completionHandler({ });
 
@@ -2516,7 +2521,7 @@ void NetworkProcess::websiteDataOriginDirectoryForTesting(PAL::SessionID session
 
 void NetworkProcess::processNotificationEvent(NotificationData&& data, NotificationEventType eventType, CompletionHandler<void(bool)>&& callback)
 {
-    auto* session = networkSession(data.sourceSession);
+    auto session = checkedNetworkSession(data.sourceSession);
     if (!session) {
         callback(false);
         return;
@@ -2527,7 +2532,7 @@ void NetworkProcess::processNotificationEvent(NotificationData&& data, Notificat
 
 void NetworkProcess::getAllBackgroundFetchIdentifiers(PAL::SessionID sessionID, CompletionHandler<void(Vector<String>&&)>&& callback)
 {
-    auto* session = networkSession(sessionID);
+    auto session = checkedNetworkSession(sessionID);
     if (!session) {
         callback({ });
         return;
@@ -2538,7 +2543,7 @@ void NetworkProcess::getAllBackgroundFetchIdentifiers(PAL::SessionID sessionID, 
 
 void NetworkProcess::getBackgroundFetchState(PAL::SessionID sessionID, const String& identifier, CompletionHandler<void(std::optional<BackgroundFetchState>&&)>&& callback)
 {
-    auto* session = networkSession(sessionID);
+    auto session = checkedNetworkSession(sessionID);
     if (!session) {
         callback({ });
         return;
@@ -2549,7 +2554,7 @@ void NetworkProcess::getBackgroundFetchState(PAL::SessionID sessionID, const Str
 
 void NetworkProcess::abortBackgroundFetch(PAL::SessionID sessionID, const String& identifier, CompletionHandler<void()>&& callback)
 {
-    auto* session = networkSession(sessionID);
+    auto session = checkedNetworkSession(sessionID);
     if (!session) {
         callback();
         return;
@@ -2560,7 +2565,7 @@ void NetworkProcess::abortBackgroundFetch(PAL::SessionID sessionID, const String
 
 void NetworkProcess::pauseBackgroundFetch(PAL::SessionID sessionID, const String& identifier, CompletionHandler<void()>&& callback)
 {
-    auto* session = networkSession(sessionID);
+    auto session = checkedNetworkSession(sessionID);
     if (!session) {
         callback();
         return;
@@ -2571,7 +2576,7 @@ void NetworkProcess::pauseBackgroundFetch(PAL::SessionID sessionID, const String
 
 void NetworkProcess::resumeBackgroundFetch(PAL::SessionID sessionID, const String& identifier, CompletionHandler<void()>&& callback)
 {
-    auto* session = networkSession(sessionID);
+    auto session = checkedNetworkSession(sessionID);
     if (!session) {
         callback();
         return;
@@ -2582,7 +2587,7 @@ void NetworkProcess::resumeBackgroundFetch(PAL::SessionID sessionID, const Strin
 
 void NetworkProcess::clickBackgroundFetch(PAL::SessionID sessionID, const String& identifier, CompletionHandler<void()>&& callback)
 {
-    auto* session = networkSession(sessionID);
+    auto session = checkedNetworkSession(sessionID);
     if (!session) {
         callback();
         return;
@@ -2594,7 +2599,7 @@ void NetworkProcess::clickBackgroundFetch(PAL::SessionID sessionID, const String
 
 void NetworkProcess::getPendingPushMessage(PAL::SessionID sessionID, CompletionHandler<void(const std::optional<WebPushMessage>&)>&& callback)
 {
-    if (auto* session = networkSession(sessionID)) {
+    if (auto session = checkedNetworkSession(sessionID)) {
         RELEASE_LOG(Push, "NetworkProcess getting pending push messages for session ID %" PRIu64, sessionID.toUInt64());
         session->protectedNotificationManager()->getPendingPushMessage(WTFMove(callback));
         return;
@@ -2606,7 +2611,7 @@ void NetworkProcess::getPendingPushMessage(PAL::SessionID sessionID, CompletionH
 
 void NetworkProcess::getPendingPushMessages(PAL::SessionID sessionID, CompletionHandler<void(const Vector<WebPushMessage>&)>&& callback)
 {
-    if (auto* session = networkSession(sessionID)) {
+    if (auto session = checkedNetworkSession(sessionID)) {
         LOG(Notifications, "NetworkProcess getting pending push messages for session ID %" PRIu64, sessionID.toUInt64());
         session->protectedNotificationManager()->getPendingPushMessages(WTFMove(callback));
         return;
@@ -2618,7 +2623,7 @@ void NetworkProcess::getPendingPushMessages(PAL::SessionID sessionID, Completion
 
 void NetworkProcess::processPushMessage(PAL::SessionID sessionID, WebPushMessage&& pushMessage, PushPermissionState permissionState, bool builtInNotficationsEnabled, CompletionHandler<void(bool, std::optional<WebCore::NotificationPayload>&&)>&& callback)
 {
-    if (auto* session = networkSession(sessionID)) {
+    if (auto session = checkedNetworkSession(sessionID)) {
         RELEASE_LOG(Push, "Networking process handling a push message from UI process in session %llu", sessionID.toUInt64());
         auto origin = SecurityOriginData::fromURL(pushMessage.registrationURL);
 
@@ -2643,7 +2648,7 @@ void NetworkProcess::processPushMessage(PAL::SessionID sessionID, WebPushMessage
         session->ensureProtectedSWServer()->processPushMessage(WTFMove(pushMessage.pushData), WTFMove(pushMessage.notificationPayload), WTFMove(pushMessage.registrationURL), [this, protectedThis = Ref { *this }, sessionID, origin = WTFMove(origin), scope = WTFMove(scope), callback = WTFMove(callback), isDeclarative, builtInNotficationsEnabled](bool result, std::optional<WebCore::NotificationPayload>&& resultPayload) mutable {
             // When using built-in notifications, we expect clients to use getPendingPushMessage, which automatically tracks silent push counts within webpushd.
             if (!builtInNotficationsEnabled &&!isDeclarative && !result) {
-                if (auto* session = networkSession(sessionID)) {
+                if (auto session = checkedNetworkSession(sessionID)) {
                     session->protectedNotificationManager()->incrementSilentPushCount(WTFMove(origin), [scope = WTFMove(scope), callback = WTFMove(callback), result](unsigned newSilentPushCount) mutable {
                         RELEASE_LOG_ERROR(Push, "Push message for scope %" SENSITIVE_LOG_STRING " not handled properly; new silent push count: %u", scope.utf8().data(), newSilentPushCount);
                         callback(result, std::nullopt);
@@ -2682,7 +2687,7 @@ void NetworkProcess::processPushMessage(PAL::SessionID, WebPushMessage&&, PushPe
 void NetworkProcess::setPushAndNotificationsEnabledForOrigin(PAL::SessionID sessionID, const SecurityOriginData& origin, bool enabled, CompletionHandler<void()>&& callback)
 {
 #if ENABLE(WEB_PUSH_NOTIFICATIONS)
-    if (auto* session = networkSession(sessionID)) {
+    if (auto session = checkedNetworkSession(sessionID)) {
         session->protectedNotificationManager()->setPushAndNotificationsEnabledForOrigin(origin, enabled, WTFMove(callback));
         return;
     }
@@ -2693,7 +2698,7 @@ void NetworkProcess::setPushAndNotificationsEnabledForOrigin(PAL::SessionID sess
 void NetworkProcess::removePushSubscriptionsForOrigin(PAL::SessionID sessionID, const SecurityOriginData& origin, CompletionHandler<void(unsigned)>&& callback)
 {
 #if ENABLE(WEB_PUSH_NOTIFICATIONS)
-    if (auto* session = networkSession(sessionID)) {
+    if (auto session = checkedNetworkSession(sessionID)) {
         session->protectedNotificationManager()->removePushSubscriptionsForOrigin(SecurityOriginData { origin }, WTFMove(callback));
         return;
     }
@@ -2704,7 +2709,7 @@ void NetworkProcess::removePushSubscriptionsForOrigin(PAL::SessionID sessionID, 
 void NetworkProcess::hasPushSubscriptionForTesting(PAL::SessionID sessionID, URL&& scopeURL, CompletionHandler<void(bool)>&& callback)
 {
 #if ENABLE(WEB_PUSH_NOTIFICATIONS)
-    if (auto* session = networkSession(sessionID)) {
+    if (auto session = checkedNetworkSession(sessionID)) {
         session->protectedNotificationManager()->getPushSubscription(WTFMove(scopeURL), [callback = WTFMove(callback)](auto &&result) mutable {
             callback(result && result->has_value());
         });
@@ -2718,7 +2723,7 @@ void NetworkProcess::hasPushSubscriptionForTesting(PAL::SessionID sessionID, URL
 void NetworkProcess::getAppBadgeForTesting(PAL::SessionID sessionID, CompletionHandler<void(std::optional<uint64_t>)>&& callback)
 {
 #if ENABLE(WEB_PUSH_NOTIFICATIONS)
-    if (auto* session = networkSession(sessionID)) {
+    if (auto session = checkedNetworkSession(sessionID)) {
         session->protectedNotificationManager()->getAppBadgeForTesting(WTFMove(callback));
         return;
     }
@@ -2731,7 +2736,7 @@ void NetworkProcess::getAppBadgeForTesting(PAL::SessionID sessionID, CompletionH
 
 void NetworkProcess::setEmulatedConditions(PAL::SessionID sessionID, std::optional<int64_t>&& bytesPerSecondLimit)
 {
-    if (auto* session = networkSession(sessionID))
+    if (auto session = checkedNetworkSession(sessionID))
         session->setEmulatedConditions(WTFMove(bytesPerSecondLimit));
 }
 
@@ -2764,13 +2769,13 @@ void NetworkProcess::platformFlushCookies(PAL::SessionID, CompletionHandler<void
 
 void NetworkProcess::storePrivateClickMeasurement(PAL::SessionID sessionID, WebCore::PrivateClickMeasurement&& privateClickMeasurement)
 {
-    if (auto* session = networkSession(sessionID))
+    if (auto session = checkedNetworkSession(sessionID))
         session->storePrivateClickMeasurement(WTFMove(privateClickMeasurement));
 }
 
 void NetworkProcess::dumpPrivateClickMeasurement(PAL::SessionID sessionID, CompletionHandler<void(String)>&& completionHandler)
 {
-    if (auto* session = networkSession(sessionID))
+    if (auto session = checkedNetworkSession(sessionID))
         return session->dumpPrivateClickMeasurement(WTFMove(completionHandler));
 
     completionHandler({ });
@@ -2778,7 +2783,7 @@ void NetworkProcess::dumpPrivateClickMeasurement(PAL::SessionID sessionID, Compl
 
 void NetworkProcess::clearPrivateClickMeasurement(PAL::SessionID sessionID, CompletionHandler<void()>&& completionHandler)
 {
-    if (auto* session = networkSession(sessionID))
+    if (auto session = checkedNetworkSession(sessionID))
         session->clearPrivateClickMeasurement(WTFMove(completionHandler));
     else
         completionHandler();
@@ -2801,7 +2806,7 @@ void NetworkProcess::setPrivateClickMeasurementOverrideTimerForTesting(PAL::Sess
     if (!allowsPrivateClickMeasurementTestFunctionality())
         return completionHandler();
 
-    if (auto* session = networkSession(sessionID))
+    if (auto session = checkedNetworkSession(sessionID))
         session->setPrivateClickMeasurementOverrideTimerForTesting(value);
     
     completionHandler();
@@ -2809,7 +2814,7 @@ void NetworkProcess::setPrivateClickMeasurementOverrideTimerForTesting(PAL::Sess
 
 void NetworkProcess::closePCMDatabase(PAL::SessionID sessionID, CompletionHandler<void()>&& completionHandler)
 {
-    if (auto* session = networkSession(sessionID)) {
+    if (auto session = checkedNetworkSession(sessionID)) {
         session->destroyPrivateClickMeasurementStore(WTFMove(completionHandler));
         return;
     }
@@ -2822,7 +2827,7 @@ void NetworkProcess::simulatePrivateClickMeasurementSessionRestart(PAL::SessionI
     if (!allowsPrivateClickMeasurementTestFunctionality())
         return completionHandler();
 
-    if (auto* session = networkSession(sessionID)) {
+    if (auto session = checkedNetworkSession(sessionID)) {
         session->destroyPrivateClickMeasurementStore([session = WeakPtr { *session }, completionHandler = WTFMove(completionHandler)] () mutable {
             if (session)
                 session->firePrivateClickMeasurementTimerImmediatelyForTesting();
@@ -2838,7 +2843,7 @@ void NetworkProcess::markAttributedPrivateClickMeasurementsAsExpiredForTesting(P
     if (!allowsPrivateClickMeasurementTestFunctionality())
         return completionHandler();
 
-    if (auto* session = networkSession(sessionID)) {
+    if (auto session = checkedNetworkSession(sessionID)) {
         session->markAttributedPrivateClickMeasurementsAsExpiredForTesting(WTFMove(completionHandler));
         return;
     }
@@ -2850,7 +2855,7 @@ void NetworkProcess::setPrivateClickMeasurementEphemeralMeasurementForTesting(PA
     if (!allowsPrivateClickMeasurementTestFunctionality())
         return completionHandler();
 
-    if (auto* session = networkSession(sessionID))
+    if (auto session = checkedNetworkSession(sessionID))
         session->setPrivateClickMeasurementEphemeralMeasurementForTesting(value);
     
     completionHandler();
@@ -2862,7 +2867,7 @@ void NetworkProcess::setPrivateClickMeasurementTokenPublicKeyURLForTesting(PAL::
     if (!allowsPrivateClickMeasurementTestFunctionality())
         return completionHandler();
 
-    if (auto* session = networkSession(sessionID))
+    if (auto session = checkedNetworkSession(sessionID))
         session->setPrivateClickMeasurementTokenPublicKeyURLForTesting(WTFMove(url));
 
     completionHandler();
@@ -2873,7 +2878,7 @@ void NetworkProcess::setPrivateClickMeasurementTokenSignatureURLForTesting(PAL::
     if (!allowsPrivateClickMeasurementTestFunctionality())
         return completionHandler();
 
-    if (auto* session = networkSession(sessionID))
+    if (auto session = checkedNetworkSession(sessionID))
         session->setPrivateClickMeasurementTokenSignatureURLForTesting(WTFMove(url));
     
     completionHandler();
@@ -2884,7 +2889,7 @@ void NetworkProcess::setPrivateClickMeasurementAttributionReportURLsForTesting(P
     if (!allowsPrivateClickMeasurementTestFunctionality())
         return completionHandler();
 
-    if (auto* session = networkSession(sessionID))
+    if (auto session = checkedNetworkSession(sessionID))
         session->setPrivateClickMeasurementAttributionReportURLsForTesting(WTFMove(sourceURL), WTFMove(destinationURL));
 
     completionHandler();
@@ -2895,7 +2900,7 @@ void NetworkProcess::markPrivateClickMeasurementsAsExpiredForTesting(PAL::Sessio
     if (!allowsPrivateClickMeasurementTestFunctionality())
         return completionHandler();
 
-    if (auto* session = networkSession(sessionID))
+    if (auto session = checkedNetworkSession(sessionID))
         session->markPrivateClickMeasurementsAsExpiredForTesting();
 
     completionHandler();
@@ -2906,7 +2911,7 @@ void NetworkProcess::setPCMFraudPreventionValuesForTesting(PAL::SessionID sessio
     if (!allowsPrivateClickMeasurementTestFunctionality())
         return completionHandler();
 
-    if (auto* session = networkSession(sessionID))
+    if (auto session = checkedNetworkSession(sessionID))
         session->setPCMFraudPreventionValuesForTesting(WTFMove(unlinkableToken), WTFMove(secretToken), WTFMove(signature), WTFMove(keyID));
 
     completionHandler();
@@ -2917,7 +2922,7 @@ void NetworkProcess::setPrivateClickMeasurementAppBundleIDForTesting(PAL::Sessio
     if (!allowsPrivateClickMeasurementTestFunctionality())
         return completionHandler();
 
-    if (auto* session = networkSession(sessionID))
+    if (auto session = checkedNetworkSession(sessionID))
         session->setPrivateClickMeasurementAppBundleIDForTesting(WTFMove(appBundleIDForTesting));
 
     completionHandler();
@@ -2925,19 +2930,19 @@ void NetworkProcess::setPrivateClickMeasurementAppBundleIDForTesting(PAL::Sessio
 
 void NetworkProcess::addKeptAliveLoad(Ref<NetworkResourceLoader>&& loader)
 {
-    if (auto* session = networkSession(loader->sessionID()))
+    if (auto session = checkedNetworkSession(loader->sessionID()))
         session->addKeptAliveLoad(WTFMove(loader));
 }
 
 void NetworkProcess::removeKeptAliveLoad(NetworkResourceLoader& loader)
 {
-    if (auto* session = networkSession(loader.sessionID()))
+    if (auto session = checkedNetworkSession(loader.sessionID()))
         session->removeKeptAliveLoad(loader);
 }
 
 void NetworkProcess::connectionToWebProcessClosed(IPC::Connection& connection, PAL::SessionID sessionID)
 {
-    if (auto* session = networkSession(sessionID))
+    if (auto session = checkedNetworkSession(sessionID))
         session->protectedStorageManager()->stopReceivingMessageFromConnection(connection);
 }
 
@@ -2990,14 +2995,14 @@ Seconds NetworkProcess::randomClosedPortDelay()
 void NetworkProcess::hasAppBoundSession(PAL::SessionID sessionID, CompletionHandler<void(bool)>&& completionHandler) const
 {
     bool result = false;
-    if (auto* session = networkSession(sessionID))
+    if (auto session = checkedNetworkSession(sessionID))
         result = session->hasAppBoundSession();
     completionHandler(result);
 }
 
 void NetworkProcess::clearAppBoundSession(PAL::SessionID sessionID, CompletionHandler<void()>&& completionHandler)
 {
-    if (auto* session = networkSession(sessionID)) {
+    if (auto session = checkedNetworkSession(sessionID)) {
         session->clearAppBoundSession();
         completionHandler();
     } else {
@@ -3063,7 +3068,7 @@ void NetworkProcess::setCORSDisablingPatterns(NetworkConnectionToWebProcess& con
 #if PLATFORM(COCOA)
 void NetworkProcess::appPrivacyReportTestingData(PAL::SessionID sessionID, CompletionHandler<void(const AppPrivacyReportTestingData&)>&& completionHandler)
 {
-    if (auto* session = networkSession(sessionID)) {
+    if (auto session = checkedNetworkSession(sessionID)) {
         completionHandler(session->appPrivacyReportTestingData());
         return;
     }
@@ -3072,7 +3077,7 @@ void NetworkProcess::appPrivacyReportTestingData(PAL::SessionID sessionID, Compl
 
 void NetworkProcess::clearAppPrivacyReportTestingData(PAL::SessionID sessionID, CompletionHandler<void()>&& completionHandler)
 {
-    if (auto* session = networkSession(sessionID))
+    if (auto session = checkedNetworkSession(sessionID))
         session->appPrivacyReportTestingData().clearAppPrivacyReportTestingData();
 
     completionHandler();
@@ -3096,13 +3101,13 @@ Ref<RTCDataChannelRemoteManagerProxy> NetworkProcess::protectedRTCDataChannelPro
 
 void NetworkProcess::addWebPageNetworkParameters(PAL::SessionID sessionID, WebPageProxyIdentifier pageID, WebPageNetworkParameters&& parameters)
 {
-    if (auto* session = networkSession(sessionID))
+    if (auto session = checkedNetworkSession(sessionID))
         session->addWebPageNetworkParameters(pageID, WTFMove(parameters));
 }
 
 void NetworkProcess::removeWebPageNetworkParameters(PAL::SessionID sessionID, WebPageProxyIdentifier pageID)
 {
-    auto* session = networkSession(sessionID);
+    auto session = checkedNetworkSession(sessionID);
     if (!session)
         return;
 
@@ -3117,7 +3122,7 @@ void NetworkProcess::removeWebPageNetworkParameters(PAL::SessionID sessionID, We
 
 void NetworkProcess::countNonDefaultSessionSets(PAL::SessionID sessionID, CompletionHandler<void(size_t)>&& completionHandler)
 {
-    auto* session = networkSession(sessionID);
+    auto session = checkedNetworkSession(sessionID);
     completionHandler(session ? session->countNonDefaultSessionSets() : 0);
 }
 
@@ -3166,19 +3171,19 @@ void NetworkProcess::setIsHoldingLockedFiles(bool isHoldingLockedFiles)
 
 void NetworkProcess::setInspectionForServiceWorkersAllowed(PAL::SessionID sessionID, bool inspectable)
 {
-    if (auto* session = networkSession(sessionID))
+    if (auto session = checkedNetworkSession(sessionID))
         session->setInspectionForServiceWorkersAllowed(inspectable);
 }
 
 void NetworkProcess::setStorageSiteValidationEnabled(PAL::SessionID sessionID, bool enabled)
 {
-    if (auto* session = networkSession(sessionID))
+    if (auto session = checkedNetworkSession(sessionID))
         session->protectedStorageManager()->setStorageSiteValidationEnabled(enabled);
 }
 
 void NetworkProcess::setPersistedDomains(PAL::SessionID sessionID, HashSet<RegistrableDomain>&& domains)
 {
-    if (auto* session = networkSession(sessionID))
+    if (auto session = checkedNetworkSession(sessionID))
         session->setPersistedDomains(WTFMove(domains));
 }
 

--- a/Source/WebKit/NetworkProcess/NetworkProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.h
@@ -194,6 +194,7 @@ public:
 
     void setSession(PAL::SessionID, std::unique_ptr<NetworkSession>&&);
     NetworkSession* networkSession(PAL::SessionID) const final;
+    CheckedPtr<NetworkSession> checkedNetworkSession(PAL::SessionID) const;
     void destroySession(PAL::SessionID, CompletionHandler<void()>&& = [] { });
     void ensureSessionWithDataStoreIdentifierRemoved(WTF::UUID, CompletionHandler<void()>&&);
 

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
@@ -147,7 +147,7 @@ NetworkResourceLoader::NetworkResourceLoader(NetworkResourceLoadParameters&& par
 {
     ASSERT(RunLoop::isMain());
 
-    if (auto* session = connection.protectedNetworkProcess()->networkSession(sessionID()))
+    if (auto session = connection.protectedNetworkProcess()->checkedNetworkSession(sessionID()))
         m_cache = session->cache();
 
     if (synchronousReply || m_parameters.shouldRestrictHTTPResponseAccess || m_parameters.options.keepAlive) {
@@ -311,7 +311,7 @@ void NetworkResourceLoader::retrieveCacheEntry(const ResourceRequest& request)
     RefPtr cache = m_cache;
     if (isMainFrameLoad()) {
         ASSERT(m_parameters.options.mode == FetchOptions::Mode::Navigate);
-        if (auto* session = protectedConnectionToWebProcess()->protectedNetworkProcess()->networkSession(sessionID())) {
+        if (auto session = protectedConnectionToWebProcess()->protectedNetworkProcess()->checkedNetworkSession(sessionID())) {
             if (auto entry = session->checkedPrefetchCache()->take(request.url())) {
                 LOADER_RELEASE_LOG("retrieveCacheEntry: retrieved an entry from the prefetch cache (isRedirect=%d)", !entry->redirectRequest.isNull());
                 if (!entry->redirectRequest.isNull()) {
@@ -406,7 +406,7 @@ void NetworkResourceLoader::startNetworkLoad(ResourceRequest&& request, FirstLoa
     if (parameters.storedCredentialsPolicy == WebCore::StoredCredentialsPolicy::Use && m_networkLoadChecker)
         parameters.storedCredentialsPolicy = m_networkLoadChecker->storedCredentialsPolicy();
 
-    auto* networkSession = protectedConnectionToWebProcess()->networkSession();
+    auto networkSession = protectedConnectionToWebProcess()->networkSession();
     if (!networkSession) {
         WTFLogAlways("Attempted to create a NetworkLoad with a session (id=%" PRIu64 ") that does not exist.", sessionID().toUInt64());
         LOADER_RELEASE_LOG_ERROR("startNetworkLoad: Attempted to create a NetworkLoad for a session that does not exist (sessionID=%" PRIu64 ")", sessionID().toUInt64());
@@ -917,7 +917,7 @@ void NetworkResourceLoader::didReceiveResponse(ResourceResponse&& receivedRespon
         connection->addNetworkLoadInformation(coreIdentifier(), WTFMove(information));
     }
 
-    if (CheckedPtr networkSession = m_response.url().protocolIs("https"_s) ? connection->networkSession() : nullptr) {
+    if (auto networkSession = m_response.url().protocolIs("https"_s) ? connection->networkSession() : nullptr) {
         if (auto metrics = computeResponseMetrics(m_response))
             networkSession->recordHTTPSConnectionTiming(*metrics);
     }
@@ -1079,7 +1079,7 @@ void NetworkResourceLoader::sendDidReceiveResponsePotentiallyInNewBrowsingContex
 
     ASSERT(loader == this);
     auto existingNetworkResourceLoadIdentifierToResume = loader->identifier();
-    if (auto* session = connection->networkSession())
+    if (auto session = connection->networkSession())
         session->addLoaderAwaitingWebProcessTransfer(loader.releaseNonNull());
     Site responseSite { response.url() };
     connection->protectedNetworkProcess()->protectedParentProcessConnection()->sendWithAsyncReply(Messages::NetworkProcessProxy::TriggerBrowsingContextGroupSwitchForNavigation(webPageProxyID(), *m_parameters.navigationID, browsingContextGroupSwitchDecision, responseSite, existingNetworkResourceLoadIdentifierToResume), [existingNetworkResourceLoadIdentifierToResume, session = WeakPtr { connection->networkSession() }](bool success) {


### PR DESCRIPTION
#### 93a2845aeb483f312ae0c384f86697b3b78a127f
<pre>
Add NetworkProcess::checkedNetworkSession()
<a href="https://bugs.webkit.org/show_bug.cgi?id=293483">https://bugs.webkit.org/show_bug.cgi?id=293483</a>

Reviewed by NOBODY (OOPS!).

WIP.

* Source/WebKit/NetworkProcess/Downloads/cocoa/DownloadCocoa.mm:
(WebKit::Download::resume):
* Source/WebKit/NetworkProcess/NetworkProcess.cpp:
(WebKit::NetworkProcess::createNetworkConnectionToWebProcess):
(WebKit::NetworkProcess::checkedNetworkSession const):
(WebKit::NetworkProcess::registrableDomainsWithLastAccessedTime):
(WebKit::NetworkProcess::registrableDomainsExemptFromWebsiteDataDeletion):
(WebKit::NetworkProcess::dumpResourceLoadStatistics):
(WebKit::NetworkProcess::isGrandfathered):
(WebKit::NetworkProcess::isPrevalentResource):
(WebKit::NetworkProcess::isVeryPrevalentResource):
(WebKit::NetworkProcess::setGrandfathered):
(WebKit::NetworkProcess::setPrevalentResource):
(WebKit::NetworkProcess::setPrevalentResourceForDebugMode):
(WebKit::NetworkProcess::setVeryPrevalentResource):
(WebKit::NetworkProcess::clearPrevalentResource):
(WebKit::NetworkProcess::scheduleCookieBlockingUpdate):
(WebKit::NetworkProcess::scheduleClearInMemoryAndPersistent):
(WebKit::NetworkProcess::getResourceLoadStatisticsDataSummary):
(WebKit::NetworkProcess::resetParametersToDefaultValues):
(WebKit::NetworkProcess::scheduleStatisticsAndDataRecordsProcessing):
(WebKit::NetworkProcess::statisticsDatabaseHasAllTables):
(WebKit::NetworkProcess::setResourceLoadStatisticsTimeAdvanceForTesting):
(WebKit::NetworkProcess::setIsRunningResourceLoadStatisticsTest):
(WebKit::NetworkProcess::setSubframeUnderTopFrameDomain):
(WebKit::NetworkProcess::isRegisteredAsRedirectingTo):
(WebKit::NetworkProcess::isRegisteredAsSubFrameUnder):
(WebKit::NetworkProcess::setSubresourceUnderTopFrameDomain):
(WebKit::NetworkProcess::setSubresourceUniqueRedirectTo):
(WebKit::NetworkProcess::setSubresourceUniqueRedirectFrom):
(WebKit::NetworkProcess::isRegisteredAsSubresourceUnder):
(WebKit::NetworkProcess::setTopFrameUniqueRedirectTo):
(WebKit::NetworkProcess::setTopFrameUniqueRedirectFrom):
(WebKit::NetworkProcess::setLastSeen):
(WebKit::NetworkProcess::domainIDExistsInDatabase):
(WebKit::NetworkProcess::mergeStatisticForTesting):
(WebKit::NetworkProcess::insertExpiredStatisticForTesting):
(WebKit::NetworkProcess::logFrameNavigation):
(WebKit::NetworkProcess::logUserInteraction):
(WebKit::NetworkProcess::hadUserInteraction):
(WebKit::NetworkProcess::isRelationshipOnlyInDatabaseOnce):
(WebKit::NetworkProcess::clearUserInteraction):
(WebKit::NetworkProcess::hasLocalStorage):
(WebKit::NetworkProcess::setGrandfatheringTime):
(WebKit::NetworkProcess::setMaxStatisticsEntries):
(WebKit::NetworkProcess::setMinimumTimeBetweenDataRecordsRemoval):
(WebKit::NetworkProcess::setPruneEntriesDownTo):
(WebKit::NetworkProcess::setTimeToLiveUserInteraction):
(WebKit::NetworkProcess::setShouldClassifyResourcesBeforeDataRecordsRemoval):
(WebKit::NetworkProcess::setTrackingPreventionEnabled):
(WebKit::NetworkProcess::setResourceLoadStatisticsDebugMode):
(WebKit::NetworkProcess::isResourceLoadStatisticsEphemeral const):
(WebKit::NetworkProcess::didCommitCrossSiteLoadWithDataTransfer):
(WebKit::NetworkProcess::setCrossSiteLoadWithLinkDecorationForTesting):
(WebKit::NetworkProcess::hasIsolatedSession const):
(WebKit::NetworkProcess::setAppBoundDomainsForResourceLoadStatistics):
(WebKit::NetworkProcess::setManagedDomainsForResourceLoadStatistics):
(WebKit::NetworkProcess::setThirdPartyCookieBlockingMode):
(WebKit::NetworkProcess::setShouldEnbleSameSiteStrictEnforcementForTesting):
(WebKit::NetworkProcess::setFirstPartyWebsiteDataRemovalModeForTesting):
(WebKit::NetworkProcess::setFirstPartyHostCNAMEDomainForTesting):
(WebKit::NetworkProcess::setThirdPartyCNAMEDomainForTesting):
(WebKit::NetworkProcess::setPrivateClickMeasurementDebugMode):
(WebKit::NetworkProcess::setShouldSendPrivateTokenIPCForTesting const):
(WebKit::NetworkProcess::setOptInCookiePartitioningEnabled const):
(WebKit::NetworkProcess::fetchWebsiteData):
(WebKit::NetworkProcess::deleteWebsiteDataImpl):
(WebKit::NetworkProcess::deleteWebsiteDataForOrigin):
(WebKit::NetworkProcess::deleteWebsiteDataForOrigins):
(WebKit::NetworkProcess::deleteAndRestrictWebsiteDataForRegistrableDomains):
(WebKit::NetworkProcess::registrableDomainsWithWebsiteData):
(WebKit::NetworkProcess::closeITPDatabase):
(WebKit::NetworkProcess::cancelDataTask):
(WebKit::NetworkProcess::allowTLSCertificateChainForLocalPCMTesting):
(WebKit::NetworkProcess::terminateRemoteWorkerContextConnectionWhenPossible):
(WebKit::NetworkProcess::runningOrTerminatingServiceWorkerCountForTesting const):
(WebKit::NetworkProcess::storeServiceWorkerRegistrations):
(WebKit::NetworkProcess::resetQuota):
(WebKit::NetworkProcess::setOriginQuotaRatioEnabledForTesting):
(WebKit::NetworkProcess::resetStoragePersistedState):
(WebKit::NetworkProcess::cloneSessionStorageForWebPage):
(WebKit::NetworkProcess::didIncreaseQuota):
(WebKit::NetworkProcess::renameOriginInWebsiteData):
(WebKit::NetworkProcess::websiteDataOriginDirectoryForTesting):
(WebKit::NetworkProcess::processNotificationEvent):
(WebKit::NetworkProcess::getAllBackgroundFetchIdentifiers):
(WebKit::NetworkProcess::getBackgroundFetchState):
(WebKit::NetworkProcess::abortBackgroundFetch):
(WebKit::NetworkProcess::pauseBackgroundFetch):
(WebKit::NetworkProcess::resumeBackgroundFetch):
(WebKit::NetworkProcess::clickBackgroundFetch):
(WebKit::NetworkProcess::getPendingPushMessage):
(WebKit::NetworkProcess::getPendingPushMessages):
(WebKit::NetworkProcess::processPushMessage):
(WebKit::NetworkProcess::setPushAndNotificationsEnabledForOrigin):
(WebKit::NetworkProcess::removePushSubscriptionsForOrigin):
(WebKit::NetworkProcess::hasPushSubscriptionForTesting):
(WebKit::NetworkProcess::getAppBadgeForTesting):
(WebKit::NetworkProcess::setEmulatedConditions):
(WebKit::NetworkProcess::storePrivateClickMeasurement):
(WebKit::NetworkProcess::dumpPrivateClickMeasurement):
(WebKit::NetworkProcess::clearPrivateClickMeasurement):
(WebKit::NetworkProcess::setPrivateClickMeasurementOverrideTimerForTesting):
(WebKit::NetworkProcess::closePCMDatabase):
(WebKit::NetworkProcess::simulatePrivateClickMeasurementSessionRestart):
(WebKit::NetworkProcess::markAttributedPrivateClickMeasurementsAsExpiredForTesting):
(WebKit::NetworkProcess::setPrivateClickMeasurementEphemeralMeasurementForTesting):
(WebKit::NetworkProcess::setPrivateClickMeasurementTokenPublicKeyURLForTesting):
(WebKit::NetworkProcess::setPrivateClickMeasurementTokenSignatureURLForTesting):
(WebKit::NetworkProcess::setPrivateClickMeasurementAttributionReportURLsForTesting):
(WebKit::NetworkProcess::markPrivateClickMeasurementsAsExpiredForTesting):
(WebKit::NetworkProcess::setPCMFraudPreventionValuesForTesting):
(WebKit::NetworkProcess::setPrivateClickMeasurementAppBundleIDForTesting):
(WebKit::NetworkProcess::addKeptAliveLoad):
(WebKit::NetworkProcess::removeKeptAliveLoad):
(WebKit::NetworkProcess::connectionToWebProcessClosed):
(WebKit::NetworkProcess::hasAppBoundSession const):
(WebKit::NetworkProcess::clearAppBoundSession):
(WebKit::NetworkProcess::appPrivacyReportTestingData):
(WebKit::NetworkProcess::clearAppPrivacyReportTestingData):
(WebKit::NetworkProcess::addWebPageNetworkParameters):
(WebKit::NetworkProcess::removeWebPageNetworkParameters):
(WebKit::NetworkProcess::countNonDefaultSessionSets):
(WebKit::NetworkProcess::setInspectionForServiceWorkersAllowed):
(WebKit::NetworkProcess::setStorageSiteValidationEnabled):
(WebKit::NetworkProcess::setPersistedDomains):
* Source/WebKit/NetworkProcess/NetworkProcess.h:
* Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp:
(WebKit::NetworkResourceLoader::retrieveCacheEntry):
(WebKit::NetworkResourceLoader::startNetworkLoad):
(WebKit::NetworkResourceLoader::didReceiveResponse):
(WebKit::NetworkResourceLoader::sendDidReceiveResponsePotentiallyInNewBrowsingContextGroup):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/93a2845aeb483f312ae0c384f86697b3b78a127f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104812 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24525 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/14946 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110027 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/55486 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/24924 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33070 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79586 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107818 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19381 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94592 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59893 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/19132 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/54869 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/88832 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/12716 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/112440 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/31977 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23509 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88666 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32341 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/90818 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88293 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33182 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10949 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/27290 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/31902 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/37256 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/31694 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35035 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33253 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->