### PR TITLE
CSS style 'filter: drop-shadow...' does not render correctly without repaint.

### DIFF
--- a/LayoutTests/compositing/filters/sw-nested-shadow-overlaps-hw-nested-shadow-expected.txt
+++ b/LayoutTests/compositing/filters/sw-nested-shadow-overlaps-hw-nested-shadow-expected.txt
@@ -7,14 +7,14 @@
       (contentsOpaque 1)
       (children 2
         (GraphicsLayer
-          (offsetFromRenderer width=-100 height=-100)
-          (position 230.00 230.00)
-          (anchor 0.75 0.75)
-          (bounds 200.00 200.00)
+          (offsetFromRenderer width=-150 height=-150)
+          (position 180.00 180.00)
+          (anchor 0.80 0.80)
+          (bounds 250.00 250.00)
           (drawsContent 1)
         )
         (GraphicsLayer
-          (bounds 200.00 200.00)
+          (bounds 250.00 250.00)
           (drawsContent 1)
         )
       )

--- a/LayoutTests/compositing/geometry/bounds-with-filters-expected.txt
+++ b/LayoutTests/compositing/geometry/bounds-with-filters-expected.txt
@@ -1,0 +1,35 @@
+Not
+overflowing
+Have some layout overflow
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (contentsOpaque 1)
+      (children 3
+        (GraphicsLayer
+          (position 58.00 50.00)
+          (bounds 100.00 100.00)
+          (contentsOpaque 1)
+          (drawsContent 1)
+        )
+        (GraphicsLayer
+          (position 58.00 200.00)
+          (bounds 100.00 100.00)
+          (contentsOpaque 1)
+          (drawsContent 1)
+        )
+        (GraphicsLayer
+          (offsetFromRenderer width=-28 height=-28)
+          (position 30.00 322.00)
+          (anchor 0.34 0.50)
+          (bounds 228.00 156.00)
+          (drawsContent 1)
+        )
+      )
+    )
+  )
+)
+

--- a/LayoutTests/compositing/geometry/bounds-with-filters.html
+++ b/LayoutTests/compositing/geometry/bounds-with-filters.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        .box {
+            margin: 50px;
+            width: 100px;
+            height: 100px;
+            background-color: green;
+            filter: drop-shadow(0 0 10px);
+        }
+
+        .composited {
+            transform: translateZ(0);
+        }
+        
+        .overflowing {
+            width: 200px;
+        }
+    </style>
+</head>
+<body>
+    <div class="composited box"></div>
+    <div class="composited box">
+        <div>Not<br>overflowing</div>
+    </div>
+    <div class="composited box">
+        <div class="overflowing">Have some layout overflow</div>
+    </div>
+<pre id="layers"></pre>
+    <script>
+        if (window.testRunner) {
+            testRunner.dumpAsText();
+            document.getElementById('layers').innerText = window.internals.layerTreeAsText(document);
+        }
+    </script>
+</body>
+</html>

--- a/LayoutTests/css3/filters/drop-shadow-target-clipped.html
+++ b/LayoutTests/css3/filters/drop-shadow-target-clipped.html
@@ -6,19 +6,19 @@
         background-color: black;
     }
     .drop-shadow-red {
-        top: -1000px;
-        left: -1000px;
-        filter: drop-shadow(1000px 1000px 0 red);
+        top: -800px;
+        left: -800px;
+        filter: drop-shadow(800px 800px 0 red);
     }
     .drop-shadow-green {
-        top: -1000px;
-        left: -1000px;
-        filter: drop-shadow(900px 900px 0 green);
+        top: -800px;
+        left: -800px;
+        filter: drop-shadow(700px 700px 0 green);
     }
     .drop-shadow-blue {
-        top: -1000px;
-        left: -1000px;
-        filter: drop-shadow(800px 800px 0 blue);
+        top: -800px;
+        left: -800px;
+        filter: drop-shadow(600px 600px 0 blue);
     }
 </style>
 <body>

--- a/LayoutTests/fast/hidpi/filters-drop-shadow.html
+++ b/LayoutTests/fast/hidpi/filters-drop-shadow.html
@@ -1,14 +1,14 @@
-<meta name="fuzzy" content="maxDifference=0-60; totalPixels=0-1200" />
+<meta name="fuzzy" content="maxDifference=0-60; totalPixels=0-2400" />
 <script src="resources/ensure-hidpi.js"></script>
 <style>
     div {
         width: 300px;
         height: 300px;
-        top: -1000px;
-        left: -1000px;
+        top: -800px;
+        left: -800px;
         background-color: red;
         position: relative;
-        filter: drop-shadow(1000px 1000px 0 green);
+        filter: drop-shadow(800px 800px 0 green);
     }
 </style>
 <body>

