### PR TITLE
Introduce toNSDataNoCopy() & toCFDataNoCopy() functions to construct NSData / CFData from a span

### DIFF
--- a/Source/WTF/wtf/cf/VectorCF.h
+++ b/Source/WTF/wtf/cf/VectorCF.h
@@ -179,6 +179,11 @@ inline RetainPtr<CFDataRef> toCFData(std::span<const uint8_t> span)
     return adoptCF(CFDataCreate(kCFAllocatorDefault, span.data(), span.size()));
 }
 
+inline RetainPtr<CFDataRef> toCFDataNoCopy(std::span<const uint8_t> span, CFAllocatorRef bytesDeallocator)
+{
+    return adoptCF(CFDataCreateWithBytesNoCopy(kCFAllocatorDefault, span.data(), span.size(), bytesDeallocator));
+}
+
 inline Vector<uint8_t> makeVector(CFDataRef data)
 {
     return span(data);
@@ -207,5 +212,6 @@ using WTF::makeVector;
 using WTF::mutableSpan;
 using WTF::span;
 using WTF::toCFData;
+using WTF::toCFDataNoCopy;
 
 #endif // USE(CF)

--- a/Source/WTF/wtf/cocoa/SpanCocoa.h
+++ b/Source/WTF/wtf/cocoa/SpanCocoa.h
@@ -43,6 +43,12 @@ inline RetainPtr<NSData> toNSData(std::span<const uint8_t> span)
 {
     return adoptNS([[NSData alloc] initWithBytes:span.data() length:span.size()]);
 }
+
+enum class FreeWhenDone : bool { No, Yes };
+inline RetainPtr<NSData> toNSDataNoCopy(std::span<const uint8_t> span, FreeWhenDone freeWhenDone)
+{
+    return adoptNS([[NSData alloc] initWithBytesNoCopy:const_cast<uint8_t*>(span.data()) length:span.size() freeWhenDone:freeWhenDone == FreeWhenDone::Yes]);
+}
 #endif // #ifdef __OBJC__
 
 template<typename> class Function;
@@ -60,6 +66,8 @@ WTF_EXPORT_PRIVATE bool dispatch_data_apply_span(dispatch_data_t, NOESCAPE const
 using WTF::dispatch_data_apply_span;
 
 #ifdef __OBJC__
+using WTF::FreeWhenDone;
 using WTF::span;
 using WTF::toNSData;
+using WTF::toNSDataNoCopy;
 #endif

--- a/Source/WebCore/bindings/js/SerializedScriptValue.cpp
+++ b/Source/WebCore/bindings/js/SerializedScriptValue.cpp
@@ -3915,7 +3915,7 @@ private:
         if (!read(dataLength) || static_cast<uint32_t>(m_data.size()) < dataLength)
             return false;
 
-        data = adoptCF(CFDataCreateWithBytesNoCopy(nullptr, m_data.data(), dataLength, kCFAllocatorNull));
+        data = toCFDataNoCopy(m_data.first(dataLength), kCFAllocatorNull);
         if (!data)
             return false;
 

--- a/Source/WebCore/crypto/cocoa/SerializedCryptoKeyWrapMac.mm
+++ b/Source/WebCore/crypto/cocoa/SerializedCryptoKeyWrapMac.mm
@@ -278,7 +278,7 @@ static std::optional<std::array<uint8_t, size>> createArrayFromData(NSData * dat
 
 std::optional<struct WrappedCryptoKey> readSerializedCryptoKey(const Vector<uint8_t>& wrappedKey)
 {
-    NSDictionary* dictionary = [NSPropertyListSerialization propertyListWithData:[NSData dataWithBytesNoCopy:(void*)wrappedKey.data() length:wrappedKey.size() freeWhenDone:NO] options:0 format:nullptr error:nullptr];
+    NSDictionary* dictionary = [NSPropertyListSerialization propertyListWithData:toNSDataNoCopy(wrappedKey.span(), FreeWhenDone::No).get() options:0 format:nullptr error:nullptr];
     if (!dictionary)
         return std::nullopt;
 

--- a/Source/WebCore/platform/cf/KeyedDecoderCF.cpp
+++ b/Source/WebCore/platform/cf/KeyedDecoderCF.cpp
@@ -42,7 +42,7 @@ std::unique_ptr<KeyedDecoder> KeyedDecoder::decoder(std::span<const uint8_t> dat
 
 KeyedDecoderCF::KeyedDecoderCF(std::span<const uint8_t> data)
 {
-    auto cfData = adoptCF(CFDataCreateWithBytesNoCopy(kCFAllocatorDefault, data.data(), data.size(), kCFAllocatorNull));
+    auto cfData = toCFDataNoCopy(data, kCFAllocatorNull);
     auto cfPropertyList = adoptCF(CFPropertyListCreateWithData(kCFAllocatorDefault, cfData.get(), kCFPropertyListImmutable, nullptr, nullptr));
 
     if (dynamic_cf_cast<CFDictionaryRef>(cfPropertyList.get()))

--- a/Source/WebCore/platform/cf/KeyedEncoderCF.cpp
+++ b/Source/WebCore/platform/cf/KeyedEncoderCF.cpp
@@ -29,6 +29,7 @@
 #include "SharedBuffer.h"
 #include <CoreFoundation/CoreFoundation.h>
 #include <wtf/TZoneMallocInlines.h>
+#include <wtf/cf/VectorCF.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
@@ -60,7 +61,7 @@ KeyedEncoderCF::~KeyedEncoderCF()
 
 void KeyedEncoderCF::encodeBytes(const String& key, std::span<const uint8_t> bytes)
 {
-    RetainPtr data = adoptCF(CFDataCreateWithBytesNoCopy(kCFAllocatorDefault, bytes.data(), bytes.size(), kCFAllocatorNull));
+    RetainPtr data = toCFDataNoCopy(bytes, kCFAllocatorNull);
     CFDictionarySetValue(m_dictionaryStack.last(), key.createCFString().get(), data.get());
 }
 

--- a/Source/WebCore/platform/cocoa/ContentFilterUnblockHandlerCocoa.mm
+++ b/Source/WebCore/platform/cocoa/ContentFilterUnblockHandlerCocoa.mm
@@ -117,8 +117,8 @@ static RetainPtr<WebFilterEvaluator> unpackWebFilterEvaluatorData(Vector<uint8_t
 {
     NSError *error { nil };
     NSSet<Class> *classes = [NSSet setWithObjects:getWebFilterEvaluatorClass(), NSNumber.class, NSURL.class, NSString.class, NSMutableString.class, nil];
-    NSData *data = [NSData dataWithBytesNoCopy:vector.data() length:vector.size() freeWhenDone:NO];
-    return [NSKeyedUnarchiver _strictlyUnarchivedObjectOfClasses:classes fromData:data error:&error];
+    RetainPtr data = toNSDataNoCopy(vector.span(), FreeWhenDone::No);
+    return [NSKeyedUnarchiver _strictlyUnarchivedObjectOfClasses:classes fromData:data.get() error:&error];
 }
 
 bool ContentFilterUnblockHandler::hasWebFilterEvaluator() const

--- a/Source/WebCore/platform/graphics/cg/ImageBufferUtilitiesCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferUtilitiesCG.cpp
@@ -35,6 +35,7 @@
 #include <ImageIO/ImageIO.h>
 #include <wtf/CheckedArithmetic.h>
 #include <wtf/ScopedLambda.h>
+#include <wtf/cf/VectorCF.h>
 #include <wtf/text/Base64.h>
 #include <wtf/text/MakeString.h>
 
@@ -194,7 +195,7 @@ static bool encode(std::span<const uint8_t> data, const String& mimeType, std::o
     if (!destinationUTI)
         return false;
 
-    auto cfData = adoptCF(CFDataCreateWithBytesNoCopy(nullptr, data.data(), data.size(), kCFAllocatorNull));
+    RetainPtr cfData = toCFDataNoCopy(data, kCFAllocatorNull);
     if (!cfData)
         return false;
 

--- a/Source/WebKit/Shared/Cocoa/CoreIPCPKPaymentSetupFeature.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCPKPaymentSetupFeature.mm
@@ -40,7 +40,7 @@ CoreIPCPKPaymentSetupFeature::CoreIPCPKPaymentSetupFeature(PKPaymentSetupFeature
 
 RetainPtr<id> CoreIPCPKPaymentSetupFeature::toID() const
 {
-    RetainPtr data = adoptNS([[NSData alloc] initWithBytesNoCopy:const_cast<uint8_t*>(m_data.data()) length:m_data.size() freeWhenDone:NO]);
+    RetainPtr data = toNSDataNoCopy(m_data.span(), FreeWhenDone::No);
     RELEASE_ASSERT(isInWebProcess());
     return [NSKeyedUnarchiver unarchivedObjectOfClass:PAL::getPKPaymentSetupFeatureClass() fromData:data.get() error:nil];
 }

--- a/Source/WebKit/Shared/Cocoa/CoreIPCPKSecureElementPass.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCPKSecureElementPass.mm
@@ -40,7 +40,7 @@ CoreIPCPKSecureElementPass::CoreIPCPKSecureElementPass(PKSecureElementPass *pass
 
 RetainPtr<id> CoreIPCPKSecureElementPass::toID() const
 {
-    RetainPtr data = adoptNS([[NSData alloc] initWithBytesNoCopy:const_cast<uint8_t*>(m_data.data()) length:m_data.size() freeWhenDone:NO]);
+    RetainPtr data = toNSDataNoCopy(m_data.span(), FreeWhenDone::No);
     RELEASE_ASSERT(isInWebProcess());
     return [NSKeyedUnarchiver unarchivedObjectOfClass:PAL::getPKSecureElementPassClass() fromData:data.get() error:nil];
 }

--- a/Source/WebKit/UIProcess/WebAuthentication/Mock/MockNfcService.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Mock/MockNfcService.mm
@@ -109,7 +109,7 @@ uint8_t tagID2[] = { 0x02 };
 
 - (instancetype)initWithType:(NFTagType)type
 {
-    return [self initWithType:type tagID:adoptNS([[NSData alloc] initWithBytesNoCopy:tagID1 length:sizeof(tagID1) freeWhenDone:NO]).get()];
+    return [self initWithType:type tagID:toNSDataNoCopy(std::span { tagID1 }, FreeWhenDone::No).get()];
 }
 
 - (instancetype)initWithType:(NFTagType)type tagID:(NSData *)tagID
@@ -268,7 +268,7 @@ void MockNfcService::detectTags() const
             [tags addObject:adoptNS([[WKMockNFTag alloc] initWithType:NFTagTypeGeneric4A]).get()];
 
         if (configuration.nfc->multiplePhysicalTags)
-            [tags addObject:adoptNS([[WKMockNFTag alloc] initWithType:NFTagTypeGeneric4A tagID:adoptNS([[NSData alloc] initWithBytesNoCopy:tagID2 length:sizeof(tagID2) freeWhenDone:NO]).get()]).get()];
+            [tags addObject:adoptNS([[WKMockNFTag alloc] initWithType:NFTagTypeGeneric4A tagID:toNSDataNoCopy(std::span { tagID2 }, FreeWhenDone::No).get()]).get()];
 
         auto readerSession = adoptNS([allocNFReaderSessionInstance() initWithUIType:NFReaderSessionUINone]);
         [globalNFReaderSessionDelegate readerSession:readerSession.get() didDetectTags:tags.get()];

--- a/Source/WebKit/UIProcess/mac/LegacySessionStateCoding.cpp
+++ b/Source/WebKit/UIProcess/mac/LegacySessionStateCoding.cpp
@@ -403,7 +403,7 @@ static RetainPtr<CFDataRef> encodeSessionHistoryEntryData(const FrameState& fram
     size_t bufferSize;
     auto buffer = encodeSessionHistoryEntryData(frameState, bufferSize);
 
-    return adoptCF(CFDataCreateWithBytesNoCopy(kCFAllocatorDefault, buffer.leakSpan().data(), bufferSize, fastMallocDeallocator.get().get()));
+    return toCFDataNoCopy(buffer.leakSpan().first(bufferSize), fastMallocDeallocator.get().get());
 }
 
 static RetainPtr<CFDictionaryRef> createDictionary(std::initializer_list<std::pair<CFStringRef, CFTypeRef>> keyValuePairs)

--- a/Source/WebKit/UIProcess/mac/WebPageProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebPageProxyMac.mm
@@ -75,6 +75,7 @@
 #import <wtf/FileSystem.h>
 #import <wtf/ProcessPrivilege.h>
 #import <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
+#import <wtf/cocoa/SpanCocoa.h>
 #import <wtf/text/cf/StringConcatenateCF.h>
 
 #define MESSAGE_CHECK(assertion, connection) MESSAGE_CHECK_BASE(assertion, connection)
@@ -573,7 +574,7 @@ void WebPageProxy::savePDFToTemporaryFolderAndOpenWithNativeApplication(const St
 
     auto permissions = adoptNS([[NSNumber alloc] initWithInt:S_IRUSR]);
     auto fileAttributes = adoptNS([[NSDictionary alloc] initWithObjectsAndKeys:permissions.get(), NSFilePosixPermissions, nil]);
-    auto nsData = adoptNS([[NSData alloc] initWithBytesNoCopy:(void*)data.data() length:data.size() freeWhenDone:NO]);
+    RetainPtr nsData = toNSDataNoCopy(data, FreeWhenDone::No);
 
     if (![[NSFileManager defaultManager] createFileAtPath:nsPath.get() contents:nsData.get() attributes:fileAttributes.get()]) {
         WTFLogAlways("Cannot create PDF file in the temporary directory (%s).", sanitizedFilename.utf8().data());

--- a/Source/WebKit/WebProcess/InjectedBundle/mac/InjectedBundleMac.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/mac/InjectedBundleMac.mm
@@ -41,6 +41,7 @@
 #import <objc/runtime.h>
 #import <stdio.h>
 #import <wtf/RetainPtr.h>
+#import <wtf/cocoa/SpanCocoa.h>
 #import <wtf/text/CString.h>
 #import <wtf/text/WTFString.h>
 
@@ -74,7 +75,7 @@ static NSEventModifierFlags currentModifierFlags(id self, SEL _cmd)
 
 static RetainPtr<NSKeyedUnarchiver> createUnarchiver(std::span<const uint8_t> span)
 {
-    RetainPtr data = adoptNS([[NSData alloc] initWithBytesNoCopy:const_cast<uint8_t*>(span.data()) length:span.size() freeWhenDone:NO]);
+    RetainPtr data = toNSDataNoCopy(span, FreeWhenDone::No);
     RetainPtr unarchiver = adoptNS([[NSKeyedUnarchiver alloc] initForReadingFromData:data.get() error:nullptr]);
     unarchiver.get().decodingFailurePolicy = NSDecodingFailurePolicyRaiseException;
     return unarchiver;

--- a/Source/WebKitLegacy/mac/History/HistoryPropertyList.mm
+++ b/Source/WebKitLegacy/mac/History/HistoryPropertyList.mm
@@ -27,6 +27,7 @@
 
 #import "WebHistoryItemInternal.h"
 #import <WebCore/HistoryItem.h>
+#import <wtf/cf/VectorCF.h>
 
 using namespace WebCore;
 
@@ -61,7 +62,7 @@ RetainPtr<CFDataRef> HistoryPropertyListWriter::releaseData()
     if (!m_buffer)
         return nullptr;
     auto span = m_buffer.leakSpan();
-    RetainPtr data = adoptCF(CFDataCreateWithBytesNoCopy(0, span.data(), span.size(), 0));
+    RetainPtr data = toCFDataNoCopy(span, kCFAllocatorNull);
     if (!data)
         adoptMallocSpan<UInt8, CFMalloc>(span); // We need to make sure we free the data if creating the CFData failed.
     return data;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/BundleEditingDelegatePlugIn.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/BundleEditingDelegatePlugIn.mm
@@ -35,6 +35,7 @@
 #import <WebKit/_WKRemoteObjectInterface.h>
 #import <WebKit/_WKRemoteObjectRegistry.h>
 #import <wtf/RetainPtr.h>
+#import <wtf/cocoa/SpanCocoa.h>
 
 @interface BundleEditingDelegatePlugIn : NSObject <WKWebProcessPlugIn, WKWebProcessPlugInEditingDelegate>
 @end
@@ -85,7 +86,7 @@
 
 - (NSDictionary<NSString *, NSData *> *)_webProcessPlugInBrowserContextController:(WKWebProcessPlugInBrowserContextController *)controller pasteboardDataForRange:(WKWebProcessPlugInRangeHandle *)range
 {
-    return @{ @"org.webkit.data" : _shouldWriteEmptyData ? NSData.data : [NSData dataWithBytesNoCopy:(void*)"hello" length:5 freeWhenDone:NO] };
+    return @{ @"org.webkit.data" : _shouldWriteEmptyData ? NSData.data : toNSDataNoCopy("hello"_span8, FreeWhenDone::No).autorelease() };
 }
 
 - (void)_webProcessPlugInBrowserContextControllerDidWriteToPasteboard:(WKWebProcessPlugInBrowserContextController *)controller

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ProcessSwapOnNavigation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ProcessSwapOnNavigation.mm
@@ -64,6 +64,7 @@
 #import <wtf/RetainPtr.h>
 #import <wtf/RunLoop.h>
 #import <wtf/Vector.h>
+#import <wtf/cocoa/SpanCocoa.h>
 #import <wtf/text/MakeString.h>
 #import <wtf/text/StringHash.h>
 #import <wtf/text/WTFString.h>
@@ -330,7 +331,7 @@ static RetainPtr<WKWebView> createdWebView;
 
 - (void)addMappingFromURLString:(NSString *)urlString toData:(const char*)data
 {
-    _dataMappings.set(urlString, [NSData dataWithBytesNoCopy:(void*)data length:strlen(data) freeWhenDone:NO]);
+    _dataMappings.set(urlString, toNSDataNoCopy(unsafeSpan8(data), FreeWhenDone::No));
 }
 
 - (void)setShouldRespondAsynchronously:(BOOL)value
@@ -380,7 +381,7 @@ static RetainPtr<WKWebView> createdWebView;
         if (auto data = _dataMappings.get([finalURL absoluteString]))
             [task didReceiveData:data.get()];
         else if (_bytes) {
-            RetainPtr<NSData> data = adoptNS([[NSData alloc] initWithBytesNoCopy:(void *)_bytes length:strlen(_bytes) freeWhenDone:NO]);
+            RetainPtr data = toNSDataNoCopy(unsafeSpan8(_bytes), FreeWhenDone::No);
             [task didReceiveData:data.get()];
         } else
             [task didReceiveData:[@"Hello" dataUsingEncoding:NSUTF8StringEncoding]];

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ServiceWorkerBasic.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ServiceWorkerBasic.mm
@@ -67,6 +67,7 @@
 #import <wtf/Scope.h>
 #import <wtf/URL.h>
 #import <wtf/Vector.h>
+#import <wtf/cocoa/SpanCocoa.h>
 #import <wtf/cocoa/TypeCastsCocoa.h>
 #import <wtf/text/MakeString.h>
 #import <wtf/text/StringHash.h>
@@ -3011,7 +3012,7 @@ static bool didStartURLSchemeTaskForImportedScript = false;
     if (auto data = _dataMappings.get([finalURL absoluteString]))
         [task didReceiveData:data.get()];
     else if (_bytes) {
-        RetainPtr<NSData> data = adoptNS([[NSData alloc] initWithBytesNoCopy:(void *)_bytes length:strlen(_bytes) freeWhenDone:NO]);
+        RetainPtr data = toNSDataNoCopy(unsafeSpan8(_bytes), FreeWhenDone::No);
         [task didReceiveData:data.get()];
     } else
         [task didReceiveData:[@"Hello" dataUsingEncoding:NSUTF8StringEncoding]];

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKURLSchemeHandler-1.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKURLSchemeHandler-1.mm
@@ -52,6 +52,7 @@
 #import <wtf/Threading.h>
 #import <wtf/Vector.h>
 #import <wtf/WeakObjCPtr.h>
+#import <wtf/cocoa/SpanCocoa.h>
 #import <wtf/text/MakeString.h>
 #import <wtf/text/StringHash.h>
 #import <wtf/text/StringToIntegerConversion.h>
@@ -155,7 +156,7 @@ TEST(URLSchemeHandler, Basic)
 
     RetainPtr<WKWebViewConfiguration> configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
 
-    RetainPtr<SchemeHandler> handler = adoptNS([[SchemeHandler alloc] initWithData:[NSData dataWithBytesNoCopy:(void*)mainBytes length:sizeof(mainBytes) freeWhenDone:NO] mimeType:@"text/html"]);
+    RetainPtr<SchemeHandler> handler = adoptNS([[SchemeHandler alloc] initWithData:toNSDataNoCopy(unsafeSpan8IncludingNullTerminator(mainBytes),  FreeWhenDone::No).get() mimeType:@"text/html"]);
     [configuration setURLSchemeHandler:handler.get() forURLScheme:@"testing"];
 
     RetainPtr<WKWebView> webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
@@ -190,7 +191,7 @@ TEST(URLSchemeHandler, BasicWithHTTPS)
     auto configuration = adoptNS([WKWebViewConfiguration new]);
     [configuration setWebsiteDataStore:dataStore.get()];
 
-    RetainPtr<SchemeHandler> handler = adoptNS([[SchemeHandler alloc] initWithData:[NSData dataWithBytesNoCopy:(void*)mainBytes length:sizeof(mainBytes) freeWhenDone:NO] mimeType:@"text/html"]);
+    RetainPtr<SchemeHandler> handler = adoptNS([[SchemeHandler alloc] initWithData:toNSDataNoCopy(unsafeSpan8IncludingNullTerminator(mainBytes),  FreeWhenDone::No).get() mimeType:@"text/html"]);
     [configuration setURLSchemeHandler:handler.get() forURLScheme:@"testing"];
 
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
@@ -216,7 +217,7 @@ TEST(URLSchemeHandler, BasicWithAsyncPolicyDelegate)
 
     RetainPtr<WKWebViewConfiguration> configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
 
-    RetainPtr<SchemeHandler> handler = adoptNS([[SchemeHandler alloc] initWithData:[NSData dataWithBytesNoCopy:(void*)mainBytes length:sizeof(mainBytes) freeWhenDone:NO] mimeType:@"text/html"]);
+    RetainPtr<SchemeHandler> handler = adoptNS([[SchemeHandler alloc] initWithData:toNSDataNoCopy(unsafeSpan8IncludingNullTerminator(mainBytes),  FreeWhenDone::No).get() mimeType:@"text/html"]);
     [configuration setURLSchemeHandler:handler.get() forURLScheme:@"testing"];
 
     RetainPtr<WKWebView> webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
@@ -243,7 +244,7 @@ TEST(URLSchemeHandler, NoMIMEType)
 
     RetainPtr<WKWebViewConfiguration> configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
 
-    RetainPtr<SchemeHandler> handler = adoptNS([[SchemeHandler alloc] initWithData:[NSData dataWithBytesNoCopy:(void*)mainBytes length:sizeof(mainBytes) freeWhenDone:NO] mimeType:nil]);
+    RetainPtr<SchemeHandler> handler = adoptNS([[SchemeHandler alloc] initWithData:toNSDataNoCopy(unsafeSpan8IncludingNullTerminator(mainBytes),  FreeWhenDone::No).get() mimeType:nil]);
     handler.get().shouldFinish = NO;
     [configuration setURLSchemeHandler:handler.get() forURLScheme:@"testing"];
 
@@ -530,7 +531,7 @@ static bool receivedStop;
     RetainPtr<NSURLResponse> response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:entry->value.mimeType.get() expectedContentLength:1 textEncodingName:nil]);
     [task didReceiveResponse:response.get()];
 
-    [task didReceiveData:[NSData dataWithBytesNoCopy:(void*)entry->value.data length:strlen(entry->value.data) freeWhenDone:NO]];
+    [task didReceiveData:toNSDataNoCopy(unsafeSpan8(entry->value.data), FreeWhenDone::No).get()];
     [task didFinish];
 
     if (entry->key == "syncxhr://host/test.dat"_s)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebsitePolicies.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebsitePolicies.mm
@@ -55,6 +55,7 @@
 #import <wtf/HashMap.h>
 #import <wtf/MainThread.h>
 #import <wtf/RetainPtr.h>
+#import <wtf/cocoa/SpanCocoa.h>
 #import <wtf/text/MakeString.h>
 #import <wtf/text/StringHash.h>
 #import <wtf/text/WTFString.h>
@@ -1101,7 +1102,7 @@ static unsigned loadCount;
 
 - (void)addMappingFromURLString:(NSString *)urlString toData:(const char*)data
 {
-    _dataMappings.set(urlString, [NSData dataWithBytesNoCopy:(void*)data length:strlen(data) freeWhenDone:NO]);
+    _dataMappings.set(urlString, toNSDataNoCopy(unsafeSpan8(data), FreeWhenDone::No));
 }
 
 - (void)setTaskHandler:(Function<void(id <WKURLSchemeTask>)>&&)handler

--- a/Tools/TestWebKitAPI/Tests/mac/WebViewIconLoading.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/WebViewIconLoading.mm
@@ -28,6 +28,7 @@
 #import <WebKit/WebFrameLoadDelegate.h>
 #import <WebKit/WebView.h>
 #import <wtf/RetainPtr.h>
+#import <wtf/cocoa/SpanCocoa.h>
 
 static NSString *MainFrameIconKeyPath = @"mainFrameIcon";
 static bool messageReceived = false;
@@ -42,9 +43,9 @@ static const char customFaviconHTML[] =
 "</head>";
 
 static const char* currentMainHTML;
-static NSData *mainResourceData()
+static RetainPtr<NSData> mainResourceData()
 {
-    return [NSData dataWithBytesNoCopy:(void*)currentMainHTML length:strlen(currentMainHTML) freeWhenDone:NO];
+    return toNSDataNoCopy(unsafeSpan8(currentMainHTML), FreeWhenDone::No);
 }
 
 static NSData *defaultFaviconData()
@@ -85,7 +86,7 @@ static NSImage *imageFromData(NSData *data)
 
 - (void)startLoading
 {
-    NSData *resourceData = nil;
+    RetainPtr<NSData> resourceData;
     RetainPtr<NSURLResponse> response;
 
     if ([self.request.URL.path hasSuffix:@"main"]) {
@@ -101,7 +102,7 @@ static NSImage *imageFromData(NSData *data)
         RELEASE_ASSERT_NOT_REACHED();
 
     [self.client URLProtocol:self didReceiveResponse:response.get() cacheStoragePolicy:NSURLCacheStorageNotAllowed];
-    [self.client URLProtocol:self didLoadData:resourceData];
+    [self.client URLProtocol:self didLoadData:resourceData.get()];
     [self.client URLProtocolDidFinishLoading:self];
 }
 


### PR DESCRIPTION
#### 0bd38f2ed4df267d2a3b791c8095129eb82c1fe4
<pre>
Introduce toNSDataNoCopy() &amp; toCFDataNoCopy() functions to construct NSData / CFData from a span
<a href="https://bugs.webkit.org/show_bug.cgi?id=293776">https://bugs.webkit.org/show_bug.cgi?id=293776</a>

Reviewed by Geoffrey Garen.

Introduce toNSDataNoCopy() &amp; toCFDataNoCopy() functions to construct NSData / CFData
from a span. We already had toNSData() / toCFData() equivalents that actually copied
the input data.

* Source/WTF/wtf/cf/CFURLExtras.cpp:
(WTF::bytesAsCFData):
* Source/WTF/wtf/cf/VectorCF.h:
(WTF::toCFDataNoCopy):
* Source/WTF/wtf/cocoa/SpanCocoa.h:
(WTF::toNSDataNoCopy):
* Source/WebCore/bindings/js/SerializedScriptValue.cpp:
(WebCore::CloneDeserializer::read):
* Source/WebCore/crypto/cocoa/SerializedCryptoKeyWrapMac.mm:
(WebCore::readSerializedCryptoKey):
* Source/WebCore/platform/cf/KeyedDecoderCF.cpp:
(WebCore::KeyedDecoderCF::KeyedDecoderCF):
* Source/WebCore/platform/cf/KeyedEncoderCF.cpp:
(WebCore::KeyedEncoderCF::encodeBytes):
* Source/WebCore/platform/cocoa/ContentFilterUnblockHandlerCocoa.mm:
(WebCore::unpackWebFilterEvaluatorData):
* Source/WebCore/platform/graphics/cg/ImageBufferUtilitiesCG.cpp:
(WebCore::encode):
* Source/WebKit/Shared/Cocoa/CoreIPCPKPaymentSetupFeature.mm:
(WebKit::CoreIPCPKPaymentSetupFeature::toID const):
* Source/WebKit/Shared/Cocoa/CoreIPCPKSecureElementPass.mm:
(WebKit::CoreIPCPKSecureElementPass::toID const):
* Source/WebKit/UIProcess/WebAuthentication/Mock/MockNfcService.mm:
(-[WKMockNFTag initWithType:]):
(WebKit::MockNfcService::detectTags const):
* Source/WebKit/UIProcess/mac/LegacySessionStateCoding.cpp:
(WebKit::encodeSessionHistoryEntryData):
* Source/WebKit/UIProcess/mac/WebPageProxyMac.mm:
(WebKit::WebPageProxy::savePDFToTemporaryFolderAndOpenWithNativeApplication):
* Source/WebKit/WebProcess/InjectedBundle/mac/InjectedBundleMac.mm:
(WebKit::createUnarchiver):
* Source/WebKitLegacy/mac/History/HistoryPropertyList.mm:
(HistoryPropertyListWriter::releaseData):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/BundleEditingDelegatePlugIn.mm:
(-[BundleEditingDelegatePlugIn _webProcessPlugInBrowserContextController:pasteboardDataForRange:]):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ProcessSwapOnNavigation.mm:
(-[PSONScheme addMappingFromURLString:toData:]):
(-[PSONScheme webView:startURLSchemeTask:]):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ServiceWorkerBasic.mm:
(-[ServiceWorkerSchemeHandler webView:startURLSchemeTask:]):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKURLSchemeHandler-1.mm:
(TEST(URLSchemeHandler, Basic)):
(TEST(URLSchemeHandler, BasicWithHTTPS)):
(TEST(URLSchemeHandler, BasicWithAsyncPolicyDelegate)):
(TEST(URLSchemeHandler, NoMIMEType)):
(-[SyncScheme webView:startURLSchemeTask:]):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebsitePolicies.mm:
(-[DataMappingSchemeHandler addMappingFromURLString:toData:]):
* Tools/TestWebKitAPI/Tests/mac/WebViewIconLoading.mm:
(mainResourceData):
(-[IconLoadingProtocol startLoading]):

Canonical link: <a href="https://commits.webkit.org/295594@main">https://commits.webkit.org/295594@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3a14dc65f1183bdccb2846531f1f98cd31aed43c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105554 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25303 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15693 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110751 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/56187 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/107595 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/25735 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33804 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80160 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/56187 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108560 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/20084 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95257 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60470 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/19832 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13349 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55588 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/98192 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/89540 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13389 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/113557 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/104172 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32693 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/24107 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89239 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33056 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91487 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88900 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22669 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33773 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11578 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/28138 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32618 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/38018 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/128473 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32368 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/35105 "Found 1 new JSC stress test failure: wasm.yaml/wasm/gc/ref-i31-eq.js.wasm-eager (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35717 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33961 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->