### PR TITLE
Sync `content-security-policy/securitypolicyviolation` from WPT upstream

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/securitypolicyviolation/blockeduri-eval-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/securitypolicyviolation/blockeduri-eval-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Eval violations have a blockedURI of 'eval' assert_equals: expected 12 but got 17
+FAIL Eval violations have a blockedURI of 'eval' assert_equals: expected 13 but got 17
 

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/securitypolicyviolation/blockeduri-eval.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/securitypolicyviolation/blockeduri-eval.html
@@ -8,7 +8,7 @@
         watcher.wait_for('securitypolicyviolation').then(t.step_func_done(e => {
             assert_equals(e.blockedURI, "eval");
             assert_equals(e.lineNumber, 15);
-            assert_equals(e.columnNumber, 12);
+            assert_equals(e.columnNumber, 13);
         }));
 
         try {

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/securitypolicyviolation/blockeduri-inline-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/securitypolicyviolation/blockeduri-inline-expected.txt
@@ -1,3 +1,3 @@
 
-PASS Inline violations have a blockedURI of 'inline'
+FAIL Inline violations have a blockedURI of 'inline' assert_equals: expected 9 but got 1
 

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/securitypolicyviolation/blockeduri-inline.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/securitypolicyviolation/blockeduri-inline.html
@@ -8,7 +8,7 @@
         watcher.wait_for('securitypolicyviolation').then(t.step_func_done(e => {
             assert_equals(e.blockedURI, "inline");
             assert_equals(e.lineNumber, 15);
-            assert_equals(e.columnNumber, 1);
+            assert_equals(e.columnNumber, 9);
         }));
     }, "Inline violations have a blockedURI of 'inline'");
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/securitypolicyviolation/constructor-required-fields-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/securitypolicyviolation/constructor-required-fields-expected.txt
@@ -1,12 +1,12 @@
 
 PASS SecurityPolicyViolationEvent constructor should throw with no parameters
 PASS SecurityPolicyViolationEvent constructor works with an init dict
-PASS SecurityPolicyViolationEvent constructor requires documentURI
-PASS SecurityPolicyViolationEvent constructor requires violatedDirective
-PASS SecurityPolicyViolationEvent constructor requires effectiveDirective
-PASS SecurityPolicyViolationEvent constructor requires originalPolicy
-PASS SecurityPolicyViolationEvent constructor requires disposition
-PASS SecurityPolicyViolationEvent constructor requires statusCode
+FAIL SecurityPolicyViolationEvent constructor does not require documentURI Member SecurityPolicyViolationEventInit.documentURI is required and must be an instance of USVString
+FAIL SecurityPolicyViolationEvent constructor does not require violatedDirective Member SecurityPolicyViolationEventInit.violatedDirective is required and must be an instance of DOMString
+FAIL SecurityPolicyViolationEvent constructor does not require effectiveDirective Member SecurityPolicyViolationEventInit.effectiveDirective is required and must be an instance of DOMString
+FAIL SecurityPolicyViolationEvent constructor does not require originalPolicy Member SecurityPolicyViolationEventInit.originalPolicy is required and must be an instance of DOMString
+FAIL SecurityPolicyViolationEvent constructor does not require disposition Member SecurityPolicyViolationEventInit.disposition is required and must be an instance of SecurityPolicyViolationEventDisposition
+FAIL SecurityPolicyViolationEvent constructor does not require statusCode Member SecurityPolicyViolationEventInit.statusCode is required and must be an instance of unsigned short
 PASS SecurityPolicyViolationEvent constructor does not require referrer
 PASS SecurityPolicyViolationEvent constructor does not require blockedURI
 PASS SecurityPolicyViolationEvent constructor does not require sourceFile

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/securitypolicyviolation/constructor-required-fields.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/securitypolicyviolation/constructor-required-fields.html
@@ -25,118 +25,111 @@
       }), undefined);
     }, "SecurityPolicyViolationEvent constructor works with an init dict");
 
