### PR TITLE
[GStreamer] Local video files are unexpectedly blocked by web process sandbox

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -1052,6 +1052,7 @@ std::optional<bool> MediaPlayerPrivateGStreamer::isCrossOrigin(const SecurityOri
 
 void MediaPlayerPrivateGStreamer::simulateAudioInterruption()
 {
+    GST_DEBUG_OBJECT(pipeline(), "Simulating audio interruption by pausing the pipeline");
     GstMessage* message = gst_message_new_request_state(GST_OBJECT(m_pipeline.get()), GST_STATE_PAUSED);
     gst_element_post_message(m_pipeline.get(), message);
 }
@@ -1110,9 +1111,10 @@ void MediaPlayerPrivateGStreamer::sourceSetupCallback(MediaPlayerPrivateGStreame
     player->sourceSetup(sourceElement);
 }
 
-MediaPlayerPrivateGStreamer::ChangePipelineStateResult MediaPlayerPrivateGStreamer::changePipelineState(GstState newState)
+MediaPlayerPrivateGStreamer::ChangePipelineStateResult MediaPlayerPrivateGStreamer::changePipelineState(GstState newState, bool isForInterruptionSimulation)
 {
     ASSERT(m_pipeline);
+    m_isPipelinePausedForInterruptionSimulation = isForInterruptionSimulation;
 
     if (isPausedByViewport() && newState > GST_STATE_PAUSED) {
         GST_DEBUG_OBJECT(pipeline(), "Saving state for when player becomes visible: %s", gst_state_get_name(newState));
@@ -2303,7 +2305,7 @@ void MediaPlayerPrivateGStreamer::handleMessage(GstMessage* message)
             GST_INFO_OBJECT(pipeline(), "Element %s requested state change to %s", GST_MESSAGE_SRC_NAME(message),
                 gst_state_get_name(requestedState));
             m_requestedState = requestedState;
-            if (changePipelineState(requestedState) == ChangePipelineStateResult::Failed)
+            if (changePipelineState(requestedState, true) == ChangePipelineStateResult::Failed)
                 loadingFailed(MediaPlayer::NetworkState::Empty);
         }
         break;
@@ -2361,14 +2363,9 @@ void MediaPlayerPrivateGStreamer::handleMessage(GstMessage* message)
         } else if (gst_structure_has_name(structure, "webkit-network-statistics")) {
             if (gst_structure_get(structure, "read-position", G_TYPE_UINT64, &m_networkReadPosition, "size", G_TYPE_UINT64, &m_httpResponseTotalSize, nullptr)) {
                 GST_LOG_OBJECT(pipeline(), "Updated network read position %" G_GUINT64_FORMAT ", size: %" G_GUINT64_FORMAT, m_networkReadPosition, m_httpResponseTotalSize);
-
-                MediaTime mediaDuration = duration();
-
-                // Update maxTimeLoaded only if the media duration is available. Otherwise we can't compute it.
-                if (mediaDuration && m_httpResponseTotalSize) {
+                if (m_httpResponseTotalSize) {
                     const double fillStatus = 100.0 * (static_cast<double>(m_networkReadPosition) / static_cast<double>(m_httpResponseTotalSize));
                     updateMaxTimeLoaded(fillStatus);
-                    GST_DEBUG("Updated maxTimeLoaded base on network read position: %s", m_maxTimeLoaded.toString().utf8().data());
                 }
             }
         } else if (gst_structure_has_name(structure, "GstCacheDownloadComplete")) {
@@ -2447,8 +2444,10 @@ void MediaPlayerPrivateGStreamer::processBufferingStats(GstMessage* message)
 void MediaPlayerPrivateGStreamer::updateMaxTimeLoaded(double percentage)
 {
     MediaTime mediaDuration = duration();
-    if (!mediaDuration)
+    if (!mediaDuration) {
+        GST_DEBUG_OBJECT(pipeline(), "Duration unknown, unable to update maxTimeLoaded");
         return;
+    }
 
     m_maxTimeLoaded = MediaTime(percentage * static_cast<double>(toGstUnsigned64Time(mediaDuration)) / 100, GST_SECOND);
     GST_DEBUG_OBJECT(pipeline(), "[Buffering] Updated maxTimeLoaded: %s", toString(m_maxTimeLoaded).utf8().data());
@@ -2471,31 +2470,33 @@ void MediaPlayerPrivateGStreamer::updateBufferingStatus(GstBufferingMode mode, d
         lowWatermark = 20.0;
     }
 
-    // Hysteresis for m_didDownloadFinish.
-    if (m_didDownloadFinish && percentage < lowWatermark) {
-        GST_TRACE("[Buffering] m_didDownloadFinish: %s, percentage: %f, lowWatermark: %f. Setting m_didDownloadFinish to false",
-            boolForPrinting(m_didDownloadFinish), percentage, lowWatermark);
-        m_didDownloadFinish = false;
-    } else if (!m_didDownloadFinish && percentage >= highWatermark) {
-        GST_TRACE("[Buffering] m_didDownloadFinish: %s, percentage: %f, highWatermark: %f. Setting m_didDownloadFinish to true",
-            boolForPrinting(m_didDownloadFinish), percentage, highWatermark);
-        m_didDownloadFinish = true;
-    } else {
-        GST_TRACE("[Buffering] m_didDownloadFinish remains %s, lowWatermark: %f, percentage: %f, highWatermark: %f",
-            boolForPrinting(m_didDownloadFinish), lowWatermark, percentage, highWatermark);
+    if (mode == GST_BUFFERING_DOWNLOAD) {
+        // Hysteresis for m_didDownloadFinish.
+        if (m_didDownloadFinish && percentage < lowWatermark) {
+            GST_TRACE_OBJECT(pipeline(), "[Buffering] m_didDownloadFinish: %s, percentage: %f, lowWatermark: %f. Setting m_didDownloadFinish to false",
+                boolForPrinting(m_didDownloadFinish), percentage, lowWatermark);
+            m_didDownloadFinish = false;
+        } else if (!m_didDownloadFinish && percentage >= highWatermark) {
+            GST_TRACE_OBJECT(pipeline(), "[Buffering] m_didDownloadFinish: %s, percentage: %f, highWatermark: %f. Setting m_didDownloadFinish to true",
+                boolForPrinting(m_didDownloadFinish), percentage, highWatermark);
+            m_didDownloadFinish = true;
+        } else {
+            GST_TRACE_OBJECT(pipeline(), "[Buffering] m_didDownloadFinish remains %s, lowWatermark: %f, percentage: %f, highWatermark: %f",
+                boolForPrinting(m_didDownloadFinish), lowWatermark, percentage, highWatermark);
+        }
     }
 
     // Hysteresis for m_isBuffering.
     if (!m_isBuffering && percentage < lowWatermark) {
-        GST_TRACE("[Buffering] m_isBuffering: %s, percentage: %f, lowWatermark: %f. Setting m_isBuffering to true",
+        GST_TRACE_OBJECT(pipeline(), "[Buffering] m_isBuffering: %s, percentage: %f, lowWatermark: %f. Setting m_isBuffering to true",
             boolForPrinting(m_isBuffering), percentage, lowWatermark);
         m_isBuffering = true;
     } else if (m_isBuffering && percentage >= highWatermark) {
-        GST_TRACE("[Buffering] m_isBuffering: %s, percentage: %f, highWatermark: %f. Setting m_isBuffering to false",
+        GST_TRACE_OBJECT(pipeline(), "[Buffering] m_isBuffering: %s, percentage: %f, highWatermark: %f. Setting m_isBuffering to false",
             boolForPrinting(m_isBuffering), percentage, highWatermark);
         m_isBuffering = false;
     } else {
-        GST_TRACE("[Buffering] m_isBuffering remains %s, lowWatermark: %f, percentage: %f, highWatermark: %f",
+        GST_TRACE_OBJECT(pipeline(), "[Buffering] m_isBuffering remains %s, lowWatermark: %f, percentage: %f, highWatermark: %f",
             boolForPrinting(m_isBuffering), lowWatermark, percentage, highWatermark);
     }
 
@@ -2522,7 +2523,7 @@ void MediaPlayerPrivateGStreamer::updateBufferingStatus(GstBufferingMode mode, d
     updateMaxTimeLoaded(percentage);
     if (shouldUpdateStates)
         updateStates();
-    GST_TRACE("[Buffering] Settled results: m_wasBuffering: %s, m_isBuffering: %s, m_previousBufferingPercentage: %d, m_bufferingPercentage: %d",
+    GST_TRACE_OBJECT(pipeline(), "[Buffering] Settled results: m_wasBuffering: %s, m_isBuffering: %s, m_previousBufferingPercentage: %d, m_bufferingPercentage: %d",
         boolForPrinting(m_wasBuffering), boolForPrinting(m_isBuffering), m_previousBufferingPercentage, m_bufferingPercentage);
 }
 
@@ -2931,9 +2932,9 @@ void MediaPlayerPrivateGStreamer::updateStates()
             [[fallthrough]];
         case GST_STATE_PLAYING: {
             bool isLooping = player && player->isLooping();
-            if (m_wasBuffering) {
-                GST_TRACE("[Buffering] m_isBuffering: %s --> %s", boolForPrinting(m_wasBuffering), boolForPrinting(m_isBuffering));
+            GST_TRACE_OBJECT(pipeline(), "[Buffering] m_isBuffering: %s --> %s", boolForPrinting(m_wasBuffering), boolForPrinting(m_isBuffering));
 
+            if (m_wasBuffering) {
                 if (!m_isBuffering) {
                     GST_INFO_OBJECT(pipeline(), "[Buffering] Complete.");
                     m_readyState = MediaPlayer::ReadyState::HaveEnoughData;
@@ -2943,6 +2944,11 @@ void MediaPlayerPrivateGStreamer::updateStates()
                     m_networkState = MediaPlayer::NetworkState::Loading;
                 }
             } else if (m_didDownloadFinish || isLooping) {
+                m_readyState = MediaPlayer::ReadyState::HaveEnoughData;
+                m_networkState = MediaPlayer::NetworkState::Loaded;
+            } else if (!m_isBuffering && m_readyState == MediaPlayer::ReadyState::HaveFutureData) {
+                if (auto percentage = queryBufferingPercentage())
+                    updateMaxTimeLoaded(static_cast<double>(*percentage));
                 m_readyState = MediaPlayer::ReadyState::HaveEnoughData;
                 m_networkState = MediaPlayer::NetworkState::Loaded;
             } else {
@@ -2966,7 +2972,7 @@ void MediaPlayerPrivateGStreamer::updateStates()
                 m_areVolumeAndMuteInitialized = true;
             }
 
-            if ((m_wasBuffering && !m_isBuffering && !m_isPaused && m_playbackRatePausedState != PlaybackRatePausedState::ManuallyPaused && m_playbackRate)
+            if ((m_wasBuffering && !m_isBuffering && !m_isPaused && m_playbackRatePausedState != PlaybackRatePausedState::ManuallyPaused && m_playbackRate && !m_isPipelinePausedForInterruptionSimulation)
                 || m_playbackRatePausedState == PlaybackRatePausedState::ShouldMoveToPlaying) {
                 m_playbackRatePausedState = PlaybackRatePausedState::Playing;
                 GST_INFO_OBJECT(pipeline(), "[Buffering] Restarting playback (because of buffering or resuming from zero playback rate)");
@@ -3375,6 +3381,18 @@ void MediaPlayerPrivateGStreamer::updateDownloadBufferingFlag()
 
     if (m_url.protocolIsBlob()) {
         GST_DEBUG_OBJECT(pipeline(), "Blob URI detected. Disabling on-disk buffering");
+        disableDownloading();
+        return;
+    }
+
+    if (m_url.protocolIsData()) {
+        GST_DEBUG_OBJECT(pipeline(), "Data URI detected. Disabling on-disk buffering");
+        disableDownloading();
+        return;
+    }
+
+    if (m_url.protocolIsFile()) {
+        GST_DEBUG_OBJECT(pipeline(), "File URI detected. Disabling on-disk buffering");
         disableDownloading();
         return;
     }

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -2349,17 +2349,7 @@ void MediaPlayerPrivateGStreamer::handleMessage(GstMessage* message)
             if (gst_structure_get(structure, "response-headers", GST_TYPE_STRUCTURE, &responseHeaders.outPtr(), nullptr)) {
                 auto contentLengthHeaderName = httpHeaderNameString(HTTPHeaderName::ContentLength);
                 auto contentLengthFromResponse = gstStructureGet<uint64_t>(responseHeaders.get(), contentLengthHeaderName);
-                uint64_t contentLength = 0;
-                if (!contentLengthFromResponse) {
-                    // souphttpsrc sets a string for Content-Length, so
-                    // handle it here, until we remove the webkit+ protocol
-                    // prefix from webkitwebsrc.
-                    if (auto contentLengthValue = gstStructureGetString(responseHeaders.get(), contentLengthHeaderName)) {
-                        if (auto parsedContentLength = parseInteger<uint64_t>(contentLengthValue.span()))
-                            contentLength = *parsedContentLength;
-                    }
-                } else
-                    contentLength = *contentLengthFromResponse;
+                uint64_t contentLength = contentLengthFromResponse.value_or(0);
                 if (!isRangeRequest) {
                     m_isLiveStream = !contentLength;
                     if (*m_isLiveStream && WEBKIT_IS_WEB_SRC(m_source.get()) && webKitSrcIsSeekable(WEBKIT_WEB_SRC_CAST(m_source.get())))

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
@@ -302,7 +302,7 @@ protected:
         Rejected,
         Failed,
     };
-    ChangePipelineStateResult changePipelineState(GstState);
+    ChangePipelineStateResult changePipelineState(GstState, bool isForInterruptionSimulation = false);
 
     static bool isAvailable();
 
@@ -401,6 +401,7 @@ protected:
     GstState m_currentState { GST_STATE_NULL };
     GstState m_oldState { GST_STATE_NULL };
     GstState m_requestedState { GST_STATE_VOID_PENDING };
+    bool m_isPipelinePausedForInterruptionSimulation { false };
     bool m_shouldResetPipeline { false };
     bool m_isSeeking { false };
     bool m_isSeekPending { false };

--- a/Source/WebCore/platform/graphics/gstreamer/WebKitWebSourceGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/WebKitWebSourceGStreamer.cpp
@@ -1204,7 +1204,7 @@ void CachedResourceStreamingClient::dataReceived(PlatformMediaResource&, const S
         members->downloadStartTime = WallTime::now();
     }
 
-    int length = data.size();
+    int length = data.size() - members->requestedPosition;
     GST_LOG_OBJECT(src.get(), "R%u: Have %d bytes of data", m_requestNumber, length);
 
     members->readPosition += length;
@@ -1214,7 +1214,7 @@ void CachedResourceStreamingClient::dataReceived(PlatformMediaResource&, const S
         gst_structure_new("webkit-network-statistics", "read-position", G_TYPE_UINT64, members->readPosition, "size", G_TYPE_UINT64, members->size.value_or(0), nullptr)));
 
     checkUpdateBlocksize(length);
-    auto dataSpan = data.span();
+    auto dataSpan = data.span().subspan(members->requestedPosition);
     GstBuffer* buffer = gstBufferNewWrappedFast(fastMemDup(dataSpan.data(), dataSpan.size()), length);
     gst_adapter_push(members->adapter.get(), buffer);
 

--- a/Source/WebCore/platform/graphics/gstreamer/WebKitWebSourceGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/WebKitWebSourceGStreamer.cpp
@@ -800,9 +800,9 @@ static gboolean webKitWebSrcQuery(GstBaseSrc* baseSrc, GstQuery* query)
     if (!result)
         result = GST_BASE_SRC_CLASS(webkit_web_src_parent_class)->query(baseSrc, query);
 
-    URL url { String::fromLatin1(priv->originalURI.data()) };
-    if (url.protocolIsBlob() || url.protocolIsFile())
-        return result;
+    // URL url { String::fromLatin1(priv->originalURI.data()) };
+    // if (url.protocolIsBlob() || url.protocolIsFile())
+    //     return result;
 
     if (GST_QUERY_TYPE(query) == GST_QUERY_SCHEDULING) {
         GstSchedulingFlags flags;

--- a/Source/WebCore/platform/graphics/gstreamer/WebKitWebSourceGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/WebKitWebSourceGStreamer.cpp
@@ -543,8 +543,10 @@ static GstFlowReturn webKitWebSrcCreate(GstPushSrc* pushSrc, GstBuffer** buffer)
         members->responseCondition.wait(members.mutex(), [&] {
             return members->isFlushing || gst_adapter_available(members->adapter.get()) || members->doesHaveEOS;
         });
-        if (members->isFlushing)
+        if (members->isFlushing) {
+            GST_TRACE_OBJECT(src, "Still flushing");
             return GST_FLOW_FLUSHING;
+        }
 
         queueSize = gst_adapter_available(members->adapter.get());
         GST_TRACE_OBJECT(src, "available %" G_GSIZE_FORMAT, queueSize);
@@ -850,6 +852,7 @@ static gboolean webKitWebSrcUnLock(GstBaseSrc* baseSrc)
         RunLoop::mainSingleton().dispatch([resource = WTF::move(members->resource), requestNumber = members->requestNumber] {
             GST_DEBUG("Stopping resource request R%u", requestNumber);
             resource->shutdown();
+            GST_DEBUG("Stopping resource request R%u DONE", requestNumber);
         });
     }
     ASSERT(!members->resource);
@@ -1081,8 +1084,9 @@ void CachedResourceStreamingClient::responseReceived(PlatformMediaResource&, con
     members->pendingHttpHeadersMessage = adoptGRef(gst_message_new_element(GST_OBJECT_CAST(src.get()), gst_structure_copy(httpHeaders.get())));
     members->pendingHttpHeadersEvent = adoptGRef(gst_event_new_custom(GST_EVENT_CUSTOM_DOWNSTREAM_STICKY, httpHeaders.release()));
 
-    if (response.httpStatusCode() >= 400) {
-        GST_ELEMENT_ERROR(src.get(), RESOURCE, READ, ("R%u: Received %d HTTP error code", m_requestNumber, response.httpStatusCode()), (nullptr));
+    auto httpStatusCode = response.httpStatusCode();
+    if (httpStatusCode >= 400) {
+        GST_ELEMENT_ERROR(src.get(), RESOURCE, READ, ("R%u: Received %d HTTP error code", m_requestNumber, httpStatusCode), (nullptr));
         members->doesHaveEOS = true;
         members->responseCondition.notifyOne();
         completionHandler(ShouldContinuePolicyCheck::No);
@@ -1091,9 +1095,9 @@ void CachedResourceStreamingClient::responseReceived(PlatformMediaResource&, con
 
     if (members->requestedPosition) {
         // Seeking ... we expect a 206 == PARTIAL_CONTENT
-        if (response.httpStatusCode() != 206) {
+        if (httpStatusCode && httpStatusCode != 206) {
             // Range request completely failed.
-            GST_ELEMENT_ERROR(src.get(), RESOURCE, READ, ("R%u: Received unexpected %d HTTP status code for range request", m_requestNumber, response.httpStatusCode()), (nullptr));
+            GST_ELEMENT_ERROR(src.get(), RESOURCE, READ, ("R%u: Received unexpected %d HTTP status code for range request", m_requestNumber, httpStatusCode), (nullptr));
             members->doesHaveEOS = true;
             members->responseCondition.notifyOne();
             completionHandler(ShouldContinuePolicyCheck::No);

--- a/Source/WebCore/platform/graphics/gstreamer/WebKitWebSourceGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/WebKitWebSourceGStreamer.cpp
@@ -1095,7 +1095,7 @@ void CachedResourceStreamingClient::responseReceived(PlatformMediaResource&, con
 
     if (members->requestedPosition) {
         // Seeking ... we expect a 206 == PARTIAL_CONTENT
-        if (httpStatusCode && httpStatusCode != 206) {
+        if (httpStatusCode && (httpStatusCode != 206)) {
             // Range request completely failed.
             GST_ELEMENT_ERROR(src.get(), RESOURCE, READ, ("R%u: Received unexpected %d HTTP status code for range request", m_requestNumber, httpStatusCode), (nullptr));
             members->doesHaveEOS = true;

--- a/Source/WebCore/platform/graphics/gstreamer/WebKitWebSourceGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/WebKitWebSourceGStreamer.cpp
@@ -1204,7 +1204,11 @@ void CachedResourceStreamingClient::dataReceived(PlatformMediaResource&, const S
         members->downloadStartTime = WallTime::now();
     }
 
-    int length = data.size() - members->requestedPosition;
+    int length = data.size();
+
+    URL url { String::fromLatin1(priv->originalURI.data()) };
+    if (url.protocolIsFile())
+        length -= members->requestedPosition;
     GST_LOG_OBJECT(src.get(), "R%u: Have %d bytes of data", m_requestNumber, length);
 
     members->readPosition += length;
@@ -1214,7 +1218,9 @@ void CachedResourceStreamingClient::dataReceived(PlatformMediaResource&, const S
         gst_structure_new("webkit-network-statistics", "read-position", G_TYPE_UINT64, members->readPosition, "size", G_TYPE_UINT64, members->size.value_or(0), nullptr)));
 
     checkUpdateBlocksize(length);
-    auto dataSpan = data.span().subspan(members->requestedPosition);
+    auto dataSpan = data.span();
+    if (url.protocolIsFile())
+        dataSpan = dataSpan.subspan(members->requestedPosition);
     GstBuffer* buffer = gstBufferNewWrappedFast(fastMemDup(dataSpan.data(), dataSpan.size()), length);
     gst_adapter_push(members->adapter.get(), buffer);
 

--- a/Source/WebCore/platform/graphics/gstreamer/WebKitWebSourceGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/WebKitWebSourceGStreamer.cpp
@@ -798,6 +798,10 @@ static gboolean webKitWebSrcQuery(GstBaseSrc* baseSrc, GstQuery* query)
     if (!result)
         result = GST_BASE_SRC_CLASS(webkit_web_src_parent_class)->query(baseSrc, query);
 
+    URL url { String::fromLatin1(priv->originalURI.data()) };
+    if (url.protocolIsBlob() || url.protocolIsFile())
+        return result;
+
     if (GST_QUERY_TYPE(query) == GST_QUERY_SCHEDULING) {
         GstSchedulingFlags flags;
         int minSize, maxSize, align;
@@ -875,7 +879,7 @@ static gboolean webKitWebSrcUnLockStop(GstBaseSrc* baseSrc)
 
 static bool urlHasSupportedProtocol(const URL& url)
 {
-    return url.isValid() && (url.protocolIsInHTTPFamily() || url.protocolIsBlob());
+    return url.isValid() && (url.protocolIsInHTTPFamily() || url.protocolIsBlob() || url.protocolIsFile());
 }
 
 // uri handler interface
@@ -887,7 +891,7 @@ static GstURIType webKitWebSrcUriGetType(GType)
 
 const gchar* const* webKitWebSrcGetProtocols(GType)
 {
-    static std::array<const char*, 4> protocols { "http", "https", "blob" };
+    static std::array<const char*, 5> protocols { "http", "https", "blob", "file" };
     return protocols.data();
 }
 


### PR DESCRIPTION
#### abed7fc23981121da6e0cfd4c58d0baf96d2f992
<pre>
wip5
</pre>
----------------------------------------------------------------------
#### 0081ff37d2d0edba7c21dab4c95cb635eb526a30
<pre>
wip42
</pre>
----------------------------------------------------------------------
#### 482fe4e9ecec5ca349892a7f63163f6ca1ab102f
<pre>
wip4
</pre>
----------------------------------------------------------------------
#### f2295196b7cf65340e1971582d2dc76b25119fbd
<pre>
wip3
</pre>
----------------------------------------------------------------------
#### 060f75061e9b1ae234027b0df4b00fe9ae4ea6ac
<pre>
wip2
</pre>
----------------------------------------------------------------------
#### 2560587be5042efc2f60953075a0824411f52e50
<pre>
wip
</pre>
----------------------------------------------------------------------
#### 9e48aaea319c20492240104ec800a76627625216
<pre>
[GStreamer] Local video files are unexpectedly blocked by web process sandbox
<a href="https://bugs.webkit.org/show_bug.cgi?id=293696">https://bugs.webkit.org/show_bug.cgi?id=293696</a>

Reviewed by NOBODY (OOPS!).

Use our WebSource GStreamer element to load file:// URIs. This is required especially when the
WebProcess is sandboxed and thus has limited access to the filesystem.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/abed7fc23981121da6e0cfd4c58d0baf96d2f992

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146567 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19240 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/12751 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155230 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99958 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/148442 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19701 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19144 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112930 "Found 59 new test failures: fast/canvas/webgl/texImage2D-video-flipY-false.html fast/canvas/webgl/texImage2D-video-flipY-true.html imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/createImageBitmap-invalid-args.html imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/createImageBitmap-serializable.html imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/createImageBitmap-transfer.html media/audio-data-url.html media/data-url-cross-origin.html media/media-controller-playback.html media/media-element-play-after-eos.html media/media-ended-fired-once.html ... (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80656 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149530 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15163 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131691 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93675 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14423 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12193 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2674 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124002 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/9558 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157555 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/706 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/10989 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120940 "Found 59 new test failures: imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/createImageBitmap-invalid-args.html imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/createImageBitmap-serializable.html imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/createImageBitmap-transfer.html media/audio-data-url.html media/data-url-cross-origin.html media/media-controller-playback.html media/media-element-play-after-eos.html media/media-ended-fired-once.html media/media-fragments/TC0004.html media/media-fragments/TC0005.html ... (failure)") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19043 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15989 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121144 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19052 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131310 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74843 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16781 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8217 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18662 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82413 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18392 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18542 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18450 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->