### PR TITLE
[macOS] Mitigate sync IPC hangs under WebViewImpl::writeSelectionToPasteboard()

### DIFF
--- a/Source/WebKit/Platform/Logging.h
+++ b/Source/WebKit/Platform/Logging.h
@@ -136,6 +136,7 @@ extern "C" {
     M(PDF) \
     M(PDFAsyncRendering) \
     M(PageLoadObserver) \
+    M(Pasteboard) \
     M(PerformanceLogging) \
     M(Plugins) \
     M(Printing) \

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -2761,7 +2761,9 @@ bool WebViewImpl::writeSelectionToPasteboard(NSPasteboard *pasteboard, NSArray *
     size_t numTypes = types.count;
     [pasteboard declareTypes:types owner:nil];
     for (size_t i = 0; i < numTypes; ++i) {
-        if ([[types objectAtIndex:i] isEqualTo:WebCore::legacyStringPasteboardType()])
+        BOOL wantsPlainText = [[types objectAtIndex:i] isEqualTo:WebCore::legacyStringPasteboardType()];
+        RELEASE_LOG(Pasteboard, "Synchronously requesting %{public}s for selected range", wantsPlainText ? "plain text" : "data");
+        if (wantsPlainText)
             [pasteboard setString:m_page->stringSelectionForPasteboard().createNSString().get() forType:WebCore::legacyStringPasteboardType()];
         else {
             RefPtr<WebCore::SharedBuffer> buffer = m_page->dataSelectionForPasteboard([types objectAtIndex:i]);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/CopyHTML.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/CopyHTML.mm
@@ -267,6 +267,7 @@ TEST(CopyHTML, WriteRichTextSelectionToPasteboard)
     auto webView = createWebViewWithCustomPasteboardDataEnabled();
     [webView synchronouslyLoadHTMLString:@"<strong style='color: rgb(255, 0, 0);'>This is some text to copy.</strong>"];
     [webView stringByEvaluatingJavaScript:@"getSelection().selectAllChildren(document.body)"];
+    [webView waitForNextPresentationUpdate];
 
     auto pasteboard = [NSPasteboard pasteboardWithUniqueName];
     [webView writeSelectionToPasteboard:pasteboard types:@[ (__bridge NSString *)kUTTypeWebArchive ]];


### PR DESCRIPTION
#### 0f81719cec3c6628bef8bfb675340ae4e3726b7e
<pre>
[macOS] Mitigate sync IPC hangs under WebViewImpl::writeSelectionToPasteboard()
<a href="https://bugs.webkit.org/show_bug.cgi?id=293521">https://bugs.webkit.org/show_bug.cgi?id=293521</a>
<a href="https://rdar.apple.com/151923464">rdar://151923464</a>

Reviewed by Aditya Keerthi and Abrar Rahman Protyasha.

Mitigate hangs due to synchronous IPC, when calling into `WebViewImpl::writeSelectionToPasteboard()`
to write selected text onto the system pasteboard. This codepath is invoked by system services
through the `NSServicesMenuRequestor` protocol, and must be performed synchronously; to mitigate
hangs due to the web process being unresponsive, we make a couple of adjustments:

1.  Early return with empty string/null data in the case where there is no ranged selection in the
    focused or main frame; this avoids the need for any sync IPC, in the common case.

2.  Lower the sync IPC timeout from 20 seconds to 5 seconds (which is more consistent with most
    other sync IPC timeouts).

* Source/WebKit/Platform/Logging.h:
* Source/WebKit/UIProcess/mac/WebPageProxyMac.mm:
(WebKit::WebPageProxy::stringSelectionForPasteboard):
(WebKit::WebPageProxy::dataSelectionForPasteboard):
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::writeSelectionToPasteboard):

Additionally add logging to make it a bit easier to diagnose and debug issues where we&apos;re hanging
underneath these sync IPC codepaths.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/CopyHTML.mm:
(TEST(CopyHTML, WriteRichTextSelectionToPasteboard)):

Adjust this API test to copy HTML after waiting for at least 1 presentation update, to ensure that
the UI-side `EditorState` is up to date.

Canonical link: <a href="https://commits.webkit.org/295393@main">https://commits.webkit.org/295393@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e600da5df3f81a1883a1264f43d3f99615401fde

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104913 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24627 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15047 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110129 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/55587 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/106954 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/25027 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33171 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79658 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107919 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19465 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94681 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59965 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/19216 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/12759 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/54970 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/88931 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/12805 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/112603 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32078 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23595 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88736 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32442 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/90907 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88367 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33259 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11034 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/27393 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17031 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32003 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/37361 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/31795 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35136 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33354 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->