### PR TITLE
Add ReflectSetter

### DIFF
--- a/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
@@ -2122,10 +2122,10 @@ URL AccessibilityNodeObject::url() const
         return anchor->href();
 
     if (RefPtr image = dynamicDowncast<HTMLImageElement>(node); image && isImage())
-        return image->src();
+        return image->getURLAttribute(srcAttr);
 
     if (RefPtr input = dynamicDowncast<HTMLInputElement>(node); input && isInputImage())
-        return input->src();
+        return input->getURLAttribute(srcAttr);
 
 #if ENABLE(VIDEO)
     if (RefPtr video = dynamicDowncast<HTMLVideoElement>(node); video && isVideo())

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -1457,8 +1457,7 @@ RenderView* AccessibilityObject::topRenderer() const
 
 unsigned AccessibilityObject::ariaLevel() const
 {
-    int level = getIntegralAttribute(aria_levelAttr);
-    return level > 0 ? level : 0;
+    return std::max(0, integralAttribute(aria_levelAttr));
 }
 
 String AccessibilityObject::language() const
@@ -2499,7 +2498,7 @@ String AccessibilityObject::nameAttribute() const
     return getAttribute(nameAttr);
 }
 
-int AccessibilityObject::getIntegralAttribute(const QualifiedName& attributeName) const
+int AccessibilityObject::integralAttribute(const QualifiedName& attributeName) const
 {
     return parseHTMLInteger(getAttribute(attributeName)).value_or(0);
 }
@@ -3226,16 +3225,15 @@ int AccessibilityObject::setSize() const
 {
     // https://github.com/w3c/aria/pull/2341
     // When aria-setsize isn't a positive integer (greater than or equal to 1), its value should be indeterminate, i.e., -1.
-    int setSize = getIntegralAttribute(aria_setsizeAttr);
-    return (setSize >= 1) ? setSize : -1;
+    int setSize = integralAttribute(aria_setsizeAttr);
+    return setSize >= 1 ? setSize : -1;
 }
 
 int AccessibilityObject::posInSet() const
 {
     // https://github.com/w3c/aria/pull/2341
     // When aria-posinset isn't a positive integer (greater than or equal to 1), its value should be 1.
-    int posInSet = getIntegralAttribute(aria_posinsetAttr);
-    return (posInSet >= 1) ? posInSet : 1;
+    return std::max(1, integralAttribute(aria_posinsetAttr));
 }
 
 String AccessibilityObject::identifierAttribute() const

--- a/Source/WebCore/accessibility/AccessibilityObject.h
+++ b/Source/WebCore/accessibility/AccessibilityObject.h
@@ -564,7 +564,7 @@ public:
     String getAttributeTrimmed(const QualifiedName&) const;
 
     String nameAttribute() const final;
-    int getIntegralAttribute(const QualifiedName&) const;
+    int integralAttribute(const QualifiedName&) const;
     bool hasElementName(const ElementName) const final;
     bool hasAttachmentTag() const final { return hasElementName(ElementName::HTML_attachment); }
     bool hasBodyTag() const final { return hasElementName(ElementName::HTML_body); }

--- a/Source/WebCore/accessibility/AccessibilityTable.cpp
+++ b/Source/WebCore/accessibility/AccessibilityTable.cpp
@@ -180,7 +180,7 @@ bool AccessibilityTable::isDataTable() const
     // If the author has used ARIA to specify a valid column or row count, assume they
     // want us to treat the table as a data table.
     auto ariaRowOrColCountIsSet = [this] (const QualifiedName& attribute) {
-        int result = getIntegralAttribute(attribute);
+        int result = integralAttribute(attribute);
         return result == -1 || result > 0;
     };
     if (ariaRowOrColCountIsSet(aria_colcountAttr) || ariaRowOrColCountIsSet(aria_rowcountAttr))
@@ -257,7 +257,7 @@ bool AccessibilityTable::isDataTable() const
                 if (isDataTableBasedOnRowColumnCount())
                     return true;
 
-                if (tableRow->getIntegralAttribute(aria_rowindexAttr) >= 1 || tableRow->getIntegralAttribute(aria_colindexAttr) || hasRole(*tableRow, "row"_s))
+                if (tableRow->integralAttribute(aria_rowindexAttr) >= 1 || tableRow->integralAttribute(aria_colindexAttr) || hasRole(*tableRow, "row"_s))
                     return true;
 
                 // For the first 5 rows, cache the background color so we can check if this table has zebra-striped rows.
@@ -292,13 +292,13 @@ bool AccessibilityTable::isDataTable() const
 
                 // If the author has used ARIA to specify a valid column or row index, assume they want us
                 // to treat the table as a data table.
-                if (cell->getIntegralAttribute(aria_colindexAttr) >= 1 || cell->getIntegralAttribute(aria_rowindexAttr) >= 1)
+                if (cell->integralAttribute(aria_colindexAttr) >= 1 || cell->integralAttribute(aria_rowindexAttr) >= 1)
                     return true;
 
                 // If the author has used ARIA to specify a column or row span, we're supposed to ignore
                 // the value for the purposes of exposing the span. But assume they want us to treat the
                 // table as a data table.
-                if (cell->getIntegralAttribute(aria_colspanAttr) >= 1 || cell->getIntegralAttribute(aria_rowspanAttr) >= 1)
+                if (cell->integralAttribute(aria_colspanAttr) >= 1 || cell->integralAttribute(aria_rowspanAttr) >= 1)
                     return true;
 
                 const auto* cellStyle = styleFrom(*cell);
