### PR TITLE
[Safer CPP] Address issues in WebGLRenderingContextBase

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -326,7 +326,6 @@ html/canvas/CanvasRenderingContext2DBase.cpp
 html/canvas/CanvasRenderingContext2DBase.h
 html/canvas/EXTDisjointTimerQuery.cpp
 html/canvas/OffscreenCanvasRenderingContext2D.cpp
-html/canvas/WebGLRenderingContextBase.cpp
 html/parser/HTMLConstructionSite.cpp
 html/parser/HTMLConstructionSite.h
 html/parser/HTMLDocumentParser.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -605,7 +605,6 @@ html/canvas/WebGLMultiDrawInstancedBaseVertexBaseInstance.cpp
 html/canvas/WebGLObject.cpp
 html/canvas/WebGLObject.h
 html/canvas/WebGLProgram.cpp
-html/canvas/WebGLRenderingContextBase.cpp
 html/canvas/WebGLSync.cpp
 html/canvas/WebGLTransformFeedback.cpp
 html/canvas/WebGLVertexArrayObject.cpp

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
@@ -1037,6 +1037,9 @@ private:
     void maybeRestoreContextSoon(Seconds timeout = 0_s);
     void maybeRestoreContext();
 
+    RefPtr<WebGLVertexArrayObjectBase> protectedBoundVertexArrayObject() const { return m_boundVertexArrayObject; }
+    RefPtr<WebGLFramebuffer> protectedFramebufferBinding() const { return m_framebufferBinding; }
+
     ExceptionOr<void> texImageSource(TexImageFunctionID, GCGLenum target, GCGLint level, GCGLint internalformat, GCGLint border, GCGLenum format, GCGLenum type, GCGLint xoffset, GCGLint yoffset, GCGLint zoffset, const IntRect& inputSourceImageRect, GCGLsizei depth, GCGLint unpackImageHeight, ImageBitmap& source);
     ExceptionOr<void> texImageSource(TexImageFunctionID, GCGLenum target, GCGLint level, GCGLint internalformat, GCGLint border, GCGLenum format, GCGLenum type, GCGLint xoffset, GCGLint yoffset, GCGLint zoffset, const IntRect& inputSourceImageRect, GCGLsizei depth, GCGLint unpackImageHeight, ImageData& source);
     ExceptionOr<void> texImageSource(TexImageFunctionID, GCGLenum target, GCGLint level, GCGLint internalformat, GCGLint border, GCGLenum format, GCGLenum type, GCGLint xoffset, GCGLint yoffset, GCGLint zoffset, const IntRect& inputSourceImageRect, GCGLsizei depth, GCGLint unpackImageHeight, HTMLImageElement& source);


### PR DESCRIPTION
#### adb15d99f5bfd1cdfaa55dc922e5435f56e9d2d6
<pre>
[Safer CPP] Address issues in WebGLRenderingContextBase
<a href="https://bugs.webkit.org/show_bug.cgi?id=293792">https://bugs.webkit.org/show_bug.cgi?id=293792</a>
<a href="https://rdar.apple.com/152294456">rdar://152294456</a>

Reviewed by Chris Dumez.

Address outstanding Safer CPP issues in WebGLRenderingContextBase.

* Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::WebGLRenderingContextBase):
(WebCore::WebGLRenderingContextBase::initializeContextState):
(WebCore::WebGLRenderingContextBase::clearIfComposited):
(WebCore::WebGLRenderingContextBase::surfaceBufferToImageBuffer):
(WebCore::WebGLRenderingContextBase::drawingBufferToPixelBuffer):
(WebCore::WebGLRenderingContextBase::surfaceBufferToVideoFrame):
(WebCore::WebGLRenderingContextBase::transferToImageBuffer):
(WebCore::WebGLRenderingContextBase::reshape):
(WebCore::WebGLRenderingContextBase::setDrawingBufferColorSpace):
(WebCore::WebGLRenderingContextBase::activeTexture):
(WebCore::WebGLRenderingContextBase::attachShader):
(WebCore::WebGLRenderingContextBase::bindAttribLocation):
(WebCore::WebGLRenderingContextBase::validateAndCacheBufferBinding):
(WebCore::WebGLRenderingContextBase::bindBuffer):
(WebCore::WebGLRenderingContextBase::bindRenderbuffer):
(WebCore::WebGLRenderingContextBase::bindTexture):
(WebCore::WebGLRenderingContextBase::blendColor):
(WebCore::WebGLRenderingContextBase::blendEquation):
(WebCore::WebGLRenderingContextBase::blendEquationSeparate):
(WebCore::WebGLRenderingContextBase::blendFunc):
(WebCore::WebGLRenderingContextBase::blendFuncSeparate):
(WebCore::WebGLRenderingContextBase::bufferData):
(WebCore::WebGLRenderingContextBase::checkFramebufferStatus):
(WebCore::WebGLRenderingContextBase::clear):
(WebCore::WebGLRenderingContextBase::clearColor):
(WebCore::WebGLRenderingContextBase::clearDepth):
(WebCore::WebGLRenderingContextBase::clearStencil):
(WebCore::WebGLRenderingContextBase::colorMask):
(WebCore::WebGLRenderingContextBase::compileShader):
(WebCore::WebGLRenderingContextBase::compressedTexImage2D):
(WebCore::WebGLRenderingContextBase::compressedTexSubImage2D):
(WebCore::WebGLRenderingContextBase::copyTexSubImage2D):
(WebCore::WebGLRenderingContextBase::cullFace):
(WebCore::WebGLRenderingContextBase::uncacheDeletedBuffer):
(WebCore::WebGLRenderingContextBase::deleteFramebuffer):
(WebCore::WebGLRenderingContextBase::deleteRenderbuffer):
(WebCore::WebGLRenderingContextBase::deleteTexture):
(WebCore::WebGLRenderingContextBase::depthFunc):
(WebCore::WebGLRenderingContextBase::depthMask):
(WebCore::WebGLRenderingContextBase::depthRange):
(WebCore::WebGLRenderingContextBase::detachShader):
(WebCore::WebGLRenderingContextBase::disable):
(WebCore::WebGLRenderingContextBase::disableVertexAttribArray):
(WebCore::WebGLRenderingContextBase::validateVertexArrayObject):
(WebCore::WebGLRenderingContextBase::drawArrays):
(WebCore::WebGLRenderingContextBase::drawElements):
(WebCore::WebGLRenderingContextBase::enable):
(WebCore::WebGLRenderingContextBase::enableVertexAttribArray):
(WebCore::WebGLRenderingContextBase::finish):
(WebCore::WebGLRenderingContextBase::flush):
(WebCore::WebGLRenderingContextBase::frontFace):
(WebCore::WebGLRenderingContextBase::generateMipmap):
(WebCore::WebGLRenderingContextBase::getActiveAttrib):
(WebCore::WebGLRenderingContextBase::getActiveUniform):
(WebCore::WebGLRenderingContextBase::getAttribLocation):
(WebCore::WebGLRenderingContextBase::getBufferParameter):
(WebCore::WebGLRenderingContextBase::updateErrors):
(WebCore::WebGLRenderingContextBase::getParameter):
(WebCore::WebGLRenderingContextBase::getProgramParameter):
(WebCore::WebGLRenderingContextBase::getProgramInfoLog):
(WebCore::WebGLRenderingContextBase::getRenderbufferParameter):
(WebCore::WebGLRenderingContextBase::getShaderParameter):
(WebCore::WebGLRenderingContextBase::getShaderInfoLog):
(WebCore::WebGLRenderingContextBase::getShaderPrecisionFormat):
(WebCore::WebGLRenderingContextBase::getTexParameter):
(WebCore::WebGLRenderingContextBase::getUniform):
(WebCore::WebGLRenderingContextBase::getUniformLocation):
(WebCore::WebGLRenderingContextBase::getVertexAttrib):
(WebCore::WebGLRenderingContextBase::getVertexAttribOffset):
(WebCore::WebGLRenderingContextBase::hint):
(WebCore::WebGLRenderingContextBase::isBuffer):
(WebCore::WebGLRenderingContextBase::isEnabled):
(WebCore::WebGLRenderingContextBase::isFramebuffer):
(WebCore::WebGLRenderingContextBase::isProgram):
(WebCore::WebGLRenderingContextBase::isRenderbuffer):
(WebCore::WebGLRenderingContextBase::isShader):
(WebCore::WebGLRenderingContextBase::isTexture):
(WebCore::WebGLRenderingContextBase::lineWidth):
(WebCore::WebGLRenderingContextBase::linkProgramWithoutInvalidatingAttribLocations):
(WebCore::WebGLRenderingContextBase::pixelStorei):
(WebCore::WebGLRenderingContextBase::polygonOffset):
(WebCore::WebGLRenderingContextBase::readPixels):
(WebCore::WebGLRenderingContextBase::renderbufferStorageImpl):
(WebCore::WebGLRenderingContextBase::sampleCoverage):
(WebCore::WebGLRenderingContextBase::scissor):
(WebCore::WebGLRenderingContextBase::shaderSource):
(WebCore::WebGLRenderingContextBase::stencilFunc):
(WebCore::WebGLRenderingContextBase::stencilFuncSeparate):
(WebCore::WebGLRenderingContextBase::stencilMask):
(WebCore::WebGLRenderingContextBase::stencilMaskSeparate):
(WebCore::WebGLRenderingContextBase::stencilOp):
(WebCore::WebGLRenderingContextBase::stencilOpSeparate):
(WebCore::WebGLRenderingContextBase::texImageSource):
(WebCore::WebGLRenderingContextBase::texImageArrayBufferViewHelper):
(WebCore::WebGLRenderingContextBase::texImageImpl):
(WebCore::WebGLRenderingContextBase::texImage2DBase):
(WebCore::WebGLRenderingContextBase::texSubImage2DBase):
(WebCore::WebGLRenderingContextBase::copyTexImage2D):
(WebCore::WebGLRenderingContextBase::texParameter):
(WebCore::WebGLRenderingContextBase::uniform1f):
(WebCore::WebGLRenderingContextBase::uniform2f):
(WebCore::WebGLRenderingContextBase::uniform3f):
(WebCore::WebGLRenderingContextBase::uniform4f):
(WebCore::WebGLRenderingContextBase::uniform1i):
(WebCore::WebGLRenderingContextBase::uniform2i):
(WebCore::WebGLRenderingContextBase::uniform3i):
(WebCore::WebGLRenderingContextBase::uniform4i):
(WebCore::WebGLRenderingContextBase::uniform1fv):
(WebCore::WebGLRenderingContextBase::uniform2fv):
(WebCore::WebGLRenderingContextBase::uniform3fv):
(WebCore::WebGLRenderingContextBase::uniform4fv):
(WebCore::WebGLRenderingContextBase::uniform1iv):
(WebCore::WebGLRenderingContextBase::uniform2iv):
(WebCore::WebGLRenderingContextBase::uniform3iv):
(WebCore::WebGLRenderingContextBase::uniform4iv):
(WebCore::WebGLRenderingContextBase::uniformMatrix2fv):
(WebCore::WebGLRenderingContextBase::uniformMatrix3fv):
(WebCore::WebGLRenderingContextBase::uniformMatrix4fv):
(WebCore::WebGLRenderingContextBase::useProgram):
(WebCore::WebGLRenderingContextBase::validateProgram):
(WebCore::WebGLRenderingContextBase::vertexAttribPointer):
(WebCore::WebGLRenderingContextBase::viewport):
(WebCore::WebGLRenderingContextBase::forceLostContext):
(WebCore::WebGLRenderingContextBase::layerContentsDisplayDelegate):
(WebCore::WebGLRenderingContextBase::getBooleanParameter):
(WebCore::WebGLRenderingContextBase::getBooleanArrayParameter):
(WebCore::WebGLRenderingContextBase::getFloatParameter):
(WebCore::WebGLRenderingContextBase::getIntParameter):
(WebCore::WebGLRenderingContextBase::getUnsignedIntParameter):
(WebCore::WebGLRenderingContextBase::getWebGLFloatArrayParameter):
(WebCore::WebGLRenderingContextBase::getWebGLIntArrayParameter):
(WebCore::WebGLRenderingContextBase::vertexAttribfImpl):
(WebCore::WebGLRenderingContextBase::vertexAttribfvImpl):
(WebCore::WebGLRenderingContextBase::scheduleTaskToDispatchContextLostEvent):
(WebCore::WebGLRenderingContextBase::maybeRestoreContextSoon):
(WebCore::WebGLRenderingContextBase::maybeRestoreContext):
(WebCore::WebGLRenderingContextBase::simulateEventForTesting):
(WebCore::WebGLRenderingContextBase::maxDrawBuffers):
(WebCore::WebGLRenderingContextBase::maxColorAttachments):
(WebCore::WebGLRenderingContextBase::setFramebuffer):
(WebCore::WebGLRenderingContextBase::drawArraysInstanced):
(WebCore::WebGLRenderingContextBase::drawElementsInstanced):
(WebCore::WebGLRenderingContextBase::vertexAttribDivisor):
(WebCore::WebGLRenderingContextBase::enableSupportedExtension):
(WebCore::WebGLRenderingContextBase::prepareForDisplay):
* Source/WebCore/html/canvas/WebGLRenderingContextBase.h:
(WebCore::WebGLRenderingContextBase::protectedBoundVertexArrayObject const):
(WebCore::WebGLRenderingContextBase::protectedFramebufferBinding const):

Canonical link: <a href="https://commits.webkit.org/296020@main">https://commits.webkit.org/296020@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f65a23c2e8a374d4a97742e15a451aea9a3ed567

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/106995 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/26702 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/17099 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/112203 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/57553 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/108988 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/27375 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/35204 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/81237 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/109953 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/21733 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/96498 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/61593 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/21160 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/14615 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/57001 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/91076 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/14639 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/115248 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/34088 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/25140 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/90284 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/34456 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/92737 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/90012 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22962 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34936 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/12738 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/29800 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/34012 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/39465 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/33760 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/37112 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/35392 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->