### PR TITLE
anchor-scope scopes names, not elements

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scope-basic.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scope-basic.html
@@ -11,7 +11,8 @@
 
   .anchor-a { anchor-name: --a; }
   .anchor-b { anchor-name: --b; }
-  .anchor-a, .anchor-b {
+  .anchor-ab { anchor-name: --a, --b; }
+  .anchor-a, .anchor-b, .anchor-ab {
     background: skyblue;
     height: 10px;
   }
@@ -159,7 +160,8 @@
   <div class=anchor-b></div>
   <div class=anchor-a></div><!--A-->
   <div class=scope-a>
-    <div class=anchor-b></div><!--B-->
+    <div class=anchor-b></div>
+    <div class=anchor-ab></div><!--B-->
     <div class=anchor-a></div>
   </div>
   <div class=anchored-a></div>
@@ -169,7 +171,7 @@
   test((t) => {
     inflate(t, test_scope_a);
     assert_equals(getComputedStyle(main.querySelector('.anchored-a')).top, '20px');
-    assert_equals(getComputedStyle(main.querySelector('.anchored-b')).top, '30px');
+    assert_equals(getComputedStyle(main.querySelector('.anchored-b')).top, '40px');
   }, 'anchor-scope:--a scopes only --a');
 </script>
 
@@ -177,8 +179,8 @@
   <div class=anchor-b></div><!--B-->
   <div class=anchor-a></div>
   <div class=scope-b>
-    <div class=anchor-b></div>
     <div class=anchor-a></div><!--A-->
+    <div class=anchor-b></div>
   </div>
   <div class=anchored-a></div>
   <div class=anchored-b></div>
@@ -186,7 +188,7 @@
 <script>
   test((t) => {
     inflate(t, test_scope_b);
-    assert_equals(getComputedStyle(main.querySelector('.anchored-a')).top, '40px');
+    assert_equals(getComputedStyle(main.querySelector('.anchored-a')).top, '30px');
     assert_equals(getComputedStyle(main.querySelector('.anchored-b')).top, '10px');
   }, 'anchor-scope:--b scopes only --b');
 </script>


### PR DESCRIPTION
#### 013f4f81fdd5023a8e11a155df7340c565b2e662
<pre>
anchor-scope scopes names, not elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=293438">https://bugs.webkit.org/show_bug.cgi?id=293438</a>
<a href="https://rdar.apple.com/151866809">rdar://151866809</a>

Reviewed by Antti Koivisto.

Previously we were eliminating an element from consideration if it had
any of the scoped names. But the names which are not scoped should still
be available for matching.

* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scope-basic.html:
Update test to check this case.

* Source/WebCore/style/AnchorPositionEvaluator.cpp:
(WebCore::Style::anchorScopeForAnchorName):
Scope the name, not the element.

(WebCore::Style::isAcceptableAnchorElement):
Adjust function call.

(WebCore::Style::findLastAcceptableAnchorWithName):
(WebCore::Style::anchorScopeForAnchorElement): Deleted.
Renamed to reflect focus on name scoping, see above.

Canonical link: <a href="https://commits.webkit.org/295576@main">https://commits.webkit.org/295576@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4f141100e5ed0b6fef0c40146ee4af54b7018e40

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105458 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25169 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15597 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110659 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/56083 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/107499 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/25630 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33708 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80097 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108464 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/20004 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95174 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60406 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/19731 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13264 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55496 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/89463 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13305 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/113409 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32601 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24038 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89175 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32964 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91403 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88831 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22661 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33702 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11505 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/28061 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32527 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/37947 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32284 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35631 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33870 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->