### PR TITLE
[Site Isolation] Pointer Lock

### DIFF
--- a/LayoutTests/http/tests/site-isolation/pointer-lock-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/pointer-lock-expected.txt
@@ -1,0 +1,10 @@
+CONSOLE MESSAGE: requesting pointer lock
+CONSOLE MESSAGE: pointerlockchange event called
+CONSOLE MESSAGE: PointerLock is locked:
+CONSOLE MESSAGE: Iframe pointer lock changed:
+CONSOLE MESSAGE: Parent document locked:
+CONSOLE MESSAGE: Site isolation working correctly
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/site-isolation/pointer-lock.html
+++ b/LayoutTests/http/tests/site-isolation/pointer-lock.html
@@ -1,0 +1,36 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+
+<script src="/js-test-resources/js-test.js"></script>
+<script>
+    if (window.testRunner)
+        testRunner.waitUntilDone();
+
+    window.addEventListener('message', (event) => {
+        if (event.data.type === 'pointerLockChanged') {
+            console.log('Iframe pointer lock changed:', event.data.locked);
+
+            // Verify site isolation - parent should NOT have pointer lock
+            const parentLocked = document.pointerLockElement !== null;
+            console.log('Parent document locked:', parentLocked);
+
+            if (event.data.locked && !parentLocked)
+                console.log('Site isolation working correctly');
+
+            if (window.testRunner)
+                testRunner.notifyDone();
+        }
+    });
+
+    // Pointer lock not supported on iOS
+    const hasPointerLock = 'pointerLockElement' in document;
+    if (!hasPointerLock) {
+        console.log("Pointerlock not supported");
+
+        if (window.testRunner)
+            testRunner.notifyDone();
+    }
+</script>
+
+<body>
+    <iframe src="http://localhost:8000/site-isolation/resources/pointer-lock.html" />
+</body>

--- a/LayoutTests/http/tests/site-isolation/resources/pointer-lock.html
+++ b/LayoutTests/http/tests/site-isolation/resources/pointer-lock.html
@@ -1,0 +1,41 @@
+<script src="/js-test-resources/js-test.js"></script>
+<script src="/js-test-resources/ui-helper.js"></script>
+
+<script>
+    document.addEventListener('pointerlockchange', () => {
+        const isLocked = document.pointerLockElement !== null;
+
+        console.log("pointerlockchange event called");
+        console.log("PointerLock is locked: ", isLocked);
+
+        window.parent.postMessage({
+            type: 'pointerLockChanged',
+            locked: isLocked,
+            element: document.pointerLockElement ? document.pointerLockElement.id : null
+        }, '*');
+    });
+
+    document.addEventListener('pointerlockerror', () => {
+        console.log("Pointer lock failed");
+    });
+
+    window.onload = (event) => {
+        const element = document.getElementById('pointer-lock-element');
+        if (element) {
+            element.addEventListener('click', () => {
+                element.requestPointerLock();
+                console.log("requesting pointer lock");
+            });
+        } else {
+            console.error("Element still not found after timeout!");
+        }
+
+        if (window.eventSender) {
+            UIHelper.activateElement(element);
+        }
+    };
+</script>
+
+<div id='pointer-lock-element' style="width: 200px; height: 200px; background: lightblue; cursor: pointer;">
+    Click me to request pointer lock
+</div>

--- a/LayoutTests/platform/ios/http/tests/site-isolation/pointer-lock-expected.txt
+++ b/LayoutTests/platform/ios/http/tests/site-isolation/pointer-lock-expected.txt
@@ -1,0 +1,2 @@
+CONSOLE MESSAGE: Pointerlock not supported
+

--- a/LayoutTests/platform/mac-wk1/pointer-lock/pointer-lock-option-unadjusted-movement-expected.txt
+++ b/LayoutTests/platform/mac-wk1/pointer-lock/pointer-lock-option-unadjusted-movement-expected.txt
@@ -1,0 +1,21 @@
+Test pointer lock unadjustedMovement option.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS window.testRunner is defined.
+     requestPointerLock()
+PASS [object Promise] is non-null.
+     Promise resolved.
+     requestPointerLock({unadjustedMovement: true})
+PASS [object Promise] is non-null.
+     unadjustedMovement is supported.
+     Unlock
+PASS onpointerlockchange received after: Unlock
+     Lock with PointerLockOptionsEnabled = false
+PASS undefined is undefined.
+FAIL onpointerlockerror received after: Lock with PointerLockOptionsEnabled = false
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/Source/WebCore/page/ChromeClient.h
+++ b/Source/WebCore/page/ChromeClient.h
@@ -198,6 +198,12 @@ class GPU;
 }
 #endif
 