-    // missing required members
-    test(function() {
-      assert_throws_js(TypeError,
-        function() { new SecurityPolicyViolationEvent("securitypolicyviolation", {
-          // documentURI: "http://example.com",
-          referrer: "http://example.com",
-          blockedURI: "http://example.com",
-          violatedDirective: "default-src",
-          effectiveDirective: "default-src",
-          originalPolicy: "default-src 'none'",
-          sourceFile: "example.js",
-          sample: "<script>alert('1');</scr" + "ipt>",
-          disposition: "enforce",
-          statusCode: 200,
-          lineNumber: 1,
-          columnNumber: 1,
-      })});
-    }, "SecurityPolicyViolationEvent constructor requires documentURI");
-
-    test(function() {
-      assert_throws_js(TypeError,
-        function() { new SecurityPolicyViolationEvent("securitypolicyviolation", {
-          documentURI: "http://example.com",
-          referrer: "http://example.com",
-          blockedURI: "http://example.com",
-          // violatedDirective: "default-src",
-          effectiveDirective: "default-src",
-          originalPolicy: "default-src 'none'",
-          sourceFile: "example.js",
-          sample: "<script>alert('1');</scr" + "ipt>",
-          disposition: "enforce",
-          statusCode: 200,
-          lineNumber: 1,
-          columnNumber: 1,
-      })});
-    }, "SecurityPolicyViolationEvent constructor requires violatedDirective");
-
-    test(function() {
-      assert_throws_js(TypeError,
-        function() { new SecurityPolicyViolationEvent("securitypolicyviolation", {
-          documentURI: "http://example.com",
-          referrer: "http://example.com",
-          blockedURI: "http://example.com",
-          violatedDirective: "default-src",
-          // effectiveDirective: "default-src",
-          originalPolicy: "default-src 'none'",
-          sourceFile: "example.js",
-          sample: "<script>alert('1');</scr" + "ipt>",
-          disposition: "enforce",
-          statusCode: 200,
-          lineNumber: 1,
-          columnNumber: 1,
-      })});
-    }, "SecurityPolicyViolationEvent constructor requires effectiveDirective");
-
-    test(function() {
-      assert_throws_js(TypeError,
-        function() { new SecurityPolicyViolationEvent("securitypolicyviolation", {
-          documentURI: "http://example.com",
-          referrer: "http://example.com",
-          blockedURI: "http://example.com",
-          violatedDirective: "default-src",
-          effectiveDirective: "default-src",
-          // originalPolicy: "default-src 'none'",
-          sourceFile: "example.js",
-          sample: "<script>alert('1');</scr" + "ipt>",
-          disposition: "enforce",
-          statusCode: 200,
-          lineNumber: 1,
-          columnNumber: 1,
-      })});
-    }, "SecurityPolicyViolationEvent constructor requires originalPolicy");
-
-    test(function() {
-      assert_throws_js(TypeError,
-        function() { new SecurityPolicyViolationEvent("securitypolicyviolation", {
-          documentURI: "http://example.com",
-          referrer: "http://example.com",
-          blockedURI: "http://example.com",
-          violatedDirective: "default-src",
-          effectiveDirective: "default-src",
-          originalPolicy: "default-src 'none'",
-          sourceFile: "example.js",
-          sample: "<script>alert('1');</scr" + "ipt>",
-          // disposition: "enforce",
-          statusCode: 200,
-          lineNumber: 1,
-          columnNumber: 1,
-      })});
-    }, "SecurityPolicyViolationEvent constructor requires disposition");
-
-    test(function() {
-      assert_throws_js(TypeError,
-        function() { new SecurityPolicyViolationEvent("securitypolicyviolation", {
-          documentURI: "http://example.com",
-          referrer: "http://example.com",
-          blockedURI: "http://example.com",
-          violatedDirective: "default-src",
-          effectiveDirective: "default-src",
-          originalPolicy: "default-src 'none'",
-          sourceFile: "example.js",
-          sample: "<script>alert('1');</scr" + "ipt>",
-          disposition: "enforce",
-          // statusCode: 200,
-          lineNumber: 1,
-          columnNumber: 1,
-      })});
-    }, "SecurityPolicyViolationEvent constructor requires statusCode");
-
     // missing optional members
     test(function() {
-      assert_not_equals(new SecurityPolicyViolationEvent("securitypolicyviolation", {
+      assert_equals(new SecurityPolicyViolationEvent("securitypolicyviolation", {
+        // documentURI: "http://example.com",
+        referrer: "http://example.com",
+        blockedURI: "http://example.com",
+        violatedDirective: "default-src",
+        effectiveDirective: "default-src",
+        originalPolicy: "default-src 'none'",
+        sourceFile: "example.js",
+        sample: "<script>alert('1');</scr" + "ipt>",
+        disposition: "enforce",
+        statusCode: 200,
+        lineNumber: 1,
+        columnNumber: 1,
+      }).documentURI, "");
+    }, "SecurityPolicyViolationEvent constructor does not require documentURI");
+
+    test(function() {
+      assert_equals(new SecurityPolicyViolationEvent("securitypolicyviolation", {
+        documentURI: "http://example.com",
+        referrer: "http://example.com",
+        blockedURI: "http://example.com",
+        // violatedDirective: "default-src",
+        effectiveDirective: "default-src",
+        originalPolicy: "default-src 'none'",
+        sourceFile: "example.js",
+        sample: "<script>alert('1');</scr" + "ipt>",
+        disposition: "enforce",
+        statusCode: 200,
+        lineNumber: 1,
+        columnNumber: 1,
+      }).violatedDirective, "");
+    }, "SecurityPolicyViolationEvent constructor does not require violatedDirective");
+
+    test(function() {
+      assert_equals(new SecurityPolicyViolationEvent("securitypolicyviolation", {
+        documentURI: "http://example.com",
+        referrer: "http://example.com",
+        blockedURI: "http://example.com",
+        violatedDirective: "default-src",
+        // effectiveDirective: "default-src",
+        originalPolicy: "default-src 'none'",
+        sourceFile: "example.js",
+        sample: "<script>alert('1');</scr" + "ipt>",
+        disposition: "enforce",
+        statusCode: 200,
+        lineNumber: 1,
+        columnNumber: 1,
+      }).effectiveDirective, "");
+    }, "SecurityPolicyViolationEvent constructor does not require effectiveDirective");
+
+    test(function() {
+      assert_equals(new SecurityPolicyViolationEvent("securitypolicyviolation", {
+        documentURI: "http://example.com",
+        referrer: "http://example.com",
+        blockedURI: "http://example.com",
+        violatedDirective: "default-src",
+        effectiveDirective: "default-src",
+        // originalPolicy: "default-src 'none'",
+        sourceFile: "example.js",
+        sample: "<script>alert('1');</scr" + "ipt>",
+        disposition: "enforce",
+        statusCode: 200,
+        lineNumber: 1,
+        columnNumber: 1,
+      }).originalPolicy, "");
+    }, "SecurityPolicyViolationEvent constructor does not require originalPolicy");
+
+    test(function() {
+      assert_equals(new SecurityPolicyViolationEvent("securitypolicyviolation", {
+        documentURI: "http://example.com",
+        referrer: "http://example.com",
+        blockedURI: "http://example.com",
+        violatedDirective: "default-src",
+        effectiveDirective: "default-src",
+        originalPolicy: "default-src 'none'",
+        sourceFile: "example.js",
+        sample: "<script>alert('1');</scr" + "ipt>",
+        // disposition: "enforce",
+        statusCode: 200,
+        lineNumber: 1,
+        columnNumber: 1,
+      }).disposition, "enforce");
+    }, "SecurityPolicyViolationEvent constructor does not require disposition");
+
+    test(function() {
+      assert_equals(new SecurityPolicyViolationEvent("securitypolicyviolation", {
+        documentURI: "http://example.com",
+        referrer: "http://example.com",
+        blockedURI: "http://example.com",
+        violatedDirective: "default-src",
+        effectiveDirective: "default-src",
+        originalPolicy: "default-src 'none'",
+        sourceFile: "example.js",
+        sample: "<script>alert('1');</scr" + "ipt>",
+        disposition: "enforce",
+        // statusCode: 200,
+        lineNumber: 1,
+        columnNumber: 1,
+      }).statusCode, 0);
+    }, "SecurityPolicyViolationEvent constructor does not require statusCode");
+
+    test(function() {
+      assert_equals(new SecurityPolicyViolationEvent("securitypolicyviolation", {
         documentURI: "http://example.com",
         // referrer: "http://example.com",
         blockedURI: "http://example.com",
@@ -149,11 +142,11 @@
         statusCode: 200,
         lineNumber: 1,
         columnNumber: 1,
-      }), undefined);
+      }).referrer, "");
     }, "SecurityPolicyViolationEvent constructor does not require referrer");
 
     test(function() {
-      assert_not_equals(new SecurityPolicyViolationEvent("securitypolicyviolation", {
+      assert_equals(new SecurityPolicyViolationEvent("securitypolicyviolation", {
         documentURI: "http://example.com",
         referrer: "http://example.com",
         // blockedURI: "http://example.com",
@@ -166,11 +159,11 @@
         statusCode: 200,
         lineNumber: 1,
         columnNumber: 1,
-      }), undefined);
+      }).blockedURI, "");
     }, "SecurityPolicyViolationEvent constructor does not require blockedURI");
 
     test(function() {
-      assert_not_equals(new SecurityPolicyViolationEvent("securitypolicyviolation", {
+      assert_equals(new SecurityPolicyViolationEvent("securitypolicyviolation", {
         documentURI: "http://example.com",
         referrer: "http://example.com",
         blockedURI: "http://example.com",
@@ -183,11 +176,11 @@
         statusCode: 200,
         lineNumber: 1,
         columnNumber: 1,
-      }), undefined);
+      }).sourceFile, "");
     }, "SecurityPolicyViolationEvent constructor does not require sourceFile");
 
     test(function() {
-      assert_not_equals(new SecurityPolicyViolationEvent("securitypolicyviolation", {
+      assert_equals(new SecurityPolicyViolationEvent("securitypolicyviolation", {
         documentURI: "http://example.com",
         referrer: "http://example.com",
         blockedURI: "http://example.com",
@@ -200,11 +193,11 @@
         statusCode: 200,
         lineNumber: 1,
         columnNumber: 1,
-      }), undefined);
+      }).sample, "");
     }, "SecurityPolicyViolationEvent constructor does not require sample");
 
     test(function() {
-      assert_not_equals(new SecurityPolicyViolationEvent("securitypolicyviolation", {
+      assert_equals(new SecurityPolicyViolationEvent("securitypolicyviolation", {
         documentURI: "http://example.com",
         referrer: "http://example.com",
         blockedURI: "http://example.com",
@@ -217,11 +210,11 @@
         statusCode: 200,
         // lineNumber: 1,
         columnNumber: 1,
-      }), undefined);
+      }).lineNumber, 0);
     }, "SecurityPolicyViolationEvent constructor does not require lineNumber");
 
     test(function() {
-      assert_not_equals(new SecurityPolicyViolationEvent("securitypolicyviolation", {
+      assert_equals(new SecurityPolicyViolationEvent("securitypolicyviolation", {
         documentURI: "http://example.com",
         referrer: "http://example.com",
         blockedURI: "http://example.com",
@@ -234,6 +227,6 @@
         statusCode: 200,
         lineNumber: 1,
         // columnNumber: 1,
-      }), undefined);
+      }).columnNumber, 0);
     }, "SecurityPolicyViolationEvent constructor does not require columnNumber");
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/securitypolicyviolation/linenumber.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/securitypolicyviolation/linenumber.tentative-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (TIMEOUT), message = null
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/securitypolicyviolation/linenumber.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/securitypolicyviolation/linenumber.tentative.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="content-security-policy" content="script-src 'self' 'nonce-abc'">
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<script nonce="abc">

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/securitypolicyviolation/securitypolicyviolation-block-cross-origin-image-from-script.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/securitypolicyviolation/securitypolicyviolation-block-cross-origin-image-from-script.sub.html
@@ -16,8 +16,16 @@
         assert_equals(e.originalPolicy, "img-src \'none\'");
         assert_equals(e.disposition, "enforce");
         assert_equals(new URL(e.sourceFile).pathname, "/content-security-policy/support/inject-image.sub.js");
