### PR TITLE
Move TextIndicatorWindow to WebKitLegacy.

### DIFF
--- a/Source/WebCore/SourcesCocoa.txt
+++ b/Source/WebCore/SourcesCocoa.txt
@@ -244,7 +244,6 @@ page/mac/DragControllerMac.mm
 page/mac/EventHandlerMac.mm
 page/mac/ImageOverlayControllerMac.mm
 page/mac/ServicesOverlayController.mm
-page/mac/TextIndicatorWindow.mm
 page/mac/WheelEventDeltaFilterMac.mm
 page/scrolling/cocoa/ScrollingStateNode.mm
 page/scrolling/cocoa/ScrollingTreeFixedNodeCocoa.mm

--- a/Source/WebCore/page/TextIndicator.h
+++ b/Source/WebCore/page/TextIndicator.h
@@ -167,7 +167,7 @@ public:
     TextIndicatorPresentationTransition presentationTransition() const { return m_data.presentationTransition; }
     void setPresentationTransition(TextIndicatorPresentationTransition transition) { m_data.presentationTransition = transition; }
 
-    bool wantsBounce() const;
+    WEBCORE_EXPORT bool wantsBounce() const;
     WEBCORE_EXPORT bool wantsManualAnimation() const;
 
     TextIndicatorData data() const { return m_data; }

--- a/Source/WebKitLegacy/SourcesCocoa.txt
+++ b/Source/WebKitLegacy/SourcesCocoa.txt
@@ -167,6 +167,7 @@ mac/Plugins/WebPluginController.mm
 mac/Plugins/WebPluginDatabase.mm
 
 mac/History/WebBackForwardList.mm
+mac/WebCoreSupport/TextIndicatorWindow.mm
 mac/WebCoreSupport/WebFrameLoaderClient.mm
 
 mac/WebInspector/WebInspector.mm

--- a/Source/WebKitLegacy/WebKitLegacy.xcodeproj/project.pbxproj
+++ b/Source/WebKitLegacy/WebKitLegacy.xcodeproj/project.pbxproj
@@ -107,6 +107,7 @@
 		3ABB3C7A1309C3B500E93D94 /* WebStorageTrackerClient.h in Headers */ = {isa = PBXBuildFile; fileRef = 3ABB3C781309C3B500E93D94 /* WebStorageTrackerClient.h */; };
 		3ABB3C7B1309C3B500E93D94 /* WebStorageTrackerClient.mm in Sources */ = {isa = PBXBuildFile; fileRef = 3ABB3C791309C3B500E93D94 /* WebStorageTrackerClient.mm */; };
 		3AE15D5012DBDED4009323C8 /* WebStorageManagerInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AE15D4F12DBDED4009323C8 /* WebStorageManagerInternal.h */; };
+		4447DA332DE7A93700C3CB99 /* TextIndicatorWindow.h in Headers */ = {isa = PBXBuildFile; fileRef = 4447DA292DE783EF00C3CB99 /* TextIndicatorWindow.h */; };
 		44BB8B141241A022001E3A22 /* WebArchiveInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 44BB8B131241A022001E3A22 /* WebArchiveInternal.h */; };
 		44DDD0822540F97F00836F81 /* TestingFunctions.h in Headers */ = {isa = PBXBuildFile; fileRef = 44DDD0812540F8C800836F81 /* TestingFunctions.h */; };
 		460135E5269FAD31007A8A95 /* WebBroadcastChannelRegistry.h in Headers */ = {isa = PBXBuildFile; fileRef = 460135E3269FAD31007A8A95 /* WebBroadcastChannelRegistry.h */; };
