### PR TITLE
[Fix] Clicking on the CSS resize handle doesn't trigger mouse down

### DIFF
--- a/LayoutTests/fast/events/mouse-events-on-textarea-resize-expected.txt
+++ b/LayoutTests/fast/events/mouse-events-on-textarea-resize-expected.txt
@@ -7,6 +7,7 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 --- test with preventDefault on 'mousedown' ---
 --- move mouse into target ---
 --- start resizing ---
+Received mousedown
 --- mouse released ---
 Received mouseup
 Received click

--- a/LayoutTests/fast/events/mouse_resizer_mousedown-expected.txt
+++ b/LayoutTests/fast/events/mouse_resizer_mousedown-expected.txt
@@ -1,0 +1,11 @@
+Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+Tests if mouse down event is fired when in resizer control
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+mouse down event fired
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/events/mouse_resizer_mousedown.html
+++ b/LayoutTests/fast/events/mouse_resizer_mousedown.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        .target {
+            margin: 10px;
+            overflow: hidden;
+            width: 200px;
+            height: 100px;
+            resize: both;
+            border: 12px solid silver;
+        }
+    </style>
+    <script src="../../resources/js-test.js"></script>
+    <script src="../../resources/ui-helper.js"></script>
+    <script>
+        window.jsTestIsAsync = true;
+        if (window.testRunner) {
+            testRunner.dumpAsText();
+    
+        }
+
+        const borderWidth = 12;
+        function MouseDownEventHandler() {
+            debug('mouse down event fired');
+            finishJSTest();
+        }
+
+        window.addEventListener('load', async () => {
+            description("Tests if mouse down event is fired when in resizer control");
+            let target = document.getElementById('target');
+            target.addEventListener("mousedown" , MouseDownEventHandler);
+            let targetBounds = target.getBoundingClientRect();
+            await UIHelper.moveMouseAndWaitForFrame(targetBounds.right - borderWidth - 4, targetBounds.bottom - borderWidth - 4);
+            eventSender.mouseDown();
+        }, false);
+    </script>
+</head>
+<body>
+    <div id="test-container">
+        <div id="target" class="target">
+            Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+        </div>
+    </div>
+    <div id="console"></div>
+</body>
+</html>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -1302,6 +1302,7 @@ fast/css/resize-rtl.html [ Skip ]
 fast/css/resize-single-axis.html [ Skip ]
 fast/css/resize-textarea-align-content.html [ Skip ]
 fast/events/mouse-events-on-textarea-resize.html [ Skip ]
+fast/events/mouse_resizer_mousedown.html [ Skip ]
 
 # The file-wrapper part of <attachment> is not yet working on iOS
 fast/attachment/attachment-type-attribute.html [ Skip ]

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -2039,6 +2039,7 @@ HandleUserInputEventResult EventHandler::handleMousePressEvent(const PlatformMou
         layer->setInResizeMode(true);
         m_resizeLayer = *layer;
         m_offsetFromResizeCorner = layer->offsetFromResizeCorner(localPoint);
+        dispatchMouseEvent(eventNames().mousedownEvent, mouseEvent.protectedTargetNode().get(), m_clickCount, platformMouseEvent, FireMouseOverOut::Yes);
         return true;
     }
 


### PR DESCRIPTION
#### f63100da315a92b0ac5660cd5d1dd0a7917f0ca7
<pre>
[Fix] Clicking on the CSS resize handle doesn&apos;t trigger mouse down
<a href="https://bugs.webkit.org/show_bug.cgi?id=280956">https://bugs.webkit.org/show_bug.cgi?id=280956</a>

Reviewed by Simon Fraser.

The bug occurred because the function that dispatch mouse down events was returning
before dispatch mouse down events when the click was in resizer coordinates
In the event handler for the mouse down event, there was a condition that checked whether the click coordinates were inside a resizer control.
If true, some condition variables were being set, and the function returned early
preventing the rest of the mouse down logic dispatch code from executing.

this patch align this behavior with other browsers.

* LayoutTests/fast/events/mouse_resizer_mousedown-expected.txt: Added.
* LayoutTests/fast/events/mouse_resizer_mousedown.html: Added.
* LayoutTests/fast/events/mouse-events-on-textarea-resize-expected.txt:
* LayoutTests/platform/ios/TestExpectations:
* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::handleMousePressEvent):

Canonical link: <a href="https://commits.webkit.org/295846@main">https://commits.webkit.org/295846@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/80a2843346027d850f09a65e5a4772d2756f7b33

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105233 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24944 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15370 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110446 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/55892 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/107274 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/25375 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33489 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79925 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108239 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19784 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94983 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60232 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/19539 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13057 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55287 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/89240 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13101 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/113037 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32393 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23863 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89002 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32757 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91199 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88638 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33531 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11320 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/27801 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17230 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32316 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/37728 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32097 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35441 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33663 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->