### PR TITLE
[inline-block][vertical-lr] update width calculation of inline-block with vertical-lr element.

### DIFF
--- a/LayoutTests/fast/inline-block/inline-block-width-vertical-lr-expected.txt
+++ b/LayoutTests/fast/inline-block/inline-block-width-vertical-lr-expected.txt
@@ -1,0 +1,11 @@
+Test case for bug 187454. This tests that the width of inline blocks containing vertical-lr child elements is calculated correctly.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS document.getElementById("t1").offsetWidth is 17
+PASS document.getElementById("t2").offsetWidth is 34
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/inline-block/inline-block-width-vertical-lr.html
+++ b/LayoutTests/fast/inline-block/inline-block-width-vertical-lr.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="zh">
+  <meta charset="utf-8"/>
+  <title>Testcase, bug 1473789</title>
+  <style>
+    div {
+      background-color:silver;
+      display:inline-block;
+    }
+    span {
+      writing-mode:vertical-lr;
+      font-size: 12px;
+    }
+  </style>
+
+<div id="testContent">
+  <div id = "t1"><span>Test Content 1</span></div>
+  <div id = "t2"><span>Test Content 1</span><span>Test Content 2</span></div>
+</div>
+
+  <script src="../../resources/js-test-pre.js"></script>
+  <script>
+    description("Test case for bug 187454. This tests that the width of inline blocks containing vertical-lr child elements is calculated correctly.");
+    shouldBe('document.getElementById("t1").offsetWidth', '17');
+    shouldBe('document.getElementById("t2").offsetWidth', '34');
+    document.getElementById("testContent").style.display = 'none';
+</script>
+<script src="../../resources/js-test-post.js"></script>

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -4781,9 +4781,12 @@ void RenderBlockFlow::computeInlinePreferredLogicalWidths(LayoutUnit& minLogical
                 LayoutUnit childMaxPreferredLogicalWidth;
                 CheckedPtr box = dynamicDowncast<RenderBox>(*child);
                 if (box->isHorizontalWritingMode() != isHorizontalWritingMode()) {
-                    auto extent = box->computeLogicalHeight(box->borderAndPaddingLogicalHeight(), 0).m_extent;
-                    childMinPreferredLogicalWidth = extent;
-                    childMaxPreferredLogicalWidth = extent;
+                    // If the child is an orthogonal flow, child's height determines the width,
+                    // but the height is not available until layout.
+                    if (box->needsLayout())
+                        box->layout();
+                    childMinPreferredLogicalWidth = box->minPreferredLogicalWidth();
+                    childMaxPreferredLogicalWidth = box->maxPreferredLogicalWidth();
                 } else
                     computeChildPreferredLogicalWidths(*box, childMinPreferredLogicalWidth, childMaxPreferredLogicalWidth);
                 childMin += childMinPreferredLogicalWidth.ceilToFloat();


### PR DESCRIPTION
#### 1bc3e6d31b97d19f1b67aa023b3a6f18e8556654
<pre>
[inline-block][vertical-lr] update width calculation of inline-block with vertical-lr element.
<a href="https://bugs.webkit.org/show_bug.cgi?id=187454">https://bugs.webkit.org/show_bug.cgi?id=187454</a>
&lt;<a href="https://rdar.apple.com/41980917">rdar://41980917</a>&gt;

Reviewed by NOBODY (OOPS!).

This PR addresses an issue where the preferred logical width of parents of orthogonal flow
children may be incorrectly calculated. This is acomplished by calling layout() on orthogonal
flow children that need layout.

The previous implementation essentially estimated the height to be borderAndPaddingLogicalHeight()
and avoided a layout() call.

auto extent = box-&gt;computeLogicalHeight(box-&gt;borderAndPaddingLogicalHeight(), 0).m_extent;

was functionally identical to:

RenderBox::computeLogicalHeightWithoutLayout()

As the height of orthogonal flow children is not available until layout.

Combined changes:
* LayoutTests/fast/inline-block/inline-block-width-vertical-lr-expected.txt: Added.
* LayoutTests/fast/inline-block/inline-block-width-vertical-lr.html: Added.
* Source/WebCore/rendering/RenderBlockFlow.cpp:
(WebCore::RenderBlockFlow::computeInlinePreferredLogicalWidths const):
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::hasEquivalentGridPositioningStyle):
(WebCore::RenderBox::updateGridPositionAfterStyleChange):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1bc3e6d31b97d19f1b67aa023b3a6f18e8556654

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105384 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25098 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15523 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110590 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/56026 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/107425 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/25606 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33636 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80039 "Found 20 new test failures: imported/w3c/web-platform-tests/css/css-flexbox/flexbox-align-self-horiz-002.xhtml imported/w3c/web-platform-tests/css/css-grid/alignment/self-baseline/grid-self-baseline-003.html imported/w3c/web-platform-tests/css/css-grid/alignment/self-baseline/grid-self-baseline-004.html imported/w3c/web-platform-tests/css/css-grid/alignment/self-baseline/grid-self-baseline-006.html imported/w3c/web-platform-tests/css/css-grid/alignment/self-baseline/grid-self-baseline-007.html imported/w3c/web-platform-tests/css/css-writing-modes/img-intrinsic-size-contribution-002.html imported/w3c/web-platform-tests/css/css-writing-modes/inline-box-orthogonal-child-with-margins.html imported/w3c/web-platform-tests/css/css-writing-modes/orthogonal-parent-shrink-to-fit-001.html imported/w3c/web-platform-tests/css/css-writing-modes/orthogonal-parent-shrink-to-fit-001b.html imported/w3c/web-platform-tests/css/css-writing-modes/orthogonal-parent-shrink-to-fit-001d.html ... (failure)") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108390 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19989 "Found 1 new test failure: fast/inline-block/inline-block-width-vertical-lr.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95112 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60348 "Passed tests") | 
| | [💥 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/19720 "An unexpected error occured. Recent messages:Printed configuration") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13198 "Found 19 new test failures: fast/inline-block/inline-block-width-vertical-lr.html imported/w3c/web-platform-tests/css/css-grid/alignment/self-baseline/grid-self-baseline-003.html imported/w3c/web-platform-tests/css/css-grid/alignment/self-baseline/grid-self-baseline-004.html imported/w3c/web-platform-tests/css/css-grid/alignment/self-baseline/grid-self-baseline-006.html imported/w3c/web-platform-tests/css/css-grid/alignment/self-baseline/grid-self-baseline-007.html imported/w3c/web-platform-tests/css/css-writing-modes/inline-box-orthogonal-child-with-margins.html imported/w3c/web-platform-tests/css/css-writing-modes/orthogonal-parent-shrink-to-fit-001.html imported/w3c/web-platform-tests/css/css-writing-modes/orthogonal-parent-shrink-to-fit-001b.html imported/w3c/web-platform-tests/css/css-writing-modes/orthogonal-parent-shrink-to-fit-001d.html imported/w3c/web-platform-tests/css/css-writing-modes/orthogonal-parent-shrink-to-fit-001f.html ... (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55431 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/89452 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13239 "Found 21 new test failures: fast/inline-block/inline-block-width-vertical-lr.html imported/w3c/web-platform-tests/css/css-flexbox/flexbox-align-self-horiz-002.xhtml imported/w3c/web-platform-tests/css/css-grid/alignment/self-baseline/grid-self-baseline-003.html imported/w3c/web-platform-tests/css/css-grid/alignment/self-baseline/grid-self-baseline-004.html imported/w3c/web-platform-tests/css/css-grid/alignment/self-baseline/grid-self-baseline-006.html imported/w3c/web-platform-tests/css/css-grid/alignment/self-baseline/grid-self-baseline-007.html imported/w3c/web-platform-tests/css/css-writing-modes/img-intrinsic-size-contribution-002.html imported/w3c/web-platform-tests/css/css-writing-modes/inline-box-orthogonal-child-with-margins.html imported/w3c/web-platform-tests/css/css-writing-modes/orthogonal-parent-shrink-to-fit-001.html imported/w3c/web-platform-tests/css/css-writing-modes/orthogonal-parent-shrink-to-fit-001b.html ... (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/113296 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32534 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23980 "Found 20 new test failures: fast/inline-block/inline-block-width-vertical-lr.html imported/w3c/web-platform-tests/css/css-grid/alignment/self-baseline/grid-self-baseline-003.html imported/w3c/web-platform-tests/css/css-grid/alignment/self-baseline/grid-self-baseline-004.html imported/w3c/web-platform-tests/css/css-grid/alignment/self-baseline/grid-self-baseline-006.html imported/w3c/web-platform-tests/css/css-grid/alignment/self-baseline/grid-self-baseline-007.html imported/w3c/web-platform-tests/css/css-writing-modes/inline-box-orthogonal-child-with-margins.html imported/w3c/web-platform-tests/css/css-writing-modes/orthogonal-parent-shrink-to-fit-001.html imported/w3c/web-platform-tests/css/css-writing-modes/orthogonal-parent-shrink-to-fit-001b.html imported/w3c/web-platform-tests/css/css-writing-modes/orthogonal-parent-shrink-to-fit-001d.html imported/w3c/web-platform-tests/css/css-writing-modes/orthogonal-parent-shrink-to-fit-001f.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89115 "Found 21 new test failures: fast/inline-block/inline-block-width-vertical-lr.html imported/w3c/web-platform-tests/css/css-flexbox/flexbox-align-self-horiz-002.xhtml imported/w3c/web-platform-tests/css/css-grid/alignment/self-baseline/grid-self-baseline-003.html imported/w3c/web-platform-tests/css/css-grid/alignment/self-baseline/grid-self-baseline-004.html imported/w3c/web-platform-tests/css/css-grid/alignment/self-baseline/grid-self-baseline-006.html imported/w3c/web-platform-tests/css/css-grid/alignment/self-baseline/grid-self-baseline-007.html imported/w3c/web-platform-tests/css/css-writing-modes/img-intrinsic-size-contribution-002.html imported/w3c/web-platform-tests/css/css-writing-modes/inline-box-orthogonal-child-with-margins.html imported/w3c/web-platform-tests/css/css-writing-modes/orthogonal-parent-shrink-to-fit-001.html imported/w3c/web-platform-tests/css/css-writing-modes/orthogonal-parent-shrink-to-fit-001b.html ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32897 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91337 "Exiting early after 10 failures. 10 tests run. 1 failures") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88758 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33641 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11445 "Found 21 new test failures: fast/inline-block/inline-block-width-vertical-lr.html imported/w3c/web-platform-tests/css/css-flexbox/flexbox-align-self-horiz-002.xhtml imported/w3c/web-platform-tests/css/css-grid/alignment/self-baseline/grid-self-baseline-003.html imported/w3c/web-platform-tests/css/css-grid/alignment/self-baseline/grid-self-baseline-004.html imported/w3c/web-platform-tests/css/css-grid/alignment/self-baseline/grid-self-baseline-006.html imported/w3c/web-platform-tests/css/css-grid/alignment/self-baseline/grid-self-baseline-007.html imported/w3c/web-platform-tests/css/css-writing-modes/img-intrinsic-size-contribution-002.html imported/w3c/web-platform-tests/css/css-writing-modes/inline-box-orthogonal-child-with-margins.html imported/w3c/web-platform-tests/css/css-writing-modes/orthogonal-parent-shrink-to-fit-001.html imported/w3c/web-platform-tests/css/css-writing-modes/orthogonal-parent-shrink-to-fit-001b.html ... (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/27999 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32459 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/37886 "") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32221 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35569 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33805 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->