### PR TITLE
[visionOS] Include a log identifier in LinearMediaPlayer logging

### DIFF
--- a/Source/WebKit/Platform/ios/PlaybackSessionInterfaceLMK.mm
+++ b/Source/WebKit/Platform/ios/PlaybackSessionInterfaceLMK.mm
@@ -67,19 +67,19 @@
 
 - (void)linearMediaPlayerPlay:(WKSLinearMediaPlayer *)player
 {
-    if (auto model = _model.get())
+    if (CheckedPtr model = _model.get())
         model->play();
 }
 
 - (void)linearMediaPlayerPause:(WKSLinearMediaPlayer *)player
 {
-    if (auto model = _model.get())
+    if (CheckedPtr model = _model.get())
         model->pause();
 }
 
 - (void)linearMediaPlayerTogglePlayback:(WKSLinearMediaPlayer *)player
 {
-    auto model = _model.get();
+    CheckedPtr model = _model.get();
     if (!model)
         return;
 
@@ -91,7 +91,7 @@
 
 - (void)linearMediaPlayer:(WKSLinearMediaPlayer *)player setPlaybackRate:(double)playbackRate
 {
-    if (auto model = _model.get())
+    if (CheckedPtr model = _model.get())
         model->setPlaybackRate(playbackRate);
 }
 
@@ -103,13 +103,13 @@
 
 - (void)linearMediaPlayer:(WKSLinearMediaPlayer *)player seekByDelta:(NSTimeInterval)delta
 {
-    if (auto model = _model.get())
+    if (CheckedPtr model = _model.get())
         model->seekToTime(player.currentTime + delta);
 }
 
 - (NSTimeInterval)linearMediaPlayer:(WKSLinearMediaPlayer *)player seekToDestination:(NSTimeInterval)destination fromSource:(NSTimeInterval)source
 {
-    auto model = _model.get();
+    CheckedPtr model = _model.get();
     if (!model)
         return 0;
 
@@ -122,61 +122,61 @@
     // FIXME: The intent of this method is to seek the contents of LinearMediaPlayer's thumbnailLayer,
     // which LMPlayableViewController displays in a popover when scrubbing. Since we don't currently
     // provide a thumbnail layer, fast seek the main content instead.
-    if (auto model = _model.get())
+    if (CheckedPtr model = _model.get())
         model->fastSeek(time);
 }
 
 - (void)linearMediaPlayerBeginScrubbing:(WKSLinearMediaPlayer *)player
 {
-    if (auto model = _model.get())
+    if (CheckedPtr model = _model.get())
         model->beginScrubbing();
 }
 
 - (void)linearMediaPlayerEndScrubbing:(WKSLinearMediaPlayer *)player
 {
-    if (auto model = _model.get())
+    if (CheckedPtr model = _model.get())
         model->endScrubbing();
 }
 
 - (void)linearMediaPlayerBeginScanningForward:(WKSLinearMediaPlayer *)player
 {
-    if (auto model = _model.get())
+    if (CheckedPtr model = _model.get())
         model->beginScanningForward();
 }
 
 - (void)linearMediaPlayerEndScanningForward:(WKSLinearMediaPlayer *)player
 {
-    if (auto model = _model.get())
+    if (CheckedPtr model = _model.get())
         model->endScanning();
 }
 
 - (void)linearMediaPlayerBeginScanningBackward:(WKSLinearMediaPlayer *)player
 {
-    if (auto model = _model.get())
+    if (CheckedPtr model = _model.get())
         model->beginScanningBackward();
 }
 
 - (void)linearMediaPlayerEndScanningBackward:(WKSLinearMediaPlayer *)player
 {
-    if (auto model = _model.get())
+    if (CheckedPtr model = _model.get())
         model->endScanning();
 }
 
 - (void)linearMediaPlayer:(WKSLinearMediaPlayer *)player setVolume:(double)volume
 {
-    if (auto model = _model.get())
+    if (CheckedPtr model = _model.get())
         model->setVolume(volume);
 }
 
 - (void)linearMediaPlayer:(WKSLinearMediaPlayer *)player setMuted:(BOOL)muted
 {
-    if (auto model = _model.get())
+    if (CheckedPtr model = _model.get())
         model->setMuted(muted);
 }
 
 - (void)linearMediaPlayer:(WKSLinearMediaPlayer *)player setAudioTrack:(WKSLinearMediaTrack * _Nullable)audioTrack
 {
-    auto model = _model.get();
+    CheckedPtr model = _model.get();
     if (!model)
         return;
 
@@ -196,7 +196,7 @@
 
 - (void)linearMediaPlayer:(WKSLinearMediaPlayer *)player setLegibleTrack:(WKSLinearMediaTrack * _Nullable)legibleTrack
 {
-    auto model = _model.get();
+    CheckedPtr model = _model.get();
     if (!model)
         return;
 
@@ -216,13 +216,13 @@
 
 - (void)linearMediaPlayerEnterFullscreen:(WKSLinearMediaPlayer *)player
 {
-    if (auto model = _model.get())
+    if (CheckedPtr model = _model.get())
         model->enterFullscreen();
 }
 
 - (void)linearMediaPlayerExitFullscreen:(WKSLinearMediaPlayer *)player
 {
-    auto model = _model.get();
+    CheckedPtr model = _model.get();
     if (!model)
         return;
 
@@ -232,14 +232,24 @@
 
 - (void)linearMediaPlayer:(WKSLinearMediaPlayer *)player setVideoReceiverEndpoint:(xpc_object_t)videoReceiverEndpoint
 {
-    if (auto model = _model.get())
+    if (CheckedPtr model = _model.get())
         model->setVideoReceiverEndpoint(videoReceiverEndpoint);
 }
 
 - (void)linearMediaPlayerClearVideoReceiverEndpoint:(WKSLinearMediaPlayer *)player
 {
-    if (auto model = _model.get())
+    if (CheckedPtr model = _model.get())
         model->setVideoReceiverEndpoint(nullptr);
+}
+
+- (uint64_t)linearMediaPlayerLogIdentifier:(WKSLinearMediaPlayer *)player
+{
+#if !RELEASE_LOG_DISABLED
+    if (CheckedPtr model = _model.get())
+        return model->logIdentifier();
+#endif
+
+    return 0;
 }
 
 @end

--- a/Source/WebKit/WebKitSwift/LinearMediaKit/LinearMediaPlayer.swift
+++ b/Source/WebKit/WebKitSwift/LinearMediaKit/LinearMediaPlayer.swift
@@ -36,7 +36,7 @@ import LinearMediaKit
 #endif
 
 private extension Logger {
-    static let linearMediaPlayer = Logger(subsystem: "com.apple.WebKit", category: "LinearMediaPlayer")
+    static let linearMediaPlayer = Logger(subsystem: "com.apple.WebKit", category: "Fullscreen")
 }
 
 private class SwiftOnlyData: NSObject {
@@ -138,7 +138,7 @@ enum LinearMediaPlayerErrors: Error {
     var isImmersiveVideo: Bool {
         get { swiftOnlyData.isImmersiveVideo }
         set {
-            Logger.linearMediaPlayer.log("\(#function) \(newValue)")
+            Logger.linearMediaPlayer.log("\(#function)(\(self.logIdentifier, privacy: .public)) \(newValue)")
             swiftOnlyData.isImmersiveVideo = newValue
             // FIXME: Should limit ContentTypePublisher to only publish changes to contentType if we have already created a default entity
             // rather than having to use a isImmersive attribute.
@@ -171,6 +171,10 @@ enum LinearMediaPlayerErrors: Error {
     @nonobjc private var swiftOnlyData: SwiftOnlyData
     @nonobjc private var cancellables: [AnyCancellable] = []
 
+    @nonobjc private final var logIdentifier: String {
+        String(delegate?.linearMediaPlayerLogIdentifier?(self) ?? 0, radix: 16, uppercase: true)
+    }
+
     private static let preferredTimescale: CMTimeScale = 600
 
     public override init() {
@@ -190,7 +194,7 @@ enum LinearMediaPlayerErrors: Error {
     }
 
     func makeViewController() -> WKSPlayableViewControllerHost {
-        Logger.linearMediaPlayer.log("\(#function)")
+        Logger.linearMediaPlayer.log("\(#function)(\(self.logIdentifier, privacy: .public))")
 
         if let viewController = swiftOnlyData.viewController {
             return viewController
@@ -202,9 +206,9 @@ enum LinearMediaPlayerErrors: Error {
 
         return viewController
     }
-    
+
     func enterExternalPresentation(completionHandler: @MainActor @Sendable @escaping (Bool, (any Error)?) -> Void) {
-        Logger.linearMediaPlayer.log("\(#function)")
+        Logger.linearMediaPlayer.log("\(#function)(\(self.logIdentifier, privacy: .public))")
 
         switch presentationState {
         case .enteringFullscreen, .exitingFullscreen, .fullscreen, .external:
@@ -220,9 +224,9 @@ enum LinearMediaPlayerErrors: Error {
             fatalError()
         }
     }
-    
+
     func exitExternalPresentation(completionHandler: @MainActor @Sendable @escaping (Bool, (any Error)?) -> Void) {
-        Logger.linearMediaPlayer.log("\(#function)")
+        Logger.linearMediaPlayer.log("\(#function)(\(self.logIdentifier, privacy: .public))")
 
         switch presentationState {
         case .enteringFullscreen, .exitingFullscreen, .fullscreen, .inline:
@@ -241,10 +245,10 @@ enum LinearMediaPlayerErrors: Error {
     }
 
     func enterFullscreen(completionHandler: @MainActor @Sendable @escaping (Bool, (any Error)?) -> Void) {
-        Logger.linearMediaPlayer.log("\(#function)")
+        Logger.linearMediaPlayer.log("\(#function)(\(self.logIdentifier, privacy: .public))")
 
         if let enterFullscreenCompletionHandler = enterFullscreenCompletionHandler {
-            Logger.linearMediaPlayer.error("\(#function): invalidating existing enterFullscreenCompletionHandler")
+            Logger.linearMediaPlayer.error("\(#function)(\(self.logIdentifier, privacy: .public)): invalidating existing enterFullscreenCompletionHandler")
             enterFullscreenCompletionHandler(false, LinearMediaPlayerErrors.invalidStateError)
             self.enterFullscreenCompletionHandler = nil
         }
@@ -265,10 +269,10 @@ enum LinearMediaPlayerErrors: Error {
     }
 
     func exitFullscreen(completionHandler: @MainActor @Sendable @escaping (Bool, (any Error)?) -> Void) {
-        Logger.linearMediaPlayer.log("\(#function)")
+        Logger.linearMediaPlayer.log("\(#function)(\(self.logIdentifier, privacy: .public))")
 
         if let exitFullscreenCompletionHandler = exitFullscreenCompletionHandler {
-            Logger.linearMediaPlayer.error("\(#function): invalidating existing exitFullscreenCompletionHandler")
+            Logger.linearMediaPlayer.error("\(#function)(\(self.logIdentifier, privacy: .public)): invalidating existing exitFullscreenCompletionHandler")
             exitFullscreenCompletionHandler(false, LinearMediaPlayerErrors.invalidStateError)
             self.exitFullscreenCompletionHandler = nil
         }
@@ -289,7 +293,7 @@ enum LinearMediaPlayerErrors: Error {
 
 extension WKSLinearMediaPlayer {
     private func presentationStateChanged(_ presentationState: WKSLinearMediaPresentationState) {
-        Logger.linearMediaPlayer.log("\(#function): \(presentationState, privacy: .public)")
+        Logger.linearMediaPlayer.log("\(#function)(\(self.logIdentifier, privacy: .public)): \(presentationState, privacy: .public)")
 
         switch presentationState {
         case .inline:
@@ -613,103 +617,103 @@ extension WKSLinearMediaPlayer {
     }
 
     public func play() {
-        Logger.linearMediaPlayer.log("\(#function)")
+        Logger.linearMediaPlayer.log("\(#function)(\(self.logIdentifier, privacy: .public))")
         delegate?.linearMediaPlayerPlay?(self)
     }
 
     public func pause() {
-        Logger.linearMediaPlayer.log("\(#function)")
+        Logger.linearMediaPlayer.log("\(#function)(\(self.logIdentifier, privacy: .public))")
         delegate?.linearMediaPlayerPause?(self)
     }
 
     public func togglePlayback() {
-        Logger.linearMediaPlayer.log("\(#function)")
+        Logger.linearMediaPlayer.log("\(#function)(\(self.logIdentifier, privacy: .public))")
         delegate?.linearMediaPlayerTogglePlayback?(self)
     }
 
     public func setPlaybackRate(_ rate: Double) {
-        Logger.linearMediaPlayer.log("\(#function) \(rate)")
+        Logger.linearMediaPlayer.log("\(#function)(\(self.logIdentifier, privacy: .public)) \(rate)")
         delegate?.linearMediaPlayer?(self, setPlaybackRate: rate)
     }
 
     public func seek(to time: TimeInterval) {
-        Logger.linearMediaPlayer.log("\(#function) \(time)")
+        Logger.linearMediaPlayer.log("\(#function)(\(self.logIdentifier, privacy: .public)) \(time)")
         delegate?.linearMediaPlayer?(self, seekToTime: time)
     }
 
     public func seek(delta: TimeInterval) {
-        Logger.linearMediaPlayer.log("\(#function) \(delta)")
+        Logger.linearMediaPlayer.log("\(#function)(\(self.logIdentifier, privacy: .public)) \(delta)")
         delegate?.linearMediaPlayer?(self, seekByDelta: delta)
     }
 
     public func seek(to destination: TimeInterval, from source: TimeInterval, metadata: SeekMetadata) -> TimeInterval {
-        Logger.linearMediaPlayer.log("\(#function) destination=\(destination) source=\(source)")
+        Logger.linearMediaPlayer.log("\(#function)(\(self.logIdentifier, privacy: .public)) destination=\(destination) source=\(source)")
         return delegate?.linearMediaPlayer?(self, seekToDestination: destination, fromSource: source) ?? TimeInterval.zero
     }
 
     public func completeTrimming(commitChanges: Bool) {
-        Logger.linearMediaPlayer.log("\(#function) \(commitChanges)")
+        Logger.linearMediaPlayer.log("\(#function)(\(self.logIdentifier, privacy: .public)) \(commitChanges)")
         delegate?.linearMediaPlayer?(self, completeTrimming: commitChanges)
     }
 
     public func updateStartTime(_ time: TimeInterval) {
-        Logger.linearMediaPlayer.log("\(#function) \(time)")
+        Logger.linearMediaPlayer.log("\(#function)(\(self.logIdentifier, privacy: .public)) \(time)")
         delegate?.linearMediaPlayer?(self, updateStartTime: time)
     }
 
     public func updateEndTime(_ time: TimeInterval) {
-        Logger.linearMediaPlayer.log("\(#function) \(time)")
+        Logger.linearMediaPlayer.log("\(#function)(\(self.logIdentifier, privacy: .public)) \(time)")
         delegate?.linearMediaPlayer?(self, updateEndTime: time)
     }
 
     public func beginEditingVolume() {
-        Logger.linearMediaPlayer.log("\(#function)")
+        Logger.linearMediaPlayer.log("\(#function)(\(self.logIdentifier, privacy: .public))")
         delegate?.linearMediaPlayerBeginEditingVolume?(self)
     }
 
     public func endEditingVolume() {
-        Logger.linearMediaPlayer.log("\(#function)")
+        Logger.linearMediaPlayer.log("\(#function)(\(self.logIdentifier, privacy: .public))")
         delegate?.linearMediaPlayerEndEditingVolume?(self)
     }
 
     public func setAudioTrack(_ newTrack: Track?) {
-        Logger.linearMediaPlayer.log("\(#function) \(newTrack?.localizedDisplayName ?? "nil")")
+        Logger.linearMediaPlayer.log("\(#function)(\(self.logIdentifier, privacy: .public)) \(newTrack?.localizedDisplayName ?? "nil")")
         delegate?.linearMediaPlayer?(self, setAudioTrack: newTrack as? WKSLinearMediaTrack)
     }
 
     public func setLegibleTrack(_ newTrack: Track?) {
-        Logger.linearMediaPlayer.log("\(#function) \(newTrack?.localizedDisplayName ?? "nil")")
+        Logger.linearMediaPlayer.log("\(#function)(\(self.logIdentifier, privacy: .public)) \(newTrack?.localizedDisplayName ?? "nil")")
         delegate?.linearMediaPlayer?(self, setLegibleTrack: newTrack as? WKSLinearMediaTrack)
     }
 
     public func skipActiveInterstitial() {
-        Logger.linearMediaPlayer.log("\(#function)")
+        Logger.linearMediaPlayer.log("\(#function)(\(self.logIdentifier, privacy: .public))")
         delegate?.linearMediaPlayerSkipActiveInterstitial?(self)
     }
 
     public func setCaptionContentInsets(_ insets: UIEdgeInsets) {
-        Logger.linearMediaPlayer.log("\(#function) \(NSCoder.string(for: insets), privacy: .public)")
+        Logger.linearMediaPlayer.log("\(#function)(\(self.logIdentifier, privacy: .public)) \(NSCoder.string(for: insets), privacy: .public)")
         delegate?.linearMediaPlayer?(self, setCaptionContentInsets: insets)
     }
 
     public func updateVideoBounds(_ bounds: CGRect) {
-        Logger.linearMediaPlayer.log("\(#function) \(NSCoder.string(for: bounds), privacy: .public)")
+        Logger.linearMediaPlayer.log("\(#function)(\(self.logIdentifier, privacy: .public)) \(NSCoder.string(for: bounds), privacy: .public)")
         delegate?.linearMediaPlayer?(self, updateVideoBounds: bounds)
     }
 
     public func updateViewingMode(_ mode: ViewingMode?) {
         let viewingMode = WKSLinearMediaViewingMode(mode)
-        Logger.linearMediaPlayer.log("\(#function) \(viewingMode)")
+        Logger.linearMediaPlayer.log("\(#function)(\(self.logIdentifier, privacy: .public)) \(viewingMode)")
         delegate?.linearMediaPlayer?(self, update: viewingMode)
     }
 
     public func togglePip() {
-        Logger.linearMediaPlayer.log("\(#function)")
+        Logger.linearMediaPlayer.log("\(#function)(\(self.logIdentifier, privacy: .public))")
         delegate?.linearMediaPlayerTogglePip?(self)
     }
 
     public func toggleInlineMode() {
-        Logger.linearMediaPlayer.log("\(#function): presentationState=\(self.presentationState, privacy: .public)")
+        Logger.linearMediaPlayer.log("\(#function)(\(self.logIdentifier, privacy: .public)): presentationState=\(self.presentationState, privacy: .public)")
 
         switch presentationState {
         case .inline:
@@ -724,7 +728,7 @@ extension WKSLinearMediaPlayer {
     }
 
     public func willEnterFullscreen() {
-        Logger.linearMediaPlayer.log("\(#function): presentationState=\(self.presentationState, privacy: .public)")
+        Logger.linearMediaPlayer.log("\(#function)(\(self.logIdentifier, privacy: .public)): presentationState=\(self.presentationState, privacy: .public)")
 
         switch presentationState {
         case .inline:
@@ -743,16 +747,16 @@ extension WKSLinearMediaPlayer {
 
         switch result {
         case .success():
-            Logger.linearMediaPlayer.log("\(#function): success")
+            Logger.linearMediaPlayer.log("\(#function)(\(self.logIdentifier, privacy: .public)): success")
             completionHandler?(true, nil)
         case .failure(let error):
-            Logger.linearMediaPlayer.error("\(#function): \(error)")
+            Logger.linearMediaPlayer.error("\(#function)(\(self.logIdentifier, privacy: .public)): \(error)")
             completionHandler?(false, error)
         }
     }
 
     public func willExitFullscreen() {
-        Logger.linearMediaPlayer.log("\(#function): presentationState=\(self.presentationState, privacy: .public)")
+        Logger.linearMediaPlayer.log("\(#function)(\(self.logIdentifier, privacy: .public)): presentationState=\(self.presentationState, privacy: .public)")
 
         switch presentationState {
         case .fullscreen:
@@ -772,16 +776,16 @@ extension WKSLinearMediaPlayer {
 
         switch result {
         case .success():
-            Logger.linearMediaPlayer.log("\(#function): success")
+            Logger.linearMediaPlayer.log("\(#function)(\(self.logIdentifier, privacy: .public)): success")
             completionHandler?(true, nil)
         case .failure(let error):
-            Logger.linearMediaPlayer.error("\(#function): \(error)")
+            Logger.linearMediaPlayer.error("\(#function)(\(self.logIdentifier, privacy: .public)): \(error)")
             completionHandler?(false, error)
         }
     }
 
     public func makeDefaultEntity() -> Entity? {
-        Logger.linearMediaPlayer.log("\(#function)")
+        Logger.linearMediaPlayer.log("\(#function)(\(self.logIdentifier, privacy: .public))")
 
         // This gets called from maybeCreateSpatialOrImmersiveEntity through the KVO when setting
         // peculiarEntity. As such, we can't check if the peculiarEntity is set or not.
@@ -796,75 +800,75 @@ extension WKSLinearMediaPlayer {
             return entity
         }
 
-        Logger.linearMediaPlayer.error("\(#function): failed to find spatialVideoMetadata and captionLayer")
+        Logger.linearMediaPlayer.error("\(#function)(\(self.logIdentifier, privacy: .public)): failed to find spatialVideoMetadata and captionLayer")
         swiftOnlyData.defaultEntity = nil
         return nil
     }
 
     public func setTimeResolverInterval(_ interval: TimeInterval) {
-        Logger.linearMediaPlayer.log("\(#function) \(interval)")
+        Logger.linearMediaPlayer.log("\(#function)(\(self.logIdentifier, privacy: .public)) \(interval)")
         delegate?.linearMediaPlayer?(self, setTimeResolverInterval: interval)
     }
 
     public func setTimeResolverResolution(_ resolution: TimeInterval) {
-        Logger.linearMediaPlayer.log("\(#function) \(resolution)")
+        Logger.linearMediaPlayer.log("\(#function)(\(self.logIdentifier, privacy: .public)) \(resolution)")
         delegate?.linearMediaPlayer?(self, setTimeResolverResolution: resolution)
     }
 
     public func setThumbnailSize(_ size: CGSize) {
-        Logger.linearMediaPlayer.log("\(#function) \(NSCoder.string(for: size), privacy: .public)")
+        Logger.linearMediaPlayer.log("\(#function)(\(self.logIdentifier, privacy: .public)) \(NSCoder.string(for: size), privacy: .public)")
         delegate?.linearMediaPlayer?(self, setThumbnailSize: size)
     }
 
     public func seekThumbnail(to time: TimeInterval) {
-        Logger.linearMediaPlayer.log("\(#function) \(time)")
+        Logger.linearMediaPlayer.log("\(#function)(\(self.logIdentifier, privacy: .public)) \(time)")
         delegate?.linearMediaPlayer?(self, seekThumbnailToTime: time)
     }
 
     public func beginScrubbing() {
-        Logger.linearMediaPlayer.log("\(#function)")
+        Logger.linearMediaPlayer.log("\(#function)(\(self.logIdentifier, privacy: .public))")
         delegate?.linearMediaPlayerBeginScrubbing?(self)
     }
 
     public func endScrubbing() {
-        Logger.linearMediaPlayer.log("\(#function)")
+        Logger.linearMediaPlayer.log("\(#function)(\(self.logIdentifier, privacy: .public))")
         delegate?.linearMediaPlayerEndScrubbing?(self)
     }
 
     public func beginScanningForward() {
-        Logger.linearMediaPlayer.log("\(#function)")
+        Logger.linearMediaPlayer.log("\(#function)(\(self.logIdentifier, privacy: .public))")
         delegate?.linearMediaPlayerBeginScanningForward?(self)
     }
 
     public func endScanningForward() {
-        Logger.linearMediaPlayer.log("\(#function)")
+        Logger.linearMediaPlayer.log("\(#function)(\(self.logIdentifier, privacy: .public))")
         delegate?.linearMediaPlayerEndScanningForward?(self)
     }
 
     public func beginScanningBackward() {
-        Logger.linearMediaPlayer.log("\(#function)")
+        Logger.linearMediaPlayer.log("\(#function)(\(self.logIdentifier, privacy: .public))")
         delegate?.linearMediaPlayerBeginScanningBackward?(self)
     }
 
     public func endScanningBackward() {
-        Logger.linearMediaPlayer.log("\(#function)")
+        Logger.linearMediaPlayer.log("\(#function)(\(self.logIdentifier, privacy: .public))")
         delegate?.linearMediaPlayerEndScanningBackward?(self)
     }
 
     public func setVolume(_ volume: Double) {
-        Logger.linearMediaPlayer.log("\(#function) \(volume)")
+        Logger.linearMediaPlayer.log("\(#function)(\(self.logIdentifier, privacy: .public)) \(volume)")
         delegate?.linearMediaPlayer?(self, setVolume: volume)
     }
 
     public func setIsMuted(_ value: Bool) {
-        Logger.linearMediaPlayer.log("\(#function) \(value)")
+        Logger.linearMediaPlayer.log("\(#function)(\(self.logIdentifier, privacy: .public)) \(value)")
         delegate?.linearMediaPlayer?(self, setMuted: value)
     }
 
 // FIXME (147782145): Define a clang module for XPC to be used in Public SDK builds
 #if canImport(XPC)
     public func setVideoReceiverEndpoint(_ endpoint: xpc_object_t) {
-        Logger.linearMediaPlayer.log("\(#function)")
+        Logger.linearMediaPlayer.log("\(#function)(\(self.logIdentifier, privacy: .public))")
         delegate?.linearMediaPlayer?(self, setVideoReceiverEndpoint: endpoint)
     }
 #endif

--- a/Source/WebKit/WebKitSwift/LinearMediaKit/WKSLinearMediaPlayer.h
+++ b/Source/WebKit/WebKitSwift/LinearMediaKit/WKSLinearMediaPlayer.h
@@ -87,6 +87,7 @@ NS_SWIFT_UI_ACTOR
 - (void)linearMediaPlayer:(WKSLinearMediaPlayer *)player seekThumbnailToTime:(NSTimeInterval)time;
 - (void)linearMediaPlayer:(WKSLinearMediaPlayer *)player setVideoReceiverEndpoint:(xpc_object_t)videoReceiverEndpoint;
 - (void)linearMediaPlayerClearVideoReceiverEndpoint:(WKSLinearMediaPlayer *)player;
+- (uint64_t)linearMediaPlayerLogIdentifier:(WKSLinearMediaPlayer *)player;
 @end
 
 NS_SWIFT_UI_ACTOR


### PR DESCRIPTION
#### 26906da8b16296f99cbe56166aa5cfd6c2771053
<pre>
[visionOS] Include a log identifier in LinearMediaPlayer logging
<a href="https://bugs.webkit.org/show_bug.cgi?id=293524">https://bugs.webkit.org/show_bug.cgi?id=293524</a>
<a href="https://rdar.apple.com/151957283">rdar://151957283</a>

Reviewed by Jer Noble.

Prefixed LinearMediaPlayer&apos;s log messages with PlaybackSessionInterface&apos;s log identifier so that we
can correlate them with other media logging.

Ideally this would have been done with a Swift macro, but this isn&apos;t currently practical with
Apple&apos;s build system. To avoid letting the perfect be the enemy of the good, this just modifies
each logging call site to include the log identifier. While here, use a CheckedPtr when
dereferencing WKLinearMediaPlayerDelegate._model.

* Source/WebKit/Platform/ios/PlaybackSessionInterfaceLMK.mm:
(-[WKLinearMediaPlayerDelegate linearMediaPlayerPlay:]):
(-[WKLinearMediaPlayerDelegate linearMediaPlayerPause:]):
(-[WKLinearMediaPlayerDelegate linearMediaPlayerTogglePlayback:]):
(-[WKLinearMediaPlayerDelegate linearMediaPlayer:setPlaybackRate:]):
(-[WKLinearMediaPlayerDelegate linearMediaPlayer:seekByDelta:]):
(-[WKLinearMediaPlayerDelegate linearMediaPlayer:seekToDestination:fromSource:]):
(-[WKLinearMediaPlayerDelegate linearMediaPlayer:seekThumbnailToTime:]):
(-[WKLinearMediaPlayerDelegate linearMediaPlayerBeginScrubbing:]):
(-[WKLinearMediaPlayerDelegate linearMediaPlayerEndScrubbing:]):
(-[WKLinearMediaPlayerDelegate linearMediaPlayerBeginScanningForward:]):
(-[WKLinearMediaPlayerDelegate linearMediaPlayerEndScanningForward:]):
(-[WKLinearMediaPlayerDelegate linearMediaPlayerBeginScanningBackward:]):
(-[WKLinearMediaPlayerDelegate linearMediaPlayerEndScanningBackward:]):
(-[WKLinearMediaPlayerDelegate linearMediaPlayer:setVolume:]):
(-[WKLinearMediaPlayerDelegate linearMediaPlayer:setMuted:]):
(-[WKLinearMediaPlayerDelegate linearMediaPlayer:setAudioTrack:]):
(-[WKLinearMediaPlayerDelegate linearMediaPlayer:setLegibleTrack:]):
(-[WKLinearMediaPlayerDelegate linearMediaPlayerEnterFullscreen:]):
(-[WKLinearMediaPlayerDelegate linearMediaPlayerExitFullscreen:]):
(-[WKLinearMediaPlayerDelegate linearMediaPlayer:setVideoReceiverEndpoint:]):
(-[WKLinearMediaPlayerDelegate linearMediaPlayerClearVideoReceiverEndpoint:]):
(-[WKLinearMediaPlayerDelegate linearMediaPlayerLogIdentifier:]):
* Source/WebKit/WebKitSwift/LinearMediaKit/LinearMediaPlayer.swift:
(WKSLinearMediaPlayer.isImmersiveVideo):
(WKSLinearMediaPlayer.logIdentifier):
(WKSLinearMediaPlayer.makeViewController):
(WKSLinearMediaPlayer.enterExternalPresentation(_:(any Error)?) -&gt; Void:)):
(WKSLinearMediaPlayer.exitExternalPresentation(_:(any Error)?) -&gt; Void:)):
(WKSLinearMediaPlayer.enterFullscreen(_:(any Error)?) -&gt; Void:)):
(WKSLinearMediaPlayer.exitFullscreen(_:(any Error)?) -&gt; Void:)):
(WKSLinearMediaPlayer.presentationStateChanged(_:)):
(WKSLinearMediaPlayer.play):
(WKSLinearMediaPlayer.pause):
(WKSLinearMediaPlayer.togglePlayback):
(WKSLinearMediaPlayer.setPlaybackRate(_:)):
(WKSLinearMediaPlayer.seek(to:)):
(WKSLinearMediaPlayer.seek(_:)):
(WKSLinearMediaPlayer.seek(to:from:metadata:)):
(WKSLinearMediaPlayer.completeTrimming(_:)):
(WKSLinearMediaPlayer.updateStartTime(_:)):
(WKSLinearMediaPlayer.updateEndTime(_:)):
(WKSLinearMediaPlayer.beginEditingVolume):
(WKSLinearMediaPlayer.endEditingVolume):
(WKSLinearMediaPlayer.setAudioTrack(_:)):
(WKSLinearMediaPlayer.setLegibleTrack(_:)):
(WKSLinearMediaPlayer.skipActiveInterstitial):
(WKSLinearMediaPlayer.setCaptionContentInsets(_:)):
(WKSLinearMediaPlayer.updateVideoBounds(_:)):
(WKSLinearMediaPlayer.updateViewingMode(_:)):
(WKSLinearMediaPlayer.togglePip):
(WKSLinearMediaPlayer.toggleInlineMode):
(WKSLinearMediaPlayer.willEnterFullscreen):
(WKSLinearMediaPlayer.didCompleteEnterFullscreen(_:any:)):
(WKSLinearMediaPlayer.willExitFullscreen):
(WKSLinearMediaPlayer.didCompleteExitFullscreen(_:any:)):
(WKSLinearMediaPlayer.makeDefaultEntity):
(WKSLinearMediaPlayer.setTimeResolverInterval(_:)):
(WKSLinearMediaPlayer.setTimeResolverResolution(_:)):
(WKSLinearMediaPlayer.setThumbnailSize(_:)):
(WKSLinearMediaPlayer.seekThumbnail(to:)):
(WKSLinearMediaPlayer.beginScrubbing):
(WKSLinearMediaPlayer.endScrubbing):
(WKSLinearMediaPlayer.beginScanningForward):
(WKSLinearMediaPlayer.endScanningForward):
(WKSLinearMediaPlayer.beginScanningBackward):
(WKSLinearMediaPlayer.endScanningBackward):
(WKSLinearMediaPlayer.setVolume(_:)):
(WKSLinearMediaPlayer.setIsMuted(_:)):
(WKSLinearMediaPlayer.setVideoReceiverEndpoint(_:)):
* Source/WebKit/WebKitSwift/LinearMediaKit/WKSLinearMediaPlayer.h:

Canonical link: <a href="https://commits.webkit.org/297703@main">https://commits.webkit.org/297703@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/990abab00afded8cee823d686bb6e1aa8b8c9e9d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/112579 "9 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/32311 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/22789 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/118778 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/63040 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/32963 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/40874 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/85686 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/36308 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/115526 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26308 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101278 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65990 "Found 138 new API test failures: /WPE/TestLoaderClient:/webkit/WebKitWebView/loading-status, /WPE/TestWebKitFindController:/webkit/WebKitFindController/options, /WPE/TestLoaderClient:/webkit/WebKitWebView/reload, /WPE/TestWebKitUserContentManager:/webkit/WebKitUserContentManager/script-message-received, /WPE/TestWebKitWebView:/webkit/WebKitWebView/run-javascript, /WPE/TestWebKitWebView:/webkit/WebKitWebView/disable-web-security, /WPE/TestWebKitWebView:/webkit/WebKitWebView/notification-initial-permission-allowed, /WPE/TestWebKitWebContext:/webkit/WebKitWebContext/uri-scheme, /WPE/TestSSL:/webkit/WebKitWebView/tls-subresource, /WPE/TestDownloads:/webkit/Downloads/policy-decision-download ... (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/25605 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/62537 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/95698 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/19488 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/121999 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/39653 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/29540 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/94552 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40035 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97514 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94289 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24078 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39407 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17208 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/35741 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/39541 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/45029 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39178 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/42513 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/40919 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->