### PR TITLE
ASAN_TRAP | WebCore::LocalFrameViewLayoutContext::performLayout; WebCore::LocalFrameViewLayoutContext::layout; WebCore::Document::updateLayout

### DIFF
--- a/LayoutTests/fast/dom/StyleSheet/stylesheet-layout-insert-rule-audio-expected.txt
+++ b/LayoutTests/fast/dom/StyleSheet/stylesheet-layout-insert-rule-audio-expected.txt
@@ -1,0 +1,2 @@
+
+This test passes if it doesn't crash.

--- a/LayoutTests/fast/dom/StyleSheet/stylesheet-layout-insert-rule-audio.html
+++ b/LayoutTests/fast/dom/StyleSheet/stylesheet-layout-insert-rule-audio.html
@@ -1,0 +1,30 @@
+<style></style>
+<script>
+testRunner?.dumpAsText();
+testRunner?.waitUntilDone();
+(async () => {
+  const styleSheet = document.styleSheets[0];
+  styleSheet.disabled = true;
+  styleSheet.insertRule(`:where(*) { display: table-cell; }`);
+
+  const audio = document.createElement('audio');
+  document.documentElement.append(audio);
+  audio.controls = true;
+  audio.focus({ preventScroll: true });
+
+  await new Promise((resolve) => setTimeout(resolve));
+
+  styleSheet.insertRule(`audio { content: linear-gradient(red, blue rem(562pt, 7.86dvmin)) }`, styleSheet.length);
+  document.execCommand('SelectAll');
+  styleSheet.disabled = false;
+  getSelection().extend(document.documentElement);
+  document.designMode = 'on';
+  document.execCommand('FontSize', false, '6');
+
+  // The following is just to reduce noise in the output.
+  await new Promise(resolve => requestAnimationFrame(resolve));
+  styleSheet.disabled = true;
+  testRunner?.notifyDone();
+})();
+</script>
+<p>This test passes if it doesn't crash.</p>

--- a/Source/WebCore/inspector/InspectorInstrumentation.cpp
+++ b/Source/WebCore/inspector/InspectorInstrumentation.cpp
@@ -528,10 +528,16 @@ void InspectorInstrumentation::willLayoutImpl(InstrumentingAgents& instrumenting
         pageTimelineAgent->willLayout();
 }
 
-void InspectorInstrumentation::didLayoutImpl(InstrumentingAgents& instrumentingAgents, RenderObject& root)
+void InspectorInstrumentation::setLayoutQuadsImpl(InstrumentingAgents& instrumentingAgents, RenderObject& root)
 {
     if (auto* pageTimelineAgent = instrumentingAgents.trackingPageTimelineAgent())
-        pageTimelineAgent->didLayout(root);
+        pageTimelineAgent->setLayoutQuads(root);
+}
+
+void InspectorInstrumentation::didLayoutImpl(InstrumentingAgents& instrumentingAgents)
+{
+    if (auto* pageTimelineAgent = instrumentingAgents.trackingPageTimelineAgent())
+        pageTimelineAgent->didLayout();
     if (auto* pageAgent = instrumentingAgents.enabledPageAgent())
         pageAgent->didLayout();
 }

--- a/Source/WebCore/inspector/InspectorInstrumentation.h
+++ b/Source/WebCore/inspector/InspectorInstrumentation.h
@@ -187,7 +187,8 @@ public:
     static void didFireTimer(ScriptExecutionContext&, int timerId, bool oneShot);
     static void didInvalidateLayout(LocalFrame&);
     static void willLayout(LocalFrame&);
-    static void didLayout(LocalFrame&, RenderObject&);
+    static void setLayoutQuads(LocalFrame&, RenderObject&);
+    static void didLayout(LocalFrame&);
     static void didScroll(Page&);
     static void willComposite(LocalFrame&);
     static void didComposite(LocalFrame&);
@@ -417,7 +418,8 @@ private:
     static void didFireTimerImpl(InstrumentingAgents&, int timerId, bool oneShot);
     static void didInvalidateLayoutImpl(InstrumentingAgents&);
     static void willLayoutImpl(InstrumentingAgents&);
-    static void didLayoutImpl(InstrumentingAgents&, RenderObject&);
+    static void setLayoutQuadsImpl(InstrumentingAgents&, RenderObject&);
+    static void didLayoutImpl(InstrumentingAgents&);
     static void didScrollImpl(InstrumentingAgents&);
     static void willCompositeImpl(InstrumentingAgents&);
     static void didCompositeImpl(InstrumentingAgents&);
@@ -1025,11 +1027,18 @@ inline void InspectorInstrumentation::willLayout(LocalFrame& frame)
         willLayoutImpl(*agents);
 }
 
-inline void InspectorInstrumentation::didLayout(LocalFrame& frame, RenderObject& root)
+inline void InspectorInstrumentation::setLayoutQuads(LocalFrame& frame, RenderObject& root)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
     if (auto* agents = instrumentingAgents(frame))
