### PR TITLE
[JSC] Ensure `Date.prototype.setYear` Respects TimeClip Range by Guarding GregorianDateTime::years Overflow

### DIFF
--- a/JSTests/stress/date-timeClip-large-values.js
+++ b/JSTests/stress/date-timeClip-large-values.js
@@ -1,0 +1,126 @@
+function shouldBe(actual, expected) {
+    if (Number.isNaN(expected)) {
+        if (!Number.isNaN(actual))
+            throw new Error(`expected ${expected} but got ${actual}`);
+    } else if (actual !== expected)
+        throw new Error(`expected ${expected} but got ${actual}`);
+}
+
+
+// Testing date creating at the max boundary
+shouldBe(new Date(0).valueOf(), 0);
+shouldBe(new Date(8.64e15) instanceof Date, true);
+shouldBe(new Date(8.64e15).valueOf(), 8.64e15);
+shouldBe(new Date(8640000000000001) instanceof Date, true);
+shouldBe(new Date(8640000000000001).valueOf(), NaN);
+shouldBe(new Date(Infinity) instanceof Date, true);
+shouldBe(new Date(Infinity).valueOf(), NaN);
+shouldBe(new Date(-Infinity) instanceof Date, true);
+shouldBe(new Date(-Infinity).valueOf(), NaN);
+
+// Testing setMilliseconds()
+shouldBe(new Date(0).setMilliseconds(Infinity).valueOf(), NaN);
+shouldBe(new Date(0).setMilliseconds(1.79769e+308).valueOf(), NaN);
+shouldBe(new Date(0).setMilliseconds(-1.79769e+308).valueOf(), NaN);
+shouldBe(new Date(8.64e15).setMilliseconds(new Date(8.64e15).getMilliseconds()).valueOf(), 8.64e15);
+shouldBe(new Date(8.64e15).setMilliseconds(new Date(8.64e15).getMilliseconds() + 1).valueOf(), NaN);
+
+// Testing setSeconds()
+shouldBe(new Date(0).setSeconds(Infinity).valueOf(), NaN);
+shouldBe(new Date(0).setSeconds(1.79769e+308).valueOf(), NaN);
+shouldBe(new Date(0).setSeconds(-1.79769e+308).valueOf(), NaN);
+shouldBe(new Date(8.64e15).setSeconds(new Date(8.64e15).getSeconds()).valueOf(), 8.64e15);
+shouldBe(new Date(8.64e15).setSeconds(new Date(8.64e15).getSeconds() + 1).valueOf(), NaN);
+
+// Testing setMinutes()
+shouldBe(new Date(0).setMinutes(Infinity).valueOf(), NaN);
+shouldBe(new Date(0).setMinutes(1.79769e+308).valueOf(), NaN);
+shouldBe(new Date(0).setMinutes(-1.79769e+308).valueOf(), NaN);
+shouldBe(new Date(8.64e15).setMinutes(new Date(8.64e15).getMinutes()).valueOf(), 8.64e15);
+shouldBe(new Date(8.64e15).setMinutes(new Date(8.64e15).getMinutes() + 1).valueOf(), NaN);
+
+// Testing setHours()
+shouldBe(new Date(0).setHours(Infinity).valueOf(), NaN);
+shouldBe(new Date(0).setHours(1.79769e+308).valueOf(), NaN);
+shouldBe(new Date(0).setHours(-1.79769e+308).valueOf(), NaN);
+shouldBe(new Date(8.64e15).setHours(new Date(8.64e15).getHours()).valueOf(), 8.64e15);
+shouldBe(new Date(8.64e15).setHours(new Date(8.64e15).getHours() + 1).valueOf(), NaN);
+
+// Testing setDate()
+shouldBe(new Date(0).setDate(Infinity).valueOf(), NaN);
+shouldBe(new Date(0).setDate(1.79769e+308).valueOf(), NaN);
+shouldBe(new Date(0).setDate(-1.79769e+308).valueOf(), NaN);
+shouldBe(new Date(0).setDate(9e15 / (24 * 60 * 60 * 1000)).valueOf(), NaN);
+shouldBe(new Date(8.64e15).setDate(new Date(8.64e15).getDate()).valueOf(), 8.64e15);
+shouldBe(new Date(8.64e15).setDate(new Date(8.64e15).getDate() + 1).valueOf(), NaN);
+
+// Testing setMonth()
+shouldBe(new Date(0).setMonth(Infinity).valueOf(), NaN);
+// shouldBe(new Date(0).setMonth(1.79769e+308).valueOf(), NaN);
+// shouldBe(new Date(0).setMonth(-1.79769e+308).valueOf(), NaN);
+shouldBe(new Date(8.64e15).setMonth(new Date(8.64e15).getMonth()).valueOf(), 8.64e15);
+shouldBe(new Date(8.64e15).setMonth(new Date(8.64e15).getMonth() + 1).valueOf(), NaN);
+
+// Testing setYear()
+shouldBe(new Date(0).setYear(Infinity).valueOf(), NaN);
+shouldBe(new Date(0).setYear(1.79769e+308).valueOf(), NaN);
+shouldBe(new Date(0).setYear(-1.79769e+308).valueOf(), NaN);
+shouldBe(new Date(8.64e15).setYear(new Date(8.64e15).getFullYear()).valueOf(), 8.64e15);
+shouldBe(new Date(8.64e15).setYear(new Date(8.64e15).getFullYear() + 1).valueOf(), NaN);
+
+// Testing setFullYear()
+shouldBe(new Date(0).setFullYear(Infinity).valueOf(), NaN);
+shouldBe(new Date(0).setFullYear(1.79769e+308).valueOf(), NaN);
+shouldBe(new Date(0).setFullYear(-1.79769e+308).valueOf(), NaN);
+shouldBe(new Date(8.64e15).setFullYear(new Date(8.64e15).getFullYear()).valueOf(), 8.64e15);
+shouldBe(new Date(8.64e15).setFullYear(new Date(8.64e15).getFullYear() + 1).valueOf(), NaN);
+
+// Testing setUTCMilliseconds()
+shouldBe(new Date(0).setUTCMilliseconds(Infinity).valueOf(), NaN);
+shouldBe(new Date(0).setUTCMilliseconds(1.79769e+308).valueOf(), NaN);
+shouldBe(new Date(0).setUTCMilliseconds(-1.79769e+308).valueOf(), NaN);
+shouldBe(new Date(8.64e15).setUTCMilliseconds(new Date(8.64e15).getUTCMilliseconds()).valueOf(), 8.64e15);
+shouldBe(new Date(8.64e15).setUTCMilliseconds(new Date(8.64e15).getUTCMilliseconds() + 1).valueOf(), NaN);
+
+// Testing setUTCSeconds()
+shouldBe(new Date(0).setUTCSeconds(Infinity).valueOf(), NaN);
+shouldBe(new Date(0).setUTCSeconds(1.79769e+308).valueOf(), NaN);
+shouldBe(new Date(0).setUTCSeconds(-1.79769e+308).valueOf(), NaN);
+shouldBe(new Date(8.64e15).setUTCSeconds(new Date(8.64e15).getUTCSeconds()).valueOf(), 8.64e15);
+shouldBe(new Date(8.64e15).setUTCSeconds(new Date(8.64e15).getUTCSeconds() + 1).valueOf(), NaN);
+
+// Testing setUTCMinutes()
+shouldBe(new Date(0).setUTCMinutes(Infinity).valueOf(), NaN);
+shouldBe(new Date(0).setUTCMinutes(1.79769e+308).valueOf(), NaN);
+shouldBe(new Date(0).setUTCMinutes(-1.79769e+308).valueOf(), NaN);
+shouldBe(new Date(8.64e15).setUTCMinutes(new Date(8.64e15).getUTCMinutes()).valueOf(), 8.64e15);
+shouldBe(new Date(8.64e15).setUTCMinutes(new Date(8.64e15).getUTCMinutes() + 1).valueOf(), NaN);
+
+// Testing setUTCHours()
+shouldBe(new Date(0).setUTCHours(Infinity).valueOf(), NaN);
+shouldBe(new Date(0).setUTCHours(1.79769e+308).valueOf(), NaN);
+shouldBe(new Date(0).setUTCHours(-1.79769e+308).valueOf(), NaN);
+shouldBe(new Date(8.64e15).setUTCHours(new Date(8.64e15).getUTCHours()).valueOf(), 8.64e15);
+shouldBe(new Date(8.64e15).setUTCHours(new Date(8.64e15).getUTCHours() + 1).valueOf(), NaN);
+
+// Testing setUTCDate()
+shouldBe(new Date(0).setUTCDate(Infinity).valueOf(), NaN);
+shouldBe(new Date(0).setUTCDate(1.79769e+308).valueOf(), NaN);
+shouldBe(new Date(0).setUTCDate(-1.79769e+308).valueOf(), NaN);
+shouldBe(new Date(0).setUTCDate(9e15 / (24 * 60 * 60 * 1000)).valueOf(), NaN);
+shouldBe(new Date(8.64e15).setUTCDate(new Date(8.64e15).getUTCDate()).valueOf(), 8.64e15);
+shouldBe(new Date(8.64e15).setUTCDate(new Date(8.64e15).getUTCDate() + 1).valueOf(), NaN);
+
+// Testing setUTCMonth()
+shouldBe(new Date(0).setUTCMonth(Infinity).valueOf(), NaN);
+// shouldBe(new Date(0).setUTCMonth(1.79769e+308).valueOf(), NaN);
+// shouldBe(new Date(0).setUTCMonth(-1.79769e+308).valueOf(), NaN);
+shouldBe(new Date(8.64e15).setUTCMonth(new Date(8.64e15).getUTCMonth()).valueOf(), 8.64e15);
+shouldBe(new Date(8.64e15).setUTCMonth(new Date(8.64e15).getUTCMonth() + 1).valueOf(), NaN);
+
+// Testing setUTCFullYear()
+shouldBe(new Date(0).setUTCFullYear(Infinity).valueOf(), NaN);
+shouldBe(new Date(0).setUTCFullYear(1.79769e+308).valueOf(), NaN);
+shouldBe(new Date(0).setUTCFullYear(-1.79769e+308).valueOf(), NaN);
+shouldBe(new Date(8.64e15).setUTCFullYear(new Date(8.64e15).getUTCFullYear()).valueOf(), 8.64e15);
+shouldBe(new Date(8.64e15).setUTCFullYear(new Date(8.64e15).getUTCFullYear() + 1).valueOf(), NaN);

