### PR TITLE
[JSC] Further enhance DFG mayExit validation

### DIFF
--- a/JSTests/stress/make-rope-overflow-nested-catch.js
+++ b/JSTests/stress/make-rope-overflow-nested-catch.js
@@ -1,0 +1,43 @@
+//@ skip if $memoryLimited
+(function () {
+    function shouldBe(actual, expected) {
+        if (actual !== expected)
+            throw new Error('bad value: ' + actual);
+    }
+
+    function f0(a, b)
+    {
+        return a + b;
+    }
+
+    function f1(a, b)
+    {
+        return f0(a, b);
+    }
+
+    function f2(a, b)
+    {
+        return f1(a, b);
+    }
+
+    function f3(a, b)
+    {
+        try {
+            return f2(a, b);
+        } catch (e) {
+            return "ERROR";
+        }
+    }
+    noInline(f3);
+
+    var string0 = "hello";
+    var string1 = "test";
+    var string2 = "testing";
+    var string3 = "t".repeat(0x7fffffff);
+    for (var i = 0; i < testLoopCount; ++i) {
+        f3(string0, string1);
+        f3(string0, string2);
+        f3(string1, string2);
+        shouldBe(f3(string0, string3), "ERROR");
+    }
+}());

--- a/JSTests/stress/make-rope-overflow-nested.js
+++ b/JSTests/stress/make-rope-overflow-nested.js
@@ -1,0 +1,44 @@
+//@ skip if $memoryLimited
+(function () {
+    function shouldBe(actual, expected) {
+        if (actual !== expected)
+            throw new Error('bad value: ' + actual);
+    }
+
+    function f0(a, b)
+    {
+        return a + b;
+    }
+
+    function f1(a, b)
+    {
+        return f0(a, b);
+    }
+
+    function f2(a, b)
+    {
+        return f1(a, b);
+    }
+
+    function f3(a, b)
+    {
+        return f2(a, b);
+    }
+    noInline(f3);
+
+    var string0 = "hello";
+    var string1 = "test";
+    var string2 = "testing";
+    var string3 = "t".repeat(0x7fffffff);
+    for (var i = 0; i < testLoopCount; ++i) {
+        f3(string0, string1);
+        f3(string0, string2);
+        f3(string1, string2);
+        try {
+            f3(string0, string3);
+        } catch (e) {
+            shouldBe(String(e), `RangeError: Out of memory`);
+            shouldBe(e.stack.split('\n').length, 6);
+        }
+    }
+}());

