### PR TITLE
[SwfitUI] SwiftBrowser is not compiled when building with `make`

### DIFF
--- a/Tools/Makefile
+++ b/Tools/Makefile
@@ -5,7 +5,7 @@ SCHEME = All WebKit Tools
 
 else
 
-MODULES = DumpRenderTree WebKitTestRunner MiniBrowser ../Source/ThirdParty/gtest/xcode TestWebKitAPI
+MODULES = DumpRenderTree WebKitTestRunner MiniBrowser SwiftBrowser ../Source/ThirdParty/gtest/xcode TestWebKitAPI
 
 TO_LOWER = $(shell echo $(1) | tr [:upper:] [:lower:])
 

--- a/Tools/SwiftBrowser/Makefile
+++ b/Tools/SwiftBrowser/Makefile
@@ -1,0 +1,2 @@
+SCRIPTS_PATH = ../Scripts
+include ../../Makefile.shared

--- a/Tools/SwiftBrowser/SwiftBrowser.xcodeproj/project.pbxproj
+++ b/Tools/SwiftBrowser/SwiftBrowser.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 77;
+	objectVersion = 63;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -227,7 +227,7 @@
 			);
 			mainGroup = 07A58BCB2D0400B300CAB4ED;
 			minimizedProjectReferenceProxies = 1;
-			preferredProjectObjectVersion = 77;
+			preferredProjectObjectVersion = 63;
 			productRefGroup = 07A58BD52D0400B300CAB4ED /* Products */;
 			projectDirPath = "";
 			projectRoot = "";

--- a/WebKit.xcworkspace/contents.xcworkspacedata
+++ b/WebKit.xcworkspace/contents.xcworkspacedata
@@ -53,6 +53,9 @@
       location = "group:Tools/MobileMiniBrowser/MobileMiniBrowser.xcodeproj">
    </FileRef>
    <FileRef
+      location = "group:Tools/SwiftBrowser/SwiftBrowser.xcodeproj">
+   </FileRef>
+   <FileRef
       location = "group:Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj">
    </FileRef>
    <FileRef


### PR DESCRIPTION
#### c01174de7385a344caa81c5ffb35062101a599d1
<pre>
[SwfitUI] SwiftBrowser is not compiled when building with `make`
<a href="https://bugs.webkit.org/show_bug.cgi?id=293705">https://bugs.webkit.org/show_bug.cgi?id=293705</a>
<a href="https://rdar.apple.com/152188186">rdar://152188186</a>

Reviewed by Richard Robinson.

Firstly, there was no Makefile for the SwiftBrowser tool. Secondly, the
Tools/Makefile was not aware of any SwiftBrowser target to include when
invoking `make`. This patch addresses both issues.

* Tools/Makefile:
* Tools/SwiftBrowser/Makefile: Added.
* WebKit.xcworkspace/contents.xcworkspacedata:
Drive-by fix: Make the open source WebKit Xcode workspace aware of
SwiftBrowser.

Canonical link: <a href="https://commits.webkit.org/295553@main">https://commits.webkit.org/295553@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/42c10fee0bc5f27d97fc7a280df879a5c69f4372

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105419 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25132 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15558 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110622 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/56051 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/107460 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/25620 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33669 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80069 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108425 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19995 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95142 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60378 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/19726 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13229 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55459 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/98065 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/89458 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13270 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/113362 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/104037 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32563 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24006 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89146 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32926 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91368 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88797 "Found 99 new API test failures: /TestWebKit:WebKit.CanHandleRequest, /WebKitGTK/TestGeolocationManager:/webkit/WebKitGeolocationManager/watch-position, /TestWebKit:WebKit.UserMediaBasic, /TestWebKit:WebKit.PageLoadEmptyURL, /WebKitGTK/TestOptionMenu:/webkit/WebKitWebView/option-menu-groups, /TestWebKit:WebKit.GeolocationTransitionToHighAccuracy, /TestWebKit:WebKit.PendingAPIRequestURL, /TestWebKit:WebKit.FirstMeaningfulPaint, /WebKitGTK/TestUIClient:/webkit/WebKitWebView/file-chooser-request, /WebKitGTK/TestWebViewEditor:/webkit/WebKitWebView/editor-state/typing-attributes ... (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33669 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11471 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/28025 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17097 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32491 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/128338 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32248 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/35086 "Found 2 new JSC stress test failures: wasm.yaml/wasm/gc/ref-i31-eq.js.wasm-eager-jettison, wasm.yaml/wasm/gc/ref-i31-eq.js.wasm-slow-memory (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35596 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33833 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->