+enum class PointerLockRequestResult : uint8_t {
+    Success,
+    Failure,
+    Unsupported
+};
+
 class ChromeClient {
 public:
     virtual void chromeDestroyed() = 0;
@@ -581,8 +587,8 @@ public:
     virtual bool isSVGImageChromeClient() const { return false; }
 
 #if ENABLE(POINTER_LOCK)
-    virtual bool requestPointerLock() { return false; }
-    virtual void requestPointerUnlock() { }
+    virtual void requestPointerLock(CompletionHandler<void(PointerLockRequestResult)>&& completionHandler) { completionHandler(PointerLockRequestResult::Unsupported); }
+    virtual void requestPointerUnlock(CompletionHandler<void(bool)>&& completionHandler) { completionHandler(false); }
 #endif
 
     virtual FloatSize minimumWindowSize() const { return FloatSize(100, 100); };

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -367,7 +367,7 @@ Page::Page(PageConfiguration&& pageConfiguration)
     , m_inspectorController(makeUniqueRefWithoutRefCountedCheck<InspectorController>(*this, WTFMove(pageConfiguration.inspectorBackendClient)))
     , m_pointerCaptureController(makeUniqueRef<PointerCaptureController>(*this))
 #if ENABLE(POINTER_LOCK)
-    , m_pointerLockController(makeUniqueRef<PointerLockController>(*this))
+    , m_pointerLockController(makeUniqueRefWithoutRefCountedCheck<PointerLockController>(*this))
 #endif
     , m_elementTargetingController(makeUniqueRef<ElementTargetingController>(*this))
     , m_settings(Settings::create(this))

--- a/Source/WebCore/page/PointerLockController.cpp
+++ b/Source/WebCore/page/PointerLockController.cpp
@@ -40,6 +40,7 @@
 #include "PointerCaptureController.h"
 #include "UserGestureIndicator.h"
 #include "VoidCallback.h"
+#include <wtf/Ref.h>
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
@@ -61,6 +62,17 @@ PointerLockController::PointerLockController(Page& page)
 }
 
 PointerLockController::~PointerLockController() = default;
+
+void PointerLockController::ref() const
+{
+    m_page.ref();
+}
+
+void PointerLockController::deref() const
+{
+    m_page.deref();
+}
+
 
 void PointerLockController::requestPointerLock(Element* target, std::optional<PointerLockOptions>&& options, RefPtr<DeferredPromise> promise)
 {
@@ -127,12 +139,22 @@ void PointerLockController::requestPointerLock(Element* target, std::optional<Po
         m_options = WTFMove(options);
         if (promise)
             m_promises.append(promise.releaseNonNull());
-        // ChromeClient::requestPointerLock() can call back into didAcquirePointerLock(), so all state including element, options, and promise needs to be stored before it is called.
-        if (!m_page.chrome().client().requestPointerLock()) {
-            enqueueEvent(eventNames().pointerlockerrorEvent, target);
-            rejectPromises(ExceptionCode::NotSupportedError, "Pointer lock is unavailable."_s);
-            clearElement();
-        }
+
+        m_page.chrome().client().requestPointerLock([this, protectedThis = Ref { *this }, target = RefPtr { target }](PointerLockRequestResult result) {
+            switch (result) {
+            case PointerLockRequestResult::Success:
+                didAcquirePointerLock();
+                break;
+            case PointerLockRequestResult::Failure:
+                didNotAcquirePointerLock();
+                break;
+            case PointerLockRequestResult::Unsupported:
+                enqueueEvent(eventNames().pointerlockerrorEvent, target.get());
+                rejectPromises(ExceptionCode::NotSupportedError, "Pointer lock is unavailable."_s);
+                clearElement();
+                break;
+            }
+        });
     }
 }
 
@@ -142,7 +164,12 @@ void PointerLockController::requestPointerUnlock()
         return;
 
     m_unlockPending = true;
-    m_page.chrome().client().requestPointerUnlock();
+    m_page.chrome().client().requestPointerUnlock([this, protectedThis = Ref { *this }](bool result) {
+        if (result)
+            didLosePointerLock();
+        else
+            didNotAcquirePointerLock();
+    });
 }
 
 void PointerLockController::requestPointerUnlockAndForceCursorVisible()
