### PR TITLE
[libpas] Add PAS_ASSERT_NOT_REACHED() macro

### DIFF
--- a/Source/bmalloc/libpas/src/libpas/jit_heap_config.c
+++ b/Source/bmalloc/libpas/src/libpas/jit_heap_config.c
@@ -349,7 +349,7 @@ void jit_heap_config_dump_shared_page_directory_arg(
 {
     PAS_UNUSED_PARAM(stream);
     PAS_UNUSED_PARAM(directory);
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
 }
 
 void jit_heap_config_add_fresh_memory(pas_range range)

--- a/Source/bmalloc/libpas/src/libpas/pas_allocation_kind.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_allocation_kind.h
@@ -50,7 +50,7 @@ static inline const char* pas_allocation_kind_get_string(pas_allocation_kind kin
     case pas_delegate_allocation:
         return "delegate";
     }
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
     return NULL;
 }
 

--- a/Source/bmalloc/libpas/src/libpas/pas_allocation_mode.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_allocation_mode.h
@@ -63,7 +63,7 @@ static inline const char* pas_allocation_mode_get_string(pas_allocation_mode all
     case pas_always_compact_allocation_mode:
         return "always compact";
     }
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
     return NULL;
 }
 

--- a/Source/bmalloc/libpas/src/libpas/pas_allocator_scavenge_action.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_allocator_scavenge_action.h
@@ -56,7 +56,7 @@ pas_allocator_scavenge_action_get_string(pas_allocator_scavenge_action action)
         return "force_stop_action";
     }
     
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
     return NULL;
 }
 

--- a/Source/bmalloc/libpas/src/libpas/pas_basic_heap_page_caches.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_basic_heap_page_caches.h
@@ -74,7 +74,7 @@ pas_basic_heap_page_caches_get_shared_page_directories(
     case pas_small_segregated_page_config_variant:
         return &caches->small_shared_page_directories;
     }
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
     return NULL;
 }
 

--- a/Source/bmalloc/libpas/src/libpas/pas_biasing_directory_kind.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_biasing_directory_kind.h
@@ -45,7 +45,7 @@ static inline const char* pas_biasing_directory_kind_get_string(pas_biasing_dire
     case pas_biasing_directory_bitfit_kind:
         return "bitfit_biasing_directory";
     }
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
     return NULL;
 }
 

--- a/Source/bmalloc/libpas/src/libpas/pas_bitfit_page_config.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_bitfit_page_config.h
@@ -159,7 +159,7 @@ static inline bool pas_bitfit_page_config_is_enabled(pas_bitfit_page_config conf
     case pas_marge_bitfit_page_config_variant:
         return pas_marge_bitfit_page_config_variant_is_enabled_override;
     }
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
     return false;
 }
 

--- a/Source/bmalloc/libpas/src/libpas/pas_bitfit_page_config_variant.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_bitfit_page_config_variant.h
@@ -62,7 +62,7 @@ pas_bitfit_page_config_variant_get_string(pas_bitfit_page_config_variant variant
     case pas_marge_bitfit_page_config_variant:
         return "marge";
     }
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
     return NULL;
 }
 
@@ -77,7 +77,7 @@ pas_bitfit_page_config_variant_get_capitalized_string(pas_bitfit_page_config_var
     case pas_marge_bitfit_page_config_variant:
         return "Marge";
     }
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
     return NULL;
 }
 

--- a/Source/bmalloc/libpas/src/libpas/pas_bitfit_page_inlines.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_bitfit_page_inlines.h
@@ -530,7 +530,7 @@ static inline const char* pas_bitfit_page_deallocate_with_page_impl_mode_get_str
     case pas_bitfit_page_deallocate_with_page_impl_shrink_mode:
         return "shrink";
     }
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
     return NULL;
 }
 
@@ -784,7 +784,7 @@ static PAS_ALWAYS_INLINE uintptr_t pas_bitfit_page_deallocate_with_page_impl(
                     }
 
                     default:
-                        PAS_ASSERT(!"Should not be reached");
+                        PAS_ASSERT_NOT_REACHED();
                         /* Tell the compiler to chill out. */
                         modified_word_index = 0;
                         modified_bit_index_in_word = 0;
@@ -858,7 +858,7 @@ static PAS_ALWAYS_INLINE uintptr_t pas_bitfit_page_deallocate_with_page_impl(
                 break;
 
             default:
-                PAS_ASSERT(!"Should not be reached");
+                PAS_ASSERT_NOT_REACHED();
                 range = pas_range_create_empty();
                 break;
             }

--- a/Source/bmalloc/libpas/src/libpas/pas_cartesian_tree.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_cartesian_tree.h
@@ -83,7 +83,7 @@ static PAS_ALWAYS_INLINE pas_compact_cartesian_tree_node_ptr* pas_cartesian_tree
     case pas_tree_direction_right:
         return &node->right;
     }
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
     return NULL;
 }
 
@@ -655,7 +655,7 @@ pas_cartesian_tree_insert(pas_cartesian_tree* tree,
         current = pas_compact_cartesian_tree_node_ptr_load(child_ptr);
     }
 
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
 
 update_minimum_if_necessary_and_return:
     if (should_update_minimum)

--- a/Source/bmalloc/libpas/src/libpas/pas_commit_mode.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_commit_mode.h
@@ -47,7 +47,7 @@ static inline const char* pas_commit_mode_get_string(pas_commit_mode mode)
     case pas_committed:
         return "committed";
     }
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
     return NULL;
 }
 

--- a/Source/bmalloc/libpas/src/libpas/pas_compact_expendable_memory.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_compact_expendable_memory.h
@@ -69,7 +69,7 @@ static PAS_ALWAYS_INLINE bool pas_compact_expendable_memory_touch(
     case pas_expendable_memory_touch_to_commit_if_necessary:
         return pas_compact_expendable_memory_commit_if_necessary(object, size);
     }
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
     return false;
 }
 

--- a/Source/bmalloc/libpas/src/libpas/pas_deallocate.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_deallocate.c
@@ -56,7 +56,7 @@ bool pas_try_deallocate_known_large(void* ptr,
             pas_deallocation_did_fail("Large heap did not find object", begin);
             break;
         }
-        PAS_ASSERT(!"Should not be reached");
+        PAS_ASSERT_NOT_REACHED();
     }
     
     pas_heap_lock_unlock();
@@ -171,7 +171,7 @@ bool pas_try_deallocate_slow_no_cache(void* ptr,
                 begin);
             return true;
         default:
-            PAS_ASSERT(!"Should not be reached");
+            PAS_ASSERT_NOT_REACHED();
             return false;
         }
     }
@@ -225,7 +225,7 @@ bool pas_try_deallocate_slow_no_cache(void* ptr,
         return pas_try_deallocate_slow(begin, config_ptr, deallocation_mode);
     } }
 
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
     return false;
 }
 

--- a/Source/bmalloc/libpas/src/libpas/pas_deallocate.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_deallocate.h
@@ -98,7 +98,7 @@ static PAS_ALWAYS_INLINE bool pas_try_deallocate_not_small_exclusive_segregated(
                 begin);
             return true;
         default:
-            PAS_ASSERT(!"Should not be reached");
+            PAS_ASSERT_NOT_REACHED();
             return false;
         }
     }

--- a/Source/bmalloc/libpas/src/libpas/pas_deallocation_mode.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_deallocation_mode.h
@@ -45,7 +45,7 @@ static inline const char* pas_deallocation_mode_get_string(pas_deallocation_mode
     case pas_deallocate_mode:
         return "deallocate";
     }
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
     return NULL;
 }
 

--- a/Source/bmalloc/libpas/src/libpas/pas_deallocator_scavenge_action.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_deallocator_scavenge_action.h
@@ -51,7 +51,7 @@ pas_deallocator_scavenge_action_get_string(pas_deallocator_scavenge_action actio
         return "flush_log_action";
     }
     
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
     return NULL;
 }
 

--- a/Source/bmalloc/libpas/src/libpas/pas_debug_heap.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_debug_heap.h
@@ -64,7 +64,7 @@ static inline bool pas_debug_heap_is_enabled(pas_heap_config_kind kind)
 static inline void* pas_debug_heap_malloc(size_t size)
 {
     PAS_UNUSED_PARAM(size);
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
     return NULL;
 }
 
@@ -72,7 +72,7 @@ static inline void* pas_debug_heap_memalign(size_t alignment, size_t size)
 {
     PAS_UNUSED_PARAM(alignment);
     PAS_UNUSED_PARAM(size);
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
     return NULL;
 }
 
@@ -80,14 +80,14 @@ static inline void* pas_debug_heap_realloc(void* ptr, size_t size)
 {
     PAS_UNUSED_PARAM(ptr);
     PAS_UNUSED_PARAM(size);
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
     return NULL;
 }
 
 static inline void* pas_debug_heap_malloc_compact(size_t size)
 {
     PAS_UNUSED_PARAM(size);
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
     return NULL;
 }
 
