### PR TITLE
[WPE][wayland]: Toggle fullscreen on F11 key press

### DIFF
--- a/Source/WebKit/WPEPlatform/wpe/wayland/WPEWaylandSeat.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/WPEWaylandSeat.cpp
@@ -671,6 +671,16 @@ void WaylandSeat::handleKeyEvent(uint32_t time, uint32_t key, uint32_t state, bo
             return;
         }
         break;
+    case WPE_KEY_F11:
+        if (!state || eventModifiers)
+            break;
+        auto* toplevel = WPE_TOPLEVEL(m_keyboard.toplevel.get());
+        auto topLevelState = wpe_toplevel_get_state(toplevel);
+        if (topLevelState & WPE_TOPLEVEL_STATE_FULLSCREEN)
+            wpe_toplevel_unfullscreen(toplevel);
+        else
+            wpe_toplevel_fullscreen(toplevel);
+        break;
     }
 
     auto* event = wpe_event_keyboard_new(state ? WPE_EVENT_KEYBOARD_KEY_DOWN : WPE_EVENT_KEYBOARD_KEY_UP, view.get(), m_keyboard.source, time,


### PR DESCRIPTION
#### b2987687b5d7f2f1d3ab8370972454ef98c987a3
<pre>
[WPE][wayland]: Toggle fullscreen on F11 key press
<a href="https://bugs.webkit.org/show_bug.cgi?id=293613">https://bugs.webkit.org/show_bug.cgi?id=293613</a>

Reviewed by NOBODY (OOPS!).

Handle F11 in Wayland seat key event logic for toggling
the WPE toplevel fullscreen state.

* Source/WebKit/WPEPlatform/wpe/wayland/WPEWaylandSeat.cpp:
(WPE::WaylandSeat::handleKeyEvent):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b2987687b5d7f2f1d3ab8370972454ef98c987a3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105132 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24846 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15269 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110348 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/55805 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/25272 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33390 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79851 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108138 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19693 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94891 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60158 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/19443 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55189 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/89157 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13011 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/112888 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32297 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23787 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88929 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32663 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91109 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88559 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33450 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11237 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/27708 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32220 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/37596 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32010 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35353 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33571 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->