### PR TITLE
Web Inspector: Rebaseline test results after 293715@main dropped implicit NSString conversion

### DIFF
--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/commands-with-async-attribute.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/commands-with-async-attribute.json-result
@@ -956,16 +956,16 @@ void ObjCInspectorDatabaseBackendDispatcher::executeSQLSyncOptionalReturnValues(
         if (!!out_opt_sqlError)
             protocol_jsonMessage->setObject("sqlError"_s, [*out_opt_sqlError toJSONObject]);
         if (!!out_opt_screenColor)
-            protocol_jsonMessage->setString("screenColor"_s, toProtocolString(*out_opt_screenColor));
+            protocol_jsonMessage->setString("screenColor"_s, toProtocolString(*out_opt_screenColor).createNSString().get());
         if (!!out_opt_alternateColors)
             protocol_jsonMessage->setArray("alternateColors"_s, toJSONStringArray(*out_opt_alternateColors));
         if (!!out_opt_printColor)
-            protocol_jsonMessage->setString("printColor"_s, toProtocolString(*out_opt_printColor));
+            protocol_jsonMessage->setString("printColor"_s, toProtocolString(*out_opt_printColor).createNSString().get());
         backendDispatcher()->sendResponse(protocol_requestId, WTFMove(protocol_jsonMessage), false);
     };
 
     int o_in_databaseId = in_databaseId;
-    NSString *o_in_query = in_query;
+    NSString *o_in_query = in_query.createNSString().autorelease();
     [m_delegate executeSQLSyncOptionalReturnValuesWithErrorCallback:errorCallback successCallback:successCallback databaseId:o_in_databaseId query:o_in_query];
 }
 
@@ -1005,16 +1005,16 @@ void ObjCInspectorDatabaseBackendDispatcher::executeSQLAsyncOptionalReturnValues
         if (!!out_opt_sqlError)
             protocol_jsonMessage->setObject("sqlError"_s, [*out_opt_sqlError toJSONObject]);
         if (!!out_opt_screenColor)
-            protocol_jsonMessage->setString("screenColor"_s, toProtocolString(*out_opt_screenColor));
+            protocol_jsonMessage->setString("screenColor"_s, toProtocolString(*out_opt_screenColor).createNSString().get());
         if (!!out_opt_alternateColors)
             protocol_jsonMessage->setArray("alternateColors"_s, toJSONStringArray(*out_opt_alternateColors));
         if (!!out_opt_printColor)
-            protocol_jsonMessage->setString("printColor"_s, toProtocolString(*out_opt_printColor));
+            protocol_jsonMessage->setString("printColor"_s, toProtocolString(*out_opt_printColor).createNSString().get());
         backendDispatcher()->sendResponse(protocol_requestId, WTFMove(protocol_jsonMessage), false);
     };
 
     int o_in_databaseId = in_databaseId;
-    NSString *o_in_query = in_query;
+    NSString *o_in_query = in_query.createNSString().autorelease();
     [m_delegate executeSQLAsyncOptionalReturnValuesWithErrorCallback:errorCallback successCallback:successCallback databaseId:o_in_databaseId query:o_in_query];
 }
 
@@ -1047,13 +1047,13 @@ void ObjCInspectorDatabaseBackendDispatcher::executeSQLSync(long protocol_reques
         protocol_jsonMessage->setInteger("databaseId"_s, out_databaseId);
         protocol_jsonMessage->setObject("sqlError"_s, [out_sqlError toJSONObject]);
         protocol_jsonMessage->setArray("alternateColors"_s, toJSONStringArray(out_alternateColors));
-        protocol_jsonMessage->setString("screenColor"_s, toProtocolString(out_screenColor));
-        protocol_jsonMessage->setString("printColor"_s, toProtocolString(out_printColor));
+        protocol_jsonMessage->setString("screenColor"_s, toProtocolString(out_screenColor).createNSString().get());
+        protocol_jsonMessage->setString("printColor"_s, toProtocolString(out_printColor).createNSString().get());
         backendDispatcher()->sendResponse(protocol_requestId, WTFMove(protocol_jsonMessage), false);
     };
 
     int o_in_databaseId = in_databaseId;
