### PR TITLE
View transitions don't ignore fragmented content.

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7076,8 +7076,6 @@ imported/w3c/web-platform-tests/css/css-view-transitions/fractional-translation-
 
 # Timeouts
 imported/w3c/web-platform-tests/css/css-view-transitions/iframe-transition.sub.html [ Skip ]
-imported/w3c/web-platform-tests/css/css-view-transitions/fragmented-during-transition-skips.html [ Skip ]
-imported/w3c/web-platform-tests/css/css-view-transitions/root-element-display-none-during-transition-crash.html [ Skip ]
 
 # Flakes
 imported/w3c/web-platform-tests/css/css-view-transitions/synchronous-callback-skipped-before-run.html [ Failure Pass ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/column-span-during-transition-doesnt-skip-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/column-span-during-transition-doesnt-skip-expected.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<title>View transitions: column-span elements in a fragmented container aren't skipped</title>
+<link rel="help" href="https://www.w3.org/TR/css-view-transitions-1/">
+<link rel="author" href="mailto:mattwoodrow@apple.com">
+
+<style>
+html {
+  background: pink;
+}
+#container {
+  width: 500px;
+  height: 500px;
+  columns: 2;
+}
+#target {
+  height: 200px;
+  background: green;
+  column-span: all;
+}
+</style>
+<div id=container>
+  <div id=target></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/column-span-during-transition-doesnt-skip-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/column-span-during-transition-doesnt-skip-ref.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<title>View transitions: column-span elements in a fragmented container aren't skipped</title>
+<link rel="help" href="https://www.w3.org/TR/css-view-transitions-1/">
+<link rel="author" href="mailto:mattwoodrow@apple.com">
+
+<style>
+html {
+  background: pink;
+}
+#container {
+  width: 500px;
+  height: 500px;
+  columns: 2;
+}
+#target {
+  height: 200px;
+  background: green;
+  column-span: all;
+}
+</style>
+<div id=container>
+  <div id=target></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/column-span-during-transition-doesnt-skip.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/column-span-during-transition-doesnt-skip.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html class=reftest-wait>
+<title>View transitions: column-span elements in a fragmented container aren't skipped</title>
+<link rel="help" href="https://www.w3.org/TR/css-view-transitions-1/">
+<link rel="author" href="mailto:mattwoodrow@apple.com">
+<link rel="match" href="column-span-during-transition-doesnt-skip-ref.html">
+
+<script src="/common/reftest-wait.js"></script>
+<style>
+#container {
+  width: 500px;
+  height: 500px;
+}
+.fragment {
+  columns: 2;
+}
+#target {
+  height: 200px;
+  background: green;
+  view-transition-name: target;
+  column-span: all;
+}
+
+::view-transition {
+  background: pink;
+}
+::view-transition-group(root) {
+  animation-duration: 500s;
+  visibility: hidden;
+}
+</style>
+<div id=container>
+  <div id=target></div>
+</div>
+
+<script>
+failIfNot(document.startViewTransition, "Missing document.startViewTransition");
+
+function runTransition() {
+  let t = document.startViewTransition();
+  t.ready.then(() => {
+    requestAnimationFrame(() => {
+      container.classList.add("fragment")
+      requestAnimationFrame(takeScreenshot);
+    });
+  });
+}
+
+requestAnimationFrame(() => requestAnimationFrame(runTransition))
+</script>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -4127,6 +4127,7 @@ imported/w3c/web-platform-tests/css/css-view-transitions/no-white-flash-before-a
 imported/w3c/web-platform-tests/css/css-view-transitions/input-targets-root-while-render-blocked.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-view-transitions/no-css-animation-while-render-blocked.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-view-transitions/no-raf-while-render-blocked.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/css/css-view-transitions/column-span-during-transition-doesnt-skip.html [ ImageOnlyFailure ]
 
 imported/w3c/web-platform-tests/css/css-view-transitions/navigation/at-rule-opt-in-auto.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-view-transitions/navigation/hide-before-reveal.html [ Failure ]

--- a/Source/WebCore/dom/ViewTransition.h
+++ b/Source/WebCore/dom/ViewTransition.h
@@ -223,7 +223,7 @@ private:
 
     void callUpdateCallback();
 
-    void updatePseudoElementStylesRead();
+    ExceptionOr<void> updatePseudoElementStylesRead();
     void updatePseudoElementStylesWrite();
     ExceptionOr<void> updatePseudoElementRenderers();
     ExceptionOr<void> checkForViewportSizeChange();

--- a/Source/WebCore/rendering/RenderFragmentContainer.h
+++ b/Source/WebCore/rendering/RenderFragmentContainer.h
@@ -119,6 +119,7 @@ public:
     VisiblePosition positionForPoint(const LayoutPoint&, HitTestSource, const RenderFragmentContainer*) override;
 
     virtual Vector<LayoutRect> fragmentRectsForFlowContentRect(const LayoutRect&) const;
+    virtual bool contentRectSpansFragments(const LayoutRect&) const { return false; }
 
 protected:
     RenderFragmentContainer(Type, Element&, RenderStyle&&, RenderFragmentedFlow*);

--- a/Source/WebCore/rendering/RenderFragmentedFlow.cpp
+++ b/Source/WebCore/rendering/RenderFragmentedFlow.cpp
@@ -249,6 +249,25 @@ bool RenderFragmentedFlow::absoluteQuadsForBox(Vector<FloatQuad>& quads, bool* w
     return true;
 }
 