@@ -786,6 +787,8 @@
 		3ABB3C781309C3B500E93D94 /* WebStorageTrackerClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebStorageTrackerClient.h; sourceTree = "<group>"; };
 		3ABB3C791309C3B500E93D94 /* WebStorageTrackerClient.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebStorageTrackerClient.mm; sourceTree = "<group>"; };
 		3AE15D4F12DBDED4009323C8 /* WebStorageManagerInternal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebStorageManagerInternal.h; sourceTree = "<group>"; };
+		4447DA292DE783EF00C3CB99 /* TextIndicatorWindow.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TextIndicatorWindow.h; sourceTree = "<group>"; };
+		4447DA2A2DE783EF00C3CB99 /* TextIndicatorWindow.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = TextIndicatorWindow.mm; sourceTree = "<group>"; };
 		44BB8B131241A022001E3A22 /* WebArchiveInternal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebArchiveInternal.h; sourceTree = "<group>"; };
 		44DDD0812540F8C800836F81 /* TestingFunctions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = TestingFunctions.h; path = mac/TestingFunctions.h; sourceTree = "<group>"; };
 		460135E2269FAD31007A8A95 /* WebBroadcastChannelRegistry.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = WebBroadcastChannelRegistry.cpp; path = WebCoreSupport/WebBroadcastChannelRegistry.cpp; sourceTree = SOURCE_ROOT; };
@@ -2498,6 +2501,8 @@
 				5CB05C8829CA18C400CC1AA0 /* SocketStreamHandleImpl.cpp */,
 				5CB05C8929CA18C400CC1AA0 /* SocketStreamHandleImpl.h */,
 				5CB05C8629CA18C400CC1AA0 /* SocketStreamHandleImplCFNet.cpp */,
+				4447DA292DE783EF00C3CB99 /* TextIndicatorWindow.h */,
+				4447DA2A2DE783EF00C3CB99 /* TextIndicatorWindow.mm */,
 				CEDA12DA152CBE6800D9E08D /* WebAlternativeTextClient.h */,
 				CEDA12D9152CBE6800D9E08D /* WebAlternativeTextClient.mm */,
 				460135E2269FAD31007A8A95 /* WebBroadcastChannelRegistry.cpp */,
@@ -2835,6 +2840,7 @@
 				1A6B313C1A51F3A900422975 /* StorageTracker.h in Headers */,
 				1A6B313D1A51F3A900422975 /* StorageTrackerClient.h in Headers */,
 				44DDD0822540F97F00836F81 /* TestingFunctions.h in Headers */,
+				4447DA332DE7A93700C3CB99 /* TextIndicatorWindow.h in Headers */,
 				7C1FB3C21846E8E1001A03D8 /* WebAllowDenyPolicyListener.h in Headers */,
 				CEDA12DC152CBE6800D9E08D /* WebAlternativeTextClient.h in Headers */,
 				9398109A0824BF01008DF038 /* WebArchive.h in Headers */,

--- a/Source/WebKitLegacy/mac/WebCoreSupport/TextIndicatorWindow.h
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/TextIndicatorWindow.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#import "TextIndicator.h"
+#import <WebCore/TextIndicator.h>
 #import <wtf/CheckedPtr.h>
 #import <wtf/Noncopyable.h>
 #import <wtf/RefPtr.h>
@@ -37,8 +37,6 @@
 OBJC_CLASS NSView;
 OBJC_CLASS WebTextIndicatorLayer;
 
