### PR TITLE
[Grid] Remove GridAxis and stop using it from GridBaselineAlignment.

### DIFF
--- a/Source/WebCore/rendering/GridBaselineAlignment.h
+++ b/Source/WebCore/rendering/GridBaselineAlignment.h
@@ -49,37 +49,37 @@ public:
     // Collects the items participating in baseline alignment and updates the corresponding baseline-sharing
     // group of the Baseline Context the items belongs to.
     // All the baseline offsets are updated accordingly based on the added item.
-    void updateBaselineAlignmentContext(ItemPosition, unsigned sharedContext, const RenderBox&, GridAxis);
+    void updateBaselineAlignmentContext(ItemPosition, unsigned sharedContext, const RenderBox&, GridTrackSizingDirection alignmentContextType);
 
     // Returns the baseline offset of a particular item, based on the max-ascent for its associated
     // baseline-sharing group
-    LayoutUnit baselineOffsetForGridItem(ItemPosition, unsigned sharedContext, const RenderBox&, GridAxis) const;
+    LayoutUnit baselineOffsetForGridItem(ItemPosition, unsigned sharedContext, const RenderBox&, GridTrackSizingDirection alignmentContextType) const;
 
     // Sets the Grid Container's writing mode so that we can avoid the dependecy of the LayoutGrid class for
     // determining whether a grid item is orthogonal or not.
     void setWritingMode(WritingMode writingMode) { m_writingMode = writingMode; };
 
     // Clearing the Baseline Alignment context and their internal classes and data structures.
-    void clear(GridAxis);
+    void clear(GridTrackSizingDirection alignmentContextType);
 
 private:
-    const BaselineGroup& baselineGroupForGridItem(ItemPosition, unsigned sharedContext, const RenderBox&, GridAxis) const;
-    LayoutUnit marginOverForGridItem(const RenderBox&, GridAxis) const;
-    LayoutUnit marginUnderForGridItem(const RenderBox&, GridAxis) const;
-    LayoutUnit logicalAscentForGridItem(const RenderBox&, GridAxis, ItemPosition) const;
-    LayoutUnit ascentForGridItem(const RenderBox&, GridAxis, ItemPosition) const;
-    LayoutUnit descentForGridItem(const RenderBox&, LayoutUnit, GridAxis, ExtraMarginsFromSubgrids) const;
-    bool isDescentBaselineForGridItem(const RenderBox&, GridAxis) const;
-    bool isVerticalAlignmentContext(GridAxis) const;
+    const BaselineGroup& baselineGroupForGridItem(ItemPosition, unsigned sharedContext, const RenderBox&, GridTrackSizingDirection alignmentContextType) const;
+    LayoutUnit marginOverForGridItem(const RenderBox&, GridTrackSizingDirection alignmentContextType) const;
+    LayoutUnit marginUnderForGridItem(const RenderBox&, GridTrackSizingDirection alignmentContextType) const;
+    LayoutUnit logicalAscentForGridItem(const RenderBox&, GridTrackSizingDirection alignmentContextType, ItemPosition) const;
+    LayoutUnit ascentForGridItem(const RenderBox&, GridTrackSizingDirection alignmentContextType, ItemPosition) const;
+    LayoutUnit descentForGridItem(const RenderBox&, LayoutUnit, GridTrackSizingDirection alignmentContextType, ExtraMarginsFromSubgrids) const;
+    bool isDescentBaselineForGridItem(const RenderBox&, GridTrackSizingDirection alignmentContextType) const;
+    bool isVerticalAlignmentContext(GridTrackSizingDirection alignmentContextType) const;
     bool isOrthogonalGridItemForBaseline(const RenderBox&) const;
-    bool isParallelToAlignmentAxisForGridItem(const RenderBox&, GridAxis) const;
+    bool isParallelToAlignmentAxisForGridItem(const RenderBox&, GridTrackSizingDirection alignmentContextType) const;
 
     typedef UncheckedKeyHashMap<unsigned, std::unique_ptr<BaselineAlignmentState>, DefaultHash<unsigned>, WTF::UnsignedWithZeroKeyHashTraits<unsigned>> BaselineAlignmentStateMap;
 
     // Grid Container's writing mode, used to determine grid item's orthogonality.
     WritingMode m_writingMode;
