### PR TITLE
Fix crashes and assertions with AudioData.copyTo

### DIFF
--- a/LayoutTests/fast/webcodecs/audio-data-copy-to-crash-expected.txt
+++ b/LayoutTests/fast/webcodecs/audio-data-copy-to-crash-expected.txt
@@ -1,0 +1,1 @@
+PASS if no crash.

--- a/LayoutTests/fast/webcodecs/audio-data-copy-to-crash.html
+++ b/LayoutTests/fast/webcodecs/audio-data-copy-to-crash.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<script>
+  window.addEventListener("load", () => {
+    window.testRunner?.dumpAsText();
+
+    // Bug 288440: assertion/crash in audioElementSpan() because copyDestination
+    // is not castable to a buffer of 16bits elements.
+    let rawData = new Uint8ClampedArray(4);
+    let audioData = new AudioData({
+      format: "s16-planar",
+      sampleRate: 1,
+      numberOfFrames: 1,
+      numberOfChannels: 2,
+      timestamp: 0,
+      data: rawData
+    });
+    let copyDestination = new Uint8ClampedArray(3);
+    audioData.copyTo(copyDestination, {planeIndex: 0});
+
+    document.body.innerHTML = "PASS if no crash.";
+  });
+</script>
+<video></video>

--- a/Source/WebCore/Modules/webcodecs/WebCodecsAudioDataAlgorithms.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsAudioDataAlgorithms.cpp
@@ -171,19 +171,23 @@ AudioSampleFormat audioSampleElementFormat(AudioSampleFormat format)
 
 AudioSampleFormatSpan audioElementSpan(AudioSampleFormat format, std::span<uint8_t> buffer)
 {
+    auto bytesPerSample = computeBytesPerSample(format);
+    auto clampedBufferSize = buffer.size_bytes();
+    clampedBufferSize -= clampedBufferSize % bytesPerSample;
+
     switch (format) {
     case AudioSampleFormat::U8:
     case AudioSampleFormat::U8Planar:
         return buffer;
     case AudioSampleFormat::S16:
     case AudioSampleFormat::S16Planar:
-        return spanReinterpretCast<int16_t>(buffer);
+        return spanReinterpretCast<int16_t>(buffer.first(clampedBufferSize));
     case AudioSampleFormat::S32:
     case AudioSampleFormat::S32Planar:
-        return spanReinterpretCast<int32_t>(buffer);
+        return spanReinterpretCast<int32_t>(buffer.first(clampedBufferSize));
     case AudioSampleFormat::F32:
     case AudioSampleFormat::F32Planar:
-        return spanReinterpretCast<float>(buffer);
+        return spanReinterpretCast<float>(buffer.first(clampedBufferSize));
     }
     RELEASE_ASSERT_NOT_REACHED();
     return buffer;


### PR DESCRIPTION
#### 875d8a670798f8ed578475c026d24a9982433e00
<pre>
Fix crashes and assertions with AudioData.copyTo
<a href="https://bugs.webkit.org/show_bug.cgi?id=288440">https://bugs.webkit.org/show_bug.cgi?id=288440</a>
<a href="https://rdar.apple.com/145467725">rdar://145467725</a>

Reviewed by Youenn Fablet.

When AudioData.copyTo() is executed, audioElementSpan() performs
spanReinterpretCast on the destination buffer but this crashes if the buffer
byte size is not a multiple of the byte size of the desired type.

* LayoutTests/fast/webcodecs/audio-data-copy-to-crash-expected.txt: Added.
* LayoutTests/fast/webcodecs/audio-data-copy-to-crash.html: Added.
* Source/WebCore/Modules/webcodecs/WebCodecsAudioDataAlgorithms.cpp:
(WebCore::audioElementSpan): Ignore the extra bytes to make the cast successful.

Originally-landed-as: 289651.11@webkit-2025.2-embargoed (9cd83b245d8d). <a href="https://rdar.apple.com/151713264">rdar://151713264</a>
Canonical link: <a href="https://commits.webkit.org/295546@main">https://commits.webkit.org/295546@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1fc9e5ada74eb21af1bbdaa8f2a9712c49554c37

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105321 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25033 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15459 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110529 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/55987 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/107362 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/25471 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33576 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79992 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108327 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19868 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95058 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60298 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/19629 "") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13136 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55373 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/89325 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13175 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/113180 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32478 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23940 "") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89071 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32841 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91273 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88709 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33606 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11392 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/27960 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17094 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32401 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/37837 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32176 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35521 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33748 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->