--- a/LayoutTests/fast/repaint/blur-change-expected.txt
+++ b/LayoutTests/fast/repaint/blur-change-expected.txt
@@ -1,0 +1,14 @@
+Test repaint rects when the drop-shadow filter property changes
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+(repaint rects
+  (rect 24 36 268 268)
+  (rect 24 256 268 268)
+)
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/repaint/blur-change.html
+++ b/LayoutTests/fast/repaint/blur-change.html
@@ -1,0 +1,58 @@
+<html>
+<head>
+    <style>
+        .box {
+            width: 100px;
+            height: 100px;
+            margin: 120px 100px;
+            background-color: silver;
+        }
+        
+        .box.bigtosmall {
+            filter: blur(30px);
+        }
+        
+        .box.smalltobig {
+            filter: blur(1px);
+        }
+        
+        body.changed .box.bigtosmall {
+            filter: blur(1px);
+        }
+
+        body.changed .box.smalltobig {
+            filter: blur(30px);
+        }
+    </style>
+    <script src="../../resources/js-test.js"></script>
+    <script src="../../resources/ui-helper.js"></script>
+    <script>
+        jsTestIsAsync = true;
+
+        var layerTreeAsText;
+        window.addEventListener('load', async () => {
+            description("Test repaint rects when the drop-shadow filter property changes");
+            await UIHelper.renderingUpdate();
+
+            if (window.internals)
+                internals.startTrackingRepaints();
+            
+            await UIHelper.delayFor(1500);
+        
+            document.body.classList.add('changed');
+
+            if (window.internals) {
+                debug(window.internals.repaintRectsAsText());
+                internals.stopTrackingRepaints();
+            }
+
+            finishJSTest();
+        }, false);
+    </script>
+</head>
+<body>
+    <div class="box smalltobig"></div>
+    <div class="box bigtosmall"></div>
+
+    <div id="console"></div>
+</html>

--- a/LayoutTests/fast/repaint/drop-shadow-box-change-expected.txt
+++ b/LayoutTests/fast/repaint/drop-shadow-box-change-expected.txt
@@ -1,0 +1,13 @@
+Test repaint rects when a box with drop-shadow changes size
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+(repaint rects
+  (rect 192 192 206 156)
+)
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/repaint/drop-shadow-box-change.html
+++ b/LayoutTests/fast/repaint/drop-shadow-box-change.html
@@ -1,0 +1,45 @@
+<html>
+<head>
+    <style>
+        .box {
+            position: absolute;
+            top: 200px;
+            left: 200px;
+            width: 100px;
+            height: 100px;
+            background-color: silver;
+            filter: drop-shadow(20px 20px 10px black);
+        }
+        
+        body.changed .box {
+            width: 150px;
+        }
+    </style>
+    <script src="../../resources/js-test.js"></script>
+    <script src="../../resources/ui-helper.js"></script>
+    <script>
+        jsTestIsAsync = true;
+
+        var layerTreeAsText;
+        window.addEventListener('load', async () => {
+            description("Test repaint rects when a box with drop-shadow changes size");
+            await UIHelper.renderingUpdate();
+
+            if (window.internals)
+                internals.startTrackingRepaints();
+        
+            document.body.classList.add('changed');
+
+            if (window.internals) {
+                debug(window.internals.repaintRectsAsText());
+                internals.stopTrackingRepaints();
+            }
+
+            finishJSTest();
+        }, false);
+    </script>
+</head>
+<body>
+    <div class="box"></div>
+    <div id="console"></div>
+</html>

--- a/LayoutTests/fast/repaint/drop-shadow-change-expected.txt
+++ b/LayoutTests/fast/repaint/drop-shadow-change-expected.txt
@@ -1,0 +1,14 @@
+Test repaint rects when the drop-shadow filter property changes
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+(repaint rects
+  (rect 108 100 100 100)
+  (rect 100 92 156 156)
+)
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/repaint/drop-shadow-change.html
+++ b/LayoutTests/fast/repaint/drop-shadow-change.html
@@ -1,0 +1,42 @@
+<html>
+<head>
+    <style>
+        .box {
+            width: 100px;
+            height: 100px;
+            margin: 100px;
+            background-color: silver;
+        }
+        
+        body.changed .box {
+            filter: drop-shadow(20px 20px 10px black);
+        }
+    </style>
+    <script src="../../resources/js-test.js"></script>
+    <script src="../../resources/ui-helper.js"></script>
+    <script>
+        jsTestIsAsync = true;
+
+        var layerTreeAsText;
+        window.addEventListener('load', async () => {
+            description("Test repaint rects when the drop-shadow filter property changes");
+            await UIHelper.renderingUpdate();
+
+            if (window.internals)
+                internals.startTrackingRepaints();
+        
+            document.body.classList.add('changed');
+
+            if (window.internals) {
+                debug(window.internals.repaintRectsAsText());
+                internals.stopTrackingRepaints();
+            }
+
+            finishJSTest();
+        }, false);
+    </script>
+</head>
+<body>
+    <div class="box"></div>
+    <div id="console"></div>
+</html>

