### PR TITLE
Reland [WebAuthn] Implement batching for checking allowCredentials

### DIFF
--- a/LayoutTests/http/wpt/webauthn/public-key-credential-get-failure-hid.https-expected.txt
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-get-failure-hid.https-expected.txt
@@ -5,4 +5,5 @@ PASS PublicKeyCredential's [[get]] with authenticator downgrade failed in a mock
 PASS PublicKeyCredential's [[get]] with authenticator downgrade failed in a mock hid authenticator. 2
 PASS PublicKeyCredential's [[get]] with authenticator downgrade succeeded and then U2F failed in a mock hid authenticator.
 PASS PublicKeyCredential's [[get]] with getNextAssertion failed in a mock hid authenticator.
+PASS PublicKeyCredential's [[get]] with many allowedCredentials necessitating batching without a match.
 

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-get-failure-hid.https.html
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-get-failure-hid.https.html
@@ -83,4 +83,25 @@
             internals.setMockWebAuthenticationConfiguration({ hid: { stage: "request", subStage: "msg", error: "malicious-payload", payloadBase64: [testAssertionMessageLongBase64, testCtapErrNotAllowedResponseBase64] } });
         return promiseRejects(t, "UnknownError", navigator.credentials.get(options), "Unknown internal error. Error code: 48");
     }, "PublicKeyCredential's [[get]] with getNextAssertion failed in a mock hid authenticator.");
+
+    promise_test(function(t) {
+        const config = { hid: { stage: "request", subStage: "msg", error: "malicious-payload", payloadBase64: [testCtapErrInvalidCredentialResponseBase64] } };
+        const options = {
+            publicKey: {
+                challenge: asciiToUint8Array("123456"),
+                allowCredentials: [],
+            }
+        };
+
+        const numCredentials = 5;
+
+        for (let i = 0; i < numCredentials; i++) {
+            config.hid.payloadBase64.unshift("Lg==");
+            options.publicKey.allowCredentials.push({ type: "public-key", id: generateID(i) });
+        }
+
+        if (window.internals)
+            internals.setMockWebAuthenticationConfiguration(config);
+        return promiseRejects(t, "UnknownError", navigator.credentials.get(options), "Unknown internal error. Error code: 34");
+    }, "PublicKeyCredential's [[get]] with many allowedCredentials necessitating batching without a match.");
 </script>

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-get-success-hid.https-expected.txt
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-get-success-hid.https-expected.txt
@@ -8,4 +8,6 @@ PASS PublicKeyCredential's [[get]] with mixed options in a mock hid authenticato
 PASS PublicKeyCredential's [[get]] with two consecutive requests.
 PASS PublicKeyCredential's [[get]] with multiple accounts in a mock hid authenticator.
 PASS PublicKeyCredential's [[get]] with PIN supported in the authenticator but userVerification = 'discouraged' in a mock hid authenticator.
+PASS PublicKeyCredential's [[get]] with many allowCredentials necessitating batching in a mock hid authenticator.
+PASS PublicKeyCredential's [[get]] with many allowCredentials necessitating batching in a mock hid authenticator. 2
 

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-get-success-hid.https.html
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-get-success-hid.https.html
@@ -159,4 +159,52 @@
             return checkCtapGetAssertionResult(credential);
         });
     }, "PublicKeyCredential's [[get]] with PIN supported in the authenticator but userVerification = 'discouraged' in a mock hid authenticator.");
