### PR TITLE
Don't use CSSParserFastPaths to parse declarations inside at-rules

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/at-position-try-cssom-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/at-position-try-cssom-expected.txt
@@ -242,9 +242,9 @@ PASS CSSPositionTryDescriptors.setProperty(background)
 PASS CSSPositionTryDescriptors[background] (set)
 PASS CSSPositionTryDescriptors[background] (get)
 PASS CSSPositionTryDescriptors.getPropertyValue(display)
-FAIL CSSPositionTryDescriptors.setProperty(display) assert_equals: expected "" but got "unset"
+PASS CSSPositionTryDescriptors.setProperty(display)
 PASS CSSPositionTryDescriptors[display] (set)
-FAIL CSSPositionTryDescriptors[display] (get) assert_equals: expected "" but got "unset"
+PASS CSSPositionTryDescriptors[display] (get)
 PASS CSSPositionTryDescriptors.getPropertyValue(position)
 PASS CSSPositionTryDescriptors.setProperty(position)
 PASS CSSPositionTryDescriptors[position] (set)

--- a/Source/WebCore/css/parser/CSSParserFastPaths.cpp
+++ b/Source/WebCore/css/parser/CSSParserFastPaths.cpp
@@ -744,10 +744,6 @@ static RefPtr<CSSValue> parseKeywordValue(CSSPropertyID property, StringView str
 {
     ASSERT(!string.isEmpty());
 
-    // Fast path keyword parsing is currently only supported for style properties.
-    if (state.currentRule != StyleRuleType::Style)
-        return nullptr;
-
     if (!CSSPropertyParsing::isKeywordFastPathEligibleStyleProperty(property)) {
         // All properties, including non-keyword properties, accept the CSS-wide keywords.
         if (!isUniversalKeyword(string))
@@ -1044,6 +1040,12 @@ static RefPtr<CSSValue> parseColorWithAuto(StringView string, const CSSParserCon
 
 RefPtr<CSSValue> CSSParserFastPaths::maybeParseValue(CSSPropertyID property, StringView string, CSS::PropertyParserState& state)
 {
+    // Some at-rules like @keyframes, @position-try restrict which properties
+    // are allowed inside the rule. Fallback to slow path for at-rules since
+    // the restriction logic is in the slow-path parser (CSSPropertyParser).
+    if (state.currentRule != StyleRuleType::Style)
+        return nullptr;
+
     switch (property) {
     case CSSPropertyDisplay:
         return parseDisplay(string);


### PR DESCRIPTION
#### ab883ac44d669e6dc2b9ac0f17f8dba8d910aa5c
<pre>
Don&apos;t use CSSParserFastPaths to parse declarations inside at-rules
<a href="https://rdar.apple.com/152190645">rdar://152190645</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=293710">https://bugs.webkit.org/show_bug.cgi?id=293710</a>

Reviewed by Tim Nguyen and Antti Koivisto.

At-rules like @keyframes or @position-try restrict what CSS properties
can be declared in the rule. This logic is present in the &quot;slow&quot;-path
parser (CSSPropertyParser) but not in the fast path parser. Since it&apos;s
rare to parse at-rules with declarations inside anyway, this patch
forces declarations inside at-rules to use the slow path instead
of the fast path.

* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/at-position-try-cssom-expected.txt:
* Source/WebCore/css/parser/CSSParserFastPaths.cpp:
(WebCore::parseKeywordValue):
(WebCore::CSSParserFastPaths::maybeParseValue):

Canonical link: <a href="https://commits.webkit.org/295820@main">https://commits.webkit.org/295820@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/183a83e89842ad553d54e2e196afa42df48a5824

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105516 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25227 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15655 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110716 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/56167 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/107557 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/26567 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33768 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80136 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108522 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/20991 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95227 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60445 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/20555 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13318 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55553 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/90353 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13359 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/113502 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32658 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24085 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89217 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33021 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91457 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88877 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22817 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33747 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11553 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/28111 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32584 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/37992 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32339 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35686 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33927 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->