### PR TITLE
Exclude non-user portions of the main thread stack from stack scanning on 32 bits.

### DIFF
--- a/Source/JavaScriptCore/jsc.cpp
+++ b/Source/JavaScriptCore/jsc.cpp
@@ -4531,6 +4531,7 @@ int jscmain(int argc, char** argv)
     JSC::Config::enableRestrictedOptions();
     JSC::Options::machExceptionHandlerSandboxPolicy = JSC::Options::SandboxPolicy::Allow;
 
+    WTF::StackBounds::setBottomOfMainThreadMain(__builtin_frame_address(0));
     WTF::initializeMainThread();
 
     // Note that the options parsing can affect VM creation, and thus

--- a/Source/JavaScriptCore/runtime/JSLock.cpp
+++ b/Source/JavaScriptCore/runtime/JSLock.cpp
@@ -155,6 +155,10 @@ void JSLock::didAcquireLock()
             samplingProfiler->noticeJSLockAcquisition();
     }
 #endif
+#if ASSERT_ENABLED
+    StackBounds::currentThreadStackBounds(); // Check stack bounds consistency.
+#endif
+
 }
 
 void JSLock::unlock()

--- a/Source/WTF/wtf/StackBounds.cpp
+++ b/Source/WTF/wtf/StackBounds.cpp
@@ -21,6 +21,8 @@
 #include "config.h"
 #include <wtf/StackBounds.h>
 
+#include "MainThread.h"
+
 #if OS(DARWIN)
 
 #include <pthread.h>
@@ -49,6 +51,18 @@
 #endif
 
 namespace WTF {
+
+#if !CPU(ADDRESS64)
+static std::atomic<void*> bottomOfMainThreadMain = nullptr;
+#endif
+
+void StackBounds::setBottomOfMainThreadMain([[maybe_unused]] void* stack)
+{
+#if !CPU(ADDRESS64)
+    RELEASE_ASSERT(bottomOfMainThreadMain == nullptr);
+    bottomOfMainThreadMain = stack;
+#endif
+}
 
 #if OS(DARWIN)
 
@@ -161,15 +175,23 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
         static char** oldestEnviron = environ;
 
-        // In 32bit architecture, it is possible that environment variables are having a characters which looks like a pointer,
-        // and conservative GC will find it as a live pointer. We would like to avoid that to precisely exclude non user stack
-        // data region from this stack bounds. As the article (https://lwn.net/Articles/631631/) and the elf loader implementation
-        // explain how Linux main thread stack is organized, environment variables vector is placed on the stack, so we can exclude
-        // environment variables if we use `environ` global variable as a origin of the stack.
+        // On 32bit, it is possible that environment variables and other random data in libc have bytes which look like a pointer,
+        // and conservative GC will find it as a live pointer. We would like to avoid that, so we exclude the non-user stack
+        // data region from these stack bounds. This article explains how the main thread looks (https://lwn.net/Articles/631631/).
+        //
+        // First, we exclude environment variables by using `environ` global variable as a origin of the stack.
         // But `setenv` / `putenv` may alter `environ` variable's content. So we record the oldest `environ` variable content, and use it.
+
         StackBounds stackBounds { origin, bound };
         if (stackBounds.contains(oldestEnviron))
             stackBounds = { oldestEnviron, bound };
+
+        // Then, we exclude any greater region based on manual calls to setBottomOfMainThreadMain.
+#if !CPU(ADDRESS64)
+        if (stackBounds.contains(bottomOfMainThreadMain))
+            stackBounds = { bottomOfMainThreadMain, bound };
+#endif
+
         return stackBounds;
     }
 #endif

--- a/Source/WTF/wtf/StackBounds.h
+++ b/Source/WTF/wtf/StackBounds.h
@@ -65,6 +65,7 @@ public:
         result.checkConsistency();
         return result;
     }
+    WTF_EXPORT_PRIVATE static void setBottomOfMainThreadMain(void*);
 
     void* origin() const
     {
@@ -144,10 +145,10 @@ private:
 
     void checkConsistency() const
     {
-#if ASSERT_ENABLED
+#if ASSERT_ENABLED || OS(LINUX)
         void* currentPosition = currentStackPointer();
-        ASSERT(m_origin != m_bound);
-        ASSERT(currentPosition < m_origin && currentPosition > m_bound);
+        RELEASE_ASSERT(m_origin != m_bound);
+        RELEASE_ASSERT(currentPosition < m_origin && currentPosition > m_bound);
 #endif
     }
 

--- a/Source/WebKit/WebProcess/gtk/WebProcessMainGtk.cpp
+++ b/Source/WebKit/WebProcess/gtk/WebProcessMainGtk.cpp
@@ -30,6 +30,7 @@
 #include "AuxiliaryProcessMain.h"
 #include "WebProcess.h"
 #include <libintl.h>
+#include <wtf/StackBounds.h>
 
 #if !USE(GTK4) && USE(CAIRO)
 #include <gtk/gtk.h>
@@ -114,6 +115,7 @@ int WebProcessMain(int argc, char** argv)
     unsetenv("GTK_THEME");
 #endif
 
+    WTF::StackBounds::setBottomOfMainThreadMain(__builtin_frame_address(0));
     return AuxiliaryProcessMain<WebProcessMainGtk>(argc, argv);
 }
 

