### PR TITLE
Rename `-prepareResouceMonitorRulesForStore:` to `-prepareResourceMonitorRulesForStore:`

### DIFF
--- a/Source/WebCore/PAL/pal/spi/cocoa/WebPrivacySPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/WebPrivacySPI.h
@@ -171,13 +171,13 @@ typedef void (^WPRestrictedOpenerDomainsCompletionHandler)(NSArray<WPRestrictedO
 typedef void (^WKWPResourcesPrepareCompletionHandler)(WKContentRuleList *, bool, NSError *);
 
 @interface WPResources (Staging_141646051)
-- (void)prepareResouceMonitorRulesForStore:(WKContentRuleListStore *)store completionHandler:(WKWPResourcesPrepareCompletionHandler)completionHandler;
+- (void)prepareResourceMonitorRulesForStore:(WKContentRuleListStore *)store completionHandler:(WKWPResourcesPrepareCompletionHandler)completionHandler;
 @end
 
 typedef void (^WKWPResourcesGetSourceCompletionHandler)(NSString *, NSError *);
 
 @interface WPResources (Staging_146076707)
-- (void)requestResouceMonitorRulesSource:(WPResourceRequestOptions *)options completionHandler:(WKWPResourcesGetSourceCompletionHandler)completion;
+- (void)requestResourceMonitorRulesSource:(WPResourceRequestOptions *)options completionHandler:(WKWPResourcesGetSourceCompletionHandler)completion;
 @end
 
 WTF_EXTERN_C_BEGIN

--- a/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.mm
+++ b/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.mm
@@ -415,7 +415,7 @@ ResourceMonitorURLsController& ResourceMonitorURLsController::singleton()
 void ResourceMonitorURLsController::prepare(CompletionHandler<void(WKContentRuleList*, bool)>&& completionHandler)
 {
     ASSERT(RunLoop::isMain());
-    if (!PAL::isWebPrivacyFrameworkAvailable() || ![PAL::getWPResourcesClass() instancesRespondToSelector:@selector(prepareResouceMonitorRulesForStore:completionHandler:)]) {
+    if (!PAL::isWebPrivacyFrameworkAvailable() || ![PAL::getWPResourcesClass() instancesRespondToSelector:@selector(prepareResourceMonitorRulesForStore:completionHandler:)]) {
         completionHandler(nullptr, false);
         return;
     }
@@ -427,7 +427,7 @@ void ResourceMonitorURLsController::prepare(CompletionHandler<void(WKContentRule
 
     WKContentRuleListStore *store = [WKContentRuleListStore defaultStore];
 
-    [[PAL::getWPResourcesClass() sharedInstance] prepareResouceMonitorRulesForStore:store completionHandler:^(WKContentRuleList *list, bool updated, NSError *error) {
+    [[PAL::getWPResourcesClass() sharedInstance] prepareResourceMonitorRulesForStore:store completionHandler:^(WKContentRuleList *list, bool updated, NSError *error) {
         if (error)
             RELEASE_LOG_ERROR(ResourceMonitoring, "Failed to request resource monitor urls from WebPrivacy: %@", error);
 
@@ -439,7 +439,7 @@ void ResourceMonitorURLsController::prepare(CompletionHandler<void(WKContentRule
 void ResourceMonitorURLsController::getSource(CompletionHandler<void(String&&)>&& completionHandler)
 {
     ASSERT(RunLoop::isMain());
-    if (!PAL::isWebPrivacyFrameworkAvailable() || ![PAL::getWPResourcesClass() instancesRespondToSelector:@selector(requestResouceMonitorRulesSource:completionHandler:)]) {
+    if (!PAL::isWebPrivacyFrameworkAvailable() || ![PAL::getWPResourcesClass() instancesRespondToSelector:@selector(requestResourceMonitorRulesSource:completionHandler:)]) {
         completionHandler({ });
         return;
     }
@@ -449,7 +449,7 @@ void ResourceMonitorURLsController::getSource(CompletionHandler<void(String&&)>&
     if (lookupCompletionHandlers->size() > 1)
         return;
 
-    [[PAL::getWPResourcesClass() sharedInstance] requestResouceMonitorRulesSource:nil completionHandler:^(NSString *source, NSError *error) {
+    [[PAL::getWPResourcesClass() sharedInstance] requestResourceMonitorRulesSource:nil completionHandler:^(NSString *source, NSError *error) {
         if (error)
             RELEASE_LOG_ERROR(ResourceMonitoring, "Failed to request resource monitor urls source from WebPrivacy");
 


### PR DESCRIPTION
#### afc2b48caf8b621e71b81668e2f2ef82e2cc1f99
<pre>
Rename `-prepareResouceMonitorRulesForStore:` to `-prepareResourceMonitorRulesForStore:`
<a href="https://bugs.webkit.org/show_bug.cgi?id=293802">https://bugs.webkit.org/show_bug.cgi?id=293802</a>

Reviewed by Abrar Rahman Protyasha.

Fix the spelling for this staged declaration, from `ResouceMonitor` to `ResourceMonitor`.
Note that the new (fixed) name was introduced in <a href="https://rdar.apple.com/152277854">rdar://152277854</a>, so this change can&apos;t land until
that change is available in all relevant configurations.

* Source/WebCore/PAL/pal/spi/cocoa/WebPrivacySPI.h:
* Source/WebKit/Platform/cocoa/WebPrivacyHelpers.mm:
(WebKit::ResourceMonitorURLsController::prepare):
(WebKit::ResourceMonitorURLsController::getSource):

Canonical link: <a href="https://commits.webkit.org/295836@main">https://commits.webkit.org/295836@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/655d9bd9c28b8c74cd1c0660f70975e656cd43bc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105631 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25380 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15772 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110824 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/56229 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/107672 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/25908 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33881 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80219 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108637 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/20264 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95323 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60528 "Found 140 new API test failures: /WPE/TestFrame:/webkit/WebKitFrame/main-frame, /WPE/TestAuthentication:/webkit/Authentication/authentication-cancel, /WPE/TestUIClient:/webkit/WebKitWebView/usermedia-enumeratedevices-permission-check, /WPE/TestWebKitFindController:/webkit/WebKitFindController/counted-matches, /WPE/TestWebKitWebView:/webkit/WebKitWebView/disable-web-security, /WPE/TestWebsiteData:/webkit/WebKitWebsiteData/cache, /WPE/TestWebKitFindController:/webkit/WebKitFindController/options, /WPE/TestCookieManager:/webkit/WebKitCookieManager/get-cookies, /WPE/TestResources:/webkit/WebKitWebResource/response, /WPE/TestWebsiteData:/webkit/WebKitWebsiteData/storage ... (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/19988 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13415 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55662 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/89714 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13475 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/113685 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32769 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24163 "Found 1 new test failure: imported/w3c/web-platform-tests/css/cssom-view/scrollintoview-containingblock-chain.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89313 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33131 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91552 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88969 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22826 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33833 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11633 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/28219 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32695 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/38079 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32441 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35789 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34038 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->