### PR TITLE
[Safer CPP] Address issues in ColorSpaceCG

### DIFF
--- a/Source/WebCore/Modules/system-preview/ARKitBadgeSystemImage.mm
+++ b/Source/WebCore/Modules/system-preview/ARKitBadgeSystemImage.mm
@@ -142,7 +142,7 @@ void ARKitBadgeSystemImage::draw(GraphicsContext& graphicsContext, const FloatRe
 
     // The circle must have an alpha channel value of 1 for the shadow color to appear.
     CGFloat circleColorComponents[4] = { 0, 0, 0, 1 };
-    RetainPtr<CGColorRef> circleColor = adoptCF(CGColorCreate(sRGBColorSpaceRef(), circleColorComponents));
+    RetainPtr<CGColorRef> circleColor = adoptCF(CGColorCreate(sRGBColorSpaceSingleton(), circleColorComponents));
     CGContextSetFillColorWithColor(ctx, circleColor.get());
 
     // Clip out the circle to only show the shadow.
@@ -204,7 +204,7 @@ void ARKitBadgeSystemImage::draw(GraphicsContext& graphicsContext, const FloatRe
         auto surfaceDimension = useSmallBadge ? smallBadgeDimension : largeBadgeDimension;
         std::unique_ptr<IOSurface> badgeSurface = IOSurface::create(&IOSurfacePool::sharedPoolSingleton(), { surfaceDimension, surfaceDimension }, DestinationColorSpace::SRGB());
         IOSurfaceRef surface = badgeSurface->surface();
-        [ciContext render:translatedImage toIOSurface:surface bounds:badgeRect colorSpace:sRGBColorSpaceRef()];
+        [ciContext render:translatedImage toIOSurface:surface bounds:badgeRect colorSpace:sRGBColorSpaceSingleton()];
         auto surfaceContext = badgeSurface->createPlatformContext();
         cgImage = badgeSurface->createImage(surfaceContext.get());
     } else

--- a/Source/WebCore/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
@@ -59,7 +59,6 @@ loader/cocoa/PrivateClickMeasurementCocoa.mm
 page/CaptionUserPreferencesMediaAF.cpp
 page/cocoa/MemoryReleaseCocoa.mm
 page/cocoa/PageCocoa.mm
-page/cocoa/ResourceUsageOverlayCocoa.mm
 page/cocoa/WebTextIndicatorLayer.mm
 page/mac/EventHandlerMac.mm
 page/mac/ImageOverlayControllerMac.mm
@@ -140,10 +139,8 @@ platform/graphics/ca/TileCoverageMap.cpp
 platform/graphics/ca/cocoa/PlatformCAAnimationCocoa.mm
 platform/graphics/ca/cocoa/PlatformCAFiltersCocoa.mm
 platform/graphics/ca/cocoa/PlatformCALayerCocoa.mm
-platform/graphics/ca/cocoa/WebSystemBackdropLayer.mm
 platform/graphics/cg/CGSubimageCacheWithTimer.cpp
 platform/graphics/cg/ColorCG.cpp
-platform/graphics/cg/ColorSpaceCG.cpp
 platform/graphics/cg/GradientCG.cpp
 platform/graphics/cg/GradientRendererCG.cpp
 platform/graphics/cg/GraphicsContextCG.cpp
@@ -152,7 +149,6 @@ platform/graphics/cg/ImageBufferCGBitmapBackend.cpp
 platform/graphics/cg/ImageBufferCGPDFDocumentBackend.cpp
 platform/graphics/cg/ImageBufferIOSurfaceBackend.cpp
 platform/graphics/cg/ImageBufferUtilitiesCG.cpp
-platform/graphics/cg/NativeImageCG.cpp
 platform/graphics/cg/PathCG.cpp
 platform/graphics/cg/ShareableBitmapCG.mm
 platform/graphics/cocoa/CMUtilities.mm

--- a/Source/WebCore/page/cocoa/ResourceUsageOverlayCocoa.mm
+++ b/Source/WebCore/page/cocoa/ResourceUsageOverlayCocoa.mm
@@ -125,7 +125,7 @@ private:
 static RetainPtr<CGColorRef> createColor(float r, float g, float b, float a)
 {
     CGFloat components[4] = { r, g, b, a };
-    return adoptCF(CGColorCreate(sRGBColorSpaceRef(), components));
+    return adoptCF(CGColorCreate(sRGBColorSpaceSingleton(), components));
 }
 
 struct HistoricMemoryCategoryInfo {

--- a/Source/WebCore/platform/graphics/DestinationColorSpace.cpp
+++ b/Source/WebCore/platform/graphics/DestinationColorSpace.cpp
@@ -65,7 +65,7 @@ template<PlatformColorSpace::Name name> static const DestinationColorSpace& know
 const DestinationColorSpace& DestinationColorSpace::SRGB()
 {
 #if USE(CG) || USE(SKIA)
-    return knownColorSpace<sRGBColorSpaceRef>();
+    return knownColorSpace<sRGBColorSpaceSingleton>();
 #else
     return knownColorSpace<PlatformColorSpace::Name::SRGB>();
 #endif
@@ -74,7 +74,7 @@ const DestinationColorSpace& DestinationColorSpace::SRGB()
 const DestinationColorSpace& DestinationColorSpace::LinearSRGB()
 {
 #if USE(CG) || USE(SKIA)
-    return knownColorSpace<linearSRGBColorSpaceRef>();
+    return knownColorSpace<linearSRGBColorSpaceSingleton>();
 #else
     return knownColorSpace<PlatformColorSpace::Name::LinearSRGB>();
 #endif
@@ -84,7 +84,7 @@ const DestinationColorSpace& DestinationColorSpace::LinearSRGB()
 const DestinationColorSpace& DestinationColorSpace::DisplayP3()
 {
 #if USE(CG) || USE(SKIA)
-    return knownColorSpace<displayP3ColorSpaceRef>();
+    return knownColorSpace<displayP3ColorSpaceSingleton>();
 #else
     return knownColorSpace<PlatformColorSpace::Name::DisplayP3>();
 #endif
@@ -93,7 +93,7 @@ const DestinationColorSpace& DestinationColorSpace::DisplayP3()
 const DestinationColorSpace& DestinationColorSpace::ExtendedDisplayP3()
 {
 #if USE(CG) || USE(SKIA)
-    return knownColorSpace<extendedDisplayP3ColorSpaceRef>();
+    return knownColorSpace<extendedDisplayP3ColorSpaceSingleton>();
 #else
     return knownColorSpace<PlatformColorSpace::Name::ExtendedDisplayP3>();
 #endif
@@ -104,7 +104,7 @@ const DestinationColorSpace& DestinationColorSpace::ExtendedDisplayP3()
 const DestinationColorSpace& DestinationColorSpace::ExtendedSRGB()
 {
 #if USE(CG) || USE(SKIA)
-    return knownColorSpace<extendedSRGBColorSpaceRef>();
+    return knownColorSpace<extendedSRGBColorSpaceSingleton>();
 #else
     return knownColorSpace<PlatformColorSpace::Name::ExtendedSRGB>();
 #endif
@@ -115,7 +115,7 @@ const DestinationColorSpace& DestinationColorSpace::ExtendedSRGB()
 const DestinationColorSpace& DestinationColorSpace::ExtendedRec2020()
 {
 #if USE(CG)
-    return knownColorSpace<ITUR_2020ColorSpaceRef>();
+    return knownColorSpace<ITUR_2020ColorSpaceSingleton>();
 #else
     return knownColorSpace<PlatformColorSpace::Name::ExtendedRec2020>();
 #endif

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
@@ -2033,8 +2033,8 @@ RetainPtr<CGImageRef> MediaPlayerPrivateAVFoundationObjC::createImageForTimeInRe
 
     [m_imageGenerator setMaximumSize:CGSize(rect.size())];
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    RetainPtr<CGImageRef> rawImage = adoptCF([m_imageGenerator copyCGImageAtTime:PAL::CMTimeMakeWithSeconds(time, 600) actualTime:nil error:nil]);
-    RetainPtr<CGImageRef> image = adoptCF(CGImageCreateCopyWithColorSpace(rawImage.get(), sRGBColorSpaceRef()));
+    RetainPtr rawImage = adoptCF([m_imageGenerator copyCGImageAtTime:PAL::CMTimeMakeWithSeconds(time, 600) actualTime:nil error:nil]);
+    RetainPtr image = adoptCF(CGImageCreateCopyWithColorSpace(rawImage.get(), sRGBColorSpaceSingleton()));
 ALLOW_DEPRECATED_DECLARATIONS_END
 
     INFO_LOG(LOGIDENTIFIER, "creating image took ", (MonotonicTime::now() - start).seconds());

--- a/Source/WebCore/platform/graphics/ca/cocoa/WebSystemBackdropLayer.mm
+++ b/Source/WebCore/platform/graphics/ca/cocoa/WebSystemBackdropLayer.mm
@@ -49,7 +49,7 @@
 #endif
 
     CGFloat components[4] = { 0.8, 0.8, 0.8, 0.8 };
-    [super setBackgroundColor:adoptCF(CGColorCreate(WebCore::sRGBColorSpaceRef(), components)).get()];
+    [super setBackgroundColor:adoptCF(CGColorCreate(WebCore::sRGBColorSpaceSingleton(), components)).get()];
 
     return self;
 }
@@ -75,7 +75,7 @@
 #endif
 
     CGFloat components[4] = { 0.2, 0.2, 0.2, 0.8 };
-    [super setBackgroundColor:adoptCF(CGColorCreate(WebCore::sRGBColorSpaceRef(), components)).get()];
+    [super setBackgroundColor:adoptCF(CGColorCreate(WebCore::sRGBColorSpaceSingleton(), components)).get()];
 
     return self;
 }

--- a/Source/WebCore/platform/graphics/cg/ColorSpaceCG.h
+++ b/Source/WebCore/platform/graphics/cg/ColorSpaceCG.h
@@ -36,89 +36,154 @@ namespace WebCore {
 
 template<ColorSpace> struct CGColorSpaceMapping;
 
-WEBCORE_EXPORT CGColorSpaceRef sRGBColorSpaceRef();
-template<> struct CGColorSpaceMapping<ColorSpace::SRGB> { static CGColorSpaceRef colorSpace() { return sRGBColorSpaceRef(); } };
+WEBCORE_EXPORT CGColorSpaceRef sRGBColorSpaceSingleton();
+template<> struct CGColorSpaceMapping<ColorSpace::SRGB> {
+    static CGColorSpaceRef colorSpace()
+    {
+        return sRGBColorSpaceSingleton();
+    }
+};
 
 #if HAVE(CORE_GRAPHICS_ADOBE_RGB_1998_COLOR_SPACE)
-WEBCORE_EXPORT CGColorSpaceRef adobeRGB1998ColorSpaceRef();
-template<> struct CGColorSpaceMapping<ColorSpace::A98RGB> { static CGColorSpaceRef colorSpace() { return adobeRGB1998ColorSpaceRef(); } };
+WEBCORE_EXPORT CGColorSpaceRef adobeRGB1998ColorSpaceSingleton();
+template<> struct CGColorSpaceMapping<ColorSpace::A98RGB> {
+    static CGColorSpaceRef colorSpace()
+    {
+        return adobeRGB1998ColorSpaceSingleton();
+    }
+};
 #else
 template<> struct CGColorSpaceMapping<ColorSpace::A98RGB> { };
 #endif
 
 #if HAVE(CORE_GRAPHICS_DISPLAY_P3_COLOR_SPACE)
-WEBCORE_EXPORT CGColorSpaceRef displayP3ColorSpaceRef();
-template<> struct CGColorSpaceMapping<ColorSpace::DisplayP3> { static CGColorSpaceRef colorSpace() { return displayP3ColorSpaceRef(); } };
+WEBCORE_EXPORT CGColorSpaceRef displayP3ColorSpaceSingleton();
+template<> struct CGColorSpaceMapping<ColorSpace::DisplayP3> {
+    static CGColorSpaceRef colorSpace()
+    {
+        return displayP3ColorSpaceSingleton();
+    }
+};
 #else
 template<> struct CGColorSpaceMapping<ColorSpace::DisplayP3> { };
 #endif
 
 #if HAVE(CORE_GRAPHICS_EXTENDED_ADOBE_RGB_1998_COLOR_SPACE)
-WEBCORE_EXPORT CGColorSpaceRef extendedAdobeRGB1998ColorSpaceRef();
-template<> struct CGColorSpaceMapping<ColorSpace::ExtendedA98RGB> { static CGColorSpaceRef colorSpace() { return extendedAdobeRGB1998ColorSpaceRef(); } };
+WEBCORE_EXPORT CGColorSpaceRef extendedAdobeRGB1998ColorSpaceSingleton();
+template<> struct CGColorSpaceMapping<ColorSpace::ExtendedA98RGB> {
+    static CGColorSpaceRef colorSpace()
+    {
+        return extendedAdobeRGB1998ColorSpaceSingleton();
+    }
+};
 #else
 template<> struct CGColorSpaceMapping<ColorSpace::ExtendedA98RGB> { };
 #endif
 
 #if HAVE(CORE_GRAPHICS_EXTENDED_DISPLAY_P3_COLOR_SPACE)
-WEBCORE_EXPORT CGColorSpaceRef extendedDisplayP3ColorSpaceRef();
-template<> struct CGColorSpaceMapping<ColorSpace::ExtendedDisplayP3> { static CGColorSpaceRef colorSpace() { return extendedDisplayP3ColorSpaceRef(); } };
+WEBCORE_EXPORT CGColorSpaceRef extendedDisplayP3ColorSpaceSingleton();
+template<> struct CGColorSpaceMapping<ColorSpace::ExtendedDisplayP3> {
+    static CGColorSpaceRef colorSpace()
+    {
+        return extendedDisplayP3ColorSpaceSingleton();
+    }
+};
 #else
 template<> struct CGColorSpaceMapping<ColorSpace::ExtendedDisplayP3> { };
 #endif
 
 #if HAVE(CORE_GRAPHICS_EXTENDED_ITUR_2020_COLOR_SPACE)
-WEBCORE_EXPORT CGColorSpaceRef extendedITUR_2020ColorSpaceRef();
-template<> struct CGColorSpaceMapping<ColorSpace::ExtendedRec2020> { static CGColorSpaceRef colorSpace() { return extendedITUR_2020ColorSpaceRef(); } };
+WEBCORE_EXPORT CGColorSpaceRef extendedITUR_2020ColorSpaceSingleton();
+template<> struct CGColorSpaceMapping<ColorSpace::ExtendedRec2020> {
+    static CGColorSpaceRef colorSpace()
+    {
+        return extendedITUR_2020ColorSpaceSingleton();
+    }
+};
 #else
 template<> struct CGColorSpaceMapping<ColorSpace::ExtendedRec2020> { };
 #endif
 
 #if HAVE(CORE_GRAPHICS_EXTENDED_LINEAR_SRGB_COLOR_SPACE)
-WEBCORE_EXPORT CGColorSpaceRef extendedLinearSRGBColorSpaceRef();
-template<> struct CGColorSpaceMapping<ColorSpace::ExtendedLinearSRGB> { static CGColorSpaceRef colorSpace() { return extendedLinearSRGBColorSpaceRef(); } };
+WEBCORE_EXPORT CGColorSpaceRef extendedLinearSRGBColorSpaceSingleton();
+template<> struct CGColorSpaceMapping<ColorSpace::ExtendedLinearSRGB> {
+    static CGColorSpaceRef colorSpace()
+    {
+        return extendedLinearSRGBColorSpaceSingleton();
+    }
+};
 #else
 template<> struct CGColorSpaceMapping<ColorSpace::ExtendedLinearSRGB> { };
 #endif
 
 #if HAVE(CORE_GRAPHICS_EXTENDED_ROMMRGB_COLOR_SPACE)
-WEBCORE_EXPORT CGColorSpaceRef extendedROMMRGBColorSpaceRef();
-template<> struct CGColorSpaceMapping<ColorSpace::ExtendedProPhotoRGB> { static CGColorSpaceRef colorSpace() { return extendedROMMRGBColorSpaceRef(); } };
+WEBCORE_EXPORT CGColorSpaceRef extendedROMMRGBColorSpaceSingleton();
+template<> struct CGColorSpaceMapping<ColorSpace::ExtendedProPhotoRGB> {
+    static CGColorSpaceRef colorSpace()
+    {
+        return extendedROMMRGBColorSpaceSingleton();
+    }
+};
 #else
 template<> struct CGColorSpaceMapping<ColorSpace::ExtendedProPhotoRGB> { };
 #endif
 
 #if HAVE(CORE_GRAPHICS_EXTENDED_SRGB_COLOR_SPACE)
-WEBCORE_EXPORT CGColorSpaceRef extendedSRGBColorSpaceRef();
-template<> struct CGColorSpaceMapping<ColorSpace::ExtendedSRGB> { static CGColorSpaceRef colorSpace() { return extendedSRGBColorSpaceRef(); } };
+WEBCORE_EXPORT CGColorSpaceRef extendedSRGBColorSpaceSingleton();
+template<> struct CGColorSpaceMapping<ColorSpace::ExtendedSRGB> {
+    static CGColorSpaceRef colorSpace()
+    {
+        return extendedSRGBColorSpaceSingleton();
+    }
+};
 #else
 template<> struct CGColorSpaceMapping<ColorSpace::ExtendedSRGB> { };
 #endif
 
 #if HAVE(CORE_GRAPHICS_ITUR_2020_COLOR_SPACE)
-WEBCORE_EXPORT CGColorSpaceRef ITUR_2020ColorSpaceRef();
-template<> struct CGColorSpaceMapping<ColorSpace::Rec2020> { static CGColorSpaceRef colorSpace() { return ITUR_2020ColorSpaceRef(); } };
+WEBCORE_EXPORT CGColorSpaceRef ITUR_2020ColorSpaceSingleton();
+template<> struct CGColorSpaceMapping<ColorSpace::Rec2020> {
+    static CGColorSpaceRef colorSpace()
+    {
+        return ITUR_2020ColorSpaceSingleton();
+    }
+};
 #else
 template<> struct CGColorSpaceMapping<ColorSpace::Rec2020> { };
 #endif
 
 #if HAVE(CORE_GRAPHICS_LINEAR_SRGB_COLOR_SPACE)
-WEBCORE_EXPORT CGColorSpaceRef linearSRGBColorSpaceRef();
-template<> struct CGColorSpaceMapping<ColorSpace::LinearSRGB> { static CGColorSpaceRef colorSpace() { return linearSRGBColorSpaceRef(); } };
+WEBCORE_EXPORT CGColorSpaceRef linearSRGBColorSpaceSingleton();
+template<> struct CGColorSpaceMapping<ColorSpace::LinearSRGB> {
+    static CGColorSpaceRef colorSpace()
+    {
+        return linearSRGBColorSpaceSingleton();
+    }
+};
 #else
 template<> struct CGColorSpaceMapping<ColorSpace::LinearSRGB> { };
 #endif
 
 #if HAVE(CORE_GRAPHICS_ROMMRGB_COLOR_SPACE)
-WEBCORE_EXPORT CGColorSpaceRef ROMMRGBColorSpaceRef();
-template<> struct CGColorSpaceMapping<ColorSpace::ProPhotoRGB> { static CGColorSpaceRef colorSpace() { return ROMMRGBColorSpaceRef(); } };
+WEBCORE_EXPORT CGColorSpaceRef ROMMRGBColorSpaceSingleton();
+template<> struct CGColorSpaceMapping<ColorSpace::ProPhotoRGB> {
+    static CGColorSpaceRef colorSpace()
+    {
+        return ROMMRGBColorSpaceSingleton();
+    }
+};
 #else
 template<> struct CGColorSpaceMapping<ColorSpace::ProPhotoRGB> { };
 #endif
 
 #if HAVE(CORE_GRAPHICS_XYZ_D50_COLOR_SPACE)
-WEBCORE_EXPORT CGColorSpaceRef xyzD50ColorSpaceRef();
-template<> struct CGColorSpaceMapping<ColorSpace::XYZ_D50> { static CGColorSpaceRef colorSpace() { return xyzD50ColorSpaceRef(); } };
+WEBCORE_EXPORT CGColorSpaceRef xyzD50ColorSpaceSingleton();
+template<> struct CGColorSpaceMapping<ColorSpace::XYZ_D50> {
+    static CGColorSpaceRef colorSpace()
+    {
+        return xyzD50ColorSpaceSingleton();
+    }
+};
 #else
 template<> struct CGColorSpaceMapping<ColorSpace::XYZ_D50> { };
 #endif

--- a/Source/WebCore/platform/graphics/cg/GraphicsContextGLCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/GraphicsContextGLCG.cpp
@@ -354,7 +354,7 @@ bool GraphicsContextGLImageExtractor::extractImage(bool premultiplyAlpha, bool i
         // alpha channel. Creation of a bitmap context with an alpha channel
         // doesn't seem to work unless it's premultiplied.
         bitmapContext = adoptCF(CGBitmapContextCreate(0, m_imageWidth, m_imageHeight, 8, m_imageWidth * 4,
-            sRGBColorSpaceRef(), static_cast<uint32_t>(kCGImageAlphaPremultipliedFirst) | static_cast<uint32_t>(kCGBitmapByteOrder32Host)));
+            sRGBColorSpaceSingleton(), static_cast<uint32_t>(kCGImageAlphaPremultipliedFirst) | static_cast<uint32_t>(kCGBitmapByteOrder32Host)));
         if (!bitmapContext)
             return false;
 

--- a/Source/WebCore/platform/graphics/cg/NativeImageCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/NativeImageCG.cpp
@@ -93,7 +93,7 @@ std::optional<Color> NativeImage::singlePixelSolidColor() const
         return std::nullopt;
 
     std::array<uint8_t, 4> pixel; // RGBA
-    auto bitmapContext = adoptCF(CGBitmapContextCreate(pixel.data(), 1, 1, 8, pixel.size(), sRGBColorSpaceRef(), static_cast<uint32_t>(kCGImageAlphaPremultipliedLast) | static_cast<uint32_t>(kCGBitmapByteOrder32Big)));
+    auto bitmapContext = adoptCF(CGBitmapContextCreate(pixel.data(), 1, 1, 8, pixel.size(), sRGBColorSpaceSingleton(), static_cast<uint32_t>(kCGImageAlphaPremultipliedLast) | static_cast<uint32_t>(kCGBitmapByteOrder32Big)));
 
     if (!bitmapContext)
         return std::nullopt;

--- a/Source/WebCore/platform/graphics/cv/CVUtilities.mm
+++ b/Source/WebCore/platform/graphics/cv/CVUtilities.mm
@@ -163,7 +163,7 @@ RetainPtr<CGColorSpaceRef> createCGColorSpaceForCVPixelBuffer(CVPixelBufferRef b
     // that requires an embedded ICC profile is unlikely to be presented
     // correctly with any particular fallback color space we choose, so we
     // choose sRGB for ease.
-    return sRGBColorSpaceRef();
+    return sRGBColorSpaceSingleton();
 }
 
 void setOwnershipIdentityForCVPixelBuffer(CVPixelBufferRef pixelBuffer, const ProcessIdentity& owner)

--- a/Source/WebCore/platform/graphics/cv/ImageTransferSessionVT.mm
+++ b/Source/WebCore/platform/graphics/cv/ImageTransferSessionVT.mm
@@ -213,7 +213,7 @@ RetainPtr<CVPixelBufferRef> ImageTransferSessionVT::createPixelBuffer(CGImageRef
     CVPixelBufferLockBaseAddress(rgbBuffer, 0);
     void* data = CVPixelBufferGetBaseAddress(rgbBuffer);
     auto retainedRGBBuffer = adoptCF(rgbBuffer);
-    auto context = adoptCF(CGBitmapContextCreate(data, imageSize.width(), imageSize.height(), 8, CVPixelBufferGetBytesPerRow(rgbBuffer), sRGBColorSpaceRef(), (CGBitmapInfo) kCGImageAlphaNoneSkipFirst));
+    auto context = adoptCF(CGBitmapContextCreate(data, imageSize.width(), imageSize.height(), 8, CVPixelBufferGetBytesPerRow(rgbBuffer), sRGBColorSpaceSingleton(), (CGBitmapInfo) kCGImageAlphaNoneSkipFirst));
     if (!context) {
         RELEASE_LOG(Media, "ImageTransferSessionVT::createPixelBuffer: CGBitmapContextCreate returned nullptr");
         return nullptr;

--- a/Source/WebCore/platform/graphics/mac/controls/MenuListButtonMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/MenuListButtonMac.mm
@@ -106,7 +106,7 @@ static void drawMenuListBackground(GraphicsContext& context, const FloatRect& re
 
     bool useDarkAppearance = style.states.contains(ControlStyle::State::DarkAppearance);
 
-    CGColorSpaceRef cspace = sRGBColorSpaceRef();
+    CGColorSpaceRef cspace = sRGBColorSpaceSingleton();
 
     FloatRect topGradient(rect.x(), rect.y(), rect.width(), rect.height() / 2.0f);
     struct CGFunctionCallbacks topCallbacks = { 0, useDarkAppearance ? darkTopGradientInterpolate : topGradientInterpolate, NULL };

--- a/Source/WebCore/platform/graphics/mac/controls/SliderTrackMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/SliderTrackMac.mm
@@ -80,7 +80,7 @@ void SliderTrackMac::draw(GraphicsContext& context, const FloatRoundedRect& bord
     static constexpr IntSize sliderRadius(sliderTrackRadius, sliderTrackRadius);
 
     CGContextRef cgContext = context.platformContext();
-    CGColorSpaceRef cspace = sRGBColorSpaceRef();
+    CGColorSpaceRef cspace = sRGBColorSpaceSingleton();
 
     auto& sliderTrackPart = owningSliderTrackPart();
 

--- a/Source/WebCore/platform/graphics/skia/ColorSpaceSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/ColorSpaceSkia.cpp
@@ -32,18 +32,18 @@
 
 namespace WebCore {
 
-sk_sp<SkColorSpace> sRGBColorSpaceRef()
+sk_sp<SkColorSpace> sRGBColorSpaceSingleton()
 {
     return SkColorSpace::MakeSRGB();
 }
 
-sk_sp<SkColorSpace> linearSRGBColorSpaceRef()
+sk_sp<SkColorSpace> linearSRGBColorSpaceSingleton()
 {
     return SkColorSpace::MakeSRGBLinear();
 }
 
 #if ENABLE(DESTINATION_COLOR_SPACE_DISPLAY_P3)
-sk_sp<SkColorSpace> displayP3ColorSpaceRef()
+sk_sp<SkColorSpace> displayP3ColorSpaceSingleton()
 {
     return SkColorSpace::MakeRGB(SkNamedTransferFn::kSRGB, SkNamedGamut::kDisplayP3);
 }

--- a/Source/WebCore/platform/graphics/skia/ColorSpaceSkia.h
+++ b/Source/WebCore/platform/graphics/skia/ColorSpaceSkia.h
@@ -33,10 +33,10 @@ WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 
 namespace WebCore {
 
-WEBCORE_EXPORT sk_sp<SkColorSpace> sRGBColorSpaceRef();
-WEBCORE_EXPORT sk_sp<SkColorSpace> linearSRGBColorSpaceRef();
+WEBCORE_EXPORT sk_sp<SkColorSpace> sRGBColorSpaceSingleton();
+WEBCORE_EXPORT sk_sp<SkColorSpace> linearSRGBColorSpaceSingleton();
 #if ENABLE(DESTINATION_COLOR_SPACE_DISPLAY_P3)
-WEBCORE_EXPORT sk_sp<SkColorSpace> displayP3ColorSpaceRef();
+WEBCORE_EXPORT sk_sp<SkColorSpace> displayP3ColorSpaceSingleton();
 #endif
 
 } // namespace WebCore

--- a/Source/WebCore/platform/ios/ColorIOS.mm
+++ b/Source/WebCore/platform/ios/ColorIOS.mm
@@ -51,7 +51,7 @@ Color colorFromCocoaColor(UIColor *color)
         // The color space conversion above can fail if the UIColor is in an incompatible color space.
         // To workaround this we simply draw a one pixel image of the color and use that pixel's color.
         uint8_t pixel[4];
-        auto bitmapContext = adoptCF(CGBitmapContextCreate(pixel, 1, 1, 8, 4, sRGBColorSpaceRef(), kCGImageAlphaPremultipliedLast));
+        auto bitmapContext = adoptCF(CGBitmapContextCreate(pixel, 1, 1, 8, 4, sRGBColorSpaceSingleton(), kCGImageAlphaPremultipliedLast));
 
         CGContextSetFillColorWithColor(bitmapContext.get(), color.CGColor);
         CGContextFillRect(bitmapContext.get(), CGRectMake(0, 0, 1, 1));

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
@@ -551,7 +551,7 @@ void RemoteLayerTreeDrawingAreaProxy::initializeDebugIndicator()
     [m_tileMapHostLayer setMasksToBounds:YES];
     [m_tileMapHostLayer setBorderWidth:2];
 
-    RetainPtr colorSpace = sRGBColorSpaceRef();
+    RetainPtr colorSpace = sRGBColorSpaceSingleton();
     {
         const CGFloat components[] = { 1, 1, 1, 0.6 };
         RetainPtr<CGColorRef> color = adoptCF(CGColorCreate(colorSpace.get(), components));

--- a/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
@@ -6905,7 +6905,7 @@ static CGImageRef imageFromRect(WebCore::LocalFrame* frame, CGRect rect)
     size_t bitsPerComponent = 8;
     size_t bitsPerPixel = 4 * bitsPerComponent;
     size_t bytesPerRow = ((bitsPerPixel + 7) / 8) * width;
-    RetainPtr<CGContextRef> context = adoptCF(CGBitmapContextCreate(NULL, width, height, bitsPerComponent, bytesPerRow, WebCore::sRGBColorSpaceRef(), kCGImageAlphaPremultipliedLast));
+    RetainPtr<CGContextRef> context = adoptCF(CGBitmapContextCreate(NULL, width, height, bitsPerComponent, bytesPerRow, WebCore::sRGBColorSpaceSingleton(), kCGImageAlphaPremultipliedLast));
     if (!context)
         return nil;
     


### PR DESCRIPTION
#### ec77ec4587d561c161d193b086dbc46fbc8b5b24
<pre>
[Safer CPP] Address issues in ColorSpaceCG
<a href="https://bugs.webkit.org/show_bug.cgi?id=293643">https://bugs.webkit.org/show_bug.cgi?id=293643</a>
<a href="https://rdar.apple.com/152111464">rdar://152111464</a>

Reviewed by Chris Dumez.

Address SaferCPP issues in ColorSpaceCG. Refactor files to support function name changes in ColorSpaceCG. Fix SaferCPP issues in a few other files via refactoring in ColorSpaceCG.

* Source/WebCore/Modules/system-preview/ARKitBadgeSystemImage.mm:
(WebCore::ARKitBadgeSystemImage::draw const):
* Source/WebCore/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations:
* Source/WebCore/page/cocoa/ResourceUsageOverlayCocoa.mm:
(WebCore::createColor):
* Source/WebCore/platform/graphics/DestinationColorSpace.cpp:
(WebCore::DestinationColorSpace::SRGB):
(WebCore::DestinationColorSpace::LinearSRGB):
(WebCore::DestinationColorSpace::DisplayP3):
(WebCore::DestinationColorSpace::ExtendedDisplayP3):
(WebCore::DestinationColorSpace::ExtendedSRGB):
(WebCore::DestinationColorSpace::ExtendedRec2020):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm:
(WebCore::MediaPlayerPrivateAVFoundationObjC::createImageForTimeInRect):
* Source/WebCore/platform/graphics/ca/cocoa/WebSystemBackdropLayer.mm:
(-[WebLightSystemBackdropLayer init]):
(-[WebDarkSystemBackdropLayer init]):
* Source/WebCore/platform/graphics/cg/ColorSpaceCG.cpp:
(WebCore::namedColorSpace):
(WebCore::extendedNamedColorSpace):
(WebCore::sRGBColorSpaceSingleton):
(WebCore::adobeRGB1998ColorSpaceSingleton):
(WebCore::displayP3ColorSpaceSingleton):
(WebCore::extendedAdobeRGB1998ColorSpaceSingleton):
(WebCore::extendedDisplayP3ColorSpaceSingleton):
(WebCore::extendedITUR_2020ColorSpaceSingleton):
(WebCore::extendedLinearSRGBColorSpaceSingleton):
(WebCore::extendedROMMRGBColorSpaceSingleton):
(WebCore::extendedSRGBColorSpaceSingleton):
(WebCore::ITUR_2020ColorSpaceSingleton):
(WebCore::linearSRGBColorSpaceSingleton):
(WebCore::ROMMRGBColorSpaceSingleton):
(WebCore::xyzD50ColorSpaceSingleton):
(WebCore::colorSpaceForCGColorSpace):
(WebCore::sRGBColorSpaceRef): Deleted.
(WebCore::adobeRGB1998ColorSpaceRef): Deleted.
(WebCore::displayP3ColorSpaceRef): Deleted.
(WebCore::extendedAdobeRGB1998ColorSpaceRef): Deleted.
(WebCore::extendedDisplayP3ColorSpaceRef): Deleted.
(WebCore::extendedITUR_2020ColorSpaceRef): Deleted.
(WebCore::extendedLinearSRGBColorSpaceRef): Deleted.
(WebCore::extendedROMMRGBColorSpaceRef): Deleted.
(WebCore::extendedSRGBColorSpaceRef): Deleted.
(WebCore::ITUR_2020ColorSpaceRef): Deleted.
(WebCore::linearSRGBColorSpaceRef): Deleted.
(WebCore::ROMMRGBColorSpaceRef): Deleted.
(WebCore::xyzD50ColorSpaceRef): Deleted.
* Source/WebCore/platform/graphics/cg/ColorSpaceCG.h:
(WebCore::CGColorSpaceMapping&lt;ColorSpace::SRGB&gt;::colorSpace):
(WebCore::CGColorSpaceMapping&lt;ColorSpace::A98RGB&gt;::colorSpace):
(WebCore::CGColorSpaceMapping&lt;ColorSpace::DisplayP3&gt;::colorSpace):
(WebCore::CGColorSpaceMapping&lt;ColorSpace::ExtendedA98RGB&gt;::colorSpace):
(WebCore::CGColorSpaceMapping&lt;ColorSpace::ExtendedDisplayP3&gt;::colorSpace):
(WebCore::CGColorSpaceMapping&lt;ColorSpace::ExtendedRec2020&gt;::colorSpace):
(WebCore::CGColorSpaceMapping&lt;ColorSpace::ExtendedLinearSRGB&gt;::colorSpace):
(WebCore::CGColorSpaceMapping&lt;ColorSpace::ExtendedProPhotoRGB&gt;::colorSpace):
(WebCore::CGColorSpaceMapping&lt;ColorSpace::ExtendedSRGB&gt;::colorSpace):
(WebCore::CGColorSpaceMapping&lt;ColorSpace::Rec2020&gt;::colorSpace):
(WebCore::CGColorSpaceMapping&lt;ColorSpace::LinearSRGB&gt;::colorSpace):
(WebCore::CGColorSpaceMapping&lt;ColorSpace::ProPhotoRGB&gt;::colorSpace):
(WebCore::CGColorSpaceMapping&lt;ColorSpace::XYZ_D50&gt;::colorSpace):
* Source/WebCore/platform/graphics/cg/GraphicsContextGLCG.cpp:
(WebCore::GraphicsContextGLImageExtractor::extractImage):
* Source/WebCore/platform/graphics/cg/NativeImageCG.cpp:
(WebCore::NativeImage::singlePixelSolidColor const):
* Source/WebCore/platform/graphics/cv/CVUtilities.mm:
(WebCore::createCGColorSpaceForCVPixelBuffer):
* Source/WebCore/platform/graphics/cv/ImageTransferSessionVT.mm:
(WebCore::ImageTransferSessionVT::createPixelBuffer):
* Source/WebCore/platform/graphics/mac/controls/MenuListButtonMac.mm:
(WebCore::drawMenuListBackground):
* Source/WebCore/platform/graphics/mac/controls/SliderTrackMac.mm:
(WebCore::SliderTrackMac::draw):
* Source/WebCore/platform/graphics/skia/ColorSpaceSkia.cpp:
(WebCore::sRGBColorSpaceSingleton):
(WebCore::linearSRGBColorSpaceSingleton):
(WebCore::displayP3ColorSpaceSingleton):
(WebCore::sRGBColorSpaceRef): Deleted.
(WebCore::linearSRGBColorSpaceRef): Deleted.
(WebCore::displayP3ColorSpaceRef): Deleted.
* Source/WebCore/platform/graphics/skia/ColorSpaceSkia.h:
* Source/WebCore/platform/ios/ColorIOS.mm:
(WebCore::colorFromCocoaColor):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm:
(WebKit::RemoteLayerTreeDrawingAreaProxy::initializeDebugIndicator):
* Source/WebKitLegacy/mac/WebView/WebHTMLView.mm:
(imageFromRect):

Canonical link: <a href="https://commits.webkit.org/295849@main">https://commits.webkit.org/295849@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f83f3b13e70fc0e0af78d02d1468c91bb15c97dd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/106123 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25872 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/16266 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/111320 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/56719 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/108162 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/26528 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34375 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80609 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/109127 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/20959 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95767 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60947 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/20532 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13870 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/56158 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/90325 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13905 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/114176 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33261 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24540 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89689 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33625 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/92000 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89381 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22838 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34246 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/12061 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/29026 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/33186 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/38598 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32932 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/36282 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34530 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->