### PR TITLE
css/css-view-transitions/pseudo-computed-style-stays-in-sync-with-new-element.html fails due to no object-view-box support.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-computed-style-stays-in-sync-with-new-element-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-computed-style-stays-in-sync-with-new-element-expected.txt
@@ -1,10 +1,3 @@
-CONSOLE MESSAGE: Unhandled Promise Rejection: Error: assert_equals: incorrect viewbox undefined expected (string) "none" but got (undefined) undefined
 
-Harness Error (FAIL), message = Unhandled rejection: assert_equals: incorrect viewbox undefined expected (string) "none" but got (undefined) undefined
-
-TIMEOUT computed style on pseudo-element stays in sync with the DOM element Test timed out
-
-Harness Error (FAIL), message = Unhandled rejection: assert_equals: incorrect viewbox undefined expected (string) "none" but got (undefined) undefined
-
-TIMEOUT computed style on pseudo-element stays in sync with the DOM element Test timed out
+PASS computed style on pseudo-element stays in sync with the DOM element
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-computed-style-stays-in-sync-with-new-element.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-computed-style-stays-in-sync-with-new-element.html
@@ -29,12 +29,12 @@ promise_test(async t => {
 
     let viewbox = window.getComputedStyle(
       document.documentElement, "::view-transition-new(target)").objectViewBox;
-    assert_equals(viewbox, "none", "incorrect viewbox " + viewbox);
+    assert_in_array(viewbox, ["none", undefined], "incorrect viewbox " + viewbox);
 
     first.style.filter = "blur(5px)";
     viewbox = window.getComputedStyle(
       document.documentElement, "::view-transition-new(target)").objectViewBox;
-    assert_equals(viewbox, "none", "incorrect viewbox " + viewbox);
+    assert_in_array(viewbox, ["none", undefined], "incorrect viewbox " + viewbox);
 
     transition.finished.then(resolve, reject);
   });


### PR DESCRIPTION
#### e51eaf10f99fad0998bffa8e499b52d1a0acf815
<pre>
css/css-view-transitions/pseudo-computed-style-stays-in-sync-with-new-element.html fails due to no object-view-box support.
<a href="https://bugs.webkit.org/show_bug.cgi?id=293794">https://bugs.webkit.org/show_bug.cgi?id=293794</a>

Reviewed by Tim Nguyen.

The test is checking that no changes happen, which is true, since it&apos;s not
supported at all. Allow undefined as a value, since that should respect the
intention of the test while letting it pass for UAs without object-view-box
support.

* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-computed-style-stays-in-sync-with-new-element-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-computed-style-stays-in-sync-with-new-element.html:

Canonical link: <a href="https://commits.webkit.org/295713@main">https://commits.webkit.org/295713@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9554b852c12132df30ea2652319462b4da5030d2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105601 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25350 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15742 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110798 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/56212 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/25801 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33851 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80197 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108607 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/20147 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95298 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60506 "Passed tests") | 
| | [💥 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/19894 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13390 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55636 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/89596 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13429 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/113631 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32739 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24136 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89274 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33101 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91527 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88938 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22741 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33809 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11611 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/28182 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32665 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32411 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35759 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34008 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->