### PR TITLE
[macOS] Dragging the Safari window makes page start autoscrolling

### DIFF
--- a/LayoutTests/fast/events/no-autoscroll-over-content-inset-expected.txt
+++ b/LayoutTests/fast/events/no-autoscroll-over-content-inset-expected.txt
@@ -1,0 +1,7 @@
+PASS pageYOffset is pageYOffsetBefore
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Hello world
+
+

--- a/LayoutTests/fast/events/no-autoscroll-over-content-inset.html
+++ b/LayoutTests/fast/events/no-autoscroll-over-content-inset.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ContentInsetBackgroundFillEnabled=true ] -->
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<style>
+body, html {
+    width: 100%;
+    margin: 0;
+    font-family: system-ui;
+    font-size: 16px;
+    line-height: 2;
+}
+
+p {
+    padding: 0 1em;
+}
+
+.tall {
+    height: 3000px;
+}
+
+.short {
+    height: 90vh;
+}
+</style>
+<script src="../../resources/js-test.js"></script>
+<script src="../../resources/ui-helper.js"></script>
+<script>
+jsTestIsAsync = true;
+
+addEventListener("load", async () => {
+    await UIHelper.setObscuredInsets(100, 0, 0, 0);
+    await UIHelper.renderingUpdate();
+    scrollBy(0, document.body.scrollHeight);
+    await UIHelper.ensurePresentationUpdate();
+
+    pageYOffsetBefore = pageYOffset;
+
+    await eventSender.asyncMouseMoveTo(200, 50);
+    await eventSender.asyncMouseDown();
+    for (let i = 0; i < 100; i += 10) {
+        await eventSender.asyncMouseMoveTo(200 + i, 50);
+        await UIHelper.delayFor(100);
+    }
+    await eventSender.asyncMouseUp();
+
+    shouldBe("pageYOffset", "pageYOffsetBefore");
+
+    await UIHelper.setObscuredInsets(0, 0, 0, 0);
+    finishJSTest();
+});
+</script>
+</head>
+<body>
+    <div class="tall"></div>
+    <p>Hello world</p>
+    <div class="short"></div>
+</body>
+</html>


### PR DESCRIPTION
#### cda556736068075939b7b429c415aef864adf9f5
<pre>
[macOS] Dragging the Safari window makes page start autoscrolling
<a href="https://bugs.webkit.org/show_bug.cgi?id=293517">https://bugs.webkit.org/show_bug.cgi?id=293517</a>
<a href="https://rdar.apple.com/151778621">rdar://151778621</a>

Reviewed by Abrar Rahman Protyasha.

Don&apos;t allow autoscrolling to begin, in the case where the mousedown is happening outside of the
visual viewport. When obscured content insets are applied, this can happen in the case where the
user is clicking and dragging inside one of the inset areas. While this doesn&apos;t hit-test to any DOM
nodes, it currently still allows autoscrolling to start, which conflicts with dragging to move the
window.

Fix this by setting `m_mouseDownMayStartAutoscroll` to `false` in the case where the mouse event
location is outside of the visual viewport (which does not include obscured content insets).

* LayoutTests/fast/events/no-autoscroll-over-content-inset-expected.txt: Added.
* LayoutTests/fast/events/no-autoscroll-over-content-inset.html: Added.
* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::handleMousePressEvent):

Canonical link: <a href="https://commits.webkit.org/295392@main">https://commits.webkit.org/295392@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3a80133ad2f5b377b0efdad50cf9128870b2b8b3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104928 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24642 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15063 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110144 "Built successfully") | [⏳ 🛠 win ](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/106969 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/25044 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33186 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79670 "Passed tests") | [⏳ 🧪 win-tests ](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107934 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19481 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94698 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59977 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/19230 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/12776 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/54985 "Built successfully") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/97609 "Build is in progress. Recent messages:") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/88942 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/12822 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/112624 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32093 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23603 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88747 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Passed layout tests; Running layout-tests; Uploaded test results; Running layout-tests-repeat-failures") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32458 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/90924 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88378 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22530 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33271 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11051 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/27408 "Build is in progress. Recent messages:Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32018 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/37386 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/31810 "Built successfully") | | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35151 "Build is in progress. Recent messages:Running configuration; Running apply-patch; Running checkout-pull-request; Compiled WebKit (warnings)") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33369 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->