### PR TITLE
Use the same EnvironmentResource instance for default lighting for all entities in the Model process

### DIFF
--- a/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm
+++ b/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm
@@ -924,15 +924,7 @@ void ModelProcessModelPlayerProxy::applyStageModeOperationToDriver()
 
 void ModelProcessModelPlayerProxy::applyDefaultIBL()
 {
-    [m_modelRKEntity applyDefaultIBLWithAttributionHandler:makeBlockPtr([weakThis = WeakPtr { *this }] (REAssetRef coreEnvironmentResourceAsset) {
-        RefPtr protectedThis = weakThis.get();
-        if (!protectedThis || !protectedThis->m_attributionTaskID || !coreEnvironmentResourceAsset)
-            return;
-
-#if HAVE(MODEL_MEMORY_ATTRIBUTION)
-        setIBLAssetOwnership(*(protectedThis->m_attributionTaskID), coreEnvironmentResourceAsset);
-#endif
-    }).get()];
+    [m_modelRKEntity applyDefaultIBL];
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebKitSwift/RealityKit/RealityKitBridging.h
+++ b/Source/WebKit/WebKitSwift/RealityKit/RealityKitBridging.h
@@ -70,7 +70,7 @@ typedef struct {
 - (void)applyIBLData:(NSData *)data attributionHandler:(void (^)(REAssetRef coreEnvironmentResourceAsset))attributionHandler withCompletion:(void (^)(BOOL success))completion;
 - (void)interactionContainerDidRecenterFromTransform:(simd_float4x4)transform NS_SWIFT_NAME(interactionContainerDidRecenter(_:));
 - (void)recenterEntityAtTransform:(WKEntityTransform)transform NS_SWIFT_NAME(recenterEntity(at:));
-- (void)applyDefaultIBLWithAttributionHandler:(void (^)(REAssetRef coreEnvironmentResourceAsset))attributionHandler NS_SWIFT_NAME(applyDefaultIBL(attributionHandler:));
+- (void)applyDefaultIBL;
 @end
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
#### 590a90ef44375b0f8b15d43f54411f44e58ec7af
<pre>
Use the same EnvironmentResource instance for default lighting for all entities in the Model process
<a href="https://bugs.webkit.org/show_bug.cgi?id=293781">https://bugs.webkit.org/show_bug.cgi?id=293781</a>
<a href="https://rdar.apple.com/152262994">rdar://152262994</a>

Reviewed by Mike Wyrzykowski.

We don&apos;t need duplicate copies of the default EnvironmentResource for multiple
entities in the Model process. One instance can be shared across them, but we
cannot set up its attribution target to a Web Content process anymore, hence
removing the attributionHandler for the applyDefaultIBL() method.

* Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm:
(WebKit::ModelProcessModelPlayerProxy::applyDefaultIBL):
* Source/WebKit/WebKitSwift/RealityKit/RKEntity.swift:
(WKSRKEntity._defaultEnvironmentResource):
(WKSRKEntity.applyIBL(_:)):
New helper method for setting up the entity&apos;s lighting components.
(WKSRKEntity.applyIBL(_:attributionHandler:completion:)):
Adopt the new helper method.
(WKSRKEntity.applyDefaultIBL):
Use the default EnvironmentResource if it exists. If the default
EnvironmentResource has not been created yet, create it asynchronously
and apply the IBL back on the main thread.
(WKSRKEntity.applyDefaultIBL(_:)): Deleted.
* Source/WebKit/WebKitSwift/RealityKit/RealityKitBridging.h:

Canonical link: <a href="https://commits.webkit.org/295628@main">https://commits.webkit.org/295628@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0382606797ca55d6e7c90435d4b2e65c44068dd5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105564 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25313 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15703 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110761 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/56191 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/25910 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33814 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80165 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/56191 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108570 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/20266 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95267 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60475 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/19990 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55598 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/89716 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13398 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/113571 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32703 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24162 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89244 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33066 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91496 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88906 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22686 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33783 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11586 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/28146 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32628 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/38023 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32377 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35726 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33971 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->