### PR TITLE
Reduce unsafeness in InputType classes even more

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -278,11 +278,8 @@ html/AttachmentAssociatedElement.cpp
 html/BaseButtonInputType.cpp
 html/CachedHTMLCollection.h
 html/CachedHTMLCollectionInlines.h
-html/CheckboxInputType.cpp
 html/CollectionTraversalInlines.h
-html/ColorInputType.cpp
 html/DOMTokenList.cpp
-html/EmailInputType.cpp
 html/FTPDirectoryDocument.cpp
 html/FileInputType.cpp
 html/FormAssociatedCustomElement.cpp
@@ -334,7 +331,6 @@ html/HTMLTextFormControlElement.cpp
 html/HTMLTitleElement.cpp
 html/HTMLVideoElement.cpp
 html/HTMLWBRElement.cpp
-html/HiddenInputType.cpp
 html/ImageBitmap.cpp
 html/ImageDocument.cpp
 html/ImageInputType.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -625,13 +625,11 @@ history/HistoryItem.cpp
 html/AttachmentAssociatedElement.cpp
 html/CachedHTMLCollection.h
 html/CachedHTMLCollectionInlines.h
-html/CheckboxInputType.cpp
 html/CollectionTraversalInlines.h
 html/CustomPaintCanvas.cpp
 html/DOMTokenList.cpp
 html/DOMURL.cpp
 html/DirectoryFileListCreator.cpp
-html/EmailInputType.cpp
 html/FTPDirectoryDocument.cpp
 html/FormAssociatedCustomElement.cpp
 html/FormAssociatedElement.cpp
@@ -675,10 +673,8 @@ html/HTMLTextFormControlElement.cpp
 html/HTMLTitleElement.cpp
 html/HTMLTrackElement.cpp
 html/HTMLVideoElement.cpp
-html/HiddenInputType.cpp
 html/ImageBitmap.cpp
 html/ImageDocument.cpp
-html/ImageInputType.cpp
 html/LabelsNodeList.cpp
 html/LazyLoadFrameObserver.cpp
 html/LazyLoadImageObserver.cpp
@@ -692,8 +688,6 @@ html/PermissionsPolicy.cpp
 html/PluginDocument.cpp
 html/PublicURLManager.cpp
 html/RadioNodeList.cpp
-html/RangeInputType.cpp
-html/TextFieldInputType.cpp
 html/ValidatedFormListedElement.cpp
 html/ValidatedFormListedElement.h
 html/ValidationMessage.cpp

--- a/Source/WebCore/html/CheckboxInputType.cpp
+++ b/Source/WebCore/html/CheckboxInputType.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2010 Google Inc. All rights reserved.
- * Copyright (C) 2011-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2011-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -42,6 +42,7 @@
 #include "InputTypeNames.h"
 #include "KeyboardEvent.h"
 #include "LocalFrame.h"
+#include "LocalFrameInlines.h"
 #include "LocalizedStrings.h"
 #include "MouseEvent.h"
 #include "Page.h"
