### PR TITLE
[GStreamer][EME] imported/w3c/web-platform-tests/encrypted-media/clearkey-mp4-playback-temporary-clear-encrypted-segmented.https.html is failing

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -2789,11 +2789,8 @@ webkit.org/b/190991 imported/w3c/web-platform-tests/encrypted-media/clearkey-mp4
 webkit.org/b/190991 imported/w3c/web-platform-tests/encrypted-media/clearkey-mp4-playback-retrieve-persistent-usage-record.https.html [ Skip ]
 webkit.org/b/211840 imported/w3c/web-platform-tests/encrypted-media/clearkey-mp4-playback-retrieve-persistent-license.https.html [ Failure ]
 webkit.org/b/211840 imported/w3c/web-platform-tests/encrypted-media/clearkey-mp4-playback-destroy-persistent-license.https.html [ Failure ]
-webkit.org/b/211375 imported/w3c/web-platform-tests/encrypted-media/clearkey-mp4-playback-temporary-clear-encrypted-segmented.https.html [ Skip ]
 webkit.org/b/210113 imported/w3c/web-platform-tests/encrypted-media/clearkey-mp4-reset-src-after-setmediakeys.https.html [ Failure ]
 webkit.org/b/178707 imported/w3c/web-platform-tests/encrypted-media/encrypted-media-default-feature-policy.https.sub.html [ Skip ]
-
-# Doesn't recover from media decode error.
 
 imported/w3c/web-platform-tests/encrypted-media/idlharness.https.html [ Pass ]
 imported/w3c/web-platform-tests/encrypted-media/clearkey-check-encryption-scheme.https.html [ Pass ]
@@ -2803,6 +2800,7 @@ imported/w3c/web-platform-tests/encrypted-media/clearkey-events-session-closed-e
 imported/w3c/web-platform-tests/encrypted-media/clearkey-invalid-license.https.html [ Pass ]
 imported/w3c/web-platform-tests/encrypted-media/clearkey-keystatuses.https.html [ Pass ]
 imported/w3c/web-platform-tests/encrypted-media/clearkey-keystatuses-multiple-sessions.https.html [ Pass ]
+imported/w3c/web-platform-tests/encrypted-media/clearkey-mp4-playback-temporary-clear-encrypted-segmented.https.html [ Pass ]
 imported/w3c/web-platform-tests/encrypted-media/clearkey-mp4-playback-temporary-clear-encrypted.https.html [ Pass ]
 imported/w3c/web-platform-tests/encrypted-media/clearkey-mp4-playback-temporary-encrypted-clear.https.html [ Pass ]
 imported/w3c/web-platform-tests/encrypted-media/clearkey-mp4-playback-temporary-encrypted-clear-sources.https.html [ Pass ]

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/encrypted-media/clearkey-mp4-playback-temporary-clear-encrypted-segmented.https-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/encrypted-media/clearkey-mp4-playback-temporary-clear-encrypted-segmented.https-expected.txt
@@ -1,0 +1,3 @@
+
+PASS org.w3.clearkey, temporary, mp4, playback, encrypted and clear sources in separate segments
+

--- a/Source/WebCore/platform/SourcesGStreamer.txt
+++ b/Source/WebCore/platform/SourcesGStreamer.txt
@@ -85,6 +85,7 @@ platform/graphics/gstreamer/eme/CDMThunder.cpp
 platform/graphics/gstreamer/eme/GStreamerEMEUtilities.cpp
 platform/graphics/gstreamer/eme/WebKitCommonEncryptionDecryptorGStreamer.cpp
 platform/graphics/gstreamer/eme/WebKitThunderDecryptorGStreamer.cpp
+platform/graphics/gstreamer/eme/WebKitThunderParser.cpp
 
 platform/graphics/gstreamer/mse/AppendPipeline.cpp
 platform/graphics/gstreamer/mse/GStreamerMediaDescription.cpp

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
@@ -85,6 +85,7 @@
 #if ENABLE(ENCRYPTED_MEDIA) && ENABLE(THUNDER)
 #include "CDMThunder.h"
 #include "WebKitThunderDecryptorGStreamer.h"
+#include "WebKitThunderParser.h"
 #endif
 
 #if ENABLE(VIDEO)