@@ -95,7 +95,7 @@ static inline void* pas_debug_heap_memalign_compact(size_t alignment, size_t siz
 {
     PAS_UNUSED_PARAM(alignment);
     PAS_UNUSED_PARAM(size);
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
     return NULL;
 }
 
@@ -103,14 +103,14 @@ static inline void* pas_debug_heap_realloc_compact(void* ptr, size_t size)
 {
     PAS_UNUSED_PARAM(ptr);
     PAS_UNUSED_PARAM(size);
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
     return NULL;
 }
 
 static inline void pas_debug_heap_free(void* ptr)
 {
     PAS_UNUSED_PARAM(ptr);
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
 }
 
 #endif /* PAS_BMALLOC -> so end of !PAS_BMALLOC */

--- a/Source/bmalloc/libpas/src/libpas/pas_deferred_decommit_log.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_deferred_decommit_log.c
@@ -173,7 +173,7 @@ bool pas_deferred_decommit_log_add_maybe_locked(pas_deferred_decommit_log* log,
     case pas_range_is_not_locked:
         return pas_deferred_decommit_log_add(log, range, heap_lock_hold_mode);
     }
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
     return false;
 }
 

--- a/Source/bmalloc/libpas/src/libpas/pas_fast_megapage_kind.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_fast_megapage_kind.h
@@ -48,7 +48,7 @@ static inline const char* pas_fast_megapage_kind_get_string(pas_fast_megapage_ki
     case pas_small_other_fast_megapage_kind:
         return "small_other_fast_megapage";
     }
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
     return NULL;
 }
 

--- a/Source/bmalloc/libpas/src/libpas/pas_free_range_kind.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_free_range_kind.h
@@ -45,7 +45,7 @@ static inline const char* pas_free_range_kind_get_string(pas_free_range_kind kin
     case pas_free_meta_range:
         return "free_meta_range";
     }
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
     return NULL;
 }
 

--- a/Source/bmalloc/libpas/src/libpas/pas_get_allocation_size.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_get_allocation_size.h
@@ -62,7 +62,7 @@ static PAS_ALWAYS_INLINE size_t pas_get_allocation_size(void* ptr,
                 pas_page_base_get_bitfit(page_and_kind.page_base),
                 begin);
         default:
-            PAS_ASSERT(!"Should not be reached");
+            PAS_ASSERT_NOT_REACHED();
             return 0;
         }
     }
@@ -136,7 +136,7 @@ static PAS_ALWAYS_INLINE size_t pas_get_allocation_size(void* ptr,
         return result;
     } }
     
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
     return 0;
 }
 

--- a/Source/bmalloc/libpas/src/libpas/pas_get_heap.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_get_heap.h
@@ -62,7 +62,7 @@ static PAS_ALWAYS_INLINE pas_heap* pas_get_heap(void* ptr,
             page_base = page_and_kind.page_base;
             goto bitfit_case_with_page_base;
         default:
-            PAS_ASSERT(!"Should not be reached");
+            PAS_ASSERT_NOT_REACHED();
             return NULL;
         }
     }
@@ -120,7 +120,7 @@ static PAS_ALWAYS_INLINE pas_heap* pas_get_heap(void* ptr,
         return result;
     } }
     
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
     return NULL;
 
 bitfit_case_with_page_base:

--- a/Source/bmalloc/libpas/src/libpas/pas_get_object_kind.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_get_object_kind.h
@@ -69,7 +69,7 @@ static PAS_ALWAYS_INLINE pas_object_kind pas_get_object_kind(void* ptr,
         return pas_large_object_kind;
     } }
     
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
     return pas_not_an_object_kind;
 
 use_page_kind:

--- a/Source/bmalloc/libpas/src/libpas/pas_get_page_base.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_get_page_base.h
@@ -55,7 +55,7 @@ static PAS_ALWAYS_INLINE pas_page_base* pas_get_page_base(void* ptr,
         return NULL;
     } }
     
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
     return NULL;
 }
 

--- a/Source/bmalloc/libpas/src/libpas/pas_has_object.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_has_object.h
@@ -57,7 +57,7 @@ static PAS_ALWAYS_INLINE bool pas_has_object(void* ptr,
         return !pas_large_map_entry_is_empty(entry);
     } }
     
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
     return false;
 }
 

--- a/Source/bmalloc/libpas/src/libpas/pas_heap.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_heap.c
@@ -202,11 +202,11 @@ void pas_heap_reset_heap_ref(pas_heap* heap)
         ((pas_primitive_heap_ref*)heap->heap_ref)->cached_index = UINT_MAX;
         return;
     case pas_fake_heap_ref_kind:
-        PAS_ASSERT(!"Should not be reached");
+        PAS_ASSERT_NOT_REACHED();
         return;
     }
 
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
 }
 
 pas_segregated_size_directory*

--- a/Source/bmalloc/libpas/src/libpas/pas_heap_kind.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_heap_kind.h
@@ -67,7 +67,7 @@ static inline const char* pas_heap_kind_get_string(pas_heap_kind kind)
     case pas_large_expendable_heap_kind:
         return "large_expendable_heap";
     }
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
     return NULL;
 }
 

--- a/Source/bmalloc/libpas/src/libpas/pas_heap_ref_kind.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_heap_ref_kind.h
@@ -53,7 +53,7 @@ static inline const char* pas_heap_ref_kind_get_string(pas_heap_ref_kind kind)
     case pas_fake_heap_ref_kind:
         return "fake";
     }
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
     return NULL;
 }
 

--- a/Source/bmalloc/libpas/src/libpas/pas_heap_table.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_heap_table.h
@@ -57,7 +57,7 @@ static inline bool pas_heap_table_has_index(pas_large_heap* heap)
             pas_log("going to get an index for heap %p.\n", heap);
         return true;
     default:
-        PAS_ASSERT(!"Should not be reached");
+        PAS_ASSERT_NOT_REACHED();
         return false;
     }
 }

--- a/Source/bmalloc/libpas/src/libpas/pas_heap_table_state.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_heap_table_state.h
@@ -48,7 +48,7 @@ static inline const char* pas_heap_table_state_get_string(pas_heap_table_state s
     case pas_heap_table_state_has_index:
         return "has_index";
     }
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
     return NULL;
 }
 

--- a/Source/bmalloc/libpas/src/libpas/pas_large_expendable_memory.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_large_expendable_memory.h
@@ -96,7 +96,7 @@ static PAS_ALWAYS_INLINE bool pas_large_expendable_memory_touch(
     case pas_expendable_memory_touch_to_commit_if_necessary:
         return pas_large_expendable_memory_commit_if_necessary(object, size);
     }
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
     return false;
 }
 

--- a/Source/bmalloc/libpas/src/libpas/pas_large_sharing_pool.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_large_sharing_pool.c
@@ -574,7 +574,7 @@ static const char* splat_command_get_string(splat_command command)
     case splat_boot_free:
         return "boot_free";
     }
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
     return NULL;
 }
 
@@ -590,7 +590,7 @@ static pas_free_mode splat_command_get_free_mode(splat_command command)
     case splat_boot_free:
         return pas_free;
     }
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
     return pas_free;
 }
 

--- a/Source/bmalloc/libpas/src/libpas/pas_large_sharing_pool_epoch_update_mode.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_large_sharing_pool_epoch_update_mode.h
@@ -47,7 +47,7 @@ pas_large_sharing_pool_epoch_update_mode_get_string(
     case pas_large_sharing_pool_combined_use_epoch:
         return "combined_use_epoch";
     }
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
     return NULL;
 }
 

--- a/Source/bmalloc/libpas/src/libpas/pas_large_virtual_range_min_heap.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_large_virtual_range_min_heap.h
@@ -44,7 +44,7 @@ static inline int pas_large_virtual_range_compare_begin(pas_large_virtual_range*
 
 static inline size_t pas_large_virtual_range_get_index(pas_large_virtual_range* range)
 {
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
     PAS_UNUSED_PARAM(range);
     return 0;
 }

--- a/Source/bmalloc/libpas/src/libpas/pas_list_direction.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_list_direction.h
@@ -45,7 +45,7 @@ static inline const char* pas_list_direction_get_string(pas_list_direction direc
     case pas_list_direction_next:
         return "next";
     }
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
     return NULL;
 }
 
@@ -57,7 +57,7 @@ static inline pas_list_direction pas_list_direction_invert(pas_list_direction di
     case pas_list_direction_next:
         return pas_list_direction_prev;
     }
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
     return pas_list_direction_prev;
 }
 

--- a/Source/bmalloc/libpas/src/libpas/pas_local_allocator.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_local_allocator.c
@@ -228,7 +228,7 @@ bool pas_local_allocator_stop(
                 allocator->scavenger_data.is_in_use ? "yes" : "no");
         pas_log("at time of assert: allocator->scavenger_data.is_in_use = %s\n",
                 is_in_use ? "yes" : "no");
