### PR TITLE
Refactor jitMemcpy into atomic and non-atomic versions

### DIFF
--- a/Source/JavaScriptCore/assembler/LinkBuffer.cpp
+++ b/Source/JavaScriptCore/assembler/LinkBuffer.cpp
@@ -414,9 +414,9 @@ void LinkBuffer::copyCompactAndLinkCode(MacroAssembler& macroAssembler, JITCompi
         else
             target = codeOutData + to - executableOffsetFor(to);
         if (shouldCopyDirectlyToJITRegion)
-            MacroAssembler::link<memcpyRepatch>(linkRecord, outData + linkRecord.from(), location, target);
-        else
             MacroAssembler::link<jitMemcpyRepatch>(linkRecord, outData + linkRecord.from(), location, target);
+        else
+            MacroAssembler::link<memcpyRepatch>(linkRecord, outData + linkRecord.from(), location, target);
     }
 
     size_t compactSize = writePtr + initialSize - readPtr;
@@ -424,9 +424,9 @@ void LinkBuffer::copyCompactAndLinkCode(MacroAssembler& macroAssembler, JITCompi
         size_t nopSizeInBytes = initialSize - compactSize;
 
         if (shouldCopyDirectlyToJITRegion)
-            Assembler::fillNops<memcpyRepatch>(outData + compactSize, nopSizeInBytes);
-        else
             Assembler::fillNops<jitMemcpyRepatch>(outData + compactSize, nopSizeInBytes);
+        else
+            Assembler::fillNops<memcpyRepatch>(outData + compactSize, nopSizeInBytes);
     }
     if (g_jscConfig.useFastJITPermissions)
         threadSelfRestrict<MemoryRestriction::kRwxToRx>();

--- a/Source/JavaScriptCore/assembler/MacroAssemblerARM64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerARM64.h
@@ -5211,7 +5211,7 @@ public:
 
     static void reemitInitialMoveWithPatch(void* address, void* value)
     {
-        Assembler::setPointer<jitMemcpyRepatchFlush>(static_cast<int*>(address), value, dataTempRegister);
+        Assembler::setPointer<jitMemcpyRepatchAtomicFlush>(static_cast<int*>(address), value, dataTempRegister);
     }
 
     // Miscellaneous operations:
@@ -6452,10 +6452,10 @@ public:
         Assembler::replaceWithJump(instructionStart.dataLocation(), destination.dataLocation());
     }
 
-    template<PtrTag startTag>
+    template<RepatchingInfo repatch, PtrTag startTag>
     static void replaceWithNops(CodeLocationLabel<startTag> instructionStart, size_t memoryToFillWithNopsInBytes)
     {
-        Assembler::replaceWithNops(instructionStart.dataLocation(), memoryToFillWithNopsInBytes);
+        Assembler::replaceWithNops<repatch>(instructionStart.dataLocation(), memoryToFillWithNopsInBytes);
     }
 
     static ptrdiff_t maxJumpReplacementSize()

--- a/Source/JavaScriptCore/assembler/MacroAssemblerARMv7.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerARMv7.h
@@ -2425,10 +2425,10 @@ public:
         ARMv7Assembler::replaceWithJump(instructionStart.dataLocation(), destination.dataLocation());
     }
 
-    template<PtrTag startTag>
+    template<RepatchingInfo repatch, PtrTag startTag>
     static void replaceWithNops(CodeLocationLabel<startTag> instructionStart, size_t memoryToFillWithNopsInBytes)
     {
-        ARMv7Assembler::replaceWithNops(instructionStart.dataLocation(), memoryToFillWithNopsInBytes);
+        ARMv7Assembler::replaceWithNops<repatch>(instructionStart.dataLocation(), memoryToFillWithNopsInBytes);
     }
     
     static ptrdiff_t maxJumpReplacementSize()
@@ -3445,13 +3445,13 @@ public:
     template<PtrTag callTag, PtrTag destTag>
     static void repatchCall(CodeLocationCall<callTag> call, CodeLocationLabel<destTag> destination)
     {
-        ARMv7Assembler::relinkCall(call.dataLocation(), destination.taggedPtr());
+        ARMv7Assembler::relinkCall<jitMemcpyRepatchAtomicFlush>(call.dataLocation(), destination.taggedPtr());
     }
 
     template<PtrTag callTag, PtrTag destTag>
     static void repatchCall(CodeLocationCall<callTag> call, CodePtr<destTag> destination)
     {
-        ARMv7Assembler::relinkCall(call.dataLocation(), destination.taggedPtr());
+        ARMv7Assembler::relinkCall<jitMemcpyRepatchFlush>(call.dataLocation(), destination.taggedPtr());
     }
 
     void convertDoubleToFloat16(FPRegisterID src, FPRegisterID dest)

