### PR TITLE
[SVG2] Add `fetchPriority` property support for `SVGImageElement`, `SVGFEImageElement` and `SVGScriptElement`

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/embedded/attr-image-fetchpriority-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/embedded/attr-image-fetchpriority-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL fetchpriority attribute on <image> elements should reflect valid IDL values assert_equals: high fetchPriority is a valid IDL value on the image element expected (string) "high" but got (undefined) undefined
-FAIL default fetchpriority attribute on <image> elements should be 'auto' assert_equals: expected (string) "auto" but got (undefined) undefined
+PASS fetchpriority attribute on <image> elements should reflect valid IDL values
+PASS default fetchpriority attribute on <image> elements should be 'auto'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/scripted/attr-script-fetchpriority-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/scripted/attr-script-fetchpriority-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL fetchpriority attribute on SVG <script> elements should reflect valid IDL values assert_equals: high fetchPriority is a valid IDL value on the script element expected (string) "high" but got (undefined) undefined
-FAIL default fetchpriority attribute on SVG <script> elements should be 'auto' assert_equals: expected (string) "auto" but got (undefined) undefined
+PASS fetchpriority attribute on SVG <script> elements should reflect valid IDL values
+PASS default fetchpriority attribute on SVG <script> elements should be 'auto'
 

--- a/Source/WebCore/svg/SVGFEImageElement.cpp
+++ b/Source/WebCore/svg/SVGFEImageElement.cpp
@@ -2,7 +2,7 @@
  * Copyright (C) 2004, 2005, 2007 Nikolas Zimmermann <zimmermann@kde.org>
  * Copyright (C) 2004, 2005 Rob Buis <buis@kde.org>
  * Copyright (C) 2010 Dirk Schulze <krit@webkit.org>
- * Copyright (C) 2018-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2018-2025 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -30,10 +30,12 @@
 #include "Document.h"
 #include "FEImage.h"
 #include "Image.h"
+#include "JSRequestPriority.h"
 #include "LegacyRenderSVGResource.h"
 #include "NativeImage.h"
 #include "NodeInlines.h"
 #include "RenderObject.h"
+#include "RequestPriority.h"
 #include "SVGElementInlines.h"
 #include "SVGNames.h"
 #include "SVGPreserveAspectRatioValue.h"
@@ -244,6 +246,16 @@ void SVGFEImageElement::addSubresourceAttributeURLs(ListHashSet<URL>& urls) cons
     SVGFilterPrimitiveStandardAttributes::addSubresourceAttributeURLs(urls);
 
     addSubresourceURL(urls, document().completeURL(href()));
