### PR TITLE
[GTK][WPE] Add new 'Pointers for contribution' section to manual

### DIFF
--- a/Source/WebKit/PlatformGTK.cmake
+++ b/Source/WebKit/PlatformGTK.cmake
@@ -598,6 +598,7 @@ GI_INTROSPECT(WebKit${WEBKITGTK_API_INFIX} ${WEBKITGTK_API_VERSION} webkit${WEBK
 GI_DOCGEN(WebKit${WEBKITGTK_API_INFIX} gtk/gtk${GTK_API_VERSION}-webkitgtk.toml.in
     CONTENT_TEMPLATES
         gtk/gtk${GTK_API_VERSION}-urlmap.js
+        glib/contributing.md
         glib/environment-variables.md
         glib/profiling.md
         glib/remote-inspector.md

--- a/Source/WebKit/PlatformWPE.cmake
+++ b/Source/WebKit/PlatformWPE.cmake
@@ -767,6 +767,7 @@ GI_INTROSPECT(WPEWebKit ${WPE_API_VERSION} wpe/webkit.h
 )
 GI_DOCGEN(WPEWebKit wpe/wpewebkit.toml.in
     CONTENT_TEMPLATES
+        glib/contributing.md
         glib/environment-variables.md
         glib/profiling.md
         glib/remote-inspector.md

--- a/Source/WebKit/glib/contributing.md.in
+++ b/Source/WebKit/glib/contributing.md.in
@@ -1,0 +1,43 @@
+Title: Pointers for contribution
+Slug: contributing
+
+## Contacting Us
+
+#if WPE
+
+You can find the developers behind WPE WebKit on various platforms:
+
+- [Mastodon](https://floss.social/@WPEWebKit).
+- [Bluesky](https://bsky.app/profile/wpewebkit.org).
+- [#wpe channel](https://matrix.to/#/#wpe:matrix.org) on **Matrix**.
+- [#wpe channel](https://webchat.oftc.net/?channels=wpe) on the **OTFC** IRC network (bridged to the Matrix one).
+
+#else
+
+You can find the developers behind WebKitGTK on various platforms:
+
+- [Mastodon](https://floss.social/@WebKitGTK).
+- [Bluesky](https://bsky.app/profile/webkitgtk.org).
+- [#webkitgtk channel](https://matrix.to/#/#webkitgtk:matrix.org) on **Matrix**.
+
+#endif
+
+Feel free to reach out to us if you have any questions. For reporting issues and requesting new features, please follow the contribution guidelines in the following section.
+
+## Reporting Feedback
+
+If you encountered a bug, an unusual behavior, or would like to request a new feature, the [WebKit Bugzilla](https://bugs.webkit.org) is the place to visit. Bugs specific to the GTK and WPE ports, as well as cross-platform bugs affecting all WebKit ports (including e.g. macOS/iOS variants), are reported there.
+
+WebKit is a large software project with many contributors and billions of users, receiving a lot of bug reports. Before reporting a new issue, be sure to [search for the existing ones](https://bugs.webkit.org/query.cgi) to make sure your issue may be already known. However, do not refrain from opening a ticket if you cannot find any describing your issue.
+
+If you are unfamiliar with the [WebKit bug writing guidelines](https://bugs.webkit.org/page.cgi?id=bug-writing.html), you might want to have a look before opening a ticket. Prefix the bug title with **[WPE]** or **[GTK]** depending on the port flavour that you are using, and ideally assign a component that matches the problem domain. If unsure, select WebKitGTK or WPE WebKit, but do not leave it unassigned.
+
+Last but not least, thanks for your contribution! You can make a difference and help us improve and evolve our project.
+
+## Code Contributions
+
+To contribute, you should first setup a local development environment. The easiest solution is to use the [WebKit Container SDK](https://github.com/Igalia/webkit-container-sdk). It contains a set of scripts that assist in creating and running a [Podman](https://podman.io/)-based container on your Linux machine, which contains all dependencies needed to compile WebKit.
+
+The **webkit.org** page contains a [section](https://webkit.org/contributing-code/) dedicated to code contributions&mdash;be sure to read it, as it contains many interesting articles, covering the [WebKit Early Warning System (EWS)](http://ews-build.webkit.org), the [coding style guidelines](https://webkit.org/code-style-guidelines/) and much more.
+
+Additionally there is a [Wiki](https://github.com/WebKit/WebKit/wiki) page with further information about the WebKit project, and links to all aforementioned pages.

--- a/Source/WebKit/gtk/gtk3-webkitgtk.toml.in
+++ b/Source/WebKit/gtk/gtk3-webkitgtk.toml.in
@@ -41,6 +41,7 @@ urlmap_file = "gtk@GTK_API_VERSION@-urlmap.js"
 
 [extra]
 content_files = [
+    "contributing.md",
     "environment-variables.md",
     "profiling.md",
     "remote-inspector.md",

--- a/Source/WebKit/gtk/gtk4-webkitgtk.toml.in
+++ b/Source/WebKit/gtk/gtk4-webkitgtk.toml.in
@@ -40,6 +40,7 @@ base_url = "https://github.com/WebKit/WebKit/tree/main/"
 [extra]
 content_files = [
     "overview.md",
+    "contributing.md",
     "environment-variables.md",
     "profiling.md",
     "remote-inspector.md",

--- a/Source/WebKit/wpe/wpewebkit.toml.in
+++ b/Source/WebKit/wpe/wpewebkit.toml.in
@@ -35,6 +35,7 @@ base_url = "https://github.com/WebKit/WebKit/tree/main/"
 [extra]
 urlmap_file = "wpe@WPE_API_MAJOR_VERSION@-urlmap.js"
 content_files = [
+    "contributing.md",
     "environment-variables.md",
     "profiling.md",
     "remote-inspector.md",


### PR DESCRIPTION
#### 49b528cf23145a97f8bc9ce1c960d79e5b614ac4
<pre>
[GTK][WPE] Add new &apos;Pointers for contribution&apos; section to manual
<a href="https://bugs.webkit.org/show_bug.cgi?id=293595">https://bugs.webkit.org/show_bug.cgi?id=293595</a>

Reviewed by Adrian Perez de Castro and Michael Catanzaro.

Add new &apos;Pointers for contribution&apos; section to Gtk/WPE manuals.

* Source/WebKit/PlatformGTK.cmake:
* Source/WebKit/PlatformWPE.cmake:
* Source/WebKit/glib/contributing.md.in: Added.
* Source/WebKit/gtk/gtk3-webkitgtk.toml.in:
* Source/WebKit/gtk/gtk4-webkitgtk.toml.in:
* Source/WebKit/wpe/wpewebkit.toml.in:

Canonical link: <a href="https://commits.webkit.org/295867@main">https://commits.webkit.org/295867@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/592c40d8d7ee9f23f08d89e4760fc84f9e9fb51c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/106380 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/26129 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/16527 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/111581 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/56976 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/26796 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34632 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/111581 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/56976 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/109384 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/21233 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/96004 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/111581 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/20725 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/56416 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/90571 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/14138 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/114440 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33518 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/24710 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/114440 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33882 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/92233 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/114440 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/34464 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/12283 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/29113 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17237 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/33443 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/38855 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/33189 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/36542 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34787 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->