### PR TITLE
[GStreamer][WebRTC] DTMF support

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -2448,11 +2448,9 @@ webkit.org/b/235885 imported/w3c/web-platform-tests/webrtc-extensions/RTCRtpSync
 # We don't support spatial encoding yet.
 webkit.org/b/235885 webrtc/vp9-svc.html [ Skip ]
 
-# DTMF not supported.
-webkit.org/b/235885 imported/w3c/web-platform-tests/webrtc/RTCDTMFSender-insertDTMF.https.html [ Skip ]
-webkit.org/b/235885 imported/w3c/web-platform-tests/webrtc/RTCDTMFSender-ontonechange-long.https.html [ Skip ]
-webkit.org/b/235885 imported/w3c/web-platform-tests/webrtc/RTCDTMFSender-ontonechange.https.html [ Skip ]
-webkit.org/b/235885 webrtc/dtmf-gc.html [ Skip ]
+imported/w3c/web-platform-tests/webrtc/RTCDTMFSender-insertDTMF.https.html [ Pass ]
+imported/w3c/web-platform-tests/webrtc/RTCDTMFSender-ontonechange.https.html [ Pass ]
+imported/w3c/web-platform-tests/webrtc/RTCDTMFSender-ontonechange-long.https.html [ Pass ]
 
 # This test is buggy, has duplicate (copy/paste?) addTransceiver calls. That issue was fixed in upstream WPT.
 imported/w3c/web-platform-tests/webrtc-extensions/RTCRtpReceiver-jitterBufferTarget-stats.html [ Skip ]

--- a/LayoutTests/platform/glib/fast/mediastream/RTCPeerConnection-inspect-answer-expected.txt
+++ b/LayoutTests/platform/glib/fast/mediastream/RTCPeerConnection-inspect-answer-expected.txt
@@ -57,21 +57,21 @@ a=extmap:3 urn:ietf:params:rtp-hdrext:sdes:repaired-rtp-stream-id
 a=extmap:4 urn:ietf:params:rtp-hdrext:sdes:rtp-stream-id
 a=extmap:5 urn:ietf:params:rtp-hdrext:ntp-64
 a=extmap:6 urn:ietf:params:rtp-hdrext:ssrc-audio-level
-m=video 9 UDP/TLS/RTP/SAVPF 97 96
+m=video 9 UDP/TLS/RTP/SAVPF 99 96
 c=IN IP4 0.0.0.0
 a=ice-ufrag:{ice-ufrag:OK}
 a=ice-pwd:{ice-password:OK}
 a=rtcp-mux
 a=mid:{mid:OK}
 a=setup:active
-a=rtpmap:97 H264/90000
-a=rtcp-fb:97 nack
-a=rtcp-fb:97 nack pli
-a=rtcp-fb:97 ccm fir
-a=rtcp-fb:97 transport-cc
-a=fmtp:97 packetization-mode=1;level-asymmetry-allowed=1
+a=rtpmap:99 H264/90000
+a=rtcp-fb:99 nack
+a=rtcp-fb:99 nack pli
+a=rtcp-fb:99 ccm fir
+a=rtcp-fb:99 transport-cc
+a=fmtp:99 packetization-mode=1;level-asymmetry-allowed=1
 a=rtpmap:96 rtx/90000
-a=fmtp:96 apt=97
+a=fmtp:96 apt=99
 a=recvonly
 a=fingerprint:sha-256 {fingerprint:OK}
 a=extmap:1 http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpSenderBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpSenderBackend.cpp
@@ -272,7 +272,7 @@ void GStreamerRtpSenderBackend::setParameters(const RTCRtpSendParameters& parame
 
 std::unique_ptr<RTCDTMFSenderBackend> GStreamerRtpSenderBackend::createDTMFBackend()
 {
-    return makeUnique<GStreamerDTMFSenderBackend>();
+    return makeUnique<GStreamerDTMFSenderBackend>(audioSourceWeak());
 }
 
 Ref<RTCRtpTransformBackend> GStreamerRtpSenderBackend::rtcRtpTransformBackend()

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpSenderBackend.h
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpSenderBackend.h
@@ -59,6 +59,13 @@ public:
         );
     }
 