--- a/Source/JavaScriptCore/assembler/MacroAssemblerRISCV64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerRISCV64.h
@@ -2063,10 +2063,10 @@ public:
         Assembler::replaceWithJump(instructionStart.dataLocation(), destination.dataLocation());
     }
 
-    template<PtrTag startTag>
+    template<RepatchingInfo repatch, PtrTag startTag>
     static void replaceWithNops(CodeLocationLabel<startTag> instructionStart, size_t memoryToFillWithNopsInBytes)
     {
-        Assembler::replaceWithNops(instructionStart.dataLocation(), memoryToFillWithNopsInBytes);
+        Assembler::replaceWithNops<repatch>(instructionStart.dataLocation(), memoryToFillWithNopsInBytes);
     }
 
     static ptrdiff_t maxJumpReplacementSize()

--- a/Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h
@@ -4422,7 +4422,7 @@ public:
         X86Assembler::replaceWithJump(instructionStart.taggedPtr(), destination.taggedPtr());
     }
 
-    template<PtrTag startTag>
+    template<RepatchingInfo repatch, PtrTag startTag>
     static void replaceWithNops(CodeLocationLabel<startTag> instructionStart, size_t memoryToFillWithNopsInBytes)
     {
         X86Assembler::replaceWithNops(instructionStart.taggedPtr(), memoryToFillWithNopsInBytes);

--- a/Source/JavaScriptCore/assembler/RISCV64Assembler.h
+++ b/Source/JavaScriptCore/assembler/RISCV64Assembler.h
@@ -1638,6 +1638,7 @@ public:
         cacheFlush(location, sizeof(uint32_t) * 2);
     }
 
+    template <RepatchingInfo repatch>
     static void relinkCall(void* from, void* to)
     {
         uint32_t* location = static_cast<uint32_t*>(from);
@@ -1645,6 +1646,7 @@ public:
         cacheFlush(location, sizeof(uint32_t) * 2);
     }
 
+    template <RepatchingInfo repatch>
     static void relinkTailCall(void* from, void* to)
     {
         relinkJump(from, to);
@@ -1676,9 +1678,12 @@ public:
         cacheFlush(from, sizeof(uint32_t) * 2);
     }
 
+    template<RepatchingInfo repatch>
     static void replaceWithNops(void* from, size_t memoryToFillWithNopsInBytes)
     {
-        fillNops(from, memoryToFillWithNopsInBytes);
+        static_assert(repatch->contains(RepatchingFlag::Flush));
+        static_assert(repatch->contains(RepatchingFlag::Atomic));
+        fillNops<repatch>(from, memoryToFillWithNopsInBytes);
         cacheFlush(from, memoryToFillWithNopsInBytes);
     }
 

--- a/Source/JavaScriptCore/assembler/X86Assembler.h
+++ b/Source/JavaScriptCore/assembler/X86Assembler.h
@@ -6215,16 +6215,19 @@ public:
         setPointer(static_cast<char*>(code) + where.offset(), value);
     }
 
+    template<RepatchingInfo repatch = memcpyRepatch>
     static void relinkJump(void* from, void* to)
     {
         setRel32(from, to);
     }
     
+    template <RepatchingInfo repatch = memcpyRepatch>
     static void relinkCall(void* from, void* to)
     {
         setRel32(from, to);
     }
 
+    template <RepatchingInfo repatch = memcpyRepatch>
     static void relinkTailCall(void* from, void* to)
     {
         relinkJump(from, to);

--- a/Source/JavaScriptCore/bytecode/CallLinkInfo.cpp
+++ b/Source/JavaScriptCore/bytecode/CallLinkInfo.cpp
@@ -521,7 +521,7 @@ void DirectCallLinkInfo::initialize()
         RELEASE_ASSERT(fastPathStart());
         CCallHelpers::replaceWithJump(fastPathStart(), slowPathStart());
     } else
-        MacroAssembler::repatchNearCall(m_callLocation, slowPathStart());
+        MacroAssembler::repatchNearCall<jitMemcpyRepatchFlush>(m_callLocation, slowPathStart());
 }
 
 void DirectCallLinkInfo::setCallTarget(CodeBlock* codeBlock, CodeLocationLabel<JSEntryPtrTag> target)
