### PR TITLE
StorageManager::getDirectory should throw SecurityError for opaque origin

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/file-system-access/opaque-origin.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/file-system-access/opaque-origin.https.window-expected.txt
@@ -2,5 +2,5 @@
 PASS showDirectoryPicker() must be undefined for data URI iframes.
 PASS FileSystemDirectoryHandle must be undefined for data URI iframes.
 FAIL navigator.storage.getDirectory() and showDirectoryPicker() must reject in a sandboxed iframe. assert_equals: expected "showDirectoryPicker(): REJECTED: SecurityError" but got "showDirectoryPicker(): EXCEPTION: TypeError"
-FAIL navigator.storage.getDirectory() and showDirectoryPicker() must reject in a sandboxed opened window. assert_equals: expected "showDirectoryPicker(): REJECTED: SecurityError" but got "navigator.storage.getDirectory(): REJECTED: TypeError"
+FAIL navigator.storage.getDirectory() and showDirectoryPicker() must reject in a sandboxed opened window. assert_equals: expected "showDirectoryPicker(): REJECTED: SecurityError" but got "navigator.storage.getDirectory(): REJECTED: SecurityError"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/fs/opaque-origin.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fs/opaque-origin.https.window-expected.txt
@@ -1,5 +1,5 @@
 
 FAIL FileSystemDirectoryHandle must be defined for data URI iframes. assert_true: Data URI iframes must define 'FileSystemDirectoryHandle'. expected true got false
-FAIL navigator.storage.getDirectory() must reject in a sandboxed iframe. assert_equals: expected "navigator.storage.getDirectory(): REJECTED: SecurityError" but got "navigator.storage.getDirectory(): REJECTED: TypeError"
-FAIL navigator.storage.getDirectory() must reject in a sandboxed opened window. assert_equals: expected "navigator.storage.getDirectory(): REJECTED: SecurityError" but got "navigator.storage.getDirectory(): REJECTED: TypeError"
+PASS navigator.storage.getDirectory() must reject in a sandboxed iframe.
+PASS navigator.storage.getDirectory() must reject in a sandboxed opened window.
 

--- a/Source/WebCore/Modules/storage/StorageManager.cpp
+++ b/Source/WebCore/Modules/storage/StorageManager.cpp
@@ -62,7 +62,7 @@ struct ConnectionInfo {
     ClientOrigin origin;
 };
 
-static ExceptionOr<ConnectionInfo> connectionInfo(NavigatorBase* navigator)
+static ExceptionOr<ConnectionInfo> connectionInfo(NavigatorBase* navigator, ExceptionCode exceptionCodeForNoAccess)
 {
     if (!navigator)
         return Exception { ExceptionCode::InvalidStateError, "Navigator does not exist"_s };
@@ -72,7 +72,7 @@ static ExceptionOr<ConnectionInfo> connectionInfo(NavigatorBase* navigator)
         return Exception { ExceptionCode::InvalidStateError, "Context is invalid"_s };
 
     if (context->canAccessResource(ScriptExecutionContext::ResourceType::StorageManager) == ScriptExecutionContext::HasResourceAccess::No)
-        return Exception { ExceptionCode::TypeError, "Context not access storage"_s };
+        return Exception { exceptionCodeForNoAccess, "Context not access storage"_s };
 
     RefPtr origin = context->securityOrigin();
     ASSERT(origin);
@@ -92,7 +92,7 @@ static ExceptionOr<ConnectionInfo> connectionInfo(NavigatorBase* navigator)
 
 void StorageManager::persisted(DOMPromiseDeferred<IDLBoolean>&& promise)
 {
-    auto connectionInfoOrException = connectionInfo(m_navigator.get());
+    auto connectionInfoOrException = connectionInfo(m_navigator.get(), ExceptionCode::TypeError);
     if (connectionInfoOrException.hasException())
         return promise.reject(connectionInfoOrException.releaseException());
 
@@ -104,7 +104,7 @@ void StorageManager::persisted(DOMPromiseDeferred<IDLBoolean>&& promise)
 
 void StorageManager::persist(DOMPromiseDeferred<IDLBoolean>&& promise)
 {
-    auto connectionInfoOrException = connectionInfo(m_navigator.get());
+    auto connectionInfoOrException = connectionInfo(m_navigator.get(), ExceptionCode::TypeError);
     if (connectionInfoOrException.hasException())
         return promise.reject(connectionInfoOrException.releaseException());
 
@@ -116,7 +116,7 @@ void StorageManager::persist(DOMPromiseDeferred<IDLBoolean>&& promise)
 
 void StorageManager::estimate(DOMPromiseDeferred<IDLDictionary<StorageEstimate>>&& promise)
 {
-    auto connectionInfoOrException = connectionInfo(m_navigator.get());
+    auto connectionInfoOrException = connectionInfo(m_navigator.get(), ExceptionCode::TypeError);
     if (connectionInfoOrException.hasException())
         return promise.reject(connectionInfoOrException.releaseException());
 
@@ -128,7 +128,7 @@ void StorageManager::estimate(DOMPromiseDeferred<IDLDictionary<StorageEstimate>>
 
 void StorageManager::fileSystemAccessGetDirectory(DOMPromiseDeferred<IDLInterface<FileSystemDirectoryHandle>>&& promise)
 {
-    auto connectionInfoOrException = connectionInfo(m_navigator.get());
+    auto connectionInfoOrException = connectionInfo(m_navigator.get(), ExceptionCode::SecurityError);
     if (connectionInfoOrException.hasException())
         return promise.reject(connectionInfoOrException.releaseException());
 


### PR DESCRIPTION
#### d59f05ad4902e46dba4a308287c9679d9ca0da9b
<pre>
StorageManager::getDirectory should throw SecurityError for opaque origin
<a href="https://rdar.apple.com/152269409">rdar://152269409</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=293763">https://bugs.webkit.org/show_bug.cgi?id=293763</a>

Reviewed by Per Arne Vollan.

To match the behavior in other browsers.

* LayoutTests/imported/w3c/web-platform-tests/file-system-access/opaque-origin.https.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fs/opaque-origin.https.window-expected.txt:
* Source/WebCore/Modules/storage/StorageManager.cpp:
(WebCore::connectionInfo):
(WebCore::StorageManager::persisted):
(WebCore::StorageManager::persist):
(WebCore::StorageManager::estimate):
(WebCore::StorageManager::fileSystemAccessGetDirectory):

Canonical link: <a href="https://commits.webkit.org/295843@main">https://commits.webkit.org/295843@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d8c6f0b2e0709deb3441131a81ae5604f2a508c7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/106117 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25866 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/16260 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/111314 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/56713 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/108156 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/26522 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34369 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80601 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/109121 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/21099 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95763 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60923 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/20525 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13866 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/56152 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/90318 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13901 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/114170 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33255 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24626 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89683 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33619 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91996 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89374 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22831 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34242 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/12057 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/28828 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/33180 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/38592 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32926 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/36276 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34524 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->