### PR TITLE
[Model Element] Delete model player when the HTMLModelElement has been stopped

### DIFF
--- a/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
@@ -1299,6 +1299,15 @@ bool HTMLModelElement::virtualHasPendingActivity() const
     return m_resource;
 }
 
+void HTMLModelElement::stop()
+{
+    RELEASE_LOG(ModelElement, "%p - HTMLModelElement::stop()", this);
+
+    // Once an active DOM object has been stopped it cannot be restarted,
+    // so we can delete the model player now.
+    deleteModelPlayer();
+}
+
 #if PLATFORM(COCOA)
 Vector<RetainPtr<id>> HTMLModelElement::accessibilityChildren()
 {

--- a/Source/WebCore/Modules/model-element/HTMLModelElement.h
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.h
@@ -82,8 +82,6 @@ public:
     // ActiveDOMObject.
     void ref() const final { HTMLElement::ref(); }
     void deref() const final { HTMLElement::deref(); }
-    void suspend(ReasonForSuspension) final;
-    void resume() final;
 
     // VisibilityChangeClient.
     void visibilityStateChanged() final;
@@ -207,6 +205,9 @@ private:
 
     // ActiveDOMObject.
     bool virtualHasPendingActivity() const final;
+    void resume() final;
+    void suspend(ReasonForSuspension) final;
+    void stop() final;
 
     // DOM overrides.
     void didMoveToNewDocument(Document& oldDocument, Document& newDocument) final;

--- a/Source/WebKit/ModelProcess/ModelProcess.cpp
+++ b/Source/WebKit/ModelProcess/ModelProcess.cpp
@@ -35,6 +35,7 @@
 #include "ModelConnectionToWebProcess.h"
 #include "ModelProcessConnectionParameters.h"
 #include "ModelProcessCreationParameters.h"
+#include "ModelProcessModelPlayerProxy.h"
 #include "ModelProcessProxyMessages.h"
 #include "WebPageProxyMessages.h"
 #include "WebProcessPoolMessages.h"
@@ -256,6 +257,11 @@ void ModelProcess::requestSharedSimulationConnection(WebCore::ProcessIdentifier 
 void ModelProcess::webProcessConnectionCountForTesting(CompletionHandler<void(uint64_t)>&& completionHandler)
 {
     completionHandler(ModelConnectionToWebProcess::objectCountForTesting());
+}
+
+void ModelProcess::modelPlayerCountForTesting(CompletionHandler<void(uint64_t)>&& completionHandler)
+{
+    completionHandler(ModelProcessModelPlayerProxy::objectCountForTesting());
 }
 
 void ModelProcess::addSession(PAL::SessionID sessionID)

--- a/Source/WebKit/ModelProcess/ModelProcess.h
+++ b/Source/WebKit/ModelProcess/ModelProcess.h
@@ -82,6 +82,7 @@ public:
 #endif
 
     void webProcessConnectionCountForTesting(CompletionHandler<void(uint64_t)>&&);
+    void modelPlayerCountForTesting(CompletionHandler<void(uint64_t)>&&);
 
 private:
     void lowMemoryHandler(Critical, Synchronous);

--- a/Source/WebKit/ModelProcess/ModelProcess.messages.in
+++ b/Source/WebKit/ModelProcess/ModelProcess.messages.in
@@ -40,6 +40,7 @@ messages -> ModelProcess : AuxiliaryProcess {
     RemoveSession(PAL::SessionID sessionID)
 
     WebProcessConnectionCountForTesting() -> (uint64_t count)
+    ModelPlayerCountForTesting() -> (uint64_t count)
 }
 
 #endif // ENABLE(MODEL_PROCESS)

--- a/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.h
+++ b/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.h
@@ -145,6 +145,7 @@ public:
     USING_CAN_MAKE_WEAKPTR(WebCore::REModelLoaderClient);
 
     void disableUnloadDelayForTesting() { m_unloadDelayDisabledForTesting = true; }
+    static uint64_t objectCountForTesting() { return gObjectCountForTesting; }
 
 private:
     ModelProcessModelPlayerProxy(ModelProcessModelPlayerManagerProxy&, WebCore::ModelPlayerIdentifier, Ref<IPC::Connection>&&, const std::optional<String>&);
@@ -196,6 +197,7 @@ private:
 
     // For testing
     bool m_unloadDelayDisabledForTesting { false };
+    static uint64_t gObjectCountForTesting;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm
+++ b/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm
@@ -220,6 +220,8 @@ static Ref<REModelLoader> loadREModelUsingRKUSDLoader(Model& model, const std::o
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(ModelProcessModelPlayerProxy);
 
+uint64_t ModelProcessModelPlayerProxy::gObjectCountForTesting = 0;
+
 Ref<ModelProcessModelPlayerProxy> ModelProcessModelPlayerProxy::create(ModelProcessModelPlayerManagerProxy& manager, WebCore::ModelPlayerIdentifier identifier, Ref<IPC::Connection>&& connection, const std::optional<String>& attributionTaskID)
 {
     return adoptRef(*new ModelProcessModelPlayerProxy(manager, identifier, WTFMove(connection), attributionTaskID));
@@ -234,6 +236,7 @@ ModelProcessModelPlayerProxy::ModelProcessModelPlayerProxy(ModelProcessModelPlay
 {
     RELEASE_LOG(ModelElement, "%p - ModelProcessModelPlayerProxy initialized id=%" PRIu64, this, identifier.toUInt64());
     m_objCAdapter = adoptNS([[WKModelProcessModelPlayerProxyObjCAdapter alloc] initWithModelProcessModelPlayerProxy:*this]);
+    ++gObjectCountForTesting;
 }
 
 ModelProcessModelPlayerProxy::~ModelProcessModelPlayerProxy()
@@ -250,6 +253,9 @@ ModelProcessModelPlayerProxy::~ModelProcessModelPlayerProxy()
     [m_stageModeInteractionDriver removeInteractionContainerFromSceneOrParent];
 
     RELEASE_LOG(ModelElement, "%p - ModelProcessModelPlayerProxy deallocated id=%" PRIu64, this, m_id.toUInt64());
+
+    ASSERT(gObjectCountForTesting > 0);
+    --gObjectCountForTesting;
 }
 
 std::optional<SharedPreferencesForWebProcess> ModelProcessModelPlayerProxy::sharedPreferencesForWebProcess() const

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h
@@ -172,6 +172,8 @@ struct WKAppPrivacyReportTestingData {
 
 - (unsigned)_forwardedLogsCountForTesting;
 
+- (void)_modelProcessModelPlayerCountForTesting:(void(^)(NSUInteger))completionHandler;
+
 @end
 
 typedef NS_ENUM(NSInteger, _WKMediaSessionReadyState) {

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
@@ -72,6 +72,10 @@
 #import "WKWebViewIOS.h"
 #endif
 
+#if ENABLE(MODEL_PROCESS)
+#import "ModelProcessProxy.h"
+#endif
+
 #if ENABLE(MEDIA_SESSION_COORDINATOR)
 @interface WKMediaSessionCoordinatorHelper : NSObject <_WKMediaSessionCoordinatorDelegate>
 - (id)initWithCoordinator:(WebCore::MediaSessionCoordinatorClient*)coordinator;
@@ -1031,6 +1035,23 @@ static void dumpCALayer(TextStream& ts, CALayer *layer, bool traverse)
     return WebKit::LogStream::logCountForTesting();
 #else
     return 0;
+#endif
+}
+
+- (void)_modelProcessModelPlayerCountForTesting:(void(^)(NSUInteger))completionHandler
+{
+#if ENABLE(MODEL_PROCESS)
+    RefPtr modelProcess = _page->configuration().processPool().modelProcess();
+    if (!modelProcess) {
+        completionHandler(0);
+        return;
+    }
+
+    modelProcess->modelPlayerCountForTesting([completionHandler = makeBlockPtr(completionHandler)](uint64_t count) {
+        completionHandler(count);
+    });
+#else
+    completionHandler(0);
 #endif
 }
 

--- a/Source/WebKit/UIProcess/Model/ModelProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/Model/ModelProcessProxy.cpp
@@ -242,6 +242,11 @@ void ModelProcessProxy::webProcessConnectionCountForTesting(CompletionHandler<vo
     sendWithAsyncReply(Messages::ModelProcess::WebProcessConnectionCountForTesting(), WTFMove(completionHandler));
 }
 
+void ModelProcessProxy::modelPlayerCountForTesting(CompletionHandler<void(uint64_t)>&& completionHandler)
+{
+    sendWithAsyncReply(Messages::ModelProcess::ModelPlayerCountForTesting(), WTFMove(completionHandler));
+}
+
 void ModelProcessProxy::didClose(IPC::Connection&)
 {
     RELEASE_LOG_ERROR(Process, "%p - ModelProcessProxy::didClose:", this);

--- a/Source/WebKit/UIProcess/Model/ModelProcessProxy.h
+++ b/Source/WebKit/UIProcess/Model/ModelProcessProxy.h
@@ -72,6 +72,7 @@ public:
 
     void terminateForTesting();
     void webProcessConnectionCountForTesting(CompletionHandler<void(uint64_t)>&&);
+    void modelPlayerCountForTesting(CompletionHandler<void(uint64_t)>&&);
 
     void removeSession(PAL::SessionID);
 

--- a/Tools/TestWebKitAPI/SourcesCocoa.txt
+++ b/Tools/TestWebKitAPI/SourcesCocoa.txt
@@ -31,6 +31,7 @@ cocoa/DaemonTestUtilities.mm
 cocoa/DragAndDropSimulator.mm
 cocoa/HostWindowManager.mm
 cocoa/ImageAnalysisTestingUtilities.mm
+cocoa/ModelLoadingMessageHandler.mm
 cocoa/NSItemProviderAdditions.mm
 cocoa/PlatformUtilitiesCocoa.mm
 cocoa/TestCocoa.mm
@@ -192,6 +193,7 @@ Tests/WebKitCocoa/MediaType.mm
 Tests/WebKitCocoa/MemoryFootprintThreshold.mm
 Tests/WebKitCocoa/MessagePortProviders.mm
 Tests/WebKitCocoa/ModalAlerts.mm
+Tests/WebKitCocoa/ModelProcess.mm
 Tests/WebKitCocoa/MouseSupportUIDelegate.mm
 Tests/WebKitCocoa/NSAttributedStringWebKitAdditions.mm
 Tests/WebKitCocoa/NSFileManagerExtras.mm

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -2834,6 +2834,9 @@
 		524BBC9B19DF3714002F1AF1 /* file-with-video.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "file-with-video.html"; sourceTree = "<group>"; };
 		524BBC9C19DF377A002F1AF1 /* WKPageIsPlayingAudio.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WKPageIsPlayingAudio.cpp; sourceTree = "<group>"; };
 		524BBCA019E30C63002F1AF1 /* test.mp4 */ = {isa = PBXFileReference; lastKnownFileType = file; path = test.mp4; sourceTree = "<group>"; };
+		5261EAF92DE9768900A721AE /* ModelProcess.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ModelProcess.mm; sourceTree = "<group>"; };
+		5261EB052DE97BC200A721AE /* ModelLoadingMessageHandler.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ModelLoadingMessageHandler.h; path = cocoa/ModelLoadingMessageHandler.h; sourceTree = "<group>"; };
+		5261EB062DE97BC200A721AE /* ModelLoadingMessageHandler.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = ModelLoadingMessageHandler.mm; path = cocoa/ModelLoadingMessageHandler.mm; sourceTree = "<group>"; };
 		52B8CF9415868CF000281053 /* SetDocumentURI.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = SetDocumentURI.html; sourceTree = "<group>"; };
 		52B8CF9515868CF000281053 /* SetDocumentURI.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = SetDocumentURI.mm; sourceTree = "<group>"; };
 		52C8C1372706437C00BDF3B7 /* web-authentication-make-credential-hid-internal-uv.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = "web-authentication-make-credential-hid-internal-uv.html"; sourceTree = "<group>"; };
@@ -4278,6 +4281,8 @@
 				F42F081627449FFD007E0D90 /* ImageAnalysisTestingUtilities.mm */,
 				F44A530D21B8976900DBB99C /* InstanceMethodSwizzler.h */,
 				F44A531021B8976900DBB99C /* InstanceMethodSwizzler.mm */,
+				5261EB052DE97BC200A721AE /* ModelLoadingMessageHandler.h */,
+				5261EB062DE97BC200A721AE /* ModelLoadingMessageHandler.mm */,
 				FA65F0042C87F4CF00A0A123 /* NetworkConnection.h */,
 				FA65F0052C87F4CF00A0A123 /* NetworkConnection.mm */,
 				0F139E721A423A2B00F590F5 /* PlatformUtilitiesCocoa.mm */,
@@ -4567,6 +4572,7 @@
 				EBCD30F72B7C075F00268DA5 /* MemoryFootprintThreshold.mm */,
 				5165FE03201EE617009F7EC3 /* MessagePortProviders.mm */,
 				51CD1C6A1B38CE3600142CA5 /* ModalAlerts.mm */,
+				5261EAF92DE9768900A721AE /* ModelProcess.mm */,
 				331987702CEF456200BC283C /* MouseSupportUIDelegate.h */,
 				331987782CEF457300BC283C /* MouseSupportUIDelegate.mm */,
 				1ABC3DED1899BE6D004F0626 /* Navigation.mm */,

--- a/Tools/TestWebKitAPI/Tests/WebKit/simple-model-page.html
+++ b/Tools/TestWebKitAPI/Tests/WebKit/simple-model-page.html
@@ -1,3 +1,6 @@
+<script>
+    internals.disableModelLoadDelaysForTesting()
+</script>
 <model>
     <source src='cube.usdz'>
 </model>

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ModelProcess.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ModelProcess.mm
@@ -1,0 +1,125 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+
+#if ENABLE(MODEL_PROCESS)
+
+#import "ModelLoadingMessageHandler.h"
+#import "PlatformUtilities.h"
+#import "TestNavigationDelegate.h"
+#import "TestWKWebView.h"
+#import "WKWebViewConfigurationExtras.h"
+#import <WebKit/WKPreferencesPrivate.h>
+#import <WebKit/WKPreferencesRefPrivate.h>
+#import <WebKit/WKString.h>
+#import <WebKit/WKWebViewConfigurationPrivate.h>
+#import <WebKit/WKWebViewPrivate.h>
+#import <notify.h>
+#import <objc/runtime.h>
+#import <wtf/Function.h>
+#import <wtf/RetainPtr.h>
+
+namespace TestWebKitAPI {
+
+TEST(ModelProcess, CleanUpOnReload)
+{
+    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    WKPreferencesSetBoolValueForKeyForTesting((__bridge WKPreferencesRef)[configuration preferences], true, WKStringCreateWithUTF8CString("ModelElementEnabled"));
+    WKPreferencesSetBoolValueForKeyForTesting((__bridge WKPreferencesRef)[configuration preferences], true, WKStringCreateWithUTF8CString("ModelProcessEnabled"));
+
+    RetainPtr messageHandler = adoptNS([[ModelLoadingMessageHandler alloc] init]);
+    [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"modelLoading"];
+
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400) configuration:configuration.get()]);
+    [webView synchronouslyLoadTestPageNamed:@"simple-model-page"];
+
+    while (![messageHandler modelIsReady])
+        Util::spinRunLoop();
+
+    EXPECT_EQ([webView modelProcessModelPlayerCount], 1u);
+
+    [messageHandler setModelIsReady:NO];
+    [webView reload];
+
+    while (![messageHandler modelIsReady])
+        Util::spinRunLoop();
+
+    EXPECT_EQ([webView modelProcessModelPlayerCount], 1u);
+}
+
+TEST(ModelProcess, CleanUpOnNavigate)
+{
+    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    WKPreferencesSetBoolValueForKeyForTesting((__bridge WKPreferencesRef)[configuration preferences], true, WKStringCreateWithUTF8CString("ModelElementEnabled"));
+    WKPreferencesSetBoolValueForKeyForTesting((__bridge WKPreferencesRef)[configuration preferences], true, WKStringCreateWithUTF8CString("ModelProcessEnabled"));
+
+    RetainPtr messageHandler = adoptNS([[ModelLoadingMessageHandler alloc] init]);
+    [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"modelLoading"];
+
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400) configuration:configuration.get()]);
+    [webView synchronouslyLoadTestPageNamed:@"simple-model-page"];
+
+    while (![messageHandler modelIsReady])
+        Util::spinRunLoop();
+
+    EXPECT_EQ([webView modelProcessModelPlayerCount], 1u);
+
+    [webView synchronouslyLoadTestPageNamed:@"simple"];
+    [webView waitForNextPresentationUpdate];
+
+    EXPECT_EQ([webView modelProcessModelPlayerCount], 0u);
+}
+
+TEST(ModelProcess, CleanUpOnHide)
+{
+    WKWebViewConfiguration *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
+    WKPreferencesSetBoolValueForKeyForTesting((__bridge WKPreferencesRef)configuration.preferences, true, WKStringCreateWithUTF8CString("ModelElementEnabled"));
+    WKPreferencesSetBoolValueForKeyForTesting((__bridge WKPreferencesRef)configuration.preferences, true, WKStringCreateWithUTF8CString("ModelProcessEnabled"));
+
+    RetainPtr messageHandler = adoptNS([[ModelLoadingMessageHandler alloc] init]);
+    [configuration.userContentController addScriptMessageHandler:messageHandler.get() name:@"modelLoading"];
+
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400) configuration:configuration]);
+    [webView synchronouslyLoadTestPageNamed:@"simple-model-page"];
+
+    bool isHidden = false;
+    [webView performAfterReceivingMessage:@"hidden" action:[&] { isHidden = true; }];
+    [webView objectByEvaluatingJavaScript:@"document.addEventListener('visibilitychange', event => { if (document.hidden) window.webkit.messageHandlers.testHandler.postMessage('hidden') })"];
+
+    while (![messageHandler modelIsReady])
+        Util::spinRunLoop();
+
+    EXPECT_EQ([webView modelProcessModelPlayerCount], 1u);
+
+    [webView objectByEvaluatingJavaScript:@"window.internals.setPageVisibility(false)"];
+    TestWebKitAPI::Util::run(&isHidden);
+
+    EXPECT_EQ([webView modelProcessModelPlayerCount], 0u);
+}
+
+} // namespace TestWebKitAPI
+
+#endif

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ProcessSwapOnNavigation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ProcessSwapOnNavigation.mm
@@ -46,6 +46,7 @@
 #import <WebKit/WKURLSchemeHandler.h>
 #import <WebKit/WKURLSchemeTaskPrivate.h>
 #import <WebKit/WKWebViewConfigurationPrivate.h>