@@ -937,7 +937,7 @@ String AccessibilityTable::title() const
 
 int AccessibilityTable::axColumnCount() const
 {
-    int colCountInt = getIntegralAttribute(aria_colcountAttr);
+    int colCountInt = integralAttribute(aria_colcountAttr);
     // The ARIA spec states, "Authors must set the value of aria-colcount to an integer equal to the
     // number of columns in the full table. If the total number of columns is unknown, authors must
     // set the value of aria-colcount to -1 to indicate that the value should not be calculated by
@@ -950,7 +950,7 @@ int AccessibilityTable::axColumnCount() const
 
 int AccessibilityTable::axRowCount() const
 {
-    int rowCountInt = getIntegralAttribute(aria_rowcountAttr);
+    int rowCountInt = integralAttribute(aria_rowcountAttr);
     // The ARIA spec states, "Authors must set the value of aria-rowcount to an integer equal to the
     // number of rows in the full table. If the total number of rows is unknown, authors must set
     // the value of aria-rowcount to -1 to indicate that the value should not be calculated by the

--- a/Source/WebCore/accessibility/AccessibilityTableCell.cpp
+++ b/Source/WebCore/accessibility/AccessibilityTableCell.cpp
@@ -354,7 +354,7 @@ AccessibilityObject* AccessibilityTableCell::titleUIElement() const
     
 std::optional<unsigned> AccessibilityTableCell::axColumnIndex() const
 {
-    if (int value = getIntegralAttribute(aria_colindexAttr); value >= 1)
+    if (int value = integralAttribute(aria_colindexAttr); value >= 1)
         return value;
 
     // "ARIA 1.1: If the set of columns which is present in the DOM is contiguous, and if there are no cells which span more than one row
@@ -370,7 +370,7 @@ std::optional<unsigned> AccessibilityTableCell::axRowIndex() const
 {
     // ARIA 1.1: Authors should place aria-rowindex on each row. Authors may also place
     // aria-rowindex on all of the children or owned elements of each row.
-    if (int value = getIntegralAttribute(aria_rowindexAttr); value >= 1)
+    if (int value = integralAttribute(aria_rowindexAttr); value >= 1)
         return value;
 
     if (RefPtr parentRow = this->parentRow())
@@ -419,7 +419,7 @@ int AccessibilityTableCell::axColumnSpan() const
         return -1;
 
     // ARIA 1.1: Authors must set the value of aria-colspan to an integer greater than or equal to 1.
-    if (int value = getIntegralAttribute(aria_colspanAttr); value >= 1)
+    if (int value = integralAttribute(aria_colspanAttr); value >= 1)
         return value;
 
     return -1;
@@ -436,7 +436,7 @@ int AccessibilityTableCell::axRowSpan() const
     // Setting the value to 0 indicates that the cell or gridcell is to span all the remaining rows in the row group.
     if (getAttribute(aria_rowspanAttr) == "0"_s)
         return 0;
-    if (int value = getIntegralAttribute(aria_rowspanAttr); value >= 1)
+    if (int value = integralAttribute(aria_rowspanAttr); value >= 1)
         return value;
 
     return -1;

--- a/Source/WebCore/accessibility/AccessibilityTableRow.cpp
+++ b/Source/WebCore/accessibility/AccessibilityTableRow.cpp
@@ -162,13 +162,13 @@ void AccessibilityTableRow::addChildren()
 
 std::optional<unsigned> AccessibilityTableRow::axColumnIndex() const
 {
-    int value = getIntegralAttribute(aria_colindexAttr);
+    int value = integralAttribute(aria_colindexAttr);
     return value >= 1 ? std::optional(value) : std::nullopt;
 }
 
 std::optional<unsigned> AccessibilityTableRow::axRowIndex() const
 {
-    int value = getIntegralAttribute(aria_rowindexAttr);
+    int value = integralAttribute(aria_rowindexAttr);
     return value >= 1 ? std::optional(value) : std::nullopt;
 }
     

--- a/Source/WebCore/bindings/scripts/CodeGenerator.pm
+++ b/Source/WebCore/bindings/scripts/CodeGenerator.pm
@@ -1110,12 +1110,16 @@ sub AttributeNameForGetterAndSetter
 
 sub ContentAttributeName
 {
-    my ($generator, $implIncludes, $interfaceName, $attribute) = @_;
+    my ($generator, $implIncludes, $interfaceName, $attribute, $getterOrSetter) = @_;
 
-    my $contentAttributeName = $attribute->extendedAttributes->{"Reflect"};
+    my $reflect = $attribute->extendedAttributes->{Reflect};
+    my $reflectSetter = $attribute->extendedAttributes->{ReflectSetter};
+    die "Do not use both [Reflect] and [ReflectSetter] on the same attribute" if $reflect && $reflectSetter;
+
+    my $contentAttributeName = ($getterOrSetter eq "setter" ? $reflect || $reflectSetter : $reflect);
     return undef if !$contentAttributeName;
 
-    $contentAttributeName = lc $generator->AttributeNameForGetterAndSetter($attribute) if $contentAttributeName eq "VALUE_IS_MISSING";
+    $contentAttributeName = lc $attribute->name if $contentAttributeName eq "VALUE_IS_MISSING";
 
     my $namespace = $generator->NamespaceForAttributeName($interfaceName, $contentAttributeName);
 
@@ -1127,7 +1131,7 @@ sub GetterExpression
 {
     my ($generator, $implIncludes, $interfaceName, $attribute) = @_;
 
-    my $contentAttributeName = $generator->ContentAttributeName($implIncludes, $interfaceName, $attribute);
+    my $contentAttributeName = $generator->ContentAttributeName($implIncludes, $interfaceName, $attribute, "getter");
 
     if (!$contentAttributeName) {
         return ($generator->WK_lcfirst($generator->AttributeNameForGetterAndSetter($attribute)));
@@ -1142,10 +1146,12 @@ sub GetterExpression
     } elsif ($attributeType->name eq "boolean") {
         $implIncludes->{"ElementInlines.h"} = 1;
         $functionName = "hasAttributeWithoutSynchronization";
+    } elsif ($attributeType->name eq "double") {
+        $functionName = "numericAttribute";
     } elsif ($attributeType->name eq "long") {
-        $functionName = "getIntegralAttribute";
+        $functionName = "integralAttribute";
     } elsif ($attributeType->name eq "unsigned long") {
-        $functionName = "getUnsignedIntegralAttribute";
+        $functionName = "unsignedIntegralAttribute";
     } elsif ($attributeType->name eq "Element") {
         $functionName = "getElementAttributeForBindings";
     } elsif ($attributeType->name eq "FrozenArray" && scalar @{$attributeType->subtypes} == 1 && @{$attributeType->subtypes}[0]->name eq "Element") {
@@ -1173,7 +1179,7 @@ sub SetterExpression
 {
     my ($generator, $implIncludes, $interfaceName, $attribute) = @_;
 
-    my $contentAttributeName = $generator->ContentAttributeName($implIncludes, $interfaceName, $attribute);
+    my $contentAttributeName = $generator->ContentAttributeName($implIncludes, $interfaceName, $attribute, "setter");
 
     if (!$contentAttributeName) {
         return ("set" . $generator->WK_ucfirst($generator->AttributeNameForGetterAndSetter($attribute)));
@@ -1184,6 +1190,8 @@ sub SetterExpression
     my $functionName;
     if ($attributeType->name eq "boolean") {
         $functionName = "setBooleanAttribute";
+    } elsif ($attributeType->name eq "double") {
+        $functionName = "setNumericAttribute";
     } elsif ($attributeType->name eq "long") {
         $functionName = "setIntegralAttribute";
     } elsif ($attributeType->name eq "unsigned long") {

--- a/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
+++ b/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
@@ -7682,7 +7682,7 @@ sub NativeToJSValue
     # We could instead overload a function to work with optional as well as non-optional numbers, but this
     # is slightly better because it guarantees we will fail to compile if the IDL file doesn't match the C++.
     if ($context->extendedAttributes->{Reflect} and ($type->name eq "unsigned long" or $type->name eq "unsigned short")) {
-        $value =~ s/getUnsignedIntegralAttribute/getIntegralAttribute/g;
+        $value =~ s/unsignedIntegral/integral/g;
         $value = "std::max(0, $value)";
     }
 

--- a/Source/WebCore/bindings/scripts/IDLAttributes.json
+++ b/Source/WebCore/bindings/scripts/IDLAttributes.json
@@ -421,6 +421,11 @@
             "contextsAllowed": ["attribute"],
             "values": ["*"]
         },
+        "ReflectSetter": {
+            "contextsAllowed": ["attribute"],
+            "values": ["*"],
+            "notes": "Variant of Reflect that relies on C++ implementation for the getter, but automatically generates the setter"
+        },
         "Replaceable": {
             "contextsAllowed": ["attribute"],
             "standard": {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestObj.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestObj.cpp
@@ -2001,6 +2001,32 @@ static JSC_DECLARE_CUSTOM_GETTER(jsTestObj_reflectedCustomBooleanAttr);
 static JSC_DECLARE_CUSTOM_SETTER(setJSTestObj_reflectedCustomBooleanAttr);
 static JSC_DECLARE_CUSTOM_GETTER(jsTestObj_reflectedCustomURLAttr);
 static JSC_DECLARE_CUSTOM_SETTER(setJSTestObj_reflectedCustomURLAttr);
+static JSC_DECLARE_CUSTOM_GETTER(jsTestObj_reflectedSetterStringAttr);
+static JSC_DECLARE_CUSTOM_SETTER(setJSTestObj_reflectedSetterStringAttr);
+static JSC_DECLARE_CUSTOM_GETTER(jsTestObj_reflectedSetterUSVStringAttr);
+static JSC_DECLARE_CUSTOM_SETTER(setJSTestObj_reflectedSetterUSVStringAttr);
+static JSC_DECLARE_CUSTOM_GETTER(jsTestObj_reflectedSetterIntegralAttr);
+static JSC_DECLARE_CUSTOM_SETTER(setJSTestObj_reflectedSetterIntegralAttr);
+static JSC_DECLARE_CUSTOM_GETTER(jsTestObj_reflectedSetterUnsignedIntegralAttr);
+static JSC_DECLARE_CUSTOM_SETTER(setJSTestObj_reflectedSetterUnsignedIntegralAttr);
+static JSC_DECLARE_CUSTOM_GETTER(jsTestObj_reflectedSetterBooleanAttr);
+static JSC_DECLARE_CUSTOM_SETTER(setJSTestObj_reflectedSetterBooleanAttr);
+static JSC_DECLARE_CUSTOM_GETTER(jsTestObj_reflectedSetterElementAttr);
+static JSC_DECLARE_CUSTOM_SETTER(setJSTestObj_reflectedSetterElementAttr);
+static JSC_DECLARE_CUSTOM_GETTER(jsTestObj_reflectedSetterElementsArrayAttr);
+static JSC_DECLARE_CUSTOM_SETTER(setJSTestObj_reflectedSetterElementsArrayAttr);
+static JSC_DECLARE_CUSTOM_GETTER(jsTestObj_reflectedSetterURLAttr);
+static JSC_DECLARE_CUSTOM_SETTER(setJSTestObj_reflectedSetterURLAttr);
+static JSC_DECLARE_CUSTOM_GETTER(jsTestObj_reflectedSetterUSVURLAttr);
+static JSC_DECLARE_CUSTOM_SETTER(setJSTestObj_reflectedSetterUSVURLAttr);
+static JSC_DECLARE_CUSTOM_GETTER(jsTestObj_reflectedSetterStringAttr);
+static JSC_DECLARE_CUSTOM_SETTER(setJSTestObj_reflectedSetterStringAttr);
+static JSC_DECLARE_CUSTOM_GETTER(jsTestObj_reflectedSetterCustomIntegralAttr);
+static JSC_DECLARE_CUSTOM_SETTER(setJSTestObj_reflectedSetterCustomIntegralAttr);
+static JSC_DECLARE_CUSTOM_GETTER(jsTestObj_reflectedSetterCustomBooleanAttr);
+static JSC_DECLARE_CUSTOM_SETTER(setJSTestObj_reflectedSetterCustomBooleanAttr);
+static JSC_DECLARE_CUSTOM_GETTER(jsTestObj_reflectedSetterCustomURLAttr);
+static JSC_DECLARE_CUSTOM_SETTER(setJSTestObj_reflectedSetterCustomURLAttr);
 #if ENABLE(TEST_FEATURE)
 static JSC_DECLARE_CUSTOM_GETTER(jsTestObj_enabledAtRuntimeAttribute);
 static JSC_DECLARE_CUSTOM_SETTER(setJSTestObj_enabledAtRuntimeAttribute);
@@ -2320,7 +2346,7 @@ template<> void JSTestObjDOMConstructor::initializeProperties(VM& vm, JSDOMGloba
 
 /* Hash table for prototype */
 
-static const std::array<HashTableValue, 272> JSTestObjPrototypeTableValues {
+static const std::array<HashTableValue, 285> JSTestObjPrototypeTableValues {
     HashTableValue { "constructor"_s, static_cast<unsigned>(PropertyAttribute::DontEnum), NoIntrinsic, { HashTableValue::GetterSetterType, jsTestObjConstructor, 0 } },
     HashTableValue { "readOnlyLongAttr"_s, JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute, NoIntrinsic, { HashTableValue::GetterSetterType, jsTestObj_readOnlyLongAttr, 0 } },
     HashTableValue { "readOnlyStringAttr"_s, JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute, NoIntrinsic, { HashTableValue::GetterSetterType, jsTestObj_readOnlyStringAttr, 0 } },
@@ -2372,6 +2398,19 @@ static const std::array<HashTableValue, 272> JSTestObjPrototypeTableValues {
     HashTableValue { "reflectedCustomIntegralAttr"_s, JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute, NoIntrinsic, { HashTableValue::GetterSetterType, jsTestObj_reflectedCustomIntegralAttr, setJSTestObj_reflectedCustomIntegralAttr } },
     HashTableValue { "reflectedCustomBooleanAttr"_s, JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute, NoIntrinsic, { HashTableValue::GetterSetterType, jsTestObj_reflectedCustomBooleanAttr, setJSTestObj_reflectedCustomBooleanAttr } },
     HashTableValue { "reflectedCustomURLAttr"_s, JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute, NoIntrinsic, { HashTableValue::GetterSetterType, jsTestObj_reflectedCustomURLAttr, setJSTestObj_reflectedCustomURLAttr } },
+    HashTableValue { "reflectedSetterStringAttr"_s, JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute, NoIntrinsic, { HashTableValue::GetterSetterType, jsTestObj_reflectedSetterStringAttr, setJSTestObj_reflectedSetterStringAttr } },
+    HashTableValue { "reflectedSetterUSVStringAttr"_s, JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute, NoIntrinsic, { HashTableValue::GetterSetterType, jsTestObj_reflectedSetterUSVStringAttr, setJSTestObj_reflectedSetterUSVStringAttr } },
+    HashTableValue { "reflectedSetterIntegralAttr"_s, JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute, NoIntrinsic, { HashTableValue::GetterSetterType, jsTestObj_reflectedSetterIntegralAttr, setJSTestObj_reflectedSetterIntegralAttr } },
+    HashTableValue { "reflectedSetterUnsignedIntegralAttr"_s, JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute, NoIntrinsic, { HashTableValue::GetterSetterType, jsTestObj_reflectedSetterUnsignedIntegralAttr, setJSTestObj_reflectedSetterUnsignedIntegralAttr } },
+    HashTableValue { "reflectedSetterBooleanAttr"_s, JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute, NoIntrinsic, { HashTableValue::GetterSetterType, jsTestObj_reflectedSetterBooleanAttr, setJSTestObj_reflectedSetterBooleanAttr } },
+    HashTableValue { "reflectedSetterElementAttr"_s, JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute, NoIntrinsic, { HashTableValue::GetterSetterType, jsTestObj_reflectedSetterElementAttr, setJSTestObj_reflectedSetterElementAttr } },
+    HashTableValue { "reflectedSetterElementsArrayAttr"_s, JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute, NoIntrinsic, { HashTableValue::GetterSetterType, jsTestObj_reflectedSetterElementsArrayAttr, setJSTestObj_reflectedSetterElementsArrayAttr } },
+    HashTableValue { "reflectedSetterURLAttr"_s, JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute, NoIntrinsic, { HashTableValue::GetterSetterType, jsTestObj_reflectedSetterURLAttr, setJSTestObj_reflectedSetterURLAttr } },
+    HashTableValue { "reflectedSetterUSVURLAttr"_s, JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute, NoIntrinsic, { HashTableValue::GetterSetterType, jsTestObj_reflectedSetterUSVURLAttr, setJSTestObj_reflectedSetterUSVURLAttr } },
+    HashTableValue { "reflectedSetterStringAttr"_s, JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute, NoIntrinsic, { HashTableValue::GetterSetterType, jsTestObj_reflectedSetterStringAttr, setJSTestObj_reflectedSetterStringAttr } },
+    HashTableValue { "reflectedSetterCustomIntegralAttr"_s, JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute, NoIntrinsic, { HashTableValue::GetterSetterType, jsTestObj_reflectedSetterCustomIntegralAttr, setJSTestObj_reflectedSetterCustomIntegralAttr } },
+    HashTableValue { "reflectedSetterCustomBooleanAttr"_s, JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute, NoIntrinsic, { HashTableValue::GetterSetterType, jsTestObj_reflectedSetterCustomBooleanAttr, setJSTestObj_reflectedSetterCustomBooleanAttr } },
+    HashTableValue { "reflectedSetterCustomURLAttr"_s, JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute, NoIntrinsic, { HashTableValue::GetterSetterType, jsTestObj_reflectedSetterCustomURLAttr, setJSTestObj_reflectedSetterCustomURLAttr } },
 #if ENABLE(TEST_FEATURE)
     HashTableValue { "enabledAtRuntimeAttribute"_s, JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute, NoIntrinsic, { HashTableValue::GetterSetterType, jsTestObj_enabledAtRuntimeAttribute, setJSTestObj_enabledAtRuntimeAttribute } },
 #else
@@ -4260,7 +4299,7 @@ static inline JSValue jsTestObj_reflectedIntegralAttrGetter(JSGlobalObject& lexi
     SUPPRESS_UNCOUNTED_LOCAL auto& vm = JSC::getVM(&lexicalGlobalObject);
     auto throwScope = DECLARE_THROW_SCOPE(vm);
     SUPPRESS_UNCOUNTED_LOCAL auto& impl = thisObject.wrapped();
-    RELEASE_AND_RETURN(throwScope, (toJS<IDLLong>(lexicalGlobalObject, throwScope, impl.getIntegralAttribute(WebCore::HTMLNames::reflectedintegralattrAttr))));
+    RELEASE_AND_RETURN(throwScope, (toJS<IDLLong>(lexicalGlobalObject, throwScope, impl.integralAttribute(WebCore::HTMLNames::reflectedintegralattrAttr))));
 }
 
 JSC_DEFINE_CUSTOM_GETTER(jsTestObj_reflectedIntegralAttr, (JSGlobalObject* lexicalGlobalObject, EncodedJSValue thisValue, PropertyName attributeName))
@@ -4293,7 +4332,7 @@ static inline JSValue jsTestObj_reflectedUnsignedIntegralAttrGetter(JSGlobalObje
     SUPPRESS_UNCOUNTED_LOCAL auto& vm = JSC::getVM(&lexicalGlobalObject);
     auto throwScope = DECLARE_THROW_SCOPE(vm);
     SUPPRESS_UNCOUNTED_LOCAL auto& impl = thisObject.wrapped();
-    RELEASE_AND_RETURN(throwScope, (toJS<IDLUnsignedLong>(lexicalGlobalObject, throwScope, std::max(0, impl.getIntegralAttribute(WebCore::HTMLNames::reflectedunsignedintegralattrAttr)))));
+    RELEASE_AND_RETURN(throwScope, (toJS<IDLUnsignedLong>(lexicalGlobalObject, throwScope, std::max(0, impl.integralAttribute(WebCore::HTMLNames::reflectedunsignedintegralattrAttr)))));
 }
 
 JSC_DEFINE_CUSTOM_GETTER(jsTestObj_reflectedUnsignedIntegralAttr, (JSGlobalObject* lexicalGlobalObject, EncodedJSValue thisValue, PropertyName attributeName))
@@ -4524,7 +4563,7 @@ static inline JSValue jsTestObj_reflectedCustomIntegralAttrGetter(JSGlobalObject
     SUPPRESS_UNCOUNTED_LOCAL auto& vm = JSC::getVM(&lexicalGlobalObject);
     auto throwScope = DECLARE_THROW_SCOPE(vm);
     SUPPRESS_UNCOUNTED_LOCAL auto& impl = thisObject.wrapped();
-    RELEASE_AND_RETURN(throwScope, (toJS<IDLLong>(lexicalGlobalObject, throwScope, impl.getIntegralAttribute(WebCore::HTMLNames::customContentIntegralAttrAttr))));
+    RELEASE_AND_RETURN(throwScope, (toJS<IDLLong>(lexicalGlobalObject, throwScope, impl.integralAttribute(WebCore::HTMLNames::customContentIntegralAttrAttr))));
 }
 
 JSC_DEFINE_CUSTOM_GETTER(jsTestObj_reflectedCustomIntegralAttr, (JSGlobalObject* lexicalGlobalObject, EncodedJSValue thisValue, PropertyName attributeName))
@@ -4616,6 +4655,435 @@ static inline bool setJSTestObj_reflectedCustomURLAttrSetter(JSGlobalObject& lex
 JSC_DEFINE_CUSTOM_SETTER(setJSTestObj_reflectedCustomURLAttr, (JSGlobalObject* lexicalGlobalObject, EncodedJSValue thisValue, EncodedJSValue encodedValue, PropertyName attributeName))
 {
     return IDLAttribute<JSTestObj>::set<setJSTestObj_reflectedCustomURLAttrSetter>(*lexicalGlobalObject, thisValue, encodedValue, attributeName);
+}
+
+static inline JSValue jsTestObj_reflectedSetterStringAttrGetter(JSGlobalObject& lexicalGlobalObject, JSTestObj& thisObject)
+{
+    SUPPRESS_UNCOUNTED_LOCAL auto& vm = JSC::getVM(&lexicalGlobalObject);
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+    SUPPRESS_UNCOUNTED_LOCAL auto& impl = thisObject.wrapped();
+    RELEASE_AND_RETURN(throwScope, (toJS<IDLDOMString>(lexicalGlobalObject, throwScope, impl.reflectedSetterStringAttr())));
+}
+
+JSC_DEFINE_CUSTOM_GETTER(jsTestObj_reflectedSetterStringAttr, (JSGlobalObject* lexicalGlobalObject, EncodedJSValue thisValue, PropertyName attributeName))
+{
+    return IDLAttribute<JSTestObj>::get<jsTestObj_reflectedSetterStringAttrGetter, CastedThisErrorBehavior::Assert>(*lexicalGlobalObject, thisValue, attributeName);
+}
+
+static inline bool setJSTestObj_reflectedSetterStringAttrSetter(JSGlobalObject& lexicalGlobalObject, JSTestObj& thisObject, JSValue value)
+{
+    SUPPRESS_UNCOUNTED_LOCAL auto& vm = JSC::getVM(&lexicalGlobalObject);
+    UNUSED_PARAM(vm);
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+    SUPPRESS_UNCOUNTED_LOCAL auto& impl = thisObject.wrapped();
+    auto nativeValueConversionResult = convert<IDLDOMString>(lexicalGlobalObject, value);
+    if (nativeValueConversionResult.hasException(throwScope)) [[unlikely]]
+        return false;
+    invokeFunctorPropagatingExceptionIfNecessary(lexicalGlobalObject, throwScope, [&] {
+        return impl.setAttributeWithoutSynchronization(WebCore::HTMLNames::reflectedsetterstringattrAttr, nativeValueConversionResult.releaseReturnValue());
+    });
+    return true;
+}
+
+JSC_DEFINE_CUSTOM_SETTER(setJSTestObj_reflectedSetterStringAttr, (JSGlobalObject* lexicalGlobalObject, EncodedJSValue thisValue, EncodedJSValue encodedValue, PropertyName attributeName))
+{
+    return IDLAttribute<JSTestObj>::set<setJSTestObj_reflectedSetterStringAttrSetter>(*lexicalGlobalObject, thisValue, encodedValue, attributeName);
+}
+
+static inline JSValue jsTestObj_reflectedSetterUSVStringAttrGetter(JSGlobalObject& lexicalGlobalObject, JSTestObj& thisObject)
+{
+    SUPPRESS_UNCOUNTED_LOCAL auto& vm = JSC::getVM(&lexicalGlobalObject);
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+    SUPPRESS_UNCOUNTED_LOCAL auto& impl = thisObject.wrapped();
+    RELEASE_AND_RETURN(throwScope, (toJS<IDLUSVString>(lexicalGlobalObject, throwScope, impl.reflectedSetterUSVStringAttr())));
+}
+
+JSC_DEFINE_CUSTOM_GETTER(jsTestObj_reflectedSetterUSVStringAttr, (JSGlobalObject* lexicalGlobalObject, EncodedJSValue thisValue, PropertyName attributeName))
+{
+    return IDLAttribute<JSTestObj>::get<jsTestObj_reflectedSetterUSVStringAttrGetter, CastedThisErrorBehavior::Assert>(*lexicalGlobalObject, thisValue, attributeName);
+}
+
+static inline bool setJSTestObj_reflectedSetterUSVStringAttrSetter(JSGlobalObject& lexicalGlobalObject, JSTestObj& thisObject, JSValue value)
+{
+    SUPPRESS_UNCOUNTED_LOCAL auto& vm = JSC::getVM(&lexicalGlobalObject);
+    UNUSED_PARAM(vm);
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+    SUPPRESS_UNCOUNTED_LOCAL auto& impl = thisObject.wrapped();
+    auto nativeValueConversionResult = convert<IDLUSVString>(lexicalGlobalObject, value);
+    if (nativeValueConversionResult.hasException(throwScope)) [[unlikely]]
+        return false;
+    invokeFunctorPropagatingExceptionIfNecessary(lexicalGlobalObject, throwScope, [&] {
+        return impl.setAttributeWithoutSynchronization(WebCore::HTMLNames::reflectedsetterusvstringattrAttr, nativeValueConversionResult.releaseReturnValue());
+    });
+    return true;
+}
+
+JSC_DEFINE_CUSTOM_SETTER(setJSTestObj_reflectedSetterUSVStringAttr, (JSGlobalObject* lexicalGlobalObject, EncodedJSValue thisValue, EncodedJSValue encodedValue, PropertyName attributeName))
+{
+    return IDLAttribute<JSTestObj>::set<setJSTestObj_reflectedSetterUSVStringAttrSetter>(*lexicalGlobalObject, thisValue, encodedValue, attributeName);
+}
+
+static inline JSValue jsTestObj_reflectedSetterIntegralAttrGetter(JSGlobalObject& lexicalGlobalObject, JSTestObj& thisObject)
+{
+    SUPPRESS_UNCOUNTED_LOCAL auto& vm = JSC::getVM(&lexicalGlobalObject);
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+    SUPPRESS_UNCOUNTED_LOCAL auto& impl = thisObject.wrapped();
+    RELEASE_AND_RETURN(throwScope, (toJS<IDLLong>(lexicalGlobalObject, throwScope, impl.reflectedSetterIntegralAttr())));
+}
+
+JSC_DEFINE_CUSTOM_GETTER(jsTestObj_reflectedSetterIntegralAttr, (JSGlobalObject* lexicalGlobalObject, EncodedJSValue thisValue, PropertyName attributeName))
+{
+    return IDLAttribute<JSTestObj>::get<jsTestObj_reflectedSetterIntegralAttrGetter, CastedThisErrorBehavior::Assert>(*lexicalGlobalObject, thisValue, attributeName);
+}
+
+static inline bool setJSTestObj_reflectedSetterIntegralAttrSetter(JSGlobalObject& lexicalGlobalObject, JSTestObj& thisObject, JSValue value)
+{
+    SUPPRESS_UNCOUNTED_LOCAL auto& vm = JSC::getVM(&lexicalGlobalObject);
+    UNUSED_PARAM(vm);
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+    SUPPRESS_UNCOUNTED_LOCAL auto& impl = thisObject.wrapped();
+    auto nativeValueConversionResult = convert<IDLLong>(lexicalGlobalObject, value);
+    if (nativeValueConversionResult.hasException(throwScope)) [[unlikely]]
+        return false;
+    invokeFunctorPropagatingExceptionIfNecessary(lexicalGlobalObject, throwScope, [&] {
+        return impl.setIntegralAttribute(WebCore::HTMLNames::reflectedsetterintegralattrAttr, nativeValueConversionResult.releaseReturnValue());
+    });
+    return true;
+}
+
+JSC_DEFINE_CUSTOM_SETTER(setJSTestObj_reflectedSetterIntegralAttr, (JSGlobalObject* lexicalGlobalObject, EncodedJSValue thisValue, EncodedJSValue encodedValue, PropertyName attributeName))
+{
+    return IDLAttribute<JSTestObj>::set<setJSTestObj_reflectedSetterIntegralAttrSetter>(*lexicalGlobalObject, thisValue, encodedValue, attributeName);
+}
+
+static inline JSValue jsTestObj_reflectedSetterUnsignedIntegralAttrGetter(JSGlobalObject& lexicalGlobalObject, JSTestObj& thisObject)
+{
+    SUPPRESS_UNCOUNTED_LOCAL auto& vm = JSC::getVM(&lexicalGlobalObject);
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+    SUPPRESS_UNCOUNTED_LOCAL auto& impl = thisObject.wrapped();
+    RELEASE_AND_RETURN(throwScope, (toJS<IDLUnsignedLong>(lexicalGlobalObject, throwScope, impl.reflectedSetterUnsignedIntegralAttr())));
+}
+
+JSC_DEFINE_CUSTOM_GETTER(jsTestObj_reflectedSetterUnsignedIntegralAttr, (JSGlobalObject* lexicalGlobalObject, EncodedJSValue thisValue, PropertyName attributeName))
+{
+    return IDLAttribute<JSTestObj>::get<jsTestObj_reflectedSetterUnsignedIntegralAttrGetter, CastedThisErrorBehavior::Assert>(*lexicalGlobalObject, thisValue, attributeName);
+}
+
+static inline bool setJSTestObj_reflectedSetterUnsignedIntegralAttrSetter(JSGlobalObject& lexicalGlobalObject, JSTestObj& thisObject, JSValue value)
+{
+    SUPPRESS_UNCOUNTED_LOCAL auto& vm = JSC::getVM(&lexicalGlobalObject);
+    UNUSED_PARAM(vm);
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+    SUPPRESS_UNCOUNTED_LOCAL auto& impl = thisObject.wrapped();
+    auto nativeValueConversionResult = convert<IDLUnsignedLong>(lexicalGlobalObject, value);
+    if (nativeValueConversionResult.hasException(throwScope)) [[unlikely]]
+        return false;
+    invokeFunctorPropagatingExceptionIfNecessary(lexicalGlobalObject, throwScope, [&] {
+        return impl.setUnsignedIntegralAttribute(WebCore::HTMLNames::reflectedsetterunsignedintegralattrAttr, nativeValueConversionResult.releaseReturnValue());
+    });
+    return true;
+}
+
+JSC_DEFINE_CUSTOM_SETTER(setJSTestObj_reflectedSetterUnsignedIntegralAttr, (JSGlobalObject* lexicalGlobalObject, EncodedJSValue thisValue, EncodedJSValue encodedValue, PropertyName attributeName))
+{
+    return IDLAttribute<JSTestObj>::set<setJSTestObj_reflectedSetterUnsignedIntegralAttrSetter>(*lexicalGlobalObject, thisValue, encodedValue, attributeName);
+}
+
+static inline JSValue jsTestObj_reflectedSetterBooleanAttrGetter(JSGlobalObject& lexicalGlobalObject, JSTestObj& thisObject)
+{
+    SUPPRESS_UNCOUNTED_LOCAL auto& vm = JSC::getVM(&lexicalGlobalObject);
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+    SUPPRESS_UNCOUNTED_LOCAL auto& impl = thisObject.wrapped();
+    RELEASE_AND_RETURN(throwScope, (toJS<IDLBoolean>(lexicalGlobalObject, throwScope, impl.reflectedSetterBooleanAttr())));
+}
+
+JSC_DEFINE_CUSTOM_GETTER(jsTestObj_reflectedSetterBooleanAttr, (JSGlobalObject* lexicalGlobalObject, EncodedJSValue thisValue, PropertyName attributeName))
+{
+    return IDLAttribute<JSTestObj>::get<jsTestObj_reflectedSetterBooleanAttrGetter, CastedThisErrorBehavior::Assert>(*lexicalGlobalObject, thisValue, attributeName);
+}
+
+static inline bool setJSTestObj_reflectedSetterBooleanAttrSetter(JSGlobalObject& lexicalGlobalObject, JSTestObj& thisObject, JSValue value)
+{
+    SUPPRESS_UNCOUNTED_LOCAL auto& vm = JSC::getVM(&lexicalGlobalObject);
+    UNUSED_PARAM(vm);
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+    SUPPRESS_UNCOUNTED_LOCAL auto& impl = thisObject.wrapped();
+    auto nativeValueConversionResult = convert<IDLBoolean>(lexicalGlobalObject, value);
+    if (nativeValueConversionResult.hasException(throwScope)) [[unlikely]]
+        return false;
+    invokeFunctorPropagatingExceptionIfNecessary(lexicalGlobalObject, throwScope, [&] {
+        return impl.setBooleanAttribute(WebCore::HTMLNames::reflectedsetterbooleanattrAttr, nativeValueConversionResult.releaseReturnValue());
+    });
+    return true;
+}
+
+JSC_DEFINE_CUSTOM_SETTER(setJSTestObj_reflectedSetterBooleanAttr, (JSGlobalObject* lexicalGlobalObject, EncodedJSValue thisValue, EncodedJSValue encodedValue, PropertyName attributeName))
+{
+    return IDLAttribute<JSTestObj>::set<setJSTestObj_reflectedSetterBooleanAttrSetter>(*lexicalGlobalObject, thisValue, encodedValue, attributeName);
+}
+
+static inline JSValue jsTestObj_reflectedSetterElementAttrGetter(JSGlobalObject& lexicalGlobalObject, JSTestObj& thisObject)
+{
+    SUPPRESS_UNCOUNTED_LOCAL auto& vm = JSC::getVM(&lexicalGlobalObject);
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+    SUPPRESS_UNCOUNTED_LOCAL auto& impl = thisObject.wrapped();
+    RELEASE_AND_RETURN(throwScope, (toJS<IDLInterface<Element>>(lexicalGlobalObject, *thisObject.globalObject(), throwScope, impl.reflectedSetterElementAttr())));
+}
+
+JSC_DEFINE_CUSTOM_GETTER(jsTestObj_reflectedSetterElementAttr, (JSGlobalObject* lexicalGlobalObject, EncodedJSValue thisValue, PropertyName attributeName))
+{
+    return IDLAttribute<JSTestObj>::get<jsTestObj_reflectedSetterElementAttrGetter, CastedThisErrorBehavior::Assert>(*lexicalGlobalObject, thisValue, attributeName);
+}
+
+static inline bool setJSTestObj_reflectedSetterElementAttrSetter(JSGlobalObject& lexicalGlobalObject, JSTestObj& thisObject, JSValue value)
+{
+    SUPPRESS_UNCOUNTED_LOCAL auto& vm = JSC::getVM(&lexicalGlobalObject);
+    UNUSED_PARAM(vm);
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+    SUPPRESS_UNCOUNTED_LOCAL auto& impl = thisObject.wrapped();
+    auto nativeValueConversionResult = convert<IDLInterface<Element>>(lexicalGlobalObject, value, [](JSC::JSGlobalObject& lexicalGlobalObject, JSC::ThrowScope& scope) { throwAttributeTypeError(lexicalGlobalObject, scope, "TestObject"_s, "reflectedSetterElementAttr"_s, "Element"_s); });
+    if (nativeValueConversionResult.hasException(throwScope)) [[unlikely]]
+        return false;
+    invokeFunctorPropagatingExceptionIfNecessary(lexicalGlobalObject, throwScope, [&] {
+        return impl.setElementAttribute(WebCore::HTMLNames::reflectedsetterelementattrAttr, *nativeValueConversionResult.releaseReturnValue());
+    });
+    return true;
+}
+
+JSC_DEFINE_CUSTOM_SETTER(setJSTestObj_reflectedSetterElementAttr, (JSGlobalObject* lexicalGlobalObject, EncodedJSValue thisValue, EncodedJSValue encodedValue, PropertyName attributeName))
+{
+    return IDLAttribute<JSTestObj>::set<setJSTestObj_reflectedSetterElementAttrSetter>(*lexicalGlobalObject, thisValue, encodedValue, attributeName);
+}
+
+static inline JSValue jsTestObj_reflectedSetterElementsArrayAttrGetter(JSGlobalObject& lexicalGlobalObject, JSTestObj& thisObject)
+{
+    SUPPRESS_UNCOUNTED_LOCAL auto& vm = JSC::getVM(&lexicalGlobalObject);
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+    SUPPRESS_UNCOUNTED_LOCAL auto& impl = thisObject.wrapped();
+    RELEASE_AND_RETURN(throwScope, (toJS<IDLFrozenArray<IDLInterface<Element>>>(lexicalGlobalObject, *thisObject.globalObject(), throwScope, impl.reflectedSetterElementsArrayAttr())));
+}
+
+JSC_DEFINE_CUSTOM_GETTER(jsTestObj_reflectedSetterElementsArrayAttr, (JSGlobalObject* lexicalGlobalObject, EncodedJSValue thisValue, PropertyName attributeName))
+{
+    return IDLAttribute<JSTestObj>::get<jsTestObj_reflectedSetterElementsArrayAttrGetter, CastedThisErrorBehavior::Assert>(*lexicalGlobalObject, thisValue, attributeName);
+}
+
+static inline bool setJSTestObj_reflectedSetterElementsArrayAttrSetter(JSGlobalObject& lexicalGlobalObject, JSTestObj& thisObject, JSValue value)
+{
+    SUPPRESS_UNCOUNTED_LOCAL auto& vm = JSC::getVM(&lexicalGlobalObject);
+    UNUSED_PARAM(vm);
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+    SUPPRESS_UNCOUNTED_LOCAL auto& impl = thisObject.wrapped();
+    auto nativeValueConversionResult = convert<IDLFrozenArray<IDLInterface<Element>>>(lexicalGlobalObject, value);
+    if (nativeValueConversionResult.hasException(throwScope)) [[unlikely]]
+        return false;
+    invokeFunctorPropagatingExceptionIfNecessary(lexicalGlobalObject, throwScope, [&] {
+        return impl.setElementsArrayAttribute(WebCore::HTMLNames::reflectedsetterelementsarrayattrAttr, nativeValueConversionResult.releaseReturnValue());
+    });
+    return true;
+}
+
+JSC_DEFINE_CUSTOM_SETTER(setJSTestObj_reflectedSetterElementsArrayAttr, (JSGlobalObject* lexicalGlobalObject, EncodedJSValue thisValue, EncodedJSValue encodedValue, PropertyName attributeName))
+{
+    return IDLAttribute<JSTestObj>::set<setJSTestObj_reflectedSetterElementsArrayAttrSetter>(*lexicalGlobalObject, thisValue, encodedValue, attributeName);
+}
+
+static inline JSValue jsTestObj_reflectedSetterURLAttrGetter(JSGlobalObject& lexicalGlobalObject, JSTestObj& thisObject)
+{
+    SUPPRESS_UNCOUNTED_LOCAL auto& vm = JSC::getVM(&lexicalGlobalObject);
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+    SUPPRESS_UNCOUNTED_LOCAL auto& impl = thisObject.wrapped();
+    RELEASE_AND_RETURN(throwScope, (toJS<IDLDOMString>(lexicalGlobalObject, throwScope, impl.reflectedSetterURLAttr())));
+}
+
+JSC_DEFINE_CUSTOM_GETTER(jsTestObj_reflectedSetterURLAttr, (JSGlobalObject* lexicalGlobalObject, EncodedJSValue thisValue, PropertyName attributeName))
+{
+    return IDLAttribute<JSTestObj>::get<jsTestObj_reflectedSetterURLAttrGetter, CastedThisErrorBehavior::Assert>(*lexicalGlobalObject, thisValue, attributeName);
+}
+
+static inline bool setJSTestObj_reflectedSetterURLAttrSetter(JSGlobalObject& lexicalGlobalObject, JSTestObj& thisObject, JSValue value)
+{
+    SUPPRESS_UNCOUNTED_LOCAL auto& vm = JSC::getVM(&lexicalGlobalObject);
+    UNUSED_PARAM(vm);
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+    SUPPRESS_UNCOUNTED_LOCAL auto& impl = thisObject.wrapped();
+    auto nativeValueConversionResult = convert<IDLDOMString>(lexicalGlobalObject, value);
+    if (nativeValueConversionResult.hasException(throwScope)) [[unlikely]]
+        return false;
+    invokeFunctorPropagatingExceptionIfNecessary(lexicalGlobalObject, throwScope, [&] {
+        return impl.setAttributeWithoutSynchronization(WebCore::HTMLNames::reflectedsetterurlattrAttr, nativeValueConversionResult.releaseReturnValue());
+    });
+    return true;
+}
+
+JSC_DEFINE_CUSTOM_SETTER(setJSTestObj_reflectedSetterURLAttr, (JSGlobalObject* lexicalGlobalObject, EncodedJSValue thisValue, EncodedJSValue encodedValue, PropertyName attributeName))
+{
+    return IDLAttribute<JSTestObj>::set<setJSTestObj_reflectedSetterURLAttrSetter>(*lexicalGlobalObject, thisValue, encodedValue, attributeName);
+}
+
+static inline JSValue jsTestObj_reflectedSetterUSVURLAttrGetter(JSGlobalObject& lexicalGlobalObject, JSTestObj& thisObject)
+{
+    SUPPRESS_UNCOUNTED_LOCAL auto& vm = JSC::getVM(&lexicalGlobalObject);
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+    SUPPRESS_UNCOUNTED_LOCAL auto& impl = thisObject.wrapped();
+    RELEASE_AND_RETURN(throwScope, (toJS<IDLUSVString>(lexicalGlobalObject, throwScope, impl.reflectedSetterUSVURLAttr())));
+}
+
+JSC_DEFINE_CUSTOM_GETTER(jsTestObj_reflectedSetterUSVURLAttr, (JSGlobalObject* lexicalGlobalObject, EncodedJSValue thisValue, PropertyName attributeName))
+{
+    return IDLAttribute<JSTestObj>::get<jsTestObj_reflectedSetterUSVURLAttrGetter, CastedThisErrorBehavior::Assert>(*lexicalGlobalObject, thisValue, attributeName);
+}
+
+static inline bool setJSTestObj_reflectedSetterUSVURLAttrSetter(JSGlobalObject& lexicalGlobalObject, JSTestObj& thisObject, JSValue value)
+{
+    SUPPRESS_UNCOUNTED_LOCAL auto& vm = JSC::getVM(&lexicalGlobalObject);
+    UNUSED_PARAM(vm);
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+    SUPPRESS_UNCOUNTED_LOCAL auto& impl = thisObject.wrapped();
+    auto nativeValueConversionResult = convert<IDLUSVString>(lexicalGlobalObject, value);
+    if (nativeValueConversionResult.hasException(throwScope)) [[unlikely]]
+        return false;
+    invokeFunctorPropagatingExceptionIfNecessary(lexicalGlobalObject, throwScope, [&] {
+        return impl.setAttributeWithoutSynchronization(WebCore::HTMLNames::reflectedsetterusvurlattrAttr, nativeValueConversionResult.releaseReturnValue());
+    });
+    return true;
+}
+
+JSC_DEFINE_CUSTOM_SETTER(setJSTestObj_reflectedSetterUSVURLAttr, (JSGlobalObject* lexicalGlobalObject, EncodedJSValue thisValue, EncodedJSValue encodedValue, PropertyName attributeName))
+{
+    return IDLAttribute<JSTestObj>::set<setJSTestObj_reflectedSetterUSVURLAttrSetter>(*lexicalGlobalObject, thisValue, encodedValue, attributeName);
+}
+
+static inline JSValue jsTestObj_reflectedSetterStringAttrGetter(JSGlobalObject& lexicalGlobalObject, JSTestObj& thisObject)
+{
+    SUPPRESS_UNCOUNTED_LOCAL auto& vm = JSC::getVM(&lexicalGlobalObject);
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+    SUPPRESS_UNCOUNTED_LOCAL auto& impl = thisObject.wrapped();
+    RELEASE_AND_RETURN(throwScope, (toJS<IDLDOMString>(lexicalGlobalObject, throwScope, impl.reflectedSetterStringAttr())));
+}
+
+JSC_DEFINE_CUSTOM_GETTER(jsTestObj_reflectedSetterStringAttr, (JSGlobalObject* lexicalGlobalObject, EncodedJSValue thisValue, PropertyName attributeName))
+{
+    return IDLAttribute<JSTestObj>::get<jsTestObj_reflectedSetterStringAttrGetter, CastedThisErrorBehavior::Assert>(*lexicalGlobalObject, thisValue, attributeName);
+}
+
+static inline bool setJSTestObj_reflectedSetterStringAttrSetter(JSGlobalObject& lexicalGlobalObject, JSTestObj& thisObject, JSValue value)
+{
+    SUPPRESS_UNCOUNTED_LOCAL auto& vm = JSC::getVM(&lexicalGlobalObject);
+    UNUSED_PARAM(vm);
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+    SUPPRESS_UNCOUNTED_LOCAL auto& impl = thisObject.wrapped();
+    auto nativeValueConversionResult = convert<IDLDOMString>(lexicalGlobalObject, value);
+    if (nativeValueConversionResult.hasException(throwScope)) [[unlikely]]
+        return false;
+    invokeFunctorPropagatingExceptionIfNecessary(lexicalGlobalObject, throwScope, [&] {
+        return impl.setAttributeWithoutSynchronization(WebCore::HTMLNames::customContentStringAttrAttr, nativeValueConversionResult.releaseReturnValue());
+    });
+    return true;
+}
+
+JSC_DEFINE_CUSTOM_SETTER(setJSTestObj_reflectedSetterStringAttr, (JSGlobalObject* lexicalGlobalObject, EncodedJSValue thisValue, EncodedJSValue encodedValue, PropertyName attributeName))
+{
+    return IDLAttribute<JSTestObj>::set<setJSTestObj_reflectedSetterStringAttrSetter>(*lexicalGlobalObject, thisValue, encodedValue, attributeName);
+}
+
+static inline JSValue jsTestObj_reflectedSetterCustomIntegralAttrGetter(JSGlobalObject& lexicalGlobalObject, JSTestObj& thisObject)
+{
+    SUPPRESS_UNCOUNTED_LOCAL auto& vm = JSC::getVM(&lexicalGlobalObject);
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+    SUPPRESS_UNCOUNTED_LOCAL auto& impl = thisObject.wrapped();
+    RELEASE_AND_RETURN(throwScope, (toJS<IDLLong>(lexicalGlobalObject, throwScope, impl.reflectedSetterCustomIntegralAttr())));
+}
+
+JSC_DEFINE_CUSTOM_GETTER(jsTestObj_reflectedSetterCustomIntegralAttr, (JSGlobalObject* lexicalGlobalObject, EncodedJSValue thisValue, PropertyName attributeName))
+{
+    return IDLAttribute<JSTestObj>::get<jsTestObj_reflectedSetterCustomIntegralAttrGetter, CastedThisErrorBehavior::Assert>(*lexicalGlobalObject, thisValue, attributeName);
+}
+
+static inline bool setJSTestObj_reflectedSetterCustomIntegralAttrSetter(JSGlobalObject& lexicalGlobalObject, JSTestObj& thisObject, JSValue value)
+{
+    SUPPRESS_UNCOUNTED_LOCAL auto& vm = JSC::getVM(&lexicalGlobalObject);
+    UNUSED_PARAM(vm);
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+    SUPPRESS_UNCOUNTED_LOCAL auto& impl = thisObject.wrapped();
+    auto nativeValueConversionResult = convert<IDLLong>(lexicalGlobalObject, value);
+    if (nativeValueConversionResult.hasException(throwScope)) [[unlikely]]
+        return false;
+    invokeFunctorPropagatingExceptionIfNecessary(lexicalGlobalObject, throwScope, [&] {
+        return impl.setIntegralAttribute(WebCore::HTMLNames::customContentIntegralAttrAttr, nativeValueConversionResult.releaseReturnValue());
+    });
+    return true;
+}
+
+JSC_DEFINE_CUSTOM_SETTER(setJSTestObj_reflectedSetterCustomIntegralAttr, (JSGlobalObject* lexicalGlobalObject, EncodedJSValue thisValue, EncodedJSValue encodedValue, PropertyName attributeName))
+{
+    return IDLAttribute<JSTestObj>::set<setJSTestObj_reflectedSetterCustomIntegralAttrSetter>(*lexicalGlobalObject, thisValue, encodedValue, attributeName);
+}
+
+static inline JSValue jsTestObj_reflectedSetterCustomBooleanAttrGetter(JSGlobalObject& lexicalGlobalObject, JSTestObj& thisObject)
+{
+    SUPPRESS_UNCOUNTED_LOCAL auto& vm = JSC::getVM(&lexicalGlobalObject);
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+    SUPPRESS_UNCOUNTED_LOCAL auto& impl = thisObject.wrapped();
+    RELEASE_AND_RETURN(throwScope, (toJS<IDLBoolean>(lexicalGlobalObject, throwScope, impl.reflectedSetterCustomBooleanAttr())));
+}
+
+JSC_DEFINE_CUSTOM_GETTER(jsTestObj_reflectedSetterCustomBooleanAttr, (JSGlobalObject* lexicalGlobalObject, EncodedJSValue thisValue, PropertyName attributeName))
+{
+    return IDLAttribute<JSTestObj>::get<jsTestObj_reflectedSetterCustomBooleanAttrGetter, CastedThisErrorBehavior::Assert>(*lexicalGlobalObject, thisValue, attributeName);
+}
+
+static inline bool setJSTestObj_reflectedSetterCustomBooleanAttrSetter(JSGlobalObject& lexicalGlobalObject, JSTestObj& thisObject, JSValue value)
+{
+    SUPPRESS_UNCOUNTED_LOCAL auto& vm = JSC::getVM(&lexicalGlobalObject);
+    UNUSED_PARAM(vm);
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+    SUPPRESS_UNCOUNTED_LOCAL auto& impl = thisObject.wrapped();
+    auto nativeValueConversionResult = convert<IDLBoolean>(lexicalGlobalObject, value);
+    if (nativeValueConversionResult.hasException(throwScope)) [[unlikely]]
+        return false;
+    invokeFunctorPropagatingExceptionIfNecessary(lexicalGlobalObject, throwScope, [&] {
+        return impl.setBooleanAttribute(WebCore::HTMLNames::customContentBooleanAttrAttr, nativeValueConversionResult.releaseReturnValue());
+    });
+    return true;
+}
+
+JSC_DEFINE_CUSTOM_SETTER(setJSTestObj_reflectedSetterCustomBooleanAttr, (JSGlobalObject* lexicalGlobalObject, EncodedJSValue thisValue, EncodedJSValue encodedValue, PropertyName attributeName))
+{
+    return IDLAttribute<JSTestObj>::set<setJSTestObj_reflectedSetterCustomBooleanAttrSetter>(*lexicalGlobalObject, thisValue, encodedValue, attributeName);
+}
+
+static inline JSValue jsTestObj_reflectedSetterCustomURLAttrGetter(JSGlobalObject& lexicalGlobalObject, JSTestObj& thisObject)
+{
+    SUPPRESS_UNCOUNTED_LOCAL auto& vm = JSC::getVM(&lexicalGlobalObject);
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+    SUPPRESS_UNCOUNTED_LOCAL auto& impl = thisObject.wrapped();
+    RELEASE_AND_RETURN(throwScope, (toJS<IDLDOMString>(lexicalGlobalObject, throwScope, impl.reflectedSetterCustomURLAttr())));
+}
+
+JSC_DEFINE_CUSTOM_GETTER(jsTestObj_reflectedSetterCustomURLAttr, (JSGlobalObject* lexicalGlobalObject, EncodedJSValue thisValue, PropertyName attributeName))
+{
+    return IDLAttribute<JSTestObj>::get<jsTestObj_reflectedSetterCustomURLAttrGetter, CastedThisErrorBehavior::Assert>(*lexicalGlobalObject, thisValue, attributeName);
+}
+
+static inline bool setJSTestObj_reflectedSetterCustomURLAttrSetter(JSGlobalObject& lexicalGlobalObject, JSTestObj& thisObject, JSValue value)
+{
+    SUPPRESS_UNCOUNTED_LOCAL auto& vm = JSC::getVM(&lexicalGlobalObject);
+    UNUSED_PARAM(vm);
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+    SUPPRESS_UNCOUNTED_LOCAL auto& impl = thisObject.wrapped();
+    auto nativeValueConversionResult = convert<IDLDOMString>(lexicalGlobalObject, value);
+    if (nativeValueConversionResult.hasException(throwScope)) [[unlikely]]
+        return false;
+    invokeFunctorPropagatingExceptionIfNecessary(lexicalGlobalObject, throwScope, [&] {
+        return impl.setAttributeWithoutSynchronization(WebCore::HTMLNames::customContentURLAttrAttr, nativeValueConversionResult.releaseReturnValue());
+    });
+    return true;
+}
+
+JSC_DEFINE_CUSTOM_SETTER(setJSTestObj_reflectedSetterCustomURLAttr, (JSGlobalObject* lexicalGlobalObject, EncodedJSValue thisValue, EncodedJSValue encodedValue, PropertyName attributeName))
+{
+    return IDLAttribute<JSTestObj>::set<setJSTestObj_reflectedSetterCustomURLAttrSetter>(*lexicalGlobalObject, thisValue, encodedValue, attributeName);
 }
 
 #if ENABLE(TEST_FEATURE)

--- a/Source/WebCore/bindings/scripts/test/TestObj.idl
+++ b/Source/WebCore/bindings/scripts/test/TestObj.idl
@@ -116,6 +116,21 @@ enum TestConfidence { "high", "kinda-low" };
     [Reflect=customContentBooleanAttr] attribute boolean reflectedCustomBooleanAttr;
     [Reflect=customContentURLAttr, URL] attribute DOMString reflectedCustomURLAttr;
 
+    // Reflected for setter only DOM attributes
+    [ReflectSetter] attribute DOMString reflectedSetterStringAttr;
+    [ReflectSetter] attribute USVString reflectedSetterUSVStringAttr;
+    [ReflectSetter] attribute long reflectedSetterIntegralAttr;
+    [ReflectSetter] attribute unsigned long reflectedSetterUnsignedIntegralAttr;
+    [ReflectSetter] attribute boolean reflectedSetterBooleanAttr;
+    [ReflectSetter] attribute Element reflectedSetterElementAttr;
+    [ReflectSetter] attribute FrozenArray<Element> reflectedSetterElementsArrayAttr;
+    [ReflectSetter, URL] attribute DOMString reflectedSetterURLAttr;
+    [ReflectSetter, URL] attribute USVString reflectedSetterUSVURLAttr;
+    [ReflectSetter=customContentStringAttr] attribute DOMString reflectedSetterStringAttr;
+    [ReflectSetter=customContentIntegralAttr] attribute long reflectedSetterCustomIntegralAttr;
+    [ReflectSetter=customContentBooleanAttr] attribute boolean reflectedSetterCustomBooleanAttr;
+    [ReflectSetter=customContentURLAttr, URL] attribute DOMString reflectedSetterCustomURLAttr;
+
     // [EnabledByDeprecatedGlobalSetting] attributes and operations.
     [Conditional=TEST_FEATURE, EnabledByDeprecatedGlobalSetting=TestFeatureEnabled&TestFeature1Enabled] attribute DOMString enabledAtRuntimeAttribute;
     [Conditional=TEST_FEATURE, EnabledByDeprecatedGlobalSetting=TestFeatureEnabled] undefined enabledAtRuntimeOperation(DOMString testParam);

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -10197,7 +10197,7 @@ const AtomString& Document::dir() const
 void Document::setDir(const AtomString& value)
 {
     if (RefPtr documentElement = dynamicDowncast<HTMLHtmlElement>(this->documentElement()))
-        documentElement->setDir(value);
+        documentElement->setAttributeWithoutSynchronization(dirAttr, value);
 }
 
 DOMSelection* Document::getSelection()

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -726,7 +726,7 @@ bool Element::removeAttribute(const QualifiedName& name)
 void Element::setBooleanAttribute(const QualifiedName& name, bool value)
 {
     if (value)
-        setAttribute(name, emptyAtom());
+        setAttributeWithoutSynchronization(name, emptyAtom());
     else
         removeAttribute(name);
 }
@@ -4944,24 +4944,24 @@ URL Element::getNonEmptyURLAttribute(const QualifiedName& name) const
     return document().completeURL(value);
 }
 
-int Element::getIntegralAttribute(const QualifiedName& attributeName) const
+int Element::integralAttribute(const QualifiedName& attributeName) const
 {
-    return parseHTMLInteger(getAttribute(attributeName)).value_or(0);
+    return parseHTMLInteger(attributeWithoutSynchronization(attributeName)).value_or(0);
 }
 
 void Element::setIntegralAttribute(const QualifiedName& attributeName, int value)
 {
-    setAttribute(attributeName, AtomString::number(value));
+    setAttributeWithoutSynchronization(attributeName, AtomString::number(value));
 }
 
-unsigned Element::getUnsignedIntegralAttribute(const QualifiedName& attributeName) const
+unsigned Element::unsignedIntegralAttribute(const QualifiedName& attributeName) const
 {
-    return parseHTMLNonNegativeInteger(getAttribute(attributeName)).value_or(0);
+    return parseHTMLNonNegativeInteger(attributeWithoutSynchronization(attributeName)).value_or(0);
 }
 
 void Element::setUnsignedIntegralAttribute(const QualifiedName& attributeName, unsigned value)
 {
-    setAttribute(attributeName, AtomString::number(limitToOnlyHTMLNonNegative(value)));
+    setAttributeWithoutSynchronization(attributeName, AtomString::number(limitToOnlyHTMLNonNegative(value)));
 }
 
 bool Element::childShouldCreateRenderer(const Node& child) const
@@ -6309,6 +6309,11 @@ bool Element::hasRandomCachingKeyMap() const
     if (!hasRareData())
         return false;
     return elementRareData()->hasRandomCachingKeyMap();
+}
+
+void Element::setNumericAttribute(const QualifiedName& attributeName, double value)
+{
+    setAttributeWithoutSynchronization(attributeName, AtomString::number(value));
 }
 
 } // namespace WebCore

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -196,9 +196,11 @@ public:
     Vector<String> getAttributeNames() const;
 
     // Typed getters and setters for language bindings.
-    WEBCORE_EXPORT int getIntegralAttribute(const QualifiedName& attributeName) const;
+    WEBCORE_EXPORT int integralAttribute(const QualifiedName& attributeName) const;
+    WEBCORE_EXPORT unsigned unsignedIntegralAttribute(const QualifiedName& attributeName) const;
+    WEBCORE_EXPORT void setBooleanAttribute(const QualifiedName& attributeName, bool);
     WEBCORE_EXPORT void setIntegralAttribute(const QualifiedName& attributeName, int value);
-    WEBCORE_EXPORT unsigned getUnsignedIntegralAttribute(const QualifiedName& attributeName) const;
+    WEBCORE_EXPORT void setNumericAttribute(const QualifiedName& attributeName, double value);
     WEBCORE_EXPORT void setUnsignedIntegralAttribute(const QualifiedName& attributeName, unsigned value);
     WEBCORE_EXPORT RefPtr<Element> getElementAttributeForBindings(const QualifiedName& attributeName) const;
     WEBCORE_EXPORT void setElementAttribute(const QualifiedName& attributeName, Element* value);
@@ -370,8 +372,6 @@ public:
     Ref<Element> cloneElementWithoutChildren(Document&, CustomElementRegistry*);
 
     void normalizeAttributes();
-
-    WEBCORE_EXPORT void setBooleanAttribute(const QualifiedName& name, bool);
 
     // For exposing to DOM only.
     WEBCORE_EXPORT NamedNodeMap& attributesMap() const;

--- a/Source/WebCore/dom/ElementContentEditable.idl
+++ b/Source/WebCore/dom/ElementContentEditable.idl
@@ -26,7 +26,7 @@
 // https://html.spec.whatwg.org/#elementcontenteditable
 interface mixin ElementContentEditable {
     [CEReactions=Needed] attribute DOMString contentEditable;
-    [CEReactions=Needed, EnabledBySetting=EnterKeyHintEnabled] attribute [AtomString] DOMString enterKeyHint;
+    [CEReactions=Needed, EnabledBySetting=EnterKeyHintEnabled, ReflectSetter] attribute [AtomString] DOMString enterKeyHint;
     readonly attribute boolean isContentEditable;
-    [CEReactions=Needed] attribute [AtomString] DOMString inputMode;
+    [CEReactions=Needed, ReflectSetter] attribute [AtomString] DOMString inputMode;
 };

--- a/Source/WebCore/dom/ElementInternals.h
+++ b/Source/WebCore/dom/ElementInternals.h
@@ -36,8 +36,8 @@
 namespace WebCore {
 
 class CustomStateSet;
-class HTMLFormElement;
 class FormAssociatedCustomElement;
+class HTMLFormElement;
 
 class ElementInternals final : public ScriptWrappable, public RefCounted<ElementInternals> {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(ElementInternals);

--- a/Source/WebCore/editing/BreakBlockquoteCommand.cpp
+++ b/Source/WebCore/editing/BreakBlockquoteCommand.cpp
@@ -88,7 +88,7 @@ void BreakBlockquoteCommand::doApply()
             return lineBreak;
 
         auto container = HTMLDivElement::create(document());
-        container->setDir(autoAtom());
+        container->setAttributeWithoutSynchronization(dirAttr, autoAtom());
         container->appendChild(lineBreak);
         return container;
     }();

--- a/Source/WebCore/editing/CreateLinkCommand.cpp
+++ b/Source/WebCore/editing/CreateLinkCommand.cpp
@@ -45,8 +45,8 @@ void CreateLinkCommand::doApply()
 
     Ref document = this->document();
     Ref anchorElement = HTMLAnchorElement::create(document);
-    anchorElement->setHref(AtomString { m_url });
-    
+    anchorElement->setAttributeWithoutSynchronization(HTMLNames::hrefAttr, AtomString { m_url });
+
     if (endingSelection().isRange())
         applyStyledElement(WTFMove(anchorElement));
     else {

--- a/Source/WebCore/editing/Editor.cpp
+++ b/Source/WebCore/editing/Editor.cpp
@@ -4736,7 +4736,7 @@ void Editor::registerAttachmentIdentifier(const String& identifier, const Attach
         if (!imageData)
             return std::nullopt;
 
-        String name = imageElement->alt();
+        String name = imageElement->attributeWithoutSynchronization(altAttr);
         if (name.isEmpty())
             name = imageElement->document().completeURL(imageElement->imageSourceURL()).lastPathComponent().toString();
 

--- a/Source/WebCore/editing/EditorCommand.cpp
+++ b/Source/WebCore/editing/EditorCommand.cpp
@@ -479,9 +479,9 @@ static bool executeInsertHTML(LocalFrame& frame, Event*, EditorCommandSource, co
 static bool executeInsertImage(LocalFrame& frame, Event*, EditorCommandSource, const String& value)
 {
     // FIXME: If userInterface is true, we should display a dialog box and let the user choose a local image.
-    Ref<HTMLImageElement> image = HTMLImageElement::create(*frame.document());
+    Ref image = HTMLImageElement::create(*frame.document());
     if (!value.isEmpty())
-        image->setSrc(AtomString { value });
+        image->setAttributeWithoutSynchronization(srcAttr, AtomString { value });
     return executeInsertNode(frame, WTFMove(image));
 }
 

--- a/Source/WebCore/editing/cocoa/DataDetection.mm
+++ b/Source/WebCore/editing/cocoa/DataDetection.mm
@@ -657,9 +657,9 @@ static NSArray * processDataDetectorScannerResults(DDScannerRef scanner, OptionS
             auto newTextNode = Text::create(document, WTFMove(textNodeData));
             parentNode->insertBefore(newTextNode.copyRef(), currentTextNode.get());
 
-            Ref<HTMLAnchorElement> anchorElement = HTMLAnchorElement::create(document);
-            anchorElement->setHref(correspondingURL.get());
-            anchorElement->setDir("ltr"_s);
+            Ref anchorElement = HTMLAnchorElement::create(document);
+            anchorElement->setAttributeWithoutSynchronization(hrefAttr, correspondingURL.get());
+            anchorElement->setAttributeWithoutSynchronization(dirAttr, "ltr"_s);
 
             if (shouldUseLightLinks) {
                 document.updateStyleIfNeeded();

--- a/Source/WebCore/editing/cocoa/EditorCocoa.mm
+++ b/Source/WebCore/editing/cocoa/EditorCocoa.mm
@@ -458,7 +458,7 @@ void Editor::insertMultiRepresentationHEIC(const std::span<const uint8_t>& data,
     picture->appendChild(WTFMove(source));
 
     auto image = HTMLImageElement::create(document);
-    image->setSrc(AtomString { DOMURL::createObjectURL(document, Blob::create(document.ptr(), fallbackBuffer->copyData(), fallbackType)) });
+    image->setAttributeWithoutSynchronization(srcAttr, AtomString { DOMURL::createObjectURL(document, Blob::create(document.ptr(), fallbackBuffer->copyData(), fallbackType)) });
     if (!altText.isEmpty())
         image->setAttributeWithoutSynchronization(HTMLNames::altAttr, AtomString { altText });
     picture->appendChild(WTFMove(image));

--- a/Source/WebCore/html/FileInputType.cpp
+++ b/Source/WebCore/html/FileInputType.cpp
@@ -232,7 +232,7 @@ void FileInputType::createShadowSubtree()
     Ref button = HTMLInputElement::create(inputTag, element->protectedDocument(), nullptr, false);
     {
         ScriptDisallowedScope::EventAllowedScope eventAllowedScopeBeforeAppend { button };
-        button->setType(InputTypeNames::button());
+        button->setAttributeWithoutSynchronization(typeAttr, InputTypeNames::button());
         button->setUserAgentPart(UserAgentParts::fileSelectorButton());
         button->setValue(element->multiple() ? fileButtonChooseMultipleFilesLabel() : fileButtonChooseFileLabel());
     }

--- a/Source/WebCore/html/HTMLAnchorElement.cpp
+++ b/Source/WebCore/html/HTMLAnchorElement.cpp
@@ -263,11 +263,6 @@ URL HTMLAnchorElement::href() const
     return protectedDocument()->completeURL(attributeWithoutSynchronization(hrefAttr));
 }
 
-void HTMLAnchorElement::setHref(const AtomString& value)
-{
-    setAttributeWithoutSynchronization(hrefAttr, value);
-}
-
 bool HTMLAnchorElement::hasRel(Relation relation) const
 {
     return m_linkRelations.contains(relation);
@@ -696,11 +691,6 @@ void HTMLAnchorElement::setRootEditableElementForSelectionOnMouseDown(Element* e
     m_hasRootEditableElementForSelectionOnMouseDown = true;
 }
 
-void HTMLAnchorElement::setReferrerPolicyForBindings(const AtomString& value)
-{
-    setAttributeWithoutSynchronization(referrerpolicyAttr, value);
-}
-
 String HTMLAnchorElement::referrerPolicyForBindings() const
 {
     return referrerPolicyToString(referrerPolicy());
@@ -716,6 +706,11 @@ Node::InsertedIntoAncestorResult HTMLAnchorElement::insertedIntoAncestor(Inserti
     auto result = HTMLElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);
     document().processInternalResourceLinks(this);
     return result;
+}
+
+void HTMLAnchorElement::setFullURL(const URL& fullURL)
+{
+    setAttributeWithoutSynchronization(hrefAttr, AtomString { fullURL.string() });
 }
 
 }

--- a/Source/WebCore/html/HTMLAnchorElement.h
+++ b/Source/WebCore/html/HTMLAnchorElement.h
@@ -54,7 +54,6 @@ public:
     virtual ~HTMLAnchorElement();
 
     WEBCORE_EXPORT URL href() const;
-    void setHref(const AtomString&);
 
     const AtomString& name() const;
 
@@ -79,7 +78,6 @@ public:
     WEBCORE_EXPORT bool isSystemPreviewLink();
 #endif
 
-    void setReferrerPolicyForBindings(const AtomString&);
     String referrerPolicyForBindings() const;
     ReferrerPolicy referrerPolicy() const;
 
@@ -128,7 +126,7 @@ private:
     void clearRootEditableElementForSelectionOnMouseDown();
 
     URL fullURL() const final { return href(); }
-    void setFullURL(const URL& fullURL) final { setHref(AtomString { fullURL.string() }); }
+    void setFullURL(const URL&) final;
 
     bool m_hasRootEditableElementForSelectionOnMouseDown { false };
     bool m_wasShiftKeyDownOnMouseDown { false };

--- a/Source/WebCore/html/HTMLAnchorElement.idl
+++ b/Source/WebCore/html/HTMLAnchorElement.idl
@@ -40,7 +40,7 @@
 
     [PutForwards=value] readonly attribute DOMTokenList relList;
 
-    [CEReactions=NotNeeded, ImplementedAs=referrerPolicyForBindings] attribute [AtomString] DOMString referrerPolicy;
+    [CEReactions=NotNeeded, ImplementedAs=referrerPolicyForBindings, ReflectSetter] attribute [AtomString] DOMString referrerPolicy;
 };
 
 HTMLAnchorElement includes HTMLHyperlinkElementUtils;

--- a/Source/WebCore/html/HTMLAreaElement.idl
+++ b/Source/WebCore/html/HTMLAreaElement.idl
@@ -30,7 +30,7 @@
     [CEReactions=NotNeeded, Reflect] attribute DOMString target;
 
     [CEReactions=NotNeeded, EnabledBySetting=DownloadAttributeEnabled, Reflect] attribute DOMString download;
-    [CEReactions=NotNeeded, ImplementedAs=referrerPolicyForBindings] attribute [AtomString] DOMString referrerPolicy;
+    [CEReactions=NotNeeded, ImplementedAs=referrerPolicyForBindings, ReflectSetter] attribute [AtomString] DOMString referrerPolicy;
 
     [PutForwards=value] readonly attribute DOMTokenList relList;
 };

--- a/Source/WebCore/html/HTMLAttachmentElement.cpp
+++ b/Source/WebCore/html/HTMLAttachmentElement.cpp
@@ -857,11 +857,11 @@ void HTMLAttachmentElement::updateImage()
 
     if (!m_iconForWideLayout.isEmpty()) {
         dispatchEvent(Event::create(eventNames().loadeddataEvent, Event::CanBubble::No, Event::IsCancelable::No));
-        m_imageElement->setSrc(AtomString { DOMURL::createObjectURL(document(), Blob::create(protectedDocument().ptr(), Vector<uint8_t>(m_iconForWideLayout), "image/png"_s)) });
+        m_imageElement->setAttributeWithoutSynchronization(srcAttr, AtomString { DOMURL::createObjectURL(document(), Blob::create(protectedDocument().ptr(), Vector<uint8_t>(m_iconForWideLayout), "image/png"_s)) });
         return;
     }
 
-    m_imageElement->setSrc(nullAtom());
+    m_imageElement->removeAttribute(srcAttr);
 }
 
 void HTMLAttachmentElement::updateIconForNarrowLayout(const RefPtr<Image>& icon, const WebCore::FloatSize& iconSize)

--- a/Source/WebCore/html/HTMLBaseElement.cpp
+++ b/Source/WebCore/html/HTMLBaseElement.cpp
@@ -94,9 +94,4 @@ String HTMLBaseElement::href() const
     return urlRecord.string();
 }
 
-void HTMLBaseElement::setHref(const AtomString& value)
-{
-    setAttributeWithoutSynchronization(hrefAttr, value);
-}
-
 }

--- a/Source/WebCore/html/HTMLBaseElement.h
+++ b/Source/WebCore/html/HTMLBaseElement.h
@@ -33,7 +33,6 @@ public:
     static Ref<HTMLBaseElement> create(const QualifiedName&, Document&);
 
     WEBCORE_EXPORT String href() const;
-    WEBCORE_EXPORT void setHref(const AtomString&);
 
 private:
     HTMLBaseElement(const QualifiedName&, Document&);

--- a/Source/WebCore/html/HTMLBaseElement.idl
+++ b/Source/WebCore/html/HTMLBaseElement.idl
@@ -20,7 +20,7 @@
 [
     Exposed=Window
 ] interface HTMLBaseElement : HTMLElement {
-    [CEReactions=NotNeeded] attribute [AtomString] USVString href;
+    [CEReactions=NotNeeded, ReflectSetter] attribute [AtomString] USVString href;
 
     [CEReactions=NotNeeded, Reflect] attribute DOMString target;
 };

--- a/Source/WebCore/html/HTMLButtonElement.cpp
+++ b/Source/WebCore/html/HTMLButtonElement.cpp
@@ -71,11 +71,6 @@ Ref<HTMLButtonElement> HTMLButtonElement::create(Document& document)
     return adoptRef(*new HTMLButtonElement(buttonTag, document, nullptr));
 }
 
-void HTMLButtonElement::setType(const AtomString& type)
-{
-    setAttributeWithoutSynchronization(typeAttr, type);
-}
-
 RenderPtr<RenderElement> HTMLButtonElement::createElementRenderer(RenderStyle&& style, const RenderTreePosition& position)
 {
     // https://html.spec.whatwg.org/multipage/rendering.html#button-layout
@@ -259,11 +254,6 @@ const AtomString& HTMLButtonElement::command() const
 
     ASSERT_NOT_REACHED();
     return nullAtom();
-}
-
-void HTMLButtonElement::setCommand(const AtomString& value)
-{
-    setAttributeWithoutSynchronization(HTMLNames::commandAttr, value);
 }
 
 void HTMLButtonElement::defaultEventHandler(Event& event)

--- a/Source/WebCore/html/HTMLButtonElement.h
+++ b/Source/WebCore/html/HTMLButtonElement.h
@@ -35,13 +35,9 @@ class HTMLButtonElement final : public HTMLFormControlElement {
 public:
     static Ref<HTMLButtonElement> create(const QualifiedName&, Document&, HTMLFormElement*);
     static Ref<HTMLButtonElement> create(Document&);
-
-    WEBCORE_EXPORT void setType(const AtomString&);
     
     const AtomString& value() const;
-
     const AtomString& command() const;
-    void setCommand(const AtomString&);
 
     RefPtr<Element> commandForElement() const;
     CommandType commandType() const;

--- a/Source/WebCore/html/HTMLButtonElement.idl
+++ b/Source/WebCore/html/HTMLButtonElement.idl
@@ -23,11 +23,11 @@
 ] interface HTMLButtonElement : HTMLElement {
     [CEReactions=NotNeeded, Reflect] attribute boolean disabled;
     [ImplementedAs=formForBindings] readonly attribute HTMLFormElement form;
-    [CEReactions=NotNeeded] attribute [AtomString] USVString formAction;
+    [CEReactions=NotNeeded, ReflectSetter] attribute [AtomString] USVString formAction;
 
-    [CEReactions=NotNeeded] attribute [AtomString] DOMString formEnctype;
-    [CEReactions=NotNeeded] attribute [AtomString] DOMString formMethod;
-    [CEReactions=NotNeeded] attribute [AtomString] DOMString type;
+    [CEReactions=NotNeeded, ReflectSetter] attribute [AtomString] DOMString formEnctype;
+    [CEReactions=NotNeeded, ReflectSetter] attribute [AtomString] DOMString formMethod;
+    [CEReactions=NotNeeded, ReflectSetter] attribute [AtomString] DOMString type;
 
     [CEReactions=NotNeeded, Reflect] attribute boolean formNoValidate;
     [CEReactions=NotNeeded, Reflect] attribute DOMString formTarget;
@@ -36,7 +36,7 @@
 
     // Command Invokers
     [CEReactions=NotNeeded, Reflect=commandfor, EnabledBySetting=CommandAttributesEnabled] attribute Element? commandForElement;
-    [CEReactions=NotNeeded, EnabledBySetting=CommandAttributesEnabled] attribute [AtomString] DOMString command;
+    [CEReactions=NotNeeded, EnabledBySetting=CommandAttributesEnabled, ReflectSetter] attribute [AtomString] DOMString command;
 
     readonly attribute boolean willValidate;
     readonly attribute ValidityState validity;

--- a/Source/WebCore/html/HTMLDetailsElement.cpp
+++ b/Source/WebCore/html/HTMLDetailsElement.cpp
@@ -118,7 +118,7 @@ void HTMLDetailsElement::didAddUserAgentShadowRoot(ShadowRoot& root)
 
     Ref defaultSlot = HTMLSlotElement::create(slotTag, document);
     defaultSlot->setUserAgentPart(UserAgentParts::detailsContent());
-    ASSERT(!hasAttribute(openAttr));
+    ASSERT(!hasAttributeWithoutSynchronization(openAttr));
     defaultSlot->setInlineStyleProperty(CSSPropertyContentVisibility, CSSValueHidden);
     defaultSlot->setInlineStyleProperty(CSSPropertyDisplay, CSSValueBlock);
     root.appendChild(defaultSlot);
@@ -202,15 +202,20 @@ Vector<RefPtr<HTMLDetailsElement>> HTMLDetailsElement::otherElementsInNameGroup(
 
 void HTMLDetailsElement::ensureDetailsExclusivityAfterMutation()
 {
-    if (hasAttribute(openAttr) && !attributeWithoutSynchronization(nameAttr).isEmpty()) {
+    if (hasAttributeWithoutSynchronization(openAttr) && !attributeWithoutSynchronization(nameAttr).isEmpty()) {
         ShouldNotFireMutationEventsScope scope(document());
         for (auto& otherDetailsElement : otherElementsInNameGroup()) {
-            if (otherDetailsElement->hasAttribute(openAttr)) {
+            if (otherDetailsElement->hasAttributeWithoutSynchronization(openAttr)) {
                 toggleOpen();
                 break;
             }
         }
     }
+}
+
+void HTMLDetailsElement::toggleOpen()
+{
+    setBooleanAttribute(HTMLNames::openAttr, !hasAttributeWithoutSynchronization(HTMLNames::openAttr));
 }
 
 } // namespace WebCore

--- a/Source/WebCore/html/HTMLDetailsElement.h
+++ b/Source/WebCore/html/HTMLDetailsElement.h
@@ -35,7 +35,7 @@ public:
     static Ref<HTMLDetailsElement> create(const QualifiedName& tagName, Document&);
     ~HTMLDetailsElement();
 
-    void toggleOpen() { setBooleanAttribute(HTMLNames::openAttr, !hasAttribute(HTMLNames::openAttr)); }
+    void toggleOpen();
 
     bool isActiveSummary(const HTMLSummaryElement&) const;
 

--- a/Source/WebCore/html/HTMLDialogElement.cpp
+++ b/Source/WebCore/html/HTMLDialogElement.cpp
@@ -76,7 +76,7 @@ ExceptionOr<void> HTMLDialogElement::show()
 
     queueDialogToggleEventTask(ToggleState::Closed, ToggleState::Open);
 
-    setBooleanAttribute(openAttr, true);
+    setAttributeWithoutSynchronization(openAttr, emptyAtom());
 
     Ref document = this->document();
     m_previouslyFocusedElement = document->focusedElement();
@@ -126,10 +126,10 @@ ExceptionOr<void> HTMLDialogElement::showModal()
 
     queueDialogToggleEventTask(ToggleState::Closed, ToggleState::Open);
 
-    // setBooleanAttribute will dispatch a DOMSubtreeModified event.
+    // setAttributeWihoutSynchronization will dispatch a DOMSubtreeModified event.
     // Postpone callback execution that can potentially make the dialog disconnected.
     EventQueueScope scope;
-    setBooleanAttribute(openAttr, true);
+    setAttributeWithoutSynchronization(openAttr, emptyAtom());
 
     setIsModal(true);
 
@@ -166,7 +166,7 @@ void HTMLDialogElement::close(const String& result)
 
     queueDialogToggleEventTask(ToggleState::Open, ToggleState::Closed);
 
-    setBooleanAttribute(openAttr, false);
+    removeAttribute(openAttr);
 
     if (isModal())
         removeFromTopLayer();
@@ -299,4 +299,9 @@ void HTMLDialogElement::queueDialogToggleEventTask(ToggleState oldState, ToggleS
     RefPtr { m_toggleEventTask }->queue(oldState, newState);
 }
 
-};
+bool HTMLDialogElement::isOpen() const
+{
+    return hasAttributeWithoutSynchronization(HTMLNames::openAttr);
+}
+
+}

--- a/Source/WebCore/html/HTMLDialogElement.h
+++ b/Source/WebCore/html/HTMLDialogElement.h
@@ -30,15 +30,13 @@
 
 namespace WebCore {
 
-class ToggleEventTask;
-
 class HTMLDialogElement final : public HTMLElement {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(HTMLDialogElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLDialogElement);
 public:
     template<typename... Args> static Ref<HTMLDialogElement> create(Args&&... args) { return adoptRef(*new HTMLDialogElement(std::forward<Args>(args)...)); }
 
-    bool isOpen() const { return hasAttribute(HTMLNames::openAttr); }
+    bool isOpen() const;
 
     const String& returnValue() const { return m_returnValue; }
     void setReturnValue(String&& value) { m_returnValue = WTFMove(value); }

--- a/Source/WebCore/html/HTMLElement.cpp
+++ b/Source/WebCore/html/HTMLElement.cpp
@@ -479,11 +479,6 @@ const AtomString& HTMLElement::dir() const
     return toValidDirValue(attributeWithoutSynchronization(dirAttr));
 }
 
-void HTMLElement::setDir(const AtomString& value)
-{
-    setAttributeWithoutSynchronization(dirAttr, value);
-}
-
 ExceptionOr<void> HTMLElement::setInnerText(String&& text)
 {
     // FIXME: This doesn't take whitespace collapsing into account at all.
@@ -948,11 +943,6 @@ AutocapitalizeType HTMLElement::autocapitalizeType() const
     return autocapitalizeTypeForAttributeValue(attributeWithoutSynchronization(HTMLNames::autocapitalizeAttr));
 }
 
-void HTMLElement::setAutocapitalize(const AtomString& value)
-{
-    setAttributeWithoutSynchronization(autocapitalizeAttr, value);
-}
-
 #endif
 
 #if ENABLE(AUTOCORRECT)
@@ -981,11 +971,6 @@ const AtomString& HTMLElement::inputMode() const
     return stringForInputMode(canonicalInputMode());
 }
 
-void HTMLElement::setInputMode(const AtomString& value)
-{
-    setAttributeWithoutSynchronization(inputmodeAttr, value);
-}
-
 EnterKeyHint HTMLElement::canonicalEnterKeyHint() const
 {
     return enterKeyHintForAttributeValue(attributeWithoutSynchronization(enterkeyhintAttr));
@@ -994,11 +979,6 @@ EnterKeyHint HTMLElement::canonicalEnterKeyHint() const
 String HTMLElement::enterKeyHint() const
 {
     return attributeValueForEnterKeyHint(canonicalEnterKeyHint());
-}
-
-void HTMLElement::setEnterKeyHint(const AtomString& value)
-{
-    setAttributeWithoutSynchronization(enterkeyhintAttr, value);
 }
 
 // https://html.spec.whatwg.org/#dom-hidden
@@ -1101,7 +1081,7 @@ static void runPopoverFocusingSteps(HTMLElement& popover)
         return;
     }
 
-    RefPtr control = popover.hasAttribute(autofocusAttr) ? &popover : popover.findAutofocusDelegate();
+    RefPtr control = popover.hasAttributeWithoutSynchronization(autofocusAttr) ? &popover : popover.findAutofocusDelegate();
     if (!control)
         return;
 

--- a/Source/WebCore/html/HTMLElement.h
+++ b/Source/WebCore/html/HTMLElement.h
@@ -93,7 +93,6 @@ public:
     String accessKeyLabel() const;
 
     WEBCORE_EXPORT const AtomString& dir() const;
-    WEBCORE_EXPORT void setDir(const AtomString&);
 
     virtual bool isTextControlInnerTextElement() const { return false; }
     virtual bool isSearchFieldResultsButtonElement() const { return false; }
@@ -120,7 +119,6 @@ public:
 #if ENABLE(AUTOCAPITALIZE)
     WEBCORE_EXPORT virtual AutocapitalizeType autocapitalizeType() const;
     WEBCORE_EXPORT const AtomString& autocapitalize() const;
-    WEBCORE_EXPORT void setAutocapitalize(const AtomString& value);
 #endif
 
 #if ENABLE(AUTOCORRECT)
@@ -131,11 +129,9 @@ public:
 
     WEBCORE_EXPORT InputMode canonicalInputMode() const;
     const AtomString& inputMode() const;
-    void setInputMode(const AtomString& value);
 
     WEBCORE_EXPORT EnterKeyHint canonicalEnterKeyHint() const;
     String enterKeyHint() const;
-    void setEnterKeyHint(const AtomString& value);
 
     std::optional<Variant<bool, double, String>> hidden() const;
     void setHidden(const std::optional<Variant<bool, double, String>>&);

--- a/Source/WebCore/html/HTMLElement.idl
+++ b/Source/WebCore/html/HTMLElement.idl
@@ -33,7 +33,7 @@
     [CEReactions=Needed, Reflect] attribute DOMString title;
     [CEReactions=Needed, Reflect] attribute DOMString lang;
     [CEReactions=Needed] attribute boolean translate;
-    [CEReactions=Needed] attribute [AtomString] DOMString dir;
+    [CEReactions=Needed, ReflectSetter] attribute [AtomString] DOMString dir;
 
     // TextTrackCue related
     [CEReactions=Needed, Reflect] attribute boolean cue;
@@ -46,7 +46,7 @@
     readonly attribute DOMString accessKeyLabel;
     [CEReactions=Needed] attribute boolean draggable;
     [CEReactions=Needed] attribute boolean spellcheck;
-    [Conditional=AUTOCAPITALIZE, CEReactions=Needed] attribute [AtomString] DOMString autocapitalize;
+    [Conditional=AUTOCAPITALIZE, CEReactions=Needed, ReflectSetter] attribute [AtomString] DOMString autocapitalize;
 
     [CEReactions=Needed] attribute [LegacyNullToEmptyString] DOMString innerText;
 

--- a/Source/WebCore/html/HTMLFormControlElement.cpp
+++ b/Source/WebCore/html/HTMLFormControlElement.cpp
@@ -81,22 +81,12 @@ String HTMLFormControlElement::formEnctype() const
     return FormSubmission::Attributes::parseEncodingType(formEnctypeAttr);
 }
 
-void HTMLFormControlElement::setFormEnctype(const AtomString& value)
-{
-    setAttributeWithoutSynchronization(formenctypeAttr, value);
-}
-
 String HTMLFormControlElement::formMethod() const
 {
     auto& formMethodAttr = attributeWithoutSynchronization(formmethodAttr);
     if (formMethodAttr.isNull())
         return emptyString();
     return FormSubmission::Attributes::methodString(FormSubmission::Attributes::parseMethodType(formMethodAttr));
-}
-
-void HTMLFormControlElement::setFormMethod(const AtomString& value)
-{
-    setAttributeWithoutSynchronization(formmethodAttr, value);
 }
 
 bool HTMLFormControlElement::formNoValidate() const
@@ -110,11 +100,6 @@ String HTMLFormControlElement::formAction() const
     if (value.isEmpty())
         return document().url().string();
     return document().completeURL(value).string();
-}
-
-void HTMLFormControlElement::setFormAction(const AtomString& value)
-{
-    setAttributeWithoutSynchronization(formactionAttr, value);
 }
 
 Node::InsertedIntoAncestorResult HTMLFormControlElement::insertedIntoAncestor(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
@@ -307,11 +292,6 @@ String HTMLFormControlElement::autocomplete() const
     return autofillData().idlExposedValue;
 }
 
-void HTMLFormControlElement::setAutocomplete(const AtomString& value)
-{
-    setAttributeWithoutSynchronization(autocompleteAttr, value);
-}
-
 AutofillMantle HTMLFormControlElement::autofillMantle() const
 {
     auto* input = dynamicDowncast<HTMLInputElement>(this);
@@ -386,11 +366,6 @@ const AtomString& HTMLFormControlElement::popoverTargetAction() const
         return hideAtom();
 
     return toggleAtom();
-}
-
-void HTMLFormControlElement::setPopoverTargetAction(const AtomString& value)
-{
-    setAttributeWithoutSynchronization(HTMLNames::popovertargetactionAttr, value);
 }
 
 // https://html.spec.whatwg.org/#popover-target-attribute-activation-behavior

--- a/Source/WebCore/html/HTMLFormControlElement.h
+++ b/Source/WebCore/html/HTMLFormControlElement.h
@@ -51,12 +51,9 @@ public:
     bool supportsFocus() const override { return !isDisabled(); }
 
     WEBCORE_EXPORT String formEnctype() const;
-    WEBCORE_EXPORT void setFormEnctype(const AtomString&);
     WEBCORE_EXPORT String formMethod() const;
-    WEBCORE_EXPORT void setFormMethod(const AtomString&);
     bool formNoValidate() const;
     WEBCORE_EXPORT String formAction() const;
-    WEBCORE_EXPORT void setFormAction(const AtomString&);
 
     bool formControlValueMatchesRenderer() const { return m_valueMatchesRenderer; }
     void setFormControlValueMatchesRenderer(bool b) { m_valueMatchesRenderer = b; }
@@ -89,7 +86,6 @@ public:
 #endif
 
     WEBCORE_EXPORT String autocomplete() const;
-    WEBCORE_EXPORT void setAutocomplete(const AtomString&);
 
     AutofillMantle autofillMantle() const;
 
@@ -101,7 +97,6 @@ public:
 
     RefPtr<HTMLElement> popoverTargetElement() const;
     const AtomString& popoverTargetAction() const;
-    void setPopoverTargetAction(const AtomString& value);
 
     bool isKeyboardFocusable(KeyboardEvent*) const override;
 

--- a/Source/WebCore/html/HTMLFormElement.cpp
+++ b/Source/WebCore/html/HTMLFormElement.cpp
@@ -695,24 +695,9 @@ String HTMLFormElement::action() const
     return document().completeURL(value).string();
 }
 
-void HTMLFormElement::setAction(const AtomString& value)
-{
-    setAttributeWithoutSynchronization(actionAttr, value);
-}
-
-void HTMLFormElement::setEnctype(const AtomString& value)
-{
-    setAttributeWithoutSynchronization(enctypeAttr, value);
-}
-
 String HTMLFormElement::method() const
 {
     return FormSubmission::Attributes::methodString(m_attributes.method());
-}
-
-void HTMLFormElement::setMethod(const AtomString& value)
-{
-    setAttributeWithoutSynchronization(methodAttr, value);
 }
 
 DOMTokenList& HTMLFormElement::relList()
@@ -967,11 +952,6 @@ Vector<Ref<ValidatedFormListedElement>> HTMLFormElement::copyValidatedListedElem
 HTMLFormElement* HTMLFormElement::findClosestFormAncestor(const Element& startElement)
 {
     return const_cast<HTMLFormElement*>(ancestorsOfType<HTMLFormElement>(startElement).first());
-}
-
-void HTMLFormElement::setAutocomplete(const AtomString& value)
-{
-    setAttributeWithoutSynchronization(autocompleteAttr, value);
 }
 
 const AtomString& HTMLFormElement::autocomplete() const

--- a/Source/WebCore/html/HTMLFormElement.h
+++ b/Source/WebCore/html/HTMLFormElement.h
@@ -61,11 +61,9 @@ public:
     Vector<AtomString> supportedPropertyNames() const;
 
     String enctype() const { return m_attributes.encodingType(); }
-    WEBCORE_EXPORT void setEnctype(const AtomString&);
 
     bool shouldAutocomplete() const;
 
-    WEBCORE_EXPORT void setAutocomplete(const AtomString&);
     WEBCORE_EXPORT const AtomString& autocomplete() const;
 
     void registerFormListedElement(FormListedElement&);
@@ -93,10 +91,7 @@ public:
     void setAcceptCharset(const String&);
 
     WEBCORE_EXPORT String action() const;
-    WEBCORE_EXPORT void setAction(const AtomString&);
-
     WEBCORE_EXPORT String method() const;
-    WEBCORE_EXPORT void setMethod(const AtomString&);
 
     DOMTokenList& relList();
 

--- a/Source/WebCore/html/HTMLFormElement.idl
+++ b/Source/WebCore/html/HTMLFormElement.idl
@@ -25,11 +25,11 @@
     Exposed=Window
 ] interface HTMLFormElement : HTMLElement {
     [CEReactions=NotNeeded, Reflect=accept_charset] attribute DOMString acceptCharset;
-    [CEReactions=NotNeeded] attribute [AtomString] USVString action;
-    [CEReactions=NotNeeded] attribute [AtomString] DOMString autocomplete;
-    [CEReactions=NotNeeded] attribute [AtomString] DOMString enctype;
-    [CEReactions=NotNeeded, ImplementedAs=enctype] attribute [AtomString] DOMString encoding;
-    [CEReactions=NotNeeded] attribute [AtomString] DOMString method;
+    [CEReactions=NotNeeded, ReflectSetter] attribute [AtomString] USVString action;
+    [CEReactions=NotNeeded, ReflectSetter] attribute [AtomString] DOMString autocomplete;
+    [CEReactions=NotNeeded, ReflectSetter] attribute [AtomString] DOMString enctype;
+    [CEReactions=NotNeeded, ImplementedAs=enctype, ReflectSetter=enctype] attribute [AtomString] DOMString encoding;
+    [CEReactions=NotNeeded, ReflectSetter] attribute [AtomString] DOMString method;
     [CEReactions=NotNeeded, Reflect] attribute DOMString name;
     [CEReactions=NotNeeded, Reflect] attribute boolean noValidate;
     [CEReactions=NotNeeded, Reflect] attribute DOMString target;

--- a/Source/WebCore/html/HTMLIFrameElement.cpp
+++ b/Source/WebCore/html/HTMLIFrameElement.cpp
@@ -167,11 +167,6 @@ RenderPtr<RenderElement> HTMLIFrameElement::createElementRenderer(RenderStyle&& 
     return createRenderer<RenderIFrame>(*this, WTFMove(style));
 }
 
-void HTMLIFrameElement::setReferrerPolicyForBindings(const AtomString& value)
-{
-    setAttributeWithoutSynchronization(referrerpolicyAttr, value);
-}
-
 String HTMLIFrameElement::referrerPolicyForBindings() const
 {
     return referrerPolicyToString(referrerPolicy());
@@ -187,11 +182,6 @@ ReferrerPolicy HTMLIFrameElement::referrerPolicy() const
 const AtomString& HTMLIFrameElement::loading() const
 {
     return equalLettersIgnoringASCIICase(attributeWithoutSynchronization(HTMLNames::loadingAttr), "lazy"_s) ? lazyAtom() : eagerAtom();
-}
-
-void HTMLIFrameElement::setLoading(const AtomString& value)
-{
-    setAttributeWithoutSynchronization(loadingAttr, value);
 }
 
 String HTMLIFrameElement::srcdoc() const

--- a/Source/WebCore/html/HTMLIFrameElement.h
+++ b/Source/WebCore/html/HTMLIFrameElement.h
@@ -43,7 +43,6 @@ public:
 
     DOMTokenList& sandbox();
 
-    void setReferrerPolicyForBindings(const AtomString&);
     String referrerPolicyForBindings() const;
     ReferrerPolicy referrerPolicy() const final;
 

--- a/Source/WebCore/html/HTMLIFrameElement.idl
+++ b/Source/WebCore/html/HTMLIFrameElement.idl
@@ -32,8 +32,8 @@
     [Reflect, CEReactions=NotNeeded] attribute boolean allowFullscreen;
     [Reflect, CEReactions=NotNeeded] attribute DOMString width;
     [Reflect, CEReactions=NotNeeded] attribute DOMString height;
-    [CEReactions=NotNeeded, ImplementedAs=referrerPolicyForBindings] attribute [AtomString] DOMString referrerPolicy;
-    [CEReactions=NotNeeded, EnabledBySetting=LazyIframeLoadingEnabled] attribute [AtomString] DOMString loading;
+    [CEReactions=NotNeeded, ImplementedAs=referrerPolicyForBindings, ReflectSetter] attribute [AtomString] DOMString referrerPolicy;
+    [CEReactions=NotNeeded, EnabledBySetting=LazyIframeLoadingEnabled, ReflectSetter] attribute [AtomString] DOMString loading;
     [CheckSecurityForNode] readonly attribute Document? contentDocument;
     readonly attribute WindowProxy? contentWindow;
     [CheckSecurityForNode] Document? getSVGDocument();

--- a/Source/WebCore/html/HTMLImageElement.cpp
+++ b/Source/WebCore/html/HTMLImageElement.cpp
@@ -143,9 +143,9 @@ Ref<HTMLImageElement> HTMLImageElement::createForLegacyFactoryFunction(Document&
 {
     auto image = adoptRef(*new HTMLImageElement(imgTag, document));
     if (width)
-        image->setWidth(width.value());
+        image->setUnsignedIntegralAttribute(widthAttr, width.value());
     if (height)
-        image->setHeight(height.value());
+        image->setUnsignedIntegralAttribute(heightAttr, height.value());
     image->suspendIfNeeded();
     return image;
 }
@@ -715,31 +715,6 @@ RefPtr<HTMLMapElement> HTMLImageElement::associatedMapElement() const
     return treeScope().getImageMap(m_parsedUsemap);
 }
 
-const AtomString& HTMLImageElement::alt() const
-{
-    return attributeWithoutSynchronization(altAttr);
-}
-
-void HTMLImageElement::setHeight(unsigned value)
-{
-    setUnsignedIntegralAttribute(heightAttr, value);
-}
-
-URL HTMLImageElement::src() const
-{
-    return document().completeURL(attributeWithoutSynchronization(srcAttr));
-}
-
-void HTMLImageElement::setSrc(const AtomString& value)
-{
-    setAttributeWithoutSynchronization(srcAttr, value);
-}
-
-void HTMLImageElement::setWidth(unsigned value)
-{
-    setUnsignedIntegralAttribute(widthAttr, value);
-}
-
 int HTMLImageElement::x() const
 {
     protectedDocument()->updateLayoutIgnorePendingStylesheets({ LayoutOptions::TreatContentVisibilityHiddenAsVisible, LayoutOptions::TreatContentVisibilityAutoAsVisible }, this);
@@ -765,11 +740,6 @@ int HTMLImageElement::y() const
 bool HTMLImageElement::complete() const
 {
     return m_imageLoader->imageComplete();
-}
-
-void HTMLImageElement::setDecoding(AtomString&& decodingMode)
-{
-    setAttributeWithoutSynchronization(decodingAttr, WTFMove(decodingMode));
 }
 
 String HTMLImageElement::decoding() const
@@ -845,11 +815,6 @@ bool HTMLImageElement::isServerMap() const
         return false;
 
     return document().completeURL(usemap).isEmpty();
-}
-
-void HTMLImageElement::setCrossOrigin(const AtomString& value)
-{
-    setAttributeWithoutSynchronization(crossoriginAttr, value);
 }
 
 String HTMLImageElement::crossOrigin() const
@@ -1004,20 +969,10 @@ AtomString HTMLImageElement::srcsetForBindings() const
     return getAttributeForBindings(srcsetAttr);
 }
 
-void HTMLImageElement::setSrcsetForBindings(const AtomString& value)
-{
-    setAttributeWithoutSynchronization(srcsetAttr, value);
-}
-
 const AtomString& HTMLImageElement::loadingForBindings() const
 {
     auto& attributeValue = attributeWithoutSynchronization(HTMLNames::loadingAttr);
     return hasLazyLoadableAttributeValue(attributeValue) ? lazyAtom() : eagerAtom();
-}
-
-void HTMLImageElement::setLoadingForBindings(const AtomString& value)
-{
-    setAttributeWithoutSynchronization(loadingAttr, value);
 }
 
 bool HTMLImageElement::isDeferred() const
@@ -1030,11 +985,6 @@ bool HTMLImageElement::isLazyLoadable() const
     if (!document().frame() || !document().frame()->script().canExecuteScripts(ReasonForCallingCanExecuteScripts::NotAboutToExecuteScript))
         return false;
     return hasLazyLoadableAttributeValue(attributeWithoutSynchronization(HTMLNames::loadingAttr));
-}
-
-void HTMLImageElement::setReferrerPolicyForBindings(const AtomString& value)
-{
-    setAttributeWithoutSynchronization(referrerpolicyAttr, value);
 }
 
 String HTMLImageElement::referrerPolicyForBindings() const
@@ -1073,11 +1023,6 @@ Ref<Element> HTMLImageElement::cloneElementWithoutAttributesAndChildren(Document
     cloneAttachmentAssociatedElementWithoutAttributesAndChildren(clone, document);
 #endif
     return clone;
-}
-
-void HTMLImageElement::setFetchPriorityForBindings(const AtomString& value)
-{
-    setAttributeWithoutSynchronization(fetchpriorityAttr, value);
 }
 
 String HTMLImageElement::fetchPriorityForBindings() const

--- a/Source/WebCore/html/HTMLImageElement.h
+++ b/Source/WebCore/html/HTMLImageElement.h
@@ -90,24 +90,10 @@ public:
     bool matchesUsemap(const AtomString&) const;
     RefPtr<HTMLMapElement> associatedMapElement() const;
 
-    WEBCORE_EXPORT const AtomString& alt() const;
-
-    WEBCORE_EXPORT void setHeight(unsigned);
-
-    URL src() const;
-    void setSrc(const AtomString&);
-
-    WEBCORE_EXPORT void setCrossOrigin(const AtomString&);
     WEBCORE_EXPORT String crossOrigin() const;
-
-    WEBCORE_EXPORT void setWidth(unsigned);
-
     WEBCORE_EXPORT int x() const;
     WEBCORE_EXPORT int y() const;
-
     WEBCORE_EXPORT bool complete() const;
-
-    void setDecoding(AtomString&&);
     String decoding() const;
 
     DecodingMode decodingMode() const;
@@ -150,12 +136,10 @@ public:
     void loadDeferredImage();
 
     AtomString srcsetForBindings() const;
-    void setSrcsetForBindings(const AtomString&);
 
     bool usesSrcsetOrPicture() const;
 
     const AtomString& loadingForBindings() const;
-    void setLoadingForBindings(const AtomString&);
 
     bool isLazyLoadable() const;
     static bool hasLazyLoadableAttributeValue(StringView);
@@ -167,7 +151,6 @@ public:
 
     void evaluateDynamicMediaQueryDependencies();
 
-    void setReferrerPolicyForBindings(const AtomString&);
     String referrerPolicyForBindings() const;
     ReferrerPolicy referrerPolicy() const;
 
@@ -178,7 +161,6 @@ public:
     WEBCORE_EXPORT void setAllowsAnimation(std::optional<bool>);
 #endif
 
-    void setFetchPriorityForBindings(const AtomString&);
     String fetchPriorityForBindings() const;
     RequestPriority fetchPriority() const;
 

--- a/Source/WebCore/html/HTMLImageElement.idl
+++ b/Source/WebCore/html/HTMLImageElement.idl
@@ -29,21 +29,21 @@
 ] interface HTMLImageElement : HTMLElement {
     [CEReactions=NotNeeded, Reflect] attribute DOMString alt;
     [CEReactions=NotNeeded, Reflect, URL] attribute USVString src;
-    [CEReactions=NotNeeded, ImplementedAs=srcsetForBindings] attribute [AtomString] USVString srcset;
+    [CEReactions=NotNeeded, ImplementedAs=srcsetForBindings, ReflectSetter] attribute [AtomString] USVString srcset;
     [CEReactions=NotNeeded, Reflect] attribute DOMString sizes;
-    [CEReactions=NotNeeded] attribute [AtomString] DOMString? crossOrigin;
+    [CEReactions=NotNeeded, ReflectSetter] attribute [AtomString] DOMString? crossOrigin;
     [CEReactions=NotNeeded, Reflect] attribute DOMString useMap;
     [CEReactions=NotNeeded, Reflect] attribute boolean isMap;
     [CEReactions=NotNeeded, Conditional=SPATIAL_IMAGE_CONTROLS, EnabledBySetting=SpatialImageControlsEnabled, Reflect] attribute boolean controls;
-    [CEReactions=NotNeeded] attribute unsigned long width;
-    [CEReactions=NotNeeded] attribute unsigned long height;
+    [CEReactions=NotNeeded, ReflectSetter] attribute unsigned long width;
+    [CEReactions=NotNeeded, ReflectSetter] attribute unsigned long height;
     readonly attribute unsigned long naturalHeight;
     readonly attribute unsigned long naturalWidth;
     readonly attribute boolean complete;
     readonly attribute USVString currentSrc;
-    [CEReactions=NotNeeded, ImplementedAs=referrerPolicyForBindings] attribute [AtomString] DOMString referrerPolicy;
-    [CEReactions=NotNeeded] attribute [AtomString] DOMString decoding;
-    [CEReactions=NotNeeded, EnabledBySetting=LazyImageLoadingEnabled, ImplementedAs=loadingForBindings] attribute [AtomString] DOMString loading;
+    [CEReactions=NotNeeded, ImplementedAs=referrerPolicyForBindings, ReflectSetter] attribute [AtomString] DOMString referrerPolicy;
+    [CEReactions=NotNeeded, ReflectSetter] attribute [AtomString] DOMString decoding;
+    [CEReactions=NotNeeded, EnabledBySetting=LazyImageLoadingEnabled, ImplementedAs=loadingForBindings, ReflectSetter] attribute [AtomString] DOMString loading;
 
     Promise<undefined> decode();
 
@@ -57,7 +57,7 @@
 
     [CEReactions=NotNeeded, Reflect] attribute [LegacyNullToEmptyString] DOMString border;
 
-    [CEReactions=NotNeeded, ImplementedAs=fetchPriorityForBindings] attribute [AtomString] DOMString fetchPriority;
+    [CEReactions=NotNeeded, ImplementedAs=fetchPriorityForBindings, ReflectSetter] attribute [AtomString] DOMString fetchPriority;
 
     // Non-standard
     [Conditional=ATTACHMENT_ELEMENT, EnabledByDeprecatedGlobalSetting=AttachmentElementEnabled] readonly attribute DOMString attachmentIdentifier;

--- a/Source/WebCore/html/HTMLInputElement.cpp
+++ b/Source/WebCore/html/HTMLInputElement.cpp
@@ -505,11 +505,6 @@ void HTMLInputElement::handleBlurEvent()
     invalidateStyleOnFocusChangeIfNeeded();
 }
 
-void HTMLInputElement::setType(const AtomString& type)
-{
-    setAttributeWithoutSynchronization(typeAttr, type);
-}
-
 void HTMLInputElement::resignStrongPasswordAppearance()
 {
     if (!hasAutofillStrongPasswordButton())
@@ -1456,16 +1451,6 @@ ExceptionOr<void> HTMLInputElement::showPicker()
     return { };
 }
 
-const AtomString& HTMLInputElement::defaultValue() const
-{
-    return attributeWithoutSynchronization(valueAttr);
-}
-
-void HTMLInputElement::setDefaultValue(const AtomString& value)
-{
-    setAttributeWithoutSynchronization(valueAttr, value);
-}
-
 static inline bool isRFC2616TokenCharacter(UChar ch)
 {
     return isASCII(ch) && ch > ' ' && ch != '"' && ch != '(' && ch != ')' && ch != ',' && ch != '/' && (ch < ':' || ch > '@') && (ch < '[' || ch > ']') && ch != '{' && ch != '}' && ch != 0x7f;
@@ -1518,11 +1503,6 @@ Vector<String> HTMLInputElement::acceptFileExtensions() const
     return parseAcceptAttribute(attributeWithoutSynchronization(acceptAttr), isValidFileExtension);
 }
 
-String HTMLInputElement::alt() const
-{
-    return attributeWithoutSynchronization(altAttr);
-}
-
 unsigned HTMLInputElement::effectiveMaxLength() const
 {
     // The number -1 represents no maximum at all; conveniently it becomes a super-large value when converted to unsigned.
@@ -1540,11 +1520,6 @@ ExceptionOr<void> HTMLInputElement::setSize(unsigned size)
         return Exception { ExceptionCode::IndexSizeError };
     setUnsignedIntegralAttribute(sizeAttr, limitToOnlyHTMLNonNegativeNumbersGreaterThanZero(size, defaultSize));
     return { };
-}
-
-URL HTMLInputElement::src() const
-{
-    return document().completeURL(attributeWithoutSynchronization(srcAttr));
 }
 
 void HTMLInputElement::logUserInteraction()
@@ -1740,7 +1715,7 @@ bool HTMLInputElement::needsSuspensionCallback()
     // the page is restored. Non-empty textual default values indicate that the field
     // is not really sensitive -- there's no default value for an account number --
     // and we would see unexpected results if we reset to something other than blank.
-    bool isSensitive = m_autocomplete == Off && !(m_inputType->isTextType() && !defaultValue().isEmpty());
+    bool isSensitive = m_autocomplete == Off && !(m_inputType->isTextType() && !attributeWithoutSynchronization(valueAttr).isEmpty());
 
     return isSensitive;
 }
@@ -1881,7 +1856,7 @@ void HTMLInputElement::addSubresourceAttributeURLs(ListHashSet<URL>& urls) const
 {
     HTMLTextFormControlElement::addSubresourceAttributeURLs(urls);
 
-    addSubresourceURL(urls, src());
+    addSubresourceURL(urls, getURLAttribute(srcAttr));
 }
 
 bool HTMLInputElement::computeWillValidate() const
@@ -2259,16 +2234,6 @@ unsigned HTMLInputElement::height() const
 unsigned HTMLInputElement::width() const
 {
     return m_inputType->width();
-}
-
-void HTMLInputElement::setHeight(unsigned height)
-{
-    setUnsignedIntegralAttribute(heightAttr, height);
-}
-
-void HTMLInputElement::setWidth(unsigned width)
-{
-    setUnsignedIntegralAttribute(widthAttr, width);
 }
 
 ListAttributeTargetObserver::ListAttributeTargetObserver(const AtomString& id, HTMLInputElement& element)

--- a/Source/WebCore/html/HTMLInputElement.h
+++ b/Source/WebCore/html/HTMLInputElement.h
@@ -77,15 +77,11 @@ public:
     FileList* filesForBindings() { return files(); }
     void setFilesForBindings(RefPtr<FileList>&& fileList) { return setFiles(WTFMove(fileList), WasSetByJavaScript::Yes); }
     WEBCORE_EXPORT unsigned height() const;
-    WEBCORE_EXPORT void setHeight(unsigned);
     bool indeterminate() const { return m_isIndeterminate; }
     WEBCORE_EXPORT void setIndeterminate(bool);
     WEBCORE_EXPORT RefPtr<HTMLElement> list() const;
     unsigned size() const { return m_size; }
     WEBCORE_EXPORT ExceptionOr<void> setSize(unsigned);
-    WEBCORE_EXPORT const AtomString& defaultValue() const;
-    WEBCORE_EXPORT void setDefaultValue(const AtomString&);
-    WEBCORE_EXPORT void setType(const AtomString&);
     WEBCORE_EXPORT ValueOrReference<String> value() const final;
     WEBCORE_EXPORT ExceptionOr<void> setValue(const String&, TextFieldEventBehavior = DispatchNoEvent, TextControlSetValueSelection = TextControlSetValueSelection::SetSelectionToEnd) final;
     WEBCORE_EXPORT void setValueForUser(const String&);
@@ -97,7 +93,6 @@ public:
     WEBCORE_EXPORT ExceptionOr<void> stepUp(int = 1);
     WEBCORE_EXPORT ExceptionOr<void> stepDown(int = 1);
     WEBCORE_EXPORT unsigned width() const;
-    WEBCORE_EXPORT void setWidth(unsigned);
     bool hasSwitchAttribute() const { return m_hasSwitchAttribute; }
     WEBCORE_EXPORT String validationMessage() const final;
     std::optional<unsigned> selectionStartForBindings() const;
@@ -245,9 +240,6 @@ public:
 
     Vector<String> acceptMIMETypes() const;
     Vector<String> acceptFileExtensions() const;
-    WEBCORE_EXPORT String alt() const;
-
-    URL src() const;
 
     unsigned effectiveMaxLength() const;
 

--- a/Source/WebCore/html/HTMLInputElement.idl
+++ b/Source/WebCore/html/HTMLInputElement.idl
@@ -42,7 +42,7 @@ enum AutofillButtonType {
     [CEReactions=NotNeeded, Reflect] attribute DOMString accept;
     [EnabledBySetting=InputTypeColorEnhancementsEnabled, CEReactions=NotNeeded, Reflect] attribute boolean alpha;
     [CEReactions=NotNeeded, Reflect] attribute DOMString alt;
-    [CEReactions=NotNeeded] attribute [AtomString] DOMString autocomplete;
+    [CEReactions=NotNeeded, ReflectSetter] attribute [AtomString] DOMString autocomplete;
     [CEReactions=NotNeeded, Reflect=checked] attribute boolean defaultChecked;
     attribute boolean checked;
     [EnabledBySetting=InputTypeColorEnhancementsEnabled, CEReactions=NotNeeded] attribute [AtomString] DOMString colorSpace;
@@ -50,14 +50,14 @@ enum AutofillButtonType {
     [CEReactions=NotNeeded, Reflect] attribute boolean disabled;
     [ImplementedAs=formForBindings] readonly attribute HTMLFormElement form;
     [ImplementedAs=filesForBindings] attribute FileList? files;
-    [CEReactions=NotNeeded] attribute [AtomString] USVString formAction;
+    [CEReactions=NotNeeded, ReflectSetter] attribute [AtomString] USVString formAction;
 
-    [CEReactions=NotNeeded] attribute [AtomString] DOMString formEnctype;
-    [CEReactions=NotNeeded] attribute [AtomString] DOMString formMethod;
+    [CEReactions=NotNeeded, ReflectSetter] attribute [AtomString] DOMString formEnctype;
+    [CEReactions=NotNeeded, ReflectSetter] attribute [AtomString] DOMString formMethod;
 
     [CEReactions=NotNeeded, Reflect] attribute boolean formNoValidate;
     [CEReactions=NotNeeded, Reflect] attribute DOMString formTarget;
-    [CEReactions=NotNeeded] attribute unsigned long height;
+    [CEReactions=NotNeeded, ReflectSetter] attribute unsigned long height;
     attribute boolean indeterminate;
     readonly attribute HTMLElement list;
     [CEReactions=NotNeeded, Reflect] attribute DOMString max;
@@ -74,17 +74,17 @@ enum AutofillButtonType {
     [CEReactions=NotNeeded, Reflect, URL] attribute USVString src;
     [CEReactions=NotNeeded, Reflect] attribute DOMString step;
     [EnabledBySetting=SwitchControlEnabled, CEReactions=NotNeeded, Reflect] attribute boolean switch;
-    [CEReactions=NotNeeded] attribute [AtomString] DOMString type;
-    [CEReactions=NotNeeded] attribute [AtomString] DOMString defaultValue;
+    [CEReactions=NotNeeded, ReflectSetter] attribute [AtomString] DOMString type;
+    [CEReactions=NotNeeded, Reflect=value] attribute DOMString defaultValue;
     // See the discussion in https://bugs.webkit.org/show_bug.cgi?id=100085
     [CEReactions=NotNeeded] attribute [LegacyNullToEmptyString] DOMString value;
     attribute Date? valueAsDate;
     attribute unrestricted double valueAsNumber;
+    [CEReactions=NotNeeded, ReflectSetter] attribute unsigned long width;
 
     undefined stepUp(optional long n = 1);
     undefined stepDown(optional long n = 1);
 
-    [CEReactions=NotNeeded] attribute unsigned long width;
     readonly attribute boolean willValidate;
     readonly attribute ValidityState validity;
     readonly attribute DOMString validationMessage;
@@ -122,4 +122,3 @@ enum AutofillButtonType {
 };
 
 HTMLInputElement includes PopoverInvokerElement;
-

--- a/Source/WebCore/html/HTMLLinkElement.cpp
+++ b/Source/WebCore/html/HTMLLinkElement.cpp
@@ -278,19 +278,9 @@ bool HTMLLinkElement::shouldLoadLink()
     return isConnected();
 }
 
-void HTMLLinkElement::setCrossOrigin(const AtomString& value)
-{
-    setAttributeWithoutSynchronization(crossoriginAttr, value);
-}
-
 String HTMLLinkElement::crossOrigin() const
 {
     return parseCORSSettingsAttribute(attributeWithoutSynchronization(crossoriginAttr));
-}
-
-void HTMLLinkElement::setAs(const AtomString& value)
-{
-    setAttributeWithoutSynchronization(asAttr, value);
 }
 
 String HTMLLinkElement::as() const
@@ -850,11 +840,6 @@ void HTMLLinkElement::removePendingSheet()
     m_styleScope->removePendingSheet(*this);
 }
 
-void HTMLLinkElement::setReferrerPolicyForBindings(const AtomString& value)
-{
-    setAttributeWithoutSynchronization(referrerpolicyAttr, value);
-}
-
 String HTMLLinkElement::referrerPolicyForBindings() const
 {
     return referrerPolicyToString(referrerPolicy());
@@ -868,11 +853,6 @@ ReferrerPolicy HTMLLinkElement::referrerPolicy() const
 String HTMLLinkElement::debugDescription() const
 {
     return makeString(HTMLElement::debugDescription(), ' ', type(), ' ', href().string());
-}
-
-void HTMLLinkElement::setFetchPriorityForBindings(const AtomString& value)
-{
-    setAttributeWithoutSynchronization(fetchpriorityAttr, value);
 }
 
 String HTMLLinkElement::fetchPriorityForBindings() const

--- a/Source/WebCore/html/HTMLLinkElement.h
+++ b/Source/WebCore/html/HTMLLinkElement.h
@@ -78,9 +78,7 @@ public:
 
     WEBCORE_EXPORT bool mediaAttributeMatches() const;
 
-    WEBCORE_EXPORT void setCrossOrigin(const AtomString&);
     WEBCORE_EXPORT String crossOrigin() const;
-    WEBCORE_EXPORT void setAs(const AtomString&);
     WEBCORE_EXPORT String as() const;
 
     void dispatchPendingEvent(LinkEventSender*, const AtomString& eventType);
@@ -95,11 +93,9 @@ public:
 
     void allowPrefetchLoadAndErrorForTesting() { m_allowPrefetchLoadAndErrorForTesting = true; }
 
-    void setReferrerPolicyForBindings(const AtomString&);
     String referrerPolicyForBindings() const;
     ReferrerPolicy referrerPolicy() const;
 
-    void setFetchPriorityForBindings(const AtomString&);
     String fetchPriorityForBindings() const;
     RequestPriority fetchPriority() const;
 

--- a/Source/WebCore/html/HTMLLinkElement.idl
+++ b/Source/WebCore/html/HTMLLinkElement.idl
@@ -35,13 +35,13 @@
     [PutForwards=value] readonly attribute DOMTokenList sizes;
     [CEReactions=NotNeeded, Reflect] attribute DOMString target;
     [CEReactions=NotNeeded, Reflect] attribute DOMString type;
-    [CEReactions=NotNeeded] attribute [AtomString] DOMString as;
-    [CEReactions=NotNeeded] attribute [AtomString] DOMString? crossOrigin;
+    [CEReactions=NotNeeded, ReflectSetter] attribute [AtomString] DOMString as;
+    [CEReactions=NotNeeded, ReflectSetter] attribute [AtomString] DOMString? crossOrigin;
     [CEReactions=NotNeeded, Reflect] attribute DOMString imageSrcset;
     [CEReactions=NotNeeded, Reflect] attribute DOMString imageSizes;
-    [CEReactions=NotNeeded, ImplementedAs=referrerPolicyForBindings] attribute [AtomString] DOMString referrerPolicy;
+    [CEReactions=NotNeeded, ImplementedAs=referrerPolicyForBindings, ReflectSetter] attribute [AtomString] DOMString referrerPolicy;
     [PutForwards=value] readonly attribute DOMTokenList blocking;
-    [CEReactions=NotNeeded, ImplementedAs=fetchPriorityForBindings] attribute [AtomString] DOMString fetchPriority;
+    [CEReactions=NotNeeded, ImplementedAs=fetchPriorityForBindings, ReflectSetter] attribute [AtomString] DOMString fetchPriority;
 
     readonly attribute StyleSheet sheet;
 

--- a/Source/WebCore/html/HTMLMarqueeElement.cpp
+++ b/Source/WebCore/html/HTMLMarqueeElement.cpp
@@ -176,7 +176,7 @@ void HTMLMarqueeElement::setScrollDelay(unsigned scrollDelay)
     
 int HTMLMarqueeElement::loop() const
 {
-    int loopValue = getIntegralAttribute(loopAttr);
+    int loopValue = integralAttribute(loopAttr);
     return loopValue > 0 ? loopValue : -1;
 }
     

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -1371,11 +1371,6 @@ void HTMLMediaElement::setSrcObject(MediaProvider&& mediaProvider)
     prepareForLoad();
 }
 
-void HTMLMediaElement::setCrossOrigin(const AtomString& value)
-{
-    setAttributeWithoutSynchronization(crossoriginAttr, value);
-}
-
 String HTMLMediaElement::crossOrigin() const
 {
     return parseCORSSettingsAttribute(attributeWithoutSynchronization(crossoriginAttr));
@@ -8416,7 +8411,7 @@ Vector<RefPtr<PlatformTextTrack>> HTMLMediaElement::outOfBandTrackSources()
             continue;
         }
 
-        outOfBandTrackSources.append(PlatformTextTrack::createOutOfBand(trackElement.label(), trackElement.srclang(), url.string(), toPlatform(track.mode()), toPlatform(kind), track.uniqueId(), trackElement.isDefault()));
+        outOfBandTrackSources.append(PlatformTextTrack::createOutOfBand(trackElement.attributeWithoutSynchronization(labelAttr), trackElement.attributeWithoutSynchronization(srclangAttr), url.string(), toPlatform(track.mode()), toPlatform(kind), track.uniqueId(), trackElement.isDefault()));
     }
 
     return outOfBandTrackSources;

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -274,7 +274,6 @@ public:
     const MediaProvider& srcObject() const { return m_mediaProvider; }
     void setSrcObject(MediaProvider&&);
 
-    WEBCORE_EXPORT void setCrossOrigin(const AtomString&);
     WEBCORE_EXPORT String crossOrigin() const;
 
 // network state

--- a/Source/WebCore/html/HTMLMediaElement.idl
+++ b/Source/WebCore/html/HTMLMediaElement.idl
@@ -54,7 +54,7 @@ typedef (
     [CEReactions=NotNeeded, Reflect, URL] attribute USVString src;
     attribute MediaProvider? srcObject;
     [URL] readonly attribute USVString currentSrc;
-    [CEReactions=NotNeeded] attribute [AtomString] DOMString? crossOrigin;
+    [CEReactions=NotNeeded, ReflectSetter] attribute [AtomString] DOMString? crossOrigin;
 
     const unsigned short NETWORK_EMPTY = 0;
     const unsigned short NETWORK_IDLE = 1;

--- a/Source/WebCore/html/HTMLMeterElement.cpp
+++ b/Source/WebCore/html/HTMLMeterElement.cpp
@@ -95,19 +95,9 @@ double HTMLMeterElement::min() const
     return parseHTMLFloatingPointNumberValue(attributeWithoutSynchronization(minAttr), 0);
 }
 
-void HTMLMeterElement::setMin(double min)
-{
-    setAttributeWithoutSynchronization(minAttr, AtomString::number(min));
-}
-
 double HTMLMeterElement::max() const
 {
     return std::max(parseHTMLFloatingPointNumberValue(attributeWithoutSynchronization(maxAttr), std::max(1.0, min())), min());
-}
-
-void HTMLMeterElement::setMax(double max)
-{
-    setAttributeWithoutSynchronization(maxAttr, AtomString::number(max));
 }
 
 double HTMLMeterElement::value() const
@@ -116,20 +106,10 @@ double HTMLMeterElement::value() const
     return std::min(std::max(value, min()), max());
 }
 
-void HTMLMeterElement::setValue(double value)
-{
-    setAttributeWithoutSynchronization(valueAttr, AtomString::number(value));
-}
-
 double HTMLMeterElement::low() const
 {
     double low = parseHTMLFloatingPointNumberValue(attributeWithoutSynchronization(lowAttr), min());
     return std::min(std::max(low, min()), max());
-}
-
-void HTMLMeterElement::setLow(double low)
-{
-    setAttributeWithoutSynchronization(lowAttr, AtomString::number(low));
 }
 
 double HTMLMeterElement::high() const
@@ -138,20 +118,10 @@ double HTMLMeterElement::high() const
     return std::min(std::max(high, low()), max());
 }
 
-void HTMLMeterElement::setHigh(double high)
-{
-    setAttributeWithoutSynchronization(highAttr, AtomString::number(high));
-}
-
 double HTMLMeterElement::optimum() const
 {
     double optimum = parseHTMLFloatingPointNumberValue(attributeWithoutSynchronization(optimumAttr), std::midpoint(min(), max()));
     return std::clamp(optimum, min(), max());
-}
-
-void HTMLMeterElement::setOptimum(double optimum)
-{
-    setAttributeWithoutSynchronization(optimumAttr, AtomString::number(optimum));
 }
 
 HTMLMeterElement::GaugeRegion HTMLMeterElement::gaugeRegion() const

--- a/Source/WebCore/html/HTMLMeterElement.h
+++ b/Source/WebCore/html/HTMLMeterElement.h
@@ -40,22 +40,11 @@ public:
     };
 
     double min() const;
-    void setMin(double);
-
     double max() const;
-    void setMax(double);
-
     double value() const;
-    void setValue(double);
-
     double low() const;
-    void setLow(double);
-
     double high() const;
-    void setHigh(double);
-
     double optimum() const;
-    void setOptimum(double);
 
     double valueRatio() const;
     GaugeRegion gaugeRegion() const;

--- a/Source/WebCore/html/HTMLMeterElement.idl
+++ b/Source/WebCore/html/HTMLMeterElement.idl
@@ -20,11 +20,11 @@
 [
     Exposed=Window
 ] interface HTMLMeterElement : HTMLElement {
-    [CEReactions=NotNeeded] attribute double value;
-    [CEReactions=NotNeeded] attribute double min;
-    [CEReactions=NotNeeded] attribute double max;
-    [CEReactions=NotNeeded] attribute double low;
-    [CEReactions=NotNeeded] attribute double high;
-    [CEReactions=NotNeeded] attribute double optimum;
+    [CEReactions=NotNeeded, ReflectSetter] attribute double value;
+    [CEReactions=NotNeeded, ReflectSetter] attribute double min;
+    [CEReactions=NotNeeded, ReflectSetter] attribute double max;
+    [CEReactions=NotNeeded, ReflectSetter] attribute double low;
+    [CEReactions=NotNeeded, ReflectSetter] attribute double high;
+    [CEReactions=NotNeeded, ReflectSetter] attribute double optimum;
     readonly attribute NodeList labels;
 };

--- a/Source/WebCore/html/HTMLOListElement.cpp
+++ b/Source/WebCore/html/HTMLOListElement.cpp
@@ -109,11 +109,6 @@ void HTMLOListElement::attributeChanged(const QualifiedName& name, const AtomStr
     }
 }
 
-void HTMLOListElement::setStartForBindings(int start)
-{
-    setIntegralAttribute(startAttr, start);
-}
-
 unsigned HTMLOListElement::itemCount() const
 {
     if (!m_itemCount)

--- a/Source/WebCore/html/HTMLOListElement.h
+++ b/Source/WebCore/html/HTMLOListElement.h
@@ -34,7 +34,6 @@ public:
     static Ref<HTMLOListElement> create(const QualifiedName&, Document&);
 
     int startForBindings() const { return m_start.value_or(1); }
-    WEBCORE_EXPORT void setStartForBindings(int);
 
     // FIXME: The reason start() does not trigger layout is because it is called
     // from rendering code. This is unfortunately one of the few cases where the

--- a/Source/WebCore/html/HTMLOListElement.idl
+++ b/Source/WebCore/html/HTMLOListElement.idl
@@ -21,7 +21,7 @@
     Exposed=Window
 ] interface HTMLOListElement : HTMLElement {
     [CEReactions=NotNeeded, Reflect] attribute boolean compact;
-    [CEReactions=NotNeeded, ImplementedAs=startForBindings] attribute long start;
+    [CEReactions=NotNeeded, ImplementedAs=startForBindings, ReflectSetter] attribute long start;
     [CEReactions=NotNeeded, Reflect] attribute boolean reversed;
     [CEReactions=NotNeeded, Reflect] attribute DOMString type;
 };

--- a/Source/WebCore/html/HTMLOptionElement.h
+++ b/Source/WebCore/html/HTMLOptionElement.h
@@ -49,7 +49,6 @@ public:
     WEBCORE_EXPORT int index() const;
 
     WEBCORE_EXPORT String value() const;
-    WEBCORE_EXPORT void setValue(const AtomString&);
 
     WEBCORE_EXPORT bool selected(AllowStyleInvalidation = AllowStyleInvalidation::Yes) const;
     WEBCORE_EXPORT void setSelected(bool);
@@ -57,7 +56,7 @@ public:
     WEBCORE_EXPORT HTMLSelectElement* ownerSelectElement() const;
 
     WEBCORE_EXPORT String label() const;
-    WEBCORE_EXPORT void setLabel(const AtomString&);
+    WEBCORE_EXPORT String displayLabel() const;
 
     bool ownElementDisabled() const { return m_disabled; }
 
@@ -84,6 +83,7 @@ private:
     void willResetComputedStyle() final;
 
     String collectOptionInnerText() const;
+    String collectOptionInnerTextCollapsingWhitespace() const;
 
     bool m_disabled { false };
     bool m_isSelected { false };

--- a/Source/WebCore/html/HTMLOptionElement.idl
+++ b/Source/WebCore/html/HTMLOptionElement.idl
@@ -26,10 +26,10 @@
 ] interface HTMLOptionElement : HTMLElement {
     [CEReactions=NotNeeded, Reflect] attribute boolean disabled;
     [ImplementedAs=formForBindings] readonly attribute HTMLFormElement form;
-    [CEReactions=NotNeeded] attribute [AtomString] DOMString label;
+    [CEReactions=NotNeeded, ReflectSetter] attribute [AtomString] DOMString label;
     [CEReactions=NotNeeded, Reflect=selected] attribute boolean defaultSelected;
     attribute boolean selected;
-    [CEReactions=NotNeeded] attribute [AtomString] DOMString value;
+    [CEReactions=NotNeeded, ReflectSetter] attribute [AtomString] DOMString value;
 
     [CEReactions=Needed] attribute DOMString text;
     readonly attribute long index;

--- a/Source/WebCore/html/HTMLProgressElement.cpp
+++ b/Source/WebCore/html/HTMLProgressElement.cpp
@@ -98,11 +98,6 @@ double HTMLProgressElement::value() const
     return !std::isfinite(value) || value < 0 ? 0 : std::min(value, max());
 }
 
-void HTMLProgressElement::setValue(double value)
-{
-    setAttributeWithoutSynchronization(valueAttr, AtomString::number(value));
-}
-
 double HTMLProgressElement::max() const
 {
     double max = parseHTMLFloatingPointNumberValue(attributeWithoutSynchronization(maxAttr));

--- a/Source/WebCore/html/HTMLProgressElement.h
+++ b/Source/WebCore/html/HTMLProgressElement.h
@@ -37,7 +37,6 @@ public:
     static Ref<HTMLProgressElement> create(const QualifiedName&, Document&);
 
     double value() const;
-    void setValue(double);
 
     double max() const;
     void setMax(double);

--- a/Source/WebCore/html/HTMLProgressElement.idl
+++ b/Source/WebCore/html/HTMLProgressElement.idl
@@ -20,7 +20,7 @@
 [
     Exposed=Window
 ] interface HTMLProgressElement : HTMLElement {
-    [CEReactions=NotNeeded] attribute double value;
+    [CEReactions=NotNeeded, ReflectSetter] attribute double value;
     [CEReactions=NotNeeded] attribute double max;
     readonly attribute double position;
     readonly attribute NodeList labels;

--- a/Source/WebCore/html/HTMLScriptElement.cpp
+++ b/Source/WebCore/html/HTMLScriptElement.cpp
@@ -194,11 +194,6 @@ bool HTMLScriptElement::async() const
     return hasAttributeWithoutSynchronization(asyncAttr) || forceAsync();
 }
 
-void HTMLScriptElement::setCrossOrigin(const AtomString& value)
-{
-    setAttributeWithoutSynchronization(crossoriginAttr, value);
-}
-
 String HTMLScriptElement::crossOrigin() const
 {
     return parseCORSSettingsAttribute(attributeWithoutSynchronization(crossoriginAttr));
@@ -294,11 +289,6 @@ Ref<Element> HTMLScriptElement::cloneElementWithoutAttributesAndChildren(Documen
     return adoptRef(*new HTMLScriptElement(tagQName(), document, false, alreadyStarted()));
 }
 
-void HTMLScriptElement::setReferrerPolicyForBindings(const AtomString& value)
-{
-    setAttributeWithoutSynchronization(referrerpolicyAttr, value);
-}
-
 String HTMLScriptElement::referrerPolicyForBindings() const
 {
     return referrerPolicyToString(referrerPolicy());
@@ -307,11 +297,6 @@ String HTMLScriptElement::referrerPolicyForBindings() const
 ReferrerPolicy HTMLScriptElement::referrerPolicy() const
 {
     return parseReferrerPolicy(attributeWithoutSynchronization(referrerpolicyAttr), ReferrerPolicySource::ReferrerPolicyAttribute).value_or(ReferrerPolicy::EmptyString);
-}
-
-void HTMLScriptElement::setFetchPriorityForBindings(const AtomString& value)
-{
-    setAttributeWithoutSynchronization(fetchpriorityAttr, value);
 }
 
 String HTMLScriptElement::fetchPriorityForBindings() const

--- a/Source/WebCore/html/HTMLScriptElement.h
+++ b/Source/WebCore/html/HTMLScriptElement.h
@@ -56,10 +56,8 @@ public:
     WEBCORE_EXPORT void setAsync(bool);
     WEBCORE_EXPORT bool async() const;
 
-    WEBCORE_EXPORT void setCrossOrigin(const AtomString&);
     WEBCORE_EXPORT String crossOrigin() const;
 
-    void setReferrerPolicyForBindings(const AtomString&);
     String referrerPolicyForBindings() const;
     ReferrerPolicy referrerPolicy() const final;
 
@@ -68,9 +66,8 @@ public:
 
     static bool supports(StringView type) { return type == "classic"_s || type == "module"_s || type == "importmap"_s; }
 
-    void setFetchPriorityForBindings(const AtomString&);
     String fetchPriorityForBindings() const;
-    RequestPriority fetchPriority() const override;
+    RequestPriority fetchPriority() const final;
 
     WEBCORE_EXPORT DOMTokenList& blocking();
 

--- a/Source/WebCore/html/HTMLScriptElement.idl
+++ b/Source/WebCore/html/HTMLScriptElement.idl
@@ -31,11 +31,11 @@
     [CEReactions=NotNeeded, Reflect] attribute boolean defer;
     [CEReactions=NotNeeded] attribute (TrustedScriptURL or USVString) src;
     [CEReactions=NotNeeded, Reflect] attribute DOMString type;
-    [CEReactions=NotNeeded] attribute [AtomString] DOMString? crossOrigin;
+    [CEReactions=NotNeeded, ReflectSetter] attribute [AtomString] DOMString? crossOrigin;
     [CEReactions=NotNeeded, Reflect] attribute boolean noModule;
     [CEReactions=NotNeeded, Reflect] attribute DOMString integrity;
-    [CEReactions=NotNeeded, ImplementedAs=referrerPolicyForBindings] attribute [AtomString] DOMString referrerPolicy;
-    [CEReactions=NotNeeded, ImplementedAs=fetchPriorityForBindings] attribute [AtomString] DOMString fetchPriority;
+    [CEReactions=NotNeeded, ImplementedAs=referrerPolicyForBindings, ReflectSetter] attribute [AtomString] DOMString referrerPolicy;
+    [CEReactions=NotNeeded, ImplementedAs=fetchPriorityForBindings, ReflectSetter] attribute [AtomString] DOMString fetchPriority;
     [PutForwards=value] readonly attribute DOMTokenList blocking;
 
     static boolean supports(DOMString type);

--- a/Source/WebCore/html/HTMLSelectElement.idl
+++ b/Source/WebCore/html/HTMLSelectElement.idl
@@ -23,7 +23,7 @@
     JSGenerateToNativeObject,
     Exposed=Window
 ] interface HTMLSelectElement : HTMLElement {
-    [CEReactions=NotNeeded] attribute [AtomString] DOMString autocomplete;
+    [CEReactions=NotNeeded, ReflectSetter] attribute [AtomString] DOMString autocomplete;
     [CEReactions=NotNeeded, Reflect] attribute boolean disabled;
     [ImplementedAs=formForBindings] readonly attribute HTMLFormElement? form;
     [CEReactions=NotNeeded, Reflect] attribute boolean multiple;

--- a/Source/WebCore/html/HTMLTableCellElement.cpp
+++ b/Source/WebCore/html/HTMLTableCellElement.cpp
@@ -193,11 +193,6 @@ const AtomString& HTMLTableCellElement::scope() const
     return emptyAtom();
 }
 
-void HTMLTableCellElement::setScope(const AtomString& scope)
-{
-    setAttributeWithoutSynchronization(scopeAttr, scope);
-}
-
 void HTMLTableCellElement::addSubresourceAttributeURLs(ListHashSet<URL>& urls) const
 {
     HTMLTablePartElement::addSubresourceAttributeURLs(urls);

--- a/Source/WebCore/html/HTMLTableCellElement.h
+++ b/Source/WebCore/html/HTMLTableCellElement.h
@@ -58,7 +58,6 @@ public:
     String axis() const;
     String headers() const;
     WEBCORE_EXPORT const AtomString& scope() const;
-    WEBCORE_EXPORT void setScope(const AtomString&);
 
     WEBCORE_EXPORT HTMLTableCellElement* cellAbove() const;
     WEBCORE_EXPORT RefPtr<HTMLTableCellElement> protectedCellAbove() const;

--- a/Source/WebCore/html/HTMLTableCellElement.idl
+++ b/Source/WebCore/html/HTMLTableCellElement.idl
@@ -39,6 +39,6 @@
     [CEReactions=NotNeeded, Reflect] attribute DOMString width;
 
     [CEReactions=NotNeeded, Reflect] attribute DOMString abbr;
-    [CEReactions=NotNeeded] attribute [AtomString] DOMString scope;
+    [CEReactions=NotNeeded, ReflectSetter] attribute [AtomString] DOMString scope;
 };
 

--- a/Source/WebCore/html/HTMLTemplateElement.cpp
+++ b/Source/WebCore/html/HTMLTemplateElement.cpp
@@ -101,11 +101,6 @@ const AtomString& HTMLTemplateElement::shadowRootMode() const
     return emptyAtom();
 }
 
-void HTMLTemplateElement::setShadowRootMode(const AtomString& value)
-{
-    setAttribute(HTMLNames::shadowrootmodeAttr, value);
-}
-
 void HTMLTemplateElement::setDeclarativeShadowRoot(ShadowRoot& shadowRoot)
 {
     m_declarativeShadowRoot = shadowRoot;

--- a/Source/WebCore/html/HTMLTemplateElement.h
+++ b/Source/WebCore/html/HTMLTemplateElement.h
@@ -49,7 +49,6 @@ public:
     DocumentFragment* contentIfAvailable() const;
 
     const AtomString& shadowRootMode() const;
-    void setShadowRootMode(const AtomString&);
 
     void setDeclarativeShadowRoot(ShadowRoot&);
 

--- a/Source/WebCore/html/HTMLTemplateElement.idl
+++ b/Source/WebCore/html/HTMLTemplateElement.idl
@@ -34,7 +34,7 @@
     Exposed=Window
 ] interface HTMLTemplateElement : HTMLElement {
     readonly attribute DocumentFragment content;
-    [CEReactions=NotNeeded] attribute [AtomString] DOMString shadowRootMode;
+    [CEReactions=NotNeeded, ReflectSetter] attribute [AtomString] DOMString shadowRootMode;
     [CEReactions=NotNeeded, Reflect=shadowrootdelegatesfocus] attribute boolean shadowRootDelegatesFocus;
     [CEReactions=NotNeeded, Reflect=shadowrootclonable] attribute boolean shadowRootClonable;
     [CEReactions=NotNeeded, Reflect=shadowrootserializable] attribute boolean shadowRootSerializable;

--- a/Source/WebCore/html/HTMLTextAreaElement.idl
+++ b/Source/WebCore/html/HTMLTextAreaElement.idl
@@ -61,5 +61,5 @@
 
     [ImplementedAs=setSelectionRangeForBindings] undefined setSelectionRange(unsigned long start, unsigned long end, optional DOMString direction);
 
-    [CEReactions=NotNeeded] attribute [AtomString] DOMString autocomplete;
+    [CEReactions=NotNeeded, ReflectSetter] attribute [AtomString] DOMString autocomplete;
 };

--- a/Source/WebCore/html/HTMLTrackElement.cpp
+++ b/Source/WebCore/html/HTMLTrackElement.cpp
@@ -66,7 +66,7 @@ static String urlForLoggingTrack(const URL& url)
 inline HTMLTrackElement::HTMLTrackElement(const QualifiedName& tagName, Document& document)
     : HTMLElement(tagName, document, TypeFlag::HasDidMoveToNewDocument)
     , ActiveDOMObject(document)
-    , m_track(LoadableTextTrack::create(*this, attributeWithoutSynchronization(kindAttr).convertToASCIILowercase(), label(), srclang()))
+    , m_track(LoadableTextTrack::create(*this, nullAtom(), nullAtom(), nullAtom()))
 {
     m_track->addClient(*this);
     LOG(Media, "HTMLTrackElement::HTMLTrackElement - %p", this);
@@ -142,21 +142,6 @@ void HTMLTrackElement::attributeChanged(const QualifiedName& name, const AtomStr
 const AtomString& HTMLTrackElement::kind()
 {
     return track().kindKeyword();
-}
-
-void HTMLTrackElement::setKind(const AtomString& kind)
-{
-    setAttributeWithoutSynchronization(kindAttr, kind);
-}
-
-const AtomString& HTMLTrackElement::srclang() const
-{
-    return attributeWithoutSynchronization(srclangAttr);
-}
-
-const AtomString& HTMLTrackElement::label() const
-{
-    return attributeWithoutSynchronization(labelAttr);
 }
 
 bool HTMLTrackElement::isDefault() const

--- a/Source/WebCore/html/HTMLTrackElement.h
+++ b/Source/WebCore/html/HTMLTrackElement.h
@@ -52,10 +52,6 @@ public:
     USING_CAN_MAKE_WEAKPTR(HTMLElement);
 
     const AtomString& kind();
-    void setKind(const AtomString&);
-
-    const AtomString& srclang() const;
-    const AtomString& label() const;
     bool isDefault() const;
 
     enum ReadyState { NONE = 0, LOADING = 1, LOADED = 2, TRACK_ERROR = 3 };

--- a/Source/WebCore/html/HTMLTrackElement.idl
+++ b/Source/WebCore/html/HTMLTrackElement.idl
@@ -28,7 +28,7 @@
     Conditional=VIDEO,
     Exposed=Window
 ] interface HTMLTrackElement : HTMLElement {
-    [CEReactions=NotNeeded] attribute [AtomString] DOMString kind;
+    [CEReactions=NotNeeded, ReflectSetter] attribute [AtomString] DOMString kind;
     [CEReactions=NotNeeded, Reflect, URL] attribute USVString src;
     [CEReactions=NotNeeded, Reflect] attribute DOMString srclang;
     [CEReactions=NotNeeded, Reflect] attribute DOMString label;

--- a/Source/WebCore/html/HTMLVideoElement.cpp
+++ b/Source/WebCore/html/HTMLVideoElement.cpp
@@ -436,15 +436,12 @@ void HTMLVideoElement::ancestorWillEnterFullscreen()
 }
 
 #if ENABLE(WIRELESS_PLAYBACK_TARGET)
+
 bool HTMLVideoElement::webkitWirelessVideoPlaybackDisabled() const
 {
     return mediaSession().wirelessVideoPlaybackDisabled();
 }
 
-void HTMLVideoElement::setWebkitWirelessVideoPlaybackDisabled(bool disabled)
-{
-    setBooleanAttribute(webkitwirelessvideoplaybackdisabledAttr, disabled);
-}
 #endif
 
 void HTMLVideoElement::didMoveToNewDocument(Document& oldDocument, Document& newDocument)

--- a/Source/WebCore/html/HTMLVideoElement.h
+++ b/Source/WebCore/html/HTMLVideoElement.h
@@ -65,7 +65,6 @@ public:
 
 #if ENABLE(WIRELESS_PLAYBACK_TARGET)
     bool webkitWirelessVideoPlaybackDisabled() const;
-    void setWebkitWirelessVideoPlaybackDisabled(bool);
 #endif
 
 #if ENABLE(MEDIA_STATISTICS)

--- a/Source/WebCore/html/HTMLVideoElement.idl
+++ b/Source/WebCore/html/HTMLVideoElement.idl
@@ -50,7 +50,7 @@
     [ImplementedAs=webkitEnterFullscreen] undefined webkitEnterFullScreen();
     [ImplementedAs=webkitExitFullscreen] undefined webkitExitFullScreen();
 
-    [Conditional=WIRELESS_PLAYBACK_TARGET] attribute boolean webkitWirelessVideoPlaybackDisabled;
+    [Conditional=WIRELESS_PLAYBACK_TARGET, ReflectSetter] attribute boolean webkitWirelessVideoPlaybackDisabled;
 
     // The number of frames that have been decoded and made available for playback.
     [Conditional=MEDIA_STATISTICS] readonly attribute unsigned long webkitDecodedFrameCount;

--- a/Source/WebCore/html/ImageDocument.cpp
+++ b/Source/WebCore/html/ImageDocument.cpp
@@ -256,7 +256,7 @@ void ImageDocument::createDocumentStructure()
     else
         imageElement->setAttribute(styleAttr, "-webkit-user-select:none; display:block; padding:env(safe-area-inset-top) env(safe-area-inset-right) env(safe-area-inset-bottom) env(safe-area-inset-left);"_s);
     imageElement->setLoadManually(true);
-    imageElement->setSrc(AtomString { url().string() });
+    imageElement->setAttributeWithoutSynchronization(srcAttr, AtomString { url().string() });
     if (auto* cachedImage = imageElement->cachedImage(); documentLoader && cachedImage)
         cachedImage->setResponse(ResourceResponse { documentLoader->response() });
     body->appendChild(imageElement);
@@ -330,8 +330,8 @@ void ImageDocument::resizeImageToFit()
     LayoutSize imageSize = this->imageSize();
 
     float scale = this->scale();
-    m_imageElement->setWidth(static_cast<int>(imageSize.width() * scale));
-    m_imageElement->setHeight(static_cast<int>(imageSize.height() * scale));
+    m_imageElement->setIntegralAttribute(widthAttr, imageSize.width() * scale);
+    m_imageElement->setIntegralAttribute(heightAttr, imageSize.height() * scale);
 
     m_imageElement->setInlineStyleProperty(CSSPropertyCursor, CSSValueZoomIn);
 }
@@ -342,8 +342,8 @@ void ImageDocument::restoreImageSize()
         return;
 
     LayoutSize imageSize = this->imageSize();
-    m_imageElement->setWidth(imageSize.width().toUnsigned());
-    m_imageElement->setHeight(imageSize.height().toUnsigned());
+    m_imageElement->setUnsignedIntegralAttribute(widthAttr, imageSize.width().toUnsigned());
+    m_imageElement->setUnsignedIntegralAttribute(heightAttr, imageSize.height().toUnsigned());
 
     if (imageFitsInWindow())
         m_imageElement->removeInlineStyleProperty(CSSPropertyCursor);

--- a/Source/WebCore/html/InputType.cpp
+++ b/Source/WebCore/html/InputType.cpp
@@ -265,10 +265,10 @@ FormControlState InputType::saveFormControlState() const
 {
     ASSERT(element());
     Ref input = *element();
-    auto currentValue = input->value();
-    if (currentValue == input->defaultValue())
+    AtomString currentValue { input->value().get() };
+    if (currentValue == input->attributeWithoutSynchronization(valueAttr))
         return { };
-    return { { AtomString { currentValue } } };
+    return { { currentValue } };
 }
 
 void InputType::restoreFormControlState(const FormControlState& state)

--- a/Source/WebCore/html/PermissionsPolicy.cpp
+++ b/Source/WebCore/html/PermissionsPolicy.cpp
@@ -367,7 +367,7 @@ PermissionsPolicy::PolicyDirective PermissionsPolicy::processPermissionsPolicyAt
     auto allowAttributeValue = iframe.attributeWithoutSynchronization(allowAttr);
     auto policyDirective = parsePolicyDirective(allowAttributeValue, iframe.protectedDocument()->securityOrigin().data(), declaredOrigin(iframe)->data());
 
-    if (iframe.hasAttribute(allowfullscreenAttr) || iframe.hasAttribute(webkitallowfullscreenAttr))
+    if (iframe.hasAttributeWithoutSynchronization(allowfullscreenAttr) || iframe.hasAttributeWithoutSynchronization(webkitallowfullscreenAttr))
         policyDirective.add(Feature::Fullscreen, Allowlist::AllowAllOrigins { });
 
     return policyDirective;

--- a/Source/WebCore/html/PopoverInvokerElement.idl
+++ b/Source/WebCore/html/PopoverInvokerElement.idl
@@ -26,5 +26,5 @@
 [EnabledBySetting=PopoverAttributeEnabled]
 interface mixin PopoverInvokerElement {
     [CEReactions=NotNeeded, Reflect=popovertarget] attribute Element? popoverTargetElement;
-    [CEReactions=NotNeeded] attribute [AtomString] DOMString popoverTargetAction;
+    [CEReactions=NotNeeded, ReflectSetter] attribute [AtomString] DOMString popoverTargetAction;
 };

--- a/Source/WebCore/html/shadow/DateTimeNumericFieldElement.cpp
+++ b/Source/WebCore/html/shadow/DateTimeNumericFieldElement.cpp
@@ -130,8 +130,9 @@ void DateTimeNumericFieldElement::setValueAsIntegerByStepping(int value)
 
 void DateTimeNumericFieldElement::setARIAValueAttributesWithInteger(int value)
 {
-    setAttributeWithoutSynchronization(HTMLNames::aria_valuenowAttr, AtomString::number(value));
-    setAttributeWithoutSynchronization(HTMLNames::aria_valuetextAttr, AtomString::number(value));
+    auto string = AtomString::number(value);
+    setAttributeWithoutSynchronization(HTMLNames::aria_valuenowAttr, string);
+    setAttributeWithoutSynchronization(HTMLNames::aria_valuetextAttr, string);
 }
 
 void DateTimeNumericFieldElement::stepDown()

--- a/Source/WebCore/loader/ImageLoader.cpp
+++ b/Source/WebCore/loader/ImageLoader.cpp
@@ -290,7 +290,7 @@ void ImageLoader::updateFromElement(RelevantMutation relevantMutation)
         // Adaptive image glyphs need to load both the high fidelity HEIC and the
         // fallback PNG resource, as both resources are treated as an atomic unit.
         if (imageElement && imageElement->isMultiRepresentationHEIC()) {
-            auto fallbackURL = imageElement->src();
+            auto fallbackURL = imageElement->getURLAttribute(HTMLNames::srcAttr);
             if (!fallbackURL.isNull()) {
                 ResourceRequest resourceRequest(WTFMove(fallbackURL));
                 resourceRequest.setInspectorInitiatorNodeIdentifier(InspectorInstrumentation::identifierForNode(*imageElement));

--- a/Source/WebCore/mathml/MathMLMencloseElement.cpp
+++ b/Source/WebCore/mathml/MathMLMencloseElement.cpp
@@ -104,7 +104,7 @@ void MathMLMencloseElement::addNotationFlags(StringView notation)
 void MathMLMencloseElement::parseNotationAttribute()
 {
     clearNotations();
-    if (!hasAttribute(notationAttr)) {
+    if (!hasAttributeWithoutSynchronization(notationAttr)) {
         addNotation(LongDiv); // The default value is longdiv.
         return;
     }

--- a/Source/WebCore/mathml/MathMLSelectElement.cpp
+++ b/Source/WebCore/mathml/MathMLSelectElement.cpp
@@ -118,7 +118,7 @@ int MathMLSelectElement::getSelectedActionChildAndIndex(Element*& selectedChild)
     if (!selectedChild)
         return 1;
 
-    int selection = getIntegralAttribute(MathMLNames::selectionAttr);
+    int selection = integralAttribute(MathMLNames::selectionAttr);
     int i;
     for (i = 1; i < selection; i++) {
         auto* nextChild = selectedChild->nextElementSibling();

--- a/Source/WebCore/page/DragController.cpp
+++ b/Source/WebCore/page/DragController.cpp
@@ -163,7 +163,7 @@ static RefPtr<DocumentFragment> documentFragmentFromDragData(const DragData& dra
             if (!url.isEmpty()) {
                 Ref document = context.start.document();
                 Ref anchor = HTMLAnchorElement::create(document);
-                anchor->setHref(AtomString { url });
+                anchor->setAttributeWithoutSynchronization(HTMLNames::hrefAttr, AtomString { url });
                 if (title.isEmpty()) {
                     // Try the plain text first because the URL might be normalized or escaped.
                     if (dragData.containsPlainText())

--- a/Source/WebCore/page/text-extraction/TextExtraction.cpp
+++ b/Source/WebCore/page/text-extraction/TextExtraction.cpp
@@ -316,7 +316,7 @@ static inline Variant<SkipExtraction, ItemData, URL, Editable> extractItemData(N
         return { Editable { } };
 
     if (RefPtr image = dynamicDowncast<HTMLImageElement>(element))
-        return { ImageItemData { image->src().lastPathComponent().toString(), image->altText() } };
+        return { ImageItemData { image->getURLAttribute(HTMLNames::srcAttr).lastPathComponent().toString(), image->altText() } };
 
     if (RefPtr control = dynamicDowncast<HTMLTextFormControlElement>(element); control && control->isTextField()) {
         RefPtr input = dynamicDowncast<HTMLInputElement>(control);

--- a/Source/WebCore/rendering/HitTestResult.cpp
+++ b/Source/WebCore/rendering/HitTestResult.cpp
@@ -373,7 +373,7 @@ String HitTestResult::altDisplayString() const
         return displayString(image->attributeWithoutSynchronization(altAttr), m_innerNonSharedNode.get());
 
     if (RefPtr input = dynamicDowncast<HTMLInputElement>(*m_innerNonSharedNode))
-        return displayString(input->alt(), m_innerNonSharedNode.get());
+        return displayString(input->attributeWithoutSynchronization(altAttr), m_innerNonSharedNode.get());
 
     return String();
 }

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLBaseElement.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLBaseElement.mm
@@ -48,7 +48,7 @@
 - (void)setHref:(NSString *)newHref
 {
     WebCore::JSMainThreadNullState state;
-    IMPL->setHref(newHref);
+    IMPL->setAttributeWithoutSynchronization(WebCore::HTMLNames::hrefAttr, newHref);
 }
 
 - (NSString *)target

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLButtonElement.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLButtonElement.mm
@@ -83,7 +83,7 @@
 - (void)setType:(NSString *)newType
 {
     WebCore::JSMainThreadNullState state;
-    IMPL->setType(newType);
+    IMPL->setAttributeWithoutSynchronization(WebCore::HTMLNames::typeAttr, newType);
 }
 
 - (NSString *)name

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLElement.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLElement.mm
@@ -90,7 +90,7 @@
 - (void)setDir:(NSString *)newDir
 {
     WebCore::JSMainThreadNullState state;
-    IMPL->setDir(newDir);
+    IMPL->setAttributeWithoutSynchronization(WebCore::HTMLNames::dirAttr, newDir);
 }
 
 - (int)tabIndex
@@ -259,12 +259,14 @@
 
 #if ENABLE(AUTOCORRECT)
 
+// FIXME: This method isn't in a header. Is it used? Can we remove it?
 - (BOOL)autocorrect
 {
     WebCore::JSMainThreadNullState state;
     return IMPL->shouldAutocorrect();
 }
 
+// FIXME: This method isn't in a header. Is it used? Can we remove it?
 - (void)setAutocorrect:(BOOL)newAutocorrect
 {
     WebCore::JSMainThreadNullState state;
@@ -275,16 +277,18 @@
 
 #if ENABLE(AUTOCAPITALIZE)
 
+// FIXME: This method isn't in a header. Is it used? Can we remove it?
 - (NSString *)autocapitalize
 {
     WebCore::JSMainThreadNullState state;
     return IMPL->autocapitalize().createNSString().autorelease();
 }
 
+// FIXME: This method isn't in a header. Is it used? Can we remove it?
 - (void)setAutocapitalize:(NSString *)newAutocapitalize
 {
     WebCore::JSMainThreadNullState state;
-    IMPL->setAutocapitalize(newAutocapitalize);
+    IMPL->setAttributeWithoutSynchronization(WebCore::HTMLNames::autocapitalizeAttr, newAutocapitalize);
 }
 
 #endif

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLEmbedElement.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLEmbedElement.mm
@@ -54,7 +54,7 @@
 - (int)height
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getIntegralAttribute(WebCore::HTMLNames::heightAttr);
+    return IMPL->integralAttribute(WebCore::HTMLNames::heightAttr);
 }
 
 - (void)setHeight:(int)newHeight
@@ -102,7 +102,7 @@
 - (int)width
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getIntegralAttribute(WebCore::HTMLNames::widthAttr);
+    return IMPL->integralAttribute(WebCore::HTMLNames::widthAttr);
 }
 
 - (void)setWidth:(int)newWidth

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLFormElement.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLFormElement.mm
@@ -75,7 +75,7 @@
 - (void)setAutocomplete:(NSString *)newAutocomplete
 {
     WebCore::JSMainThreadNullState state;
-    IMPL->setAutocomplete(newAutocomplete);
+    IMPL->setAttributeWithoutSynchronization(WebCore::HTMLNames::autocompleteAttr, newAutocomplete);
 }
 
 - (NSString *)enctype
@@ -87,7 +87,7 @@
 - (void)setEnctype:(NSString *)newEnctype
 {
     WebCore::JSMainThreadNullState state;
-    IMPL->setEnctype(newEnctype);
+    IMPL->setAttributeWithoutSynchronization(WebCore::HTMLNames::enctypeAttr, newEnctype);
 }
 
 - (NSString *)encoding
@@ -99,7 +99,7 @@
 - (void)setEncoding:(NSString *)newEncoding
 {
     WebCore::JSMainThreadNullState state;
-    IMPL->setEnctype(newEncoding);
+    IMPL->setAttributeWithoutSynchronization(WebCore::HTMLNames::enctypeAttr, newEncoding);
 }
 
 - (NSString *)method
@@ -111,7 +111,7 @@
 - (void)setMethod:(NSString *)newMethod
 {
     WebCore::JSMainThreadNullState state;
-    IMPL->setMethod(newMethod);
+    IMPL->setAttributeWithoutSynchronization(WebCore::HTMLNames::methodAttr, newMethod);
 }
 
 - (NSString *)name

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLImageElement.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLImageElement.mm
@@ -99,7 +99,7 @@
 - (void)setCrossOrigin:(NSString *)newCrossOrigin
 {
     WebCore::JSMainThreadNullState state;
-    IMPL->setCrossOrigin(newCrossOrigin);
+    IMPL->setAttributeWithoutSynchronization(WebCore::HTMLNames::crossoriginAttr, newCrossOrigin);
 }
 
 - (int)height
@@ -111,13 +111,13 @@
 - (void)setHeight:(int)newHeight
 {
     WebCore::JSMainThreadNullState state;
-    IMPL->setHeight(newHeight);
+    IMPL->setIntegralAttribute(WebCore::HTMLNames::heightAttr, newHeight);
 }
 
 - (int)hspace
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getIntegralAttribute(WebCore::HTMLNames::hspaceAttr);
+    return IMPL->integralAttribute(WebCore::HTMLNames::hspaceAttr);
 }
 
 - (void)setHspace:(int)newHspace
@@ -207,7 +207,7 @@
 - (int)vspace
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getIntegralAttribute(WebCore::HTMLNames::vspaceAttr);
+    return IMPL->integralAttribute(WebCore::HTMLNames::vspaceAttr);
 }
 
 - (void)setVspace:(int)newVspace
@@ -225,7 +225,7 @@
 - (void)setWidth:(int)newWidth
 {
     WebCore::JSMainThreadNullState state;
-    IMPL->setWidth(newWidth);
+    IMPL->setIntegralAttribute(WebCore::HTMLNames::widthAttr, newWidth);
 }
 
 - (BOOL)complete
@@ -273,7 +273,7 @@
 - (NSString *)altDisplayString
 {
     WebCore::JSMainThreadNullState state;
-    return WebCore::displayString(IMPL->alt(), core(self)).createNSString().autorelease();
+    return WebCore::displayString(IMPL->attributeWithoutSynchronization(WebCore::HTMLNames::altAttr), core(self)).createNSString().autorelease();
 }
 
 - (NSURL *)absoluteImageURL

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLInputElement.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLInputElement.mm
@@ -106,7 +106,7 @@
 - (void)setAutocomplete:(NSString *)newAutocomplete
 {
     WebCore::JSMainThreadNullState state;
-    IMPL->setAutocomplete(newAutocomplete);
+    IMPL->setAttributeWithoutSynchronization(WebCore::HTMLNames::autocompleteAttr, newAutocomplete);
 }
 
 - (BOOL)autofocus
@@ -198,7 +198,7 @@
 - (void)setFormAction:(NSString *)newFormAction
 {
     WebCore::JSMainThreadNullState state;
-    IMPL->setFormAction(newFormAction);
+    IMPL->setAttributeWithoutSynchronization(WebCore::HTMLNames::formactionAttr, newFormAction);
 }
 
 - (NSString *)formEnctype
@@ -210,7 +210,7 @@
 - (void)setFormEnctype:(NSString *)newFormEnctype
 {
     WebCore::JSMainThreadNullState state;
-    IMPL->setFormEnctype(newFormEnctype);
+    IMPL->setAttributeWithoutSynchronization(WebCore::HTMLNames::formenctypeAttr, newFormEnctype);
 }
 
 - (NSString *)formMethod
@@ -222,7 +222,7 @@
 - (void)setFormMethod:(NSString *)newFormMethod
 {
     WebCore::JSMainThreadNullState state;
-    IMPL->setFormMethod(newFormMethod);
+    IMPL->setAttributeWithoutSynchronization(WebCore::HTMLNames::formmethodAttr, newFormMethod);
 }
 
 - (BOOL)formNoValidate
@@ -258,7 +258,7 @@
 - (void)setHeight:(unsigned)newHeight
 {
     WebCore::JSMainThreadNullState state;
-    IMPL->setHeight(newHeight);
+    IMPL->setUnsignedIntegralAttribute(WebCore::HTMLNames::heightAttr, newHeight);
 }
 
 - (BOOL)indeterminate
@@ -282,7 +282,7 @@
 - (NSString *)max
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::maxAttr).createNSString().autorelease();
+    return IMPL->attributeWithoutSynchronization(WebCore::HTMLNames::maxAttr).createNSString().autorelease();
 }
 
 - (void)setMax:(NSString *)newMax
@@ -306,7 +306,7 @@
 - (NSString *)min
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::minAttr).createNSString().autorelease();
+    return IMPL->attributeWithoutSynchronization(WebCore::HTMLNames::minAttr).createNSString().autorelease();
 }
 
 - (void)setMin:(NSString *)newMin
@@ -342,7 +342,7 @@
 - (NSString *)pattern
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::patternAttr).createNSString().autorelease();
+    return IMPL->attributeWithoutSynchronization(WebCore::HTMLNames::patternAttr).createNSString().autorelease();
 }
 
 - (void)setPattern:(NSString *)newPattern
@@ -354,7 +354,7 @@
 - (NSString *)placeholder
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::placeholderAttr).createNSString().autorelease();
+    return IMPL->attributeWithoutSynchronization(WebCore::HTMLNames::placeholderAttr).createNSString().autorelease();
 }
 
 - (void)setPlaceholder:(NSString *)newPlaceholder
@@ -414,7 +414,7 @@
 - (NSString *)step
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::stepAttr).createNSString().autorelease();
+    return IMPL->attributeWithoutSynchronization(WebCore::HTMLNames::stepAttr).createNSString().autorelease();
 }
 
 - (void)setStep:(NSString *)newStep
