### PR TITLE
[Grid] m_hasAnyBaselineAlignmentItem is unused

### DIFF
--- a/Source/WebCore/rendering/RenderGrid.h
+++ b/Source/WebCore/rendering/RenderGrid.h
@@ -321,7 +321,6 @@ private:
     OutOfFlowPositionsMap m_outOfFlowItemRow;
 
     bool m_baselineItemsCached {false};
-    bool m_hasAnyBaselineAlignmentItem { false };
 
     mutable std::optional<GridItemSizeCache> m_intrinsicLogicalHeightsForRowSizingFirstPass;
 };


### PR DESCRIPTION
#### 18a3b07d5e31117fb960752556e4b7f30927596e
<pre>
[Grid] m_hasAnyBaselineAlignmentItem is unused
<a href="https://bugs.webkit.org/show_bug.cgi?id=293498">https://bugs.webkit.org/show_bug.cgi?id=293498</a>
<a href="https://rdar.apple.com/151938347">rdar://151938347</a>

Reviewed by Ryan Reno and Alan Baradlay.

This member variable does appear to be used anywhere.

Canonical link: <a href="https://commits.webkit.org/295381@main">https://commits.webkit.org/295381@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9227d8607f968e71a1fdf7eeb730fbc892804f65

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104864 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24577 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/14998 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110079 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/55538 "Built successfully") 
| [❌ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/106904 "Found 86 Binding test failures: JSTestPluginInterface.cpp, JSTestNode.cpp, JSTestCEReactions.cpp, JSTestStringifierReadWriteAttribute.cpp, JSTestNamedDeleterNoIdentifier.cpp, JSTestIndexedSetterThrowingException.cpp, JSTestNamedAndIndexedSetterWithIdentifier.cpp, JSTestDefaultToJSONFilteredByExposed.cpp, JSTestEventTarget.cpp, JSShadowRealmGlobalScope.cpp, JSTestStringifierOperationImplementedAs.cpp, JSTestOverloadedConstructorsWithSequence.cpp, JSTestCallTracer.cpp, JSTestNamedSetterWithIndexedGetter.cpp, JSTestInterface.cpp, JSSharedWorkerGlobalScope.cpp, JSTestCEReactionsStringifier.cpp, JSTestPromiseRejectionEvent.cpp, JSTestScheduledAction.cpp, JSTestStringifierOperationNamedToString.cpp, JSTestNamedSetterWithLegacyUnforgeableProperties.cpp, JSTestOverloadedConstructors.cpp, JSTestSetLikeWithOverriddenOperations.cpp, JSTestSetLike.cpp, JSTestLegacyOverrideBuiltIns.cpp, JSTestIndexedSetterWithIdentifier.cpp, JSServiceWorkerGlobalScope.cpp, JSTestConditionallyReadWrite.cpp, JSTestNamedGetterWithIdentifier.cpp, JSExposedStar.cpp, JSTestMapLike.cpp, JSTestNamedDeleterThrowingException.cpp, JSTestNamedGetterCallWith.cpp, JSWorkletGlobalScope.cpp, JSTestDefaultToJSON.cpp, JSTestGenerateAddOpaqueRoot.cpp, JSTestSerializedScriptValueInterface.cpp, JSTestObj.cpp, JSTestIndexedSetterNoIdentifier.cpp, JSTestStringifier.cpp, JSTestInterfaceLeadingUnderscore.cpp, JSTestReadOnlyMapLike.cpp, JSTestEnabledBySetting.cpp, JSTestGlobalObject.cpp, JSTestNamedAndIndexedSetterNoIdentifier.cpp, JSTestReportExtraMemoryCost.cpp, JSTestException.cpp, JSTestStringifierReadOnlyAttribute.cpp, JSTestIterable.cpp, JSTestNamedSetterThrowingException.cpp, JSTestOperationConditional.cpp, JSTestReadOnlySetLike.cpp, JSTestClassWithJSBuiltinConstructor.cpp, JSTestDomainSecurity.cpp, JSTestDefaultToJSONIndirectInheritance.cpp, JSTestDelegateToSharedSyntheticAttribute.cpp, JSTestLegacyFactoryFunction.cpp, JSTestDOMJIT.cpp, JSTestNamedSetterWithLegacyUnforgeablePropertiesAndLegacyOverrideBuiltIns.cpp, JSTestNamedDeleterWithIdentifier.cpp, JSTestNamedSetterWithLegacyOverrideBuiltIns.cpp, JSDOMWindow.cpp, JSTestGenerateIsReachable.cpp, JSTestNamedSetterNoIdentifier.cpp, JSPaintWorkletGlobalScope.cpp, JSTestNamedAndIndexedSetterThrowingException.cpp, JSTestMapLikeWithOverriddenOperations.cpp, JSTestNamedSetterWithIndexedGetterAndSetter.cpp, JSTestTypedefs.cpp, JSTestEnabledForContext.cpp, JSWorkerGlobalScope.cpp, JSExposedToWorkerAndWindow.cpp, JSDedicatedWorkerGlobalScope.cpp, JSTestDefaultToJSONInheritFinal.cpp, JSTestLegacyNoInterfaceObject.cpp, JSTestNamedSetterWithIdentifier.cpp, JSTestNamedDeleterWithIndexedGetter.cpp, JSTestAsyncIterable.cpp, JSTestStringifierAnonymousOperation.cpp, JSTestNamedGetterNoIdentifier.cpp, JSTestStringifierNamedOperation.cpp, JSTestAsyncKeyValueIterable.cpp, JSTestTaggedWrapper.cpp, JSTestEventConstructor.cpp, JSTestConditionalIncludes.cpp, JSTestDefaultToJSONInherit.cpp") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/24977 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33122 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79623 "Found 1 new test failure: imported/w3c/web-platform-tests/service-workers/service-worker/redirected-response.https.html (failure)") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107870 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19425 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94637 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59930 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/12714 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/54921 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/88870 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/12761 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/112526 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32029 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23545 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88702 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32393 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/90863 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88330 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22523 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33225 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10991 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/27343 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/31954 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/37309 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/31746 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35087 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33305 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->