### PR TITLE
Slider thumb may be slightly misaligned when vector-based controls enabled

### DIFF
--- a/Source/WebCore/html/shadow/SliderThumbElement.cpp
+++ b/Source/WebCore/html/shadow/SliderThumbElement.cpp
@@ -71,6 +71,10 @@ using namespace HTMLNames;
 WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(SliderThumbElement);
 WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(SliderContainerElement);
 
+#if USE(APPLE_INTERNAL_SDK) && __has_include(<WebKitAdditions/SliderThumbElementAdditions.mm>)
+#import <WebKitAdditions/SliderThumbElementAdditions.mm>
+#endif
+
 inline static Decimal sliderPosition(HTMLInputElement& element)
 {
     const StepRange stepRange(element.createStepRange(AnyStepHandling::Reject));
@@ -166,6 +170,20 @@ void RenderSliderContainer::layout()
     availableExtent -= isVertical ? thumb->height() : thumb->width();
     LayoutUnit offset { percentageOffset * availableExtent };
     LayoutPoint thumbLocation = thumb->location();
+
+    auto updateThumbLocationAndRepaint = [&] {
+        thumb->setLocation(thumbLocation);
+        track->repaint();
+        thumb->repaint();
+    };
+
+#if ENABLE(VECTOR_BASED_CONTROLS_ON_MAC)
+    if (adjustThumbLocationForVectorBasedControls(thumbLocation, *track, *thumb, percentageOffset, offset)) {
+        updateThumbLocationAndRepaint();
+        return;
+    }
+#endif
+
     if (isVertical) {
         // appearance: slider-vertical in horizontal writing mode.
         if (writingMode().isHorizontal())
@@ -182,9 +200,8 @@ void RenderSliderContainer::layout()
         else
             thumbLocation.setX(thumbLocation.x() - offset);
     }
-    thumb->setLocation(thumbLocation);
-    track->repaint();
-    thumb->repaint();
+
+    updateThumbLocationAndRepaint();
 }
 
 // --------------------------------


### PR DESCRIPTION
#### 3707417c51c4ce96fd6e999c5a14c841aacc1c2e
<pre>
Slider thumb may be slightly misaligned when vector-based controls enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=293788">https://bugs.webkit.org/show_bug.cgi?id=293788</a>
<a href="https://rdar.apple.com/152286911">rdar://152286911</a>

Reviewed by NOBODY (OOPS!).

When vector-based controls are enabled, the slider thumb may be misaligned
by 1px due to pixel snapping that occurs at paint time. Perform adjustments
during layout to correct this issue, if needed.

* Source/WebCore/html/shadow/SliderThumbElement.cpp:
(WebCore::RenderSliderContainer::layout):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3707417c51c4ce96fd6e999c5a14c841aacc1c2e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105585 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25334 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15726 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110782 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/56201 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/107626 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/25781 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33835 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80183 "Found 1 new test failure: webgl/2.0.y/conformance/textures/misc/video-rotation.html (failure)") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108591 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/20124 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95284 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60492 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/19866 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13376 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55620 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/89575 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13415 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/113606 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32724 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24124 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89261 "Passed tests") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33086 "Hash 3707417c for PR 46101 does not build (failure)") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91513 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88925 "Passed tests") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11600 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/28164 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32649 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/38035 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32395 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35744 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33992 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->