### PR TITLE
[Swift in WebKit] Use swift-format to lint _WebKit_SwiftUI code

### DIFF
--- a/Source/WebKit/_WebKit_SwiftUI/API/View+WebViewModifiers.swift
+++ b/Source/WebKit/_WebKit_SwiftUI/API/View+WebViewModifiers.swift
@@ -67,8 +67,7 @@ extension View {
 
     /// Adds an item-based context menu to a WebView, replacing the default set of context menu items.
     ///
-    /// - Parameters:
-    ///   - menu: A closure that produces the menu. The single parameter to the closure describes the type of webpage element that was acted upon.
+    /// - Parameter menu: A closure that produces the menu. The single parameter to the closure describes the type of webpage element that was acted upon.
     /// - Returns: A view that can display an item-based context menu.
     @available(WK_MAC_TBA, *)
     @available(iOS, unavailable)
@@ -96,6 +95,7 @@ extension View {
     /// not use this behavior and instead provide a custom background using SwiftUI.
     ///
     /// - Parameter visibility: The visibility to use for the background.
+    /// - Returns: A view with the specified content background visibility.
     @available(WK_IOS_TBA, WK_MAC_TBA, WK_XROS_TBA, *)
     @available(watchOS, unavailable)
     @available(tvOS, unavailable)
@@ -109,6 +109,7 @@ extension View {
     ///   - type: The type of value transformed from a ``ScrollGeometry``.
     ///   - transform: A closure that transforms a ``ScrollGeometry`` to your type.
     ///   - action: A closure to run when the transformed data changes.
+    /// - Returns: A view that invokes the action when the relevant part of a web view's scroll geometry changes.
     ///
     /// - Note: The content size of web content may exceed the current size of the view's frame, however it will never be smaller than it.
     @available(WK_IOS_TBA, WK_MAC_TBA, WK_XROS_TBA, *)
@@ -122,6 +123,9 @@ extension View {
         let change = OnScrollGeometryChangeContext {
             AnyHashable(transform($0))
         } action: {
+            // This is a safe force cast because the result of `transform($0)` above is guaranteed to be a `T`,
+            // which is the type of the `base` value of the `AnyHashable` parameters of `action`.
+            // swift-format-ignore: NeverForceUnwrap
             action($0.base as! T, $1.base as! T)
         }
 
@@ -143,6 +147,7 @@ extension View {
     /// - Parameters:
     ///   - behavior: Whether scrolling should be enabled or disabled for this input.
     ///   - input: The input for which to enable or disable scrolling.
+    /// - Returns: A view with the configured scroll input behavior for web views.
     @available(WK_IOS_TBA, WK_MAC_TBA, WK_XROS_TBA, *)
     @available(watchOS, unavailable)
     @available(tvOS, unavailable)

--- a/Source/WebKit/_WebKit_SwiftUI/API/WebPage+SwiftUI.swift
+++ b/Source/WebKit/_WebKit_SwiftUI/API/WebPage+SwiftUI.swift
@@ -45,6 +45,7 @@ extension WebPage {
     ///
     /// - Parameter configuration: The object that specifies the portion of the web page to capture, and other capture-related behaviors.
     /// - Returns: An image that contains the specified portion of the webpage.
+    /// - Throws: An error if a problem occurred when generating the snapshot.
     @available(WK_IOS_TBA, WK_MAC_TBA, WK_XROS_TBA, *)
     @available(watchOS, unavailable)
     @available(tvOS, unavailable)

--- a/Source/WebKit/_WebKit_SwiftUI/API/WebView.swift
+++ b/Source/WebKit/_WebKit_SwiftUI/API/WebView.swift
@@ -67,6 +67,7 @@ public struct WebView: View {
 
     private let storage: Storage
 
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public var body: some View {
         GeometryReader { proxy in
             WebViewRepresentable(page: storage.webPage, safeAreaInsets: proxy.safeAreaInsets)
@@ -83,6 +84,7 @@ public struct WebView: View {
 }
 
 extension WebView {
+    /// A type that defines the behavior of how horizontal swipe gestures trigger backward and forward page navigation.
     @available(WK_IOS_TBA, WK_MAC_TBA, WK_XROS_TBA, *)
     @available(watchOS, unavailable)
     @available(tvOS, unavailable)
@@ -93,10 +95,20 @@ extension WebView {
             case disabled
         }
 
+        /// The automatic behavior.
+        ///
+        /// The web view automatically chooses whether horizontal swipe gestures trigger backward and forward page navigation.
+        /// By default, web views use the ``WebView/BackForwardNavigationGesturesBehavior/enabled`` behavior.
         public static let automatic: BackForwardNavigationGesturesBehavior = .init(.automatic)
 
+        /// Backward and forward navigation gestures are enabled.
+        ///
+        /// The web view allows horizontal swipe gestures to trigger backward and forward page navigation.
         public static let enabled: BackForwardNavigationGesturesBehavior = .init(.enabled)
 
+        /// Backward and forward navigation gestures are disabled.
+        ///
+        /// The web view prevents horizontal swipe gestures from triggering backward and forward page navigation.
         public static let disabled: BackForwardNavigationGesturesBehavior = .init(.disabled)
 
         init(_ value: Value) {
@@ -106,6 +118,7 @@ extension WebView {
         let value: Value
     }
 
+    /// The options for controlling the behavior for how magnification gestures interact with web views.
     @available(WK_IOS_TBA, WK_MAC_TBA, WK_XROS_TBA, *)
     @available(watchOS, unavailable)
     @available(tvOS, unavailable)
@@ -116,11 +129,21 @@ extension WebView {
             case disabled
         }
 
-        public static let automatic: Self = .init(.automatic)
+        /// The automatic behavior.
+        ///
+        /// The web view automatically chooses whether magnify gestures change the web view’s magnification.
+        /// By default, web views use the ``WebView/MagnificationGesturesBehavior/enabled`` behavior.
+        public static let automatic: MagnificationGesturesBehavior = .init(.automatic)
 
-        public static let enabled: Self = .init(.enabled)
+        /// Magnify gestures are enabled.
+        ///
+        /// The web view allows magnify gestures to change its magnification.
+        public static let enabled: MagnificationGesturesBehavior = .init(.enabled)
 
-        public static let disabled: Self = .init(.disabled)
+        /// Magnify gestures are disabled.
+        ///
+        /// The web view prevents magnify gestures from changing its magnification.
+        public static let disabled: MagnificationGesturesBehavior = .init(.disabled)
 
         init(_ value: Value) {
             self.value = value
@@ -129,6 +152,7 @@ extension WebView {
         let value: Value
     }
 
+    /// A type specifying the behavior for the presentation of link previews when pressing a link.
     @available(WK_IOS_TBA, WK_MAC_TBA, WK_XROS_TBA, *)
     @available(watchOS, unavailable)
     @available(tvOS, unavailable)
@@ -139,10 +163,20 @@ extension WebView {
             case disabled
         }
 
+        /// The automatic behavior.
+        ///
+        /// The web view automatically chooses whether pressing a link displays a preview of the destination for the link.
+        /// By default, web views use the ``WebView/LinkPreviewBehavior/enabled`` behavior.
         public static let automatic: LinkPreviewBehavior = .init(.automatic)
 
+        /// Link previews are enabled.
+        ///
+        /// The web view allows pressing a link to display a preview of the destination for the link.
         public static let enabled: LinkPreviewBehavior = .init(.enabled)
 
+        /// Link previews are disabled.
+        ///
+        /// The web view prevents pressing a link from displaying a preview of the destination for the link.
         public static let disabled: LinkPreviewBehavior = .init(.disabled)
 
         init(_ value: Value) {
@@ -152,6 +186,7 @@ extension WebView {
         let value: Value
     }
 
+    /// The behavior that determines whether a web view can display content full screen.
     @available(WK_IOS_TBA, WK_MAC_TBA, WK_XROS_TBA, *)
     @available(watchOS, unavailable)
     @available(tvOS, unavailable)
@@ -162,10 +197,20 @@ extension WebView {
             case disabled
         }
 
+        /// The automatic behavior.
+        ///
+        /// The web view automatically chooses whether content can be displayed in full screen.
+        /// By default, web views use the ``WebView/ElementFullscreenBehavior/disabled`` behavior.
         public static let automatic: ElementFullscreenBehavior = .init(.automatic)
 
+        /// Element full screen is enabled.
+        ///
+        /// The web view allows content to be displayed in full screen.
         public static let enabled: ElementFullscreenBehavior = .init(.enabled)
 
+        /// Element full screen is disabled.
+        ///
+        /// The web view prevents content from being displayed in full screen.
         public static let disabled: ElementFullscreenBehavior = .init(.disabled)
 
         init(_ value: Value) {
@@ -176,15 +221,12 @@ extension WebView {
     }
 
     /// Contains information about an element the user activated in a webpage, which may be used to configure a context menu for that element.
+    ///
     /// For links, the information contains the URL that is linked to.
     @available(WK_IOS_TBA, WK_MAC_TBA, WK_XROS_TBA, *)
     @available(watchOS, unavailable)
     @available(tvOS, unavailable)
     public struct ActivatedElementInfo: Hashable, Sendable {
-        init(linkURL: URL?) {
-            self.linkURL = linkURL
-        }
-
         /// The URL of the link that the user clicked.
         public let linkURL: URL?
     }

--- a/Source/WebKit/_WebKit_SwiftUI/Implementation/CocoaWebViewAdapter.swift
+++ b/Source/WebKit/_WebKit_SwiftUI/Implementation/CocoaWebViewAdapter.swift
@@ -229,9 +229,10 @@ class CocoaWebViewAdapter: CocoaView, PlatformTextSearching {
             webView.bottomAnchor.constraint(equalTo: bottomAnchor),
         ]
 
-        webViewHeightConstraint = webView.heightAnchor.constraint(equalTo: heightAnchor)
+        let heightConstraint = webView.heightAnchor.constraint(equalTo: heightAnchor)
+        self.webViewHeightConstraint = heightConstraint
 
-        NSLayoutConstraint.activate(webViewConstraints + [webViewHeightConstraint!])
+        NSLayoutConstraint.activate(webViewConstraints + [heightConstraint])
     }
 
     // MARK: Main content view

--- a/Source/WebKit/_WebKit_SwiftUI/Implementation/WebViewRepresentable.swift
+++ b/Source/WebKit/_WebKit_SwiftUI/Implementation/WebViewRepresentable.swift
@@ -22,7 +22,7 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 
 internal import SwiftUI
-@_spi(Private) @_spi(CrossImportOverlay) import WebKit
+@_spi(CrossImportOverlay) import WebKit
 
 @MainActor
 struct WebViewRepresentable {
@@ -96,7 +96,7 @@ struct WebViewRepresentable {
         }
 
         webView.configuration.preferences.isTextInteractionEnabled = environment.webViewTextSelection
-        webView.configuration.preferences.isElementFullscreenEnabled = environment.webViewElementFullscreenBehavior.value == .enabled // automatic -> false
+        webView.configuration.preferences.isElementFullscreenEnabled = environment.webViewElementFullscreenBehavior.value == .enabled
 
         platformView.onScrollGeometryChange = environment.webViewOnScrollGeometryChange
 


### PR DESCRIPTION
#### 36ee5fbb5ae7b6a6d75afc4ed7b487f80533ff8e
<pre>
[Swift in WebKit] Use swift-format to lint _WebKit_SwiftUI code
<a href="https://bugs.webkit.org/show_bug.cgi?id=293564">https://bugs.webkit.org/show_bug.cgi?id=293564</a>
<a href="https://rdar.apple.com/152014439">rdar://152014439</a>

Reviewed by Abrar Rahman Protyasha.

Work towards having consistently formatted and linted Swift code; lint the _WebKit_SwiftUI codebase
for improved correctness and readability.

* Source/WebKit/_WebKit_SwiftUI/API/View+WebViewModifiers.swift:

- Fix documentation syntax inconsistencies
- Add missing documentation
- Allow a force unwrap with a justified explanation

* Source/WebKit/_WebKit_SwiftUI/API/WebPage+SwiftUI.swift:

- Add missing documentation

* Source/WebKit/_WebKit_SwiftUI/API/WebView.swift:

- Ignore the AllPublicDeclarationsHaveDocumentation rule for `body` since protocol requirements conventionally
do not have documentation comments of their own.
- Add missing documentation
- Remove a useless initializer

* Source/WebKit/_WebKit_SwiftUI/Implementation/CocoaWebViewAdapter.swift:

- Remove a force unwrap

* Source/WebKit/_WebKit_SwiftUI/Implementation/WebViewRepresentable.swift:

- Remove a useless spi import
- Remove a useless and inconsistent comment

Canonical link: <a href="https://commits.webkit.org/295488@main">https://commits.webkit.org/295488@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/371a61816d007e04571458121ee4997738329ab0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104999 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24713 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15135 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110216 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/55679 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/25121 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33257 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79731 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108005 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19551 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94767 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60038 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/19296 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55056 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/89018 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/12890 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/112714 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32164 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23668 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88812 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32529 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/90992 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88440 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33333 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11119 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/27518 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17066 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32088 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/37460 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/31881 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35222 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33440 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->