### PR TITLE
[WebDriver][BiDi] Implement the browsingContext.getTree method

### DIFF
--- a/Source/JavaScriptCore/inspector/scripts/codegen/generate_cpp_protocol_types_header.py
+++ b/Source/JavaScriptCore/inspector/scripts/codegen/generate_cpp_protocol_types_header.py
@@ -266,6 +266,8 @@ class CppProtocolTypesHeaderGenerator(CppGenerator):
         for type_member in required_members:
             lines.append(self._generate_builder_setter_for_member(type_member, domain))
         lines.append(Template(CppTemplates.ProtocolObjectBuilderDeclarationPostlude).substitute(None, **builder_args))
+        for member in [member for member in required_members if member.is_nullable]:
+            lines.append(self._generate_unchecked_setter_for_member(member, domain))
         for member in optional_members:
             lines.append(self._generate_unchecked_setter_for_member(member, domain))
 
@@ -343,6 +345,14 @@ class CppProtocolTypesHeaderGenerator(CppGenerator):
         lines.append('            m_result->%(setter)s("%(memberKey)s"_s, %(memberValue)s);' % setter_args)
         lines.append('            return castState<%(camelName)sSet>();' % setter_args)
         lines.append('        }')
+        if type_member.is_nullable:
+            lines.append('')
+            lines.append('        Builder<STATE | %(camelName)sSet>& set%(camelName)sIsNull()' % setter_args)
+            lines.append('        {')
+            lines.append('            static_assert(!(STATE & %(camelName)sSet), "property %(memberKey)s already set");' % setter_args)
+            lines.append('            m_result->setValue("%(memberKey)s"_s, JSON::Value::null());' % setter_args)
+            lines.append('            return castState<%(camelName)sSet>();' % setter_args)
+            lines.append('        }')
         return '\n'.join(lines)
 
     def _generate_unchecked_setter_for_member(self, type_member, domain):
@@ -369,6 +379,12 @@ class CppProtocolTypesHeaderGenerator(CppGenerator):
         lines.append('    {')
         lines.append('        JSON::ObjectBase::%(setter)s("%(memberKey)s"_s, %(memberValue)s);' % setter_args)
         lines.append('    }')
+        if type_member.is_nullable:
+            lines.append('')
+            lines.append('    void set%(camelName)sIsNull()' % setter_args)
+            lines.append('    {')
+            lines.append('        JSON::ObjectBase::setValue("%(memberKey)s"_s, JSON::Value::null());' % setter_args)
+            lines.append('    }')
         return '\n'.join(lines)
 
     def _generate_forward_declarations_for_binding_traits(self, domains):

--- a/Source/JavaScriptCore/inspector/scripts/codegen/models.py
+++ b/Source/JavaScriptCore/inspector/scripts/codegen/models.py
@@ -455,7 +455,7 @@ class Protocol:
         log.debug("parse type member %s" % json['name'])
 
         type_ref = TypeReference(json.get('type'), json.get('$ref'), json.get('enum'), json.get('items'))
-        return TypeMember(json['name'], type_ref, json.get('optional', False), json.get('description', ""))
+        return TypeMember(json['name'], type_ref, json.get('optional', False), json.get('nullable', False), json.get('description', ""))
 
     def parse_command(self, json, debuggable_types):
         check_for_required_properties(['name'], json, "command")
@@ -693,10 +693,11 @@ class TypeDeclaration:
 
 
 class TypeMember:
-    def __init__(self, member_name, type_ref, is_optional, description):
+    def __init__(self, member_name, type_ref, is_optional, is_nullable, description):
         self.member_name = member_name
         self.type_ref = type_ref
         self.is_optional = is_optional
+        self.is_nullable = is_nullable
         self.description = description
 
         if not isinstance(self.is_optional, bool):

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/type-declaration-object-type.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/type-declaration-object-type.json-result
@@ -363,6 +363,7 @@ class OptionalParameterBundle;
 class ParameterBundle;
 class ObjectWithPropertyNameConflicts;
 class DummyObject;
