### PR TITLE
[WPE] Move the new API runtime check to a common place

### DIFF
--- a/Source/WebKit/SourcesWPE.txt
+++ b/Source/WebKit/SourcesWPE.txt
@@ -258,6 +258,7 @@ UIProcess/soup/WebProcessPoolSoup.cpp
 UIProcess/wpe/AcceleratedBackingStoreDMABuf.cpp
 UIProcess/wpe/ScreenManagerWPE.cpp
 UIProcess/wpe/SystemSettingsManagerProxyWPE.cpp
+UIProcess/wpe/WPEUtilities.cpp
 UIProcess/wpe/WebPageProxyWPE.cpp
 UIProcess/wpe/WebPasteboardProxyWPE.cpp
 UIProcess/wpe/WebPreferencesWPE.cpp

--- a/Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.cpp
@@ -64,8 +64,11 @@
 #include <gtk/gtk.h>
 #endif
 
-#if PLATFORM(WPE) && ENABLE(WPE_PLATFORM)
+#if PLATFORM(WPE)
+#include "WPEUtilities.h"
+#if ENABLE(WPE_PLATFORM)
 #include <wpe/wpe-platform.h>
+#endif
 #endif
 
 #if USE(GBM)
@@ -449,12 +452,7 @@ void WebKitProtocolHandler::handleGPU(WebKitURISchemeRequest* request)
 #endif
 
 #if PLATFORM(WPE)
