### PR TITLE
[ iOS Mac ] TestWebKitAPI.WebKit.QuotaDelegate (api-test) is a flaky failure

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/StorageQuota.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/StorageQuota.mm
@@ -278,15 +278,11 @@ TEST(WebKit, QuotaDelegateHidden)
     auto *hostWindow = [webView hostWindow];
     [hostWindow miniaturize:hostWindow];
 
-    NSLog(@"QuotaDelegateHidden 1");
-
     receivedQuotaDelegateCalled = false;
     receivedMessage = false;
     [messageHandler setExpectedMessage: @"put failed"];
     [webView loadRequest:server.request()];
     Util::run(&receivedMessage);
-
-    NSLog(@"QuotaDelegateHidden 2");
 
     EXPECT_FALSE(receivedQuotaDelegateCalled);
 
@@ -298,12 +294,8 @@ TEST(WebKit, QuotaDelegateHidden)
     [webView reload];
     Util::run(&receivedQuotaDelegateCalled);
 
-    NSLog(@"QuotaDelegateHidden 3");
-
     [delegate grantQuota];
     Util::run(&receivedMessage);
-
-    NSLog(@"QuotaDelegateHidden 4");
 }
 #endif
 
@@ -357,6 +349,10 @@ TEST(WebKit, QuotaDelegate)
     receivedMessage = false;
     Util::run(&receivedMessage);
 
+    [messageHandler setExpectedMessage: @"start"];
+    receivedMessage = false;
+    Util::run(&receivedMessage);
+
     while (!delegate2.get().quotaDelegateCalled)
         TestWebKitAPI::Util::runFor(0.1_s);
 
@@ -365,8 +361,6 @@ TEST(WebKit, QuotaDelegate)
     [messageHandler setExpectedMessage: @"fail"];
     receivedMessage = false;
     Util::run(&receivedMessage);
-
-    NSLog(@"QuotaDelegate 6");
 }
 
 TEST(WebKit, QuotaDelegateReload)


### PR DESCRIPTION
#### 7951a67822a90d8de21b99931066be03b5e1f26b
<pre>
[ iOS Mac ] TestWebKitAPI.WebKit.QuotaDelegate (api-test) is a flaky failure
<a href="https://rdar.apple.com/151713831">rdar://151713831</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=293304">https://bugs.webkit.org/show_bug.cgi?id=293304</a>

Reviewed by Per Arne Vollan.

The start message can race with the delegate callback.
To prevent this race, we wait for the start message before checking the delegate callback.
We also remove no longer needed NSLogs.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/StorageQuota.mm:
((WebKit, QuotaDelegateHidden)):
((WebKit, QuotaDelegate)):

Canonical link: <a href="https://commits.webkit.org/295508@main">https://commits.webkit.org/295508@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6ccd56165e907a9d3b4821518c31d9ad4a588149

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105158 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24872 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15297 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110392 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/55831 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/107199 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/25299 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33416 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79883 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108164 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19720 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94919 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60191 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/19477 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/12995 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55215 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/89185 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13039 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/112921 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32323 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23813 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88949 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32689 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91137 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88588 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22618 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33476 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11265 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/27740 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32246 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32036 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35379 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33597 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->