@@ -153,7 +180,12 @@ void PointerLockController::requestPointerUnlockAndForceCursorVisible()
         return;
 
     m_unlockPending = true;
-    m_page.chrome().client().requestPointerUnlock();
+    m_page.chrome().client().requestPointerUnlock([this, protectedThis = Ref { *this }](bool result) {
+        if (result)
+            didLosePointerLock();
+        else
+            didNotAcquirePointerLock();
+    });
     m_forceCursorVisibleUponUnlock = true;
 }
 

--- a/Source/WebCore/page/PointerLockController.h
+++ b/Source/WebCore/page/PointerLockController.h
@@ -56,6 +56,9 @@ public:
     ~PointerLockController();
     void requestPointerLock(Element* target, std::optional<PointerLockOptions>&& = std::nullopt, RefPtr<DeferredPromise> = nullptr);
 
+    void ref() const;
+    void deref() const;
+
     void requestPointerUnlock();
     void requestPointerUnlockAndForceCursorVisible();
     void elementWasRemoved(Element&);

--- a/Source/WebKit/UIProcess/API/APIUIClient.h
+++ b/Source/WebKit/UIProcess/API/APIUIClient.h
@@ -191,7 +191,7 @@ public:
 #endif
 
 #if ENABLE(POINTER_LOCK)
-    virtual void requestPointerLock(WebKit::WebPageProxy*) { }
+    virtual void requestPointerLock(WebKit::WebPageProxy*, CompletionHandler<void(bool)>&& completionHandler) { completionHandler(false); }
     virtual void didLosePointerLock(WebKit::WebPageProxy*) { }
 #endif
 

--- a/Source/WebKit/UIProcess/API/C/WKPage.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKPage.cpp
@@ -2240,12 +2240,13 @@ void WKPageSetPageUIClient(WKPageRef pageRef, const WKPageUIClientBase* wkClient
         }
 
 #if ENABLE(POINTER_LOCK)
-        void requestPointerLock(WebPageProxy* page) final
+        void requestPointerLock(WebPageProxy* page, CompletionHandler<void(bool)>&& completionHandler) final
         {
             if (!m_client.requestPointerLock)
-                return;
-            
-            m_client.requestPointerLock(toAPI(page), m_client.base.clientInfo);
+                return completionHandler(false);
+
+            Ref listener = CompletionListener::create([completionHandler = WTFMove(completionHandler)] mutable { completionHandler(true); });
+            m_client.requestPointerLock(toAPI(page), toAPI(listener.ptr()), m_client.base.clientInfo);
         }
 
         void didLosePointerLock(WebPageProxy* page) final
@@ -3024,31 +3025,11 @@ bool WKPageGetMediaCaptureEnabled(WKPageRef page)
     return toProtectedImpl(page)->mediaCaptureEnabled();
 }
 
