### PR TITLE
Remove special `quirk` mode handling of `labels` with `option` element

### DIFF
--- a/LayoutTests/fast/dom/HTMLOptionElement/option-label-quirksmode-expected.html
+++ b/LayoutTests/fast/dom/HTMLOptionElement/option-label-quirksmode-expected.html
@@ -1,8 +1,8 @@
 <html>
 <body>
-<p>Tests that the option's label is not displayed in quirks mode.</p>
+<p>Tests that the option's label is displayed in quirks mode.</p>
 <select>
-    <option value="X"></option>
+    <option value="X">X</option>
     <option value="-" >-</option>
 </select>
 </body>

--- a/LayoutTests/fast/dom/HTMLOptionElement/option-label-quirksmode.html
+++ b/LayoutTests/fast/dom/HTMLOptionElement/option-label-quirksmode.html
@@ -1,6 +1,6 @@
 <html>
 <body>
-<p>Tests that the option's label is not displayed in quirks mode.</p>
+<p>Tests that the option's label is displayed in quirks mode.</p>
 <select>
     <option value="X" label="X"></option>
     <option value="-" >-</option>

--- a/LayoutTests/fast/dom/HTMLOptionElement/option-label-quirksmode2-expected.html
+++ b/LayoutTests/fast/dom/HTMLOptionElement/option-label-quirksmode2-expected.html
@@ -1,8 +1,8 @@
 <html>
 <body>
-<p>Tests that the option's label is not displayed in quirks mode.</p>
+<p>Tests that the option's label is displayed in quirks mode.</p>
 <select>
-    <option value="X">X</option>
+    <option value="X">Y</option>
     <option value="-" >-</option>
 </select>
 </body>

--- a/LayoutTests/fast/dom/HTMLOptionElement/option-label-quirksmode2.html
+++ b/LayoutTests/fast/dom/HTMLOptionElement/option-label-quirksmode2.html
@@ -1,6 +1,6 @@
 <html>
 <body>
-<p>Tests that the option's label is not displayed in quirks mode.</p>
+<p>Tests that the option's label is displayed in quirks mode.</p>
 <select>
     <option value="X" label="Y">X</option>
     <option value="-" >-</option>

--- a/LayoutTests/fast/forms/ios/select-option-label-quirks-mode-expected.txt
+++ b/LayoutTests/fast/forms/ios/select-option-label-quirks-mode-expected.txt
@@ -1,10 +1,10 @@
-This test verifies that an option's label attribute is not used as the corresponding menu item's title in quirks mode.
+This test verifies that an option's label attribute is used as the corresponding menu item's title in quirks mode.
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
 PASS select.value is "Option 1 Text"
-PASS areArraysEqual(items, ["Option 1 Text", "", "Option 3 Text"]) is true
+PASS areArraysEqual(items, ["Option 1 Text", "Option 2 Label", "Option 3 Label"]) is true
 PASS select.value is "Option 2 Value"
 PASS successfullyParsed is true
 

