### PR TITLE
[macOS] Content under left obscured content inset area is clipped when pinch-zooming

### DIFF
--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -996,6 +996,13 @@ GraphicsLayer* LocalFrameView::graphicsLayerForScrolledContents()
     return nullptr;
 }
 
+GraphicsLayer* LocalFrameView::clipLayer() const
+{
+    if (CheckedPtr renderView = m_frame->contentRenderer())
+        return renderView->compositor().clipLayer();
+    return nullptr;
+}
+
 #if HAVE(RUBBER_BANDING)
 GraphicsLayer* LocalFrameView::graphicsLayerForTransientZoomShadow()
 {

--- a/Source/WebCore/page/LocalFrameView.h
+++ b/Source/WebCore/page/LocalFrameView.h
@@ -168,6 +168,7 @@ public:
     WEBCORE_EXPORT GraphicsLayer* graphicsLayerForPlatformWidget(PlatformWidget);
     WEBCORE_EXPORT GraphicsLayer* graphicsLayerForPageScale();
     WEBCORE_EXPORT GraphicsLayer* graphicsLayerForScrolledContents();
+    WEBCORE_EXPORT GraphicsLayer* clipLayer() const;
 #if HAVE(RUBBER_BANDING)
     WEBCORE_EXPORT GraphicsLayer* graphicsLayerForTransientZoomShadow();
 #endif

--- a/Source/WebCore/platform/graphics/GeometryUtilities.cpp
+++ b/Source/WebCore/platform/graphics/GeometryUtilities.cpp
@@ -385,4 +385,9 @@ float normalizeAngleInRadians(float radians)
     return radiansPerTurnFloat * (circles - floor(circles));
 }
 
+FloatRect scaledRectAtOrigin(const FloatRect& rect, float scale, const FloatPoint& origin)
+{
+    return { origin + (rect.location() - origin) * scale, rect.size() * scale };
+}
+
 }

--- a/Source/WebCore/platform/graphics/GeometryUtilities.h
+++ b/Source/WebCore/platform/graphics/GeometryUtilities.h
@@ -103,6 +103,8 @@ float toRelatedAcuteAngle(float angle);
 
 float normalizeAngleInRadians(float radians);
 