-        assert_equals(e.lineNumber, 2);
-        assert_equals(e.columnNumber, 0);
+        // Per https://html.spec.whatwg.org/#relevant-mutations:
+        //     The img or source HTML element insertion steps or HTML element removing steps count the mutation as a relevant mutation.
+        // So when the src load is async, line 3 (appendChild, and thus the insertion steps) is what triggers the relevant load, not the src setter.
+        // But there's some interesting discussions going on about what the right trigger is, see https://github.com/whatwg/html/issues/10531.
+        // So for now, we allow both.
+        assert_true(
+          (e.lineNumber == 3 && e.columnNumber == 15) ||
+            (e.lineNumber == 2 && e.columnNumber == 1),
+          `Location should be reasonable, got [${e.lineNumber}, ${e.columnNumber}]`
+        );
         assert_equals(e.statusCode, 200);
       }));
 

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/securitypolicyviolation/securitypolicyviolation-block-cross-origin-image.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/securitypolicyviolation/securitypolicyviolation-block-cross-origin-image.sub-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Non-redirected cross-origin URLs are not stripped. assert_equals: expected 4 but got 6
+FAIL Non-redirected cross-origin URLs are not stripped. assert_equals: expected 5 but got 6
 

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/securitypolicyviolation/securitypolicyviolation-block-cross-origin-image.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/securitypolicyviolation/securitypolicyviolation-block-cross-origin-image.sub.html
@@ -17,7 +17,7 @@
         assert_equals(e.disposition, "enforce");
         assert_equals(new URL(e.sourceFile).pathname, "/content-security-policy/securitypolicyviolation/securitypolicyviolation-block-cross-origin-image.sub.html");
         assert_equals(e.lineNumber, 25);
