### PR TITLE
Reduce unsafeness in FetchEvent class

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -317,7 +317,6 @@ bindings/js/JSElementCustom.cpp
 bindings/js/JSElementInternalsCustom.cpp
 bindings/js/JSEventListener.cpp
 bindings/js/JSEventTargetCustom.cpp
-bindings/js/JSFetchEventCustom.cpp
 bindings/js/JSHTMLCanvasElementCustom.cpp
 bindings/js/JSHTMLElementCustom.cpp
 bindings/js/JSHTMLTemplateElementCustom.cpp
@@ -1368,7 +1367,6 @@ workers/WorkerOrWorkletGlobalScope.cpp
 workers/WorkerOrWorkletThread.cpp
 workers/WorkerRunLoop.cpp
 workers/WorkerScriptLoader.cpp
-workers/service/FetchEvent.cpp
 workers/service/ServiceWorker.cpp
 workers/service/ServiceWorkerContainer.cpp
 workers/service/ServiceWorkerGlobalScope.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -720,7 +720,6 @@ workers/WorkerOrWorkletGlobalScope.cpp
 workers/WorkerOrWorkletThread.cpp
 workers/WorkerScriptLoader.cpp
 workers/service/ExtendableEvent.cpp
-workers/service/FetchEvent.cpp
 workers/service/ServiceWorker.cpp
 workers/service/ServiceWorkerClient.cpp
 workers/service/ServiceWorkerClientData.cpp

--- a/Source/WebCore/workers/service/FetchEvent.cpp
+++ b/Source/WebCore/workers/service/FetchEvent.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -90,10 +90,10 @@ ExceptionOr<void> FetchEvent::respondWith(Ref<DOMPromise>&& promise)
     if (m_respondWithEntered)
         return Exception { ExceptionCode::InvalidStateError, "Event respondWith flag is set"_s };
 
-    m_respondPromise = WTFMove(promise);
-    addExtendLifetimePromise(*m_respondPromise);
+    m_respondPromise = promise.copyRef();
+    addExtendLifetimePromise(promise.get());
 
-    auto isRegistered = m_respondPromise->whenSettled([protectedThis = Ref { *this }] {
+    auto isRegistered = promise->whenSettled([protectedThis = Ref { *this }] {
         protectedThis->promiseIsSettled();
     });
 
@@ -131,14 +131,15 @@ void FetchEvent::processResponse(Expected<Ref<FetchResponse>, std::optional<Reso
 
 void FetchEvent::promiseIsSettled()
 {
-    if (m_respondPromise->status() == DOMPromise::Status::Rejected) {
-        auto reason = m_respondPromise->result().toWTFString(m_respondPromise->globalObject());
+    Ref respondPromise = *m_respondPromise;
+    if (respondPromise->status() == DOMPromise::Status::Rejected) {
+        auto reason = respondPromise->result().toWTFString(respondPromise->globalObject());
         respondWithError(createResponseError(m_request->url(), reason, ResourceError::IsSanitized::Yes));
         return;
     }
 
-    ASSERT(m_respondPromise->status() == DOMPromise::Status::Fulfilled);
-    auto response = JSFetchResponse::toWrapped(m_respondPromise->globalObject()->vm(), m_respondPromise->result());
+    ASSERT(respondPromise->status() == DOMPromise::Status::Fulfilled);
+    RefPtr response = JSFetchResponse::toWrapped(respondPromise->globalObject()->vm(), respondPromise->result());
     if (!response) {
         respondWithError(createResponseError(m_request->url(), "Returned response is null."_s, ResourceError::IsSanitized::Yes));
         return;
@@ -173,7 +174,7 @@ void FetchEvent::navigationPreloadIsReady(ResourceResponse&& response)
     ASSERT(!response.isRedirected());
 
     auto* globalObject = m_handled->globalObject();
-    auto* context = globalObject ? globalObject->scriptExecutionContext() : nullptr;
+    RefPtr context = globalObject ? globalObject->scriptExecutionContext() : nullptr;
     if (!context)
         return;
 

--- a/Source/WebCore/workers/service/FetchEvent.h
+++ b/Source/WebCore/workers/service/FetchEvent.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -89,7 +89,7 @@ private:
     void processResponse(Expected<Ref<FetchResponse>, std::optional<ResourceError>>&&);
     void respondWithError(ResourceError&&);
 
-    Ref<FetchRequest> m_request;
+    const Ref<FetchRequest> m_request;
     String m_clientId;
     String m_resultingClientId;
 
@@ -97,7 +97,7 @@ private:
     bool m_waitToRespond { false };
     bool m_respondWithError { false };
     RefPtr<DOMPromise> m_respondPromise;
-    Ref<DOMPromise> m_handled;
+    const Ref<DOMPromise> m_handled;
 
     ResponseCallback m_onResponse;
 


### PR DESCRIPTION
#### 4a66bebe11889cad351d1aab4295d1b57ac37c7a
<pre>
Reduce unsafeness in FetchEvent class
<a href="https://bugs.webkit.org/show_bug.cgi?id=293615">https://bugs.webkit.org/show_bug.cgi?id=293615</a>
<a href="https://rdar.apple.com/152083443">rdar://152083443</a>

Reviewed by NOBODY (OOPS!).

Apply https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4a66bebe11889cad351d1aab4295d1b57ac37c7a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105332 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25044 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15471 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110540 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/55993 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/107373 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/25484 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33587 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80004 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/55993 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108338 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19879 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95069 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60310 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/19636 "") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13145 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55384 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/89355 "") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13188 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/113199 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32489 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23946 "") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89080 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32852 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91286 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88720 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33614 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11401 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/27966 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17090 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32412 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/37825 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32185 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35531 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33759 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->