+WEBCORE_EXPORT FloatRect scaledRectAtOrigin(const FloatRect& sourceRect, float scale, const FloatPoint& origin);
+
 struct RotatedRect {
     FloatPoint center;
     FloatSize size;

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in
@@ -142,6 +142,7 @@ header: "RemoteLayerBackingStore.h"
 #if PLATFORM(MAC)
     Markable<WebCore::PlatformLayerIdentifier> m_pageScalingLayerID;
     Markable<WebCore::PlatformLayerIdentifier> m_scrolledContentsLayerID;
+    Markable<WebCore::PlatformLayerIdentifier> m_mainFrameClipLayerID;
 #endif
 
     double m_pageScaleFactor;

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.h
@@ -200,7 +200,10 @@ public:
 
     std::optional<WebCore::PlatformLayerIdentifier> scrolledContentsLayerID() const { return m_scrolledContentsLayerID.asOptional(); }
     void setScrolledContentsLayerID(std::optional<WebCore::PlatformLayerIdentifier> layerID) { m_scrolledContentsLayerID = layerID; }
-#endif
+
+    std::optional<WebCore::PlatformLayerIdentifier> mainFrameClipLayerID() const { return m_mainFrameClipLayerID.asOptional(); }
+    void setMainFrameClipLayerID(std::optional<WebCore::PlatformLayerIdentifier> layerID) { m_mainFrameClipLayerID = layerID; }
+#endif // PLATFORM(MAC)
 
     uint64_t renderTreeSize() const { return m_renderTreeSize; }
     void setRenderTreeSize(uint64_t renderTreeSize) { m_renderTreeSize = renderTreeSize; }
@@ -293,6 +296,7 @@ private:
 #if PLATFORM(MAC)
     Markable<WebCore::PlatformLayerIdentifier> m_pageScalingLayerID; // Only used for non-delegated scaling.
     Markable<WebCore::PlatformLayerIdentifier> m_scrolledContentsLayerID;
+    Markable<WebCore::PlatformLayerIdentifier> m_mainFrameClipLayerID;
 #endif
 
     double m_pageScaleFactor { 1 };

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.mm
@@ -289,6 +289,7 @@ String RemoteLayerTreeTransaction::description() const
 #if PLATFORM(MAC)
     ts.dumpProperty("pageScalingLayer"_s, m_pageScalingLayerID);
     ts.dumpProperty("scrolledContentsLayerID"_s, m_scrolledContentsLayerID);
+    ts.dumpProperty("mainFrameClipLayerID"_s, m_mainFrameClipLayerID);
 #endif
 
     ts.dumpProperty("minimumScaleFactor"_s, m_minimumScaleFactor);

--- a/Source/WebKit/UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.cpp
+++ b/Source/WebKit/UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.cpp
@@ -197,9 +197,9 @@ void DrawingAreaProxyCoordinatedGraphics::setBackingStoreIsDiscardable(bool isBa
 }
 
 #if PLATFORM(GTK)
-void DrawingAreaProxyCoordinatedGraphics::adjustTransientZoom(double scale, FloatPoint origin)
+void DrawingAreaProxyCoordinatedGraphics::adjustTransientZoom(double scale, FloatPoint originInLayerForPageScale, FloatPoint)
 {
-    send(Messages::DrawingArea::AdjustTransientZoom(scale, origin));
+    send(Messages::DrawingArea::AdjustTransientZoom(scale, originInLayerForPageScale));
 }
 
 void DrawingAreaProxyCoordinatedGraphics::commitTransientZoom(double scale, FloatPoint origin)

--- a/Source/WebKit/UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.h
+++ b/Source/WebKit/UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.h
@@ -76,8 +76,8 @@ private:
 #endif
 
 #if PLATFORM(GTK)
-    void adjustTransientZoom(double scale, WebCore::FloatPoint origin) override;
-    void commitTransientZoom(double scale, WebCore::FloatPoint origin) override;
+    void adjustTransientZoom(double scale, WebCore::FloatPoint originInLayerForPageScale, WebCore::FloatPoint originInVisibleRect) override;
+    void commitTransientZoom(double scale, WebCore::FloatPoint originInLayerForPageScale) override;
 #endif
 
     // IPC message handlers

--- a/Source/WebKit/UIProcess/DrawingAreaProxy.h
+++ b/Source/WebKit/UIProcess/DrawingAreaProxy.h
@@ -99,8 +99,8 @@ public:
     virtual void sizeToContentAutoSizeMaximumSizeDidChange() { }
     virtual void windowKindDidChange() { }
 
-    virtual void adjustTransientZoom(double, WebCore::FloatPoint) { }
-    virtual void commitTransientZoom(double, WebCore::FloatPoint) { }
+    virtual void adjustTransientZoom(double, WebCore::FloatPoint /* originInLayerForPageScale */, WebCore::FloatPoint /* originInVisibleRect */) { }
+    virtual void commitTransientZoom(double, WebCore::FloatPoint /* originInLayerForPageScale */) { }
 
     virtual void viewIsBecomingVisible() { }
     virtual void viewIsBecomingInvisible() { }

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h
@@ -41,7 +41,6 @@ namespace WebKit {
 class RemoteLayerTreeTransaction;
 class RemotePageDrawingAreaProxy;
 class RemoteScrollingCoordinatorProxy;
-class RemoteScrollingCoordinatorProxy;
 class RemoteScrollingCoordinatorTransaction;
 
 class RemoteLayerTreeDrawingAreaProxy : public DrawingAreaProxy, public RefCounted<RemoteLayerTreeDrawingAreaProxy> {

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.h
@@ -57,6 +57,8 @@ public:
     void updateZoomTransactionID();
     std::optional<WebCore::PlatformLayerIdentifier> pageScalingLayerID() { return m_pageScalingLayerID.asOptional(); }
     std::optional<WebCore::PlatformLayerIdentifier> pageScrollingLayerID() { return m_pageScrollingLayerID.asOptional(); }
+    std::optional<WebCore::PlatformLayerIdentifier> scrolledContentsLayerID() const { return m_scrolledContentsLayerID.asOptional(); }
+    std::optional<WebCore::PlatformLayerIdentifier> mainFrameClipLayerID() const { return m_mainFrameClipLayerID.asOptional(); }
 
 private:
     RemoteLayerTreeDrawingAreaProxyMac(WebPageProxy&, WebProcessProxy&);
@@ -70,7 +72,7 @@ private:
 
     void didCommitLayerTree(IPC::Connection&, const RemoteLayerTreeTransaction&, const RemoteScrollingCoordinatorTransaction&) override;
 
-    void adjustTransientZoom(double, WebCore::FloatPoint) override;
+    void adjustTransientZoom(double, WebCore::FloatPoint originInLayerForPageScale, WebCore::FloatPoint originInVisibleRect) override;
     void commitTransientZoom(double, WebCore::FloatPoint) override;
 
     void sendCommitTransientZoom(double, WebCore::FloatPoint, std::optional<WebCore::ScrollingNodeID>);
@@ -109,6 +111,8 @@ private:
 
     Markable<WebCore::PlatformLayerIdentifier> m_pageScalingLayerID;
     Markable<WebCore::PlatformLayerIdentifier> m_pageScrollingLayerID;
+    Markable<WebCore::PlatformLayerIdentifier> m_scrolledContentsLayerID;
+    Markable<WebCore::PlatformLayerIdentifier> m_mainFrameClipLayerID;
 
     bool m_shouldLogNextObserverChange { false };
     bool m_shouldLogNextDisplayRefresh { false };
@@ -117,7 +121,8 @@ private:
 
     std::optional<TransactionID> m_transactionIDAfterEndingTransientZoom;
     std::optional<double> m_transientZoomScale;
-    std::optional<WebCore::FloatPoint> m_transientZoomOrigin;
+    std::optional<WebCore::FloatPoint> m_transientZoomOriginInLayerForPageScale;
+    std::optional<WebCore::FloatPoint> m_transientZoomOriginInVisibleRect;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/ViewGestureController.cpp
+++ b/Source/WebKit/UIProcess/ViewGestureController.cpp
@@ -781,7 +781,7 @@ void ViewGestureController::applyMagnification()
         if (RefPtr page = m_webPageProxy.get())
             page->scalePage(m_magnification, roundedIntPoint(m_magnificationOrigin), [] { });
     } else if (auto* drawingArea = m_webPageProxy ? m_webPageProxy->drawingArea() : nullptr)
-        drawingArea->adjustTransientZoom(m_magnification, scaledMagnificationOrigin(m_magnificationOrigin, m_magnification));
+        drawingArea->adjustTransientZoom(m_magnification, scaledMagnificationOrigin(m_magnificationOrigin, m_magnification), m_magnificationOrigin);
 }
 
 void ViewGestureController::endMagnificationGesture()

--- a/Source/WebKit/UIProcess/mac/TiledCoreAnimationDrawingAreaProxy.h
+++ b/Source/WebKit/UIProcess/mac/TiledCoreAnimationDrawingAreaProxy.h
@@ -57,8 +57,8 @@ private:
     void updateAcceleratedCompositingMode(uint64_t backingStoreStateID, const LayerTreeContext&) override;
     void didFirstLayerFlush(uint64_t /* backingStoreStateID */, const LayerTreeContext&) override;
 
-    void adjustTransientZoom(double scale, WebCore::FloatPoint origin) override;
-    void commitTransientZoom(double scale, WebCore::FloatPoint origin) override;
+    void adjustTransientZoom(double scale, WebCore::FloatPoint originInLayerForPageScale, WebCore::FloatPoint originInVisibleRect) override;
+    void commitTransientZoom(double scale, WebCore::FloatPoint originInLayerForPageScale) override;
 
     void waitForDidUpdateActivityState(ActivityStateChangeID) override;
     void dispatchPresentationCallbacksAfterFlushingLayers(IPC::Connection&, Vector<IPC::AsyncReplyID>&&) final;

--- a/Source/WebKit/UIProcess/mac/TiledCoreAnimationDrawingAreaProxy.mm
+++ b/Source/WebKit/UIProcess/mac/TiledCoreAnimationDrawingAreaProxy.mm
@@ -221,9 +221,9 @@ void TiledCoreAnimationDrawingAreaProxy::sendUpdateGeometry()
     });
 }
 