@@ -442,8 +443,10 @@ void registerWebKitGStreamerElements()
         // - Use GST_RANK_NONE for elements explicitely created by WebKit (no auto-plugging).
 
 #if ENABLE(ENCRYPTED_MEDIA) && ENABLE(THUNDER)
-        if (!CDMFactoryThunder::singleton().supportedKeySystems().isEmpty())
-            gst_element_register(nullptr, "webkitthunder", GST_RANK_PRIMARY + 100, WEBKIT_TYPE_MEDIA_THUNDER_DECRYPT);
+        if (!CDMFactoryThunder::singleton().supportedKeySystems().isEmpty()) {
+            gst_element_register(nullptr, "webkitthunder", GST_RANK_NONE, WEBKIT_TYPE_MEDIA_THUNDER_DECRYPT);
+            gst_element_register(nullptr, "webkitthunderparser", GST_RANK_PRIMARY + 100, WEBKIT_TYPE_MEDIA_THUNDER_PARSER);
+        }
 #endif
 
 #if ENABLE(MEDIA_STREAM)

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -70,6 +70,9 @@
 #include "GStreamerEMEUtilities.h"
 #include "SharedBuffer.h"
 #include "WebKitCommonEncryptionDecryptorGStreamer.h"
+#if ENABLE(THUNDER)
+#include "CDMThunder.h"
+#endif
 #endif
 
 #if ENABLE(WEB_AUDIO)
@@ -2542,7 +2545,12 @@ void MediaPlayerPrivateGStreamer::configureParsebin(GstElement* parsebin)
     g_signal_connect(parsebin, "autoplug-select",
         G_CALLBACK(+[](GstElement*, GstPad*, GstCaps* caps, GstElementFactory* factory, MediaPlayerPrivateGStreamer* player) -> unsigned {
             static auto tryAutoPlug = *gstGetAutoplugSelectResult("try"_s);
+            static auto skipAutoPlug = *gstGetAutoplugSelectResult("skip"_s);
             static auto exposeAutoPlug = *gstGetAutoplugSelectResult("expose"_s);
+
+            auto name = StringView::fromLatin1(gst_plugin_feature_get_name(GST_PLUGIN_FEATURE_CAST(factory)));
+            if (name == "webkitthunderparser"_s && player->m_url.protocolIsBlob())
+                return skipAutoPlug;
 
             auto* structure = gst_caps_get_structure(caps, 0);
             if (!structure)
@@ -2572,6 +2580,24 @@ void MediaPlayerPrivateGStreamer::configureParsebin(GstElement* parsebin)
         }), this);
 }
 
