### PR TITLE
REGRESSION(295342@main): [iOS] imported/w3c/web-platform-tests/css/cssom/stylesheet-same-origin.sub.html is constant failure (flaky failure in EWS)

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/stylesheet-same-origin.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/stylesheet-same-origin.sub-expected.txt
@@ -7,15 +7,11 @@ Blocked access to external URL http://www1.localhost:8801/css/cssom/stylesheet-s
 FAIL Origin-clean check in cross-origin CSSOM Stylesheets assert_throws_dom: stylesheet.cssRules should throw SecurityError. function "function () {
                     sheet.cssRules;
                 }" threw object "TypeError: null is not an object (evaluating 'sheet.cssRules')" that is not a DOMException SecurityError: property "code" is equal to undefined, expected 18
-FAIL Origin-clean check in cross-origin CSSOM Stylesheets (redirect from same-origin to cross-origin) assert_throws_dom: stylesheet.cssRules should throw SecurityError. function "function () {
-                    sheet.cssRules;
-                }" did not throw
+PASS Origin-clean check in cross-origin CSSOM Stylesheets (redirect from same-origin to cross-origin)
 FAIL Origin-clean check in cross-origin CSSOM Stylesheets (redirect from cross-origin to same-origin) assert_throws_dom: stylesheet.cssRules should throw SecurityError. function "function () {
                     sheet.cssRules;
                 }" threw object "TypeError: null is not an object (evaluating 'sheet.cssRules')" that is not a DOMException SecurityError: property "code" is equal to undefined, expected 18
-FAIL Origin-clean check in loading error CSSOM Stylesheets assert_throws_dom: stylesheet.cssRules should throw SecurityError. function "function () {
-                    sheet.cssRules;
-                }" did not throw
+PASS Origin-clean check in loading error CSSOM Stylesheets
 PASS Origin-clean check in same-origin CSSOM Stylesheets
-FAIL Origin-clean check in data:css CSSOM Stylesheets Not allowed to access cross-origin stylesheet
+PASS Origin-clean check in data:css CSSOM Stylesheets
 

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -959,8 +959,6 @@ webkit.org/b/189483 imported/w3c/web-platform-tests/css/css-fonts/variations/sln
 # Pass instead of removing this line.
 webkit.org/b/234606 fast/gradients/conic-gradient-alpha.html [ ImageOnlyFailure ]
 
-webkit.org/b/214682 imported/w3c/web-platform-tests/css/cssom/stylesheet-same-origin.sub.html [ Failure ]
-
 webkit.org/b/216767 css3/font-feature-settings-stylistic-set.html [ ImageOnlyFailure ]
 
 webkit.org/b/216853 css3/font-synthesis-small-caps.html [ ImageOnlyFailure ]

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/css/cssom/stylesheet-same-origin.sub-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/css/cssom/stylesheet-same-origin.sub-expected.txt
@@ -1,0 +1,8 @@
+
+PASS Origin-clean check in cross-origin CSSOM Stylesheets
+PASS Origin-clean check in cross-origin CSSOM Stylesheets (redirect from same-origin to cross-origin)
+PASS Origin-clean check in cross-origin CSSOM Stylesheets (redirect from cross-origin to same-origin)
+PASS Origin-clean check in loading error CSSOM Stylesheets
+PASS Origin-clean check in same-origin CSSOM Stylesheets
+PASS Origin-clean check in data:css CSSOM Stylesheets
+

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -7865,8 +7865,6 @@ imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-form.html
 
 webkit.org/b/292650 http/tests/iframe-monitor/throttler.html [ Timeout ]
 
-webkit.org/b/293642 imported/w3c/web-platform-tests/css/cssom/stylesheet-same-origin.sub.html [ Failure ]
-
 webkit.org/b/288957 imported/w3c/web-platform-tests/css/CSS2/tables/border-collapse-dynamic-column-001.xht [ ImageOnlyFailure ]
 
 # rdar://146986685 (REGRESSION(Sequoia 15.4): fast/canvas/webgl/gl-teximage.html is a constant text failure)


### PR DESCRIPTION
#### 46083abd0d17d472ed82cd2bf2a2dd5cb83869eb
<pre>
REGRESSION(295342@main): [iOS] imported/w3c/web-platform-tests/css/cssom/stylesheet-same-origin.sub.html is constant failure (flaky failure in EWS)
<a href="https://rdar.apple.com/152111622">rdar://152111622</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=293642">https://bugs.webkit.org/show_bug.cgi?id=293642</a>

Reviewed by Anne van Kesteren.

295342@main progresses LayoutTests/imported/w3c/web-platform-tests/css/cssom/stylesheet-same-origin.sub.html,
so adjusting baseline.

Why this wasn&apos;t discovered earlier: the test was marked as Failed on
glib and flaky on mac-wk1/mac-wk2, so the baseline change in 295342@main
wasn&apos;t caught. This got caught because the iOS baseline also changed,
and it wasn&apos;t marked as Failed on iOS.

Unfortunately the test is still flaky on mac-wk1/mac-wk2, there&apos;s a spurious
&quot;Blocked access from external URL&quot; log from WebKitTestRunner that doesn&apos;t
affect the test result, but nevertheless makes the output different
from the expected output. See <a href="https://bugs.webkit.org/show_bug.cgi?id=214682.">https://bugs.webkit.org/show_bug.cgi?id=214682.</a>

About the remaining FAILs: The test accesses WPT subdomains to simulate
cross origin. run-webkit-tests on Apple platforms doesn&apos;t allow external
URL access besides localhost, hence the FAILs. This is only an issue when
running layout tests; all subtests pass when manually running in the browser.

Why different baseline for glib: run-webkit-tests on glib allows access to
external URL unlike Apple platforms, so the failing subtests now pass.

* LayoutTests/imported/w3c/web-platform-tests/css/cssom/stylesheet-same-origin.sub-expected.txt:
* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/css/cssom/stylesheet-same-origin.sub-expected.txt: Added.
* LayoutTests/platform/ios/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/295793@main">https://commits.webkit.org/295793@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f6c4bbe6bc8b5749673b65671c483a15d941d3b5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/106085 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25834 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/16228 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/111282 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/56681 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/26490 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34337 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80581 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/109089 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/20927 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95728 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60904 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/20506 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13826 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/56119 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/90294 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13861 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/114137 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33223 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24515 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89663 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33587 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91956 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89352 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22793 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34219 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/12024 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/28796 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/33148 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32894 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/36244 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34492 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->