-#if ENABLE(WPE_PLATFORM)
-    bool usingWPEPlatformAPI = !!g_type_class_peek(WPE_TYPE_DISPLAY);
-#else
-    bool usingWPEPlatformAPI = false;
-#endif
-
+    bool usingWPEPlatformAPI = WKWPE::isUsingWPEPlatformAPI();
     if (!usingWPEPlatformAPI) {
         addTableRow(versionObject, "WPE version"_s, makeString(WPE_MAJOR_VERSION, '.', WPE_MINOR_VERSION, '.', WPE_MICRO_VERSION, " (build) "_s, wpe_get_major_version(), '.', wpe_get_minor_version(), '.', wpe_get_micro_version(), " (runtime)"_s));
         addTableRow(versionObject, "WPE backend"_s, String::fromUTF8(wpe_loader_get_loaded_implementation_library_name()));

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
@@ -107,6 +107,7 @@
 #endif
 
 #if PLATFORM(WPE)
+#include "WPEUtilities.h"
 #include "WPEWebViewLegacy.h"
 #include "WPEWebViewPlatform.h"
 #include "WebKitOptionMenuPrivate.h"
@@ -904,7 +905,7 @@ static void webkitWebViewConstructed(GObject* object)
         if (priv->display) {
             g_critical("WebKitWebView backend can't be set when display is set too, passed backend is ignored.");
             priv->backend = nullptr;
-        } else if (g_type_class_peek(WPE_TYPE_DISPLAY)) {
+        } else if (WKWPE::isUsingWPEPlatformAPI()) {
             g_critical("WebKitWebView backend can't be set when WPE platform API is already in use, passed backend is ignored.");
             priv->backend = nullptr;
             priv->display = wpe_display_get_default();

--- a/Source/WebKit/UIProcess/API/wpe/WebKitWebViewWPE.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/WebKitWebViewWPE.cpp
@@ -21,6 +21,7 @@
 #include "WebKitWebView.h"
 
 #include "PageClientImpl.h"
+#include "WPEUtilities.h"
 #include "WebInspectorUIProxy.h"
 #include "WebKitColorPrivate.h"
 #include "WebKitScriptDialogPrivate.h"
@@ -84,7 +85,7 @@ void webkitWebViewRestoreWindow(WebKitWebView*, CompletionHandler<void()>&& comp
 WebKitWebView* webkit_web_view_new(WebKitWebViewBackend* backend)
 {
 #if ENABLE(WPE_PLATFORM)
-    g_return_val_if_fail(!backend || !g_type_class_peek(WPE_TYPE_DISPLAY), nullptr);
+    g_return_val_if_fail(!backend || !WKWPE::isUsingWPEPlatformAPI(), nullptr);
 #else
     g_return_val_if_fail(backend, nullptr);
 #endif

--- a/Source/WebKit/UIProcess/Gamepad/libwpe/UIGamepadProviderLibWPE.cpp
+++ b/Source/WebKit/UIProcess/Gamepad/libwpe/UIGamepadProviderLibWPE.cpp
@@ -35,6 +35,7 @@
 
 #if ENABLE(WPE_PLATFORM)
 #include "GamepadProviderWPE.h"
+#include "WPEUtilities.h"
 #include "WPEWebViewPlatform.h"
 #include <wpe/wpe-platform.h>
 #endif
@@ -43,20 +44,13 @@
 namespace WebKit {
 using namespace WebCore;
 
-#if ENABLE(WPE_PLATFORM)
-static inline bool usingWPEPlatformAPI()
-{
-    return !!g_type_class_peek(WPE_TYPE_DISPLAY);
-}
-#endif
-
 void UIGamepadProvider::platformSetDefaultGamepadProvider()
 {
     if (GamepadProvider::singleton().isMockGamepadProvider())
         return;
 
 #if ENABLE(WPE_PLATFORM)
-    if (usingWPEPlatformAPI()) {
+    if (WKWPE::isUsingWPEPlatformAPI()) {
         GamepadProvider::setSharedProvider(GamepadProviderWPE::singleton());
         return;
     }
@@ -71,7 +65,7 @@ WebPageProxy* UIGamepadProvider::platformWebPageProxyForGamepadInput()
 {
 #if PLATFORM(WPE)
 #if ENABLE(WPE_PLATFORM)
-    if (usingWPEPlatformAPI())
+    if (WKWPE::isUsingWPEPlatformAPI())
         return WKWPE::ViewPlatform::platformWebPageProxyForGamepadInput();
 #endif
     return WKWPE::ViewLegacy::platformWebPageProxyForGamepadInput();
@@ -83,7 +77,7 @@ WebPageProxy* UIGamepadProvider::platformWebPageProxyForGamepadInput()
 void UIGamepadProvider::platformStopMonitoringInput()
 {
 #if ENABLE(WPE_PLATFORM)
-    if (usingWPEPlatformAPI())
+    if (WKWPE::isUsingWPEPlatformAPI())
         GamepadProviderWPE::singleton().stopMonitoringInput();
 #endif
 }
@@ -91,7 +85,7 @@ void UIGamepadProvider::platformStopMonitoringInput()
 void UIGamepadProvider::platformStartMonitoringInput()
 {
 #if ENABLE(WPE_PLATFORM)
-    if (usingWPEPlatformAPI())
+    if (WKWPE::isUsingWPEPlatformAPI())
         GamepadProviderWPE::singleton().startMonitoringInput();
 #endif
 }

--- a/Source/WebKit/UIProcess/glib/DRMDevice.cpp
+++ b/Source/WebKit/UIProcess/glib/DRMDevice.cpp
@@ -38,6 +38,7 @@
 #endif
 
 #if PLATFORM(WPE) && ENABLE(WPE_PLATFORM)
+#include "WPEUtilities.h"
 #include <wpe/wpe-platform.h>
 #endif
 
@@ -170,7 +171,7 @@ const String& drmPrimaryDevice()
     static std::once_flag once;
     std::call_once(once, [] {
 #if PLATFORM(WPE) && ENABLE(WPE_PLATFORM)
-        if (g_type_class_peek(WPE_TYPE_DISPLAY)) {
+        if (WKWPE::isUsingWPEPlatformAPI()) {
             primaryDevice.construct(String::fromUTF8(wpe_display_get_drm_device(wpe_display_get_primary())));
             return;
         }
@@ -193,7 +194,7 @@ const String& drmRenderNodeDevice()
     static std::once_flag once;
     std::call_once(once, [] {
 #if PLATFORM(WPE) && ENABLE(WPE_PLATFORM)
-        if (g_type_class_peek(WPE_TYPE_DISPLAY)) {
+        if (WKWPE::isUsingWPEPlatformAPI()) {
             renderNodeDevice.construct(String::fromUTF8(wpe_display_get_drm_render_node(wpe_display_get_primary())));
             return;
         }

--- a/Source/WebKit/UIProcess/glib/DisplayVBlankMonitorDRM.cpp
+++ b/Source/WebKit/UIProcess/glib/DisplayVBlankMonitorDRM.cpp
@@ -40,7 +40,7 @@
 #include <xf86drm.h>
 #include <xf86drmMode.h>
 
-#if PLATFORM(GTK) || (PLATFORM(WPE) && ENABLE(WPE_PLATFORM))
+#if PLATFORM(GTK) || ENABLE(WPE_PLATFORM)
 #include "ScreenManager.h"
 #endif
 
@@ -48,7 +48,8 @@
 #include <gtk/gtk.h>
 #endif
 
-#if PLATFORM(WPE) && ENABLE(WPE_PLATFORM)
+#if ENABLE(WPE_PLATFORM)
+#include "WPEUtilities.h"
 #include <wpe/wpe-platform.h>
 #ifdef WPE_PLATFORM_DRM
 #include <wpe/drm/wpe-drm.h>
@@ -59,7 +60,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // GTK/WPE port
 
 namespace WebKit {
 
-#if PLATFORM(GTK) || (PLATFORM(WPE) && ENABLE(WPE_PLATFORM))
+#if PLATFORM(GTK) || ENABLE(WPE_PLATFORM)
 static std::optional<std::pair<uint32_t, uint32_t>> findCrtc(int fd, PlatformScreen* screen)
 {
     drmModeRes* resources = drmModeGetResources(fd);
@@ -188,7 +189,7 @@ struct DrmNodeWithCrtc {
     UnixFileDescriptor drmNodeFd;
     std::pair<uint32_t, uint32_t> crtcInfo;
 };
-#if PLATFORM(GTK) || (PLATFORM(WPE) && ENABLE(WPE_PLATFORM))
+#if PLATFORM(GTK) || ENABLE(WPE_PLATFORM)
 static std::optional<DrmNodeWithCrtc> findDrmNodeWithCrtc(PlatformScreen* screen = nullptr)
 #else
 static std::optional<DrmNodeWithCrtc> findDrmNodeWithCrtc()
@@ -205,7 +206,7 @@ static std::optional<DrmNodeWithCrtc> findDrmNodeWithCrtc()
         if (!fd)
             continue;
         std::optional<std::pair<uint32_t, uint32_t>> crtcInfo;
-#if PLATFORM(WPE) && ENABLE(WPE_PLATFORM)
+#if ENABLE(WPE_PLATFORM)
         if (screen)
             crtcInfo = findCrtc(fd.value(), screen);
         else
@@ -235,11 +236,11 @@ static int crtcBitmaskForIndex(uint32_t crtcIndex)
 
 std::unique_ptr<DisplayVBlankMonitor> DisplayVBlankMonitorDRM::create(PlatformDisplayID displayID)
 {
-#if PLATFORM(WPE) && ENABLE(WPE_PLATFORM)
-    static bool usingWPEPlatformAPI = !!g_type_class_peek(WPE_TYPE_DISPLAY);
+#if ENABLE(WPE_PLATFORM)
+    bool usingWPEPlatformAPI = WKWPE::isUsingWPEPlatformAPI();
 #endif
 
-#if PLATFORM(WPE) && ENABLE(WPE_PLATFORM)
+#if ENABLE(WPE_PLATFORM)
     PlatformScreen* screen = nullptr;
     if (usingWPEPlatformAPI) {
         screen = ScreenManager::singleton().screen(displayID);
@@ -259,7 +260,7 @@ std::unique_ptr<DisplayVBlankMonitor> DisplayVBlankMonitorDRM::create(PlatformDi
 #endif
 
     std::optional<DrmNodeWithCrtc> drmNodeWithCrtcInfo;
-#if PLATFORM(WPE) && ENABLE(WPE_PLATFORM)
+#if ENABLE(WPE_PLATFORM)
 #ifdef WPE_PLATFORM_DRM
     if (usingWPEPlatformAPI && WPE_IS_SCREEN_DRM(screen)) {
         String filename = String::fromUTF8(wpe_display_get_drm_device(wpe_display_get_primary()));

--- a/Source/WebKit/UIProcess/glib/WebProcessPoolGLib.cpp
+++ b/Source/WebKit/UIProcess/glib/WebProcessPoolGLib.cpp
@@ -57,7 +57,7 @@
 #include <wpe/wpe.h>
 #endif
 
-#if PLATFORM(GTK) || (PLATFORM(WPE) && ENABLE(WPE_PLATFORM))
+#if PLATFORM(GTK) || ENABLE(WPE_PLATFORM)
 #include "ScreenManager.h"
 #endif
 
@@ -67,7 +67,8 @@
 #include <gtk/gtk.h>
 #endif
 
-#if PLATFORM(WPE) && ENABLE(WPE_PLATFORM)
+#if ENABLE(WPE_PLATFORM)
+#include "WPEUtilities.h"
 #include <wpe/wpe-platform.h>
 #endif
 
@@ -79,7 +80,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 namespace WebKit {
 
-#if PLATFORM(WPE) && ENABLE(WPE_PLATFORM)
+#if ENABLE(WPE_PLATFORM)
 static OptionSet<AvailableInputDevices> toAvailableInputDevices(WPEAvailableInputDevices inputDevices)
 {
     OptionSet<AvailableInputDevices> availableInputDevices;
@@ -112,8 +113,7 @@ static OptionSet<AvailableInputDevices> toAvailableInputDevices(GdkSeatCapabilit
 static OptionSet<AvailableInputDevices> availableInputDevices()
 {
 #if ENABLE(WPE_PLATFORM)
-    bool usingWPEPlatformAPI = !!g_type_class_peek(WPE_TYPE_DISPLAY);
-    if (usingWPEPlatformAPI) {
+    if (WKWPE::isUsingWPEPlatformAPI()) {
         const auto inputDevices = wpe_display_get_available_input_devices(wpe_display_get_primary());
         return toAvailableInputDevices(inputDevices);
     }
@@ -166,8 +166,7 @@ void WebProcessPool::platformInitialize(NeedsGlobalStaticInitialization)
 #endif
 
 #if ENABLE(WPE_PLATFORM)
-    bool usingWPEPlatformAPI = !!g_type_class_peek(WPE_TYPE_DISPLAY);
-    if (usingWPEPlatformAPI) {
+    if (WKWPE::isUsingWPEPlatformAPI()) {
         auto* display = wpe_display_get_primary();
         g_signal_connect(display, "notify::available-input-devices", G_CALLBACK(+[](WPEDisplay* display, GParamSpec*, WebProcessPool* pool) {
             auto availableInputDevices = toAvailableInputDevices(wpe_display_get_available_input_devices(display));
@@ -188,8 +187,8 @@ void WebProcessPool::platformInitialize(NeedsGlobalStaticInitialization)
 
 void WebProcessPool::platformInitializeWebProcess(const WebProcessProxy& process, WebProcessCreationParameters& parameters)
 {
-#if PLATFORM(WPE) && ENABLE(WPE_PLATFORM)
-    bool usingWPEPlatformAPI = !!g_type_class_peek(WPE_TYPE_DISPLAY);
+#if ENABLE(WPE_PLATFORM)
+    bool usingWPEPlatformAPI = WKWPE::isUsingWPEPlatformAPI();
 #endif
 
 #if USE(GBM)
@@ -198,7 +197,7 @@ void WebProcessPool::platformInitializeWebProcess(const WebProcessProxy& process
 
 #if PLATFORM(GTK)
     parameters.rendererBufferTransportMode = AcceleratedBackingStoreDMABuf::rendererBufferTransportMode();
-#elif PLATFORM(WPE) && ENABLE(WPE_PLATFORM)
+#elif ENABLE(WPE_PLATFORM)
     if (usingWPEPlatformAPI) {
 #if USE(GBM)
         if (!parameters.renderDeviceFile.isEmpty())
@@ -260,7 +259,7 @@ void WebProcessPool::platformInitializeWebProcess(const WebProcessProxy& process
     parameters.screenProperties = ScreenManager::singleton().collectScreenProperties();
 #endif
 
-#if PLATFORM(WPE) && ENABLE(WPE_PLATFORM)
+#if ENABLE(WPE_PLATFORM)
     if (usingWPEPlatformAPI)
         parameters.screenProperties = ScreenManager::singleton().collectScreenProperties();
 #endif
@@ -269,8 +268,7 @@ void WebProcessPool::platformInitializeWebProcess(const WebProcessProxy& process
 void WebProcessPool::platformInvalidateContext()
 {
 #if ENABLE(WPE_PLATFORM)
-    bool usingWPEPlatformAPI = !!g_type_class_peek(WPE_TYPE_DISPLAY);
-    if (usingWPEPlatformAPI) {
+    if (WKWPE::isUsingWPEPlatformAPI()) {
         auto* display = wpe_display_get_primary();
         g_signal_handlers_disconnect_by_data(display, this);
     }

--- a/Source/WebKit/UIProcess/wpe/WPEUtilities.cpp
+++ b/Source/WebKit/UIProcess/wpe/WPEUtilities.cpp
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2025 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE COMPUTER, INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE COMPUTER, INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WPEUtilities.h"
+
+#if ENABLE(WPE_PLATFORM)
+#include <wpe/wpe-platform.h>
+#endif
+
+namespace WKWPE {
+
+bool isUsingWPEPlatformAPI()
+{
+#if ENABLE(WPE_PLATFORM)
+    return !!g_type_class_peek(WPE_TYPE_DISPLAY);
+#else
+    return false;
+#endif
+}
+
+} // namespace WKWPE

--- a/Source/WebKit/UIProcess/wpe/WPEUtilities.h
+++ b/Source/WebKit/UIProcess/wpe/WPEUtilities.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2025 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE COMPUTER, INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE COMPUTER, INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+namespace WKWPE {
+
+bool isUsingWPEPlatformAPI();
+
+} // namespace WKWPE


### PR DESCRIPTION
#### 1f8ecb5de8b7b7bb8533ba16fcd991d3882920fb
<pre>
[WPE] Move the new API runtime check to a common place
<a href="https://bugs.webkit.org/show_bug.cgi?id=293678">https://bugs.webkit.org/show_bug.cgi?id=293678</a>

Reviewed by Adrian Perez de Castro.

We are using g_type_class_peek(WPE_TYPE_DISPLAY) to check whether the
new api is being used in several places, we could add a common helper

WKWPE::isUsingWPEPlatformAPI() and use it instead.
Canonical link: <a href="https://commits.webkit.org/295498@main">https://commits.webkit.org/295498@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/df084700e3680c653ac6ac00b08064e4a4312c2f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105264 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24976 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15401 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110475 "Built successfully") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/55920 "Failed to checkout and rebase branch from PR 45987") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/25408 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33519 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/79954 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/55920 "Failed to checkout and rebase branch from PR 45987") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108270 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19813 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95010 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60260 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/19568 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55318 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/89267 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13127 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/113085 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32422 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/23888 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/89028 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32786 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91226 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88666 "Passed tests") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/33561 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11346 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/27846 "Failed to checkout and rebase branch from PR 45987") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17072 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32346 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/37758 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32124 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/35469 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33693 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->