### PR TITLE
[GTK][WPE] Use an enum class for mouse button and modifiers in GLib API tests

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestDownloads.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestDownloads.cpp
@@ -651,7 +651,7 @@ public:
         m_contextMenuDownloadItem = nullptr;
         auto id = g_signal_connect(m_webView.get(), "context-menu", G_CALLBACK(contextMenuCallback), this);
         RunLoop::protectedMain()->dispatch([this, x, y] {
-            clickMouseButton(x, y, 3);
+            clickMouseButton(x, y, WebViewTest::MouseButton::Secondary);
         });
         g_main_loop_run(m_mainLoop);
         g_signal_handler_disconnect(m_webView.get(), id);
@@ -1024,7 +1024,7 @@ static void testBlobDownload(WebViewDownloadTest* test, gconstpointer)
 
     g_idle_add([](gpointer userData) -> gboolean {
         auto* test = static_cast<WebViewDownloadTest*>(userData);
-        test->clickMouseButton(1, 1, 1);
+        test->clickMouseButton(1, 1);
         return FALSE;
     }, test);
     test->waitUntilDownloadStarted();

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestUIClient.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestUIClient.cpp
@@ -445,7 +445,7 @@ public:
     }
 #endif
 
-    WebKitHitTestResult* moveMouseAndWaitUntilMouseTargetChanged(int x, int y, unsigned mouseModifiers = 0)
+    WebKitHitTestResult* moveMouseAndWaitUntilMouseTargetChanged(int x, int y, OptionSet<Modifiers> mouseModifiers = OptionSet<Modifiers>())
     {
         m_waitingForMouseTargetChange = true;
         mouseMoveTo(x, y, mouseModifiers);
@@ -604,7 +604,7 @@ public:
     void clickAndWaitUntilMainLoopFinishes(int x, int y)
     {
         clearNavigation();
-        clickMouseButton(x, y, 1);
+        clickMouseButton(x, y);
         g_main_loop_run(m_mainLoop);
     }
 
@@ -883,7 +883,7 @@ static void testWebViewMouseTarget(UIClientTest* test, gconstpointer)
     g_assert_cmpuint(test->m_mouseTargetModifiers, ==, 0);
 
     // Move over image with GDK_CONTROL_MASK.
-    hitTestResult = test->moveMouseAndWaitUntilMouseTargetChanged(1, 10, GDK_CONTROL_MASK);
+    hitTestResult = test->moveMouseAndWaitUntilMouseTargetChanged(1, 10, { WebViewTest::Modifiers::Control });
     g_assert_false(webkit_hit_test_result_context_is_link(hitTestResult));
     g_assert_true(webkit_hit_test_result_context_is_image(hitTestResult));
     g_assert_false(webkit_hit_test_result_context_is_media(hitTestResult));
@@ -1333,12 +1333,12 @@ static void testWebViewPointerLockPermissionRequest(UIClientTest* test, gconstpo
 
     // Test denying a permission request.
     test->m_allowPermissionRequests = false;
-    test->clickMouseButton(5, 5, 1);
+    test->clickMouseButton(5, 5);
     test->waitUntilTitleChangedTo("Error");
 
     // Test allowing a permission request.
     test->m_allowPermissionRequests = true;
-    test->clickMouseButton(5, 5, 1);
+    test->clickMouseButton(5, 5);
     test->waitUntilTitleChangedTo("Locked");
 }
 #endif

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitWebView.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitWebView.cpp
@@ -757,7 +757,7 @@ public:
 
     static gboolean doClickIdleCallback(FormClientTest* test)
     {
-        test->clickMouseButton(test->m_submitPositionX, test->m_submitPositionY, 1);
+        test->clickMouseButton(test->m_submitPositionX, test->m_submitPositionY);
         return FALSE;
     }
 

--- a/Tools/TestWebKitAPI/Tests/WebKitGtk/TestContextMenu.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGtk/TestContextMenu.cpp
@@ -242,7 +242,7 @@ public:
 
     static gboolean doRightClickIdleCallback(ContextMenuTest* test)
     {
-        test->clickMouseButton(test->m_menuPositionX, test->m_menuPositionY, 3);
+        test->clickMouseButton(test->m_menuPositionX, test->m_menuPositionY, WebViewTest::MouseButton::Secondary);
         return FALSE;
     }
 

--- a/Tools/TestWebKitAPI/Tests/WebKitGtk/TestDOMDOMWindow.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGtk/TestDOMDOMWindow.cpp
@@ -55,7 +55,7 @@ static void signalsNotifyCallback(const gchar *key, const gchar *value, gconstpo
         status.test->showInWindow();
 
         // Click in a known location where the text is
-        status.test->clickMouseButton(20, 18, 1, 0);
+        status.test->clickMouseButton(20, 18);
     }
 
     if (g_str_equal(key, "clicked"))

--- a/Tools/TestWebKitAPI/Tests/WebKitGtk/TestPrinting.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGtk/TestPrinting.cpp
@@ -416,7 +416,7 @@ public:
     void jumpToCustomWidget()
     {
         // Jump back to the GtkNotebook
-        keyStroke(GDK_KEY_Tab, GDK_SHIFT_MASK);
+        keyStroke(GDK_KEY_Tab, { WebViewTest::Modifiers::Shift });
         // Custom widget is on the third tab
         keyStroke(GDK_KEY_Right);
         keyStroke(GDK_KEY_Right);

--- a/Tools/TestWebKitAPI/glib/WebKitGLib/TestMain.h
+++ b/Tools/TestWebKitAPI/glib/WebKitGLib/TestMain.h
@@ -100,6 +100,12 @@
     } while(0)
 #endif
 
+#if PLATFORM(GTK)
+#define KEY(x) GDK_KEY_##x
+#elif PLATFORM(WPE)
+#define KEY(x) WPE_KEY_##x
+#endif
+
 class Test {
 public:
     MAKE_GLIB_TEST_FIXTURE(Test);

--- a/Tools/TestWebKitAPI/glib/WebKitGLib/WebViewTest.h
+++ b/Tools/TestWebKitAPI/glib/WebKitGLib/WebViewTest.h
@@ -21,6 +21,8 @@
 #pragma once
 
 #include "TestMain.h"
+#include <optional>
+#include <wtf/OptionSet.h>
 #include <wtf/text/CString.h>
 
 class WebViewTest: public Test {
@@ -64,9 +66,22 @@ public:
     bool isEditable();
     void setEditable(bool);
 
-    void mouseMoveTo(int x, int y, unsigned mouseModifiers = 0);
-    void clickMouseButton(int x, int y, unsigned button = 1, unsigned mouseModifiers = 0);
-    void keyStroke(unsigned keyVal, unsigned keyModifiers = 0);
+    enum class MouseButton : uint8_t {
+        Primary,
+        Middle,
+        Secondary
+    };
+
+    enum class Modifiers : uint8_t {
+        Shift   = 1 << 0,
+        Control = 1 << 1,
+        Alt     = 1 << 2,
+        Meta    = 1 << 3
+    };
+
+    void mouseMoveTo(int x, int y, OptionSet<Modifiers> = OptionSet<Modifiers>());
+    void clickMouseButton(int x, int y, MouseButton = MouseButton::Primary, OptionSet<Modifiers> = OptionSet<Modifiers>());
+    void keyStroke(unsigned keyVal, OptionSet<Modifiers> = OptionSet<Modifiers>());
 
     void showInWindow(int width = 0, int height = 0);
 


### PR DESCRIPTION
#### d3864cb3bdb872eadea2cac871f91cee298173d6
<pre>
[GTK][WPE] Use an enum class for mouse button and modifiers in GLib API tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=293581">https://bugs.webkit.org/show_bug.cgi?id=293581</a>

Reviewed by Adrian Perez de Castro.

Canonical link: <a href="https://commits.webkit.org/295432@main">https://commits.webkit.org/295432@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c8457596d680ba3cd384d7364df68931159de427

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105034 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24748 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15171 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110251 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/55714 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/107075 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/25207 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33292 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79763 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108040 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19632 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94804 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60070 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/19390 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/12880 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55091 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/89100 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/12925 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/112758 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32199 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23701 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88843 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32565 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91024 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88477 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33365 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11154 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/27576 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17038 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32123 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/31916 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35257 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33475 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->