@@ -432,19 +432,19 @@
 - (void)setType:(NSString *)newType
 {
     WebCore::JSMainThreadNullState state;
-    IMPL->setType(newType);
+    IMPL->setAttributeWithoutSynchronization(WebCore::HTMLNames::typeAttr, newType);
 }
 
 - (NSString *)defaultValue
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->defaultValue().createNSString().autorelease();
+    return IMPL->attributeWithoutSynchronization(WebCore::HTMLNames::valueAttr).createNSString().autorelease();
 }
 
 - (void)setDefaultValue:(NSString *)newDefaultValue
 {
     WebCore::JSMainThreadNullState state;
-    IMPL->setDefaultValue(newDefaultValue);
+    IMPL->setAttributeWithoutSynchronization(WebCore::HTMLNames::valueAttr, newDefaultValue);
 }
 
 - (NSString *)value
@@ -492,7 +492,7 @@
 - (void)setWidth:(unsigned)newWidth
 {
     WebCore::JSMainThreadNullState state;
-    IMPL->setWidth(newWidth);
+    IMPL->setUnsignedIntegralAttribute(WebCore::HTMLNames::widthAttr, newWidth);
 }
 
 - (BOOL)willValidate
@@ -597,7 +597,7 @@
 - (NSString *)altDisplayString
 {
     WebCore::JSMainThreadNullState state;
-    return WebCore::displayString(IMPL->alt(), core(self)).createNSString().autorelease();
+    return WebCore::displayString(IMPL->attributeWithoutSynchronization(WebCore::HTMLNames::altAttr), core(self)).createNSString().autorelease();
 }
 
 - (NSURL *)absoluteImageURL

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLLIElement.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLLIElement.mm
@@ -54,7 +54,7 @@
 - (int)value
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getIntegralAttribute(WebCore::HTMLNames::valueAttr);
+    return IMPL->integralAttribute(WebCore::HTMLNames::valueAttr);
 }
 
 - (void)setValue:(int)newValue

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLLinkElement.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLLinkElement.mm
@@ -174,7 +174,7 @@
 - (void)setCrossOrigin:(NSString *)newCrossOrigin
 {
     WebCore::JSMainThreadNullState state;
-    IMPL->setCrossOrigin(newCrossOrigin);
+    IMPL->setAttributeWithoutSynchronization(WebCore::HTMLNames::crossoriginAttr, newCrossOrigin);
 }
 
 - (DOMStyleSheet *)sheet

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLMarqueeElement.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLMarqueeElement.mm
@@ -91,7 +91,7 @@
 - (unsigned)hspace
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getUnsignedIntegralAttribute(WebCore::HTMLNames::hspaceAttr);
+    return IMPL->unsignedIntegralAttribute(WebCore::HTMLNames::hspaceAttr);
 }
 
 - (void)setHspace:(unsigned)newHspace
