### PR TITLE
Remove unneeded forward declarations.

### DIFF
--- a/Source/WebKit/Platform/spi/ios/BackBoardServicesSPI.h
+++ b/Source/WebKit/Platform/spi/ios/BackBoardServicesSPI.h
@@ -31,6 +31,8 @@ DECLARE_SYSTEM_HEADER
 
 #import <BackBoardServices/BKSAnimationFence.h>
 #import <BackBoardServices/BKSAnimationFence_Private.h>
+#import <BackBoardServices/BKSHIDEventAttributes.h>
+#import <BackBoardServices/BKSHIDEventKeyCommand.h>
 #import <BackBoardServices/BKSMousePointerService.h>
 
 #else
@@ -54,13 +56,6 @@ DECLARE_SYSTEM_HEADER
 - (id<BSInvalidatable>)addPointerDeviceObserver:(id<BKSMousePointerDeviceObserver>)observer;
 @end
 
-#endif // USE(APPLE_INTERNAL_SDK)
-
-// Unfortunately, the following declarations need to be forward declared even when using the internal SDK,
-// since the headers that define these symbols (BKSHIDEventKeyCommand.h and BKSHIDEventAttributes.h) include
-// additional private headers that attempt to define macros, which conflict with other macros within WebKit
-// (in particular, `kB` being defined in BrightnessSystemKeys.h, and Sizes.h in bmalloc).
-
 typedef NS_OPTIONS(NSInteger, BKSKeyModifierFlags) {
     BKSKeyModifierShift = 1 << 17,
     BKSKeyModifierControl = 1 << 18,
@@ -74,3 +69,5 @@ typedef NS_OPTIONS(NSInteger, BKSKeyModifierFlags) {
 @interface BKSHIDEventDigitizerAttributes : BKSHIDEventBaseAttributes
 @property (nonatomic) BKSKeyModifierFlags activeModifiers;
 @end
+
+#endif // USE(APPLE_INTERNAL_SDK)


### PR DESCRIPTION
#### 96991c3190a6b29d6dd3cccb196f533ab7cc1775
<pre>
Remove unneeded forward declarations.
<a href="https://bugs.webkit.org/show_bug.cgi?id=293658">https://bugs.webkit.org/show_bug.cgi?id=293658</a>
<a href="https://rdar.apple.com/148771459">rdar://148771459</a>

Reviewed by Tim Horton and Abrar Rahman Protyasha.

After <a href="https://rdar.apple.com/107586783">rdar://107586783</a> was fixed, we not longer have the
clashing kB definition, so we can move this to only be pre-declared
for non-internal situations, and have the correct includes for internal builds.

* Source/WebKit/Platform/spi/ios/BackBoardServicesSPI.h:

Canonical link: <a href="https://commits.webkit.org/295487@main">https://commits.webkit.org/295487@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2876c99c7a8a2633bc7442452c9cae38c9e2a11c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105230 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24941 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15367 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110443 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/55890 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/25371 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33486 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79923 "Found 2 new test failures: imported/w3c/web-platform-tests/html/semantics/forms/constraints/infinite_backtracking.html imported/w3c/web-platform-tests/service-workers/service-worker/redirected-response.https.html (failure)") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108236 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19778 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94980 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60230 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/19533 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55284 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/89235 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13094 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/113032 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32390 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/23861 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88999 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32755 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91192 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88635 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22606 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33530 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11314 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/27799 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32313 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/37726 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32095 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35439 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33661 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->