### PR TITLE
[WebDriver] Driver segfault when a pointer move or scroll action is missing a coordinate

### DIFF
--- a/Source/WebDriver/Session.cpp
+++ b/Source/WebDriver/Session.cpp
@@ -2889,6 +2889,8 @@ void Session::performActions(Vector<Vector<Action>>&& actionsByTick, Function<vo
                         currentState.pressedButton = action.button.value();
                         break;
                     case Action::Subtype::PointerMove: {
+                        if (!action.x || !action.y)
+                            return completionHandler(CommandResult::fail(CommandResult::ErrorCode::InvalidArgument, "Pointer move action must have x and y coordinates."_s));
                         state->setString("origin"_s, automationOriginType(action.origin->type));
                         auto location = JSON::Object::create();
                         location->setInteger("x"_s, action.x.value());
@@ -2958,6 +2960,10 @@ void Session::performActions(Vector<Vector<Action>>&& actionsByTick, Function<vo
                 case Action::Type::Wheel:
                     switch (action.subtype) {
                     case Action::Subtype::Scroll: {
+                        if (!action.x || !action.y)
+                            return completionHandler(CommandResult::fail(CommandResult::ErrorCode::InvalidArgument, "Scroll action must have x and y coordinates."_s));
+                        if (!action.deltaX || !action.deltaY)
+                            return completionHandler(CommandResult::fail(CommandResult::ErrorCode::InvalidArgument, "Scroll action must have deltaX and deltaY values."_s));
                         state->setString("origin"_s, automationOriginType(action.origin->type));
                         auto location = JSON::Object::create();
                         location->setInteger("x"_s, action.x.value());


### PR DESCRIPTION
#### 80ff32d5e1aedf822c3117464e01d85d9cf7214e
<pre>
[WebDriver] Driver segfault when a pointer move or scroll action is missing a coordinate
<a href="https://bugs.webkit.org/show_bug.cgi?id=293703">https://bugs.webkit.org/show_bug.cgi?id=293703</a>

Reviewed by BJ Burg.

Both pointerMove and scroll actions require the presence of the x and y
coordinates, alongside deltaX and deltaY for the latter.

This commit ensures we check for their presence when processing the
incoming actions, alongside validating the coordinate presence before
actually sending the actions to the browser as an extra blanket.

We also add extra checks as the scroll coordinates must be integers,
while pointer move recently started allowing fractional coordinates.

Lastly, this commit fixes some typos in the actions error messages,
also rephrasing for clarity and uniformity.

* Source/WebDriver/Session.cpp:
(WebDriver::Session::performActions):
* Source/WebDriver/WebDriverService.cpp:
(WebDriver::processPauseAction):
(WebDriver::processNullAction):
(WebDriver::processKeyAction):
(WebDriver::processPointerMoveAction):
(WebDriver::processPointerAction):
(WebDriver::processWheelAction):
(WebDriver::processPointerParameters):
(WebDriver::processInputActionSequence):
(WebDriver::WebDriverService::performActions):

Canonical link: <a href="https://commits.webkit.org/295789@main">https://commits.webkit.org/295789@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/85daae1da43a393e3aaea54bcc73ecc0970ccd7a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105445 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25156 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15584 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110646 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/56071 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/25614 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33695 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80084 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108451 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19990 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95161 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60393 "Passed tests") | 
| | [💥 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/19721 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13248 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55483 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/89453 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13289 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/113394 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32588 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24030 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89164 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32951 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91387 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88823 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22789 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33689 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11490 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/28049 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32514 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/37939 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32271 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35618 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33857 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->