### PR TITLE
WebDriver BiDi: support for `browsingContext.getTree` command

### DIFF
--- a/Source/WebKit/UIProcess/Automation/BidiBrowsingContextAgent.cpp
+++ b/Source/WebKit/UIProcess/Automation/BidiBrowsingContextAgent.cpp
@@ -29,13 +29,18 @@
 
 #if ENABLE(WEBDRIVER_BIDI)
 
+#include "APIPageConfiguration.h"
 #include "AutomationProtocolObjects.h"
+#include "BrowsingContextGroup.h"
+#include "FrameInfoData.h"
+#include "FrameTreeNodeData.h"
 #include "Logging.h"
 #include "PageLoadState.h"
 #include "WebAutomationSession.h"
 #include "WebAutomationSessionMacros.h"
 #include "WebDriverBidiFrontendDispatchers.h"
 #include "WebDriverBidiProtocolObjects.h"
+#include "WebFrameProxy.h"
 #include "WebPageProxy.h"
 #include "WebProcessPool.h"
 
@@ -125,35 +130,158 @@ void BidiBrowsingContextAgent::create(Inspector::Protocol::BidiBrowsingContext::
     });
 }
 
+class PageTreeAggregator : public RefCounted<PageTreeAggregator> {
+public:
+    static Ref<PageTreeAggregator> create(CommandCallback<Ref<JSON::ArrayOf<Protocol::BidiBrowsingContext::Info>>>&& completionHandler, WebAutomationSession& session, size_t expectedTrees, std::optional<double> maxDepth, std::optional<BrowsingContext> optionalRoot)
+    {
+        return adoptRef(*new PageTreeAggregator(WTFMove(completionHandler), session, expectedTrees, WTFMove(maxDepth), WTFMove(optionalRoot)));
+    }
+
+    void addTree(BrowsingContext rootHandle, std::optional<FrameTreeNodeData>&& data)
+    {
+        m_results.set(rootHandle, WTFMove(data));
+        checkIfComplete();
+    }
+
+    void noteEmpty(BrowsingContext rootHandle)
+    {
+        m_results.set(rootHandle, std::nullopt);
+        checkIfComplete();
+    }
+
+private:
+    PageTreeAggregator(CommandCallback<Ref<JSON::ArrayOf<Protocol::BidiBrowsingContext::Info>>>&& completionHandler, WebAutomationSession& session, size_t expectedTrees, std::optional<double> maxDepth, std::optional<BrowsingContext> optionalRoot)
+        : m_completionHandler(WTFMove(completionHandler)), m_session(session), m_expectedTrees(expectedTrees), m_maxDepth(WTFMove(maxDepth)), m_optionalRoot(WTFMove(optionalRoot))
+    {
+        if (m_expectedTrees <= 0)
+            checkIfComplete();
+    }
+
+    std::optional<Ref<Protocol::BidiBrowsingContext::Info>> convertFrameTreeNodeDataToBidiInfo(const FrameTreeNodeData& node, int currentDepth)
+    {
+
+        auto contextHandle = m_session->handleForWebFrameID(node.info.frameID);
+        if (contextHandle.isEmpty())
+            return std::nullopt;
+
+        RefPtr<WebPageProxy> page = m_session->webPageProxyForHandle(contextHandle);
+        if (!page)
+            return std::nullopt;
+
+        auto info = Protocol::BidiBrowsingContext::Info::create()
+            .setContext(contextHandle)
+            .setUrl(node.info.request.url().string())
+            .setUserContext("default"_s)
+            .setClientWindow("defaut"_s)
+            .release();
+
+        if (page->mainFrame()->frameID() == node.info.frameID) {
+            if (auto openerInfo = page->configuration().openerInfo()) {
+                auto openerHandle = m_session->handleForWebFrameID(openerInfo->frameID);
+                if (!openerHandle.isEmpty())
+                    info->setOriginalOpener(openerHandle);
+            }
+        }
+
+        if (node.info.parentFrameID) {
+            auto parentContextHandle = m_session->handleForWebFrameID(node.info.parentFrameID);
+            info->setParent(parentContextHandle);
+        }
+
+        bool atMaxDepth = m_maxDepth.has_value() && currentDepth >= m_maxDepth.value();
+        if (!atMaxDepth) {
+            auto childrenInfo = JSON::ArrayOf<Protocol::BidiBrowsingContext::Info>::create();
+            for (const auto& childNode : node.children) {
+                if (auto childInfo = convertFrameTreeNodeDataToBidiInfo(childNode, currentDepth + 1))
+                    childrenInfo->addItem(WTFMove(childInfo.value()));
+            }
+
+            if (childrenInfo->length() > 0)
+                info->setChildren(WTFMove(childrenInfo));
+        }
+
+        return info;
+    }
+
+    void checkIfComplete()
+    {
+        if (m_results.size() < m_expectedTrees)
+            return;
+
+        auto finalArray = JSON::ArrayOf<Protocol::BidiBrowsingContext::Info>::create();
+        for (auto& entry : m_results) {
+            const auto& rootHandle = entry.key;
+            auto& rootData = entry.value;
+
+            if (rootData) {
+                if (auto rootInfo = convertFrameTreeNodeDataToBidiInfo(*rootData, 0)) {
+                    if (m_optionalRoot.has_value() && m_optionalRoot.value() == rootHandle) {
+                        if (rootData->info.parentFrameID) {
+                            auto parentContextHandle = m_session->handleForWebFrameID(rootData->info.parentFrameID);
+                            if (!parentContextHandle.isEmpty())
+                                rootInfo.value()->setParent(parentContextHandle);
+                        }
+                    }
+                    finalArray->addItem(rootInfo.value());
+                }
+            }
+        }
+        m_completionHandler({ { WTFMove(finalArray) } });
+    }
+
+    CommandCallback<Ref<JSON::ArrayOf<Protocol::BidiBrowsingContext::Info>>> m_completionHandler;
+    Ref<WebAutomationSession> m_session;
+    size_t m_expectedTrees { 0 };
+    std::optional<double> m_maxDepth;
+    std::optional<BrowsingContext> m_optionalRoot;
+    HashMap<BrowsingContext, std::optional<FrameTreeNodeData>> m_results;
+};
+
 void BidiBrowsingContextAgent::getTree(const BrowsingContext& optionalRoot, std::optional<double>&& optionalMaxDepth, CommandCallback<Ref<JSON::ArrayOf<Protocol::BidiBrowsingContext::Info>>>&& callback)
 {
     RefPtr session = m_session.get();
     ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!session, InternalError);
 
