### PR TITLE
[GStreamer][WebRTC] Handle generation field in ICE candidate SDP string parser

### DIFF
--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.cpp
@@ -295,7 +295,8 @@ enum class NextSDPField {
     Raddr,
     Rport,
     TcpType,
-    Ufrag
+    Ufrag,
+    Generation
 };
 
 std::optional<RTCIceCandidate::Fields> parseIceCandidateSDP(const String& sdp)
@@ -370,6 +371,8 @@ std::optional<RTCIceCandidate::Fields> parseIceCandidateSDP(const String& sdp)
                 nextSdpField = NextSDPField::TcpType;
             else if (token == "ufrag"_s)
                 nextSdpField = NextSDPField::Ufrag;
+            else if (token == "generation"_s)
+                nextSdpField = NextSDPField::Generation;
             else {
                 switch (nextSdpField) {
                 case NextSDPField::None:
@@ -388,6 +391,10 @@ std::optional<RTCIceCandidate::Fields> parseIceCandidateSDP(const String& sdp)
                     break;
                 case NextSDPField::Ufrag:
                     usernameFragment = tokenString;
+                    break;
+                case NextSDPField::Generation:
+                    // Unsupported.
+                    GST_WARNING("Unsupported 'generation' ICE candidate field detected when parsing \"%s\"", sdp.utf8().data());
                     break;
                 }
             }


### PR DESCRIPTION
#### dac01964cb2d9b38fccc247be9d909e508122430
<pre>
[GStreamer][WebRTC] Handle generation field in ICE candidate SDP string parser
<a href="https://bugs.webkit.org/show_bug.cgi?id=293539">https://bugs.webkit.org/show_bug.cgi?id=293539</a>

Reviewed by Xabier Rodriguez-Calvar.

The generation field isn&apos;t defined in the RTCIceCandidateFields struct and isn&apos;t supported at the
spec level, but that doesn&apos;t prevent 3rd-parties to supply it anyway, so we need to handle it.
Without this we might end-up with candidates of the wrong &quot;type&quot;.

Canonical link: <a href="https://commits.webkit.org/295414@main">https://commits.webkit.org/295414@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dbc7a012e84a9d7b69796bca4e50d00b0fb2f632

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105021 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24735 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15157 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110238 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/55701 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/107062 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/25145 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33279 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/79752 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108027 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19572 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94789 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60059 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/19324 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/12865 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55078 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/89040 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/12910 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/112741 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32186 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23690 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88833 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32552 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/91010 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88462 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22548 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33351 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11139 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/27551 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32110 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/37483 "Failed to build and analyze WebKit") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/31903 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35244 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33462 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->