-    NSString *o_in_query = in_query;
+    NSString *o_in_query = in_query.createNSString().autorelease();
     [m_delegate executeSQLSyncWithErrorCallback:errorCallback successCallback:successCallback databaseId:o_in_databaseId query:o_in_query];
 }
 
@@ -1085,14 +1085,14 @@ void ObjCInspectorDatabaseBackendDispatcher::executeSQLAsync(long protocol_reque
         protocol_jsonMessage->setValue("payload"_s, [out_payload toJSONObject]);
         protocol_jsonMessage->setInteger("databaseId"_s, out_databaseId);
         protocol_jsonMessage->setObject("sqlError"_s, [out_sqlError toJSONObject]);
-        protocol_jsonMessage->setString("screenColor"_s, toProtocolString(out_screenColor));
+        protocol_jsonMessage->setString("screenColor"_s, toProtocolString(out_screenColor).createNSString().get());
         protocol_jsonMessage->setArray("alternateColors"_s, toJSONStringArray(out_alternateColors));
-        protocol_jsonMessage->setString("printColor"_s, toProtocolString(out_printColor));
+        protocol_jsonMessage->setString("printColor"_s, toProtocolString(out_printColor).createNSString().get());
         backendDispatcher()->sendResponse(protocol_requestId, WTFMove(protocol_jsonMessage), false);
     };
 
     int o_in_databaseId = in_databaseId;
-    NSString *o_in_query = in_query;
+    NSString *o_in_query = in_query.createNSString().autorelease();
     [m_delegate executeSQLAsyncWithErrorCallback:errorCallback successCallback:successCallback databaseId:o_in_databaseId query:o_in_query];
 }
 

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/commands-with-optional-call-return-parameters.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/commands-with-optional-call-return-parameters.json-result
@@ -868,11 +868,11 @@ void ObjCInspectorDatabaseBackendDispatcher::executeAllOptionalParameters(long p
         if (!!out_opt_sqlError)
             protocol_jsonMessage->setObject("sqlError"_s, [*out_opt_sqlError toJSONObject]);
         if (!!out_opt_screenColor)
-            protocol_jsonMessage->setString("screenColor"_s, toProtocolString(*out_opt_screenColor));
+            protocol_jsonMessage->setString("screenColor"_s, toProtocolString(*out_opt_screenColor).createNSString().get());
         if (!!out_opt_alternateColors)
             protocol_jsonMessage->setArray("alternateColors"_s, toJSONStringArray(*out_opt_alternateColors));
         if (!!out_opt_printColor)
-            protocol_jsonMessage->setString("printColor"_s, toProtocolString(*out_opt_printColor));
+            protocol_jsonMessage->setString("printColor"_s, toProtocolString(*out_opt_printColor).createNSString().get());
         backendDispatcher()->sendResponse(protocol_requestId, WTFMove(protocol_jsonMessage), false);
     };
 
