### PR TITLE
dNR: allow and allowAllRequests rules aren't respecting priority

### DIFF
--- a/Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionDeclarativeNetRequestRule.h
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionDeclarativeNetRequestRule.h
@@ -27,6 +27,10 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+WK_EXTERN NSString * const declarativeNetRequestRuleActionTypeKey;
+WK_EXTERN NSString * const declarativeNetRequestRuleActionTypeAllow;
+WK_EXTERN NSString * const declarativeNetRequestRuleActionTypeAllowAllRequests;
+
 WK_EXTERN
 @interface _WKWebExtensionDeclarativeNetRequestRule : NSObject
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionDeclarativeNetRequestRule.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionDeclarativeNetRequestRule.mm
@@ -26,6 +26,10 @@
 #import "config.h"
 #import "_WKWebExtensionDeclarativeNetRequestRule.h"
 
+NSString * const declarativeNetRequestRuleActionTypeKey = @"type";
+NSString * const declarativeNetRequestRuleActionTypeAllow = @"allow";
+NSString * const declarativeNetRequestRuleActionTypeAllowAllRequests = @"allowAllRequests";
+
 #if ENABLE(WK_WEB_EXTENSIONS)
 
 #if !__has_feature(objc_arc)
@@ -45,9 +49,6 @@ static NSString * const declarativeNetRequestRuleActionKey = @"action";
 static NSString * const declarativeNetRequestRuleConditionKey = @"condition";
 
 // Key and values in the `action` dictionary.
-static NSString * const declarativeNetRequestRuleActionTypeKey = @"type";
-static NSString * const declarativeNetRequestRuleActionTypeAllow = @"allow";
-static NSString * const declarativeNetRequestRuleActionTypeAllowAllRequests = @"allowAllRequests";
 static NSString * const declarativeNetRequestRuleActionTypeBlock = @"block";
 static NSString * const declarativeNetRequestRuleActionTypeUpgradeScheme = @"upgradeScheme";
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionDeclarativeNetRequestTranslator.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionDeclarativeNetRequestTranslator.mm
@@ -68,6 +68,36 @@ using namespace WebKit;
         return [a compare:b];
     }].mutableCopy;
 
+    // Because WebKit Content Blocking "allow" rules just ignore all previous rules, they have to go *after* lower priority rules, rather than before.
+    BOOL (^isAllowRule)(_WKWebExtensionDeclarativeNetRequestRule *) = ^BOOL (_WKWebExtensionDeclarativeNetRequestRule *rule) {
+        NSString *allowRuleType = rule.action[declarativeNetRequestRuleActionTypeKey];
+        return [allowRuleType isEqualToString:declarativeNetRequestRuleActionTypeAllow] || [allowRuleType isEqualToString:declarativeNetRequestRuleActionTypeAllowAllRequests];
+    };
+
+    NSMutableArray<_WKWebExtensionDeclarativeNetRequestRule *> *allowRules = [filterObjects((NSArray *)allValidatedRules, ^bool (id key, _WKWebExtensionDeclarativeNetRequestRule *rule) {
+        return isAllowRule(rule);
+    }) mutableCopy];
+    NSMutableArray<_WKWebExtensionDeclarativeNetRequestRule *> *otherRules = [filterObjects((NSArray *)allValidatedRules, ^bool (id key, _WKWebExtensionDeclarativeNetRequestRule *rule) {
+        return !isAllowRule(rule);
+    }) mutableCopy];
+    [allValidatedRules removeAllObjects];
+
+    while (allowRules.count || otherRules.count) {
+        if (!allowRules.count) {
+            [allValidatedRules addObject:otherRules.firstObject];
+            [otherRules removeObjectAtIndex:0];
+        } else if (!otherRules.count) {
+            [allValidatedRules addObject:allowRules.lastObject];
+            [allowRules removeLastObject];
+        } else if (allowRules.lastObject.priority < otherRules.firstObject.priority) {
+            [allValidatedRules addObject:allowRules.lastObject];
+            [allowRules removeLastObject];
+        } else {
+            [allValidatedRules addObject:otherRules.firstObject];
+            [otherRules removeObjectAtIndex:0];
+        }
+    }
+
     NSMutableArray<NSDictionary<NSString *, id> *> *translatedRules = [NSMutableArray array];
     for (_WKWebExtensionDeclarativeNetRequestRule *rule in allValidatedRules) {
         NSArray<NSDictionary<NSString *, id> *> *translatedRule = rule.ruleInWebKitFormat;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIDeclarativeNetRequest.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIDeclarativeNetRequest.mm
@@ -2832,8 +2832,8 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, RulesSortByPriorityFromDifferentRul
     NSArray *sortedTranslatedRules = [_WKWebExtensionDeclarativeNetRequestTranslator translateRules:rules errorStrings:nil];
     EXPECT_NOT_NULL(sortedTranslatedRules);
 
-    EXPECT_NS_EQUAL(sortedTranslatedRules[0][@"action"][@"type"], @"ignore-previous-rules");
-    EXPECT_NS_EQUAL(sortedTranslatedRules[1][@"action"][@"type"], @"block");
+    EXPECT_NS_EQUAL(sortedTranslatedRules[0][@"action"][@"type"], @"block");
+    EXPECT_NS_EQUAL(sortedTranslatedRules[1][@"action"][@"type"], @"ignore-previous-rules");
 }
 
 TEST(WKWebExtensionAPIDeclarativeNetRequest, RulesSortWithoutExplicitPriority)
