### PR TITLE
Stop using UncheckedKey containers in WebCore/loader

### DIFF
--- a/Source/WebCore/css/CSSImportRule.cpp
+++ b/Source/WebCore/css/CSSImportRule.cpp
@@ -153,7 +153,7 @@ void CSSImportRule::setMediaQueries(MQ::MediaQueryList&& queries)
     m_importRule->setMediaQueries(WTFMove(queries));
 }
 
-void CSSImportRule::getChildStyleSheets(UncheckedKeyHashSet<RefPtr<CSSStyleSheet>>& childStyleSheets)
+void CSSImportRule::getChildStyleSheets(HashSet<RefPtr<CSSStyleSheet>>& childStyleSheets)
 {
     RefPtr sheet = styleSheet();
     if (!sheet)

--- a/Source/WebCore/css/CSSImportRule.h
+++ b/Source/WebCore/css/CSSImportRule.h
@@ -55,7 +55,7 @@ private:
     String cssText() const final;
     String cssText(const CSS::SerializationContext&) const final;
     void reattach(StyleRuleBase&) final;
-    void getChildStyleSheets(UncheckedKeyHashSet<RefPtr<CSSStyleSheet>>&) final;
+    void getChildStyleSheets(HashSet<RefPtr<CSSStyleSheet>>&) final;
 
     String cssTextInternal(const String& urlString) const;
     const MQ::MediaQueryList& mediaQueries() const;

--- a/Source/WebCore/css/CSSRule.h
+++ b/Source/WebCore/css/CSSRule.h
@@ -61,7 +61,7 @@ public:
     bool hasStyleRuleAncestor() const;
     CSSParserEnum::NestedContext nestedContext() const;
     virtual RefPtr<StyleRuleWithNesting> prepareChildStyleRuleForNesting(StyleRule&);
-    virtual void getChildStyleSheets(UncheckedKeyHashSet<RefPtr<CSSStyleSheet>>&) { }
+    virtual void getChildStyleSheets(HashSet<RefPtr<CSSStyleSheet>>&) { }
 
     WEBCORE_EXPORT ExceptionOr<void> setCssText(const String&);
 

--- a/Source/WebCore/css/CSSStyleRule.cpp
+++ b/Source/WebCore/css/CSSStyleRule.cpp
@@ -315,7 +315,7 @@ CSSRuleList& CSSStyleRule::cssRules() const
     return *m_ruleListCSSOMWrapper;
 }
 
-void CSSStyleRule::getChildStyleSheets(UncheckedKeyHashSet<RefPtr<CSSStyleSheet>>& childStyleSheets)
+void CSSStyleRule::getChildStyleSheets(HashSet<RefPtr<CSSStyleSheet>>& childStyleSheets)
 {
     for (unsigned index = 0; index < length(); ++index)
         item(index)->getChildStyleSheets(childStyleSheets);

--- a/Source/WebCore/css/CSSStyleRule.h
+++ b/Source/WebCore/css/CSSStyleRule.h
@@ -67,7 +67,7 @@ private:
     String cssText(const CSS::SerializationContext&) const final;
     String cssTextInternal(StringBuilder& declarations, StringBuilder& rules) const;
     void reattach(StyleRuleBase&) final;
-    void getChildStyleSheets(UncheckedKeyHashSet<RefPtr<CSSStyleSheet>>&) final;
+    void getChildStyleSheets(HashSet<RefPtr<CSSStyleSheet>>&) final;
 
     String generateSelectorText() const;
     Vector<Ref<StyleRuleBase>> nestedRules() const;

--- a/Source/WebCore/css/CSSStyleSheet.cpp
+++ b/Source/WebCore/css/CSSStyleSheet.cpp
@@ -593,7 +593,7 @@ Ref<StyleSheetContents> CSSStyleSheet::protectedContents()
     return m_contents;
 }
 