-    // FIXME: implement `root` option.
-    // FIXME: implement `maxDepth` option.
+    Vector<RefPtr<WebFrameProxy>> navigableRoots;
 
-    auto infos = JSON::ArrayOf<Inspector::Protocol::BidiBrowsingContext::Info>::create();
-    for (Ref process : session->protectedProcessPool()->processes()) {
-        for (Ref page : process->pages()) {
-            if (!page->isControlledByAutomation())
-                continue;
+    if (!optionalRoot.isEmpty()) {
+        auto page = session->webPageProxyForHandle(optionalRoot);
+        ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!page, InternalError);
 
-            // FIXME: implement `parent` field.
-            // FIXME: implement `children` field.
-            // FIXME: implement `originalOpener` field.
-            // FIXME: implement `clientWindow` field.
-            // FIXME: implement `userContext` field.
-            infos->addItem(Inspector::Protocol::BidiBrowsingContext::Info::create()
-                .setContext(session->handleForWebPageProxy(page))
-                .setUrl(page->currentURL())
-                .setClientWindow("placeholder_window"_s)
-                .setUserContext("placeholder_context"_s)
-                .release());
+        RefPtr<WebFrameProxy> rootFrame = page->mainFrame();
+        ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!rootFrame, InternalError);
+
+        navigableRoots.append(rootFrame);
+
+    } else {
+        for (auto& process : m_session->protectedProcessPool()->processes()) {
+            for (auto& page : process->pages()) {
+                if (!page->isControlledByAutomation())
+                    continue;
+                navigableRoots.append(page->mainFrame());
+            }
         }
     }
 