+class ObjectWithNullableProperties;
 enum class MouseButton;
 } // Database
 
@@ -835,6 +836,90 @@ public:
     static Builder<NoFieldsSet> create()
     {
         return Builder<NoFieldsSet>(JSON::Object::create());
+    }
+};
+
+/* An object with properties that can be null. */
+class ObjectWithNullableProperties final : public JSON::ObjectBase {
+public:
+    enum {
+        NoFieldsSet = 0,
+        NullableObjectSet = 1 << 0,
+        AllFieldsSet = (NullableObjectSet)
+    };
+
+    template<int STATE>
+    class Builder {
+    private:
+        RefPtr<JSON::Object> m_result;
+
+        template<int STEP> Builder<STATE | STEP>& castState()
+        {
+            return *reinterpret_cast<Builder<STATE | STEP>*>(this);
+        }
+
+        Builder(Ref</*ObjectWithNullableProperties*/JSON::Object>&& object)
+            : m_result(WTFMove(object))
+        {
+            static_assert(STATE == NoFieldsSet, "builder created in non init state");
+        }
+        friend class ObjectWithNullableProperties;
+    public:
+
+        Builder<STATE | NullableObjectSet>& setNullableObject(Ref<Protocol::Database::DummyObject>&& in_nullableObject)
+        {
+            static_assert(!(STATE & NullableObjectSet), "property nullableObject already set");
+            m_result->setObject("nullableObject"_s, WTFMove(in_nullableObject));
+            return castState<NullableObjectSet>();
+        }
+
+        Builder<STATE | NullableObjectSet>& setNullableObjectIsNull()
+        {
+            static_assert(!(STATE & NullableObjectSet), "property nullableObject already set");
+            m_result->setValue("nullableObject"_s, JSON::Value::null());
+            return castState<NullableObjectSet>();
+        }
+
+        Ref<ObjectWithNullableProperties> release()
+        {
+            static_assert(STATE == AllFieldsSet, "result is not ready");
+            static_assert(sizeof(ObjectWithNullableProperties) == sizeof(JSON::Object), "cannot cast");
+
+            Ref<JSON::Object> jsonResult = m_result.releaseNonNull();
+            auto result = WTFMove(*reinterpret_cast<Ref<ObjectWithNullableProperties>*>(&jsonResult));
+            return result;
+        }
+    };
+
+    /*
+     * Synthetic constructor:
+     * Ref<ObjectWithNullableProperties> result = ObjectWithNullableProperties::create()
+     *     .setNullableObject(...)
+     *     .release();
+     */
+    static Builder<NoFieldsSet> create()
+    {
+        return Builder<NoFieldsSet>(JSON::Object::create());
+    }
+
+    void setNullableObject(Ref<Protocol::Database::DummyObject>&& in_opt_nullableObject)
+    {
+        JSON::ObjectBase::setObject("nullableObject"_s, WTFMove(in_opt_nullableObject));
+    }
+
+    void setNullableObjectIsNull()
+    {
+        JSON::ObjectBase::setValue("nullableObject"_s, JSON::Value::null());
+    }
+
+    void setNullableOptionalObject(Ref<Protocol::Database::DummyObject>&& in_opt_nullableOptionalObject)
+    {
+        JSON::ObjectBase::setObject("nullableOptionalObject"_s, WTFMove(in_opt_nullableOptionalObject));
+    }
+
+    void setNullableOptionalObjectIsNull()
+    {
+        JSON::ObjectBase::setValue("nullableOptionalObject"_s, JSON::Value::null());
     }
 };
 
@@ -1390,6 +1475,7 @@ using namespace Inspector;
 @class TestProtocolDatabaseParameterBundle;
 @class TestProtocolDatabaseObjectWithPropertyNameConflicts;
 @class TestProtocolDatabaseDummyObject;
