### PR TITLE
[SwiftUI] Add a run-swiftbrowser helper script

### DIFF
--- a/Tools/Scripts/run-swiftbrowser
+++ b/Tools/Scripts/run-swiftbrowser
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2025 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+# BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+# THE POSSIBILITY OF SUCH DAMAGE.
+
+"""Wrapper around webkitpy/swiftbrowser/run_webkit_app.py"""
+import sys
+from webkitpy.swiftbrowser import run_webkit_app
+
+if __name__ == '__main__':
+    sys.exit(run_webkit_app.main(sys.argv[1:]))

--- a/Tools/Scripts/run-swiftbrowser-perl-wrapper
+++ b/Tools/Scripts/run-swiftbrowser-perl-wrapper
@@ -1,0 +1,42 @@
+#!/usr/bin/env perl
+
+# Copyright (C) 2025 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+# BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+# THE POSSIBILITY OF SUCH DAMAGE.
+
+# Simplified "run" script for launching SwiftBrowser.
+
+use strict;
+use warnings;
+use FindBin;
+use lib $FindBin::Bin;
+use webkitdirs;
+
+prohibitUnknownPort();
+setConfiguration();
+
+if (isAppleCocoaWebKit()) {
+    printHelpAndExitForRunAndDebugWebKitAppIfNeeded();
+    exit exitStatus(runSwiftBrowser());
+} else {
+    die "Unsupported platform."
+}

--- a/Tools/Scripts/webkitdirs.pm
+++ b/Tools/Scripts/webkitdirs.pm
@@ -99,6 +99,7 @@ BEGIN {
        &currentPerlPath
        &currentSVNRevision
        &debugMiniBrowser
+       &debugSwiftBrowser
        &debugSafari
        &debugWebKitTestRunner
        &determineCurrentSVNRevision
@@ -168,6 +169,7 @@ BEGIN {
        &runInFlatpakIfAvailable
        &runMacWebKitApp
        &runMiniBrowser
+       &runSwiftBrowser
        &runSafari
        &runWebKitTestRunner
        &safariPath
@@ -3216,6 +3218,21 @@ sub mobileMiniBrowserBundle()
     return installedMobileMiniBrowserBundle();
 }
 
+sub installedSwiftBrowserBundle()
+{
+    return File::Spec->catfile(iosSimulatorApplicationsPath(), "SwiftBrowser.app");
+}
+
+sub swiftBrowserBundle()
+{
+    determineConfigurationProductDir();
+
+    if (isIOSWebKit() && -d "$configurationProductDir/SwiftBrowser.app") {
+        return "$configurationProductDir/SwiftBrowser.app";
+    }
+    return installedSwiftBrowserBundle();
+}
+
 
 sub plistPathFromBundle($)
 {
@@ -3584,6 +3601,26 @@ sub debugMiniBrowser
         execMacWebKitAppForDebugging(File::Spec->catfile(productDir(), "MiniBrowser.app", "Contents", "MacOS", "MiniBrowser"));
     }
     
+    return 1;
+}
+
+sub runSwiftBrowser
+{
+    if (isAppleMacWebKit()) {
+        return runMacWebKitApp(File::Spec->catfile(productDir(), "SwiftBrowser.app", "Contents", "MacOS", "SwiftBrowser"));
+    }
+    if (isIOSWebKit()) {
+        return runIOSWebKitApp(swiftBrowserBundle());
+    }
+    return 1;
+}
+
+sub debugSwiftBrowser
+{
+    if (isAppleMacWebKit()) {
+        execMacWebKitAppForDebugging(File::Spec->catfile(productDir(), "SwiftBrowser.app", "Contents", "MacOS", "SwiftBrowser"));
+    }
+
     return 1;
 }
 

--- a/Tools/Scripts/webkitpy/port/base.py
+++ b/Tools/Scripts/webkitpy/port/base.py
@@ -1215,6 +1215,12 @@ class Port(object):
         args.append("--%s" % self.get_option('platform'))
         return self._executive.run_command([miniBrowser] + args, stdout=None, cwd=self.webkit_base(), return_stderr=False, decode_output=False, ignore_errors=True)
 