+#import <WebKit/WKWebViewPrivate.h>
 #import <WebKit/WKWebViewPrivateForTesting.h>
 #import <WebKit/WKWebpagePreferences.h>
 #import <WebKit/WKWebpagePreferencesPrivate.h>

--- a/Tools/TestWebKitAPI/Tests/ios/DragAndDropTestsIOS.mm
+++ b/Tools/TestWebKitAPI/Tests/ios/DragAndDropTestsIOS.mm
@@ -29,6 +29,7 @@
 
 #import "ClassMethodSwizzler.h"
 #import "DragAndDropSimulator.h"
+#import "ModelLoadingMessageHandler.h"
 #import "NSItemProviderAdditions.h"
 #import "PlatformUtilities.h"
 #import "TestURLSchemeHandler.h"
@@ -98,28 +99,6 @@ static NSData *testZIPArchive()
 }
 
 @end
-
-@interface ModelLoadingMessageHandler : NSObject <WKScriptMessageHandler>
-
-@property (nonatomic) BOOL didLoadModel;
-@property (nonatomic) BOOL modelIsReady;
-
-@end
-
-@implementation ModelLoadingMessageHandler
-- (void)userContentController:(WKUserContentController *)userContentController didReceiveScriptMessage:(WKScriptMessage *)message
-{
-    if ([[message body] isEqualToString:@"LOADED"])
-        _didLoadModel = YES;
-    else if ([[message body] isEqualToString:@"READY"])
-        _modelIsReady = YES;
-    else {
-        EXPECT_TRUE(false);
-        NSLog(@"Unexpected message received: %@", [message body]);
-    }
-}
-@end
-
 
 static void loadTestPageAndEnsureInputSession(DragAndDropSimulator *simulator, NSString *testPageName)
 {

--- a/Tools/TestWebKitAPI/cocoa/ModelLoadingMessageHandler.h
+++ b/Tools/TestWebKitAPI/cocoa/ModelLoadingMessageHandler.h
@@ -23,31 +23,13 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#import "config.h"
+#pragma once
 
-#if PLATFORM(MAC)
+#import <WebKit/WKScriptMessageHandler.h>
 
-#import "TestWKWebView.h"
-#import <WebKit/WKWebViewPrivate.h>
-#import <WebKit/WKWebViewPrivateForTesting.h>
+@interface ModelLoadingMessageHandler : NSObject <WKScriptMessageHandler>
 
-namespace TestWebKitAPI {
+@property (nonatomic) BOOL didLoadModel;
+@property (nonatomic) BOOL modelIsReady;
 
-TEST(CustomSwipeViewTests, WindowRelativeBoundsForCustomSwipeViews)
-{
-    RetainPtr customSwipeView = adoptNS([[NSView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
-    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
-    [webView addSubview:customSwipeView.get()];
-    [webView _setCustomSwipeViews:@[ customSwipeView.get() ]];
-    [webView _setCustomSwipeViewsObscuredContentInsets:NSEdgeInsetsMake(100, 200, 50, 50)];
-
-    __auto_type boundsForCustomSwipeView = [webView _windowRelativeBoundsForCustomSwipeViewsForTesting];
-    EXPECT_EQ(boundsForCustomSwipeView.origin.x, 200.0);
-    EXPECT_EQ(boundsForCustomSwipeView.origin.y, 50.0);
-    EXPECT_EQ(boundsForCustomSwipeView.size.width, 550.0);
-    EXPECT_EQ(boundsForCustomSwipeView.size.height, 450.0);
-}
-
-} // namespace TestWebKitAPI
-
-#endif // PLATFORM(MAC)
+@end

--- a/Tools/TestWebKitAPI/cocoa/ModelLoadingMessageHandler.mm
+++ b/Tools/TestWebKitAPI/cocoa/ModelLoadingMessageHandler.mm
@@ -23,31 +23,22 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#import "config.h"
+#include "config.h"
+#include "ModelLoadingMessageHandler.h"
 
-#if PLATFORM(MAC)
+#include "Utilities.h"
+#include <wtf/Deque.h>
 
-#import "TestWKWebView.h"
-#import <WebKit/WKWebViewPrivate.h>
-#import <WebKit/WKWebViewPrivateForTesting.h>
-
-namespace TestWebKitAPI {
-
-TEST(CustomSwipeViewTests, WindowRelativeBoundsForCustomSwipeViews)
+@implementation ModelLoadingMessageHandler
+- (void)userContentController:(WKUserContentController *)userContentController didReceiveScriptMessage:(WKScriptMessage *)message
 {
-    RetainPtr customSwipeView = adoptNS([[NSView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
-    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
-    [webView addSubview:customSwipeView.get()];
-    [webView _setCustomSwipeViews:@[ customSwipeView.get() ]];
-    [webView _setCustomSwipeViewsObscuredContentInsets:NSEdgeInsetsMake(100, 200, 50, 50)];
-
-    __auto_type boundsForCustomSwipeView = [webView _windowRelativeBoundsForCustomSwipeViewsForTesting];
-    EXPECT_EQ(boundsForCustomSwipeView.origin.x, 200.0);
-    EXPECT_EQ(boundsForCustomSwipeView.origin.y, 50.0);
-    EXPECT_EQ(boundsForCustomSwipeView.size.width, 550.0);
-    EXPECT_EQ(boundsForCustomSwipeView.size.height, 450.0);
+    if ([[message body] isEqualToString:@"LOADED"])
+        _didLoadModel = YES;
+    else if ([[message body] isEqualToString:@"READY"])
+        _modelIsReady = YES;
+    else {
+        EXPECT_TRUE(false);
+        NSLog(@"Unexpected message received: %@", [message body]);
+    }
 }
-
-} // namespace TestWebKitAPI
-
-#endif // PLATFORM(MAC)
+@end

--- a/Tools/TestWebKitAPI/cocoa/TestWKWebView.h
+++ b/Tools/TestWebKitAPI/cocoa/TestWKWebView.h
@@ -108,6 +108,7 @@ class Color;
 
 @property (nonatomic, readonly) CGImageRef snapshotAfterScreenUpdates;
 @property (nonatomic, readonly) NSUInteger gpuToWebProcessConnectionCount;
+@property (nonatomic, readonly) NSUInteger modelProcessModelPlayerCount;
 @property (nonatomic, readonly) NSString *contentsAsString;
 @property (nonatomic, readonly) NSData *contentsAsWebArchive;
 @property (nonatomic, readonly) NSArray<NSString *> *tagsInBody;

--- a/Tools/TestWebKitAPI/cocoa/TestWKWebView.mm
+++ b/Tools/TestWebKitAPI/cocoa/TestWKWebView.mm
@@ -523,6 +523,18 @@ static WebEvent *unwrap(BEKeyEntry *event)
     return count;
 }
 
+- (NSUInteger)modelProcessModelPlayerCount
+{
+    __block bool done = false;
+    __block NSUInteger count = 0;
+    [self _modelProcessModelPlayerCountForTesting:^(NSUInteger result) {
+        done = true;
+        count = result;
+    }];
+    TestWebKitAPI::Util::run(&done);
+    return count;
+}
+
 - (NSString *)contentsAsString
 {
     __block bool done = false;


### PR DESCRIPTION
#### 6caee26b090589e4939095c109751ca27b796075
<pre>
[Model Element] Delete model player when the HTMLModelElement has been stopped
<a href="https://bugs.webkit.org/show_bug.cgi?id=293817">https://bugs.webkit.org/show_bug.cgi?id=293817</a>
<a href="https://rdar.apple.com/151798302">rdar://151798302</a>

Reviewed by Mike Wyrzykowski.

Once the HTMLModelElement has been stopped (after a page reload for example),
it cannot be restarted. We can delete the model player at this point to free up
system resources.

Add plumbing to get the current count of ModelProcessModelPlayerProxy
for testing. Add API tests to make sure ModelProcessModelPlayerProxy is
released after page reloading, navigation, and becoming hidden.

* Source/WebCore/Modules/model-element/HTMLModelElement.cpp:
(WebCore::HTMLModelElement::stop):
* Source/WebCore/Modules/model-element/HTMLModelElement.h:
* Source/WebKit/ModelProcess/ModelProcess.cpp:
(WebKit::ModelProcess::modelPlayerCountForTesting):
* Source/WebKit/ModelProcess/ModelProcess.h:
* Source/WebKit/ModelProcess/ModelProcess.messages.in:
* Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.h:
* Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm:
(WebKit::ModelProcessModelPlayerProxy::ModelProcessModelPlayerProxy):
(WebKit::ModelProcessModelPlayerProxy::~ModelProcessModelPlayerProxy):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm:
(-[WKWebView _modelProcessModelPlayerCountForTesting:]):
* Source/WebKit/UIProcess/Model/ModelProcessProxy.cpp:
(WebKit::ModelProcessProxy::modelPlayerCountForTesting):
* Source/WebKit/UIProcess/Model/ModelProcessProxy.h:
* Tools/TestWebKitAPI/SourcesCocoa.txt:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKit/simple-model-page.html:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ModelProcess.mm: Added.
(TestWebKitAPI::TEST(ModelProcess, CleanUpOnReload)):
After reloading a page with a single model, the number of model player
should stay at 1.
(TestWebKitAPI::TEST(ModelProcess, CleanUpOnNavigate)):
After navigating away from a page with a single model, there should be
no more model players.
(TestWebKitAPI::TEST(ModelProcess, CleanUpOnHide)):
After changing the page visibility to be hidden, there should be no more
model players.
* Tools/TestWebKitAPI/Tests/ios/DragAndDropTestsIOS.mm:
(-[ModelLoadingMessageHandler userContentController:didReceiveScriptMessage:]): Deleted.
* Tools/TestWebKitAPI/cocoa/ModelLoadingMessageHandler.h: Added.
* Tools/TestWebKitAPI/cocoa/ModelLoadingMessageHandler.mm: Added.
(-[ModelLoadingMessageHandler userContentController:didReceiveScriptMessage:]):
* Tools/TestWebKitAPI/cocoa/TestWKWebView.h:
* Tools/TestWebKitAPI/cocoa/TestWKWebView.mm:
(-[WKWebView modelProcessModelPlayerCount]):

Canonical link: <a href="https://commits.webkit.org/295706@main">https://commits.webkit.org/295706@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6adb84b04c93730a1fc905eb05e555981439d557

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105724 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25475 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15868 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110921 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/56319 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/107765 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/26053 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33978 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80288 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108730 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/20418 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95406 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60598 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/20108 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13500 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55759 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/89845 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13539 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/113770 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32864 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24223 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89367 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33228 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91634 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89032 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22739 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33908 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11712 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/28324 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32789 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/38199 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32535 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35884 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34133 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->