+@class TestProtocolDatabaseObjectWithNullableProperties;
 @class TestProtocolTestParameterBundle;
 
 typedef NS_ENUM(NSInteger, TestProtocolDatabaseMouseButton) {
@@ -1469,6 +1555,15 @@ __attribute__((visibility ("default")))
 @interface TestProtocolDatabaseDummyObject : RWIProtocolJSONObject
 - (instancetype)initWithPayload:(NSDictionary<NSString *, id> *)payload;
 - (instancetype)initWithProtocolObject:(RWIProtocolJSONObject *)jsonObject;
+@end
+
+__attribute__((visibility ("default")))
+@interface TestProtocolDatabaseObjectWithNullableProperties : RWIProtocolJSONObject
+- (instancetype)initWithPayload:(NSDictionary<NSString *, id> *)payload;
+- (instancetype)initWithProtocolObject:(RWIProtocolJSONObject *)jsonObject;
+- (instancetype)initWithNullableObject:(TestProtocolDatabaseDummyObject *)nullableObject;
+/* required */ @property (nonatomic, retain) TestProtocolDatabaseDummyObject *nullableObject;
+/* optional */ @property (nonatomic, retain) TestProtocolDatabaseDummyObject *nullableOptionalObject;
 @end
 __attribute__((visibility ("default")))
 @interface TestProtocolTestParameterBundle : RWIProtocolJSONObject
@@ -1722,6 +1817,7 @@ using namespace Inspector;
 + (void)_parseParameterBundle:(TestProtocolDatabaseParameterBundle **)outValue fromPayload:(id)payload;
 + (void)_parseObjectWithPropertyNameConflicts:(TestProtocolDatabaseObjectWithPropertyNameConflicts **)outValue fromPayload:(id)payload;
 + (void)_parseDummyObject:(TestProtocolDatabaseDummyObject **)outValue fromPayload:(id)payload;
++ (void)_parseObjectWithNullableProperties:(TestProtocolDatabaseObjectWithNullableProperties **)outValue fromPayload:(id)payload;
 
 @end
 @interface TestProtocolTypeConversions (TestDomain)
@@ -1774,6 +1870,12 @@ using namespace Inspector;
 {
     THROW_EXCEPTION_FOR_BAD_TYPE(payload, [NSDictionary class]);
     *outValue = [[TestProtocolDatabaseDummyObject alloc] initWithPayload:payload];
+}
+
++ (void)_parseObjectWithNullableProperties:(TestProtocolDatabaseObjectWithNullableProperties **)outValue fromPayload:(id)payload
+{
+    THROW_EXCEPTION_FOR_BAD_TYPE(payload, [NSDictionary class]);
+    *outValue = [[TestProtocolDatabaseObjectWithNullableProperties alloc] initWithPayload:payload];
 }
 
 @end
@@ -2319,6 +2421,68 @@ using namespace Inspector;
         return nil;
 
     return self;
+}
+
+@end
+
+@implementation TestProtocolDatabaseObjectWithNullableProperties
+
+- (instancetype)initWithPayload:(nonnull NSDictionary<NSString *, id> *)payload
+{
+    if (!(self = [super init]))
+        return nil;
+
+    THROW_EXCEPTION_FOR_REQUIRED_PROPERTY(payload[@"nullableObject"], @"nullableObject");
+    self.nullableObject = [[TestProtocolDatabaseDummyObject alloc] initWithPayload:payload[@"nullableObject"]];
+
+    self.nullableOptionalObject = [[TestProtocolDatabaseDummyObject alloc] initWithPayload:payload[@"nullableOptionalObject"]];
+
+    return self;
+}
+- (instancetype)initWithProtocolObject:(RWIProtocolJSONObject *)object
+{
+    if (!(self = [super initWithJSONObject:[object toJSONObject].get()]))
+        return nil;
+
+    return self;
+}
+
+- (instancetype)initWithNullableObject:(TestProtocolDatabaseDummyObject *)nullableObject
+{
+    if (!(self = [super init]))
+        return nil;
+
+    THROW_EXCEPTION_FOR_REQUIRED_PROPERTY(nullableObject, @"nullableObject");
+
+    self.nullableObject = nullableObject;
+
+    return self;
+}
+
+- (void)setNullableObject:(TestProtocolDatabaseDummyObject *)nullableObject
+{
+    [super setObject:nullableObject forKey:@"nullableObject"];
+}
+
+- (TestProtocolDatabaseDummyObject *)nullableObject
+{
+    RWIProtocolJSONObject *object = [super objectForKey:@"nullableObject"];
+    if (!object)
+        return nil;
+    return [[TestProtocolDatabaseDummyObject alloc] initWithJSONObject:[[super objectForKey:@"nullableObject"] toJSONObject].get()];
+}
+
+- (void)setNullableOptionalObject:(TestProtocolDatabaseDummyObject *)nullableOptionalObject
+{
+    [super setObject:nullableOptionalObject forKey:@"nullableOptionalObject"];
+}
+
+- (TestProtocolDatabaseDummyObject *)nullableOptionalObject
+{
+    RWIProtocolJSONObject *object = [super objectForKey:@"nullableOptionalObject"];
+    if (!object)
+        return nil;
+    return [[TestProtocolDatabaseDummyObject alloc] initWithJSONObject:[[super objectForKey:@"nullableOptionalObject"] toJSONObject].get()];
 }
 
 @end

