### PR TITLE
WorkerNavigator::gpu() can only be invoked from a worker

### DIFF
--- a/Source/WebCore/Modules/gamepad/NavigatorGamepad.cpp
+++ b/Source/WebCore/Modules/gamepad/NavigatorGamepad.cpp
@@ -54,12 +54,7 @@ NavigatorGamepad::NavigatorGamepad(Navigator& navigator)
 
 NavigatorGamepad::~NavigatorGamepad()
 {
-    GamepadManager::singleton().unregisterNavigator(protectedNavigator());
-}
-
-Ref<Navigator> NavigatorGamepad::protectedNavigator() const
-{
-    return m_navigator.get();
+    GamepadManager::singleton().unregisterNavigator(m_navigator.get());
 }
 
 ASCIILiteral NavigatorGamepad::supplementName()

--- a/Source/WebCore/Modules/gamepad/NavigatorGamepad.h
+++ b/Source/WebCore/Modules/gamepad/NavigatorGamepad.h
@@ -71,14 +71,13 @@ public:
 
 private:
     static ASCIILiteral supplementName();
-    Ref<Navigator> protectedNavigator() const;
 
     void gamepadsBecameVisible();
     void maybeNotifyRecentAccess();
 
     const Vector<RefPtr<Gamepad>>& gamepads();
 
-    CheckedRef<Navigator> m_navigator;
+    const CheckedRef<Navigator> m_navigator;
     Vector<RefPtr<Gamepad>> m_gamepads;
 };
 

--- a/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -12,7 +12,6 @@ Modules/fetch/FetchBodyOwner.cpp
 Modules/fetch/FetchLoader.cpp
 Modules/fetch/FetchResponse.cpp
 Modules/gamepad/GamepadManager.cpp
-Modules/gamepad/NavigatorGamepad.cpp
 Modules/geolocation/Geolocation.cpp
 Modules/geolocation/GeolocationController.cpp
 Modules/highlight/AppHighlightStorage.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -463,7 +463,6 @@ page/IntersectionObserver.cpp
 page/LocalDOMWindow.cpp
 page/LocalFrame.cpp
 page/LocalFrameView.cpp
-page/Navigator.cpp
 page/OpportunisticTaskScheduler.cpp
 page/PageColorSampler.cpp
 page/PageConsoleClient.cpp
@@ -498,7 +497,6 @@ page/UserMessageHandlersNamespace.cpp
 page/VisitedLinkStore.cpp
 page/VisualViewport.cpp
 page/WindowOrWorkerGlobalScope.cpp
-page/WorkerNavigator.cpp
 page/cocoa/ResourceUsageThreadCocoa.mm
 page/cocoa/WebTextIndicatorLayer.mm
 page/mac/EventHandlerMac.mm

