### PR TITLE
Deprecate hasLocalDataForLinkURL and linkLocalDataMIMEType from _WKHitTestResult

### DIFF
--- a/Source/WebKit/Shared/API/Cocoa/_WKHitTestResult.h
+++ b/Source/WebKit/Shared/API/Cocoa/_WKHitTestResult.h
@@ -45,8 +45,8 @@ WK_CLASS_AVAILABLE(macos(10.12), ios(16.0))
 
 @property (nonatomic, readonly, copy) NSURL *absolutePDFURL;
 @property (nonatomic, readonly, copy) NSURL *absoluteLinkURL;
-@property (nonatomic, readonly) BOOL hasLocalDataForLinkURL WK_API_AVAILABLE(macos(15.0), ios(18.0), visionos(2.0));
-@property (nonatomic, readonly, copy) NSString *linkLocalDataMIMEType WK_API_AVAILABLE(macos(15.0), ios(18.0), visionos(2.0));
+@property (nonatomic, readonly) BOOL hasLocalDataForLinkURL WK_API_DEPRECATED_WITH_REPLACEMENT("linkLocalResourceResponse");
+@property (nonatomic, readonly, copy) NSString *linkLocalDataMIMEType WK_API_DEPRECATED_WITH_REPLACEMENT("linkLocalResourceResponse.MIMEType");
 @property (nonatomic, readonly, copy) NSURL *absoluteMediaURL;
 @property (nonatomic, readonly, copy) NSURLResponse *linkLocalResourceResponse WK_API_AVAILABLE(macos(WK_MAC_TBA));
 

--- a/Source/WebKit/Shared/API/Cocoa/_WKHitTestResult.mm
+++ b/Source/WebKit/Shared/API/Cocoa/_WKHitTestResult.mm
@@ -67,12 +67,12 @@ static NSURL *URLFromString(const WTF::String& urlString)
 
 - (BOOL)hasLocalDataForLinkURL
 {
-    return _hitTestResult->hasLocalDataForLinkURL();
+    return NO;
 }
 
 - (NSString *)linkLocalDataMIMEType
 {
-    return _hitTestResult->linkLocalDataMIMEType().createNSString().autorelease();
+    return nil;
 }
 
 - (NSURL *)absoluteMediaURL

--- a/Source/WebKit/Shared/WebHitTestResultData.cpp
+++ b/Source/WebKit/Shared/WebHitTestResultData.cpp
@@ -56,18 +56,6 @@ static RefPtr<WebFrame> webFrameFromHitTestResult(const HitTestResult& hitTestRe
     return WebFrame::fromCoreFrame(*coreFrame);
 }
 
