### PR TITLE
Align `lists` quirk by extending to have `dir` and `menu` as per Web Specification

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/lists/lists-styles-quirks-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/lists/lists-styles-quirks-expected.txt
@@ -58,7 +58,7 @@ PASS <li> (in <dir>) - counter-set
 PASS <li> (in <dir>) - counter-reset
 PASS <li> (in <dir>) - counter-increment
 PASS <li> (in <dir>) - text-align
-FAIL <li> (in <dir>) - list-style-position assert_equals: expected "outside" but got "inside"
+PASS <li> (in <dir>) - list-style-position
 PASS <dt> - display
 PASS <dt> - margin-top
 PASS <dt> - margin-right
@@ -193,7 +193,7 @@ PASS <li> (in <menu>) - counter-set
 PASS <li> (in <menu>) - counter-reset
 PASS <li> (in <menu>) - counter-increment
 PASS <li> (in <menu>) - text-align
-FAIL <li> (in <menu>) - list-style-position assert_equals: expected "outside" but got "inside"
+PASS <li> (in <menu>) - list-style-position
 PASS <ol>
    <li> - display
 PASS <ol>

--- a/Source/WebCore/css/quirks.css
+++ b/Source/WebCore/css/quirks.css
@@ -2,7 +2,7 @@
  * Additonal style sheet used to render HTML pages in quirks mode.
  *
  * Copyright (C) 2000-2003 Lars Knoll (knoll@kde.org)
- * Copyright (C) 2004, 2006, 2007, 2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2004-2025 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -29,12 +29,12 @@ li {
 }
 
 /* Restore outside position for lists inside lis */
-li :is(ul, ol) {
+li :is(dir, menu, ol, ul) {
     list-style-position: outside;
 }
 
 /* Undo previous two rules for properly nested lists */
-:is(ul, ol) :is(ul, ol, li) {
+:is(dir, menu, ol, ul) :is(dir, menu, ol, ul, li) {
     list-style-position: unset;
 }
 


### PR DESCRIPTION
#### 59dad14edcfba43713eccdb835342ca8505a4ada
<pre>
Align `lists` quirk by extending to have `dir` and `menu` as per Web Specification
<a href="https://bugs.webkit.org/show_bug.cgi?id=293559">https://bugs.webkit.org/show_bug.cgi?id=293559</a>
<a href="https://rdar.apple.com/152011557">rdar://152011557</a>

Reviewed by Tim Nguyen.

This patch aligns WebKit with web specification [1]:

[1] <a href="https://html.spec.whatwg.org/#lists">https://html.spec.whatwg.org/#lists</a>

In 287114@main, we added this quirk only for `ol` and `ul` lists but now
as per web specification, we are extending it to `dir` and `menu` as well.

* Source/WebCore/css/quirks.css:
(li :is(dir, menu, ol, ul)):
(:is(dir, menu, ol, ul) :is(dir, menu, ol, ul, li)):
(li :is(ul, ol)): Deleted.
(:is(ul, ol) :is(ul, ol, li)): Deleted.
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/lists/lists-styles-quirks-expected.txt: Progression

Canonical link: <a href="https://commits.webkit.org/295796@main">https://commits.webkit.org/295796@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fe3991dc1d16cbd933fc74e6e9c4e58362d5af2c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104990 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24704 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15126 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110207 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/55669 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/107031 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/25111 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33248 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79723 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107996 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19538 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94753 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60030 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/19282 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/12832 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55047 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/89003 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/12877 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/112699 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32155 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23659 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88802 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32520 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/90979 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88430 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22796 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33325 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11106 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/27498 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32079 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/37451 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/31872 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35213 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33431 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->