### PR TITLE
Stage Manager resize is very jumpy

### DIFF
--- a/Source/WebKit/Platform/spi/ios/UIKitSPI.h
+++ b/Source/WebKit/Platform/spi/ios/UIKitSPI.h
@@ -1267,6 +1267,10 @@ typedef NS_ENUM(NSUInteger, _UIScrollDeviceCategory) {
 - (void)_registerInternalBSActionHandler:(id<_UIApplicationBSActionHandler>)handler;
 @end
 
+@interface UIWindowSceneGeometry (Staging_143004359)
+@property (nonatomic, readonly, getter=isInteractivelyResizing) BOOL interactivelyResizing;
+@end
+
 WTF_EXTERN_C_BEGIN
 
 BOOL UIKeyboardEnabledInputModesAllowOneToManyShortcuts(void);


### PR DESCRIPTION
#### 06265c042be1975112546b4b5f026f8ea6aa440d
<pre>
Stage Manager resize is very jumpy
<a href="https://bugs.webkit.org/show_bug.cgi?id=293530">https://bugs.webkit.org/show_bug.cgi?id=293530</a>
<a href="https://rdar.apple.com/151952483">rdar://151952483</a>

Reviewed by Wenson Hsieh.

Fix two bugs with the &quot;automatic live resize&quot; mechanism:

1) In _beginLiveResize, we record the current scroll position; in _updateLiveResizeTransform
   we pass the scroll position through _contentOffsetAdjustedForObscuredInset before comparing
   it to the current one. But, the originally saved scroll position had the obscured inset
   factored into it. Subtract it out so that the math works out (this didn&apos;t cause trouble
   where automatic live resize was originally introduced, on visionOS, because it has no
   obscured insets).

2) Don&apos;t start a animated resize if we&apos;re about to kick off an automatic live resize.
   The precise timing of `_beginLiveResize` vs. clients calling into `_beginAnimatedResizeWithUpdates`
   is hard to guarantee, so make sure that if `_beginAnimatedResizeWithUpdates` is called first
   in a situation where we *will* start a live resize, we bail from the animated resize.
   We already guard against animated resize happening *during* live resize, we just missed this
   ordering.

* Source/WebKit/Platform/spi/ios/UIKitSPI.h:
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _canBeginAutomaticLiveResize]):
(-[WKWebView _beginLiveResize]):
(-[WKWebView _beginAnimatedResizeWithUpdates:]):

Canonical link: <a href="https://commits.webkit.org/295400@main">https://commits.webkit.org/295400@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/621b6c0b3547766b7bc4d04ddd332aa635673410

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104962 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24676 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15097 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110178 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/55641 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/25082 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33220 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79696 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107968 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19513 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94728 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60003 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/19257 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55019 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/88976 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/12852 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/112664 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32127 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23631 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88777 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32492 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/90954 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88406 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22537 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33301 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11081 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/27459 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32051 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/37422 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/31844 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35185 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33403 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->