### PR TITLE
Refactor RenderThemeMac::iconForAttachment to return the same data as RenderThemeIOS (i.e., image as well as its size)

### DIFF
--- a/Source/WebCore/rendering/cocoa/RenderThemeCocoa.h
+++ b/Source/WebCore/rendering/cocoa/RenderThemeCocoa.h
@@ -38,6 +38,15 @@ class RenderThemeCocoa : public RenderTheme {
 public:
     WEBCORE_EXPORT static RenderThemeCocoa& singleton();
 
+    struct IconAndSize {
+#if PLATFORM(IOS_FAMILY)
+        RetainPtr<UIImage> icon;
+#else
+        RetainPtr<NSImage> icon;
+#endif
+        FloatSize size;
+    };
+
 protected:
     virtual Color pictureFrameColor(const RenderObject&);
 #if ENABLE(ATTACHMENT_ELEMENT)

--- a/Source/WebCore/rendering/ios/RenderThemeIOS.h
+++ b/Source/WebCore/rendering/ios/RenderThemeIOS.h
@@ -59,11 +59,6 @@ public:
 
     WEBCORE_EXPORT static Color systemFocusRingColor();
 
-    struct IconAndSize {
-        RetainPtr<UIImage> icon;
-        FloatSize size;
-    };
-
     WEBCORE_EXPORT static IconAndSize iconForAttachment(const String& fileName, const String& attachmentType, const String& title);
 
 private:

--- a/Source/WebCore/rendering/ios/RenderThemeIOS.mm
+++ b/Source/WebCore/rendering/ios/RenderThemeIOS.mm
@@ -1251,7 +1251,7 @@ Color RenderThemeIOS::pictureFrameColor(const RenderObject& buttonRenderer)
 
 #if ENABLE(ATTACHMENT_ELEMENT)
 
-RenderThemeIOS::IconAndSize RenderThemeIOS::iconForAttachment(const String& fileName, const String& attachmentType, const String& title)
+RenderThemeCocoa::IconAndSize RenderThemeIOS::iconForAttachment(const String& fileName, const String& attachmentType, const String& title)
 {
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     auto documentInteractionController = adoptNS([PAL::allocUIDocumentInteractionControllerInstance() init]);

--- a/Source/WebCore/rendering/mac/RenderThemeMac.h
+++ b/Source/WebCore/rendering/mac/RenderThemeMac.h
@@ -89,7 +89,7 @@ public:
     // Controls color values returned from platformFocusRingColor(). systemColor() will be used when false.
     bool usesTestModeFocusRingColor() const;
 
-    WEBCORE_EXPORT static RetainPtr<NSImage> iconForAttachment(const String& fileName, const String& attachmentType, const String& title);
+    WEBCORE_EXPORT static IconAndSize iconForAttachment(const String& fileName, const String& attachmentType, const String& title);
 
 private:
     RenderThemeMac();

--- a/Source/WebCore/rendering/mac/RenderThemeMac.mm
+++ b/Source/WebCore/rendering/mac/RenderThemeMac.mm
@@ -1409,15 +1409,18 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 #undef LOG_ATTACHMENT
 }
 
-RetainPtr<NSImage> RenderThemeMac::iconForAttachment(const String& fileName, const String& attachmentType, const String& title)
+RenderThemeCocoa::IconAndSize RenderThemeMac::iconForAttachment(const String& fileName, const String& attachmentType, const String& title)
 {
     if (fileName.isNull() && attachmentType.isNull() && title.isNull())
-        return nil;
+        return IconAndSize { nil, FloatSize() };
 
-    if (auto icon = WebCore::iconForAttachment(fileName, attachmentType, title))
-        return icon->image();
+    if (auto icon = WebCore::iconForAttachment(fileName, attachmentType, title)) {
+        auto image = icon->image();
+        auto size = [image size];
+        return IconAndSize { image, FloatSize(size) };
+    }
 
-    return nil;
+    return IconAndSize { nil, FloatSize() };
 }
 
 static void paintAttachmentIconBackground(const RenderAttachment& attachment, GraphicsContext& context, AttachmentLayout& layout)

--- a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
@@ -415,11 +415,11 @@ RefPtr<WebCore::ShareableBitmap> WebPageProxy::iconForAttachment(const String& f
 {
 #if PLATFORM(IOS_FAMILY)
     auto iconAndSize = RenderThemeIOS::iconForAttachment(fileName, contentType, title);
+#else
+    auto iconAndSize = RenderThemeMac::iconForAttachment(fileName, contentType, title);
+#endif
     auto icon = iconAndSize.icon;
     size = iconAndSize.size;
-#else
-    auto icon = RenderThemeMac::iconForAttachment(fileName, contentType, title);
-#endif
     return convertPlatformImageToBitmap(icon.get(), iconSize);
 }
 


### PR DESCRIPTION
#### 422447d4300066da2c72be6d63be74beb48441f1
<pre>
Refactor RenderThemeMac::iconForAttachment to return the same data as RenderThemeIOS (i.e., image as well as its size)
&lt;<a href="https://rdar.apple.com/problem/152281297">rdar://problem/152281297</a>&gt;
<a href="https://bugs.webkit.org/show_bug.cgi?id=293778">https://bugs.webkit.org/show_bug.cgi?id=293778</a>

Reviewed by Brent Fulgham and Per Arne Vollan.

Merged IconAndSize to be used by both IOS and macOS. Updated both classes to utilize the new data type.

* Source/WebCore/rendering/cocoa/RenderThemeCocoa.h:
* Source/WebCore/rendering/ios/RenderThemeIOS.h:
* Source/WebCore/rendering/ios/RenderThemeIOS.mm:
(WebCore::RenderThemeIOS::iconForAttachment):
* Source/WebCore/rendering/mac/RenderThemeMac.mm:
(WebCore::RenderThemeMac::iconForAttachment):
* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
(WebKit::WebPageProxy::iconForAttachment):

Canonical link: <a href="https://commits.webkit.org/295710@main">https://commits.webkit.org/295710@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c64f2351a449c8b98f101972c22a84c62894f6f3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105906 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25657 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/16051 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/111104 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/56504 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/107947 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/26282 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34160 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80447 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108912 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/20706 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95572 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60767 "Found 132 new API test failures: /WPE/TestUIClient:/webkit/WebKitWebView/query-permission-requests, /WPE/TestWebsiteData:/webkit/WebKitWebsiteData/deviceidhashsalt, /WPE/TestCookieManager:/webkit/WebKitCookieManager/ephemeral, /WPE/TestWebKitWebView:/webkit/WebKitWebView/is-playing-audio, /WPE/TestWebsiteData:/webkit/WebKitWebsiteData/configuration, /WPE/TestCookieManager:/webkit/WebKitCookieManager/delete-cookies, /WPE/TestWebKitWebView:/webkit/WebKitWebView/terminate-unresponsive-web-process, /WPE/TestSSL:/webkit/WebKitWebView/insecure-content, /WPE/TestAuthentication:/webkit/Authentication/authentication-storage, /WPE/TestWebKitWebContext:/webkit/WebKitWebContext/timezone-worker ... (failure)") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/20345 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13670 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55942 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/90096 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13706 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/113955 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33046 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24379 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89527 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33410 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91801 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89204 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34068 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11875 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/28583 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17176 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32971 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/38382 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32717 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/36066 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34315 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->