-void CSSStyleSheet::getChildStyleSheets(UncheckedKeyHashSet<RefPtr<CSSStyleSheet>>& childStyleSheets)
+void CSSStyleSheet::getChildStyleSheets(HashSet<RefPtr<CSSStyleSheet>>& childStyleSheets)
 {
     RefPtr ruleList = cssRules();
     if (!ruleList)

--- a/Source/WebCore/css/CSSStyleSheet.h
+++ b/Source/WebCore/css/CSSStyleSheet.h
@@ -159,7 +159,7 @@ public:
 
     String debugDescription() const final;
     String cssText(const CSS::SerializationContext&);
-    void getChildStyleSheets(UncheckedKeyHashSet<RefPtr<CSSStyleSheet>>&);
+    void getChildStyleSheets(HashSet<RefPtr<CSSStyleSheet>>&);
 
     bool isDetached() const;
 

--- a/Source/WebCore/css/values/CSSSerializationContext.cpp
+++ b/Source/WebCore/css/values/CSSSerializationContext.cpp
@@ -33,7 +33,7 @@ namespace CSS {
 SerializationContext::SerializationContext() = default;
 SerializationContext::~SerializationContext() = default;
 
-SerializationContext::SerializationContext(UncheckedKeyHashMap<String, String>&& replacementURLStrings, UncheckedKeyHashMap<Ref<CSSStyleSheet>, String>&& replacementURLStringsForCSSStyleSheet, bool shouldUseResolvedURLInCSSText)
+SerializationContext::SerializationContext(HashMap<String, String>&& replacementURLStrings, HashMap<Ref<CSSStyleSheet>, String>&& replacementURLStringsForCSSStyleSheet, bool shouldUseResolvedURLInCSSText)
     : replacementURLStrings { WTFMove(replacementURLStrings) }
     , replacementURLStringsForCSSStyleSheet { WTFMove(replacementURLStringsForCSSStyleSheet) }
     , shouldUseResolvedURLInCSSText { shouldUseResolvedURLInCSSText }

--- a/Source/WebCore/css/values/CSSSerializationContext.h
+++ b/Source/WebCore/css/values/CSSSerializationContext.h
@@ -35,11 +35,11 @@ namespace CSS {
 
 struct SerializationContext {
     SerializationContext();
-    SerializationContext(UncheckedKeyHashMap<String, String>&&, UncheckedKeyHashMap<Ref<CSSStyleSheet>, String>&&, bool);
+    SerializationContext(HashMap<String, String>&&, HashMap<Ref<CSSStyleSheet>, String>&&, bool);
     ~SerializationContext();
 
-    UncheckedKeyHashMap<String, String> replacementURLStrings;
-    UncheckedKeyHashMap<Ref<CSSStyleSheet>, String> replacementURLStringsForCSSStyleSheet;
+    HashMap<String, String> replacementURLStrings;
+    HashMap<Ref<CSSStyleSheet>, String> replacementURLStringsForCSSStyleSheet;
     bool shouldUseResolvedURLInCSSText = false;
 };
 

--- a/Source/WebCore/editing/MarkupAccumulator.cpp
+++ b/Source/WebCore/editing/MarkupAccumulator.cpp
@@ -207,7 +207,7 @@ MarkupAccumulator::MarkupAccumulator(Vector<Ref<Node>>* nodes, ResolveURLs resol
 
 MarkupAccumulator::~MarkupAccumulator() = default;
 
-void MarkupAccumulator::enableURLReplacement(UncheckedKeyHashMap<String, String>&& replacementURLStrings, UncheckedKeyHashMap<Ref<CSSStyleSheet>, String>&& replacementURLStringsForCSSStyleSheet)
+void MarkupAccumulator::enableURLReplacement(HashMap<String, String>&& replacementURLStrings, HashMap<Ref<CSSStyleSheet>, String>&& replacementURLStringsForCSSStyleSheet)
 {
     m_serializationContext = CSS::SerializationContext {
         WTFMove(replacementURLStrings),

--- a/Source/WebCore/editing/MarkupAccumulator.h
+++ b/Source/WebCore/editing/MarkupAccumulator.h
@@ -75,7 +75,7 @@ public:
     String serializeNodes(Node& targetNode, SerializedNodes);
 
     static void appendCharactersReplacingEntities(StringBuilder&, const String&, OptionSet<EntityMask>);
-    void enableURLReplacement(UncheckedKeyHashMap<String, String>&& replacementURLStrings, UncheckedKeyHashMap<Ref<CSSStyleSheet>, String>&& replacementURLStringsForCSSStyleSheet);
+    void enableURLReplacement(HashMap<String, String>&& replacementURLStrings, HashMap<Ref<CSSStyleSheet>, String>&& replacementURLStringsForCSSStyleSheet);
 
     static SerializationSyntax serializationSyntax(Document&);
 

--- a/Source/WebCore/editing/markup.cpp
+++ b/Source/WebCore/editing/markup.cpp
@@ -1286,7 +1286,7 @@ String serializeFragment(const Node& node, SerializedNodes root, Vector<Ref<Node
     return accumulator.serializeNodes(const_cast<Node&>(node), root);
 }
 
-String serializeFragmentWithURLReplacement(const Node& node, SerializedNodes root, Vector<Ref<Node>>* nodes, ResolveURLs resolveURLs, std::optional<SerializationSyntax> serializationSyntax, UncheckedKeyHashMap<String, String>&& replacementURLStrings, UncheckedKeyHashMap<Ref<CSSStyleSheet>, String>&& replacementURLStringsForCSSStyleSheet, SerializeShadowRoots serializeShadowRoots, Vector<Ref<ShadowRoot>>&& explicitShadowRoots, const Vector<MarkupExclusionRule>& exclusionRules)
+String serializeFragmentWithURLReplacement(const Node& node, SerializedNodes root, Vector<Ref<Node>>* nodes, ResolveURLs resolveURLs, std::optional<SerializationSyntax> serializationSyntax, HashMap<String, String>&& replacementURLStrings, HashMap<Ref<CSSStyleSheet>, String>&& replacementURLStringsForCSSStyleSheet, SerializeShadowRoots serializeShadowRoots, Vector<Ref<ShadowRoot>>&& explicitShadowRoots, const Vector<MarkupExclusionRule>& exclusionRules)
 {
     if (!serializationSyntax)
         serializationSyntax = MarkupAccumulator::serializationSyntax(node.document());

--- a/Source/WebCore/editing/markup.h
+++ b/Source/WebCore/editing/markup.h
@@ -107,7 +107,7 @@ enum class SerializedNodes : uint8_t { SubtreeIncludingNode, SubtreesOfChildren 
 enum class SerializationSyntax : uint8_t { HTML, XML, HTMLLegacyAttributeValue };
 enum class SerializeShadowRoots : uint8_t { Explicit, Serializable, AllForInterchange };
 WEBCORE_EXPORT String serializeFragment(const Node&, SerializedNodes, Vector<Ref<Node>>* = nullptr, ResolveURLs = ResolveURLs::No, std::optional<SerializationSyntax> = std::nullopt, SerializeShadowRoots = SerializeShadowRoots::Explicit, Vector<Ref<ShadowRoot>>&& explicitShadowRoots = { }, const Vector<MarkupExclusionRule>& exclusionRules = { });
-WEBCORE_EXPORT String serializeFragmentWithURLReplacement(const Node&, SerializedNodes, Vector<Ref<Node>>*, ResolveURLs, std::optional<SerializationSyntax>, UncheckedKeyHashMap<String, String>&& replacementURLStrings, UncheckedKeyHashMap<Ref<CSSStyleSheet>, String>&& replacementURLStringsForCSSStyleSheet, SerializeShadowRoots = SerializeShadowRoots::Explicit, Vector<Ref<ShadowRoot>>&& explicitShadowRoots = { }, const Vector<MarkupExclusionRule>& exclusionRules = { });
+WEBCORE_EXPORT String serializeFragmentWithURLReplacement(const Node&, SerializedNodes, Vector<Ref<Node>>*, ResolveURLs, std::optional<SerializationSyntax>, HashMap<String, String>&& replacementURLStrings, HashMap<Ref<CSSStyleSheet>, String>&& replacementURLStringsForCSSStyleSheet, SerializeShadowRoots = SerializeShadowRoots::Explicit, Vector<Ref<ShadowRoot>>&& explicitShadowRoots = { }, const Vector<MarkupExclusionRule>& exclusionRules = { });
 
 String urlToMarkup(const URL&, const String& title);
 

--- a/Source/WebCore/loader/CrossOriginPreflightResultCache.h
+++ b/Source/WebCore/loader/CrossOriginPreflightResultCache.h
@@ -47,7 +47,7 @@ class CrossOriginPreflightResultCacheItem {
 public:
     static Expected<UniqueRef<CrossOriginPreflightResultCacheItem>, String> create(StoredCredentialsPolicy, const ResourceResponse&);
 
-    CrossOriginPreflightResultCacheItem(MonotonicTime, StoredCredentialsPolicy, UncheckedKeyHashSet<String>&&, UncheckedKeyHashSet<String, ASCIICaseInsensitiveHash>&&);
+    CrossOriginPreflightResultCacheItem(MonotonicTime, StoredCredentialsPolicy, HashSet<String>&&, HashSet<String, ASCIICaseInsensitiveHash>&&);
 
     std::optional<String> validateMethodAndHeaders(const String& method, const HTTPHeaderMap&) const;
     bool allowsRequest(StoredCredentialsPolicy, const String& method, const HTTPHeaderMap&) const;
@@ -61,8 +61,8 @@ private:
     // it fires.
     MonotonicTime m_absoluteExpiryTime;
     StoredCredentialsPolicy m_storedCredentialsPolicy;
-    UncheckedKeyHashSet<String> m_methods;
-    UncheckedKeyHashSet<String, ASCIICaseInsensitiveHash> m_headers;
+    HashSet<String> m_methods;
+    HashSet<String, ASCIICaseInsensitiveHash> m_headers;
 };
 
 class CrossOriginPreflightResultCache {
@@ -80,7 +80,7 @@ private:
     HashMap<std::tuple<PAL::SessionID, ClientOrigin, URL>, std::unique_ptr<CrossOriginPreflightResultCacheItem>> m_preflightHashMap;
 };
 
-inline CrossOriginPreflightResultCacheItem::CrossOriginPreflightResultCacheItem(MonotonicTime absoluteExpiryTime, StoredCredentialsPolicy  storedCredentialsPolicy, UncheckedKeyHashSet<String>&& methods, UncheckedKeyHashSet<String, ASCIICaseInsensitiveHash>&& headers)
+inline CrossOriginPreflightResultCacheItem::CrossOriginPreflightResultCacheItem(MonotonicTime absoluteExpiryTime, StoredCredentialsPolicy  storedCredentialsPolicy, HashSet<String>&& methods, HashSet<String, ASCIICaseInsensitiveHash>&& headers)
     : m_absoluteExpiryTime(absoluteExpiryTime)
     , m_storedCredentialsPolicy(storedCredentialsPolicy)
     , m_methods(WTFMove(methods))

--- a/Source/WebCore/loader/appcache/ApplicationCacheGroup.cpp
+++ b/Source/WebCore/loader/appcache/ApplicationCacheGroup.cpp
@@ -1024,7 +1024,7 @@ void ApplicationCacheGroup::scheduleReachedMaxAppCacheSizeCallback()
     // The timer will delete itself once it fires.
 }
 
-void ApplicationCacheGroup::postListenerTask(const AtomString& eventType, int progressTotal, int progressDone, const UncheckedKeyHashSet<DocumentLoader*>& loaderSet)
+void ApplicationCacheGroup::postListenerTask(const AtomString& eventType, int progressTotal, int progressDone, const HashSet<DocumentLoader*>& loaderSet)
 {
     for (auto& loader : loaderSet)
         postListenerTask(eventType, progressTotal, progressDone, *loader);

--- a/Source/WebCore/loader/appcache/ApplicationCacheGroup.h
+++ b/Source/WebCore/loader/appcache/ApplicationCacheGroup.h
@@ -103,9 +103,9 @@ public:
     void disassociateDocumentLoader(DocumentLoader&);
 
 private:
-    static void postListenerTask(const AtomString& eventType, const UncheckedKeyHashSet<DocumentLoader*>& set) { postListenerTask(eventType, 0, 0, set); }
+    static void postListenerTask(const AtomString& eventType, const HashSet<DocumentLoader*>& set) { postListenerTask(eventType, 0, 0, set); }
     static void postListenerTask(const AtomString& eventType, DocumentLoader& loader)  { postListenerTask(eventType, 0, 0, loader); }
-    static void postListenerTask(const AtomString& eventType, int progressTotal, int progressDone, const UncheckedKeyHashSet<DocumentLoader*>&);
+    static void postListenerTask(const AtomString& eventType, int progressTotal, int progressDone, const HashSet<DocumentLoader*>&);
     static void postListenerTask(const AtomString& eventType, int progressTotal, int progressDone, DocumentLoader&);
 
     void scheduleReachedMaxAppCacheSizeCallback();
@@ -144,19 +144,19 @@ private:
     RefPtr<ApplicationCache> m_newestCache;
     
     // All complete caches in this cache group.
-    UncheckedKeyHashSet<ApplicationCache*> m_caches;
+    HashSet<ApplicationCache*> m_caches;
     
     // The cache being updated (if any). Note that cache updating does not immediately create a new
     // ApplicationCache object, so this may be null even when update status is not Idle.
     RefPtr<ApplicationCache> m_cacheBeingUpdated;
 
     // List of pending master entries, used during the update process to ensure that new master entries are cached.
-    UncheckedKeyHashSet<DocumentLoader*> m_pendingMasterResourceLoaders;
+    HashSet<DocumentLoader*> m_pendingMasterResourceLoaders;
     // How many of the above pending master entries have not yet finished downloading.
     int m_downloadingPendingMasterResourceLoadersCount { 0 };
     
     // These are all the document loaders that are associated with a cache in this group.
-    UncheckedKeyHashSet<DocumentLoader*> m_associatedDocumentLoaders;
+    HashSet<DocumentLoader*> m_associatedDocumentLoaders;
 
     // The URLs and types of pending cache entries.
     HashMap<String, unsigned> m_pendingEntries;

--- a/Source/WebCore/loader/appcache/ApplicationCacheManifestParser.h
+++ b/Source/WebCore/loader/appcache/ApplicationCacheManifestParser.h
@@ -36,7 +36,7 @@ using FallbackURLVector = Vector<std::pair<URL, URL>>;
 
 struct ApplicationCacheManifest {
     Vector<URL> onlineAllowedURLs;
-    UncheckedKeyHashSet<String> explicitURLs;
+    HashSet<String> explicitURLs;
     FallbackURLVector fallbackURLs;
     bool allowAllNetworkRequests { false }; // Wildcard found in NETWORK section.
 };

--- a/Source/WebCore/loader/appcache/ApplicationCacheStorage.cpp
+++ b/Source/WebCore/loader/appcache/ApplicationCacheStorage.cpp
@@ -1459,7 +1459,7 @@ long long ApplicationCacheStorage::flatFileAreaSize()
     return totalSize;
 }
 
-UncheckedKeyHashSet<SecurityOriginData> ApplicationCacheStorage::originsWithCache()
+HashSet<SecurityOriginData> ApplicationCacheStorage::originsWithCache()
 {
     auto urls = manifestURLs();
     if (!urls)
@@ -1467,7 +1467,7 @@ UncheckedKeyHashSet<SecurityOriginData> ApplicationCacheStorage::originsWithCach
 
     // Multiple manifest URLs might share the same SecurityOrigin, so we might be creating extra, wasted origins here.
     // The current schema doesn't allow for a more efficient way of building this list.
-    UncheckedKeyHashSet<SecurityOriginData> origins;
+    HashSet<SecurityOriginData> origins;
     for (auto& url : *urls)
         origins.add(SecurityOriginData::fromURL(url));
     return origins;

--- a/Source/WebCore/loader/appcache/ApplicationCacheStorage.h
+++ b/Source/WebCore/loader/appcache/ApplicationCacheStorage.h
@@ -87,7 +87,7 @@ public:
 
     WEBCORE_EXPORT void empty();
 
-    WEBCORE_EXPORT UncheckedKeyHashSet<SecurityOriginData> originsWithCache();
+    WEBCORE_EXPORT HashSet<SecurityOriginData> originsWithCache();
     WEBCORE_EXPORT void deleteAllEntries();
 
     // FIXME: This should be consolidated with deleteAllEntries().

--- a/Source/WebCore/loader/archive/Archive.cpp
+++ b/Source/WebCore/loader/archive/Archive.cpp
@@ -38,12 +38,12 @@ Archive::~Archive() = default;
 
 void Archive::clearAllSubframeArchives()
 {
-    UncheckedKeyHashSet<Archive*> clearedArchives;
+    HashSet<Archive*> clearedArchives;
     clearedArchives.add(this);
     clearAllSubframeArchives(clearedArchives);
 }
 
-void Archive::clearAllSubframeArchives(UncheckedKeyHashSet<Archive*>& clearedArchives)
+void Archive::clearAllSubframeArchives(HashSet<Archive*>& clearedArchives)
 {
     ASSERT(clearedArchives.contains(this));
     for (auto& archive : m_subframeArchives) {

--- a/Source/WebCore/loader/archive/Archive.h
+++ b/Source/WebCore/loader/archive/Archive.h
@@ -59,7 +59,7 @@ protected:
     void clearAllSubframeArchives();
 
 private:
-    void clearAllSubframeArchives(UncheckedKeyHashSet<Archive*>&);
+    void clearAllSubframeArchives(HashSet<Archive*>&);
 
     RefPtr<ArchiveResource> m_mainResource;
     Vector<Ref<ArchiveResource>> m_subresources;

--- a/Source/WebCore/loader/archive/cf/LegacyWebArchive.cpp
+++ b/Source/WebCore/loader/archive/cf/LegacyWebArchive.cpp
@@ -116,7 +116,7 @@ static String getFileNameFromURIComponent(StringView input)
     return result.toString();
 }
 
-static String generateValidFileName(const URL& url, const UncheckedKeyHashSet<String>& existingFileNames, const String& extension = { })
+static String generateValidFileName(const URL& url, const HashSet<String>& existingFileNames, const String& extension = { })
 {
     String suffix = extension.isEmpty() ? emptyString() : makeString('.', extension);
     auto extractedFileName = getFileNameFromURIComponent(url.lastPathComponent());
@@ -615,7 +615,7 @@ static void addSubresourcesForAttachmentElementsIfNecessary(LocalFrame& frame, c
 
 #endif
 
-static UncheckedKeyHashMap<Ref<CSSStyleSheet>, String> addSubresourcesForCSSStyleSheetsIfNecessary(LocalFrame& frame, const String& subresourcesDirectoryName, UncheckedKeyHashSet<String>& uniqueFileNames, UncheckedKeyHashMap<String, String>& uniqueSubresources, Vector<Ref<ArchiveResource>>& subresources)
+static HashMap<Ref<CSSStyleSheet>, String> addSubresourcesForCSSStyleSheetsIfNecessary(LocalFrame& frame, const String& subresourcesDirectoryName, HashSet<String>& uniqueFileNames, HashMap<String, String>& uniqueSubresources, Vector<Ref<ArchiveResource>>& subresources)
 {
     if (subresourcesDirectoryName.isEmpty())
         return { };
@@ -626,7 +626,7 @@ static UncheckedKeyHashMap<Ref<CSSStyleSheet>, String> addSubresourcesForCSSStyl
 
     CSS::SerializationContext serializationContext;
 
-    UncheckedKeyHashMap<Ref<CSSStyleSheet>, String> uniqueCSSStyleSheets;
+    HashMap<Ref<CSSStyleSheet>, String> uniqueCSSStyleSheets;
     Ref documentStyleSheets = document->styleSheets();
     for (unsigned index = 0; index < documentStyleSheets->length(); ++index) {
         RefPtr cssStyleSheet = dynamicDowncast<CSSStyleSheet>(documentStyleSheets->item(index));
@@ -636,7 +636,7 @@ static UncheckedKeyHashMap<Ref<CSSStyleSheet>, String> addSubresourcesForCSSStyl
         if (uniqueCSSStyleSheets.contains(*cssStyleSheet))
             continue;
 
-        UncheckedKeyHashSet<RefPtr<CSSStyleSheet>> cssStyleSheets;
+        HashSet<RefPtr<CSSStyleSheet>> cssStyleSheets;
         cssStyleSheets.add(cssStyleSheet.get());
         cssStyleSheet->getChildStyleSheets(cssStyleSheets);
         for (auto& currentCSSStyleSheet : cssStyleSheets) {
@@ -703,8 +703,8 @@ RefPtr<LegacyWebArchive> LegacyWebArchive::create(const String& markupString, bo
     Vector<Ref<LegacyWebArchive>> subframeArchives;
     Vector<FrameIdentifier> subframeIdentifiers;
     Vector<Ref<ArchiveResource>> subresources;
-    UncheckedKeyHashMap<String, String> uniqueSubresources;
-    UncheckedKeyHashSet<String> uniqueFileNames;
+    HashMap<String, String> uniqueSubresources;
+    HashSet<String> uniqueFileNames;
     String subresourcesDirectoryName = mainFrameFilePath.isNull() ? String { } : makeString(mainFrameFilePath, "_files"_s);
 
     for (auto& node : nodes) {

--- a/Source/WebCore/loader/cache/CachedResource.h
+++ b/Source/WebCore/loader/cache/CachedResource.h
@@ -404,7 +404,7 @@ private:
 
     // These handles will need to be updated to point to the m_resourceToRevalidate in case we get 304 response.
     // FIXME: This should use a smart pointer.
-    UncheckedKeyHashSet<CachedResourceHandleBase*> m_handlesToRevalidate;
+    HashSet<CachedResourceHandleBase*> m_handlesToRevalidate;
 
     Vector<std::pair<String, String>> m_varyingHeaderValues;
 

--- a/Source/WebCore/loader/cache/MemoryCache.cpp
+++ b/Source/WebCore/loader/cache/MemoryCache.cpp
@@ -583,7 +583,7 @@ void MemoryCache::removeResourcesWithOrigins(PAL::SessionID sessionID, const Has
     if (!resourceMap)
         return;
 
-    UncheckedKeyHashSet<String> originPartitions;
+    HashSet<String> originPartitions;
 
     for (auto& origin : origins)
         originPartitions.add(ResourceRequest::partitionName(origin->host()));
@@ -621,11 +621,11 @@ void MemoryCache::getOriginsWithCache(SecurityOriginSet& origins)
     }
 }
 
-UncheckedKeyHashSet<RefPtr<SecurityOrigin>> MemoryCache::originsWithCache(PAL::SessionID sessionID) const
+HashSet<RefPtr<SecurityOrigin>> MemoryCache::originsWithCache(PAL::SessionID sessionID) const
 {
     RELEASE_ASSERT(isMainThread());
 
-    UncheckedKeyHashSet<RefPtr<SecurityOrigin>> origins;
+    HashSet<RefPtr<SecurityOrigin>> origins;
 
     auto it = m_sessionResources.find(sessionID);
     if (it != m_sessionResources.end()) {

--- a/Source/WebCore/loader/cache/MemoryCache.h
+++ b/Source/WebCore/loader/cache/MemoryCache.h
@@ -157,13 +157,13 @@ public:
     void resourceAccessed(CachedResource&);
     bool inLiveDecodedResourcesList(CachedResource&) const;
 
-    typedef UncheckedKeyHashSet<RefPtr<SecurityOrigin>> SecurityOriginSet;
+    using SecurityOriginSet = HashSet<RefPtr<SecurityOrigin>>;
     WEBCORE_EXPORT void removeResourcesWithOrigin(const SecurityOrigin&);
     void removeResourcesWithOrigin(const SecurityOrigin&, const String& cachePartition);
     WEBCORE_EXPORT void removeResourcesWithOrigin(const ClientOrigin&);
     WEBCORE_EXPORT void removeResourcesWithOrigins(PAL::SessionID, const HashSet<RefPtr<SecurityOrigin>>&);
     WEBCORE_EXPORT void getOriginsWithCache(SecurityOriginSet& origins);
-    WEBCORE_EXPORT UncheckedKeyHashSet<RefPtr<SecurityOrigin>> originsWithCache(PAL::SessionID) const;
+    WEBCORE_EXPORT HashSet<RefPtr<SecurityOrigin>> originsWithCache(PAL::SessionID) const;
 
     // pruneDead*() - Flush decoded and encoded data from resources not referenced by Web pages.
     // pruneLive*() - Flush decoded data from resources still referenced by Web pages.

--- a/Source/WebCore/platform/network/HTTPParsers.h
+++ b/Source/WebCore/platform/network/HTTPParsers.h
@@ -36,7 +36,7 @@
 
 namespace WebCore {
 
-typedef UncheckedKeyHashSet<String, ASCIICaseInsensitiveHash> HTTPHeaderSet;
+using HTTPHeaderSet = HashSet<String, ASCIICaseInsensitiveHash>;
 
 class ResourceResponse;
 enum class HTTPHeaderName : uint16_t;
@@ -126,7 +126,7 @@ bool isSafeMethod(const String&);
 WEBCORE_EXPORT CrossOriginResourcePolicy parseCrossOriginResourcePolicyHeader(StringView);
 
 template<class HashType>
-bool addToAccessControlAllowList(const String& string, unsigned start, unsigned end, UncheckedKeyHashSet<String, HashType>& set)
+bool addToAccessControlAllowList(const String& string, unsigned start, unsigned end, HashSet<String, HashType>& set)
 {
     StringImpl* stringImpl = string.impl();
     if (!stringImpl)
@@ -153,9 +153,9 @@ bool addToAccessControlAllowList(const String& string, unsigned start, unsigned 
 }
 
 template<class HashType = DefaultHash<String>>
-std::optional<UncheckedKeyHashSet<String, HashType>> parseAccessControlAllowList(const String& string)
+std::optional<HashSet<String, HashType>> parseAccessControlAllowList(const String& string)
 {
-    UncheckedKeyHashSet<String, HashType> set;
+    HashSet<String, HashType> set;
     unsigned start = 0;
     size_t end;
     while ((end = string.find(',', start)) != notFound) {


### PR DESCRIPTION
#### 7278c80043f8fddd7042c4b3c0683f6ee4c0b534
<pre>
Stop using UncheckedKey containers in WebCore/loader
<a href="https://bugs.webkit.org/show_bug.cgi?id=293722">https://bugs.webkit.org/show_bug.cgi?id=293722</a>

Reviewed by Sihui Liu.

Stop using UncheckedKey containers in WebCore/loader, for extra safety.

* Source/WebCore/css/CSSImportRule.cpp:
(WebCore::CSSImportRule::getChildStyleSheets):
* Source/WebCore/css/CSSImportRule.h:
* Source/WebCore/css/CSSRule.h:
(WebCore::CSSRule::getChildStyleSheets):
* Source/WebCore/css/CSSStyleRule.cpp:
(WebCore::CSSStyleRule::getChildStyleSheets):
* Source/WebCore/css/CSSStyleRule.h:
* Source/WebCore/css/CSSStyleSheet.cpp:
(WebCore::CSSStyleSheet::getChildStyleSheets):
* Source/WebCore/css/CSSStyleSheet.h:
* Source/WebCore/css/values/CSSSerializationContext.cpp:
(WebCore::CSS::SerializationContext::SerializationContext):
* Source/WebCore/css/values/CSSSerializationContext.h:
* Source/WebCore/editing/MarkupAccumulator.cpp:
(WebCore::MarkupAccumulator::enableURLReplacement):
* Source/WebCore/editing/MarkupAccumulator.h:
* Source/WebCore/editing/markup.cpp:
(WebCore::serializeFragmentWithURLReplacement):
* Source/WebCore/editing/markup.h:
(WebCore::serializeFragmentWithURLReplacement):
* Source/WebCore/loader/CrossOriginPreflightResultCache.h:
(WebCore::CrossOriginPreflightResultCacheItem::CrossOriginPreflightResultCacheItem):
* Source/WebCore/loader/appcache/ApplicationCacheGroup.cpp:
(WebCore::ApplicationCacheGroup::postListenerTask):
* Source/WebCore/loader/appcache/ApplicationCacheGroup.h:
(WebCore::ApplicationCacheGroup::postListenerTask):
* Source/WebCore/loader/appcache/ApplicationCacheManifestParser.h:
* Source/WebCore/loader/appcache/ApplicationCacheStorage.cpp:
(WebCore::ApplicationCacheStorage::originsWithCache):
* Source/WebCore/loader/appcache/ApplicationCacheStorage.h:
* Source/WebCore/loader/archive/Archive.cpp:
(WebCore::Archive::clearAllSubframeArchives):
* Source/WebCore/loader/archive/Archive.h:
* Source/WebCore/loader/archive/cf/LegacyWebArchive.cpp:
(WebCore::generateValidFileName):
(WebCore::addSubresourcesForCSSStyleSheetsIfNecessary):
(WebCore::LegacyWebArchive::create):
* Source/WebCore/loader/cache/CachedResource.h:
* Source/WebCore/loader/cache/MemoryCache.cpp:
(WebCore::MemoryCache::removeResourcesWithOrigins):
(WebCore::MemoryCache::originsWithCache const):
* Source/WebCore/loader/cache/MemoryCache.h:
* Source/WebCore/platform/network/HTTPParsers.h:
(WebCore::addToAccessControlAllowList):
(WebCore::parseAccessControlAllowList):

Canonical link: <a href="https://commits.webkit.org/295558@main">https://commits.webkit.org/295558@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0853b61ce713f177a134abc6d9e12dd0c78cea7f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105400 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25113 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15539 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110605 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/56037 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/107441 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/25582 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33651 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80052 "Found 1 new test failure: imported/w3c/web-platform-tests/html/semantics/forms/constraints/infinite_backtracking.html (failure)") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108406 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19963 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95123 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60361 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/19698 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13210 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55443 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/89426 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13251 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/113335 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32546 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23991 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89135 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32910 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91349 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88784 "Found 98 new API test failures: /TestWebKit:WebKit.CanHandleRequest, /WebKitGTK/TestGeolocationManager:/webkit/WebKitGeolocationManager/watch-position, /TestWebKit:WebKit.UserMediaBasic, /TestWebKit:WebKit.PageLoadEmptyURL, /WebKitGTK/TestOptionMenu:/webkit/WebKitWebView/option-menu-groups, /TestWebKit:WebKit.GeolocationTransitionToHighAccuracy, /TestWebKit:WebKit.PendingAPIRequestURL, /TestWebKit:WebKit.FirstMeaningfulPaint, /WebKitGTK/TestUIClient:/webkit/WebKitWebView/file-chooser-request, /WebKitGTK/TestWebViewEditor:/webkit/WebKitWebView/editor-state/typing-attributes ... (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22649 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33654 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11454 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/28010 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32474 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/37897 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32232 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35580 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33817 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->