### PR TITLE
[Refactor] Pass AudioBus by reference everywhere possible

### DIFF
--- a/Source/WebCore/Modules/webaudio/AnalyserNode.cpp
+++ b/Source/WebCore/Modules/webaudio/AnalyserNode.cpp
@@ -76,28 +76,28 @@ AnalyserNode::~AnalyserNode()
 
 void AnalyserNode::process(size_t framesToProcess)
 {
-    AudioBus* outputBus = output(0)->bus();
+    AudioBus& outputBus = output(0)->bus();
 
     if (!isInitialized()) {
-        outputBus->zero();
+        outputBus.zero();
         return;
     }
 
-    AudioBus* inputBus = input(0)->bus();
-    
+    AudioBus& inputBus = input(0)->bus();
+
     // Give the analyser the audio which is passing through this AudioNode. This must always
     // be done so that the state of the Analyser reflects the current input.
     m_analyser.writeInput(inputBus, framesToProcess);
 
     if (!input(0)->isConnected()) {
-        outputBus->zero();
+        outputBus.zero();
         return;
     }
 
     // For in-place processing, our override of pullInputs() will just pass the audio data through unchanged if the channel count matches from input to output
     // (resulting in inputBus == outputBus). Otherwise, do an up-mix to stereo.
-    if (inputBus != outputBus)
-        outputBus->copyFrom(*inputBus);
+    if (&inputBus != &outputBus)
+        outputBus.copyFrom(inputBus);
 }
 
 ExceptionOr<void> AnalyserNode::setFftSize(unsigned size)

--- a/Source/WebCore/Modules/webaudio/AudioBasicInspectorNode.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioBasicInspectorNode.cpp
@@ -49,7 +49,7 @@ void AudioBasicInspectorNode::pullInputs(size_t framesToProcess)
 {
     // Render input stream - try to render directly into output bus for pass-through processing where process() doesn't need to do anything...
     auto* output = this->output(0);
-    input(0)->pull(output ? output->bus() : nullptr, framesToProcess);
+    input(0)->pull(output ? &output->bus() : nullptr, framesToProcess);
 }
 
 void AudioBasicInspectorNode::checkNumberOfChannelsForInput(AudioNodeInput* input)

