### PR TITLE
Fix the BUILD_WEBKIT_OPTIONS="--webGpuSwift" build in main

### DIFF
--- a/Source/WTF/wtf/CheckedArithmetic.h
+++ b/Source/WTF/wtf/CheckedArithmetic.h
@@ -632,39 +632,39 @@ enum ResultOverflowedTag { ResultOverflowed };
 template <typename T, class OverflowHandler> class Checked : public OverflowHandler {
 public:
     template <typename _T, class _OverflowHandler> friend class Checked;
-    Checked()
+    constexpr Checked()
         : m_value(0)
     {
     }
 
-    Checked(ResultOverflowedTag)
+    constexpr Checked(ResultOverflowedTag)
         : m_value(0)
     {
         this->overflowed();
     }
 
-    Checked(const Checked& value)
+    constexpr Checked(const Checked& value)
     {
         if (value.hasOverflowed())
             this->overflowed();
         m_value = static_cast<T>(value.m_value);
     }
 
-    template <typename U> Checked(U value)
+    template <typename U> constexpr Checked(U value)
     {
         if (!isInBounds<T>(value))
             this->overflowed();
         m_value = static_cast<T>(value);
     }
     
-    template <typename V> Checked(const Checked<T, V>& rhs)
+    template <typename V> constexpr Checked(const Checked<T, V>& rhs)
         : m_value(rhs.m_value)
     {
         if (rhs.hasOverflowed())
             this->overflowed();
     }
     
-    template <typename U> Checked(const Checked<U, OverflowHandler>& rhs)
+    template <typename U> constexpr Checked(const Checked<U, OverflowHandler>& rhs)
         : OverflowHandler(rhs)
     {
         if (!isInBounds<T>(rhs.m_value))
@@ -672,7 +672,7 @@ public:
         m_value = static_cast<T>(rhs.m_value);
     }
     
-    template <typename U, typename V> Checked(const Checked<U, V>& rhs)
+    template <typename U, typename V> constexpr Checked(const Checked<U, V>& rhs)
     {
         if (rhs.hasOverflowed())
             this->overflowed();

--- a/Source/WebGPU/WebGPU/Internal/WebGPUSwiftInternal.h
+++ b/Source/WebGPU/WebGPU/Internal/WebGPUSwiftInternal.h
@@ -74,7 +74,7 @@ inline void logString(const char * input)
 }
 
 using RefComputePassEncoder = Ref<WebGPU::ComputePassEncoder>;
-inline unsigned long roundUpToMultipleOfNonPowerOfTwoCheckedUInt32UnsignedLong(Checked<uint32_t> x, unsigned long y) { return WTF::roundUpToMultipleOfNonPowerOfTwo<unsigned long int, Checked<uint32_t>>(x, y); }
+inline unsigned long roundUpToMultipleOfNonPowerOfTwoCheckedUInt32UnsignedLong(Checked<uint32_t> x, unsigned long y) { return WTF::roundUpToMultipleOfNonPowerOfTwo(x, y); }
 inline uint32_t roundUpToMultipleOfNonPowerOfTwoUInt32UInt32(uint32_t a, uint32_t b) { return WTF::roundUpToMultipleOfNonPowerOfTwo<uint32_t, Checked<uint32_t>>(a, b); }
 
 inline Checked<size_t> checkedDifferenceSizeT(size_t left, size_t right)


### PR DESCRIPTION
#### ef3b9deb58153642424424f1d1a1f3083cdc3af8
<pre>
Fix the BUILD_WEBKIT_OPTIONS=&quot;--webGpuSwift&quot; build in main
<a href="https://bugs.webkit.org/show_bug.cgi?id=293509">https://bugs.webkit.org/show_bug.cgi?id=293509</a>
<a href="https://rdar.apple.com/151945915">rdar://151945915</a>

Reviewed by Mike Wyrzykowski.

The Swift-clang importer is complaining about:

    * ambiguity in conversion of &apos;Checked&lt;unsigned long, Checked&lt;unsigned int, CrashOnOverflow&gt;&gt;&apos; to &apos;int&apos;

    * &apos;Checked&lt;unsigned long, WTF::Checked&lt;unsigned int&gt;&gt;&apos; is not literal because it is not an aggregate and has no constexpr constructors other than copy or move constructors

I don&apos;t fully understand these complaints, and I&apos;m not certain why Swift-clang
behaves differently from clang itself, within a given toolchain.

That said, I just did what the complaints said and then they went away.

* Source/WTF/wtf/CheckedArithmetic.h:
(WTF::Checked::Checked): Say &apos;contexpr&apos; because the compiler has a sad when you
don&apos;t, and these functions do, in fact, appear to be constexpr.

* Source/WebGPU/WebGPU/Internal/WebGPUSwiftInternal.h:
(WebGPU_Internal::roundUpToMultipleOfNonPowerOfTwoCheckedUInt32UnsignedLong):
Avoid explicit template arguments because they&apos;re redundant and I think they had
the wrong types anyway.

Canonical link: <a href="https://commits.webkit.org/295383@main">https://commits.webkit.org/295383@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6f3aa5c18d1511959b16ce5cb2aff97199aa8f60

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104888 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24602 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15022 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110103 "Built successfully") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/55562 "Hash 6f3aa5c1 for PR 45858 does not build (failure)") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/25001 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33146 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79646 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/55562 "Hash 6f3aa5c1 for PR 45858 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107894 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19441 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94659 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59953 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/19199 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/12737 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/54945 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/97569 "Built successfully and passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/88884 "Build is in progress. Recent messages:OS: Sequoia (15.2), Xcode: 16.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-api-tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/12783 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/112558 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/103506 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32053 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23560 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88732 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32417 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/90885 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88362 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33241 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11013 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/27367 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17026 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/31978 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/37334 "Built successfully") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/127785 "Build was cancelled. Recent messages:Printed configuration") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/31770 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/127785 "Build was cancelled. Recent messages:Printed configuration") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35111 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33329 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->