### PR TITLE
Use-after-free due to a life-cycle issue with MediaStreamTrackProcessor::Source

### DIFF
--- a/LayoutTests/http/wpt/mediastream/crash-mediastreamtrackprocessor-source-expected.txt
+++ b/LayoutTests/http/wpt/mediastream/crash-mediastreamtrackprocessor-source-expected.txt
@@ -1,0 +1,3 @@
+
+PASS crash-mediastreamtrackprocessor-source
+

--- a/LayoutTests/http/wpt/mediastream/crash-mediastreamtrackprocessor-source.html
+++ b/LayoutTests/http/wpt/mediastream/crash-mediastreamtrackprocessor-source.html
@@ -1,0 +1,52 @@
+<html>
+<body>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+const WORKER_SOURCE = `
+self.onmessage = event => {
+    const processor = new MediaStreamTrackProcessor({ track: event.data });
+
+    function overflowStack() {
+        try {
+            overflowStack();
+        } catch {
+            try {
+                processor.readable;
+            } catch {
+                self.postMessage("done");
+            }
+        }
+    }
+
+    overflowStack();
+};
+`;
+
+const WORKER_URL = URL.createObjectURL(new Blob([WORKER_SOURCE], { type: 'text/javascript' }));
+
+async function sleep(ms) {
+    await new Promise(resolve => {
+        setTimeout(() => {
+            resolve();
+        }, ms);
+    });
+}
+
+promise_test(async () => {
+    const canvas = document.createElement('canvas');
+    const [track] = canvas.captureStream(30).getVideoTracks();
+
+    const worker = new Worker(WORKER_URL);
+
+    worker.postMessage(track);
+
+    await new Promise(resolve => worker.onmessage = resolve);
+
+    worker.terminate();
+
+    sleep(100);
+});
+</script>
+</body>
+</html>


### PR DESCRIPTION
#### 08e3cb08fc23ca7d8a34f88e439c4838721ad88b
<pre>
Use-after-free due to a life-cycle issue with MediaStreamTrackProcessor::Source
<a href="https://rdar.apple.com/147222917">rdar://147222917</a>

Reviewed by Jean-Yves Avenard.

Make sure to not nullify m_readableStreamSource to guarantee its lifetime.
We set the cancelled flag if creating the readable stream fails so that the source will do nothing.

* LayoutTests/http/wpt/mediastream/crash-mediastreamtrackprocessor-source-expected.txt: Added.
* LayoutTests/http/wpt/mediastream/crash-mediastreamtrackprocessor-source.html: Added.
* Source/WebCore/Modules/mediastream/MediaStreamTrackProcessor.cpp:
(WebCore::MediaStreamTrackProcessor::readable):
(WebCore::MediaStreamTrackProcessor::contextDestroyed):
(WebCore::MediaStreamTrackProcessor::tryEnqueueingVideoFrame):
* Source/WebCore/Modules/mediastream/MediaStreamTrackProcessor.h:

Originally-landed-as: 289651.294@safari-7621-branch (c03d1d685a07). <a href="https://rdar.apple.com/151710235">rdar://151710235</a>
Canonical link: <a href="https://commits.webkit.org/295521@main">https://commits.webkit.org/295521@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e8be45401fc03461ac177b86f638a8d7749657bd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105315 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25027 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15453 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110523 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/55983 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/25465 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33570 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79989 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/55983 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108321 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19860 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95055 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60295 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/19622 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13128 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55367 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/89316 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13172 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/113167 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32472 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23929 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89063 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32835 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91270 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88701 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33598 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11389 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/27956 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17083 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32395 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32170 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35515 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33742 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->