-    callback({ { WTFMove(infos) } });
+    if (navigableRoots.isEmpty()) {
+        callback({ { JSON::ArrayOf<Protocol::BidiBrowsingContext::Info>::create() } });
+        return;
+    }
+
+    Ref aggregator = PageTreeAggregator::create(WTFMove(callback), *session, navigableRoots.size(), WTFMove(optionalMaxDepth), optionalRoot);
+    for (RefPtr rootFrame : navigableRoots) {
+        if (!rootFrame) {
+            continue;
+        }
+        auto rootContext = session->handleForWebPageProxy(*rootFrame->page());
+        rootFrame->getFrameTree([aggregator, rootContext = WTFMove(rootContext)](std::optional<FrameTreeNodeData>&& data) mutable {
+            if (data)
+                aggregator->addTree(WTFMove(rootContext), WTFMove(data));
+            else
+                aggregator->noteEmpty(WTFMove(rootContext));
+        });
+    }
+
 }
 
 void BidiBrowsingContextAgent::handleUserPrompt(const BrowsingContext& browsingContext, std::optional<bool>&& optionalShouldAccept, const String&, CommandCallback<void>&& callback)

--- a/Source/WebKit/UIProcess/Automation/WebAutomationSession.h
+++ b/Source/WebKit/UIProcess/Automation/WebAutomationSession.h
@@ -289,14 +289,13 @@ public:
 
     RefPtr<WebPageProxy> webPageProxyForHandle(const String&);
     String handleForWebPageProxy(const WebPageProxy&);
-
+    String handleForWebFrameID(std::optional<WebCore::FrameIdentifier>);
+    String handleForWebFrameProxy(const WebFrameProxy&);
 private:
     Ref<Inspector::Protocol::Automation::BrowsingContext> buildBrowsingContextForPage(WebPageProxy&, WebCore::FloatRect windowFrame);
     void getNextContext(Vector<Ref<WebPageProxy>>&&, Ref<JSON::ArrayOf<Inspector::Protocol::Automation::BrowsingContext>>, Inspector::CommandCallback<Ref<JSON::ArrayOf<Inspector::Protocol::Automation::BrowsingContext>>>&&);
 
     std::optional<WebCore::FrameIdentifier> webFrameIDForHandle(const String&, bool& frameNotFound);
-    String handleForWebFrameID(std::optional<WebCore::FrameIdentifier>);
-    String handleForWebFrameProxy(const WebFrameProxy&);
 
     void waitForNavigationToCompleteOnPage(WebPageProxy&, Inspector::Protocol::Automation::PageLoadStrategy, Seconds, Inspector::CommandCallback<void>&&);
     void waitForNavigationToCompleteOnFrame(WebFrameProxy&, Inspector::Protocol::Automation::PageLoadStrategy, Seconds, Inspector::CommandCallback<void>&&);


### PR DESCRIPTION
#### 729c0046b41ef51d9a71319507c153c6a9eae1d7
<pre>
WebDriver BiDi: support for `browsingContext.getTree` command
Need the bug URL (OOPS!).
<a href="https://rdar.apple.com/137020207">rdar://137020207</a>

Reviewed by NOBODY (OOPS!).

WIP

* Source/WebKit/UIProcess/Automation/BidiBrowsingContextAgent.cpp:
(WebKit::PageTreeAggregator::create):
(WebKit::PageTreeAggregator::addTree):
(WebKit::PageTreeAggregator::noteEmpty):
(WebKit::PageTreeAggregator::PageTreeAggregator):
(WebKit::PageTreeAggregator::convertFrameTreeNodeDataToBidiInfo):
(WebKit::PageTreeAggregator::checkIfComplete):
(WebKit::BidiBrowsingContextAgent::getTree):
* Source/WebKit/UIProcess/Automation/WebAutomationSession.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/729c0046b41ef51d9a71319507c153c6a9eae1d7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105486 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25197 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15625 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/110687 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/56110 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/25663 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33739 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/110687 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/56110 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108492 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/20025 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/95202 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/110687 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/19749 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/55524 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/89481 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/13333 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/113448 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/32629 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/24061 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/89194 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/32992 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/91431 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/88851 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/11530 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/28086 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/32555 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/37968 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/32311 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/35658 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33898 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->