### PR TITLE
Reduce unsafeness in FileSystem APIs

### DIFF
--- a/Source/WebCore/Modules/entriesapi/DOMFileSystem.h
+++ b/Source/WebCore/Modules/entriesapi/DOMFileSystem.h
@@ -72,9 +72,9 @@ private:
     Ref<FileSystemEntry> fileAsEntry(ScriptExecutionContext&);
 
     String m_name;
-    Ref<File> m_file;
+    const Ref<File> m_file;
     String m_rootPath;
-    Ref<WorkQueue> m_workQueue;
+    const Ref<WorkQueue> m_workQueue;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/entriesapi/FileSystemDirectoryReader.cpp
+++ b/Source/WebCore/Modules/entriesapi/FileSystemDirectoryReader.cpp
@@ -29,6 +29,7 @@
 #include "DOMException.h"
 #include "DOMFileSystem.h"
 #include "Document.h"
+#include "DocumentInlines.h"
 #include "ErrorCallback.h"
 #include "ExceptionOr.h"
 #include "FileSystemDirectoryEntry.h"
@@ -90,7 +91,7 @@ void FileSystemDirectoryReader::readEntries(ScriptExecutionContext& context, Ref
             if (result.hasException()) {
                 pendingActivity->object().m_error = result.releaseException();
                 if (errorCallback && document) {
-                    document->eventLoop().queueTask(TaskSource::Networking, [errorCallback = WTFMove(errorCallback), pendingActivity = WTFMove(pendingActivity)]() mutable {
+                    document->checkedEventLoop()->queueTask(TaskSource::Networking, [errorCallback = WTFMove(errorCallback), pendingActivity = WTFMove(pendingActivity)]() mutable {
                         errorCallback->invoke(DOMException::create(*pendingActivity->object().m_error));
                     });
                 }
@@ -98,7 +99,7 @@ void FileSystemDirectoryReader::readEntries(ScriptExecutionContext& context, Ref
             }
             pendingActivity->object().m_isDone = true;
             if (document) {
-                document->eventLoop().queueTask(TaskSource::Networking, [successCallback = WTFMove(successCallback), pendingActivity = WTFMove(pendingActivity), result = result.releaseReturnValue()]() mutable {
+                document->checkedEventLoop()->queueTask(TaskSource::Networking, [successCallback = WTFMove(successCallback), pendingActivity = WTFMove(pendingActivity), result = result.releaseReturnValue()]() mutable {
                     successCallback->invoke(WTFMove(result));
                 });
             }

--- a/Source/WebCore/Modules/entriesapi/FileSystemEntry.cpp
+++ b/Source/WebCore/Modules/entriesapi/FileSystemEntry.cpp
@@ -29,6 +29,7 @@
 #include "DOMException.h"
 #include "DOMFileSystem.h"
 #include "Document.h"
+#include "DocumentInlines.h"
 #include "ErrorCallback.h"
 #include "FileSystemDirectoryEntry.h"
 #include "FileSystemEntryCallback.h"
@@ -71,7 +72,7 @@ void FileSystemEntry::getParent(ScriptExecutionContext& context, RefPtr<FileSyst
         if (!document)
             return;
 
-        document->eventLoop().queueTask(TaskSource::Networking, [successCallback = WTFMove(successCallback), errorCallback = WTFMove(errorCallback), result = std::forward<Result>(result), pendingActivity = WTFMove(pendingActivity)] () mutable {
+        document->checkedEventLoop()->queueTask(TaskSource::Networking, [successCallback = WTFMove(successCallback), errorCallback = WTFMove(errorCallback), result = std::forward<Result>(result), pendingActivity = WTFMove(pendingActivity)] () mutable {
             if (result.hasException()) {
                 if (errorCallback)
                     errorCallback->invoke(DOMException::create(result.releaseException()));

--- a/Source/WebCore/Modules/entriesapi/FileSystemEntry.h
+++ b/Source/WebCore/Modules/entriesapi/FileSystemEntry.h
@@ -58,7 +58,7 @@ protected:
     Document* document() const;
 
 private:
-    Ref<DOMFileSystem> m_filesystem;
+    const Ref<DOMFileSystem> m_filesystem;
     String m_name;
     String m_virtualPath;
 };

--- a/Source/WebCore/Modules/filesystemaccess/FileSystemDirectoryHandle.h
+++ b/Source/WebCore/Modules/filesystemaccess/FileSystemDirectoryHandle.h
@@ -68,7 +68,7 @@ public:
         }
         void advance(CompletionHandler<void(ExceptionOr<Result>&&)>&&);
 
-        Ref<FileSystemDirectoryHandle> m_source;
+        const Ref<FileSystemDirectoryHandle> m_source;
         size_t m_index { 0 };
         Vector<String> m_keys;
         bool m_isInitialized { false };

--- a/Source/WebCore/Modules/filesystemaccess/FileSystemHandle.h
+++ b/Source/WebCore/Modules/filesystemaccess/FileSystemHandle.h
@@ -69,7 +69,7 @@ private:
     Kind m_kind { Kind::File };
     String m_name;
     FileSystemHandleIdentifier m_identifier;
-    Ref<FileSystemStorageConnection> m_connection;
+    const Ref<FileSystemStorageConnection> m_connection;
     bool m_isClosed { false };
 };
 

--- a/Source/WebCore/Modules/filesystemaccess/FileSystemHandleCloseScope.h
+++ b/Source/WebCore/Modules/filesystemaccess/FileSystemHandleCloseScope.h
@@ -64,7 +64,7 @@ private:
     Lock m_lock;
     Markable<FileSystemHandleIdentifier> m_identifier WTF_GUARDED_BY_LOCK(m_lock);
     bool m_isDirectory;
-    Ref<FileSystemStorageConnection> m_connection;
+    const Ref<FileSystemStorageConnection> m_connection;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/filesystemaccess/FileSystemSyncAccessHandle.h
+++ b/Source/WebCore/Modules/filesystemaccess/FileSystemSyncAccessHandle.h
@@ -72,7 +72,7 @@ private:
     // ActiveDOMObject.
     void stop() final;
 
-    Ref<FileSystemFileHandle> m_source;
+    const Ref<FileSystemFileHandle> m_source;
     FileSystemSyncAccessHandleIdentifier m_identifier;
     FileSystem::FileHandle m_file;
     bool m_isClosed { false };

--- a/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -6,7 +6,6 @@ Modules/cookie-store/CookieStore.cpp
 Modules/credentialmanagement/CredentialsContainer.cpp
 Modules/encryptedmedia/legacy/LegacyCDM.cpp
 Modules/encryptedmedia/legacy/WebKitMediaKeySession.cpp
-Modules/entriesapi/FileSystemDirectoryReader.cpp
 Modules/fetch/FetchBody.cpp
 Modules/fetch/FetchBody.h
 Modules/fetch/FetchBodyOwner.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -49,9 +49,7 @@ Modules/encryptedmedia/MediaKeys.cpp
 Modules/encryptedmedia/legacy/LegacyCDMSessionClearKey.cpp
 Modules/encryptedmedia/legacy/WebKitMediaKeySession.cpp
 Modules/encryptedmedia/legacy/WebKitMediaKeys.cpp
-Modules/entriesapi/DOMFileSystem.cpp
 Modules/entriesapi/FileSystemDirectoryEntry.cpp
-Modules/entriesapi/FileSystemDirectoryReader.cpp
 Modules/entriesapi/FileSystemEntry.cpp
 Modules/entriesapi/FileSystemFileEntry.cpp
 Modules/fetch/FetchBody.cpp
@@ -59,11 +57,7 @@ Modules/fetch/FetchBodyConsumer.cpp
 Modules/fetch/FetchBodySource.cpp
 Modules/fetch/FetchLoader.cpp
 Modules/fetch/FetchRequest.cpp
-Modules/filesystemaccess/FileSystemDirectoryHandle.cpp
 Modules/filesystemaccess/FileSystemFileHandle.cpp
-Modules/filesystemaccess/FileSystemHandle.cpp
-Modules/filesystemaccess/FileSystemHandleCloseScope.h
-Modules/filesystemaccess/FileSystemSyncAccessHandle.cpp
 Modules/filesystemaccess/WorkerFileSystemStorageConnection.cpp
 Modules/gamepad/GamepadManager.cpp
 Modules/gamepad/NavigatorGamepad.cpp
@@ -635,7 +629,6 @@ html/CachedHTMLCollectionInlines.h
 html/CheckboxInputType.cpp
 html/CollectionTraversalInlines.h
 html/CustomPaintCanvas.cpp
-html/DOMFormData.cpp
 html/DOMTokenList.cpp
 html/DOMURL.cpp
 html/DirectoryFileListCreator.cpp

--- a/Source/WebCore/dom/DOMImplementation.cpp
+++ b/Source/WebCore/dom/DOMImplementation.cpp
@@ -202,7 +202,7 @@ Ref<Document> DOMImplementation::createDocument(const String& contentType, Local
 
     // The following is the relatively costly lookup that requires initializing the plug-in database.
     if (frame && frame->page()) {
-        if (frame->page()->pluginData().supportsWebVisibleMimeType(contentType, PluginData::OnlyApplicationPlugins))
+        if (frame->page()->protectedPluginData()->supportsWebVisibleMimeType(contentType, PluginData::OnlyApplicationPlugins))
             return PluginDocument::create(*frame, url);
     }
 

--- a/Source/WebCore/html/DOMFormData.cpp
+++ b/Source/WebCore/html/DOMFormData.cpp
@@ -95,10 +95,10 @@ static auto createFileEntry(const String& name, Blob& blob, const String& filena
 
     if (RefPtr file = dynamicDowncast<File>(blob)) {
         if (!filename.isNull())
-            return { usvName, File::create(blob.scriptExecutionContext(), *file, filename) };
+            return { usvName, File::create(blob.protectedScriptExecutionContext().get(), *file, filename) };
         return { usvName, WTFMove(file) };
     }
-    return { usvName, File::create(blob.scriptExecutionContext(), blob, filename.isNull() ? "blob"_s : filename) };
+    return { usvName, File::create(blob.protectedScriptExecutionContext().get(), blob, filename.isNull() ? "blob"_s : filename) };
 }
 
 void DOMFormData::append(const String& name, const String& value)


### PR DESCRIPTION
#### 4757b471ac978a5af3380e2f531456e16ea7ad70
<pre>
Reduce unsafeness in FileSystem APIs
<a href="https://bugs.webkit.org/show_bug.cgi?id=293647">https://bugs.webkit.org/show_bug.cgi?id=293647</a>
<a href="https://rdar.apple.com/152112464">rdar://152112464</a>

Reviewed by Chris Dumez.

Apply <a href="https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines">https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines</a>

* Source/WebCore/dom/DOMImplementation.cpp:
* Source/WebCore/html/DOMFormData.cpp:

These came along for the ride.

Canonical link: <a href="https://commits.webkit.org/295530@main">https://commits.webkit.org/295530@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ff2064f35c6878789a71b77dfd04d3792d1ffd13

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105379 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/131/builds/25093 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15518 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/110585 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/56021 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/107420 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/25526 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/123/builds/33631 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/110585 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/56021 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108385 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/130/builds/25526 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/95104 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/110585 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/130/builds/25526 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/13188 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/55426 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/130/builds/25526 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/13230 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/113287 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/32529 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/123/builds/33631 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/113287 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/32892 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/91328 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/113287 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/11437 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/27994 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17088 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/32454 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/37873 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/32216 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/35564 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/33800 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->