### PR TITLE
[WPE] WPE Platform: remove circular dependency between WPEView and WPEBuffer

### DIFF
--- a/Source/WebKit/UIProcess/wpe/AcceleratedBackingStoreDMABuf.cpp
+++ b/Source/WebKit/UIProcess/wpe/AcceleratedBackingStoreDMABuf.cpp
@@ -100,7 +100,7 @@ void AcceleratedBackingStoreDMABuf::didCreateBuffer(uint64_t id, const WebCore::
     fileDescriptors.reserveInitialCapacity(fds.size());
     for (auto& fd : fds)
         fileDescriptors.append(fd.release());
-    GRefPtr<WPEBuffer> buffer = adoptGRef(WPE_BUFFER(wpe_buffer_dma_buf_new(m_wpeView.get(), size.width(), size.height(), format, fds.size(), fileDescriptors.data(), offsets.data(), strides.data(), modifier)));
+    GRefPtr<WPEBuffer> buffer = adoptGRef(WPE_BUFFER(wpe_buffer_dma_buf_new(wpe_view_get_display(m_wpeView.get()), size.width(), size.height(), format, fds.size(), fileDescriptors.data(), offsets.data(), strides.data(), modifier)));
     g_object_set_data(G_OBJECT(buffer.get()), "wk-buffer-format-usage", GUINT_TO_POINTER(usage));
     m_bufferIDs.add(buffer.get(), id);
     m_buffers.add(id, WTFMove(buffer));
@@ -119,7 +119,7 @@ void AcceleratedBackingStoreDMABuf::didCreateBufferSHM(uint64_t id, WebCore::Sha
         delete static_cast<WebCore::ShareableBitmap*>(userData);
     }, bitmap.leakRef()));
 
-    GRefPtr<WPEBuffer> buffer = adoptGRef(WPE_BUFFER(wpe_buffer_shm_new(m_wpeView.get(), size.width(), size.height(), WPE_PIXEL_FORMAT_ARGB8888, bytes.get(), stride)));
+    GRefPtr<WPEBuffer> buffer = adoptGRef(WPE_BUFFER(wpe_buffer_shm_new(wpe_view_get_display(m_wpeView.get()), size.width(), size.height(), WPE_PIXEL_FORMAT_ARGB8888, bytes.get(), stride)));
     m_bufferIDs.add(buffer.get(), id);
     m_buffers.add(id, WTFMove(buffer));
 }

--- a/Source/WebKit/WPEPlatform/wpe/WPEBuffer.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEBuffer.cpp
@@ -27,6 +27,7 @@
 #include "WPEBuffer.h"
 
 #include <wtf/glib/GRefPtr.h>
