### PR TITLE
Reduce unsafeness in InputType classes

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -279,9 +279,6 @@ history/BackForwardCache.cpp
 history/CachedFrame.cpp
 html/AttachmentAssociatedElement.cpp
 html/BaseButtonInputType.cpp
-html/BaseCheckableInputType.cpp
-html/BaseClickableWithKeyInputType.cpp
-html/BaseTextInputType.cpp
 html/CachedHTMLCollection.h
 html/CachedHTMLCollectionInlines.h
 html/CheckboxInputType.cpp
@@ -351,14 +348,11 @@ html/LazyLoadImageObserver.cpp
 html/MediaDocument.cpp
 html/MediaElementSession.cpp
 html/ModelDocument.cpp
-html/NumberInputType.cpp
 html/PermissionsPolicy.cpp
 html/PluginDocument.cpp
 html/RadioNodeList.cpp
 html/RangeInputType.cpp
-html/ResetInputType.cpp
 html/SearchInputType.cpp
-html/SubmitInputType.cpp
 html/TextFieldInputType.cpp
 html/ValidatedFormListedElement.cpp
 html/ValidationMessage.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
@@ -187,13 +187,11 @@ editing/markup.cpp
 fileapi/BlobURL.cpp
 history/CachedFrame.cpp
 html/Autofill.cpp
-html/BaseCheckableInputType.cpp
 html/BaseDateAndTimeInputType.cpp
 html/CachedHTMLCollectionInlines.h
 html/CanvasBase.cpp
 html/CollectionTraversalInlines.h
 html/CustomPaintImage.cpp
-html/FileInputType.cpp
 html/FormAssociatedCustomElement.cpp
 html/FormListedElement.cpp
 html/HTMLAttachmentElement.cpp
@@ -224,10 +222,8 @@ html/HTMLTableRowElement.cpp
 html/HTMLTextFormControlElement.cpp
 html/HTMLTitleElement.cpp
 html/HTMLVideoElement.cpp
-html/ImageInputType.cpp
 html/MediaElementSession.cpp
 html/ModelDocument.cpp
-html/NumberInputType.cpp
 html/PermissionsPolicy.cpp
 html/PluginDocument.cpp
 html/RangeInputType.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -631,10 +631,6 @@ history/CachedFrame.cpp
 history/CachedPage.cpp
 history/HistoryItem.cpp
 html/AttachmentAssociatedElement.cpp
-html/BaseButtonInputType.cpp
-html/BaseCheckableInputType.cpp
-html/BaseClickableWithKeyInputType.cpp
-html/BaseTextInputType.cpp
 html/CachedHTMLCollection.h
 html/CachedHTMLCollectionInlines.h
 html/CheckboxInputType.cpp
@@ -700,15 +696,12 @@ html/MediaController.cpp
 html/MediaDocument.cpp
 html/MediaElementSession.cpp
 html/ModelDocument.cpp
-html/NumberInputType.cpp
 html/OffscreenCanvas.cpp
 html/PermissionsPolicy.cpp
 html/PluginDocument.cpp
 html/PublicURLManager.cpp
 html/RadioNodeList.cpp
 html/RangeInputType.cpp
-html/ResetInputType.cpp
-html/SubmitInputType.cpp
 html/TextFieldInputType.cpp
 html/ValidatedFormListedElement.cpp
 html/ValidatedFormListedElement.h

--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -334,7 +334,6 @@ history/CachedFrame.cpp
 history/CachedPage.cpp
 history/HistoryItem.cpp
 html/Autofill.cpp
-html/BaseCheckableInputType.cpp
 html/CachedHTMLCollectionInlines.h
 html/CanvasBase.cpp
 html/CollectionTraversalInlines.h
@@ -369,12 +368,10 @@ html/LazyLoadFrameObserver.cpp
 html/LazyLoadImageObserver.cpp
 html/MediaElementSession.cpp
 html/ModelDocument.cpp
-html/NumberInputType.cpp
 html/OffscreenCanvas.cpp
 html/PermissionsPolicy.cpp
 html/PluginDocument.cpp
 html/RangeInputType.cpp
-html/TextFieldInputType.cpp
 html/ValidatedFormListedElement.cpp
 html/ValidationMessage.cpp
 html/canvas/CanvasRenderingContext2D.cpp