@@ -2929,6 +2929,58 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, RulesSortByActionType)
     EXPECT_NS_EQUAL(sortedTranslatedRules[3][@"action"][@"type"], @"block");
     EXPECT_NS_EQUAL(sortedTranslatedRules[4][@"action"][@"type"], @"ignore-previous-rules");
     EXPECT_NS_EQUAL(sortedTranslatedRules[5][@"action"][@"type"], @"ignore-previous-rules");
+}
+
+TEST(WKWebExtensionAPIDeclarativeNetRequest, RulesSortWithMixedPriorityAndActionTypes)
+{
+    NSArray *rules = @[
+        @[
+            @{
+                @"id": @1,
+                @"priority": @1,
+                @"action": @{ @"type": @"allow" },
+                @"condition": @{
+                    @"regexFilter": @"apple.com",
+                    @"resourceTypes": @[ @"script" ],
+                }
+            },
+            @{
+                @"id": @1,
+                @"priority": @2,
+                @"action": @{ @"type": @"block" },
+                @"condition": @{
+                    @"regexFilter": @"bananas.com",
+                    @"resourceTypes": @[ @"script" ],
+                },
+            },
+            @{
+                @"id": @1,
+                @"priority": @4,
+                @"action": @{ @"type": @"allow" },
+                @"condition": @{
+                    @"regexFilter": @"cars.com",
+                    @"resourceTypes": @[ @"script" ],
+                }
+            },
+            @{
+                @"id": @1,
+                @"priority": @3,
+                @"action": @{ @"type": @"block" },
+                @"condition": @{
+                    @"regexFilter": @"dji.com",
+                    @"resourceTypes": @[ @"script" ],
+                },
+            },
+        ]
+    ];
+
+    NSArray *sortedTranslatedRules = [_WKWebExtensionDeclarativeNetRequestTranslator translateRules:rules errorStrings:nil];
+    EXPECT_NOT_NULL(sortedTranslatedRules);
+
+    EXPECT_NS_EQUAL(sortedTranslatedRules[0][@"action"][@"type"], @"ignore-previous-rules");
+    EXPECT_NS_EQUAL(sortedTranslatedRules[1][@"action"][@"type"], @"block");
+    EXPECT_NS_EQUAL(sortedTranslatedRules[2][@"action"][@"type"], @"block");
+    EXPECT_NS_EQUAL(sortedTranslatedRules[3][@"action"][@"type"], @"ignore-previous-rules");
 }
 
 TEST(WKWebExtensionAPIDeclarativeNetRequest, RemoveAllContentRuleListsDoesNotRemoveWebExtensionRuleLists)