--- a/Source/JavaScriptCore/bytecode/ExitKind.h
+++ b/Source/JavaScriptCore/bytecode/ExitKind.h
@@ -58,6 +58,7 @@ enum ExitKind : uint8_t {
     WatchdogTimerFired, // We exited because we need to service the watchdog timer.
     DebuggerEvent, // We exited because we need to service the debugger.
     ExceptionCheck, // We exited because a direct exception check showed that we threw an exception from a C call.
+    WillThrowOutOfMemoryError, // We exited because we would like to throw OutOfMemory error.
     GenericUnwind, // We exited because we arrived at this OSR exit from genericUnwind.
     BigInt32Overflow, // We exited because of an BigInt32 overflow.
     UnexpectedResizableArrayBufferView, // We exited because we made an incorrect assumption about what type of ArrayBufferView we would see.

--- a/Source/JavaScriptCore/dfg/DFGJITCompiler.cpp
+++ b/Source/JavaScriptCore/dfg/DFGJITCompiler.cpp
@@ -448,16 +448,6 @@ void JITCompiler::noticeOSREntry(BasicBlock& basicBlock, JITCompiler::Label bloc
     m_osrEntry.append(WTFMove(entry));
 }
 
-void JITCompiler::appendExceptionHandlingOSRExit(SpeculativeJIT* speculative, ExitKind kind, unsigned eventStreamIndex, CodeOrigin opCatchOrigin, HandlerInfo* exceptionHandler, CallSiteIndex callSite, MacroAssembler::JumpList jumpsToFail)
-{
-    OSRExit exit(kind, JSValueRegs(), MethodOfGettingAValueProfile(), speculative, eventStreamIndex);
-    exit.m_codeOrigin = opCatchOrigin;
-    exit.m_exceptionHandlerCallSiteIndex = callSite;
-    OSRExitCompilationInfo& exitInfo = appendExitInfo(jumpsToFail);
-    m_osrExit.append(WTFMove(exit));
-    m_exceptionHandlerOSRExitCallSites.append(ExceptionHandlingOSRExitInfo { exitInfo, *exceptionHandler, callSite });
-}
-
 void JITCompiler::setEndOfMainPath(CodeOrigin semanticOrigin)
 {
     m_pcToCodeOriginMapBuilder.appendItem(labelIgnoringWatchpoints(), semanticOrigin);

--- a/Source/JavaScriptCore/dfg/DFGJITCompiler.h
+++ b/Source/JavaScriptCore/dfg/DFGJITCompiler.h
@@ -373,8 +373,6 @@ public:
     std::tuple<CompileTimeCallLinkInfo, LinkableConstant> addCallLinkInfo(CodeOrigin);
     LinkerIR::Constant addToConstantPool(LinkerIR::Type, void*);
 
-    void appendExceptionHandlingOSRExit(SpeculativeJIT*, ExitKind, unsigned eventStreamIndex, CodeOrigin, HandlerInfo* exceptionHandler, CallSiteIndex, MacroAssembler::JumpList jumpsToFail = MacroAssembler::JumpList());
-
 protected:
     friend class OSRExitJumpPlaceholder;
     

--- a/Source/JavaScriptCore/dfg/DFGOSRExitBase.h
+++ b/Source/JavaScriptCore/dfg/DFGOSRExitBase.h
@@ -57,10 +57,17 @@ struct OSRExitBase {
     CodeOrigin m_codeOrigin;
     CodeOrigin m_codeOriginForExitProfile;
     CallSiteIndex m_exceptionHandlerCallSiteIndex;
+    CallSiteIndex m_exitCallSiteIndex;
     uint32_t m_dfgNodeIndex;
 
     ALWAYS_INLINE bool isExceptionHandler() const
     {
+        return m_kind == ExceptionCheck || m_kind == GenericUnwind || m_kind == WillThrowOutOfMemoryError;
+    }
+
+    ALWAYS_INLINE bool isOSRExitDueToException() const
+    {
+        // WillThrowOutOfMemoryError will throw an error. It is not an OSR due to thrown exception.
         return m_kind == ExceptionCheck || m_kind == GenericUnwind;
     }
 

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
@@ -1878,6 +1878,8 @@ public:
     // Add a speculation check with additional recovery.
     void speculationCheck(ExitKind, JSValueSource, Node*, Jump jumpToFail, const SpeculationRecovery&);
     void speculationCheck(ExitKind, JSValueSource, Edge, Jump jumpToFail, const SpeculationRecovery&);
+
+    void speculationCheckOutOfMemory(JSValueSource, Node*, const JumpList&);
     
     void compileInvalidationPoint(Node*);
     
@@ -1987,8 +1989,9 @@ public:
     void arrayify(Node*, GPRReg baseReg, GPRReg propertyReg);
     void arrayify(Node*);
 
-    unsigned appendOSRExit(OSRExit&&);
-    
+    unsigned appendOSRExit(OSRExit&&, bool isExceptionHandler = false);
+    unsigned appendExceptionHandlingOSRExit(ExitKind, unsigned eventStreamIndex, CodeOrigin, HandlerInfo* exceptionHandler, CallSiteIndex, MacroAssembler::JumpList jumpsToFail = MacroAssembler::JumpList());
+
     template<bool strict>
     GPRReg fillSpeculateInt32Internal(Edge, DataFormat& returnFormat);
     

--- a/Source/JavaScriptCore/jit/JITOperations.cpp
+++ b/Source/JavaScriptCore/jit/JITOperations.cpp
@@ -139,6 +139,21 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationThrowStackOverflowErrorFromThunk, voi
     ASSERT(vm.targetMachinePCForThrow);
 }
 
+JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationThrowOutOfMemoryError, void, (VM* vmPointer))
+{
+    VM& vm = *vmPointer;
+    CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
+    JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    CodeBlock* codeBlock = callFrame->codeBlock();
+    if (JSC::JITCode::isOptimizingJIT(codeBlock->jitType()))
+        codeBlock = baselineCodeBlockForOriginAndBaselineCodeBlock(callFrame->codeOrigin(), codeBlock->baselineAlternative());
+
+    JSGlobalObject* globalObject = codeBlock->globalObject();
+    scope.throwException(globalObject, createOutOfMemoryError(globalObject));
+}
+
 static JSValue getWrappedValue(JSGlobalObject* globalObject, JSGlobalObject* targetGlobalObject, JSValue value)
 {
     VM& vm = globalObject->vm();

--- a/Source/JavaScriptCore/jit/JITOperations.h
+++ b/Source/JavaScriptCore/jit/JITOperations.h
@@ -169,6 +169,7 @@ JSC_DECLARE_JIT_OPERATION(operationMaterializeBoundFunctionTargetCode, UGPRPair,
 JSC_DECLARE_JIT_OPERATION(operationThrowRemoteFunctionException, EncodedJSValue, (JSRemoteFunction*));
 
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationThrowStackOverflowError, void, (CodeBlock*));
+JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationThrowOutOfMemoryError, void, (VM*));
 
 // IC related functions and generic helpers.
 //

--- a/Source/JavaScriptCore/jit/JITThunks.h
+++ b/Source/JavaScriptCore/jit/JITThunks.h
@@ -64,6 +64,7 @@ class NativeExecutable;
     macro(ThrowExceptionFromCall, throwExceptionFromCallGenerator) \
     macro(ThrowExceptionFromCallSlowPath, throwExceptionFromCallSlowPathGenerator) \
     macro(ThrowStackOverflowAtPrologue, throwStackOverflowAtPrologueGenerator) \
+    macro(ThrowOutOfMemoryError, throwOutOfMemoryErrorGenerator) \
     macro(VirtualThunkForRegularCall, virtualThunkForRegularCall) \
     macro(VirtualThunkForTailCall, virtualThunkForTailCall) \
     macro(VirtualThunkForConstruct, virtualThunkForConstruct) \

--- a/Source/JavaScriptCore/jit/ThunkGenerators.h
+++ b/Source/JavaScriptCore/jit/ThunkGenerators.h
@@ -44,6 +44,7 @@ MacroAssemblerCodeRef<JITThunkPtrTag> popThunkStackPreservesAndHandleExceptionGe
 MacroAssemblerCodeRef<JITThunkPtrTag> throwExceptionFromCallGenerator(VM&);
 MacroAssemblerCodeRef<JITThunkPtrTag> throwExceptionFromCallSlowPathGenerator(VM&);
 MacroAssemblerCodeRef<JITThunkPtrTag> throwStackOverflowAtPrologueGenerator(VM&);
+MacroAssemblerCodeRef<JITThunkPtrTag> throwOutOfMemoryErrorGenerator(VM&);
 
 MacroAssemblerCodeRef<JITThunkPtrTag> checkExceptionGenerator(VM&);
 MacroAssemblerCodeRef<JITThunkPtrTag> returnFromBaselineGenerator(VM&);


### PR DESCRIPTION
#### 78a8cf3ed7b1a0ee2b5d99dfae28943e6a2b270e
<pre>
[JSC] Further enhance DFG mayExit validation
<a href="https://bugs.webkit.org/show_bug.cgi?id=293529">https://bugs.webkit.org/show_bug.cgi?id=293529</a>
<a href="https://rdar.apple.com/151966700">rdar://151966700</a>

Reviewed by Yijia Huang.

This patch extends DFG mayExit validation further and fixes some of
existing code.

1. When mayExit says ExitsForException, we should generate OSR exits
   only for exception checks. We should not generate any other OSR
   exits.
2. MakeRope should use ExitsForException. But it uses normal OSR exits
   for OOM check. We should have special OSR exit
   &quot;WillThrowOutOfMemoryError&quot;, and use it instead. It generates OSR
   exit which throws out of memory error in the middle of OSR exit.
3. MaterializeNewArrayWithConstantSize should not do Int32 speculation
   check for children after the first speculations. We should ensure
   that children have Int32Use and first speculate sequence should be
   enough for these type checks.

* Source/JavaScriptCore/bytecode/ExitKind.h:
* Source/JavaScriptCore/dfg/DFGJITCompiler.cpp:
(JSC::DFG::JITCompiler::appendExceptionHandlingOSRExit): Deleted.
* Source/JavaScriptCore/dfg/DFGJITCompiler.h:
* Source/JavaScriptCore/dfg/DFGOSRExit.cpp:
(JSC::DFG::OSRExit::compileExit):
* Source/JavaScriptCore/dfg/DFGOSRExitBase.h:
* Source/JavaScriptCore/dfg/DFGObjectAllocationSinkingPhase.cpp:
* Source/JavaScriptCore/dfg/DFGOperations.cpp:
(JSC::DFG::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/dfg/DFGOperations.h:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
(JSC::DFG::SpeculativeJIT::exceptionCheck):
(JSC::DFG::SpeculativeJIT::recordCallSiteAndGenerateExceptionHandlingOSRExitIfNeeded):
(JSC::DFG::SpeculativeJIT::speculationCheckOutOfMemory):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h:
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::cachedPutById):
(JSC::FTL::DFG::LowerDFGToB3::compileMakeRope):
(JSC::FTL::DFG::LowerDFGToB3::compileCompareStrictEq):
* Source/JavaScriptCore/ftl/FTLOSRExit.cpp:
(JSC::FTL::OSRExitDescriptor::prepareOSRExitHandle):
* Source/JavaScriptCore/ftl/FTLOSRExitCompiler.cpp:
(JSC::FTL::compileStub):

Canonical link: <a href="https://commits.webkit.org/295441@main">https://commits.webkit.org/295441@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3e1a3e65ef7a41c2a9338ba263495e6dfaedff7e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105120 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24834 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15257 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110336 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/55795 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/25259 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33378 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79843 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108126 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19681 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94882 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60150 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/19431 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/12958 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55177 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/97802 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/89145 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13002 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/112874 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/103738 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32285 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23774 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88920 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32651 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91100 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88550 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33438 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11228 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/27688 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17043 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32208 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/37584 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/128045 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/31999 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/35018 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35342 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33559 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->