### PR TITLE
ASAN_TRAP | URLPatternUtilities::Tokenizer::tokenize; WebCore::URLPatternConstructorStringParser::parse; WebCore::URLPattern::create

### DIFF
--- a/LayoutTests/fast/url/urlpattern-invalid-pattern-expected.txt
+++ b/LayoutTests/fast/url/urlpattern-invalid-pattern-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Test unclosed token
+

--- a/LayoutTests/fast/url/urlpattern-invalid-pattern.html
+++ b/LayoutTests/fast/url/urlpattern-invalid-pattern.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script>
+test(() => {
+  assert_throws_js(TypeError, () => { new URLPattern(new URL('https://example.org/%(')); } );
+  assert_throws_js(TypeError, () => { new URLPattern(new URL('https://example.org/%((')); } );
+}, `Test unclosed token`);
+</script>

--- a/Source/WebCore/Modules/url-pattern/URLPatternTokenizer.cpp
+++ b/Source/WebCore/Modules/url-pattern/URLPatternTokenizer.cpp
@@ -223,7 +223,7 @@ ExceptionOr<Vector<Token>> Tokenizer::tokenize()
                 if (m_codepoint == '(') {
                     depth = depth + 1;
 
-                    if (m_index == m_input.length() - 1) {
+                    if (regexPosition == m_input.length() - 1) {
                         maybeException = processTokenizingError(regexStart, m_index, "No closing token is provided by end of string."_s);
                         hasError = true;
                         break;


### PR DESCRIPTION
#### 388c0587a90242bdbb96fbdd49db496b35590430
<pre>
ASAN_TRAP | URLPatternUtilities::Tokenizer::tokenize; WebCore::URLPatternConstructorStringParser::parse; WebCore::URLPattern::create
<a href="https://bugs.webkit.org/show_bug.cgi?id=289383">https://bugs.webkit.org/show_bug.cgi?id=289383</a>
<a href="https://rdar.apple.com/145468328">rdar://145468328</a>

Reviewed by Youenn Fablet.

Fix a faulty check for end of input in URLPatternTokenizer.

* LayoutTests/fast/url/urlpattern-invalid-pattern-expected.txt: Added.
* LayoutTests/fast/url/urlpattern-invalid-pattern.html: Added.
* Source/WebCore/Modules/url-pattern/URLPatternTokenizer.cpp:
(WebCore::URLPatternUtilities::Tokenizer::tokenize):

Originally-landed-as: 289651.10@webkit-2025.2-embargoed (a1041748ac6b). <a href="https://rdar.apple.com/151713428">rdar://151713428</a>
Canonical link: <a href="https://commits.webkit.org/295545@main">https://commits.webkit.org/295545@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/79c8c6b72dd1f82637110bf826ea33667a91377e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105322 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25034 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15460 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110530 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/55988 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/107363 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/25473 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33577 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79994 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108328 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19866 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95060 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60300 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/19627 "") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13134 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55374 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/89323 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13178 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/113186 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32479 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23941 "") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89073 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32842 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91276 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88711 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33604 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11393 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/27961 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17095 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32402 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/37815 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32177 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35522 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33749 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->