### PR DESCRIPTION
#### de999d7b0c4091ae15c36d778b976f5dbf51f3d6
<pre>
dNR: allow and allowAllRequests rules aren&apos;t respecting priority
<a href="https://bugs.webkit.org/show_bug.cgi?id=293809">https://bugs.webkit.org/show_bug.cgi?id=293809</a>
<a href="https://rdar.apple.com/152193087">rdar://152193087</a>

Reviewed by NOBODY (OOPS!).

This patch fixes a bug where, after a recent change, the priority of allow rules
are inverted. Lower priority numbers of allow rules are (incorrectly) higher in
priority.

This is happening because we sort dNR rules by priority first and then by type;
however, once the dNR rules are converted into WebKit Content Blocking rules,
&quot;allow&quot; rules are converted into &quot;ignore-previous-rules&quot; rules, meaning that
they should be *after* lower priority rules, not before.

The way that I fixed this is by separting the &quot;allow&quot; rules and all other rules
into their own arrays and then merging the &quot;allow&quot; rules back in with the other
rules but in reverse order. This runs in linear time since the arrays are
already sorted.

We end up with something like:

AFTER SORTING ALL dNR RULES:
Priority | Type
--------------------------------
      30 | ignore-previous-rules
      30 | block
      30 | block
--------------------------------
      20 | block
      20 | block
--------------------------------
      10 | ignore-previous-rules
--------------------------------

AFTER INVERTING ALL ALLOW RULES:
Priority | Type
--------------------------------
      10 | ignore-previous-rules
      30 | block
      30 | block
--------------------------------
      20 | block
      20 | block
--------------------------------
      30 | ignore-previous-rules
--------------------------------

Also see: <a href="https://commits.webkit.org/293546@main">https://commits.webkit.org/293546@main</a>

* Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionDeclarativeNetRequestRule.h:
* Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionDeclarativeNetRequestTranslator.mm:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIDeclarativeNetRequest.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPIDeclarativeNetRequest, RulesSortByPriorityFromDifferentRulesets)):
(TestWebKitAPI::TEST(WKWebExtensionAPIDeclarativeNetRequest, RulesSortWithMixedPriorityAndActionTypes)):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/de999d7b0c4091ae15c36d778b976f5dbf51f3d6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105903 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25654 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/16048 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/111101 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/56501 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/107944 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/26278 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34157 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80444 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108909 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/20701 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95574 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60763 "Found 147 new API test failures: /WPE/TestUIClient:/webkit/WebKitWebView/query-permission-requests, /WPE/TestWebsiteData:/webkit/WebKitWebsiteData/deviceidhashsalt, /WPE/TestLoaderClient:/webkit/WebKitWebView/load-twice-and-reload, /WPE/TestCookieManager:/webkit/WebKitCookieManager/ephemeral, /WPE/TestWebKitWebView:/webkit/WebKitWebView/is-playing-audio, /WPE/TestConsoleMessage:/webkit/WebKitConsoleMessage/network-error, /WPE/TestWebsiteData:/webkit/WebKitWebsiteData/configuration, /WPE/TestCookieManager:/webkit/WebKitCookieManager/delete-cookies, /WPE/TestWebKitWebView:/webkit/WebKitWebView/terminate-unresponsive-web-process, /WPE/TestSSL:/webkit/WebKitWebView/insecure-content ... (failure)") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/20340 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13672 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55939 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/90090 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13708 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/113952 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33043 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24374 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89525 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33407 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91803 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89199 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34065 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11877 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/28579 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32968 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/38379 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32714 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/36063 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34312 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->