+bool RenderFragmentedFlow::boxIsFragmented(const RenderBox& box) const
+{
+    ASSERT(hasValidFragmentInfo());
+
+    auto boxRect = FloatRect { { }, box.size() };
+    auto boxRectInFlowCoordinates = LayoutRect { box.localToContainerQuad(boxRect, this).boundingBox() };
+
+    RenderFragmentContainer* startFragment = nullptr;
+    RenderFragmentContainer* endFragment = nullptr;
+    computedFragmentRangeForBox(box, startFragment, endFragment);
+    if (startFragment != endFragment)
+        return true;
+
+    if (startFragment->contentRectSpansFragments(boxRectInFlowCoordinates))
+        return true;
+
+    return false;
+}
+
 class RenderFragmentedFlow::FragmentSearchAdapter {
 public:
     explicit FragmentSearchAdapter(LayoutUnit offset)

--- a/Source/WebCore/rendering/RenderFragmentedFlow.h
+++ b/Source/WebCore/rendering/RenderFragmentedFlow.h
@@ -166,6 +166,8 @@ public:
 
     bool absoluteQuadsForBox(Vector<FloatQuad>&, bool*, const RenderBox&) const;
 
+    bool boxIsFragmented(const RenderBox&) const;
+
     void layout() override;
 
     void setCurrentFragmentMaintainer(CurrentRenderFragmentContainerMaintainer* currentFragmentMaintainer) { m_currentFragmentMaintainer = currentFragmentMaintainer; }

--- a/Source/WebCore/rendering/RenderMultiColumnSet.cpp
+++ b/Source/WebCore/rendering/RenderMultiColumnSet.cpp
@@ -775,6 +775,18 @@ Vector<LayoutRect> RenderMultiColumnSet::fragmentRectsForFlowContentRect(const L
     return perColumnRects;
 }
 
+bool RenderMultiColumnSet::contentRectSpansFragments(const LayoutRect& rect) const
+{
+    auto fragmentedFlowRect = rect;
+    fragmentedFlow()->flipForWritingMode(fragmentedFlowRect);
+
+    auto logicalTop = isHorizontalWritingMode() ? fragmentedFlowRect.y() : fragmentedFlowRect.x();
+    auto logicalBottom = isHorizontalWritingMode() ? fragmentedFlowRect.maxY() : fragmentedFlowRect.maxX();
+
+    auto startAndEndColumns = firstAndLastColumnsFromOffsets(logicalTop, logicalBottom);
+    return startAndEndColumns.first != startAndEndColumns.second;
+}
+
 LayoutUnit RenderMultiColumnSet::initialBlockOffsetForPainting() const
 {
     bool progressionReversed = multiColumnFlow()->progressionIsReversed();

--- a/Source/WebCore/rendering/RenderMultiColumnSet.h
+++ b/Source/WebCore/rendering/RenderMultiColumnSet.h
@@ -165,6 +165,7 @@ private:
     void collectLayerFragments(LayerFragments&, const LayoutRect& layerBoundingBox, const LayoutRect& dirtyRect) override;
 
     Vector<LayoutRect> fragmentRectsForFlowContentRect(const LayoutRect&) const final;
+    bool contentRectSpansFragments(const LayoutRect&) const final;
 
     VisiblePosition positionForPoint(const LayoutPoint&, HitTestSource, const RenderFragmentContainer*) override;
 


### PR DESCRIPTION
#### e5d8d9678c91bb0d98ca391b2447c206cdf49acb
<pre>
View transitions don&apos;t ignore fragmented content.
<a href="https://bugs.webkit.org/show_bug.cgi?id=265734">https://bugs.webkit.org/show_bug.cgi?id=265734</a>
&lt;<a href="https://rdar.apple.com/119081264">rdar://119081264</a>&gt;

Reviewed by Alan Baradlay

Check for fragmented content when looking up view-transition-name properties in
the new/old state captures, and ignore names belonging to fragmented content.

If an element becomes fragmented in the middle of the transition, abort.

Add handing for the case where the content belongs to a single
RenderMultiColumnSet (and thus isn&apos;t fragmented in the render tree), but still
is visually fragmented across columns by adding a new lookup that works
similarly to absoluteQuadsForBox.

Adds new tests for content spanning across a fragmentainer.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/column-span-during-transition-doesnt-skip-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/column-span-during-transition-doesnt-skip-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/column-span-during-transition-doesnt-skip.html: Added.
* Source/WebCore/dom/ViewTransition.cpp:
(WebCore::rendererIsFragmented):
(WebCore::ViewTransition::captureOldState):
(WebCore::ViewTransition::captureNewState):
(WebCore::ViewTransition::handleTransitionFrame):
(WebCore::ViewTransition::updatePseudoElementStylesRead):
* Source/WebCore/dom/ViewTransition.h:
* Source/WebCore/rendering/RenderFragmentContainer.h:
(WebCore::RenderFragmentContainer::contentRectSpansFragments const):
* Source/WebCore/rendering/RenderFragmentedFlow.cpp:
(WebCore::RenderFragmentedFlow::boxIsFragmented const):
* Source/WebCore/rendering/RenderFragmentedFlow.h:
* Source/WebCore/rendering/RenderMultiColumnSet.cpp:
(WebCore::RenderMultiColumnSet::contentRectSpansFragments const):
* Source/WebCore/rendering/RenderMultiColumnSet.h:

Canonical link: <a href="https://commits.webkit.org/295430@main">https://commits.webkit.org/295430@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/84cb7238d5f60f244d29ba4918b9345b7d260142

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105090 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24804 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15227 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110307 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/55770 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/107131 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/25224 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33348 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79811 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108096 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19648 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94856 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60118 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/19405 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/12931 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55147 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/89116 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/12976 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/112832 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32255 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23751 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88891 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32621 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91075 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88521 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22563 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33413 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11204 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/27655 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32178 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/37641 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/31971 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35312 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33530 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->