### PR TITLE
[web-animations] `ASAN_ILL` in `AnimationEffectTiming::getBasicTiming()`

### DIFF
--- a/LayoutTests/webanimations/asan-crash-in-animation-effect-timing-get-computed-timing-expected.txt
+++ b/LayoutTests/webanimations/asan-crash-in-animation-effect-timing-get-computed-timing-expected.txt
@@ -1,0 +1,1 @@
+x\3V Q9?'A QtA%'1tJk

--- a/LayoutTests/webanimations/asan-crash-in-animation-effect-timing-get-computed-timing.html
+++ b/LayoutTests/webanimations/asan-crash-in-animation-effect-timing-get-computed-timing.html
@@ -1,0 +1,46 @@
+<!-- this test passes if it doesn't crash -->
+<script>
+
+if (window.testRunner)
+    window.testRunner.dumpAsText();
+
+var myFeedback = [];
+function UpdateFeedback(line, res) { myFeedback.push([line, res]) }
+
+var runcount = {'jsfuzzer':0, 'eventhandler1':0, 'eventhandler2':0, 'eventhandler3':0, 'eventhandler4':0, 'eventhandler5':0}
+
+function GetVariable(fuzzervars, var_type) { if(fuzzervars[var_type]) { return fuzzervars[var_type]; } else { return null; }}
+
+function SetVariable(fuzzervars, var_name, var_type) { fuzzervars[var_type] = var_name; }
+
+function jsfuzzer() {
+
+runcount["jsfuzzer"]++; if(runcount["jsfuzzer"] > 2) { return; }
+
+var fuzzervars = {};
+
+SetVariable(fuzzervars, window, 'Window');
+SetVariable(fuzzervars, document, 'Document');
+try { if (!var00001) { var00001 = GetVariable(fuzzervars, 'GPUTextureFormat'); } else { SetVariable(fuzzervars, var00001, 'GPUTextureFormat');  };  UpdateFeedback(String.raw`if (!var00001) { var00001 = GetVariable(fuzzervars, 'GPUTextureFormat'); } else { SetVariable(fuzzervars, var00001, 'GPUTextureFormat');  }`, "Valid"); } catch(e) {  UpdateFeedback(String.raw`if (!var00001) { var00001 = GetVariable(fuzzervars, 'GPUTextureFormat'); } else { SetVariable(fuzzervars, var00001, 'GPUTextureFormat');  }`, e.name) }
+try { window.releaseEvents();;  UpdateFeedback(String.raw`window.releaseEvents();`, "Valid"); } catch(e) {  UpdateFeedback(String.raw`window.releaseEvents();`, e.name) }
+try { /* newvar{var00025:Element} */ var var00025 = document.firstElementChild;;  UpdateFeedback(String.raw`/* newvar{var00025:Element} */ var var00025 = document.firstElementChild;`, "Valid"); } catch(e) {  UpdateFeedback(String.raw`/* newvar{var00025:Element} */ var var00025 = document.firstElementChild;`, e.name) }
+try { if (!var00025) { var00025 = GetVariable(fuzzervars, 'Element'); } else { SetVariable(fuzzervars, var00025, 'Element'); SetVariable(fuzzervars, var00025, 'Node;');  };  UpdateFeedback(String.raw`if (!var00025) { var00025 = GetVariable(fuzzervars, 'Element'); } else { SetVariable(fuzzervars, var00025, 'Element'); SetVariable(fuzzervars, var00025, 'Node;');  }`, "Valid"); } catch(e) {  UpdateFeedback(String.raw`if (!var00025) { var00025 = GetVariable(fuzzervars, 'Element'); } else { SetVariable(fuzzervars, var00025, 'Element'); SetVariable(fuzzervars, var00025, 'Node;');  }`, e.name) }
+try { /* newvar{var00023:Element} */ var var00023 = var00024.activeElement;;  UpdateFeedback(String.raw`/* newvar{var00023:Element} */ var var00023 = var00024.activeElement;`, "Valid"); } catch(e) {  UpdateFeedback(String.raw`/* newvar{var00023:Element} */ var var00023 = var00024.activeElement;`, e.name) }
+try { if (!var00023) { var00023 = GetVariable(fuzzervars, 'Element'); } else { SetVariable(fuzzervars, var00023, 'Element'); SetVariable(fuzzervars, var00023, 'Node;');  };  UpdateFeedback(String.raw`if (!var00023) { var00023 = GetVariable(fuzzervars, 'Element'); } else { SetVariable(fuzzervars, var00023, 'Element'); SetVariable(fuzzervars, var00023, 'Node;');  }`, "Valid"); } catch(e) {  UpdateFeedback(String.raw`if (!var00023) { var00023 = GetVariable(fuzzervars, 'Element'); } else { SetVariable(fuzzervars, var00023, 'Element'); SetVariable(fuzzervars, var00023, 'Node;');  }`, e.name) }
+try { /* newvar{var00031:PressureUpdateCallback} */ var var00031 = function(x){console.log("ok")};;  UpdateFeedback(String.raw`/* newvar{var00031:PressureUpdateCallback} */ var var00031 = function(x){console.log("ok")};`, "Valid"); } catch(e) {  UpdateFeedback(String.raw`/* newvar{var00031:PressureUpdateCallback} */ var var00031 = function(x){console.log("ok")};`, e.name) }
+try { /* newvar{var00027:object} */ var var00027 = var00028.toJSON();;  UpdateFeedback(String.raw`/* newvar{var00027:object} */ var var00027 = var00028.toJSON();`, "Valid"); } catch(e) {  UpdateFeedback(String.raw`/* newvar{var00027:object} */ var var00027 = var00028.toJSON();`, e.name) }
+try { /* newvar{var00022:KeyframeEffect} */ var var00022 = new KeyframeEffect(var00023,var00027);;  UpdateFeedback(String.raw`/* newvar{var00022:KeyframeEffect} */ var var00022 = new KeyframeEffect(var00023,var00027);`, "Valid"); } catch(e) {  UpdateFeedback(String.raw`/* newvar{var00022:KeyframeEffect} */ var var00022 = new KeyframeEffect(var00023,var00027);`, e.name) }
+try { /* newvar{var00021:AnimationEffect} */ var var00021 = var00022;;  UpdateFeedback(String.raw`/* newvar{var00021:AnimationEffect} */ var var00021 = var00022;`, "Valid"); } catch(e) {  UpdateFeedback(String.raw`/* newvar{var00021:AnimationEffect} */ var var00021 = var00022;`, e.name) }
+try { if (!var00021) { var00021 = GetVariable(fuzzervars, 'AnimationEffect'); } else { SetVariable(fuzzervars, var00021, 'AnimationEffect');  };  UpdateFeedback(String.raw`if (!var00021) { var00021 = GetVariable(fuzzervars, 'AnimationEffect'); } else { SetVariable(fuzzervars, var00021, 'AnimationEffect');  }`, "Valid"); } catch(e) {  UpdateFeedback(String.raw`if (!var00021) { var00021 = GetVariable(fuzzervars, 'AnimationEffect'); } else { SetVariable(fuzzervars, var00021, 'AnimationEffect');  }`, e.name) }
+try { /* newvar{var00019:AnimationEffect} */ var var00019 = var00020.firstChild;;  UpdateFeedback(String.raw`/* newvar{var00019:AnimationEffect} */ var var00019 = var00020.firstChild;`, "Valid"); } catch(e) {  UpdateFeedback(String.raw`/* newvar{var00019:AnimationEffect} */ var var00019 = var00020.firstChild;`, e.name) }
+try { if (!var00019) { var00019 = GetVariable(fuzzervars, 'AnimationEffect'); } else { SetVariable(fuzzervars, var00019, 'AnimationEffect');  };  UpdateFeedback(String.raw`if (!var00019) { var00019 = GetVariable(fuzzervars, 'AnimationEffect'); } else { SetVariable(fuzzervars, var00019, 'AnimationEffect');  }`, "Valid"); } catch(e) {  UpdateFeedback(String.raw`if (!var00019) { var00019 = GetVariable(fuzzervars, 'AnimationEffect'); } else { SetVariable(fuzzervars, var00019, 'AnimationEffect');  }`, e.name) }
+try { /* newvar{var00033:ScrollTimeline} */ var var00033 = new ScrollTimeline();;  UpdateFeedback(String.raw`/* newvar{var00033:ScrollTimeline} */ var var00033 = new ScrollTimeline();`, "Valid"); } catch(e) {  UpdateFeedback(String.raw`/* newvar{var00033:ScrollTimeline} */ var var00033 = new ScrollTimeline();`, e.name) }
+try { /* newvar{var00032:AnimationTimeline} */ var var00032 = var00033;;  UpdateFeedback(String.raw`/* newvar{var00032:AnimationTimeline} */ var var00032 = var00033;`, "Valid"); } catch(e) {  UpdateFeedback(String.raw`/* newvar{var00032:AnimationTimeline} */ var var00032 = var00033;`, e.name) }
+try { /* newvar{var00018:Animation} */ var var00018 = new Animation(var00019,var00032);;  UpdateFeedback(String.raw`/* newvar{var00018:Animation} */ var var00018 = new Animation(var00019,var00032);`, "Valid"); } catch(e) {  UpdateFeedback(String.raw`/* newvar{var00018:Animation} */ var var00018 = new Animation(var00019,var00032);`, e.name) }
+try { var00018.finish();;  UpdateFeedback(String.raw`var00018.finish();`, "Valid"); } catch(e) {  UpdateFeedback(String.raw`var00018.finish();`, e.name) }
+try { /* newvar{var00395:union_Node1DOMString_} */ var var00395 = String.fromCharCode(120, 92, 51, 86, 32, 81, 57, 63, 39, 65, 32, 81, 116, 65, 37, 39, 49, 116, 74, 107);;  UpdateFeedback(String.raw`/* newvar{var00395:union_Node1DOMString_} */ var var00395 = String.fromCharCode(120, 92, 51, 86, 32, 81, 57, 63, 39, 65, 32, 81, 116, 65, 37, 39, 49, 116, 74, 107);`, "Valid"); } catch(e) {  UpdateFeedback(String.raw`/* newvar{var00395:union_Node1DOMString_} */ var var00395 = String.fromCharCode(120, 92, 51, 86, 32, 81, 57, 63, 39, 65, 32, 81, 116, 65, 37, 39, 49, 116, 74, 107);`, e.name) }
+try { var00025.replaceChildren(var00395);;  UpdateFeedback(String.raw`var00025.replaceChildren(var00395);`, "Valid"); } catch(e) {  UpdateFeedback(String.raw`var00025.replaceChildren(var00395);`, e.name) }
+}
+</script>
+<body onload=jsfuzzer()>
+</body>


