### PR TITLE
AX: Crash when navigating character-by-character via VoiceOver in text with multi-byte glyphs (e.g. emojis)

### DIFF
--- a/LayoutTests/accessibility/mac/bounds-for-range-multibyte-glyphs-expected.txt
+++ b/LayoutTests/accessibility/mac/bounds-for-range-multibyte-glyphs-expected.txt
@@ -1,0 +1,25 @@
+This test ensures we produce the right rects via the bounds-for-range API for multi-byte glyphs.
+
+PASS: text.role.toLowerCase().includes('text') === true
+PASS: text.boundsForRangeWithPagePosition(0, 1) was equal or approximately equal to (x: 8, y: 14, w: 13, h: 18).
+PASS: text.boundsForRangeWithPagePosition(1, 1) was equal or approximately equal to (x: 19, y: 14, w: 10, h: 18).
+PASS: text.boundsForRangeWithPagePosition(2, 1) was equal or approximately equal to (x: 27, y: 14, w: 9, h: 18).
+PASS: text.boundsForRangeWithPagePosition(3, 2) was equal or approximately equal to (x: 34, y: 14, w: 23, h: 18).
+PASS: text.boundsForRangeWithPagePosition(5, 1) was equal or approximately equal to (x: 55, y: 14, w: 10, h: 18).
+PASS: text.boundsForRangeWithPagePosition(6, 1) was equal or approximately equal to (x: 63, y: 14, w: 9, h: 18).
+PASS: text.boundsForRangeWithPagePosition(7, 1) was equal or approximately equal to (x: 70, y: 14, w: 7, h: 18).
+PASS: text.boundsForRangeWithPagePosition(8, 11) was equal or approximately equal to (x: 75, y: 14, w: 23, h: 18).
+PASS: text.boundsForRangeWithPagePosition(19, 1) was equal or approximately equal to (x: 96, y: 14, w: 10, h: 18).
+PASS: text.boundsForRangeWithPagePosition(20, 1) was equal or approximately equal to (x: 104, y: 14, w: 10, h: 18).
+PASS: text.boundsForRangeWithPagePosition(21, 1) was equal or approximately equal to (x: 112, y: 14, w: 7, h: 18).
+PASS: text.boundsForRangeWithPagePosition(22, 2) was equal or approximately equal to (x: 117, y: 14, w: 23, h: 18).
+PASS: text.boundsForRangeWithPagePosition(24, 1) was equal or approximately equal to (x: 138, y: 14, w: 13, h: 18).
+PASS: text.boundsForRangeWithPagePosition(25, 1) was equal or approximately equal to (x: 149, y: 14, w: 10, h: 18).
+PASS: text.boundsForRangeWithPagePosition(26, 1) was equal or approximately equal to (x: 157, y: 14, w: 9, h: 18).
+PASS: text.boundsForRangeWithPagePosition(0, 26) was equal or approximately equal to (x: 8, y: 14, w: 151, h: 18).
+PASS: text.boundsForRangeWithPagePosition(0, 27) was equal or approximately equal to (x: 8, y: 14, w: 158, h: 18).
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/mac/bounds-for-range-multibyte-glyphs.html
+++ b/LayoutTests/accessibility/mac/bounds-for-range-multibyte-glyphs.html
@@ -1,0 +1,75 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<meta charset="utf-8">
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+
+<div id="content" role="presentation">
+Abc⁉️def🧑‍🧑‍🧒‍🧒ghi👫Abc
+</div>
+
+<script>
+var output = "This test ensures we produce the right rects via the bounds-for-range API for multi-byte glyphs.\n\n";
+// VoiceOver uses NSAccessibilityBoundsForRangeParameterizedAttribute when navigating character-by-character.
+
+var text;
+function verifyRect(location, length, x, width) {
+    // y and height are hardcoded because all rects in this test should have y=14 and height=18.
+    output += expectRectWithVariance(`text.boundsForRangeWithPagePosition(${location}, ${length})`, x, 14, width, 18, /* allowedVariance */ 2);
+}
+
+if (window.accessibilityController) {
+    var webarea = accessibilityController.rootElement.childAtIndex(0);
+    text = webarea.childAtIndex(0);
+
+    output += expect("text.role.toLowerCase().includes('text')", "true");
+    // This sequence mirrors the exact ranges VoiceOver passes to NSAccessibilityBoundsForRangeParameterizedAttribute
+    // when navigating this text character-by-character.
+    // A
+    verifyRect(0, 1, 8, 13); 
+    // b
+    verifyRect(1, 1, 19, 10); 
+    // c
+    verifyRect(2, 1, 27, 9); 
+    // ⁉️
+    verifyRect(3, 2, 34, 23); 
+    // d
+    verifyRect(5, 1, 55, 10); 
+    // e
+    verifyRect(6, 1, 63, 9); 
+    // f
+    verifyRect(7, 1, 70, 7); 
+    // 🧑‍🧑‍🧒‍🧒
+    verifyRect(8, 11, 75, 23); 
+    // g
+    verifyRect(19, 1, 96, 10); 
+    // h
+    verifyRect(20, 1, 104, 10); 
+    // i
+    verifyRect(21, 1, 112, 7); 
+    // 👫
+    verifyRect(22, 2, 117, 23); 
+    // A
+    verifyRect(24, 1, 138, 13); 
+    // b
+    verifyRect(25, 1, 149, 10); 
+    // c
+    verifyRect(26, 1, 157, 9); 
+
+    // The full range minus the last character ("c").
+    verifyRect(0, 26, 8, 151); 
+
+    // The full range.
+    verifyRect(0, 27, 8, 158); 
+
+    document.getElementById("content").style.visibility = "hidden";
+    debug(output);
+}
+</script>
+</body>
+</html>
+
+

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -959,6 +959,8 @@ accessibility/text-marker/text-marker-range-with-unordered-markers.html
 accessibility/mac/line-boundary-at-br.html [ Skip ]
 accessibility/mac/text-marker-ordering.html [ Skip ]
 