--- a/Source/WebCore/html/BaseButtonInputType.cpp
+++ b/Source/WebCore/html/BaseButtonInputType.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2010 Google Inc. All rights reserved.
- * Copyright (C) 2011-2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2011-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -57,7 +57,7 @@ bool BaseButtonInputType::appendFormData(DOMFormData&) const
 RenderPtr<RenderElement> BaseButtonInputType::createInputRenderer(RenderStyle&& style)
 {
     ASSERT(element());
-    return createRenderer<RenderButton>(*element(), WTFMove(style));
+    return createRenderer<RenderButton>(*protectedElement(), WTFMove(style));
 }
 
 bool BaseButtonInputType::storesValueSeparateFromAttribute()
@@ -68,7 +68,7 @@ bool BaseButtonInputType::storesValueSeparateFromAttribute()
 void BaseButtonInputType::setValue(const String& sanitizedValue, bool, TextFieldEventBehavior, TextControlSetValueSelection)
 {
     ASSERT(element());
-    element()->setAttributeWithoutSynchronization(valueAttr, AtomString { sanitizedValue });
+    protectedElement()->setAttributeWithoutSynchronization(valueAttr, AtomString { sanitizedValue });
 }
 
 bool BaseButtonInputType::dirAutoUsesValue() const

--- a/Source/WebCore/html/BaseCheckableInputType.cpp
+++ b/Source/WebCore/html/BaseCheckableInputType.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2010 Google Inc. All rights reserved.
- * Copyright (C) 2011-2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2011-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -56,15 +56,16 @@ FormControlState BaseCheckableInputType::saveFormControlState() const
 void BaseCheckableInputType::restoreFormControlState(const FormControlState& state)
 {
     ASSERT(element());
-    element()->setChecked(state[0] == onAtom());
+    protectedElement()->setChecked(state[0] == onAtom());
 }
 
 bool BaseCheckableInputType::appendFormData(DOMFormData& formData) const
 {
     ASSERT(element());
-    if (!element()->checked())
+    Ref element = *this->element();
+    if (!element->checked())
         return false;
-    formData.append(element()->name(), element()->value());
+    formData.append(element->name(), element->value());
     return true;
 }
 