--- a/Source/WebCore/page/Navigator.cpp
+++ b/Source/WebCore/page/Navigator.cpp
@@ -73,7 +73,7 @@ Navigator::~Navigator() = default;
 
 String Navigator::appVersion() const
 {
-    auto* frame = this->frame();
+    RefPtr frame = this->frame();
     if (!frame)
         return String();
     if (frame->settings().webAPIStatisticsEnabled())
@@ -300,7 +300,7 @@ void Navigator::initializePluginAndMimeTypeArrays()
 
 DOMPluginArray& Navigator::plugins()
 {
-    if (auto* frame = this->frame(); frame && frame->settings().webAPIStatisticsEnabled())
+    if (RefPtr frame = this->frame(); frame && frame->settings().webAPIStatisticsEnabled())
         ResourceLoadObserver::shared().logNavigatorAPIAccessed(*frame->protectedDocument(), NavigatorAPIsAccessed::Plugins);
 
     initializePluginAndMimeTypeArrays();
@@ -309,7 +309,7 @@ DOMPluginArray& Navigator::plugins()
 
 DOMMimeTypeArray& Navigator::mimeTypes()
 {
-    if (auto* frame = this->frame(); frame && frame->settings().webAPIStatisticsEnabled())
+    if (RefPtr frame = this->frame(); frame && frame->settings().webAPIStatisticsEnabled())
         ResourceLoadObserver::shared().logNavigatorAPIAccessed(*frame->protectedDocument(), NavigatorAPIsAccessed::MimeTypes);
 
     initializePluginAndMimeTypeArrays();
@@ -325,7 +325,7 @@ bool Navigator::pdfViewerEnabled()
 
 bool Navigator::cookieEnabled() const
 {
-    auto* frame = this->frame();
+    RefPtr frame = this->frame();
     if (!frame)
         return false;
 
@@ -350,7 +350,7 @@ bool Navigator::cookieEnabled() const
 
 bool Navigator::standalone() const
 {
-    auto* frame = this->frame();
+    RefPtr frame = this->frame();
     return frame && frame->settings().standalone();
 }
 
@@ -360,15 +360,15 @@ GPU* Navigator::gpu()
 {
 #if HAVE(WEBGPU_IMPLEMENTATION)
     if (!m_gpuForWebGPU) {
-        auto* frame = this->frame();
+        RefPtr frame = this->frame();
         if (!frame)
             return nullptr;
         if (!frame->settings().webGPUEnabled())
             return nullptr;
-        auto* page = frame->page();
+        RefPtr page = frame->page();
         if (!page)
             return nullptr;
-        auto gpu = page->chrome().createGPUForWebGPU();
+        RefPtr gpu = page->chrome().createGPUForWebGPU();
         if (!gpu)
             return nullptr;
 
@@ -381,7 +381,7 @@ GPU* Navigator::gpu()
 
 Page* Navigator::page()
 {
-    auto* frame = this->frame();
+    RefPtr frame = this->frame();
     return frame ? frame->page() : nullptr;
 }
 

--- a/Source/WebCore/page/WorkerNavigator.cpp
+++ b/Source/WebCore/page/WorkerNavigator.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2008 Apple Inc. All Rights Reserved.
+ * Copyright (C) 2008-2025 Apple Inc. All Rights Reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -65,28 +65,15 @@ GPU* WorkerNavigator::gpu()
 {
 #if HAVE(WEBGPU_IMPLEMENTATION)
     if (!m_gpuForWebGPU) {
-        auto scriptExecutionContext = this->scriptExecutionContext();
-        if (scriptExecutionContext->isWorkerGlobalScope()) {
-            WorkerGlobalScope& workerGlobalScope = downcast<WorkerGlobalScope>(*scriptExecutionContext);
-            if (!workerGlobalScope.graphicsClient())
-                return nullptr;
+        Ref context = downcast<WorkerGlobalScope>(*this->scriptExecutionContext());
+        if (!context->graphicsClient())
+            return nullptr;
 
-            RefPtr gpu = workerGlobalScope.graphicsClient()->createGPUForWebGPU();
-            if (!gpu)
-                return nullptr;
+        RefPtr gpu = context->graphicsClient()->createGPUForWebGPU();
+        if (!gpu)
+            return nullptr;
 
-            m_gpuForWebGPU = GPU::create(*gpu);
-        } else if (scriptExecutionContext->isDocument()) {
-            Ref document = downcast<Document>(*scriptExecutionContext);
-            RefPtr page = document->page();
-            if (!page)
-                return nullptr;
-            RefPtr gpu = page->chrome().createGPUForWebGPU();
-            if (!gpu)
-                return nullptr;
-
-            m_gpuForWebGPU = GPU::create(*gpu);
-        }
+        m_gpuForWebGPU = GPU::create(*gpu);
     }
 
     return m_gpuForWebGPU.get();
@@ -98,15 +85,15 @@ GPU* WorkerNavigator::gpu()
 void WorkerNavigator::setAppBadge(std::optional<unsigned long long> badge, Ref<DeferredPromise>&& promise)
 {
 #if ENABLE(DECLARATIVE_WEB_PUSH)
-    if (is<ServiceWorkerGlobalScope>(scriptExecutionContext())) {
-        if (RefPtr declarativePushEvent = downcast<ServiceWorkerGlobalScope>(scriptExecutionContext())->declarativePushEvent()) {
+    if (RefPtr context = dynamicDowncast<ServiceWorkerGlobalScope>(scriptExecutionContext())) {
+        if (RefPtr declarativePushEvent = context->declarativePushEvent()) {
             declarativePushEvent->setUpdatedAppBadge(WTFMove(badge));
             return;
         }
     }
 #endif // ENABLE(DECLARATIVE_WEB_PUSH)
 
-    auto* scope = downcast<WorkerGlobalScope>(scriptExecutionContext());
+    RefPtr scope = downcast<WorkerGlobalScope>(scriptExecutionContext());
     if (!scope) {
         promise->reject(ExceptionCode::InvalidStateError);
         return;


### PR DESCRIPTION
#### 4635a5d12b4bcaf0c05d88c9e22ee9f408f09ac6
<pre>
WorkerNavigator::gpu() can only be invoked from a worker
<a href="https://bugs.webkit.org/show_bug.cgi?id=293800">https://bugs.webkit.org/show_bug.cgi?id=293800</a>

Reviewed by Mike Wyrzykowski.

* Source/WebCore/Modules/gamepad/NavigatorGamepad.cpp:
(WebCore::NavigatorGamepad::protectedNavigator const): Deleted.

This method is unneeded as we can const m_navigator instead.

* Source/WebCore/page/Navigator.cpp:

Apply <a href="https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines">https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines</a>

* Source/WebCore/page/WorkerNavigator.cpp:
(WebCore::WorkerNavigator::gpu):

As this method can only be invoked from a worker, it does not make
sense for it to implement logic for documents.

(WebCore::WorkerNavigator::setAppBadge):

Adopt dynamicDowncast&lt;&gt; and RefPtr.

Canonical link: <a href="https://commits.webkit.org/295642@main">https://commits.webkit.org/295642@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/78a7f695f5b120dd9c5db2fe9355b7446b34c87b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105647 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25396 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15793 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110840 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/56242 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/107688 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/25868 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33903 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80236 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108653 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/20232 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95350 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60542 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/19968 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13439 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55678 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/89681 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13482 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/113688 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32785 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24181 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89316 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33147 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91573 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88974 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33848 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11657 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/28242 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17155 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32710 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/38105 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32456 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35805 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34054 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->