### PR TITLE
FileSystemFileHandle::createWritable should throw NotFoundError if file is removed

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemDirectoryHandle-removeEntry.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemDirectoryHandle-removeEntry.https.any-expected.txt
@@ -10,5 +10,5 @@ PASS removeEntry() with ".." name should fail
 PASS removeEntry() with a path separator should fail.
 FAIL removeEntry() while the file has an open writable fails assert_unreached: Should have rejected: undefined Reached unreachable code
 FAIL removeEntry() of a directory while a containing file has an open writable fails promise_rejects_dom: function "function() { throw e }" threw object "UnknownError: The operation failed for an unknown transient reason (e.g. out of memory)." that is not a DOMException NoModificationAllowedError: property "code" is equal to 0, expected 7
-FAIL createWritable after removeEntry succeeds but doesnt recreate the file assert_unreached: Should have rejected: undefined Reached unreachable code
+PASS createWritable after removeEntry succeeds but doesnt recreate the file
 

--- a/LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemDirectoryHandle-removeEntry.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemDirectoryHandle-removeEntry.https.any.worker-expected.txt
@@ -10,5 +10,5 @@ PASS removeEntry() with ".." name should fail
 PASS removeEntry() with a path separator should fail.
 FAIL removeEntry() while the file has an open writable fails assert_unreached: Should have rejected: undefined Reached unreachable code
 FAIL removeEntry() of a directory while a containing file has an open writable fails promise_rejects_dom: function "function() { throw e }" threw object "UnknownError: The operation failed for an unknown transient reason (e.g. out of memory)." that is not a DOMException NoModificationAllowedError: property "code" is equal to 0, expected 7
-FAIL createWritable after removeEntry succeeds but doesnt recreate the file assert_unreached: Should have rejected: undefined Reached unreachable code
+PASS createWritable after removeEntry succeeds but doesnt recreate the file
 

--- a/LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemWritableFileStream.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemWritableFileStream.https.any-expected.txt
@@ -1,7 +1,7 @@
 
 PASS truncate() to shrink a file
 PASS truncate() to grow a file
-FAIL createWritable() fails when parent directory is removed assert_unreached: Should have rejected: undefined Reached unreachable code
+PASS createWritable() fails when parent directory is removed
 PASS createWritable({keepExistingData: true}): atomic writable file stream initialized with source contents
 PASS createWritable({keepExistingData: false}): atomic writable file stream initialized with empty file
 PASS createWritable() can be called on two handles representing the same file

--- a/LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemWritableFileStream.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemWritableFileStream.https.any.worker-expected.txt
@@ -1,7 +1,7 @@
 
 PASS truncate() to shrink a file
 PASS truncate() to grow a file
-FAIL createWritable() fails when parent directory is removed assert_unreached: Should have rejected: undefined Reached unreachable code
+PASS createWritable() fails when parent directory is removed
 PASS createWritable({keepExistingData: true}): atomic writable file stream initialized with source contents
 PASS createWritable({keepExistingData: false}): atomic writable file stream initialized with empty file
 PASS createWritable() can be called on two handles representing the same file

--- a/Source/WebKit/NetworkProcess/storage/FileSystemStorageHandle.cpp
+++ b/Source/WebKit/NetworkProcess/storage/FileSystemStorageHandle.cpp
@@ -241,6 +241,9 @@ Expected<WebCore::FileSystemWritableFileStreamIdentifier, FileSystemStorageError
     if (!manager)
         return makeUnexpected(FileSystemStorageError::Unknown);
 
+    if (!FileSystem::fileExists(m_path))
+        return makeUnexpected(FileSystemStorageError::FileNotFound);
+
     bool acquired = manager->acquireLockForFile(m_path, FileSystemStorageManager::LockType::Shared);
     if (!acquired)
         return makeUnexpected(FileSystemStorageError::InvalidState);


### PR DESCRIPTION
#### 35bd379f1e564c3fcf853d7294ce2a3d1c0783d4
<pre>
FileSystemFileHandle::createWritable should throw NotFoundError if file is removed
<a href="https://bugs.webkit.org/show_bug.cgi?id=293751">https://bugs.webkit.org/show_bug.cgi?id=293751</a>
<a href="https://rdar.apple.com/problem/152254509">rdar://problem/152254509</a>

Reviewed by Per Arne Vollan.

To match the behavior in other browsers.

* LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemDirectoryHandle-removeEntry.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemDirectoryHandle-removeEntry.https.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemWritableFileStream.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemWritableFileStream.https.any.worker-expected.txt:
* Source/WebKit/NetworkProcess/storage/FileSystemStorageHandle.cpp:
(WebKit::FileSystemStorageHandle::createWritable):

Canonical link: <a href="https://commits.webkit.org/295729@main">https://commits.webkit.org/295729@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bdc4d79e83868550e548248a71b40f47521d0cf6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105512 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25223 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15651 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110712 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/56163 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/25748 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33764 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80131 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108518 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/20092 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95223 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60440 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/19845 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13314 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55549 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/89547 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13355 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/113491 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32654 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24082 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89213 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33017 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91453 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88873 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22751 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33742 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11549 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/28107 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32580 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/37988 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32335 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35682 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33923 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->