### PR TITLE
WebGL canvas element disappears for one frame drawn to while starting a view transition.

### DIFF
--- a/LayoutTests/fast/css/view-transitions-webgl-expected.html
+++ b/LayoutTests/fast/css/view-transitions-webgl-expected.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<div style="width:400px; height: 400px; background: rgb(0, 255, 0)"></div>

--- a/LayoutTests/fast/css/view-transitions-webgl.html
+++ b/LayoutTests/fast/css/view-transitions-webgl.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<script src="../../resources/ui-helper.js"></script>
+<style>
+/* We're verifying what we capture, so just display the new contents for 5 minutes.  */
+html::view-transition-group(*) { animation-duration: 300s; }
+html::view-transition-new(*) { animation: unset; opacity: 1; }
+html::view-transition-old(*) { animation: unset; opacity: 0; }
+</style>
+<canvas id="canvas1" width=400px height=400px></canvas>
+<script>
+if (window.testRunner) {
+  testRunner.waitUntilDone();
+  if (testRunner.dontForceRepaint)
+    testRunner.dontForceRepaint();
+}
+
+async function runTest() {
+
+  var canvas1 = document.getElementById("canvas1");
+  var gl = canvas1.getContext('webgl', { preserveDrawingBuffer: false } );
+  gl.clearColor(0, 1, 0, 1);
+  gl.clear(gl.COLOR_BUFFER_BIT);
+
+  document.startViewTransition();
+
+  await UIHelper.renderingUpdate();
+
+  if (window.testRunner)
+    testRunner.notifyDone();
+}
+onload = () => requestAnimationFrame(() => requestAnimationFrame(runTest));
+</script>

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -5613,9 +5613,8 @@ Lock& WebGLRenderingContextBase::objectGraphLock()
 
 void WebGLRenderingContextBase::prepareForDisplay()
 {
-    if (!m_context)
+    if (!m_context || !m_compositingResultsNeedUpdating)
         return;
-    ASSERT(m_compositingResultsNeedUpdating);
 
     clearIfComposited(CallerTypeOther);
     m_context->prepareForDisplay();


### PR DESCRIPTION
#### cd808a6b87221d008b61536079a3b26d8aa77795
<pre>
WebGL canvas element disappears for one frame drawn to while starting a view transition.
<a href="https://bugs.webkit.org/show_bug.cgi?id=291537">https://bugs.webkit.org/show_bug.cgi?id=291537</a>
&lt;<a href="https://rdar.apple.com/149709642">rdar://149709642</a>&gt;

Reviewed by Simon Fraser.

Drawing the canvas element into a snapshot calls
WebGLRenderingContextBase::prepareForDisplay which clears the drawing buffer.
Running this a second time during the main rendering update results in the
cleared drawing buffer being used instead.

Don&apos;t prepare for display for a second time if it&apos;s already been done by another
caller.

* LayoutTests/fast/css/view-transitions-webgl-expected.html: Added.
* LayoutTests/fast/css/view-transitions-webgl.html: Added.
* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::prepareForDisplay):

Canonical link: <a href="https://commits.webkit.org/295467@main">https://commits.webkit.org/295467@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ccae5fb2526711f080758b8b9f6c9ff11335ab3c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105100 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24814 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15237 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110317 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/55779 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/107141 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/25235 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33358 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79818 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108106 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19659 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94868 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60125 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/19414 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/12944 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55157 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/89125 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/12988 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/112853 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32265 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23760 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88900 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32631 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91087 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88530 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22593 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33422 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11214 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/27664 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32188 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/37564 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/31981 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35322 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33540 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->