### PR TITLE
[Web Inspector] Display "Navigated To:" in the Web Inspector Console when accessing a website

### DIFF
--- a/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
+++ b/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
@@ -1255,6 +1255,7 @@ localizedStrings["PDF"] = "PDF";
 localizedStrings["PNG"] = "PNG";
 localizedStrings["Page"] = "Page";
 localizedStrings["Page Issue"] = "Page Issue";
+localizedStrings["Page navigated to %s at %s"] = "Page navigated to %s at %s";
 /* Heading for list of flex overlay options */
 localizedStrings["Page Overlay Options @ Layout Panel Flex Section Header"] = "Page Overlay Options";
 /* Heading for list of grid overlay options */
@@ -1263,7 +1264,6 @@ localizedStrings["Page Overlay Options @ Layout Panel Grid Section Header"] = "P
 localizedStrings["Page Overlays @ Layout Sidebar Section Header"] = "Grid Overlays";
 /* Heading for list of flex container nodes */
 localizedStrings["Page Overlays for Flex containers @ Layout Sidebar Section Header"] = "Flexbox Overlays";
-localizedStrings["Page navigated at %s"] = "Page navigated at %s";
 localizedStrings["Page reloaded at %s"] = "Page reloaded at %s";
 /* Paint (render) phase timeline records */
 localizedStrings["Paint @ Timeline record"] = "Paint";

--- a/Source/WebInspectorUI/UserInterface/Views/ConsoleSession.js
+++ b/Source/WebInspectorUI/UserInterface/Views/ConsoleSession.js
@@ -40,26 +40,24 @@ WI.ConsoleSession = class ConsoleSession extends WI.Object
         let header = document.createElement("div");
         header.classList.add("console-session-header");
 
-        let headerText = "";
+        let timestampText = (new Date(data.timestamp || Date.now())).toLocaleTimeString();
+
         switch (data.newSessionReason) {
         case WI.ConsoleSession.NewSessionReason.PageReloaded:
-            headerText = WI.UIString("Page reloaded at %s");
+            header.textContent = WI.UIString("Page reloaded at %s").format(timestampText);
             break;
         case WI.ConsoleSession.NewSessionReason.PageNavigated:
-            headerText = WI.UIString("Page navigated at %s");
+            header.textContent = WI.UIString("Page navigated to %s at %s").format(WI.networkManager.mainFrame.url.truncateMiddle(100), timestampText);
             break;
         case WI.ConsoleSession.NewSessionReason.ConsoleCleared:
-            headerText = WI.UIString("Console cleared at %s");
+            header.textContent = WI.UIString("Console cleared at %s").format(timestampText);
             break;
         default:
-            headerText = WI.UIString("Console opened at %s");
+            header.textContent = WI.UIString("Console opened at %s").format(timestampText);
             break;
         }
-
-        let timestamp = data.timestamp || Date.now();
-        header.textContent = headerText.format(new Date(timestamp).toLocaleTimeString());
+        
         element.append(header);
-
         this.element = element;
         this._messagesElement = element;
     }


### PR DESCRIPTION
#### 62dfa4f50d482c4862b22ce8b8cd3e63ccd391bc
<pre>
[Web Inspector] Display &quot;Navigated To:&quot; in the Web Inspector Console when accessing a website
<a href="https://bugs.webkit.org/show_bug.cgi?id=263108">https://bugs.webkit.org/show_bug.cgi?id=263108</a>

Reviewed by Devin Rousso.

Currently, when a page is accessed, it shows &apos;Page navigated at %s&apos;.
Change this to &apos;Page navigated to %s at %s&apos; to provide better information for the user.

* Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js:
* Source/WebInspectorUI/UserInterface/Views/ConsoleSession.js:
(WI.ConsoleSession):

Canonical link: <a href="https://commits.webkit.org/295764@main">https://commits.webkit.org/295764@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2f6a631e37aaf4cc4d94ff1b7425041784d51ed9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105997 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25746 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/16140 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/111193 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/56593 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/26397 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34249 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80516 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/109001 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/20824 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95658 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60836 "Found 140 new API test failures: /WPE/TestUIClient:/webkit/WebKitWebView/query-permission-requests, /WPE/TestWebsiteData:/webkit/WebKitWebsiteData/deviceidhashsalt, /WPE/TestLoaderClient:/webkit/WebKitWebView/load-twice-and-reload, /WPE/TestCookieManager:/webkit/WebKitCookieManager/ephemeral, /WPE/TestWebKitWebView:/webkit/WebKitWebView/is-playing-audio, /WPE/TestConsoleMessage:/webkit/WebKitConsoleMessage/network-error, /WPE/TestWebsiteData:/webkit/WebKitWebsiteData/configuration, /WPE/TestCookieManager:/webkit/WebKitCookieManager/delete-cookies, /WPE/TestWebKitWebView:/webkit/WebKitWebView/terminate-unresponsive-web-process, /WPE/TestSSL:/webkit/WebKitWebView/insecure-content ... (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/20433 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13755 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/56031 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/90203 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13791 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/114047 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33135 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24449 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89595 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33499 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91886 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89278 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34144 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11958 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/28681 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17205 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/33060 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/38472 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32806 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/36155 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34404 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->