### PR TITLE
Add Test Case coverage for `dirty min/max on certain children` for inline and block layouts

### DIFF
--- a/LayoutTests/fast/css-intrinsic-dimensions/fixed-height-stf-img-block-child-percent-height-expected.txt
+++ b/LayoutTests/fast/css-intrinsic-dimensions/fixed-height-stf-img-block-child-percent-height-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS STF fixed height, percent height img
+

--- a/LayoutTests/fast/css-intrinsic-dimensions/fixed-height-stf-img-block-child-percent-height.html
+++ b/LayoutTests/fast/css-intrinsic-dimensions/fixed-height-stf-img-block-child-percent-height.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<div id="container" style="float:left; height:100px;">
+    <!-- 1x1 pixel GIF -->
+    <img id="img" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACwAAAAAAQABAAACAkQBADs=" style="display:block; height:100%;">
+</div>
+<div style="clear:both;"></div>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script>
+    var container = document.getElementById("container");
+    var img = document.getElementById("img");
+    test(function() {
+        assert_equals(container.offsetWidth, 100, "container width");
+        assert_equals(container.offsetHeight, 100, "container height");
+        assert_equals(img.offsetWidth, 100, "image width");
+        assert_equals(img.offsetHeight, 100, "image height");
+
+        container.style.height = "200px";
+        assert_equals(container.offsetWidth, 200, "container width");
+        assert_equals(container.offsetHeight, 200, "container height");
+        assert_equals(img.offsetWidth, 200, "image width");
+        assert_equals(img.offsetHeight, 200, "image height");
+
+        container.style.height = "100px";
+        assert_equals(container.offsetWidth, 100, "container width");
+        assert_equals(container.offsetHeight, 100, "container height");
+        assert_equals(img.offsetWidth, 100, "image width");
+        assert_equals(img.offsetHeight, 100, "image height");
+    }, "STF fixed height, percent height img");
+</script>

--- a/LayoutTests/fast/css-intrinsic-dimensions/fixed-height-stf-img-inline-child-percent-height-expected.txt
+++ b/LayoutTests/fast/css-intrinsic-dimensions/fixed-height-stf-img-inline-child-percent-height-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS STF fixed height, percent height img
+

--- a/LayoutTests/fast/css-intrinsic-dimensions/fixed-height-stf-img-inline-child-percent-height.html
+++ b/LayoutTests/fast/css-intrinsic-dimensions/fixed-height-stf-img-inline-child-percent-height.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<div id="container" style="float:left; height:100px;">
+    <!-- 1x1 pixel GIF -->
+    <img id="img" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACwAAAAAAQABAAACAkQBADs=" style="height:100%;">
+</div>
+<div style="clear:both;"></div>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script>
+    var container = document.getElementById("container");
+    var img = document.getElementById("img");
+    test(function() {
+        assert_equals(container.offsetWidth, 100, "container width");
+        assert_equals(container.offsetHeight, 100, "container height");
+        assert_equals(img.offsetWidth, 100, "image width");
+        assert_equals(img.offsetHeight, 100, "image height");
+
+        container.style.height = "200px";
+        assert_equals(container.offsetWidth, 200, "container width");
+        assert_equals(container.offsetHeight, 200, "container height");
+        assert_equals(img.offsetWidth, 200, "image width");
+        assert_equals(img.offsetHeight, 200, "image height");
+
+        container.style.height = "100px";
+        assert_equals(container.offsetWidth, 100, "container width");
+        assert_equals(container.offsetHeight, 100, "container height");
+        assert_equals(img.offsetWidth, 100, "image width");
+        assert_equals(img.offsetHeight, 100, "image height");
+    }, "STF fixed height, percent height img");
+</script>


### PR DESCRIPTION
#### d0f08b1bb8c1deb154ed6e1e1e43f7ea1d9ef88e
<pre>
Add Test Case coverage for `dirty min/max on certain children` for inline and block layouts

<a href="https://bugs.webkit.org/show_bug.cgi?id=293458">https://bugs.webkit.org/show_bug.cgi?id=293458</a>

Reviewed by Alan Baradlay.

Partial Merge (Tests): <a href="https://source.chromium.org/chromium/chromium/src/+/da2324ac7def06da46cbedba42084461af7db0f1">https://source.chromium.org/chromium/chromium/src/+/da2324ac7def06da46cbedba42084461af7db0f1</a>

We were failing test case for `block` layout, so it is add test case,
so we don&apos;t regress it in future.

* LayoutTests/fast/css-intrinsic-dimensions/fixed-height-stf-img-block-child-percent-height.html:
* LayoutTests/fast/css-intrinsic-dimensions/fixed-height-stf-img-block-child-percent-height-expected.txt:
* LayoutTests/fast/css-intrinsic-dimensions/fixed-height-stf-img-inline-child-percent-height-expected.txt:
* LayoutTests/fast/css-intrinsic-dimensions/fixed-height-stf-img-inline-child-percent-height.html:

Canonical link: <a href="https://commits.webkit.org/295847@main">https://commits.webkit.org/295847@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/38f8deb40bae71e2a07b219a7eaaab60d7b9de14

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/106114 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25863 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/16257 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/111311 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/56710 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/26519 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34366 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80602 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/109118 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/20975 "Found 1 new test failure: fast/forms/state-restore-to-non-edited-controls.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95759 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60924 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/20528 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13862 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/56149 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/90321 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13897 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/114167 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33252 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24536 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89685 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33616 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91992 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89376 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22835 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34240 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/12054 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/28825 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/33177 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32923 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/36273 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34521 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->