### PR TITLE
[UnifiedPDF][iOS] Page number indicator may be illegible over dark content

### DIFF
--- a/Source/WebKit/UIProcess/PDF/WKPDFPageNumberIndicator.mm
+++ b/Source/WebKit/UIProcess/PDF/WKPDFPageNumberIndicator.mm
@@ -93,7 +93,8 @@ static constexpr Seconds indicatorMoveDuration { 0.3_s };
     [_label setBackgroundColor:nil];
     [_label setTextAlignment:NSTextAlignmentCenter];
     [_label setFont:[UIFont boldSystemFontOfSize:indicatorFontSize]];
-    [_label setTextColor:[UIColor blackColor]];
+    if (shouldUseVisualEffectViewForBackdrop)
+        [_label setTextColor:[UIColor blackColor]];
     [_label setAlpha:indicatorLabelOpacity];
     [_label setAdjustsFontSizeToFitWidth:YES];
     [_label setAutoresizingMask:UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight];


### PR DESCRIPTION
#### 99be1a85bafb7a3b1d0d0ab778e8c76d6ba1ffc4
<pre>
[UnifiedPDF][iOS] Page number indicator may be illegible over dark content
<a href="https://bugs.webkit.org/show_bug.cgi?id=293743">https://bugs.webkit.org/show_bug.cgi?id=293743</a>
<a href="https://rdar.apple.com/151680460">rdar://151680460</a>

Reviewed by Abrar Rahman Protyasha.

In configurations where a `UIVisualEffectView` is not used as the backdrop,
the backdrop is not always light. In this scenario, the label color should not
be forced to black, and should instead use the default system text color, which
is dynamic.

* Source/WebKit/UIProcess/PDF/WKPDFPageNumberIndicator.mm:
(-[WKPDFPageNumberIndicator initWithFrame:view:pageCount:]):

Canonical link: <a href="https://commits.webkit.org/295578@main">https://commits.webkit.org/295578@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/333287c8229e66cd008e7e042d39c1c124f3e3de

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105464 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25175 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15603 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110665 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/56089 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/25637 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33714 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80101 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108470 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/20008 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95180 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60410 "Passed tests") | 
| | [💥 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/19733 "An unexpected error occured. Recent messages:Printed configuration") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55502 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/89466 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13311 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/113418 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32607 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24042 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89179 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32970 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91409 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88836 "Found 99 new API test failures: /TestWebKit:WebKit.CanHandleRequest, /WebKitGTK/TestGeolocationManager:/webkit/WebKitGeolocationManager/watch-position, /TestWebKit:WebKit.UserMediaBasic, /TestWebKit:WebKit.PageLoadEmptyURL, /WebKitGTK/TestOptionMenu:/webkit/WebKitWebView/option-menu-groups, /TestWebKit:WebKit.GeolocationTransitionToHighAccuracy, /TestWebKit:WebKit.PendingAPIRequestURL, /TestWebKit:WebKit.FirstMeaningfulPaint, /WebKitGTK/TestUIClient:/webkit/WebKitWebView/file-chooser-request, /WebKitGTK/TestWebViewEditor:/webkit/WebKitWebView/editor-state/typing-attributes ... (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33708 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11509 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/28067 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17110 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32533 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/37949 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32290 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35637 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33876 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->