### PR TITLE
Crash in SelectorChecker::attributeSelectorMatches

### DIFF
--- a/LayoutTests/fast/selectors/nested-declaration-crash-expected.txt
+++ b/LayoutTests/fast/selectors/nested-declaration-crash-expected.txt
@@ -1,0 +1,2 @@
+This test passes if it doesn't crash.
+

--- a/LayoutTests/fast/selectors/nested-declaration-crash.html
+++ b/LayoutTests/fast/selectors/nested-declaration-crash.html
@@ -1,0 +1,20 @@
+<body>
+This test passes if it doesn't crash.
+<host-element id=host>
+<template shadowrootmode=open>foo</template>
+</host-element>
+<div id=t></div>
+<script>
+window.testRunner?.dumpAsText();
+
+const css = new CSSStyleSheet();
+css.replaceSync(`[foo=bar] {
+    @media(screen) { }
+    color: green;
+}`);
+document.adoptedStyleSheets.push(css);
+host.shadowRoot.adoptedStyleSheets.push(css);
+document.body.offsetWidth;
+
+t.setAttribute("foo", "baz");
+</script>

--- a/Source/WebCore/style/RuleSetBuilder.cpp
+++ b/Source/WebCore/style/RuleSetBuilder.cpp
@@ -351,9 +351,11 @@ void RuleSetBuilder::addStyleRule(StyleRuleNestedDeclarations& rule)
             return *m_selectorListStack.last();
         ASSERT(m_ancestorStack.last() == CSSParserEnum::NestedContextType::Scope);
         return CSSSelectorList { MutableCSSSelectorList::from(whereScopeSelector()) };
-    }();
+    };
 
-    rule.wrapperAdoptSelectorList(WTFMove(selectorList));
+    if (m_shouldResolveNestingForSheet)
+        rule.wrapperAdoptSelectorList(selectorList());
+
     addStyleRuleWithSelectorList(rule.selectorList(), rule);
 }
 


### PR DESCRIPTION
#### 684ed1f48d9b6791319b1e40dda2f239348b9618
<pre>
Crash in SelectorChecker::attributeSelectorMatches
<a href="https://bugs.webkit.org/show_bug.cgi?id=290102">https://bugs.webkit.org/show_bug.cgi?id=290102</a>
<a href="https://rdar.apple.com/147274140">rdar://147274140</a>

Reviewed by Alan Baradlay and Matthieu Dubet.

* LayoutTests/fast/selectors/nested-declaration-crash-expected.txt: Added.
* LayoutTests/fast/selectors/nested-declaration-crash.html: Added.
* Source/WebCore/style/RuleSetBuilder.cpp:
(WebCore::Style::RuleSetBuilder::addStyleRule):

Selector list in StyleRuleNestedDeclarations must not be mutated when nesting resolution is disabled,
same as with regular StyleRules.

Originally-landed-as: 289651.299@safari-7621-branch (5db513ab60a3). <a href="https://rdar.apple.com/151709573">rdar://151709573</a>
Canonical link: <a href="https://commits.webkit.org/295397@main">https://commits.webkit.org/295397@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4b3c07f3de442cc34c6d66fc14c26d0464c667cd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104890 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24604 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15024 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110105 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/55564 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/106931 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/25003 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33148 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79643 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107896 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19442 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94653 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59950 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/19200 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/12731 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/54947 "Built successfully") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/88885 "Build is in progress. Recent messages:OS: Sequoia (15.2), Xcode: 16.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-api-tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/12777 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/112561 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32055 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23561 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88721 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32419 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/90879 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88350 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22534 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33240 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11007 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/27369 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/31980 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/37338 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/31772 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35113 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33331 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->