@@ -73,7 +74,7 @@ auto BaseCheckableInputType::handleKeydownEvent(KeyboardEvent& event) -> ShouldC
     const String& key = event.keyIdentifier();
     if (key == "U+0020"_s) {
         ASSERT(element());
-        element()->setActive(true);
+        protectedElement()->setActive(true);
         // No setDefaultHandled(), because IE dispatches a keypress in this case
         // and the caller will only dispatch a keypress if we don't call setDefaultHandled().
         return ShouldCallBaseEventHandler::No;
@@ -114,21 +115,22 @@ bool BaseCheckableInputType::storesValueSeparateFromAttribute()
 void BaseCheckableInputType::setValue(const String& sanitizedValue, bool, TextFieldEventBehavior, TextControlSetValueSelection)
 {
     ASSERT(element());
-    element()->setAttributeWithoutSynchronization(valueAttr, AtomString { sanitizedValue });
+    protectedElement()->setAttributeWithoutSynchronization(valueAttr, AtomString { sanitizedValue });
 }
 
 void BaseCheckableInputType::fireInputAndChangeEvents()
 {
-    if (!element()->isConnected())
+    Ref element = *this->element();
+    if (!element->isConnected())
         return;
 
     if (!shouldSendChangeEventAfterCheckedChanged())
         return;
 
     Ref protectedThis { *this };
-    element()->setTextAsOfLastFormControlChangeEvent(String());
-    element()->dispatchInputEvent();
-    if (auto* element = this->element())
+    element->setTextAsOfLastFormControlChangeEvent(String());
+    element->dispatchInputEvent();
+    if (RefPtr element = this->element())
         element->dispatchFormControlChangeEvent();
 }
 

--- a/Source/WebCore/html/BaseClickableWithKeyInputType.cpp
+++ b/Source/WebCore/html/BaseClickableWithKeyInputType.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2010, 2012 Google Inc. All rights reserved.
- * Copyright (C) 2011-2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2011-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -86,13 +86,13 @@ bool BaseClickableWithKeyInputType::accessKeyAction(HTMLInputElement& element, b
 auto BaseClickableWithKeyInputType::handleKeydownEvent(KeyboardEvent& event) -> ShouldCallBaseEventHandler
 {
     ASSERT(element());
-    return handleKeydownEvent(*element(), event);
+    return handleKeydownEvent(*protectedElement(), event);
 }
 
 void BaseClickableWithKeyInputType::handleKeypressEvent(KeyboardEvent& event)
 {
     ASSERT(element());
-    handleKeypressEvent(*element(), event);
+    handleKeypressEvent(*protectedElement(), event);
 }
 
 void BaseClickableWithKeyInputType::handleKeyupEvent(KeyboardEvent& event)
@@ -104,7 +104,7 @@ bool BaseClickableWithKeyInputType::accessKeyAction(bool sendMouseEvents)
 {
     InputType::accessKeyAction(sendMouseEvents);
     ASSERT(element());
-    return accessKeyAction(*element(), sendMouseEvents);
+    return accessKeyAction(*protectedElement(), sendMouseEvents);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/html/BaseTextInputType.cpp
+++ b/Source/WebCore/html/BaseTextInputType.cpp
@@ -3,7 +3,7 @@
  *
  * Copyright (C) 2009 Michelangelo De Simone <micdesim@gmail.com>
  * Copyright (C) 2010 Google Inc. All rights reserved.
- * Copyright (C) 2018-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2018-2025 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -41,9 +41,10 @@ using namespace HTMLNames;
 bool BaseTextInputType::patternMismatch(const String& value) const
 {
     ASSERT(element());
+    Ref element = *this->element();
     // FIXME: We should execute RegExp parser first to check validity instead of creating an actual RegularExpression.
     // https://bugs.webkit.org/show_bug.cgi?id=183361
-    const AtomString& rawPattern = element()->attributeWithoutSynchronization(patternAttr);
+    const AtomString& rawPattern = element->attributeWithoutSynchronization(patternAttr);
     if (rawPattern.isNull() || value.isEmpty() || !JSC::Yarr::RegularExpression(rawPattern, { JSC::Yarr::Flags::UnicodeSets }).isValid())
         return false;
 
@@ -56,7 +57,7 @@ bool BaseTextInputType::patternMismatch(const String& value) const
         return matchOffset || matchLength != valueLength;
     };
 
-    if (isEmailField() && element()->multiple()) {
+    if (isEmailField() && element->multiple()) {
         auto values = value.split(',');
         return values.findIf(valuePatternMismatch) != notFound;
     }

--- a/Source/WebCore/html/FileInputType.cpp
+++ b/Source/WebCore/html/FileInputType.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2004-2025 Apple Inc. All rights reserved.
  * Copyright (C) 2010-2014 Google Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
@@ -338,7 +338,7 @@ void FileInputType::setFiles(RefPtr<FileList>&& files, RequestIcon shouldRequest
         return;
 
     ASSERT(element());
-    Ref<HTMLInputElement> protectedInputElement(*element());
+    Ref element = *this->element();
 
     unsigned length = files->length();
 
@@ -357,14 +357,14 @@ void FileInputType::setFiles(RefPtr<FileList>&& files, RequestIcon shouldRequest
 
     m_fileList = files.releaseNonNull();
 
-    protectedInputElement->setFormControlValueMatchesRenderer(true);
-    protectedInputElement->updateValidity();
+    element->setFormControlValueMatchesRenderer(true);
+    element->updateValidity();
 
     if (shouldRequestIcon == RequestIcon::Yes)
         requestIcon(protectedFiles()->paths());
 
-    if (protectedInputElement->renderer())
-        protectedInputElement->renderer()->repaint();
+    if (CheckedPtr renderer = element->renderer())
+        renderer->repaint();
 
     if (wasSetByJavaScript == WasSetByJavaScript::Yes)
         return;
@@ -372,13 +372,13 @@ void FileInputType::setFiles(RefPtr<FileList>&& files, RequestIcon shouldRequest
     if (pathsChanged) {
         // This call may cause destruction of this instance.
         // input instance is safe since it is ref-counted.
-        protectedInputElement->dispatchInputEvent();
-        protectedInputElement->dispatchChangeEvent();
+        element->dispatchInputEvent();
+        element->dispatchChangeEvent();
     } else
-        protectedInputElement->dispatchCancelEvent();
+        element->dispatchCancelEvent();
 
-    protectedInputElement->setChangedSinceLastFormControlChangeEvent(false);
-    protectedInputElement->setInteractedWithSinceLastFormSubmitEvent(true);
+    element->setChangedSinceLastFormControlChangeEvent(false);
+    element->setInteractedWithSinceLastFormSubmitEvent(true);
 }
 
 void FileInputType::filesChosen(const Vector<FileChooserFileInfo>& paths, const String& displayString, Icon* icon)
@@ -429,9 +429,7 @@ void FileInputType::filesChosen(const Vector<String>& paths, const Vector<String
 void FileInputType::fileChoosingCancelled()
 {
     ASSERT(element());
-    Ref<HTMLInputElement> protectedInputElement(*element());
-
-    protectedInputElement->dispatchCancelEvent();
+    protectedElement()->dispatchCancelEvent();
 }
 
 void FileInputType::didCreateFileList(Ref<FileList>&& fileList, RefPtr<Icon>&& icon)
@@ -458,7 +456,7 @@ void FileInputType::iconLoaded(RefPtr<Icon>&& icon)
 
     m_icon = WTFMove(icon);
     ASSERT(element());
-    if (auto* renderer = element()->renderer())
+    if (CheckedPtr renderer = element()->renderer())
         renderer->repaint();
 }
 

--- a/Source/WebCore/html/ImageInputType.cpp
+++ b/Source/WebCore/html/ImageInputType.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2004-2025 Apple Inc. All rights reserved.
  * Copyright (C) 2010 Google Inc. All rights reserved.
  * Copyright (C) 2012 Samsung Electronics. All rights reserved.
  *
@@ -83,11 +83,11 @@ bool ImageInputType::appendFormData(DOMFormData& formData) const
 void ImageInputType::handleDOMActivateEvent(Event& event)
 {
     ASSERT(element());
-    Ref<HTMLInputElement> protectedElement(*element());
-    if (protectedElement->isDisabledFormControl() || !protectedElement->form())
+    Ref element = *this->element();
+    if (element->isDisabledFormControl() || !element->form())
         return;
 
-    Ref<HTMLFormElement> protectedForm(*protectedElement->form());
+    Ref protectedForm = *element->form();
 
     m_clickLocation = IntPoint();
     if (event.underlyingEvent()) {
@@ -100,10 +100,10 @@ void ImageInputType::handleDOMActivateEvent(Event& event)
 
     // Update layout before processing form actions in case the style changes
     // the Form or button relationships.
-    protectedElement->protectedDocument()->updateLayoutIgnorePendingStylesheets();
+    element->protectedDocument()->updateLayoutIgnorePendingStylesheets();
 
-    if (RefPtr currentForm = protectedElement->form())
-        currentForm->submitIfPossible(&event, element()); // Event handlers can run.
+    if (RefPtr currentForm = element->form())
+        currentForm->submitIfPossible(&event, element.ptr()); // Event handlers can run.
 
     event.setDefaultHandled();
 }
@@ -118,8 +118,7 @@ void ImageInputType::attributeChanged(const QualifiedName& name)
 {
     if (name == altAttr) {
         if (RefPtr element = this->element()) {
-            auto* renderer = element->renderer();
-            if (auto* renderImage = dynamicDowncast<RenderImage>(renderer))
+            if (CheckedPtr renderImage = dynamicDowncast<RenderImage>(element->renderer()))
                 renderImage->updateAltText();
         }
     } else if (name == srcAttr) {
@@ -136,22 +135,22 @@ void ImageInputType::attach()
     BaseButtonInputType::attach();
 
     ASSERT(element());
-    HTMLImageLoader& imageLoader = protectedElement()->ensureImageLoader();
-    imageLoader.updateFromElement();
+    Ref imageLoader = protectedElement()->ensureImageLoader();
+    imageLoader->updateFromElement();
 
-    auto* renderer = downcast<RenderImage>(element()->renderer());
+    CheckedPtr renderer = downcast<RenderImage>(element()->renderer());
     if (!renderer)
         return;
 
-    if (imageLoader.hasPendingBeforeLoadEvent())
+    if (imageLoader->hasPendingBeforeLoadEvent())
         return;
 
-    auto& imageResource = renderer->imageResource();
-    imageResource.setCachedImage(imageLoader.protectedImage());
+    CheckedRef imageResource = renderer->imageResource();
+    imageResource->setCachedImage(imageLoader->protectedImage());
 
     // If we have no image at all because we have no src attribute, set
     // image height and width for the alt text instead.
-    if (!imageLoader.image() && !imageResource.cachedImage())
+    if (!imageLoader->image() && !imageResource->cachedImage())
         renderer->setImageSizeForAltText();
 }
 
@@ -173,11 +172,11 @@ bool ImageInputType::shouldRespectHeightAndWidthAttributes()
 unsigned ImageInputType::height() const
 {
     ASSERT(element());
-    Ref<HTMLInputElement> element(*this->element());
+    Ref element = *this->element();
 
     element->protectedDocument()->updateLayout({ LayoutOptions::TreatContentVisibilityHiddenAsVisible, LayoutOptions::TreatContentVisibilityAutoAsVisible }, element.ptr());
 
-    if (auto* renderer = element->renderer())
+    if (CheckedPtr renderer = element->renderer())
         return adjustForAbsoluteZoom(downcast<RenderBox>(*renderer).contentBoxHeight(), *renderer);
 
     // Check the attribute first for an explicit pixel value.
@@ -185,7 +184,7 @@ unsigned ImageInputType::height() const
         return optionalHeight.value();
 
     // If the image is available, use its height.
-    auto* imageLoader = element->imageLoader();
+    CheckedPtr imageLoader = element->imageLoader();
     if (imageLoader && imageLoader->image())
         return imageLoader->image()->imageSizeForRenderer(element->renderer(), 1).height().toUnsigned();
 
@@ -195,11 +194,11 @@ unsigned ImageInputType::height() const
 unsigned ImageInputType::width() const
 {
     ASSERT(element());
-    Ref<HTMLInputElement> element(*this->element());
+    Ref element = *this->element();
 
     element->protectedDocument()->updateLayout({ LayoutOptions::TreatContentVisibilityHiddenAsVisible, LayoutOptions::TreatContentVisibilityAutoAsVisible }, element.ptr());
 
-    if (auto* renderer = element->renderer())
+    if (CheckedPtr renderer = element->renderer())
         return adjustForAbsoluteZoom(downcast<RenderBox>(*renderer).contentBoxWidth(), *renderer);
 
     // Check the attribute first for an explicit pixel value.
@@ -207,7 +206,7 @@ unsigned ImageInputType::width() const
         return optionalWidth.value();
 
     // If the image is available, use its width.
-    auto* imageLoader = element->imageLoader();
+    CheckedPtr imageLoader = element->imageLoader();
     if (imageLoader && imageLoader->image())
         return imageLoader->image()->imageSizeForRenderer(element->renderer(), 1).width().toUnsigned();
 

--- a/Source/WebCore/html/NumberInputType.cpp
+++ b/Source/WebCore/html/NumberInputType.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2010-2014 Google Inc. All rights reserved.
- * Copyright (C) 2011-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2011-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -104,7 +104,7 @@ const AtomString& NumberInputType::formControlType() const
 void NumberInputType::setValue(const String& sanitizedValue, bool valueChanged, TextFieldEventBehavior eventBehavior, TextControlSetValueSelection selection)
 {
     ASSERT(element());
-    if (!valueChanged && sanitizedValue.isEmpty() && !element()->innerTextValue().isEmpty())
+    if (!valueChanged && sanitizedValue.isEmpty() && !protectedElement()->innerTextValue().isEmpty())
         updateInnerTextValue();
     TextFieldInputType::setValue(sanitizedValue, valueChanged, eventBehavior, selection);
 }
@@ -112,20 +112,20 @@ void NumberInputType::setValue(const String& sanitizedValue, bool valueChanged, 
 double NumberInputType::valueAsDouble() const
 {
     ASSERT(element());
-    return parseToDoubleForNumberType(element()->value().get());
+    return parseToDoubleForNumberType(protectedElement()->value().get());
 }
 
 ExceptionOr<void> NumberInputType::setValueAsDouble(double newValue, TextFieldEventBehavior eventBehavior) const
 {
     ASSERT(element());
-    element()->setValue(serializeForNumberType(newValue), eventBehavior);
+    protectedElement()->setValue(serializeForNumberType(newValue), eventBehavior);
     return { };
 }
 
 ExceptionOr<void> NumberInputType::setValueAsDecimal(const Decimal& newValue, TextFieldEventBehavior eventBehavior) const
 {
     ASSERT(element());
-    element()->setValue(serializeForNumberType(newValue), eventBehavior);
+    protectedElement()->setValue(serializeForNumberType(newValue), eventBehavior);
     return { };
 }
 
@@ -137,7 +137,7 @@ bool NumberInputType::typeMismatchFor(const String& value) const
 bool NumberInputType::typeMismatch() const
 {
     ASSERT(element());
-    ASSERT(!typeMismatchFor(element()->value()));
+    ASSERT(!typeMismatchFor(protectedElement()->value()));
     return false;
 }
 
@@ -200,8 +200,8 @@ float NumberInputType::decorationWidth() const
     ASSERT(element());
 
     float width = 0;
-    RefPtr<HTMLElement> spinButton = element()->innerSpinButtonElement();
-    if (RenderBox* spinRenderer = spinButton ? spinButton->renderBox() : 0) {
+    RefPtr spinButton = protectedElement()->innerSpinButtonElement();
+    if (CheckedPtr spinRenderer = spinButton ? spinButton->renderBox() : nullptr) {
         width += spinRenderer->borderAndPaddingLogicalWidth();
         // Since the width of spinRenderer is not calculated yet, spinRenderer->logicalWidth() returns 0.
         // So computedStyle()->logicalWidth() is used instead.
@@ -243,13 +243,13 @@ String NumberInputType::localizeValue(const String& proposedValue) const
     if (proposedValue.find(isE) != notFound)
         return proposedValue;
     ASSERT(element());
-    return element()->locale().convertToLocalizedNumber(proposedValue);
+    return protectedElement()->locale().convertToLocalizedNumber(proposedValue);
 }
 
 String NumberInputType::visibleValue() const
 {
     ASSERT(element());
-    return localizeValue(element()->value());
+    return localizeValue(protectedElement()->value());
 }
 
 String NumberInputType::convertFromVisibleValue(const String& visibleValue) const
@@ -260,7 +260,7 @@ String NumberInputType::convertFromVisibleValue(const String& visibleValue) cons
     if (visibleValue.find(isE) != notFound)
         return visibleValue;
     ASSERT(element());
-    return element()->locale().convertFromLocalizedNumber(visibleValue);
+    return protectedElement()->locale().convertFromLocalizedNumber(visibleValue);
 }
 
 ValueOrReference<String> NumberInputType::sanitizeValue(const String& proposedValue LIFETIME_BOUND) const
@@ -275,7 +275,7 @@ ValueOrReference<String> NumberInputType::sanitizeValue(const String& proposedVa
 bool NumberInputType::hasBadInput() const
 {
     ASSERT(element());
-    String standardValue = convertFromVisibleValue(element()->innerTextValue());
+    String standardValue = convertFromVisibleValue(protectedElement()->innerTextValue());
     return !standardValue.isEmpty() && !std::isfinite(parseToDoubleForNumberType(standardValue));
 }
 
@@ -295,16 +295,16 @@ void NumberInputType::attributeChanged(const QualifiedName& name)
     switch (name.nodeName()) {
     case AttributeNames::maxAttr:
     case AttributeNames::minAttr:
-        if (auto* element = this->element()) {
+        if (RefPtr element = this->element()) {
             element->invalidateStyleForSubtree();
-            if (auto* renderer = element->renderer())
+            if (CheckedPtr renderer = element->renderer())
                 renderer->setNeedsLayoutAndPrefWidthsRecalc();
         }
         break;
     case AttributeNames::classAttr:
     case AttributeNames::stepAttr:
-        if (auto* element = this->element()) {
-            if (auto* renderer = element->renderer())
+        if (RefPtr element = this->element()) {
+            if (CheckedPtr renderer = element->renderer())
                 renderer->setNeedsLayoutAndPrefWidthsRecalc();
         }
         break;

--- a/Source/WebCore/html/RangeInputType.h
+++ b/Source/WebCore/html/RangeInputType.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2010 Google Inc. All rights reserved.
- * Copyright (C) 2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -72,6 +72,7 @@ private:
     HTMLElement* sliderTrackElement() const final;
 
     SliderThumbElement& typedSliderThumbElement() const;
+    Ref<SliderThumbElement> protectedTypedSliderThumbElement() const;
 
     void dataListMayHaveChanged() final;
     void updateTickMarkValues();

--- a/Source/WebCore/html/ResetInputType.cpp
+++ b/Source/WebCore/html/ResetInputType.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2010 Google Inc. All rights reserved.
- * Copyright (C) 2011 Apple Inc. All rights reserved.
+ * Copyright (C) 2011-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -52,9 +52,12 @@ const AtomString& ResetInputType::formControlType() const
 void ResetInputType::handleDOMActivateEvent(Event& event)
 {
     ASSERT(element());
-    if (element()->isDisabledFormControl() || !element()->form())
+    if (element()->isDisabledFormControl())
         return;
-    element()->form()->reset();
+    RefPtr form = element()->form();
+    if (!form)
+        return;
+    form->reset();
     event.setDefaultHandled();
 }
 

--- a/Source/WebCore/html/SubmitInputType.cpp
+++ b/Source/WebCore/html/SubmitInputType.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2010 Google Inc. All rights reserved.
- * Copyright (C) 2011 Apple Inc. All rights reserved.
+ * Copyright (C) 2011-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -56,11 +56,12 @@ const AtomString& SubmitInputType::formControlType() const
 bool SubmitInputType::appendFormData(DOMFormData& formData) const
 {
     ASSERT(element());
-    if (!element()->isActivatedSubmit())
+    Ref element = *this->element();
+    if (!element->isActivatedSubmit())
         return false;
-    formData.append(element()->name(), element()->valueWithDefault());
-    if (auto& dirname = element()->attributeWithoutSynchronization(HTMLNames::dirnameAttr); !dirname.isNull())
-        formData.append(dirname, element()->directionForFormData());
+    formData.append(element->name(), element->valueWithDefault());
+    if (auto& dirname = element->attributeWithoutSynchronization(HTMLNames::dirnameAttr); !dirname.isNull())
+        formData.append(dirname, element->directionForFormData());
     return true;
 }
 
@@ -72,18 +73,18 @@ bool SubmitInputType::supportsRequired() const
 void SubmitInputType::handleDOMActivateEvent(Event& event)
 {
     ASSERT(element());
-    Ref<HTMLInputElement> protectedElement(*element());
-    if (protectedElement->isDisabledFormControl() || !protectedElement->form())
+    Ref element = *this->element();
+    if (element->isDisabledFormControl() || !element->form())
         return;
 
-    Ref<HTMLFormElement> protectedForm(*protectedElement->form());
+    Ref protectedForm = *element->form();
 
     // Update layout before processing form actions in case the style changes
     // the Form or button relationships.
-    protectedElement->protectedDocument()->updateLayoutIgnorePendingStylesheets();
+    element->protectedDocument()->updateLayoutIgnorePendingStylesheets();
 
-    if (RefPtr currentForm = protectedElement->form())
-        currentForm->submitIfPossible(&event, element()); // Event handlers can run.
+    if (RefPtr currentForm = element->form())
+        currentForm->submitIfPossible(&event, element.ptr()); // Event handlers can run.
     event.setDefaultHandled();
 }
 


### PR DESCRIPTION
#### fdf604a6e81bbccb78e9e3f99d23c57bb345a697
<pre>
Reduce unsafeness in InputType classes
<a href="https://bugs.webkit.org/show_bug.cgi?id=293592">https://bugs.webkit.org/show_bug.cgi?id=293592</a>
<a href="https://rdar.apple.com/152049455">rdar://152049455</a>

Reviewed by Chris Dumez.

Apply <a href="https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines">https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines</a> and
modernize code patterns as appropriate.

Canonical link: <a href="https://commits.webkit.org/295453@main">https://commits.webkit.org/295453@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fa4560df7bb2597effa998d2954a66ad4fd5badf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105153 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24867 "Failed to checkout and rebase branch from PR 45920") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15292 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/110369 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/55826 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/107194 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/25294 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33411 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/110369 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/55826 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108159 "Build is in progress. Recent messages:OS: Sequoia (15.3), Xcode: 16.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Passed webkitperl tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/19712 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/94909 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/110369 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/19469 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/12985 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/55210 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/89177 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/13029 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/112911 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/32318 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/23807 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/112911 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/32684 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/91127 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/112911 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/11255 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/27735 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17048 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/32241 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/37622 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/32031 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/35374 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/33592 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->