### PR TITLE
[WebCodec] Support odd-size I420/NV12 video frames

### DIFF
--- a/LayoutTests/http/wpt/mediastream/getUserMedia-odd-size-expected.txt
+++ b/LayoutTests/http/wpt/mediastream/getUserMedia-odd-size-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS Test camera video frame with odd size
+

--- a/LayoutTests/http/wpt/mediastream/getUserMedia-odd-size.html
+++ b/LayoutTests/http/wpt/mediastream/getUserMedia-odd-size.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<head>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<video id=video autoplay playsinline muted></video>
+<script>
+async function validateNV12Frame(test, frame, testName)
+{
+    if (frame.format != 'NV12')
+        return;
+
+    const widthU = Math.ceil(frame.codedWidth / 2);
+    const heightU = Math.ceil(frame.codedHeight / 2);
+
+    assert_equals(frame.allocationSize(), frame.codedWidth * frame.codedHeight + 2 * (widthU * heightU), testName + " allocation size");
+
+    const buffer = new Uint8Array(frame.allocationSize());
+    const layout = await frame.copyTo(buffer);
+
+    assert_equals(layout.length, 2, testName + " layout length");
+
+    assert_equals(layout[0].offset, 0, testName + " layout offset 0");
+    assert_equals(layout[0].stride, frame.codedWidth, testName + " laout stride 0");
+
+    assert_equals(layout[1].offset, frame.codedWidth * frame.codedHeight, testName + " layout offset 1");
+    assert_equals(layout[1].stride, widthU * 2, testName + " laout stride 1");
+}
+
+promise_test(async (t) => {
+    const stream = await navigator.mediaDevices.getUserMedia({ video: { width:99, height: 97 } });
+    const track = stream.getVideoTracks()[0];
+    t.add_cleanup(() => track.stop());
+
+    video.srcObject = stream;
+    await video.play();
+
+    const frame1 = new VideoFrame(video);
+    t.add_cleanup(() => frame1.close());
+
+    assert_equals(frame1.codedWidth, 99);
+    assert_equals(frame1.codedHeight, 97);
+    await validateNV12Frame(t, frame1, "frame1");
+
+    track.applyConstraints({ width: 99, height: 96 });
+
+    while (video.videoHeight != 96)
+       await new Promise(resolve => setTimeout(resolve, 50));
+
+    const frame2 = new VideoFrame(video);
+    t.add_cleanup(() => frame2.close());
+
+    assert_equals(frame2.codedWidth, 99);
+    assert_equals(frame2.codedHeight, 96);
+    await validateNV12Frame(t, frame2, "frame2");
+
+    track.applyConstraints({ width: 98, height: 95 });
+
+    while (video.videoHeight != 95)
+       await new Promise(resolve => setTimeout(resolve, 50));
+
+    const frame3 = new VideoFrame(video);
+    t.add_cleanup(() => frame3.close());
+
+    assert_equals(frame3.codedWidth, 98);
+    assert_equals(frame3.codedHeight, 95);
+    await validateNV12Frame(t, frame3, "frame3");
+
+},'Test camera video frame with odd size');
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/transfering.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/transfering.https.any-expected.txt
@@ -1,6 +1,6 @@
 
 FAIL Test transfering ArrayBuffer to VideoFrame assert_equals: data.length after detach expected 0 but got 16
-FAIL Test transfering buffers to VideoFrame with uneven samples promise_test: Unhandled rejection with value: object "TypeError: layout width bytes is zero"
+FAIL Test transfering buffers to VideoFrame with uneven samples assert_equals: data.length after detach expected 0 but got 3
 PASS Test transfering detached buffer to VideoFrame
 FAIL Test transfering view of an ArrayBuffer to VideoFrame assert_equals: data.length after detach expected 0 but got 16
 PASS Test transfering same array buffer twice

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/transfering.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/transfering.https.any.worker-expected.txt
@@ -1,6 +1,6 @@
 
 FAIL Test transfering ArrayBuffer to VideoFrame assert_equals: data.length after detach expected 0 but got 16
