### PR TITLE
Web Inspector: Timelines Tab: always show target hierarchical path component for JavaScript & Events

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/ScriptClusterTimelineView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/ScriptClusterTimelineView.js
@@ -53,7 +53,9 @@ WI.ScriptClusterTimelineView = class ScriptClusterTimelineView extends WI.Cluste
         this._selectedTarget = null;
         this._displayedTarget = (!this.representedObject.imported && targets.includes(WI.mainTarget)) ? WI.mainTarget : (targets.firstValue || WI.assumingMainTarget());
 
-        this._pathComponentForTarget = new Map(targets.map((target) => [target, this._createTargetPathComponent(target)]));
+        this._pathComponentForTarget = new Map;
+        for (let target of targets)
+            this._addPathComponentForTarget(target);
         this._sortTargetPathComponents();
 
         this._contentViewsForTarget = new Map;
@@ -120,8 +122,9 @@ WI.ScriptClusterTimelineView = class ScriptClusterTimelineView extends WI.Cluste
 
         let components = [];
 
-        if (this._pathComponentForTarget.size > 1)
-            components.push(this._pathComponentForTarget.get(this._displayedTarget))
+        let targetPathComponent = this._pathComponentForTarget.get(this._displayedTarget);
+        if (targetPathComponent)
+            components.push(targetPathComponent);
 
         switch (this._currentContentViewSetting.value) {
         case WI.ScriptClusterTimelineView.EventsIdentifier:
@@ -178,32 +181,34 @@ WI.ScriptClusterTimelineView = class ScriptClusterTimelineView extends WI.Cluste
         this.contentViewContainer.showContentView(contentViewToShow);
     }
 
-    _createTargetPathComponent(target)
+    _addPathComponentForTarget(target)
     {
+        if (this._pathComponentForTarget.size === 1)
+            this._pathComponentForTarget.firstValue.selectorArrows = true;
+
         let className = target.type === WI.TargetType.Worker ? "worker-icon" : "page-icon";
         const textOnly = false;
-        const showSelectorArrows = true;
-        let pathComponent = new WI.HierarchicalPathComponent(target.displayName, className, target, false, showSelectorArrows);
+        let showSelectorArrows = this._pathComponentForTarget.size >= 1;
+        let pathComponent = new WI.HierarchicalPathComponent(target.displayName, className, target, textOnly, showSelectorArrows);
         pathComponent.addEventListener(WI.HierarchicalPathComponent.Event.SiblingWasSelected, this._handleTargetPathComponentSelected, this);
         pathComponent.comparisonData = target;
-        return pathComponent;
+
+        console.assert(!this._pathComponentForTarget.has(target), target, this);
+        this._pathComponentForTarget.set(target, pathComponent);
     }
 
     _sortTargetPathComponents()
     {
         const rankFunctions = [
-            (representedObject) => representedObject === WI.mainTarget,
-            (representedObject) => representedObject.type === WI.TargetType.Page,
-            (representedObject) => representedObject.type === WI.TargetType.Worker,
+            (target) => target === WI.mainTarget,
+            (target) => target.type === WI.TargetType.Page,
+            (target) => target.type === WI.TargetType.Worker,
+            () => true, // Fallback for all other targets (which shouldn't be reached, but just to be safe).
         ];
         let sortedComponents = Array.from(this._pathComponentForTarget.values()).sort((a, b) => {
-            let aRank = rankFunctions.findIndex((rankFunction) => rankFunction(a));
-            let bRank = rankFunctions.findIndex((rankFunction) => rankFunction(b));
-            if ((aRank >= 0 && bRank < 0) || aRank < bRank)
-                return -1;
-            if ((bRank >= 0 && aRank < 0) || bRank < aRank)
-                return 1;
-            return a.displayName.extendedLocaleCompare(b.displayName);
+            let aRank = rankFunctions.findIndex((rankFunction) => rankFunction(a.representedObject));
+            let bRank = rankFunctions.findIndex((rankFunction) => rankFunction(b.representedObject));
+            return aRank - bRank || a.displayName.extendedLocaleCompare(b.displayName);
         });
         for (let [a, b] of sortedComponents.adjacencies()) {
             a.nextSibling = b;
@@ -223,8 +228,7 @@ WI.ScriptClusterTimelineView = class ScriptClusterTimelineView extends WI.Cluste
     {
         let {target} = event.data;
 
-        console.assert(!this._pathComponentForTarget.has(target), target, this);
-        this._pathComponentForTarget.set(target, this._createTargetPathComponent(target));
+        this._addPathComponentForTarget(target);
         this._sortTargetPathComponents();
 
         console.assert(target === this._displayedTarget || !this._contentViewsForTarget.has(target), target, this);
@@ -238,8 +242,7 @@ WI.ScriptClusterTimelineView = class ScriptClusterTimelineView extends WI.Cluste
             }
         }
 
-        if (this._pathComponentForTarget.size > 1)
-            this.dispatchEventToListeners(WI.ContentView.Event.SelectionPathComponentsDidChange);
+        this.dispatchEventToListeners(WI.ContentView.Event.SelectionPathComponentsDidChange);
     }
 
     _handleTargetPathComponentSelected(event)


### PR DESCRIPTION
#### a4b389c50afb504bb42c5081ef7a8ae14f4860ed
<pre>
Web Inspector: Timelines Tab: always show target hierarchical path component for JavaScript &amp; Events
<a href="https://bugs.webkit.org/show_bug.cgi?id=293782">https://bugs.webkit.org/show_bug.cgi?id=293782</a>

Reviewed by BJ Burg.

This will help increase awareness of the fact that multiple targets exist and avoid confusion when switching between pages with a single target vs multiple (i.e. the UI would change).

It also clarifies what target was profiled in the case that only one of multiple targets had activity while recording.

* Source/WebInspectorUI/UserInterface/Views/ScriptClusterTimelineView.js:
(WI.ScriptClusterTimelineView):
(WI.ScriptClusterTimelineView.prototype.get selectionPathComponents):
(WI.ScriptClusterTimelineView.prototype._addPathComponentForTarget): Renamed from `_createTargetPathComponent`.
(WI.ScriptClusterTimelineView.prototype._sortTargetPathComponents): Drive-by: fix sorting logic to use the right objects.
(WI.ScriptClusterTimelineView.prototype._handleTargetAdded):

Canonical link: <a href="https://commits.webkit.org/295640@main">https://commits.webkit.org/295640@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/20e110c6247b2f5abcdef1e8762285dfc0bf7ab7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105759 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25510 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15903 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110956 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/56355 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/26001 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34013 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80313 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/56355 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108765 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/20343 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95432 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60625 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/20058 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13529 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55794 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/89786 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13568 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/113805 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32899 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/24242 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89389 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33263 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91663 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89058 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22696 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33933 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11737 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/28363 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32824 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/38234 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32570 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35919 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34168 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->