### PR TITLE
FileSystemWritableFileStream::write should throw SyntaxError if data param is missing

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemWritableFileStream-write.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemWritableFileStream-write.https.any-expected.txt
@@ -23,7 +23,7 @@ PASS atomic writes: close() after close() fails
 PASS atomic writes: only one close() operation may succeed
 PASS getWriter() can be used
 PASS WriteParams: truncate missing size param
-FAIL WriteParams: write missing data param promise_rejects_dom: write without data function "function() { throw e }" threw object "TypeError: Data is missing" that is not a DOMException SyntaxError: property "code" is equal to undefined, expected 12
+PASS WriteParams: write missing data param
 PASS WriteParams: write null data param
 PASS WriteParams: seek missing position param
 PASS write() with an invalid blob to an empty file should reject

--- a/LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemWritableFileStream-write.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemWritableFileStream-write.https.any.worker-expected.txt
@@ -23,7 +23,7 @@ PASS atomic writes: close() after close() fails
 PASS atomic writes: only one close() operation may succeed
 PASS getWriter() can be used
 PASS WriteParams: truncate missing size param
-FAIL WriteParams: write missing data param promise_rejects_dom: write without data function "function() { throw e }" threw object "TypeError: Data is missing" that is not a DOMException SyntaxError: property "code" is equal to undefined, expected 12
+PASS WriteParams: write missing data param
 PASS WriteParams: write null data param
 PASS WriteParams: seek missing position param
 PASS write() with an invalid blob to an empty file should reject

--- a/Source/WebCore/Modules/filesystemaccess/FileSystemWritableFileStream.h
+++ b/Source/WebCore/Modules/filesystemaccess/FileSystemWritableFileStream.h
@@ -43,7 +43,7 @@ public:
         WriteCommandType type;
         std::optional<uint64_t> size { };
         std::optional<uint64_t> position { };
-        std::optional<DataVariant> data;
+        std::optional<DataVariant> data { RefPtr<JSC::ArrayBufferView> { nullptr } };
     };
 
     using ChunkType = Variant<RefPtr<JSC::ArrayBufferView>, RefPtr<JSC::ArrayBuffer>, RefPtr<Blob>, String, WriteParams>;

--- a/Source/WebCore/Modules/filesystemaccess/FileSystemWritableFileStreamSink.cpp
+++ b/Source/WebCore/Modules/filesystemaccess/FileSystemWritableFileStreamSink.cpp
@@ -43,7 +43,7 @@ static ExceptionOr<FileSystemWritableFileStream::WriteParams> writeParamsFromChu
         switch (params.type) {
         case FileSystemWriteCommandType::Write:
             if (!params.data)
-                return Exception { ExceptionCode::TypeError, "Data is missing"_s };
+                return Exception { ExceptionCode::SyntaxError, "Data is missing"_s };
             return params;
         case FileSystemWriteCommandType::Seek:
             // FIXME: Reconsider exception type when https://github.com/whatwg/fs/issues/168 is closed.


### PR DESCRIPTION
#### 4b09192e1f08eb413f7ab0131f0176ab3c291eea
<pre>
FileSystemWritableFileStream::write should throw SyntaxError if data param is missing
<a href="https://bugs.webkit.org/show_bug.cgi?id=293744">https://bugs.webkit.org/show_bug.cgi?id=293744</a>
<a href="https://rdar.apple.com/problem/152249184">rdar://problem/152249184</a>

Reviewed by Per Arne Vollan.

To match the behavior in other browsers.

* LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemWritableFileStream-write.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemWritableFileStream-write.https.any.worker-expected.txt:
* Source/WebCore/Modules/filesystemaccess/FileSystemWritableFileStream.h:
* Source/WebCore/Modules/filesystemaccess/FileSystemWritableFileStreamSink.cpp:
(WebCore::writeParamsFromChunk):

Canonical link: <a href="https://commits.webkit.org/295730@main">https://commits.webkit.org/295730@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bbd44b8cec47e321a824618ee980f291a6507ef0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105487 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25198 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15626 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110688 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/56151 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/107528 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/25664 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33740 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80115 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108493 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/20029 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95201 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60424 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/19753 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13291 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55525 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/89484 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13332 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/113456 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32630 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24058 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89197 "Failure limit exceed. At least found 1 new test failure: compositing/patterns/direct-pattern-compositing-size.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32993 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91430 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88854 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22750 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33727 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11529 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/28087 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32556 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/37969 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32312 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35659 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33899 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->