@@ -534,10 +534,10 @@ void DirectCallLinkInfo::setCallTarget(CodeBlock* codeBlock, CodeLocationLabel<J
             RELEASE_ASSERT(fastPathStart());
             // We reserved this many bytes for the jump at fastPathStart(). Make that
             // code nops now so we fall through to the jump to the fast path.
-            CCallHelpers::replaceWithNops(fastPathStart(), CCallHelpers::patchableJumpSize());
+            CCallHelpers::replaceWithNops<jitMemcpyRepatchFlush>(fastPathStart(), CCallHelpers::patchableJumpSize());
         }
 
-        MacroAssembler::repatchNearCall(m_callLocation, target);
+        MacroAssembler::repatchNearCall<jitMemcpyRepatchFlush>(m_callLocation, target);
         MacroAssembler::repatchPointer(m_codeBlockLocation, codeBlock);
     }
 }

--- a/Source/JavaScriptCore/dfg/DFGOSRExit.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOSRExit.cpp
@@ -218,7 +218,7 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationCompileOSRExit, void, (CallFrame* cal
     }
 
     if (exit.codeLocationForRepatch())
-        MacroAssembler::repatchJump(exit.codeLocationForRepatch(), CodeLocationLabel<OSRExitPtrTag>(exitCode.code()));
+        MacroAssembler::repatchJump<jitMemcpyRepatchFlush>(exit.codeLocationForRepatch(), CodeLocationLabel<OSRExitPtrTag>(exitCode.code()));
 
     vm.osrExitJumpDestination = exitCode.code().taggedPtr();
 }

--- a/Source/JavaScriptCore/ftl/FTLLazySlowPath.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLazySlowPath.cpp
@@ -69,7 +69,7 @@ void LazySlowPath::generate(CodeBlock* codeBlock)
     LinkBuffer linkBuffer(jit, codeBlock, LinkBuffer::Profile::FTLThunk, JITCompilationMustSucceed);
     m_stub = FINALIZE_CODE_FOR(codeBlock, linkBuffer, JITStubRoutinePtrTag, nullptr, "Lazy slow path call stub");
 
-    MacroAssembler::repatchJump(m_patchableJump, CodeLocationLabel<JITStubRoutinePtrTag>(m_stub.code()));
+    MacroAssembler::repatchJump<jitMemcpyRepatchFlush>(m_patchableJump, CodeLocationLabel<JITStubRoutinePtrTag>(m_stub.code()));
 }
 
 } } // namespace JSC::FTL