+void MediaPlayerPrivateGStreamer::configureUriDecodebin2(GstElement* element)
+{
+    ASSERT(m_isLegacyPlaybin);
+#if ENABLE(ENCRYPTED_MEDIA) && ENABLE(THUNDER)
+    if (CDMFactoryThunder::singleton().supportedKeySystems().isEmpty())
+        return;
+
+    g_signal_connect(element, "autoplug-select", G_CALLBACK(+[](GstElement*, GstPad*, GstCaps*, GstElementFactory* factory, gpointer) -> unsigned {
+        static auto tryAutoPlug = *gstGetAutoplugSelectResult("try"_s);
+        static auto skipAutoPlug = *gstGetAutoplugSelectResult("skip"_s);
+        auto name = StringView::fromLatin1(gst_plugin_feature_get_name(GST_PLUGIN_FEATURE_CAST(factory)));
+        if (name == "webkitthunderparser"_s)
+            return skipAutoPlug;
+        return tryAutoPlug;
+    }), nullptr);
+#endif
+}
+
 void MediaPlayerPrivateGStreamer::configureElement(GstElement* element)
 {
     configureElementPlatformQuirks(element);
@@ -2591,6 +2617,11 @@ void MediaPlayerPrivateGStreamer::configureElement(GstElement* element)
 
     if (nameView.startsWith("parsebin"_s))
         configureParsebin(element);
+
+    // The legacy decodebin2 stack doesn't integrate well with parsebin, so prevent auto-plugging of
+    // the webkitthunderparser.
+    if (nameView.startsWith("uridecodebin"_s) && m_isLegacyPlaybin)
+        configureUriDecodebin2(element);
 
     // In case of playbin3 with <video ... preload="auto">, instantiate downloadbuffer element,
     // otherwise the playbin3 would instantiate a queue element instead. When playing blob URIs,

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
@@ -536,6 +536,7 @@ private:
     void configureVideoDecoder(GstElement*);
     void configureElement(GstElement*);
     void configureParsebin(GstElement*);
+    void configureUriDecodebin2(GstElement*);
 
     void configureElementPlatformQuirks(GstElement*);
 

--- a/Source/WebCore/platform/graphics/gstreamer/eme/GStreamerEMEUtilities.h
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/GStreamerEMEUtilities.h
@@ -98,6 +98,10 @@ public:
     static constexpr auto s_unspecifiedUUID = GST_PROTECTION_UNSPECIFIED_SYSTEM_ID ""_s;
     static constexpr auto s_unspecifiedKeySystem = GST_PROTECTION_UNSPECIFIED_SYSTEM_ID ""_s;
 
+    static constexpr std::array<ASCIILiteral, 11> s_cencEncryptionMediaTypes = { "video/mp4"_s, "audio/mp4"_s, "video/x-h264"_s, "video/x-h265"_s, "audio/mpeg"_s,
+        "audio/x-eac3"_s, "audio/x-ac3"_s, "audio/x-flac"_s, "audio/x-opus"_s, "video/x-vp9"_s, "video/x-av1"_s };
+    static constexpr std::array<ASCIILiteral, 7> s_webmEncryptionMediaTypes = { "video/webm"_s, "audio/webm"_s, "video/x-vp9"_s, "video/x-av1"_s, "audio/x-opus"_s, "audio/x-vorbis"_s, "video/x-vp8"_s };
+
     static bool isClearKeyKeySystem(const String& keySystem)
     {
         return equalIgnoringASCIICase(keySystem, s_ClearKeyKeySystem);
@@ -175,6 +179,6 @@ public:
     }
 };
 
-}
+} // namespace WebCore
 
 #endif // ENABLE(ENCRYPTED_MEDIA) && USE(GSTREAMER)