@@ -151,7 +151,7 @@
 - (unsigned)vspace
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getUnsignedIntegralAttribute(WebCore::HTMLNames::vspaceAttr);
+    return IMPL->unsignedIntegralAttribute(WebCore::HTMLNames::vspaceAttr);
 }
 
 - (void)setVspace:(unsigned)newVspace

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLMediaElement.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLMediaElement.mm
@@ -81,7 +81,7 @@
 - (void)setCrossOrigin:(NSString *)newCrossOrigin
 {
     WebCore::JSMainThreadNullState state;
-    IMPL->setCrossOrigin(newCrossOrigin);
+    IMPL->setAttributeWithoutSynchronization(WebCore::HTMLNames::crossoriginAttr, newCrossOrigin);
 }
 
 - (unsigned short)networkState

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLOListElement.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLOListElement.mm
@@ -61,7 +61,7 @@
 - (void)setStart:(int)newStart
 {
     WebCore::JSMainThreadNullState state;
-    IMPL->setStartForBindings(newStart);
+    IMPL->setIntegralAttribute(WebCore::HTMLNames::startAttr, newStart);
 }
 
 - (BOOL)reversed

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLObjectElement.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLObjectElement.mm
@@ -164,7 +164,7 @@
 - (int)hspace
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getIntegralAttribute(WebCore::HTMLNames::hspaceAttr);
+    return IMPL->integralAttribute(WebCore::HTMLNames::hspaceAttr);
 }
 
 - (void)setHspace:(int)newHspace
