### PR TITLE
[WPE] WPE Platform: add support for running WebKit API tests with the new API

### DIFF
--- a/Tools/Scripts/run-wpe-tests
+++ b/Tools/Scripts/run-wpe-tests
@@ -58,7 +58,9 @@ if __name__ == "__main__":
     option_parser = optparse.OptionParser(usage='usage: %prog [options] [test...]')
     add_options(option_parser);
     option_parser.add_option('--display-server', choices=['headless', 'wayland'], default='headless',
-                             help='"headless": Use headless view backend. "wayland": Use the current wayland session.'),
+                             help='"headless": Use headless view backend. "wayland": Use the current wayland session.')
+    option_parser.add_option('--wpe-legacy-api', action="store_true", default=False,
+                             help='Use WPE legacy API.')
 
     args = sys.argv[1:]
     if flatpakutils.is_sandboxed():

--- a/Tools/TestWebKitAPI/PlatformWPE.cmake
+++ b/Tools/TestWebKitAPI/PlatformWPE.cmake
@@ -61,10 +61,9 @@ list(APPEND TestWebCore_LIBRARIES
 
 # TestWebKit
 list(APPEND TestWebKit_SOURCES
-    ${test_main_SOURCES}
-
     wpe/PlatformUtilitiesWPE.cpp
     wpe/PlatformWebViewWPE.cpp
+    wpe/WebKitTestMain.cpp
 )
 
 add_subdirectory(wpe/mock-platform)
@@ -82,6 +81,16 @@ list(APPEND TestWebKit_SYSTEM_INCLUDE_DIRECTORIES
 list(APPEND TestWebKit_PRIVATE_LIBRARIES
     WebKit::WPEToolingBackends
 )
+
+if (ENABLE_WPE_PLATFORM)
+    list(APPEND TestWebKit_PRIVATE_INCLUDE_DIRECTORIES
+        ${WPEPlatform_DERIVED_SOURCES_DIR}
+        ${WEBKIT_DIR}/WPEPlatform
+    )
+    list(APPEND TestWebKit_PRIVATE_LIBRARIES
+        WPEPlatform-${WPE_API_VERSION}
+    )
+endif ()
 
 # TestWebKitAPIBase
 target_include_directories(TestWebKitAPIBase PRIVATE

--- a/Tools/TestWebKitAPI/PlatformWebView.h
+++ b/Tools/TestWebKitAPI/PlatformWebView.h
@@ -50,12 +50,8 @@ typedef NSWindow *PlatformWindow;
 typedef WKViewRef PlatformWKView;
 typedef GtkWidget *PlatformWindow;
 #elif PLATFORM(WPE)
-namespace WPEToolingBackends {
-class HeadlessViewBackend;
-}
-struct wpe_view_backend;
 typedef WKViewRef PlatformWKView;
-typedef WPEToolingBackends::HeadlessViewBackend *PlatformWindow;
+typedef void* PlatformWindow;
 #elif PLATFORM(WIN)
 typedef WKViewRef PlatformWKView;
 typedef HWND PlatformWindow;

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitWebView.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitWebView.cpp
@@ -118,6 +118,12 @@ static void testWebViewCloseQuickly(WebViewTest* test, gconstpointer)
 #if PLATFORM(WPE)
 static void testWebViewWebBackend(Test* test, gconstpointer)
 {
+#if ENABLE(WPE_PLATFORM)
+    if (test->m_display) {
+        g_test_skip(nullptr);
+        return;
+    }
+#endif
     static struct wpe_view_backend_interface s_testingInterface = {
         // create
         [](void*, struct wpe_view_backend*) -> void* { return nullptr; },
@@ -1689,6 +1695,12 @@ public:
 
 static void testWebViewFrameDisplayed(FrameDisplayedTest* test, gconstpointer)
 {
+#if ENABLE(WPE_PLATFORM)
+    if (test->m_display) {
+        g_test_skip(nullptr);
+        return;
+    }
+#endif
     test->showInWindow();
 
     test->loadHtml("<html></html>", nullptr);

--- a/Tools/TestWebKitAPI/glib/PlatformWPE.cmake
+++ b/Tools/TestWebKitAPI/glib/PlatformWPE.cmake
@@ -25,3 +25,12 @@ list(APPEND WebKitGLibAPITestsCore_LIBRARIES
 list(APPEND WebKitGLibAPITest_LIBRARIES
     WebKit::WPEToolingBackends
 )
+
+if (ENABLE_WPE_PLATFORM)
+    list(APPEND WebKitGLibAPITestsCore_LIBRARIES
+        WPEPlatform-${WPE_API_VERSION}
+    )
+    list(APPEND WebKitGLibAPITest_LIBRARIES
+        WPEPlatform-${WPE_API_VERSION}
+    )
+endif ()

--- a/Tools/TestWebKitAPI/glib/WebKitGLib/TestMain.cpp
+++ b/Tools/TestWebKitAPI/glib/WebKitGLib/TestMain.cpp
@@ -33,6 +33,9 @@ GRefPtr<GDBusServer> Test::s_dbusServer;
 Vector<GRefPtr<GDBusConnection>> Test::s_dbusConnections;
 HashMap<uint64_t, GDBusConnection*> Test::s_dbusConnectionPageMap;
 WebKitMemoryPressureSettings* Test::s_memoryPressureSettings = nullptr;
+#if ENABLE(WPE_PLATFORM)
+bool Test::s_useWPELegacyAPI = false;
+#endif
 
 void beforeAll();
 void afterAll();
@@ -118,6 +121,16 @@ static void stopDBusServer()
     Test::s_dbusServer = nullptr;
 }
 
+#if ENABLE(WPE_PLATFORM)
+static void parseWPEArgs(int argc, char** argv)
+{
+    for (int i = 1; i < argc; ++i) {
+        if (!g_strcmp0(argv[i], "--wpe-legacy-api"))
+            Test::s_useWPELegacyAPI = true;
+    }
+}
+#endif
+
 int main(int argc, char** argv)
 {
     g_unsetenv("DBUS_SESSION_BUS_ADDRESS");
@@ -126,6 +139,10 @@ int main(int argc, char** argv)
 #else
     g_test_init(&argc, &argv, nullptr);
 #endif
+#if ENABLE(WPE_PLATFORM)
+    parseWPEArgs(argc, argv);
+#endif
+
     g_set_prgname(FileSystem::currentExecutableName().data());
     g_setenv("WEBKIT_EXEC_PATH", WEBKIT_EXEC_PATH, FALSE);
     g_setenv("WEBKIT_INJECTED_BUNDLE_PATH", WEBKIT_INJECTED_BUNDLE_PATH, FALSE);

--- a/Tools/TestWebKitAPI/glib/WebKitGLib/WebViewTest.cpp
+++ b/Tools/TestWebKitAPI/glib/WebKitGLib/WebViewTest.cpp
@@ -63,6 +63,11 @@ void WebViewTest::initializeWebView()
 
     assertObjectIsDeletedWhenTestFinishes(G_OBJECT(m_webView.get()));
 
+#if ENABLE(WPE_PLATFORM)
+    if (auto* view = webkit_web_view_get_wpe_view(m_webView.get()))
+        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(view));
+#endif
+
     g_signal_connect(m_webView.get(), "web-process-terminated", G_CALLBACK(WebViewTest::webProcessTerminated), this);
 }
 

--- a/Tools/TestWebKitAPI/glib/WebKitGLib/wpe/WebViewTestWPE.cpp
+++ b/Tools/TestWebKitAPI/glib/WebKitGLib/wpe/WebViewTestWPE.cpp
@@ -21,6 +21,7 @@
 #include "WebViewTest.h"
 
 #include <wpe/wpe.h>
+#include <wtf/glib/GUniquePtr.h>
 
 void WebViewTest::platformDestroy()
 {
@@ -37,14 +38,33 @@ void WebViewTest::resizeView(int width, int height)
     // FIXME: implement.
 }
 
-void WebViewTest::showInWindow(int, int)
+void WebViewTest::showInWindow(int width, int height)
 {
+#if ENABLE(WPE_PLATFORM)
+    if (m_display) {
+        auto* view = webkit_web_view_get_wpe_view(m_webView.get());
+        g_assert_true(WPE_IS_VIEW(view));
+        if (width && height)
+            wpe_toplevel_resize(wpe_view_get_toplevel(view), width, height);
+        wpe_view_set_visible(view, TRUE);
+        wpe_view_focus_in(view);
+        return;
+    }
+#endif
     auto* backend = webkit_web_view_backend_get_wpe_backend(webkit_web_view_get_backend(m_webView.get()));
     wpe_view_backend_add_activity_state(backend, wpe_view_activity_state_visible | wpe_view_activity_state_in_window | wpe_view_activity_state_focused);
 }
 
 void WebViewTest::hideView()
 {
+#if ENABLE(WPE_PLATFORM)
+    if (m_display) {
+        auto* view = webkit_web_view_get_wpe_view(m_webView.get());
+        wpe_view_set_visible(view, FALSE);
+        wpe_view_focus_out(view);
+        return;
+    }
+#endif
     auto* backend = webkit_web_view_backend_get_wpe_backend(webkit_web_view_get_backend(m_webView.get()));
     wpe_view_backend_remove_activity_state(backend, wpe_view_activity_state_visible | wpe_view_activity_state_focused);
 }
@@ -76,6 +96,35 @@ static unsigned testMouseButtonToWPELegacy(WebViewTest::MouseButton button)
     RELEASE_ASSERT_NOT_REACHED();
 }
 
+#if ENABLE(WPE_PLATFORM)
+static WPEModifiers testModifiersToWPE(const OptionSet<WebViewTest::Modifiers>& modifiers)
+{
+    unsigned wpeModifiers = 0;
+    if (modifiers.contains(WebViewTest::Modifiers::Control))
+        wpeModifiers |= WPE_MODIFIER_KEYBOARD_CONTROL;
+    if (modifiers.contains(WebViewTest::Modifiers::Shift))
+        wpeModifiers |= WPE_MODIFIER_KEYBOARD_SHIFT;
+    if (modifiers.contains(WebViewTest::Modifiers::Alt))
+        wpeModifiers |= WPE_MODIFIER_KEYBOARD_ALT;
+    if (modifiers.contains(WebViewTest::Modifiers::Meta))
+        wpeModifiers |= WPE_MODIFIER_KEYBOARD_META;
+    return static_cast<WPEModifiers>(wpeModifiers);
+}
+
+static unsigned testMouseButtonToWPE(WebViewTest::MouseButton button)
+{
+    switch (button) {
+    case WebViewTest::MouseButton::Primary:
+        return WPE_BUTTON_PRIMARY;
+    case WebViewTest::MouseButton::Middle:
+        return WPE_BUTTON_MIDDLE;
+    case WebViewTest::MouseButton::Secondary:
+        return WPE_BUTTON_SECONDARY;
+    }
+    RELEASE_ASSERT_NOT_REACHED();
+}
+#endif
+
 void WebViewTest::mouseMoveTo(int x, int y, OptionSet<Modifiers> mouseModifiers)
 {
     // FIXME: implement.
@@ -83,6 +132,20 @@ void WebViewTest::mouseMoveTo(int x, int y, OptionSet<Modifiers> mouseModifiers)
 
 void WebViewTest::clickMouseButton(int x, int y, MouseButton button, OptionSet<Modifiers> mouseModifiers)
 {
+#if ENABLE(WPE_PLATFORM)
+    if (m_display) {
+        auto wpeModifiers = testModifiersToWPE(mouseModifiers);
+        auto wpeButton = testMouseButtonToWPE(button);
+        auto* view = webkit_web_view_get_wpe_view(m_webView.get());
+        auto* event = wpe_event_pointer_button_new(WPE_EVENT_POINTER_DOWN, view, WPE_INPUT_SOURCE_MOUSE, 0, wpeModifiers, wpeButton, x, y, 1);
+        wpe_view_event(view, event);
+        wpe_event_unref(event);
+        event = wpe_event_pointer_button_new(WPE_EVENT_POINTER_UP, view, WPE_INPUT_SOURCE_MOUSE, 0, wpeModifiers, wpeButton, x, y, 0);
+        wpe_view_event(view, event);
+        wpe_event_unref(event);
+        return;
+    }
+#endif
     auto* backend = webkit_web_view_backend_get_wpe_backend(webkit_web_view_get_backend(m_webView.get()));
     struct wpe_input_pointer_event event { wpe_input_pointer_event_type_button, 0, x, y, testMouseButtonToWPELegacy(button), 1, testModifiersToWPELegacy(mouseModifiers) };
     wpe_view_backend_dispatch_pointer_event(backend, &event);
@@ -92,6 +155,26 @@ void WebViewTest::clickMouseButton(int x, int y, MouseButton button, OptionSet<M
 
 void WebViewTest::keyStroke(unsigned keyVal, OptionSet<Modifiers> keyModifiers)
 {
+#if ENABLE(WPE_PLATFORM)
+    if (m_display) {
+        auto* view = webkit_web_view_get_wpe_view(m_webView.get());
+        unsigned keycode = 0;
+        auto* keymap = wpe_display_get_keymap(wpe_view_get_display(view));
+        GUniqueOutPtr<WPEKeymapEntry> entries;
+        guint entriesCount;
+        if (wpe_keymap_get_entries_for_keyval(keymap, keyVal, &entries.outPtr(), &entriesCount))
+            keycode = entries.get()[0].keycode;
+
+        auto wpeModifiers = testModifiersToWPE(keyModifiers);
+        auto* event = wpe_event_keyboard_new(WPE_EVENT_KEYBOARD_KEY_DOWN, view, WPE_INPUT_SOURCE_KEYBOARD, 0, wpeModifiers, keycode, keyVal);
+        wpe_view_event(view, event);
+        wpe_event_unref(event);
+        event = wpe_event_keyboard_new(WPE_EVENT_KEYBOARD_KEY_UP, view, WPE_INPUT_SOURCE_KEYBOARD, 0, wpeModifiers, keycode, keyVal);
+        wpe_view_event(view, event);
+        wpe_event_unref(event);
+        return;
+    }
+#endif
     auto* backend = webkit_web_view_backend_get_wpe_backend(webkit_web_view_get_backend(m_webView.get()));
     struct wpe_input_xkb_keymap_entry* entries;
     uint32_t entriesCount;

--- a/Tools/TestWebKitAPI/wpe/WebKitTestMain.cpp
+++ b/Tools/TestWebKitAPI/wpe/WebKitTestMain.cpp
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2025 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "TestsController.h"
+
+#if ENABLE(WPE_PLATFORM)
+#include <wpe/headless/wpe-headless.h>
+#endif
+
+#if ENABLE(WPE_PLATFORM)
+static bool useWPEPlatformAPI(int argc, char** argv)
+{
+    for (int i = 1; i < argc; ++i) {
+        if (!g_strcmp0(argv[i], "--wpe-legacy-api"))
+            return false;
+    }
+    return true;
+}
+#endif
+
+int main(int argc, char** argv)
+{
+#if ENABLE(WPE_PLATFORM)
+    WPEDisplay* display = nullptr;
+    if (useWPEPlatformAPI(argc, argv))
+        display = wpe_display_headless_new();
+#endif
+
+    bool passed = TestWebKitAPI::TestsController::singleton().run(argc, argv);
+
+#if ENABLE(WPE_PLATFORM)
+    g_clear_object(&display);
+#endif
+
+    return passed ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/Tools/TestWebKitAPI/wpe/mock-platform/WPEDisplayMock.cpp
+++ b/Tools/TestWebKitAPI/wpe/mock-platform/WPEDisplayMock.cpp
@@ -35,6 +35,16 @@ struct _WPEDisplayMock {
 
 G_DEFINE_DYNAMIC_TYPE(WPEDisplayMock, wpe_display_mock, WPE_TYPE_DISPLAY)
 
+static void wpeDisplayMockConstructed(GObject* object)
+{
+    G_OBJECT_CLASS(wpe_display_mock_parent_class)->constructed(object);
+
+    // FIXME: wpe platform tests expect the mock display to be the default, but we are using the WebKit
+    // GLib tests helpers that create a headless display. We should not use WebKit GLib tests helpers,
+    // but in the meantime we can just set the mock display as primary on creation.
+    wpe_display_set_primary(WPE_DISPLAY(object));
+}
+
 static void wpeDisplayMockDispose(GObject* object)
 {
     G_OBJECT_CLASS(wpe_display_mock_parent_class)->dispose(object);
@@ -99,6 +109,7 @@ static gboolean wpeDisplayMockUseExplicitSync(WPEDisplay* display)
 static void wpe_display_mock_class_init(WPEDisplayMockClass* displayMockClass)
 {
     GObjectClass* objectClass = G_OBJECT_CLASS(displayMockClass);
+    objectClass->constructed = wpeDisplayMockConstructed;
     objectClass->dispose = wpeDisplayMockDispose;
 
     WPEDisplayClass* displayClass = WPE_DISPLAY_CLASS(displayMockClass);

--- a/Tools/glib/glib_test_runner.py
+++ b/Tools/glib/glib_test_runner.py
@@ -92,9 +92,10 @@ class Message(object):
 
 class GLibTestRunner(object):
 
-    def __init__(self, test_binary, timeout, is_slow_function=None, slow_timeout=0):
+    def __init__(self, test_binary, timeout, wpe_legacy_api=False, is_slow_function=None, slow_timeout=0):
         self._test_binary = test_binary
         self._timeout = timeout
+        self._wpe_legacy_api = wpe_legacy_api
         if is_slow_function is not None:
             self._is_test_slow = is_slow_function
         else:
@@ -240,6 +241,8 @@ class GLibTestRunner(object):
         command = [self._test_binary, '--quiet', '--keep-going', '--GTestLogFD=%d' % pipe_w]
         if self._results:
             command.append('--GTestSkipCount=%d' % len(self._results))
+        if self._wpe_legacy_api:
+            command.append('--wpe-legacy-api')
         for subtest in subtests:
             command.extend(['-p', subtest])
         for skip in skipped:


### PR DESCRIPTION
#### 33804636d79d9b1e9d5a941ae5aa307068343764
<pre>
[WPE] WPE Platform: add support for running WebKit API tests with the new API
<a href="https://bugs.webkit.org/show_bug.cgi?id=293609">https://bugs.webkit.org/show_bug.cgi?id=293609</a>

Reviewed by Alejandro G. Castro.

And switch to use the new API by default when running API tests.

Canonical link: <a href="https://commits.webkit.org/295605@main">https://commits.webkit.org/295605@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9317ea0d0a833277fc08fdb10f66d3d9315ad376

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105624 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25373 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15765 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110817 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/56224 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/107665 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/25834 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33874 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/80213 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/56224 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108630 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/20180 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95318 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60522 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/19916 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13410 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55655 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/89629 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/13450 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/113664 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32762 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/24148 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/89288 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33124 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91547 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88952 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33828 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11628 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/28207 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17128 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32688 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32434 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35782 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34031 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->