### PR TITLE
Inline Module Scripts ignore default TT policy mutation

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/block-text-node-insertion-into-script-element-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/block-text-node-insertion-into-script-element-expected.txt
@@ -12,6 +12,7 @@ CONSOLE MESSAGE: Refused to connect to ws://common/blank.html because it does no
 CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
 CONSOLE MESSAGE: Refused to connect to ws://common/blank.html because it does not appear in the connect-src directive of the Content Security Policy.
 CONSOLE MESSAGE: Refused to connect to ws://common/blank.html because it does not appear in the connect-src directive of the Content Security Policy.
+CONSOLE MESSAGE: Refused to connect to ws://common/blank.html because it does not appear in the connect-src directive of the Content Security Policy.
 CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
 CONSOLE MESSAGE: Refused to connect to ws://common/blank.html because it does not appear in the connect-src directive of the Content Security Policy.
 CONSOLE MESSAGE: Refused to connect to ws://common/blank.html because it does not appear in the connect-src directive of the Content Security Policy.
@@ -26,6 +27,7 @@ PASS Regression test: Bypass via appendChild into live script element.
 PASS Spot tests around script + innerHTML interaction.
 PASS Prep for subsequent tests: Create default policy.
 PASS Test that default policy applies.
+PASS Test that default policy applies to module script.
 PASS Test a failing default policy.
 PASS Spot tests around script + innerHTML interaction with default policy.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/block-text-node-insertion-into-script-element.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/block-text-node-insertion-into-script-element.html
@@ -49,12 +49,12 @@
     assert_equals(s.text, "");
 
     // Try to insertAdjacentText into the <script>, starting from the <p>
-    await checkMessage(_ =>
+    await checkMessage(t, _ =>
       p.insertAdjacentText("beforebegin",
                            "postMessage('beforebegin should be blocked', '*');")
     );
     assert_true(s.text.includes("postMessage"));
-    await checkMessage(_ =>
+    await checkMessage(t, _ =>
       p.insertAdjacentText("afterend",
                            "postMessage('afterend should be blocked', '*');")
     );
@@ -74,12 +74,12 @@
     container.appendChild(s);
 
     // Try to insertAdjacentText into the <script>, starting from the <p>
-    await checkMessage(_ =>
+    await checkMessage(t, _ =>
       p.insertAdjacentText("beforebegin",
                            "postMessage('beforebegin should be blocked', '*');")
     );
     assert_true(s.textContent.includes("postMessage"));
-    await checkMessage(_ =>
+    await checkMessage(t, _ =>
       p.insertAdjacentText("afterend",
                            "postMessage('afterend should be blocked', '*');")
     );
@@ -94,7 +94,7 @@
     let text = document.createTextNode("postMessage('appendChild with a " +
                                        "text node should be blocked', '*');");
     s.appendChild(text);
-    await checkMessage(_ => container.appendChild(s));
+    await checkMessage(t, _ => container.appendChild(s));
   }, "Regression test: Bypass via appendChild into off-document script element.");
 
   // Variant: Create a <script> element and insert it into the document. Then
@@ -106,7 +106,7 @@
     container.appendChild(s);
     let text = document.createTextNode("postMessage('appendChild with a live " +
                                        "text node should be blocked', '*');");
-    await checkMessage(_ => s.appendChild(text));
+    await checkMessage(t, _ => s.appendChild(text));
   }, "Regression test: Bypass via appendChild into live script element.");
 
   promise_test(async t => {
@@ -150,7 +150,7 @@
     let text = document.createTextNode("postMessage('default', '*');");
     s.appendChild(text);
     await no_trusted_type_violation_for(async _ =>
-      await checkMessage(_ => container.appendChild(s), 1)
+      await checkMessage(t, _ => container.appendChild(s), 1)
     );
     assert_array_equals(seenSinks, ["HTMLScriptElement text"]);
   }, "Test that default policy applies.");
@@ -158,10 +158,22 @@
   promise_test(async t => {
     t.add_cleanup(clearSeenSinks);
     let s = createScriptElement();
+    s.setAttribute("type", "module")
+    let text = document.createTextNode("postMessage('default', '*');");
+    s.appendChild(text);
+    await no_trusted_type_violation_for(async _ =>
+      await checkMessage(t, _ => container.appendChild(s), 1)
+    );
+    assert_array_equals(seenSinks, ["HTMLScriptElement text"]);
+  }, "Test that default policy applies to module script.");
+
+  promise_test(async t => {
+    t.add_cleanup(clearSeenSinks);
+    let s = createScriptElement();
     let text = document.createTextNode("fail");
     s.appendChild(text);
     await trusted_type_violation_without_exception_for(async _ =>
-      await checkMessage(_ => container.appendChild(s), 0)
+      await checkMessage(t, _ => container.appendChild(s), 0)
     );
     assert_array_equals(seenSinks, ["HTMLScriptElement text"]);
   }, "Test a failing default policy.");

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/block-text-node-insertion-into-svg-script-element-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/block-text-node-insertion-into-svg-script-element-expected.txt
@@ -10,6 +10,7 @@ CONSOLE MESSAGE: Refused to connect to ws://common/blank.html because it does no
 CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
 CONSOLE MESSAGE: Refused to connect to ws://common/blank.html because it does not appear in the connect-src directive of the Content Security Policy.
 CONSOLE MESSAGE: Refused to connect to ws://common/blank.html because it does not appear in the connect-src directive of the Content Security Policy.
