### PR TITLE
AX: AXObjectCache::characterOffsetFromVisiblePosition iterates over the result of VisiblePosition::canonicalPosition(const Position&), which can return previous positions, resulting in infinite loops

### DIFF
--- a/LayoutTests/accessibility/editable-svg-arrow-movement-expected.txt
+++ b/LayoutTests/accessibility/editable-svg-arrow-movement-expected.txt
@@ -1,0 +1,11 @@
+This test ensures we do not enter an infinite loop when moving the cursor through this markup.
+
+PASS: accessibilityController.accessibleElementById('button').isExpanded === true
+PASS: accessibilityController.accessibleElementById('button').isExpanded === false
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+
+
+Foo

--- a/LayoutTests/accessibility/editable-svg-arrow-movement.html
+++ b/LayoutTests/accessibility/editable-svg-arrow-movement.html
@@ -1,0 +1,76 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../resources/accessibility-helper.js"></script>
+<script src="../resources/js-test.js"></script>
+<style>
+svg { height: 1em; }
+a { display: inline-flex; }
+</style>
+</head>
+<body>
+<div id="editable" tabindex="0" contenteditable="true">
+<fieldset>
+    <input type=checkbox style="display:none !important">
+    <label>
+        <svg id="svg-0" role=img xmlns=http://www.w3.org/2000/svg viewBox="0 0 512 512">
+            <path d="M256,8 A248,248 0 1,1 255.9,8 Z"></path>
+        </svg>
+    </label>
+</fieldset>
+<a href="#">
+    <svg id="svg-1" role=img xmlns=http://www.w3.org/2000/svg viewBox="0 0 320 512">
+        <path d="M256,8 A248,248 0 1,1 255.9,8 Z"></path>
+    </svg>
+</a>
+<a href="#">
+    <svg id="svg-2" role=img xmlns=http://www.w3.org/2000/svg viewBox="0 0 448 512">
+        <path d="M256,8 A248,248 0 1,1 255.9,8 Z"></path>
+    </svg>
+</a>
+<a href="#">
+    <svg id="svg-3" role=img xmlns=http://www.w3.org/2000/svg viewBox="0 0 576 512">
+        <path d="M256,8 A248,248 0 1,1 255.9,8 Z"></path>
+    </svg>
+</a>
+</div>
+
+<button id="button" aria-expanded="true">Foo</button>
+
+<script>
+var output = "This test ensures we do not enter an infinite loop when moving the cursor through this markup.\n\n";
+// The point of this test is to use the cursor movement to pass all possible VisiblePositions in this markup to
+// textMarkerDataForVisiblePosition, which is where the hang occurred. Using contenteditable + arrow key movement is
+// a convenient way to achieve this (since we'll post text-state changed notifications for the movements, which
+// currently exercise this function). But keep in mind that you can hit this hang without any contenteditable.
+// In the real webpage, simply clicking a checkbox with the right SVG content triggered the hang, though I had
+// trouble extracting that into a layout test — hence the approach taken in this test.
+  document.getElementById("editable").focus();
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    var webArea = accessibilityController.rootElement.childAtIndex(0);
+    output += expect("accessibilityController.accessibleElementById('button').isExpanded", "true");
+
+    setTimeout(async function() {
+        for (let i = 0; i < 8; i++) {
+            eventSender.keyDown("rightArrow");
+            await sleep(5);
+        }
+        for (let i = 0; i < 8; i++) {
+            eventSender.keyDown("leftArrow");
+            await sleep(5);
+        }
+        // Verify the main-thread isn't hung by performing an update and waiting for it to take effect in the accessibility tree. 
+        document.getElementById("button").setAttribute("aria-expanded", "false");
+        output += await expectAsync("accessibilityController.accessibleElementById('button').isExpanded", "false");
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>
+


### PR DESCRIPTION
#### d8184230a66a6f34ff32f0bcbbb6318a60231b14
<pre>
AX: AXObjectCache::characterOffsetFromVisiblePosition iterates over the result of VisiblePosition::canonicalPosition(const Position&amp;), which can return previous positions, resulting in infinite loops
<a href="https://bugs.webkit.org/show_bug.cgi?id=293619">https://bugs.webkit.org/show_bug.cgi?id=293619</a>
<a href="https://rdar.apple.com/152094332">rdar://152094332</a>

Reviewed by Joshua Hoffman.

Over time, we&apos;ve added various attempts to catch infinite loops in AXObjectCache::characterOffsetFromVisiblePosition
that result from getting the &quot;next&quot; position actually returning previous positions, thus resulting in us looping forever.

This commit removes all of these workarounds, and eliminates the root cause for getting any previous positions in the
first place. This happened because we maintained `currentPosition` by constructing a `VisiblePosition` from the
`nextVisuallyDistinctCandidate`, then extracting the `deepEquivalent` from the `VisiblePosition`. The problem with that
is that the VisiblePosition constructor calls `canonicalPosition` on the passed `Position`, which critically can return
a previous `Position`. When this happens, we will loop forever.

There is no code comment or layout test proving why we need to canonicalize the positions we use, so this commit stops
doing it. Instead, we solely loop over `nextVisuallyDistinctCandidate`, which should guarantee forward progress.

New test added that exhibited a full hang before this change.

* LayoutTests/accessibility/editable-svg-arrow-movement-expected.txt: Added.
* LayoutTests/accessibility/editable-svg-arrow-movement.html: Added.
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::characterOffsetFromVisiblePosition):

Canonical link: <a href="https://commits.webkit.org/295486@main">https://commits.webkit.org/295486@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/107319a6a9e8183fe9b0feb23536ab091261f2f1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105206 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24918 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15343 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110421 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/55872 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/107247 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/25359 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33462 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79907 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108212 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19769 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94959 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60214 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/19525 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13028 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55260 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/89228 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13072 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/113001 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32368 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23846 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88983 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32734 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91170 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88614 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22605 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33513 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11296 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/27781 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32292 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/37707 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32078 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35421 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33640 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->