-    BaselineAlignmentStateMap m_rowAxisBaselineAlignmentStates;
-    BaselineAlignmentStateMap m_colAxisBaselineAlignmentStates;
+    BaselineAlignmentStateMap m_rowAlignmentContextStates;
+    BaselineAlignmentStateMap m_columnAlignmentContextStates;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/GridLayoutFunctions.cpp
+++ b/Source/WebCore/rendering/GridLayoutFunctions.cpp
@@ -231,17 +231,6 @@ void clearOverridingContentSizeForGridItem(const RenderGrid& renderGrid, RenderB
         direction == GridTrackSizingDirection::ForColumns ? gridItem.clearOverridingBorderBoxLogicalHeight() : gridItem.clearOverridingBorderBoxLogicalWidth();
 }
 
-
-GridAxis gridAxisForDirection(GridTrackSizingDirection direction)
-{
-    return direction == GridTrackSizingDirection::ForColumns ? GridAxis::GridRowAxis : GridAxis::GridColumnAxis;
-}
-
-GridTrackSizingDirection gridDirectionForAxis(GridAxis axis)
-{
-    return axis == GridAxis::GridRowAxis ? GridTrackSizingDirection::ForColumns : GridTrackSizingDirection::ForRows;
-}
-
 } // namespace GridLayoutFunctions
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/GridLayoutFunctions.h
+++ b/Source/WebCore/rendering/GridLayoutFunctions.h
@@ -35,11 +35,6 @@ enum class ItemPosition : uint8_t;
 class RenderElement;
 class RenderGrid;
 
-enum class GridAxis : uint8_t {
-    GridRowAxis = 1 << 0,
-    GridColumnAxis = 1 << 1
-};
-
 struct ExtraMarginsFromSubgrids {
     inline LayoutUnit extraTrackStartMargin() const { return m_extraMargins.first; }
     inline LayoutUnit extraTrackEndMargin() const { return m_extraMargins.second; }
@@ -78,9 +73,6 @@ bool isSubgridReversedDirection(const RenderGrid&, GridTrackSizingDirection oute
 ExtraMarginsFromSubgrids extraMarginForSubgridAncestors(GridTrackSizingDirection, const RenderBox& gridItem);
 
 unsigned alignmentContextForBaselineAlignment(const GridSpan&, const ItemPosition& alignment);
-
-GridAxis gridAxisForDirection(GridTrackSizingDirection);
-GridTrackSizingDirection gridDirectionForAxis(GridAxis);
 
 }
 

--- a/Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp
+++ b/Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp
@@ -133,17 +133,6 @@ void GridTrack::ensureGrowthLimitIsBiggerThanBaseSize()
         m_growthLimit = std::max(m_baseSize, 0_lu);
 }
 
