### PR TITLE
Switch to TextIndicator for DragImage.

### DIFF
--- a/Source/WebCore/page/DragController.cpp
+++ b/Source/WebCore/page/DragController.cpp
@@ -1097,7 +1097,7 @@ bool DragController::startDrag(LocalFrame& src, const DragState& state, OptionSe
             TextIndicatorData textIndicator;
             dragImage = DragImage { dissolveDragImageToFraction(createDragImageForSelection(src, textIndicator), DragImageAlpha) };
             if (textIndicator.contentImage)
-                dragImage.setIndicatorData(textIndicator);
+                dragImage.setTextIndicator(TextIndicator::create(textIndicator));
             dragLoc = dragLocForSelectionDrag(src);
             m_dragOffset = IntPoint(dragOrigin.x() - dragLoc.x(), dragOrigin.y() - dragLoc.y());
         }
@@ -1197,7 +1197,7 @@ bool DragController::startDrag(LocalFrame& src, const DragState& state, OptionSe
                 dragLoc = IntPoint(dragOrigin.x() + m_dragOffset.x(), dragOrigin.y() + m_dragOffset.y());
                 dragImage = DragImage { platformAdjustDragImageForDeviceScaleFactor(dragImage.get(), m_page->deviceScaleFactor()) };
                 if (textIndicator.contentImage)
-                    dragImage.setIndicatorData(textIndicator);
+                    dragImage.setTextIndicator(TextIndicator::create(textIndicator));
             }
         }
 
@@ -1248,7 +1248,7 @@ bool DragController::startDrag(LocalFrame& src, const DragState& state, OptionSe
             if (attachmentRenderer)
                 attachmentRenderer->setShouldDrawBorder(true);
             if (textIndicator.contentImage)
-                dragImage.setIndicatorData(textIndicator);
+                dragImage.setTextIndicator(TextIndicator::create(textIndicator));
             dragLoc = dragLocForSelectionDrag(src);
             m_dragOffset = IntPoint(dragOrigin.x() - dragLoc.x(), dragOrigin.y() - dragLoc.y());
         }

--- a/Source/WebCore/platform/DragImage.cpp
+++ b/Source/WebCore/platform/DragImage.cpp
@@ -257,7 +257,7 @@ DragImage::DragImage(DragImageRef dragImageRef)
 
 DragImage::DragImage(DragImage&& other)
     : m_dragImageRef { std::exchange(other.m_dragImageRef, nullptr) }
-    , m_indicatorData { WTFMove(other.m_indicatorData) }
+    , m_textIndicator { WTFMove(other.m_textIndicator) }
     , m_visiblePath { WTFMove(other.m_visiblePath) }
 {
 }
@@ -268,7 +268,7 @@ DragImage& DragImage::operator=(DragImage&& other)
         deleteDragImage(m_dragImageRef);
 
     m_dragImageRef = std::exchange(other.m_dragImageRef, nullptr);
-    m_indicatorData = WTFMove(other.m_indicatorData);
+    m_textIndicator = WTFMove(other.m_textIndicator);
     m_visiblePath = WTFMove(other.m_visiblePath);
 
     return *this;

--- a/Source/WebCore/platform/DragImage.h
+++ b/Source/WebCore/platform/DragImage.h
@@ -108,16 +108,16 @@ public:
     WEBCORE_EXPORT DragImage(DragImage&&);
     WEBCORE_EXPORT ~DragImage();
 
-    DragImage(std::optional<TextIndicatorData>&& indicatorData, std::optional<Path>&& visiblePath)
-        : m_indicatorData(WTFMove(indicatorData))
+    DragImage(RefPtr<TextIndicator> textIndicator, std::optional<Path>&& visiblePath)
+        : m_textIndicator(WTFMove(textIndicator))
         , m_visiblePath(WTFMove(visiblePath))
     { }
 
     WEBCORE_EXPORT DragImage& operator=(DragImage&&);
 
-    void setIndicatorData(const TextIndicatorData& data) { m_indicatorData = data; }
-    bool hasIndicatorData() const { return !!m_indicatorData; }
-    const std::optional<TextIndicatorData>& indicatorData() const { return m_indicatorData; }
+    void setTextIndicator(const RefPtr<TextIndicator> textIndicator) { m_textIndicator = textIndicator; }
+    bool hasTextIndicator() const { return !!m_textIndicator; }
+    const RefPtr<TextIndicator> textIndicator() const { return m_textIndicator; }
 
     void setVisiblePath(const Path& path) { m_visiblePath = path; }
     bool hasVisiblePath() const { return !!m_visiblePath; }
