### PR TITLE
Switch to TextIndicator for IntelligenceTextEffectsSupport.

### DIFF
--- a/Source/WebCore/page/IntelligenceTextEffectsSupport.cpp
+++ b/Source/WebCore/page/IntelligenceTextEffectsSupport.cpp
@@ -75,7 +75,7 @@ void updateTextVisibility(Document& document, const SimpleRange& scope, const Ch
     }
 }
 
-std::optional<TextIndicatorData> textPreviewDataForRange(Document&, const SimpleRange& scope, const CharacterRange& range)
+RefPtr<TextIndicator> textPreviewDataForRange(Document&, const SimpleRange& scope, const CharacterRange& range)
 {
     auto resolvedRange = resolveCharacterRange(scope, range);
 
@@ -90,11 +90,7 @@ std::optional<TextIndicatorData> textPreviewDataForRange(Document&, const Simple
 #endif
     };
 
-    RefPtr textIndicator = WebCore::TextIndicator::createWithRange(resolvedRange, textIndicatorOptions, WebCore::TextIndicatorPresentationTransition::None, { });
-    if (!textIndicator)
-        return std::nullopt;
-
-    return textIndicator->data();
+    return WebCore::TextIndicator::createWithRange(resolvedRange, textIndicatorOptions, WebCore::TextIndicatorPresentationTransition::None, { });
 }
 
 #if ENABLE(WRITING_TOOLS)

--- a/Source/WebCore/page/IntelligenceTextEffectsSupport.h
+++ b/Source/WebCore/page/IntelligenceTextEffectsSupport.h
@@ -33,10 +33,10 @@ namespace WebCore {
 
 class Document;
 class FloatRect;
+class TextIndicator;
 
 struct CharacterRange;
 struct SimpleRange;
-struct TextIndicatorData;
 
 namespace IntelligenceTextEffectsSupport {
 
@@ -46,7 +46,7 @@ WEBCORE_EXPORT Vector<FloatRect> writingToolsTextSuggestionRectsInRootViewCoordi
 
 WEBCORE_EXPORT void updateTextVisibility(Document&, const SimpleRange& scope, const CharacterRange&, bool visible, const WTF::UUID&);
 
-WEBCORE_EXPORT std::optional<TextIndicatorData> textPreviewDataForRange(Document&, const SimpleRange& scope, const CharacterRange&);
+WEBCORE_EXPORT RefPtr<TextIndicator> textPreviewDataForRange(Document&, const SimpleRange& scope, const CharacterRange&);
 
 #if ENABLE(WRITING_TOOLS)
 WEBCORE_EXPORT void decorateWritingToolsTextReplacements(Document&, const SimpleRange& scope, const CharacterRange&);

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -5473,7 +5473,12 @@ std::optional<TextIndicatorData> Page::textPreviewDataForActiveWritingToolsSessi
         return std::nullopt;
     }
 
-    return IntelligenceTextEffectsSupport::textPreviewDataForRange(*localTopDocument, *scope, rangeRelativeToSessionRange);
+    RefPtr textIndicator = IntelligenceTextEffectsSupport::textPreviewDataForRange(*localTopDocument, *scope, rangeRelativeToSessionRange);
+
+    if (textIndicator)
+        return textIndicator->data();
+
+    return std::nullopt;
 }
 
 void Page::decorateTextReplacementsForActiveWritingToolsSession(const CharacterRange& rangeRelativeToSessionRange)


### PR DESCRIPTION
#### 1f3a1b388545d8704a3a2d0a096009436d326366
<pre>
Switch to TextIndicator for IntelligenceTextEffectsSupport.
<a href="https://bugs.webkit.org/show_bug.cgi?id=293725">https://bugs.webkit.org/show_bug.cgi?id=293725</a>
<a href="https://rdar.apple.com/152244508">rdar://152244508</a>

Reviewed by Richard Robinson.

We would like to switch to TextIndicator instead of TextIndicatorData
everywhere. This is a huge task, so I am breaking it down into much smaller
pieces.

* Source/WebCore/page/IntelligenceTextEffectsSupport.cpp:
(WebCore::IntelligenceTextEffectsSupport::textPreviewForRange):
(WebCore::IntelligenceTextEffectsSupport::textPreviewDataForRange): Deleted.
* Source/WebCore/page/IntelligenceTextEffectsSupport.h:
* Source/WebCore/page/Page.cpp:
(WebCore::Page::textPreviewDataForActiveWritingToolsSession):

Canonical link: <a href="https://commits.webkit.org/295588@main">https://commits.webkit.org/295588@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5adb97f8393124e7ba4c82862d95e7d97abfd5ea

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105500 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25211 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15639 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110701 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/56153 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/107541 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/25738 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33752 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80126 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/56153 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108506 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/20043 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95213 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60435 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/19767 "Unexpected infrastructure issue, retrying build") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13303 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55537 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/89497 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13344 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/113476 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32642 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24071 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89207 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33005 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91442 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88867 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22664 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33736 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11540 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/28097 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32568 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/37978 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32323 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35670 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33911 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->