### PR TITLE
[JSC] Migrate DateTime code from WTF::TimeType enum to enum class TimeType

### DIFF
--- a/Source/JavaScriptCore/runtime/DateConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/DateConstructor.cpp
@@ -107,7 +107,7 @@ static inline double makeDay(double year, double month, double date)
     return days + date - 1;
 }
 
-static double millisecondsFromComponents(JSGlobalObject* globalObject, const ArgList& args, WTF::TimeType timeType)
+static double millisecondsFromComponents(JSGlobalObject* globalObject, const ArgList& args, TimeType timeType)
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
@@ -165,7 +165,7 @@ JSObject* constructDate(JSGlobalObject* globalObject, JSValue newTarget, const A
             }
         }
     } else {
-        value = millisecondsFromComponents(globalObject, args, WTF::LocalTime);
+        value = millisecondsFromComponents(globalObject, args, TimeType::LocalTime);
         RETURN_IF_EXCEPTION(scope, nullptr);
     }
 
@@ -191,7 +191,7 @@ JSC_DEFINE_HOST_FUNCTION(callDate, (JSGlobalObject* globalObject, CallFrame*))
 {
     VM& vm = globalObject->vm();
     GregorianDateTime ts;
-    vm.dateCache.msToGregorianDateTime(WallTime::now().secondsSinceEpoch().milliseconds(), WTF::LocalTime, ts);
+    vm.dateCache.msToGregorianDateTime(WallTime::now().secondsSinceEpoch().milliseconds(), TimeType::LocalTime, ts);
     return JSValue::encode(jsNontrivialString(vm, formatDateTime(ts, DateTimeFormatDateAndTime, false, vm.dateCache)));
 }
 
@@ -216,7 +216,7 @@ JSC_DEFINE_HOST_FUNCTION(dateNow, (JSGlobalObject*, CallFrame*))
 
 JSC_DEFINE_HOST_FUNCTION(dateUTC, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
-    double ms = millisecondsFromComponents(globalObject, ArgList(callFrame), WTF::UTCTime);
+    double ms = millisecondsFromComponents(globalObject, ArgList(callFrame), TimeType::UTCTime);
     return JSValue::encode(jsNumber(ms));
 }
 

