### PR TITLE
Introduce safe & convenient wrappers for unsafe sqlite APIs

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2542,6 +2542,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/sql/SQLiteDatabase.h
     platform/sql/SQLiteDatabaseTracker.h
     platform/sql/SQLiteDatabaseTrackerClient.h
+    platform/sql/SQLiteExtras.h
     platform/sql/SQLiteFileSystem.h
     platform/sql/SQLiteStatement.h
     platform/sql/SQLiteStatementAutoResetScope.h

--- a/Source/WebCore/platform/sql/SQLiteExtras.h
+++ b/Source/WebCore/platform/sql/SQLiteExtras.h
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <span>
+#include <sqlite3.h>
+#include <wtf/StdLibExtras.h>
+#include <wtf/text/CString.h>
+#include <wtf/text/WTFString.h>
+
+namespace WebCore {
+
+inline int sqliteBindBlob(sqlite3_stmt* statement, int index, std::span<const uint8_t> data, void(*destructor)(void*) = SQLITE_TRANSIENT)
+{
+    // sqlite3_bind_blob64() symbol is undefined on the PlayStation port.
+#if PLATFORM(PLAYSTATION)
+    return sqlite3_bind_blob(statement, index, data.data(), data.size(), destructor); // NOLINT
+#else
+    return sqlite3_bind_blob64(statement, index, data.data(), data.size(), destructor); // NOLINT
+#endif
+}
+
+inline int sqliteBindText(sqlite3_stmt* statement, int index, std::span<const char> text, void(*destructor)(void*) = SQLITE_TRANSIENT)
+{
+    return sqlite3_bind_text(statement, index, text.data(), text.size(), destructor); // NOLINT
+}
+
+inline int sqliteBindText(sqlite3_stmt* statement, int index, const CString& text, void(*destructor)(void*) = SQLITE_TRANSIENT)
+{
+    return sqliteBindText(statement, index, text.span(), destructor);
+}
+
+inline String sqliteColumnName(sqlite3_stmt* statement, int index)
+{
+    return String::fromUTF8(sqlite3_column_name(statement, index)); // NOLINT
+}
+
+inline String sqliteValueText(sqlite3_value* value)
+{
+    return String::fromUTF8(unsafeMakeSpan(sqlite3_value_text(value), sqlite3_value_bytes(value))); // NOLINT
+}
+
+inline String sqliteColumnText(sqlite3_stmt* statement, int index)
+{
+    return String::fromUTF8(unsafeMakeSpan(sqlite3_column_text(statement, index), sqlite3_column_bytes(statement, index))); // NOLINT
+}
+
+template<typename T = uint8_t>
+inline std::span<const T> sqliteColumnBlob(sqlite3_stmt* statement, int index)
+{
+    auto* blob = static_cast<const T*>(sqlite3_column_blob(statement, index)); // NOLINT
+    if (!blob)
+        return { };
+    auto blobSize = sqlite3_column_bytes(statement, index); // NOLINT
+    if (blobSize < 0)
+        return { };
+    ASSERT(!(blobSize % sizeof(T)));
+    return unsafeMakeSpan(blob, blobSize / sizeof(T));
+}
+
+} // namespace WebCore

--- a/Source/WebKit/Shared/Extensions/_WKWebExtensionSQLiteRow.h
+++ b/Source/WebKit/Shared/Extensions/_WKWebExtensionSQLiteRow.h
@@ -50,8 +50,7 @@ typedef int _WKSQLiteErrorCode;
 
 struct RawData {
     const bool isNull;
-    const void* bytes;
-    const int length;
+    const std::span<const uint8_t> bytes;
 };
 
 - (struct RawData)uncopiedRawDataAtIndex:(NSUInteger)index;

--- a/Tools/Scripts/webkitpy/style/checkers/cpp.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp.py
@@ -3627,6 +3627,24 @@ def check_safer_cpp(clean_lines, line_number, error):
     if uses_xpc_string_get_string_ptr:
         error(line_number, 'safercpp/xpc_string_get_string_ptr', 4, "Use xpcStringGetString() instead of xpc_string_get_string_ptr().")
 