--- a/Source/JavaScriptCore/inspector/scripts/tests/type-declaration-object-type.json
+++ b/Source/JavaScriptCore/inspector/scripts/tests/type-declaration-object-type.json
@@ -74,6 +74,15 @@
             "id": "DummyObject",
             "description": "An open object that doesn't have any predefined fields.",
             "type": "object"
+        },
+        {
+            "id": "ObjectWithNullableProperties",
+            "description": "An object with properties that can be null.",
+            "type": "object",
+            "properties": [
+                { "name": "nullableObject", "$ref": "DummyObject", "nullable": true },
+                { "name": "nullableOptionalObject", "$ref": "DummyObject", "nullable": true, "optional": true }
+            ]
         }
     ]
 },

--- a/Source/WebKit/UIProcess/Automation/BidiBrowsingContextAgent.h
+++ b/Source/WebKit/UIProcess/Automation/BidiBrowsingContextAgent.h
@@ -26,17 +26,23 @@
 
 #pragma once
 
+
 #if ENABLE(WEBDRIVER_BIDI)
 
 #include "WebDriverBidiBackendDispatchers.h"
 #include <JavaScriptCore/InspectorBackendDispatcher.h>
+#include <WebCore/FrameIdentifier.h>
+#include <cstdint>
+#include <optional>
 #include <wtf/Forward.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebKit {
 
+struct FrameTreeNodeData;
 class WebAutomationSession;
+class WebPageProxy;
 
 class BidiBrowsingContextAgent final : public Inspector::BidiBrowsingContextBackendDispatcherHandler {
     WTF_MAKE_TZONE_ALLOCATED(BidiBrowsingContextAgent);
@@ -54,6 +60,12 @@ public:
     void reload(const Inspector::Protocol::BidiBrowsingContext::BrowsingContext&, std::optional<bool>&& optionalIgnoreCache, std::optional<Inspector::Protocol::BidiBrowsingContext::ReadinessState>&& optionalWait, Inspector::CommandCallbackOf<String, String>&&) override;
 
 private:
+    enum class IncludeParentID: bool { No, Yes };
+
+    void getNextTree(Vector<Ref<WebPageProxy>>&&, Ref<JSON::ArrayOf<Inspector::Protocol::BidiBrowsingContext::Info>>, std::optional<uint64_t> maxDepth, Inspector::CommandCallback<Ref<JSON::ArrayOf<Inspector::Protocol::BidiBrowsingContext::Info>>>&&);
+    Ref<Inspector::Protocol::BidiBrowsingContext::Info> getNavigableInfo(const WebKit::FrameTreeNodeData&, std::optional<uint64_t> maxDepth, IncludeParentID);
+    Inspector::Protocol::BidiBrowsingContext::BrowsingContext getBrowsingContextID(const WebCore::FrameIdentifier&) const;
+
     WeakPtr<WebAutomationSession> m_session;
     Ref<Inspector::BidiBrowsingContextBackendDispatcher> m_browsingContextDomainDispatcher;
 };