+    def run_swiftbrowser(self, args):
+        swiftBrowser = self.path_to_script("run-swiftbrowser-perl-wrapper")
+        args.append(self._config.flag_for_configuration(self.get_option('configuration')))
+        args.append("--%s" % self.get_option('platform'))
+        return self._executive.run_command([swiftBrowser] + args, stdout=None, cwd=self.webkit_base(), return_stderr=False, decode_output=False, ignore_errors=True)
+
     def run_webdriver(self, args):
         raise NotImplementedError('Port.run_webdriver')
 

--- a/Tools/Scripts/webkitpy/swiftbrowser/run_webkit_app.py
+++ b/Tools/Scripts/webkitpy/swiftbrowser/run_webkit_app.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2025 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+# BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+# THE POSSIBILITY OF SUCH DAMAGE.
+
+from __future__ import print_function
+import argparse
+import sys
+import traceback
+
+from webkitpy.common.host import Host
+from webkitpy.port import configuration_options, platform_options, factory
+from webkitcorepy.string_utils import decode
+
+
+def main(argv):
+    option_parser = argparse.ArgumentParser(formatter_class=argparse.RawDescriptionHelpFormatter, usage="%(prog)s")
+    groups = [("Platform options", platform_options()), ("Configuration options", configuration_options())]
+
+    # Convert options to argparse, so that we can use parse_known_args() which is not supported in optparse.
+    # FIXME: Globally migrate to argparse. https://bugs.webkit.org/show_bug.cgi?id=213463
+    for group_name, group_options in groups:
+        option_group = option_parser.add_argument_group(group_name)
+
+        for option in group_options:
+            # Skip deprecated option
+            if option.get_opt_string() != "--target":
+                default = None
+                if option.default != ("NO", "DEFAULT"):
+                    default = option.default
+                option_group.add_argument(option.get_opt_string(), action=option.action, dest=option.dest,
+                                          help=option.help, const=option.const, default=default)
+
+    options, args = option_parser.parse_known_args(argv)
+
+    if not options.platform:
+        options.platform = "mac"
+
+    # Make this a well-formed arg list if SwiftBrowser ever supports command line arguments.
+    browser_args = []
+
+    try:
+        port = factory.PortFactory(Host()).get(options.platform, options=options)
+        return port.run_swiftbrowser(browser_args)
+    except BaseException as e:
+        if isinstance(e, Exception):
+            print('\n%s raised: %s' % (e.__class__.__name__, str(e)), file=sys.stderr)
+            traceback.print_exc(file=sys.stderr)
+        return 1
+
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
#### 9e279054f1988b2e1e165952f7005d2a6264b90e
<pre>
[SwiftUI] Add a run-swiftbrowser helper script
<a href="https://bugs.webkit.org/show_bug.cgi?id=293770">https://bugs.webkit.org/show_bug.cgi?id=293770</a>
<a href="https://rdar.apple.com/152275119">rdar://152275119</a>

Reviewed by Aditya Keerthi.

This patch adds a `run-swiftbrowser` helper script to simplify the
SwiftBrowser launching dance from the command line. It is mostly modeled
after `run-minibrowser`, minus some simplification because SwiftBrowser
does not currently support any command line arguments. I&apos;ve decided to
keep the &quot;actually invoke SwiftBrowser&quot; logic in the webkitdirs.pm perl
library since it allows us to reuse some binary searching helpers (iOS
specifically).

* Tools/Scripts/run-swiftbrowser: Added.
* Tools/Scripts/run-swiftbrowser-perl-wrapper: Added.
* Tools/Scripts/webkitdirs.pm:
(installedSwiftBrowserBundle):
(swiftBrowserBundle):
(runSwiftBrowser):
(debugSwiftBrowser):
* Tools/Scripts/webkitpy/port/base.py:
(Port.run_swiftbrowser):
* Tools/Scripts/webkitpy/swiftbrowser/__init__.py: Added.
* Tools/Scripts/webkitpy/swiftbrowser/run_webkit_app.py: Added.
(main):

Canonical link: <a href="https://commits.webkit.org/295583@main">https://commits.webkit.org/295583@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4b30ff1b70cbaa0642a8ab614592df15f8380d7a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105537 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/131/builds/25288 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15676 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110734 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/56177 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/107578 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/25718 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33787 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/80148 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/56177 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108543 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/20070 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95238 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60457 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/105015 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/19818 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13329 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55571 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/98178 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/89525 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13370 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/113534 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/104155 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32676 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/24094 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/89228 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33039 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91468 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/88889 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33764 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/11563 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/28125 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17115 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32602 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/128456 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32355 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/35103 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35704 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33946 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->