### PR TITLE
The browser.tabs.create API allows index wraparound through integer overflow

### DIFF
--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITabsCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITabsCocoa.mm
@@ -193,6 +193,11 @@ NSDictionary *toWebAPI(const WebExtensionTabParameters& parameters)
     return [result copy];
 }
 
+static inline size_t clampIndex(double index)
+{
+    return static_cast<size_t>(std::max(0.0, std::min(index, static_cast<double>(std::numeric_limits<size_t>::max()))));
+}
+
 bool WebExtensionAPITabs::parseTabCreateOptions(NSDictionary *options, WebExtensionTabParameters& parameters, NSString *sourceKey, NSString **outExceptionString)
 {
     if (!parseTabUpdateOptions(options, parameters, sourceKey, outExceptionString))
@@ -218,7 +223,7 @@ bool WebExtensionAPITabs::parseTabCreateOptions(NSDictionary *options, WebExtens
     }
 
     if (NSNumber *index = objectForKey<NSNumber>(options, indexKey))
-        parameters.index = index.unsignedIntegerValue;
+        parameters.index = clampIndex(index.doubleValue);
 
     if (NSNumber *openInReaderMode = objectForKey<NSNumber>(options, openInReaderModeKey))
         parameters.showingReaderMode = openInReaderMode.boolValue;
@@ -294,7 +299,7 @@ bool WebExtensionAPITabs::parseTabDuplicateOptions(NSDictionary *options, WebExt
         parameters.active = active.boolValue;
 
     if (NSNumber *index = objectForKey<NSNumber>(options, indexKey))
-        parameters.index = index.unsignedIntegerValue;
+        parameters.index = clampIndex(index.doubleValue);
 
     return true;
 }
@@ -386,7 +391,7 @@ bool WebExtensionAPITabs::parseTabQueryOptions(NSDictionary *options, WebExtensi
         parameters.hidden = hidden.boolValue;
 
     if (NSNumber *index = objectForKey<NSNumber>(options, indexKey))
-        parameters.index = index.unsignedIntegerValue;
+        parameters.index = clampIndex(index.doubleValue);
 
     if (NSNumber *active = objectForKey<NSNumber>(options, activeKey))
         parameters.active = active.boolValue;
@@ -436,7 +441,7 @@ bool WebExtensionAPITabs::parseCaptureVisibleTabOptions(NSDictionary *options, W
     }
 
     if (NSNumber *quality = objectForKey<NSNumber>(options, qualityKey)) {
-        if (quality.integerValue < 0 || quality.integerValue > 100) {
+        if (quality.doubleValue < 0 || quality.doubleValue > 100) {
             *outExceptionString = toErrorString(nullString(), qualityKey, @"it must specify a value between 0 and 100").createNSString().autorelease();
             return false;
         }

--- a/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm
+++ b/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm
@@ -809,6 +809,8 @@ static WKUserContentController *userContentController(BOOL usingPrivateBrowsing)
     if (!_activeTab)
         _activeTab = newTab;
 
+    index = std::min(index, _tabs.count);
+
     [_tabs insertObject:newTab atIndex:index];
     [_extensionController didOpenTab:newTab];
 


### PR DESCRIPTION
#### de9aadffaee1bd1457867d7cf89d7ebd131f5914
<pre>
The browser.tabs.create API allows index wraparound through integer overflow
<a href="https://rdar.apple.com/150693489">rdar://150693489</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=293652">https://bugs.webkit.org/show_bug.cgi?id=293652</a>

Reviewed by Timothy Hatcher.

Changed unsignedInteger to doubleValue and created a clamp from 0 to size_t&apos;s max value. added test with Overflow index. added test with zero index. true value or tabs.count for testing

* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITabsCocoa.mm:
(WebKit::clampIndex): created new function that clamps the value from 0 to size_t&apos;s max value
(WebKit::WebExtensionAPITabs::parseTabCreateOptions): Used the clamp function and changed unsignedInteger to doubleValue
(WebKit::WebExtensionAPITabs::parseTabDuplicateOptions): Changed unsignedInteger to doubleValue
(WebKit::WebExtensionAPITabs::parseTabQueryOptions): Changed unsignedInteger to doubleValue
(WebKit::WebExtensionAPITabs::parseCaptureVisibleTabOptions): changed integerValue to doubleValue

Canonical link: <a href="https://commits.webkit.org/295750@main">https://commits.webkit.org/295750@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8c07f5daad5d425ae5470a5abf64e4cba2794051

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105976 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25725 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/16119 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/111172 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/56572 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/108015 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/26399 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34228 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80501 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108980 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/20829 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95641 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60821 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/20438 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13738 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/56010 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/90207 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13774 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/114026 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33114 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24432 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89579 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33478 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91869 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89259 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34124 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11941 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/28653 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17196 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/33039 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/38450 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32785 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/36134 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34383 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->