-        assert_equals(e.columnNumber, 4);
+        assert_equals(e.columnNumber, 5);
         assert_equals(e.statusCode, 200);
       }));
 

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/securitypolicyviolation/securitypolicyviolation-block-image-from-script.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/securitypolicyviolation/securitypolicyviolation-block-image-from-script.sub-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL Non-redirected cross-origin URLs are not stripped. assert_equals: expected 0 but got 2
+FAIL Non-redirected cross-origin URLs are not stripped. assert_true: Location should be reasonable, got [2, 2] expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/securitypolicyviolation/securitypolicyviolation-block-image-from-script.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/securitypolicyviolation/securitypolicyviolation-block-image-from-script.sub.html
@@ -16,8 +16,16 @@
         assert_equals(e.originalPolicy, "img-src \'none\'");
         assert_equals(e.disposition, "enforce");
         assert_equals(new URL(e.sourceFile).pathname, "/content-security-policy/support/inject-image.sub.js");
-        assert_equals(e.lineNumber, 2);
-        assert_equals(e.columnNumber, 0);
+        // Per https://html.spec.whatwg.org/#relevant-mutations:
+        //     The img or source HTML element insertion steps or HTML element removing steps count the mutation as a relevant mutation.
+        // So when the src load is async, line 3 (appendChild, and thus the insertion steps) is what triggers the relevant load, not the src setter.
+        // But there's some interesting discussions going on about what the right trigger is, see https://github.com/whatwg/html/issues/10531.
+        // So for now, we allow both.
+        assert_true(
+          (e.lineNumber == 3 && e.columnNumber == 15) ||
+            (e.lineNumber == 2 && e.columnNumber == 1),
+          `Location should be reasonable, got [${e.lineNumber}, ${e.columnNumber}]`
+        );
         assert_equals(e.statusCode, 200);
       }));
 

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/securitypolicyviolation/securitypolicyviolation-block-image.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/securitypolicyviolation/securitypolicyviolation-block-image.sub-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Non-redirected same-origin URLs are not stripped. assert_equals: expected 4 but got 6
+FAIL Non-redirected same-origin URLs are not stripped. assert_equals: expected 5 but got 6
 

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/securitypolicyviolation/securitypolicyviolation-block-image.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/securitypolicyviolation/securitypolicyviolation-block-image.sub.html
@@ -17,7 +17,7 @@
         assert_equals(e.disposition, "enforce");
         assert_equals(new URL(e.sourceFile).pathname, "/content-security-policy/securitypolicyviolation/securitypolicyviolation-block-image.sub.html");
         assert_equals(e.lineNumber, 25);