-void TiledCoreAnimationDrawingAreaProxy::adjustTransientZoom(double scale, FloatPoint origin)
+void TiledCoreAnimationDrawingAreaProxy::adjustTransientZoom(double scale, FloatPoint originInLayerForPageScale, WebCore::FloatPoint)
 {
-    send(Messages::DrawingArea::AdjustTransientZoom(scale, origin));
+    send(Messages::DrawingArea::AdjustTransientZoom(scale, originInLayerForPageScale));
 }
 
 void TiledCoreAnimationDrawingAreaProxy::commitTransientZoom(double scale, FloatPoint origin)

--- a/Source/WebKit/UIProcess/mac/ViewGestureControllerMac.mm
+++ b/Source/WebKit/UIProcess/mac/ViewGestureControllerMac.mm
@@ -238,7 +238,7 @@ void ViewGestureController::didCollectGeometryForSmartMagnificationGesture(Float
     m_initialMagnificationOrigin = { };
 
     auto pageScaleFactor = page->pageScaleFactor();
-    page->drawingArea()->adjustTransientZoom(pageScaleFactor, scaledMagnificationOrigin(FloatPoint(), pageScaleFactor));
+    page->drawingArea()->adjustTransientZoom(pageScaleFactor, scaledMagnificationOrigin(FloatPoint(), pageScaleFactor), m_magnificationOrigin);
     page->drawingArea()->commitTransientZoom(targetMagnification, targetOrigin);
 
     m_lastSmartMagnificationUnscaledTargetRect = unscaledTargetRect;

--- a/Source/WebKit/WebProcess/WebPage/mac/RemoteLayerTreeDrawingAreaMac.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/RemoteLayerTreeDrawingAreaMac.mm
@@ -90,17 +90,14 @@ void RemoteLayerTreeDrawingAreaMac::willCommitLayerTree(RemoteLayerTreeTransacti
     if (!frameView)
         return;
 
-    RefPtr renderViewGraphicsLayer = frameView->graphicsLayerForPageScale();
-    if (!renderViewGraphicsLayer)
-        return;
+    if (RefPtr renderViewGraphicsLayer = frameView->graphicsLayerForPageScale())
+        transaction.setPageScalingLayerID(renderViewGraphicsLayer->primaryLayerID());
 
-    transaction.setPageScalingLayerID(renderViewGraphicsLayer->primaryLayerID());
+    if (RefPtr scrolledContentsLayer = frameView->graphicsLayerForScrolledContents())
+        transaction.setScrolledContentsLayerID(scrolledContentsLayer->primaryLayerID());
 
-    RefPtr scrolledContentsLayer = frameView->graphicsLayerForScrolledContents();
-    if (!scrolledContentsLayer)
-        return;
-
-    transaction.setScrolledContentsLayerID(scrolledContentsLayer->primaryLayerID());
+    if (RefPtr mainFrameClipLayerID = frameView->clipLayer())
+        transaction.setMainFrameClipLayerID(mainFrameClipLayerID->primaryLayerID());
 }
 
 } // namespace WebKit


