### PR TITLE
Remove references to TextIndicatorWindow.

### DIFF
--- a/Source/WebCore/page/TextIndicator.h
+++ b/Source/WebCore/page/TextIndicator.h
@@ -58,7 +58,7 @@ enum class TextIndicatorDismissalAnimation : uint8_t {
     FadeOut
 };
 
-// FIXME: Move PresentationTransition to TextIndicatorWindow, because it's about presentation.
+// FIXME: Perhaps move TextIndicatorPresentationTransition to TextIndicatorLayer, because it's about presentation.
 enum class TextIndicatorPresentationTransition : uint8_t {
     None,
 
@@ -66,7 +66,7 @@ enum class TextIndicatorPresentationTransition : uint8_t {
     Bounce,
     BounceAndCrossfade,
 
-    // This animation needs to be driven manually via TextIndicatorWindow::setAnimationProgress.
+    // This animation needs to be driven manually via TextIndicatorLayer::setAnimationProgress.
     FadeIn,
 };
 
@@ -145,7 +145,7 @@ struct TextIndicatorData {
 class TextIndicator : public RefCounted<TextIndicator> {
 public:
     // FIXME: These are fairly Mac-specific, and they don't really belong here.
-    // But they're needed at TextIndicator creation time, so they can't go in TextIndicatorWindow.
+    // But they're needed at TextIndicator creation time, so they can't go in TextIndicatorLayer.
     // Maybe they can live in some Theme code somewhere?
     constexpr static float defaultHorizontalMargin { 2 };
     constexpr static float defaultVerticalMargin { 1 };

--- a/Source/WebCore/page/cocoa/WebTextIndicatorLayer.mm
+++ b/Source/WebCore/page/cocoa/WebTextIndicatorLayer.mm
@@ -31,7 +31,6 @@
 #import "NativeImage.h"
 #import "PathUtilities.h"
 #import "TextIndicator.h"
-#import "TextIndicatorWindow.h"
 #import "WebActionDisablingCALayerDelegate.h"
 #import <pal/spi/cg/CoreGraphicsSPI.h>
 #import <pal/spi/cocoa/QuartzCoreSPI.h>

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -140,7 +140,6 @@
 #import <WebCore/TextAlternativeWithRange.h>
 #import <WebCore/TextAnimationTypes.h>
 #import <WebCore/TextIndicator.h>
-#import <WebCore/TextIndicatorWindow.h>
 #import <WebCore/TextRecognitionResult.h>
 #import <WebCore/TouchAction.h>
 #import <WebCore/UTIRegistry.h>

--- a/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
+++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
@@ -76,7 +76,6 @@
 #import <WebCore/PromisedAttachmentInfo.h>
 #import <WebCore/SharedBuffer.h>
 #import <WebCore/TextIndicator.h>
-#import <WebCore/TextIndicatorWindow.h>
 #import <WebCore/TextUndoInsertionMarkupMac.h>
 #import <WebCore/ValidationBubble.h>
 #import <WebCore/WebCoreCALayerExtras.h>

--- a/Source/WebKit/UIProcess/mac/WKImmediateActionController.mm
+++ b/Source/WebKit/UIProcess/mac/WKImmediateActionController.mm
@@ -39,7 +39,6 @@
 #import "WebViewImpl.h"
 #import <WebCore/DictionaryLookup.h>
 #import <WebCore/GeometryUtilities.h>
-#import <WebCore/TextIndicatorWindow.h>
 #import <pal/spi/mac/LookupSPI.h>
 #import <pal/spi/mac/NSMenuSPI.h>
 #import <pal/spi/mac/NSPopoverSPI.h>

--- a/Source/WebKit/WebProcess/WebPage/FindController.cpp
+++ b/Source/WebKit/WebProcess/WebPage/FindController.cpp
@@ -57,10 +57,6 @@
 #include <WebCore/SimpleRange.h>
 #include <wtf/TZoneMallocInlines.h>
 
-#if PLATFORM(COCOA)
-#include <WebCore/TextIndicatorWindow.h>
-#endif
-
 namespace WebKit {
 using namespace WebCore;
 


### PR DESCRIPTION
#### f57df1da0a42bb498717b36c5bf797e088c719d0
<pre>
Remove references to TextIndicatorWindow.
<a href="https://bugs.webkit.org/show_bug.cgi?id=293661">https://bugs.webkit.org/show_bug.cgi?id=293661</a>
<a href="https://rdar.apple.com/152124244">rdar://152124244</a>

Reviewed by Abrar Rahman Protyasha.

TextIndicatorWindow was removed from use in
WebKit <a href="https://commits.webkit.org/294860@main">https://commits.webkit.org/294860@main</a>
but I left behind a few includes and references to it.
Remove those.

* Source/WebCore/page/TextIndicator.h:
* Source/WebCore/page/cocoa/WebTextIndicatorLayer.mm:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
* Source/WebKit/UIProcess/mac/PageClientImplMac.mm:
* Source/WebKit/UIProcess/mac/WKImmediateActionController.mm:
* Source/WebKit/WebProcess/WebPage/FindController.cpp:

Canonical link: <a href="https://commits.webkit.org/295511@main">https://commits.webkit.org/295511@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2ea7855fefa3a96950922d847c4e3df88611be57

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105231 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24945 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15368 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110444 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/55891 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/107272 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/25372 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33487 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79924 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108237 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19782 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94981 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60231 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/19536 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13055 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55285 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/89238 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13099 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/113033 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32391 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23862 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89000 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32756 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91197 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88636 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22622 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33532 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11319 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/27800 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32314 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/37794 "Failed to build and analyze WebKit") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32096 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35440 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33662 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->