### PR TITLE
[Swift in WebKit] Use swift-format to format WebKit code

### DIFF
--- a/.swift-format
+++ b/.swift-format
@@ -66,7 +66,7 @@
     "UseExplicitNilCheckInConditions" : true,
     "UseLetInEveryBoundCaseVariable" : true,
     "UseShorthandTypeNames" : true,
-    "UseSingleLinePropertyGetter" : true,
+    "UseSingleLinePropertyGetter" : false,
     "UseSynthesizedInitializer" : true,
     "UseTripleSlashForDocumentationComments" : true,
     "UseWhereClausesInForLoops" : true,

--- a/Source/WebKit/Platform/cocoa/WKMaterialHostingSupport.swift
+++ b/Source/WebKit/Platform/cocoa/WKMaterialHostingSupport.swift
@@ -96,7 +96,12 @@ private struct MaterialHostingView<P: MaterialHostingProvider>: View {
         }
     }
 
-    init(content: P.Source, materialEffectType: WKHostedMaterialEffectType = .none, colorScheme: WKHostedMaterialColorScheme = .light, cornerRadius: CGFloat = 0) {
+    init(
+        content: P.Source,
+        materialEffectType: WKHostedMaterialEffectType = .none,
+        colorScheme: WKHostedMaterialColorScheme = .light,
+        cornerRadius: CGFloat = 0
+    ) {
         self.content = content
         self.materialEffectType = materialEffectType
         self.colorScheme = colorScheme
@@ -115,10 +120,10 @@ private struct MaterialHostingView<P: MaterialHostingProvider>: View {
     }
 }
 
-private extension CALayer {
+extension CALayer {
     private static let materialHostingContentLayerKey = "_materialHostingContentLayerKey"
 
-    var materialHostingContentLayer: CALayer? {
+    fileprivate var materialHostingContentLayer: CALayer? {
         get {
             value(forKeyPath: Self.materialHostingContentLayerKey) as? CALayer
         }
@@ -128,13 +133,15 @@ private extension CALayer {
     }
 }
 
-@objc @implementation extension WKMaterialHostingSupport {
+@objc
+@implementation
+extension WKMaterialHostingSupport {
     class func isMaterialHostingAvailable() -> Bool {
         guard #_hasSymbol(Material.self) else {
             return false
         }
 
-        return true;
+        return true
     }
 
     class func hostingLayer() -> CALayer {
@@ -147,7 +154,12 @@ private extension CALayer {
         return hostingLayer
     }
 
-    class func updateHostingLayer(_ layer: CALayer, materialEffectType: WKHostedMaterialEffectType, colorScheme: WKHostedMaterialColorScheme, cornerRadius: CGFloat) {
+    class func updateHostingLayer(
+        _ layer: CALayer,
+        materialEffectType: WKHostedMaterialEffectType,
+        colorScheme: WKHostedMaterialColorScheme,
+        cornerRadius: CGFloat
+    ) {
         guard let hostingLayer = layer as? CAHostingLayer<MaterialHostingView<LayerBackedMaterialHostingProvider>> else {
             assertionFailure("updateHostingLayer should only be called with a hosting layer.")
             return
@@ -158,29 +170,44 @@ private extension CALayer {
             return
         }
 
-        hostingLayer.rootView = MaterialHostingView<LayerBackedMaterialHostingProvider>(content: contentLayer, materialEffectType: materialEffectType, colorScheme: colorScheme, cornerRadius: cornerRadius)
+        hostingLayer.rootView = MaterialHostingView<LayerBackedMaterialHostingProvider>(
+            content: contentLayer,
+            materialEffectType: materialEffectType,
+            colorScheme: colorScheme,
+            cornerRadius: cornerRadius
+        )
     }
 
     class func contentLayer(forMaterialHostingLayer layer: CALayer) -> CALayer? {
         layer.materialHostingContentLayer
     }
 
-#if canImport(UIKit)
+    #if canImport(UIKit)
 
     class func hostingView(_ contentView: UIView) -> UIView {
         _UIHostingView(rootView: MaterialHostingView<ViewBackedMaterialHostingProvider>(content: contentView))
     }
 
-    class func updateHostingView(_ view: UIView, contentView: UIView, materialEffectType: WKHostedMaterialEffectType, colorScheme: WKHostedMaterialColorScheme, cornerRadius: CGFloat) {
+    class func updateHostingView(
+        _ view: UIView,
+        contentView: UIView,
+        materialEffectType: WKHostedMaterialEffectType,
+        colorScheme: WKHostedMaterialColorScheme,
+        cornerRadius: CGFloat
+    ) {
         guard let hostingView = view as? _UIHostingView<MaterialHostingView<ViewBackedMaterialHostingProvider>> else {
-            return;
+            return
         }
 
-        hostingView.rootView = MaterialHostingView<ViewBackedMaterialHostingProvider>(content: contentView, materialEffectType: materialEffectType, colorScheme: colorScheme, cornerRadius: cornerRadius)
+        hostingView.rootView = MaterialHostingView<ViewBackedMaterialHostingProvider>(
+            content: contentView,
+            materialEffectType: materialEffectType,
+            colorScheme: colorScheme,
+            cornerRadius: cornerRadius
+        )
     }
 
-#endif
-
+    #endif
 }
 
 #endif

--- a/Source/WebKit/Shared/AuxiliaryProcessExtensions/GPUProcessExtension.swift
+++ b/Source/WebKit/Shared/AuxiliaryProcessExtensions/GPUProcessExtension.swift
@@ -26,7 +26,7 @@
 import BrowserEngineKit
 
 @main
-class GPUProcessExtension : WKProcessExtension {
+class GPUProcessExtension: WKProcessExtension {
     override required init() {
         super.init()
         setSharedInstance(self)
@@ -39,16 +39,14 @@ extension GPUProcessExtension: RenderingExtension {
     }
 
     override func lockdownSandbox(_ version: String) {
-        if (version == "1.0") {
+        if version == "1.0" {
             self.applyRestrictedSandbox(revision: RestrictedSandboxRevision.revision1)
             return
         }
-#if ENABLE_BROWSERENGINEKIT_SANDBOX_REVISION_2
-        if (version == "2.0") {
+        #if ENABLE_BROWSERENGINEKIT_SANDBOX_REVISION_2
+        if version == "2.0" {
             self.applyRestrictedSandbox(revision: RestrictedSandboxRevision.revision2)
         }
-#endif
-
+        #endif
     }
-
 }

--- a/Source/WebKit/Shared/AuxiliaryProcessExtensions/NetworkingProcessExtension.swift
+++ b/Source/WebKit/Shared/AuxiliaryProcessExtensions/NetworkingProcessExtension.swift
@@ -26,22 +26,21 @@
 import BrowserEngineKit
 
 @main
-class NetworkingProcessExtension : WKProcessExtension {
+class NetworkingProcessExtension: WKProcessExtension {
     override required init() {
         super.init()
         setSharedInstance(self)
     }
 }
 
-extension NetworkingProcessExtension : NetworkingExtension {
+extension NetworkingProcessExtension: NetworkingExtension {
     func handle(xpcConnection: xpc_connection_t) {
         handleNewConnection(xpcConnection)
     }
 
     override func lockdownSandbox(_ version: String) {
-        if (version == "1.0") {
+        if version == "1.0" {
             self.applyRestrictedSandbox(revision: RestrictedSandboxRevision.revision1)
         }
     }
-
 }

--- a/Source/WebKit/Shared/AuxiliaryProcessExtensions/WebContentProcessExtension.swift
+++ b/Source/WebKit/Shared/AuxiliaryProcessExtensions/WebContentProcessExtension.swift
@@ -26,13 +26,12 @@
 import BrowserEngineKit
 
 @main
-class WebContentProcessExtension : WKProcessExtension {
+class WebContentProcessExtension: WKProcessExtension {
     override required init() {
         super.init()
         setSharedInstance(self)
     }
 }
-
 
 extension WebContentProcessExtension: WebContentExtension {
     func handle(xpcConnection: xpc_connection_t) {
@@ -40,14 +39,14 @@ extension WebContentProcessExtension: WebContentExtension {
     }
 
     override func lockdownSandbox(_ version: String) {
-        if (version == "1.0") {
+        if version == "1.0" {
             self.applyRestrictedSandbox(revision: RestrictedSandboxRevision.revision1)
             return
         }
-#if ENABLE_BROWSERENGINEKIT_SANDBOX_REVISION_2
-        if (version == "2.0") {
+        #if ENABLE_BROWSERENGINEKIT_SANDBOX_REVISION_2
+        if version == "2.0" {
             self.applyRestrictedSandbox(revision: RestrictedSandboxRevision.revision2)
         }
-#endif
+        #endif
     }
 }

--- a/Source/WebKit/SwiftOverlay/Tests/JavaScriptToSwiftTypeConversions.swift
+++ b/Source/WebKit/SwiftOverlay/Tests/JavaScriptToSwiftTypeConversions.swift
@@ -23,10 +23,10 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import XCTest
 import WebKit
+import XCTest
 
-final class JavaScriptToSwiftConversions : XCTestCase {
+final class JavaScriptToSwiftConversions: XCTestCase {
     #if os(macOS)
     let window = NSWindow()
     #elseif os(iOS)
@@ -54,7 +54,7 @@ final class JavaScriptToSwiftConversions : XCTestCase {
         #endif
     }
 
-    func evaluateJavaScript<T : Equatable>(_ javaScript: String, andExpect expectedValue: T) {
+    func evaluateJavaScript<T: Equatable>(_ javaScript: String, andExpect expectedValue: T) {
         let evaluationExpectation = self.expectation(description: "Evaluation of \(javaScript.debugDescription)")
         webView.evaluateJavaScript(javaScript, in: nil, in: .defaultClient) { result in
             do {
@@ -99,7 +99,7 @@ final class JavaScriptToSwiftConversions : XCTestCase {
         // This uses [AnyHashable:AnyHashable], instead of [AnyHashable:Any], so we can perform an
         // equality check for testing. An object’s keys are always converted to strings, so even
         // though we input `1:` we expect `"1":` back.
-        let result: [AnyHashable:AnyHashable] = ["1": 2, "cat": "dog"]
+        let result: [AnyHashable: AnyHashable] = ["1": 2, "cat": "dog"]
         evaluateJavaScript(#"const value = { 1: 2, "cat": "dog" }; value"#, andExpect: result)
     }
 

--- a/Source/WebKit/SwiftOverlay/Tests/WebKitTests.swift
+++ b/Source/WebKit/SwiftOverlay/Tests/WebKitTests.swift
@@ -23,8 +23,8 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import XCTest
 import WebKit
+import XCTest
 
 class WebKitTests: XCTestCase {
     /// This is a compile-time test that ensures the function names are what we expect.

--- a/Source/WebKit/UIProcess/API/Cocoa/ObjectiveCBlockConversions.swift
+++ b/Source/WebKit/UIProcess/API/Cocoa/ObjectiveCBlockConversions.swift
@@ -44,8 +44,10 @@ enum ObjCBlockConversion {
     /// The result block must be called with exactly one non-null argument. If both arguments are
     /// non-null then `handler` will be called with `.success(T)`. If both arguments are `nil`
     /// the conversion will trap.
-    static nonisolated func exclusive<Value>(_ handler: @MainActor @escaping (Result<Value, Error>) -> Void) -> @MainActor (Value?, Error?) -> Void {
-        return { value, error in
+    static nonisolated func exclusive<Value>(
+        _ handler: @MainActor @escaping (Result<Value, Error>) -> Void
+    ) -> @MainActor (Value?, Error?) -> Void {
+        { value, error in
             if let value = value {
                 handler(.success(value))
             } else if let error = error {
@@ -60,8 +62,10 @@ enum ObjCBlockConversion {
     ///
     /// This performs the same conversion as `Self.exclusive(_:)`, but if the result block is called
     /// with `(nil, nil)` then `handler` is called with `.success(nil)`.
-    static nonisolated func treatNilAsSuccess<Value>(_ handler: @MainActor @escaping (Result<Value?, Error>) -> Void) -> @MainActor (Value?, Error?) -> Void {
-        return { value, error in
+    static nonisolated func treatNilAsSuccess<Value>(
+        _ handler: @MainActor @escaping (Result<Value?, Error>) -> Void
+    ) -> @MainActor (Value?, Error?) -> Void {
+        { value, error in
             if let error = error {
                 handler(.failure(error))
             } else {
@@ -76,8 +80,10 @@ enum ObjCBlockConversion {
     /// with `(nil, nil)` then `handler` is called with `.success(Optional<Any>.none as Any)`. This
     /// is a compatibility behavior for http://webkit.org/b/216198, and should not be adopted by
     /// new code.
-    static nonisolated func boxingNilAsAnyForCompatibility(_ handler: @MainActor @escaping (Result<Any, Error>) -> Void) -> @MainActor (Any?, Error?) -> Void {
-        return { value, error in
+    static nonisolated func boxingNilAsAnyForCompatibility(
+        _ handler: @MainActor @escaping (Result<Any, Error>) -> Void
+    ) -> @MainActor (Any?, Error?) -> Void {
+        { value, error in
             if let error = error {
                 handler(.failure(error))
             } else if let success = value {

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration+Extras.swift
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration+Extras.swift
@@ -44,22 +44,22 @@ extension WKWebViewConfiguration {
         self.supportsAdaptiveImageGlyph = wrapped.supportsAdaptiveImageGlyph
         self._loadsSubresources = wrapped.loadsSubresources
 
-#if !os(visionOS)
+        #if !os(visionOS)
         self.showsSystemScreenTimeBlockingView = wrapped.showsSystemScreenTimeBlockingView
-#endif
+        #endif
 
-#if os(iOS)
+        #if os(iOS)
         self.dataDetectorTypes = wrapped.dataDetectorTypes
         self.ignoresViewportScaleLimits = wrapped.ignoresViewportScaleLimits
 
         if wrapped.mediaPlaybackBehavior != .automatic {
             self.allowsInlineMediaPlayback = wrapped.mediaPlaybackBehavior == .allowsInlinePlayback
         }
-#endif
+        #endif
 
-#if os(macOS)
+        #if os(macOS)
         self.userInterfaceDirectionPolicy = wrapped.userInterfaceDirectionPolicy
-#endif
+        #endif
 
         for (scheme, handler) in wrapped.urlSchemeHandlers {
             let handlerAdapter = WKURLSchemeHandlerAdapter(handler)

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences+Extras.swift
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences+Extras.swift
@@ -28,22 +28,24 @@ internal import WebKit_Internal
 
 extension WKWebpagePreferences.ContentMode {
     init(_ wrapped: WebPage.NavigationPreferences.ContentMode) {
-        self = switch wrapped {
-        case .recommended: .recommended
-        case .mobile: .mobile
-        case .desktop: .desktop
-        }
+        self =
+            switch wrapped {
+            case .recommended: .recommended
+            case .mobile: .mobile
+            case .desktop: .desktop
+            }
     }
 }
 
 extension WKWebpagePreferences.UpgradeToHTTPSPolicy {
     init(_ wrapped: WebPage.NavigationPreferences.UpgradeToHTTPSPolicy) {
-        self = switch wrapped {
-        case .keepAsRequested: .keepAsRequested
-        case .automaticFallbackToHTTP: .automaticFallbackToHTTP
-        case .userMediatedFallbackToHTTP: .userMediatedFallbackToHTTP
-        case .errorOnFailure: .errorOnFailure
-        }
+        self =
+            switch wrapped {
+            case .keepAsRequested: .keepAsRequested
+            case .automaticFallbackToHTTP: .automaticFallbackToHTTP
+            case .userMediatedFallbackToHTTP: .userMediatedFallbackToHTTP
+            case .errorOnFailure: .errorOnFailure
+            }
     }
 }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WebKitSwiftOverlay.swift
+++ b/Source/WebKit/UIProcess/API/Cocoa/WebKitSwiftOverlay.swift
@@ -45,33 +45,61 @@ extension WKPDFConfiguration {
 
 @available(iOS 14.0, macOS 10.16, *)
 extension WKWebView {
-    @preconcurrency public func callAsyncJavaScript(_ functionBody: String, arguments: [String:Any] = [:], in frame: WKFrameInfo? = nil, in contentWorld: WKContentWorld, completionHandler: (@MainActor (Result<Any, Error>) -> Void)? = nil) {
+    @preconcurrency
+    public func callAsyncJavaScript(
+        _ functionBody: String,
+        arguments: [String: Any] = [:],
+        in frame: WKFrameInfo? = nil,
+        in contentWorld: WKContentWorld,
+        completionHandler: (@MainActor (Result<Any, Error>) -> Void)? = nil
+    ) {
         let thunk = completionHandler.map { ObjCBlockConversion.boxingNilAsAnyForCompatibility($0) }
         __callAsyncJavaScript(functionBody, arguments: arguments, inFrame: frame, in: contentWorld, completionHandler: thunk)
     }
 
-    @preconcurrency public func createPDF(configuration: WKPDFConfiguration = .init(), completionHandler: @MainActor @escaping (Result<Data, Error>) -> Void) {
+    @preconcurrency
+    public func createPDF(
+        configuration: WKPDFConfiguration = .init(),
+        completionHandler: @MainActor @escaping (Result<Data, Error>) -> Void
+    ) {
         __createPDF(with: configuration, completionHandler: ObjCBlockConversion.exclusive(completionHandler))
     }
 
-    @preconcurrency public func createWebArchiveData(completionHandler: @MainActor @escaping (Result<Data, Error>) -> Void) {
+    @preconcurrency
+    public func createWebArchiveData(completionHandler: @MainActor @escaping (Result<Data, Error>) -> Void) {
         __createWebArchiveData(completionHandler: ObjCBlockConversion.exclusive(completionHandler))
     }
 
-    @preconcurrency public func evaluateJavaScript(_ javaScript: String, in frame: WKFrameInfo? = nil, in contentWorld: WKContentWorld, completionHandler: (@MainActor (Result<Any, Error>) -> Void)? = nil) {
+    @preconcurrency
+    public func evaluateJavaScript(
+        _ javaScript: String,
+        in frame: WKFrameInfo? = nil,
+        in contentWorld: WKContentWorld,
+        completionHandler: (@MainActor (Result<Any, Error>) -> Void)? = nil
+    ) {
         let thunk = completionHandler.map { ObjCBlockConversion.boxingNilAsAnyForCompatibility($0) }
         __evaluateJavaScript(javaScript, inFrame: frame, in: contentWorld, completionHandler: thunk)
     }
 
-    @preconcurrency public func find(_ string: String, configuration: WKFindConfiguration = .init(), completionHandler: @MainActor @escaping (WKFindResult) -> Void) {
+    @preconcurrency
+    public func find(
+        _ string: String,
+        configuration: WKFindConfiguration = .init(),
+        completionHandler: @MainActor @escaping (WKFindResult) -> Void
+    ) {
         __find(string, with: configuration, completionHandler: completionHandler)
     }
 }
 
 @available(iOS 15.0, macOS 12.0, *)
 extension WKWebView {
-    public func callAsyncJavaScript(_ functionBody: String, arguments: [String:Any] = [:], in frame: WKFrameInfo? = nil, contentWorld: WKContentWorld) async throws -> Any? {
-        return try await __callAsyncJavaScript(functionBody, arguments: arguments, inFrame: frame, in: contentWorld)
+    public func callAsyncJavaScript(
+        _ functionBody: String,
+        arguments: [String: Any] = [:],
+        in frame: WKFrameInfo? = nil,
+        contentWorld: WKContentWorld
+    ) async throws -> Any? {
+        try await __callAsyncJavaScript(functionBody, arguments: arguments, inFrame: frame, in: contentWorld)
     }
 
     public func pdf(configuration: WKPDFConfiguration = .init()) async throws -> Data {

--- a/Source/WebKit/UIProcess/API/Swift/WebPage+Configuration.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WebPage+Configuration.swift
@@ -57,7 +57,7 @@ extension WebPage {
         public var defaultNavigationPreferences: WebPage.NavigationPreferences = WebPage.NavigationPreferences()
 
         /// Allows registering an object to load resources associated with a specified URL scheme.
-        public var urlSchemeHandlers: [URLScheme : any URLSchemeHandler] = [:]
+        public var urlSchemeHandlers: [URLScheme: any URLSchemeHandler] = [:]
 
         /// Allows specifying how web resources may access device sensors.
         ///
@@ -90,7 +90,7 @@ extension WebPage {
         /// Indicates whether the webpage loads all of its subresources in addition to the main resource.
         ///
         /// The default value of this property is `true`.
-        public var loadsSubresources: Bool  = true
+        public var loadsSubresources: Bool = true
 
         /// Indicates whether inline predictions are allowed.
         ///
@@ -116,7 +116,7 @@ extension WebPage {
 
         private var _showsSystemScreenTimeBlockingView = true
 
-#if os(iOS)
+        #if os(iOS)
         /// The types of data detectors to apply to the webpage's content.
         ///
         /// Data detectors add interactivity to web content by creating links for specially formatted text.
@@ -136,14 +136,14 @@ extension WebPage {
 
         /// Indicates whether HTML5 videos play inline or use the native full-screen controller.
         public var mediaPlaybackBehavior: MediaPlaybackBehavior = .automatic
-#endif
+        #endif
 
-#if os(macOS)
+        #if os(macOS)
         /// The directionality of user interface elements.
         ///
         /// The default value of this property is `.content`.
         public var userInterfaceDirectionPolicy: WKUserInterfaceDirectionPolicy = .content
-#endif
+        #endif
     }
 }
 

--- a/Source/WebKit/UIProcess/API/Swift/WebPage+DialogPresenting.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WebPage+DialogPresenting.swift
@@ -103,7 +103,11 @@ extension WebPage {
         ///   - frame: Information about the frame whose JavaScript process initiated this call.
         /// - Returns: The result of handling the invocation; if the result is affirmative, the response will include some text returned to JavaScript.
         @MainActor
-        func handleJavaScriptPrompt(message: String, defaultText: String?, initiatedBy frame: WebPage.FrameInfo) async -> WebPage.JavaScriptPromptResult
+        func handleJavaScriptPrompt(
+            message: String,
+            defaultText: String?,
+            initiatedBy frame: WebPage.FrameInfo
+        ) async -> WebPage.JavaScriptPromptResult
 
         /// Returns the result of handling a JavaScript request to open files.
         ///
@@ -111,7 +115,10 @@ extension WebPage {
         ///   - frame: Information about the frame whose JavaScript process initiated this call.
         /// - Returns: The result of handling the invocation; if the result is affirmative, the response will include a set of files returned to JavaScript.
         @MainActor
-        func handleFileInputPrompt(parameters: WKOpenPanelParameters, initiatedBy frame: WebPage.FrameInfo) async -> WebPage.FileInputPromptResult
+        func handleFileInputPrompt(
+            parameters: WKOpenPanelParameters,
+            initiatedBy frame: WebPage.FrameInfo
+        ) async -> WebPage.FileInputPromptResult
     }
 }
 
@@ -120,29 +127,36 @@ extension WebPage {
 @available(WK_IOS_TBA, WK_MAC_TBA, WK_XROS_TBA, *)
 @available(watchOS, unavailable)
 @available(tvOS, unavailable)
-public extension WebPage.DialogPresenting {
+extension WebPage.DialogPresenting {
     /// By default, this method immediately returns.
     @MainActor
-    func handleJavaScriptAlert(message: String, initiatedBy frame: WebPage.FrameInfo) async {
+    public func handleJavaScriptAlert(message: String, initiatedBy frame: WebPage.FrameInfo) async {
     }
 
     /// By default, this method immediately returns with a result of `.cancel`.
     @MainActor
-    func handleJavaScriptConfirm(message: String, initiatedBy frame: WebPage.FrameInfo) async -> WebPage.JavaScriptConfirmResult {
+    public func handleJavaScriptConfirm(message: String, initiatedBy frame: WebPage.FrameInfo) async -> WebPage.JavaScriptConfirmResult {
         .cancel
     }
 
     /// By default, this method immediately returns with a result of `.cancel`.
     @MainActor
-    func handleJavaScriptPrompt(message: String, defaultText: String?, initiatedBy frame: WebPage.FrameInfo) async -> WebPage.JavaScriptPromptResult {
+    public func handleJavaScriptPrompt(
+        message: String,
+        defaultText: String?,
+        initiatedBy frame: WebPage.FrameInfo
+    ) async -> WebPage.JavaScriptPromptResult {
         .cancel
     }
 
     /// By default, this method immediately returns with a result of `.cancel`.
     @MainActor
-    func handleFileInputPrompt(parameters: WKOpenPanelParameters, initiatedBy frame: WebPage.FrameInfo) async -> WebPage.FileInputPromptResult {
+    public func handleFileInputPrompt(
+        parameters: WKOpenPanelParameters,
+        initiatedBy frame: WebPage.FrameInfo
+    ) async -> WebPage.FileInputPromptResult {
         .cancel
     }
 }
 
- #endif
+#endif

--- a/Source/WebKit/UIProcess/API/Swift/WebPage+NavigationDeciding.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WebPage+NavigationDeciding.swift
@@ -56,13 +56,13 @@ extension WebPage {
         /// Indicates whether the web content provided an attribute that indicates a download.
         public var shouldPerformDownload: Bool { wrapped.shouldPerformDownload }
 
-#if canImport(UIKit)
+        #if canImport(UIKit)
         /// The number of the mouse button that caused the navigation request.
         public var buttonNumber: UIEvent.ButtonMask { wrapped.buttonNumber }
-#else
+        #else
         /// The number of the mouse button that caused the navigation request.
         public var buttonNumber: Int { wrapped.buttonNumber }
-#endif
+        #endif
 
         @_spi(CrossImportOverlay)
         public var wrapped: WKNavigationAction
@@ -113,7 +113,10 @@ extension WebPage {
         ///   - preferences: The preferences to use when displaying the new webpage.
         /// - Returns: The navigation policy for the action.
         @MainActor
-        mutating func decidePolicy(for action: WebPage.NavigationAction, preferences: inout WebPage.NavigationPreferences) async -> WKNavigationActionPolicy
+        mutating func decidePolicy(
+            for action: WebPage.NavigationAction,
+            preferences: inout WebPage.NavigationPreferences
+        ) async -> WKNavigationActionPolicy
 
         /// Determines permission to navigate to new content after the response to the navigation request is known.
         ///
@@ -127,7 +130,9 @@ extension WebPage {
         /// - Parameter challenge: The authentication challenge.
         /// - Returns: The option to use to handle the challenge, and the credential to use for authentication when the disposition is ``URLSession/AuthChallengeDisposition/useCredential``.
         @MainActor
-        mutating func decideAuthenticationChallengeDisposition(for challenge: URLAuthenticationChallenge) async -> (URLSession.AuthChallengeDisposition, URLCredential?)
+        mutating func decideAuthenticationChallengeDisposition(
+            for challenge: URLAuthenticationChallenge
+        ) async -> (URLSession.AuthChallengeDisposition, URLCredential?)
     }
 }
 
@@ -136,24 +141,29 @@ extension WebPage {
 @available(WK_IOS_TBA, WK_MAC_TBA, WK_XROS_TBA, *)
 @available(watchOS, unavailable)
 @available(tvOS, unavailable)
-public extension WebPage.NavigationDeciding {
+extension WebPage.NavigationDeciding {
     /// By default, this method immediately returns with a policy of `.allow`.
     @MainActor
-    func decidePolicy(for action: WebPage.NavigationAction, preferences: inout WebPage.NavigationPreferences) async -> WKNavigationActionPolicy {
+    public func decidePolicy(
+        for action: WebPage.NavigationAction,
+        preferences: inout WebPage.NavigationPreferences
+    ) async -> WKNavigationActionPolicy {
         .allow
     }
 
     /// By default, this method immediately returns with a policy of `.allow`.
     @MainActor
-    func decidePolicy(for response: WebPage.NavigationResponse) async -> WKNavigationResponsePolicy {
+    public func decidePolicy(for response: WebPage.NavigationResponse) async -> WKNavigationResponsePolicy {
         .allow
     }
 
     /// By default, this method immediately returns with a disposition of `performDefaultHandling` and a `nil` credential.
     @MainActor
-    func decideAuthenticationChallengeDisposition(for challenge: URLAuthenticationChallenge) async -> (URLSession.AuthChallengeDisposition, URLCredential?) {
+    public func decideAuthenticationChallengeDisposition(
+        for challenge: URLAuthenticationChallenge
+    ) async -> (URLSession.AuthChallengeDisposition, URLCredential?) {
         (.performDefaultHandling, nil)
     }
 }
 
- #endif
+#endif

--- a/Source/WebKit/UIProcess/API/Swift/WebPage+NavigationPreferences.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WebPage+NavigationPreferences.swift
@@ -103,26 +103,28 @@ extension WebPage {
 
 extension WebPage.NavigationPreferences.ContentMode {
     init(_ wrapped: WKWebpagePreferences.ContentMode) {
-        self = switch wrapped {
-        case .recommended: .recommended
-        case .mobile: .mobile
-        case .desktop: .desktop
-        @unknown default:
-            fatalError()
-        }
+        self =
+            switch wrapped {
+            case .recommended: .recommended
+            case .mobile: .mobile
+            case .desktop: .desktop
+            @unknown default:
+                fatalError()
+            }
     }
 }
 
 extension WebPage.NavigationPreferences.UpgradeToHTTPSPolicy {
     init(_ wrapped: WKWebpagePreferences.UpgradeToHTTPSPolicy) {
-        self = switch wrapped {
-        case .keepAsRequested: .keepAsRequested
-        case .automaticFallbackToHTTP: .automaticFallbackToHTTP
-        case .userMediatedFallbackToHTTP: .userMediatedFallbackToHTTP
-        case .errorOnFailure: .errorOnFailure
-        @unknown default:
-            fatalError()
-        }
+        self =
+            switch wrapped {
+            case .keepAsRequested: .keepAsRequested
+            case .automaticFallbackToHTTP: .automaticFallbackToHTTP
+            case .userMediatedFallbackToHTTP: .userMediatedFallbackToHTTP
+            case .errorOnFailure: .errorOnFailure
+            @unknown default:
+                fatalError()
+            }
     }
 }
 

--- a/Source/WebKit/UIProcess/Cocoa/GroupActivities/WKGroupSession.swift
+++ b/Source/WebKit/UIProcess/Cocoa/GroupActivities/WKGroupSession.swift
@@ -42,8 +42,8 @@ internal import WebKit_Internal
 @_implementationOnly import WebKit_Internal
 #endif
 
-fileprivate extension WKGroupSessionState {
-    init(_ state: GroupSession<URLActivity>.State) {
+extension WKGroupSessionState {
+    fileprivate init(_ state: GroupSession<URLActivity>.State) {
         switch state {
         case .waiting:
             self = .waiting
@@ -59,33 +59,43 @@ fileprivate extension WKGroupSessionState {
     }
 }
 
-@_objcImplementation extension WKURLActivity {
+@_objcImplementation
+extension WKURLActivity {
     // Used to workaround the fact that `@_objcImplementation` does not support stored properties whose size can change
     // due to Library Evolution. Do not use this property directly.
-    @nonobjc private var _urlActivity: Any
+    @nonobjc
+    private var _urlActivity: Any
 
-    @nonobjc final private var urlActivity: URLActivity {
+    @nonobjc
+    final private var urlActivity: URLActivity {
         _urlActivity as! URLActivity
     }
 
     var fallbackURL: URL? { urlActivity.webpageURL }
 
-    @nonobjc fileprivate convenience init(activity: URLActivity) {
+    @nonobjc
+    fileprivate convenience init(activity: URLActivity) {
         self.init()
         self._urlActivity = activity as Any
     }
 
-#if compiler(<6.0)
-    @objc deinit { }
-#endif
+    #if compiler(<6.0)
+    @objc
+    deinit {}
+    #endif
 }
 
-@_objcImplementation extension WKGroupSession {
-    @nonobjc private var groupSession: GroupSession<URLActivity>
-    @nonobjc private var _activity: WKURLActivity
-    @nonobjc private var cancellables: Set<AnyCancellable> = []
+@_objcImplementation
+extension WKGroupSession {
+    @nonobjc
+    private var groupSession: GroupSession<URLActivity>
+    @nonobjc
+    private var _activity: WKURLActivity
+    @nonobjc
+    private var cancellables: Set<AnyCancellable> = []
 
-    @nonobjc fileprivate convenience init(groupSession: GroupSession<URLActivity>) {
+    @nonobjc
+    fileprivate convenience init(groupSession: GroupSession<URLActivity>) {
         self.init()
 
         self.groupSession = groupSession
@@ -122,7 +132,8 @@ fileprivate extension WKGroupSessionState {
         coordinator.coordinateWithSession(groupSession)
     }
 
-    @nonobjc private final func activityChanged(activity: URLActivity) {
+    @nonobjc
+    private final func activityChanged(activity: URLActivity) {
         _activity = .init(activity: groupSession.activity)
 
         guard let callback = newActivityCallback else {
@@ -132,7 +143,8 @@ fileprivate extension WKGroupSessionState {
         callback(_activity)
     }
 
-    @nonobjc private final func stateChanged(state: GroupSession<URLActivity>.State) {
+    @nonobjc
+    private final func stateChanged(state: GroupSession<URLActivity>.State) {
         guard let callback = stateChangedCallback else {
             return
         }
@@ -140,13 +152,16 @@ fileprivate extension WKGroupSessionState {
         callback(.init(state))
     }
 
-#if compiler(<6.0)
-    @objc deinit { }
-#endif
+    #if compiler(<6.0)
+    @objc
+    deinit {}
+    #endif
 }
 
-@_objcImplementation extension WKGroupSessionObserver {
-    @nonobjc private var incomingSessionsTask: Task<Void, Never>?
+@_objcImplementation
+extension WKGroupSessionObserver {
+    @nonobjc
+    private var incomingSessionsTask: Task<Void, Never>?
 
     var newSessionCallback: ((WKGroupSession) -> Void)?
 
@@ -160,7 +175,8 @@ fileprivate extension WKGroupSessionState {
         }
     }
 
-    @nonobjc final private func receivedSession(_ session: GroupSession<URLActivity>) {
+    @nonobjc
+    final private func receivedSession(_ session: GroupSession<URLActivity>) {
         guard let callback = newSessionCallback else {
             return
         }
@@ -168,9 +184,10 @@ fileprivate extension WKGroupSessionState {
         callback(.init(groupSession: session))
     }
 
-#if compiler(<6.0)
-    @objc deinit { }
-#endif
+    #if compiler(<6.0)
+    @objc
+    deinit {}
+    #endif
 }
 
 #endif // ENABLE_MEDIA_SESSION_COORDINATOR && HAVE_GROUP_ACTIVITIES

--- a/Source/WebKit/UIProcess/Cocoa/TextExtraction/WKTextExtractionItem.swift
+++ b/Source/WebKit/UIProcess/Cocoa/TextExtraction/WKTextExtractionItem.swift
@@ -33,7 +33,8 @@ internal import WebKit_Internal
 // FIXME: Adopt `@objc @implementation` when support for macOS Sonoma is no longer needed.
 // FIXME: (rdar://110719676) Remove all `@objc deinit`s when support for macOS Sonoma is no longer needed.
 
-@_objcImplementation extension WKTextExtractionItem {
+@_objcImplementation
+extension WKTextExtractionItem {
     let rectInWebView: CGRect
     let children: [WKTextExtractionItem]
 
@@ -43,12 +44,14 @@ internal import WebKit_Internal
         self.children = children
     }
 
-#if compiler(<6.0)
-    @objc deinit { }
-#endif
+    #if compiler(<6.0)
+    @objc
+    deinit {}
+    #endif
 }
 
-@_objcImplementation extension WKTextExtractionContainerItem {
+@_objcImplementation
+extension WKTextExtractionContainerItem {
     let container: WKTextExtractionContainer
 
     init(container: WKTextExtractionContainer, rectInWebView: CGRect, children: [WKTextExtractionItem]) {
@@ -56,17 +59,20 @@ internal import WebKit_Internal
         super.init(with: rectInWebView, children: children)
     }
 
-#if compiler(<6.0)
-    @objc deinit { }
-#endif
+    #if compiler(<6.0)
+    @objc
+    deinit {}
+    #endif
 }
 
-@_objcImplementation extension WKTextExtractionEditable {
+@_objcImplementation
+extension WKTextExtractionEditable {
     let label: String
     let placeholder: String
 
     // Properties with a customized getter are incorrectly mapped when using ObjCImplementation.
-    @nonobjc private let backingIsSecure: Bool
+    @nonobjc
+    private let backingIsSecure: Bool
     @objc(secure)
     var isSecure: Bool {
         @objc(isSecure)
@@ -74,7 +80,8 @@ internal import WebKit_Internal
     }
 
     // Properties with a customized getter are incorrectly mapped when using ObjCImplementation.
-    @nonobjc private let backingIsFocused: Bool
+    @nonobjc
+    private let backingIsFocused: Bool
     @objc(focused)
     var isFocused: Bool {
         @objc(isFocused)
@@ -88,15 +95,18 @@ internal import WebKit_Internal
         self.backingIsFocused = isFocused
     }
 
-#if compiler(<6.0)
-    @objc deinit { }
-#endif
+    #if compiler(<6.0)
+    @objc
+    deinit {}
+    #endif
 }
 
-@_objcImplementation extension WKTextExtractionLink {
+@_objcImplementation
+extension WKTextExtractionLink {
     // Used to workaround the fact that `@_objcImplementation` does not support stored properties whose size can change
     // due to Library Evolution. Do not use this property directly.
-    @nonobjc private let _url: NSURL
+    @nonobjc
+    private let _url: NSURL
 
     var url: URL { _url as URL }
 
@@ -108,18 +118,27 @@ internal import WebKit_Internal
         self.range = range
     }
 
-#if compiler(<6.0)
-    @objc deinit { }
-#endif
+    #if compiler(<6.0)
+    @objc
+    deinit {}
+    #endif
 }
 
-@_objcImplementation extension WKTextExtractionTextItem {
+@_objcImplementation
+extension WKTextExtractionTextItem {
     let content: String
     let selectedRange: NSRange
     let links: [WKTextExtractionLink]
     let editable: WKTextExtractionEditable?
 
-    init(content: String, selectedRange: NSRange, links: [WKTextExtractionLink], editable: WKTextExtractionEditable?, rectInWebView: CGRect, children: [WKTextExtractionItem]) {
+    init(
+        content: String,
+        selectedRange: NSRange,
+        links: [WKTextExtractionLink],
+        editable: WKTextExtractionEditable?,
+        rectInWebView: CGRect,
+        children: [WKTextExtractionItem]
+    ) {
         self.content = content
         self.selectedRange = selectedRange
         self.links = links
@@ -127,12 +146,14 @@ internal import WebKit_Internal
         super.init(with: rectInWebView, children: children)
     }
 
-#if compiler(<6.0)
-    @objc deinit { }
-#endif
+    #if compiler(<6.0)
+    @objc
+    deinit {}
+    #endif
 }
 
-@_objcImplementation extension WKTextExtractionScrollableItem {
+@_objcImplementation
+extension WKTextExtractionScrollableItem {
     let contentSize: CGSize
 
     init(contentSize: CGSize, rectInWebView: CGRect, children: [WKTextExtractionItem]) {
@@ -140,12 +161,14 @@ internal import WebKit_Internal
         super.init(with: rectInWebView, children: children)
     }
 
-#if compiler(<6.0)
-    @objc deinit { }
-#endif
+    #if compiler(<6.0)
+    @objc
+    deinit {}
+    #endif
 }
 
-@_objcImplementation extension WKTextExtractionImageItem {
+@_objcImplementation
+extension WKTextExtractionImageItem {
     let name: String
     let altText: String
 
@@ -155,9 +178,10 @@ internal import WebKit_Internal
         super.init(with: rectInWebView, children: children)
     }
 
-#if compiler(<6.0)
-    @objc deinit { }
-#endif
+    #if compiler(<6.0)
+    @objc
+    deinit {}
+    #endif
 }
 
 #endif // USE_APPLE_INTERNAL_SDK || (!os(tvOS) && !os(watchOS))

--- a/Source/WebKit/UIProcess/Cocoa/TextExtraction/WKWebView+TextExtraction.swift
+++ b/Source/WebKit/UIProcess/Cocoa/TextExtraction/WKWebView+TextExtraction.swift
@@ -41,7 +41,13 @@ private func createEditable(for editable: WKTextExtractionEditable?) -> Intellig
         return nil
     }
 
-    return .init(label: editable.label, prompt: editable.placeholder, contentType: nil, isSecure: editable.isSecure, isFocused: editable.isFocused)
+    return .init(
+        label: editable.label,
+        prompt: editable.placeholder,
+        contentType: nil,
+        isSecure: editable.isSecure,
+        isFocused: editable.isFocused
+    )
 }
 
 private func createElementContent(for item: WKTextExtractionItem) -> IntelligenceElement.Content {
@@ -79,15 +85,18 @@ extension WKWebView {
     }
 
     open override func _intelligenceCollectContent(in visibleRect: CGRect, collector: UIIntelligenceElementCollector) {
-#if canImport(UIIntelligenceSupport, _version: 9007)
+        #if canImport(UIIntelligenceSupport, _version: 9007)
         let context = collector.context.createRemoteContext(description: "WKWebView")
-#else
+        #else
         let context = collector.context.createRemoteContext()
-#endif
+        #endif
         collector.collect(.remote(context))
     }
 
-    open override func _intelligenceCollectRemoteContent(in visibleRect: CGRect, remoteContextWrapper: UIIntelligenceCollectionRemoteContextWrapper) {
+    open override func _intelligenceCollectRemoteContent(
+        in visibleRect: CGRect,
+        remoteContextWrapper: UIIntelligenceCollectionRemoteContextWrapper
+    ) {
         Task { @MainActor in
             let coordinator = IntelligenceCollectionCoordinator.shared
             let collector = coordinator.createCollector(remoteContextWrapper: remoteContextWrapper)

--- a/Source/WebKit/UIProcess/Cocoa/WKScrollGeometryAdapter.swift
+++ b/Source/WebKit/UIProcess/Cocoa/WKScrollGeometryAdapter.swift
@@ -30,11 +30,11 @@ internal import WebKit_Internal
 public struct WKScrollGeometryAdapter {
     public let containerSize: CGSize
 
-#if canImport(UIKit)
+    #if canImport(UIKit)
     public let contentInsets: UIEdgeInsets
-#else
+    #else
     public let contentInsets: NSEdgeInsets
-#endif
+    #endif
 
     public let contentOffset: CGPoint
 

--- a/Source/WebKit/UIProcess/Cocoa/WKUIDelegateAdapter.swift
+++ b/Source/WebKit/UIProcess/Cocoa/WKUIDelegateAdapter.swift
@@ -43,9 +43,9 @@ final class WKUIDelegateAdapter: NSObject, WKUIDelegatePrivate {
 
     weak var owner: WebPage? = nil
 
-#if os(macOS) && !targetEnvironment(macCatalyst)
+    #if os(macOS) && !targetEnvironment(macCatalyst)
     var menuBuilder: ((WKContextMenuElementInfoAdapter) -> NSMenu)? = nil
-#endif
+    #endif
 
     private let dialogPresenter: any WebPage.DialogPresenting
 
@@ -55,7 +55,11 @@ final class WKUIDelegateAdapter: NSObject, WKUIDelegatePrivate {
         await dialogPresenter.handleJavaScriptAlert(message: message, initiatedBy: .init(frame))
     }
 
-    func webView(_ webView: WKWebView, runJavaScriptConfirmPanelWithMessage message: String, initiatedByFrame frame: WKFrameInfo) async -> Bool {
+    func webView(
+        _ webView: WKWebView,
+        runJavaScriptConfirmPanelWithMessage message: String,
+        initiatedByFrame frame: WKFrameInfo
+    ) async -> Bool {
         let result = await dialogPresenter.handleJavaScriptConfirm(message: message, initiatedBy: .init(frame))
 
         return switch result {
@@ -64,27 +68,40 @@ final class WKUIDelegateAdapter: NSObject, WKUIDelegatePrivate {
         }
     }
 
-    func webView(_ webView: WKWebView, runJavaScriptTextInputPanelWithPrompt prompt: String, defaultText: String?, initiatedByFrame frame: WKFrameInfo) async -> String? {
+    func webView(
+        _ webView: WKWebView,
+        runJavaScriptTextInputPanelWithPrompt prompt: String,
+        defaultText: String?,
+        initiatedByFrame frame: WKFrameInfo
+    ) async -> String? {
         let result = await dialogPresenter.handleJavaScriptPrompt(message: prompt, defaultText: defaultText, initiatedBy: .init(frame))
 
         return switch result {
-        case let .ok(value): value
+        case .ok(let value): value
         case .cancel: nil
         }
     }
 
-    func webView(_ webView: WKWebView, runOpenPanelWith parameters: WKOpenPanelParameters, initiatedByFrame frame: WKFrameInfo) async -> [URL]? {
+    func webView(
+        _ webView: WKWebView,
+        runOpenPanelWith parameters: WKOpenPanelParameters,
+        initiatedByFrame frame: WKFrameInfo
+    ) async -> [URL]? {
         let result = await dialogPresenter.handleFileInputPrompt(parameters: parameters, initiatedBy: .init(frame))
 
         return switch result {
-        case let .selected(value): value
+        case .selected(let value): value
         case .cancel: nil
         }
     }
 
     // MARK: Permissions
 
-    func webView(_ webView: WKWebView, requestDeviceOrientationAndMotionPermissionFor origin: WKSecurityOrigin, initiatedByFrame frame: WKFrameInfo) async -> WKPermissionDecision {
+    func webView(
+        _ webView: WKWebView,
+        requestDeviceOrientationAndMotionPermissionFor origin: WKSecurityOrigin,
+        initiatedByFrame frame: WKFrameInfo
+    ) async -> WKPermissionDecision {
         guard let owner else {
             return .prompt
         }
@@ -92,7 +109,12 @@ final class WKUIDelegateAdapter: NSObject, WKUIDelegatePrivate {
         return await owner.configuration.deviceSensorAuthorization.decisionHandler(.deviceOrientationAndMotion, .init(frame), origin)
     }
 
-    func webView(_ webView: WKWebView, decideMediaCapturePermissionsFor origin: WKSecurityOrigin, initiatedBy frame: WKFrameInfo, type: WKMediaCaptureType) async -> WKPermissionDecision {
+    func webView(
+        _ webView: WKWebView,
+        decideMediaCapturePermissionsFor origin: WKSecurityOrigin,
+        initiatedBy frame: WKFrameInfo,
+        type: WKMediaCaptureType
+    ) async -> WKPermissionDecision {
         guard let owner else {
             return .prompt
         }
@@ -102,9 +124,14 @@ final class WKUIDelegateAdapter: NSObject, WKUIDelegatePrivate {
 
     // MARK: Context menu support
 
-#if os(macOS)
+    #if os(macOS)
     @objc(_webView:getContextMenuFromProposedMenu:forElement:userInfo:completionHandler:)
-    func _webView(_ webView: WKWebView!, getContextMenuFromProposedMenu menu: NSMenu!, forElement element: _WKContextMenuElementInfo!, userInfo: (any NSSecureCoding)!) async -> NSMenu? {
+    func _webView(
+        _ webView: WKWebView!,
+        getContextMenuFromProposedMenu menu: NSMenu!,
+        forElement element: _WKContextMenuElementInfo!,
+        userInfo: (any NSSecureCoding)!
+    ) async -> NSMenu? {
         guard let menuBuilder else {
             return menu
         }
@@ -112,7 +139,7 @@ final class WKUIDelegateAdapter: NSObject, WKUIDelegatePrivate {
         let info = WKContextMenuElementInfoAdapter(linkURL: element.hitTestResult.absoluteLinkURL)
         return menuBuilder(info)
     }
-#endif
+    #endif
 
     @objc(_webView:geometryDidChange:)
     func _webView(_ webView: WKWebView!, geometryDidChange geometry: WKScrollGeometry) {

--- a/Source/WebKit/UIProcess/Cocoa/WKURLSchemeHandlerAdapter.swift
+++ b/Source/WebKit/UIProcess/Cocoa/WKURLSchemeHandlerAdapter.swift
@@ -40,10 +40,10 @@ final class WKURLSchemeHandlerAdapter: NSObject, WKURLSchemeHandler {
             do {
                 for try await result in wrapped.reply(for: urlSchemeTask.request) {
                     switch result {
-                    case let .response(response):
+                    case .response(let response):
                         urlSchemeTask.didReceive(response)
 
-                    case let .data(data):
+                    case .data(let data):
                         urlSchemeTask.didReceive(data)
                     }
                 }

--- a/Source/WebKit/UIProcess/Cocoa/WebPageWebView.swift
+++ b/Source/WebKit/UIProcess/Cocoa/WebPageWebView.swift
@@ -31,7 +31,7 @@ internal import WebKit_Internal
 public final class WebPageWebView: WKWebView {
     public weak var delegate: (any Delegate)? = nil
 
-#if os(iOS)
+    #if os(iOS)
     override func findInteraction(_ interaction: UIFindInteraction, didBegin session: UIFindSession) {
         super.findInteraction(interaction, didBegin: session)
         delegate?.findInteraction(interaction, didBegin: session)
@@ -49,7 +49,7 @@ public final class WebPageWebView: WKWebView {
 
         return super.supportsTextReplacement() && delegate.supportsTextReplacement()
     }
-#endif
+    #endif
 
     func geometryDidChange(_ geometry: WKScrollGeometryAdapter) {
         delegate?.geometryDidChange(geometry)
@@ -59,13 +59,13 @@ public final class WebPageWebView: WKWebView {
 extension WebPageWebView {
     @MainActor
     public protocol Delegate: AnyObject {
-#if os(iOS)
+        #if os(iOS)
         func findInteraction(_ interaction: UIFindInteraction, didBegin session: UIFindSession)
 
         func findInteraction(_ interaction: UIFindInteraction, didEnd session: UIFindSession)
 
         func supportsTextReplacement() -> Bool
-#endif
+        #endif
 
         func geometryDidChange(_ geometry: WKScrollGeometryAdapter)
     }
@@ -74,7 +74,7 @@ extension WebPageWebView {
 extension WebPageWebView {
     // MARK: Platform-agnostic scrolling capabilities
 
-#if canImport(UIKit)
+    #if canImport(UIKit)
     public var alwaysBounceVertical: Bool {
         get { scrollView.alwaysBounceVertical }
         set { scrollView.alwaysBounceVertical = newValue }
@@ -110,7 +110,7 @@ extension WebPageWebView {
     public func scrollTo(edge: NSDirectionalRectEdge, animated: Bool) {
         self._scroll(to: _WKRectEdge(edge), animated: animated)
     }
-#else
+    #else
     public var alwaysBounceVertical: Bool {
         get { self._alwaysBounceVertical }
         set { self._alwaysBounceVertical = newValue }
@@ -138,7 +138,7 @@ extension WebPageWebView {
     public func scrollTo(edge: NSDirectionalRectEdge, animated: Bool) {
         self._scroll(to: _WKRectEdge(edge), animated: animated)
     }
-#endif
+    #endif
 }
 
 #endif


### PR DESCRIPTION
#### e53c2ebf03b14a115adda72865ab31f5f3ec5ccb
<pre>
[Swift in WebKit] Use swift-format to format WebKit code
<a href="https://bugs.webkit.org/show_bug.cgi?id=293568">https://bugs.webkit.org/show_bug.cgi?id=293568</a>
<a href="https://rdar.apple.com/152017066">rdar://152017066</a>

Reviewed by Aditya Keerthi.

Continue work towards using swift-format by formatting code in WebKit.

* .swift-format:

Disable the `UseSingleLinePropertyGetter` rule. This is needed to avoid `swift-format` introducing a
runtime crash as a result of a combination of both a swift-format bug (<a href="https://rdar.apple.com/152016568">rdar://152016568</a>) and a Swift
compile bug (<a href="https://rdar.apple.com/151815769">rdar://151815769</a>) related to using `@objc @implementation` with an Obj-C interface containing
a property with a non-default getter. Once either of these bugs are fixed, the rule can be re-enabled.

* Source/WebKit/Platform/cocoa/WKMaterialHostingSupport.swift:
* Source/WebKit/Shared/AuxiliaryProcessExtensions/GPUProcessExtension.swift:
* Source/WebKit/Shared/AuxiliaryProcessExtensions/NetworkingProcessExtension.swift:
* Source/WebKit/Shared/AuxiliaryProcessExtensions/WebContentProcessExtension.swift:
* Source/WebKit/SwiftOverlay/Tests/JavaScriptToSwiftTypeConversions.swift:
* Source/WebKit/SwiftOverlay/Tests/WebKitTests.swift:
* Source/WebKit/UIProcess/API/Cocoa/ObjectiveCBlockConversions.swift:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration+Extras.swift:
* Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences+Extras.swift:
* Source/WebKit/UIProcess/API/Cocoa/WebKitSwiftOverlay.swift:
* Source/WebKit/UIProcess/API/Swift/WebPage+Configuration.swift:
* Source/WebKit/UIProcess/API/Swift/WebPage+DialogPresenting.swift:
* Source/WebKit/UIProcess/API/Swift/WebPage+NavigationDeciding.swift:
* Source/WebKit/UIProcess/API/Swift/WebPage+NavigationPreferences.swift:
* Source/WebKit/UIProcess/API/Swift/WebPage.swift:
* Source/WebKit/UIProcess/Cocoa/GroupActivities/WKGroupSession.swift:
* Source/WebKit/UIProcess/Cocoa/TextExtraction/WKTextExtractionItem.swift:
* Source/WebKit/UIProcess/Cocoa/TextExtraction/WKWebView+TextExtraction.swift:
* Source/WebKit/UIProcess/Cocoa/WKNavigationDelegateAdapter.swift:
* Source/WebKit/UIProcess/Cocoa/WKScrollGeometryAdapter.swift:
* Source/WebKit/UIProcess/Cocoa/WKUIDelegateAdapter.swift:
* Source/WebKit/UIProcess/Cocoa/WKURLSchemeHandlerAdapter.swift:
* Source/WebKit/UIProcess/Cocoa/WebPageWebView.swift:

Apply formatting.

Canonical link: <a href="https://commits.webkit.org/295490@main">https://commits.webkit.org/295490@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/afe352d4d6b84a6962c985863f836ef4e767d324

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105006 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24720 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15142 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110223 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/55686 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/25130 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33264 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79737 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108012 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19558 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94773 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60044 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/19305 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55063 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/89025 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/12896 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/112724 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32171 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23673 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88818 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32536 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/90998 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88446 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22607 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33339 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11125 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/27528 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32095 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/37467 "Failed to build and analyze WebKit") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/31888 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35229 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33447 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->