-static String linkLocalDataMIMETypeFromHitTestResult(const HitTestResult& hitTestResult)
-{
-    if (!hitTestResult.hasLocalDataForLinkURL())
-        return nullString();
-
-    RefPtr webFrame = webFrameFromHitTestResult(hitTestResult);
-    if (!webFrame)
-        return nullString();
-
-    return webFrame->mimeTypeForResourceWithURL(hitTestResult.absoluteLinkURL());
-}
-
 static std::optional<ResourceResponse> linkLocalResourceFromHitTestResult(const HitTestResult& hitTestResult)
 {
     if (!hitTestResult.hasLocalDataForLinkURL())
@@ -117,8 +105,6 @@ WebHitTestResultData::WebHitTestResultData(const HitTestResult& hitTestResult, c
     , elementType(elementTypeFromHitTestResult(hitTestResult))
     , frameInfo(frameInfoDataFromHitTestResult(hitTestResult))
     , toolTipText(tooltipText)
-    , linkLocalDataMIMEType(linkLocalDataMIMETypeFromHitTestResult(hitTestResult))
-    , hasLocalDataForLinkURL(hitTestResult.hasLocalDataForLinkURL())
     , hasEntireImage(hitTestResult.hasEntireImage())
     , allowsFollowingLink(hitTestResult.allowsFollowingLink())
     , allowsFollowingImageURL(hitTestResult.allowsFollowingImageURL())
@@ -163,7 +149,7 @@ WebHitTestResultData::WebHitTestResultData(const HitTestResult& hitTestResult, c
 WebHitTestResultData::WebHitTestResultData(const HitTestResult& hitTestResult, bool includeImage)
     : WebHitTestResultData(hitTestResult, String(), includeImage) { }
 
-WebHitTestResultData::WebHitTestResultData(const String& absoluteImageURL, const String& absolutePDFURL, const String& absoluteLinkURL, const String& absoluteMediaURL, const String& linkLabel, const String& linkTitle, const String& linkSuggestedFilename, const String& imageSuggestedFilename, bool isContentEditable, const WebCore::IntRect& elementBoundingBox, const WebKit::WebHitTestResultData::IsScrollbar& isScrollbar, bool isSelected, bool isTextNode, bool isOverTextInsideFormControlElement, bool isDownloadableMedia, bool mediaIsInFullscreen, bool isActivePDFAnnotation, const WebHitTestResultData::ElementType& elementType, std::optional<FrameInfoData>&& frameInfo, std::optional<WebCore::RemoteUserInputEventData> remoteUserInputEventData, const String& lookupText, const String& toolTipText, const String& imageText, std::optional<WebCore::SharedMemory::Handle>&& imageHandle, const RefPtr<WebCore::ShareableBitmap>& imageBitmap, const String& sourceImageMIMEType, const String& linkLocalDataMIMEType, bool hasLocalDataForLinkURL, bool hasEntireImage, bool allowsFollowingLink, bool allowsFollowingImageURL, std::optional<WebCore::ResourceResponse>&& linkLocalResourceResponse,
+WebHitTestResultData::WebHitTestResultData(const String& absoluteImageURL, const String& absolutePDFURL, const String& absoluteLinkURL, const String& absoluteMediaURL, const String& linkLabel, const String& linkTitle, const String& linkSuggestedFilename, const String& imageSuggestedFilename, bool isContentEditable, const WebCore::IntRect& elementBoundingBox, const WebKit::WebHitTestResultData::IsScrollbar& isScrollbar, bool isSelected, bool isTextNode, bool isOverTextInsideFormControlElement, bool isDownloadableMedia, bool mediaIsInFullscreen, bool isActivePDFAnnotation, const WebHitTestResultData::ElementType& elementType, std::optional<FrameInfoData>&& frameInfo, std::optional<WebCore::RemoteUserInputEventData> remoteUserInputEventData, const String& lookupText, const String& toolTipText, const String& imageText, std::optional<WebCore::SharedMemory::Handle>&& imageHandle, const RefPtr<WebCore::ShareableBitmap>& imageBitmap, const String& sourceImageMIMEType, bool hasEntireImage, bool allowsFollowingLink, bool allowsFollowingImageURL, std::optional<WebCore::ResourceResponse>&& linkLocalResourceResponse,
 #if PLATFORM(MAC)
     const WebHitTestResultPlatformData& platformData,
 #endif
@@ -193,8 +179,6 @@ WebHitTestResultData::WebHitTestResultData(const String& absoluteImageURL, const
         , imageText(imageText)
         , imageBitmap(imageBitmap)
         , sourceImageMIMEType(sourceImageMIMEType)
-        , linkLocalDataMIMEType(linkLocalDataMIMEType)
-        , hasLocalDataForLinkURL(hasLocalDataForLinkURL)
         , hasEntireImage(hasEntireImage)
         , allowsFollowingLink(allowsFollowingLink)
         , allowsFollowingImageURL(allowsFollowingImageURL)

--- a/Source/WebKit/Shared/WebHitTestResultData.h
+++ b/Source/WebKit/Shared/WebHitTestResultData.h
@@ -100,8 +100,6 @@ struct WebHitTestResultData {
     RefPtr<WebCore::SharedMemory> imageSharedMemory;
     RefPtr<WebCore::ShareableBitmap> imageBitmap;
     String sourceImageMIMEType;
-    String linkLocalDataMIMEType;
-    bool hasLocalDataForLinkURL;
     bool hasEntireImage;
     bool allowsFollowingLink;
     bool allowsFollowingImageURL;
@@ -123,7 +121,7 @@ struct WebHitTestResultData {
     WebHitTestResultData& operator=(const WebHitTestResultData&) = default;
     WebHitTestResultData(const WebCore::HitTestResult&, const String& toolTipText);
     WebHitTestResultData(const WebCore::HitTestResult&, bool includeImage);
-    WebHitTestResultData(const String& absoluteImageURL, const String& absolutePDFURL, const String& absoluteLinkURL, const String& absoluteMediaURL, const String& linkLabel, const String& linkTitle, const String& linkSuggestedFilename, const String& imageSuggestedFilename, bool isContentEditable, const WebCore::IntRect& elementBoundingBox, const WebKit::WebHitTestResultData::IsScrollbar&, bool isSelected, bool isTextNode, bool isOverTextInsideFormControlElement, bool isDownloadableMedia, bool mediaIsInFullscreen, bool isActivePDFAnnotation, const WebKit::WebHitTestResultData::ElementType&, std::optional<FrameInfoData>&&, std::optional<WebCore::RemoteUserInputEventData>, const String& lookupText, const String& toolTipText, const String& imageText, std::optional<WebCore::SharedMemory::Handle>&& imageHandle, const RefPtr<WebCore::ShareableBitmap>& imageBitmap, const String& sourceImageMIMEType, const String& linkLocalDataMIMEType, bool hasLocalDataForLinkURL, bool hasEntireImage, bool allowsFollowingLink, bool allowsFollowingImageURL, std::optional<WebCore::ResourceResponse>&&,
+    WebHitTestResultData(const String& absoluteImageURL, const String& absolutePDFURL, const String& absoluteLinkURL, const String& absoluteMediaURL, const String& linkLabel, const String& linkTitle, const String& linkSuggestedFilename, const String& imageSuggestedFilename, bool isContentEditable, const WebCore::IntRect& elementBoundingBox, const WebKit::WebHitTestResultData::IsScrollbar&, bool isSelected, bool isTextNode, bool isOverTextInsideFormControlElement, bool isDownloadableMedia, bool mediaIsInFullscreen, bool isActivePDFAnnotation, const WebKit::WebHitTestResultData::ElementType&, std::optional<FrameInfoData>&&, std::optional<WebCore::RemoteUserInputEventData>, const String& lookupText, const String& toolTipText, const String& imageText, std::optional<WebCore::SharedMemory::Handle>&& imageHandle, const RefPtr<WebCore::ShareableBitmap>& imageBitmap, const String& sourceImageMIMEType, bool hasEntireImage, bool allowsFollowingLink, bool allowsFollowingImageURL, std::optional<WebCore::ResourceResponse>&&,
 #if PLATFORM(MAC)
         const WebHitTestResultPlatformData&,
 #endif

--- a/Source/WebKit/Shared/WebHitTestResultData.serialization.in
+++ b/Source/WebKit/Shared/WebHitTestResultData.serialization.in
@@ -61,8 +61,6 @@ struct WebKit::WebHitTestResultData {
     std::optional<WebCore::SharedMemoryHandle> getImageSharedMemoryHandle();
     RefPtr<WebCore::ShareableBitmap> imageBitmap;
     String sourceImageMIMEType;
-    String linkLocalDataMIMEType;
-    bool hasLocalDataForLinkURL;
     bool hasEntireImage;
     bool allowsFollowingLink;
     bool allowsFollowingImageURL;

--- a/Source/WebKit/UIProcess/API/APIHitTestResult.h
+++ b/Source/WebKit/UIProcess/API/APIHitTestResult.h
@@ -56,7 +56,6 @@ public:
 
     WTF::String linkLabel() const { return m_data.linkLabel; }
     WTF::String linkTitle() const { return m_data.linkTitle; }
-    WTF::String linkLocalDataMIMEType() const { return m_data.linkLocalDataMIMEType; }
     WTF::String linkSuggestedFilename() const { return m_data.linkSuggestedFilename; }
     WTF::String imageSuggestedFilename() const { return m_data.imageSuggestedFilename; }
     WTF::String lookupText() const { return m_data.lookupText; }
@@ -83,8 +82,6 @@ public:
     WebKit::WebPageProxy* page() { return m_page.get(); }
 
     const std::optional<WebKit::FrameInfoData>& frameInfo() const { return m_data.frameInfo; }
-
-    bool hasLocalDataForLinkURL() const { return m_data.hasLocalDataForLinkURL; }
 
     bool allowsFollowingLink() const { return m_data.allowsFollowingLink; }
 

--- a/Tools/TestWebKitAPI/Tests/mac/ContextMenuTests.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/ContextMenuTests.mm
@@ -746,27 +746,6 @@ TEST(ContextMenuTests, HitTestResultImageMIMEType)
     Util::run(&gotProposedMenu);
 }
 
-TEST(ContextMenuTests, HitTestResultLinkLocalDataMIMEType)
-{
-    auto delegate = adoptNS([[TestUIDelegate alloc] init]);
-
-    __block bool gotProposedMenu = false;
-    [delegate setGetContextMenuFromProposedMenu:^(NSMenu *menu, _WKContextMenuElementInfo *elementInfo, id<NSSecureCoding>, void (^completion)(NSMenu *)) {
-        EXPECT_NOT_NULL(elementInfo.hitTestResult);
-        EXPECT_TRUE([elementInfo.hitTestResult.linkLocalDataMIMEType isEqualToString:@"image/jpeg"]);
-        completion(nil);
-        gotProposedMenu = true;
-    }];
-
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
-    [webView setUIDelegate:delegate.get()];
-    [webView synchronouslyLoadHTMLString:@"<a href='sunset-in-cupertino-600px.jpg'><img src='sunset-in-cupertino-600px.jpg'></img></a>"];
-
-    [webView mouseDownAtPoint:NSMakePoint(200, 200) simulatePressure:NO withFlags:0 eventType:NSEventTypeRightMouseDown];
-    [webView mouseUpAtPoint:NSMakePoint(200, 200) withFlags:0 eventType:NSEventTypeRightMouseUp];
-    Util::run(&gotProposedMenu);
-}
-
 TEST(ContextMenuTests, HitTestResultLinkLocalResourceResponse)
 {
     _WKContextMenuElementInfo *elementInfo;
@@ -823,27 +802,6 @@ TEST(ContextMenuTests, HitTestResultImageSuggestedFilename)
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView setUIDelegate:delegate.get()];
     [webView synchronouslyLoadHTMLString:@"<img src='sunset-in-cupertino-600px.jpg'></img>"];
-
-    [webView mouseDownAtPoint:NSMakePoint(200, 200) simulatePressure:NO withFlags:0 eventType:NSEventTypeRightMouseDown];
-    [webView mouseUpAtPoint:NSMakePoint(200, 200) withFlags:0 eventType:NSEventTypeRightMouseUp];
-    Util::run(&gotProposedMenu);
-}
-
-TEST(ContextMenuTests, HitTestResultHasLocalDataForLinkURL)
-{
-    auto delegate = adoptNS([[TestUIDelegate alloc] init]);
-
-    __block bool gotProposedMenu = false;
-    [delegate setGetContextMenuFromProposedMenu:^(NSMenu *menu, _WKContextMenuElementInfo *elementInfo, id<NSSecureCoding>, void (^completion)(NSMenu *)) {
-        EXPECT_NOT_NULL(elementInfo.hitTestResult);
-        EXPECT_TRUE(elementInfo.hitTestResult.hasLocalDataForLinkURL);
-        completion(nil);
-        gotProposedMenu = true;
-    }];
-
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
-    [webView setUIDelegate:delegate.get()];
-    [webView synchronouslyLoadHTMLString:@"<a href='sunset-in-cupertino-600px.jpg'><img src='sunset-in-cupertino-600px.jpg'></img></a>"];
 
     [webView mouseDownAtPoint:NSMakePoint(200, 200) simulatePressure:NO withFlags:0 eventType:NSEventTypeRightMouseDown];
     [webView mouseUpAtPoint:NSMakePoint(200, 200) withFlags:0 eventType:NSEventTypeRightMouseUp];


### PR DESCRIPTION
#### 25ff2adaf0b46b3623a4475a01df1d4eabad3d1a
<pre>
Deprecate hasLocalDataForLinkURL and linkLocalDataMIMEType from _WKHitTestResult
<a href="https://bugs.webkit.org/show_bug.cgi?id=293769">https://bugs.webkit.org/show_bug.cgi?id=293769</a>
<a href="https://rdar.apple.com/151944429">rdar://151944429</a>

Reviewed by Alex Christensen.

Those two methods are not used anymore and can be deprecated.
linkLocalResourceResponse can be used to get access to the same
informations.

* Source/WebKit/Shared/API/Cocoa/_WKHitTestResult.h:
* Source/WebKit/Shared/API/Cocoa/_WKHitTestResult.mm:
(-[_WKHitTestResult hasLocalDataForLinkURL]):
(-[_WKHitTestResult linkLocalDataMIMEType]):
* Source/WebKit/Shared/WebHitTestResultData.cpp:
(WebKit::WebHitTestResultData::WebHitTestResultData):
(WebKit::linkLocalDataMIMETypeFromHitTestResult): Deleted.
* Source/WebKit/Shared/WebHitTestResultData.h:
* Source/WebKit/Shared/WebHitTestResultData.serialization.in:
* Source/WebKit/UIProcess/API/APIHitTestResult.h:
(API::HitTestResult::linkTitle const):
(API::HitTestResult::linkLocalDataMIMEType const): Deleted.
(API::HitTestResult::hasLocalDataForLinkURL const): Deleted.
* Tools/TestWebKitAPI/Tests/mac/ContextMenuTests.mm:
(TestWebKitAPI::TEST(ContextMenuTests, HitTestResultImageSuggestedFilename)):
(TestWebKitAPI::TEST(ContextMenuTests, HitTestResultLinkLocalDataMIMEType)): Deleted.
(TestWebKitAPI::TEST(ContextMenuTests, HitTestResultHasLocalDataForLinkURL)): Deleted.

Canonical link: <a href="https://commits.webkit.org/295585@main">https://commits.webkit.org/295585@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f99f06d8a3f542a834a6e251b6ec8c8c6574b963

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105532 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25279 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15671 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110729 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/56175 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/107573 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/25713 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33782 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/80144 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/56175 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108538 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/20067 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95235 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60453 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/19815 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13326 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55566 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/89522 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13367 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/113523 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32671 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/24092 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/89222 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33034 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91465 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/88883 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33754 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/28120 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17118 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32597 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/38001 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32350 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35699 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33941 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->