### PR DESCRIPTION
#### 4b2e8efe1e41086db284a3f93e48b80e96b1143d
<pre>
[web-animations] `ASAN_ILL` in `AnimationEffectTiming::getBasicTiming()`
<a href="https://bugs.webkit.org/show_bug.cgi?id=289273">https://bugs.webkit.org/show_bug.cgi?id=289273</a>
<a href="https://rdar.apple.com/146074584">rdar://146074584</a>

Reviewed by Cameron McCormack.

Our debug-only assertion would have caught the case reported in this bug had it been
a release assertion. Since we now know there it is possible for the timeline time to
be `std::nullopt` if the start time holds a value, we check for both values before
using them.

* LayoutTests/webanimations/asan-crash-in-animation-effect-timing-get-computed-timing-expected.txt: Added.
* LayoutTests/webanimations/asan-crash-in-animation-effect-timing-get-computed-timing.html: Added.
* Source/WebCore/animation/AnimationEffectTiming.cpp:
(WebCore::AnimationEffectTiming::getBasicTiming const):

Originally-landed-as: 289651.247@safari-7621-branch (3fab4bc68ab2). <a href="https://rdar.apple.com/151707584">rdar://151707584</a>
Canonical link: <a href="https://commits.webkit.org/295853@main">https://commits.webkit.org/295853@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/38715d5443ce168d394b47301b7c18750ea17d71

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105364 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25082 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15503 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/111522 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/56010 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/25561 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33620 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80760 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108370 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19940 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95092 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/61088 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/19676 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13174 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55415 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/89405 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13216 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/113254 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32518 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23967 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89101 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32881 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91314 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89531 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22842 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33629 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11425 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/27983 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32443 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32205 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35553 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33788 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->