### PR TITLE
VideoMediaSampleRenderer can enqueue sample with a presentation time lower than the last calculated minimum time

### DIFF
--- a/Source/WebCore/platform/graphics/SourceBufferPrivate.h
+++ b/Source/WebCore/platform/graphics/SourceBufferPrivate.h
@@ -152,7 +152,7 @@ public:
     using SamplesPromise = NativePromise<Vector<String>, PlatformMediaError>;
     WEBCORE_EXPORT virtual Ref<SamplesPromise> bufferedSamplesForTrackId(TrackID);
     WEBCORE_EXPORT virtual Ref<SamplesPromise> enqueuedSamplesForTrackID(TrackID);
-    virtual MediaTime minimumUpcomingPresentationTimeForTrackID(TrackID) { return MediaTime::invalidTime(); }
+    WEBCORE_EXPORT virtual MediaTime minimumUpcomingPresentationTimeForTrackID(TrackID);
     virtual void setMaximumQueueDepthForTrackID(TrackID, uint64_t) { }
 
 #if !RELEASE_LOG_DISABLED
@@ -194,7 +194,6 @@ protected:
 
     virtual bool canSetMinimumUpcomingPresentationTime(TrackID) const { return false; }
     virtual void setMinimumUpcomingPresentationTime(TrackID, const MediaTime&) { }
