### PR TITLE
[JSC] Support `notation` option for `Intl.PluralRules`

### DIFF
--- a/JSTests/test262/expectations.yaml
+++ b/JSTests/test262/expectations.yaml
@@ -1165,27 +1165,12 @@ test/intl402/NumberFormat/prototype/formatToParts/unit-ja-JP.js:
 test/intl402/NumberFormat/prototype/formatToParts/unit-zh-TW.js:
   default: 'Test262Error: undefined: length Expected SameValue(«3», «4») to be true'
   strict mode: 'Test262Error: undefined: length Expected SameValue(«3», «4») to be true'
-test/intl402/PluralRules/constructor-option-read-order.js:
-  default: 'Test262Error: Actual [localeMatcher, type, minimumIntegerDigits, minimumFractionDigits, maximumFractionDigits, minimumSignificantDigits, maximumSignificantDigits, roundingIncrement, roundingMode, roundingPriority, trailingZeroDisplay] and expected [localeMatcher, type, notation, minimumIntegerDigits, minimumFractionDigits, maximumFractionDigits, minimumSignificantDigits, maximumSignificantDigits, roundingIncrement, roundingMode, roundingPriority, trailingZeroDisplay] should have the same contents. Intl.PluralRules options read order'
-  strict mode: 'Test262Error: Actual [localeMatcher, type, minimumIntegerDigits, minimumFractionDigits, maximumFractionDigits, minimumSignificantDigits, maximumSignificantDigits, roundingIncrement, roundingMode, roundingPriority, trailingZeroDisplay] and expected [localeMatcher, type, notation, minimumIntegerDigits, minimumFractionDigits, maximumFractionDigits, minimumSignificantDigits, maximumSignificantDigits, roundingIncrement, roundingMode, roundingPriority, trailingZeroDisplay] should have the same contents. Intl.PluralRules options read order'
-test/intl402/PluralRules/constructor-options-throwing-getters.js:
-  default: 'Test262Error: Exception from notation getter should be propagated Expected a CustomError to be thrown but no exception was thrown at all'
-  strict mode: 'Test262Error: Exception from notation getter should be propagated Expected a CustomError to be thrown but no exception was thrown at all'
-test/intl402/PluralRules/default-options-object-prototype.js:
-  default: 'Test262Error: Expected SameValue(«"compact"», «"standard"») to be true'
-  strict mode: 'Test262Error: Expected SameValue(«"compact"», «"standard"») to be true'
 test/intl402/PluralRules/prototype/constructor/notation.js:
   default: 'Test262Error: Resolved options should have notation standard'
   strict mode: 'Test262Error: Resolved options should have notation standard'
-test/intl402/PluralRules/prototype/resolvedOptions/order.js:
-  default: 'Test262Error: "type" precedes "notation"'
-  strict mode: 'Test262Error: "type" precedes "notation"'
-test/intl402/PluralRules/prototype/resolvedOptions/properties.js:
-  default: 'Test262Error: Expected SameValue(«undefined», «"standard"») to be true'
-  strict mode: 'Test262Error: Expected SameValue(«undefined», «"standard"») to be true'
 test/intl402/PluralRules/prototype/select/notation.js:
-  default: 'Test262Error: compact notation Expected SameValue(«"few"», «"one"») to be true'
-  strict mode: 'Test262Error: compact notation Expected SameValue(«"few"», «"one"») to be true'
+  default: 'Test262Error: compact notation Expected SameValue(«"other"», «"one"») to be true'
+  strict mode: 'Test262Error: compact notation Expected SameValue(«"other"», «"one"») to be true'
 test/intl402/Temporal/Duration/compare/relativeto-sub-minute-offset.js:
   default: 'RangeError: Cannot compare a duration of years, months, or weeks without a relativeTo option'
   strict mode: 'RangeError: Cannot compare a duration of years, months, or weeks without a relativeTo option'

--- a/Source/JavaScriptCore/runtime/IntlPluralRules.h
+++ b/Source/JavaScriptCore/runtime/IntlPluralRules.h
@@ -96,6 +96,7 @@ private:
     RoundingMode m_roundingMode { RoundingMode::HalfExpand };
     IntlRoundingType m_roundingType { IntlRoundingType::FractionDigits };
     Type m_type { Type::Cardinal };
+    IntlNotation m_notation { IntlNotation::Standard };
 };
 
 } // namespace JSC


### PR DESCRIPTION
#### 5feaca187db84f5193c53a2518afa95930d6819d
<pre>
[JSC] Support `notation` option for `Intl.PluralRules`
<a href="https://bugs.webkit.org/show_bug.cgi?id=293582">https://bugs.webkit.org/show_bug.cgi?id=293582</a>

Reviewed by Yusuke Suzuki.

This patch changes to add `notation` option for `Intl.PluralRules`[1].

[1]: <a href="https://github.com/tc39/ecma402/pull/989">https://github.com/tc39/ecma402/pull/989</a>

* Source/JavaScriptCore/runtime/IntlPluralRules.cpp:
(JSC::IntlPluralRules::initializePluralRules):
(JSC::IntlPluralRules::resolvedOptions const):
* Source/JavaScriptCore/runtime/IntlPluralRules.h:

Canonical link: <a href="https://commits.webkit.org/295502@main">https://commits.webkit.org/295502@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/38915a48ce6a6da95e8c8263dfd94f4f2dd31b3c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105036 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24750 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15173 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110253 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/55716 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/25163 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33294 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79766 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108042 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19590 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94806 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60073 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/19345 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/12882 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55093 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/97718 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/89058 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/12927 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/112760 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/103654 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32201 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23703 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88846 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32567 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91026 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88475 "run-api-tests-without-change (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33367 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11156 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/27579 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17074 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32125 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/37498 "Failed to build and analyze WebKit") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/127958 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/31918 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/35002 "Found 1 new JSC stress test failure: wasm.yaml/wasm/gc/ref-i31-eq.js.wasm-eager-jettison (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35259 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33477 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->