+
+    promise_test(t => {
+        let config = { hid: { stage: "request", subStage: "msg", error: "success", payloadBase64: [testAssertionMessageBase64] } };
+        const options = {
+            publicKey: {
+                challenge: Base64URL.parse("MTIzNDU2"),
+                timeout: 1000,
+                allowCredentials: [],
+            }
+        };
+
+        const numCredentials = 20;
+
+        for (let i = 0; i < numCredentials; i++) {
+            options.publicKey.allowCredentials.push({ type: "public-key", id: generateID(i) });
+            config.hid.payloadBase64.unshift("Lg==");
+        }
+
+        if (window.internals)
+            internals.setMockWebAuthenticationConfiguration(config);
+        return navigator.credentials.get(options).then(credential => {
+            return checkCtapGetAssertionResult(credential);
+        });
+    }, "PublicKeyCredential's [[get]] with many allowCredentials necessitating batching in a mock hid authenticator.");
+
+    promise_test(t => {
+        let config = { hid: { maxCredentialCountInList: 5, stage: "request", subStage: "msg", error: "success", payloadBase64: [testAssertionMessageBase64] } };
+        const options = {
+            publicKey: {
+                challenge: Base64URL.parse("MTIzNDU2"),
+                timeout: 1000,
+                allowCredentials: [],
+            }
+        };
+
+        const numCredentials = 20;
+
+        for (let i = 0; i < numCredentials; i++)
+            options.publicKey.allowCredentials.push({ type: "public-key", id: generateID(i) });
+        for (let i = 0; i < Math.ceil(numCredentials/config.hid.maxCredentialCountInList); i++)
+            config.hid.payloadBase64.unshift("Lg==");
+
+        if (window.internals)
+            internals.setMockWebAuthenticationConfiguration(config);
+        return navigator.credentials.get(options).then(credential => {
+            checkCtapGetAssertionResult(credential);
+        });
+    }, "PublicKeyCredential's [[get]] with many allowCredentials necessitating batching in a mock hid authenticator. 2");
 </script>

--- a/Source/WebCore/Modules/webauthn/fido/DeviceRequestConverter.cpp
+++ b/Source/WebCore/Modules/webauthn/fido/DeviceRequestConverter.cpp
@@ -222,13 +222,17 @@ Vector<uint8_t> encodeSilentGetAssertion(const String& rpId, const Vector<uint8_
     return cborRequest;
 }
 
-Vector<uint8_t> encodeGetAssertionRequestAsCBOR(const Vector<uint8_t>& hash, const PublicKeyCredentialRequestOptions& options, UVAvailability uvCapability, const Vector<String>& authenticatorSupportedExtensions, std::optional<PinParameters> pin)
+Vector<uint8_t> encodeGetAssertionRequestAsCBOR(const Vector<uint8_t>& hash, const PublicKeyCredentialRequestOptions& options, UVAvailability uvCapability, const Vector<String>& authenticatorSupportedExtensions, std::optional<PinParameters> pin, std::optional<Vector<PublicKeyCredentialDescriptor>>&& overrideAllowCredentials)
 {
     CBORValue::MapValue cborMap;
     cborMap[CBORValue(1)] = CBORValue(options.rpId);
     cborMap[CBORValue(2)] = CBORValue(hash);
-
-    if (!options.allowCredentials.isEmpty()) {
+    if (overrideAllowCredentials) {
+        CBORValue::ArrayValue allowListArray;
+        for (const auto& descriptor : *overrideAllowCredentials)
+            allowListArray.append(convertDescriptorToCBOR(descriptor));
+        cborMap[CBORValue(3)] = CBORValue(WTFMove(allowListArray));
+    } else if (!options.allowCredentials.isEmpty()) {
         CBORValue::ArrayValue allowListArray;
         for (const auto& descriptor : options.allowCredentials)
             allowListArray.append(convertDescriptorToCBOR(descriptor));

--- a/Source/WebCore/Modules/webauthn/fido/DeviceRequestConverter.h
+++ b/Source/WebCore/Modules/webauthn/fido/DeviceRequestConverter.h
@@ -57,7 +57,7 @@ WEBCORE_EXPORT Vector<uint8_t> encodeMakeCredentialRequestAsCBOR(const Vector<ui
 // Serializes GetAssertion request parameter into CBOR encoded map with
 // integer keys and CBOR encoded values as defined by the CTAP spec.
 // https://fidoalliance.org/specs/fido-v2.0-ps-20170927/fido-client-to-authenticator-protocol-v2.0-ps-20170927.html#authenticatorGetAssertion
-WEBCORE_EXPORT Vector<uint8_t> encodeGetAssertionRequestAsCBOR(const Vector<uint8_t>& hash, const WebCore::PublicKeyCredentialRequestOptions&, AuthenticatorSupportedOptions::UserVerificationAvailability, const Vector<String>& authenticatorSupportedExtensions, std::optional<PinParameters> = std::nullopt);
+WEBCORE_EXPORT Vector<uint8_t> encodeGetAssertionRequestAsCBOR(const Vector<uint8_t>& hash, const WebCore::PublicKeyCredentialRequestOptions&, AuthenticatorSupportedOptions::UserVerificationAvailability, const Vector<String>& authenticatorSupportedExtensions, std::optional<PinParameters> = std::nullopt, std::optional<Vector<WebCore::PublicKeyCredentialDescriptor>>&& = std::nullopt);
 
 WEBCORE_EXPORT Vector<uint8_t> encodeBogusRequestForAuthenticatorSelection();
 WEBCORE_EXPORT Vector<uint8_t> encodeSilentGetAssertion(const String& rpId, const Vector<uint8_t>& hash, const Vector<WebCore::PublicKeyCredentialDescriptor>& credentials, std::optional<PinParameters> = std::nullopt);

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.cpp
@@ -135,20 +135,26 @@ void CtapAuthenticator::makeCredential()
             ASSERT(RunLoop::isMain());
             if (!weakThis)
                 return;
-            weakThis->continueCheckExcludedCredentialsAfterResponseRecieved(WTFMove(data));
+            weakThis->continueSilentlyCheckCredentials(WTFMove(data), [weakThis = WTFMove(weakThis)] (bool foundMatch) mutable {
+                if (!weakThis)
+                    return;
+                weakThis->continueMakeCredentialAfterCheckExcludedCredentials(foundMatch);
+            });
         });
     } else
         continueMakeCredentialAfterCheckExcludedCredentials();
 }
 
