### PR TITLE
There are double .jpg on the test-successful-screenshot for iOS performance benchmarks

### DIFF
--- a/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/browser_driver.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/browser_driver.py
@@ -58,6 +58,9 @@ class BrowserDriver:
     def diagnose_test_failure(self, debug_directory, error):
         pass
 
+    def save_successful_screenshot(self, diagnose_directory):
+        pass
+
     @contextmanager
     def prevent_sleep(self, timeout):
         yield

--- a/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/linux_browser_driver.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/linux_browser_driver.py
@@ -127,6 +127,9 @@ class LinuxBrowserDriver(BrowserDriver):
         # FIXME: store a screenshoot or some debug data for later analysis before closing the browser.
         self.close_browsers()
 
+    def save_successful_screenshot(self, diagnose_directory):
+        pass
+
     def _get_first_executable_path_from_list(self, searchlist):
         searchpath = [os.path.curdir] + os.environ['PATH'].split(os.pathsep)
         for program in searchlist:

--- a/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/osx_browser_driver.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/osx_browser_driver.py
@@ -147,6 +147,26 @@ class OSXBrowserDriver(BrowserDriver):
 
         self._save_screenshot_to_path(diagnose_directory, 'test-failure-screenshot-{}.jpg'.format(int(time.time())))
 
+    def save_successful_screenshot(self, diagnose_directory):
+        if not diagnose_directory:
+            _log.info('Diagnose directory is not specified, will skip diagnosing.')
+            return
+
+        if os.path.exists(diagnose_directory):
+            _log.info('Diagnose directory: "{}" already exists, cleaning it up'.format(diagnose_directory))
+            try:
+                if os.path.isdir(diagnose_directory):
+                    if len(os.listdir(diagnose_directory)):
+                        shutil.rmtree(diagnose_directory)
+                elif os.path.isfile(diagnose_directory):
+                    os.remove(diagnose_directory)
+            except Exception as error:
+                _log.error('Could not remove diagnose directory {} - error: {}'.format(diagnose_directory, error))
+        if not os.path.exists(diagnose_directory):
+            os.makedirs(diagnose_directory)
+
+        self._save_screenshot_to_path(diagnose_directory, f'test-successful-screenshot-{int(time.time())}.jpg')
+
     def _launch_process(self, build_dir, app_name, url, args, env=None):
         if not build_dir:
             build_dir = '/Applications/'

--- a/Tools/Scripts/webkitpy/benchmark_runner/webdriver_benchmark_runner.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/webdriver_benchmark_runner.py
@@ -28,7 +28,7 @@ class WebDriverBenchmarkRunner(BenchmarkRunner):
             raise error
         else:
             if not any(file.startswith('test-successful-screenshot-') for file in os.listdir(self._diagnose_dir)):
-                self._browser_driver._save_screenshot_to_path(self._diagnose_dir, f'test-successful-screenshot-{int(time.time())}.jpg')
+                self._browser_driver.save_successful_screenshot(self.diagnose_dir)
             self._browser_driver.close_browsers()
 
         return json.loads(result)

--- a/Tools/Scripts/webkitpy/benchmark_runner/webserver_benchmark_runner.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/webserver_benchmark_runner.py
@@ -49,7 +49,7 @@ class WebServerBenchmarkRunner(BenchmarkRunner):
             raise error
         else:
             if not any(file.startswith('test-successful-screenshot-') for file in os.listdir(self._diagnose_dir)):
-                self._browser_driver._save_screenshot_to_path(self._diagnose_dir, f'test-successful-screenshot-{int(time.time())}.jpg')
+                self._browser_driver.save_successful_screenshot(self.diagnose_dir)
             self._browser_driver.close_browsers()
         finally:
             self._http_server_driver.kill_server()


### PR DESCRIPTION
#### 4cd5cf95582c7f80fcebb13513ed28bd9b900567
<pre>
There are double .jpg on the test-successful-screenshot for iOS performance benchmarks
<a href="https://bugs.webkit.org/show_bug.cgi?id=293702">https://bugs.webkit.org/show_bug.cgi?id=293702</a>

Reviewed by NOBODY (OOPS!).

This commit fixes double .jpg naming for test-successful-screenshots on iOS testing.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4cd5cf95582c7f80fcebb13513ed28bd9b900567

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105370 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25086 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15509 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110577 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/56014 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/107411 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/25660 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33624 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80027 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108376 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/20024 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95096 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60336 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/104848 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/19748 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13179 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55419 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/89480 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13221 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/113266 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32522 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23968 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89103 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32885 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91319 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88746 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33643 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11429 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/27987 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32447 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32209 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35557 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33792 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->