+}
+
+String SVGFEImageElement::fetchPriorityForBindings() const
+{
+    return convertEnumerationToString(fetchPriority());
+}
+
+RequestPriority SVGFEImageElement::fetchPriority() const
+{
+    return parseEnumerationFromString<RequestPriority>(attributeWithoutSynchronization(SVGNames::fetchpriorityAttr)).value_or(RequestPriority::Auto);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/svg/SVGFEImageElement.h
+++ b/Source/WebCore/svg/SVGFEImageElement.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2004, 2005, 2007 Nikolas Zimmermann <zimmermann@kde.org>
  * Copyright (C) 2004, 2005 Rob Buis <buis@kde.org>
- * Copyright (C) 2018-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2018-2025 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -29,6 +29,8 @@
 
 namespace WebCore {
 
+enum class RequestPriority : uint8_t;
+
 class SVGFEImageElement final : public SVGFilterPrimitiveStandardAttributes, public SVGURIReference, private CachedImageClient {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(SVGFEImageElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGFEImageElement);
@@ -47,6 +49,9 @@ public:
 
     const SVGPreserveAspectRatioValue& preserveAspectRatio() const { return m_preserveAspectRatio->currentValue(); }
     SVGAnimatedPreserveAspectRatio& preserveAspectRatioAnimated() { return m_preserveAspectRatio; }
+
+    String fetchPriorityForBindings() const;
+    RequestPriority fetchPriority() const;
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGFEImageElement, SVGFilterPrimitiveStandardAttributes, SVGURIReference>;
 

--- a/Source/WebCore/svg/SVGFEImageElement.idl
+++ b/Source/WebCore/svg/SVGFEImageElement.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006 Apple Inc. All rights reserved.
+ * Copyright (C) 2006-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -27,6 +27,7 @@
     Exposed=Window
 ] interface SVGFEImageElement : SVGElement {
     readonly attribute SVGAnimatedPreserveAspectRatio preserveAspectRatio;
+    [ImplementedAs=fetchPriorityForBindings, ReflectSetter] attribute [AtomString] DOMString fetchPriority;
 };
 
 SVGFEImageElement includes SVGFilterPrimitiveStandardAttributes;

--- a/Source/WebCore/svg/SVGImageElement.cpp
+++ b/Source/WebCore/svg/SVGImageElement.cpp
@@ -3,7 +3,7 @@
  * Copyright (C) 2004, 2005, 2006, 2007, 2008, 2009 Rob Buis <buis@kde.org>
  * Copyright (C) 2006 Alexander Kellett <lypanov@kde.org>
  * Copyright (C) 2014 Adobe Systems Incorporated. All rights reserved.
- * Copyright (C) 2018-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2018-2025 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -27,12 +27,14 @@
 #include "CSSPropertyNames.h"
 #include "ContainerNodeInlines.h"
 #include "HTMLParserIdioms.h"
+#include "JSRequestPriority.h"
 #include "LegacyRenderSVGImage.h"
 #include "LegacyRenderSVGResource.h"
 #include "NodeInlines.h"
 #include "NodeName.h"
 #include "RenderImageResource.h"
 #include "RenderSVGImage.h"
+#include "RequestPriority.h"
 #include "SVGElementInlines.h"
 #include "SVGNames.h"
 #include "SVGParsingError.h"
@@ -225,6 +227,16 @@ void SVGImageElement::didMoveToNewDocument(Document& oldDocument, Document& newD
 void SVGImageElement::decode(Ref<DeferredPromise>&& promise)
 {
     return m_imageLoader.decode(WTFMove(promise));
+}
+
+String SVGImageElement::fetchPriorityForBindings() const
+{
+    return convertEnumerationToString(fetchPriority());
+}
+
+RequestPriority SVGImageElement::fetchPriority() const
+{
+    return parseEnumerationFromString<RequestPriority>(attributeWithoutSynchronization(SVGNames::fetchpriorityAttr)).value_or(RequestPriority::Auto);
 }
 
 }

--- a/Source/WebCore/svg/SVGImageElement.h
+++ b/Source/WebCore/svg/SVGImageElement.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2004, 2005, 2006, 2008 Nikolas Zimmermann <zimmermann@kde.org>
  * Copyright (C) 2004, 2005, 2006 Rob Buis <buis@kde.org>
- * Copyright (C) 2018-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2018-2025 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -27,6 +27,8 @@
 #include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
+
+enum class RequestPriority : uint8_t;
 
 class SVGImageElement final : public SVGGraphicsElement, public SVGURIReference {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(SVGImageElement);
@@ -54,6 +56,9 @@ public:
     SVGAnimatedPreserveAspectRatio& preserveAspectRatioAnimated() { return m_preserveAspectRatio; }
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGImageElement, SVGGraphicsElement, SVGURIReference>;
+
+    String fetchPriorityForBindings() const;
+    RequestPriority fetchPriority() const;
 
     void decode(Ref<DeferredPromise>&&);
 

--- a/Source/WebCore/svg/SVGImageElement.idl
+++ b/Source/WebCore/svg/SVGImageElement.idl
@@ -23,6 +23,8 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
  */
 
+// https://svgwg.org/svg2-draft/embedded.html#InterfaceSVGImageElement
+
 [
     Exposed=Window,
     JSGenerateToNativeObject
@@ -33,6 +35,7 @@
     readonly attribute SVGAnimatedLength height;
     readonly attribute SVGAnimatedPreserveAspectRatio preserveAspectRatio;
     [CEReactions=NotNeeded] attribute [AtomString] DOMString? crossOrigin;
+    [ImplementedAs=fetchPriorityForBindings, ReflectSetter] attribute [AtomString] DOMString fetchPriority;
 
     Promise<undefined> decode();
 };

--- a/Source/WebCore/svg/SVGScriptElement.cpp
+++ b/Source/WebCore/svg/SVGScriptElement.cpp
@@ -25,7 +25,9 @@
 #include "Document.h"
 #include "DocumentInlines.h"
 #include "Event.h"
+#include "JSRequestPriority.h"
 #include "NodeInlines.h"
+#include "RequestPriority.h"
 #include "ScriptElement.h"
 #include <wtf/TZoneMallocInlines.h>
 
@@ -117,6 +119,16 @@ void SVGScriptElement::dispatchErrorEvent()
 {
     setErrorOccurred(true);
     ScriptElement::dispatchErrorEvent();
+}
+
+String SVGScriptElement::fetchPriorityForBindings() const
+{
+    return convertEnumerationToString(fetchPriority());
+}
+
+RequestPriority SVGScriptElement::fetchPriority() const
+{
+    return parseEnumerationFromString<RequestPriority>(attributeWithoutSynchronization(SVGNames::fetchpriorityAttr)).value_or(RequestPriority::Auto);
 }
 
 }

--- a/Source/WebCore/svg/SVGScriptElement.h
+++ b/Source/WebCore/svg/SVGScriptElement.h
@@ -29,6 +29,8 @@
 
 namespace WebCore {
 
+enum class RequestPriority : uint8_t;
+
 class SVGScriptElement final : public SVGElement, public SVGURIReference, public ScriptElement {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(SVGScriptElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGScriptElement);
@@ -38,6 +40,9 @@ public:
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGScriptElement, SVGElement, SVGURIReference>;
     using SVGElement::ref;
     using SVGElement::deref;
+
+    String fetchPriorityForBindings() const;
+    RequestPriority fetchPriority() const final;
 
     bool async() const;
 

--- a/Source/WebCore/svg/SVGScriptElement.idl
+++ b/Source/WebCore/svg/SVGScriptElement.idl
@@ -30,6 +30,7 @@
 ] interface SVGScriptElement : SVGElement {
     [Reflect] attribute DOMString type;
     [ReflectSetter] attribute boolean async;
+    [ImplementedAs=fetchPriorityForBindings, ReflectSetter] attribute [AtomString] DOMString fetchPriority;
 };
 
 SVGScriptElement includes SVGURIReference;

--- a/Source/WebCore/svg/svgattrs.in
+++ b/Source/WebCore/svg/svgattrs.in
@@ -47,6 +47,7 @@ edgeMode
 elevation
 end
 exponent
+fetchpriority
 fill
 fill-opacity
 fill-rule


### PR DESCRIPTION
#### f1e771f6cb988f0e92c9aaff580c4fc9a00416c8
<pre>
[SVG2] Add `fetchPriority` property support for `SVGImageElement`, `SVGFEImageElement` and `SVGScriptElement`
<a href="https://bugs.webkit.org/show_bug.cgi?id=293585">https://bugs.webkit.org/show_bug.cgi?id=293585</a>
<a href="https://rdar.apple.com/152044271">rdar://152044271</a>

Reviewed by NOBODY (OOPS!).

This patch aligns WebKit with Gecko / Firefox.

This patch aims to add `fetchPriority` to to following interfaces:

- SVGImageElement
- SVGFEImageElement
- SVGScriptElement

Basically, we are extending `fetchPriority` from HTML counter-part to
SVG.

* Source/WebCore/svg/SVGFEImageElement.cpp:
(WebCore::SVGFEImageElement::fetchPriorityForBindings const):
(WebCore::SVGFEImageElement::fetchPriority const):
* Source/WebCore/svg/SVGFEImageElement.h:
* Source/WebCore/svg/SVGFEImageElement.idl:
* Source/WebCore/svg/SVGImageElement.cpp:
(WebCore::SVGImageElement::fetchPriorityForBindings const):
(WebCore::SVGImageElement::fetchPriority const):
* Source/WebCore/svg/SVGImageElement.h:
* Source/WebCore/svg/SVGImageElement.idl:
* Source/WebCore/svg/SVGScriptElement.cpp:
(WebCore::SVGScriptElement::fetchPriorityForBindings const):
(WebCore::SVGScriptElement::fetchPriority const):
* Source/WebCore/svg/SVGScriptElement.h:
* Source/WebCore/svg/SVGScriptElement.idl:
* Source/WebCore/svg/svgattrs.in:
* LayoutTests/imported/w3c/web-platform-tests/svg/embedded/attr-image-fetchpriority-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/svg/scripted/attr-script-fetchpriority-expected.txt:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f1e771f6cb988f0e92c9aaff580c4fc9a00416c8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/120688 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40382 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31034 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/127081 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/72763 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3316b713-41c2-422c-b4bd-776b1f672558) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/122564 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41079 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/48959 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91670 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/60922 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/99fa357c-a723-4d55-95bc-09b940bacf2a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/123640 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32807 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108186 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72220 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/641af175-1ab1-42d2-ab14-8d977d3eab0b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31836 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26293 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/70686 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102295 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26475 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/129949 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/47609 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36151 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100292 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/47977 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104368 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100131 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45579 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23609 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/44269 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47471 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/53176 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/46940 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50286 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/48626 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->