-void CtapAuthenticator::continueCheckExcludedCredentialsAfterResponseRecieved(Vector<uint8_t>&& data)
+void CtapAuthenticator::continueSilentlyCheckCredentials(Vector<uint8_t>&& data, CompletionHandler<void(bool)>&& completionHandler)
 {
     auto error = getResponseCode(data);
-    CTAP_RELEASE_LOG("continueCheckExcludedCredentialsAfterResponseRecieved: Got error code: %hhu from authenticator.", enumToUnderlyingType(error));
+    CTAP_RELEASE_LOG("continueSilentlyCheckCredentials: Got error code: %hhu from authenticator.", enumToUnderlyingType(error));
 
     if (error == CtapDeviceResponseCode::kSuccess)
-        return continueMakeCredentialAfterCheckExcludedCredentials(true);
+        return completionHandler(true);
     if (error == CtapDeviceResponseCode::kCtap2ErrNoCredentials) {
+        if (m_currentBatch + 1 >= m_batches.size())
+            return completionHandler(false);
         m_currentBatch += 1;
         if (m_currentBatch >= m_batches.size())
             return continueMakeCredentialAfterCheckExcludedCredentials();
@@ -160,18 +166,23 @@ void CtapAuthenticator::continueCheckExcludedCredentialsAfterResponseRecieved(Ve
         if (tryRestartPin(error))
             return;
     }
-    auto& options = std::get<PublicKeyCredentialCreationOptions>(requestData().options);
 
+    Vector<uint8_t> cborCmd;
     auto response = readCTAPGetAssertionResponse(data, AuthenticatorAttachment::CrossPlatform);
     std::optional<PinParameters> pinParameters;
     if (!m_pinAuth.isEmpty())
         pinParameters = PinParameters { pin::kProtocolVersion, m_pinAuth };
-    Vector<uint8_t> cborCmd = encodeSilentGetAssertion(options.rp.id, requestData().hash, m_batches[m_currentBatch], pinParameters);
-    protectedDriver()->transact(WTFMove(cborCmd), [weakThis = WeakPtr { *this }](Vector<uint8_t>&& data) {
+    WTF::switchOn(requestData().options, [&](const PublicKeyCredentialCreationOptions& options) {
+        cborCmd = encodeSilentGetAssertion(options.rp.id, requestData().hash, m_batches[m_currentBatch], pinParameters);
+    }, [&](const PublicKeyCredentialRequestOptions& options) {
+        cborCmd = encodeSilentGetAssertion(options.rpId, requestData().hash, m_batches[m_currentBatch], pinParameters);
+    });
+
+    protectedDriver()->transact(WTFMove(cborCmd), [weakThis = WeakPtr { *this }, completionHandler = WTFMove(completionHandler)](Vector<uint8_t>&& data) mutable {
         ASSERT(RunLoop::isMain());
         if (!weakThis)
-            return;
-        weakThis->continueCheckExcludedCredentialsAfterResponseRecieved(WTFMove(data));
+            return completionHandler(false);
+        weakThis->continueSilentlyCheckCredentials(WTFMove(data), WTFMove(completionHandler));
     });
 }
 
@@ -271,19 +282,52 @@ void CtapAuthenticator::continueMakeCredentialAfterResponseReceived(Vector<uint8
 
 void CtapAuthenticator::getAssertion()
 {
+    CTAP_RELEASE_LOG("getAssertion");
+
+    auto& options = std::get<PublicKeyCredentialRequestOptions>(requestData().options);
+    if (options.allowCredentials.size() > 1) {
+        uint32_t maxBatchSize = 1;
+        if (m_info.maxCredentialIDLength() && m_info.maxCredentialCountInList())
+            maxBatchSize = *m_info.maxCredentialCountInList();
+        m_batches = batchesForCredentials(options.allowCredentials, maxBatchSize, m_info.maxCredentialIDLength());
+        ASSERT(m_batches.size());
+        if (!m_batches.size())
+            return continueGetAssertionAfterCheckAllowCredentials();
+        m_currentBatch = 0;
+        Vector<uint8_t> cborCmd = encodeSilentGetAssertion(options.rpId, requestData().hash, m_batches[m_currentBatch], std::nullopt);
+        protectedDriver()->transact(WTFMove(cborCmd), [weakThis = WeakPtr { *this }](Vector<uint8_t>&& data) {
+            ASSERT(RunLoop::isMain());
+            if (!weakThis)
+                return;
+            weakThis->continueSilentlyCheckCredentials(WTFMove(data), [weakThis = WTFMove(weakThis)] (bool) mutable {
+                if (!weakThis)
+                    return;
+                weakThis->continueGetAssertionAfterCheckAllowCredentials();
+            });
+        });
+    } else
+        continueGetAssertionAfterCheckAllowCredentials();
+}
+
+void CtapAuthenticator::continueGetAssertionAfterCheckAllowCredentials()
+{
     ASSERT(!m_isDowngraded);
     Vector<uint8_t> cborCmd;
     auto& options = std::get<PublicKeyCredentialRequestOptions>(requestData().options);
+
     auto internalUVAvailability = m_info.options().userVerificationAvailability();
     Vector<String> authenticatorSupportedExtensions;
+    Vector<PublicKeyCredentialDescriptor> overrideAllowCredentials;
+    if (m_currentBatch < m_batches.size())
+        overrideAllowCredentials = m_batches[m_currentBatch];
     CTAP_RELEASE_LOG("getAssertion uv: %hhu internalUvAvailability %d", options.userVerification, internalUVAvailability);
     // If UV is required, then either built-in uv or a pin will work.
     if (internalUVAvailability == UVAvailability::kSupportedAndConfigured && options.userVerification != UserVerificationRequirement::Discouraged && m_pinAuth.isEmpty())
-        cborCmd = encodeGetAssertionRequestAsCBOR(requestData().hash, options, internalUVAvailability, authenticatorSupportedExtensions);
+        cborCmd = encodeGetAssertionRequestAsCBOR(requestData().hash, options, internalUVAvailability, authenticatorSupportedExtensions, std::nullopt, WTFMove(overrideAllowCredentials));
     else if (m_info.options().clientPinAvailability() == AuthenticatorSupportedOptions::ClientPinAvailability::kSupportedAndPinSet && options.userVerification != UserVerificationRequirement::Discouraged)
-        cborCmd = encodeGetAssertionRequestAsCBOR(requestData().hash, options, internalUVAvailability, authenticatorSupportedExtensions, PinParameters { pin::kProtocolVersion, m_pinAuth });
+        cborCmd = encodeGetAssertionRequestAsCBOR(requestData().hash, options, internalUVAvailability, authenticatorSupportedExtensions, PinParameters { pin::kProtocolVersion, m_pinAuth }, WTFMove(overrideAllowCredentials));
     else
-        cborCmd = encodeGetAssertionRequestAsCBOR(requestData().hash, options, internalUVAvailability, authenticatorSupportedExtensions);
+        cborCmd = encodeGetAssertionRequestAsCBOR(requestData().hash, options, internalUVAvailability, authenticatorSupportedExtensions, std::nullopt, WTFMove(overrideAllowCredentials));
     if (m_info.maxMsgSize() && cborCmd.size() >= *m_info.maxMsgSize())
         CTAP_RELEASE_LOG("getAssertion cmdSize = %lu maxMsgSize = %u", cborCmd.size(), *m_info.maxMsgSize());
     CTAP_RELEASE_LOG("getAssertion: Sending %s", base64EncodeToString(cborCmd).utf8().data());

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.h
@@ -55,8 +55,9 @@ private:
     void makeCredential() final;
     void continueMakeCredentialAfterResponseReceived(Vector<uint8_t>&&);
     void getAssertion() final;
-    void continueCheckExcludedCredentialsAfterResponseRecieved(Vector<uint8_t>&& data);
+    void continueSilentlyCheckCredentials(Vector<uint8_t>&&, CompletionHandler<void(bool)>&&);
     void continueMakeCredentialAfterCheckExcludedCredentials(bool includeCurrentBatch = false);
+    void continueGetAssertionAfterCheckAllowCredentials();
     void continueGetAssertionAfterResponseReceived(Vector<uint8_t>&&);
     void continueGetNextAssertionAfterResponseReceived(Vector<uint8_t>&&);
 


### PR DESCRIPTION
#### 4886788e43af189ee5e27458d300abb1b9f652ac
<pre>
Reland [WebAuthn] Implement batching for checking allowCredentials
<a href="https://bugs.webkit.org/show_bug.cgi?id=293805">https://bugs.webkit.org/show_bug.cgi?id=293805</a>
<a href="https://rdar.apple.com/problem/152317844">rdar://problem/152317844</a>

Reviewed by Brent Fulgham.

This change implements checking the allowCredentials in batches as supported by
the authenticator during getAssertion. This is accomplished with smaller up=0,
get requests to determine if credentials are present on the authenticator.

Then if a credential is detected as present, it is included in the allowCredentials list
in the real request. If no credentials matched, then we already know the call will not
be able to succeed, so we just include the last batch.

Added layout tests for the new behaviors.

This patch includes improved behavior with security keys that by policy always require
user verification. This fixes an issue with the previous iteration of this patch where
we would not retain the pin information during silent requests, causing users to be
prompted for a pin multiple times.

Canonical link: <a href="https://commits.webkit.org/295931@main">https://commits.webkit.org/295931@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1626cf25da216c6dd8bedb36be013fd3d70a6a39

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/106516 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/26266 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/16663 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/111804 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/57112 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/108555 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/26936 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34768 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/80950 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/109520 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/21355 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/96113 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/61286 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/20816 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/14215 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/56553 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/90693 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/14249 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/114578 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33654 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24805 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89955 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/34018 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/92344 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89665 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22900 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34562 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/12383 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/29263 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/33579 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/38992 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/33325 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/36678 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34924 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->