--- a/Source/JavaScriptCore/ftl/FTLOSRExitCompiler.cpp
+++ b/Source/JavaScriptCore/ftl/FTLOSRExitCompiler.cpp
@@ -696,7 +696,7 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationCompileFTLOSRExit, void*, (CallFrame*
 
     compileStub(vm, exitID, jitCode, exit, codeBlock);
 
-    MacroAssembler::repatchJump(
+    MacroAssembler::repatchJump<jitMemcpyRepatchFlush>(
         exit.codeLocationForRepatch(codeBlock), CodeLocationLabel<OSRExitPtrTag>(exit.m_code.code()));
     
     return exit.m_code.code().taggedPtr();

--- a/Source/JavaScriptCore/jit/ExecutableAllocator.h
+++ b/Source/JavaScriptCore/jit/ExecutableAllocator.h
@@ -276,8 +276,8 @@ ALWAYS_INLINE void jitMemcpyChecks(void *dst, const void *src, size_t n)
 template<RepatchingInfo repatch>
 ALWAYS_INLINE void* performJITMemcpy(void *dst, const void *src, size_t n)
 {
-    static_assert(!(*repatch).contains(RepatchingFlag::Memcpy));
-    static_assert(!(*repatch).contains(RepatchingFlag::Flush));
+    static_assert(!repatch->contains(RepatchingFlag::Memcpy));
+    static_assert(!repatch->contains(RepatchingFlag::Flush));
     jitMemcpyChecks(dst, src, n);
     if (isJITPC(dst)) {
 #if ENABLE(MPROTECT_RX_TO_RWX)
@@ -288,10 +288,10 @@ ALWAYS_INLINE void* performJITMemcpy(void *dst, const void *src, size_t n)
 
         if (g_jscConfig.useFastJITPermissions) {
             threadSelfRestrict<MemoryRestriction::kRwxToRw>();
-            if constexpr ((*repatch).contains(RepatchingFlag::Atomic))
+            if constexpr (repatch->contains(RepatchingFlag::Atomic))
                 memcpyAtomic(dst, src, n);
             else
-                memcpyAtomicIfPossible(dst, src, n);
+                memcpyTearing(dst, src, n);
             threadSelfRestrict<MemoryRestriction::kRwxToRx>();
             jitMemcpyCheckForZeros(dst, src, n);
             return dst;
@@ -308,12 +308,16 @@ ALWAYS_INLINE void* performJITMemcpy(void *dst, const void *src, size_t n)
             return dst;
         }
 #endif
-        memcpyAtomicIfPossible(dst, src, n);
-        jitMemcpyCheckForZeros(dst, src, n);
+
+        if constexpr (repatch->contains(RepatchingFlag::Atomic))
+            memcpyAtomic(dst, src, n);
+        else
+            memcpyTearing(dst, src, n);
         return dst;
     }
 
-    return memcpyAtomicIfPossible(dst, src, n);
+    RELEASE_ASSERT_NOT_REACHED();
+    return nullptr;
 }
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
@@ -383,6 +387,7 @@ private:
     ~ExecutableAllocator() = default;
 };
 
+template<RepatchingInfo repatch>
 inline void* performJITMemcpy(void *dst, const void *src, size_t n)
 {
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN

--- a/Source/JavaScriptCore/wasm/WasmBBQPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQPlan.cpp
@@ -147,7 +147,7 @@ void BBQPlan::work()
                 entrypoint = calleeCallee->entrypoint().retagged<WasmEntryPtrTag>();
             }
 
-            MacroAssembler::repatchNearCall(call.callLocation, CodeLocationLabel<WasmEntryPtrTag>(entrypoint));
+            MacroAssembler::repatchNearCall<jitMemcpyRepatchAtomic>(call.callLocation, CodeLocationLabel<WasmEntryPtrTag>(entrypoint));
         }
 
         m_calleeGroup->updateCallsitesToCallUs(locker, CodeLocationLabel<WasmEntryPtrTag>(entrypoint), m_functionIndex);

--- a/Source/JavaScriptCore/wasm/WasmCalleeGroup.cpp
+++ b/Source/JavaScriptCore/wasm/WasmCalleeGroup.cpp
@@ -262,12 +262,9 @@ void CalleeGroup::updateCallsitesToCallUs(const AbstractLocker& locker, CodeLoca
 
     m_wasmIndirectCallEntryPoints[functionIndex] = entrypoint;
 
-    // FIXME: This does an icache flush for each repatch but we
-    // 1) only need one at the end.
-    // 2) probably don't need one at all because we don't compile wasm on mutator threads so we don't have to worry about cache coherency.
     for (auto& callsite : callsites) {
         dataLogLnIf(verbose, "Repatching call at: ", RawPointer(callsite.callLocation.dataLocation()), " to ", RawPointer(entrypoint.taggedPtr()));
-        MacroAssembler::repatchNearCall(callsite.callLocation, callsite.target);
+        MacroAssembler::repatchNearCall<jitMemcpyRepatchAtomic>(callsite.callLocation, callsite.target);
     }
 }
 

--- a/Source/JavaScriptCore/wasm/WasmIPIntPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIPIntPlan.cpp
@@ -217,7 +217,7 @@ void IPIntPlan::didCompleteCompilation()
                 executableAddress = m_wasmToWasmExitStubs.at(call.functionIndexSpace).code();
             } else
                 executableAddress = m_callees[call.functionIndexSpace - m_moduleInformation->importFunctionCount()]->entrypoint();
-            MacroAssembler::repatchNearCall(call.callLocation, CodeLocationLabel<WasmEntryPtrTag>(executableAddress));
+            MacroAssembler::repatchNearCall<jitMemcpyRepatchAtomicFlush>(call.callLocation, CodeLocationLabel<WasmEntryPtrTag>(executableAddress));
         }
     }
 }

--- a/Source/JavaScriptCore/wasm/WasmOMGPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGPlan.cpp
@@ -198,9 +198,7 @@ void OMGPlan::work()
                 entrypoint = calleeCallee->entrypoint().retagged<WasmEntryPtrTag>();
             }
 