--- a/Source/WebKit/WebProcess/wpe/WebProcessMainWPE.cpp
+++ b/Source/WebKit/WebProcess/wpe/WebProcessMainWPE.cpp
@@ -30,6 +30,7 @@
 #include "AuxiliaryProcessMain.h"
 #include "WebProcess.h"
 #include <glib.h>
+#include <wtf/StackBounds.h>
 
 #if USE(GCRYPT)
 #include <pal/crypto/gcrypt/Initialization.h>
@@ -97,6 +98,7 @@ public:
 
 int WebProcessMain(int argc, char** argv)
 {
+    WTF::StackBounds::setBottomOfMainThreadMain(__builtin_frame_address(0));
     return AuxiliaryProcessMain<WebProcessMainWPE>(argc, argv);
 }
 


### PR DESCRIPTION
#### 3f2163b2a67dfeff796165912f76fe215f3ec7dc
<pre>
Exclude non-user portions of the main thread stack from stack scanning on 32 bits.
<a href="https://bugs.webkit.org/show_bug.cgi?id=293720">https://bugs.webkit.org/show_bug.cgi?id=293720</a>

Reviewed by NOBODY (OOPS!).

On 32-bit armv7/linux we run into an issue where the environment strings
located at the bottom of the stack, as well as some random bits inside
the libc portion of the stack are interpreted as cells pointing
into the heap, keeping actually dead objects alive.

Yusuke previously attempted to fix this by excluding environ and before,
but there are additional fake roots only a few hundred bytes below that.

This patch excludes the caller of main entirely.

* Source/JavaScriptCore/jsc.cpp:
(jscmain):
* Source/WTF/wtf/StackBounds.cpp:
(WTF::StackBounds::setBottomOfMainThreadMain):
(WTF::StackBounds::currentThreadStackBoundsInternal):
* Source/WTF/wtf/StackBounds.h:
* Source/WebKit/WebProcess/gtk/WebProcessMainGtk.cpp:
* Source/WebKit/WebProcess/wpe/WebProcessMainWPE.cpp:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c356a16ffcdfc236c2f8226378c6f4c7de80789f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133358 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5859 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44494 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140913 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/85405 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6371 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/5724 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/102017 "Found 14 new test failures: editing/selection/caret-at-bidi-boundary.html fast/workers/worker-cloneport.html imported/w3c/web-platform-tests/css/css-anchor-position/scroll-to-anchored-fixed-003.html imported/w3c/web-platform-tests/css/css-scoping/css-scoping-shadow-dynamic-remove-style-detached.html imported/w3c/web-platform-tests/dom/events/Event-dispatch-single-activation-behavior.html imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/cross-origin-top-navigation-with-user-activation-in-parent.window.html imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/javascript-url-return-value-handling-dynamic.html imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-details-element/toggleEvent.html imported/w3c/web-platform-tests/html/semantics/popovers/popover-events.html imported/w3c/web-platform-tests/mimesniff/mime-types/parsing.any.worker.html ... (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/69463 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136305 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/4525 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119541 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82808 "Found 1 new API test failure: WPE/TestInputMethodContext:/webkit/WebKitInputMethodContext/surrounding (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4404 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/1994 "Passed tests") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/125430 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113499 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/37649 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143560 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/131868 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5529 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38235 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110396 "Found 32 new test failures: fast/workers/worker-cloneport.html imported/w3c/web-platform-tests/IndexedDB/get-databases.any.worker.html imported/w3c/web-platform-tests/css/css-contain/contain-inline-size-replaced.html imported/w3c/web-platform-tests/dom/events/Event-dispatch-single-activation-behavior.html imported/w3c/web-platform-tests/dom/nodes/MutationObserver-callback-order-between-document-with-and-without-browsing-context.html imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/cross-origin-top-navigation-with-user-activation-in-parent.window.html imported/w3c/web-platform-tests/html/dom/idlharness.https.html?exclude=(Document\|Window\|HTML.*) imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-details-element/toggleEvent.html imported/w3c/web-platform-tests/html/webappapis/timers/timer-nesting-not-inherited-in-microtask.html imported/w3c/web-platform-tests/mimesniff/mime-types/parsing.any.worker.html ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5611 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4750 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110575 "Found 1 new API test failure: WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/surrounding (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4269 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115796 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/59279 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5584 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/34134 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/164834 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/5430 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/69036 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/43069 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5673 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5540 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->