### PR TITLE
Address miscellaneous style guide issues in AsyncPDFRenderer

### DIFF
--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.h
@@ -259,7 +259,7 @@ private:
     static WebCore::AffineTransform tileToPaintingTransform(float tilingScaleFactor);
     static WebCore::AffineTransform paintingToTileTransform(float tilingScaleFactor);
 #if ENABLE(RE_DYNAMIC_CONTENT_SCALING)
-    WebCore::DynamicContentScalingResourceCache dynamicContentScalingResourceCache();
+    WebCore::DynamicContentScalingResourceCache ensureDynamicContentScalingResourceCache();
 #endif
 
     ThreadSafeWeakPtr<PDFPresentationController> m_presentationController;

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.mm
@@ -556,7 +556,7 @@ TileRenderInfo AsyncPDFRenderer::renderInfoForTile(const TiledBacking& tiledBack
     return TileRenderInfo { tileRect, renderRect, WTFMove(background), pageCoverage, m_showDebugBorders };
 }
 
-static void renderPDFTile(PDFDocument* pdfDocument, const TileRenderInfo& renderInfo, GraphicsContext& context)
+static void renderPDFTile(PDFDocument *pdfDocument, const TileRenderInfo& renderInfo, GraphicsContext& context)
 {
     context.translate(-renderInfo.tileRect.location());
     if (renderInfo.tileRect != renderInfo.renderRect)
@@ -587,7 +587,7 @@ static void renderPDFTile(PDFDocument* pdfDocument, const TileRenderInfo& render
     }
 }
 
-static RefPtr<NativeImage> renderPDFTileToImage(PDFDocument* pdfDocument, const TileRenderInfo& renderInfo)
+static RefPtr<NativeImage> renderPDFTileToImage(PDFDocument *pdfDocument, const TileRenderInfo& renderInfo)
 {
     ASSERT(!isMainRunLoop());
     RefPtr tileBuffer = ImageBuffer::create(renderInfo.tileRect.size(), RenderingMode::Unaccelerated, RenderingPurpose::Unspecified, renderInfo.pageCoverage.deviceScaleFactor, DestinationColorSpace::SRGB(), ImageBufferPixelFormat::BGRA8);
@@ -603,7 +603,7 @@ static RefPtr<NativeImage> renderPDFTileToImage(PDFDocument* pdfDocument, const 
 }
 
 #if ENABLE(RE_DYNAMIC_CONTENT_SCALING)
-static std::optional<DynamicContentScalingDisplayList> renderPDFTileToDynamicContentScalingDisplayList(WebCore::DynamicContentScalingResourceCache& dynamicContentScalingResourceCache, PDFDocument* pdfDocument, const TileRenderInfo& renderInfo)
+static std::optional<DynamicContentScalingDisplayList> renderPDFTileToDynamicContentScalingDisplayList(WebCore::DynamicContentScalingResourceCache& dynamicContentScalingResourceCache, PDFDocument *pdfDocument, const TileRenderInfo& renderInfo)
 {
     ASSERT(!isMainRunLoop());
     WebCore::ImageBufferCreationContext creationContext;
@@ -653,7 +653,7 @@ void AsyncPDFRenderer::serviceRequestQueues()
         m_workQueueSlots--;
         m_workQueue->dispatch([weakThis = ThreadSafeWeakPtr { *this }, pdfDocument = RetainPtr { presentationController->pluginPDFDocument() }, renderKey, renderData = WTFMove(*renderData)
 #if ENABLE(RE_DYNAMIC_CONTENT_SCALING)
-            , dynamicContentScalingResourceCache = dynamicContentScalingResourceCache()
+            , dynamicContentScalingResourceCache = ensureDynamicContentScalingResourceCache()
 #endif
         ] mutable {
             RenderedPDFTile tile { renderData.renderInfo };
@@ -866,7 +866,7 @@ void AsyncPDFRenderer::invalidatePreviewsForPageCoverage(const PDFPageCoverage& 
 }
 
 #if ENABLE(RE_DYNAMIC_CONTENT_SCALING)
-DynamicContentScalingResourceCache AsyncPDFRenderer::dynamicContentScalingResourceCache()
+DynamicContentScalingResourceCache AsyncPDFRenderer::ensureDynamicContentScalingResourceCache()
 {
     if (!m_dynamicContentScalingResourceCache)
         m_dynamicContentScalingResourceCache = WebCore::DynamicContentScalingResourceCache::create();


### PR DESCRIPTION
#### 433b351cb87c60a659153d1b7911a3e4370be503
<pre>
Address miscellaneous style guide issues in AsyncPDFRenderer
<a href="https://bugs.webkit.org/show_bug.cgi?id=293656">https://bugs.webkit.org/show_bug.cgi?id=293656</a>
<a href="https://rdar.apple.com/152122237">rdar://152122237</a>

Reviewed by Aditya Keerthi, Tim Horton, and Megan Gardner.

Fix some violations of &quot;Non-C++ pointer types should be written with a
space between the type and the `*`&quot;,
c.f. <a href="https://www.webkit.org/code-style-guidelines/#pointers-non-cpp.">https://www.webkit.org/code-style-guidelines/#pointers-non-cpp.</a>

* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.mm:
(WebKit::renderPDFTile):
(WebKit::renderPDFTileToImage):
(WebKit::renderPDFTileToDynamicContentScalingDisplayList):
(WebKit::AsyncPDFRenderer::serviceRequestQueues):
(WebKit::operator&lt;&lt;):
(WebKit::AsyncPDFRenderer::dynamicContentScalingResourceCache): Deleted.
Drive-by fix: Rename with an `ensure` prefix to make the single
initialization intent clearer.

Canonical link: <a href="https://commits.webkit.org/295481@main">https://commits.webkit.org/295481@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aa082c6e97d4fcab5b126b6c7c2bb68fdf952efe

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105222 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24933 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15359 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110435 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/55883 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/25363 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33478 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/79916 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/55883 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108228 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/19773 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/94977 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/60223 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/19528 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55276 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/89231 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/13096 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/113022 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32382 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/23855 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/88994 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32747 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/91194 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/88630 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/33524 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/11316 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/27792 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17064 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32305 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/37719 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/32088 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/35432 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33653 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->