--- a/Source/WebCore/Modules/webaudio/AudioBasicProcessorNode.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioBasicProcessorNode.cpp
@@ -74,16 +74,16 @@ void AudioBasicProcessorNode::uninitialize()
 
 void AudioBasicProcessorNode::process(size_t framesToProcess)
 {
-    AudioBus* destinationBus = output(0)->bus();
-    
+    AudioBus& destinationBus = output(0)->bus();
+
     if (!isInitialized() || !processor() || processor()->numberOfChannels() != numberOfChannels())
-        destinationBus->zero();
+        destinationBus.zero();
     else {
-        AudioBus* sourceBus = input(0)->bus();
+        AudioBus& sourceBus = input(0)->bus();
 
         // FIXME: if we take "tail time" into account, then we can avoid calling processor()->process() once the tail dies down.
         if (!input(0)->isConnected())
-            sourceBus->zero();
+            sourceBus.zero();
 
         processor()->process(sourceBus, destinationBus, framesToProcess);  
     }
@@ -101,7 +101,7 @@ void AudioBasicProcessorNode::processOnlyAudioParams(size_t framesToProcess)
 void AudioBasicProcessorNode::pullInputs(size_t framesToProcess)
 {
     // Render input stream - suggest to the input to render directly into output bus for in-place processing in process() if possible.
-    input(0)->pull(output(0)->bus(), framesToProcess);
+    input(0)->pull(&output(0)->bus(), framesToProcess);
 }
 
 // As soon as we know the channel count of our input, we can lazily initialize.

--- a/Source/WebCore/Modules/webaudio/AudioBufferSourceNode.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioBufferSourceNode.cpp
@@ -98,7 +98,7 @@ AudioBufferSourceNode::~AudioBufferSourceNode()
 
 void AudioBufferSourceNode::process(size_t framesToProcess)
 {
-    auto& outputBus = *output(0)->bus();
+    auto& outputBus = output(0)->bus();
 
     if (!isInitialized()) {
         outputBus.zero();
@@ -140,7 +140,7 @@ void AudioBufferSourceNode::process(size_t framesToProcess)
         m_destinationChannels[i] = outputBus.channel(i)->mutableSpan();
 
     // Render by reading directly from the buffer.
-    if (!renderFromBuffer(&outputBus, quantumFrameOffset, bufferFramesToProcess, startFrameOffset)) {
+    if (!renderFromBuffer(outputBus, quantumFrameOffset, bufferFramesToProcess, startFrameOffset)) {
         outputBus.zero();
         return;
     }
@@ -149,7 +149,7 @@ void AudioBufferSourceNode::process(size_t framesToProcess)
 }
 
 // Returns true if we're finished.
-bool AudioBufferSourceNode::renderSilenceAndFinishIfNotLooping(AudioBus*, unsigned index, size_t framesToProcess)
+bool AudioBufferSourceNode::renderSilenceAndFinishIfNotLooping(AudioBus&, unsigned index, size_t framesToProcess)
 {
     if (!m_isLooping) {
         // If we're not looping, then stop playing when we get to the end.
@@ -168,18 +168,17 @@ bool AudioBufferSourceNode::renderSilenceAndFinishIfNotLooping(AudioBus*, unsign
     return false;
 }
 
-bool AudioBufferSourceNode::renderFromBuffer(AudioBus* bus, unsigned destinationFrameOffset, size_t numberOfFrames, double startFrameOffset)
+bool AudioBufferSourceNode::renderFromBuffer(AudioBus& bus, unsigned destinationFrameOffset, size_t numberOfFrames, double startFrameOffset)
 {
     ASSERT(context().isAudioThread());
 
     // Basic sanity checking
-    ASSERT(bus);
     ASSERT(m_buffer);
-    if (!bus || !m_buffer)
+    if (!m_buffer)
         return false;
 
     unsigned numberOfChannels = this->numberOfChannels();
-    unsigned busNumberOfChannels = bus->numberOfChannels();
+    unsigned busNumberOfChannels = bus.numberOfChannels();
 
     bool channelCountGood = numberOfChannels && numberOfChannels == busNumberOfChannels;
     ASSERT(channelCountGood);
@@ -187,7 +186,7 @@ bool AudioBufferSourceNode::renderFromBuffer(AudioBus* bus, unsigned destination
         return false;
 
     // Sanity check destinationFrameOffset, numberOfFrames.
-    size_t destinationLength = bus->length();
+    size_t destinationLength = bus.length();
 
     bool isLengthGood = destinationLength <= 4096 && numberOfFrames <= 4096;
     ASSERT(isLengthGood);
@@ -420,7 +419,7 @@ bool AudioBufferSourceNode::renderFromBuffer(AudioBus* bus, unsigned destination
         }
     }
 
-    bus->clearSilentFlag();
+    bus.clearSilentFlag();
 
     m_virtualReadIndex = virtualReadIndex;
 

--- a/Source/WebCore/Modules/webaudio/AudioBufferSourceNode.h
+++ b/Source/WebCore/Modules/webaudio/AudioBufferSourceNode.h
@@ -94,10 +94,10 @@ private:
     void adjustGrainParameters() WTF_REQUIRES_LOCK(m_processLock);
 
     // Returns true on success.
-    bool renderFromBuffer(AudioBus*, unsigned destinationFrameOffset, size_t numberOfFrames, double startFrameOffset) WTF_REQUIRES_LOCK(m_processLock);
+    bool renderFromBuffer(AudioBus&, unsigned destinationFrameOffset, size_t numberOfFrames, double startFrameOffset) WTF_REQUIRES_LOCK(m_processLock);
 
     // Render silence starting from "index" frame in AudioBus.
-    inline bool renderSilenceAndFinishIfNotLooping(AudioBus*, unsigned index, size_t framesToProcess) WTF_REQUIRES_LOCK(m_processLock);
+    inline bool renderSilenceAndFinishIfNotLooping(AudioBus&, unsigned index, size_t framesToProcess) WTF_REQUIRES_LOCK(m_processLock);
 
     // m_buffer holds the sample data which this node outputs.
     RefPtr<AudioBuffer> m_buffer WTF_GUARDED_BY_LOCK(m_processLock); // Only modified on the main thread but used on the audio thread.

--- a/Source/WebCore/Modules/webaudio/AudioDestinationNode.h
+++ b/Source/WebCore/Modules/webaudio/AudioDestinationNode.h
@@ -69,7 +69,7 @@ protected:
     double tailTime() const final { return 0; }
     double latencyTime() const final { return 0; }
 
-    void renderQuantum(AudioBus* destinationBus, size_t numberOfFrames, const AudioIOPosition& outputPosition);
+    void renderQuantum(AudioBus& destinationBus, size_t numberOfFrames, const AudioIOPosition& outputPosition);
 
 private:
     // Counts the number of sample-frames processed by the destination.

--- a/Source/WebCore/Modules/webaudio/AudioNode.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioNode.cpp
@@ -514,7 +514,7 @@ void AudioNode::pullInputs(size_t framesToProcess)
 bool AudioNode::inputsAreSilent()
 {
     for (auto& input : m_inputs) {
-        if (!input->bus()->isSilent())
+        if (!input->bus().isSilent())
             return false;
     }
     return true;
@@ -523,7 +523,7 @@ bool AudioNode::inputsAreSilent()
 void AudioNode::silenceOutputs()
 {
     for (auto& output : m_outputs)
-        output->bus()->zero();
+        output->bus().zero();
 }
 
 void AudioNode::enableOutputsIfNecessary()

--- a/Source/WebCore/Modules/webaudio/AudioNodeInput.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioNodeInput.cpp
@@ -43,9 +43,9 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(AudioNodeInput);
 AudioNodeInput::AudioNodeInput(AudioNode* node)
     : AudioSummingJunction(node->context())
     , m_node(node, EnableWeakPtrThreadingAssertions::No) // WebAudio code uses locking when accessing the context.
+    , m_internalSummingBus { AudioBus::create(1, AudioUtilities::renderQuantumSize) }
 {
     // Set to mono by default.
-    m_internalSummingBus = AudioBus::create(1, AudioUtilities::renderQuantumSize);
 }
 
 void AudioNodeInput::connect(AudioNodeOutput* output)
@@ -173,7 +173,7 @@ unsigned AudioNodeInput::numberOfChannels() const
     return maxChannels;
 }
 
-AudioBus* AudioNodeInput::bus()
+AudioBus& AudioNodeInput::bus()
 {
     ASSERT(context());
     ASSERT(context()->isAudioThread());
@@ -183,18 +183,18 @@ AudioBus* AudioNodeInput::bus()
         return renderingOutput(0)->bus();
 
     // Multiple connections case or complex ChannelCountMode (or no connections).
-    return internalSummingBus();
+    return m_internalSummingBus;
 }
 
-AudioBus* AudioNodeInput::internalSummingBus()
+AudioBus& AudioNodeInput::internalSummingBus()
 {
     ASSERT(context());
     ASSERT(context()->isAudioThread());
 
-    return m_internalSummingBus.get();
+    return m_internalSummingBus;
 }
 
-void AudioNodeInput::sumAllConnections(AudioBus* summingBus, size_t framesToProcess)
+void AudioNodeInput::sumAllConnections(AudioBus& summingBus, size_t framesToProcess)
 {
     ASSERT(context());
     ASSERT(context()->isAudioThread());
@@ -202,11 +202,7 @@ void AudioNodeInput::sumAllConnections(AudioBus* summingBus, size_t framesToProc
     // We shouldn't be calling this method if there's only one connection, since it's less efficient.
     ASSERT(numberOfRenderingConnections() > 1 || node()->channelCountMode() != ChannelCountMode::Max);
 
-    ASSERT(summingBus);
-    if (!summingBus)
-        return;
-        
-    summingBus->zero();
+    summingBus.zero();
 
     auto interpretation = node()->channelInterpretation();
 
@@ -214,14 +210,14 @@ void AudioNodeInput::sumAllConnections(AudioBus* summingBus, size_t framesToProc
         ASSERT(output);
 
         // Render audio from this output.
-        AudioBus* connectionBus = output->pull(0, framesToProcess);
+        AudioBus& connectionBus = output->pull(nullptr, framesToProcess);
 
         // Sum, with unity-gain.
-        summingBus->sumFrom(*connectionBus, interpretation);
+        summingBus.sumFrom(connectionBus, interpretation);
     }
 }
 
-AudioBus* AudioNodeInput::pull(AudioBus* inPlaceBus, size_t framesToProcess)
+AudioBus& AudioNodeInput::pull(AudioBus* inPlaceBus, size_t framesToProcess)
 {
     ASSERT(context());
     ASSERT(context()->isAudioThread());
@@ -233,19 +229,17 @@ AudioBus* AudioNodeInput::pull(AudioBus* inPlaceBus, size_t framesToProcess)
         return output->pull(inPlaceBus, framesToProcess);
     }
 
-    AudioBus* internalSummingBus = this->internalSummingBus();
-
     if (!numberOfRenderingConnections()) {
         // At least, generate silence if we're not connected to anything.
         // FIXME: if we wanted to get fancy, we could propagate a 'silent hint' here to optimize the downstream graph processing.
-        internalSummingBus->zero();
-        return internalSummingBus;
+        m_internalSummingBus->zero();
+        return m_internalSummingBus;
     }
 
     // Handle multiple connections case.
-    sumAllConnections(internalSummingBus, framesToProcess);
-    
-    return internalSummingBus;
+    sumAllConnections(m_internalSummingBus, framesToProcess);
+
+    return m_internalSummingBus;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/webaudio/AudioNodeInput.h
+++ b/Source/WebCore/Modules/webaudio/AudioNodeInput.h
@@ -68,12 +68,12 @@ public:
     // In the single connection case, it allows in-place processing where possible using inPlaceBus.
     // It returns the bus which it rendered into, returning inPlaceBus if in-place processing was performed.
     // Called from context's audio thread.
-    AudioBus* pull(AudioBus* inPlaceBus, size_t framesToProcess);
+    AudioBus& pull(AudioBus* inPlaceBus, size_t framesToProcess);
 
     // bus() contains the rendered audio after pull() has been called for each time quantum.
     // Called from context's audio thread.
-    AudioBus* bus();
-    
+    AudioBus& bus();
+
     // updateInternalBus() updates m_internalSummingBus appropriately for the number of channels.
     // This must be called when we own the context's graph lock in the audio thread at the very start or end of the render quantum.
     void updateInternalBus();
@@ -90,10 +90,10 @@ private:
     HashSet<AudioNodeOutput*> m_disabledOutputs;
 
     // Called from context's audio thread.
-    AudioBus* internalSummingBus();
-    void sumAllConnections(AudioBus* summingBus, size_t framesToProcess);
+    AudioBus& internalSummingBus();
+    void sumAllConnections(AudioBus& summingBus, size_t framesToProcess);
 
-    RefPtr<AudioBus> m_internalSummingBus;
+    Ref<AudioBus> m_internalSummingBus;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/webaudio/AudioNodeOutput.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioNodeOutput.cpp
@@ -45,10 +45,9 @@ AudioNodeOutput::AudioNodeOutput(AudioNode* node, unsigned numberOfChannels)
     : m_node(node, EnableWeakPtrThreadingAssertions::No) // WebAudio code uses locking when accessing the context.
     , m_numberOfChannels(numberOfChannels)
     , m_desiredNumberOfChannels(numberOfChannels)
+    , m_internalBus { AudioBus::create(numberOfChannels, AudioUtilities::renderQuantumSize) }
 {
     ASSERT(numberOfChannels <= AudioContext::maxNumberOfChannels);
-
-    m_internalBus = AudioBus::create(numberOfChannels, AudioUtilities::renderQuantumSize);
 }
 
 void AudioNodeOutput::setNumberOfChannels(unsigned numberOfChannels)
@@ -109,7 +108,7 @@ void AudioNodeOutput::propagateChannelCount()
     }
 }
 
-AudioBus* AudioNodeOutput::pull(AudioBus* inPlaceBus, size_t framesToProcess)
+AudioBus& AudioNodeOutput::pull(AudioBus* inPlaceBus, size_t framesToProcess)
 {
     ASSERT(context().isAudioThread());
     ASSERT(m_renderingFanOutCount > 0 || m_renderingParamFanOutCount > 0);
@@ -120,18 +119,18 @@ AudioBus* AudioNodeOutput::pull(AudioBus* inPlaceBus, size_t framesToProcess)
     // In this case pull() is called multiple times per rendering quantum, and the processIfNecessary() call below will
     // cause our node to process() only the first time, caching the output in m_internalOutputBus for subsequent calls.    
     
-    m_isInPlace = inPlaceBus && inPlaceBus->numberOfChannels() == numberOfChannels() && (m_renderingFanOutCount + m_renderingParamFanOutCount) == 1;
+    bool isInPlace = inPlaceBus && inPlaceBus->numberOfChannels() == numberOfChannels() && (m_renderingFanOutCount + m_renderingParamFanOutCount) == 1;
 
-    m_inPlaceBus = m_isInPlace ? inPlaceBus : 0;
+    m_inPlaceBus = isInPlace ? inPlaceBus : nullptr;
 
     node()->processIfNecessary(framesToProcess);
     return bus();
 }
 
-AudioBus* AudioNodeOutput::bus() const
+AudioBus& AudioNodeOutput::bus() const
 {
     ASSERT(const_cast<AudioNodeOutput*>(this)->context().isAudioThread());
-    return m_isInPlace ? m_inPlaceBus.get() : m_internalBus.get();
+    return m_inPlaceBus ? *m_inPlaceBus : m_internalBus.get();
 }
 
 unsigned AudioNodeOutput::fanOutCount()

--- a/Source/WebCore/Modules/webaudio/AudioNodeOutput.h
+++ b/Source/WebCore/Modules/webaudio/AudioNodeOutput.h
@@ -54,11 +54,11 @@ public:
     // Causes our AudioNode to process if it hasn't already for this render quantum.
     // It returns the bus containing the processed audio for this output, returning inPlaceBus if in-place processing was possible.
     // Called from context's audio thread.
-    AudioBus* pull(AudioBus* inPlaceBus, size_t framesToProcess);
+    AudioBus& pull(AudioBus* inPlaceBus, size_t framesToProcess);
 
     // bus() will contain the rendered audio after pull() is called for each rendering time quantum.
     // Called from context's audio thread.
-    AudioBus* bus() const;
+    AudioBus& bus() const;
 
     // renderingFanOutCount() is the number of AudioNodeInputs that we're connected to during rendering.
     // Unlike fanOutCount() it will not change during the course of a render quantum.
@@ -138,10 +138,9 @@ private:
     unsigned m_desiredNumberOfChannels;
     
     // m_internalBus and m_inPlaceBus must only be changed in the audio thread with the context's graph lock (or constructor).
-    RefPtr<AudioBus> m_internalBus;
+    Ref<AudioBus> m_internalBus;
+    // If m_inPlaceBus is non-null, use m_inPlaceBus as the valid AudioBus; If null, use the default m_internalBus.
     RefPtr<AudioBus> m_inPlaceBus;
-    // If m_isInPlace is true, use m_inPlaceBus as the valid AudioBus; If false, use the default m_internalBus.
-    bool m_isInPlace { false };
 
     using InputsMap = HashMap<AudioNodeInput*, AudioConnectionRefPtr<AudioNode>>;
     InputsMap m_inputs;

--- a/Source/WebCore/Modules/webaudio/AudioParam.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioParam.cpp
@@ -320,10 +320,10 @@ void AudioParam::calculateFinalValues(std::span<float> values, bool sampleAccura
         ASSERT(output);
 
         // Render audio from this output.
-        AudioBus* connectionBus = output->pull(0, AudioUtilities::renderQuantumSize);
+        AudioBus& connectionBus = output->pull(0, AudioUtilities::renderQuantumSize);
 
         // Sum, with unity-gain.
-        m_summingBus->sumFrom(*connectionBus);
+        m_summingBus->sumFrom(connectionBus);
     }
 
     // If we're not sample accurate, duplicate the first element of |values| to all of the elements.

--- a/Source/WebCore/Modules/webaudio/AudioWorkletNode.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioWorkletNode.cpp
@@ -197,7 +197,7 @@ void AudioWorkletNode::process(size_t framesToProcess)
 
     auto zeroOutput = [&] {
         for (unsigned i = 0; i < numberOfOutputs(); ++i)
-            output(i)->bus()->zero();
+            output(i)->bus().zero();
     };
 
     if (!m_processLock.tryLock()) {
@@ -213,9 +213,9 @@ void AudioWorkletNode::process(size_t framesToProcess)
 
     // If the input is not connected, pass nullptr to the processor.
     for (unsigned i = 0; i < numberOfInputs(); ++i)
-        m_inputs[i] = input(i)->isConnected() ? input(i)->bus() : nullptr;
+        m_inputs[i] = input(i)->isConnected() ? &input(i)->bus() : nullptr;
     for (unsigned i = 0; i < numberOfOutputs(); ++i)
-        m_outputs[i] = *output(i)->bus();
+        m_outputs[i] = output(i)->bus();
 
     if (noiseInjectionPolicies().contains(NoiseInjectionPolicy::Minimal)) {
         for (unsigned inputIndex = 0; inputIndex < numberOfInputs(); ++inputIndex) {

--- a/Source/WebCore/Modules/webaudio/BiquadProcessor.cpp
+++ b/Source/WebCore/Modules/webaudio/BiquadProcessor.cpp
@@ -95,10 +95,10 @@ void BiquadProcessor::checkForDirtyCoefficients()
     }
 }
 
-void BiquadProcessor::process(const AudioBus* source, AudioBus* destination, size_t framesToProcess)
+void BiquadProcessor::process(const AudioBus& source, AudioBus& destination, size_t framesToProcess)
 {
     if (!isInitialized()) {
-        destination->zero();
+        destination.zero();
         return;
     }
         
@@ -106,7 +106,7 @@ void BiquadProcessor::process(const AudioBus* source, AudioBus* destination, siz
             
     // For each channel of our input, process using the corresponding BiquadDSPKernel into the output channel.
     for (unsigned i = 0; i < m_kernels.size(); ++i)
-        m_kernels[i]->process(source->channel(i)->span().first(framesToProcess), destination->channel(i)->mutableSpan());
+        m_kernels[i]->process(source.channel(i)->span().first(framesToProcess), destination.channel(i)->mutableSpan());
 }
 
 void BiquadProcessor::processOnlyAudioParams(size_t framesToProcess)

--- a/Source/WebCore/Modules/webaudio/BiquadProcessor.h
+++ b/Source/WebCore/Modules/webaudio/BiquadProcessor.h
@@ -48,7 +48,7 @@ public:
     
     std::unique_ptr<AudioDSPKernel> createKernel() override;
         
-    void process(const AudioBus* source, AudioBus* destination, size_t framesToProcess) override;
+    void process(const AudioBus& source, AudioBus& destination, size_t framesToProcess) override;
     void processOnlyAudioParams(size_t framesToProcess) final;
 
     // Get the magnitude and phase response of the filter at the given

--- a/Source/WebCore/Modules/webaudio/ChannelMergerNode.cpp
+++ b/Source/WebCore/Modules/webaudio/ChannelMergerNode.cpp
@@ -74,14 +74,14 @@ void ChannelMergerNode::process(size_t framesToProcess)
 {
     AudioNodeOutput* output = this->output(0);
     ASSERT(output);
-    ASSERT_UNUSED(framesToProcess, framesToProcess == output->bus()->length());
+    ASSERT_UNUSED(framesToProcess, framesToProcess == output->bus().length());
     ASSERT(numberOfInputs() == output->numberOfChannels());
     
     // Merge all the channels from all the inputs into one output.
     for (unsigned i = 0; i < numberOfInputs(); ++i) {
         AudioNodeInput* input = this->input(i);
         ASSERT(input->numberOfChannels() == 1u);
-        auto* outputChannel = output->bus()->channel(i);
+        auto* outputChannel = output->bus().channel(i);
         if (input->isConnected()) {
             // The mixing rules will be applied so multiple channels are down-
             // mixed to mono (when the mixing rule is defined). Note that only
@@ -90,7 +90,7 @@ void ChannelMergerNode::process(size_t framesToProcess)
             //
             // See:
             // http://webaudio.github.io/web-audio-api/#channel-up-mixing-and-down-mixing
-            auto* inputChannel = input->bus()->channel(0);
+            auto* inputChannel = input->bus().channel(0);
             outputChannel->copyFrom(inputChannel);
         } else {
             // If input is unconnected, fill zeros in the channel.

--- a/Source/WebCore/Modules/webaudio/ChannelSplitterNode.cpp
+++ b/Source/WebCore/Modules/webaudio/ChannelSplitterNode.cpp
@@ -65,23 +65,21 @@ ChannelSplitterNode::ChannelSplitterNode(BaseAudioContext& context, unsigned num
 
 void ChannelSplitterNode::process(size_t framesToProcess)
 {
-    AudioBus* source = input(0)->bus();
-    ASSERT(source);
-    ASSERT_UNUSED(framesToProcess, framesToProcess == source->length());
-    
-    unsigned numberOfSourceChannels = source->numberOfChannels();
+    AudioBus& source = input(0)->bus();
+    ASSERT_UNUSED(framesToProcess, framesToProcess == source.length());
+
+    unsigned numberOfSourceChannels = source.numberOfChannels();
     
     for (unsigned i = 0; i < numberOfOutputs(); ++i) {
-        AudioBus* destination = output(i)->bus();
-        ASSERT(destination);
-        
+        AudioBus& destination = output(i)->bus();
+
         if (i < numberOfSourceChannels) {
             // Split the channel out if it exists in the source.
             // It would be nice to avoid the copy and simply pass along pointers, but this becomes extremely difficult with fanout and fanin.
-            destination->channel(0)->copyFrom(source->channel(i));
+            destination.channel(0)->copyFrom(source.channel(i));
         } else if (output(i)->renderingFanOutCount() > 0) {
             // Only bother zeroing out the destination if it's connected to anything
-            destination->zero();
+            destination.zero();
         }
     }
 }

--- a/Source/WebCore/Modules/webaudio/ConstantSourceNode.cpp
+++ b/Source/WebCore/Modules/webaudio/ConstantSourceNode.cpp
@@ -63,7 +63,7 @@ ConstantSourceNode::~ConstantSourceNode()
 
 void ConstantSourceNode::process(size_t framesToProcess)
 {
-    auto& outputBus = *output(0)->bus();
+    auto& outputBus = output(0)->bus();
     
     if (!isInitialized() || !outputBus.numberOfChannels()) {
         outputBus.zero();

--- a/Source/WebCore/Modules/webaudio/DefaultAudioDestinationNode.cpp
+++ b/Source/WebCore/Modules/webaudio/DefaultAudioDestinationNode.cpp
@@ -262,16 +262,16 @@ MediaTime DefaultAudioDestinationNode::outputLatency() const
     return m_destination ? m_destination->outputLatency() : MediaTime::zeroTime();
 }
 
-void DefaultAudioDestinationNode::render(AudioBus*, AudioBus* destinationBus, size_t numberOfFrames, const AudioIOPosition& outputPosition)
+void DefaultAudioDestinationNode::render(AudioBus& destinationBus, size_t numberOfFrames, const AudioIOPosition& outputPosition)
 {
     renderQuantum(destinationBus, numberOfFrames, outputPosition);
 
-    setIsSilent(destinationBus->isSilent());
+    setIsSilent(destinationBus.isSilent());
 
     // The reason we are handling mute after the call to setIsSilent() is because the muted state does
     // not affect the audio destination node's effective playing state.
     if (m_muted)
-        destinationBus->zero();
+        destinationBus.zero();
 }
 
 void DefaultAudioDestinationNode::setIsSilent(bool isSilent)

--- a/Source/WebCore/Modules/webaudio/DefaultAudioDestinationNode.h
+++ b/Source/WebCore/Modules/webaudio/DefaultAudioDestinationNode.h
@@ -70,7 +70,7 @@ private:
     // AudioIOCallback
     // The audio hardware calls render() to get the next render quantum of audio into destinationBus.
     // It will optionally give us local/live audio input in sourceBus (if it's not 0).
-    void render(AudioBus* sourceBus, AudioBus* destinationBus, size_t numberOfFrames, const AudioIOPosition& outputPosition) final;
+    void render(AudioBus& destinationBus, size_t numberOfFrames, const AudioIOPosition& outputPosition) final;
     void isPlayingDidChange() final;
 
     void setIsSilent(bool);

--- a/Source/WebCore/Modules/webaudio/DynamicsCompressorNode.cpp
+++ b/Source/WebCore/Modules/webaudio/DynamicsCompressorNode.cpp
@@ -75,8 +75,7 @@ DynamicsCompressorNode::~DynamicsCompressorNode()
 
 void DynamicsCompressorNode::process(size_t framesToProcess)
 {
-    AudioBus* outputBus = output(0)->bus();
-    ASSERT(outputBus);
+    AudioBus& outputBus = output(0)->bus();
 
     float threshold = m_threshold->finalValue();
     float knee = m_knee->finalValue();

--- a/Source/WebCore/Modules/webaudio/GainNode.cpp
+++ b/Source/WebCore/Modules/webaudio/GainNode.cpp
@@ -68,13 +68,12 @@ void GainNode::process(size_t framesToProcess)
     // happen in the summing junction input of the AudioNode we're connected to.
     // Then we can avoid all of the following:
 
-    AudioBus* outputBus = output(0)->bus();
-    ASSERT(outputBus);
+    AudioBus& outputBus = output(0)->bus();
 
     if (!isInitialized() || !input(0)->isConnected())
-        outputBus->zero();
+        outputBus.zero();
     else {
-        AudioBus* inputBus = input(0)->bus();
+        AudioBus& inputBus = input(0)->bus();
 
         if (gain().hasSampleAccurateValues() && gain().automationRate() == AutomationRate::ARate) {
             // Apply sample-accurate gain scaling for precise envelopes, grain windows, etc.
@@ -82,16 +81,16 @@ void GainNode::process(size_t framesToProcess)
             if (framesToProcess <= m_sampleAccurateGainValues.size()) {
                 auto gainValues = m_sampleAccurateGainValues.span().first(framesToProcess);
                 gain().calculateSampleAccurateValues(gainValues);
-                outputBus->copyWithSampleAccurateGainValuesFrom(*inputBus, gainValues);
+                outputBus.copyWithSampleAccurateGainValuesFrom(inputBus, gainValues);
             }
         } else {
             // Apply the gain with de-zippering into the output bus.
             float gain = this->gain().hasSampleAccurateValues() ? this->gain().finalValue() : this->gain().value();
             if (!gain) {
                 // If the gain is 0 just zero the bus.
-                outputBus->zero();
+                outputBus.zero();
             } else
-                outputBus->copyWithGainFrom(*inputBus, gain);
+                outputBus.copyWithGainFrom(inputBus, gain);
         }
     }
 }

--- a/Source/WebCore/Modules/webaudio/IIRProcessor.cpp
+++ b/Source/WebCore/Modules/webaudio/IIRProcessor.cpp
@@ -85,17 +85,17 @@ std::unique_ptr<AudioDSPKernel> IIRProcessor::createKernel()
     return makeUnique<IIRDSPKernel>(*this);
 }
 
-void IIRProcessor::process(const AudioBus* source, AudioBus* destination, size_t framesToProcess)
+void IIRProcessor::process(const AudioBus& source, AudioBus& destination, size_t framesToProcess)
 {
     if (!isInitialized()) {
-        destination->zero();
+        destination.zero();
         return;
     }
 
     // For each channel of our input, process using the corresponding IIRDSPKernel
     // into the output channel.
     for (size_t i = 0; i < m_kernels.size(); ++i)
-        m_kernels[i]->process(source->channel(i)->span().first(framesToProcess), destination->channel(i)->mutableSpan());
+        m_kernels[i]->process(source.channel(i)->span().first(framesToProcess), destination.channel(i)->mutableSpan());
 }
 
 void IIRProcessor::getFrequencyResponse(unsigned length, std::span<const float> frequencyHz, std::span<float> magResponse, std::span<float> phaseResponse)

--- a/Source/WebCore/Modules/webaudio/IIRProcessor.h
+++ b/Source/WebCore/Modules/webaudio/IIRProcessor.h
@@ -41,7 +41,7 @@ public:
     ~IIRProcessor();
 
     // AudioDSPKernelProcessor.
-    void process(const AudioBus* source, AudioBus* destination, size_t framesToProcess) final;
+    void process(const AudioBus& source, AudioBus& destination, size_t framesToProcess) final;
     std::unique_ptr<AudioDSPKernel> createKernel() final;
 
     // Get the magnitude and phase response of the filter at the given set of frequencies (in Hz). The phase response is in radians.

--- a/Source/WebCore/Modules/webaudio/MediaElementAudioSourceNode.cpp
+++ b/Source/WebCore/Modules/webaudio/MediaElementAudioSourceNode.cpp
@@ -143,9 +143,7 @@ bool MediaElementAudioSourceNode::wouldTaintOrigin()
 
 void MediaElementAudioSourceNode::process(size_t numberOfFrames)
 {
-    RefPtr outputBus = output(0)->bus();
-    if (!outputBus)
-        return;
+    Ref outputBus = output(0)->bus();
 
     // Use tryLock() to avoid contention in the real-time audio thread.
     // If we fail to acquire the lock then the HTMLMediaElement must be in the middle of
@@ -169,7 +167,7 @@ void MediaElementAudioSourceNode::process(size_t numberOfFrames)
     } else {
         // Bypass the resampler completely if the source is at the context's sample-rate.
         ASSERT(m_sourceSampleRate == sampleRate());
-        provideInput(*outputBus, numberOfFrames);
+        provideInput(outputBus, numberOfFrames);
     }
 }
 

--- a/Source/WebCore/Modules/webaudio/MediaStreamAudioDestinationNode.cpp
+++ b/Source/WebCore/Modules/webaudio/MediaStreamAudioDestinationNode.cpp
@@ -69,7 +69,7 @@ MediaStreamAudioDestinationNode::~MediaStreamAudioDestinationNode()
 
 void MediaStreamAudioDestinationNode::process(size_t numberOfFrames)
 {
-    m_source->consumeAudio(*input(0)->bus(), numberOfFrames);
+    m_source->consumeAudio(input(0)->bus(), numberOfFrames);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/webaudio/MediaStreamAudioSourceNode.cpp
+++ b/Source/WebCore/Modules/webaudio/MediaStreamAudioSourceNode.cpp
@@ -132,9 +132,7 @@ void MediaStreamAudioSourceNode::provideInput(AudioBus& bus, size_t framesToProc
 
 void MediaStreamAudioSourceNode::process(size_t numberOfFrames)
 {
-    RefPtr outputBus = output(0)->bus();
-    if (!outputBus)
-        return;
+    Ref outputBus = output(0)->bus();
 
     // Use tryLock() to avoid contention in the real-time audio thread.
     // If we fail to acquire the lock then the MediaStream must be in the middle of
@@ -160,7 +158,7 @@ void MediaStreamAudioSourceNode::process(size_t numberOfFrames)
     } else {
         // Bypass the resampler completely if the source is at the context's sample-rate.
         ASSERT(m_sourceSampleRate == sampleRate());
-        provideInput(*outputBus, numberOfFrames);
+        provideInput(outputBus, numberOfFrames);
     }
 }
 

--- a/Source/WebCore/Modules/webaudio/OfflineAudioDestinationNode.cpp
+++ b/Source/WebCore/Modules/webaudio/OfflineAudioDestinationNode.cpp
@@ -155,10 +155,6 @@ void OfflineAudioDestinationNode::startRendering(CompletionHandler<void(std::opt
 auto OfflineAudioDestinationNode::renderOnAudioThread() -> RenderResult
 {
     ASSERT(!isMainThread());
-    ASSERT(m_renderBus.get());
-
-    if (!m_renderBus.get())
-        return RenderResult::Failure;
 
     RELEASE_ASSERT(context().isInitialized());
 
@@ -181,7 +177,7 @@ auto OfflineAudioDestinationNode::renderOnAudioThread() -> RenderResult
             return RenderResult::Suspended;
 
         // Render one render quantum.
-        renderQuantum(m_renderBus.get(), AudioUtilities::renderQuantumSize, { });
+        renderQuantum(m_renderBus, AudioUtilities::renderQuantumSize, { });
         
         size_t framesAvailableToCopy = std::min(m_framesToProcess, AudioUtilities::renderQuantumSize);
         

--- a/Source/WebCore/Modules/webaudio/OfflineAudioDestinationNode.h
+++ b/Source/WebCore/Modules/webaudio/OfflineAudioDestinationNode.h
@@ -69,7 +69,7 @@ private:
     RefPtr<AudioBuffer> m_renderTarget;
     
     // Temporary AudioBus for each render quantum.
-    RefPtr<AudioBus> m_renderBus;
+    const Ref<AudioBus> m_renderBus;
     
     // Rendering thread.
     RefPtr<Thread> m_renderThread;

--- a/Source/WebCore/Modules/webaudio/OscillatorNode.cpp
+++ b/Source/WebCore/Modules/webaudio/OscillatorNode.cpp
@@ -340,7 +340,7 @@ double OscillatorNode::processKRate(int n, std::span<float> destination, double 
 
 void OscillatorNode::process(size_t framesToProcess)
 {
-    auto& outputBus = *output(0)->bus();
+    auto& outputBus = output(0)->bus();
 
     if (!isInitialized() || !outputBus.numberOfChannels()) {
         outputBus.zero();

--- a/Source/WebCore/Modules/webaudio/PannerNode.h
+++ b/Source/WebCore/Modules/webaudio/PannerNode.h
@@ -128,7 +128,7 @@ private:
     void invalidateCachedPropertiesIfNecessary() WTF_REQUIRES_LOCK(m_processLock);
 
     const AzimuthElevation& azimuthElevation() WTF_REQUIRES_LOCK(m_processLock);
-    void processSampleAccurateValues(AudioBus* destination, const AudioBus* source, size_t framesToProcess) WTF_REQUIRES_LOCK(m_processLock);
+    void processSampleAccurateValues(AudioBus& destination, const AudioBus& source, size_t framesToProcess) WTF_REQUIRES_LOCK(m_processLock);
     bool hasSampleAccurateValues() const WTF_REQUIRES_LOCK(m_processLock);
     bool shouldUseARate() const WTF_REQUIRES_LOCK(m_processLock);
 

--- a/Source/WebCore/Modules/webaudio/RealtimeAnalyser.cpp
+++ b/Source/WebCore/Modules/webaudio/RealtimeAnalyser.cpp
@@ -77,9 +77,9 @@ bool RealtimeAnalyser::setFftSize(size_t size)
     return true;
 }
 
-void RealtimeAnalyser::writeInput(AudioBus* bus, size_t framesToProcess)
+void RealtimeAnalyser::writeInput(AudioBus& bus, size_t framesToProcess)
 {
-    bool isBusGood = bus && bus->numberOfChannels() > 0 && bus->channel(0)->length() >= framesToProcess;
+    bool isBusGood = bus.numberOfChannels() > 0 && bus.channel(0)->length() >= framesToProcess;
     ASSERT(isBusGood);
     if (!isBusGood)
         return;
@@ -96,7 +96,7 @@ void RealtimeAnalyser::writeInput(AudioBus* bus, size_t framesToProcess)
     // Clear the bus and downmix the input according to the down mixing rules.
     // Then save the result in the m_inputBuffer at the appropriate place.
     m_downmixBus->zero();
-    m_downmixBus->sumFrom(*bus);
+    m_downmixBus->sumFrom(bus);
     memcpySpan(destination, m_downmixBus->channel(0)->span().first(framesToProcess));
 
     m_writeIndex += framesToProcess;

--- a/Source/WebCore/Modules/webaudio/RealtimeAnalyser.h
+++ b/Source/WebCore/Modules/webaudio/RealtimeAnalyser.h
@@ -64,7 +64,7 @@ public:
     void getByteTimeDomainData(JSC::Uint8Array&);
 
     // The audio thread writes input data here.
-    void writeInput(AudioBus*, size_t framesToProcess);
+    void writeInput(AudioBus&, size_t framesToProcess);
 
     static constexpr double DefaultSmoothingTimeConstant { 0.8 };
     static constexpr double DefaultMinDecibels { -100 };
@@ -82,7 +82,7 @@ private:
     unsigned m_writeIndex { 0 };
 
     // AudioBus used for downmixing input audio before copying it to m_inputBuffer.
-    RefPtr<AudioBus> m_downmixBus;
+    const Ref<AudioBus> m_downmixBus;
     
     size_t m_fftSize { DefaultFFTSize };
     std::unique_ptr<FFTFrame> m_analysisFrame;

--- a/Source/WebCore/Modules/webaudio/ScriptProcessorNode.cpp
+++ b/Source/WebCore/Modules/webaudio/ScriptProcessorNode.cpp
@@ -145,8 +145,8 @@ void ScriptProcessorNode::process(size_t framesToProcess)
     // of the buffers for safety reasons.
 
     // Get input and output busses.
-    AudioBus* inputBus = this->input(0)->bus();
-    AudioBus* outputBus = this->output(0)->bus();
+    AudioBus& inputBus = this->input(0)->bus();
+    AudioBus& outputBus = this->output(0)->bus();
 
     // Get input and output buffers. We double-buffer both the input and output sides.
     unsigned bufferIndex = this->bufferIndex();
@@ -155,7 +155,7 @@ void ScriptProcessorNode::process(size_t framesToProcess)
     if (!m_bufferLocks[bufferIndex].tryLock()) {
         // We're late in handling the previous request. The main thread must be
         // very busy. The best we can do is clear out the buffer ourself here.
-        outputBus->zero();
+        outputBus.zero();
         return;
     }
     Locker locker { AdoptLock, m_bufferLocks[bufferIndex] };
@@ -181,7 +181,7 @@ void ScriptProcessorNode::process(size_t framesToProcess)
     if (!isFramesToProcessGood)
         return;
 
-    unsigned numberOfOutputChannels = outputBus->numberOfChannels();
+    unsigned numberOfOutputChannels = outputBus.numberOfChannels();
 
     bool channelsAreGood = (numberOfInputChannels == m_numberOfInputChannels) && (numberOfOutputChannels == m_numberOfOutputChannels);
     ASSERT(channelsAreGood);
@@ -192,11 +192,11 @@ void ScriptProcessorNode::process(size_t framesToProcess)
         m_internalInputBus->setChannelMemory(i, inputBuffer->rawChannelData(i).subspan(m_bufferReadWriteIndex).first(framesToProcess));
 
     if (numberOfInputChannels)
-        m_internalInputBus->copyFrom(*inputBus);
+        m_internalInputBus->copyFrom(inputBus);
 
     // Copy from the output buffer to the output. 
     for (unsigned i = 0; i < numberOfOutputChannels; ++i)
-        memcpySpan(outputBus->channel(i)->mutableSpan(), outputBuffer->rawChannelData(i).subspan(m_bufferReadWriteIndex, framesToProcess));
+        memcpySpan(outputBus.channel(i)->mutableSpan(), outputBuffer->rawChannelData(i).subspan(m_bufferReadWriteIndex, framesToProcess));
 
     // Update the buffering index.
     m_bufferReadWriteIndex = (m_bufferReadWriteIndex + framesToProcess) % bufferSize();

--- a/Source/WebCore/Modules/webaudio/ScriptProcessorNode.h
+++ b/Source/WebCore/Modules/webaudio/ScriptProcessorNode.h
@@ -104,7 +104,7 @@ private:
     unsigned m_numberOfInputChannels;
     unsigned m_numberOfOutputChannels;
 
-    RefPtr<AudioBus> m_internalInputBus;
+    const Ref<AudioBus> m_internalInputBus;
     bool m_hasAudioProcessEventListener { false };
 };
 

--- a/Source/WebCore/Modules/webaudio/StereoPannerNode.cpp
+++ b/Source/WebCore/Modules/webaudio/StereoPannerNode.cpp
@@ -68,18 +68,14 @@ StereoPannerNode::~StereoPannerNode()
 
 void StereoPannerNode::process(size_t framesToProcess)
 {
-    AudioBus* destination = output(0)->bus();
-    
+    AudioBus& destination = output(0)->bus();
+
     if (!isInitialized() || !input(0)->isConnected()) {
-        destination->zero();
+        destination.zero();
         return;
     }
     
-    AudioBus* source = input(0)->bus();
-    if (!source) {
-        destination->zero();
-        return;
-    }
+    AudioBus& source = input(0)->bus();
 
     if (m_pan->hasSampleAccurateValues() && m_pan->automationRate() == AutomationRate::ARate) {
         auto panValues = m_sampleAccurateValues.span().first(framesToProcess);

--- a/Source/WebCore/Modules/webaudio/WaveShaperProcessor.cpp
+++ b/Source/WebCore/Modules/webaudio/WaveShaperProcessor.cpp
@@ -76,14 +76,14 @@ void WaveShaperProcessor::setOversampleForBindings(OverSampleType oversample)
         static_cast<WaveShaperDSPKernel&>(*audioDSPKernel).lazyInitializeOversampling();
 }
 
-void WaveShaperProcessor::process(const AudioBus* source, AudioBus* destination, size_t framesToProcess)
+void WaveShaperProcessor::process(const AudioBus& source, AudioBus& destination, size_t framesToProcess)
 {
     if (!isInitialized()) {
-        destination->zero();
+        destination.zero();
         return;
     }
 
-    bool channelCountMatches = source->numberOfChannels() == destination->numberOfChannels() && source->numberOfChannels() == m_kernels.size();
+    bool channelCountMatches = source.numberOfChannels() == destination.numberOfChannels() && source.numberOfChannels() == m_kernels.size();
     ASSERT(channelCountMatches);
     if (!channelCountMatches)
         return;
@@ -91,14 +91,14 @@ void WaveShaperProcessor::process(const AudioBus* source, AudioBus* destination,
     // The audio thread can't block on this lock, so we use tryLock() instead.
     if (!m_processLock.tryLock()) {
         // Too bad - tryLock() failed. We must be in the middle of a setCurve() call.
-        destination->zero();
+        destination.zero();
         return;
     }
     Locker locker { AdoptLock, m_processLock };
 
     // For each channel of our input, process using the corresponding WaveShaperDSPKernel into the output channel.
     for (size_t i = 0; i < m_kernels.size(); ++i)
-        static_cast<WaveShaperDSPKernel&>(*m_kernels[i]).process(source->channel(i)->span().first(framesToProcess), destination->channel(i)->mutableSpan());
+        static_cast<WaveShaperDSPKernel&>(*m_kernels[i]).process(source.channel(i)->span().first(framesToProcess), destination.channel(i)->mutableSpan());
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/webaudio/WaveShaperProcessor.h
+++ b/Source/WebCore/Modules/webaudio/WaveShaperProcessor.h
@@ -53,7 +53,7 @@ public:
 
     std::unique_ptr<AudioDSPKernel> createKernel() final;
 
-    void process(const AudioBus* source, AudioBus* destination, size_t framesToProcess) final;
+    void process(const AudioBus& source, AudioBus& destination, size_t framesToProcess) final;
 
     void setCurveForBindings(Float32Array*);
     Float32Array* curveForBindings() WTF_IGNORES_THREAD_SAFETY_ANALYSIS { ASSERT(isMainThread()); return m_curve.get(); } // Doesn't grab the lock, only safe to call on the main thread.

--- a/Source/WebCore/platform/audio/AudioBus.h
+++ b/Source/WebCore/platform/audio/AudioBus.h
@@ -100,21 +100,22 @@ public:
     bool isSilent() const;
 
     // Returns true if the channel count and frame-size match.
-    bool topologyMatches(const AudioBus &sourceBus) const;
+    bool topologyMatches(const AudioBus& sourceBus) const;
+
+    static Ref<AudioBus> createCopy(const AudioBus& sourceBus);
 
     // Creates a new buffer from a range in the source buffer.
     // 0 may be returned if the range does not fit in the sourceBuffer
-    static RefPtr<AudioBus> createBufferFromRange(const AudioBus* sourceBuffer, unsigned startFrame, unsigned endFrame);
-
+    static RefPtr<AudioBus> createBufferFromRange(const AudioBus& sourceBuffer, unsigned startFrame, unsigned endFrame);
 
     // Creates a new AudioBus by sample-rate converting sourceBus to the newSampleRate.
     // setSampleRate() must have been previously called on sourceBus.
     // Note: sample-rate conversion is already handled in the file-reading code for the mac port, so we don't need this.
-    static RefPtr<AudioBus> createBySampleRateConverting(const AudioBus* sourceBus, bool mixToMono, double newSampleRate);
+    static RefPtr<AudioBus> createBySampleRateConverting(const AudioBus& sourceBus, bool mixToMono, double newSampleRate);
 
     // Creates a new AudioBus by mixing all the channels down to mono.
     // If sourceBus is already mono, then the returned AudioBus will simply be a copy.
-    static RefPtr<AudioBus> createByMixingToMono(const AudioBus* sourceBus);
+    static Ref<AudioBus> createByMixingToMono(const AudioBus& sourceBus);
 
     // Scales all samples by the same amount.
     void scale(float scale);

--- a/Source/WebCore/platform/audio/AudioDSPKernelProcessor.cpp
+++ b/Source/WebCore/platform/audio/AudioDSPKernelProcessor.cpp
@@ -79,24 +79,20 @@ void AudioDSPKernelProcessor::uninitialize()
     m_initialized = false;
 }
 
-void AudioDSPKernelProcessor::process(const AudioBus* source, AudioBus* destination, size_t framesToProcess)
+void AudioDSPKernelProcessor::process(const AudioBus& source, AudioBus& destination, size_t framesToProcess)
 {
-    ASSERT(source && destination);
-    if (!source || !destination)
-        return;
-        
     if (!isInitialized()) {
-        destination->zero();
+        destination.zero();
         return;
     }
 
-    bool channelCountMatches = source->numberOfChannels() == destination->numberOfChannels() && source->numberOfChannels() == m_kernels.size();
+    bool channelCountMatches = source.numberOfChannels() == destination.numberOfChannels() && source.numberOfChannels() == m_kernels.size();
     ASSERT(channelCountMatches);
     if (!channelCountMatches)
         return;
         
     for (unsigned i = 0; i < m_kernels.size(); ++i)
-        m_kernels[i]->process(source->channel(i)->span().first(framesToProcess), destination->channel(i)->mutableSpan());
+        m_kernels[i]->process(source.channel(i)->span().first(framesToProcess), destination.channel(i)->mutableSpan());
 }
 
 void AudioDSPKernelProcessor::processOnlyAudioParams(size_t framesToProcess)

--- a/Source/WebCore/platform/audio/AudioDSPKernelProcessor.h
+++ b/Source/WebCore/platform/audio/AudioDSPKernelProcessor.h
@@ -62,7 +62,7 @@ public:
     // AudioProcessor methods
     void initialize() override;
     void uninitialize() override;
-    void process(const AudioBus* source, AudioBus* destination, size_t framesToProcess) override;
+    void process(const AudioBus& source, AudioBus& destination, size_t framesToProcess) override;
     void processOnlyAudioParams(size_t framesToProcess) override;
     void reset() override;
     void setNumberOfChannels(unsigned) override;

--- a/Source/WebCore/platform/audio/AudioDestination.h
+++ b/Source/WebCore/platform/audio/AudioDestination.h
@@ -86,7 +86,7 @@ public:
     // or if maxChannelCount() equals 0, then numberOfOutputChannels must be 2.
     static unsigned long maxChannelCount();
 
-    void callRenderCallback(AudioBus* sourceBus, AudioBus* destinationBus, size_t framesToProcess, const AudioIOPosition& outputPosition);
+    void callRenderCallback(AudioBus& destinationBus, size_t framesToProcess, const AudioIOPosition& outputPosition);
 
     const String& inputDeviceId() const { return m_inputDeviceId; }
     unsigned numberOfInputChannels() const { return m_numberOfInputChannels; }
@@ -132,16 +132,16 @@ inline void AudioDestination::clearCallback()
     m_callback = nullptr;
 }
 
-inline void AudioDestination::callRenderCallback(AudioBus* sourceBus, AudioBus* destinationBus, size_t framesToProcess, const AudioIOPosition& outputPosition)
+inline void AudioDestination::callRenderCallback(AudioBus& destinationBus, size_t framesToProcess, const AudioIOPosition& outputPosition)
 {
     if (m_callbackLock.tryLock()) {
         Locker locker { AdoptLock, m_callbackLock };
         if (m_callback) {
-            m_callback->render(sourceBus, destinationBus, framesToProcess, outputPosition);
+            m_callback->render(destinationBus, framesToProcess, outputPosition);
             return;
         }
     }
-    destinationBus->zero();
+    destinationBus.zero();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/audio/AudioIOCallback.h
+++ b/Source/WebCore/platform/audio/AudioIOCallback.h
@@ -47,7 +47,7 @@ class AudioIOCallback {
 public:
     // render() is called periodically to get the next render quantum of audio into destinationBus.
     // Optional audio input is given in sourceBus (if it's not 0).
-    virtual void render(AudioBus* sourceBus, AudioBus* destinationBus, size_t framesToProcess, const AudioIOPosition& outputPosition) = 0;
+    virtual void render(AudioBus& destinationBus, size_t framesToProcess, const AudioIOPosition& outputPosition) = 0;
 
     virtual void isPlayingDidChange() = 0;
 

--- a/Source/WebCore/platform/audio/AudioProcessor.h
+++ b/Source/WebCore/platform/audio/AudioProcessor.h
@@ -59,7 +59,7 @@ public:
     virtual void uninitialize() = 0;
 
     // Processes the source to destination bus.  The number of channels must match in source and destination.
-    virtual void process(const AudioBus* source, AudioBus* destination, size_t framesToProcess) = 0;
+    virtual void process(const AudioBus& source, AudioBus& destination, size_t framesToProcess) = 0;
 
     // Forces all AudioParams in the processor to run the timeline, bypassing any other processing the processor
     // would do in process().

--- a/Source/WebCore/platform/audio/AudioResampler.h
+++ b/Source/WebCore/platform/audio/AudioResampler.h
@@ -46,7 +46,7 @@ public:
     ~AudioResampler() = default;
     
     // Given an AudioSourceProvider, process() resamples the source stream into destinationBus.
-    void process(AudioSourceProvider*, AudioBus* destinationBus, size_t framesToProcess);
+    void process(AudioSourceProvider*, AudioBus& destinationBus, size_t framesToProcess);
 
     // Resets the processing state.
     void reset();
@@ -62,7 +62,7 @@ public:
 private:
     double m_rate { 1 };
     Vector<std::unique_ptr<AudioResamplerKernel>> m_kernels;
-    RefPtr<AudioBus> m_sourceBus;
+    Ref<AudioBus> m_sourceBus;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/audio/DynamicsCompressor.cpp
+++ b/Source/WebCore/platform/audio/DynamicsCompressor.cpp
@@ -90,28 +90,28 @@ float DynamicsCompressor::parameterValue(unsigned parameterID)
     return m_parameters[parameterID];
 }
 
-void DynamicsCompressor::process(const AudioBus* sourceBus, AudioBus* destinationBus, unsigned framesToProcess)
+void DynamicsCompressor::process(const AudioBus& sourceBus, AudioBus& destinationBus, unsigned framesToProcess)
 {
     // Though numberOfChannels is retrived from destinationBus, we still name it numberOfChannels instead of numberOfDestinationChannels.
     // It's because we internally match sourceChannels's size to destinationBus by channel up/down mix. Thus we need numberOfChannels
     // to do the loop work for both m_sourceChannels and m_destinationChannels.
 
-    unsigned numberOfChannels = destinationBus->numberOfChannels();
-    unsigned numberOfSourceChannels = sourceBus->numberOfChannels();
+    unsigned numberOfChannels = destinationBus.numberOfChannels();
+    unsigned numberOfSourceChannels = sourceBus.numberOfChannels();
 
     ASSERT(numberOfChannels == m_numberOfChannels && numberOfSourceChannels);
 
     if (numberOfChannels != m_numberOfChannels || !numberOfSourceChannels) {
-        destinationBus->zero();
+        destinationBus.zero();
         return;
     }
 
     switch (numberOfChannels) {
     case 2: // stereo
-        m_sourceChannels[0] = sourceBus->channel(0)->span();
+        m_sourceChannels[0] = sourceBus.channel(0)->span();
 
         if (numberOfSourceChannels > 1)
-            m_sourceChannels[1] = sourceBus->channel(1)->span();
+            m_sourceChannels[1] = sourceBus.channel(1)->span();
         else
             // Simply duplicate mono channel input data to right channel for stereo processing.
             m_sourceChannels[1] = m_sourceChannels[0];
@@ -120,12 +120,12 @@ void DynamicsCompressor::process(const AudioBus* sourceBus, AudioBus* destinatio
     default:
         // FIXME : support other number of channels.
         ASSERT_NOT_REACHED();
-        destinationBus->zero();
+        destinationBus.zero();
         return;
     }
 
     for (unsigned i = 0; i < numberOfChannels; ++i)
-        m_destinationChannels[i] = destinationBus->channel(i)->mutableSpan();
+        m_destinationChannels[i] = destinationBus.channel(i)->mutableSpan();
 
     float dbThreshold = parameterValue(ParamThreshold);
     float dbKnee = parameterValue(ParamKnee);

--- a/Source/WebCore/platform/audio/DynamicsCompressor.h
+++ b/Source/WebCore/platform/audio/DynamicsCompressor.h
@@ -67,7 +67,7 @@ public:
 
     DynamicsCompressor(float sampleRate, unsigned numberOfChannels);
 
-    void process(const AudioBus* sourceBus, AudioBus* destinationBus, unsigned framesToProcess);
+    void process(const AudioBus& sourceBus, AudioBus& destinationBus, unsigned framesToProcess);
     void reset();
     void setNumberOfChannels(unsigned);
 

--- a/Source/WebCore/platform/audio/EqualPowerPanner.cpp
+++ b/Source/WebCore/platform/audio/EqualPowerPanner.cpp
@@ -77,25 +77,25 @@ void EqualPowerPanner::calculateDesiredGain(double& desiredGainL, double& desire
     desiredGainR = std::sin(piOverTwoDouble * desiredPanPosition);
 }
 
-void EqualPowerPanner::pan(double azimuth, double /*elevation*/, const AudioBus* inputBus, AudioBus* outputBus, size_t framesToProcess)
+void EqualPowerPanner::pan(double azimuth, double /*elevation*/, const AudioBus& inputBus, AudioBus& outputBus, size_t framesToProcess)
 {
-    bool isInputSafe = inputBus && (inputBus->numberOfChannels() == 1 || inputBus->numberOfChannels() == 2) && framesToProcess <= inputBus->length();
+    bool isInputSafe = (inputBus.numberOfChannels() == 1 || inputBus.numberOfChannels() == 2) && framesToProcess <= inputBus.length();
     ASSERT(isInputSafe);
     if (!isInputSafe)
         return;
 
-    unsigned numberOfInputChannels = inputBus->numberOfChannels();
+    unsigned numberOfInputChannels = inputBus.numberOfChannels();
 
-    bool isOutputSafe = outputBus && outputBus->numberOfChannels() == 2 && framesToProcess <= outputBus->length();
+    bool isOutputSafe = outputBus.numberOfChannels() == 2 && framesToProcess <= outputBus.length();
     ASSERT(isOutputSafe);
     if (!isOutputSafe)
         return;
 
-    auto sourceL = inputBus->channel(0)->span().first(framesToProcess);
-    auto sourceR = numberOfInputChannels > 1 ? inputBus->channel(1)->span().first(framesToProcess) : sourceL;
-    auto destinationL = outputBus->channelByType(AudioBus::ChannelLeft)->mutableSpan();
-    auto destinationR = outputBus->channelByType(AudioBus::ChannelRight)->mutableSpan();
-    
+    auto sourceL = inputBus.channel(0)->span().first(framesToProcess);
+    auto sourceR = numberOfInputChannels > 1 ? inputBus.channel(1)->span().first(framesToProcess) : sourceL;
+    auto destinationL = outputBus.channelByType(AudioBus::ChannelLeft)->mutableSpan();
+    auto destinationR = outputBus.channelByType(AudioBus::ChannelRight)->mutableSpan();
+
     // Clamp azimuth to allowed range of -180 -> +180.
     azimuth = std::max(-180.0, azimuth);
     azimuth = std::min(180.0, azimuth);
@@ -140,23 +140,21 @@ void EqualPowerPanner::pan(double azimuth, double /*elevation*/, const AudioBus*
     }
 }
 
-void EqualPowerPanner::panWithSampleAccurateValues(std::span<double> azimuth, std::span<double>, const AudioBus* inputBus, AudioBus* outputBus, size_t framesToProcess)
+void EqualPowerPanner::panWithSampleAccurateValues(std::span<double> azimuth, std::span<double>, const AudioBus& inputBus, AudioBus& outputBus, size_t framesToProcess)
 {
-    ASSERT(inputBus);
-    ASSERT(framesToProcess <= inputBus->length());
-    ASSERT(inputBus->numberOfChannels() >= 1u);
-    ASSERT(inputBus->numberOfChannels() <= 2u);
+    ASSERT(framesToProcess <= inputBus.length());
+    ASSERT(inputBus.numberOfChannels() >= 1u);
+    ASSERT(inputBus.numberOfChannels() <= 2u);
 
-    unsigned numberOfInputChannels = inputBus->numberOfChannels();
+    unsigned numberOfInputChannels = inputBus.numberOfChannels();
 
-    ASSERT(outputBus);
-    ASSERT(outputBus->numberOfChannels() == 2u);
-    ASSERT(framesToProcess <= outputBus->length());
+    ASSERT(outputBus.numberOfChannels() == 2u);
+    ASSERT(framesToProcess <= outputBus.length());
 
-    auto sourceL = inputBus->channel(0)->span();
-    auto sourceR = numberOfInputChannels > 1 ? inputBus->channel(1)->span() : sourceL;
-    auto destinationL = outputBus->channelByType(AudioBus::ChannelLeft)->mutableSpan();
-    auto destinationR = outputBus->channelByType(AudioBus::ChannelRight)->mutableSpan();
+    auto sourceL = inputBus.channel(0)->span();
+    auto sourceR = numberOfInputChannels > 1 ? inputBus.channel(1)->span() : sourceL;
+    auto destinationL = outputBus.channelByType(AudioBus::ChannelLeft)->mutableSpan();
+    auto destinationR = outputBus.channelByType(AudioBus::ChannelRight)->mutableSpan();
 
     int n = framesToProcess;
 

--- a/Source/WebCore/platform/audio/EqualPowerPanner.h
+++ b/Source/WebCore/platform/audio/EqualPowerPanner.h
@@ -35,8 +35,8 @@ class EqualPowerPanner final : public Panner {
 public:
     EqualPowerPanner();
 
-    void pan(double azimuth, double elevation, const AudioBus* inputBus, AudioBus* outputBuf, size_t framesToProcess) final;
-    void panWithSampleAccurateValues(std::span<double> azimuth, std::span<double> elevation, const AudioBus* inputBus, AudioBus* outputBus, size_t framesToProcess) final;
+    void pan(double azimuth, double elevation, const AudioBus& inputBus, AudioBus& outputBuf, size_t framesToProcess) final;
+    void panWithSampleAccurateValues(std::span<double> azimuth, std::span<double> elevation, const AudioBus& inputBus, AudioBus& outputBus, size_t framesToProcess) final;
 
     void reset() override { }
 

--- a/Source/WebCore/platform/audio/HRTFElevation.cpp
+++ b/Source/WebCore/platform/audio/HRTFElevation.cpp
@@ -151,8 +151,13 @@ bool HRTFElevation::calculateKernelsForAzimuthElevation(int azimuth, int elevati
     // (hardware) sample-rate.
     unsigned startFrame = index * ResponseFrameSize;
     unsigned stopFrame = startFrame + ResponseFrameSize;
-    auto preSampleRateConvertedResponse = AudioBus::createBufferFromRange(bus.get(), startFrame, stopFrame);
-    auto response = AudioBus::createBySampleRateConverting(preSampleRateConvertedResponse.get(), false, sampleRate);
+    auto preSampleRateConvertedResponse = AudioBus::createBufferFromRange(*bus, startFrame, stopFrame);
+    ASSERT(preSampleRateConvertedResponse);
+    if (!preSampleRateConvertedResponse)
+        return false;
+    auto response = AudioBus::createBySampleRateConverting(*preSampleRateConvertedResponse, false, sampleRate);
+    if (!response)
+        return false;
     AudioChannel* leftEarImpulseResponse = response->channel(AudioBus::ChannelLeft);
     AudioChannel* rightEarImpulseResponse = response->channel(AudioBus::ChannelRight);
 #else

--- a/Source/WebCore/platform/audio/HRTFPanner.cpp
+++ b/Source/WebCore/platform/audio/HRTFPanner.cpp
@@ -128,19 +128,18 @@ int HRTFPanner::calculateDesiredAzimuthIndexAndBlend(double azimuth, double& azi
     return desiredAzimuthIndex;
 }
 
-void HRTFPanner::pan(double desiredAzimuth, double elevation, const AudioBus* inputBus, AudioBus* outputBus, size_t framesToProcess)
+void HRTFPanner::pan(double desiredAzimuth, double elevation, const AudioBus& inputBus, AudioBus& outputBus, size_t framesToProcess)
 {
-    unsigned numInputChannels = inputBus ? inputBus->numberOfChannels() : 0;
+    unsigned numInputChannels = inputBus.numberOfChannels();
 
-    bool isInputGood = inputBus &&  numInputChannels >= 1 && numInputChannels <= 2;
+    bool isInputGood = numInputChannels >= 1 && numInputChannels <= 2;
     ASSERT(isInputGood);
 
-    bool isOutputGood = outputBus && outputBus->numberOfChannels() == 2 && framesToProcess <= outputBus->length();
+    bool isOutputGood = outputBus.numberOfChannels() == 2 && framesToProcess <= outputBus.length();
     ASSERT(isOutputGood);
 
     if (!isInputGood || !isOutputGood) {
-        if (outputBus)
-            outputBus->zero();
+        outputBus.zero();
         return;
     }
 
@@ -148,7 +147,7 @@ void HRTFPanner::pan(double desiredAzimuth, double elevation, const AudioBus* in
     HRTFDatabase* database = m_databaseLoader->database();
     ASSERT(database);
     if (!database) {
-        outputBus->zero();
+        outputBus.zero();
         return;
     }
 
@@ -158,20 +157,20 @@ void HRTFPanner::pan(double desiredAzimuth, double elevation, const AudioBus* in
     bool isAzimuthGood = azimuth >= -180.0 && azimuth <= 180.0;
     ASSERT(isAzimuthGood);
     if (!isAzimuthGood) {
-        outputBus->zero();
+        outputBus.zero();
         return;
     }
 
     // Normally, we'll just be dealing with mono sources.
     // If we have a stereo input, implement stereo panning with left source processed by left HRTF, and right source by right HRTF.
-    const AudioChannel* inputChannelL = inputBus->channelByType(AudioBus::ChannelLeft);
-    const AudioChannel* inputChannelR = numInputChannels > 1 ? inputBus->channelByType(AudioBus::ChannelRight) : 0;
+    const AudioChannel* inputChannelL = inputBus.channelByType(AudioBus::ChannelLeft);
+    const AudioChannel* inputChannelR = numInputChannels > 1 ? inputBus.channelByType(AudioBus::ChannelRight) : 0;
 
     // Get source and destination pointers.
     auto sourceL = inputChannelL->span();
     auto sourceR = numInputChannels > 1 ? inputChannelR->span() : sourceL;
-    auto destinationL = outputBus->channelByType(AudioBus::ChannelLeft)->mutableSpan();
-    auto destinationR = outputBus->channelByType(AudioBus::ChannelRight)->mutableSpan();
+    auto destinationL = outputBus.channelByType(AudioBus::ChannelLeft)->mutableSpan();
+    auto destinationR = outputBus.channelByType(AudioBus::ChannelRight)->mutableSpan();
 
     double azimuthBlend;
     int desiredAzimuthIndex = calculateDesiredAzimuthIndexAndBlend(azimuth, azimuthBlend);
@@ -232,7 +231,7 @@ void HRTFPanner::pan(double desiredAzimuth, double elevation, const AudioBus* in
         bool areKernelsGood = kernelL1 && kernelR1 && kernelL2 && kernelR2;
         ASSERT(areKernelsGood);
         if (!areKernelsGood) {
-            outputBus->zero();
+            outputBus.zero();
             return;
         }
 
@@ -304,7 +303,7 @@ void HRTFPanner::pan(double desiredAzimuth, double elevation, const AudioBus* in
     }
 }
 
-void HRTFPanner::panWithSampleAccurateValues(std::span<double> azimuth, std::span<double> elevation, const AudioBus* inputBus, AudioBus* outputBus, size_t framesToProcess)
+void HRTFPanner::panWithSampleAccurateValues(std::span<double> azimuth, std::span<double> elevation, const AudioBus& inputBus, AudioBus& outputBus, size_t framesToProcess)
 {
     // Sample-accurate (a-rate) HRTF panner is not implemented, just k-rate. Just
     // grab the current azimuth/elevation and use that.

--- a/Source/WebCore/platform/audio/HRTFPanner.h
+++ b/Source/WebCore/platform/audio/HRTFPanner.h
@@ -39,8 +39,8 @@ public:
     virtual ~HRTFPanner();
 
     // Panner
-    void pan(double azimuth, double elevation, const AudioBus* inputBus, AudioBus* outputBus, size_t framesToProcess) final;
-    void panWithSampleAccurateValues(std::span<double> azimuth, std::span<double> elevation, const AudioBus* inputBus, AudioBus* outputBus, size_t framesToProcess) final;
+    void pan(double azimuth, double elevation, const AudioBus& inputBus, AudioBus& outputBus, size_t framesToProcess) final;
+    void panWithSampleAccurateValues(std::span<double> azimuth, std::span<double> elevation, const AudioBus& inputBus, AudioBus& outputBus, size_t framesToProcess) final;
     void reset() override;
 
     size_t fftSize() const { return fftSizeForSampleRate(m_sampleRate); }

--- a/Source/WebCore/platform/audio/MultiChannelResampler.cpp
+++ b/Source/WebCore/platform/audio/MultiChannelResampler.cpp
@@ -54,12 +54,12 @@ MultiChannelResampler::MultiChannelResampler(double scaleFactor, unsigned number
 
 MultiChannelResampler::~MultiChannelResampler() = default;
 
-void MultiChannelResampler::process(AudioBus* destination, size_t framesToProcess)
+void MultiChannelResampler::process(AudioBus& destination, size_t framesToProcess)
 {
-    ASSERT(m_numberOfChannels == destination->numberOfChannels());
-    if (destination->numberOfChannels() == 1) {
+    ASSERT(m_numberOfChannels == destination.numberOfChannels());
+    if (destination.numberOfChannels() == 1) {
         // Fast path when the bus is mono to avoid the chunking below.
-        m_kernels[0]->process(destination->channel(0)->mutableSpan(), framesToProcess);
+        m_kernels[0]->process(destination.channel(0)->mutableSpan(), framesToProcess);
         return;
     }
 
@@ -73,7 +73,7 @@ void MultiChannelResampler::process(AudioBus* destination, size_t framesToProces
 
         for (unsigned channelIndex = 0; channelIndex < m_numberOfChannels; ++channelIndex) {
             ASSERT(chunkSize == m_kernels[channelIndex]->chunkSize());
-            auto* channel = destination->channel(channelIndex);
+            auto* channel = destination.channel(channelIndex);
             m_kernels[channelIndex]->process(channel->mutableSpan().subspan(m_outputFramesReady), framesThisTime);
         }
 
@@ -83,14 +83,11 @@ void MultiChannelResampler::process(AudioBus* destination, size_t framesToProces
 
 void MultiChannelResampler::provideInputForChannel(std::span<float> buffer, size_t framesToProcess, unsigned channelIndex)
 {
-    if (!m_multiChannelBus)
-        return;
-
     ASSERT(channelIndex < m_multiChannelBus->numberOfChannels());
     ASSERT(framesToProcess <= m_multiChannelBus->length());
 
     if (!channelIndex)
-        m_provideInput(*m_multiChannelBus, framesToProcess);
+        m_provideInput(m_multiChannelBus, framesToProcess);
 
     // Copy the channel data from what we received from m_multiChannelProvider.
     memcpySpan(buffer, m_multiChannelBus->channel(channelIndex)->span().first(framesToProcess));

--- a/Source/WebCore/platform/audio/MultiChannelResampler.h
+++ b/Source/WebCore/platform/audio/MultiChannelResampler.h
@@ -46,7 +46,7 @@ public:
     MultiChannelResampler(double scaleFactor, unsigned numberOfChannels, unsigned requestFrames, Function<void(AudioBus&, size_t framesToProcess)>&& provideInput);
     ~MultiChannelResampler();
 
-    void process(AudioBus* destination, size_t framesToProcess);
+    void process(AudioBus& destination, size_t framesToProcess);
 
 private:
     void provideInputForChannel(std::span<float> buffer, size_t framesToProcess, unsigned channelIndex);
@@ -61,7 +61,7 @@ private:
     unsigned m_numberOfChannels;
     size_t m_outputFramesReady { 0 };
     Function<void(AudioBus&, size_t framesToProcess)> m_provideInput;
-    const RefPtr<AudioBus> m_multiChannelBus;
+    const Ref<AudioBus> m_multiChannelBus;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/audio/Panner.h
+++ b/Source/WebCore/platform/audio/Panner.h
@@ -53,8 +53,8 @@ public:
 
     PanningModelType panningModel() const { return m_panningModel; }
 
-    virtual void pan(double azimuth, double elevation, const AudioBus* inputBus, AudioBus* outputBus, size_t framesToProcess) = 0;
-    virtual void panWithSampleAccurateValues(std::span<double> azimuth, std::span<double> elevation, const AudioBus* inputBus, AudioBus* outputBus, size_t framesToProcess) = 0;
+    virtual void pan(double azimuth, double elevation, const AudioBus& inputBus, AudioBus& outputBus, size_t framesToProcess) = 0;
+    virtual void panWithSampleAccurateValues(std::span<double> azimuth, std::span<double> elevation, const AudioBus& inputBus, AudioBus& outputBus, size_t framesToProcess) = 0;
     virtual void reset() = 0;
 
     virtual double tailTime() const = 0;

--- a/Source/WebCore/platform/audio/PushPullFIFO.cpp
+++ b/Source/WebCore/platform/audio/PushPullFIFO.cpp
@@ -43,18 +43,17 @@ PushPullFIFO::~PushPullFIFO() = default;
 
 // Push the data from |inputBus| to FIFO. The size of push is determined by
 // the length of |inputBus|.
-void PushPullFIFO::push(const AudioBus* inputBus)
+void PushPullFIFO::push(const AudioBus& inputBus)
 {
-    ASSERT(inputBus);
-    ASSERT(inputBus->length() <= m_fifoLength);
+    ASSERT(inputBus.length() <= m_fifoLength);
     ASSERT(m_indexWrite < m_fifoLength);
 
-    const size_t inputBusLength = inputBus->length();
+    const size_t inputBusLength = inputBus.length();
     const size_t remainder = m_fifoLength - m_indexWrite;
 
     for (unsigned i = 0; i < m_fifoBus->numberOfChannels(); ++i) {
         auto fifoBusChannel = m_fifoBus->channel(i)->mutableSpan();
-        auto inputBusChannel = inputBus->channel(i)->span();
+        auto inputBusChannel = inputBus.channel(i)->span();
         if (remainder >= inputBusLength) {
             // The remainder is big enough for the input data.
             memcpySpan(fifoBusChannel.subspan(m_indexWrite), inputBusChannel);
@@ -80,10 +79,9 @@ void PushPullFIFO::push(const AudioBus* inputBus)
 
 // Pull the data out of FIFO to |outputBus|. If remaining frame in the FIFO
 // is less than the frames to pull, provides remaining frame plus the silence.
-size_t PushPullFIFO::pull(AudioBus* outputBus, size_t framesRequested)
+size_t PushPullFIFO::pull(AudioBus& outputBus, size_t framesRequested)
 {
-    ASSERT(outputBus);
-    ASSERT(framesRequested <= outputBus->length());
+    ASSERT(framesRequested <= outputBus.length());
     ASSERT(framesRequested <= m_fifoLength);
     ASSERT(m_indexRead < m_fifoLength);
 
@@ -92,7 +90,7 @@ size_t PushPullFIFO::pull(AudioBus* outputBus, size_t framesRequested)
 
     for (unsigned i = 0; i < m_fifoBus->numberOfChannels(); ++i) {
         auto fifoBusChannel = m_fifoBus->channel(i)->span();
-        auto outputBusChannel = outputBus->channel(i)->mutableSpan();
+        auto outputBusChannel = outputBus.channel(i)->mutableSpan();
 
         // Fill up the output bus with the available frames first.
         if (remainder >= framesToFill) {

--- a/Source/WebCore/platform/audio/PushPullFIFO.h
+++ b/Source/WebCore/platform/audio/PushPullFIFO.h
@@ -52,22 +52,22 @@ public:
     //  - In case of overflow (FIFO full while push), the existing frames in FIFO
     //    will be overwritten and |indexRead| will be forcibly moved to
     //    |indexWrite| to avoid reading overwritten frames.
-    WEBCORE_EXPORT void push(const AudioBus* inputBus);
+    WEBCORE_EXPORT void push(const AudioBus& inputBus);
 
     // Pulls |framesRequested| by the audio device thread and returns the actual
     // number of frames to be rendered by the source. (i.e. WebAudio graph)
-    WEBCORE_EXPORT size_t pull(AudioBus* outputBus, size_t framesRequested);
+    WEBCORE_EXPORT size_t pull(AudioBus& outputBus, size_t framesRequested);
 
     size_t framesAvailable() const { return m_framesAvailable; }
     size_t length() const { return m_fifoLength; }
     unsigned numberOfChannels() const;
-    AudioBus* bus() const { return m_fifoBus.get(); }
+    AudioBus& bus() const { return m_fifoBus.get(); }
 
 private:
     // The size of the FIFO.
     const size_t m_fifoLength = 0;
 
-    const RefPtr<AudioBus> m_fifoBus;
+    const Ref<AudioBus> m_fifoBus;
 
     // The number of frames in the FIFO actually available for pulling.
     size_t m_framesAvailable { 0 };

--- a/Source/WebCore/platform/audio/Reverb.cpp
+++ b/Source/WebCore/platform/audio/Reverb.cpp
@@ -51,16 +51,16 @@ constexpr float GainCalibrationSampleRate = 44100;
 // A minimum power value to when normalizing a silent (or very quiet) impulse response
 constexpr float MinPower = 0.000125f;
     
-static float calculateNormalizationScale(AudioBus* response)
+static float calculateNormalizationScale(AudioBus& response)
 {
     // Normalize by RMS power
-    size_t numberOfChannels = response->numberOfChannels();
-    size_t length = response->length();
+    size_t numberOfChannels = response.numberOfChannels();
+    size_t length = response.length();
 
     float power = 0;
 
     for (size_t i = 0; i < numberOfChannels; ++i)
-        power += VectorMath::sumOfSquares(response->channel(i)->span());
+        power += VectorMath::sumOfSquares(response.channel(i)->span());
 
     power = sqrt(power / (numberOfChannels * length));
 
@@ -73,17 +73,17 @@ static float calculateNormalizationScale(AudioBus* response)
     scale *= powf(10, GainCalibration * 0.05f); // calibrate to make perceived volume same as unprocessed
 
     // Scale depends on sample-rate.
-    if (response->sampleRate())
-        scale *= GainCalibrationSampleRate / response->sampleRate();
+    if (response.sampleRate())
+        scale *= GainCalibrationSampleRate / response.sampleRate();
 
     // True-stereo compensation
-    if (response->numberOfChannels() == 4)
+    if (response.numberOfChannels() == 4)
         scale *= 0.5f;
 
     return scale;
 }
 
-Reverb::Reverb(AudioBus* impulseResponse, size_t renderSliceSize, size_t maxFFTSize, bool useBackgroundThreads, bool normalize)
+Reverb::Reverb(AudioBus& impulseResponse, size_t renderSliceSize, size_t maxFFTSize, bool useBackgroundThreads, bool normalize)
 {
     float scale = 1;
 
@@ -93,18 +93,18 @@ Reverb::Reverb(AudioBus* impulseResponse, size_t renderSliceSize, size_t maxFFTS
     initialize(impulseResponse, renderSliceSize, maxFFTSize, useBackgroundThreads, scale);
 }
 
-void Reverb::initialize(AudioBus* impulseResponseBuffer, size_t renderSliceSize, size_t maxFFTSize, bool useBackgroundThreads, float scale)
+void Reverb::initialize(AudioBus& impulseResponseBuffer, size_t renderSliceSize, size_t maxFFTSize, bool useBackgroundThreads, float scale)
 {
-    m_impulseResponseLength = impulseResponseBuffer->length();
+    m_impulseResponseLength = impulseResponseBuffer.length();
 
     // The reverb can handle a mono impulse response and still do stereo processing
-    m_numberOfResponseChannels = impulseResponseBuffer->numberOfChannels();
+    m_numberOfResponseChannels = impulseResponseBuffer.numberOfChannels();
     unsigned convolverCount = std::max(m_numberOfResponseChannels, 2u);
     m_convolvers.reserveCapacity(convolverCount);
 
     int convolverRenderPhase = 0;
     for (unsigned i = 0; i < convolverCount; ++i) {
-        auto* channel = impulseResponseBuffer->channel(std::min(i, m_numberOfResponseChannels - 1));
+        auto* channel = impulseResponseBuffer.channel(std::min(i, m_numberOfResponseChannels - 1));
 
         m_convolvers.append(makeUnique<ReverbConvolver>(channel, renderSliceSize, maxFFTSize, convolverRenderPhase, useBackgroundThreads, scale));
 
@@ -117,31 +117,29 @@ void Reverb::initialize(AudioBus* impulseResponseBuffer, size_t renderSliceSize,
         m_tempBuffer = AudioBus::create(2, MaxFrameSize);
 }
 
-void Reverb::process(const AudioBus* sourceBus, AudioBus* destinationBus, size_t framesToProcess)
+void Reverb::process(const AudioBus& sourceBus, AudioBus& destinationBus, size_t framesToProcess)
 {
     // Do a fairly comprehensive sanity check.
     // If these conditions are satisfied, all of the source and destination
     // pointers will be valid for the various matrixing cases.
-    ASSERT(sourceBus);
-    ASSERT(destinationBus);
-    ASSERT(sourceBus->numberOfChannels() > 0u);
-    ASSERT(destinationBus->numberOfChannels() > 0u);
+    ASSERT(sourceBus.numberOfChannels() > 0u);
+    ASSERT(destinationBus.numberOfChannels() > 0u);
     ASSERT(framesToProcess <= MaxFrameSize);
-    ASSERT(framesToProcess <= sourceBus->length());
-    ASSERT(framesToProcess <= destinationBus->length());
+    ASSERT(framesToProcess <= sourceBus.length());
+    ASSERT(framesToProcess <= destinationBus.length());
 
     // For now only handle mono or stereo output
-    if (destinationBus->numberOfChannels() > 2) {
-        destinationBus->zero();
+    if (destinationBus.numberOfChannels() > 2) {
+        destinationBus.zero();
         return;
     }
 
-    AudioChannel* destinationChannelL = destinationBus->channel(0);
-    const AudioChannel* sourceChannelL = sourceBus->channel(0);
+    AudioChannel* destinationChannelL = destinationBus.channel(0);
+    const AudioChannel* sourceChannelL = sourceBus.channel(0);
 
     // Handle input -> output matrixing...
-    size_t numInputChannels = sourceBus->numberOfChannels();
-    size_t numOutputChannels = destinationBus->numberOfChannels();
+    size_t numInputChannels = sourceBus.numberOfChannels();
+    size_t numOutputChannels = destinationBus.numberOfChannels();
     size_t numberOfResponseChannels = m_numberOfResponseChannels;
 
     ASSERT(numInputChannels <= 2ul);
@@ -175,14 +173,14 @@ void Reverb::process(const AudioBus* sourceBus, AudioBus* destinationBus, size_t
         // These can be handled in the same way because in the latter
         // case, two connvolvers are still created with the second being a
         // copy of the first.
-        const AudioChannel* sourceChannelR = sourceBus->channel(1);
-        AudioChannel* destinationChannelR = destinationBus->channel(1);
+        const AudioChannel* sourceChannelR = sourceBus.channel(1);
+        AudioChannel* destinationChannelR = destinationBus.channel(1);
         m_convolvers[0]->process(sourceChannelL, destinationChannelL, framesToProcess);
         m_convolvers[1]->process(sourceChannelR, destinationChannelR, framesToProcess);
     } else  if (numInputChannels == 1 && numOutputChannels == 2 && numberOfResponseChannels == 2) {
         // Case 2: 1 -> 2 -> 2
         for (int i = 0; i < 2; ++i) {
-            AudioChannel* destinationChannel = destinationBus->channel(i);
+            AudioChannel* destinationChannel = destinationBus.channel(i);
             m_convolvers[i]->process(sourceChannelL, destinationChannel, framesToProcess);
         }
     } else if (numInputChannels == 1 && numberOfResponseChannels == 1) {
@@ -191,8 +189,8 @@ void Reverb::process(const AudioBus* sourceBus, AudioBus* destinationBus, size_t
         m_convolvers[0]->process(sourceChannelL, destinationChannelL, framesToProcess);
     } else if (numInputChannels == 2 && numberOfResponseChannels == 4 && numOutputChannels == 2) {
         // Case 6: 2 -> 4 -> 2 ("True" stereo)
-        const AudioChannel* sourceChannelR = sourceBus->channel(1);
-        AudioChannel* destinationChannelR = destinationBus->channel(1);
+        const AudioChannel* sourceChannelR = sourceBus.channel(1);
+        AudioChannel* destinationChannelR = destinationBus.channel(1);
 
         RefPtr tempBuffer = m_tempBuffer;
         AudioChannel* tempChannelL = tempBuffer->channel(0);
@@ -206,12 +204,12 @@ void Reverb::process(const AudioBus* sourceBus, AudioBus* destinationBus, size_t
         m_convolvers[2]->process(sourceChannelR, tempChannelL, framesToProcess);
         m_convolvers[3]->process(sourceChannelR, tempChannelR, framesToProcess);
 
-        destinationBus->sumFrom(*tempBuffer);
+        destinationBus.sumFrom(*tempBuffer);
     } else if (numInputChannels == 1 && numberOfResponseChannels == 4 && numOutputChannels == 2) {
         // Case 3: 1 -> 4 -> 2 (Processing mono with "True" stereo impulse
         // response) This is an inefficient use of a four-channel impulse
         // response, but we should handle the case.
-        AudioChannel* destinationChannelR = destinationBus->channel(1);
+        AudioChannel* destinationChannelR = destinationBus.channel(1);
 
         RefPtr tempBuffer = m_tempBuffer;
         AudioChannel* tempChannelL = tempBuffer->channel(0);
@@ -225,10 +223,10 @@ void Reverb::process(const AudioBus* sourceBus, AudioBus* destinationBus, size_t
         m_convolvers[2]->process(sourceChannelL, tempChannelL, framesToProcess);
         m_convolvers[3]->process(sourceChannelL, tempChannelR, framesToProcess);
 
-        destinationBus->sumFrom(*tempBuffer);
+        destinationBus.sumFrom(*tempBuffer);
     } else {
         ASSERT_NOT_REACHED();
-        destinationBus->zero();
+        destinationBus.zero();
     }
 }
 

--- a/Source/WebCore/platform/audio/Reverb.h
+++ b/Source/WebCore/platform/audio/Reverb.h
@@ -45,16 +45,16 @@ public:
     enum { MaxFrameSize = 256 };
 
     // renderSliceSize is a rendering hint, so the FFTs can be optimized to not all occur at the same time (very bad when rendering on a real-time thread).
-    Reverb(AudioBus* impulseResponseBuffer, size_t renderSliceSize, size_t maxFFTSize, bool useBackgroundThreads, bool normalize);
+    Reverb(AudioBus& impulseResponseBuffer, size_t renderSliceSize, size_t maxFFTSize, bool useBackgroundThreads, bool normalize);
 
-    void process(const AudioBus* sourceBus, AudioBus* destinationBus, size_t framesToProcess);
+    void process(const AudioBus& sourceBus, AudioBus& destinationBus, size_t framesToProcess);
     void reset();
 
     size_t impulseResponseLength() const { return m_impulseResponseLength; }
     size_t latencyFrames() const;
 
 private:
-    void initialize(AudioBus* impulseResponseBuffer, size_t renderSliceSize, size_t maxFFTSize, bool useBackgroundThreads, float scale);
+    void initialize(AudioBus& impulseResponseBuffer, size_t renderSliceSize, size_t maxFFTSize, bool useBackgroundThreads, float scale);
 
     size_t m_impulseResponseLength;
 

--- a/Source/WebCore/platform/audio/SharedAudioDestination.h
+++ b/Source/WebCore/platform/audio/SharedAudioDestination.h
@@ -43,7 +43,7 @@ public:
     void ref() const final { return ThreadSafeRefCounted::ref(); }
     void deref() const final { return ThreadSafeRefCounted::deref(); }
 
-    void sharedRender(AudioBus* sourceBus, AudioBus* destinationBus, size_t framesToProcess, const AudioIOPosition&);
+    void sharedRender(AudioBus& destinationBus, size_t framesToProcess, const AudioIOPosition&);
 
 private:
     SharedAudioDestination(const CreationOptions&, AudioDestinationCreationFunction&&);

--- a/Source/WebCore/platform/audio/StereoPanner.cpp
+++ b/Source/WebCore/platform/audio/StereoPanner.cpp
@@ -38,24 +38,24 @@ namespace WebCore {
 
 namespace StereoPanner {
 
-void panWithSampleAccurateValues(const AudioBus* inputBus, AudioBus* outputBus, std::span<const float> panValues)
+void panWithSampleAccurateValues(const AudioBus& inputBus, AudioBus& outputBus, std::span<const float> panValues)
 {
-    bool isInputSafe = inputBus && (inputBus->numberOfChannels() == 1 || inputBus->numberOfChannels() == 2) && panValues.size() <= inputBus->length();
+    bool isInputSafe = (inputBus.numberOfChannels() == 1 || inputBus.numberOfChannels() == 2) && panValues.size() <= inputBus.length();
     ASSERT(isInputSafe);
     if (!isInputSafe)
         return;
     
-    unsigned numberOfInputChannels = inputBus->numberOfChannels();
-    
-    bool isOutputSafe = outputBus && outputBus->numberOfChannels() == 2 && panValues.size() <= outputBus->length();
+    unsigned numberOfInputChannels = inputBus.numberOfChannels();
+
+    bool isOutputSafe = outputBus.numberOfChannels() == 2 && panValues.size() <= outputBus.length();
     ASSERT(isOutputSafe);
     if (!isOutputSafe)
         return;
     
-    auto sourceL = inputBus->channel(0)->span();
-    auto sourceR = numberOfInputChannels > 1 ? inputBus->channel(1)->span() : sourceL;
-    auto destinationL = outputBus->channelByType(AudioBus::ChannelLeft)->mutableSpan();
-    auto destinationR = outputBus->channelByType(AudioBus::ChannelRight)->mutableSpan();
+    auto sourceL = inputBus.channel(0)->span();
+    auto sourceR = numberOfInputChannels > 1 ? inputBus.channel(1)->span() : sourceL;
+    auto destinationL = outputBus.channelByType(AudioBus::ChannelLeft)->mutableSpan();
+    auto destinationR = outputBus.channelByType(AudioBus::ChannelRight)->mutableSpan();
     
     double gainL;
     double gainR;
@@ -93,24 +93,24 @@ void panWithSampleAccurateValues(const AudioBus* inputBus, AudioBus* outputBus, 
     }
 }
 
-void panToTargetValue(const AudioBus* inputBus, AudioBus* outputBus, float panValue, size_t framesToProcess)
+void panToTargetValue(const AudioBus& inputBus, AudioBus& outputBus, float panValue, size_t framesToProcess)
 {
-    bool isInputSafe = inputBus && (inputBus->numberOfChannels() == 1 || inputBus->numberOfChannels() == 2) && framesToProcess <= inputBus->length();
+    bool isInputSafe = (inputBus.numberOfChannels() == 1 || inputBus.numberOfChannels() == 2) && framesToProcess <= inputBus.length();
     ASSERT(isInputSafe);
     if (!isInputSafe)
         return;
     
-    unsigned numberOfInputChannels = inputBus->numberOfChannels();
-    
-    bool isOutputSafe = outputBus && outputBus->numberOfChannels() == 2 && framesToProcess <= outputBus->length();
+    unsigned numberOfInputChannels = inputBus.numberOfChannels();
+
+    bool isOutputSafe = outputBus.numberOfChannels() == 2 && framesToProcess <= outputBus.length();
     ASSERT(isOutputSafe);
     if (!isOutputSafe)
         return;
     
-    auto sourceL = inputBus->channel(0)->span().first(framesToProcess);
-    auto sourceR = numberOfInputChannels > 1 ? inputBus->channel(1)->span().first(framesToProcess) : sourceL;
-    auto destinationL = outputBus->channelByType(AudioBus::ChannelLeft)->mutableSpan();
-    auto destinationR = outputBus->channelByType(AudioBus::ChannelRight)->mutableSpan();
+    auto sourceL = inputBus.channel(0)->span().first(framesToProcess);
+    auto sourceR = numberOfInputChannels > 1 ? inputBus.channel(1)->span().first(framesToProcess) : sourceL;
+    auto destinationL = outputBus.channelByType(AudioBus::ChannelLeft)->mutableSpan();
+    auto destinationR = outputBus.channelByType(AudioBus::ChannelRight)->mutableSpan();
 
     float targetPan = clampTo(panValue, -1.0, 1.0);
     

--- a/Source/WebCore/platform/audio/StereoPanner.h
+++ b/Source/WebCore/platform/audio/StereoPanner.h
@@ -33,9 +33,9 @@ namespace WebCore {
 
 namespace StereoPanner {
     
-void panWithSampleAccurateValues(const AudioBus* inputBus, AudioBus* outputBus, std::span<const float> panValues);
-    
-void panToTargetValue(const AudioBus* inputBus, AudioBus* outputBus, float panValue, size_t framesToProcess);
+void panWithSampleAccurateValues(const AudioBus& inputBus, AudioBus& outputBus, std::span<const float> panValues);
+
+void panToTargetValue(const AudioBus& inputBus, AudioBus& outputBus, float panValue, size_t framesToProcess);
 
 } // namespace StereoPanner
 

--- a/Source/WebCore/platform/audio/gstreamer/AudioFileReaderGStreamer.cpp
+++ b/Source/WebCore/platform/audio/gstreamer/AudioFileReaderGStreamer.cpp
@@ -459,7 +459,7 @@ RefPtr<AudioBus> AudioFileReader::createBus(float sampleRate, bool mixToMono)
     m_buffers.clear();
 
     if (mixToMono)
-        return AudioBus::createByMixingToMono(audioBus.ptr());
+        return AudioBus::createByMixingToMono(audioBus);
     return audioBus;
 }
 

--- a/Source/WebCore/platform/audio/gstreamer/WebKitWebAudioSourceGStreamer.cpp
+++ b/Source/WebCore/platform/audio/gstreamer/WebKitWebAudioSourceGStreamer.cpp
@@ -340,7 +340,7 @@ static void webKitWebAudioSrcRenderAndPushFrames(const GRefPtr<GstElement>& elem
 
     // FIXME: Add support for local/live audio input.
     if (priv->bus)
-        priv->destination->callRenderCallback(nullptr, priv->bus.get(), priv->framesToPull, outputTimestamp);
+        priv->destination->callRenderCallback(*priv->bus, priv->framesToPull, outputTimestamp);
 
     if (!priv->hasRenderedAudibleFrame && !priv->bus->isSilent()) {
         priv->destination->notifyIsPlaying(true);


### PR DESCRIPTION
#### 333e3890f47db063eed9abe9bd35f005f1e354fd
<pre>
[Refactor] Pass AudioBus by reference everywhere possible
<a href="https://rdar.apple.com/151925227">rdar://151925227</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=293490">https://bugs.webkit.org/show_bug.cgi?id=293490</a>

Reviewed by Eric Carlson.

AudioBus is currently passed almost everywhere inside Modules/webaudio as a pointer.
However, in many cases, the pointer bus parameter or the return value of a method
are never null-checked.

Make this guarantee explicit by changing parameter types and return values from
`AudioBus*` to `AudioBus&amp;`. For some classes, this means changing instance variable
types from `RefPtr&lt;AudioBus&gt;` to `Ref&lt;AudioBus&gt;`, which is possible after 295322@main
changed the return type of `AudioBus::create()` to `Ref&lt;AudioBus&gt;`.

Drive-by fix:

There was one case where converting a return type from `RefPtr` to `Ref` required
a change in logic. In `AudioBus::createByMixingToMono()`, only mono and stereo
channel layouts were handled, and any other channel number resulted in a nullptr
being returned. Logic was added to this function to handle any number of channels
being mixed down to mono.

* Source/WebCore/Modules/webaudio/AnalyserNode.cpp:
(WebCore::AnalyserNode::process):
* Source/WebCore/Modules/webaudio/AudioBasicInspectorNode.cpp:
(WebCore::AudioBasicInspectorNode::pullInputs):
* Source/WebCore/Modules/webaudio/AudioBasicProcessorNode.cpp:
(WebCore::AudioBasicProcessorNode::process):
(WebCore::AudioBasicProcessorNode::pullInputs):
* Source/WebCore/Modules/webaudio/AudioBufferSourceNode.cpp:
(WebCore::AudioBufferSourceNode::process):
(WebCore::AudioBufferSourceNode::renderSilenceAndFinishIfNotLooping):
(WebCore::AudioBufferSourceNode::renderFromBuffer):
* Source/WebCore/Modules/webaudio/AudioBufferSourceNode.h:
* Source/WebCore/Modules/webaudio/AudioDestinationNode.cpp:
(WebCore::AudioDestinationNode::renderQuantum):
* Source/WebCore/Modules/webaudio/AudioDestinationNode.h:
* Source/WebCore/Modules/webaudio/AudioNode.cpp:
(WebCore::AudioNode::inputsAreSilent):
(WebCore::AudioNode::silenceOutputs):
* Source/WebCore/Modules/webaudio/AudioNodeInput.cpp:
(WebCore::AudioNodeInput::AudioNodeInput):
(WebCore::AudioNodeInput::bus):
(WebCore::AudioNodeInput::internalSummingBus):
(WebCore::AudioNodeInput::sumAllConnections):
(WebCore::AudioNodeInput::pull):
* Source/WebCore/Modules/webaudio/AudioNodeInput.h:
* Source/WebCore/Modules/webaudio/AudioNodeOutput.cpp:
(WebCore::AudioNodeOutput::AudioNodeOutput):
(WebCore::AudioNodeOutput::pull):
(WebCore::AudioNodeOutput::bus const):
* Source/WebCore/Modules/webaudio/AudioNodeOutput.h:
* Source/WebCore/Modules/webaudio/AudioParam.cpp:
(WebCore::AudioParam::calculateFinalValues):
* Source/WebCore/Modules/webaudio/AudioWorkletNode.cpp:
(WebCore::AudioWorkletNode::process):
* Source/WebCore/Modules/webaudio/BiquadProcessor.cpp:
(WebCore::BiquadProcessor::process):
* Source/WebCore/Modules/webaudio/BiquadProcessor.h:
* Source/WebCore/Modules/webaudio/ChannelMergerNode.cpp:
(WebCore::ChannelMergerNode::process):
* Source/WebCore/Modules/webaudio/ChannelSplitterNode.cpp:
(WebCore::ChannelSplitterNode::process):
* Source/WebCore/Modules/webaudio/ConstantSourceNode.cpp:
(WebCore::ConstantSourceNode::process):
* Source/WebCore/Modules/webaudio/ConvolverNode.cpp:
(WebCore::ConvolverNode::process):
(WebCore::ConvolverNode::setBufferForBindings):
* Source/WebCore/Modules/webaudio/DefaultAudioDestinationNode.cpp:
(WebCore::DefaultAudioDestinationNode::render):
* Source/WebCore/Modules/webaudio/DefaultAudioDestinationNode.h:
* Source/WebCore/Modules/webaudio/DynamicsCompressorNode.cpp:
(WebCore::DynamicsCompressorNode::process):
* Source/WebCore/Modules/webaudio/GainNode.cpp:
(WebCore::GainNode::process):
* Source/WebCore/Modules/webaudio/IIRProcessor.cpp:
(WebCore::IIRProcessor::process):
* Source/WebCore/Modules/webaudio/IIRProcessor.h:
* Source/WebCore/Modules/webaudio/MediaElementAudioSourceNode.cpp:
(WebCore::MediaElementAudioSourceNode::process):
* Source/WebCore/Modules/webaudio/MediaStreamAudioDestinationNode.cpp:
(WebCore::MediaStreamAudioDestinationNode::process):
* Source/WebCore/Modules/webaudio/MediaStreamAudioSourceNode.cpp:
(WebCore::MediaStreamAudioSourceNode::process):
* Source/WebCore/Modules/webaudio/OfflineAudioDestinationNode.cpp:
(WebCore::OfflineAudioDestinationNode::renderOnAudioThread):
* Source/WebCore/Modules/webaudio/OfflineAudioDestinationNode.h:
* Source/WebCore/Modules/webaudio/OscillatorNode.cpp:
(WebCore::OscillatorNode::process):
* Source/WebCore/Modules/webaudio/PannerNode.cpp:
(WebCore::PannerNode::process):
(WebCore::PannerNode::processSampleAccurateValues):
* Source/WebCore/Modules/webaudio/PannerNode.h:
* Source/WebCore/Modules/webaudio/RealtimeAnalyser.cpp:
(WebCore::RealtimeAnalyser::writeInput):
* Source/WebCore/Modules/webaudio/RealtimeAnalyser.h:
* Source/WebCore/Modules/webaudio/ScriptProcessorNode.cpp:
(WebCore::ScriptProcessorNode::process):
* Source/WebCore/Modules/webaudio/ScriptProcessorNode.h:
* Source/WebCore/Modules/webaudio/StereoPannerNode.cpp:
(WebCore::StereoPannerNode::process):
* Source/WebCore/Modules/webaudio/WaveShaperProcessor.cpp:
(WebCore::WaveShaperProcessor::process):
* Source/WebCore/Modules/webaudio/WaveShaperProcessor.h:
* Source/WebCore/platform/audio/AudioBus.cpp:
(WebCore::AudioBus::createCopy):
(WebCore::AudioBus::createBufferFromRange):
(WebCore::AudioBus::createBySampleRateConverting):
(WebCore::AudioBus::createByMixingToMono):
* Source/WebCore/platform/audio/AudioBus.h:
* Source/WebCore/platform/audio/AudioDSPKernelProcessor.cpp:
(WebCore::AudioDSPKernelProcessor::process):
* Source/WebCore/platform/audio/AudioDSPKernelProcessor.h:
* Source/WebCore/platform/audio/AudioDestination.h:
(WebCore::AudioDestination::callRenderCallback):
* Source/WebCore/platform/audio/AudioDestinationResampler.cpp:
(WebCore::m_fifo):
(WebCore::AudioDestinationResampler::pullRendered):
(WebCore::AudioDestinationResampler::renderOnRenderingThreadIfPlaying):
* Source/WebCore/platform/audio/AudioIOCallback.h:
* Source/WebCore/platform/audio/AudioProcessor.h:
* Source/WebCore/platform/audio/AudioResampler.cpp:
(WebCore::AudioResampler::process):
* Source/WebCore/platform/audio/AudioResampler.h:
* Source/WebCore/platform/audio/DynamicsCompressor.cpp:
(WebCore::DynamicsCompressor::process):
* Source/WebCore/platform/audio/DynamicsCompressor.h:
* Source/WebCore/platform/audio/EqualPowerPanner.cpp:
(WebCore::EqualPowerPanner::pan):
(WebCore::EqualPowerPanner::panWithSampleAccurateValues):
* Source/WebCore/platform/audio/EqualPowerPanner.h:
* Source/WebCore/platform/audio/HRTFElevation.cpp:
(WebCore::HRTFElevation::calculateKernelsForAzimuthElevation):
* Source/WebCore/platform/audio/HRTFPanner.cpp:
(WebCore::HRTFPanner::pan):
(WebCore::HRTFPanner::panWithSampleAccurateValues):
* Source/WebCore/platform/audio/HRTFPanner.h:
* Source/WebCore/platform/audio/MultiChannelResampler.cpp:
(WebCore::MultiChannelResampler::process):
(WebCore::MultiChannelResampler::provideInputForChannel):
* Source/WebCore/platform/audio/MultiChannelResampler.h:
* Source/WebCore/platform/audio/Panner.h:
* Source/WebCore/platform/audio/PushPullFIFO.cpp:
(WebCore::PushPullFIFO::push):
(WebCore::PushPullFIFO::pull):
* Source/WebCore/platform/audio/PushPullFIFO.h:
(WebCore::PushPullFIFO::bus const):
* Source/WebCore/platform/audio/Reverb.cpp:
(WebCore::calculateNormalizationScale):
(WebCore::Reverb::Reverb):
(WebCore::Reverb::initialize):
(WebCore::Reverb::process):
* Source/WebCore/platform/audio/Reverb.h:
* Source/WebCore/platform/audio/SharedAudioDestination.cpp:
(WebCore::SharedAudioDestinationAdapter::render):
(WebCore::SharedAudioDestination::sharedRender):
* Source/WebCore/platform/audio/SharedAudioDestination.h:
* Source/WebCore/platform/audio/StereoPanner.cpp:
(WebCore::StereoPanner::panWithSampleAccurateValues):
(WebCore::StereoPanner::panToTargetValue):
* Source/WebCore/platform/audio/StereoPanner.h:

Canonical link: <a href="https://commits.webkit.org/295461@main">https://commits.webkit.org/295461@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/048ca08ba2dd8004d21aaf406a1e13ffee5f92f9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105155 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24869 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15294 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110371 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/55828 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/107196 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/25296 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33413 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79868 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108161 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19716 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94914 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60175 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/19473 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/12990 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55212 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/89181 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13034 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/112915 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32320 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23808 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88946 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32686 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91132 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88576 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22590 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33470 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11260 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/27737 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32243 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/37630 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32033 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35376 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33594 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->