-        PAS_ASSERT(!"Should not be reached");
+        PAS_ASSERT_NOT_REACHED();
     }
 
     /* Doing this check before setting is_in_use guards against situations where calling stop would

--- a/Source/bmalloc/libpas/src/libpas/pas_local_allocator_config_kind.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_local_allocator_config_kind.h
@@ -86,7 +86,7 @@ pas_local_allocator_config_kind_create_normal(pas_segregated_page_config_kind ki
 #include "pas_segregated_page_config_kind.def"
 #undef PAS_DEFINE_SEGREGATED_PAGE_CONFIG_KIND
     }
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
     return (pas_local_allocator_config_kind)0;
 }
 
@@ -100,7 +100,7 @@ pas_local_allocator_config_kind_create_primordial_partial(pas_segregated_page_co
 #include "pas_segregated_page_config_kind.def"
 #undef PAS_DEFINE_SEGREGATED_PAGE_CONFIG_KIND
     }
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
     return (pas_local_allocator_config_kind)0;
 }
 
@@ -114,7 +114,7 @@ pas_local_allocator_config_kind_create_bitfit(pas_bitfit_page_config_kind kind)
 #include "pas_bitfit_page_config_kind.def"
 #undef PAS_DEFINE_BITFIT_PAGE_CONFIG_KIND
     }
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
     return (pas_local_allocator_config_kind)0;
 }
 
@@ -129,7 +129,7 @@ pas_local_allocator_config_kind_get_segregated_page_config_kind(pas_local_alloca
 #include "pas_segregated_page_config_kind.def"
 #undef PAS_DEFINE_SEGREGATED_PAGE_CONFIG_KIND
     default:
-        PAS_ASSERT(!"Should not be reached");
+        PAS_ASSERT_NOT_REACHED();
         return (pas_segregated_page_config_kind)0;
     }
 }
@@ -144,7 +144,7 @@ pas_local_allocator_config_kind_get_bitfit_page_config_kind(pas_local_allocator_
 #include "pas_bitfit_page_config_kind.def"
 #undef PAS_DEFINE_BITFIT_PAGE_CONFIG_KIND
     default:
-        PAS_ASSERT(!"Should not be reached");
+        PAS_ASSERT_NOT_REACHED();
         return (pas_bitfit_page_config_kind)0;
     }
 }
@@ -170,7 +170,7 @@ pas_local_allocator_config_kind_get_string(pas_local_allocator_config_kind kind)
 #include "pas_bitfit_page_config_kind.def"
 #undef PAS_DEFINE_BITFIT_PAGE_CONFIG_KIND
     }
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
     return NULL;
 }
 

--- a/Source/bmalloc/libpas/src/libpas/pas_local_allocator_inlines.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_local_allocator_inlines.h
@@ -292,7 +292,7 @@ static PAS_ALWAYS_INLINE void pas_local_allocator_scan_bits_to_set_up_free_bits(
             break;
 
         default:
-            PAS_ASSERT(!"Should not be reached");
+            PAS_ASSERT_NOT_REACHED();
             break;
         }
         
@@ -337,7 +337,7 @@ static PAS_ALWAYS_INLINE void pas_local_allocator_scan_bits_to_set_up_free_bits(
         break;
         
     default:
-        PAS_ASSERT(!"Should not be reached");
+        PAS_ASSERT_NOT_REACHED();
         break;
     }
 }
@@ -607,7 +607,7 @@ pas_local_allocator_set_up_primordial_bump(
         return pas_allocation_result_create_failure();
     }
 
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
     return pas_allocation_result_create_failure();
 }
 
@@ -1378,7 +1378,7 @@ pas_local_allocator_return_memory_to_page(pas_local_allocator* allocator,
             pas_segregated_page_exclusive_role);
         return;
     }
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
 }
 
 /* This returns either:

--- a/Source/bmalloc/libpas/src/libpas/pas_local_allocator_kind.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_local_allocator_kind.h
@@ -54,7 +54,7 @@ static inline const char* pas_local_allocator_kind_get_string(pas_local_allocato
     case pas_local_allocator_view_cache_kind:
         return "view_cache";
     }
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
     return NULL;
 }
 
@@ -69,7 +69,7 @@ static inline bool pas_local_allocator_kind_is_stopped(pas_local_allocator_kind 
     case pas_local_allocator_view_cache_kind:
         return false;
     }
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
     return false;
 }
 

--- a/Source/bmalloc/libpas/src/libpas/pas_local_allocator_scavenger_data.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_local_allocator_scavenger_data.c
@@ -126,7 +126,7 @@ void pas_local_allocator_scavenger_data_commit_if_necessary_slow(
             done = true;
             break;
         default:
-            PAS_ASSERT(!"Should not be reached");
+            PAS_ASSERT_NOT_REACHED();
             break;
         }
         pas_lock_unlock_conditionally(&cache->node->scavenger_lock, scavenger_lock_hold_mode);
@@ -173,7 +173,7 @@ bool pas_local_allocator_scavenger_data_stop(
     case pas_local_allocator_view_cache_kind:
         return pas_local_view_cache_stop((pas_local_view_cache*)data, page_lock_mode);
     }
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
     return false;
 }
 

--- a/Source/bmalloc/libpas/src/libpas/pas_lock.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_lock.h
@@ -387,7 +387,7 @@ static inline bool pas_lock_lock_with_mode(pas_lock* lock,
         pas_lock_lock(lock);
         return true;
     }
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
     return false;
 }
 
@@ -445,7 +445,7 @@ static PAS_ALWAYS_INLINE pas_lock* pas_lock_for_switch_conditionally(pas_lock* l
     case pas_lock_is_not_held:
         return lock;
     }
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
     return NULL;
 }
 

--- a/Source/bmalloc/libpas/src/libpas/pas_mmap_capability.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_mmap_capability.h
@@ -75,7 +75,7 @@ static inline const char* pas_mmap_capability_get_string(pas_mmap_capability cap
     case pas_may_mmap:
         return "may_mmap";
     }
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
     return NULL;
 }
 

--- a/Source/bmalloc/libpas/src/libpas/pas_object_kind.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_object_kind.h
@@ -62,7 +62,7 @@ static inline const char* pas_object_kind_get_string(pas_object_kind object_kind
     case pas_not_an_object_kind:
         return "not_an_object";
     }
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
     return NULL;
 }
 
@@ -75,7 +75,7 @@ pas_object_kind_for_segregated_variant(pas_segregated_page_config_variant varian
     case pas_medium_segregated_page_config_variant:
         return pas_medium_segregated_object_kind;
     }
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
     return pas_not_an_object_kind;
 }
 
@@ -90,7 +90,7 @@ pas_object_kind_for_bitfit_variant(pas_bitfit_page_config_variant variant)
     case pas_marge_bitfit_page_config_variant:
         return pas_marge_bitfit_object_kind;
     }
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
     return pas_not_an_object_kind;
 }
 
@@ -110,7 +110,7 @@ static inline pas_object_kind pas_object_kind_for_page_kind(pas_page_kind page_k
     case pas_marge_bitfit_page_kind:
         return pas_marge_bitfit_object_kind;
     }
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
     return pas_not_an_object_kind;
 }
 

--- a/Source/bmalloc/libpas/src/libpas/pas_page_base.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_page_base.c
@@ -45,7 +45,7 @@ size_t pas_page_base_header_size(const pas_page_base_config* config,
         PAS_ASSERT(pas_page_kind_get_config_kind(page_kind) == pas_page_config_kind_bitfit);
         return pas_bitfit_page_header_size(*pas_page_base_config_get_bitfit(config));
     }
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
     return 0;
 }
 
@@ -57,7 +57,7 @@ const pas_page_base_config* pas_page_base_get_config(pas_page_base* page)
     case pas_page_config_kind_bitfit:
         return &pas_bitfit_page_get_config(pas_page_base_get_bitfit(page))->base;
     }
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
     return NULL;
 }
 
@@ -77,7 +77,7 @@ pas_page_base_get_granule_use_counts(pas_page_base* page)
         return pas_bitfit_page_get_granule_use_counts(
             bitfit_page, *pas_bitfit_page_get_config(bitfit_page));
     } }
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
     return NULL;
 }
 
@@ -117,7 +117,7 @@ bool pas_page_base_is_empty(pas_page_base* page)
     case pas_page_config_kind_bitfit:
         return !pas_page_base_get_bitfit(page)->num_live_bits;
     }
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
     return false;
 }
 

--- a/Source/bmalloc/libpas/src/libpas/pas_page_base_config.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_page_base_config.c
@@ -42,7 +42,7 @@ const char* pas_page_base_config_get_kind_string(const pas_page_base_config* con
     case pas_page_config_kind_bitfit:
         return pas_bitfit_page_config_kind_get_string(pas_page_base_config_get_bitfit(config)->kind);
     }
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
     return NULL;
 }
 

--- a/Source/bmalloc/libpas/src/libpas/pas_page_base_config_utils.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_page_base_config_utils.h
@@ -82,7 +82,7 @@ typedef struct {
             return (pas_page_base*)page_base; \
         } } \
         \
-        PAS_ASSERT(!"Should not be reached"); \
+        PAS_ASSERT_NOT_REACHED(); \
         return NULL; \
     } \
     \
@@ -109,7 +109,7 @@ typedef struct {
             return boundary; \
         } } \
         \
-        PAS_ASSERT(!"Should not be reached"); \
+        PAS_ASSERT_NOT_REACHED(); \
         return NULL; \
     } \
     \

--- a/Source/bmalloc/libpas/src/libpas/pas_page_base_config_utils_inlines.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_page_base_config_utils_inlines.h
@@ -67,7 +67,7 @@ typedef struct {
             return (pas_page_base*)page_base; \
         } } \
         \
-        PAS_ASSERT(!"Should not be reached"); \
+        PAS_ASSERT_NOT_REACHED(); \
         return NULL; \
     } \
     \
@@ -96,7 +96,7 @@ typedef struct {
             return result; \
         } } \
         \
-        PAS_ASSERT(!"Should not be reached"); \
+        PAS_ASSERT_NOT_REACHED(); \
         return NULL; \
     } \
     \
@@ -121,7 +121,7 @@ typedef struct {
             return; \
         } \
         \
-        PAS_ASSERT(!"Should not be reached"); \
+        PAS_ASSERT_NOT_REACHED(); \
         return; \
     } \
     \

--- a/Source/bmalloc/libpas/src/libpas/pas_page_config_kind.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_page_config_kind.h
@@ -45,7 +45,7 @@ static inline const char* pas_page_config_kind_get_string(pas_page_config_kind p
     case pas_page_config_kind_bitfit:
         return "bitfit";
     }
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
     return NULL;
 }
 

--- a/Source/bmalloc/libpas/src/libpas/pas_page_config_size_category.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_page_config_size_category.h
@@ -51,7 +51,7 @@ static inline const char* pas_page_config_size_category_get_string(pas_page_conf
     case pas_page_config_size_category_large:
         return "large";
     }
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
     return NULL;
 }
 

--- a/Source/bmalloc/libpas/src/libpas/pas_page_header_placement_mode.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_page_header_placement_mode.h
@@ -47,7 +47,7 @@ pas_page_header_placement_mode_get_string(
     case pas_page_header_in_table:
         return "in_table";
     }
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
     return NULL;
 }
 

--- a/Source/bmalloc/libpas/src/libpas/pas_page_kind.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_page_kind.h
@@ -64,7 +64,7 @@ static inline const char* pas_page_kind_get_string(pas_page_kind page_kind)
     case pas_marge_bitfit_page_kind:
         return "marge_bitfit";
     }
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
     return NULL;
 }
 
@@ -81,7 +81,7 @@ static inline pas_page_config_kind pas_page_kind_get_config_kind(pas_page_kind p
     case pas_marge_bitfit_page_kind:
         return pas_page_config_kind_bitfit;
     }
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
     return pas_page_config_kind_segregated;
 }
 
@@ -96,7 +96,7 @@ pas_page_kind_get_segregated_variant(pas_page_kind page_kind)
     case pas_medium_exclusive_segregated_page_kind:
         return pas_medium_segregated_page_config_variant;
     default:
-        PAS_ASSERT(!"Should not be reached");
+        PAS_ASSERT_NOT_REACHED();
         return pas_small_segregated_page_config_variant;
     }
 }
@@ -112,7 +112,7 @@ pas_page_kind_get_segregated_role(pas_page_kind page_kind)
     case pas_medium_exclusive_segregated_page_kind:
         return pas_segregated_page_exclusive_role;
     default:
-        PAS_ASSERT(!"Should not be reached");
+        PAS_ASSERT_NOT_REACHED();
         return pas_segregated_page_shared_role;
     }
 }
@@ -128,7 +128,7 @@ pas_page_kind_get_bitfit_variant(pas_page_kind page_kind)
     case pas_marge_bitfit_page_kind:
         return pas_marge_bitfit_page_config_variant;
     default:
-        PAS_ASSERT(!"Should not be reached");
+        PAS_ASSERT_NOT_REACHED();
         return pas_small_bitfit_page_config_variant;
     }
 }
@@ -145,7 +145,7 @@ static inline pas_page_kind pas_page_kind_for_segregated_variant_and_role(
         case pas_segregated_page_exclusive_role:
             return pas_small_exclusive_segregated_page_kind;
         }
-        PAS_ASSERT(!"Should not be reached");
+        PAS_ASSERT_NOT_REACHED();
         return pas_small_shared_segregated_page_kind;
     case pas_medium_segregated_page_config_variant:
         switch (role) {
@@ -154,10 +154,10 @@ static inline pas_page_kind pas_page_kind_for_segregated_variant_and_role(
         case pas_segregated_page_exclusive_role:
             return pas_medium_exclusive_segregated_page_kind;
         }
-        PAS_ASSERT(!"Should not be reached");
+        PAS_ASSERT_NOT_REACHED();
         return pas_small_shared_segregated_page_kind;
     }
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
     return pas_small_shared_segregated_page_kind;
 }
 
@@ -171,7 +171,7 @@ static inline pas_page_kind pas_page_kind_for_bitfit_variant(pas_bitfit_page_con
     case pas_marge_bitfit_page_config_variant:
         return pas_marge_bitfit_page_kind;
     }
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
     return pas_small_shared_segregated_page_kind;
 }
 

--- a/Source/bmalloc/libpas/src/libpas/pas_page_sharing_mode.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_page_sharing_mode.h
@@ -44,14 +44,14 @@ pas_page_sharing_mode_does_sharing(
 {
     switch (mode) {
     case pas_invalid_sharing_mode:
-        PAS_ASSERT(!"Should not be reached");
+        PAS_ASSERT_NOT_REACHED();
         return false;
     case pas_do_not_share_pages:
         return false;
     case pas_share_pages:
         return true;
     }
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
     return false;
 }
 
@@ -66,7 +66,7 @@ pas_page_sharing_mode_get_string(pas_page_sharing_mode mode)
     case pas_share_pages:
         return "share_pages";
     }
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
     return NULL;
 }
 

--- a/Source/bmalloc/libpas/src/libpas/pas_page_sharing_participant_kind.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_page_sharing_participant_kind.h
@@ -53,7 +53,7 @@ pas_page_sharing_participant_kind_select_for_segregated_directory(
     case pas_segregated_shared_page_directory_kind:
         return pas_page_sharing_participant_segregated_shared_page_directory;
     }
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
     return pas_page_sharing_participant_null;
 }
 
@@ -72,7 +72,7 @@ pas_page_sharing_participant_kind_get_string(pas_page_sharing_participant_kind k
     case pas_page_sharing_participant_large_sharing_pool:
         return "large_sharing_pool";
     }
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
     return NULL;
 }
 

--- a/Source/bmalloc/libpas/src/libpas/pas_physical_memory_synchronization_style.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_physical_memory_synchronization_style.h
@@ -46,7 +46,7 @@ static inline const char* pas_physical_memory_synchronization_style_get_string(
     case pas_physical_memory_is_locked_by_virtual_range_common_lock:
         return "locked_by_virtual_range_common_lock";
     }
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
     return NULL;
 }
 

--- a/Source/bmalloc/libpas/src/libpas/pas_ptr_min_heap.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_ptr_min_heap.h
@@ -48,7 +48,7 @@ static inline int pas_ptr_min_heap_compare(void** left_ptr, void** right_ptr)
 static inline size_t pas_ptr_min_heap_get_index(void** element_ptr)
 {
     PAS_UNUSED_PARAM(element_ptr);
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
     return 0;
 }
 

--- a/Source/bmalloc/libpas/src/libpas/pas_race_test_hooks.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_race_test_hooks.h
@@ -45,7 +45,7 @@ static inline const char* pas_race_test_hook_kind_get_string(pas_race_test_hook_
     case pas_race_test_hook_local_allocator_stop_before_unlock:
         return "local_allocator_stop_before_unlock";
     }
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
     return NULL;
 }
 

--- a/Source/bmalloc/libpas/src/libpas/pas_range_begin_min_heap.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_range_begin_min_heap.h
@@ -49,7 +49,7 @@ static inline int pas_range_begin_min_heap_compare(pas_range* left_ptr, pas_rang
 static inline size_t pas_range_begin_min_heap_get_index(pas_range* element_ptr)
 {
     PAS_UNUSED_PARAM(element_ptr);
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
     return 0;
 }
 

--- a/Source/bmalloc/libpas/src/libpas/pas_range_locked_mode.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_range_locked_mode.h
@@ -45,7 +45,7 @@ static inline const char* pas_range_locked_mode_get_string(pas_range_locked_mode
     case pas_range_is_locked:
         return "range_is_locked";
     }
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
     return NULL;
 }
 

--- a/Source/bmalloc/libpas/src/libpas/pas_range_min_heap.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_range_min_heap.h
@@ -43,7 +43,7 @@ static inline int pas_range_compare_begin(pas_range* left,
 
 static inline size_t pas_range_get_index(pas_range* range)
 {
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
     PAS_UNUSED_PARAM(range);
     return 0;
 }

--- a/Source/bmalloc/libpas/src/libpas/pas_scavenger.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_scavenger.c
@@ -417,7 +417,7 @@ static void* scavenger_thread_main(void* arg)
         }
     }
 
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
     return R_NULL;
 }
 
@@ -619,7 +619,7 @@ void pas_scavenger_perform_synchronous_operation(
 {
     switch (kind) {
     case pas_scavenger_invalid_synchronous_operation_kind:
-        PAS_ASSERT(!"Should not be reached");
+        PAS_ASSERT_NOT_REACHED();
         return;
     case pas_scavenger_clear_all_non_tlc_caches_kind:
         pas_scavenger_clear_all_non_tlc_caches();
@@ -640,7 +640,7 @@ void pas_scavenger_perform_synchronous_operation(
         pas_scavenger_run_synchronously_now();
         return;
     }
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
 }
 
 void pas_scavenger_disable_shut_down(void)

--- a/Source/bmalloc/libpas/src/libpas/pas_segregated_deallocation_logging_mode.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_segregated_deallocation_logging_mode.h
@@ -52,7 +52,7 @@ static inline bool pas_segregated_deallocation_logging_mode_does_logging(
     case pas_segregated_deallocation_checked_size_aware_logging_mode:
         return true;
     }
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
     return false;
 }
 
@@ -61,7 +61,7 @@ static inline bool pas_segregated_deallocation_logging_mode_is_size_aware(
 {
     switch (logging_mode) {
     case pas_segregated_deallocation_no_logging_mode:
-        PAS_ASSERT(!"Should not be reached");
+        PAS_ASSERT_NOT_REACHED();
         return false;
     case pas_segregated_deallocation_size_oblivious_logging_mode:
     case pas_segregated_deallocation_checked_size_oblivious_logging_mode:
@@ -70,7 +70,7 @@ static inline bool pas_segregated_deallocation_logging_mode_is_size_aware(
     case pas_segregated_deallocation_checked_size_aware_logging_mode:
         return true;
     }
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
     return false;
 }
 
@@ -79,7 +79,7 @@ static inline bool pas_segregated_deallocation_logging_mode_is_checked(
 {
     switch (logging_mode) {
     case pas_segregated_deallocation_no_logging_mode:
-        PAS_ASSERT(!"Should not be reached");
+        PAS_ASSERT_NOT_REACHED();
         return false;
     case pas_segregated_deallocation_size_oblivious_logging_mode:
     case pas_segregated_deallocation_size_aware_logging_mode:
@@ -88,7 +88,7 @@ static inline bool pas_segregated_deallocation_logging_mode_is_checked(
     case pas_segregated_deallocation_checked_size_aware_logging_mode:
         return true;
     }
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
     return false;
 }
 

--- a/Source/bmalloc/libpas/src/libpas/pas_segregated_deallocation_mode.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_segregated_deallocation_mode.h
@@ -46,7 +46,7 @@ static inline const char* pas_segregated_deallocation_mode_get_string(
     case pas_segregated_deallocation_to_view_cache_mode:
         return "to_view_cache";
     }
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
     return NULL;
 }
 

--- a/Source/bmalloc/libpas/src/libpas/pas_segregated_directory_first_eligible_kind.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_segregated_directory_first_eligible_kind.h
@@ -46,7 +46,7 @@ static inline const char* pas_segregated_directory_find_eligible_kind_get_string
     case pas_segregated_directory_first_eligible_and_tabled_kind:
         return "first_eligible_and_tabled";
     }
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
     return NULL;
 }
 

--- a/Source/bmalloc/libpas/src/libpas/pas_segregated_directory_kind.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_segregated_directory_kind.h
@@ -55,7 +55,7 @@ static inline const char* pas_segregated_directory_kind_get_string(
     case pas_segregated_shared_page_directory_kind:
         return "segregated_shared_page_directory";
     }
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
     return NULL;
 }
 

--- a/Source/bmalloc/libpas/src/libpas/pas_segregated_heap.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_segregated_heap.c
@@ -428,7 +428,7 @@ medium_directory_tuple_for_index_impl(
         return result;
     }
 
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
     result.tuple = NULL;
     return result;
 }
@@ -635,7 +635,7 @@ static inline int size_directory_min_heap_compare(pas_segregated_size_directory*
 static inline size_t size_directory_min_heap_get_index(pas_segregated_size_directory** entry_ptr)
 {
     PAS_UNUSED_PARAM(entry_ptr);
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
     return 0;
 }
 

--- a/Source/bmalloc/libpas/src/libpas/pas_segregated_page.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_segregated_page.c
@@ -109,7 +109,7 @@ pas_lock* pas_segregated_page_switch_lock_slow(
 
         page_lock = page->lock_ptr;
     }
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
 }
 
 void pas_segregated_page_switch_lock_and_rebias_while_ineligible_impl(
@@ -795,7 +795,7 @@ pas_segregated_page_and_config_for_address_and_heap_config(uintptr_t begin,
         case pas_small_bitfit_page_kind:
             return pas_segregated_page_and_config_create_empty();
         default:
-            PAS_ASSERT(!"Should not be reached");
+            PAS_ASSERT_NOT_REACHED();
             return pas_segregated_page_and_config_create_empty();
         }
     }
@@ -820,7 +820,7 @@ pas_segregated_page_and_config_for_address_and_heap_config(uintptr_t begin,
         }
         return pas_segregated_page_and_config_create_empty();
     } }
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
     return pas_segregated_page_and_config_create_empty();
 }
 

--- a/Source/bmalloc/libpas/src/libpas/pas_segregated_page_config.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_segregated_page_config.h
@@ -246,7 +246,7 @@ static inline bool pas_segregated_page_config_is_enabled(pas_segregated_page_con
     case pas_medium_segregated_page_config_variant:
         return pas_medium_segregated_page_config_variant_is_enabled_override;
     }
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
     return false;
 }
 
@@ -266,7 +266,7 @@ pas_segregated_page_config_payload_offset_for_role(pas_segregated_page_config co
     case pas_segregated_page_exclusive_role:
         return config.exclusive_payload_offset;
     }
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
     return 0;
 }
 
@@ -280,7 +280,7 @@ pas_segregated_page_config_payload_size_for_role(pas_segregated_page_config conf
     case pas_segregated_page_exclusive_role:
         return config.exclusive_payload_size;
     }
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
     return 0;
 }
 
@@ -320,7 +320,7 @@ pas_segregated_page_config_enable_empty_word_eligibility_optimization_for_role(
     case pas_segregated_page_exclusive_role:
         return config.enable_empty_word_eligibility_optimization_for_exclusive;
     }
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
     return pas_segregated_deallocation_no_logging_mode;
 }
 
@@ -334,7 +334,7 @@ pas_segregated_page_config_logging_mode_for_role(pas_segregated_page_config conf
     case pas_segregated_page_exclusive_role:
         return config.exclusive_logging_mode;
     }
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
     return pas_segregated_deallocation_no_logging_mode;
 }
 

--- a/Source/bmalloc/libpas/src/libpas/pas_segregated_page_config_kind_and_role.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_segregated_page_config_kind_and_role.c
@@ -43,7 +43,7 @@ pas_segregated_page_config_kind_and_role_get_string(pas_segregated_page_config_k
 #include "pas_segregated_page_config_kind.def"
 #undef PAS_DEFINE_SEGREGATED_PAGE_CONFIG_KIND
     }
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
     return NULL;
 }
 

--- a/Source/bmalloc/libpas/src/libpas/pas_segregated_page_config_variant.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_segregated_page_config_variant.h
@@ -59,7 +59,7 @@ pas_segregated_page_config_variant_get_string(pas_segregated_page_config_variant
     case pas_medium_segregated_page_config_variant:
         return "medium";
     }
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
     return NULL;
 }
 

--- a/Source/bmalloc/libpas/src/libpas/pas_segregated_page_emptiness_kind.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_segregated_page_emptiness_kind.h
@@ -46,7 +46,7 @@ pas_page_emptiness_kind_get_inverted(pas_page_emptiness_kind kind)
     case pas_page_full_emptiness:
         return pas_page_partial_emptiness;
     }
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
     return pas_page_partial_emptiness;
 }
 
@@ -59,7 +59,7 @@ pas_page_emptiness_kind_get_string(pas_page_emptiness_kind kind)
     case pas_page_full_emptiness:
         return "full";
     }
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
     return NULL;
 }
 

--- a/Source/bmalloc/libpas/src/libpas/pas_segregated_page_inlines.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_segregated_page_inlines.h
@@ -273,7 +273,7 @@ static PAS_ALWAYS_INLINE bool pas_segregated_page_switch_lock_with_mode(
         pas_segregated_page_switch_lock_impl(page, held_lock);
         return true;
     } }
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
     return true;
 }
 
@@ -538,7 +538,7 @@ pas_segregated_page_get_directory_for_address_in_page(pas_segregated_page* page,
                 pas_segregated_view_get_shared_handle(owning_view), begin, page_config)->directory);
     }
     
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
     return NULL;
 }
 
@@ -578,7 +578,7 @@ pas_segregated_page_get_object_size_for_address_in_page(pas_segregated_page* pag
                 begin, page_config)->directory)->object_size;
     } }
     
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
     return 0;
 }
 

--- a/Source/bmalloc/libpas/src/libpas/pas_segregated_page_role.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_segregated_page_role.h
@@ -45,7 +45,7 @@ static inline const char* pas_segregated_page_role_get_string(pas_segregated_pag
     case pas_segregated_page_exclusive_role:
         return "exclusive";
     }
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
     return NULL;
 }
 

--- a/Source/bmalloc/libpas/src/libpas/pas_segregated_size_directory_creation_mode.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_segregated_size_directory_creation_mode.h
@@ -46,7 +46,7 @@ static inline const char* pas_segregated_size_directory_creation_mode_get_string
     case pas_segregated_size_directory_full_creation_mode:
         return "full";
     }
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
     return NULL;
 }
 

--- a/Source/bmalloc/libpas/src/libpas/pas_segregated_view.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_segregated_view.c
@@ -53,7 +53,7 @@ pas_segregated_view_get_size_directory_slow(pas_segregated_view view)
         return pas_compact_segregated_size_directory_ptr_load_non_null(
             &pas_segregated_view_get_partial(view)->directory);
     default:
-        PAS_ASSERT(!"Should not be reached");
+        PAS_ASSERT_NOT_REACHED();
         return NULL;
     }
 }
@@ -77,7 +77,7 @@ pas_segregated_page_config_kind pas_segregated_view_get_page_config_kind(pas_seg
     case pas_segregated_size_directory_view_kind:
         return pas_segregated_view_get_size_directory(view)->base.page_config_kind;
     default:
-        PAS_ASSERT(!"Should not be reached");
+        PAS_ASSERT_NOT_REACHED();
         return pas_segregated_page_config_kind_null;
     }
 }
@@ -102,7 +102,7 @@ size_t pas_segregated_view_get_index(pas_segregated_view view)
     case pas_segregated_partial_view_kind:
         return ((pas_segregated_partial_view*)pas_segregated_view_get_ptr(view))->index;
     default:
-        PAS_ASSERT(!"Should not be reached");
+        PAS_ASSERT_NOT_REACHED();
         return 0;
     }
 }
@@ -133,7 +133,7 @@ void* pas_segregated_view_get_page_boundary(pas_segregated_view view)
                     &partial_view->directory)->base.page_config_kind));
     }
     default:
-        PAS_ASSERT(!"Should not be reached");
+        PAS_ASSERT_NOT_REACHED();
         return NULL;
     }
 }
@@ -160,7 +160,7 @@ pas_lock* pas_segregated_view_get_commit_lock(pas_segregated_view view)
         return &pas_compact_segregated_shared_view_ptr_load_non_null(
             &pas_segregated_view_get_partial(view)->shared_view)->commit_lock;
     default:
-        PAS_ASSERT(!"Should not be reached");
+        PAS_ASSERT_NOT_REACHED();
         return NULL;
     }
 }
@@ -180,7 +180,7 @@ pas_lock* pas_segregated_view_get_ownership_lock(pas_segregated_view view)
         return &pas_compact_segregated_shared_view_ptr_load_non_null(
             &pas_segregated_view_get_partial(view)->shared_view)->ownership_lock;
     default:
-        PAS_ASSERT(!"Should not be reached");
+        PAS_ASSERT_NOT_REACHED();
         return NULL;
     }
 }
@@ -203,7 +203,7 @@ bool pas_segregated_view_is_owned(pas_segregated_view view)
         return pas_compact_segregated_shared_view_ptr_load_non_null(
             &pas_segregated_view_get_partial(view)->shared_view)->is_owned;
     default:
-        PAS_ASSERT(!"Should not be reached");
+        PAS_ASSERT_NOT_REACHED();
         return NULL;
     }
 }
@@ -279,7 +279,7 @@ void pas_segregated_view_note_emptiness(
             pas_segregated_view_get_shared_handle(view));
         return;
     default:
-        PAS_ASSERT(!"Should not be reached");
+        PAS_ASSERT_NOT_REACHED();
         return;
     }
 }
@@ -575,7 +575,7 @@ pas_segregated_view pas_segregated_view_for_object(
                 pas_segregated_view_get_ptr(owning_view), begin, *page_config));
 
     default:
-        PAS_ASSERT(!"Should not be reached");
+        PAS_ASSERT_NOT_REACHED();
         return NULL;
     }
 }
@@ -596,7 +596,7 @@ pas_heap_summary pas_segregated_view_compute_summary(pas_segregated_view view,
         return pas_segregated_partial_view_compute_summary(pas_segregated_view_get_partial(view));
 
     default:
-        PAS_ASSERT(!"Should not be reached");
+        PAS_ASSERT_NOT_REACHED();
         return pas_heap_summary_create_empty();
     }
 }
@@ -612,7 +612,7 @@ bool pas_segregated_view_is_eligible(pas_segregated_view view)
         return pas_segregated_partial_view_is_eligible(pas_segregated_view_get_partial(view));
 
     default:
-        PAS_ASSERT(!"Should not be reached");
+        PAS_ASSERT_NOT_REACHED();
         return false;
     }
 }
@@ -652,7 +652,7 @@ bool pas_segregated_view_is_empty(pas_segregated_view view)
         return false;
 
     default:
-        PAS_ASSERT(!"Should not be reached");
+        PAS_ASSERT_NOT_REACHED();
         return false;
     }
 }

--- a/Source/bmalloc/libpas/src/libpas/pas_segregated_view_allocator_inlines.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_segregated_view_allocator_inlines.h
@@ -319,7 +319,7 @@ pas_segregated_view_will_start_allocating(pas_segregated_view view,
         return view;
     }
     default:
-        PAS_ASSERT(!"Should not be reached");
+        PAS_ASSERT_NOT_REACHED();
         return NULL;
     }
 }
@@ -444,7 +444,7 @@ pas_segregated_view_did_stop_allocating(pas_segregated_view view,
         return;
     }
     default:
-        PAS_ASSERT(!"Should not be reached");
+        PAS_ASSERT_NOT_REACHED();
         return;
     }
 }

--- a/Source/bmalloc/libpas/src/libpas/pas_segregated_view_kind.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_segregated_view_kind.h
@@ -60,7 +60,7 @@ static inline char pas_segregated_view_kind_get_character_code(pas_segregated_vi
     case pas_segregated_size_directory_view_kind:
         return 'S';
     }
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
     return 0;
 }
 
@@ -80,7 +80,7 @@ static inline const char* pas_segregated_view_kind_get_string(pas_segregated_vie
     case pas_segregated_size_directory_view_kind:
         return "size_directory";
     }
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
     return NULL;
 }
 
@@ -99,7 +99,7 @@ pas_segregated_view_kind_get_role_for_owner(pas_segregated_view_kind kind)
     case pas_segregated_shared_handle_kind:
         return pas_segregated_page_shared_role;
     default:
-        PAS_ASSERT(!"Should not be reached");
+        PAS_ASSERT_NOT_REACHED();
         return pas_segregated_page_exclusive_role;
     }
 }
@@ -114,7 +114,7 @@ pas_segregated_view_kind_get_role_for_allocator(pas_segregated_view_kind kind)
     case pas_segregated_partial_view_kind:
         return pas_segregated_page_shared_role;
     default:
-        PAS_ASSERT(!"Should not be reached");
+        PAS_ASSERT_NOT_REACHED();
         return pas_segregated_page_exclusive_role;
     }
 }
@@ -130,10 +130,10 @@ static inline bool pas_segregated_view_kind_can_become_empty(pas_segregated_view
         return false;
     case pas_segregated_shared_handle_kind:
     case pas_segregated_size_directory_view_kind:
-        PAS_ASSERT(!"Should not be reached");
+        PAS_ASSERT_NOT_REACHED();
         return false;
     }
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
     return false;
 }
 

--- a/Source/bmalloc/libpas/src/libpas/pas_simple_free_heap_declarations.def
+++ b/Source/bmalloc/libpas/src/libpas/pas_simple_free_heap_declarations.def
@@ -138,6 +138,6 @@ static inline void PAS_SIMPLE_FREE_HEAP_ID(_allocation_config_construct)(
         return;
     }
     
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
 }
 

--- a/Source/bmalloc/libpas/src/libpas/pas_size_lookup_mode.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_size_lookup_mode.h
@@ -45,7 +45,7 @@ static inline const char* pas_size_lookup_mode_get_string(pas_size_lookup_mode m
     case pas_force_size_lookup:
         return "force_size_lookup";
     }
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
     return NULL;
 }
 

--- a/Source/bmalloc/libpas/src/libpas/pas_status_reporter.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_status_reporter.c
@@ -1177,7 +1177,7 @@ static void* status_reporter_thread_main(void* arg)
         pas_heap_lock_unlock();
     }
     
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
     return R_NULL;
 }
 

--- a/Source/bmalloc/libpas/src/libpas/pas_thread_local_cache.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_thread_local_cache.c
@@ -681,7 +681,7 @@ process_deallocation_log_with_config(pas_thread_local_cache* cache,
             break;
 
         case pas_segregated_page_config_kind_pas_utility_small:
-            PAS_ASSERT(!"Should not be reached");
+            PAS_ASSERT_NOT_REACHED();
             break;
 
         default:

--- a/Source/bmalloc/libpas/src/libpas/pas_thread_local_cache_layout_node_kind.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_thread_local_cache_layout_node_kind.h
@@ -48,7 +48,7 @@ static inline const char* pas_thread_local_cache_layout_node_kind_get_string(
     case pas_thread_local_cache_layout_local_view_cache_node_kind:
         return "local_view_cache";
     }
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
     return NULL;
 }
 

--- a/Source/bmalloc/libpas/src/libpas/pas_tree_direction.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_tree_direction.h
@@ -45,7 +45,7 @@ static inline const char* pas_tree_direction_get_string(pas_tree_direction direc
     case pas_tree_direction_right:
         return "right";
     }
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
     return NULL;
 }
 
@@ -57,7 +57,7 @@ static inline pas_tree_direction pas_tree_direction_invert(pas_tree_direction di
     case pas_tree_direction_right:
         return pas_tree_direction_left;
     }
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
     return pas_tree_direction_left;
 }
 
@@ -72,7 +72,7 @@ pas_tree_direction_invert_comparison_result_if_right(
     case pas_tree_direction_right:
         return -comparison_result;
     }
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
     return 0;
 }
 

--- a/Source/bmalloc/libpas/src/libpas/pas_tri_state.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_tri_state.h
@@ -48,7 +48,7 @@ static inline const char* pas_tri_state_get_string(pas_tri_state tri_state)
     case pas_tri_state_yes:
         return "yes";
     }
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
     return NULL;
 }
 
@@ -62,7 +62,7 @@ static inline bool pas_tri_state_equals_boolean(pas_tri_state tri_state, bool bo
     case pas_tri_state_yes:
         return boolean;
     }
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
     return false;
 }
 

--- a/Source/bmalloc/libpas/src/libpas/pas_try_reallocate.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_try_reallocate.h
@@ -258,7 +258,7 @@ pas_try_reallocate(void* old_ptr,
                 page_and_kind.page_base, begin, heap, new_size, allocation_mode, config.small_bitfit_config,
                 teleport_rule, free_mode, allocate_callback, allocate_callback_arg);
         default:
-            PAS_ASSERT(!"Should not be reached");
+            PAS_ASSERT_NOT_REACHED();
             return pas_allocation_result_create_failure();
         }
     }

--- a/Source/bmalloc/libpas/src/libpas/pas_try_shrink.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_try_shrink.h
@@ -54,7 +54,7 @@ static PAS_ALWAYS_INLINE bool pas_try_shrink(void* ptr,
                 begin, new_size);
             return true;
         default:
-            PAS_ASSERT(!"Should not be reached");
+            PAS_ASSERT_NOT_REACHED();
             return 0;
         }
     }
@@ -101,7 +101,7 @@ static PAS_ALWAYS_INLINE bool pas_try_shrink(void* ptr,
         return true;
     } }
 
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
     return false;
 }
 

--- a/Source/bmalloc/libpas/src/libpas/pas_utility_heap_config.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_utility_heap_config.c
@@ -83,7 +83,7 @@ void pas_utility_heap_config_dump_shared_page_directory_arg(
 {
     PAS_UNUSED_PARAM(stream);
     PAS_UNUSED_PARAM(directory);
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
 }
 
 PAS_END_EXTERN_C;

--- a/Source/bmalloc/libpas/src/libpas/pas_utils.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_utils.h
@@ -477,6 +477,8 @@ PAS_IGNORE_WARNINGS_END
         pas_assertion_failed_no_inline_with_extra_detail(__FILE__, __LINE__, __PRETTY_FUNCTION__, #exp, extra); \
     } while (0)
 
+#define PAS_ASSERT_NOT_REACHED(...) PAS_ASSERT(!"Should not be reached", __VA_ARGS__)
+
 static inline bool pas_is_power_of_2(uintptr_t value)
 {
     return value && !(value & (value - 1));

--- a/Source/bmalloc/libpas/src/libpas/pas_virtual_range_min_heap.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_virtual_range_min_heap.h
@@ -44,7 +44,7 @@ static inline int pas_virtual_range_compare_begin(pas_virtual_range* left,
 
 static inline size_t pas_virtual_range_get_index(pas_virtual_range* range)
 {
-    PAS_ASSERT(!"Should not be reached");
+    PAS_ASSERT_NOT_REACHED();
     PAS_UNUSED_PARAM(range);
     return 0;
 }


### PR DESCRIPTION
#### ac53c66de7d3f49f71a24fbaf93e8ad28fdd39e8
<pre>
[libpas] Add PAS_ASSERT_NOT_REACHED() macro
<a href="https://bugs.webkit.org/show_bug.cgi?id=293700">https://bugs.webkit.org/show_bug.cgi?id=293700</a>
<a href="https://rdar.apple.com/152184364">rdar://152184364</a>

Reviewed by David Degazio and Yijia Huang.

This replaces the previous convention of just writing
`PAS_ASSERT(!&quot;Should not be reached&quot;)` with a macro that does the same
thing.

* Source/bmalloc/libpas/src/libpas/jit_heap_config.c:
(jit_heap_config_dump_shared_page_directory_arg):
* Source/bmalloc/libpas/src/libpas/pas_allocation_kind.h:
(pas_allocation_kind_get_string):
* Source/bmalloc/libpas/src/libpas/pas_allocation_mode.h:
(pas_allocation_mode_get_string):
* Source/bmalloc/libpas/src/libpas/pas_allocator_scavenge_action.h:
(pas_allocator_scavenge_action_get_string):
* Source/bmalloc/libpas/src/libpas/pas_basic_heap_page_caches.h:
(pas_basic_heap_page_caches_get_shared_page_directories):
* Source/bmalloc/libpas/src/libpas/pas_biasing_directory_kind.h:
(pas_biasing_directory_kind_get_string):
* Source/bmalloc/libpas/src/libpas/pas_bitfit_page_config.h:
(pas_bitfit_page_config_is_enabled):
* Source/bmalloc/libpas/src/libpas/pas_bitfit_page_config_variant.h:
(pas_bitfit_page_config_variant_get_string):
(pas_bitfit_page_config_variant_get_capitalized_string):
* Source/bmalloc/libpas/src/libpas/pas_bitfit_page_inlines.h:
(pas_bitfit_page_deallocate_with_page_impl_mode_get_string):
(pas_bitfit_page_deallocate_with_page_impl):
* Source/bmalloc/libpas/src/libpas/pas_cartesian_tree.h:
(pas_cartesian_tree_node_child_ptr):
(pas_cartesian_tree_insert):
* Source/bmalloc/libpas/src/libpas/pas_commit_mode.h:
(pas_commit_mode_get_string):
* Source/bmalloc/libpas/src/libpas/pas_compact_expendable_memory.h:
(pas_compact_expendable_memory_touch):
* Source/bmalloc/libpas/src/libpas/pas_deallocate.c:
(pas_try_deallocate_known_large):
(pas_try_deallocate_slow_no_cache):
* Source/bmalloc/libpas/src/libpas/pas_deallocate.h:
(pas_try_deallocate_not_small_exclusive_segregated):
* Source/bmalloc/libpas/src/libpas/pas_deallocation_mode.h:
(pas_deallocation_mode_get_string):
* Source/bmalloc/libpas/src/libpas/pas_deallocator_scavenge_action.h:
(pas_deallocator_scavenge_action_get_string):
* Source/bmalloc/libpas/src/libpas/pas_debug_heap.h:
(pas_debug_heap_malloc):
(pas_debug_heap_memalign):
(pas_debug_heap_realloc):
(pas_debug_heap_malloc_compact):
(pas_debug_heap_memalign_compact):
(pas_debug_heap_realloc_compact):
(pas_debug_heap_free):
* Source/bmalloc/libpas/src/libpas/pas_deferred_decommit_log.c:
(pas_deferred_decommit_log_add_maybe_locked):
* Source/bmalloc/libpas/src/libpas/pas_fast_megapage_kind.h:
(pas_fast_megapage_kind_get_string):
* Source/bmalloc/libpas/src/libpas/pas_free_range_kind.h:
(pas_free_range_kind_get_string):
* Source/bmalloc/libpas/src/libpas/pas_get_allocation_size.h:
(pas_get_allocation_size):
* Source/bmalloc/libpas/src/libpas/pas_get_heap.h:
(pas_get_heap):
* Source/bmalloc/libpas/src/libpas/pas_get_object_kind.h:
(pas_get_object_kind):
* Source/bmalloc/libpas/src/libpas/pas_get_page_base.h:
(pas_get_page_base):
* Source/bmalloc/libpas/src/libpas/pas_has_object.h:
(pas_has_object):
* Source/bmalloc/libpas/src/libpas/pas_heap.c:
(pas_heap_reset_heap_ref):
* Source/bmalloc/libpas/src/libpas/pas_heap_kind.h:
(pas_heap_kind_get_string):
* Source/bmalloc/libpas/src/libpas/pas_heap_ref_kind.h:
(pas_heap_ref_kind_get_string):
* Source/bmalloc/libpas/src/libpas/pas_heap_table.h:
(pas_heap_table_has_index):
* Source/bmalloc/libpas/src/libpas/pas_heap_table_state.h:
(pas_heap_table_state_get_string):
* Source/bmalloc/libpas/src/libpas/pas_large_expendable_memory.h:
(pas_large_expendable_memory_touch):
* Source/bmalloc/libpas/src/libpas/pas_large_sharing_pool.c:
(splat_command_get_string):
(splat_command_get_free_mode):
* Source/bmalloc/libpas/src/libpas/pas_large_sharing_pool_epoch_update_mode.h:
(pas_large_sharing_pool_epoch_update_mode_get_string):
* Source/bmalloc/libpas/src/libpas/pas_large_virtual_range_min_heap.h:
(pas_large_virtual_range_get_index):
* Source/bmalloc/libpas/src/libpas/pas_list_direction.h:
(pas_list_direction_get_string):
(pas_list_direction_invert):
* Source/bmalloc/libpas/src/libpas/pas_local_allocator.c:
(pas_local_allocator_stop):
* Source/bmalloc/libpas/src/libpas/pas_local_allocator_config_kind.h:
(pas_local_allocator_config_kind_create_normal):
(pas_local_allocator_config_kind_create_primordial_partial):
(pas_local_allocator_config_kind_create_bitfit):
(pas_local_allocator_config_kind_get_segregated_page_config_kind):
(pas_local_allocator_config_kind_get_bitfit_page_config_kind):
(pas_local_allocator_config_kind_get_string):
* Source/bmalloc/libpas/src/libpas/pas_local_allocator_inlines.h:
(pas_local_allocator_scan_bits_to_set_up_free_bits):
(pas_local_allocator_set_up_primordial_bump):
(pas_local_allocator_return_memory_to_page):
* Source/bmalloc/libpas/src/libpas/pas_local_allocator_kind.h:
(pas_local_allocator_kind_get_string):
(pas_local_allocator_kind_is_stopped):
* Source/bmalloc/libpas/src/libpas/pas_local_allocator_scavenger_data.c:
(pas_local_allocator_scavenger_data_commit_if_necessary_slow):
(pas_local_allocator_scavenger_data_stop):
* Source/bmalloc/libpas/src/libpas/pas_lock.h:
(pas_lock_lock_with_mode):
(pas_lock_for_switch_conditionally):
* Source/bmalloc/libpas/src/libpas/pas_mmap_capability.h:
(pas_mmap_capability_get_string):
* Source/bmalloc/libpas/src/libpas/pas_object_kind.h:
(pas_object_kind_get_string):
(pas_object_kind_for_segregated_variant):
(pas_object_kind_for_bitfit_variant):
(pas_object_kind_for_page_kind):
* Source/bmalloc/libpas/src/libpas/pas_page_base.c:
(pas_page_base_header_size):
(pas_page_base_get_config):
(pas_page_base_get_granule_use_counts):
(pas_page_base_is_empty):
* Source/bmalloc/libpas/src/libpas/pas_page_base_config.c:
(pas_page_base_config_get_kind_string):
* Source/bmalloc/libpas/src/libpas/pas_page_base_config_utils.h:
* Source/bmalloc/libpas/src/libpas/pas_page_base_config_utils_inlines.h:
* Source/bmalloc/libpas/src/libpas/pas_page_config_kind.h:
(pas_page_config_kind_get_string):
* Source/bmalloc/libpas/src/libpas/pas_page_config_size_category.h:
(pas_page_config_size_category_get_string):
* Source/bmalloc/libpas/src/libpas/pas_page_header_placement_mode.h:
(pas_page_header_placement_mode_get_string):
* Source/bmalloc/libpas/src/libpas/pas_page_kind.h:
(pas_page_kind_get_string):
(pas_page_kind_get_config_kind):
(pas_page_kind_get_segregated_variant):
(pas_page_kind_get_segregated_role):
(pas_page_kind_get_bitfit_variant):
(pas_page_kind_for_segregated_variant_and_role):
(pas_page_kind_for_bitfit_variant):
* Source/bmalloc/libpas/src/libpas/pas_page_sharing_mode.h:
(pas_page_sharing_mode_does_sharing):
(pas_page_sharing_mode_get_string):
* Source/bmalloc/libpas/src/libpas/pas_page_sharing_participant_kind.h:
(pas_page_sharing_participant_kind_select_for_segregated_directory):
(pas_page_sharing_participant_kind_get_string):
* Source/bmalloc/libpas/src/libpas/pas_physical_memory_synchronization_style.h:
(pas_physical_memory_synchronization_style_get_string):
* Source/bmalloc/libpas/src/libpas/pas_ptr_min_heap.h:
(pas_ptr_min_heap_get_index):
* Source/bmalloc/libpas/src/libpas/pas_race_test_hooks.h:
(pas_race_test_hook_kind_get_string):
* Source/bmalloc/libpas/src/libpas/pas_range_begin_min_heap.h:
(pas_range_begin_min_heap_get_index):
* Source/bmalloc/libpas/src/libpas/pas_range_locked_mode.h:
(pas_range_locked_mode_get_string):
* Source/bmalloc/libpas/src/libpas/pas_range_min_heap.h:
(pas_range_get_index):
* Source/bmalloc/libpas/src/libpas/pas_scavenger.c:
(scavenger_thread_main):
(pas_scavenger_perform_synchronous_operation):
* Source/bmalloc/libpas/src/libpas/pas_segregated_deallocation_logging_mode.h:
(pas_segregated_deallocation_logging_mode_does_logging):
(pas_segregated_deallocation_logging_mode_is_size_aware):
(pas_segregated_deallocation_logging_mode_is_checked):
* Source/bmalloc/libpas/src/libpas/pas_segregated_deallocation_mode.h:
(pas_segregated_deallocation_mode_get_string):
* Source/bmalloc/libpas/src/libpas/pas_segregated_directory_first_eligible_kind.h:
(pas_segregated_directory_find_eligible_kind_get_string):
* Source/bmalloc/libpas/src/libpas/pas_segregated_directory_kind.h:
(pas_segregated_directory_kind_get_string):
* Source/bmalloc/libpas/src/libpas/pas_segregated_heap.c:
(medium_directory_tuple_for_index_impl):
(size_directory_min_heap_get_index):
* Source/bmalloc/libpas/src/libpas/pas_segregated_page.c:
(pas_segregated_page_switch_lock_slow):
(pas_segregated_page_and_config_for_address_and_heap_config):
* Source/bmalloc/libpas/src/libpas/pas_segregated_page_config.h:
(pas_segregated_page_config_is_enabled):
(pas_segregated_page_config_payload_offset_for_role):
(pas_segregated_page_config_payload_size_for_role):
(pas_segregated_page_config_enable_empty_word_eligibility_optimization_for_role):
(pas_segregated_page_config_logging_mode_for_role):
* Source/bmalloc/libpas/src/libpas/pas_segregated_page_config_kind_and_role.c:
(pas_segregated_page_config_kind_and_role_get_string):
* Source/bmalloc/libpas/src/libpas/pas_segregated_page_config_variant.h:
(pas_segregated_page_config_variant_get_string):
* Source/bmalloc/libpas/src/libpas/pas_segregated_page_emptiness_kind.h:
(pas_page_emptiness_kind_get_inverted):
(pas_page_emptiness_kind_get_string):
* Source/bmalloc/libpas/src/libpas/pas_segregated_page_inlines.h:
(pas_segregated_page_switch_lock_with_mode):
(pas_segregated_page_get_directory_for_address_in_page):
(pas_segregated_page_get_object_size_for_address_in_page):
* Source/bmalloc/libpas/src/libpas/pas_segregated_page_role.h:
(pas_segregated_page_role_get_string):
* Source/bmalloc/libpas/src/libpas/pas_segregated_size_directory_creation_mode.h:
(pas_segregated_size_directory_creation_mode_get_string):
* Source/bmalloc/libpas/src/libpas/pas_segregated_view.c:
(pas_segregated_view_get_size_directory_slow):
(pas_segregated_view_get_page_config_kind):
(pas_segregated_view_get_index):
(pas_segregated_view_get_page_boundary):
(pas_segregated_view_get_commit_lock):
(pas_segregated_view_get_ownership_lock):
(pas_segregated_view_is_owned):
(pas_segregated_view_note_emptiness):
(pas_segregated_view_for_object):
(pas_segregated_view_compute_summary):
(pas_segregated_view_is_eligible):
(pas_segregated_view_is_empty):
* Source/bmalloc/libpas/src/libpas/pas_segregated_view_allocator_inlines.h:
(pas_segregated_view_will_start_allocating):
(pas_segregated_view_did_stop_allocating):
* Source/bmalloc/libpas/src/libpas/pas_segregated_view_kind.h:
(pas_segregated_view_kind_get_character_code):
(pas_segregated_view_kind_get_string):
(pas_segregated_view_kind_get_role_for_owner):
(pas_segregated_view_kind_get_role_for_allocator):
(pas_segregated_view_kind_can_become_empty):
* Source/bmalloc/libpas/src/libpas/pas_simple_free_heap_declarations.def:
* Source/bmalloc/libpas/src/libpas/pas_size_lookup_mode.h:
(pas_size_lookup_mode_get_string):
* Source/bmalloc/libpas/src/libpas/pas_status_reporter.c:
(status_reporter_thread_main):
* Source/bmalloc/libpas/src/libpas/pas_thread_local_cache.c:
(process_deallocation_log_with_config):
* Source/bmalloc/libpas/src/libpas/pas_thread_local_cache_layout_node_kind.h:
(pas_thread_local_cache_layout_node_kind_get_string):
* Source/bmalloc/libpas/src/libpas/pas_tree_direction.h:
(pas_tree_direction_get_string):
(pas_tree_direction_invert):
(pas_tree_direction_invert_comparison_result_if_right):
* Source/bmalloc/libpas/src/libpas/pas_tri_state.h:
(pas_tri_state_get_string):
(pas_tri_state_equals_boolean):
* Source/bmalloc/libpas/src/libpas/pas_try_reallocate.h:
(pas_try_reallocate):
* Source/bmalloc/libpas/src/libpas/pas_try_shrink.h:
(pas_try_shrink):
* Source/bmalloc/libpas/src/libpas/pas_utility_heap_config.c:
(pas_utility_heap_config_dump_shared_page_directory_arg):
* Source/bmalloc/libpas/src/libpas/pas_utils.h:
* Source/bmalloc/libpas/src/libpas/pas_virtual_range_min_heap.h:
(pas_virtual_range_get_index):

Canonical link: <a href="https://commits.webkit.org/295520@main">https://commits.webkit.org/295520@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c6f131c69ffe0ca4f80c854124429ef10d9bc08d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105343 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25055 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15482 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110551 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/56000 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/25493 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33598 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/80022 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/56000 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108349 "Build is in progress. Recent messages:OS: Sequoia (15.3), Xcode: 16.2; Running apply-patch; Checked out pull request; Passed webkitperl tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19887 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/95080 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/60331 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13160 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55395 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/98009 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/89340 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13202 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/113223 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/103961 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32498 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/23955 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/89098 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32861 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91300 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/88741 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22629 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33620 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/11412 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/27973 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32422 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/128265 "Built successfully") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/32194 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/35064 "jscore-tests (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35539 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33768 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->