### PR TITLE
The WKSeparatedImageView class should not be public

### DIFF
--- a/Source/WebKit/Modules/Internal/WebKitInternal.h
+++ b/Source/WebKit/Modules/Internal/WebKitInternal.h
@@ -32,6 +32,7 @@
 #import "WKPDFPageNumberIndicator.h"
 #import "WKPreferencesInternal.h"
 #import "WKScrollGeometry.h"
+#import "WKSeparatedImageView.h"
 #import "WKTextExtractionItem.h"
 #import "WKUIDelegateInternal.h"
 #import "WKWebViewConfigurationInternal.h"

--- a/Source/WebKit/UIProcess/Cocoa/WKSeparatedImageView.h
+++ b/Source/WebKit/UIProcess/Cocoa/WKSeparatedImageView.h
@@ -29,13 +29,22 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface WKSeparatedImageView : UIView
+@protocol WKObservingLayerDelegate
+- (void)layerSeparatedDidChange:(CALayer *)layer;
+- (void)layerWasCleared:(CALayer *)layer;
+@end
+
+@interface WKSeparatedImageView : UIView <WKObservingLayerDelegate>
 
 - (instancetype)init NS_DESIGNATED_INITIALIZER;
 - (instancetype)initWithCoder:(NSCoder *)coder NS_UNAVAILABLE;
 
 - (void)setSurface:(nullable IOSurfaceRef)surface;
 
+@end
+
+@interface WKObservingLayer : CALayer
+@property (nonatomic, weak) id<WKObservingLayerDelegate> layerDelegate;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Source/WebKit/UIProcess/Cocoa/WKSeparatedImageView.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WKSeparatedImageView.mm
@@ -25,6 +25,7 @@
 
 #import "config.h"
 #import "WKSeparatedImageView.h"
+#import <pal/spi/cocoa/QuartzCoreSPI.h>
 
 #if HAVE(CORE_ANIMATION_SEPARATED_LAYERS)
 
@@ -32,7 +33,31 @@
 
 @interface WKSeparatedImageView (WKContentControlled) <WKContentControlled>
 @end
+
 @implementation WKSeparatedImageView (WKContentControlled)
+
++ (Class)layerClass {
+    return [WKObservingLayer class];
+}
+
+@end
+
+@implementation WKObservingLayer
+
+- (void)setSeparated:(BOOL)isSeparated
+{
+    [super setSeparated:isSeparated];
+    [self.layerDelegate layerSeparatedDidChange:self];
+}
+
+- (void)setContents:(id)contents
+{
+    [super setContents:contents];
+    if (!contents)
+        [self.layerDelegate layerWasCleared:self];
+
+}
+
 @end
 
 #if USE(APPLE_INTERNAL_SDK)
@@ -57,6 +82,14 @@
 }
 
 - (void)setSurface:(nullable IOSurfaceRef)surface
+{
+}
+
+- (void)layerSeparatedDidChange:(CALayer *)layer
+{
+}
+
+- (void)layerWasCleared:(CALayer *)layer
 {
 }
 


### PR DESCRIPTION
#### 1244a0eb0ca7094c08d454d8981780da502a519d
<pre>
The WKSeparatedImageView class should not be public
<a href="https://bugs.webkit.org/show_bug.cgi?id=293623">https://bugs.webkit.org/show_bug.cgi?id=293623</a>
&lt;<a href="https://rdar.apple.com/152064738">rdar://152064738</a>&gt;

Reviewed by Aditya Keerthi and Richard Robinson.

Move the `WKObservingLayer` bit to the objc side so we can properly
transition the Swift bits to using `@objc @implementation` without
making anything public.

* Source/WebKit/Modules/Internal/WebKitInternal.h:
Add WKSeparatedImageView to WebKit internal.
* Source/WebKit/UIProcess/Cocoa/WKSeparatedImageView.h:
* Source/WebKit/UIProcess/Cocoa/WKSeparatedImageView.mm:
(+[WKSeparatedImageView layerClass]):
(-[WKObservingLayer setContents:]):
(-[WKSeparatedImageView layerSeparatedDidChange:]):
(-[WKSeparatedImageView layerWasCleared:]):
Move the WKObservingLayer class and conformance from WKA to here.

Canonical link: <a href="https://commits.webkit.org/295476@main">https://commits.webkit.org/295476@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4e71c20e30eb56dcc738d54acb845d190062d6e8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105184 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24898 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15323 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110401 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/55854 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/25326 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33442 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79894 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108190 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19743 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94942 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60201 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/19501 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55240 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/89206 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13062 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/112972 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32348 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23832 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/88971 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32714 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91160 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/88604 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22594 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33497 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11286 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/27763 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32272 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/37690 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32059 "Build is in progress. Recent messages:OS: Sequoia (15.2), Xcode: 16.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35402 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33620 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->