### PR TITLE
Web Inspector: Prettifying CSS with an asterisk and a `:not` selector changes the CSS behaviour

### DIFF
--- a/LayoutTests/inspector/formatting/resources/css-tests/selectors-expected.css
+++ b/LayoutTests/inspector/formatting/resources/css-tests/selectors-expected.css
@@ -2,6 +2,25 @@
 a {
 }
 
+/* UNIVERSAL SELECTOR, EMPTY CONTENT */
+*:not(.foo) {
+}
+
+div > *:not(.foo) {
+}
+
+* :has(.foo) {
+}
+
+div > * :has(.foo) {
+}
+
+* > :is(.foo) {
+}
+
+div > * > :is(.foo) {
+}
+
 /* COMPLEX SELECTOR */
 div div > div#id.foo.bar:hover .something > .child ~ .sibling + .sibling:after {
     color: red;

--- a/LayoutTests/inspector/formatting/resources/css-tests/selectors.css
+++ b/LayoutTests/inspector/formatting/resources/css-tests/selectors.css
@@ -1,6 +1,14 @@
 /* SHORT SELECTOR, EMPTY CONTENT */
 a{}
 
+/* UNIVERSAL SELECTOR, EMPTY CONTENT */
+*:not(.foo){}
+div>*:not(.foo){}
+* :has(.foo){}
+div>* :has(.foo){}
+*>:is(.foo){}
+div>*>:is(.foo){}
+
 /* COMPLEX SELECTOR */
 div div>div#id.foo.bar:hover .something>.child~.sibling+.sibling:after{color:red;}
 div   div   >   div#id.foo.bar:hover   .something   >   .child   ~   .sibling   +   .sibling:after   {   color   :   red   ;   }

--- a/Source/WebInspectorUI/UserInterface/Workers/Formatter/CSSFormatter.js
+++ b/Source/WebInspectorUI/UserInterface/Workers/Formatter/CSSFormatter.js
@@ -211,6 +211,11 @@ CSSFormatter = class CSSFormatter
                                 return false;
                         }
                     }
+                    if (current === `*`) {
+                        if (inSelector() && this._sourceText[index + 1] === `:`) {
+                            return false;
+                        }
+                    }
                     return true;
                 };
                 if (shouldAddSpaceAfter())


### PR DESCRIPTION
#### 4f52c5eb318382ac79e290fc8894d90b4f1cbf59
<pre>
Web Inspector: Prettifying CSS with an asterisk and a `:not` selector changes the CSS behaviour
<a href="https://bugs.webkit.org/show_bug.cgi?id=283428">https://bugs.webkit.org/show_bug.cgi?id=283428</a>
<a href="https://rdar.apple.com/71544976">rdar://71544976</a>

Reviewed by Devin Rousso.

Ensure CSS pretty-printing does not add a space after the universal selector (*)
if it&apos;s followed by what could be a pseudo-class or pseudo-element
because that would change the intent of the selector.

* LayoutTests/inspector/formatting/resources/css-tests/selectors-expected.css:
(*:not(.foo)):
(div &gt; *:not(.foo)):
(* :has(.foo)):
(div &gt; * :has(.foo)):
(* &gt; :is(.foo)):
(div &gt; * &gt; :is(.foo)):
* LayoutTests/inspector/formatting/resources/css-tests/selectors.css:
(*:not(.foo)):
(div&gt;*:not(.foo)):
(* :has(.foo)):
(div&gt;* :has(.foo)):
(*&gt;:is(.foo)):
(div&gt;*&gt;:is(.foo)):
* Source/WebInspectorUI/UserInterface/Workers/Formatter/CSSFormatter.js:

Canonical link: <a href="https://commits.webkit.org/295447@main">https://commits.webkit.org/295447@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7af156577d18efa061c5eb9b9a66eb25c4c2601b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105054 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24768 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15191 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110271 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/55735 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/25201 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33312 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79781 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108060 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19626 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94820 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60088 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/19384 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/12896 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55111 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/89094 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/12941 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/112787 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32219 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23720 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88862 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32585 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91040 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88492 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22577 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33379 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11170 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/27612 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32143 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/37517 "Failed to build and analyze WebKit") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/31936 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35277 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33495 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->