@@ -224,7 +224,7 @@
 - (int)vspace
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getIntegralAttribute(WebCore::HTMLNames::vspaceAttr);
+    return IMPL->integralAttribute(WebCore::HTMLNames::vspaceAttr);
 }
 
 - (void)setVspace:(int)newVspace

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLOptionElement.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLOptionElement.mm
@@ -69,7 +69,7 @@
 - (void)setLabel:(NSString *)newLabel
 {
     WebCore::JSMainThreadNullState state;
-    IMPL->setLabel(newLabel);
+    IMPL->setAttributeWithoutSynchronization(WebCore::HTMLNames::labelAttr, newLabel);
 }
 
 - (BOOL)defaultSelected
@@ -105,7 +105,7 @@
 - (void)setValue:(NSString *)newValue
 {
     WebCore::JSMainThreadNullState state;
-    IMPL->setValue(newValue);
+    IMPL->setAttributeWithoutSynchronization(WebCore::HTMLNames::valueAttr, newValue);
 }
 
 - (NSString *)text

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLPreElement.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLPreElement.mm
@@ -42,7 +42,7 @@
 - (int)width
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getIntegralAttribute(WebCore::HTMLNames::widthAttr);
+    return IMPL->integralAttribute(WebCore::HTMLNames::widthAttr);
 }
 
 - (void)setWidth:(int)newWidth

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLScriptElement.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLScriptElement.mm
@@ -55,7 +55,7 @@
 - (NSString *)htmlFor
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::forAttr).createNSString().autorelease();
+    return IMPL->attributeWithoutSynchronization(WebCore::HTMLNames::forAttr).createNSString().autorelease();
 }
 
 - (void)setHtmlFor:(NSString *)newHtmlFor