@@ -881,7 +881,7 @@ void ObjCInspectorDatabaseBackendDispatcher::executeAllOptionalParameters(long p
         o_in_opt_columnNames = toObjCStringArray(in_opt_columnNames.releaseNonNull());
     NSString *o_in_opt_notes;
     if (!!in_opt_notes)
-        o_in_opt_notes = in_opt_notes;
+        o_in_opt_notes = in_opt_notes.createNSString().autorelease();
     double o_in_opt_timestamp;
     if (!!in_opt_timestamp)
         o_in_opt_timestamp = *in_opt_timestamp;
@@ -937,14 +937,14 @@ void ObjCInspectorDatabaseBackendDispatcher::executeNoOptionalParameters(long pr
         protocol_jsonMessage->setValue("payload"_s, [out_payload toJSONObject]);
         protocol_jsonMessage->setInteger("databaseId"_s, out_databaseId);
         protocol_jsonMessage->setObject("sqlError"_s, [out_sqlError toJSONObject]);
-        protocol_jsonMessage->setString("screenColor"_s, toProtocolString(out_screenColor));
+        protocol_jsonMessage->setString("screenColor"_s, toProtocolString(out_screenColor).createNSString().get());
         protocol_jsonMessage->setArray("alternateColors"_s, toJSONStringArray(out_alternateColors));
-        protocol_jsonMessage->setString("printColor"_s, toProtocolString(out_printColor));
+        protocol_jsonMessage->setString("printColor"_s, toProtocolString(out_printColor).createNSString().get());
         backendDispatcher()->sendResponse(protocol_requestId, WTFMove(protocol_jsonMessage), false);
     };
 
     NSArray/*<NSString>*/ *o_in_columnNames = toObjCStringArray(WTFMove(in_columnNames));
-    NSString *o_in_notes = in_notes;
+    NSString *o_in_notes = in_notes.createNSString().autorelease();
     double o_in_timestamp = in_timestamp;
     RWIProtocolJSONObject *o_in_values = adoptNS([[RWIProtocolJSONObject alloc] initWithJSONObject:WTFMove(in_values)]).autorelease();
     RWIProtocolJSONObject *o_in_payload = adoptNS([[RWIProtocolJSONObject alloc] initWithJSONObject:WTFMove(in_payload)]).autorelease();

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/domain-exposed-as-other-name.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/domain-exposed-as-other-name.json-result
@@ -377,7 +377,8 @@ void DatabaseBackendDispatcher::executeSQLAsyncOptionalReturnValues(long protoco
     m_agent->executeSQLAsyncOptionalReturnValues(*in_databaseId, in_query, [backendDispatcher = m_backendDispatcher.copyRef(), protocol_requestId](CommandResultOf<RefPtr<JSON::ArrayOf<String>>, String, std::optional<double>, RefPtr<JSON::Object>, RefPtr<JSON::Value>, std::optional<int>, RefPtr<Protocol::Database::Error>, std::optional<Protocol::Database::PrimaryColors>, RefPtr<Protocol::Database::ColorList>, String> result) {
         if (!result) {
            ASSERT(!result.error().isEmpty());
-           backendDispatcher->reportProtocolError(BackendDispatcher::ServerError, result.error());
+           backendDispatcher->reportProtocolError(protocol_requestId, BackendDispatcher::ServerError, result.error());
+           backendDispatcher->sendPendingErrors();
            return;
         }
         auto [out_opt_columnNames, out_opt_notes, out_opt_timestamp, out_opt_values, out_opt_payload, out_opt_databaseId, out_opt_sqlError, out_opt_screenColor, out_opt_alternateColors, out_opt_printColor] = WTFMove(result.value());
@@ -465,7 +466,8 @@ void DatabaseBackendDispatcher::executeSQLAsync(long protocol_requestId, RefPtr<
     m_agent->executeSQLAsync(*in_databaseId, in_query, [backendDispatcher = m_backendDispatcher.copyRef(), protocol_requestId](CommandResultOf<Ref<JSON::ArrayOf<String>>, String, double, Ref<JSON::Object>, Ref<JSON::Value>, int, Ref<Protocol::Database::Error>, Protocol::Database::PrimaryColors, Ref<Protocol::Database::ColorList>, String> result) {
         if (!result) {
            ASSERT(!result.error().isEmpty());
-           backendDispatcher->reportProtocolError(BackendDispatcher::ServerError, result.error());
+           backendDispatcher->reportProtocolError(protocol_requestId, BackendDispatcher::ServerError, result.error());
+           backendDispatcher->sendPendingErrors();
            return;
         }
         auto [out_columnNames, out_notes, out_timestamp, out_values, out_payload, out_databaseId, out_sqlError, out_screenColor, out_alternateColors, out_printColor] = WTFMove(result.value());
@@ -977,16 +979,16 @@ void ObjCInspectorDatabaseBackendDispatcher::executeSQLSyncOptionalReturnValues(
         if (!!out_opt_sqlError)
             protocol_jsonMessage->setObject("sqlError"_s, [*out_opt_sqlError toJSONObject]);
         if (!!out_opt_screenColor)
-            protocol_jsonMessage->setString("screenColor"_s, toProtocolString(*out_opt_screenColor));
+            protocol_jsonMessage->setString("screenColor"_s, toProtocolString(*out_opt_screenColor).createNSString().get());
         if (!!out_opt_alternateColors)
             protocol_jsonMessage->setArray("alternateColors"_s, toJSONStringArray(*out_opt_alternateColors));
         if (!!out_opt_printColor)
-            protocol_jsonMessage->setString("printColor"_s, toProtocolString(*out_opt_printColor));
+            protocol_jsonMessage->setString("printColor"_s, toProtocolString(*out_opt_printColor).createNSString().get());
         backendDispatcher()->sendResponse(protocol_requestId, WTFMove(protocol_jsonMessage), false);
     };
 
     int o_in_databaseId = in_databaseId;
-    NSString *o_in_query = in_query;
+    NSString *o_in_query = in_query.createNSString().autorelease();
     [m_delegate executeSQLSyncOptionalReturnValuesWithErrorCallback:errorCallback successCallback:successCallback databaseId:o_in_databaseId query:o_in_query];
 }
 
@@ -1026,16 +1028,16 @@ void ObjCInspectorDatabaseBackendDispatcher::executeSQLAsyncOptionalReturnValues
         if (!!out_opt_sqlError)
             protocol_jsonMessage->setObject("sqlError"_s, [*out_opt_sqlError toJSONObject]);
         if (!!out_opt_screenColor)
-            protocol_jsonMessage->setString("screenColor"_s, toProtocolString(*out_opt_screenColor));
+            protocol_jsonMessage->setString("screenColor"_s, toProtocolString(*out_opt_screenColor).createNSString().get());
         if (!!out_opt_alternateColors)
             protocol_jsonMessage->setArray("alternateColors"_s, toJSONStringArray(*out_opt_alternateColors));
         if (!!out_opt_printColor)
-            protocol_jsonMessage->setString("printColor"_s, toProtocolString(*out_opt_printColor));
+            protocol_jsonMessage->setString("printColor"_s, toProtocolString(*out_opt_printColor).createNSString().get());
         backendDispatcher()->sendResponse(protocol_requestId, WTFMove(protocol_jsonMessage), false);
     };
 
     int o_in_databaseId = in_databaseId;
-    NSString *o_in_query = in_query;
+    NSString *o_in_query = in_query.createNSString().autorelease();
     [m_delegate executeSQLAsyncOptionalReturnValuesWithErrorCallback:errorCallback successCallback:successCallback databaseId:o_in_databaseId query:o_in_query];
 }
 
@@ -1068,13 +1070,13 @@ void ObjCInspectorDatabaseBackendDispatcher::executeSQLSync(long protocol_reques
         protocol_jsonMessage->setInteger("databaseId"_s, out_databaseId);
         protocol_jsonMessage->setObject("sqlError"_s, [out_sqlError toJSONObject]);
         protocol_jsonMessage->setArray("alternateColors"_s, toJSONStringArray(out_alternateColors));
-        protocol_jsonMessage->setString("screenColor"_s, toProtocolString(out_screenColor));
-        protocol_jsonMessage->setString("printColor"_s, toProtocolString(out_printColor));
+        protocol_jsonMessage->setString("screenColor"_s, toProtocolString(out_screenColor).createNSString().get());
+        protocol_jsonMessage->setString("printColor"_s, toProtocolString(out_printColor).createNSString().get());
         backendDispatcher()->sendResponse(protocol_requestId, WTFMove(protocol_jsonMessage), false);
     };
 
     int o_in_databaseId = in_databaseId;
-    NSString *o_in_query = in_query;
+    NSString *o_in_query = in_query.createNSString().autorelease();
     [m_delegate executeSQLSyncWithErrorCallback:errorCallback successCallback:successCallback databaseId:o_in_databaseId query:o_in_query];
 }
 
@@ -1106,14 +1108,14 @@ void ObjCInspectorDatabaseBackendDispatcher::executeSQLAsync(long protocol_reque
         protocol_jsonMessage->setValue("payload"_s, [out_payload toJSONObject]);
         protocol_jsonMessage->setInteger("databaseId"_s, out_databaseId);
         protocol_jsonMessage->setObject("sqlError"_s, [out_sqlError toJSONObject]);
-        protocol_jsonMessage->setString("screenColor"_s, toProtocolString(out_screenColor));
+        protocol_jsonMessage->setString("screenColor"_s, toProtocolString(out_screenColor).createNSString().get());
         protocol_jsonMessage->setArray("alternateColors"_s, toJSONStringArray(out_alternateColors));
-        protocol_jsonMessage->setString("printColor"_s, toProtocolString(out_printColor));
+        protocol_jsonMessage->setString("printColor"_s, toProtocolString(out_printColor).createNSString().get());
         backendDispatcher()->sendResponse(protocol_requestId, WTFMove(protocol_jsonMessage), false);
     };
 
     int o_in_databaseId = in_databaseId;
-    NSString *o_in_query = in_query;
+    NSString *o_in_query = in_query.createNSString().autorelease();
     [m_delegate executeSQLAsyncWithErrorCallback:errorCallback successCallback:successCallback databaseId:o_in_databaseId query:o_in_query];
 }
 

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/enum-values.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/enum-values.json-result
@@ -762,12 +762,12 @@ void ObjCInspectorCommandDomainBackendDispatcher::command(long protocol_requestI
 
     id successCallback = ^(TestProtocolTypeDomainEnum out_enumRequired, TestProtocolTypeDomainEnum *out_opt_enumOptional, TestProtocolCommandDomain(anonymous) out_returnRequired, TestProtocolCommandDomain(anonymous) *out_opt_returnOptional) {
         auto protocol_jsonMessage = JSON::Object::create();
-        protocol_jsonMessage->setString("enumRequired"_s, toProtocolString(out_enumRequired));
+        protocol_jsonMessage->setString("enumRequired"_s, toProtocolString(out_enumRequired).createNSString().get());
         if (!!out_opt_enumOptional)
-            protocol_jsonMessage->setString("enumOptional"_s, toProtocolString(*out_opt_enumOptional));
-        protocol_jsonMessage->setString("returnRequired"_s, toProtocolString(out_returnRequired));
+            protocol_jsonMessage->setString("enumOptional"_s, toProtocolString(*out_opt_enumOptional).createNSString().get());
+        protocol_jsonMessage->setString("returnRequired"_s, toProtocolString(out_returnRequired).createNSString().get());
         if (!!out_opt_returnOptional)
-            protocol_jsonMessage->setString("returnOptional"_s, toProtocolString(*out_opt_returnOptional));
+            protocol_jsonMessage->setString("returnOptional"_s, toProtocolString(*out_opt_returnOptional).createNSString().get());
         backendDispatcher()->sendResponse(protocol_requestId, WTFMove(protocol_jsonMessage), false);
     };
 
@@ -981,12 +981,12 @@ using namespace Inspector;
     auto protocol_jsonMessage = JSON::Object::create();
     protocol_jsonMessage->setString("method"_s, "EventDomain.event"_s);
     auto protocol_paramsObject = JSON::Object::create();
-    protocol_paramsObject->setString("enumRequired"_s, toProtocolString(enumRequired));
+    protocol_paramsObject->setString("enumRequired"_s, toProtocolString(enumRequired).createNSString().get());
     if (enumOptional)
-        protocol_paramsObject->setString("enumOptional"_s, toProtocolString((*enumOptional)));
-    protocol_paramsObject->setString("parameterRequired"_s, toProtocolString(parameterRequired));
+        protocol_paramsObject->setString("enumOptional"_s, toProtocolString((*enumOptional)).createNSString().get());
+    protocol_paramsObject->setString("parameterRequired"_s, toProtocolString(parameterRequired).createNSString().get());
     if (parameterOptional)
-        protocol_paramsObject->setString("parameterOptional"_s, toProtocolString((*parameterOptional)));
+        protocol_paramsObject->setString("parameterOptional"_s, toProtocolString((*parameterOptional)).createNSString().get());
     protocol_jsonMessage->setObject("params"_s, WTFMove(protocol_paramsObject));
     router.sendEvent(protocol_jsonMessage->toJSONString());
 }

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/shadowed-optional-type-setters.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/shadowed-optional-type-setters.json-result
@@ -1063,7 +1063,7 @@ using namespace Inspector;
 
 - (void)setType:(TestProtocolRuntimeKeyPathType)type
 {
-    [super setString:toProtocolString(type) forKey:@"type"];
+    [super setString:toProtocolString(type).createNSString().get() forKey:@"type"];
 }
 
 - (TestProtocolRuntimeKeyPathType)type

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/type-declaration-object-type.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/type-declaration-object-type.json-result
@@ -1945,7 +1945,7 @@ using namespace Inspector;
 
 - (void)setDirectionality:(TestProtocolDatabaseOptionalParameterBundleDirectionality)directionality
 {
-    [super setString:toProtocolString(directionality) forKey:@"directionality"];
+    [super setString:toProtocolString(directionality).createNSString().get() forKey:@"directionality"];
 }
 
 - (TestProtocolDatabaseOptionalParameterBundleDirectionality)directionality
@@ -2120,7 +2120,7 @@ using namespace Inspector;
 
 - (void)setDirectionality:(TestProtocolDatabaseParameterBundleDirectionality)directionality
 {
-    [super setString:toProtocolString(directionality) forKey:@"directionality"];
+    [super setString:toProtocolString(directionality).createNSString().get() forKey:@"directionality"];
 }
 
 - (TestProtocolDatabaseParameterBundleDirectionality)directionality
@@ -2392,7 +2392,7 @@ using namespace Inspector;
 
 - (void)setDirectionality:(TestProtocolTestParameterBundleDirectionality)directionality
 {
-    [super setString:toProtocolString(directionality) forKey:@"directionality"];
+    [super setString:toProtocolString(directionality).createNSString().get() forKey:@"directionality"];
 }
 
 - (TestProtocolTestParameterBundleDirectionality)directionality

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/type-requiring-runtime-casts.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/type-requiring-runtime-casts.json-result
@@ -1503,7 +1503,7 @@ using namespace Inspector;
 
 - (void)setAnimals:(TestProtocolTestCastedAnimals)animals
 {
-    [super setString:toProtocolString(animals) forKey:@"animals"];
+    [super setString:toProtocolString(animals).createNSString().get() forKey:@"animals"];
 }
 
 - (TestProtocolTestCastedAnimals)animals


### PR DESCRIPTION
#### c808d8343a5a8c569fa83a51809883b8179e5e1f
<pre>
Web Inspector: Rebaseline test results after 293715@main dropped implicit NSString conversion
<a href="https://bugs.webkit.org/show_bug.cgi?id=293504">https://bugs.webkit.org/show_bug.cgi?id=293504</a>

Unreviewed test rebaseline.

293715@main finished removing the implicit conversions from String to
NSString.

* Source/JavaScriptCore/inspector/scripts/tests/expected/commands-with-async-attribute.json-result:
* Source/JavaScriptCore/inspector/scripts/tests/expected/commands-with-optional-call-return-parameters.json-result:
* Source/JavaScriptCore/inspector/scripts/tests/expected/domain-exposed-as-other-name.json-result:
* Source/JavaScriptCore/inspector/scripts/tests/expected/enum-values.json-result:
* Source/JavaScriptCore/inspector/scripts/tests/expected/shadowed-optional-type-setters.json-result:
* Source/JavaScriptCore/inspector/scripts/tests/expected/type-declaration-object-type.json-result:
* Source/JavaScriptCore/inspector/scripts/tests/expected/type-requiring-runtime-casts.json-result:

Canonical link: <a href="https://commits.webkit.org/295378@main">https://commits.webkit.org/295378@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/44dab3cb546af937883519fe9ee8c338e6b9fb7a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104874 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24587 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15008 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110089 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/55548 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/24987 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33132 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79632 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107880 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19432 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94645 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59939 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/12722 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/54931 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/97555 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/88876 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/12769 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/112543 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/103492 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32039 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23550 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88711 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32403 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/90871 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88340 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22522 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33231 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10999 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/27353 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/31964 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/37320 "Built successfully") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/127771 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Failed to checkout and rebase branch from PR 45851") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/31756 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/127771 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Failed to checkout and rebase branch from PR 45851") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35097 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33315 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->