-    virtual void clearMinimumUpcomingPresentationTime(TrackID) { }
 
     enum class NeedsFlush: bool {
         No = 0,

--- a/Source/WebCore/platform/graphics/TrackBuffer.h
+++ b/Source/WebCore/platform/graphics/TrackBuffer.h
@@ -53,8 +53,6 @@ public:
     void addBufferedRange(const MediaTime& start, const MediaTime& end, AddTimeRangeOption = AddTimeRangeOption::None);
     void addSample(MediaSample&);
 
-    bool updateMinimumUpcomingPresentationTime();
-
     bool reenqueueMediaForTime(const MediaTime&, const MediaTime& timeFudgeFactor, bool isEnded = false);
     MediaTime findSeekTimeForTargetTime(const MediaTime& targetTime, const MediaTime& negativeThreshold, const MediaTime& positiveThreshold);
     int64_t removeCodedFrames(const MediaTime& start, const MediaTime& end, const MediaTime& currentTime);
@@ -82,7 +80,6 @@ public:
     const MediaTime& highestEnqueuedPresentationTime() const { return m_highestEnqueuedPresentationTime; }
     void setHighestEnqueuedPresentationTime(MediaTime timestamp) { m_highestEnqueuedPresentationTime = WTFMove(timestamp); }
     const MediaTime& minimumEnqueuedPresentationTime() const { return m_minimumEnqueuedPresentationTime; }
-    void setMinimumEnqueuedPresentationTime(MediaTime timestamp) { m_minimumEnqueuedPresentationTime = WTFMove(timestamp); }
 
     const DecodeOrderSampleMap::KeyType& lastEnqueuedDecodeKey() const { return m_lastEnqueuedDecodeKey; }
     void setLastEnqueuedDecodeKey(DecodeOrderSampleMap::KeyType key) { m_lastEnqueuedDecodeKey = WTFMove(key); }
@@ -102,8 +99,6 @@ public:
     void setEnabled(bool enabled) { m_enabled = enabled; }
     bool needsReenqueueing() const { return m_needsReenqueueing; }
     void setNeedsReenqueueing(bool flag) { m_needsReenqueueing = flag; }
-    bool needsMinimumUpcomingPresentationTimeUpdating() const { return m_needsMinimumUpcomingPresentationTimeUpdating; }
-    void setNeedsMinimumUpcomingPresentationTimeUpdating(bool flag) { m_needsMinimumUpcomingPresentationTimeUpdating = flag; }
 
     const SampleMap& samples() const { return m_samples; }
     SampleMap& samples() { return m_samples; }
@@ -125,6 +120,8 @@ private:
 
     const DecodeOrderSampleMap::MapType& decodeQueue() const { return m_decodeQueue; }
     DecodeOrderSampleMap::MapType& decodeQueue() { return m_decodeQueue; }
+    void updateMinimumUpcomingPresentationTime();
+    void clearDecodeQueue();
 
     SampleMap m_samples;
     DecodeOrderSampleMap::MapType m_decodeQueue;
@@ -157,7 +154,7 @@ private:
     bool m_needRandomAccessFlag { true };
     bool m_enabled { false };
     bool m_needsReenqueueing { false };
-    bool m_needsMinimumUpcomingPresentationTimeUpdating { false };
+    bool m_hasOutOfOrderFrames { false };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.h
@@ -170,7 +170,6 @@ private:
     void notifyClientWhenReadyForMoreSamples(TrackID) final;
     bool canSetMinimumUpcomingPresentationTime(TrackID) const override;
     void setMinimumUpcomingPresentationTime(TrackID, const MediaTime&) override;
-    void clearMinimumUpcomingPresentationTime(TrackID) override;
     bool canSwitchToType(const ContentType&) final;
     bool isSeeking() const final;
 
@@ -189,7 +188,7 @@ private:
 
     void processPendingTrackChangeTasks();
     void enqueueSample(Ref<MediaSampleAVFObjC>&&, TrackID);
-    void enqueueSampleBuffer(MediaSampleAVFObjC&);
+    void enqueueSampleBuffer(MediaSampleAVFObjC&, const MediaTime&);
     void attachContentKeyToSampleIfNeeded(const MediaSampleAVFObjC&);
     void didBecomeReadyForMoreSamples(TrackID);
     void appendCompleted(bool);

--- a/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm
@@ -1125,7 +1125,7 @@ void SourceBufferPrivateAVFObjC::enqueueSample(Ref<MediaSampleAVFObjC>&& sample,
         if (!m_videoRenderer)
             return;
 
-        enqueueSampleBuffer(sample.get());
+        enqueueSampleBuffer(sample.get(), minimumUpcomingPresentationTimeForTrackID(trackID));
 
     } else {
         // AVSampleBufferAudioRenderer will throw an un-documented exception if passed a sample
@@ -1147,12 +1147,12 @@ void SourceBufferPrivateAVFObjC::enqueueSample(Ref<MediaSampleAVFObjC>&& sample,
     }
 }
 
-void SourceBufferPrivateAVFObjC::enqueueSampleBuffer(MediaSampleAVFObjC& sample)
+void SourceBufferPrivateAVFObjC::enqueueSampleBuffer(MediaSampleAVFObjC& sample, const MediaTime& minimumUpcomingTime)
 {
     attachContentKeyToSampleIfNeeded(sample);
     WebSampleBufferVideoRendering *renderer = nil;
     if (RefPtr videoRenderer = m_videoRenderer) {
-        videoRenderer->enqueueSample(sample);
+        videoRenderer->enqueueSample(sample, minimumUpcomingTime);
 
         // Enqueuing a sample for display my synchronously fire an error, which can cause m_videoRenderer to become null.
         videoRenderer = m_videoRenderer;
@@ -1307,15 +1307,6 @@ void SourceBufferPrivateAVFObjC::setMinimumUpcomingPresentationTime(TrackID trac
     if (canSetMinimumUpcomingPresentationTime(trackID)) {
         if (RefPtr videoRenderer = m_videoRenderer)
             videoRenderer->expectMinimumUpcomingSampleBufferPresentationTime(presentationTime);
-    }
-}
-
-void SourceBufferPrivateAVFObjC::clearMinimumUpcomingPresentationTime(TrackID trackID)
-{
-    ASSERT(canSetMinimumUpcomingPresentationTime(trackID));
-    if (canSetMinimumUpcomingPresentationTime(trackID)) {
-        if (RefPtr videoRenderer = m_videoRenderer)
-            videoRenderer->resetUpcomingSampleBufferPresentationTimeExpectations();
     }
 }
 

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h
@@ -211,7 +211,6 @@ private:
     void notifyClientWhenReadyForMoreSamples(TrackID);
 
     void setMinimumUpcomingPresentationTime(TrackID, const MediaTime&);
-    void clearMinimumUpcomingPresentationTime(TrackID);
 
     bool isReadyForMoreSamples(TrackID);
     void didBecomeReadyForMoreSamples(TrackID);

--- a/Source/WebCore/platform/graphics/cocoa/WebSampleBufferVideoRendering.h
+++ b/Source/WebCore/platform/graphics/cocoa/WebSampleBufferVideoRendering.h
@@ -29,7 +29,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @protocol WebSampleBufferVideoRendering <AVQueuedSampleBufferRendering>
 - (void)expectMinimumUpcomingSampleBufferPresentationTime:(CMTime)minimumUpcomingPresentationTime;
-- (void)resetUpcomingSampleBufferPresentationTimeExpectations;
 - (nullable CVPixelBufferRef)copyDisplayedPixelBuffer;
 - (void)prerollDecodeWithCompletionHandler:(void (^)(BOOL success))block;
 - (nullable AVVideoPerformanceMetrics *)videoPerformanceMetrics;

--- a/Source/WebCore/platform/mock/mediasource/MockSourceBufferPrivate.cpp
+++ b/Source/WebCore/platform/mock/mediasource/MockSourceBufferPrivate.cpp
@@ -210,11 +210,6 @@ Ref<SourceBufferPrivate::SamplesPromise> MockSourceBufferPrivate::enqueuedSample
     return SamplesPromise::createAndResolve(copyToVector(m_enqueuedSamples));
 }
 
-MediaTime MockSourceBufferPrivate::minimumUpcomingPresentationTimeForTrackID(TrackID)
-{
-    return m_minimumUpcomingPresentationTime;
-}
-
 void MockSourceBufferPrivate::setMaximumQueueDepthForTrackID(TrackID, uint64_t maxQueueDepth)
 {
     m_maxQueueDepth = maxQueueDepth;
@@ -223,16 +218,6 @@ void MockSourceBufferPrivate::setMaximumQueueDepthForTrackID(TrackID, uint64_t m
 bool MockSourceBufferPrivate::canSetMinimumUpcomingPresentationTime(TrackID) const
 {
     return true;
-}
-
-void MockSourceBufferPrivate::setMinimumUpcomingPresentationTime(TrackID, const MediaTime& presentationTime)
-{
-    m_minimumUpcomingPresentationTime = presentationTime;
-}
-
-void MockSourceBufferPrivate::clearMinimumUpcomingPresentationTime(TrackID)
-{
-    m_minimumUpcomingPresentationTime = MediaTime::invalidTime();
 }
 
 bool MockSourceBufferPrivate::canSwitchToType(const ContentType& contentType)

--- a/Source/WebCore/platform/mock/mediasource/MockSourceBufferPrivate.h
+++ b/Source/WebCore/platform/mock/mediasource/MockSourceBufferPrivate.h
@@ -53,16 +53,13 @@ private:
     Ref<MediaPromise> appendInternal(Ref<SharedBuffer>&&) final;
     void resetParserStateInternal() final;
     bool canSetMinimumUpcomingPresentationTime(TrackID) const final;
-    void setMinimumUpcomingPresentationTime(TrackID, const MediaTime&) final;
-    void clearMinimumUpcomingPresentationTime(TrackID) final;
     bool canSwitchToType(const ContentType&) final;
 
-    void flush(TrackID) final { m_enqueuedSamples.clear(); m_minimumUpcomingPresentationTime = MediaTime::invalidTime(); }
+    void flush(TrackID) final { m_enqueuedSamples.clear(); }
     void enqueueSample(Ref<MediaSample>&&, TrackID) final;
     bool isReadyForMoreSamples(TrackID) final { return !m_maxQueueDepth || m_enqueuedSamples.size() < m_maxQueueDepth.value(); }
 
     Ref<SamplesPromise> enqueuedSamplesForTrackID(TrackID) final;
-    MediaTime minimumUpcomingPresentationTimeForTrackID(TrackID) final;
     void setMaximumQueueDepthForTrackID(TrackID, uint64_t) final;
 
     void didReceiveInitializationSegment(const MockInitializationBox&);
@@ -78,7 +75,6 @@ private:
     uint64_t sourceBufferLogIdentifier() final { return logIdentifier(); }
 #endif
 
-    MediaTime m_minimumUpcomingPresentationTime;
     Vector<String> m_enqueuedSamples;
     std::optional<uint64_t> m_maxQueueDepth;
     Vector<uint8_t> m_inputBuffer;


### PR DESCRIPTION
#### b15a127ad26331c22771febc364d671b10872729
<pre>
VideoMediaSampleRenderer can enqueue sample with a presentation time lower than the last calculated minimum time
<a href="https://bugs.webkit.org/show_bug.cgi?id=293422">https://bugs.webkit.org/show_bug.cgi?id=293422</a>
<a href="https://rdar.apple.com/151850145">rdar://151850145</a>

Reviewed by Jer Noble.

We stop attempting to determine the minimum upcoming time from the VideoMediaSampleRenderer&apos;s compressed queue.
If the number of pending samples drop below a certain threshold (such as would occur if
decoding was faster than it takes the SourceBuffer to enqueue them), the renderer would
incorrectly determine that the minimum time.
This would cause the future samples to be added after we notified the
AVSampleBufferVideoRenderer on what the expectMinimumUpcomingSampleBufferPresentationTime
was going to be.

So instead, we calculate this in the TrackBuffer which is the source of truth.
We also now always calculate such value as samples are added and removed
from the TrackBuffer so that the minimum value is always known.
Whenever a new sample is enqueued to the VideoMediaSampleRenderer we also
provide the minimum time of the upcoming samples. This value can be used
to determined if we need to decode further samples, or when to notify
the AVSampleBufferVideoRenderer of the next upcoming time.

No change in existing, observable behaviour. Covered by existing tests.
Added debug assertions that caused existing tests to crash without the fixes contained in this patch.

* Source/WebCore/platform/graphics/SourceBufferPrivate.cpp:
(WebCore::SourceBufferPrivate::minimumUpcomingPresentationTimeForTrackID): Add convenience method so that child classes
can access the minimumUpcomingPresentationTime without having access to the TrackBuffer. An alternative
would have been to pass this value all the way down to enqueueSample but this would have resulted in a much bigger change.
(WebCore::SourceBufferPrivate::updateMinimumUpcomingPresentationTime): We no longer need to explictly recalculate the value
as it is now kept up to date as samples are added or removed from the TrackBuffer.
(WebCore::SourceBufferPrivate::minimumUpcomingPresentationTimeForTrackID): Deleted.
(WebCore::SourceBufferPrivate::clearMinimumUpcomingPresentationTime): Deleted.
* Source/WebCore/platform/graphics/TrackBuffer.cpp:
(WebCore::TrackBuffer::addSample): incrementally re-calculate m_minimumEnqueuedPresentationTime if a sample
was also added to the end of the decode queue.
(WebCore::TrackBuffer::nextSample): same as above.
(WebCore::TrackBuffer::updateMinimumUpcomingPresentationTime): Convenience method.
The only codecs using out of order frames (b-frames) are H264 and HEVC and a frame
can only reference another in a window of samples that is 16-large. We can limit
the scan to a maximum of 16 samples.
(WebCore::MediaPlayerPrivateWebM::clearMinimumUpcomingPresentationTime): Deleted.
(WebCore::VideoMediaSampleRenderer::hasIncomingOutOfOrderFrame const): Deleted.
(WebCore::VideoMediaSampleRenderer::minimumUpcomingSampleTime const): Deleted.
(WebCore::VideoMediaSampleRenderer::resetUpcomingSampleBufferPresentationTimeExpectations): Deleted.
(WebCore::MockSourceBufferPrivate::minimumUpcomingPresentationTimeForTrackID): Deleted.
(WebCore::MockSourceBufferPrivate::setMinimumUpcomingPresentationTime): Deleted.
(WebCore::MockSourceBufferPrivate::clearMinimumUpcomingPresentationTime): Deleted.

Canonical link: <a href="https://commits.webkit.org/295388@main">https://commits.webkit.org/295388@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/91d0c4f49ae1a9ef4217844a1e3c2deebc98a5ed

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104845 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24558 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/14979 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110060 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/55519 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/106885 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/24958 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33103 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79610 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107851 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19407 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94621 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59917 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/19154 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/12698 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/54902 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/88854 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/12745 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/112482 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32010 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23530 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88688 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32374 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/90847 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88316 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22528 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33210 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10975 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/27324 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/31935 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/37290 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/31727 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35068 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33286 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->