@@ -85,12 +86,12 @@ void CheckboxInputType::createShadowSubtree()
 {
     ASSERT(needsShadowSubtree());
     ASSERT(element());
-    ASSERT(element()->userAgentShadowRoot());
-
-    Ref shadowRoot = *element()->userAgentShadowRoot();
+    Ref element = *this->element();
+    ASSERT(element->userAgentShadowRoot());
+    Ref shadowRoot = *element->userAgentShadowRoot();
     ScriptDisallowedScope::EventAllowedScope eventAllowedScope { shadowRoot };
 
-    Ref document = element()->document();
+    Ref document = element->document();
     Ref track = HTMLDivElement::create(document);
     {
         ScriptDisallowedScope::EventAllowedScope eventAllowedScopeBeforeAppend { track };
@@ -118,8 +119,8 @@ void CheckboxInputType::handleMouseDownEvent(MouseEvent& event)
     if (!event.isTrusted() || !isSwitch())
         return;
 
-    RefPtr element = this->element();
-    ASSERT(element);
+    ASSERT(element());
+    Ref element = *this->element();
     if (element->isDisabledFormControl() || !element->renderer())
         return;
     startSwitchPointerTracking(event.absoluteLocation());
@@ -130,12 +131,10 @@ void CheckboxInputType::handleMouseMoveEvent(MouseEvent& event)
     if (!isSwitchPointerTracking())
         return;
 
-    RefPtr element = this->element();
-    ASSERT(element);
+    ASSERT(element());
+    ASSERT(!element()->isDisabledFormControl());
 
-    ASSERT(!element->isDisabledFormControl());
-
-    if (!event.isTrusted() || !isSwitch() || !element->renderer()) {
+    if (!event.isTrusted() || !isSwitch() || !protectedElement()->renderer()) {
         stopSwitchPointerTracking();
         return;
     }
@@ -170,8 +169,8 @@ Touch* CheckboxInputType::subsequentTouchEventTouch(const TouchEvent& event) con
 
 void CheckboxInputType::handleTouchEvent(TouchEvent& event)
 {
-    RefPtr element = this->element();
-    ASSERT(element);
+    ASSERT(element());
+    Ref element = *this->element();
 
     if (!event.isTrusted() || !isSwitch() || element->isDisabledFormControl() || !element->renderer()) {
         stopSwitchPointerTracking();
@@ -225,8 +224,8 @@ void CheckboxInputType::handleTouchEvent(TouchEvent& event)
 
 void CheckboxInputType::willDispatchClick(InputElementClickState& state)
 {
-    RefPtr element = this->element();
-    ASSERT(element);
+    ASSERT(element());
+    Ref element = *this->element();
 
     // An event handler can use preventDefault or "return false" to reverse the checking we do here.
     // The InputElementClickState object contains what we need to undo what we did here in didDispatchClick.
@@ -253,8 +252,8 @@ void CheckboxInputType::willDispatchClick(InputElementClickState& state)
 void CheckboxInputType::didDispatchClick(Event& event, const InputElementClickState& state)
 {
     if (event.defaultPrevented() || event.defaultHandled()) {
-        RefPtr element = this->element();
-        ASSERT(element);
+        ASSERT(element());
+        Ref element = *this->element();
         element->setIndeterminate(state.indeterminate);
         element->setChecked(state.checked);
     } else
@@ -266,19 +265,21 @@ void CheckboxInputType::didDispatchClick(Event& event, const InputElementClickSt
 
 static int switchPointerTrackingLogicalLeftPosition(Element& element, LayoutPoint absoluteLocation)
 {
-    auto isVertical = !element.renderer()->writingMode().isHorizontal();
-    auto localLocation = element.renderer()->absoluteToLocal(absoluteLocation, UseTransforms);
+    CheckedRef renderer = *element.renderer();
+    auto isVertical = !renderer->writingMode().isHorizontal();
+    auto localLocation = renderer->absoluteToLocal(absoluteLocation, UseTransforms);
     return isVertical ? localLocation.y() : localLocation.x();
 }
 
 void CheckboxInputType::startSwitchPointerTracking(LayoutPoint absoluteLocation)
 {
     ASSERT(element());
-    ASSERT(element()->renderer());
-    if (RefPtr frame = element()->document().frame()) {
-        frame->eventHandler().setCapturingMouseEventsElement(element());
-        m_isSwitchVisuallyOn = element()->checked();
-        m_switchPointerTrackingLogicalLeftPositionStart = switchPointerTrackingLogicalLeftPosition(*element(), absoluteLocation);
+    Ref element = *this->element();
+    ASSERT(element->renderer());
+    if (RefPtr frame = element->protectedDocument()->frame()) {
+        frame->checkedEventHandler()->setCapturingMouseEventsElement(element.ptr());
+        m_isSwitchVisuallyOn = element->checked();
+        m_switchPointerTrackingLogicalLeftPositionStart = switchPointerTrackingLogicalLeftPosition(element.get(), absoluteLocation);
     }
 }
 
@@ -288,8 +289,8 @@ void CheckboxInputType::stopSwitchPointerTracking()
     if (!isSwitchPointerTracking())
         return;
 
-    if (RefPtr frame = element()->document().frame())
-        frame->eventHandler().setCapturingMouseEventsElement(nullptr);
+    if (RefPtr frame = protectedElement()->protectedDocument()->frame())
+        frame->checkedEventHandler()->setCapturingMouseEventsElement(nullptr);
     m_hasSwitchVisuallyOnChanged = false;
     m_switchPointerTrackingLogicalLeftPositionStart = { };
 }
@@ -310,9 +311,8 @@ void CheckboxInputType::disabledStateChanged()
     if (!isSwitch())
         return;
 
-    RefPtr element = this->element();
-    ASSERT(element);
-    if (element->isDisabledFormControl()) {
+    ASSERT(element());
+    if (protectedElement()->isDisabledFormControl()) {
         stopSwitchAnimation(SwitchAnimationType::VisuallyOn);
         stopSwitchAnimation(SwitchAnimationType::Held);
         stopSwitchPointerTracking();
@@ -331,9 +331,9 @@ void CheckboxInputType::willUpdateCheckedness(bool, WasSetByJavaScript wasChecke
 
 // FIXME: ideally CheckboxInputType would not be responsible for the timer specifics and instead
 // ask a more knowledgable system for a refresh callback (perhaps passing a desired FPS).
-static Seconds switchAnimationUpdateInterval(HTMLInputElement* element)
+static Seconds switchAnimationUpdateInterval(HTMLInputElement& element)
 {
-    if (RefPtr page = element->document().page())
+    if (RefPtr page = element.protectedDocument()->page())
         return page->preferredRenderingUpdateInterval();
     return 0_s;
 }
@@ -369,10 +369,11 @@ void CheckboxInputType::performSwitchAnimation(SwitchAnimationType type)
 {
     ASSERT(isSwitch());
     ASSERT(element());
-    if (!element()->renderer() || !element()->renderer()->style().hasUsedAppearance())
+    Ref element = *this->element();
+    if (!element->renderer() || !element->renderer()->style().hasUsedAppearance())
         return;
 
-    auto updateInterval = switchAnimationUpdateInterval(element());
+    auto updateInterval = switchAnimationUpdateInterval(element.get());
     auto duration = switchAnimationDuration(type);
 
     if (!m_switchAnimationTimer) {
@@ -459,11 +460,12 @@ bool CheckboxInputType::isSwitchHeld() const
 
 void CheckboxInputType::updateIsSwitchVisuallyOnFromAbsoluteLocation(LayoutPoint absoluteLocation)
 {
-    auto logicalLeftPosition = switchPointerTrackingLogicalLeftPosition(*element(), absoluteLocation);
+    Ref element = *this->element();
+    auto logicalLeftPosition = switchPointerTrackingLogicalLeftPosition(element.get(), absoluteLocation);
     auto isSwitchVisuallyOn = m_isSwitchVisuallyOn;
-    auto isRTL = element()->computedStyle()->writingMode().isBidiRTL();
+    auto isRTL = element->computedStyle()->writingMode().isBidiRTL();
     auto switchThumbIsLogicallyLeft = (!isRTL && !isSwitchVisuallyOn) || (isRTL && isSwitchVisuallyOn);
-    auto switchTrackRect = element()->renderer()->absoluteBoundingBoxRect();
+    auto switchTrackRect = element->checkedRenderer()->absoluteBoundingBoxRect();
     auto switchThumbLength = switchTrackRect.height();
     auto switchTrackWidth = switchTrackRect.width();
 
@@ -488,10 +490,14 @@ void CheckboxInputType::updateIsSwitchVisuallyOnFromAbsoluteLocation(LayoutPoint
 void CheckboxInputType::switchAnimationTimerFired()
 {
     ASSERT(m_switchAnimationTimer);
-    if (!isSwitch() || !element() || !element()->renderer())
+    if (!isSwitch())
         return;
 
-    auto updateInterval = switchAnimationUpdateInterval(element());
+    Ref element = *this->element();
+    if (!element->renderer())
+        return;
+
+    auto updateInterval = switchAnimationUpdateInterval(element.get());
     if (!(updateInterval > 0_s))
         return;
 
@@ -507,7 +513,7 @@ void CheckboxInputType::switchAnimationTimerFired()
             stopSwitchAnimation(SwitchAnimationType::Held);
     }
 
-    element()->renderer()->repaint();
+    element->checkedRenderer()->repaint();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/html/ColorInputType.cpp
+++ b/Source/WebCore/html/ColorInputType.cpp
@@ -316,8 +316,8 @@ void ColorInputType::didChooseColor(const Color& color)
 void ColorInputType::didEndChooser()
 {
     m_chooser = nullptr;
-    if (element()->renderer())
-        element()->renderer()->repaint();
+    if (CheckedPtr renderer = protectedElement()->renderer())
+        renderer->repaint();
 }
 
 void ColorInputType::endColorChooser()
@@ -349,9 +349,11 @@ HTMLElement* ColorInputType::shadowColorSwatch() const
 IntRect ColorInputType::elementRectRelativeToRootView() const
 {
     ASSERT(element());
-    if (!element()->renderer())
+    Ref element = *this->element();
+    CheckedPtr renderer = element->renderer();
+    if (!renderer)
         return IntRect();
-    return element()->protectedDocument()->protectedView()->contentsToRootView(element()->renderer()->absoluteBoundingBoxRect());
+    return element->protectedDocument()->protectedView()->contentsToRootView(renderer->absoluteBoundingBoxRect());
 }
 
 bool ColorInputType::supportsAlpha() const

--- a/Source/WebCore/html/EmailInputType.cpp
+++ b/Source/WebCore/html/EmailInputType.cpp
@@ -3,7 +3,7 @@
  *
  * Copyright (C) 2009 Michelangelo De Simone <micdesim@gmail.com>
  * Copyright (C) 2010 Google Inc. All rights reserved.
- * Copyright (C) 2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2018-2025 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -68,7 +68,7 @@ bool EmailInputType::typeMismatchFor(const String& value) const
     ASSERT(element());
     if (value.isEmpty())
         return false;
-    if (!element()->multiple())
+    if (!protectedElement()->multiple())
         return !isValidEmailAddress(value);
     for (auto& address : value.splitAllowingEmptyEntries(',')) {
         if (!isValidEmailAddress(StringView(address).trim(isASCIIWhitespace<UChar>)))
@@ -80,13 +80,13 @@ bool EmailInputType::typeMismatchFor(const String& value) const
 bool EmailInputType::typeMismatch() const
 {
     ASSERT(element());
-    return typeMismatchFor(element()->value());
+    return typeMismatchFor(protectedElement()->value());
 }
 
 String EmailInputType::typeMismatchText() const
 {
     ASSERT(element());
-    return element()->multiple() ? validationMessageTypeMismatchForMultipleEmailText() : validationMessageTypeMismatchForEmailText();
+    return protectedElement()->multiple() ? validationMessageTypeMismatchForMultipleEmailText() : validationMessageTypeMismatchForEmailText();
 }
 
 bool EmailInputType::supportsSelectionAPI() const
@@ -96,8 +96,10 @@ bool EmailInputType::supportsSelectionAPI() const
 
 void EmailInputType::attributeChanged(const QualifiedName& name)
 {
-    if (name == multipleAttr)
-        element()->setValueInternal(sanitizeValue(element()->value()), TextFieldEventBehavior::DispatchNoEvent);
+    if (name == multipleAttr) {
+        Ref element = *this->element();
+        element->setValueInternal(sanitizeValue(element->value()), TextFieldEventBehavior::DispatchNoEvent);
+    }
 
     BaseTextInputType::attributeChanged(name);
 }
@@ -113,7 +115,7 @@ ValueOrReference<String> EmailInputType::sanitizeValue(const String& proposedVal
     }
 
     ASSERT(element());
-    if (!element()->multiple())
+    if (!protectedElement()->multiple())
         return noLineBreakValue.trim(isASCIIWhitespace);
     Vector<String> addresses = noLineBreakValue.splitAllowingEmptyEntries(',');
     StringBuilder strippedValue;

--- a/Source/WebCore/html/HTMLInputElement.cpp
+++ b/Source/WebCore/html/HTMLInputElement.cpp
@@ -2,7 +2,7 @@
  * Copyright (C) 1999 Lars Knoll (knoll@kde.org)
  *           (C) 1999 Antti Koivisto (koivisto@kde.org)
  *           (C) 2001 Dirk Mueller (mueller@kde.org)
- * Copyright (C) 2004-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2004-2025 Apple Inc. All rights reserved.
  *           (C) 2006 Alexey Proskuryakov (ap@nypop.com)
  * Copyright (C) 2007 Samuel Weinig (sam@webkit.org)
  * Copyright (C) 2010-2021 Google Inc. All rights reserved.
@@ -141,6 +141,11 @@ HTMLImageLoader& HTMLInputElement::ensureImageLoader()
     if (!m_imageLoader)
         lazyInitialize(m_imageLoader, makeUniqueWithoutRefCountedCheck<HTMLImageLoader>(*this));
     return *m_imageLoader;
+}
+
+Ref<HTMLImageLoader> HTMLInputElement::ensureProtectedImageLoader()
+{
+    return ensureImageLoader();
 }
 
 HTMLInputElement::~HTMLInputElement()

--- a/Source/WebCore/html/HTMLInputElement.h
+++ b/Source/WebCore/html/HTMLInputElement.h
@@ -2,7 +2,7 @@
  * Copyright (C) 1999 Lars Knoll (knoll@kde.org)
  *           (C) 1999 Antti Koivisto (koivisto@kde.org)
  *           (C) 2000 Dirk Mueller (mueller@kde.org)
- * Copyright (C) 2004-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2004-2025 Apple Inc. All rights reserved.
  * Copyright (C) 2012 Samsung Electronics. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
@@ -343,6 +343,7 @@ public:
 
     HTMLImageLoader* imageLoader() { return m_imageLoader.get(); }
     HTMLImageLoader& ensureImageLoader();
+    Ref<HTMLImageLoader> ensureProtectedImageLoader();
 
     void capsLockStateMayHaveChanged();
 

--- a/Source/WebCore/html/HiddenInputType.cpp
+++ b/Source/WebCore/html/HiddenInputType.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2010 Google Inc. All rights reserved.
- * Copyright (C) 2011 Apple Inc. All rights reserved.
+ * Copyright (C) 2011-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -57,13 +57,14 @@ FormControlState HiddenInputType::saveFormControlState() const
     // valueAttributeWasUpdatedAfterParsing() never be true for form controls create by createElement() or cloneNode().
     // It's OK for now because we restore values only to form controls created by parsing.
     ASSERT(element());
-    return element()->valueAttributeWasUpdatedAfterParsing() ? FormControlState { { AtomString { element()->value() } } } : FormControlState { };
+    Ref element = *this->element();
+    return element->valueAttributeWasUpdatedAfterParsing() ? FormControlState { { AtomString { element->value() } } } : FormControlState { };
 }
 
 void HiddenInputType::restoreFormControlState(const FormControlState& state)
 {
     ASSERT(element());
-    element()->setAttributeWithoutSynchronization(valueAttr, AtomString { state[0] });
+    protectedElement()->setAttributeWithoutSynchronization(valueAttr, AtomString { state[0] });
 }
 
 RenderPtr<RenderElement> HiddenInputType::createInputRenderer(RenderStyle&&)
@@ -90,21 +91,22 @@ bool HiddenInputType::storesValueSeparateFromAttribute()
 void HiddenInputType::setValue(const String& sanitizedValue, bool, TextFieldEventBehavior, TextControlSetValueSelection)
 {
     ASSERT(element());
-    element()->setAttributeWithoutSynchronization(valueAttr, AtomString { sanitizedValue });
+    protectedElement()->setAttributeWithoutSynchronization(valueAttr, AtomString { sanitizedValue });
 }
 
 bool HiddenInputType::appendFormData(DOMFormData& formData) const
 {
     ASSERT(element());
-    auto name = element()->name();
+    Ref element = *this->element();
+    auto name = element->name();
 
     if (equalIgnoringASCIICase(name, "_charset_"_s)) {
         formData.append(name, String::fromLatin1(formData.encoding().name()));
         return true;
     }
     InputType::appendFormData(formData);
-    if (auto& dirname = element()->attributeWithoutSynchronization(dirnameAttr); !dirname.isNull())
-        formData.append(dirname, element()->directionForFormData());
+    if (auto& dirname = element->attributeWithoutSynchronization(dirnameAttr); !dirname.isNull())
+        formData.append(dirname, element->directionForFormData());
     return true;
 }
 

--- a/Source/WebCore/html/ImageInputType.cpp
+++ b/Source/WebCore/html/ImageInputType.cpp
@@ -64,10 +64,11 @@ bool ImageInputType::isFormDataAppendable() const
 bool ImageInputType::appendFormData(DOMFormData& formData) const
 {
     ASSERT(element());
-    if (!element()->isActivatedSubmit())
+    Ref element = *this->element();
+    if (!element->isActivatedSubmit())
         return false;
 
-    auto& name = protectedElement()->name();
+    auto& name = element->name();
     if (name.isEmpty()) {
         formData.append("x"_s, String::number(m_clickLocation.x()));
         formData.append("y"_s, String::number(m_clickLocation.y()));
@@ -111,7 +112,7 @@ void ImageInputType::handleDOMActivateEvent(Event& event)
 RenderPtr<RenderElement> ImageInputType::createInputRenderer(RenderStyle&& style)
 {
     ASSERT(element());
-    return createRenderer<RenderImage>(RenderObject::Type::Image, *element(), WTFMove(style));
+    return createRenderer<RenderImage>(RenderObject::Type::Image, *protectedElement(), WTFMove(style));
 }
 
 void ImageInputType::attributeChanged(const QualifiedName& name)
@@ -124,7 +125,7 @@ void ImageInputType::attributeChanged(const QualifiedName& name)
     } else if (name == srcAttr) {
         if (RefPtr element = this->element()) {
             if (element->renderer())
-                element->ensureImageLoader().updateFromElementIgnoringPreviousError();
+                element->ensureProtectedImageLoader()->updateFromElementIgnoringPreviousError();
         }
     }
     BaseButtonInputType::attributeChanged(name);
@@ -176,7 +177,8 @@ unsigned ImageInputType::height() const
 
     element->protectedDocument()->updateLayout({ LayoutOptions::TreatContentVisibilityHiddenAsVisible, LayoutOptions::TreatContentVisibilityAutoAsVisible }, element.ptr());
 
-    if (CheckedPtr renderer = element->renderer())
+    CheckedPtr renderer = element->renderer();
+    if (renderer)
         return adjustForAbsoluteZoom(downcast<RenderBox>(*renderer).contentBoxHeight(), *renderer);
 
     // Check the attribute first for an explicit pixel value.
@@ -186,7 +188,7 @@ unsigned ImageInputType::height() const
     // If the image is available, use its height.
     CheckedPtr imageLoader = element->imageLoader();
     if (imageLoader && imageLoader->image())
-        return imageLoader->image()->imageSizeForRenderer(element->renderer(), 1).height().toUnsigned();
+        return imageLoader->image()->imageSizeForRenderer(renderer.get(), 1).height().toUnsigned();
 
     return 0;
 }
@@ -198,7 +200,8 @@ unsigned ImageInputType::width() const
 
     element->protectedDocument()->updateLayout({ LayoutOptions::TreatContentVisibilityHiddenAsVisible, LayoutOptions::TreatContentVisibilityAutoAsVisible }, element.ptr());
 
-    if (CheckedPtr renderer = element->renderer())
+    CheckedPtr renderer = element->renderer();
+    if (renderer)
         return adjustForAbsoluteZoom(downcast<RenderBox>(*renderer).contentBoxWidth(), *renderer);
 
     // Check the attribute first for an explicit pixel value.
@@ -208,7 +211,7 @@ unsigned ImageInputType::width() const
     // If the image is available, use its width.
     CheckedPtr imageLoader = element->imageLoader();
     if (imageLoader && imageLoader->image())
-        return imageLoader->image()->imageSizeForRenderer(element->renderer(), 1).width().toUnsigned();
+        return imageLoader->image()->imageSizeForRenderer(renderer.get(), 1).width().toUnsigned();
 
     return 0;
 }

--- a/Source/WebCore/html/RangeInputType.cpp
+++ b/Source/WebCore/html/RangeInputType.cpp
@@ -123,11 +123,12 @@ bool RangeInputType::supportsRequired() const
 StepRange RangeInputType::createStepRange(AnyStepHandling anyStepHandling) const
 {
     ASSERT(element());
+    Ref element = *this->element();
     const Decimal stepBase = findStepBase(rangeDefaultStepBase);
-    const Decimal minimum = parseToNumber(element()->attributeWithoutSynchronization(minAttr), rangeDefaultMinimum);
-    const Decimal maximum = ensureMaximum(parseToNumber(element()->attributeWithoutSynchronization(maxAttr), rangeDefaultMaximum), minimum);
+    const Decimal minimum = parseToNumber(element->attributeWithoutSynchronization(minAttr), rangeDefaultMinimum);
+    const Decimal maximum = ensureMaximum(parseToNumber(element->attributeWithoutSynchronization(maxAttr), rangeDefaultMaximum), minimum);
 
-    const Decimal step = StepRange::parseStep(anyStepHandling, rangeStepDescription, element()->attributeWithoutSynchronization(stepAttr));
+    const Decimal step = StepRange::parseStep(anyStepHandling, rangeStepDescription, element->attributeWithoutSynchronization(stepAttr));
     return StepRange(stepBase, RangeLimitations::Valid, minimum, maximum, step, rangeStepDescription);
 }
 
@@ -189,7 +190,7 @@ void RangeInputType::disabledStateChanged()
 {
     if (!hasCreatedShadowSubtree())
         return;
-    typedSliderThumbElement().hostDisabledStateChanged();
+    protectedTypedSliderThumbElement()->hostDisabledStateChanged();
 }
 
 auto RangeInputType::handleKeydownEvent(KeyboardEvent& event) -> ShouldCallBaseEventHandler
@@ -386,9 +387,11 @@ bool RangeInputType::shouldRespectListAttribute()
 void RangeInputType::dataListMayHaveChanged()
 {
     m_tickMarkValuesDirty = true;
-    RefPtr<HTMLElement> sliderTrackElement = this->sliderTrackElement();
-    if (sliderTrackElement && sliderTrackElement->renderer())
-        sliderTrackElement->renderer()->setNeedsLayout();
+    RefPtr sliderTrackElement = this->sliderTrackElement();
+    if (!sliderTrackElement)
+        return;
+    if (CheckedPtr renderer = sliderTrackElement->renderer())
+        renderer->setNeedsLayout();
 }
 
 void RangeInputType::updateTickMarkValues()

--- a/Source/WebCore/html/TextFieldInputType.cpp
+++ b/Source/WebCore/html/TextFieldInputType.cpp
@@ -821,7 +821,7 @@ void TextFieldInputType::createContainer(PreserveSelectionRange preserveSelectio
     Ref innerBlock = TextControlInnerElement::create(document);
     m_innerBlock = innerBlock.copyRef();
     RefPtr { m_container }->appendChild(innerBlock);
-    innerBlock->appendChild(*m_innerText.copyRef());
+    innerBlock->appendChild(Ref { *m_innerText });
 
     if (selectionState) {
         document->checkedEventLoop()->queueTask(TaskSource::DOMManipulation, [selectionState = *selectionState, element = WeakPtr { element }] {
@@ -981,8 +981,8 @@ void TextFieldInputType::didCloseSuggestions()
     m_cachedSuggestions = { };
     if (RefPtr suggestionPicker = std::exchange(m_suggestionPicker, nullptr))
         suggestionPicker->detach();
-    if (element()->renderer())
-        element()->renderer()->repaint();
+    if (CheckedPtr renderer = element()->renderer())
+        renderer->repaint();
 }
 
 void TextFieldInputType::displaySuggestions(DataListSuggestionActivationType type)


### PR DESCRIPTION
#### a3e2de64424615dca6f99a496ff4254b6919c6d9
<pre>
Reduce unsafeness in InputType classes even more
<a href="https://bugs.webkit.org/show_bug.cgi?id=293687">https://bugs.webkit.org/show_bug.cgi?id=293687</a>
<a href="https://rdar.apple.com/152160579">rdar://152160579</a>

Reviewed by Chris Dumez.

Apply <a href="https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines">https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines</a>

* Source/WebCore/html/CheckboxInputType.cpp:
(WebCore::CheckboxInputType::switchAnimationTimerFired):

Remove the !element() conditional as it is redundant with the early
return for !isSwitch().

Canonical link: <a href="https://commits.webkit.org/295603@main">https://commits.webkit.org/295603@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/140438db21622db1ceaebb782d344f6256126ecc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105574 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25323 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15714 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110771 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/56196 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/107615 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/25825 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33824 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80179 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/56196 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108580 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/20171 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95279 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60488 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/19909 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13370 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55608 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/89619 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13410 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/113589 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32713 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24119 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89255 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33076 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91508 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88919 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33790 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11595 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/28157 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17125 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32638 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/38030 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32387 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35737 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33981 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->