-        didLayoutImpl(*agents, root);
+        setLayoutQuadsImpl(*agents, root);
+}
+
+inline void InspectorInstrumentation::didLayout(LocalFrame& frame)
+{
+    FAST_RETURN_IF_NO_FRONTENDS(void());
+    if (auto* agents = instrumentingAgents(frame))
+        didLayoutImpl(*agents);
 }
 
 inline void InspectorInstrumentation::didScroll(Page& page)

--- a/Source/WebCore/inspector/agents/page/PageTimelineAgent.cpp
+++ b/Source/WebCore/inspector/agents/page/PageTimelineAgent.cpp
@@ -189,7 +189,7 @@ void PageTimelineAgent::willLayout()
     pushCurrentRecord(JSON::Object::create(), TimelineRecordType::Layout, true);
 }
 
-void PageTimelineAgent::didLayout(RenderObject& root)
+void PageTimelineAgent::setLayoutQuads(RenderObject& root)
 {
     auto* entry = lastRecordEntry();
     if (!entry)
@@ -202,7 +202,10 @@ void PageTimelineAgent::didLayout(RenderObject& root)
     ASSERT(quads.size() >= 1);
     if (quads.size() >= 1)
         TimelineRecordFactory::appendLayoutRoot(entry->data.get(), quads[0]);
+}
 
+void PageTimelineAgent::didLayout()
+{
     didCompleteCurrentRecord(TimelineRecordType::Layout);
 }
 

--- a/Source/WebCore/inspector/agents/page/PageTimelineAgent.h
+++ b/Source/WebCore/inspector/agents/page/PageTimelineAgent.h
@@ -47,7 +47,8 @@ public:
     // InspectorInstrumentation
     void didInvalidateLayout();
     void willLayout();
-    void didLayout(RenderObject&);
+    void setLayoutQuads(RenderObject&);
+    void didLayout();
     void willComposite();
     void didComposite();
     void willPaint();

--- a/Source/WebCore/page/LocalFrameViewLayoutContext.cpp
+++ b/Source/WebCore/page/LocalFrameViewLayoutContext.cpp
@@ -286,10 +286,11 @@ void LocalFrameViewLayoutContext::performLayout(bool canDeferUpdateLayerPosition
         if (m_needsFullRepaint)
             renderView()->repaintRootContents();
         ASSERT(!layoutRoot->needsLayout());
+        InspectorInstrumentation::setLayoutQuads(frame, *layoutRoot);
         protectedView()->didLayout(layoutRoot, canDeferUpdateLayerPositions);
         runOrScheduleAsynchronousTasks(canDeferUpdateLayerPositions);
     }
-    InspectorInstrumentation::didLayout(frame, *layoutRoot);
+    InspectorInstrumentation::didLayout(frame);
     DebugPageOverlays::didLayout(frame);
 }
 


### PR DESCRIPTION
#### 17237297720e4a207a4a63574c8902c33c6b3c61
<pre>
ASAN_TRAP | WebCore::LocalFrameViewLayoutContext::performLayout; WebCore::LocalFrameViewLayoutContext::layout; WebCore::Document::updateLayout
<a href="https://bugs.webkit.org/show_bug.cgi?id=293511">https://bugs.webkit.org/show_bug.cgi?id=293511</a>
<a href="https://rdar.apple.com/147938727">rdar://147938727</a>

Reviewed by NOBODY (OOPS!).

Splitting the fuction InspectorInstrumentation::didLayout in two parts, once to set the Quads,
and the other to did the layout, the later doesn&apos;t require the layoutRoot variable to exist.

* LayoutTests/fast/dom/StyleSheet/stylesheet-layout-insert-rule-audio-expected.txt: Added.
* LayoutTests/fast/dom/StyleSheet/stylesheet-layout-insert-rule-audio.html: Added.
* Source/WebCore/inspector/InspectorInstrumentation.cpp:
(WebCore::InspectorInstrumentation::setLayoutQuadsImpl):
(WebCore::InspectorInstrumentation::didLayoutImpl):
* Source/WebCore/inspector/InspectorInstrumentation.h:
(WebCore::InspectorInstrumentation::setLayoutQuads):
(WebCore::InspectorInstrumentation::didLayout):
* Source/WebCore/inspector/agents/page/PageTimelineAgent.cpp:
(WebCore::PageTimelineAgent::setLayoutQuads):
(WebCore::PageTimelineAgent::didLayout):
* Source/WebCore/inspector/agents/page/PageTimelineAgent.h:
* Source/WebCore/page/LocalFrameViewLayoutContext.cpp:
(WebCore::LocalFrameViewLayoutContext::performLayout):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/17237297720e4a207a4a63574c8902c33c6b3c61

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105492 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25203 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15631 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110692 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/56161 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/107533 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/25700 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33744 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80121 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108498 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/20060 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95205 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60430 "Passed tests") | 
| | [💥 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/19806 "An unexpected error occured. Recent messages:Failed to print configuration") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13295 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55529 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/89515 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13336 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/113460 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32634 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24062 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89199 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32997 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91434 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88856 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33728 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11533 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/28091 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32560 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/37973 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32316 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35663 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33903 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->