@@ -128,7 +128,7 @@ public:
 
 private:
     DragImageRef m_dragImageRef;
-    std::optional<TextIndicatorData> m_indicatorData;
+    RefPtr<TextIndicator> m_textIndicator;
     std::optional<Path> m_visiblePath;
 };
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -7680,7 +7680,7 @@ class WebCore::ContentSecurityPolicyResponseHeaders {
 };
 
 class WebCore::DragImage {
-    std::optional<WebCore::TextIndicatorData> indicatorData();
+    RefPtr<WebCore::TextIndicator> textIndicator();
     std::optional<WebCore::Path> visiblePath();
 };
 

--- a/Source/WebKit/UIProcess/ios/DragDropInteractionState.mm
+++ b/Source/WebKit/UIProcess/ios/DragDropInteractionState.mm
@@ -348,7 +348,7 @@ void DragDropInteractionState::stageDragItem(const DragItem& item, DragSourceSta
         item.sourceAction,
         item.dragPreviewFrameInRootViewCoordinates,
         dragPreviewContent,
-        item.image.indicatorData(),
+        item.image.textIndicator() ? std::optional { item.image.textIndicator()->data() } : std::nullopt,
         item.image.visiblePath(),
         item.title.isEmpty() ? nil : item.title.createNSString().get(),
         item.url.isEmpty() ? nil : item.url.createNSURL().get(),

--- a/Source/WebKitLegacy/mac/WebView/WebView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebView.mm
@@ -1913,10 +1913,10 @@ static WebCore::ApplicationCacheStorage& webApplicationCacheStorage()
 {
     auto& dragImage = dragItem.image;
     auto image = dragImage.get().get();
-    auto indicatorData = dragImage.indicatorData();
+    RefPtr<WebCore::TextIndicator> textIndicator = dragImage.textIndicator();
 
-    if (indicatorData)
-        _private->textIndicatorData = adoptNS([[WebUITextIndicatorData alloc] initWithImage:image textIndicatorData:indicatorData.value() scale:_private->page->deviceScaleFactor()]);
+    if (textIndicator)
+        _private->textIndicatorData = adoptNS([[WebUITextIndicatorData alloc] initWithImage:image textIndicatorData:textIndicator->data() scale:_private->page->deviceScaleFactor()]);
     else
         _private->textIndicatorData = adoptNS([[WebUITextIndicatorData alloc] initWithImage:image scale:_private->page->deviceScaleFactor()]);
     _private->draggedLinkURL = dragItem.url.isEmpty() ? RetainPtr<NSURL>() : dragItem.url.createNSURL();


### PR DESCRIPTION
#### 2a4adc01a7029d1d5d0278d62e7411cfb4cfdcd4
<pre>
Switch to TextIndicator for DragImage.
<a href="https://bugs.webkit.org/show_bug.cgi?id=293779">https://bugs.webkit.org/show_bug.cgi?id=293779</a>
<a href="https://rdar.apple.com/152281407">rdar://152281407</a>

Reviewed by Tim Horton.

Continuing to switch away from TextIndicatorData.

* Source/WebCore/page/DragController.cpp:
(WebCore::DragController::startDrag):
* Source/WebCore/platform/DragImage.cpp:
(WebCore::createDragImageForSelection):
(WebCore::DragImage::operator=):
(WebCore::createDragImageForLink):
* Source/WebCore/platform/DragImage.h:
* Source/WebCore/platform/cocoa/DragImageCocoa.mm:
(WebCore::createDragImageForLink):
* Source/WebCore/platform/ios/DragImageIOS.mm:
(WebCore::createDragImageForLink):
(WebCore::createDragImageForSelection):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/ios/DragDropInteractionState.mm:
(WebKit::DragDropInteractionState::stageDragItem):
* Source/WebKitLegacy/mac/WebView/WebView.mm:
(-[WebView _startDrag:]):

Canonical link: <a href="https://commits.webkit.org/295630@main">https://commits.webkit.org/295630@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/64cbf626a76c832368e36dab576e2322a3585bf5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105680 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25431 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15824 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110877 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/56275 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/107721 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/25905 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33934 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80262 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/56275 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108686 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/20259 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95376 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60569 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/19985 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13466 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55715 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/89711 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13508 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/113726 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32820 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24195 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/89341 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33184 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91599 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89002 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22690 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33876 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11682 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/28280 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32745 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/38179 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32491 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35840 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34089 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->