@@ -67,7 +67,7 @@
 - (NSString *)event
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::eventAttr).createNSString().autorelease();
+    return IMPL->attributeWithoutSynchronization(WebCore::HTMLNames::eventAttr).createNSString().autorelease();
 }
 
 - (void)setEvent:(NSString *)newEvent
@@ -79,7 +79,7 @@
 - (NSString *)charset
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::charsetAttr).createNSString().autorelease();
+    return IMPL->attributeWithoutSynchronization(WebCore::HTMLNames::charsetAttr).createNSString().autorelease();
 }
 
 - (void)setCharset:(NSString *)newCharset
@@ -127,7 +127,7 @@
 - (NSString *)type
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::typeAttr).createNSString().autorelease();
+    return IMPL->attributeWithoutSynchronization(WebCore::HTMLNames::typeAttr).createNSString().autorelease();
 }
 
 - (void)setType:(NSString *)newType
@@ -145,13 +145,13 @@
 - (void)setCrossOrigin:(NSString *)newCrossOrigin
 {
     WebCore::JSMainThreadNullState state;
-    IMPL->setCrossOrigin(newCrossOrigin);
+    IMPL->setAttributeWithoutSynchronization(WebCore::HTMLNames::crossoriginAttr, newCrossOrigin);
 }
 
 - (NSString *)nonce
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getAttribute(WebCore::HTMLNames::nonceAttr).createNSString().autorelease();
+    return IMPL->attributeWithoutSynchronization(WebCore::HTMLNames::nonceAttr).createNSString().autorelease();
 }
 
 - (void)setNonce:(NSString *)newNonce

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLTableCellElement.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLTableCellElement.mm
@@ -211,7 +211,7 @@
 - (void)setScope:(NSString *)newScope
 {
     WebCore::JSMainThreadNullState state;
-    IMPL->setScope(newScope);
+    IMPL->setAttributeWithoutSynchronization(WebCore::HTMLNames::scopeAttr, newScope);
 }
 
 @end

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLTextAreaElement.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLTextAreaElement.mm
@@ -297,7 +297,7 @@ DOMHTMLTextAreaElement *kit(WebCore::HTMLTextAreaElement* value)
 - (void)setAutocomplete:(NSString *)newAutocomplete
 {
     WebCore::JSMainThreadNullState state;
-    unwrap(*self).setAutocomplete(newAutocomplete);
+    unwrap(*self).setAttributeWithoutSynchronization(WebCore::HTMLNames::autocompleteAttr, newAutocomplete);
 }
 
 - (void)select

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLVideoElement.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLVideoElement.mm
@@ -46,7 +46,7 @@
 - (unsigned)width
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getUnsignedIntegralAttribute(WebCore::HTMLNames::widthAttr);
+    return IMPL->unsignedIntegralAttribute(WebCore::HTMLNames::widthAttr);
 }
 
 - (void)setWidth:(unsigned)newWidth