+#include <wtf/glib/GWeakPtr.h>
 #include <wtf/glib/WTFGType.h>
 
 /**
@@ -34,7 +35,7 @@
  *
  */
 struct _WPEBufferPrivate {
-    GRefPtr<WPEView> view;
+    GWeakPtr<WPEDisplay> display;
     int width;
     int height;
 
@@ -58,7 +59,7 @@ G_DEFINE_QUARK(wpe-buffer-error-quark, wpe_buffer_error)
 enum {
     PROP_0,
 
-    PROP_VIEW,
+    PROP_DISPLAY,
     PROP_WIDTH,
     PROP_HEIGHT,
 
@@ -72,8 +73,8 @@ static void wpeBufferSetProperty(GObject* object, guint propId, const GValue* va
     auto* buffer = WPE_BUFFER(object);
 
     switch (propId) {
-    case PROP_VIEW:
-        buffer->priv->view = WPE_VIEW(g_value_get_object(value));
+    case PROP_DISPLAY:
+        buffer->priv->display.reset(WPE_DISPLAY(g_value_get_object(value)));
         break;
     case PROP_WIDTH:
         buffer->priv->width = g_value_get_int(value);
@@ -91,8 +92,8 @@ static void wpeBufferGetProperty(GObject* object, guint propId, GValue* value, G
     auto* buffer = WPE_BUFFER(object);
 
     switch (propId) {
-    case PROP_VIEW:
-        g_value_set_object(value, wpe_buffer_get_view(buffer));
+    case PROP_DISPLAY:
+        g_value_set_object(value, wpe_buffer_get_display(buffer));
         break;
     case PROP_WIDTH:
         g_value_set_int(value, wpe_buffer_get_width(buffer));
@@ -120,15 +121,15 @@ static void wpe_buffer_class_init(WPEBufferClass* bufferClass)
     objectClass->dispose = wpeBufferDispose;
 
     /**
-     * WPEBuffer:view:
+     * WPEBuffer:display:
      *
-     * The #WPEView of the buffer.
+     * The #WPEDisplay of the buffer.
      */
-    sObjProperties[PROP_VIEW] =
+    sObjProperties[PROP_DISPLAY] =
         g_param_spec_object(
-            "view",
+            "display",
             nullptr, nullptr,
-            WPE_TYPE_VIEW,
+            WPE_TYPE_DISPLAY,
             static_cast<GParamFlags>(WEBKIT_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
 
     /**
@@ -159,18 +160,18 @@ static void wpe_buffer_class_init(WPEBufferClass* bufferClass)
 }
 
 /**
- * wpe_buffer_get_view:
+ * wpe_buffer_get_display:
  * @buffer: a #WPEBuffer
  *
- * Get the #WPEView of @buffer
+ * Get the #WPEDisplay of @buffer
  *
- * Returns: (transfer none): a #WPEView
+ * Returns: (transfer none) (nullable): a #WPEDisplay or %NULL
  */
-WPEView* wpe_buffer_get_view(WPEBuffer* buffer)
+WPEDisplay* wpe_buffer_get_display(WPEBuffer* buffer)
 {
     g_return_val_if_fail(WPE_IS_BUFFER(buffer), nullptr);
 
-    return buffer->priv->view.get();
+    return buffer->priv->display.get();
 }
 
 /**

--- a/Source/WebKit/WPEPlatform/wpe/WPEBuffer.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPEBuffer.h
@@ -32,7 +32,7 @@
 
 #include <glib-object.h>
 #include <wpe/WPEDefines.h>
-#include <wpe/WPEView.h>
+#include <wpe/WPEDisplay.h>
 
 G_BEGIN_DECLS
 
@@ -66,7 +66,7 @@ typedef enum {
 } WPEBufferError;
 
 WPE_API GQuark      wpe_buffer_error_quark         (void);
-WPE_API WPEView    *wpe_buffer_get_view            (WPEBuffer     *buffer);
+WPE_API WPEDisplay *wpe_buffer_get_display         (WPEBuffer     *buffer);
 WPE_API int         wpe_buffer_get_width           (WPEBuffer     *buffer);
 WPE_API int         wpe_buffer_get_height          (WPEBuffer     *buffer);
 WPE_API void        wpe_buffer_set_user_data       (WPEBuffer     *buffer,

--- a/Source/WebKit/WPEPlatform/wpe/WPEBufferDMABuf.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPEBufferDMABuf.h
@@ -39,7 +39,7 @@ G_BEGIN_DECLS
 #define WPE_TYPE_BUFFER_DMA_BUF (wpe_buffer_dma_buf_get_type())
 WPE_API G_DECLARE_FINAL_TYPE (WPEBufferDMABuf, wpe_buffer_dma_buf, WPE, BUFFER_DMA_BUF, WPEBuffer)
 
-WPE_API WPEBufferDMABuf *wpe_buffer_dma_buf_new          (WPEView         *view,
+WPE_API WPEBufferDMABuf *wpe_buffer_dma_buf_new          (WPEDisplay      *display,
                                                           int              width,
                                                           int              height,
                                                           guint32          format,

--- a/Source/WebKit/WPEPlatform/wpe/WPEBufferSHM.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEBufferSHM.cpp
@@ -147,7 +147,7 @@ static void wpe_buffer_shm_class_init(WPEBufferSHMClass* bufferSHMClass)
 
 /**
  * wpe_buffer_shm_new:
- * @view: a #WPEView
+ * @display: a #WPEDisplay
  * @width: the buffer width
  * @height: the buffer height
  * @format: the buffer format
@@ -158,13 +158,13 @@ static void wpe_buffer_shm_class_init(WPEBufferSHMClass* bufferSHMClass)
  *
  * Returns: (transfer full): a #WPEBufferSHM
  */
-WPEBufferSHM* wpe_buffer_shm_new(WPEView* view, int width, int height, WPEPixelFormat format, GBytes* data, guint stride)
+WPEBufferSHM* wpe_buffer_shm_new(WPEDisplay* display, int width, int height, WPEPixelFormat format, GBytes* data, guint stride)
 {
-    g_return_val_if_fail(WPE_IS_VIEW(view), nullptr);
+    g_return_val_if_fail(WPE_IS_DISPLAY(display), nullptr);
     g_return_val_if_fail(data, nullptr);
 
     return WPE_BUFFER_SHM(g_object_new(WPE_TYPE_BUFFER_SHM,
-        "view", view,
+        "display", display,
         "width", width,
         "height", height,
         "format", format,

--- a/Source/WebKit/WPEPlatform/wpe/WPEBufferSHM.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPEBufferSHM.h
@@ -49,7 +49,7 @@ typedef enum {
     WPE_PIXEL_FORMAT_ARGB8888
 } WPEPixelFormat;
 
-WPE_API WPEBufferSHM  *wpe_buffer_shm_new        (WPEView       *view,
+WPE_API WPEBufferSHM  *wpe_buffer_shm_new        (WPEDisplay    *display,
                                                   int            width,
                                                   int            height,
                                                   WPEPixelFormat format,


### PR DESCRIPTION
#### 5264807369a3d830ba359dd22fddad2a8d90fd73
<pre>
[WPE] WPE Platform: remove circular dependency between WPEView and WPEBuffer
<a href="https://bugs.webkit.org/show_bug.cgi?id=293606">https://bugs.webkit.org/show_bug.cgi?id=293606</a>

Reviewed by Nikolas Zimmermann.

WPEBuffer keeps a reference to a WPEView and it&apos;s very common in WPEView
implementations to keep a reference of the buffer in use. The WPEBuffer
doesn&apos;t really need the view, in most of the cases it&apos;s only used to get
the display. So, we can change the view property by display and use a
weak reference instead.

Canonical link: <a href="https://commits.webkit.org/295435@main">https://commits.webkit.org/295435@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ee4afe0e077febacb1c953a79669754426b22977

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105125 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24839 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15262 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110341 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/55799 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/25265 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33383 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/79844 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108131 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/19689 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94885 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60151 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/19440 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55182 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/89153 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13005 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/112879 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32290 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23779 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/88921 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32656 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91103 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88551 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33443 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11231 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/27696 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17040 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32213 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/37589 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32003 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35346 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33564 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->