### PR TITLE
css/css-view-transitions/content-with-clip-root.html fails due to not clipping to the snapshot containing block.

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7060,7 +7060,6 @@ imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/navigate-
 
 # -- View Transitions -- #
 # Reftest failures:
-imported/w3c/web-platform-tests/css/css-view-transitions/content-with-clip-root.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-view-transitions/span-with-overflowing-text.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-view-transitions/fractional-translation-from-transform.html [ ImageOnlyFailure ]
 

--- a/LayoutTests/fast/css/view-transitions-no-content-for-new-pseudo-expected.txt
+++ b/LayoutTests/fast/css/view-transitions-no-content-for-new-pseudo-expected.txt
@@ -21,7 +21,6 @@
                   (children 1
                     (GraphicsLayer
                       (bounds 800.00 600.00)
-                      (contentsOpaque 1)
                     )
                   )
                 )

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/dialog-in-rtl-iframe.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/dialog-in-rtl-iframe.html
@@ -5,7 +5,7 @@
   <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
   <link rel="author" href="mailto:bokan@chromium.org">
   <link rel="match" href="dialog-in-rtl-iframe-ref.html">
-  <meta name=fuzzy content="maxDifference=0-80; totalPixels=0-500">
+  <meta name=fuzzy content="maxDifference=0-80; totalPixels=0-2888">
   <script src="/common/reftest-wait.js"></script>
   <style>
     iframe {

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -4126,6 +4126,7 @@ imported/w3c/web-platform-tests/css/css-view-transitions/no-raf-while-render-blo
 imported/w3c/web-platform-tests/css/css-view-transitions/column-span-during-transition-doesnt-skip.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-view-transitions/inline-with-offset-from-containing-block.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-view-transitions/paint-holding-in-iframe.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/css/css-view-transitions/content-with-clip-root.html [ ImageOnlyFailure ]
 
 imported/w3c/web-platform-tests/css/css-view-transitions/navigation/at-rule-opt-in-auto.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-view-transitions/navigation/hide-before-reveal.html [ Failure ]

--- a/LayoutTests/platform/glib/fast/css/view-transitions-no-content-for-new-pseudo-expected.txt
+++ b/LayoutTests/platform/glib/fast/css/view-transitions-no-content-for-new-pseudo-expected.txt
@@ -8,17 +8,22 @@
       (children 1
         (GraphicsLayer
           (bounds 800.00 600.00)
-          (children 2
+          (children 1
             (GraphicsLayer
               (bounds 800.00 600.00)
-              (opacity 0.00)
-            )
-            (GraphicsLayer
-              (bounds 800.00 600.00)
-              (drawsContent 1)
-              (children 1
+              (children 2
                 (GraphicsLayer
                   (bounds 800.00 600.00)
+                  (opacity 0.00)
+                )
+                (GraphicsLayer
+                  (bounds 800.00 600.00)
+                  (drawsContent 1)
+                  (children 1
+                    (GraphicsLayer
+                      (bounds 800.00 600.00)
+                    )
+                  )
                 )
               )
             )

--- a/Source/WebCore/dom/ViewTransition.h
+++ b/Source/WebCore/dom/ViewTransition.h
@@ -75,6 +75,7 @@ public:
         LayoutSize subpixelOffset;
         RefPtr<MutableStyleProperties> properties;
         bool intersectsViewport { false };
+        bool isRootElement { false };
     };
 
     // std::nullopt represents an non-capturable element.
@@ -187,6 +188,8 @@ public:
 
     void activateViewTransition();
 
+    LayoutRect containingBlockRect();
+
     UniqueRef<ViewTransitionParams> takeViewTransitionParams();
 
     DOMPromise& ready();
@@ -214,6 +217,7 @@ private:
 
     void copyElementBaseProperties(RenderLayerModelObject&, CapturedElement::State&);
     bool updatePropertiesForGroupPseudo(CapturedElement&, const AtomString&);
+    LayoutRect captureOverflowRect(RenderLayerModelObject& renderer);
 
     // Setup view transition sub-algorithms.
     ExceptionOr<void> captureOldState();

--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -3761,6 +3761,11 @@ bool RenderLayerCompositor::isSeparated(const RenderObject& renderer)
 // into the hierarchy between this layer and its children in the z-order hierarchy.
 bool RenderLayerCompositor::clipsCompositingDescendants(const RenderLayer& layer)
 {
+    // View transition new always has composited descendants in the graphics layer
+    // tree due to hosting (but not in the RenderLayer tree).
+    if (layer.renderer().style().pseudoElementType() == PseudoId::ViewTransitionNew && layer.renderer().hasClipOrNonVisibleOverflow())
+        return true;
+
     if (!(layer.hasCompositingDescendant() && layer.renderer().hasClipOrNonVisibleOverflow()))
         return false;
 

--- a/Source/WebCore/rendering/RenderViewTransitionCapture.cpp
+++ b/Source/WebCore/rendering/RenderViewTransitionCapture.cpp
@@ -38,8 +38,9 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(RenderViewTransitionCapture);
 
-RenderViewTransitionCapture::RenderViewTransitionCapture(Type type, Document& document, RenderStyle&& style)
+RenderViewTransitionCapture::RenderViewTransitionCapture(Type type, Document& document, RenderStyle&& style, bool isRootElement)
     : RenderReplaced(type, document, WTFMove(style), { }, ReplacedFlag::IsViewTransitionCapture)
+    , m_isRootElementCapture(isRootElement)
 {
 }
 
@@ -108,7 +109,10 @@ void RenderViewTransitionCapture::updateFromStyle()
 {
     RenderReplaced::updateFromStyle();
 
-    if (effectiveOverflowX() != Overflow::Visible || effectiveOverflowY() != Overflow::Visible)
+    // The ::view-transition-new(root) capture should hold exactly the snapshot containing
+    // block without overflow, but can host layers that extend outside this area. Force overflow
+    // clipping.
+    if (effectiveOverflowX() != Overflow::Visible || effectiveOverflowY() != Overflow::Visible || (m_isRootElementCapture && style().pseudoElementType() == PseudoId::ViewTransitionNew))
         setHasNonVisibleOverflow();
 }
 

--- a/Source/WebCore/rendering/RenderViewTransitionCapture.h
+++ b/Source/WebCore/rendering/RenderViewTransitionCapture.h
@@ -34,7 +34,7 @@ class RenderViewTransitionCapture final : public RenderReplaced {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(RenderViewTransitionCapture);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderViewTransitionCapture);
 public:
-    RenderViewTransitionCapture(Type, Document&, RenderStyle&&);
+    RenderViewTransitionCapture(Type, Document&, RenderStyle&&, bool isRootElement);
     virtual ~RenderViewTransitionCapture();
 
     void setImage(RefPtr<ImageBuffer>);
@@ -61,6 +61,8 @@ public:
 
     bool paintsContent() const final;
 
+    bool isRootElementCapture() const { return m_isRootElementCapture; }
+
     RefPtr<ImageBuffer> image() { return m_oldImage; }
 
 private:
@@ -85,6 +87,7 @@ private:
     LayoutSize m_imageIntrinsicSize;
     // Scale factor between the intrinsic size and the replaced content rect size.
     FloatSize m_scale;
+    bool m_isRootElementCapture;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 1676ec66eb68674ec74268edd5054277e3901a1b
<pre>
css/css-view-transitions/content-with-clip-root.html fails due to not clipping to the snapshot containing block.
<a href="https://bugs.webkit.org/show_bug.cgi?id=293597">https://bugs.webkit.org/show_bug.cgi?id=293597</a>
&lt;<a href="https://rdar.apple.com/152056118">rdar://152056118</a>&gt;

Reviewed by Tim Nguyen.

Compute the snapshot containing block on the ViewTransition object, such that it
includes area underneath intrusive scrollbars, and use that for the style on the
containing block&apos;s renderer rather than matching the view size.

RenderViewTransitionCapture objects that are hosting the live new snapshot of
the root element will have layers that extend outside the snapshot containing
block, which shouldn&apos;t be visible. Explicitly clip the pseudo in this case to
prevent this.

* LayoutTests/TestExpectations:
* Source/WebCore/dom/ViewTransition.cpp:
(WebCore::ViewTransition::captureOverflowRect):
(WebCore::ViewTransition::containingBlockRect):
(WebCore::ViewTransition::copyElementBaseProperties):
(WebCore::captureOverflowRect): Deleted.
* Source/WebCore/dom/ViewTransition.h:
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::createPrimaryGraphicsLayer):
* Source/WebCore/rendering/RenderViewTransitionCapture.cpp:
(WebCore::RenderViewTransitionCapture::RenderViewTransitionCapture):
(WebCore::m_isRootElementCapture):
(): Deleted.
* Source/WebCore/rendering/RenderViewTransitionCapture.h:
* Source/WebCore/rendering/updating/RenderTreeUpdaterViewTransition.cpp:
(WebCore::RenderTreeUpdater::ViewTransition::updatePseudoElementTree):
(WebCore::createRendererIfNeeded):

Canonical link: <a href="https://commits.webkit.org/295516@main">https://commits.webkit.org/295516@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/be9be9697fb6aeed6485ff1a552509cc3af09501

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105260 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24972 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15397 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110472 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/55917 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/107301 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/25404 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33515 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79951 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108266 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19814 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95007 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60257 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/19569 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13081 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55314 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/89268 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13125 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/113075 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32419 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23885 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89027 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32783 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91223 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88665 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22626 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33557 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11344 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/27843 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32343 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/37754 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32121 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35466 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33690 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->