-namespace WebCore {
-
 #if PLATFORM(MAC)
 
 class TextIndicatorWindow final : public CanMakeCheckedPtr<TextIndicatorWindow> {
@@ -46,14 +44,14 @@ class TextIndicatorWindow final : public CanMakeCheckedPtr<TextIndicatorWindow> 
     WTF_MAKE_NONCOPYABLE(TextIndicatorWindow);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(TextIndicatorWindow);
 public:
-    WEBCORE_EXPORT explicit TextIndicatorWindow(NSView *);
-    WEBCORE_EXPORT ~TextIndicatorWindow();
+    explicit TextIndicatorWindow(NSView *);
+    ~TextIndicatorWindow();
 
-    WEBCORE_EXPORT void setTextIndicator(Ref<TextIndicator>, CGRect contentRect, TextIndicatorLifetime);
-    WEBCORE_EXPORT void updateTextIndicator(Ref<TextIndicator>&&, CGRect contentRect);
-    WEBCORE_EXPORT void clearTextIndicator(TextIndicatorDismissalAnimation);
+    void setTextIndicator(Ref<WebCore::TextIndicator>, CGRect contentRect, WebCore::TextIndicatorLifetime);
+    void updateTextIndicator(Ref<WebCore::TextIndicator>&&, CGRect contentRect);
+    void clearTextIndicator(WebCore::TextIndicatorDismissalAnimation);
 
-    WEBCORE_EXPORT void setAnimationProgress(float);
+    void setAnimationProgress(float);
 
 private:
     void closeWindow();
@@ -61,7 +59,7 @@ private:
     void startFadeOut();
 
     WeakObjCPtr<NSView> m_targetView;
-    RefPtr<TextIndicator> m_textIndicator;
+    RefPtr<WebCore::TextIndicator> m_textIndicator;
     RetainPtr<NSWindow> m_textIndicatorWindow;
     RetainPtr<NSView> m_textIndicatorView;
     RetainPtr<WebTextIndicatorLayer> m_textIndicatorLayer;
@@ -70,7 +68,5 @@ private:
 };
 
 #endif // PLATFORM(MAC)
-
-} // namespace WebCore
 
 

--- a/Source/WebKitLegacy/mac/WebCoreSupport/TextIndicatorWindow.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/TextIndicatorWindow.mm
@@ -23,17 +23,16 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#import "config.h"
 #import "TextIndicatorWindow.h"
 
 #if PLATFORM(MAC)
 
-#import "GeometryUtilities.h"
-#import "GraphicsContext.h"
-#import "PathUtilities.h"
-#import "TextIndicator.h"
-#import "WebActionDisablingCALayerDelegate.h"
-#import "WebTextIndicatorLayer.h"
+#import <WebCore/GeometryUtilities.h>
+#import <WebCore/GraphicsContext.h>
+#import <WebCore/PathUtilities.h>
+#import <WebCore/TextIndicator.h>
+#import <WebCore/WebActionDisablingCALayerDelegate.h>
+#import <WebCore/WebTextIndicatorLayer.h>
 #import <pal/spi/cg/CoreGraphicsSPI.h>
 #import <pal/spi/cocoa/QuartzCoreSPI.h>
 #import <pal/spi/mac/NSColorSPI.h>
@@ -51,11 +50,6 @@
 }
 
 @end
-
-
-using namespace WebCore;
-
-namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(TextIndicatorWindow);
 
