### PR TITLE
Use more C++ Concepts in WebCore

### DIFF
--- a/Source/WebCore/platform/graphics/Color.h
+++ b/Source/WebCore/platform/graphics/Color.h
@@ -88,10 +88,10 @@ public:
     Color(std::optional<SRGBA<uint8_t>>, OptionSet<Flags> = { });
     WEBCORE_EXPORT Color(std::optional<ColorDataForIPC>&&);
 
-    template<typename ColorType, typename std::enable_if_t<IsColorTypeWithComponentType<ColorType, float>>* = nullptr>
+    template<IsColorTypeWithComponentType<float> ColorType>
     Color(const ColorType&, OptionSet<Flags> = { });
 
-    template<typename ColorType, typename std::enable_if_t<IsColorTypeWithComponentType<ColorType, float>>* = nullptr>
+    template<IsColorTypeWithComponentType<float> ColorType>
     Color(const std::optional<ColorType>&, OptionSet<Flags> = { });
 
     explicit Color(WTF::HashTableEmptyValueType);
@@ -365,13 +365,13 @@ inline Color::Color(std::optional<SRGBA<uint8_t>> color, OptionSet<Flags> flags)
         setColor(*color, toFlagsIncludingPrivate(flags));
 }
 
-template<typename ColorType, typename std::enable_if_t<IsColorTypeWithComponentType<ColorType, float>>*>
+template<IsColorTypeWithComponentType<float> ColorType>
 inline Color::Color(const ColorType& color, OptionSet<Flags> flags)
 {
     setOutOfLineComponents(OutOfLineComponents::create(asColorComponents(color.unresolved())), ColorSpaceFor<ColorType>, toFlagsIncludingPrivate(flags));
 }
 