--- a/Source/WebKit/UIProcess/Automation/WebAutomationSession.h
+++ b/Source/WebKit/UIProcess/Automation/WebAutomationSession.h
@@ -288,6 +288,7 @@ public:
     void didDestroyFrame(WebCore::FrameIdentifier);
 
     RefPtr<WebPageProxy> webPageProxyForHandle(const String&);
+    String handleForWebFrameID(std::optional<WebCore::FrameIdentifier>);
     String handleForWebPageProxy(const WebPageProxy&);
 
 private:
@@ -295,7 +296,6 @@ private:
     void getNextContext(Vector<Ref<WebPageProxy>>&&, Ref<JSON::ArrayOf<Inspector::Protocol::Automation::BrowsingContext>>, Inspector::CommandCallback<Ref<JSON::ArrayOf<Inspector::Protocol::Automation::BrowsingContext>>>&&);
 
     std::optional<WebCore::FrameIdentifier> webFrameIDForHandle(const String&, bool& frameNotFound);
-    String handleForWebFrameID(std::optional<WebCore::FrameIdentifier>);
     String handleForWebFrameProxy(const WebFrameProxy&);
 
     void waitForNavigationToCompleteOnPage(WebPageProxy&, Inspector::Protocol::Automation::PageLoadStrategy, Seconds, Inspector::CommandCallback<void>&&);

--- a/Source/WebKit/UIProcess/Automation/protocol/BidiBrowsingContext.json
+++ b/Source/WebKit/UIProcess/Automation/protocol/BidiBrowsingContext.json
@@ -27,9 +27,9 @@
             "properties": [
                 { "name": "context", "$ref": "BidiBrowsingContext.BrowsingContext", "description": "The navigable being described." },
                 { "name": "url", "type": "string" },
-                { "name": "originalOpener", "$ref": "BidiBrowsingContext.BrowsingContext", "optional": true },
-                { "name": "parent", "$ref": "BidiBrowsingContext.BrowsingContext", "optional": true },
-                { "name": "children", "type": "array", "items": { "$ref": "BidiBrowsingContext.Info" }, "optional": true },
+                { "name": "originalOpener", "$ref": "BidiBrowsingContext.BrowsingContext", "nullable": true },
+                { "name": "parent", "$ref": "BidiBrowsingContext.BrowsingContext", "optional": true, "nullable": true },
+                { "name": "children", "type": "array", "items": { "$ref": "BidiBrowsingContext.Info" }, "nullable": true },
                 { "name": "clientWindow", "$ref": "BidiBrowser.ClientWindow" },
                 { "name": "userContext", "$ref": "BidiBrowser.UserContext" }
             ]

