### PR TITLE
Unreviewed, fix the internal iOS build

### DIFF
--- a/Tools/TestWebKitAPI/ios/TestUIMenuBuilder.mm
+++ b/Tools/TestWebKitAPI/ios/TestUIMenuBuilder.mm
@@ -136,6 +136,58 @@
     [_menusByIdentifier setObject:menu forKey:menu.identifier];
 }
 
+- (void)replaceMenuForIdentifier:(UIMenuIdentifier)replacedIdentifier withElements:(NSArray<UIMenuElement *> *)replacementElements
+{
+}
+
+- (void)replaceActionForIdentifier:(UIActionIdentifier)replacedIdentifier withElements:(NSArray<UIMenuElement *> *)replacementElements
+{
+}
+
+- (void)replaceCommandForAction:(SEL)replacedAction propertyList:(id)replacedPropertyList withElements:(NSArray<UIMenuElement *> *)replacementElements
+{
+}
+
+- (void)insertElements:(NSArray<UIMenuElement *> *)insertedElements beforeMenuForIdentifier:(UIMenuIdentifier)siblingIdentifier
+{
+}
+
+- (void)insertElements:(NSArray<UIMenuElement *> *)insertedElements afterMenuForIdentifier:(UIMenuIdentifier)siblingIdentifier
+{
+}
+
+- (void)insertElements:(NSArray<UIMenuElement *> *)insertedElements beforeActionForIdentifier:(UIActionIdentifier)siblingIdentifier
+{
+}
+
+- (void)insertElements:(NSArray<UIMenuElement *> *)insertedElements afterActionForIdentifier:(UIActionIdentifier)siblingIdentifier
+{
+}
+
+- (void)insertElements:(NSArray<UIMenuElement *> *)insertedElements beforeCommandForAction:(SEL)siblingAction propertyList:(id)siblingPropertyList
+{
+}
+
+- (void)insertElements:(NSArray<UIMenuElement *> *)insertedElements afterCommandForAction:(SEL)siblingAction propertyList:(id)siblingPropertyList
+{
+}
+
+- (void)insertElements:(NSArray<UIMenuElement *> *)childElements atStartOfMenuForIdentifier:(UIMenuIdentifier)parentIdentifier
+{
+}
+
+- (void)insertElements:(NSArray<UIMenuElement *> *)childElements atEndOfMenuForIdentifier:(UIMenuIdentifier)parentIdentifier
+{
+}
+
+- (void)removeActionForIdentifier:(UIActionIdentifier)removedIdentifier
+{
+}
+
+- (void)removeCommandForAction:(SEL)removedAction propertyList:(id)removedPropertyList
+{
+}
+
 @end
 
 #endif // PLATFORM(IOS_FAMILY)


### PR DESCRIPTION
#### 9b4040a63917482886719f6b63edc3a0ac4168c9
<pre>
Unreviewed, fix the internal iOS build
<a href="https://rdar.apple.com/152088837">rdar://152088837</a>

Add implementation stubs for new `UIMenuBuilder` methods for now to work around build failures. We
should consider implementing these in a followup patch.

* Tools/TestWebKitAPI/ios/TestUIMenuBuilder.mm:
(-[TestUIMenuBuilder replaceMenuForIdentifier:withElements:]):
(-[TestUIMenuBuilder replaceActionForIdentifier:withElements:]):
(-[TestUIMenuBuilder replaceCommandForAction:propertyList:withElements:]):
(-[TestUIMenuBuilder insertElements:beforeMenuForIdentifier:]):
(-[TestUIMenuBuilder insertElements:afterMenuForIdentifier:]):
(-[TestUIMenuBuilder insertElements:beforeActionForIdentifier:]):
(-[TestUIMenuBuilder insertElements:afterActionForIdentifier:]):
(-[TestUIMenuBuilder insertElements:beforeCommandForAction:propertyList:]):
(-[TestUIMenuBuilder insertElements:afterCommandForAction:propertyList:]):
(-[TestUIMenuBuilder insertElements:atStartOfMenuForIdentifier:]):
(-[TestUIMenuBuilder insertElements:atEndOfMenuForIdentifier:]):
(-[TestUIMenuBuilder removeActionForIdentifier:]):
(-[TestUIMenuBuilder removeCommandForAction:propertyList:]):

Canonical link: <a href="https://commits.webkit.org/295454@main">https://commits.webkit.org/295454@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a796a20814ecaa14981e4527e6b867415409e643

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105148 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24862 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15287 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110364 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/55821 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/107189 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/25289 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33406 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/79863 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108154 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19711 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94908 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60170 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/19468 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/12984 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55205 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/89176 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13028 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/112906 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32313 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/23802 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/88942 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32679 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91126 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88572 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33466 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11254 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/27730 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17049 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32236 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32026 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35369 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33587 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->