@@ -58,7 +58,7 @@
 - (unsigned)height
 {
     WebCore::JSMainThreadNullState state;
-    return IMPL->getUnsignedIntegralAttribute(WebCore::HTMLNames::heightAttr);
+    return IMPL->unsignedIntegralAttribute(WebCore::HTMLNames::heightAttr);
 }
 
 - (void)setHeight:(unsigned)newHeight


### PR DESCRIPTION
#### 4c99b6a9d25c8faa8994c277fc98113f6a568b77
<pre>
Add ReflectSetter
<a href="https://rdar.apple.com/146613724">rdar://146613724</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=289440">https://bugs.webkit.org/show_bug.cgi?id=289440</a>

Reviewed by Sam Weinig.

We can cut down on hand-written code by adding [ReflectSetter], like [Reflect],
but only for the set function, not the get function. In addition, did some related
changes:

- removed functions that were previously used to implement setters
- removed uses of these functions, preferring to set attributes with the general
  purpose attribute setting functions rather than calling a named wrapper
- renamed some internal functions to use WebKit naming style rather than DOM, removing &quot;get&quot;
- used &quot;without synchronization&quot; versions of functions more consistently, might lead to
  small performance gains
- addded a numeric attribute setter function so we can use [ReflectSetter] with double
- moved some DOM function implementations out of the headers, not needed for optimization
  and contributes to slower build times

* Source/WebCore/WebCore.xcodeproj/project.pbxproj: Added PopoverInvokerElement.idl
so global searches in Xcode will see things in this file.

* Source/WebCore/accessibility/AccessibilityNodeObject.cpp:
(WebCore::AccessibilityNodeObject::url const): Use getURLAttribute.

* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::ariaLevel const): Use integralAttribute and std::max.
(WebCore::AccessibilityObject::integralAttribute const): Renamed from getIntegralAttribute.
(WebCore::AccessibilityObject::setSize const): Use integralAttribute.
(WebCore::AccessibilityObject::posInSet const): Use integralAttribute.

(WebCore::AccessibilityObject::getIntegralAttribute const): Deleted.
* Source/WebCore/accessibility/AccessibilityObject.h: Renamed getIntegralAttribute
to integralAttribute.

* Source/WebCore/accessibility/AccessibilityTable.cpp:
(WebCore::AccessibilityTable::isDataTable const): Use integralAttribute.
(WebCore::AccessibilityTable::axColumnCount const): Use integralAttribute.
(WebCore::AccessibilityTable::axRowCount const): Use integralAttribute.

* Source/WebCore/accessibility/AccessibilityTableCell.cpp:
(WebCore::AccessibilityTableCell::axColumnIndex const): Use integralAttribute.
(WebCore::AccessibilityTableCell::axRowIndex const): Use integralAttribute.
(WebCore::AccessibilityTableCell::axColumnSpan const): Use integralAttribute.
(WebCore::AccessibilityTableCell::axRowSpan const): Use integralAttribute.

* Source/WebCore/accessibility/AccessibilityTableRow.cpp:
(WebCore::AccessibilityTableRow::axColumnIndex const): Use integralAttribute.
(WebCore::AccessibilityTableRow::axRowIndex const): Use integralAttribute.

* Source/WebCore/bindings/scripts/CodeGenerator.pm:
(ContentAttributeName): Support ReflectSetter.
(GetterExpression): Pass in &quot;getter&quot;, also use numericAttribute, integralAttribute,
and unsignedIntegralAttribute.
(SetterExpression): Use setNumericAttribute.