--- a/WebDriverTests/TestExpectations.json
+++ b/WebDriverTests/TestExpectations.json
@@ -2064,6 +2064,11 @@
 
 
     "imported/w3c/webdriver/tests/bidi/browsing_context/activate/activate.py": {
+        "subtests": {
+            "test_keeps_element_focused": {
+                "expected": { "all": { "status": ["PASS"] }}
+            }
+        },
         "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288324"}}
     },
     "imported/w3c/webdriver/tests/bidi/browsing_context/activate/invalid.py": {
@@ -2266,12 +2271,25 @@
         }
     },
     "imported/w3c/webdriver/tests/bidi/browsing_context/create/reference_context.py": {
+        "subtests": {
+            "test_reference_context[tab]": {
+                "expected": { "all": { "status": ["PASS"]}}
+            },
+            "test_reference_context[window]": {
+                "expected": { "all": { "status": ["PASS"]}}
+            }
+        },
         "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/286790"}}
     },
     "imported/w3c/webdriver/tests/bidi/browsing_context/create/type.py": {
         "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/286790"}}
     },
     "imported/w3c/webdriver/tests/bidi/browsing_context/create/user_context.py": {
+        "subtests": {
+            "test_user_context_default": {
+                "expected": { "all": { "status": ["PASS"]}}
+            }
+        },
         "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/286790"}}
     },
     "imported/w3c/webdriver/tests/bidi/browsing_context/dom_content_loaded/dom_content_loaded.py": {
@@ -2362,6 +2380,9 @@
     },
     "imported/w3c/webdriver/tests/bidi/browsing_context/get_tree/frames.py": {
         "subtests": {
+            "test_multiple_frames": {
+                "expected": { "all": { "status": ["PASS"] }}
+            },
             "test_user_context[same_origin-default]": {
                 "expected": { "all": { "status": ["TIMEOUT"], "bug": "webkit.org/b/283784"}}
             },
@@ -2377,60 +2398,31 @@
         },
         "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/283784"}}
     },
-    "imported/w3c/webdriver/tests/bidi/browsing_context/get_tree/invalid.py": {
-        "subtests": {
-            "test_params_max_depth_invalid_value[-1]": {
-                "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/283784"}}
-            },
-            "test_params_max_depth_invalid_value[1.1]": {
-                "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/283784"}}
-            },
-            "test_params_max_depth_invalid_value[9007199254740992]": {
-                "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/283784"}}
-            },
-            "test_params_root_invalid_value": {
-                "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/283784"}}
-            }
-        }
-    },
-    "imported/w3c/webdriver/tests/bidi/browsing_context/get_tree/max_depth.py": {
-        "subtests": {
-            "test_null": {
-                "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/283784"}}
-            },
-            "test_top_level_only": {
-                "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/283784"}}
-            },
-            "test_top_level_and_one_child": {
-                "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/283784"}}
-            }
-        }
-    },
     "imported/w3c/webdriver/tests/bidi/browsing_context/get_tree/original_opener.py": {
         "subtests": {
             "test_window_open[None]": {
-                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/283784"}}
+                "expected": { "all": { "status": ["TIMEOUT"], "bug": "webkit.org/b/283784"}}
             },
             "test_window_open[]": {
-                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/283784"}}
+                "expected": { "all": { "status": ["TIMEOUT"], "bug": "webkit.org/b/283784"}}
             },
             "test_window_open[popup]": {
-                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/283784"}}
+                "expected": { "all": { "status": ["TIMEOUT"], "bug": "webkit.org/b/283784"}}
             },
             "test_window_open[noopener]": {
-                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/283784"}}
+                "expected": { "all": { "status": ["TIMEOUT"], "bug": "webkit.org/b/283784"}}
             },
             "test_window_open[noreferrer]": {
-                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/283784"}}
+                "expected": { "all": { "status": ["TIMEOUT"], "bug": "webkit.org/b/283784"}}
             },
             "test_different_origins[same_origin]": {
-                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/283784"}}
+                "expected": { "all": { "status": ["TIMEOUT"], "bug": "webkit.org/b/283784"}}
             },
             "test_different_origins[cross_origin]": {
-                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/283784"}}
+                "expected": { "all": { "status": ["TIMEOUT"], "bug": "webkit.org/b/283784"}}
             },
             "test_with_closed_original_context": {
-                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/283784"}}
+                "expected": { "all": { "status": ["TIMEOUT"], "bug": "webkit.org/b/283784"}}
             }
         },
         "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/283784"}}


