### PR TITLE
[view-transitions] Make generated names match recent resolutions

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7085,9 +7085,6 @@ imported/w3c/web-platform-tests/css/css-view-transitions/web-animations-api-pars
 imported/w3c/web-platform-tests/css/css-view-transitions/web-animations-api-parse-pseudo-argument.html?first-pseudo=::view-transition-group(first%20) [ Skip ]
 imported/w3c/web-platform-tests/css/css-view-transitions/web-animations-api-parse-pseudo-argument.html?first-pseudo=::view-transition-group(first) [ Skip ]
 
-# Spec still in flux.
-imported/w3c/web-platform-tests/css/css-view-transitions/auto-name-get-animations.html [ Failure ]
-
 # View transitions Level 2 - types.
 # Test doesn't seem to pass on Chrome Canary.
 imported/w3c/web-platform-tests/css/css-view-transitions/view-transition-types-mutable-no-document-element-crashtest.html [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/auto-name-from-id.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/auto-name-from-id.html
@@ -34,6 +34,12 @@ main.switch #item1 {
   left: 100px;
 }
 
+/* Make test fail if ID matches */
+::view-transition-group(item1),
+::view-transition-group(item2) {
+  border: 2px solid red;
+}
+
 html::view-transition {
   background: rebeccapurple;
 }

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/auto-name-get-animations-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/auto-name-get-animations-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Generated view-transition-names should not be reflected in script assert_array_equals: lengths differ, expected array ["::view-transition-group(match-element)", "::view-transition-new(match-element)", "::view-transition-old(match-element)"] length 3, got ["::view-transition-group(-ua-auto-61)", "::view-transition-old(-ua-auto-61)", "::view-transition-new(-ua-auto-61)", "::view-transition-group(-ua-auto-62)", "::view-transition-old(-ua-auto-62)", "::view-transition-new(-ua-auto-62)"] length 6
+PASS Generated view-transition-names should be prefixed with -ua- in script
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/auto-name-get-animations.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/auto-name-get-animations.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html >
-<title>View transitions: generated names should not be visible from script</title>
+<title>View transitions: generated names should be prefixed with -ua- in script</title>
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-2/">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
@@ -57,12 +57,20 @@ main.switch .item1 {
     }).ready;
     const animations = document.documentElement.getAnimations({subtree: true});
     const pseudos = Array.from(new Set(animations.map(a => a.effect.pseudoElement)));
+    const item1GeneratedName = pseudos[0].replace("::view-transition-group(", "").slice(0, -1);
+    const item2GeneratedName = pseudos[3].replace("::view-transition-group(", "").slice(0, -1);
+    assert_true(item1GeneratedName.startsWith("-ua-"), "Item 1 generated name starts with -ua-");
+    assert_true(item2GeneratedName.startsWith("-ua-"), "Item 2 generated name starts with -ua-");
     assert_array_equals(pseudos,
       [
-        "::view-transition-group(match-element)",
-        "::view-transition-new(match-element)",
-        "::view-transition-old(match-element)"]);
-  }, "Generated view-transition-names should not be reflected in script");
+        `::view-transition-group(${item1GeneratedName})`,
+        `::view-transition-old(${item1GeneratedName})`,
+        `::view-transition-new(${item1GeneratedName})`,
+        `::view-transition-group(${item2GeneratedName})`,
+        `::view-transition-old(${item2GeneratedName})`,
+        `::view-transition-new(${item2GeneratedName})`
+      ], "Generated names should start with -ua- and pseudo-elements should be in tree order");
+  }, "Generated view-transition-names should be prefixed with -ua- in script");
 </script>
 
 </body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/resources/auto-name-from-id.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/resources/auto-name-from-id.html
@@ -29,6 +29,11 @@ html::view-transition-group(*) {
   animation-timing-function: steps(2, start);
 }
 
+/* Make test fail if ID matches */
+::view-transition-group(green) {
+  border: 2px solid red;
+}
+
 #green {
   background: green;
   width: 100px;

--- a/Source/WebCore/dom/ViewTransition.cpp
+++ b/Source/WebCore/dom/ViewTransition.cpp
@@ -365,7 +365,7 @@ static AtomString effectiveViewTransitionName(RenderLayerModelObject& renderer, 
 
     Ref element = *renderer.element();
     if (transitionName.isAuto() && scope == &Style::Scope::forNode(element) && element->hasID())
-        return renderer.element()->getIdAttribute();
+        return makeAtomString("-ua-id-"_s, renderer.element()->getIdAttribute());
 
     if (isCrossDocument)
         return nullAtom();


### PR DESCRIPTION
#### 110f9aedbfee9fb85bc94d7385e49b7e91fa0058
<pre>
[view-transitions] Make generated names match recent resolutions
<a href="https://bugs.webkit.org/show_bug.cgi?id=292963">https://bugs.webkit.org/show_bug.cgi?id=292963</a>
<a href="https://rdar.apple.com/151262330">rdar://151262330</a>

Reviewed by Matt Woodrow.

Match the following resolutions:
<a href="https://github.com/w3c/csswg-drafts/issues/11614#issuecomment-2718399971">https://github.com/w3c/csswg-drafts/issues/11614#issuecomment-2718399971</a>
<a href="https://github.com/w3c/csswg-drafts/issues/12004#issuecomment-2910779457">https://github.com/w3c/csswg-drafts/issues/12004#issuecomment-2910779457</a>

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/auto-name-from-id.html:
Fix the test to fail with WebKit&apos;s previous behavior, to match &quot;RESOLVED: v-t-name:auto never matches an explicit v-t-name:&lt;ident&gt;&quot;.

* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/auto-name-get-animations-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/auto-name-get-animations.html:
Fix the test to reflect &quot;RESOLVED: Expose generated view-transition-names as -ua-&lt;generated name&gt;&quot;

* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/resources/auto-name-from-id.html:
Fix the test to fail with WebKit&apos;s previous behavior, to match &quot;RESOLVED: v-t-name:auto never matches an explicit v-t-name:&lt;ident&gt;&quot;.

* Source/WebCore/dom/ViewTransition.cpp:
(WebCore::effectiveViewTransitionName):
Namespace IDs with `-ua-id-` prefix so they don&apos;t match `view-transition-name: &lt;ident&gt;`.

Canonical link: <a href="https://commits.webkit.org/295489@main">https://commits.webkit.org/295489@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/97eb5732f8ce4f98a2eae2d0bbc24d0b840cc7b4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105241 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24953 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15378 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110454 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/55899 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/107282 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/25383 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33497 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79931 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108247 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19789 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94987 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60238 "Passed tests") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/104719 "Build is in progress. Recent messages:") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/19543 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/13061 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55295 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/89244 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13105 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/113060 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32401 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/23871 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/89013 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32765 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91203 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88650 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33537 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11324 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/27810 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17067 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32324 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/37736 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32103 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35448 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33671 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->