+CONSOLE MESSAGE: Refused to connect to ws://common/blank.html because it does not appear in the connect-src directive of the Content Security Policy.
 CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
 CONSOLE MESSAGE: Refused to connect to ws://common/blank.html because it does not appear in the connect-src directive of the Content Security Policy.
 CONSOLE MESSAGE: Refused to connect to ws://common/blank.html because it does not appear in the connect-src directive of the Content Security Policy.
@@ -23,6 +24,7 @@ PASS Regression test: Bypass via appendChild into live script element. svg:scrip
 PASS Spot tests around script + innerHTML interaction.
 PASS Prep for subsequent tests: Create default policy.
 PASS Test that default policy applies. svg:script
+PASS Test that default policy applies with module script. svg:script
 PASS Test a failing default policy. svg:script
 PASS Spot tests around script + innerHTML interaction with default policy.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/block-text-node-insertion-into-svg-script-element.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/block-text-node-insertion-into-svg-script-element.html
@@ -49,12 +49,12 @@
     container.appendChild(s);
 
     // Try to insertAdjacentText into the <script>, starting from the <p>
-    await checkMessage(_ =>
+    await checkMessage(t, _ =>
       p.insertAdjacentText("beforebegin",
                            "postMessage('beforebegin should be blocked', '*');")
     );
     assert_true(s.textContent.includes("postMessage"));
-    await checkMessage(_ =>
+    await checkMessage(t, _ =>
       p.insertAdjacentText("afterend",
                            "postMessage('afterend should be blocked', '*');")
     );
@@ -69,7 +69,7 @@
     let text = document.createTextNode("postMessage('appendChild with a " +
                                        "text node should be blocked', '*');");
     s.appendChild(text);
-    await checkMessage(_ => container.appendChild(s));
+    await checkMessage(t, _ => container.appendChild(s));
   }, "Regression test: Bypass via appendChild into off-document script element. svg:script");
 
   // Variant: Create a <script> element and insert it into the document. Then
@@ -81,7 +81,7 @@
     container.appendChild(s);
     let text = document.createTextNode("postMessage('appendChild with a live " +
                                        "text node should be blocked', '*');");
-    await checkMessage(_ => s.appendChild(text));
+    await checkMessage(t, _ => s.appendChild(text));
   }, "Regression test: Bypass via appendChild into live script element. svg:script");
 
   promise_test(async t => {
@@ -125,7 +125,7 @@
     let text = document.createTextNode("postMessage('default', '*');");
     s.appendChild(text);
     await no_trusted_type_violation_for(async _ =>
-      await checkMessage(_ => container.appendChild(s), 1)
+      await checkMessage(t, _ => container.appendChild(s), 1)
     );
     assert_array_equals(seenSinks, ["SVGScriptElement text"]);
   }, "Test that default policy applies. svg:script");
@@ -133,10 +133,22 @@
   promise_test(async t => {
     t.add_cleanup(clearSeenSinks);
     let s = createScriptElement();
+    s.setAttribute("type", "module");
+    let text = document.createTextNode("postMessage('default', '*');");
+    s.appendChild(text);
+    await no_trusted_type_violation_for(async _ =>
+      await checkMessage(t, _ => container.appendChild(s), 1)
+    );
+    assert_array_equals(seenSinks, ["SVGScriptElement text"]);
+  }, "Test that default policy applies with module script. svg:script");
+
+  promise_test(async t => {
+    t.add_cleanup(clearSeenSinks);
+    let s = createScriptElement();
     let text = document.createTextNode("fail");
     s.appendChild(text);
     await trusted_type_violation_without_exception_for(async _ =>
-      await checkMessage(_ => container.appendChild(s), 0)
+      await checkMessage(t, _ => container.appendChild(s), 0)
     );
     assert_array_equals(seenSinks, ["SVGScriptElement text"]);
   }, "Test a failing default policy. svg:script");

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/resources/block-text-node-insertion.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/resources/block-text-node-insertion.js
@@ -14,10 +14,13 @@
   // - includes "count": Count these, and later check against expect_count.
   // - includes "done": Unregister the event handler and finish the test.
   // - all else: Reject, as this is probably an error in the test.
