### PR TITLE
[JSC] Check overflow of escaped string length in FastStringifier

### DIFF
--- a/JSTests/stress/fast-stringifier-check-string-length.js
+++ b/JSTests/stress/fast-stringifier-check-string-length.js
@@ -1,0 +1,8 @@
+//@ skip if $memoryLimited
+var string = "\x00".repeat(715827883);
+try {
+    JSON.stringify(string);
+} catch { }
+try {
+    JSON.stringify(string);
+} catch { }


### PR DESCRIPTION
#### 13633f444b7f394dc99a87ffc4eb796bafe4cfe8
<pre>
[JSC] Check overflow of escaped string length in FastStringifier
<a href="https://bugs.webkit.org/show_bug.cgi?id=289387">https://bugs.webkit.org/show_bug.cgi?id=289387</a>
<a href="https://rdar.apple.com/143829386">rdar://143829386</a>

Reviewed by Yijia Huang.

Multiplying with 6 can cause overflow for unsigned size. We check the
overflow here.

* JSTests/stress/fast-stringifier-check-string-length.js: Added.
* Source/JavaScriptCore/runtime/JSONObject.cpp:
(JSC::bufferMode&gt;::append):

Originally-landed-as: 289651.250@safari-7621-branch (fce7b0571506). rdar://151707436
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/13633f444b7f394dc99a87ffc4eb796bafe4cfe8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/106452 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/26201 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/16599 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/111654 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/57048 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/26868 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34704 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80848 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/109456 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/21303 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/96060 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/61177 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/20773 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/56489 "Built successfully") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/99091 "Found 19 jsc stress test failures: stress/fast-stringifier-check-string-length.js.bytecode-cache, stress/fast-stringifier-check-string-length.js.default, stress/fast-stringifier-check-string-length.js.dfg-eager, stress/fast-stringifier-check-string-length.js.dfg-eager-no-cjit-validate, stress/fast-stringifier-check-string-length.js.eager-jettison-no-cjit ...") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/90636 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/14193 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/114514 "Built successfully") | 
| [❌ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/105069 "Found 19 new JSC stress test failures: stress/fast-stringifier-check-string-length.js.bytecode-cache, stress/fast-stringifier-check-string-length.js.default, stress/fast-stringifier-check-string-length.js.dfg-eager, stress/fast-stringifier-check-string-length.js.dfg-eager-no-cjit-validate, stress/fast-stringifier-check-string-length.js.eager-jettison-no-cjit, stress/fast-stringifier-check-string-length.js.ftl-eager, stress/fast-stringifier-check-string-length.js.ftl-eager-no-cjit, stress/fast-stringifier-check-string-length.js.ftl-eager-no-cjit-b3o1, stress/fast-stringifier-check-string-length.js.ftl-no-cjit-b3o0, stress/fast-stringifier-check-string-length.js.ftl-no-cjit-no-inline-validate ... (failure)") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33590 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24772 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89923 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33954 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/92288 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89627 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34516 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/12335 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/29199 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/33515 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/129381 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/33261 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/35233 "Found 1 new JSC stress test failure: wasm.yaml/wasm/gc/ref-i31-eq.js.default-wasm (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/36614 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34859 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->