+    if search(r'sqlite3_bind_blob\(', line) or search(r'sqlite3_bind_blob64\(', line):
+        error(line_number, 'safercpp/sqlite3_bind_blob', 4, "Use sqliteBindBlob() instead of sqlite3_bind_blob() or sqlite3_bind_blob64().")
+
+    if search(r'sqlite3_bind_text\(', line):
+        error(line_number, 'safercpp/sqlite3_bind_text', 4, "Use sqliteBindText() instead of sqlite3_bind_text().")
+
+    if search(r'sqlite3_column_name\(', line):
+        error(line_number, 'safercpp/sqlite3_column_name', 4, "Use sqliteColumnName() instead of sqlite3_column_name().")
+
+    if search(r'sqlite3_value_text\(', line):
+        error(line_number, 'safercpp/sqlite3_value_text', 4, "Use sqliteValueText() instead of sqlite3_value_text().")
+
+    if search(r'sqlite3_column_text\(', line):
+        error(line_number, 'safercpp/sqlite3_column_text', 4, "Use sqliteColumnText() instead of sqlite3_column_text().")
+
+    if search(r'sqlite3_column_blob\(', line):
+        error(line_number, 'safercpp/sqlite3_column_blob', 4, "Use sqliteColumnBlob() instead of sqlite3_column_blob().")
+
 
 def check_style(clean_lines, line_number, file_extension, class_state, file_state, enum_state, error):
     """Checks rules from the 'C++ style rules' section of cppguide.html.


### PR DESCRIPTION
#### 0544492b6127d31d7a5ed2f7f8d8ddfe99efa853
<pre>
Introduce safe &amp; convenient wrappers for unsafe sqlite APIs
<a href="https://bugs.webkit.org/show_bug.cgi?id=293741">https://bugs.webkit.org/show_bug.cgi?id=293741</a>

Reviewed by Per Arne Vollan.

* Source/WebCore/Headers.cmake:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/sql/SQLiteExtras.h: Added.
(WebCore::sqliteBindBlob):
(WebCore::sqliteBindText):
(WebCore::sqliteColumnName):
(WebCore::sqliteValueText):
(WebCore::sqliteColumnText):
(WebCore::sqliteColumnBlob):
* Source/WebCore/platform/sql/SQLiteStatement.cpp:
(WebCore::SQLiteStatement::bindBlob):
(WebCore::SQLiteStatement::bindText):
(WebCore::SQLiteStatement::columnName):
(WebCore::SQLiteStatement::columnValue):
(WebCore::SQLiteStatement::columnText):
(WebCore::SQLiteStatement::columnBlobAsString):
(WebCore::SQLiteStatement::columnBlobAsSpan):
* Source/WebKit/Shared/Extensions/WebExtensionSQLiteDatatypeTraits.h:
(WebKit::WebExtensionSQLiteDatatypeTraits&lt;String&gt;::fetch):
(WebKit::WebExtensionSQLiteDatatypeTraits&lt;String&gt;::bind):
(WebKit::WebExtensionSQLiteDatatypeTraits&lt;RefPtr&lt;API::Data&gt;&gt;::fetch):
(WebKit::WebExtensionSQLiteDatatypeTraits&lt;RefPtr&lt;API::Data&gt;&gt;::bind):
* Source/WebKit/Shared/Extensions/WebExtensionSQLiteRow.cpp:
(WebKit::WebExtensionSQLiteRow::getString):
(WebKit::WebExtensionSQLiteRow::getData):
* Source/WebKit/Shared/Extensions/WebExtensionSQLiteStatement.cpp:
(WebKit::WebExtensionSQLiteStatement::bind):
(WebKit::WebExtensionSQLiteStatement::columnNamesToIndicies):
(WebKit::WebExtensionSQLiteStatement::columnNames):
* Source/WebKit/Shared/Extensions/_WKWebExtensionSQLiteDatatypeTraits.h:
(WebKit::_WKWebExtensionSQLiteDatatypeTraits&lt;NSString::fetch):
(WebKit::_WKWebExtensionSQLiteDatatypeTraits&lt;NSString::bind):
(WebKit::_WKWebExtensionSQLiteDatatypeTraits&lt;NSData::fetch):
(WebKit::_WKWebExtensionSQLiteDatatypeTraits&lt;NSData::bind):
(WebKit::_WKWebExtensionSQLiteDatatypeTraits&lt;NSObject::bind):
* Source/WebKit/Shared/Extensions/_WKWebExtensionSQLiteRow.h:
(-[_WKWebExtensionSQLiteRow uncopiedDataAtIndex:]):
* Source/WebKit/Shared/Extensions/_WKWebExtensionSQLiteRow.mm:
(-[_WKWebExtensionSQLiteRow stringAtIndex:]):
(-[_WKWebExtensionSQLiteRow dataAtIndex:]):
(-[_WKWebExtensionSQLiteRow uncopiedDataAtIndex:]):
(-[_WKWebExtensionSQLiteRow uncopiedRawDataAtIndex:]):
* Source/WebKit/Shared/Extensions/_WKWebExtensionSQLiteStatement.mm:
(-[_WKWebExtensionSQLiteStatement bindString:atParameterIndex:]):
(-[_WKWebExtensionSQLiteStatement bindData:atParameterIndex:]):
(-[_WKWebExtensionSQLiteStatement columnNamesToIndexes]):
(-[_WKWebExtensionSQLiteStatement columnNames]):
* Tools/Scripts/webkitpy/style/checkers/cpp.py:
(check_safer_cpp):

Canonical link: <a href="https://commits.webkit.org/295652@main">https://commits.webkit.org/295652@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/77225bb8ded71fcf6ae40a81beafcb1217c3565f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105587 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25336 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15728 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110784 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/56203 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/107628 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/25841 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33837 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80185 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108593 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/20191 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95287 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60494 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/105065 "Passed tests") | [💥 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/19923 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13379 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55622 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/89637 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13418 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/113612 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32726 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24128 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89266 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33088 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91516 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88930 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22706 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33801 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11603 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/28166 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32651 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/38037 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32397 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35746 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33994 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->