--- a/LayoutTests/fast/repaint/drop-shadow-writing-modes-expected.txt
+++ b/LayoutTests/fast/repaint/drop-shadow-writing-modes-expected.txt
@@ -1,0 +1,14 @@
+Test repaint rects when the drop-shadow filter property changes
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+(repaint rects
+  (rect 108 100 100 100)
+  (rect 60 92 156 156)
+)
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/repaint/drop-shadow-writing-modes.html
+++ b/LayoutTests/fast/repaint/drop-shadow-writing-modes.html
@@ -1,0 +1,43 @@
+<html>
+<head>
+    <style>
+        .box {
+            writing-mode:vertical-rl;
+            width: 100px;
+            height: 100px;
+            margin: 100px;
+            background-color: silver;
+        }
+        
+        body.changed .box {
+            filter: drop-shadow(-20px 20px 10px black);
+        }
+    </style>
+    <script src="../../resources/js-test.js"></script>
+    <script src="../../resources/ui-helper.js"></script>
+    <script>
+        jsTestIsAsync = true;
+
+        var layerTreeAsText;
+        window.addEventListener('load', async () => {
+            description("Test repaint rects when the drop-shadow filter property changes");
+            await UIHelper.renderingUpdate();
+            
+            if (window.internals)
+                internals.startTrackingRepaints();
+        
+            document.body.classList.add('changed');
+
+            if (window.internals) {
+                debug(window.internals.repaintRectsAsText());
+                internals.stopTrackingRepaints();
+            }
+
+            finishJSTest();
+        }, false);
+    </script>
+</head>
+<body>
+    <div class="box"></div>
+    <div id="console"></div>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/filters-drop-shadow-002.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/filters-drop-shadow-002.html
@@ -4,7 +4,8 @@
 <link rel="help" href="https://drafts.fxtf.org/filter-effects-1/#FilterProperty">
 <link rel="help" href="https://bugs.chromium.org/p/chromium/issues/detail?id=350411">
 <link rel="match" href="reference/filters-drop-shadow-002-ref.html">
-<meta name="assert" content="Check that clipping gets correctly applied on children of a container with a drop-shadow filter in effect."/>
+<meta name="assert" content="Check that clipping gets correctly applied on children of a container with a drop-shadow filter in effect.">
+<meta name="fuzzy" content="maxDifference=0-2; totalPixels=0-1640">
 
 <style>
 .container {

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -4790,6 +4790,7 @@ imported/w3c/web-platform-tests/css/filter-effects/filter-function/filter-functi
 imported/w3c/web-platform-tests/css/filter-effects/filter-function/filter-function-repeating-linear-gradient.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/filter-effects/filter-function/filter-function-repeating-radial-gradient.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/filter-effects/backdrop-filter-plus-mask-large.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/css/filter-effects/filters-drop-shadow-003.html [ Pass ImageOnlyFailure ]
 
 http/tests/site-isolation/mouse-events/ [ Skip ]
 webkit.org/b/257904 http/tests/site-isolation/draw-after-navigation.html [ Skip ]

--- a/LayoutTests/platform/win/compositing/geometry/bounds-with-filters-expected.txt
+++ b/LayoutTests/platform/win/compositing/geometry/bounds-with-filters-expected.txt
@@ -1,0 +1,39 @@
+Not
+overflowing
+Have some layout overflow
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (usingTiledLayer 1)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (contentsOpaque 1)
+      (children 3
+        (GraphicsLayer
+          (position 58.00 50.00)
+          (bounds 100.00 100.00)
+          (usingTiledLayer 1)
+          (contentsOpaque 1)
+          (drawsContent 1)
+        )
+        (GraphicsLayer
+          (position 58.00 200.00)
+          (bounds 100.00 100.00)
+          (usingTiledLayer 1)
+          (contentsOpaque 1)
+          (drawsContent 1)
+        )
+        (GraphicsLayer
+          (offsetFromRenderer width=-28 height=-28)
+          (position 30.00 322.00)
+          (anchor 0.34 0.50)
+          (bounds 228.00 156.00)
+          (usingTiledLayer 1)
+          (drawsContent 1)
+        )
+      )
+    )
+  )
+)
+