+accessibility/mac/bounds-for-range-multibyte-glyphs.html [ Skip ]
+
 accessibility/aria-controlled-table-row-visibility.html [ Skip ]
 
 # AccessibilityController::setForceInitialFrameCaching not supported on WK1.

--- a/Source/WebCore/accessibility/AXTextMarker.h
+++ b/Source/WebCore/accessibility/AXTextMarker.h
@@ -158,7 +158,9 @@ inline String originToString(TextMarkerOrigin origin)
 // Options for findMarker
 enum class CoalesceObjectBreaks : bool { No, Yes };
 enum class IgnoreBRs : bool { No, Yes };
-
+// This enum represents whether to force movement by singular offsets, vs. moving multiple offsets
+// when encountering multi-byte glyphs like emojis.
+enum class ForceSingleOffsetMovement : bool { No, Yes };
 enum class IncludeTrailingLineBreak : bool { No, Yes };
 
 struct TextMarkerData {
@@ -288,7 +290,7 @@ public:
     void clampOffsetToLengthIfNeeded(unsigned) const;
 
     // Find the next or previous marker, optionally stopping at the given ID and returning an invalid marker.
-    AXTextMarker findMarker(AXDirection, CoalesceObjectBreaks = CoalesceObjectBreaks::Yes, IgnoreBRs = IgnoreBRs::No, std::optional<AXID> = std::nullopt) const;
+    AXTextMarker findMarker(AXDirection, CoalesceObjectBreaks = CoalesceObjectBreaks::Yes, IgnoreBRs = IgnoreBRs::No, std::optional<AXID> = std::nullopt, ForceSingleOffsetMovement = ForceSingleOffsetMovement::No) const;
 
     // Starting from this text marker, these functions find a position representing the given boundary (start / end) and text unit type (e.g. line, word, paragraph).
     AXTextMarker findWord(AXDirection direction, AXTextUnitBoundary boundary) const
@@ -337,7 +339,7 @@ public:
     // Returns a range pointing to the start and end positions that have the same text styles as `this`.
     AXTextMarkerRange rangeWithSameStyle() const;
     // Starting from this marker, return a text marker that is `offset` characters away.
-    AXTextMarker nextMarkerFromOffset(unsigned) const;
+    AXTextMarker nextMarkerFromOffset(unsigned, ForceSingleOffsetMovement = ForceSingleOffsetMovement::No) const;
     // Returns the number of intermediate text markers between this and the root.
     unsigned offsetFromRoot() const;
     // Starting from this marker, navigate to the last marker before the given AXID. Assumes `this`

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
@@ -2870,8 +2870,8 @@ static NSRect computeTextBoundsForRange(NSRange range, const AXCoreObject& backi
 {
 #if ENABLE(AX_THREAD_TEXT_APIS)
     if (AXObjectCache::useAXThreadTextApis()) {
-        auto markerToLocation = AXTextMarker { backingObject, 0 }.nextMarkerFromOffset(range.location);
-        auto markerToRangeEnd = markerToLocation.nextMarkerFromOffset(range.length);
+        auto markerToLocation = AXTextMarker { backingObject, 0 }.nextMarkerFromOffset(range.location, ForceSingleOffsetMovement::Yes);
+        auto markerToRangeEnd = markerToLocation.nextMarkerFromOffset(range.length, ForceSingleOffsetMovement::Yes);
         if (!markerToRangeEnd.isValid())
             return CGRectZero;
 

--- a/Source/WebCore/platform/graphics/ComplexTextController.cpp
+++ b/Source/WebCore/platform/graphics/ComplexTextController.cpp
@@ -624,7 +624,7 @@ void ComplexTextController::advance(unsigned offset, GlyphBuffer* glyphBuffer, G
                     setHeight(paintAdvance, height(paintAdvance) - glyphOrigin(glyphIndexIntoComplexTextController + 1).y() + m_complexTextRuns[currentRunIndex + 1]->initialAdvance().height());
                 }
                 setHeight(paintAdvance, -height(paintAdvance)); // Increasing y points down
-                glyphBuffer->add(m_adjustedGlyphs[glyphIndexIntoComplexTextController], complexTextRun.font(), paintAdvance, complexTextRun.indexAt(m_glyphInCurrentRun), FloatPoint(textAutoSpaceSpacing, 0));
+                glyphBuffer->add(m_adjustedGlyphs[glyphIndexIntoComplexTextController], complexTextRun.font(), paintAdvance, complexTextRun.indexAt(m_glyphInCurrentRun) + complexTextRun.stringLocation(), FloatPoint(textAutoSpaceSpacing, 0));
             }
 
             unsigned oldCharacterInCurrentGlyph = m_characterInCurrentGlyph;


### PR DESCRIPTION
#### 9a59ea98b0a6cb5746f0898a18118dba56b57c1a
<pre>
AX: Crash when navigating character-by-character via VoiceOver in text with multi-byte glyphs (e.g. emojis)
<a href="https://bugs.webkit.org/show_bug.cgi?id=293753">https://bugs.webkit.org/show_bug.cgi?id=293753</a>
<a href="https://rdar.apple.com/152255108">rdar://152255108</a>

Reviewed by Vitor Roriz.

In AccessibilityRenderObject::textRuns, when we build text runs for use off the main-thread, part of that process
is measuring and storing character widths. It&apos;s important that the character widths we cache match the length of the
string. This matters particularly when considering multi-byte glyphs like certain emojis, which can expand the length
of the string multiple times (e.g. some emojis are 10 characters long!) but only take up one position in the GlyphBuffer.

To handle this, we padded our cached character widths with zeros based on the result of GlyphBuffer::uncheckedStringOffsetAt,
which should tell us how big the gaps created by multi-byte glyphs are. Unfortunately, ComplexTextController did not
compute this value correctly when building the glyph buffer. It only added the glyph index as the string offset, and
the glyph index is only relevant in the context of a single ComplexTextRun, not the overall string. This is easily
fixed by also adding the ComplexTextRun::stringLocation to get the real string offset for the glyph. This fixes the
crash by ensuring we pad our character widths vector as intended, thus avoiding an out-of-bounds access assert.

This commit also fixes an issue where bounding boxes for text containing multi-byte glyphs became completely wrong.
This happened because when we converted an NSRange (a location, and length based on the whole length of the string,
including sub-characters of a multi-byte glyph), we walked over the multi-byte glyphs as one &quot;location&quot;, meaning
we would generate a text marker with the wrong offset.

Fix this by passing a new parameter to AXTextMarker::findMarker that forces walks through sub-characters of multi-byte
glyphs, rather than walking over them atomically. We&apos;ll need to use this in any place an accessibility API takes an
NSRange.

* LayoutTests/accessibility/mac/bounds-for-range-multibyte-glyphs-expected.txt: Added.
* LayoutTests/accessibility/mac/bounds-for-range-multibyte-glyphs.html: Added.
* LayoutTests/platform/mac-wk1/TestExpectations:
* Source/WebCore/accessibility/AXTextMarker.cpp:
(WebCore::AXTextMarker::nextMarkerFromOffset const):
(WebCore::AXTextMarker::findMarker const):
* Source/WebCore/accessibility/AXTextMarker.h:
* Source/WebCore/accessibility/AXTextRun.cpp:
(WebCore::AXTextRuns::localRect const):
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm:
(computeTextBoundsForRange):
* Source/WebCore/platform/graphics/ComplexTextController.cpp:
(WebCore::ComplexTextController::enclosingGlyphBoundsForTextRun):

Canonical link: <a href="https://commits.webkit.org/295703@main">https://commits.webkit.org/295703@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d8bbd076063d82f0281ff3cf9310fc8f62d9bf3c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105652 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25403 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15796 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110849 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/56247 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/107693 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/25875 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33906 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80238 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108658 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/20233 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95351 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60544 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/19970 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13440 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55687 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/89682 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13483 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/113698 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32792 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24180 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89320 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33156 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91574 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88979 "Found 101 new API test failures: /TestWebKit:WebKit.PageLoadDidChangeLocationWithinPage, /TestWebKit:WebKit.AboutBlankLoad, /TestWebKit:WebKit.PreventEmptyUserAgent, /TestWebKit:WebKit.PrivateBrowsingPushStateNoHistoryCallback, /WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/content-type, /WebKitGTK/TestUIClient:/webkit/WebKitWebView/pointer-lock-permission-request, /TestWebKit:WebKit.HitTestResultNodeHandle, /TestWebKit:WebKit2TextFieldBeginAndEditEditingTest.TextFieldDidBeginShouldNotBeDispatchedForAlreadyFocusedField, /TestWebKit:WebKit.Find, /WebKitGTK/TestWebProcessExtensions:/webkit/WebKitWebProcessExtension/dom-input-element-is-user-edited ... (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22736 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33852 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11658 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/28252 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32717 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/38109 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32463 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35812 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34061 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->