-        assert_equals(e.columnNumber, 4);
+        assert_equals(e.columnNumber, 5);
         assert_equals(e.statusCode, 200);
       }));
 

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/securitypolicyviolation/source-file-blob-scheme-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/securitypolicyviolation/source-file-blob-scheme-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Violations from data:-URL scripts have a sourceFile of 'blob' assert_equals: expected 16 but got 21
+FAIL Violations from data:-URL scripts have a sourceFile of 'blob' assert_equals: expected 17 but got 21
 

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/securitypolicyviolation/source-file-blob-scheme.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/securitypolicyviolation/source-file-blob-scheme.html
@@ -9,7 +9,7 @@
             assert_equals(e.blockedURI, "eval");
             assert_equals(e.sourceFile, "blob");
             assert_equals(e.lineNumber, 3);
-            assert_equals(e.columnNumber, 16);
+            assert_equals(e.columnNumber, 17);
         }));
 
         var scriptText = `

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/securitypolicyviolation/source-file-data-scheme-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/securitypolicyviolation/source-file-data-scheme-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Violations from data:-URL scripts have a sourceFile of 'data' assert_equals: expected 16 but got 21
+FAIL Violations from data:-URL scripts have a sourceFile of 'data' assert_equals: expected 17 but got 21
 

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/securitypolicyviolation/source-file-data-scheme.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/securitypolicyviolation/source-file-data-scheme.html
@@ -9,7 +9,7 @@
             assert_equals(e.blockedURI, "eval");
             assert_equals(e.sourceFile, "data");
             assert_equals(e.lineNumber, 3);
-            assert_equals(e.columnNumber, 16);
+            assert_equals(e.columnNumber, 17);
         }));
 
         var scriptText = `

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/securitypolicyviolation/source-file.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/securitypolicyviolation/source-file.html
@@ -22,11 +22,7 @@ const testSourceFile = (description, input, output) => {
       eval('');
       //# sourceURL=${input}
     `)
-    try {
-      eval(trusted_script);
-      assert_unreached();
-    } catch (e) {}
-
+    assert_throws_js(EvalError, _ => eval(trusted_script));
     assert_equals((await violation).sourceFile, output);
   }, description);
 };

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/securitypolicyviolation/targeting.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/securitypolicyviolation/targeting.html
@@ -36,28 +36,28 @@
             .then(t.step_func(e => {
                 assert_equals(e.blockedURI, "inline");
                 assert_equals(e.lineNumber, 118);
-                assert_in_array(e.columnNumber, [4, 6]);
+                assert_in_array(e.columnNumber, [5, 7]);
                 assert_equals(e.target, document, "Elements created in this document, but pushed into a same-origin frame trigger on that frame's document, not on this frame's document.");
                 return watcher.wait_for('securitypolicyviolation');
             }))
             .then(t.step_func(e => {
                 assert_equals(e.blockedURI, "inline");
                 assert_equals(e.lineNumber, 131);
-                assert_in_array(e.columnNumber, [4, 59]);
+                assert_in_array(e.columnNumber, [5, 60]);
                 assert_equals(e.target, document, "Elements created in this document, but pushed into a same-origin frame trigger on that frame's document, not on this frame's document.");
                 return watcher.wait_for('securitypolicyviolation');
             }))
             .then(t.step_func(e => {
                 assert_equals(e.blockedURI, "inline");
                 assert_equals(e.lineNumber, 139);
-                assert_in_array(e.columnNumber, [4, 6]);
+                assert_in_array(e.columnNumber, [5, 7]);
                 assert_equals(e.target, document, "Inline event handlers for disconnected elements target the document.");
                 return watcher.wait_for('securitypolicyviolation');
             }))
             .then(t.step_func(e => {
                 assert_equals(e.blockedURI, "inline");
                 assert_equals(e.lineNumber, 0);
-                assert_equals(e.columnNumber, 0);
+                assert_equals(e.columnNumber, 1);
                 assert_equals(e.target, document, "Inline event handlers for elements disconnected after triggering target the document.");
             }))
             .then(t.step_func_done(_ => {

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/securitypolicyviolation/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/securitypolicyviolation/w3c-import.log
@@ -25,6 +25,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/content-security-policy/securitypolicyviolation/inside-dedicated-worker.html
 /LayoutTests/imported/w3c/web-platform-tests/content-security-policy/securitypolicyviolation/inside-service-worker.https.html
 /LayoutTests/imported/w3c/web-platform-tests/content-security-policy/securitypolicyviolation/inside-shared-worker.html
+/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/securitypolicyviolation/linenumber.tentative.html
 /LayoutTests/imported/w3c/web-platform-tests/content-security-policy/securitypolicyviolation/script-sample-no-opt-in.html
 /LayoutTests/imported/w3c/web-platform-tests/content-security-policy/securitypolicyviolation/script-sample.html
 /LayoutTests/imported/w3c/web-platform-tests/content-security-policy/securitypolicyviolation/securitypolicyviolation-block-cross-origin-image-from-script.sub.html


### PR DESCRIPTION
#### 956a44342587d998cfcde3f1de53d1f48b290d1d
<pre>
Sync `content-security-policy/securitypolicyviolation` from WPT upstream

<a href="https://bugs.webkit.org/show_bug.cgi?id=293572">https://bugs.webkit.org/show_bug.cgi?id=293572</a>

Reviewed by Anne van Kesteren.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/5922ae1dd63568c14783aea08a22b73add79306c">https://github.com/web-platform-tests/wpt/commit/5922ae1dd63568c14783aea08a22b73add79306c</a>

* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/securitypolicyviolation/blockeduri-eval-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/securitypolicyviolation/blockeduri-eval.html:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/securitypolicyviolation/blockeduri-inline-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/securitypolicyviolation/blockeduri-inline.html:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/securitypolicyviolation/constructor-required-fields-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/securitypolicyviolation/constructor-required-fields.html:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/securitypolicyviolation/securitypolicyviolation-block-cross-origin-image-from-script.sub.html:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/securitypolicyviolation/securitypolicyviolation-block-cross-origin-image.sub-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/securitypolicyviolation/securitypolicyviolation-block-cross-origin-image.sub.html:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/securitypolicyviolation/securitypolicyviolation-block-image-from-script.sub-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/securitypolicyviolation/securitypolicyviolation-block-image-from-script.sub.html:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/securitypolicyviolation/securitypolicyviolation-block-image.sub-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/securitypolicyviolation/securitypolicyviolation-block-image.sub.html:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/securitypolicyviolation/source-file-blob-scheme-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/securitypolicyviolation/source-file-blob-scheme.html:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/securitypolicyviolation/source-file-data-scheme-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/securitypolicyviolation/source-file-data-scheme.html:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/securitypolicyviolation/source-file.html:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/securitypolicyviolation/targeting.html:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/securitypolicyviolation/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/securitypolicyviolation/linenumber.tentative.html:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/securitypolicyviolation/linenumber.tentative-expected.txt:

Canonical link: <a href="https://commits.webkit.org/295417@main">https://commits.webkit.org/295417@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8fd547dde45f80f02d6e24baaacb199fd4b9170e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105014 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24728 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15150 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110231 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/55694 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/25138 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33272 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79746 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108020 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19566 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94787 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60053 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/19317 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/12860 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55071 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/89033 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/12905 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/112733 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32179 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23683 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88827 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32544 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91007 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88456 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33347 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11134 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/27540 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17035 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32103 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/31896 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35237 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33455 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->