### PR TITLE
Update `select` as `listbox` default style for `align-items` and `cursor`

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/the-select-element/select-as-listbox-default-styles.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/the-select-element/select-as-listbox-default-styles.tentative-expected.txt
@@ -27,11 +27,11 @@ FAIL <select multiple=""><option>1 - border-top-color assert_equals: expected "r
 FAIL <select multiple=""><option>1 - border-right-color assert_equals: expected "rgb(0, 0, 0)" but got "rgb(128, 128, 128)"
 FAIL <select multiple=""><option>1 - border-bottom-color assert_equals: expected "rgb(0, 0, 0)" but got "rgb(128, 128, 128)"
 FAIL <select multiple=""><option>1 - border-left-color assert_equals: expected "rgb(0, 0, 0)" but got "rgb(128, 128, 128)"
-FAIL <select multiple=""><option>1 - align-items assert_equals: expected "normal" but got "flex-start"
+PASS <select multiple=""><option>1 - align-items
 PASS <select multiple=""><option>1 - white-space
 PASS <select multiple=""><option>1 - color
 FAIL <select multiple=""><option>1 - background-color assert_equals: expected "rgba(0, 0, 0, 0)" but got "rgb(255, 255, 255)"
-FAIL <select multiple=""><option>1 - cursor assert_equals: expected "auto" but got "default"
+PASS <select multiple=""><option>1 - cursor
 PASS <select multiple=""><option>1 - font-style
 PASS <select multiple=""><option>1 - font-weight
 FAIL <select multiple=""><option>1 - font-size assert_equals: expected "16px" but got "11px"
@@ -78,7 +78,7 @@ PASS <option>1 (in <select multiple="">) - align-items
 FAIL <option>1 (in <select multiple="">) - white-space assert_equals: expected "normal" but got "nowrap"
 PASS <option>1 (in <select multiple="">) - color
 PASS <option>1 (in <select multiple="">) - background-color
-FAIL <option>1 (in <select multiple="">) - cursor assert_equals: expected "auto" but got "default"
+PASS <option>1 (in <select multiple="">) - cursor
 PASS <option>1 (in <select multiple="">) - font-style
 PASS <option>1 (in <select multiple="">) - font-weight
 FAIL <option>1 (in <select multiple="">) - font-size assert_equals: expected "16px" but got "11px"
@@ -126,7 +126,7 @@ PASS <optgroup label="2"><option>3 (in <select multiple="">) - align-items
 PASS <optgroup label="2"><option>3 (in <select multiple="">) - white-space
 PASS <optgroup label="2"><option>3 (in <select multiple="">) - color
 PASS <optgroup label="2"><option>3 (in <select multiple="">) - background-color
-FAIL <optgroup label="2"><option>3 (in <select multiple="">) - cursor assert_equals: expected "auto" but got "default"
+PASS <optgroup label="2"><option>3 (in <select multiple="">) - cursor
 PASS <optgroup label="2"><option>3 (in <select multiple="">) - font-style
 FAIL <optgroup label="2"><option>3 (in <select multiple="">) - font-weight assert_equals: expected "400" but got "700"
 FAIL <optgroup label="2"><option>3 (in <select multiple="">) - font-size assert_equals: expected "16px" but got "11px"
@@ -174,7 +174,7 @@ PASS <option>3 (in <select multiple=""><optgroup label="2">) - align-items
 FAIL <option>3 (in <select multiple=""><optgroup label="2">) - white-space assert_equals: expected "normal" but got "nowrap"
 PASS <option>3 (in <select multiple=""><optgroup label="2">) - color
 PASS <option>3 (in <select multiple=""><optgroup label="2">) - background-color
-FAIL <option>3 (in <select multiple=""><optgroup label="2">) - cursor assert_equals: expected "auto" but got "default"
+PASS <option>3 (in <select multiple=""><optgroup label="2">) - cursor
 PASS <option>3 (in <select multiple=""><optgroup label="2">) - font-style
 PASS <option>3 (in <select multiple=""><optgroup label="2">) - font-weight
 FAIL <option>3 (in <select multiple=""><optgroup label="2">) - font-size assert_equals: expected "16px" but got "11px"

--- a/Source/WebCore/css/html.css
+++ b/Source/WebCore/css/html.css
@@ -1084,7 +1084,8 @@ select {
 
 #if !(defined(WTF_PLATFORM_IOS_FAMILY) && WTF_PLATFORM_IOS_FAMILY)
 select:is([size], [multiple]), select[size][multiple] {
-    align-items: flex-start;
+    align-items: normal;
+    cursor: auto;
     border: 1px inset gray;
     border-radius: initial;
     white-space: initial;


### PR DESCRIPTION
#### 32726c94e1afca7d5b5d9ea45dc183b7475e49d5
<pre>
Update `select` as `listbox` default style for `align-items` and `cursor`
<a href="https://bugs.webkit.org/show_bug.cgi?id=293566">https://bugs.webkit.org/show_bug.cgi?id=293566</a>
<a href="https://rdar.apple.com/152016435">rdar://152016435</a>

Reviewed by Darin Adler.

This patch updates WebKit user agent stylesheet for `select` as listbox
(multiple) to align with open issue for HTML rendering rules for all widgets [1]
and same time in case of `align-items`, we will now match Gecko / Firefox,
while for `cursor`, WebKit would be first one to adopt this change.

[1] <a href="https://github.com/whatwg/html/issues/7050">https://github.com/whatwg/html/issues/7050</a>

* Source/WebCore/css/html.css:
(select:is([size], [multiple]), select[size][multiple]):
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/the-select-element/select-as-listbox-default-styles.tentative-expected.txt:

Canonical link: <a href="https://commits.webkit.org/295451@main">https://commits.webkit.org/295451@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b9ae6f0dcca7886c184f08a38fd49242c945d756

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105002 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24716 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15138 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110219 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/55682 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/107043 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/25125 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33260 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79734 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108008 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19555 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94770 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60041 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/19301 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/12848 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55059 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/89022 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/12893 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/112718 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32167 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23672 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88815 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32532 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/90995 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88450 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22581 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33337 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11122 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/27523 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32091 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/37463 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/31884 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35225 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33443 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->