-            // FIXME: This does an icache flush for each of these... which doesn't make any sense since this code isn't runnable here
-            // and any stale cache will be evicted when updateCallsitesToCallUs is called.
-            MacroAssembler::repatchNearCall(call.callLocation, CodeLocationLabel<WasmEntryPtrTag>(entrypoint));
+            MacroAssembler::repatchNearCall<jitMemcpyRepatchAtomic>(call.callLocation, CodeLocationLabel<WasmEntryPtrTag>(entrypoint));
         }
 
         m_calleeGroup->updateCallsitesToCallUs(locker, CodeLocationLabel<WasmEntryPtrTag>(entrypoint), m_functionIndex);

--- a/Source/JavaScriptCore/wasm/WasmOSREntryPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOSREntryPlan.cpp
@@ -163,7 +163,7 @@ void OSREntryPlan::work()
                 entrypoint = wasmCallee->entrypoint().retagged<WasmEntryPtrTag>();
             }
 
-            MacroAssembler::repatchNearCall(call.callLocation, CodeLocationLabel<WasmEntryPtrTag>(entrypoint));
+            MacroAssembler::repatchNearCall<jitMemcpyRepatchAtomic>(call.callLocation, CodeLocationLabel<WasmEntryPtrTag>(entrypoint));
         }
 
         resetInstructionCacheOnAllThreads();

--- a/Source/WTF/wtf/OptionSet.h
+++ b/Source/WTF/wtf/OptionSet.h
@@ -102,6 +102,8 @@ public:
     {
     }
 
+    constexpr const OptionSet<E>* operator->() const { return this; }
+
     constexpr StorageType toRaw() const { return m_storage; }
 
     constexpr bool isEmpty() const { return !m_storage; }
@@ -235,6 +237,7 @@ struct ConstexprOptionSet {
     }
 
     ALWAYS_INLINE constexpr OptionSet<E> operator*() const { return OptionSet<E>::fromRaw(storage); }
+    ALWAYS_INLINE constexpr OptionSet<E> operator->() const { return OptionSet<E>::fromRaw(storage); }
 
     const OptionSet<E>::StorageType storage;
 };


### PR DESCRIPTION
#### 952e58054d0fd2b45264d09bf2ef391d1ddb1f3b
<pre>
Refactor jitMemcpy into atomic and non-atomic versions
<a href="https://bugs.webkit.org/show_bug.cgi?id=293649">https://bugs.webkit.org/show_bug.cgi?id=293649</a>

Reviewed by Keith Miller.

On ARMv7, there are some concurrent repatching issues because of
unaligned writes to the jit region. Instead of repatching atomically whenever it
is easy, we should be explicit about when we expect writes to the jit
region to tear or not.

Canonical link: <a href="https://commits.webkit.org/299398@main">https://commits.webkit.org/299398@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/799925395153ebde804254105216fc6ee91f4890

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/118661 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/38342 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28993 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/124841 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/70721 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/39038 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46924 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/90064 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/59596 "Found 1 new test failure: http/tests/navigation/ping-attribute/anchor-cookie.html (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/121614 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31103 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106393 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70570 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/30160 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/24504 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/68498 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/110779 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100542 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24694 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/127899 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/117175 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/45568 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/34389 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98701 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45932 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102613 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98482 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25076 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43925 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21929 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/42073 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/45438 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/51116 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/145871 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/44902 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/37505 "Found 19 new JSC stress test failures: wasm.yaml/wasm/js-api/memory-toResizableBuffer.js.default-wasm, wasm.yaml/wasm/js-api/memory-toResizableBuffer.js.wasm-bbq, wasm.yaml/wasm/js-api/memory-toResizableBuffer.js.wasm-bbq-no-consts, wasm.yaml/wasm/js-api/memory-toResizableBuffer.js.wasm-collect-continuously, wasm.yaml/wasm/js-api/memory-toResizableBuffer.js.wasm-eager, wasm.yaml/wasm/js-api/memory-toResizableBuffer.js.wasm-eager-jettison, wasm.yaml/wasm/js-api/memory-toResizableBuffer.js.wasm-no-cjit, wasm.yaml/wasm/js-api/memory-toResizableBuffer.js.wasm-slow-memory, wasm.yaml/wasm/lowExecutableMemory/executable-memory-oom.js.default-wasm, wasm.yaml/wasm/stress/cc-int-to-int-cross-module-with-exception.js.default-wasm ... (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/48248 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/46588 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->