-template<typename ColorType, typename std::enable_if_t<IsColorTypeWithComponentType<ColorType, float>>*>
+template<IsColorTypeWithComponentType<float> ColorType>
 inline Color::Color(const std::optional<ColorType>& color, OptionSet<Flags> flags)
 {
     if (color)

--- a/Source/WebCore/platform/graphics/ColorModels.h
+++ b/Source/WebCore/platform/graphics/ColorModels.h
@@ -87,14 +87,16 @@ private:
     {
     }
 
-    template<typename C, typename std::enable_if_t<std::is_same_v<typename C::ComponentType, float>>* = nullptr>
+    template<typename C>
+        requires std::is_same_v<typename C::ComponentType, float>
     static constexpr C resolve(C color)
     {
         auto [c1, c2, c3, alpha] = resolveColorComponents(asColorComponents(ExposedColorType<C, typename C::Model> { color }));
         return ColorType { c1, c2, c3, alpha };
     }
 
-    template<typename C, typename std::enable_if_t<std::is_same_v<typename C::ComponentType, uint8_t>>* = nullptr>
+    template<typename C>
+        requires std::is_same_v<typename C::ComponentType, uint8_t>
     static constexpr C resolve(C color)
     {
         return color;

--- a/Source/WebCore/platform/graphics/ColorTypes.h
+++ b/Source/WebCore/platform/graphics/ColorTypes.h
@@ -176,7 +176,7 @@ template<typename T, typename U> inline constexpr bool HasComponentTypeValue<T, 
 template<typename T, typename U> inline constexpr bool HasComponentType = HasComponentTypeValue<T, U, HasComponentTypeMember<T>>;
 
 template<typename T> inline constexpr bool IsColorType = IsConvertibleToColorComponents<T> && HasComponentTypeMember<T>;
-template<typename T, typename U> inline constexpr bool IsColorTypeWithComponentType = IsConvertibleToColorComponents<T> && HasComponentType<T, U>;
+template<typename T, typename U> concept IsColorTypeWithComponentType = IsConvertibleToColorComponents<T> && HasComponentType<T, U>;
 
 template<template<typename> class ColorType, typename Replacement> struct ColorTypeReplacingComponentTypeHelper { using type = ColorType<Replacement>; };
 template<template<typename> class ColorType, typename Replacement> using ColorTypeReplacingComponentType = typename ColorTypeReplacingComponentTypeHelper<ColorType, Replacement>::type;

--- a/Source/WebCore/platform/graphics/ImagePaintingOptions.h
+++ b/Source/WebCore/platform/graphics/ImagePaintingOptions.h
@@ -54,19 +54,23 @@ struct ImagePaintingOptions {
     // This is a single-argument initializer to support pattern of
     // ImageDrawResult drawImage(..., ImagePaintingOptions = { ImageOrientation::Orientation::FromImage });
     // Should be removed once the pattern is not so prevalent.
-    template<typename T, typename = std::enable_if_t<isOptionType<std::decay_t<T>>>>
+    template<typename T>
+        requires isOptionType<std::decay_t<T>>
     ImagePaintingOptions(std::initializer_list<T> options)
     {
         for (auto& option : options)
             setOption(option);
     }
-    template<typename T, typename = std::enable_if_t<isOptionType<std::decay_t<T>>>>
+
+    template<typename T>
+        requires isOptionType<std::decay_t<T>>
     explicit ImagePaintingOptions(T option)
     {
         setOption(option);
     }
 
-    template<typename T, typename U, typename... Rest, typename = std::enable_if_t<isOptionType<std::decay_t<T>>>>
+    template<typename T, typename U, typename... Rest>
+        requires isOptionType<std::decay_t<T>>
     ImagePaintingOptions(T first, U second, Rest... rest)
     {
         setOption(first);

--- a/Source/WebCore/platform/graphics/cairo/CairoOperationRecorder.cpp
+++ b/Source/WebCore/platform/graphics/cairo/CairoOperationRecorder.cpp
@@ -62,14 +62,18 @@ struct OperationData {
 template<> struct OperationData<> { };
 
 template<typename T, typename... Args>
-auto createCommand(Args&&... arguments) -> std::enable_if_t<std::is_base_of<OperationData<std::decay_t<Args>...>, T>::value, std::unique_ptr<PaintingOperation>> {
+    requires std::derived_from<T, OperationData<std::decay_t<Args>...>>
+auto createCommand(Args&&... arguments) -> std::unique_ptr<PaintingOperation>
+{
     auto* command = new T();
     command->arguments = std::make_tuple(std::forward<Args>(arguments)...);
     return std::unique_ptr<PaintingOperation>(command);
 }
 
 template<typename T>
-auto createCommand() -> std::enable_if_t<std::is_base_of<OperationData<>, T>::value, std::unique_ptr<PaintingOperation>> {
+    requires std::derived_from<T, OperationData<>>
+auto createCommand() -> std::unique_ptr<PaintingOperation>
+{
     return makeUnique<T>();
 }
 


### PR DESCRIPTION
#### 286bc2f2fea77c9b436308d367630adbceacf939
<pre>
Use more C++ Concepts in WebCore
<a href="https://bugs.webkit.org/show_bug.cgi?id=293810">https://bugs.webkit.org/show_bug.cgi?id=293810</a>
<a href="https://rdar.apple.com/problem/152321345">rdar://problem/152321345</a>

Reviewed by Sam Weinig.

Replace std::enable_if with C++20 requires clauses for template constraints.
This should provide better readability and better compile-time performance by utilizing
more core language features.

* Source/WebCore/platform/graphics/Color.h:
* Source/WebCore/platform/graphics/ColorModels.h:
* Source/WebCore/platform/graphics/ImagePaintingOptions.h:
* Source/WebCore/platform/graphics/cairo/CairoOperationRecorder.cpp:
(WebCore::Cairo::createCommand):

Canonical link: <a href="https://commits.webkit.org/295661@main">https://commits.webkit.org/295661@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/03f3377d826e1070211a6e4e1ac9c19f76d37c29

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105789 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25540 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15933 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110986 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/56385 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/107830 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/26118 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34043 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80337 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108795 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/20489 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95463 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60650 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/20169 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13560 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55824 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/89906 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13599 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/113835 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32929 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24266 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89416 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33293 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91694 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89086 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22712 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33962 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11768 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/28410 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32854 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/38265 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32600 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35949 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34198 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->