--- a/LayoutTests/fast/forms/ios/select-option-label-quirks-mode.html
+++ b/LayoutTests/fast/forms/ios/select-option-label-quirks-mode.html
@@ -15,13 +15,13 @@
 jsTestIsAsync = true;
 
 addEventListener("load", async () => {
-    description("This test verifies that an option's label attribute is not used as the corresponding menu item's title in quirks mode.");
+    description("This test verifies that an option's label attribute is used as the corresponding menu item's title in quirks mode.");
 
     shouldBeEqualToString("select.value", "Option 1 Text");
     await UIHelper.activateElement(select);
 
     items = await UIHelper.selectMenuItems();
-    shouldBeTrue("areArraysEqual(items, " + '["Option 1 Text", "", "Option 3 Text"]' + ")");
+    shouldBeTrue("areArraysEqual(items, " + '["Option 1 Text", "Option 2 Label", "Option 3 Label"]' + ")");
 
     await UIHelper.selectFormAccessoryPickerRow(1);
     await UIHelper.waitForContextMenuToHide();

--- a/Source/WebCore/html/HTMLOptionElement.cpp
+++ b/Source/WebCore/html/HTMLOptionElement.cpp
@@ -290,14 +290,6 @@ String HTMLOptionElement::label() const
     return collectOptionInnerText().trim(isASCIIWhitespace).simplifyWhiteSpace(isASCIIWhitespace);
 }
 
-// Same as label() but ignores the label content attribute in quirks mode for compatibility with other browsers.
-String HTMLOptionElement::displayLabel() const
-{
-    if (document().inQuirksMode())
-        return collectOptionInnerText().trim(isASCIIWhitespace).simplifyWhiteSpace(isASCIIWhitespace);
-    return label();
-}
-
 void HTMLOptionElement::setLabel(const AtomString& label)
 {
     setAttributeWithoutSynchronization(labelAttr, label);
@@ -317,8 +309,8 @@ String HTMLOptionElement::textIndentedToRespectGroupLabel() const
 {
     RefPtr parent = parentNode();
     if (is<HTMLOptGroupElement>(parent))
-        return makeString("    "_s, displayLabel());
-    return displayLabel();
+        return makeString("    "_s, label());
+    return label();
 }
 
 bool HTMLOptionElement::isDisabledFormControl() const

--- a/Source/WebCore/html/HTMLOptionElement.h
+++ b/Source/WebCore/html/HTMLOptionElement.h
@@ -57,7 +57,6 @@ public:
     WEBCORE_EXPORT HTMLSelectElement* ownerSelectElement() const;
 
     WEBCORE_EXPORT String label() const;
-    WEBCORE_EXPORT String displayLabel() const;
     WEBCORE_EXPORT void setLabel(const AtomString&);
 
     bool ownElementDisabled() const { return m_disabled; }

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -4214,7 +4214,7 @@ std::optional<FocusedElementInformation> WebPage::focusedElementInformation()
                     information.selectOptions.append(OptionItem(emptyString(), true, false, false, parentGroupID));
                 }
 
-                information.selectOptions.append(OptionItem(optionElement->displayLabel(), false, optionElement->selected(), optionElement->hasAttributeWithoutSynchronization(WebCore::HTMLNames::disabledAttr), parentGroupID));
+                information.selectOptions.append(OptionItem(optionElement->label(), false, optionElement->selected(), optionElement->hasAttributeWithoutSynchronization(WebCore::HTMLNames::disabledAttr), parentGroupID));
             } else if (auto* optGroupElement = dynamicDowncast<HTMLOptGroupElement>(item.get())) {
                 if (selectPickerUsesMenu)
                     parentGroup = optGroupElement;


### PR DESCRIPTION
#### 7f73e6048a4592575300e0781d1b69277801876f
<pre>
Remove special `quirk` mode handling of `labels` with `option` element
<a href="https://bugs.webkit.org/show_bug.cgi?id=293543">https://bugs.webkit.org/show_bug.cgi?id=293543</a>

Reviewed by Aditya Keerthi.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

This patch removes special case of `quirk` mode of `labels` with `option`
element and now will use `label` attribute matching &apos;standards&apos; mode, which
was previously ignored.

It was discussed in following github issue [1]:

[1] <a href="https://github.com/whatwg/html/issues/2988">https://github.com/whatwg/html/issues/2988</a>

Blink rolled out this change in 2023 and haven&apos;t reverted behavior to
reflect that there were not any compatibility issues, if there would be
in case of WebKit, it is easier to rollout as well.

Unfortunately, we cannot enable corresponding WPT test case yet [2] since
we still have 0.07% pixel differences due to borders of &apos;select&apos; element
but we do match now other browser on showing labels inside.

[2] html/rendering/widgets/the-select-element/option-add-label-quirks.html

* Source/WebCore/html/HTMLOptionElement.cpp:
(WebCore::HTMLOptionElement::textIndentedToRespectGroupLabel const):
(WebCore::HTMLOptionElement::displayLabel const): Deleted.
* Source/WebCore/html/HTMLOptionElement.h:
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::focusedElementInformation):

It is good to keep these local tests till we don&apos;t progress WPT properly,
this is just updating test expectations to match new behavior.
* LayoutTests/fast/dom/HTMLOptionElement/option-label-quirksmode-expected.html:
* LayoutTests/fast/dom/HTMLOptionElement/option-label-quirksmode.html:
* LayoutTests/fast/dom/HTMLOptionElement/option-label-quirksmode2-expected.html:
* LayoutTests/fast/dom/HTMLOptionElement/option-label-quirksmode2.html:
* LayoutTests/fast/forms/ios/select-option-label-quirks-mode-expected.txt:
* LayoutTests/fast/forms/ios/select-option-label-quirks-mode.html:

Canonical link: <a href="https://commits.webkit.org/295503@main">https://commits.webkit.org/295503@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1cec4a1aee19e5ed5388fac5a57e46e3a8b28dc4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105244 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24956 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15381 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110457 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/55902 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/107285 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/25386 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33500 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79938 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108250 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19792 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94990 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60240 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/19546 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13064 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55298 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/89247 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13108 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/113052 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32404 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23869 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89012 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32768 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91206 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88649 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22612 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33541 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11327 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/27813 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32327 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/37739 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32106 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35451 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33674 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->