+    ThreadSafeWeakPtr<RealtimeOutgoingAudioSourceGStreamer> audioSourceWeak()
+    {
+        return WTF::switchOn(m_source,
+            [](Ref<RealtimeOutgoingAudioSourceGStreamer>& source) -> ThreadSafeWeakPtr<RealtimeOutgoingAudioSourceGStreamer> { return source.get(); },
+            [](const auto&) -> ThreadSafeWeakPtr<RealtimeOutgoingAudioSourceGStreamer> { return nullptr; });
+    }
+
     RealtimeOutgoingVideoSourceGStreamer* videoSource()
     {
         return WTF::switchOn(m_source,

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpTransceiverBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpTransceiverBackend.cpp
@@ -85,7 +85,7 @@ std::optional<RTCRtpTransceiverDirection> GStreamerRtpTransceiverBackend::curren
     GstWebRTCRTPTransceiverDirection gstDirection;
     g_object_get(m_rtcTransceiver.get(), "current-direction", &gstDirection, nullptr);
     if (!gstDirection)
-        return std::nullopt;
+        return RTCRtpTransceiverDirection::Inactive;
     return toRTCRtpTransceiverDirection(gstDirection);
 }
 

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.cpp
@@ -603,7 +603,7 @@ GRefPtr<GstCaps> capsFromRtpCapabilities(const RTCRtpCapabilities& capabilities,
     for (unsigned index = 0; auto& codec : capabilities.codecs) {
         auto components = codec.mimeType.split('/');
         auto* codecStructure = gst_structure_new("application/x-rtp", "media", G_TYPE_STRING, components[0].ascii().data(),
-            "encoding-name", G_TYPE_STRING, components[1].convertToASCIIUppercase().ascii().data() , "clock-rate", G_TYPE_INT, codec.clockRate, nullptr);
+            "encoding-name", G_TYPE_STRING, components[1].convertToASCIIUppercase().ascii().data(), "clock-rate", G_TYPE_INT, codec.clockRate, nullptr);
 
         if (!codec.sdpFmtpLine.isEmpty()) {
             for (auto& fmtp : codec.sdpFmtpLine.split(';')) {

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
@@ -1077,6 +1077,18 @@ void GStreamerRegistryScanner::fillAudioRtpCapabilities(Configuration configurat
 
     if (factories.hasElementForMediaType(codecElement, "audio/x-alaw"_s) && factories.hasElementForMediaType(rtpElement, "audio/x-alaw"_s))
         capabilities.codecs.append({ .mimeType = "audio/PCMA"_s, .clockRate = 8000, .channels = 1, .sdpFmtpLine = emptyString() });
+
+    bool hasDtmfSupport = false;
+    if (configuration == Configuration::Encoding) {
+        if (auto factory = adoptGRef(gst_element_factory_find("rtpdtmfsrc")))
+            hasDtmfSupport = true;
+    } else
+        hasDtmfSupport = factories.hasElementForMediaType(rtpElement, "audio/x-raw, format=(string)S16LE"_s);
+
+    if (hasDtmfSupport) {
+        for (unsigned long clockRate : { 48000, 8000 })
+            capabilities.codecs.append({ .mimeType = "audio/telephone-event"_s, .clockRate = clockRate, .channels = 1, .sdpFmtpLine = emptyString() });
+    }
 }
 
 void GStreamerRegistryScanner::fillVideoRtpCapabilities(Configuration configuration, RTCRtpCapabilities& capabilities)

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerDTMFSenderBackend.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerDTMFSenderBackend.cpp
@@ -1,6 +1,6 @@
 /*
- *  Copyright (C) 2019-2022 Igalia S.L. All rights reserved.
- *  Copyright (C) 2022 Metrological Group B.V.
+ *  Copyright (C) 2019-2025 Igalia S.L.
+ *  Copyright (C) 2025 Comcast Inc.
  *
  *  This library is free software; you can redistribute it and/or
  *  modify it under the terms of the GNU Lesser General Public
@@ -20,60 +20,183 @@
 #include "config.h"
 #include "GStreamerDTMFSenderBackend.h"
 
-#if ENABLE(WEB_RTC) && USE(GSTREAMER_WEBRTC)
+#if USE(GSTREAMER_WEBRTC)
 
-#include "NotImplemented.h"
-#include <wtf/MainThread.h>
+#include "GStreamerCommon.h"
+#include <wtf/HashFunctions.h>
+#include <wtf/HashTraits.h>
 #include <wtf/TZoneMallocInlines.h>
+#include <wtf/WorkQueue.h>
 
 namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(GStreamerDTMFSenderBackend);
 
-GStreamerDTMFSenderBackend::GStreamerDTMFSenderBackend()
+GST_DEBUG_CATEGORY(webkit_webrtc_dtmf_sender_debug);
+#define GST_CAT_DEFAULT webkit_webrtc_dtmf_sender_debug
+
+RefPtr<GStreamerDTMFSenderPrivate> GStreamerDTMFSenderPrivate::create()
 {
-    notImplemented();
+    auto dtmfSrc = makeGStreamerElement("dtmfsrc"_s);
+    if (!dtmfSrc)
+        return nullptr;
+
+    return adoptRef(*new GStreamerDTMFSenderPrivate(WTFMove(dtmfSrc)));
 }
 
-GStreamerDTMFSenderBackend::~GStreamerDTMFSenderBackend()
+GStreamerDTMFSenderPrivate::GStreamerDTMFSenderPrivate(GRefPtr<GstElement>&& dtmfSrc)
+    : m_dtmfSrc(WTFMove(dtmfSrc))
 {
-    notImplemented();
+    static std::once_flag debugRegisteredFlag;
+    std::call_once(debugRegisteredFlag, [] {
+        GST_DEBUG_CATEGORY_INIT(webkit_webrtc_dtmf_sender_debug, "webkitwebrtcdtmfsender", 0, "WebKit WebRTC DTMF Sender");
+    });
+
+    static uint32_t nPipeline = 0;
+    auto pipelineName = makeString("webkit-dtmf-playout-pipeline-"_s, nPipeline);
+    m_pipeline = gst_pipeline_new(pipelineName.ascii().data());
+    registerActivePipeline(m_pipeline);
+    connectSimpleBusMessageCallback(m_pipeline.get());
+    GST_DEBUG_OBJECT(m_pipeline.get(), "DTMF sender backend created");
+
+    auto audioconvert = makeGStreamerElement("audioconvert"_s);
+    auto audioresample = makeGStreamerElement("audioresample"_s);
+    auto queue = gst_element_factory_make("queue", nullptr);
+    auto sink = createPlatformAudioSink("dtmf"_s);
+    gst_bin_add_many(GST_BIN_CAST(m_pipeline.get()), m_dtmfSrc.get(), audioconvert, audioresample, queue, sink, nullptr);
+    gst_element_link_many(m_dtmfSrc.get(), audioconvert, audioresample, queue, sink, nullptr);
+    gst_element_set_state(m_pipeline.get(), GST_STATE_PLAYING);
+}
+
+GStreamerDTMFSenderPrivate::~GStreamerDTMFSenderPrivate()
+{
+    if (!m_pipeline)
+        return;
+
+    unregisterPipeline(m_pipeline);
+    disconnectSimpleBusMessageCallback(m_pipeline.get());
+    gst_element_set_state(m_pipeline.get(), GST_STATE_NULL);
+}
+
+void GStreamerDTMFSenderPrivate::playTone(const RefPtr<RealtimeOutgoingAudioSourceGStreamer>& source, const char tone, size_t duration)
+{
+    static HashMap<char, int, WTF::IntHash<char>, WTF::UnsignedWithZeroKeyHashTraits<char>> tones = {
+        { '0', 0 },
+        { '1', 1 },
+        { '2', 2 },
+        { '3', 3 },
+        { '4', 4 },
+        { '5', 5 },
+        { '6', 6 },
+        { '7', 7 },
+        { '8', 8 },
+        { '9', 9 },
+        { '*', 10 },
+        { '#', 11 },
+        { 'A', 12 },
+        { 'B', 13 },
+        { 'C', 14 },
+        { 'D', 15 }
+    };
+
+    auto element = adoptGRef(gst_bin_get_by_name(GST_BIN_CAST(source->bin().get()), "dtmfSource"));
+    auto pad = adoptGRef(gst_element_get_static_pad(element.get(), "src"));
+
+    if (tone == ',') {
+        GST_DEBUG_OBJECT(element.get(), "Playing silence for 2 seconds");
+        sleep(2_s);
+        m_onTonePlayed();
+        GST_DEBUG_OBJECT(element.get(), "Playing tone %c DONE", tone);
+        return;
+    }
+
+    auto toneNumber = tones.get(tone);
+    GST_DEBUG_OBJECT(pad.get(), "Playing tone %c for %zu milliseconds", tone, duration);
+    sendEvent(pad, toneNumber, 25, true);
+
+    RunLoop::protectedMain()->dispatchAfter(Seconds::fromMilliseconds(duration), [toneNumber, pad = WTFMove(pad), weakThis = ThreadSafeWeakPtr { *this }] {
+        RefPtr self = weakThis.get();
+        if (!self)
+            return;
+        self->stopTone(pad, toneNumber);
+    });
+}
+
+void GStreamerDTMFSenderPrivate::sendEvent(const GRefPtr<GstPad>& pad, int number, int volume, bool start)
+{
+    auto event = adoptGRef(gst_event_new_custom(GST_EVENT_CUSTOM_UPSTREAM, gst_structure_new("dtmf-event", "type", G_TYPE_INT, 1, "number", G_TYPE_INT, number, "volume", G_TYPE_INT, volume, "start", G_TYPE_BOOLEAN, start, nullptr)));
+    gst_pad_send_event(pad.get(), gst_event_ref(event.get()));
+    gst_element_send_event(m_dtmfSrc.get(), event.leakRef());
+}
+
+void GStreamerDTMFSenderPrivate::stopTone(const GRefPtr<GstPad>& pad, int tone)
+{
+    sendEvent(pad, tone, 0, false);
+    GST_DEBUG_OBJECT(pad.get(), "Playing tone %c DONE", tone);
+    m_onTonePlayed();
+}
+
+GStreamerDTMFSenderBackend::GStreamerDTMFSenderBackend(ThreadSafeWeakPtr<RealtimeOutgoingAudioSourceGStreamer>&& source)
+    : m_source(WTFMove(source))
+{
+    RefPtr strongSource = m_source.get();
+    if (!strongSource) {
+        m_canInsertDTMF = false;
+        return;
+    }
+
+    m_senderPrivate = GStreamerDTMFSenderPrivate::create();
+    if (!m_senderPrivate) {
+        m_canInsertDTMF = false;
+        return;
+    }
+
+    m_canInsertDTMF = true;
 }
 
 bool GStreamerDTMFSenderBackend::canInsertDTMF()
 {
-    notImplemented();
-    return false;
+    RefPtr source = m_source.get();
+    if (!source)
+        return false;
+    return m_canInsertDTMF;
 }
 
-void GStreamerDTMFSenderBackend::playTone(const char, size_t, size_t)
+void GStreamerDTMFSenderBackend::playTone(const char tone, size_t duration, size_t interToneGap)
 {
-    notImplemented();
+    RefPtr source = m_source.get();
+    if (!source)
+        return;
+
+    if (!m_senderPrivate) [[unlikely]]
+        return;
+
+    m_duration = duration;
+    m_interToneGap = interToneGap;
+
+    if (m_isFirstTone)
+        m_isFirstTone = false;
+    else
+        sleep(Seconds::fromMilliseconds(interToneGap));
+
+    m_senderPrivate->playTone(source, tone, duration);
+    m_tones.append(tone);
 }
 
 String GStreamerDTMFSenderBackend::tones() const
 {
-    notImplemented();
-    return { };
-}
-
-size_t GStreamerDTMFSenderBackend::duration() const
-{
-    notImplemented();
-    return 0;
-}
-
-size_t GStreamerDTMFSenderBackend::interToneGap() const
-{
-    notImplemented();
-    return 0;
+    return m_tones.toStringPreserveCapacity();
 }
 
 void GStreamerDTMFSenderBackend::onTonePlayed(Function<void()>&& onTonePlayed)
 {
-    m_onTonePlayed = WTFMove(onTonePlayed);
+    if (!m_senderPrivate) [[unlikely]]
+        return;
+    m_senderPrivate->setOnTonePlayedCallback(WTFMove(onTonePlayed));
 }
+
+#undef GST_CAT_DEFAULT
 
 } // namespace WebCore
 
-#endif // ENABLE(WEB_RTC) && USE(GSTREAMER_WEBRTC)
+#endif // USE(GSTREAMER_WEBRTC)

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerDTMFSenderBackend.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerDTMFSenderBackend.h
@@ -1,6 +1,6 @@
 /*
- *  Copyright (C) 2019-2022 Igalia S.L. All rights reserved.
- *  Copyright (C) 2022 Metrological Group B.V.
+ *  Copyright (C) 2019-2025 Igalia S.L.
+ *  Copyright (C) 2025 Comcast Inc.
  *
  *  This library is free software; you can redistribute it and/or
  *  modify it under the terms of the GNU Lesser General Public
@@ -21,18 +21,41 @@
 
 #if ENABLE(WEB_RTC) && USE(GSTREAMER_WEBRTC)
 
+#include "GRefPtrGStreamer.h"
 #include "RTCDTMFSenderBackend.h"
+#include "RealtimeOutgoingAudioSourceGStreamer.h"
 #include <wtf/TZoneMalloc.h>
+#include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
 
-// Use eager initialization for the WeakPtrFactory since we call makeWeakPtr() from another thread.
-class GStreamerDTMFSenderBackend final : public RTCDTMFSenderBackend, public CanMakeWeakPtr<GStreamerDTMFSenderBackend, WeakPtrFactoryInitialization::Eager> {
-    WTF_MAKE_TZONE_ALLOCATED(GStreamerDTMFSenderBackend);
+class GStreamerDTMFSenderPrivate : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<GStreamerDTMFSenderPrivate, WTF::DestructionThread::Main> {
 public:
-    explicit GStreamerDTMFSenderBackend();
-    ~GStreamerDTMFSenderBackend();
+    static RefPtr<GStreamerDTMFSenderPrivate> create();
+    ~GStreamerDTMFSenderPrivate();
+
+    using OnTonePlayedCallback = Function<void()>;
+    void setOnTonePlayedCallback(OnTonePlayedCallback&& callback) { m_onTonePlayed = WTFMove(callback); }
+    void playTone(const RefPtr<RealtimeOutgoingAudioSourceGStreamer>&, const char tone, size_t duration);
+
+private:
+    explicit GStreamerDTMFSenderPrivate(GRefPtr<GstElement>&&);
+
+    void sendEvent(const GRefPtr<GstPad>&, int number, int volume, bool start);
+    void stopTone(const GRefPtr<GstPad>&, int);
+
+    OnTonePlayedCallback m_onTonePlayed;
+    GRefPtr<GstElement> m_pipeline;
+    GRefPtr<GstElement> m_dtmfSrc;
+};
+
+class GStreamerDTMFSenderBackend final : public RTCDTMFSenderBackend {
+    WTF_MAKE_TZONE_ALLOCATED(GStreamerDTMFSenderBackend);
+    WTF_MAKE_NONCOPYABLE(GStreamerDTMFSenderBackend);
+public:
+    explicit GStreamerDTMFSenderBackend(ThreadSafeWeakPtr<RealtimeOutgoingAudioSourceGStreamer>&&);
+    ~GStreamerDTMFSenderBackend() = default;
 
 private:
     // RTCDTMFSenderBackend
@@ -40,10 +63,16 @@ private:
     void playTone(const char tone, size_t duration, size_t interToneGap) final;
     void onTonePlayed(Function<void()>&&) final;
     String tones() const final;
-    size_t duration() const final;
-    size_t interToneGap() const final;
+    size_t duration() const final { return m_duration; }
+    size_t interToneGap() const final { return m_interToneGap; }
 
-    Function<void()> m_onTonePlayed;
+    ThreadSafeWeakPtr<RealtimeOutgoingAudioSourceGStreamer> m_source;
+    RefPtr<GStreamerDTMFSenderPrivate> m_senderPrivate;
+    bool m_isFirstTone { true };
+    bool m_canInsertDTMF { false };
+    StringBuilder m_tones;
+    size_t m_duration;
+    size_t m_interToneGap;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingAudioSourceGStreamer.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingAudioSourceGStreamer.h
@@ -37,6 +37,7 @@ public:
     }
     ~RealtimeOutgoingAudioSourceGStreamer();
 
+    void setInitialParameters(GUniquePtr<GstStructure>&&) final;
     WARN_UNUSED_RETURN GRefPtr<GstPad> outgoingSourcePad() const final;
     RefPtr<GStreamerRTPPacketizer> createPacketizer(RefPtr<UniqueSSRCGenerator>, const GstStructure*, GUniquePtr<GstStructure>&&) final;
 
@@ -48,8 +49,11 @@ protected:
 
 private:
     void initialize();
+    void setupDTMFSource(int pt);
 
     RTCRtpCapabilities rtpCapabilities() const final;
+
+    GRefPtr<GstElement> m_dtmfSource;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingMediaSourceGStreamer.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingMediaSourceGStreamer.h
@@ -58,7 +58,7 @@ public:
     bool configurePacketizers(GRefPtr<GstCaps>&&);
 
     GUniquePtr<GstStructure> parameters();
-    void setInitialParameters(GUniquePtr<GstStructure>&&);
+    virtual void setInitialParameters(GUniquePtr<GstStructure>&&);
     void setParameters(GUniquePtr<GstStructure>&&);
 
     void configure(GRefPtr<GstCaps>&&);


### PR DESCRIPTION
#### 0894e1f17293001ef1c06bf569b9be49a8d58d03
<pre>
[GStreamer][WebRTC] DTMF support
<a href="https://bugs.webkit.org/show_bug.cgi?id=293551">https://bugs.webkit.org/show_bug.cgi?id=293551</a>

Reviewed by Xabier Rodriguez-Calvar.

Our outgoing audio source now includes a dtmf source that can be controlled using the
GStreamerDTMFSenderBackend. Local audio playback of DTMF is handled using a new pipeline, within the
sender backend. When receiving DTMF payloads, webrtcbin currently rejects those buffers, due to:

<a href="https://gitlab.freedesktop.org/gstreamer/gstreamer/-/issues/4458">https://gitlab.freedesktop.org/gstreamer/gstreamer/-/issues/4458</a>

This isn&apos;t a critical issue though because the spec doesn&apos;t mandate actual decoding of DTMF
payloads.

Canonical link: <a href="https://commits.webkit.org/295749@main">https://commits.webkit.org/295749@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e54bd2d3b241c9926f523874006996a4437a1f44

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/106045 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25794 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/16188 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/111242 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/56641 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/108084 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/26450 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34297 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/80553 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/109049 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/20889 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95704 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60876 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/20477 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13802 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/56079 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/90261 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13837 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/114097 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33183 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/24490 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/89635 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33547 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91932 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89324 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22762 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34189 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/12002 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/28753 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/33108 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/38520 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32854 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/36204 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34452 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->