### PR TITLE
[GStreamer][WebRTC] Move payloader pt configuration to WebRTCCommon module

### DIFF
--- a/Source/WebCore/platform/SourcesGStreamer.txt
+++ b/Source/WebCore/platform/SourcesGStreamer.txt
@@ -144,6 +144,7 @@ platform/mediastream/gstreamer/GStreamerRTPVideoRotationHeaderExtension.cpp @no-
 platform/mediastream/gstreamer/GStreamerVideoCaptureSource.cpp
 platform/mediastream/gstreamer/GStreamerVideoCapturer.cpp
 platform/mediastream/gstreamer/GStreamerVideoRTPPacketizer.cpp
+platform/mediastream/gstreamer/GStreamerWebRTCCommon.cpp
 platform/mediastream/gstreamer/GStreamerWebRTCLogSink.cpp
 platform/mediastream/gstreamer/GStreamerWebRTCProvider.cpp
 platform/mediastream/gstreamer/PipeWireCaptureDeviceManager.cpp

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerRTPPacketizer.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerRTPPacketizer.h
@@ -71,7 +71,6 @@ protected:
     GUniquePtr<GstStructure> m_stats;
 
 private:
-    void setPayloadType(int);
     void updateStatsFromRTPExtensions();
     void applyEncodingParameters(const GstStructure*) const;
     virtual void configure(const GstStructure*) const { };

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerWebRTCCommon.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerWebRTCCommon.cpp
@@ -1,0 +1,71 @@
+/*
+ *  Copyright (C) 2024 Igalia S.L.
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#include "config.h"
+#include "GStreamerWebRTCCommon.h"
+
+GST_DEBUG_CATEGORY(webkit_webrtc_common_debug);
+#define GST_CAT_DEFAULT webkit_webrtc_common_debug
+
+namespace WebCore {
+
+static void ensureWebRTCCommonDebugCategoryInitialized()
+{
+    static std::once_flag debugRegisteredFlag;
+    std::call_once(debugRegisteredFlag, [] {
+        GST_DEBUG_CATEGORY_INIT(webkit_webrtc_common_debug, "webkitwebrtccommon", 0, "WebKit WebRTC Common");
+    });
+}
+
+void gstPayloaderSetPayloadType(const GRefPtr<GstElement>& payloader, int pt)
+{
+    ensureWebRTCCommonDebugCategoryInitialized();
+    auto ptSpec = g_object_class_find_property(G_OBJECT_GET_CLASS(G_OBJECT(payloader.get())), "pt");
+
+    GValue value = G_VALUE_INIT;
+    g_object_get_property(G_OBJECT(payloader.get()), "pt", &value);
+
+    if (G_VALUE_TYPE(&value) != G_TYPE_INT && G_VALUE_TYPE(&value) != G_TYPE_UINT) {
+        GST_ERROR_OBJECT(payloader.get(), "pt property is not integer or unsigned");
+        return;
+    }
+
+    if (G_VALUE_TYPE(&value) == G_TYPE_INT) {
+        auto intSpec = G_PARAM_SPEC_INT(ptSpec);
+        if (pt > intSpec->maximum || pt < intSpec->minimum) {
+            GST_ERROR_OBJECT(payloader.get(), "pt %d outside of valid range [%d, %d]", pt, intSpec->minimum, intSpec->maximum);
+            return;
+        }
+        g_object_set(payloader.get(), "pt", pt, nullptr);
+        return;
+    }
+
+    if (G_VALUE_TYPE(&value) == G_TYPE_UINT) {
+        auto uintSpec = G_PARAM_SPEC_UINT(ptSpec);
+        unsigned ptValue = static_cast<unsigned>(pt);
+        if (ptValue > uintSpec->maximum || ptValue < uintSpec->minimum) {
+            GST_ERROR_OBJECT(payloader.get(), "pt %u outside of valid range [%u, %u]", ptValue, uintSpec->minimum, uintSpec->maximum);
+            return;
+        }
+        g_object_set(payloader.get(), "pt", ptValue, nullptr);
+    }
+}
+
+} // namespace WebCore
+
+#undef GST_CAT_DEFAULT

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerWebRTCCommon.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerWebRTCCommon.h
@@ -20,6 +20,10 @@
 
 #if USE(GSTREAMER_WEBRTC)
 
+#include "GRefPtrGStreamer.h"
+#include "RealtimeMediaSource.h"
+#include <wtf/text/WTFString.h>
+
 namespace WebCore {
 
 using WebRTCTrackData = struct _WebRTCTrackData {
@@ -32,6 +36,8 @@ using WebRTCTrackData = struct _WebRTCTrackData {
     unsigned ssrc;
     String mid;
 };
+
+void gstPayloaderSetPayloadType(const GRefPtr<GstElement>&, int pt);
 
 } // namespace WebCore
 


### PR DESCRIPTION
#### 0582961a0af8476c4e7c9b25828b5cc52681c5be
<pre>
[GStreamer][WebRTC] Move payloader pt configuration to WebRTCCommon module
<a href="https://bugs.webkit.org/show_bug.cgi?id=293735">https://bugs.webkit.org/show_bug.cgi?id=293735</a>

Reviewed by Xabier Rodriguez-Calvar.

This re-factoring will allow the DTMF source to re-use this function.

Canonical link: <a href="https://commits.webkit.org/295600@main">https://commits.webkit.org/295600@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e6a8e0af3c05a342aa800bcbe3883b53d35ee536

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105605 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25354 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15746 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110802 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/56214 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/107646 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/25808 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33855 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/80203 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/56214 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108611 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/20154 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95301 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60512 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/19899 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13393 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55640 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/89603 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13432 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/113638 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32743 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/24138 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/89282 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33105 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91530 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88946 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22672 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33813 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/11614 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/28188 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32669 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/38053 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32415 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35763 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34012 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->