### PR TITLE
[GStreamer] Add gstStructureGetList() helper

### DIFF
--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.cpp
@@ -211,25 +211,15 @@ RTCRtpSendParameters toRTCRtpSendParameters(const GstStructure* rtcParameters)
     if (auto transactionId = gstStructureGetString(rtcParameters, "transaction-id"_s))
         parameters.transactionId = makeString(transactionId);
 
-    if (auto encodings = gst_structure_get_value(rtcParameters, "encodings")) {
-        unsigned size = gst_value_list_get_size(encodings);
-        parameters.encodings.reserveInitialCapacity(size);
-        for (unsigned i = 0; i < size; i++) {
-            const auto value = gst_value_list_get_value(encodings, i);
-            RELEASE_ASSERT(GST_VALUE_HOLDS_STRUCTURE(value));
-            parameters.encodings.append(toRTCEncodingParameters(gst_value_get_structure(value)));
-        }
-    }
+    auto encodings = gstStructureGetList<const GstStructure*>(rtcParameters, "encodings"_s);
+    parameters.encodings.reserveInitialCapacity(encodings.size());
+    for (const auto& encoding : encodings)
+        parameters.encodings.append(toRTCEncodingParameters(encoding));
 
-    if (auto codecs = gst_structure_get_value(rtcParameters, "codecs")) {
-        unsigned size = gst_value_list_get_size(codecs);
-        parameters.codecs.reserveInitialCapacity(size);
-        for (unsigned i = 0; i < size; i++) {
-            const auto value = gst_value_list_get_value(codecs, i);
-            RELEASE_ASSERT(GST_VALUE_HOLDS_STRUCTURE(value));
-            parameters.codecs.append(toRTCCodecParameters(gst_value_get_structure(value)));
-        }
-    }
+    auto codecs = gstStructureGetList<const GstStructure*>(rtcParameters, "codecs"_s);
+    parameters.codecs.reserveInitialCapacity(codecs.size());
+    for (const auto& codec : codecs)
+        parameters.codecs.append(toRTCCodecParameters(codec));
 
     // FIXME: The rtcp parameters should not be hardcoded.
     parameters.rtcp.cname = "unused"_s;

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
@@ -292,6 +292,9 @@ StringView gstStructureGetName(const GstStructure*);
 template<typename T>
 Vector<T> gstStructureGetArray(const GstStructure*, ASCIILiteral key);
 
+template<typename T>
+Vector<T> gstStructureGetList(const GstStructure*, ASCIILiteral key);
+
 String gstStructureToJSONString(const GstStructure*);
 
 GstClockTime webkitGstInitTime();

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCaptureSource.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCaptureSource.cpp
@@ -27,6 +27,7 @@
 
 #include "DisplayCaptureManager.h"
 #include "GStreamerCaptureDeviceManager.h"
+#include "GStreamerCommon.h"
 #include "PipeWireCaptureDevice.h"
 #include "PipeWireCaptureDeviceManager.h"
 #include <wtf/text/MakeString.h>
@@ -321,18 +322,8 @@ void GStreamerVideoCaptureSource::generatePresets()
             gst_util_fraction_to_double(framerateNumerator, framerateDenominator, &framerate);
             frameRates.append({ framerate, framerate});
         } else {
-            const GValue* frameRateValues(gst_structure_get_value(str, "framerate"));
-            unsigned frameRatesLength = static_cast<unsigned>(gst_value_list_get_size(frameRateValues));
-
-            for (unsigned j = 0; j < frameRatesLength; j++) {
-                const GValue* val = gst_value_list_get_value(frameRateValues, j);
-
-                ASSERT(val && G_VALUE_TYPE(val) == GST_TYPE_FRACTION);
-                gst_util_fraction_to_double(gst_value_get_fraction_numerator(val),
-                    gst_value_get_fraction_denominator(val), &framerate);
-
-                frameRates.append({ framerate, framerate});
-            }
+            for (const auto& framerate : gstStructureGetList<double>(str, "framerate"_s))
+                frameRates.append({ framerate, framerate });
         }
 
         presets.append(VideoPreset { { size, WTFMove(frameRates) } });

--- a/Tools/TestWebKitAPI/Tests/WebCore/gstreamer/GStreamerTest.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/gstreamer/GStreamerTest.cpp
@@ -85,6 +85,14 @@ TEST_F(GStreamerTest, gstStructureGetters)
     ASSERT_TRUE(gst_structure_is_equal(structArray.at(0), s1.get()));
     ASSERT_TRUE(gst_structure_is_equal(structArray.at(1), s2.get()));
     ASSERT_EQ(structArray.size(), 2);
+
+    GUniquePtr<GstStructure> lists(gst_structure_new_from_string("bar, empty-list=(GstStructure) {}, struct-list=(GstStructure) {[s1, a=2], [s2, b=3]}"_s));
+    ASSERT_TRUE(gstStructureGetList<const GstStructure*>(lists.get(), "empty-list"_s).isEmpty());
+
+    Vector<const GstStructure*> structList(gstStructureGetList<const GstStructure*>(lists.get(), "struct-list"_s));
+    ASSERT_TRUE(gst_structure_is_equal(structList.at(0), s1.get()));
+    ASSERT_TRUE(gst_structure_is_equal(structList.at(1), s2.get()));
+    ASSERT_EQ(structList.size(), 2);
 }
 
 TEST_F(GStreamerTest, gstStructureJSONSerializing)


### PR DESCRIPTION
#### 2e1f549db387fd6cf1ed0eff5dc7b432496aec8c
<pre>
[GStreamer] Add gstStructureGetList() helper
<a href="https://bugs.webkit.org/show_bug.cgi?id=293734">https://bugs.webkit.org/show_bug.cgi?id=293734</a>

Reviewed by Xabier Rodriguez-Calvar.

This new function will be useful to iterate on RTP encoding parameters.

Canonical link: <a href="https://commits.webkit.org/295602@main">https://commits.webkit.org/295602@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e667cd10a15aa47ff48a0836a14773eec1ca5b3b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105606 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25355 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15747 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110803 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/56215 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/107647 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/25809 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33856 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80200 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/56215 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108612 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/20155 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95304 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60509 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/19900 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13396 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55641 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/89604 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13436 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/113642 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32744 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/24140 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89278 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33106 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91533 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/88942 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22674 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33811 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11617 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/28189 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32670 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/38054 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32416 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35764 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34013 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->