### PR TITLE
[iOS] Refresh control is not visible when there is fixed top element on the page

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -3144,12 +3144,13 @@ static WebCore::CocoaColor *sampledFixedPositionContentColor(const WebCore::Fixe
     RetainPtr parentView = [self _containerForFixedColorExtension];
     auto addColorExtensionView = [&](CocoaView *extensionView) {
 #if PLATFORM(MAC)
-        if (RetainPtr contentInsetFillView = _impl->topContentInsetFillView()) {
+        if (RetainPtr contentInsetFillView = _impl->topContentInsetFillView())
             [parentView addSubview:extensionView positioned:NSWindowBelow relativeTo:contentInsetFillView.get()];
-            return;
-        }
+        else
+            [parentView addSubview:extensionView];
+#else
+        [parentView insertSubview:extensionView aboveSubview:_contentView.get()];
 #endif
-        [parentView addSubview:extensionView];
     };
 
     auto insets = [self _obscuredInsetsForFixedColorExtension];

--- a/Source/WebKit/UIProcess/ios/UIKitUtilities.h
+++ b/Source/WebKit/UIProcess/ios/UIKitUtilities.h
@@ -38,6 +38,7 @@ enum class BoxSide : uint8_t;
 @interface UIScrollView (WebKitInternal)
 @property (readonly, nonatomic) BOOL _wk_isInterruptingDeceleration;
 @property (readonly, nonatomic) BOOL _wk_isScrolledBeyondExtents;
+@property (readonly, nonatomic) BOOL _wk_isScrolledBeyondTopExtent;
 @property (readonly, nonatomic) BOOL _wk_canScrollHorizontallyWithoutBouncing;
 @property (readonly, nonatomic) BOOL _wk_canScrollVerticallyWithoutBouncing;
 @property (readonly, nonatomic) CGFloat _wk_contentWidthIncludingInsets;

--- a/Source/WebKit/UIProcess/ios/UIKitUtilities.mm
+++ b/Source/WebKit/UIProcess/ios/UIKitUtilities.mm
@@ -77,6 +77,11 @@
     return self.contentSize.height + inset.top + inset.bottom;
 }
 
+- (BOOL)_wk_isScrolledBeyondTopExtent
+{
+    return self.contentOffset.y < -self.adjustedContentInset.top;
+}
+
 - (BOOL)_wk_isScrolledBeyondExtents
 {
     auto contentOffset = self.contentOffset;


### PR DESCRIPTION
#### eed2135df5c13f8489aab2b6a7bd7ad21e191c2b
<pre>
[iOS] Refresh control is not visible when there is fixed top element on the page
<a href="https://bugs.webkit.org/show_bug.cgi?id=293791">https://bugs.webkit.org/show_bug.cgi?id=293791</a>
<a href="https://rdar.apple.com/149399460">rdar://149399460</a>

Reviewed by Richard Robinson.

The fixed color extension view is currently inserted into the view hierarchy after the content view.
This allows the extension view to properly obscure the part of the page above viewport-constrained
objects aligned to edges of the viewport. However, it also means that when scrolling up beyond the
top extent of the scroll view, it also covers the refresh control (e.g. spinner in Safari) of the
scroll view.

To mitigate this (while allowing fixed color extension views to cover the page content while
scrolling past the top), we teach the top color extension view to either:

1.  Reinsert itself before the refresh control in the scroll view&apos;s subview array when the page is
    rubber-banding against the top edge.

2.  Reinsert itself after the content view when the page is either at or scrolled past the top edge.

* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _updateFixedColorExtensionViews]):
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _reinsertTopFixedColorExtensionViewIfNeeded]):

Ensure that the top fixed color extension view is inserted in the right position, in the array of
subviews below the scroller.

(-[WKWebView scrollViewDidScroll:]):

See above.

* Source/WebKit/UIProcess/ios/UIKitUtilities.h:
* Source/WebKit/UIProcess/ios/UIKitUtilities.mm:
(-[UIScrollView _wk_isScrolledBeyondTopExtent]):

Add a category helper method to determine whether or not the scroll view is rubber-banding against
the top edge.

Canonical link: <a href="https://commits.webkit.org/295613@main">https://commits.webkit.org/295613@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5eaaddd2d24e12c84e94d445ea453dd3e1920536

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105594 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25343 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15735 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110791 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/56206 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/25791 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33844 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80191 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/56206 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108600 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/20136 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95292 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60500 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/19879 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55629 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/89586 "Found 1 new API test failure: TestWebKitAPI.GPUProcess.ExitsUnderMemoryPressureWebAudioCase (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13423 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/113621 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32732 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24130 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89270 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33094 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91521 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88934 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22677 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33803 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11606 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/28174 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32658 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/38042 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32404 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35752 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34001 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->