-  function checkMessage(fn, expect_count) {
+  function checkMessage(t, fn, expect_count) {
     return new Promise((resolve, reject) => {
       let count = 0;
       globalThis.addEventListener("message", function handler(e) {
+        t.add_cleanup(() => {
+          globalThis.removeEventListener("message", handler);
+        });
         if (e.data.includes("block")) {
           reject(`'block' received (${e.data})`);
         } else if (e.data.includes("count")) {
@@ -35,6 +38,6 @@
         }
       });
       fn();
-      postMessage("done", "*");
+      requestAnimationFrame(_ => requestAnimationFrame(_ => postMessage("done", "*")));
     });
   }

--- a/Source/WebCore/dom/ScriptElement.cpp
+++ b/Source/WebCore/dom/ScriptElement.cpp
@@ -253,7 +253,7 @@ bool ScriptElement::prepareScript(const TextPosition& scriptStartPosition)
         break;
     }
     case ScriptType::Module: {
-        if (!requestModuleScript(scriptStartPosition))
+        if (!requestModuleScript(sourceText, scriptStartPosition))
             return false;
         potentiallyBlockRendering();
         break;
@@ -355,7 +355,7 @@ bool ScriptElement::requestClassicScript(const String& sourceURL)
     return false;
 }
 
-bool ScriptElement::requestModuleScript(const TextPosition& scriptStartPosition)
+bool ScriptElement::requestModuleScript(const String& sourceText, const TextPosition& scriptStartPosition)
 {
     // https://html.spec.whatwg.org/multipage/urls-and-fetching.html#cors-settings-attributes
     // Module is always CORS request. If attribute is not given, it should be same-origin credential.
@@ -396,7 +396,7 @@ bool ScriptElement::requestModuleScript(const TextPosition& scriptStartPosition)
     Ref script = LoadableModuleScript::create(nonce, emptyAtom(), referrerPolicy(), fetchPriority(), crossOriginMode, scriptCharset(), element->localName(), element->isInUserAgentShadowTree());
 
     TextPosition position = document->isInDocumentWrite() ? TextPosition() : scriptStartPosition;
-    ScriptSourceCode sourceCode(scriptContent(), m_taintedOrigin, URL(document->url()), position, JSC::SourceProviderSourceType::Module, script.copyRef());
+    ScriptSourceCode sourceCode(sourceText, m_taintedOrigin, URL(document->url()), position, JSC::SourceProviderSourceType::Module, script.copyRef());
 
     ASSERT(document->contentSecurityPolicy());
     {

--- a/Source/WebCore/dom/ScriptElement.h
+++ b/Source/WebCore/dom/ScriptElement.h
@@ -124,7 +124,7 @@ private:
     void dispatchLoadEventRespectingUserGestureIndicator();
 
     bool requestClassicScript(const String& sourceURL);
-    bool requestModuleScript(const TextPosition& scriptStartPosition);
+    bool requestModuleScript(const String& sourceText, const TextPosition& scriptStartPosition);
 
     void updateTaintedOriginFromSourceURL();
 


### PR DESCRIPTION
#### 3954faf8b295a961b24dbffa84e15f6b00ecf6ee
<pre>
Inline Module Scripts ignore default TT policy mutation
<a href="https://bugs.webkit.org/show_bug.cgi?id=293685">https://bugs.webkit.org/show_bug.cgi?id=293685</a>

Reviewed by Frédéric Wang.

This patch updates ScriptElement::requestModuleScript() to take the source text to execute,
previoulsy it called scriptContent() which always returns the child contents of the script.

This is wrong in the case that Trusted Types has a default policy that mutates the value to
execute in the script element. Instead we now pass through the correct value from within
ScriptElement::prepareScript().

* LayoutTests/imported/w3c/web-platform-tests/trusted-types/block-text-node-insertion-into-script-element-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/block-text-node-insertion-into-script-element.html:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/block-text-node-insertion-into-svg-script-element-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/block-text-node-insertion-into-svg-script-element.html:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/resources/block-text-node-insertion.js:
(string_appeared_here.checkMessage):
* Source/WebCore/dom/ScriptElement.cpp:
(WebCore::ScriptElement::prepareScript):
(WebCore::ScriptElement::requestModuleScript):
* Source/WebCore/dom/ScriptElement.h:

Canonical link: <a href="https://commits.webkit.org/295527@main">https://commits.webkit.org/295527@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/240c4e176f6d258f1466c6b9229dfa745058ca11

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105285 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24997 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15422 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110496 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/55940 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/107326 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/25433 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33540 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79973 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108291 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19836 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95034 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60279 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/19600 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13107 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55339 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/89292 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13151 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/113115 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32444 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23906 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89047 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32807 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91249 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88685 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22637 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33580 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11369 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/27868 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32367 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/37779 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32145 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35489 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33714 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->