-
-GridAxis gridAxisForDirection(GridTrackSizingDirection direction)
-{
-    return direction == GridTrackSizingDirection::ForColumns ? GridAxis::GridRowAxis : GridAxis::GridColumnAxis;
-}
-
-GridTrackSizingDirection gridDirectionForAxis(GridAxis axis)
-{
-    return axis == GridAxis::GridRowAxis ? GridTrackSizingDirection::ForColumns : GridTrackSizingDirection::ForRows;
-}
-
 static bool hasRelativeMarginOrPaddingForGridItem(const RenderBox& gridItem, GridTrackSizingDirection direction)
 {
     if (direction == GridTrackSizingDirection::ForColumns)
@@ -1247,7 +1236,7 @@ void GridTrackSizingAlgorithm::updateBaselineAlignmentContext(const RenderBox& g
     auto align = m_renderGrid->selfAlignmentForGridItem(alignmentContextType, gridItem).position();
     const auto& span = m_renderGrid->gridSpanForGridItem(gridItem, alignmentContextType);
     auto alignmentContext = GridLayoutFunctions::alignmentContextForBaselineAlignment(span, align);
-    m_baselineAlignment.updateBaselineAlignmentContext(align, alignmentContext, gridItem, GridLayoutFunctions::gridAxisForDirection(alignmentContextType));
+    m_baselineAlignment.updateBaselineAlignmentContext(align, alignmentContext, gridItem, alignmentContextType);
 }
 
 LayoutUnit GridTrackSizingAlgorithm::baselineOffsetForGridItem(const RenderBox& gridItem, GridTrackSizingDirection alignmentContextType) const
@@ -1264,7 +1253,7 @@ LayoutUnit GridTrackSizingAlgorithm::baselineOffsetForGridItem(const RenderBox& 
     auto align = m_renderGrid->selfAlignmentForGridItem(alignmentContextType, gridItem).position();
     const auto& span = m_renderGrid->gridSpanForGridItem(gridItem, alignmentContextType);
     auto alignmentContext = GridLayoutFunctions::alignmentContextForBaselineAlignment(span, align);
-    return m_baselineAlignment.baselineOffsetForGridItem(align, alignmentContext, gridItem, GridLayoutFunctions::gridAxisForDirection(alignmentContextType));
+    return m_baselineAlignment.baselineOffsetForGridItem(align, alignmentContext, gridItem, alignmentContextType);
 }
 
 void GridTrackSizingAlgorithm::clearBaselineItemsCache()
@@ -2055,7 +2044,7 @@ void GridTrackSizingAlgorithm::setup(GridTrackSizingDirection direction, unsigne
 void GridTrackSizingAlgorithm::computeBaselineAlignmentContext()
 {
     auto alignmentContextType = m_direction;
-    m_baselineAlignment.clear(GridLayoutFunctions::gridAxisForDirection(alignmentContextType));
+    m_baselineAlignment.clear(alignmentContextType);
     m_baselineAlignment.setWritingMode(m_renderGrid->style().writingMode());
     BaselineItemsCache& baselineItemsCache = alignmentContextType == GridTrackSizingDirection::ForRows ? m_baselineAlignmentItemsForRows : m_baselineAlignmentItemsForColumns;
     BaselineItemsCache tmpBaselineItemsCache = baselineItemsCache;

--- a/Source/WebCore/rendering/GridTrackSizingAlgorithm.h
+++ b/Source/WebCore/rendering/GridTrackSizingAlgorithm.h
@@ -396,7 +396,4 @@ protected:
     GridTrackSizingAlgorithm& m_algorithm;
 };
 
-GridAxis gridAxisForDirection(GridTrackSizingDirection);
-GridTrackSizingDirection gridDirectionForAxis(GridAxis);
-
 } // namespace WebCore


### PR DESCRIPTION
#### bb01416d4c91349e7361b1b98f804517f9c3c679
<pre>
[Grid] Remove GridAxis and stop using it from GridBaselineAlignment.
<a href="https://bugs.webkit.org/show_bug.cgi?id=293493">https://bugs.webkit.org/show_bug.cgi?id=293493</a>
<a href="https://rdar.apple.com/151930667">rdar://151930667</a>

Reviewed by Alan Baradlay.

This is the final patch in the series of cleanups to stop using GridAxis
and to remove it. Instead, we now use GridTrackSizingDirection as the
type of alignment context (i.e. a grid row or grid column), which is what
GridAxis was basically doing. In each function where this was being used,
we just changed uses of:
- GridAxis::GridColumnAxis -&gt; GridTrackSizingDirection::ForRows
- GridAxis::GridRowAxis -&gt; GridTrackSizingDirection::ForColumns

I also renamed m_row/columnAxisBaselineAlignmentStates to
m_row/columnAlignmentContextStates to reflect this change.

This change makes the code simpler since we do not have to worry about
converting between these two enums in different parts of the code. As a
result, we can remove the enum and the helper functions that were used
to convert between it and GridTrackSizingDirection.

Canonical link: <a href="https://commits.webkit.org/295463@main">https://commits.webkit.org/295463@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/582b35075569fff817dd91d8c64dbea49bb2933f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105152 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24866 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15291 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110368 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/55825 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/107193 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/25293 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33410 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79866 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108158 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19714 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94913 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60173 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/19471 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/12989 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55209 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/89179 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13033 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/112910 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32317 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23806 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88943 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32683 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91131 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88573 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22588 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33468 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11259 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/27734 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32240 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/37621 "Failed to build and analyze WebKit") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32030 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35373 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33591 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->