### PR DESCRIPTION
#### 09e8854c854800fa8640edd36be6ab1ab1ec0c38
<pre>
[WebDriver][BiDi] Implement the browsingContext.getTree method
<a href="https://bugs.webkit.org/show_bug.cgi?id=283784">https://bugs.webkit.org/show_bug.cgi?id=283784</a>

Reviewed by BJ Burg.

Add support for the root and maxDepth parameter. The root selection is
done by splitting the steps of selecting the navigables to traverse
and actually traversing them.

Also, fix the presence of some fields in the returned payload. In the
current version of the spec, only the &quot;parent&quot; field is actually
optional, while the other fields must be present, even if they&apos;re
null.

In order to support the latter, this commit also adds support for a new
boolean field in object types declared in the automation protocol:
&quot;nullable&quot;. This field generates a &quot;setNull...&quot; method that sets the
related key in the underlying objet with JSON::Value::null(). That way
we can keep the original setter receiving the original types like
Ref&lt;...&gt;.

Originally, the generated inspector code also restricted the
non-optional fields to be set at construction time, with the nested
`Builder` class wrapping the generated type constructor. This commit
also exposes the normal setters for non-optional-but-nullable fields,
so we can set these fields later if needed. For example:

auto obj = Protocol::Module::Object::create()
  .setRequiredField()
  .setNullChildren() // &quot;children&quot; is a &quot;nullable&quot; member
  .release();
...
obj.setChildren(childrenArray);

This &quot;nullable&quot; tag contrasts with &quot;optional&quot; in the sense that with
optional, the key might be missing from the final object.

Note that this doesn&apos;t cover nullable command parameters nor support for
processing of incoming frontend data with nullable fields, as we only
need to support outbound data from the backend (i.e. command return
values) for now.

* Source/JavaScriptCore/inspector/scripts/codegen/generate_cpp_protocol_types_header.py:
  * Generate new setter models in Builder and actual Model classes.
* Source/JavaScriptCore/inspector/scripts/codegen/models.py:
  * Add &quot;nullable&quot; property to type declarations.
(Protocol.parse_type_member):
(TypeMember.__init__):
* Source/JavaScriptCore/inspector/scripts/tests/expected/type-declaration-object-type.json-result:
  * Rebaseline results.
* Source/JavaScriptCore/inspector/scripts/tests/type-declaration-object-type.json:
  * Add testcase declaration.
* Source/WebKit/UIProcess/Automation/BidiBrowsingContextAgent.cpp:
(WebKit::BidiBrowsingContextAgent::getBrowsingContextID const): Helper
added.
(WebKit::BidiBrowsingContextAgent::getNavigableInfo): Added.
(WebKit::BidiBrowsingContextAgent::getNextTree): Added.
(WebKit::toOptionalUint): Added.
(WebKit::BidiBrowsingContextAgent::getTree): Add support for maxDepth,
root, and actually traverse the navigable trees.
* Source/WebKit/UIProcess/Automation/BidiBrowsingContextAgent.h: Declare
  new methods and types.
* Source/WebKit/UIProcess/Automation/WebAutomationSession.h: Make
  handleForWebFrame* methods public as the BrowsingContext agent uses
  it.
* Source/WebKit/UIProcess/Automation/protocol/BidiBrowsingContext.json:
  Fix optional and nullable fields for getTree parameters.
* WebDriverTests/TestExpectations.json: Gardening results with this
  patch.

Canonical link: <a href="https://commits.webkit.org/295805@main">https://commits.webkit.org/295805@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/06cbf8faad4ec0a1c3125be95cb9e5fb7f4b9f10

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/106185 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25934 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/16328 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/111382 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/56781 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/26593 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34437 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80656 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/109189 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/21019 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95824 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60981 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/20572 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13927 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/56221 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/98824 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/90379 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13962 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/114242 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/104802 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33323 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24578 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89731 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33687 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/92057 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89430 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22804 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34299 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/12113 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/28899 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/33248 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/38660 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/129114 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32994 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/35191 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/36344 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34592 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->