-void WKPageDidAllowPointerLock(WKPageRef pageRef)
-{
-    CRASH_IF_SUSPENDED;
-#if ENABLE(POINTER_LOCK)
-    toProtectedImpl(pageRef)->didAllowPointerLock();
-#else
-    UNUSED_PARAM(pageRef);
-#endif
-}
-
 void WKPageClearUserMediaState(WKPageRef pageRef)
 {
     CRASH_IF_SUSPENDED;
 #if ENABLE(MEDIA_STREAM)
     toProtectedImpl(pageRef)->clearUserMediaState();
-#else
-    UNUSED_PARAM(pageRef);
-#endif
-}
-
-void WKPageDidDenyPointerLock(WKPageRef pageRef)
-{
-    CRASH_IF_SUSPENDED;
-#if ENABLE(POINTER_LOCK)
-    toProtectedImpl(pageRef)->didDenyPointerLock();
 #else
     UNUSED_PARAM(pageRef);
 #endif

--- a/Source/WebKit/UIProcess/API/C/WKPagePrivate.h
+++ b/Source/WebKit/UIProcess/API/C/WKPagePrivate.h
@@ -143,9 +143,6 @@ WK_EXPORT void WKPageClearUserMediaState(WKPageRef page);
 WK_EXPORT void WKPageSetMediaCaptureEnabled(WKPageRef page, bool enabled);
 WK_EXPORT bool WKPageGetMediaCaptureEnabled(WKPageRef page);
 
-WK_EXPORT void WKPageDidAllowPointerLock(WKPageRef page);
-WK_EXPORT void WKPageDidDenyPointerLock(WKPageRef page);
-
 enum {
     kWKMediaIsNotPlaying = 0,
     kWKMediaIsPlayingAudio = 1 << 0,

--- a/Source/WebKit/UIProcess/API/C/WKPageUIClient.h
+++ b/Source/WebKit/UIProcess/API/C/WKPageUIClient.h
@@ -136,7 +136,7 @@ typedef void (*WKCheckUserMediaPermissionCallback)(WKPageRef page, WKFrameRef fr
 typedef void (*WKPageDidClickAutoFillButtonCallback)(WKPageRef page, WKTypeRef userData, const void *clientInfo);
 typedef void (*WKHandleAutoplayEventCallback)(WKPageRef page, WKAutoplayEvent event, WKAutoplayEventFlags flags, const void* clientInfo);
 typedef void (*WKFullscreenMayReturnToInlineCallback)(WKPageRef page, const void* clientInfo);
-typedef void (*WKRequestPointerLockCallback)(WKPageRef page, const void* clientInfo);
+typedef void (*WKRequestPointerLockCallback)(WKPageRef page, WKCompletionListenerRef listener, const void* clientInfo);
 typedef void (*WKDidLosePointerLockCallback)(WKPageRef page, const void* clientInfo);
 typedef void (*WKHasVideoInPictureInPictureDidChangeCallback)(WKPageRef page, bool hasVideoInPictureInPicture, const void* clientInfo);
 typedef void (*WKPageDidResignInputElementStrongPasswordAppearanceCallback)(WKPageRef page, WKTypeRef userData, const void *clientInfo);

--- a/Source/WebKit/UIProcess/API/glib/WebKitPointerLockPermissionRequestPrivate.h
+++ b/Source/WebKit/UIProcess/API/glib/WebKitPointerLockPermissionRequestPrivate.h
@@ -23,8 +23,9 @@
 
 #include "WebKitPointerLockPermissionRequest.h"
 #include "WebKitWebView.h"
+#include <wtf/CompletionHandler.h>
 
-WebKitPointerLockPermissionRequest* webkitPointerLockPermissionRequestCreate(WebKitWebView*);
+WebKitPointerLockPermissionRequest* webkitPointerLockPermissionRequestCreate(WebKitWebView*, CompletionHandler<void(bool)>&&);
 void webkitPointerLockPermissionRequestDidLosePointerLock(WebKitPointerLockPermissionRequest*);
 
 #endif // ENABLE(POINTER_LOCK)

--- a/Source/WebKit/UIProcess/API/glib/WebKitUIClient.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitUIClient.cpp
@@ -349,9 +349,9 @@ private:
     }
 
 #if ENABLE(POINTER_LOCK)
-    void requestPointerLock(WebPageProxy* page) final
+    void requestPointerLock(WebPageProxy* page, CompletionHandler<void(bool)>&& completionHandler) final
     {
-        GRefPtr<WebKitPointerLockPermissionRequest> permissionRequest = adoptGRef(webkitPointerLockPermissionRequestCreate(m_webView));
+        GRefPtr<WebKitPointerLockPermissionRequest> permissionRequest = adoptGRef(webkitPointerLockPermissionRequestCreate(m_webView, WTFMove(completionHandler)));
         RELEASE_ASSERT(!m_pointerLockPermissionRequest);
         m_pointerLockPermissionRequest.reset(permissionRequest.get());
         webkitWebViewMakePermissionRequest(m_webView, WEBKIT_PERMISSION_REQUEST(permissionRequest.get()));

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
@@ -3096,20 +3096,21 @@ void webkitWebViewDidReceiveUserMessage(WebKitWebView* webView, UserMessage&& me
 }
 
 #if ENABLE(POINTER_LOCK)
-void webkitWebViewRequestPointerLock(WebKitWebView* webView)
+void webkitWebViewRequestPointerLock(WebKitWebView* webView, CompletionHandler<void(bool)>&& completionHandler)
 {
 #if PLATFORM(GTK)
-    webkitWebViewBaseRequestPointerLock(WEBKIT_WEB_VIEW_BASE(webView));
+    webkitWebViewBaseRequestPointerLock(WEBKIT_WEB_VIEW_BASE(webView), WTFMove(completionHandler));
 #endif
 
 #if PLATFORM(WPE)
     webView->priv->view->requestPointerLock();
+    completionHandler(true);
 #endif
 }
 
-void webkitWebViewDenyPointerLockRequest(WebKitWebView* webView)
+void webkitWebViewDenyPointerLockRequest(CompletionHandler<void(bool)>&& completionHandler)
 {
-    getPage(webView).didDenyPointerLock();
+    completionHandler(false);
 }
 
 void webkitWebViewDidLosePointerLock(WebKitWebView* webView)

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebViewPrivate.h
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebViewPrivate.h
@@ -115,8 +115,8 @@ void webkitWebViewDidChangePageID(WebKitWebView*);
 void webkitWebViewDidReceiveUserMessage(WebKitWebView*, WebKit::UserMessage&&, CompletionHandler<void(WebKit::UserMessage&&)>&&);
 
 #if ENABLE(POINTER_LOCK)
-void webkitWebViewRequestPointerLock(WebKitWebView*);
-void webkitWebViewDenyPointerLockRequest(WebKitWebView*);
+void webkitWebViewRequestPointerLock(WebKitWebView*, CompletionHandler<void(bool)>&&);
+void webkitWebViewDenyPointerLockRequest(CompletionHandler<void(bool)>&&);
 void webkitWebViewDidLosePointerLock(WebKitWebView*);
 #endif
 

--- a/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp
@@ -3085,7 +3085,7 @@ void webkitWebViewBaseShowEmojiChooser(WebKitWebViewBase* webkitWebViewBase, con
 }
 
 #if ENABLE(POINTER_LOCK)
-void webkitWebViewBaseRequestPointerLock(WebKitWebViewBase* webViewBase)
+void webkitWebViewBaseRequestPointerLock(WebKitWebViewBase* webViewBase, CompletionHandler<void(bool)>&& completionHandler)
 {
     WebKitWebViewBasePrivate* priv = webViewBase->priv;
     ASSERT(!priv->pointerLockManager);
@@ -3093,13 +3093,11 @@ void webkitWebViewBaseRequestPointerLock(WebKitWebViewBase* webViewBase)
         priv->lastMotionEvent = MotionEvent(GTK_WIDGET(webViewBase), nullptr);
     priv->pointerLockManager = PointerLockManager::create(*priv->pageProxy, priv->lastMotionEvent->position, priv->lastMotionEvent->globalPosition,
         priv->lastMotionEvent->button, priv->lastMotionEvent->buttons, priv->lastMotionEvent->modifiers);
-    if (priv->pointerLockManager->lock()) {
-        priv->pageProxy->didAllowPointerLock();
-        return;
-    }
+    if (priv->pointerLockManager->lock())
+        return completionHandler(true);
 
     priv->pointerLockManager = nullptr;
-    priv->pageProxy->didDenyPointerLock();
+    completionHandler(false);
 }
 
 void webkitWebViewBaseDidLosePointerLock(WebKitWebViewBase* webViewBase)

--- a/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBasePrivate.h
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBasePrivate.h
@@ -122,7 +122,7 @@ void webkitWebViewBaseDidRestoreScrollPosition(WebKitWebViewBase*);
 
 void webkitWebViewBaseShowEmojiChooser(WebKitWebViewBase*, const WebCore::IntRect&, CompletionHandler<void(String)>&&);
 
-void webkitWebViewBaseRequestPointerLock(WebKitWebViewBase*);
+void webkitWebViewBaseRequestPointerLock(WebKitWebViewBase*, CompletionHandler<void(bool)>&&);
 void webkitWebViewBaseDidLosePointerLock(WebKitWebViewBase*);
 
 void webkitWebViewBaseSetInputMethodContext(WebKitWebViewBase*, WebKitInputMethodContext*);

--- a/Source/WebKit/UIProcess/Cocoa/UIDelegate.h
+++ b/Source/WebKit/UIProcess/Cocoa/UIDelegate.h
@@ -173,7 +173,7 @@ private:
         std::optional<double> dataDetectionReferenceDate() final;
 
 #if ENABLE(POINTER_LOCK)
-        void requestPointerLock(WebPageProxy*) final;
+        void requestPointerLock(WebPageProxy*, CompletionHandler<void(bool)>&&) final;
         void didLosePointerLock(WebPageProxy*) final;
 #endif
         

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1867,9 +1867,7 @@ public:
     void requestMediaPlaybackState(CompletionHandler<void(MediaPlaybackState)>&&);
 
 #if ENABLE(POINTER_LOCK)
-    void didAllowPointerLock();
-    void didDenyPointerLock();
-    void requestPointerUnlock();
+    void requestPointerUnlock(CompletionHandler<void(bool)>&&);
 #endif
 
     void setSuppressVisibilityUpdates(bool flag);
@@ -2777,6 +2775,12 @@ public:
 
     Ref<AboutSchemeHandler> protectedAboutSchemeHandler();
 
+#if ENABLE(POINTER_LOCK)
+    RefPtr<WebProcessProxy> webContentPointerLockProcess();
+    void clearWebContentPointerLockProcess();
+    void resetPointerLockState(void);
+#endif
+
 private:
     WebPageProxy(PageClient&, WebProcessProxy&, Ref<API::PageConfiguration>&&);
     void platformInitialize();
@@ -2819,7 +2823,9 @@ private:
     void setUserAgent(String&&, IsCustomUserAgent = IsCustomUserAgent::No);
 
 #if ENABLE(POINTER_LOCK)
-    void requestPointerLock();
+    void didAllowPointerLock(CompletionHandler<void(bool)>&&);
+    void didDenyPointerLock(CompletionHandler<void(bool)>&&);
+    void requestPointerLock(IPC::Connection&, CompletionHandler<void(bool)>&&);
 #endif
 
     void didCreateSubframe(WebCore::FrameIdentifier parent, WebCore::FrameIdentifier newFrameID, String&& frameName, WebCore::SandboxFlags, WebCore::ScrollbarMode);
@@ -3804,6 +3810,7 @@ private:
 #if ENABLE(POINTER_LOCK)
     bool m_isPointerLockPending { false };
     bool m_isPointerLocked { false };
+    RefPtr<WebProcessProxy> m_webContentPointerLockProcess;
 #endif
 
     bool m_openedByDOM { false };

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -498,8 +498,8 @@ messages -> WebPageProxy {
 #endif
 
 #if ENABLE(POINTER_LOCK)
-    RequestPointerLock()
-    RequestPointerUnlock()
+    RequestPointerLock() -> (bool result)
+    RequestPointerUnlock() -> (bool result)
 #endif
 
     ImageOrMediaDocumentSizeChanged(WebCore::IntSize newSize)

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -77,6 +77,7 @@
 #import "WebEventFactory.h"
 #import "WebFrameProxy.h"
 #import "WebInspectorUIProxy.h"
+#import "WebPageMessages.h"
 #import "WebPageProxy.h"
 #import "WebProcessPool.h"
 #import "WebProcessProxy.h"
@@ -179,8 +180,8 @@
 
 #import "AppKitSoftLink.h"
 #import <pal/cocoa/RevealSoftLink.h>
-#import <pal/cocoa/VisionKitCoreSoftLink.h>
 #import <pal/cocoa/TranslationUIServicesSoftLink.h>
+#import <pal/cocoa/VisionKitCoreSoftLink.h>
 #import <pal/cocoa/WritingToolsUISoftLink.h>
 #import <pal/mac/DataDetectorsSoftLink.h>
 
@@ -1491,7 +1492,7 @@ bool WebViewImpl::isOpaque() const
 }
 
 void WebViewImpl::setShouldSuppressFirstResponderChanges(bool shouldSuppress)
-{   
+{
     m_pageClient->setShouldSuppressFirstResponderChanges(shouldSuppress);
 }
 
@@ -2132,7 +2133,7 @@ void WebViewImpl::windowDidResize()
 void WebViewImpl::windowWillBeginSheet()
 {
 #if ENABLE(POINTER_LOCK)
-    m_page->requestPointerUnlock();
+    m_page->resetPointerLockState();
 #endif
 }
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
@@ -223,8 +223,8 @@ private:
 #endif
 
 #if ENABLE(POINTER_LOCK)
-    bool requestPointerLock() final;
-    void requestPointerUnlock() final;
+    void requestPointerLock(CompletionHandler<void(WebCore::PointerLockRequestResult)>&&) final;
+    void requestPointerUnlock(CompletionHandler<void(bool)>&&) final;
 #endif
 
     void didAssociateFormControls(const Vector<RefPtr<WebCore::Element>>&, WebCore::LocalFrame&) final;

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -635,8 +635,6 @@ messages -> WebPage WantsAsyncDispatchMessage {
 #endif
 
 #if ENABLE(POINTER_LOCK)
-    DidAcquirePointerLock()
-    DidNotAcquirePointerLock()
     DidLosePointerLock()
 #endif
 

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.h
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.h
@@ -150,8 +150,8 @@ private:
     void updateTextIndicator(const WebCore::TextIndicatorData&) const final;
 
 #if ENABLE(POINTER_LOCK)
-    bool requestPointerLock() final;
-    void requestPointerUnlock() final;
+    void requestPointerLock(CompletionHandler<void(WebCore::PointerLockRequestResult)>&&) final;
+    void requestPointerUnlock(CompletionHandler<void(bool)>&&) final;
 #endif
 
     WebCore::KeyboardUIMode keyboardUIMode() final;

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.mm
@@ -730,30 +730,36 @@ void WebChromeClient::updateTextIndicator(const WebCore::TextIndicatorData& indi
 }
 
 #if ENABLE(POINTER_LOCK)
-bool WebChromeClient::requestPointerLock()
+void WebChromeClient::requestPointerLock(CompletionHandler<void(WebCore::PointerLockRequestResult)>&& completionHandler)
 {
 #if PLATFORM(MAC)
-    if (![m_webView page])
-        return false;
+    if (![m_webView page]) {
+        completionHandler(WebCore::PointerLockRequestResult::Failure);
+        return;
+    }
 
     CGDisplayHideCursor(CGMainDisplayID());
     CGAssociateMouseAndMouseCursorPosition(false);
     [m_webView page]->pointerLockController().didAcquirePointerLock();
     
-    return true;
+    completionHandler(WebCore::PointerLockRequestResult::Success);
 #else
-    return false;
+    completionHandler(WebCore::PointerLockRequestResult::Failure);
 #endif
 }
 
-void WebChromeClient::requestPointerUnlock()
+void WebChromeClient::requestPointerUnlock(CompletionHandler<void(bool)>&& completionHandler)
 {
 #if PLATFORM(MAC)
     CGAssociateMouseAndMouseCursorPosition(true);
     CGDisplayShowCursor(CGMainDisplayID());
-    if ([m_webView page])
+    if ([m_webView page]) {
         [m_webView page]->pointerLockController().didLosePointerLock();
+        completionHandler(true);
+        return;
+    }
 #endif
+    completionHandler(false);
 }
 #endif
 

--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -336,9 +336,9 @@ static void runJavaScriptConfirm(WKPageRef page, WKStringRef message, WKFrameRef
     TestController::singleton().handleJavaScriptConfirm(message, listener);
 }
 
-static void requestPointerLock(WKPageRef page, const void*)
+static void requestPointerLock(WKPageRef page, WKCompletionListenerRef listener, const void*)
 {
-    WKPageDidAllowPointerLock(page);
+    WKCompletionListenerComplete(listener);
 }
 
 static void printFrame(WKPageRef page, WKFrameRef frame, const void*)


### PR DESCRIPTION
#### d1dcb5ad565b1c852043d169b7937535b19b2c96
<pre>
[Site Isolation] Pointer Lock
<a href="https://bugs.webkit.org/show_bug.cgi?id=293767">https://bugs.webkit.org/show_bug.cgi?id=293767</a>
<a href="https://rdar.apple.com/117910429">rdar://117910429</a>

Reviewed by Alex Christensen.

Implement Pointer Lock to work under site isolation.

WK1 change: When disabling pointer lock options a pointerlockerror event will be thrown now
in place of pointerlockchange.

* LayoutTests/http/tests/site-isolation/pointer-lock-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/pointer-lock.html: Added.
* LayoutTests/http/tests/site-isolation/resources/pointer-lock.html: Added.
* LayoutTests/platform/ios/http/tests/site-isolation/pointer-lock-expected.txt: Added.
* LayoutTests/platform/mac-wk1/pointer-lock/pointer-lock-option-unadjusted-movement-expected.txt: Added.
* Source/WebCore/page/ChromeClient.h:
(WebCore::ChromeClient::requestPointerLock):
(WebCore::ChromeClient::requestPointerUnlock):
* Source/WebCore/page/Page.cpp:
(WebCore::Page::Page):
* Source/WebCore/page/PointerLockController.cpp:
(WebCore::PointerLockController::ref const):
(WebCore::PointerLockController::deref const):
(WebCore::PointerLockController::requestPointerLock):
(WebCore::PointerLockController::requestPointerUnlock):
(WebCore::PointerLockController::requestPointerUnlockAndForceCursorVisible):
* Source/WebCore/page/PointerLockController.h:
* Source/WebKit/UIProcess/API/APIUIClient.h:
(API::UIClient::requestPointerLock):
* Source/WebKit/UIProcess/API/C/WKPage.cpp:
(WKPageSetPageUIClient):
(WKPageDidAllowPointerLock):
(WKPageDidDenyPointerLock):
* Source/WebKit/UIProcess/API/C/WKPagePrivate.h:
* Source/WebKit/UIProcess/API/C/WKPageUIClient.h:
* Source/WebKit/UIProcess/API/glib/WebKitPointerLockPermissionRequest.cpp:
(webkitPointerLockPermissionRequestAllow):
(webkitPointerLockPermissionRequestDeny):
(webkitPointerLockPermissionRequestCreate):
(webkitPointerLockPermissionRequestDidLosePointerLock):
* Source/WebKit/UIProcess/API/glib/WebKitPointerLockPermissionRequestPrivate.h:
* Source/WebKit/UIProcess/API/glib/WebKitUIClient.cpp:
* Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp:
(webkitWebViewRequestPointerLock):
(webkitWebViewDenyPointerLockRequest):
* Source/WebKit/UIProcess/API/glib/WebKitWebViewPrivate.h:
* Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp:
(webkitWebViewBaseRequestPointerLock):
* Source/WebKit/UIProcess/API/gtk/WebKitWebViewBasePrivate.h:
* Source/WebKit/UIProcess/Cocoa/UIDelegate.h:
* Source/WebKit/UIProcess/Cocoa/UIDelegate.mm:
(WebKit::UIDelegate::UIClient::requestPointerLock):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::dispatchActivityStateChange):
(WebKit::WebPageProxy::didCommitLoadForFrame):
(WebKit::WebPageProxy::resetState):
(WebKit::WebPageProxy::requestPointerLock):
(WebKit::WebPageProxy::didAllowPointerLock):
(WebKit::WebPageProxy::didDenyPointerLock):
(WebKit::WebPageProxy::requestPointerUnlock):
(WebKit::WebPageProxy::webContentPointerLockProcess):
(WebKit::WebPageProxy::clearWebContentPointerLockProcess):
(WebKit::WebPageProxy::resetPointerLockState):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.messages.in:
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::setShouldSuppressFirstResponderChanges):
(WebKit::WebViewImpl::windowWillBeginSheet):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::requestPointerLock):
(WebKit::WebChromeClient::requestPointerUnlock):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:
* Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.h:
* Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.mm:
(WebChromeClient::requestPointerLock):
(WebChromeClient::requestPointerUnlock):
* Tools/WebKitTestRunner/TestController.cpp:
(WTR::requestPointerLock):

Canonical link: <a href="https://commits.webkit.org/297606@main">https://commits.webkit.org/297606@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/864c79c7cf88efca14a3d1f7c1a2d984ff7e86b3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/112287 "Passed style check") | [⏳ 🛠 ios ](https://ews-build.webkit.org/#/builders/iOS-18-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/22496 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/118365 "Build is in progress. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Compiled WebKit") | [💥 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/62637 "An unexpected error occured. Recent messages:Printed configuration") 
| [⏳ 🧪 bindings ](https://ews-build.webkit.org/#/builders/Bindings-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/32671 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/40582 "Build is in progress. Recent messages:Running configuration; Running apply-patch; Checked out pull request; Running compile-webkit") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/85300 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/62637 "An unexpected error occured. Recent messages:Printed configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/115234 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26067 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101023 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65730 "Passed tests") | 
| [⏳ 🧪 webkitpy ](https://ews-build.webkit.org/#/builders/WebKitPy-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/25372 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/19159 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/62211 "Built successfully") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/19238 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/121691 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/39361 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/123/builds/40582 "Build is in progress. Recent messages:Running configuration; Running apply-patch; Checked out pull request; Running compile-webkit") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/94112 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/39742 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97265 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93936 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39173 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/16967 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/35392 "Build is in progress. Recent messages:") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18099 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/39249 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/44737 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/38884 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/42221 "Built successfully") | | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/40627 "Build is in progress. Recent messages:OS: Sequoia (15.5), Xcode: 16.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | | | 
<!--EWS-Status-Bubble-End-->