--- a/Source/WebCore/platform/graphics/gstreamer/eme/WebKitThunderParser.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/WebKitThunderParser.cpp
@@ -1,0 +1,171 @@
+/* GStreamer Thunder Parser
+ *
+ * Copyright (C) 2025 Comcast Inc.
+ * Copyright (C) 2025 Igalia S.L.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "config.h"
+#include "WebKitThunderParser.h"
+
+#if ENABLE(ENCRYPTED_MEDIA) && ENABLE(THUNDER) && USE(GSTREAMER)
+
+#include "CDMProxyThunder.h"
+#include "GStreamerCommon.h"
+#include "GStreamerEMEUtilities.h"
+#include <wtf/glib/WTFGType.h>
+#include <wtf/text/StringView.h>
+
+GST_DEBUG_CATEGORY(webkitMediaThunderParserDebugCategory);
+#define GST_CAT_DEFAULT webkitMediaThunderParserDebugCategory
+
+typedef struct _WebKitMediaThunderParserPrivate {
+    GRefPtr<GstElement> decryptor;
+    GRefPtr<GstElement> parser;
+} WebKitMediaThunderParserPrivate;
+
+typedef struct _WebKitMediaThunderParser {
+    GstBin parent;
+    WebKitMediaThunderParserPrivate* priv;
+} WebKitMediaThunderParser;
+
+typedef struct _WebKitMediaThunderParserClass {
+    GstBinClass parentClass;
+} WebKitMediaThunderParserClass;
+
+using namespace WebCore;
+
+WEBKIT_DEFINE_TYPE(WebKitMediaThunderParser, webkit_media_thunder_parser, GST_TYPE_BIN)
+
+static GstStaticPadTemplate thunderParseSrcTemplate = GST_STATIC_PAD_TEMPLATE("src_%u",
+    GST_PAD_SRC,
+    GST_PAD_SOMETIMES,
+    GST_STATIC_CAPS(
+        "video/webm; "
+        "audio/webm; "
+        "video/mp4; "
+        "audio/mp4; "
+        "audio/mpeg; "
+        "audio/x-flac; "
+        "audio/x-eac3; "
+        "audio/x-ac3; "
+        "video/x-h264; "
+        "video/x-h265; "
+        "video/x-vp9; video/x-vp8; "
+        "video/x-av1; "
+        "audio/x-opus; audio/x-vorbis"));
+
+static GRefPtr<GstCaps> createThunderParseSinkPadTemplateCaps()
+{
+    GRefPtr<GstCaps> caps = adoptGRef(gst_caps_new_empty());
+
+    auto& supportedKeySystems = CDMFactoryThunder::singleton().supportedKeySystems();
+
+    if (supportedKeySystems.isEmpty()) {
+        GST_WARNING("no supported key systems in Thunder, we won't be able to decrypt anything with the decryptor");
+        return caps;
+    }
+
+    for (const auto& mediaType : GStreamerEMEUtilities::s_cencEncryptionMediaTypes) {
+        gst_caps_append_structure(caps.get(), gst_structure_new_empty(mediaType.characters()));
+        gst_caps_append_structure(caps.get(), gst_structure_new("application/x-cenc", "original-media-type", G_TYPE_STRING, mediaType.characters(), nullptr));
+    }
+    for (const auto& keySystem : supportedKeySystems) {
+        for (const auto& mediaType : GStreamerEMEUtilities::s_cencEncryptionMediaTypes) {
+            gst_caps_append_structure(caps.get(), gst_structure_new("application/x-cenc", "original-media-type", G_TYPE_STRING,
+                mediaType.characters(), "protection-system", G_TYPE_STRING, GStreamerEMEUtilities::keySystemToUuid(keySystem), nullptr));
+        }
+    }
+
+    if (supportedKeySystems.contains(GStreamerEMEUtilities::s_WidevineKeySystem) || supportedKeySystems.contains(GStreamerEMEUtilities::s_ClearKeyKeySystem)) {
+        for (const auto& mediaType : GStreamerEMEUtilities::s_webmEncryptionMediaTypes) {
+            gst_caps_append_structure(caps.get(), gst_structure_new_empty(mediaType.characters()));
+            gst_caps_append_structure(caps.get(), gst_structure_new("application/x-webm-enc", "original-media-type", G_TYPE_STRING, mediaType.characters(), nullptr));
+        }
+    }
+
+    return caps;
+}
+
+static void webkitMediaThunderParserConstructed(GObject* object)
+{
+    G_OBJECT_CLASS(webkit_media_thunder_parser_parent_class)->constructed(object);
+
+    auto self = WEBKIT_MEDIA_THUNDER_PARSER(object);
+
+    self->priv->decryptor = gst_element_factory_make("webkitthunder", nullptr);
+    self->priv->parser = makeGStreamerElement("parsebin"_s, "inner-parser"_s);
+
+    gst_bin_add_many(GST_BIN_CAST(self), self->priv->decryptor.get(), self->priv->parser.get(), nullptr);
+    gst_element_link(self->priv->decryptor.get(), self->priv->parser.get());
+
+    g_signal_connect(self->priv->parser.get(), "autoplug-factories", G_CALLBACK(+[](GstElement*, GstPad*, GstCaps* caps, gpointer) -> GValueArray* {
+        ALLOW_DEPRECATED_DECLARATIONS_BEGIN;
+        GValueArray* result;
+
+        auto factories = gst_element_factory_list_get_elements(GST_ELEMENT_FACTORY_TYPE_DECODABLE, GST_RANK_MARGINAL);
+        auto list = gst_element_factory_list_filter(factories, caps, GST_PAD_SINK, gst_caps_is_fixed(caps));
+        result = g_value_array_new(g_list_length(list));
+        for (GList* tmp = list; tmp; tmp = tmp->next) {
+            auto factory = GST_ELEMENT_FACTORY_CAST(tmp->data);
+            auto name = StringView::fromLatin1(gst_plugin_feature_get_name(GST_PLUGIN_FEATURE_CAST(factory)));
+            if (name == "webkitthunderparser"_s)
+                continue;
+
+            GValue value = G_VALUE_INIT;
+            g_value_init(&value, G_TYPE_OBJECT);
+            g_value_set_object(&value, factory);
+            g_value_array_append(result, &value);
+            g_value_unset(&value);
+        }
+        gst_plugin_feature_list_free(list);
+        gst_plugin_feature_list_free(factories);
+        return result;
+        ALLOW_DEPRECATED_DECLARATIONS_END;
+    }), self);
+
+    g_signal_connect(self->priv->parser.get(), "pad-added", G_CALLBACK(+[](GstElement*, GstPad* pad, gpointer userData) {
+        static unsigned counter = 0;
+        auto name = makeString("src_"_s, counter);
+        counter++;
+        gst_element_add_pad(GST_ELEMENT_CAST(userData), gst_ghost_pad_new(name.ascii().data(), pad));
+    }), self);
+
+    auto decryptorSinkPad = adoptGRef(gst_element_get_static_pad(self->priv->decryptor.get(), "sink"));
+    gst_element_add_pad(GST_ELEMENT_CAST(self), gst_ghost_pad_new("sink", decryptorSinkPad.get()));
+    gst_bin_sync_children_states(GST_BIN_CAST(self));
+}
+
+static void webkit_media_thunder_parser_class_init(WebKitMediaThunderParserClass* klass)
+{
+    GST_DEBUG_CATEGORY_INIT(webkitMediaThunderParserDebugCategory, "webkitthunderparser", 0, "Thunder parser");
+
+    auto objectClass = G_OBJECT_CLASS(klass);
+    objectClass->constructed = webkitMediaThunderParserConstructed;
+
+    auto elementClass = GST_ELEMENT_CLASS(klass);
+    auto padTemplateCaps = createThunderParseSinkPadTemplateCaps();
+    gst_element_class_add_pad_template(elementClass, gst_pad_template_new("sink", GST_PAD_SINK, GST_PAD_ALWAYS, padTemplateCaps.get()));
+    gst_element_class_add_pad_template(elementClass, gst_static_pad_template_get(&thunderParseSrcTemplate));
+
+    gst_element_class_set_static_metadata(elementClass, "Parse potentially encrypted content", "Codec/Parser/Audio/Video",
+        "Parse potentially encrypted content", "Philippe Normand <philn@igalia.com>");
+}
+
+#undef GST_CAT_DEFAULT
+
+#endif // ENABLE(ENCRYPTED_MEDIA) && ENABLE(THUNDER) && USE(GSTREAMER)

--- a/Source/WebCore/platform/graphics/gstreamer/eme/WebKitThunderParser.h
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/WebKitThunderParser.h
@@ -1,0 +1,37 @@
+/* GStreamer Thunder Parser
+ *
+ * Copyright (C) 2025 Comcast Inc.
+ * Copyright (C) 2025 Igalia S.L.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#pragma once
+
+#if ENABLE(ENCRYPTED_MEDIA) && ENABLE(THUNDER) && USE(GSTREAMER)
+
+#include <glib-object.h>
+
+G_BEGIN_DECLS
+
+#define WEBKIT_TYPE_MEDIA_THUNDER_PARSER          (webkit_media_thunder_parser_get_type())
+#define WEBKIT_MEDIA_THUNDER_PARSER(obj)          (G_TYPE_CHECK_INSTANCE_CAST((obj), WEBKIT_TYPE_MEDIA_THUNDER_PARSER, WebKitMediaThunderParser))
+
+GType webkit_media_thunder_parser_get_type(void);
+
+G_END_DECLS
+
+#endif // ENABLE(ENCRYPTED_MEDIA) && ENABLE(THUNDER) && USE(GSTREAMER)

--- a/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
@@ -41,6 +41,7 @@
 #include <gst/pbutils/pbutils.h>
 #include <gst/video/video.h>
 #include <wtf/Condition.h>
+#include <wtf/Scope.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/glib/RunLoopSourcePriority.h>
 #include <wtf/text/ASCIILiteral.h>
@@ -346,8 +347,43 @@ GstPadProbeReturn AppendPipeline::appsrcEndOfAppendCheckerProbe(GstPadProbeInfo*
 
 void AppendPipeline::handleNeedContextSyncMessage(GstMessage* message)
 {
-    // MediaPlayerPrivateGStreamerBase will take care of setting up encryption.
-    m_playerPrivate->handleNeedContextMessage(message);
+    auto scopeExit = makeScopeExit([&] {
+        // MediaPlayerPrivateGStreamerBase will take care of setting up encryption.
+        m_playerPrivate->handleNeedContextMessage(message);
+    });
+
+    if (!m_demux->numsrcpads)
+        return;
+
+    auto pad = GST_PAD_CAST(m_demux->srcpads->data);
+    auto peer = adoptGRef(gst_pad_get_peer(pad));
+    if (!peer)
+        return;
+
+    auto caps = adoptGRef(gst_pad_get_current_caps(peer.get()));
+    if (!caps) [[unlikely]]
+        return;
+
+    if (gst_caps_is_any(caps.get()) || gst_caps_is_empty(caps.get())) [[unlikely]]
+        return;
+
+    if (areEncryptedCaps(caps.get()))
+        return;
+
+    auto parser = adoptGRef(gst_pad_get_parent_element(peer.get()));
+    if (!parser) [[unlikely]]
+        return;
+
+    auto srcPad = adoptGRef(gst_element_get_static_pad(parser.get(), "src"));
+    auto parserPeerPad = adoptGRef(gst_pad_get_peer(srcPad.get()));
+    if (!parserPeerPad) [[unlikely]]
+        return;
+
+    gstElementLockAndSetState(parser.get(), GST_STATE_NULL);
+    gst_pad_unlink(pad, peer.get());
+    gst_pad_unlink(srcPad.get(), parserPeerPad.get());
+    gst_bin_remove(GST_BIN_CAST(m_pipeline.get()), parser.get());
+    gst_pad_link(pad, parserPeerPad.get());
 }
 
 std::tuple<GRefPtr<GstCaps>, StreamType, FloatSize> AppendPipeline::parseDemuxerSrcPadCaps(GstCaps* demuxerSrcPadCaps)

--- a/Tools/Scripts/webkitpy/style/checker.py
+++ b/Tools/Scripts/webkitpy/style/checker.py
@@ -305,6 +305,8 @@ _PATH_RULES_SPECIFIER = [
       os.path.join('Source', 'WebCore', 'platform', 'graphics', 'gstreamer', 'WebKitWebSourceGStreamer.cpp'),
       os.path.join('Source', 'WebCore', 'platform', 'graphics', 'gstreamer', 'WebKitAudioSinkGStreamer.cpp'),
       os.path.join('Source', 'WebCore', 'platform', 'graphics', 'gstreamer', 'WebKitAudioSinkGStreamer.h'),
+      os.path.join('Source', 'WebCore', 'platform', 'graphics', 'gstreamer', 'eme', 'WebKitThunderParser.cpp'),
+      os.path.join('Source', 'WebCore', 'platform', 'graphics', 'gstreamer', 'eme', 'WebKitThunderParser.h'),
       os.path.join('Source', 'WebCore', 'platform', 'graphics', 'gstreamer', 'mse', 'WebKitMediaSourceGStreamer.cpp'),
       os.path.join('Source', 'WebCore', 'platform', 'audio', 'gstreamer', 'WebKitWebAudioSourceGStreamer.cpp'),
       os.path.join('Source', 'WebCore', 'platform', 'gstreamer', 'VideoEncoderPrivateGStreamer.cpp'),


### PR DESCRIPTION
#### 35dba6c294cd55aaf82e1037f5f69b55808a91dc
<pre>
[GStreamer][EME] imported/w3c/web-platform-tests/encrypted-media/clearkey-mp4-playback-temporary-clear-encrypted-segmented.https.html is failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=211375">https://bugs.webkit.org/show_bug.cgi?id=211375</a>

Reviewed by Xabier Rodriguez-Calvar.

Wrap the decryptor in a new bin along with parsebin. This should allow seamless switching between
encrypted and clear content processing. As this new parser is auto-plugged by parsebin in
urisourcebin we have to be cautious regarding the infinite auto-plugging outcome by removing our new
parser from the autoplug-factories passed to the inner parsebin element.

Canonical link: <a href="https://commits.webkit.org/295500@main">https://commits.webkit.org/295500@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d5f665ccbf252c476c6095cefab383cd97fa3b46

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105263 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24975 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15400 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110474 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/55919 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/107304 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/25407 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33518 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79953 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108269 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19812 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95009 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60259 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/104741 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/19567 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13083 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55317 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/89266 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13128 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/113078 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32421 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/23886 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89026 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32785 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91225 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88664 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; run-api-tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22611 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33559 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11347 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/27845 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32345 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/37757 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32123 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35468 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33692 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->