--- a/LayoutTests/svg/filters/feMerge-nodes-unite-outsets-expected.html
+++ b/LayoutTests/svg/filters/feMerge-nodes-unite-outsets-expected.html
@@ -4,9 +4,8 @@
     <style>
         .shadow-box {
             position: absolute;
-            top: 10px;
-            left: 10px;
-            display: inline-block;
+            top: 180px;
+            left: 30px;
             width: 200px;
             height: 200px;
             background-color: green;

--- a/LayoutTests/svg/filters/feMerge-nodes-unite-outsets.html
+++ b/LayoutTests/svg/filters/feMerge-nodes-unite-outsets.html
@@ -4,14 +4,14 @@
     <meta name="fuzzy" content="maxDifference=0-255; totalPixels=0-18081" />
     <style>
         svg {
-            width: 0;
-            height: 0;
+            width: 0px;
+            height: 0px;
+            border: 1px solid black;
         }
         .shadow-box {
             position: absolute;
-            top: 30px;
-            left: 30px;
-            display: inline-block;
+            top: 200px;
+            left: 50px;
             width: 200px;
             height: 200px;
             background-color: green;
@@ -20,7 +20,7 @@
     </style>
 </head>
 <body>
-	<svg viewBox="0 0 1440 300">
+    <svg viewBox="0 0 400 400">
         <defs>
             <filter id="filter">
                 <feDropShadow dx="0" dy="0" stdDeviation="100" flood-color="black" result="drop-shadow" />
@@ -43,6 +43,7 @@
                 </feMerge>
             </filter>
         </defs>
+        <rect x=50 y=50 width=200 height=200 filter=url(#filter) fill="green">
     </svg>
     <div class="shadow-box"></div>
 </body>

--- a/Source/WebCore/rendering/CSSFilterRenderer.cpp
+++ b/Source/WebCore/rendering/CSSFilterRenderer.cpp
@@ -85,7 +85,7 @@ CSSFilterRenderer::CSSFilterRenderer(Vector<Ref<FilterFunction>>&& functions, co
     clampFilterRegionIfNeeded();
 }
 
-static RefPtr<SVGFilterElement> referenceFilterElement(const Style::FilterReference& filterReference, RenderElement& renderer)
+static RefPtr<SVGFilterElement> referenceFilterElement(const Style::FilterReference& filterReference, const RenderElement& renderer)
 {
     RefPtr filterElement = ReferencedSVGResources::referencedFilterElement(protect(renderer.treeScopeForSVGReferences()), filterReference);
 
@@ -100,7 +100,7 @@ static RefPtr<SVGFilterElement> referenceFilterElement(const Style::FilterRefere
     return filterElement;
 }
 
-static bool isIdentityReferenceFilter(const Style::FilterReference& filterReference, RenderElement& renderer)
+static bool isIdentityReferenceFilter(const Style::FilterReference& filterReference, const RenderElement& renderer)
 {
     RefPtr filterElement = referenceFilterElement(filterReference, renderer);
     if (!filterElement)
@@ -109,7 +109,7 @@ static bool isIdentityReferenceFilter(const Style::FilterReference& filterRefere
     return SVGFilterRenderer::isIdentity(*filterElement);
 }
 
-static IntOutsets calculateReferenceFilterOutsets(const Style::FilterReference& filterReference, RenderElement& renderer, const FloatRect& targetBoundingBox)
+static IntOutsets calculateReferenceFilterOutsets(const Style::FilterReference& filterReference, const RenderElement& renderer, const FloatRect& targetBoundingBox)
 {
     RefPtr filterElement = referenceFilterElement(filterReference, renderer);
     if (!filterElement)
@@ -260,7 +260,7 @@ void CSSFilterRenderer::setFilterRegion(const FloatRect& filterRegion)
     clampFilterRegionIfNeeded();
 }
 
-bool CSSFilterRenderer::isIdentity(RenderElement& renderer, const Style::Filter& filter)
+bool CSSFilterRenderer::isIdentity(const RenderElement& renderer, const Style::Filter& filter)
 {
     if (filter.hasFilterThatShouldBeRestrictedBySecurityOrigin())
         return false;
@@ -281,7 +281,7 @@ bool CSSFilterRenderer::isIdentity(RenderElement& renderer, const Style::Filter&
     return true;
 }
 
-IntOutsets CSSFilterRenderer::calculateOutsets(RenderElement& renderer, const Style::Filter& filter, const FloatRect& targetBoundingBox)
+IntOutsets CSSFilterRenderer::calculateOutsets(const RenderElement& renderer, const Style::Filter& filter, const FloatRect& targetBoundingBox)
 {
     IntOutsets outsets;
 

--- a/Source/WebCore/rendering/CSSFilterRenderer.h
+++ b/Source/WebCore/rendering/CSSFilterRenderer.h
@@ -58,8 +58,8 @@ public:
     RefPtr<FilterImage> apply(FilterImage* sourceImage, FilterResults&) final;
     FilterStyleVector createFilterStyles(GraphicsContext&, const FilterStyle& sourceStyle) const final;
 
-    static bool isIdentity(RenderElement&, const Style::Filter&);
-    static IntOutsets calculateOutsets(RenderElement&, const Style::Filter&, const FloatRect& targetBoundingBox);
+    static bool isIdentity(const RenderElement&, const Style::Filter&);
+    static IntOutsets calculateOutsets(const RenderElement&, const Style::Filter&, const FloatRect& targetBoundingBox);
 
 private:
     CSSFilterRenderer(const FilterGeometry&, OptionSet<FilterRenderingOption>, bool hasFilterThatMovesPixels, bool hasFilterThatShouldBeRestrictedBySecurityOrigin);

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -31,6 +31,7 @@
 #include "BorderPainter.h"
 #include "BorderShape.h"
 #include "ContainerNodeInlines.h"
+#include "CSSFilter.h"
 #include "CSSFontSelector.h"
 #include "Document.h"
 #include "EditingInlines.h"
@@ -4631,12 +4632,28 @@ bool RenderBox::avoidsFloats() const
     return false;
 }
 
+IntBoxExtent RenderBox::computeFilterOutsets() const
+{
+    if (!hasFilter())
+        return { };
+
+    auto zoom = style().usedZoomForLength();
+
+    if (auto outsets = style().filter().calculateOutsets(zoom))
+        return *outsets;
+
+    // FIXME: Need to compute outsets for reference filters: webkit.org/b/237538.
+    return { };
+}
+
 void RenderBox::addVisualEffectOverflow()
 {
     bool hasBoxShadow = !style().boxShadow().isNone();
     bool hasBorderImageOutsets = style().hasBorderImageOutsets();
     bool hasOutline = outlineStyleForRepaint().hasOutlineInVisualOverflow();
-    if (!hasBoxShadow && !hasBorderImageOutsets && !hasOutline)
+    bool hasInflatingFilters = hasFilter() && !computeFilterOutsets().isZero();
+
+    if (!hasBoxShadow && !hasBorderImageOutsets && !hasOutline && !hasInflatingFilters)
         return;
 
     addVisualOverflow(applyVisualEffectOverflow(borderBoxRect()));
@@ -4645,7 +4662,8 @@ void RenderBox::addVisualEffectOverflow()
         fragmentedFlow->addFragmentsVisualEffectOverflow(*this);
 }
 
-static void NODELETE convertOutsetsToOverflowCoordinates(LayoutBoxExtent& outsets, WritingMode writingMode)
+template<typename T>
+static void NODELETE convertOutsetsToOverflowCoordinates(RectEdges<T>& outsets, WritingMode writingMode)
 {
     switch (writingMode.blockDirection()) {
     case FlowDirection::TopToBottom:
@@ -4660,7 +4678,7 @@ static void NODELETE convertOutsetsToOverflowCoordinates(LayoutBoxExtent& outset
     }
 }
 
-LayoutRect RenderBox::applyVisualEffectOverflow(const LayoutRect& borderBox) const
+LayoutRect RenderBox::applyVisualEffectOverflow(const LayoutRect& borderBox, EnumSet<VisualEffectOverflowOption> options) const
 {
     LayoutUnit overflowMinX = borderBox.x();
     LayoutUnit overflowMaxX = borderBox.maxX();
@@ -4693,12 +4711,24 @@ LayoutRect RenderBox::applyVisualEffectOverflow(const LayoutRect& borderBox) con
     }
 
     if (outlineStyleForRepaint().hasOutlineInVisualOverflow()) {
-        LayoutUnit outlineSize { outlineStyleForRepaint().usedOutlineSize() };
+        auto outlineSize = LayoutUnit { outlineStyleForRepaint().usedOutlineSize() };
+
         overflowMinX = std::min(overflowMinX, borderBox.x() - outlineSize);
         overflowMaxX = std::max(overflowMaxX, borderBox.maxX() + outlineSize);
         overflowMinY = std::min(overflowMinY, borderBox.y() - outlineSize);
         overflowMaxY = std::max(overflowMaxY, borderBox.maxY() + outlineSize);
     }
+
+    if (hasFilter() && !options.contains(VisualEffectOverflowOption::ExcludeFilterOutsets)) {
+        auto outsets = computeFilterOutsets();
+        convertOutsetsToOverflowCoordinates(outsets, writingMode());
+
+        overflowMinX = std::min(overflowMinX, borderBox.x() - outsets.left());
+        overflowMaxX = std::max(overflowMaxX, borderBox.maxX() + outsets.right());
+        overflowMinY = std::min(overflowMinY, borderBox.y() - outsets.top());
+        overflowMaxY = std::max(overflowMaxY, borderBox.maxY() + outsets.bottom());
+    }
+
     // Add in the final overflow with shadows and outsets combined.
     return LayoutRect(overflowMinX, overflowMinY, overflowMaxX - overflowMinX, overflowMaxY - overflowMinY);
 }
@@ -4779,6 +4809,14 @@ void RenderBox::addOverflowWithRendererOffset(const RenderBox& renderer, LayoutS
     if (!childVisualOverflowRect)
         computeChildVisualOverflowRect();
     addVisualOverflow(*childVisualOverflowRect);
+}
+
+bool RenderBox::hasLayoutOverflow() const
+{
+    if (!m_overflow)
+        return false;
+
+    return !flippedClientBoxRect().contains(m_overflow->layoutOverflowRect());
 }
 
 LayoutOptionalOutsets RenderBox::allowedLayoutOverflow() const

--- a/Source/WebCore/rendering/RenderBox.h
+++ b/Source/WebCore/rendering/RenderBox.h
@@ -160,6 +160,7 @@ public:
     inline const LayoutRect scrollableContentAreaOverflowRect() const;
     inline const LayoutRect scrollablePaddingAreaOverflowRect() const;
     LayoutRect layoutOverflowRect() const { return m_overflow ? m_overflow->layoutOverflowRect() : flippedClientBoxRect(); }
+    bool hasLayoutOverflow() const;
     inline LayoutUnit logicalLeftLayoutOverflow() const;
     inline LayoutUnit logicalRightLayoutOverflow() const;
     LayoutRect visualOverflowRect() const { return m_overflow ? m_overflow->visualOverflowRect() : borderBoxRect(); }
@@ -174,8 +175,14 @@ public:
     void clearOverflow();
     RenderOverflow& ensureOverflow();
 
+    IntBoxExtent computeFilterOutsets() const;
+
     void addVisualEffectOverflow();
-    LayoutRect applyVisualEffectOverflow(const LayoutRect&) const;
+
+    enum class VisualEffectOverflowOption : uint8_t {
+        ExcludeFilterOutsets,
+    };
+    LayoutRect applyVisualEffectOverflow(const LayoutRect&, EnumSet<VisualEffectOverflowOption> = { }) const;
 
     enum class ComputeOverflowOptions : uint8_t {
         None,

--- a/Source/WebCore/rendering/RenderImage.cpp
+++ b/Source/WebCore/rendering/RenderImage.cpp
@@ -409,6 +409,7 @@ void RenderImage::repaintOrMarkForLayout(ImageSizeChangeType imageSizeChange, co
             FloatSize sourceSize = srcImg->size() / style().usedZoom();
             repaintRect.intersect(enclosingIntRect(mapRect(*rect, FloatRect(FloatPoint(), sourceSize), repaintRect)));
         }
+        // FIXME: This needs to account for filter outsets: webkit.org/b/293553.
         repaintRectangle(repaintRect);
     }
 

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -5579,6 +5579,9 @@ LayoutRect RenderLayer::localBoundingBox(OptionSet<CalculateLayerBoundsFlag> fla
         if (!(flags & DontConstrainForMask) && box->hasMask()) {
             result = box->maskClipRect(LayoutPoint());
             box->flipForWritingMode(result); // The mask clip rect is in physical coordinates, so we have to flip, since localBoundingBox is not.
+        } else if (flags.contains(ExcludeFilterOutsetsFromSelfBounds) && !box->hasLayoutOverflow()) {
+            ASSERT(box->hasFilter());
+            result = box->applyVisualEffectOverflow(box->borderBoxRect(), { RenderBox::VisualEffectOverflowOption::ExcludeFilterOutsets });
         } else
             result = box->visualOverflowRect();
 
@@ -5672,6 +5675,7 @@ LayoutRect RenderLayer::overlapBounds() const
 
     return localBoundingBox();
 }
+
 LayoutRect RenderLayer::calculateLayerBounds(const RenderLayer* ancestorLayer, const LayoutSize& offsetFromRoot, OptionSet<CalculateLayerBoundsFlag> flags) const
 {
     if (!isSelfPaintingLayer())
@@ -5689,7 +5693,14 @@ LayoutRect RenderLayer::calculateLayerBounds(const RenderLayer* ancestorLayer, c
         return renderer().view().unscaledDocumentRect();
     }
 
-    LayoutRect boundingBoxRect = localBoundingBox(flags | IncludeRootBackgroundPaintingArea);
+    auto localBoundingBoxFlags = flags | IncludeRootBackgroundPaintingArea;
+    // When filters are composited, the compositor applies the filter effect, so the backing
+    // layer should not be inflated by filter outsets; compute bounds excluding
+    // filter outsets when possible.
+    if (isComposited() && renderer().hasFilter() && !shouldPaintWithFilters())
+        localBoundingBoxFlags.add(ExcludeFilterOutsetsFromSelfBounds);
+
+    LayoutRect boundingBoxRect = localBoundingBox(localBoundingBoxFlags);
     if (renderer().view().frameView().hasFlippedBlockRenderers()) {
         if (CheckedPtr box = dynamicDowncast<RenderBox>(renderer()))
             box->flipForWritingMode(boundingBoxRect);
@@ -6509,9 +6520,16 @@ void RenderLayer::updateFilterPaintingStrategy()
 
 IntOutsets RenderLayer::filterOutsets() const
 {
+    if (!renderer().hasFilter())
+        return { };
+
     if (m_filters)
         return m_filters->calculateOutsets(renderer(), localBoundingBox());
-    return renderer().style().filter().calculateOutsets(renderer().style().usedZoomForLength());
+
+    if (CheckedPtr boxRenderer = renderBox())
+        return boxRenderer->computeFilterOutsets();
+
+    return { };
 }
 
 void RenderLayer::clearFilters()

--- a/Source/WebCore/rendering/RenderLayer.h
+++ b/Source/WebCore/rendering/RenderLayer.h
@@ -672,7 +672,6 @@ public:
     RenderLayer* enclosingFilterLayer(IncludeSelfOrNot = IncludeSelf) const;
     RenderLayer* enclosingFilterRepaintLayer() const;
     void setFilterBackendNeedsRepaintingInRect(const LayoutRect&);
-    bool hasAncestorWithFilterOutsets() const;
 
     inline bool NODELETE canUseOffsetFromAncestor() const;
     bool NODELETE canUseOffsetFromAncestor(const RenderLayer& ancestor) const;
@@ -785,6 +784,7 @@ public:
         PreserveAncestorFlags                          = 1 << 10,
         UseLocalClipRectExcludingCompositingIfPossible = 1 << 11,
         ExcludeViewTransitionCapturedDescendants       = 1 << 12,
+        ExcludeFilterOutsetsFromSelfBounds             = 1 << 13,
     };
     static constexpr OptionSet<CalculateLayerBoundsFlag> defaultCalculateLayerBoundsFlags() { return { IncludeSelfTransform, UseLocalClipRectIfPossible, IncludePaintedFilterOutsets, UseFragmentBoxesExcludingCompositing }; }
 
@@ -856,8 +856,10 @@ public:
 
     inline bool hasFilter() const;
     bool hasFilterOutsets() const { return !filterOutsets().isZero(); }
+    bool hasAncestorWithFilterOutsets() const;
     IntOutsets filterOutsets() const;
     void clearFilters();
+
     inline bool hasBackdropFilter() const;
 
     bool hasBackdropFilterDescendantsWithoutRoot() const { return m_hasBackdropFilterDescendantsWithoutRoot; }

--- a/Source/WebCore/style/StyleDifference.cpp
+++ b/Source/WebCore/style/StyleDifference.cpp
@@ -71,9 +71,17 @@ public:
             if (&a.nonInheritedData() == &b.nonInheritedData())
                 return false;
 
-            if (a.nonInheritedData().miscData.ptr() != b.nonInheritedData().miscData.ptr()
-                && a.nonInheritedData().miscData->boxShadow != b.nonInheritedData().miscData->boxShadow)
-                return true;
+            if (a.nonInheritedData().miscData.ptr() != b.nonInheritedData().miscData.ptr()) {
+                if (a.nonInheritedData().miscData->boxShadow != b.nonInheritedData().miscData->boxShadow)
+                    return true;
+
+                if (a.nonInheritedData().miscData->filter.ptr() != b.nonInheritedData().miscData->filter.ptr()) {
+                    auto aOutsets = a.nonInheritedData().miscData->filter->filter.calculateOutsets(a.usedZoomForLength());
+                    auto bOutsets = b.nonInheritedData().miscData->filter->filter.calculateOutsets(b.usedZoomForLength());
+                    if (aOutsets != bOutsets)
+                        return true;
+                }
+            }
 
             if (a.nonInheritedData().backgroundData.ptr() != b.nonInheritedData().backgroundData.ptr()) {
                 auto aHasOutlineInVisualOverflow = a.hasOutlineInVisualOverflow();

--- a/Source/WebCore/style/values/filter-effects/StyleFilter.cpp
+++ b/Source/WebCore/style/values/filter-effects/StyleFilter.cpp
@@ -92,9 +92,10 @@ bool Filter::hasFilterThatShouldBeRestrictedBySecurityOrigin() const
     });
 }
 
-IntOutsets Filter::calculateOutsets(ZoomFactor zoom) const
+std::optional<IntOutsets> Filter::calculateOutsets(ZoomFactor zoom) const
 {
     IntOutsets totalOutsets;
+    bool haveReferenceFilter = false;
     for (auto& filterValue : *this) {
         WTF::switchOn(filterValue,
             [&](const BlurFunction& blurFunction) {
@@ -103,12 +104,16 @@ IntOutsets Filter::calculateOutsets(ZoomFactor zoom) const
             [&](const DropShadowFunction& dropShadowFunction) {
                 totalOutsets += dropShadowFunction->calculateOutsets(zoom);
             },
-            [](const FilterReference&) {
-                ASSERT_NOT_REACHED();
+            [&](const FilterReference&) {
+                haveReferenceFilter = true;
             },
             [](const auto&) { }
         );
     }
+
+    if (haveReferenceFilter)
+        return { };
+
     return totalOutsets;
 }
 

--- a/Source/WebCore/style/values/filter-effects/StyleFilter.h
+++ b/Source/WebCore/style/values/filter-effects/StyleFilter.h
@@ -111,7 +111,7 @@ struct Filter : ListOrNone<FilterValueList> {
     bool hasReferenceFilter() const;
     bool NODELETE isReferenceFilter() const;
 
-    IntOutsets calculateOutsets(ZoomFactor) const;
+    std::optional<IntOutsets> calculateOutsets(ZoomFactor) const;
 };
 DEFINE_TYPE_MAPPING(CSS::Filter, Filter)
 


### PR DESCRIPTION
#### 3210e3e92621749e154066495e94ccbcb6f6afa1
<pre>
CSS style &apos;filter: drop-shadow...&apos; does not render correctly without repaint.
<a href="https://bugs.webkit.org/show_bug.cgi?id=207586">https://bugs.webkit.org/show_bug.cgi?id=207586</a>
<a href="https://rdar.apple.com/59430460">rdar://59430460</a>

Reviewed by Alan Baradlay.

Visual overflow needs to account for CSS filters that move pixels, like `blur()`
and `drop-shadow()` in order for repaint to work. Fix this by having
`RenderBox::applyVisualEffectOverflow()` extend visual overflow for filters,
taking writing mode into account. We also need to trigger layout when visual
overflow due to filter outset changes happen, which is done in
`RenderStyle::changeAffectsVisualOverflow()`; `blur-change.html` tests this.

Since `RenderStyle::filterOutsets()` cannot provide an answer for reference filters,
remove it, and make `FilterOperations::outsets()` return a `std::optional` in this case,
which callers need to handle. Filter outset computation now needs to bottleneck
through `RenderBox::computeFilterOutsets()`.

This change does not correctly repaint descendants of an element with a filter;
a change like <a href="https://github.com/WebKit/WebKit/pull/12797">https://github.com/WebKit/WebKit/pull/12797</a> will be required
to fix this.

This change does also not take into account reference filters, which is tracked
in webkit.org/b/237538.

RenderLayer bounds are now inflated for filters, which results in composited layers
with composited filters getting inflated bounds; this was considered as a reasonable
trade-off for the complexity of recomputing visual overflow ignoring filters.

* LayoutTests/compositing/filters/sw-nested-shadow-overlaps-hw-nested-shadow-expected.txt:
* LayoutTests/compositing/geometry/bounds-with-filters-expected.txt: Added.
* LayoutTests/compositing/geometry/bounds-with-filters.html: Added.
* LayoutTests/css3/filters/drop-shadow-target-clipped.html:
* LayoutTests/fast/hidpi/filters-drop-shadow.html:
* LayoutTests/fast/repaint/blur-change-expected.txt: Added.
* LayoutTests/fast/repaint/blur-change.html: Added.
* LayoutTests/fast/repaint/drop-shadow-box-change-expected.txt: Added.
* LayoutTests/fast/repaint/drop-shadow-box-change.html: Added.
* LayoutTests/fast/repaint/drop-shadow-change-expected.txt: Added.
* LayoutTests/fast/repaint/drop-shadow-change.html: Added.
* LayoutTests/fast/repaint/drop-shadow-writing-modes-expected.txt: Added.
* LayoutTests/fast/repaint/drop-shadow-writing-modes.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/filters-drop-shadow-002.html:
* LayoutTests/platform/ios/TestExpectations: filters-drop-shadow-003.html is failing on bots,
but passes for me locally in sim and on hardware.
* LayoutTests/platform/win/compositing/geometry/bounds-with-filters-expected.txt: Added.
* LayoutTests/svg/filters/feMerge-nodes-unite-outsets-expected.html:
* LayoutTests/svg/filters/feMerge-nodes-unite-outsets.html: This test just seemed
to be wrong and failed after the repaint fix, so fix it.
* Source/WebCore/rendering/CSSFilterRenderer.cpp:
(WebCore::referenceFilterElement):
(WebCore::isIdentityReferenceFilter):
(WebCore::calculateReferenceFilterOutsets):
(WebCore::CSSFilterRenderer::isIdentity):
(WebCore::CSSFilterRenderer::calculateOutsets):
* Source/WebCore/rendering/CSSFilterRenderer.h:
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::computeFilterOutsets const):
(WebCore::RenderBox::addVisualEffectOverflow):
(WebCore::convertOutsetsToOverflowCoordinates): Templatized because filter outsets are
RectEdges&lt;int&gt;.
(WebCore::RenderBox::applyVisualEffectOverflow const):
(WebCore::RenderBox::hasLayoutOverflow const):
* Source/WebCore/rendering/RenderBox.h:
(WebCore::RenderBox::applyVisualEffectOverflow):
* Source/WebCore/rendering/RenderImage.cpp:
(WebCore::RenderImage::repaintOrMarkForLayout):
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::calculateClipRects const):
* Source/WebCore/rendering/RenderLayer.h: hasAncestorWithFilterOutsets() can be private.
* Source/WebCore/style/StyleDifference.cpp:
* Source/WebCore/style/values/filter-effects/StyleFilter.cpp:
(WebCore::Style::Filter::calculateOutsets const):
* Source/WebCore/style/values/filter-effects/StyleFilter.h:

Canonical link: <a href="https://commits.webkit.org/313382@main">https://commits.webkit.org/313382@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8dc4b2d2fc49fc02195d1dad9a7c9f92989e59ef

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162978 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36457 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29639 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171916 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119424 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2779797a-f91b-4f5e-9d54-a1f7f51f68b5) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/164847 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/36863 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36459 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126516 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89119 "Build is in progress. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Skipped layout-tests; Running layout-tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7f44f7ad-c53f-4498-bdea-379f6b3d1381) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165937 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/36863 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146469 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107092 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0d90dbdb-cc30-4a25-9e75-64f6a9ed8d95) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/36863 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26451 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19616 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137646 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24198 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174420 "Built successfully") | | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/25107 "Found 1 new failure in wasm/WasmConstExprGenerator.cpp") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25845 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134827 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36128 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30554 "Found 1 new test failure: imported/w3c/web-platform-tests/dom/events/Event-timestamp-high-resolution.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134822 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36357 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/36586 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145994 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/98638 "Built successfully") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/29833 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22831 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35624 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/106795 "Built successfully") | | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35123 "Hash 8dc4b2d2 for PR 45888 does not build (failure)") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/853 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35370 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35271 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->