### PR TITLE
Terminate only the web processes using models after the model process has repeatedly crashed

### DIFF
--- a/Source/WebKit/UIProcess/WebProcessPool.h
+++ b/Source/WebKit/UIProcess/WebProcessPool.h
@@ -654,6 +654,11 @@ private:
     void processStoppedUsingGamepads(WebProcessProxy&);
 #endif
 
+#if ENABLE(MODEL_PROCESS)
+    void startedPlayingModels(IPC::Connection&);
+    void stoppedPlayingModels(IPC::Connection&);
+#endif
+
     void updateProcessAssertions();
     static constexpr Seconds audibleActivityClearDelay = 5_s;
     void updateAudibleMediaAssertions();
@@ -743,6 +748,7 @@ private:
 
 #if ENABLE(MODEL_PROCESS)
     ModelProcessProxy& ensureModelProcess();
+    void terminateAllWebContentProcessesWithModelPlayers();
 #endif
 
 #if ENABLE(CONTENT_EXTENSIONS)
@@ -773,6 +779,7 @@ private:
 #endif
 #if ENABLE(MODEL_PROCESS)
     RefPtr<ModelProcessProxy> m_modelProcess;
+    WeakHashSet<WebProcessProxy> m_processesWithModelPlayers;
 #endif
 
     Ref<WebPageGroup> m_defaultPageGroup;

--- a/Source/WebKit/UIProcess/WebProcessPool.messages.in
+++ b/Source/WebKit/UIProcess/WebProcessPool.messages.in
@@ -38,5 +38,10 @@ messages -> WebProcessPool {
     [EnabledBy=GamepadsEnabled] StopGamepadEffects(unsigned gamepadIndex, String gamepadID) -> ()
 #endif
 
+#if ENABLE(MODEL_PROCESS)
+    [EnabledBy=ModelElementEnabled && ModelProcessEnabled] StartedPlayingModels()
+    [EnabledBy=ModelElementEnabled && ModelProcessEnabled] StoppedPlayingModels()
+#endif
+
     ReportWebContentCPUTime(Seconds cpuTime, uint64_t activityState)
 }


### PR DESCRIPTION
#### 8d026d2b3d9578d76e8fa10bf76fbad8ac557067
<pre>
Terminate only the web processes using models after the model process has repeatedly crashed
<a href="https://bugs.webkit.org/show_bug.cgi?id=293495">https://bugs.webkit.org/show_bug.cgi?id=293495</a>
<a href="https://rdar.apple.com/150495867">rdar://150495867</a>

Reviewed by Mike Wyrzykowski.

Track the web processes using models in WebProcessPool::m_processesWithModelPlayers.
When we detect the model process has crashed multiple times within a short period of
time, we terminate the web processes that are actively showing models.

* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::modelProcessExited):
Clear out m_processesWithModelPlayers when the model process exits.
(WebKit::WebProcessPool::startedPlayingModels):
Start tracking the web process in m_processesWithModelPlayers.
(WebKit::WebProcessPool::stoppedPlayingModels):
Stop tracking the web process in m_processesWithModelPlayers.
(WebKit::WebProcessPool::terminateAllWebContentProcessesWithModelPlayers):
Go through all the web processes with existing model players and
terminate them.
(WebKit::WebProcessPool::disconnectProcess):
Stop tracking the web process in m_processesWithModelPlayers when
the web process has exited.
* Source/WebKit/UIProcess/WebProcessPool.h:
* Source/WebKit/UIProcess/WebProcessPool.messages.in:
* Source/WebKit/WebProcess/Model/ModelProcessModelPlayerManager.cpp:
(WebKit::ModelProcessModelPlayerManager::createModelProcessModelPlayer):
Notify WebProcessPool in the UI process if the web process has
created its first model player.
(WebKit::ModelProcessModelPlayerManager::deleteModelProcessModelPlayer):
Notify WebProcessPool in the UI process if the web process has
removed its last model player.
(WebKit::ModelProcessModelPlayerManager::didUnloadModelProcessModelPlayer):
Notify WebProcessPool in the UI process if the web process has
removed its last model player.

Canonical link: <a href="https://commits.webkit.org/295442@main">https://commits.webkit.org/295442@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2ca25fd3c0b5ef824ecd393fb73b5da48de733de

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104852 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24565 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/14986 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110067 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/55526 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/24965 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33110 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79617 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107858 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19412 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94627 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59924 "Passed tests") | 
| | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/19160 "Build is in progress. Recent messages:OS: Sequoia (15.2), Xcode: 16.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; 4 new passes 5 flakes 1 failures; Uploaded test results; 4 new passes 15 flakes 1 failures; Compiled WebKit (warnings); Running run-layout-tests-without-change") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/54909 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/88859 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/12751 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/112510 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32017 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23536 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88697 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32381 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/90853 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88325 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22573 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33215 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10981 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/27331 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/31942 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/37297 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/31734 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35075 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33293 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->