@@ -80,7 +74,7 @@ void TextIndicatorWindow::setAnimationProgress(float progress)
 
 void TextIndicatorWindow::clearTextIndicator(WebCore::TextIndicatorDismissalAnimation animation)
 {
-    RefPtr<TextIndicator> textIndicator = WTFMove(m_textIndicator);
+    RefPtr<WebCore::TextIndicator> textIndicator = WTFMove(m_textIndicator);
 
     if ([m_textIndicatorLayer isFadingOut])
         return;
@@ -93,7 +87,7 @@ void TextIndicatorWindow::clearTextIndicator(WebCore::TextIndicatorDismissalAnim
     closeWindow();
 }
 
-void TextIndicatorWindow::setTextIndicator(Ref<TextIndicator> textIndicator, CGRect textBoundingRectInScreenCoordinates, TextIndicatorLifetime lifetime)
+void TextIndicatorWindow::setTextIndicator(Ref<WebCore::TextIndicator> textIndicator, CGRect textBoundingRectInScreenCoordinates, WebCore::TextIndicatorLifetime lifetime)
 {
     if (m_textIndicator == textIndicator.ptr())
         return;
@@ -102,10 +96,10 @@ void TextIndicatorWindow::setTextIndicator(Ref<TextIndicator> textIndicator, CGR
 
     m_textIndicator = textIndicator.ptr();
 
-    CGFloat horizontalMargin = dropShadowBlurRadius * 2 + TextIndicator::defaultHorizontalMargin;
-    CGFloat verticalMargin = dropShadowBlurRadius * 2 + TextIndicator::defaultVerticalMargin;
+    CGFloat horizontalMargin = WebCore::dropShadowBlurRadius * 2 + WebCore::TextIndicator::defaultHorizontalMargin;
+    CGFloat verticalMargin = WebCore::dropShadowBlurRadius * 2 + WebCore::TextIndicator::defaultVerticalMargin;
 
-    RefPtr<TextIndicator> local_textIndicator = m_textIndicator;
+    RefPtr<WebCore::TextIndicator> local_textIndicator = m_textIndicator;
     if (local_textIndicator->wantsBounce()) {
         horizontalMargin = std::max(horizontalMargin, textBoundingRectInScreenCoordinates.size.width * (WebCore::midBounceScale - 1) + horizontalMargin);
         verticalMargin = std::max(verticalMargin, textBoundingRectInScreenCoordinates.size.height * (WebCore::midBounceScale - 1) + verticalMargin);
@@ -136,21 +130,21 @@ void TextIndicatorWindow::setTextIndicator(Ref<TextIndicator> textIndicator, CGR
     [[m_targetView window] addChildWindow:m_textIndicatorWindow.get() ordered:NSWindowAbove];
     [m_textIndicatorWindow setReleasedWhenClosed:NO];
 
-    if (m_textIndicator->presentationTransition() != TextIndicatorPresentationTransition::None)
+    if (m_textIndicator->presentationTransition() != WebCore::TextIndicatorPresentationTransition::None)
         [m_textIndicatorLayer present];
 
-    if (lifetime == TextIndicatorLifetime::Temporary)
+    if (lifetime == WebCore::TextIndicatorLifetime::Temporary)
         m_temporaryTextIndicatorTimer.startOneShot(WebCore::timeBeforeFadeStarts);
 }
 
-void TextIndicatorWindow::updateTextIndicator(Ref<TextIndicator>&& textIndicator, CGRect textBoundingRectInScreenCoordinates)
+void TextIndicatorWindow::updateTextIndicator(Ref<WebCore::TextIndicator>&& textIndicator, CGRect textBoundingRectInScreenCoordinates)
 {
     bool wantsBounce = textIndicator->wantsBounce();
     if (m_textIndicator != textIndicator.ptr())
         m_textIndicator = WTFMove(textIndicator);
 
-    CGFloat horizontalMargin = dropShadowBlurRadius * 2 + TextIndicator::defaultHorizontalMargin;
-    CGFloat verticalMargin = dropShadowBlurRadius * 2 + TextIndicator::defaultVerticalMargin;
+    CGFloat horizontalMargin = WebCore::dropShadowBlurRadius * 2 + WebCore::TextIndicator::defaultHorizontalMargin;
+    CGFloat verticalMargin = WebCore::dropShadowBlurRadius * 2 + WebCore::TextIndicator::defaultVerticalMargin;
 
     if (wantsBounce) {
         horizontalMargin = std::max(horizontalMargin, textBoundingRectInScreenCoordinates.size.width * (WebCore::midBounceScale - 1) + horizontalMargin);
@@ -196,7 +190,5 @@ void TextIndicatorWindow::startFadeOut()
         [indicatorWindow close];
     }];
 }
-
-} // namespace WebCore
 
 #endif // PLATFORM(MAC)

--- a/Source/WebKitLegacy/mac/WebView/WebView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebView.mm
@@ -289,6 +289,7 @@
 #import <wtf/spi/darwin/dyldSPI.h>
 
 #if !PLATFORM(IOS_FAMILY)
+#import "TextIndicatorWindow.h"
 #import "WebContextMenuClient.h"
 #import "WebFullScreenController.h"
 #import "WebImmediateActionController.h"
@@ -299,7 +300,6 @@
 #import "WebPDFView.h"
 #import "WebVideoFullscreenController.h"
 #import <WebCore/TextIndicator.h>
-#import <WebCore/TextIndicatorWindow.h>
 #import <pal/spi/cocoa/AVKitSPI.h>
 #import <pal/spi/mac/LookupSPI.h>
 #import <pal/spi/mac/NSImmediateActionGestureRecognizerSPI.h>
@@ -9069,7 +9069,7 @@ FORWARD(toggleUnderline)
 - (void)_setTextIndicator:(WebCore::TextIndicator&)textIndicator withLifetime:(WebCore::TextIndicatorLifetime)lifetime
 {
     if (!_private->textIndicatorWindow)
-        _private->textIndicatorWindow = makeUnique<WebCore::TextIndicatorWindow>(self);
+        _private->textIndicatorWindow = makeUnique<TextIndicatorWindow>(self);
 
     NSRect textBoundingRectInWindowCoordinates = [self convertRect:[self _convertRectFromRootView:textIndicator.textBoundingRectInRootViewCoordinates()] toView:nil];
     NSRect textBoundingRectInScreenCoordinates = [self.window convertRectToScreen:textBoundingRectInWindowCoordinates];

--- a/Source/WebKitLegacy/mac/WebView/WebViewData.h
+++ b/Source/WebKitLegacy/mac/WebView/WebViewData.h
@@ -49,7 +49,6 @@ namespace WebCore {
 class AlternativeTextUIController;
 class HistoryItem;
 class RunLoopObserver;
-class TextIndicatorWindow;
 class ValidationBubble;
 #if PLATFORM(MAC) && ENABLE(VIDEO_PRESENTATION_MODE)
 class PlaybackSessionInterfaceMac;
@@ -96,6 +95,7 @@ class WebMediaPlaybackTargetPicker;
 extern BOOL applicationIsTerminating;
 extern int pluginDatabaseClientCount;
 
+class TextIndicatorWindow;
 class WebViewGroup;
 class WebViewRenderingUpdateScheduler;
 
@@ -168,7 +168,7 @@ class WebSelectionServiceController;
     BOOL _needsDeferredTextTouchBarUpdate;
 #endif // HAVE(TOUCH_BAR)
 
-    std::unique_ptr<WebCore::TextIndicatorWindow> textIndicatorWindow;
+    std::unique_ptr<TextIndicatorWindow> textIndicatorWindow;
     BOOL hasInitializedLookupObserver;
     RetainPtr<WebWindowVisibilityObserver> windowVisibilityObserver;
     BOOL windowOcclusionDetectionEnabled;

--- a/Source/WebKitLegacy/mac/WebView/WebViewData.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebViewData.mm
@@ -29,6 +29,7 @@
 
 #import "WebViewData.h"
 
+#import "TextIndicatorWindow.h"
 #import "WebKitLogging.h"
 #import "WebPreferenceKeysPrivate.h"
 #import "WebSelectionServiceController.h"
@@ -39,7 +40,6 @@
 #import <WebCore/AlternativeTextUIController.h>
 #import <WebCore/HistoryItem.h>
 #import <WebCore/RunLoopObserver.h>
-#import <WebCore/TextIndicatorWindow.h>
 #import <WebCore/ValidationBubble.h>
 #import <WebCore/WebCoreJITOperations.h>
 #import <pal/spi/mac/NSWindowSPI.h>

--- a/Source/WebKitLegacy/mac/WebView/WebViewInternal.h
+++ b/Source/WebKitLegacy/mac/WebView/WebViewInternal.h
@@ -35,6 +35,7 @@
 
 #ifdef __cplusplus
 
+#import "TextIndicatorWindow.h"
 #import <WebCore/AlternativeTextClient.h>
 #import <WebCore/DragActions.h>
 #import <WebCore/FindOptions.h>
@@ -45,7 +46,6 @@
 #import <WebCore/ResourceLoaderIdentifier.h>
 #import <WebCore/TextAlternativeWithRange.h>
 #import <WebCore/TextIndicator.h>
-#import <WebCore/TextIndicatorWindow.h>
 #import <WebCore/WebCoreKeyboardUIMode.h>
 #import <functional>
 #import <wtf/Forward.h>


### PR DESCRIPTION
#### 5051d18164d2e404dcf6d5e35801616a6bd8edc8
<pre>
Move TextIndicatorWindow to WebKitLegacy.
<a href="https://bugs.webkit.org/show_bug.cgi?id=293699">https://bugs.webkit.org/show_bug.cgi?id=293699</a>
<a href="https://rdar.apple.com/152182885">rdar://152182885</a>

Reviewed by Wenson Hsieh.

Now that TextIndicatorWindow is only used in WebKitLegacy
it should live there instead of WebCore.

* Source/JavaScriptCore/DerivedSources-input.xcfilelist:
* Source/WebCore/SourcesCocoa.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/page/TextIndicator.h:
* Source/WebCore/page/scrolling/mac/ScrollerMac.h:
* Source/WebKitLegacy/SourcesCocoa.txt:
* Source/WebKitLegacy/WebKitLegacy.xcodeproj/project.pbxproj:
* Source/WebKitLegacy/mac/WebCoreSupport/TextIndicatorWindow.h: Renamed from Source/WebCore/page/mac/TextIndicatorWindow.h.
* Source/WebKitLegacy/mac/WebCoreSupport/TextIndicatorWindow.mm: Renamed from Source/WebCore/page/mac/TextIndicatorWindow.mm.
(-[WebTextIndicatorView isFlipped]):
(TextIndicatorWindow::TextIndicatorWindow):
(TextIndicatorWindow::~TextIndicatorWindow):
(TextIndicatorWindow::setAnimationProgress):
(TextIndicatorWindow::clearTextIndicator):
(TextIndicatorWindow::setTextIndicator):
(TextIndicatorWindow::updateTextIndicator):
(TextIndicatorWindow::closeWindow):
(TextIndicatorWindow::startFadeOut):
* Source/WebKitLegacy/mac/WebView/WebView.mm:
(-[WebView _setTextIndicator:withLifetime:]):
* Source/WebKitLegacy/mac/WebView/WebViewData.h:
* Source/WebKitLegacy/mac/WebView/WebViewData.mm:
* Source/WebKitLegacy/mac/WebView/WebViewInternal.h:

Canonical link: <a href="https://commits.webkit.org/295522@main">https://commits.webkit.org/295522@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d0c76ec81101e8cd6fa930aea75e24bf8eaa8032

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105342 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25054 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15481 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110550 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/55999 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/107383 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/25492 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33597 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80010 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/55999 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108348 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19883 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/95077 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60318 "run-api-tests-without-change (failure)") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13155 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55394 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/89337 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13197 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/113209 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32497 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/23953 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89086 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32860 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91295 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88727 "Found 100 new API test failures: /TestWebKit:WebKit.CanHandleRequest, /WebKitGTK/TestGeolocationManager:/webkit/WebKitGeolocationManager/watch-position, /TestWebKit:WebKit.UserMediaBasic, /TestWebKit:WebKit.PageLoadEmptyURL, /WebKitGTK/TestOptionMenu:/webkit/WebKitWebView/option-menu-groups, /TestWebKit:WebKit.GetInjectedBundleInitializationUserDataCallback, /TestWebKit:WebKit.GeolocationTransitionToHighAccuracy, /TestWebKit:WebKit.PendingAPIRequestURL, /TestWebKit:WebKit.FirstMeaningfulPaint, /WebKitGTK/TestUIClient:/webkit/WebKitWebView/file-chooser-request ... (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22628 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33619 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11409 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/27972 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32421 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/37835 "Found 1 new failure in mac/WebCoreSupport/TextIndicatorWindow.mm and found 1 fixed file: page/mac/TextIndicatorWindow.mm") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/32193 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35538 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33767 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->