### PR TITLE
Re-use RenderStyle between MediaQuery evaluations.

### DIFF
--- a/Source/WebCore/css/query/MediaQueryEvaluator.cpp
+++ b/Source/WebCore/css/query/MediaQueryEvaluator.cpp
@@ -27,11 +27,9 @@
 
 #include "CSSToLengthConversionData.h"
 #include "Document.h"
-#include "FontCascade.h"
 #include "MediaQuery.h"
 #include "MediaQueryFeatures.h"
 #include "RenderView.h"
-#include "StyleFontSizeFunctions.h"
 
 namespace WebCore {
 namespace MQ {
@@ -81,16 +79,7 @@ bool MediaQueryEvaluator::evaluate(const MediaQuery& query) const
         if (!document->view() || !document->documentElement())
             return EvaluationResult::Unknown;
 
-        auto defaultStyle = RenderStyle::create();
-        auto size = Style::fontSizeForKeyword(CSSValueMedium, false, *document);
-        if (size != defaultStyle.fontDescription().specifiedSize()) {
-            auto fontDescription = defaultStyle.fontDescription();
-            fontDescription.setSpecifiedSize(size);
-            fontDescription.setComputedSize(size);
-            defaultStyle.setFontDescription(WTFMove(fontDescription));
-        }
-
-        FeatureEvaluationContext context { *document, { *m_rootElementStyle, &defaultStyle, nullptr, document->renderView() }, nullptr };
+        FeatureEvaluationContext context { *document, { *m_rootElementStyle, &document->mediaQueryDefaultStyle(), nullptr, document->renderView() }, nullptr };
         return evaluateCondition(*query.condition, context);
     }();
 

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -99,6 +99,7 @@
 #include "FocusController.h"
 #include "FocusEvent.h"
 #include "FocusOptions.h"
+#include "FontCascade.h"
 #include "FontFaceSet.h"
 #include "FormController.h"
 #include "FragmentDirective.h"
@@ -289,6 +290,7 @@
 #include "StyleAdjuster.h"
 #include "StyleColorOptions.h"
 #include "StyleColorScheme.h"
+#include "StyleFontSizeFunctions.h"
 #include "StyleOriginatedTimelinesController.h"
 #include "StyleProperties.h"
 #include "StyleResolveForDocument.h"
@@ -1327,6 +1329,27 @@ MediaQueryMatcher& Document::mediaQueryMatcher()
     return *m_mediaQueryMatcher;
 }
 
+const RenderStyle& Document::mediaQueryDefaultStyle() const
+{
+    if (!m_cachedMediaQueryDefaultStyle) {
+        std::unique_ptr defaultStyle = RenderStyle::createPtr();
+        auto size = Style::fontSizeForKeyword(CSSValueMedium, false, settingsValues(), inQuirksMode());
+        if (size != defaultStyle->fontDescription().specifiedSize()) {
+            auto fontDescription = defaultStyle->fontDescription();
+            fontDescription.setSpecifiedSize(size);
+            fontDescription.setComputedSize(size);
+            defaultStyle->setFontDescription(WTFMove(fontDescription));
+        }
+        m_cachedMediaQueryDefaultStyle = WTFMove(defaultStyle);
+    }
+    return *m_cachedMediaQueryDefaultStyle;
+}
+
+void Document::invalidateMediaQueryDefaultStyle()
+{
+    m_cachedMediaQueryDefaultStyle = nullptr;
+}
+
 void Document::setCompatibilityMode(DocumentCompatibilityMode mode)
 {
     if (m_compatibilityModeLocked || mode == m_compatibilityMode)
@@ -1335,6 +1358,7 @@ void Document::setCompatibilityMode(DocumentCompatibilityMode mode)
     m_compatibilityMode = mode;
 
     if (inQuirksMode() != wasInQuirksMode) {
+        invalidateMediaQueryDefaultStyle();
         // All user stylesheets have to reparse using the different mode.
         if (auto* extensionStyleSheets = extensionStyleSheetsIfExists()) {
             extensionStyleSheets->clearPageUserSheet();

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -471,6 +471,9 @@ public:
 
     MediaQueryMatcher& mediaQueryMatcher();
 
+    const RenderStyle& mediaQueryDefaultStyle() const;
+    void invalidateMediaQueryDefaultStyle();
+
     using ContainerNode::ref;
     using ContainerNode::deref;
     using TreeScope::rootNode;
@@ -2375,7 +2378,9 @@ private:
     DocumentEventTiming m_eventTiming;
 
     RefPtr<MediaQueryMatcher> m_mediaQueryMatcher;
-    
+
+    mutable std::unique_ptr<RenderStyle> m_cachedMediaQueryDefaultStyle;
+
 #if ENABLE(TOUCH_EVENTS)
     std::unique_ptr<EventTargetSet> m_touchEventTargets;
 #endif

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -1071,6 +1071,7 @@ void Page::setNeedsRecalcStyleInAllFrames()
 {
     // FIXME: Figure out what this function is actually trying to add in different call sites.
     forEachDocument([] (Document& document) {
+        document.invalidateMediaQueryDefaultStyle();
         document.checkedStyleScope()->didChangeStyleSheetEnvironment();
     });
 }


### PR DESCRIPTION
#### 9213cf0bfaf50b9e6a53de8948d669fe1f770fe3
<pre>
Re-use RenderStyle between MediaQuery evaluations.

<a href="https://bugs.webkit.org/show_bug.cgi?id=293538">https://bugs.webkit.org/show_bug.cgi?id=293538</a>

Reviewed by NOBODY (OOPS!).

When `Page::updateRendering()` is called repeatedly (e.g., 60 times
per second), and the `Document` has many associated
`window.matchMedia(...)` instances, a significant amount of CPU time is
spent constructing and destructing `RenderStyle` instances.

Since the `RenderStyle` used for evaluating media queries only depends
on the `Document` settings and quirks mode, it can be cached and reused
between evaluations, avoiding unnecessary object creation and
improving performance.

* Source/WebCore/css/query/MediaQueryEvaluator.cpp:
(WebCore::MQ::MediaQueryEvaluator::evaluate const):
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::invalidateMediaQueryDefaultStyle):
(WebCore::Document::mediaQueryDefaultStyle const):
(WebCore::Document::setCompatibilityMode):
* Source/WebCore/dom/Document.h:
* Source/WebCore/dom/Page.cpp:
(WebCore::Page::setNeedsRecalcStyleInAllFrames):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9213cf0bfaf50b9e6a53de8948d669fe1f770fe3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105599 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25348 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15740 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110796 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/56210 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/107640 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/25799 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33849 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80199 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108605 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/20146 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95297 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60508 "Passed tests") | 
| | [💥 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/19893 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13389 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55634 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/89595 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13428 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/113628 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32737 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24135 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89276 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33099 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91526 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88940 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33808 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11610 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/28179 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32663 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/38047 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32409 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35757 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34006 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->