### PR TITLE
View transition containing block doesn't take content insets into account.

### DIFF
--- a/LayoutTests/fast/css/view-transitions-inset-expected.html
+++ b/LayoutTests/fast/css/view-transitions-inset-expected.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<title>View transitions: content insets</title>
+<style>
+html {
+  background: lightpink;
+}
+.box {
+  color: red;
+  background: lightblue;
+  width: 100px;
+  height: 100px;
+  contain: paint;
+  position: absolute;
+  top: 120px;
+  left: 20px;
+}
+</style>
+<div class=box></div>
+

--- a/LayoutTests/fast/css/view-transitions-inset.html
+++ b/LayoutTests/fast/css/view-transitions-inset.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+<title>View transitions: content inset</title>
+<script src="../../resources/ui-helper.js"></script>
+<style>
+.box {
+  color: red;
+  background: lightblue;
+  width: 100px;
+  height: 100px;
+  contain: paint;
+  position: absolute;
+}
+#e1 { top: 20px; left: 20px; view-transition-name: e1; }
+/* We're verifying what we capture, so just display the old capture for 5 minutes.  */
+html::view-transition-group(*) { animation-duration: 300s; }
+html::view-transition-new(*) { animation: unset; opacity: 1; }
+html::view-transition-old(*) { animation: unset; opacity: 0; }
+/* hide the root so we show transition background to ensure we're in a transition */
+html::view-transition-group(root) { animation: unset; opacity: 0; }
+html::view-transition { background: lightpink; }
+</style>
+<div id=e1 class=box></div>
+<script>
+if (window.testRunner)
+  testRunner.waitUntilDone();
+
+async function runTest() {
+
+  await UIHelper.setObscuredInsets(100, 0, 0, 0);
+  await UIHelper.renderingUpdate();
+
+  await document.startViewTransition(async () => { 
+      await UIHelper.setObscuredInsets(0, 0, 0, 0);
+  }).ready;
+
+  if (window.testRunner)
+    testRunner.notifyDone();
+}
+onload = () => requestAnimationFrame(() => requestAnimationFrame(runTest));
+</script>
+

--- a/Source/WebCore/dom/ViewTransition.h
+++ b/Source/WebCore/dom/ViewTransition.h
@@ -164,7 +164,7 @@ struct ViewTransitionParams {
 public:
 
     OrderedNamedElementsMap namedElements;
-    FloatSize initialLargeViewportSize;
+    LayoutSize initialSnapshotContainingBlockSize;
     float initialPageZoom;
     MonotonicTime startTime;
 };
@@ -245,7 +245,7 @@ private:
 
     OrderedNamedElementsMap m_namedElements;
     ViewTransitionPhase m_phase { ViewTransitionPhase::PendingCapture };
-    FloatSize m_initialLargeViewportSize;
+    LayoutSize m_initialSnapshotContainingBlockSize;
     float m_initialPageZoom;
 
     RefPtr<ViewTransitionUpdateCallback> m_updateCallback;


### PR DESCRIPTION
#### 2b0c3f2565fe840dcdda0a57279f3991cf365e8f
<pre>
View transition containing block doesn&apos;t take content insets into account.
<a href="https://bugs.webkit.org/show_bug.cgi?id=285400">https://bugs.webkit.org/show_bug.cgi?id=285400</a>
&lt;<a href="https://rdar.apple.com/142774967">rdar://142774967</a>&gt;

Reviewed by NOBODY (OOPS!).

Expand the view transition contaning block rect to cover the inset areas.

Adds a test that does an initial capture (including positioning transform) with
an inset, and then removes the inset during the VT callback. Ensures that the
view transition pseudo elenents are still placed at same screen position,
despite the inset being gone.

* LayoutTests/fast/css/view-transitions-inset-expected.html: Added.
* LayoutTests/fast/css/view-transitions-inset.html: Added.
* Source/WebCore/dom/ViewTransition.cpp:
(WebCore::ViewTransition::containingBlockRect):
(WebCore::ViewTransition::copyElementBaseProperties):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2b0c3f2565fe840dcdda0a57279f3991cf365e8f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/107272 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/26954 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/17358 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/112486 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/57806 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/109236 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/27635 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/35454 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/81430 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/110201 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/21905 "Found 1 new test failure: fast/events/ios/select-all-with-existing-selection.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/96687 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/61800 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/21332 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/14821 "Found 1 new test failure: fast/css/view-transitions-inset.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/57251 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/91261 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/14851 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/115587 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/34338 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/25302 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/90473 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/34714 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/92936 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/90207 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35112 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/12899 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/30068 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/34260 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/39793 "Failed to build and analyze WebKit") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34006 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/37361 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/35667 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->