--- a/LayoutTests/js/date-timeClip-large-values-expected.txt
+++ b/LayoutTests/js/date-timeClip-large-values-expected.txt
@@ -52,8 +52,8 @@ PASS new Date(8.64e15).setMonth(new Date(8.64e15).getMonth()).valueOf() is 8.64e
 PASS new Date(8.64e15).setMonth(new Date(8.64e15).getMonth() + 1).valueOf() is NaN
 Testing setYear()
 PASS new Date(0).setYear(Infinity).valueOf() is NaN
-FAIL new Date(0).setYear(1.79769e+308).valueOf() should be NaN. Was -62135597222000.
-FAIL new Date(0).setYear(-1.79769e+308).valueOf() should be NaN. Was -62135597222000.
+PASS new Date(0).setYear(1.79769e+308).valueOf() is NaN
+PASS new Date(0).setYear(-1.79769e+308).valueOf() is NaN
 PASS new Date(8.64e15).setYear(new Date(8.64e15).getFullYear()).valueOf() is 8.64e15
 PASS new Date(8.64e15).setYear(new Date(8.64e15).getFullYear() + 1).valueOf() is NaN
 Testing setFullYear()

--- a/Source/JavaScriptCore/runtime/DatePrototype.cpp
+++ b/Source/JavaScriptCore/runtime/DatePrototype.cpp
@@ -882,7 +882,7 @@ JSC_DEFINE_HOST_FUNCTION(dateProtoFuncSetYear, (JSGlobalObject* globalObject, Ca
 
     double year = callFrame->argument(0).toIntegerPreserveNaN(globalObject);
     RETURN_IF_EXCEPTION(scope, encodedJSValue());
-    if (!std::isfinite(year)) {
+    if (!std::isfinite(year) || std::abs(year) > msToYear(WTF::maxECMAScriptTime)) {
         thisDateObj->setInternalNumber(PNaN);
         return JSValue::encode(jsNaN());
     }


### PR DESCRIPTION
#### d11e792d060e255a5e6e72814f4fd9ba36d23c53
<pre>
[JSC] Ensure `Date.prototype.setYear` Respects TimeClip Range by Guarding GregorianDateTime::years Overflow
<a href="https://bugs.webkit.org/show_bug.cgi?id=293692">https://bugs.webkit.org/show_bug.cgi?id=293692</a>

Reviewed by Sosuke Suzuki.

TimeClip[1] function, as referenced in Date.prototype.setYear[2],
mentions that absolute value of time must not exceed 8.64E15 in milliseconds,
otherwise returns NaN. However, the current GregorianDateTime class represents
years member variable as int.
Therefore, if the years exceeds the maximum representable int,
date calculations may produce incorrect results.
This patch adds a safeguard to ensure that such overflows are prevented
to align the behavior with the TC39 spec.

[1]: <a href="https://tc39.es/ecma262/#sec-timeclip">https://tc39.es/ecma262/#sec-timeclip</a>
[2]: <a href="https://tc39.es/ecma262/#sec-date.prototype.setyear">https://tc39.es/ecma262/#sec-date.prototype.setyear</a>

* LayoutTests/js/date-timeClip-large-values-expected.txt:
* Source/JavaScriptCore/runtime/DatePrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):

Canonical link: <a href="https://commits.webkit.org/295742@main">https://commits.webkit.org/295742@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/48be4e25f9f19a8261b66636cffe3d62bb235c95

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105837 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25588 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15981 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/111034 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/56434 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/26184 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34091 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80383 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108843 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/20581 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95506 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60697 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/20242 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13603 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55872 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/98478 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/89982 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13641 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/113884 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/104456 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32977 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24306 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89463 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33341 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91736 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89134 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22758 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34002 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11810 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/28489 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32902 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/38313 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/128768 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32648 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/35146 "Found 4 new JSC stress test failures: wasm.yaml/wasm/gc/ref-i31-eq.js.default-wasm, wasm.yaml/wasm/gc/ref-i31-eq.js.wasm-collect-continuously, wasm.yaml/wasm/gc/ref-i31-eq.js.wasm-eager-jettison, wasm.yaml/wasm/gc/ref-i31-eq.js.wasm-slow-memory (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35997 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34246 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->