### PR DESCRIPTION
#### 83e10b359df5a0647ebb2cd5a9e597617a8973ce
<pre>
[macOS] Content under left obscured content inset area is clipped when pinch-zooming
<a href="https://bugs.webkit.org/show_bug.cgi?id=293600">https://bugs.webkit.org/show_bug.cgi?id=293600</a>
<a href="https://rdar.apple.com/151854427">rdar://151854427</a>

Reviewed by Abrar Rahman Protyasha and Simon Fraser.

When applying transient zoom (i.e. during pinch zooming on macOS) while the left obscured content
inset is nonzero, web content underneath the obscured content inset area is clipped by the main
frame&apos;s clip layer, until the transient zoom finishes and the clip layer size and position is
updated to include the obscured content inset area.

This happens because transient zoom currently works by applying a transform to only the layer for
page scaling (i.e. the `RenderView`&apos;s primary layer); however, since the page is contained within a
clip layer whose bounds don&apos;t change while in transient zoom state (during pinch zoom), any content
that would normally show up in the obscured inset area is clipped.

To fix this, we add logic to temporarily reposition and inflate the size of the clip layer (as well
as the scrolled contents layer underneath) while the user is in transient zoom, such that the clip
layer no longer clips any part of the page that falls inside a content inset area. See below for
more details.

* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::clipLayer const):

Add a helper method to grab the frame view&apos;s render layer compositor&apos;s top-level clip layer.

* Source/WebCore/page/LocalFrameView.h:
* Source/WebCore/platform/graphics/GeometryUtilities.cpp:
(WebCore::scaledRectAtOrigin):

Add a helper method that scales the given `FloatRect`, relative to the given `origin` point.

* Source/WebCore/platform/graphics/GeometryUtilities.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.h:
(WebKit::RemoteLayerTreeTransaction::mainFrameClipLayerID const):
(WebKit::RemoteLayerTreeTransaction::setMainFrameClipLayerID):

Add plumbing to provide the main frame clip layer ID in remote layer tree transactions, so that we
can obtain the clip layer in the UI-side remote drawing area proxy below.

* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.mm:
(WebKit::RemoteLayerTreeTransaction::description const):
* Source/WebKit/UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.cpp:
(WebKit::DrawingAreaProxyCoordinatedGraphics::adjustTransientZoom):
* Source/WebKit/UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.h:
* Source/WebKit/UIProcess/DrawingAreaProxy.h:
(WebKit::DrawingAreaProxy::adjustTransientZoom):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h:

Rename the existing `m_transientZoomOrigin` to `m_transientZoomOriginInLayerForPageScale`, to
differentiate it from the new `m_transientZoomOriginInVisibleRect` (which is used to resize and
reposition the clip layer).

* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.mm:
(WebKit::RemoteLayerTreeDrawingAreaProxyMac::didCommitLayerTree):

Obtain the layer IDs of the main frame clip layer, as well as the scrolled contents layer.

(WebKit::fillFowardsAnimationWithKeyPathAndValue):
(WebKit::transientZoomTransformOverrideAnimation):
(WebKit::transientSizeAnimation):
(WebKit::transientPositionAnimation):

Add more helper functions here to create size (`bounds.size`) and position animations, which we
apply to the clipping and scrolled contents layers below.

(WebKit::RemoteLayerTreeDrawingAreaProxyMac::applyTransientZoomToLayer):

Implement the main fix here:

1.  Compute the scaled frame of the clip layer, given the current transient zoom scale, and the
    current frame of the clip layer. Animate the `position` and `bounds.size` of the clip layer
    using this rect.

2.  Reposition the scrolled contents layer under the clip layer, to ensure that content underneath
    shows up in the correct location after repositioning the clip layer position in (1).

(WebKit::RemoteLayerTreeDrawingAreaProxyMac::removeTransientZoomFromLayer):
(WebKit::RemoteLayerTreeDrawingAreaProxyMac::adjustTransientZoom):

Plumb the `originInVisibleRect` alongside the existing `origin`, which is in `layerForPageScaling`&apos;s
coordinate space.

(WebKit::RemoteLayerTreeDrawingAreaProxyMac::commitTransientZoom):

Remove the position and size animations from the scrolled contents and clip layers when committing
the transient zoom, to prevent a jump in the case when we&apos;re rubber-banding against the min or max
scale before ending transient zooming.

* Source/WebKit/UIProcess/ViewGestureController.cpp:
(WebKit::ViewGestureController::applyMagnification):

Pass in `m_magnificationOrigin` here; this will eventually become the drawing area&apos;s
`m_transientZoomOriginInVisibleRect`.

* Source/WebKit/UIProcess/mac/TiledCoreAnimationDrawingAreaProxy.h:
* Source/WebKit/UIProcess/mac/TiledCoreAnimationDrawingAreaProxy.mm:
(WebKit::TiledCoreAnimationDrawingAreaProxy::adjustTransientZoom):
* Source/WebKit/UIProcess/mac/ViewGestureControllerMac.mm:
(WebKit::ViewGestureController::didCollectGeometryForSmartMagnificationGesture):
* Source/WebKit/WebProcess/WebPage/mac/RemoteLayerTreeDrawingAreaMac.mm:
(WebKit::RemoteLayerTreeDrawingAreaMac::willCommitLayerTree):

Set the `mainFrameClipLayerID` here.

Canonical link: <a href="https://commits.webkit.org/295495@main">https://commits.webkit.org/295495@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8955b1dbceb5988f0da36601a3f65d27f95c6c7b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105211 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24923 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15348 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110425 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/55875 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/107252 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/25351 "Build is in progress. Recent messages:OS: Sequoia (15.2), Xcode: 16.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33467 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79909 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108217 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19762 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94962 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60216 "Passed tests") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/104689 "Build is in progress. Recent messages:") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/19519 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13037 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55265 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/89222 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13081 "Build is in progress. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Running apply-patch; Checked out pull request; Running run-layout-tests-in-stress-mode; 14 flakes 2 failures; Uploaded test results; 10 flakes") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/113008 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32373 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23848 "Passed tests") | [⏳ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/GTK-WK2-Tests-EWS "Waiting to run tests") | 
| [⏳ 🧪 services ](https://ews-build.webkit.org/#/builders/Services-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32738 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91179 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88619 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22608 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33515 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11303 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/27784 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32297 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/37711 "Failed to build and analyze WebKit") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32081 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35424 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33645 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->