### PR TITLE
Use C++20's Concepts in graphics/ColorUtilities

### DIFF
--- a/Source/WebCore/platform/graphics/ColorUtilities.h
+++ b/Source/WebCore/platform/graphics/ColorUtilities.h
@@ -54,17 +54,41 @@ template<typename ColorType> auto colorWithOverriddenAlpha(const ColorType&, flo
 template<typename ColorType> constexpr auto invertedColorWithOverriddenAlpha(const ColorType&, uint8_t overrideAlpha);
 template<typename ColorType> auto invertedColorWithOverriddenAlpha(const ColorType&, float overrideAlpha);
 
-template<typename ColorType, typename std::enable_if_t<UsesLabModel<ColorType> || UsesLCHModel<ColorType> || UsesOKLabModel<ColorType> || UsesOKLCHModel<ColorType> || UsesHSLModel<ColorType>>* = nullptr> constexpr bool isBlack(const ColorType&);
-template<typename ColorType, typename std::enable_if_t<UsesRGBModel<ColorType>>* = nullptr> constexpr bool isBlack(const ColorType&);
-template<typename ColorType, typename std::enable_if_t<UsesHWBModel<ColorType>>* = nullptr> constexpr bool isBlack(const ColorType&);
-template<WhitePoint W> constexpr bool isBlack(const XYZA<float, W>&);
+template<typename ColorType> requires (UsesLabModel<ColorType> || UsesLCHModel<ColorType> || UsesOKLabModel<ColorType> || UsesOKLCHModel<ColorType> || UsesHSLModel<ColorType>)
+constexpr bool isBlack(const ColorType&);
 
-template<typename ColorType, typename std::enable_if_t<UsesLabModel<ColorType> || UsesLCHModel<ColorType> || UsesHSLModel<ColorType>>* = nullptr> constexpr bool isWhite(const ColorType&);
-template<typename ColorType, typename std::enable_if_t<UsesOKLabModel<ColorType> || UsesOKLCHModel<ColorType>>* = nullptr> constexpr bool isWhite(const ColorType&);
-template<typename ColorType, typename std::enable_if_t<UsesRGBModel<ColorType> && std::is_same_v<typename ColorType::ComponentType, float>>* = nullptr> constexpr bool isWhite(const ColorType&);
-template<typename ColorType, typename std::enable_if_t<UsesRGBModel<ColorType> && std::is_same_v<typename ColorType::ComponentType, uint8_t>>* = nullptr> constexpr bool isWhite(const ColorType&);
-template<typename ColorType, typename std::enable_if_t<UsesHWBModel<ColorType>>* = nullptr> constexpr bool isWhite(const ColorType&);
-template<WhitePoint W> constexpr bool isWhite(const XYZA<float, W>&);
+template<typename ColorType> requires UsesRGBModel<ColorType>
+constexpr bool isBlack(const ColorType&);
+
+template<typename ColorType>
+requires UsesHWBModel<ColorType>
+constexpr bool isBlack(const ColorType&);
+
+template<WhitePoint W>
+constexpr bool isBlack(const XYZA<float, W>&);
+
+template<typename ColorType>
+requires (UsesLabModel<ColorType> || UsesLCHModel<ColorType> || UsesHSLModel<ColorType>)
+constexpr bool isWhite(const ColorType&);
+
+template<typename ColorType>
+requires (UsesOKLabModel<ColorType> || UsesOKLCHModel<ColorType>)
+constexpr bool isWhite(const ColorType&);
+
+template<typename ColorType>
+requires (UsesRGBModel<ColorType> && std::is_same_v<typename ColorType::ComponentType, float>)
+constexpr bool isWhite(const ColorType&);
+
+template<typename ColorType>
+requires (UsesRGBModel<ColorType> && std::is_same_v<typename ColorType::ComponentType, uint8_t>)
+constexpr bool isWhite(const ColorType&);
+
+template<typename ColorType>
+requires UsesHWBModel<ColorType>
+constexpr bool isWhite(const ColorType&);
+
+template<WhitePoint W>
+constexpr bool isWhite(const XYZA<float, W>&);
 
 constexpr uint16_t fastMultiplyBy255(uint16_t);
 constexpr uint16_t fastDivideBy255(uint16_t);
@@ -147,68 +171,78 @@ template<typename ColorType> auto invertedColorWithOverriddenAlpha(const ColorTy
     return makeFromComponents<ColorType>(copy);
 }
 
-template<WhitePoint W> constexpr bool isBlack(const XYZA<float, W>& color)
+template<WhitePoint W>
+constexpr bool isBlack(const XYZA<float, W>& color)
 {
     auto resolvedColor = color.resolved();
     return resolvedColor.y == 0 && resolvedColor.alpha == AlphaTraits<float>::opaque;
 }
 
-template<typename ColorType, typename std::enable_if_t<UsesLabModel<ColorType> || UsesLCHModel<ColorType> || UsesOKLabModel<ColorType> || UsesOKLCHModel<ColorType> || UsesHSLModel<ColorType>>*>
+template<typename ColorType>
+requires (UsesLabModel<ColorType> || UsesLCHModel<ColorType> || UsesOKLabModel<ColorType> || UsesOKLCHModel<ColorType> || UsesHSLModel<ColorType>)
 constexpr bool isBlack(const ColorType& color)
 {
     auto resolvedColor = color.resolved();
     return resolvedColor.lightness == 0 && resolvedColor.alpha == AlphaTraits<float>::opaque;
 }
 
-template<typename ColorType, typename std::enable_if_t<UsesRGBModel<ColorType>>*>
+template<typename ColorType>
+requires UsesRGBModel<ColorType>
 constexpr bool isBlack(const ColorType& color)
 {
     auto [c1, c2, c3, alpha] = color.resolved();
     return c1 == 0 && c2 == 0 && c3 == 0 && alpha == AlphaTraits<typename ColorType::ComponentType>::opaque;
 }
 
-template<typename ColorType, typename std::enable_if_t<UsesHWBModel<ColorType>>*>
+template<typename ColorType>
+requires UsesHWBModel<ColorType>
 constexpr bool isBlack(const ColorType& color)
 {
     auto resolvedColor = color.resolved();
     return resolvedColor.blackness == 100 && resolvedColor.alpha == AlphaTraits<float>::opaque;
 }
 
-template<WhitePoint W> constexpr bool isWhite(const XYZA<float, W>& color)
+template<WhitePoint W>
+constexpr bool isWhite(const XYZA<float, W>& color)
 {
     auto resolvedColor = color.resolved();
     return resolvedColor.y == 1 && resolvedColor.alpha == AlphaTraits<float>::opaque;
 }
 
-template<typename ColorType, typename std::enable_if_t<UsesLabModel<ColorType> || UsesLCHModel<ColorType> || UsesHSLModel<ColorType>>*>
+template<typename ColorType>
+requires (UsesLabModel<ColorType> || UsesLCHModel<ColorType> || UsesHSLModel<ColorType>)
 constexpr bool isWhite(const ColorType& color)
 {
     auto resolvedColor = color.resolved();
     return resolvedColor.lightness == 100 && resolvedColor.alpha == AlphaTraits<float>::opaque;
 }
 
-template<typename ColorType, typename std::enable_if_t<UsesOKLabModel<ColorType> || UsesOKLCHModel<ColorType>>*>
+template<typename ColorType>
+requires (UsesOKLabModel<ColorType> || UsesOKLCHModel<ColorType>)
 constexpr bool isWhite(const ColorType& color)
 {
     auto resolvedColor = color.resolved();
     return resolvedColor.lightness == 1 && resolvedColor.alpha == AlphaTraits<float>::opaque;
 }
 
-template<typename ColorType, typename std::enable_if_t<UsesRGBModel<ColorType> && std::is_same_v<typename ColorType::ComponentType, float>>*>
+template<typename ColorType>
+requires (UsesRGBModel<ColorType> && std::is_same_v<typename ColorType::ComponentType, float>)
 constexpr bool isWhite(const ColorType& color)
 {
     auto [c1, c2, c3, alpha] = color.resolved();
     return c1 == 1 && c2 == 1 && c3 == 1 && alpha == AlphaTraits<float>::opaque;
 }
 
-template<typename ColorType, typename std::enable_if_t<UsesRGBModel<ColorType> && std::is_same_v<typename ColorType::ComponentType, uint8_t>>*>
+template<typename ColorType>
+requires (UsesRGBModel<ColorType> && std::is_same_v<typename ColorType::ComponentType, uint8_t>)
 constexpr bool isWhite(const ColorType& color)
 {
     auto [c1, c2, c3, alpha] = color.resolved();
     return c1 == 255 && c2 == 255 && c3 == 255 && alpha == AlphaTraits<uint8_t>::opaque;
 }
 
-template<typename ColorType, typename std::enable_if_t<UsesHWBModel<ColorType>>*>
+template<typename ColorType>
+requires UsesHWBModel<ColorType>
 constexpr bool isWhite(const ColorType& color)
 {
     auto resolvedColor = color.resolved();


### PR DESCRIPTION
#### a4c6030e03b8177351427b3ae900b151648d4059
<pre>
Use C++20&apos;s Concepts in graphics/ColorUtilities
<a href="https://bugs.webkit.org/show_bug.cgi?id=293713">https://bugs.webkit.org/show_bug.cgi?id=293713</a>
<a href="https://rdar.apple.com/problem/152199465">rdar://problem/152199465</a>

Reviewed by Chris Dumez.

Replace std::enable_if with C++20 requires clauses for template constraints.
This should provide better readability and better performance by utilizing
more core langauge features.

* Source/WebCore/platform/graphics/ColorUtilities.h:
(WebCore::isBlack):
(WebCore::isWhite):
(): Deleted.

Canonical link: <a href="https://commits.webkit.org/295575@main">https://commits.webkit.org/295575@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dbe8b85e201c5a2695fe411be07c45608560d1d8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105387 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25101 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15526 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110593 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/56028 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/107428 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/25534 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33639 "Built successfully") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80049 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-layout-tests-in-stress-mode; 16 flakes 73 failures; Uploaded test results; 9 flakes 56 failures; Compiled WebKit; 1 flakes 55 failures; Passed layout tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108393 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19923 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95111 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60358 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/19659 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13197 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55434 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/89445 "Found 1 new API test failure: TestWebKitAPI.WebKit.QuotaDelegate (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13238 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/113301 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32537 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23982 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89119 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32900 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91336 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88764 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22660 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33645 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11444 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/28001 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32462 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/37944 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32223 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35571 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33808 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->