### PR TITLE
[HDR] Enable gain map decoding if the HDR APIs are available from the system

### DIFF
--- a/Source/WebCore/platform/graphics/cg/ImageDecoderCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/ImageDecoderCG.cpp
@@ -135,7 +135,7 @@ static RetainPtr<CFMutableDictionaryRef> appendImageSourceOptions(RetainPtr<CFMu
 
 static RetainPtr<CFMutableDictionaryRef> appendImageSourceOption(RetainPtr<CFMutableDictionaryRef>&& options, ShouldDecodeToHDR shouldDecodeToHDR)
 {
-#if HAVE(FIX_FOR_RADAR_148465380)
+#if HAVE(SUPPORT_HDR_DISPLAY_APIS)
     if (shouldDecodeToHDR == ShouldDecodeToHDR::Yes)
         CFDictionarySetValue(options.get(), kCGImageSourceDecodeRequest, kCGImageSourceDecodeToHDR);
 #else


### PR DESCRIPTION
#### 32e738d6ba6e0e117b0dbf1c63e87d7ac55448c7
<pre>
[HDR] Enable gain map decoding if the HDR APIs are available from the system
<a href="https://bugs.webkit.org/show_bug.cgi?id=293503">https://bugs.webkit.org/show_bug.cgi?id=293503</a>
<a href="https://rdar.apple.com/149576289">rdar://149576289</a>

Reviewed by Cameron McCormack.

The gain-map image has to be explicitly asked for HDR decoding. Otherwise the
SDR image version will be decoded.

* Source/WebCore/platform/graphics/cg/ImageDecoderCG.cpp:
(WebCore::appendImageSourceOption):

Canonical link: <a href="https://commits.webkit.org/295360@main">https://commits.webkit.org/295360@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8a8b324b0106a93dc0a85e79a9fc8f7eeb062ba6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104872 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24585 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15006 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110087 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/55546 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [❌ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/106914 "Found 86 Binding test failures: JSTestPluginInterface.cpp, JSTestNode.cpp, JSTestCEReactions.cpp, JSTestStringifierReadWriteAttribute.cpp, JSTestNamedDeleterNoIdentifier.cpp, JSTestIndexedSetterThrowingException.cpp, JSTestNamedAndIndexedSetterWithIdentifier.cpp, JSTestDefaultToJSONFilteredByExposed.cpp, JSTestEventTarget.cpp, JSShadowRealmGlobalScope.cpp, JSTestStringifierOperationImplementedAs.cpp, JSTestOverloadedConstructorsWithSequence.cpp, JSTestCallTracer.cpp, JSTestNamedSetterWithIndexedGetter.cpp, JSTestInterface.cpp, JSSharedWorkerGlobalScope.cpp, JSTestCEReactionsStringifier.cpp, JSTestPromiseRejectionEvent.cpp, JSTestScheduledAction.cpp, JSTestStringifierOperationNamedToString.cpp, JSTestNamedSetterWithLegacyUnforgeableProperties.cpp, JSTestOverloadedConstructors.cpp, JSTestSetLikeWithOverriddenOperations.cpp, JSTestSetLike.cpp, JSTestLegacyOverrideBuiltIns.cpp, JSTestIndexedSetterWithIdentifier.cpp, JSServiceWorkerGlobalScope.cpp, JSTestConditionallyReadWrite.cpp, JSTestNamedGetterWithIdentifier.cpp, JSExposedStar.cpp, JSTestMapLike.cpp, JSTestNamedDeleterThrowingException.cpp, JSTestNamedGetterCallWith.cpp, JSWorkletGlobalScope.cpp, JSTestDefaultToJSON.cpp, JSTestGenerateAddOpaqueRoot.cpp, JSTestSerializedScriptValueInterface.cpp, JSTestObj.cpp, JSTestIndexedSetterNoIdentifier.cpp, JSTestStringifier.cpp, JSTestInterfaceLeadingUnderscore.cpp, JSTestReadOnlyMapLike.cpp, JSTestEnabledBySetting.cpp, JSTestGlobalObject.cpp, JSTestNamedAndIndexedSetterNoIdentifier.cpp, JSTestReportExtraMemoryCost.cpp, JSTestException.cpp, JSTestStringifierReadOnlyAttribute.cpp, JSTestIterable.cpp, JSTestNamedSetterThrowingException.cpp, JSTestOperationConditional.cpp, JSTestReadOnlySetLike.cpp, JSTestClassWithJSBuiltinConstructor.cpp, JSTestDomainSecurity.cpp, JSTestDefaultToJSONIndirectInheritance.cpp, JSTestDelegateToSharedSyntheticAttribute.cpp, JSTestLegacyFactoryFunction.cpp, JSTestDOMJIT.cpp, JSTestNamedSetterWithLegacyUnforgeablePropertiesAndLegacyOverrideBuiltIns.cpp, JSTestNamedDeleterWithIdentifier.cpp, JSTestNamedSetterWithLegacyOverrideBuiltIns.cpp, JSDOMWindow.cpp, JSTestGenerateIsReachable.cpp, JSTestNamedSetterNoIdentifier.cpp, JSPaintWorkletGlobalScope.cpp, JSTestNamedAndIndexedSetterThrowingException.cpp, JSTestMapLikeWithOverriddenOperations.cpp, JSTestNamedSetterWithIndexedGetterAndSetter.cpp, JSTestTypedefs.cpp, JSTestEnabledForContext.cpp, JSWorkerGlobalScope.cpp, JSExposedToWorkerAndWindow.cpp, JSDedicatedWorkerGlobalScope.cpp, JSTestDefaultToJSONInheritFinal.cpp, JSTestLegacyNoInterfaceObject.cpp, JSTestNamedSetterWithIdentifier.cpp, JSTestNamedDeleterWithIndexedGetter.cpp, JSTestAsyncIterable.cpp, JSTestStringifierAnonymousOperation.cpp, JSTestNamedGetterNoIdentifier.cpp, JSTestStringifierNamedOperation.cpp, JSTestAsyncKeyValueIterable.cpp, JSTestTaggedWrapper.cpp, JSTestEventConstructor.cpp, JSTestConditionalIncludes.cpp, JSTestDefaultToJSONInherit.cpp") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/24985 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33130 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/79630 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/55546 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107878 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/19431 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/94648 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/59937 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/12725 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/54929 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/88874 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/12772 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/112541 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/32037 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/23551 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/88708 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/32401 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/90874 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/88337 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/11002 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/27351 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17008 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/31962 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/37318 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/31754 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/35095 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33313 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->