### PR TITLE
Sync `SecurityPolicyViolationEventInit` interface as per Web Specification

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/securitypolicyviolation/constructor-required-fields-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/securitypolicyviolation/constructor-required-fields-expected.txt
@@ -1,12 +1,12 @@
 
 PASS SecurityPolicyViolationEvent constructor should throw with no parameters
 PASS SecurityPolicyViolationEvent constructor works with an init dict
-FAIL SecurityPolicyViolationEvent constructor does not require documentURI Member SecurityPolicyViolationEventInit.documentURI is required and must be an instance of USVString
-FAIL SecurityPolicyViolationEvent constructor does not require violatedDirective Member SecurityPolicyViolationEventInit.violatedDirective is required and must be an instance of DOMString
-FAIL SecurityPolicyViolationEvent constructor does not require effectiveDirective Member SecurityPolicyViolationEventInit.effectiveDirective is required and must be an instance of DOMString
-FAIL SecurityPolicyViolationEvent constructor does not require originalPolicy Member SecurityPolicyViolationEventInit.originalPolicy is required and must be an instance of DOMString
-FAIL SecurityPolicyViolationEvent constructor does not require disposition Member SecurityPolicyViolationEventInit.disposition is required and must be an instance of SecurityPolicyViolationEventDisposition
-FAIL SecurityPolicyViolationEvent constructor does not require statusCode Member SecurityPolicyViolationEventInit.statusCode is required and must be an instance of unsigned short
+PASS SecurityPolicyViolationEvent constructor does not require documentURI
+PASS SecurityPolicyViolationEvent constructor does not require violatedDirective
+PASS SecurityPolicyViolationEvent constructor does not require effectiveDirective
+PASS SecurityPolicyViolationEvent constructor does not require originalPolicy
+PASS SecurityPolicyViolationEvent constructor does not require disposition
+PASS SecurityPolicyViolationEvent constructor does not require statusCode
 PASS SecurityPolicyViolationEvent constructor does not require referrer
 PASS SecurityPolicyViolationEvent constructor does not require blockedURI
 PASS SecurityPolicyViolationEvent constructor does not require sourceFile

--- a/Source/WebCore/dom/SecurityPolicyViolationEvent.idl
+++ b/Source/WebCore/dom/SecurityPolicyViolationEvent.idl
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2013 Google Inc. All rights reserved.
- * Copyright (C) 2016-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -47,21 +47,19 @@
     readonly attribute unsigned long columnNumber; // historical alias of colno
 };
 
+// https://w3c.github.io/webappsec-csp/#dictdef-securitypolicyviolationeventinit
+
 dictionary SecurityPolicyViolationEventInit : EventInit {
-    // The spec says "USVString documentURL" but it does not match Blink.
-    required USVString documentURI;
+    USVString documentURI = "";
     USVString referrer = "";
-    // The spec says "USVString blockedURL" but it does not match Blink.
     USVString blockedURI = "";
-    required DOMString violatedDirective;
-    required DOMString effectiveDirective;
-    required DOMString originalPolicy;
+    DOMString violatedDirective = "";
+    DOMString effectiveDirective = "";
+    DOMString originalPolicy = "";
     USVString sourceFile = "";
     DOMString sample = "";
-    required SecurityPolicyViolationEventDisposition disposition;
-    required unsigned short statusCode;
-    // The spec says "unsigned long lineno" but it does not match Blink.
+    SecurityPolicyViolationEventDisposition disposition = "enforce";
+    unsigned short statusCode = 0;
     unsigned long lineNumber = 0;
-    // The spec says "unsigned long colno" but it does not match Blink.
     unsigned long columnNumber = 0;
 };


### PR DESCRIPTION
#### 022f97942332f979bfba7cd9849334c933fb3680
<pre>
Sync `SecurityPolicyViolationEventInit` interface as per Web Specification
<a href="https://bugs.webkit.org/show_bug.cgi?id=293586">https://bugs.webkit.org/show_bug.cgi?id=293586</a>

Reviewed by Anne van Kesteren.

This patch aligns WebKit with Web Specification [1]:

[1] <a href="https://w3c.github.io/webappsec-csp/#dictdef-securitypolicyviolationeventinit">https://w3c.github.io/webappsec-csp/#dictdef-securitypolicyviolationeventinit</a>

This patch mainly reomves `required` from respective since it was not needed
as per web specification and additionally, it also removes outdated comments.

* Source/WebCore/dom/SecurityPolicyViolationEvent.idl:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/securitypolicyviolation/constructor-required-fields-expected.txt: Progressions

Canonical link: <a href="https://commits.webkit.org/295425@main">https://commits.webkit.org/295425@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ff5a7aac4491f468482e92bf8a8adce62dd20c59

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105051 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24765 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15188 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110268 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/55732 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/107092 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/25179 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33309 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79778 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108057 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19605 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94817 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60085 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/19364 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/12893 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55108 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/89074 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/12938 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/112780 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32216 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23716 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88858 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32582 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91037 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88488 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22559 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33378 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11167 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/27609 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32140 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/37636 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/31933 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35274 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33492 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->