-FAIL Test transfering buffers to VideoFrame with uneven samples promise_test: Unhandled rejection with value: object "TypeError: layout width bytes is zero"
+FAIL Test transfering buffers to VideoFrame with uneven samples assert_equals: data.length after detach expected 0 but got 3
 PASS Test transfering detached buffer to VideoFrame
 FAIL Test transfering view of an ArrayBuffer to VideoFrame assert_equals: data.length after detach expected 0 but got 16
 PASS Test transfering same array buffer twice

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-odd-size.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-odd-size.any-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Test I420 VideoFrame construction with odd coded size coded width or height is odd
-FAIL Test I420 copyTo with odd coded size. promise_test: Unhandled rejection with value: object "TypeError: coded width or height is odd"
+PASS Test I420 VideoFrame construction with odd coded size
+PASS Test I420 copyTo with odd coded size.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-odd-size.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-odd-size.any.worker-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Test I420 VideoFrame construction with odd coded size coded width or height is odd
-FAIL Test I420 copyTo with odd coded size. promise_test: Unhandled rejection with value: object "TypeError: coded width or height is odd"
+PASS Test I420 VideoFrame construction with odd coded size
+PASS Test I420 copyTo with odd coded size.
 

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/videoFrame-odd-size.any-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/videoFrame-odd-size.any-expected.txt
@@ -1,0 +1,4 @@
+
+PASS Test I420 VideoFrame construction with odd coded size
+FAIL Test I420 copyTo with odd coded size. assert_equals: buffer contents at index 11 expected 12 but got 0
+

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/videoFrame-odd-size.any.worker-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/videoFrame-odd-size.any.worker-expected.txt
@@ -1,0 +1,4 @@
+
+PASS Test I420 VideoFrame construction with odd coded size
+FAIL Test I420 copyTo with odd coded size. assert_equals: buffer contents at index 11 expected 12 but got 0
+

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrameAlgorithms.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrameAlgorithms.h
@@ -33,7 +33,6 @@ namespace WebCore {
 
 bool isValidVideoFrameBufferInit(const WebCodecsVideoFrame::BufferInit&);
 bool verifyRectOffsetAlignment(VideoPixelFormat, const DOMRectInit&);
-bool verifyRectSizeAlignment(VideoPixelFormat, const DOMRectInit&);
 ExceptionOr<DOMRectInit> parseVisibleRect(const DOMRectInit&, const std::optional<DOMRectInit>&, size_t codedWidth, size_t codedHeight, VideoPixelFormat);
 size_t videoPixelFormatToPlaneCount(VideoPixelFormat);
 size_t videoPixelFormatToSampleByteSizePerPlane();


### PR DESCRIPTION
#### a5455fe296f31f259f161739ba416fc0b6859733
<pre>
[WebCodec] Support odd-size I420/NV12 video frames
<a href="https://rdar.apple.com/152041418">rdar://152041418</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=293583">https://bugs.webkit.org/show_bug.cgi?id=293583</a>

Reviewed by Jean-Yves Avenard.

We update the implementation according <a href="https://github.com/w3c/webcodecs/pull/666/files">https://github.com/w3c/webcodecs/pull/666/files</a> and Chromium implementation.
We round up both width and height so that UV allocated size is big enough.

We rebase glib test expectation as a short term fix.

* LayoutTests/http/wpt/mediastream/getUserMedia-odd-size-expected.txt: Added.
* LayoutTests/http/wpt/mediastream/getUserMedia-odd-size.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/transfering.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/transfering.https.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-odd-size.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-odd-size.any.worker-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/videoFrame-odd-size.any-expected.txt: Added.
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/videoFrame-odd-size.any.worker-expected.txt: Added.
* Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.cpp:
(WebCore::validateI420Sizes):
(WebCore::WebCodecsVideoFrame::create):
* Source/WebCore/Modules/webcodecs/WebCodecsVideoFrameAlgorithms.cpp:
(WebCore::divideAndRoundUpToNearestInteger):
(WebCore::computeLayoutAndAllocationSize):
(WebCore::parseVideoFrameCopyToOptions):
(WebCore::verifyRectSizeAlignment): Deleted.
* Source/WebCore/Modules/webcodecs/WebCodecsVideoFrameAlgorithms.h:

Canonical link: <a href="https://commits.webkit.org/295492@main">https://commits.webkit.org/295492@main</a>
</pre>
