### PR TITLE
AbortController.signal.reason is lost after garbage collection

### DIFF
--- a/LayoutTests/http/tests/fetch/abort-signal-gc-expected.txt
+++ b/LayoutTests/http/tests/fetch/abort-signal-gc-expected.txt
@@ -1,4 +1,5 @@
 
 PASS GC should collect a signal after its controller
 PASS GC should collect a signal after its request
+PASS GC should not collect reason of a controller signal
 

--- a/LayoutTests/http/tests/fetch/abort-signal-gc.html
+++ b/LayoutTests/http/tests/fetch/abort-signal-gc.html
@@ -39,6 +39,22 @@ promise_test(() => {
     window.gc();
     return promise;
 }, "GC should collect a signal after its request");
+
+function createAbortedController(message)
+{
+    const controller = new AbortController();
+    controller.abort(new Error(message));
+    return controller;
+}
+
+test(() => {
+    const errorMessage = "my potato";
+    const controller = createAbortedController(errorMessage);
+
+    window.gc();
+
+    assert_equals(controller.signal.reason.message, errorMessage);
+}, "GC should not collect reason of a controller signal");
         </script>
     </body>
 </html>

--- a/Source/WebCore/dom/AbortController.cpp
+++ b/Source/WebCore/dom/AbortController.cpp
@@ -27,6 +27,7 @@
 #include "AbortController.h"
 
 #include "AbortSignal.h"
+#include "JSAbortController.h"
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
@@ -64,5 +65,13 @@ Ref<AbortSignal> AbortController::protectedSignal() const
 {
     return m_signal;
 }
+
+template<typename Visitor>
+void JSAbortController::visitAdditionalChildren(Visitor& visitor)
+{
+    wrapped().signal().reason().visit(visitor);
+}
+
+DEFINE_VISIT_ADDITIONAL_CHILDREN(JSAbortController);
 
 }

--- a/Source/WebCore/dom/AbortController.idl
+++ b/Source/WebCore/dom/AbortController.idl
@@ -25,6 +25,7 @@
 
 [
     Exposed=*,
+    JSCustomMarkFunction,
     GenerateAddOpaqueRoot
 ] interface AbortController {
     [CallWith=CurrentScriptExecutionContext] constructor();


### PR DESCRIPTION
#### f1292b56a628be716afa4d6b8b4cd4c2f441b62f
<pre>
AbortController.signal.reason is lost after garbage collection
<a href="https://bugs.webkit.org/show_bug.cgi?id=293319">https://bugs.webkit.org/show_bug.cgi?id=293319</a>
<a href="https://rdar.apple.com/problem/152111446">rdar://problem/152111446</a>

Reviewed by Per Arne Vollan and Chris Dumez.

Make sure that JSAbortController marks its signal reason to prevent GC.

* LayoutTests/http/tests/fetch/abort-signal-gc-expected.txt:
* LayoutTests/http/tests/fetch/abort-signal-gc.html:
* Source/WebCore/dom/AbortController.cpp:
(WebCore::JSAbortController::visitAdditionalChildren):
* Source/WebCore/dom/AbortController.idl:

Canonical link: <a href="https://commits.webkit.org/295688@main">https://commits.webkit.org/295688@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aa016ad0fa9008579594f0a13727a5086b34d479

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105891 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25642 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/16035 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/111088 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/56489 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/107932 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/26259 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34145 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/80433 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108897 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/20680 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95561 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60751 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/20325 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13659 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55926 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/90069 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13695 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/113938 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33031 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24362 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/89513 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33395 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91790 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89185 "Found 101 new API test failures: /TestWebKit:WebKit.PageLoadDidChangeLocationWithinPage, /TestWebKit:WebKit.AboutBlankLoad, /TestWebKit:WebKit.PreventEmptyUserAgent, /TestWebKit:WebKit.PrivateBrowsingPushStateNoHistoryCallback, /WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/content-type, /WebKitGTK/TestUIClient:/webkit/WebKitWebView/pointer-lock-permission-request, /TestWebKit:WebKit.HitTestResultNodeHandle, /TestWebKit:WebKit2TextFieldBeginAndEditEditingTest.TextFieldDidBeginShouldNotBeDispatchedForAlreadyFocusedField, /TestWebKit:WebKit.Find, /WebKitGTK/TestWebProcessExtensions:/webkit/WebKitWebProcessExtension/dom-input-element-is-user-edited ... (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22725 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34054 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11864 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/28567 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32956 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/38367 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32702 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/36051 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34300 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->