--- a/Source/JavaScriptCore/runtime/DateInstance.cpp
+++ b/Source/JavaScriptCore/runtime/DateInstance.cpp
@@ -51,7 +51,7 @@ const GregorianDateTime* DateInstance::calculateGregorianDateTime(DateCache& cac
         m_data = cache.cachedDateInstanceData(milli);
 
     if (m_data->m_gregorianDateTimeCachedForMS != milli) {
-        cache.msToGregorianDateTime(milli, WTF::LocalTime, m_data->m_cachedGregorianDateTime);
+        cache.msToGregorianDateTime(milli, TimeType::LocalTime, m_data->m_cachedGregorianDateTime);
         m_data->m_gregorianDateTimeCachedForMS = milli;
     }
     return &m_data->m_cachedGregorianDateTime;
@@ -67,7 +67,7 @@ const GregorianDateTime* DateInstance::calculateGregorianDateTimeUTC(DateCache& 
         m_data = cache.cachedDateInstanceData(milli);
 
     if (m_data->m_gregorianDateTimeUTCCachedForMS != milli) {
-        cache.msToGregorianDateTime(milli, WTF::UTCTime, m_data->m_cachedGregorianDateTimeUTC);
+        cache.msToGregorianDateTime(milli, TimeType::UTCTime, m_data->m_cachedGregorianDateTimeUTC);
         m_data->m_gregorianDateTimeUTCCachedForMS = milli;
     }
     return &m_data->m_cachedGregorianDateTimeUTC;

--- a/Source/JavaScriptCore/runtime/DatePrototype.cpp
+++ b/Source/JavaScriptCore/runtime/DatePrototype.cpp
@@ -680,7 +680,7 @@ JSC_DEFINE_HOST_FUNCTION(dateProtoFuncSetTime, (JSGlobalObject* globalObject, Ca
     return JSValue::encode(jsNumber(milli));
 }
 
-static EncodedJSValue setNewValueFromTimeArgs(JSGlobalObject* globalObject, CallFrame* callFrame, unsigned numArgsToUse, WTF::TimeType inputTimeType)
+static EncodedJSValue setNewValueFromTimeArgs(JSGlobalObject* globalObject, CallFrame* callFrame, unsigned numArgsToUse, TimeType inputTimeType)
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
@@ -708,7 +708,7 @@ static EncodedJSValue setNewValueFromTimeArgs(JSGlobalObject* globalObject, Call
     double secs = floor(milli / msPerSecond);
     double ms = milli - secs * msPerSecond;
 
-    const GregorianDateTime* other = inputTimeType == WTF::UTCTime
+    const GregorianDateTime* other = inputTimeType == TimeType::UTCTime
         ? thisDateObj->gregorianDateTimeUTC(cache)
         : thisDateObj->gregorianDateTime(cache);
     if (!other) {
@@ -731,7 +731,7 @@ static EncodedJSValue setNewValueFromTimeArgs(JSGlobalObject* globalObject, Call
     return JSValue::encode(jsNumber(result));
 }
 
-static EncodedJSValue setNewValueFromDateArgs(JSGlobalObject* globalObject, CallFrame* callFrame, unsigned numArgsToUse, WTF::TimeType inputTimeType)
+static EncodedJSValue setNewValueFromDateArgs(JSGlobalObject* globalObject, CallFrame* callFrame, unsigned numArgsToUse, TimeType inputTimeType)
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
@@ -752,10 +752,10 @@ static EncodedJSValue setNewValueFromDateArgs(JSGlobalObject* globalObject, Call
 
     GregorianDateTime gregorianDateTime; 
     if (numArgsToUse == 3 && std::isnan(milli)) 
-        cache.msToGregorianDateTime(0, WTF::UTCTime, gregorianDateTime);
+        cache.msToGregorianDateTime(0, TimeType::UTCTime, gregorianDateTime);
     else { 
         ms = milli - floor(milli / msPerSecond) * msPerSecond; 
-        const GregorianDateTime* other = inputTimeType == WTF::UTCTime
+        const GregorianDateTime* other = inputTimeType == TimeType::UTCTime
             ? thisDateObj->gregorianDateTimeUTC(cache)
             : thisDateObj->gregorianDateTime(cache);
         if (!other) {
@@ -781,72 +781,72 @@ static EncodedJSValue setNewValueFromDateArgs(JSGlobalObject* globalObject, Call
 
 JSC_DEFINE_HOST_FUNCTION(dateProtoFuncSetMilliSeconds, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
-    return setNewValueFromTimeArgs(globalObject, callFrame, 1, WTF::LocalTime);
+    return setNewValueFromTimeArgs(globalObject, callFrame, 1, TimeType::LocalTime);
 }
 
 JSC_DEFINE_HOST_FUNCTION(dateProtoFuncSetUTCMilliseconds, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
-    return setNewValueFromTimeArgs(globalObject, callFrame, 1, WTF::UTCTime);
+    return setNewValueFromTimeArgs(globalObject, callFrame, 1, TimeType::UTCTime);
 }
 
 JSC_DEFINE_HOST_FUNCTION(dateProtoFuncSetSeconds, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
-    return setNewValueFromTimeArgs(globalObject, callFrame, 2, WTF::LocalTime);
+    return setNewValueFromTimeArgs(globalObject, callFrame, 2, TimeType::LocalTime);
 }
 
 JSC_DEFINE_HOST_FUNCTION(dateProtoFuncSetUTCSeconds, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
-    return setNewValueFromTimeArgs(globalObject, callFrame, 2, WTF::UTCTime);
+    return setNewValueFromTimeArgs(globalObject, callFrame, 2, TimeType::UTCTime);
 }
 
 JSC_DEFINE_HOST_FUNCTION(dateProtoFuncSetMinutes, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
-    return setNewValueFromTimeArgs(globalObject, callFrame, 3, WTF::LocalTime);
+    return setNewValueFromTimeArgs(globalObject, callFrame, 3, TimeType::LocalTime);
 }
 
 JSC_DEFINE_HOST_FUNCTION(dateProtoFuncSetUTCMinutes, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
-    return setNewValueFromTimeArgs(globalObject, callFrame, 3, WTF::UTCTime);
+    return setNewValueFromTimeArgs(globalObject, callFrame, 3, TimeType::UTCTime);
 }
 
 JSC_DEFINE_HOST_FUNCTION(dateProtoFuncSetHours, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
-    return setNewValueFromTimeArgs(globalObject, callFrame, 4, WTF::LocalTime);
+    return setNewValueFromTimeArgs(globalObject, callFrame, 4, TimeType::LocalTime);
 }
 
 JSC_DEFINE_HOST_FUNCTION(dateProtoFuncSetUTCHours, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
-    return setNewValueFromTimeArgs(globalObject, callFrame, 4, WTF::UTCTime);
+    return setNewValueFromTimeArgs(globalObject, callFrame, 4, TimeType::UTCTime);
 }
 
 JSC_DEFINE_HOST_FUNCTION(dateProtoFuncSetDate, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
-    return setNewValueFromDateArgs(globalObject, callFrame, 1, WTF::LocalTime);
+    return setNewValueFromDateArgs(globalObject, callFrame, 1, TimeType::LocalTime);
 }
 
 JSC_DEFINE_HOST_FUNCTION(dateProtoFuncSetUTCDate, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
-    return setNewValueFromDateArgs(globalObject, callFrame, 1, WTF::UTCTime);
+    return setNewValueFromDateArgs(globalObject, callFrame, 1, TimeType::UTCTime);
 }
 
 JSC_DEFINE_HOST_FUNCTION(dateProtoFuncSetMonth, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
-    return setNewValueFromDateArgs(globalObject, callFrame, 2, WTF::LocalTime);
+    return setNewValueFromDateArgs(globalObject, callFrame, 2, TimeType::LocalTime);
 }
 
 JSC_DEFINE_HOST_FUNCTION(dateProtoFuncSetUTCMonth, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
-    return setNewValueFromDateArgs(globalObject, callFrame, 2, WTF::UTCTime);
+    return setNewValueFromDateArgs(globalObject, callFrame, 2, TimeType::UTCTime);
 }
 
 JSC_DEFINE_HOST_FUNCTION(dateProtoFuncSetFullYear, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
-    return setNewValueFromDateArgs(globalObject, callFrame, 3, WTF::LocalTime);
+    return setNewValueFromDateArgs(globalObject, callFrame, 3, TimeType::LocalTime);
 }
 
 JSC_DEFINE_HOST_FUNCTION(dateProtoFuncSetUTCFullYear, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
-    return setNewValueFromDateArgs(globalObject, callFrame, 3, WTF::UTCTime);
+    return setNewValueFromDateArgs(globalObject, callFrame, 3, TimeType::UTCTime);
 }
 
 JSC_DEFINE_HOST_FUNCTION(dateProtoFuncSetYear, (JSGlobalObject* globalObject, CallFrame* callFrame))
@@ -872,7 +872,7 @@ JSC_DEFINE_HOST_FUNCTION(dateProtoFuncSetYear, (JSGlobalObject* globalObject, Ca
     if (std::isnan(milli))
         // Based on ECMA 262 B.2.5 (setYear)
         // the time must be reset to +0 if it is NaN.
-        cache.msToGregorianDateTime(0, WTF::UTCTime, gregorianDateTime);
+        cache.msToGregorianDateTime(0, TimeType::UTCTime, gregorianDateTime);
     else {
         double secs = floor(milli / msPerSecond);
         ms = milli - secs * msPerSecond;
@@ -888,7 +888,7 @@ JSC_DEFINE_HOST_FUNCTION(dateProtoFuncSetYear, (JSGlobalObject* globalObject, Ca
     }
 
     gregorianDateTime.setYear(toInt32((year >= 0 && year <= 99) ? (year + 1900) : year));
-    double timeInMilliseconds = cache.gregorianDateTimeToMS(gregorianDateTime, ms, WTF::LocalTime);
+    double timeInMilliseconds = cache.gregorianDateTimeToMS(gregorianDateTime, ms, TimeType::LocalTime);
     double result = timeClip(timeInMilliseconds);
     thisDateObj->setInternalNumber(result);
     return JSValue::encode(jsNumber(result));

--- a/Source/JavaScriptCore/runtime/JSDateMath.h
+++ b/Source/JavaScriptCore/runtime/JSDateMath.h
@@ -53,6 +53,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace JSC {
 
+class DateInstance;
 class JSGlobalObject;
 class OpaqueICUTimeZone;
 class VM;
@@ -112,9 +113,9 @@ public:
     String timeZoneDisplayName(bool isDST);
     Ref<DateInstanceData> cachedDateInstanceData(double millisecondsFromEpoch);
 
-    void msToGregorianDateTime(double millisecondsFromEpoch, WTF::TimeType outputTimeType, GregorianDateTime&);
-    double gregorianDateTimeToMS(const GregorianDateTime&, double milliseconds, WTF::TimeType);
-    double localTimeToMS(double milliseconds, WTF::TimeType);
+    void msToGregorianDateTime(double millisecondsFromEpoch, TimeType outputTimeType, GregorianDateTime&);
+    double gregorianDateTimeToMS(const GregorianDateTime&, double milliseconds, TimeType);
+    double localTimeToMS(double milliseconds, TimeType);
     JS_EXPORT_PRIVATE double parseDate(JSGlobalObject*, VM&, const WTF::String&);
 
     static void timeZoneChanged();
@@ -150,7 +151,7 @@ private:
             m_epoch = 0;
         }
 
-        LocalTimeOffset localTimeOffset(DateCache&, int64_t millisecondsFromEpoch, WTF::TimeType);
+        LocalTimeOffset localTimeOffset(DateCache&, int64_t millisecondsFromEpoch, TimeType);
 
     private:
         LocalTimeOffsetCache* leastRecentlyUsed(LocalTimeOffsetCache* exclude);
@@ -171,14 +172,15 @@ private:
     };
 
     void timeZoneCacheSlow();
-    LocalTimeOffset localTimeOffset(int64_t millisecondsFromEpoch, WTF::TimeType inputTimeType = WTF::UTCTime)
+    LocalTimeOffset localTimeOffset(int64_t millisecondsFromEpoch, TimeType inputTimeType = TimeType::UTCTime)
     {
-        static_assert(!WTF::UTCTime);
-        static_assert(WTF::LocalTime == 1);
+        using Underlying = std::underlying_type_t<TimeType>;
+        static_assert(!static_cast<Underlying>(TimeType::UTCTime));
+        static_assert(static_cast<Underlying>(TimeType::LocalTime) == 1);
         return m_caches[static_cast<unsigned>(inputTimeType)].localTimeOffset(*this, millisecondsFromEpoch, inputTimeType);
     }
 
-    LocalTimeOffset calculateLocalTimeOffset(double millisecondsFromEpoch, WTF::TimeType inputTimeType);
+    LocalTimeOffset calculateLocalTimeOffset(double millisecondsFromEpoch, TimeType inputTimeType);
 
     OpaqueICUTimeZone* timeZoneCache()
     {

--- a/Source/WTF/wtf/DateMath.cpp
+++ b/Source/WTF/wtf/DateMath.cpp
@@ -302,11 +302,11 @@ static double calculateDSTOffset(time_t localTime, double utcOffset)
 LocalTimeOffset calculateLocalTimeOffset(double ms, TimeType inputTimeType)
 {
 #if HAVE(TM_GMTOFF)
-    double localToUTCTimeOffset = inputTimeType == LocalTime ? calculateUTCOffset() : 0;
+    double localToUTCTimeOffset = inputTimeType == TimeType::LocalTime ? calculateUTCOffset() : 0;
 #else
     double localToUTCTimeOffset = calculateUTCOffset();
 #endif
-    if (inputTimeType == LocalTime)
+    if (inputTimeType == TimeType::LocalTime)
         ms -= localToUTCTimeOffset;
 
     // On Mac OS X, the call to localtime (see calculateDSTOffset) will return historically accurate
@@ -966,7 +966,7 @@ double parseDate(std::span<const LChar> dateString)
     double value = parseDate(dateString, isLocalTime);
 
     if (isLocalTime)
-        value -= calculateLocalTimeOffset(value, LocalTime).offset;
+        value -= calculateLocalTimeOffset(value, TimeType::LocalTime).offset;
 
     return value;
 }

--- a/Source/WTF/wtf/DateMath.h
+++ b/Source/WTF/wtf/DateMath.h
@@ -52,7 +52,7 @@
 
 namespace WTF {
 
-enum TimeType {
+enum class TimeType : uint8_t {
     UTCTime = 0,
     LocalTime
 };
@@ -499,7 +499,7 @@ WTF_EXPORT_PRIVATE bool setTimeZoneOverride(StringView);
 WTF_EXPORT_PRIVATE void getTimeZoneOverride(Vector<UChar, 32>& timeZoneID);
 
 // Returns combined offset in millisecond (UTC + DST).
-WTF_EXPORT_PRIVATE LocalTimeOffset calculateLocalTimeOffset(double utcInMilliseconds, TimeType = UTCTime);
+WTF_EXPORT_PRIVATE LocalTimeOffset calculateLocalTimeOffset(double utcInMilliseconds, TimeType = TimeType::UTCTime);
 
 } // namespace WTF
 
@@ -531,3 +531,4 @@ using WTF::secondsPerMinute;
 using WTF::setTimeZoneOverride;
 using WTF::timeClip;
 using WTF::timeToMS;
+using WTF::TimeType;

--- a/Tools/TestWebKitAPI/Tests/WTF/DateMath.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/DateMath.cpp
@@ -150,71 +150,71 @@ TEST(WTF_DateMath, calculateLocalTimeOffset)
         GTEST_SKIP() << "Not in Pacific Time Zone";
 
     // DST Start: April 30, 1967 (02:00 am)
-    LocalTimeOffset dstStart1967 = calculateLocalTimeOffset(-84301200000, WTF::LocalTime);
+    LocalTimeOffset dstStart1967 = calculateLocalTimeOffset(-84301200000, TimeType::LocalTime);
     EXPECT_TRUE(dstStart1967.isDST);
     EXPECT_EQ(-25200000, dstStart1967.offset);
 
     // November 1, 1967 (02:00 am)
-    LocalTimeOffset dstAlmostEnd1967 = calculateLocalTimeOffset(-68317200000, WTF::LocalTime);
+    LocalTimeOffset dstAlmostEnd1967 = calculateLocalTimeOffset(-68317200000, TimeType::LocalTime);
     EXPECT_TRUE(dstAlmostEnd1967.isDST);
     EXPECT_EQ(-25200000, dstAlmostEnd1967.offset);
 
     // DST End: November 11, 1967 (02:00 am)
-    LocalTimeOffset dstEnd1967 = calculateLocalTimeOffset(-67536000000, WTF::LocalTime);
+    LocalTimeOffset dstEnd1967 = calculateLocalTimeOffset(-67536000000, TimeType::LocalTime);
     EXPECT_FALSE(dstEnd1967.isDST);
     EXPECT_EQ(-25200000, dstStart1967.offset);
 
     // DST Start: April 3, 1988 (02:00 am)
-    LocalTimeOffset dstStart1988 = calculateLocalTimeOffset(576054000000, WTF::LocalTime);
+    LocalTimeOffset dstStart1988 = calculateLocalTimeOffset(576054000000, TimeType::LocalTime);
     EXPECT_TRUE(dstStart1988.isDST);
     EXPECT_EQ(-25200000, dstStart1988.offset);
 
     // DST End: November 4, 2012 (02:00 am)
-    LocalTimeOffset dstEnd2012 = calculateLocalTimeOffset(1352012400000, WTF::LocalTime);
+    LocalTimeOffset dstEnd2012 = calculateLocalTimeOffset(1352012400000, TimeType::LocalTime);
     EXPECT_FALSE(dstEnd2012.isDST);
     EXPECT_EQ(-28800000, dstEnd2012.offset);
 
     // DST Begin: March 8, 2015
-    LocalTimeOffset dstBegin2015 = calculateLocalTimeOffset(1425801600000, WTF::LocalTime);
+    LocalTimeOffset dstBegin2015 = calculateLocalTimeOffset(1425801600000, TimeType::LocalTime);
     EXPECT_TRUE(dstBegin2015.isDST);
     EXPECT_EQ(-25200000, dstBegin2015.offset);
 
-    LocalTimeOffset dstBegin2015UTC = calculateLocalTimeOffset(1425801600000, WTF::UTCTime);
+    LocalTimeOffset dstBegin2015UTC = calculateLocalTimeOffset(1425801600000, TimeType::UTCTime);
     EXPECT_FALSE(dstBegin2015UTC.isDST);
     EXPECT_EQ(-28800000, dstBegin2015UTC.offset);
 
     // DST End: November 1, 2015
-    LocalTimeOffset dstEnd2015 = calculateLocalTimeOffset(1446361200000, WTF::LocalTime);
+    LocalTimeOffset dstEnd2015 = calculateLocalTimeOffset(1446361200000, TimeType::LocalTime);
     EXPECT_FALSE(dstEnd2015.isDST);
     EXPECT_EQ(-28800000, dstEnd2015.offset);
 
     // DST Begin: March 13, 2016
-    LocalTimeOffset dstBegin2016 = calculateLocalTimeOffset(1458111600000, WTF::LocalTime);
+    LocalTimeOffset dstBegin2016 = calculateLocalTimeOffset(1458111600000, TimeType::LocalTime);
     EXPECT_TRUE(dstBegin2016.isDST);
     EXPECT_EQ(-25200000, dstBegin2016.offset);
 
     // DST End: November 6, 2016
-    LocalTimeOffset dstEnd2016 = calculateLocalTimeOffset(1478415600000, WTF::LocalTime);
+    LocalTimeOffset dstEnd2016 = calculateLocalTimeOffset(1478415600000, TimeType::LocalTime);
     EXPECT_FALSE(dstEnd2016.isDST);
     EXPECT_EQ(-28800000, dstEnd2016.offset);
 
     // DST Begin: March 12, 2017
-    LocalTimeOffset dstBegin2017 = calculateLocalTimeOffset(1489305600000, WTF::LocalTime);
+    LocalTimeOffset dstBegin2017 = calculateLocalTimeOffset(1489305600000, TimeType::LocalTime);
     EXPECT_TRUE(dstBegin2017.isDST);
     EXPECT_EQ(-25200000, dstBegin2017.offset);
 
     // DST End: November 5, 2017
-    LocalTimeOffset dstEnd2017 = calculateLocalTimeOffset(1509865200000, WTF::LocalTime);
+    LocalTimeOffset dstEnd2017 = calculateLocalTimeOffset(1509865200000, TimeType::LocalTime);
     EXPECT_FALSE(dstEnd2017.isDST);
     EXPECT_EQ(-28800000, dstEnd2017.offset);
 
     // DST Begin: March 11, 2018
-    LocalTimeOffset dstBegin2018 = calculateLocalTimeOffset(1520755200000, WTF::LocalTime);
+    LocalTimeOffset dstBegin2018 = calculateLocalTimeOffset(1520755200000, TimeType::LocalTime);
     EXPECT_TRUE(dstBegin2018.isDST);
     EXPECT_EQ(-25200000, dstBegin2018.offset);
 
     // DST End: November 4, 2018
-    LocalTimeOffset dstEnd2018 = calculateLocalTimeOffset(1541314800000, WTF::LocalTime);
+    LocalTimeOffset dstEnd2018 = calculateLocalTimeOffset(1541314800000, TimeType::LocalTime);
     EXPECT_FALSE(dstEnd2018.isDST);
     EXPECT_EQ(-28800000, dstEnd2018.offset);
 }


### PR DESCRIPTION
#### ce0096b930f86b5a2d76968a8018d810cb9dd557
<pre>
[JSC] Migrate DateTime code from WTF::TimeType enum to enum class TimeType
<a href="https://bugs.webkit.org/show_bug.cgi?id=293701">https://bugs.webkit.org/show_bug.cgi?id=293701</a>
<a href="https://rdar.apple.com/152185079">rdar://152185079</a>

Reviewed by Yusuke Suzuki.

Refactored the DateMath and DatePrototype code to use a scoped enum class for TimeType
instead of the old unscoped enum. This improves type safety and reduces namespace pollution.
No functional change in behavior. All tests continue to pass.

* Source/JavaScriptCore/runtime/DateConstructor.cpp:
(JSC::millisecondsFromComponents):
(JSC::constructDate):
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/DateInstance.cpp:
(JSC::DateInstance::calculateGregorianDateTime const):
(JSC::DateInstance::calculateGregorianDateTimeUTC const):
* Source/JavaScriptCore/runtime/DatePrototype.cpp:
(JSC::setNewValueFromTimeArgs):
(JSC::setNewValueFromDateArgs):
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/JSDateMath.cpp:
(JSC::DateCache::calculateLocalTimeOffset):
(JSC::DateCache::DSTCache::localTimeOffset):
(JSC::DateCache::gregorianDateTimeToMS):
(JSC::DateCache::localTimeToMS):
(JSC::DateCache::msToGregorianDateTime):
(JSC::DateCache::parseDate):
* Source/JavaScriptCore/runtime/JSDateMath.h:
(JSC::DateCache::localTimeOffset):
* Source/WTF/wtf/DateMath.cpp:
(WTF::calculateLocalTimeOffset):
(WTF::parseDate):
* Source/WTF/wtf/DateMath.h:
* Tools/TestWebKitAPI/Tests/WTF/DateMath.cpp:
(TestWebKitAPI::TEST(WTF_DateMath, calculateLocalTimeOffset)):

Canonical link: <a href="https://commits.webkit.org/295669@main">https://commits.webkit.org/295669@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fa7632bfb7042292172f5f6e327c2687ed1ef672

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105361 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25071 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15500 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110569 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/56007 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/107402 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/26037 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33722 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80023 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108367 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/20389 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95091 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60332 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/20270 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13173 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55412 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/98017 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/89821 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13215 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/113247 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/103979 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32515 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24049 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89104 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32878 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91313 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88819 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33630 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11424 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/27980 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17164 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32440 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/37855 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/128282 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32202 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/35068 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35550 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33785 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->