* Source/WebCore/bindings/scripts/CodeGeneratorJS.pm:
(NativeToJSValue): Updated for name change to unsignedIntegralAttribute
and integralAttribute.

* Source/WebCore/bindings/scripts/IDLAttributes.json: Added ReflectSetter.

* Source/WebCore/bindings/scripts/test/JS/JSTestObj.cpp: Use integralAttribute.
Added reflected setter tests.

(WebCore::JSTestObjDOMConstructor::construct):
(WebCore::JSTestObjPrototype::finishCreation):
(WebCore::jsTestObj_reflectedIntegralAttrGetter):
(WebCore::jsTestObj_reflectedUnsignedIntegralAttrGetter):
(WebCore::jsTestObj_reflectedCustomIntegralAttrGetter):
(WebCore::JSC_DEFINE_CUSTOM_SETTER):
(WebCore::jsTestObj_reflectedSetterStringAttrGetter):
(WebCore::JSC_DEFINE_CUSTOM_GETTER):
(WebCore::setJSTestObj_reflectedSetterStringAttrSetter):
(WebCore::jsTestObj_reflectedSetterUSVStringAttrGetter):
(WebCore::setJSTestObj_reflectedSetterUSVStringAttrSetter):
(WebCore::jsTestObj_reflectedSetterIntegralAttrGetter):
(WebCore::setJSTestObj_reflectedSetterIntegralAttrSetter):
(WebCore::jsTestObj_reflectedSetterUnsignedIntegralAttrGetter):
(WebCore::setJSTestObj_reflectedSetterUnsignedIntegralAttrSetter):
(WebCore::jsTestObj_reflectedSetterBooleanAttrGetter):
(WebCore::setJSTestObj_reflectedSetterBooleanAttrSetter):
(WebCore::jsTestObj_reflectedSetterElementAttrGetter):
(WebCore::setJSTestObj_reflectedSetterElementAttrSetter):
(WebCore::jsTestObj_reflectedSetterElementsArrayAttrGetter):
(WebCore::setJSTestObj_reflectedSetterElementsArrayAttrSetter):
(WebCore::jsTestObj_reflectedSetterURLAttrGetter):
(WebCore::setJSTestObj_reflectedSetterURLAttrSetter):
(WebCore::jsTestObj_reflectedSetterUSVURLAttrGetter):
(WebCore::setJSTestObj_reflectedSetterUSVURLAttrSetter):
(WebCore::jsTestObj_reflectedSetterCustomIntegralAttrGetter):
(WebCore::setJSTestObj_reflectedSetterCustomIntegralAttrSetter):
(WebCore::jsTestObj_reflectedSetterCustomBooleanAttrGetter):
(WebCore::setJSTestObj_reflectedSetterCustomBooleanAttrSetter):
(WebCore::jsTestObj_reflectedSetterCustomURLAttrGetter):
(WebCore::setJSTestObj_reflectedSetterCustomURLAttrSetter):
* Source/WebCore/bindings/scripts/test/TestObj.idl: Added reflected setter tests.

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::setDir): Use setAttributeWithoutSynchronization.

* Source/WebCore/dom/Element.cpp:
(WebCore::Element::setBooleanAttribute): Use setAttributeWIthoutSynchronization.
(WebCore::Element::integralAttribute const): Renamed from getIntegralAttribute.
Use attributeWithoutSynchronization.
(WebCore::Element::setIntegralAttribute): Use setAttributeWIthoutSynchronization.
(WebCore::Element::unsignedIntegralAttribute const): Renamed from
getUnsignedIntegralAttribute. Use attributeWithoutSynchronization.
(WebCore::Element::setUnsignedIntegralAttribute): Use setAttributeWIthoutSynchronization.
(WebCore::Element::setNumericAttribute): Added.

(WebCore::Element::getIntegralAttribute const): Deleted.
(WebCore::Element::getUnsignedIntegralAttribute const): Deleted.
* Source/WebCore/dom/Element.h: Updated for above changes.

* Source/WebCore/dom/ElementContentEditable.idl: Use ReflectSetter.

* Source/WebCore/dom/ElementInternals.h: Sorted forward declarations.

* Source/WebCore/editing/BreakBlockquoteCommand.cpp:
(WebCore::BreakBlockquoteCommand::doApply): Use setAttributeWithoutSynchronization.
* Source/WebCore/editing/CreateLinkCommand.cpp:
(WebCore::CreateLinkCommand::doApply): Use setAttributeWithoutSynchronization.
* Source/WebCore/editing/Editor.cpp:
(WebCore::Editor::registerAttachmentIdentifier): Use attributeWithoutSynchronization.
* Source/WebCore/editing/EditorCommand.cpp:
(WebCore::executeInsertImage): Use setAttributeWithoutSynchronization.
* Source/WebCore/editing/cocoa/DataDetection.mm:
(WebCore::processDataDetectorScannerResults): Use setAttributeWithoutSynchronization.
* Source/WebCore/editing/cocoa/EditorCocoa.mm:
(WebCore::Editor::insertMultiRepresentationHEIC): Use setAttributeWithoutSynchronization.
* Source/WebCore/html/FileInputType.cpp:
(WebCore::FileInputType::createShadowSubtree): Use setAttributeWithoutSynchronization.

* Source/WebCore/html/HTMLAnchorElement.cpp:
(WebCore::HTMLAnchorElement::setFullURL): Moved this here out of the header.

(WebCore::HTMLAnchorElement::setHref): Deleted.
(WebCore::HTMLAnchorElement::setReferrerPolicyForBindings): Deleted.
* Source/WebCore/html/HTMLAnchorElement.h: Removed setHref
and setReferrerPolicyForBindings, and moved the implementation of setFullURL into
the implementation file.

* Source/WebCore/html/HTMLAnchorElement.idl: Use RelectSetter.

* Source/WebCore/html/HTMLAreaElement.idl: Use RelectSetter.

* Source/WebCore/html/HTMLAttachmentElement.cpp:
(WebCore::HTMLAttachmentElement::updateImage): Use setAttributeWithoutSychronization.
Use removeAttribute.

* Source/WebCore/html/HTMLBaseElement.cpp:
(WebCore::HTMLBaseElement::setHref): Deleted.
* Source/WebCore/html/HTMLBaseElement.h: Deleted setHref.
* Source/WebCore/html/HTMLBaseElement.idl: Use ReflectSetter.

* Source/WebCore/html/HTMLButtonElement.cpp:
(WebCore::HTMLButtonElement::setType): Deleted.
(WebCore::HTMLButtonElement::setCommand): Deleted.
* Source/WebCore/html/HTMLButtonElement.h: Deleted setType and setCommand.
* Source/WebCore/html/HTMLButtonElement.idl: Use ReflectSetter.

* Source/WebCore/html/HTMLDetailsElement.cpp:
(WebCore::HTMLDetailsElement::didAddUserAgentShadowRoot): Use
hasAttributeWithoutSynchronization.
(WebCore::HTMLDetailsElement::ensureDetailsExclusivityAfterMutation):
Use hasAttributeWithoutSynchronization and attributeWithoutSynchronization.
(WebCore::HTMLDetailsElement::toggleOpen): Moved this here out of the header.
* Source/WebCore/html/HTMLDetailsElement.h: Moved toggleOpen out of the header.

* Source/WebCore/html/HTMLDialogElement.cpp:
(WebCore::HTMLDialogElement::show): Use setAttributeWithoutSynchronization.
(WebCore::HTMLDialogElement::showModal): Use setAttributeWithoutSynchronization.
(WebCore::HTMLDialogElement::close): Use removeAttribute.
(WebCore::HTMLDialogElement::isOpen const): Moved this here out of the header.
* Source/WebCore/html/HTMLDialogElement.h: Removed unneeded declaration of
ToggleEventTask and moved isOpen out of the header.

* Source/WebCore/html/HTMLElement.cpp:
(WebCore::runPopoverFocusingSteps): Use hasAttributeWithoutSynchronization.

(WebCore::HTMLElement::setDir): Deleted.
(WebCore::HTMLElement::setAutocapitalize): Deleted.
(WebCore::HTMLElement::setInputMode): Deleted.
(WebCore::HTMLElement::setEnterKeyHint): Deleted.
* Source/WebCore/html/HTMLElement.h: Removed setDir, setInputMode, setAutocapitalize,
and setEnterKeyHint.
* Source/WebCore/html/HTMLElement.idl: Use ReflectSetter.

* Source/WebCore/html/HTMLFormControlElement.cpp:
(WebCore::HTMLFormControlElement::setFormEnctype): Deleted.
(WebCore::HTMLFormControlElement::setFormMethod): Deleted.
(WebCore::HTMLFormControlElement::setFormAction): Deleted.
(WebCore::HTMLFormControlElement::setAutocomplete): Deleted.
(WebCore::HTMLFormControlElement::setPopoverTargetAction): Deleted.
* Source/WebCore/html/HTMLFormControlElement.h: Removed setFormEnctype, setFormMethod,
and setFormAction.

* Source/WebCore/html/HTMLFormElement.cpp:
(WebCore::HTMLFormElement::setAction): Deleted.
(WebCore::HTMLFormElement::setEnctype): Deleted.
(WebCore::HTMLFormElement::setMethod): Deleted.
(WebCore::HTMLFormElement::setAutocomplete): Deleted.
* Source/WebCore/html/HTMLFormElement.h: Removed setEnctype, setAutocomplete, setAction,
and setMethod.
* Source/WebCore/html/HTMLFormElement.idl: Use ReflectSetter.

* Source/WebCore/html/HTMLIFrameElement.cpp:
(WebCore::HTMLIFrameElement::setReferrerPolicyForBindings): Deleted.
(WebCore::HTMLIFrameElement::setLoading): Deleted.
* Source/WebCore/html/HTMLIFrameElement.h: Removed setReferrerPolicyForBindings and
setLoading.
* Source/WebCore/html/HTMLIFrameElement.idl: Use ReflectSetter.

* Source/WebCore/html/HTMLImageElement.cpp:
(WebCore::HTMLImageElement::createForLegacyFactoryFunction): Use
setUnsignedIntegralAttribute.
(WebCore::HTMLImageElement::alt const): Deleted.
(WebCore::HTMLImageElement::setHeight): Deleted.
(WebCore::HTMLImageElement::src const): Deleted.
(WebCore::HTMLImageElement::setSrc): Deleted.
(WebCore::HTMLImageElement::setWidth): Deleted.
(WebCore::HTMLImageElement::setDecoding): Deleted.
(WebCore::HTMLImageElement::setCrossOrigin): Deleted.
(WebCore::HTMLImageElement::setSrcsetForBindings): Deleted.
(WebCore::HTMLImageElement::setLoadingForBindings): Deleted.
(WebCore::HTMLImageElement::setReferrerPolicyForBindings): Deleted.
(WebCore::HTMLImageElement::setFetchPriorityForBindings): Deleted.
* Source/WebCore/html/HTMLImageElement.h: Removed alt, setHeight, src, setSrc,
setCrossOrigin, setWidth, setDecodeing, setSrcsetForBindings, setLoadingForBindings,
setReferrerPolicyForBindings, and setFetchPriorityForBindings.
* Source/WebCore/html/HTMLImageElement.idl: Use Reflect for more cases where it works.
Use ReflectSetter.

* Source/WebCore/html/HTMLInputElement.cpp:
(WebCore::HTMLInputElement::needsSuspensionCallback): Use atttributeWithoutSynchronization.
(WebCore::HTMLInputElement::addSubresourceAttributeURLs const): Use getURLAttribute.
(WebCore::HTMLInputElement::setType): Deleted.
(WebCore::HTMLInputElement::defaultValue const): Deleted.
(WebCore::HTMLInputElement::setDefaultValue): Deleted.
(WebCore::HTMLInputElement::alt const): Deleted.
(WebCore::HTMLInputElement::src const): Deleted.
(WebCore::HTMLInputElement::setHeight): Deleted.
(WebCore::HTMLInputElement::setWidth): Deleted.
* Source/WebCore/html/HTMLInputElement.h: Removed setHeight, defaultValue, setDefaultValue,
setType, setWidth, alt, and src.
* Source/WebCore/html/HTMLInputElement.idl: Use ReflectSetter.

* Source/WebCore/html/HTMLLinkElement.cpp:
(WebCore::HTMLLinkElement::setCrossOrigin): Deleted.
(WebCore::HTMLLinkElement::setAs): Deleted.
(WebCore::HTMLLinkElement::setReferrerPolicyForBindings): Deleted.
(WebCore::HTMLLinkElement::setFetchPriorityForBindings): Deleted.
* Source/WebCore/html/HTMLLinkElement.h: Removed setCrossOrigin, setAs,
setReferrerPolicyForBindings, and setFetchPriorityForBindings.
* Source/WebCore/html/HTMLLinkElement.idl: Use ReflectSetter.

* Source/WebCore/html/HTMLMarqueeElement.cpp:
(WebCore::HTMLMarqueeElement::loop const): Use integralAttribute.

* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::outOfBandTrackSources): Use attributeWithoutSynchronization.
(WebCore::HTMLMediaElement::setCrossOrigin): Deleted.
* Source/WebCore/html/HTMLMediaElement.h: Removed setCrossOrigin.
* Source/WebCore/html/HTMLMediaElement.idl: Use ReflectSetter.

* Source/WebCore/html/HTMLMeterElement.cpp:
(WebCore::HTMLMeterElement::setMin): Deleted.
(WebCore::HTMLMeterElement::setMax): Deleted.
(WebCore::HTMLMeterElement::setValue): Deleted.
(WebCore::HTMLMeterElement::setLow): Deleted.
(WebCore::HTMLMeterElement::setHigh): Deleted.
(WebCore::HTMLMeterElement::setOptimum): Deleted.
* Source/WebCore/html/HTMLMeterElement.h: Removed setMin, setMax, setValue, setLow,
setHigh, and setOptimum.
* Source/WebCore/html/HTMLMeterElement.idl: Use ReflectSetter.

* Source/WebCore/html/HTMLOListElement.cpp:
(WebCore::HTMLOListElement::setStartForBindings): Deleted.
* Source/WebCore/html/HTMLOListElement.h: Removed setStartForBindings.
* Source/WebCore/html/HTMLOListElement.idl: Use ReflectSetter.

* Source/WebCore/html/HTMLOptionElement.cpp:
(WebCore::HTMLOptionElement::createForLegacyFactoryFunction):
Use setAttributeWithoutSynchronization.
(WebCore::HTMLOptionElement::value const):
(WebCore::HTMLOptionElement::label const):
(WebCore::HTMLOptionElement::displayLabel const):
(WebCore::HTMLOptionElement::collectOptionInnerTextCollapsingWhitespace const):
(WebCore::HTMLOptionElement::setValue): Deleted.
(WebCore::HTMLOptionElement::setLabel): Deleted.
* Source/WebCore/html/HTMLOptionElement.h: Removed setValue and setLabel.
* Source/WebCore/html/HTMLOptionElement.idl: Use ReflectSetter.

* Source/WebCore/html/HTMLProgressElement.cpp:
(WebCore::HTMLProgressElement::setValue): Deleted.
* Source/WebCore/html/HTMLProgressElement.h: Removed setValue.
* Source/WebCore/html/HTMLProgressElement.idl: Use ReflectSetter.

* Source/WebCore/html/HTMLScriptElement.cpp:
(WebCore::HTMLScriptElement::setCrossOrigin): Deleted.
(WebCore::HTMLScriptElement::setReferrerPolicyForBindings): Deleted.
(WebCore::HTMLScriptElement::setFetchPriorityForBindings): Deleted.
* Source/WebCore/html/HTMLScriptElement.h: Removed setCrossOrigin,
setReferrerPolicyForBindings, and setFetchPriorityForBindings.
* Source/WebCore/html/HTMLScriptElement.idl: Use ReflectSetter.

* Source/WebCore/html/HTMLSelectElement.idl: Use ReflectSetter.

* Source/WebCore/html/HTMLTableCellElement.cpp:
(WebCore::HTMLTableCellElement::setScope): Deleted.
* Source/WebCore/html/HTMLTableCellElement.h: Removed setScope.
* Source/WebCore/html/HTMLTableCellElement.idl: Use ReflectSetter.

* Source/WebCore/html/HTMLTemplateElement.cpp:
(WebCore::HTMLTemplateElement::setShadowRootMode): Deleted.
* Source/WebCore/html/HTMLTemplateElement.h: Removed setShadowRootMode.
* Source/WebCore/html/HTMLTemplateElement.idl: Use ReflectSetter.

* Source/WebCore/html/HTMLTextAreaElement.idl: Use ReflectSetter.

* Source/WebCore/html/HTMLTrackElement.cpp:
(WebCore::HTMLTrackElement::HTMLTrackElement): Replaced pointless code that
called attributeWithoutSynchronization in the constructor. There are no
attributes yet at construction time, so this is just a slow way to get what
is always a null string.
(WebCore::HTMLTrackElement::setKind): Deleted.
(WebCore::HTMLTrackElement::srclang const): Deleted.
(WebCore::HTMLTrackElement::label const): Deleted.
* Source/WebCore/html/HTMLTrackElement.h: Deleted setKind, srclang, and label.
* Source/WebCore/html/HTMLTrackElement.idl: Use ReflectSetter.

* Source/WebCore/html/HTMLVideoElement.cpp:
(WebCore::HTMLVideoElement::setWebkitWirelessVideoPlaybackDisabled): Deleted.
* Source/WebCore/html/HTMLVideoElement.h: Removed setWebkitWirelessVideoPlaybackDisabled.
* Source/WebCore/html/HTMLVideoElement.idl: Use ReflectSetter.

* Source/WebCore/html/ImageDocument.cpp:
(WebCore::ImageDocument::createDocumentStructure): Use setAttributeWithoutSynchronization.
(WebCore::ImageDocument::resizeImageToFit): Use setIntegralAttribute.
(WebCore::ImageDocument::restoreImageSize): Use setIntegralAttribute.

* Source/WebCore/html/InputType.cpp:
(WebCore::InputType::saveFormControlState const): Use attributeWithoutSynchronization.

* Source/WebCore/html/PermissionsPolicy.cpp:
(WebCore::PermissionsPolicy::processPermissionsPolicyAttribute): Use
hasAttributeWithoutSynchronization.

* Source/WebCore/html/PopoverInvokerElement.idl: Use ReflectSetter.

* Source/WebCore/html/shadow/DateTimeNumericFieldElement.cpp:
(WebCore::DateTimeNumericFieldElement::setARIAValueAttributesWithInteger):
Use a single call to AtomString::number for better efficiency.

* Source/WebCore/loader/ImageLoader.cpp:
(WebCore::ImageLoader::updateFromElement): Use getURLAttribute.

* Source/WebCore/mathml/MathMLMencloseElement.cpp:
(WebCore::MathMLMencloseElement::parseNotationAttribute): Use
hasAttributeWithoutSynchronization.

* Source/WebCore/mathml/MathMLSelectElement.cpp:
(WebCore::MathMLSelectElement::getSelectedActionChildAndIndex): Use
integralAttribute.

* Source/WebCore/page/DragController.cpp:
(WebCore::documentFragmentFromDragData): Use setAttributeWithoutSynchronization.

* Source/WebCore/page/text-extraction/TextExtraction.cpp:
(WebCore::TextExtraction::extractItemData): Use getURLAttribute.

* Source/WebCore/rendering/HitTestResult.cpp:
(WebCore::HitTestResult::altDisplayString const): Use attributeWithoutSynchronization.

* Source/WebKitLegacy/mac/DOM/DOMHTMLBaseElement.mm:
(-[DOMHTMLBaseElement setHref:]): Use setAttributeWithoutSynchronization.
* Source/WebKitLegacy/mac/DOM/DOMHTMLButtonElement.mm:
(-[DOMHTMLButtonElement setType:]): Use setAttributeWithoutSynchronization.
* Source/WebKitLegacy/mac/DOM/DOMHTMLElement.mm:
(-[DOMHTMLElement setDir:]): Use setAttributeWithoutSynchronization.
(-[DOMHTMLElement setAutocapitalize:]): Use setAttributeWithoutSynchronization.
* Source/WebKitLegacy/mac/DOM/DOMHTMLEmbedElement.mm:
(-[DOMHTMLEmbedElement height]): Use integralAttribute.
(-[DOMHTMLEmbedElement width]): Use integralAttribute.
* Source/WebKitLegacy/mac/DOM/DOMHTMLFormElement.mm:
(-[DOMHTMLFormElement setAutocomplete:]): Use setAttributeWithoutSynchronization.
(-[DOMHTMLFormElement setEnctype:]): Use setAttributeWithoutSynchronization.
(-[DOMHTMLFormElement setEncoding:]): Use setAttributeWithoutSynchronization.
(-[DOMHTMLFormElement setMethod:]): Use setAttributeWithoutSynchronization.
* Source/WebKitLegacy/mac/DOM/DOMHTMLImageElement.mm:
(-[DOMHTMLImageElement setCrossOrigin:]): Use setAttributeWithoutSynchronization.
(-[DOMHTMLImageElement setHeight:]): Use setAttributeWithoutSynchronization.
(-[DOMHTMLImageElement hspace]): Use integralAttribute.
(-[DOMHTMLImageElement vspace]): Use integralAttribute.
(-[DOMHTMLImageElement setWidth:]): Use setIntegralAttribute.
(-[DOMHTMLImageElement altDisplayString]): Use attributeWithoutSynchronization.
* Source/WebKitLegacy/mac/DOM/DOMHTMLInputElement.mm:
(-[DOMHTMLInputElement setAutocomplete:]): Use setAttributeWithoutSynchronization.
(-[DOMHTMLInputElement setFormAction:]): Use setAttributeWithoutSynchronization.
(-[DOMHTMLInputElement setFormEnctype:]): Use setAttributeWithoutSynchronization.
(-[DOMHTMLInputElement setFormMethod:]): Use setAttributeWithoutSynchronization.
(-[DOMHTMLInputElement setHeight:]): Use setUnsignedIntegralAttribute.
(-[DOMHTMLInputElement max]): Use attributeWithoutSynchronization.
(-[DOMHTMLInputElement min]): Use attributeWithoutSynchronization.
(-[DOMHTMLInputElement pattern]): Use attributeWithoutSynchronization.
(-[DOMHTMLInputElement placeholder]): Use attributeWithoutSynchronization.
(-[DOMHTMLInputElement step]): Use attributeWithoutSynchronization.
(-[DOMHTMLInputElement setType:]): Use setAttributeWithoutSynchronization.
(-[DOMHTMLInputElement defaultValue]): Use attributeWithoutSynchronization.
(-[DOMHTMLInputElement setDefaultValue:]): Use setAttributeWithoutSynchronization.
(-[DOMHTMLInputElement setWidth:]): Use setUnsignedIntegralAttribute.
(-[DOMHTMLInputElement altDisplayString]): Use attributeWithoutSynchronization.
* Source/WebKitLegacy/mac/DOM/DOMHTMLLIElement.mm:
(-[DOMHTMLLIElement value]): Use integralAttribute.
* Source/WebKitLegacy/mac/DOM/DOMHTMLLinkElement.mm:
(-[DOMHTMLLinkElement setCrossOrigin:]): Use setAttributeWithoutSynchronization.
* Source/WebKitLegacy/mac/DOM/DOMHTMLMarqueeElement.mm:
(-[DOMHTMLMarqueeElement hspace]): Use unsignedIntegralAttribute.
(-[DOMHTMLMarqueeElement vspace]): Use unsignedIntegralAttribute.
* Source/WebKitLegacy/mac/DOM/DOMHTMLMediaElement.mm:
(-[DOMHTMLMediaElement setCrossOrigin:]): Use setAttributeWithoutSynchronization.
* Source/WebKitLegacy/mac/DOM/DOMHTMLOListElement.mm:
(-[DOMHTMLOListElement setStart:]): Use setIntegralAttribute.
* Source/WebKitLegacy/mac/DOM/DOMHTMLObjectElement.mm:
(-[DOMHTMLObjectElement hspace]): Use integralAttribute.
(-[DOMHTMLObjectElement vspace]): Use integralAttribute.
* Source/WebKitLegacy/mac/DOM/DOMHTMLOptionElement.mm:
(-[DOMHTMLOptionElement setLabel:]): Use setAttributeWithoutSynchronization.
(-[DOMHTMLOptionElement setValue:]): Use setAttributeWithoutSynchronization.
* Source/WebKitLegacy/mac/DOM/DOMHTMLPreElement.mm:
(-[DOMHTMLPreElement width]): Use integralAttribute.
* Source/WebKitLegacy/mac/DOM/DOMHTMLScriptElement.mm:
(-[DOMHTMLScriptElement htmlFor]): Use attributeWithoutSynchronization.
(-[DOMHTMLScriptElement event]): Use attributeWithoutSynchronization.
(-[DOMHTMLScriptElement charset]): Use attributeWithoutSynchronization.
(-[DOMHTMLScriptElement type]): Use attributeWithoutSynchronization.
(-[DOMHTMLScriptElement setCrossOrigin:]): Use setAttributeWithoutSynchronization.
(-[DOMHTMLScriptElement nonce]): Use attributeWithoutSynchronization.
* Source/WebKitLegacy/mac/DOM/DOMHTMLTableCellElement.mm:
(-[DOMHTMLTableCellElement setScope:]): Use setAttributeWithoutSynchronization.
* Source/WebKitLegacy/mac/DOM/DOMHTMLTextAreaElement.mm:
(-[DOMHTMLTextAreaElement setAutocomplete:]): Use setAttributeWithoutSynchronization.
* Source/WebKitLegacy/mac/DOM/DOMHTMLVideoElement.mm:
(-[DOMHTMLVideoElement width]): Use unsignedIntegralAttribute.
(-[DOMHTMLVideoElement height]): Use unsignedIntegralAttribute.

Canonical link: <a href="https://commits.webkit.org/296427@main">https://commits.webkit.org/296427@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fc4391d18cf6b17c99ae2b940532bc51ad35864a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108501 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28162 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18586 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/113710 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/58900 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/110464 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/28851 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/36714 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82400 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111449 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22888 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97729 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62836 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22306 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/15867 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58426 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92259 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15920 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/116831 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35555 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26201 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91425 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/35928 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94003 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91226 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23243 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36121 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13884 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/31302 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35457 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/40992 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35166 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38518 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/36847 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->