### PR TITLE
Tweak media tests exercising dynamic-range-limit

### DIFF
--- a/LayoutTests/media/video-dynamic-range-limit.html
+++ b/LayoutTests/media/video-dynamic-range-limit.html
@@ -35,8 +35,8 @@
   <body>
     <video style="dynamic-range-limit: no-limit"></video>
     <video style="dynamic-range-limit: standard"></video>
-    <video style="dynamic-range-limit: constrained-high"></video>
-    <video style="dynamic-range-limit: dynamic-range-limit-mix(standard 25%, constrained-high 75%)"></video>
+    <video style="dynamic-range-limit: constrained"></video>
+    <video style="dynamic-range-limit: dynamic-range-limit-mix(standard 25%, constrained 75%)"></video>
     <p>Note: These are SDR videos anyway, this tests the minimal code paths when specifying dynamic-range-limit.
     FIXME: Add HDR videos.
   </body>

--- a/LayoutTests/media/video-suppress-hdr-dynamic-range-limit-constrained-disabled-expected.txt
+++ b/LayoutTests/media/video-suppress-hdr-dynamic-range-limit-constrained-disabled-expected.txt
@@ -1,0 +1,5 @@
+PASS CSS.supports("dynamic-range-limit", "constrained") is false
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/media/video-suppress-hdr-dynamic-range-limit-constrained-disabled.html
+++ b/LayoutTests/media/video-suppress-hdr-dynamic-range-limit-constrained-disabled.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ SupportHDRDisplayEnabled=true CSSConstrainedDynamicRangeLimitEnabled=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ SupportHDRDisplayEnabled=true CSSConstrainedDynamicRangeLimitEnabled=false ] -->
 <html id="html">
 <body>
 <script src='../resources/js-test-pre.js'></script>
@@ -23,7 +23,7 @@ function verifyVideo(expectations)
 if (!window.internals) {
     failTest('This test requires window.internals.');
 } else if (CSS.supports("dynamic-range-limit", "standard") && CSS.supports("dynamic-range-limit", "no-limit")) {
-    shouldBe('CSS.supports("dynamic-range-limit", "constrained")', 'true');
+    shouldBe('CSS.supports("dynamic-range-limit", "constrained")', 'false');
 
     videon = document.getElementById("videon");
     videoc = document.getElementById("videoc");
@@ -31,12 +31,12 @@ if (!window.internals) {
 
     internals.setPageShouldSuppressHDR(false);
     verifyVideo({video: 'videon', limit: '""', computed: '"no-limit"', value: '1.0'});
-    verifyVideo({video: 'videoc', limit: '"constrained"', computed: '"constrained"', value: '0.5'});
+    verifyVideo({video: 'videoc', limit: '""', computed: '"no-limit"', value: '1.0'});
     verifyVideo({video: 'videos', limit: '"standard"', computed: '"standard"', value: '0.0'});
 
     internals.setPageShouldSuppressHDR(true);
     verifyVideo({video: 'videon', limit: '""', computed: '"no-limit"', value: '0.5'});
-    verifyVideo({video: 'videoc', limit: '"constrained"', computed: '"constrained"', value: '0.5'});
+    verifyVideo({video: 'videoc', limit: '""', computed: '"no-limit"', value: '0.5'});
     verifyVideo({video: 'videos', limit: '"standard"', computed: '"standard"', value: '0.0'});
 
     video2 = document.createElement("video");
@@ -45,7 +45,7 @@ if (!window.internals) {
 
     internals.setPageShouldSuppressHDR(false);
     verifyVideo({video: 'videon', limit: '""', computed: '"no-limit"', value: '1.0'});
-    verifyVideo({video: 'videoc', limit: '"constrained"', computed: '"constrained"', value: '0.5'});
+    verifyVideo({video: 'videoc', limit: '""', computed: '"no-limit"', value: '1.0'});
     verifyVideo({video: 'videos', limit: '"standard"', computed: '"standard"', value: '0.0'});
     verifyVideo({video: 'video2', limit: '""', computed: '"no-limit"', value: '1.0'});
 

--- a/LayoutTests/media/video-suppress-hdr-dynamic-range-limit-expected.txt
+++ b/LayoutTests/media/video-suppress-hdr-dynamic-range-limit-expected.txt
@@ -1,3 +1,4 @@
+PASS CSS.supports("dynamic-range-limit", "constrained") is true
 PASS successfullyParsed is true
 
 TEST COMPLETE


### PR DESCRIPTION
#### cf26fc25448e1cd718c2e6cb5730b7aebc2a7a9b
<pre>
Tweak media tests exercising dynamic-range-limit
<a href="https://bugs.webkit.org/show_bug.cgi?id=293736">https://bugs.webkit.org/show_bug.cgi?id=293736</a>
<a href="https://rdar.apple.com/152232664">rdar://152232664</a>

Reviewed by Anne van Kesteren.

- Rename `constrained-high` to `constrained`.
- Test both with and without `constrained` enabled.
- Tests don&apos;t need to be async.

* LayoutTests/media/video-dynamic-range-limit.html:
* LayoutTests/media/video-suppress-hdr-dynamic-range-limit-constrained-disabled-expected.txt: Added.
* LayoutTests/media/video-suppress-hdr-dynamic-range-limit-constrained-disabled.html: Added.
* LayoutTests/media/video-suppress-hdr-dynamic-range-limit-expected.txt:
* LayoutTests/media/video-suppress-hdr-dynamic-range-limit.html:

Canonical link: <a href="https://commits.webkit.org/295601@main">https://commits.webkit.org/295601@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a1fe347a999d7a1ac36c7e5addb1c875d3fef579

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105529 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25283 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15668 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110727 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/56174 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/25768 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33780 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80142 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/56174 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108535 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/20114 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95231 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60451 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/19859 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13322 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55564 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/89571 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13363 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/113519 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32669 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24091 "Found 7 new test failures: imported/w3c/web-platform-tests/mimesniff/media/media-sniff.window.html imported/w3c/web-platform-tests/url/IdnaTestV2.window.html imported/w3c/web-platform-tests/url/toascii.window.html platform/mac/fast/text/line-break-locale.html svg/zoom/page/text-with-non-scaling-stroke.html webgl/1.0.x/conformance/textures/misc/gl-teximage.html webgl/2.0.y/conformance/textures/misc/gl-teximage.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89220 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33032 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91461 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88881 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22673 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33753 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11557 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/28119 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32595 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32348 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35697 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33939 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->