### PR TITLE
Fix MessageChannel with site isolation enabled

### DIFF
--- a/Source/WebCore/dom/MessageChannel.cpp
+++ b/Source/WebCore/dom/MessageChannel.cpp
@@ -52,7 +52,7 @@ MessageChannel::MessageChannel(ScriptExecutionContext& context)
     if (!context.activeDOMObjectsAreStopped()) {
         ASSERT(!port1().isDetached());
         ASSERT(!port2().isDetached());
-        MessagePortChannelProvider::fromContext(context).createNewMessagePortChannel(port1().identifier(), port2().identifier());
+        MessagePortChannelProvider::fromContext(context).createNewMessagePortChannel(port1().identifier(), port2().identifier(), context.settingsValues().siteIsolationEnabled);
     } else {
         ASSERT(port1().isDetached());
         ASSERT(port2().isDetached());

--- a/Source/WebCore/dom/messageports/MessagePortChannelProvider.h
+++ b/Source/WebCore/dom/messageports/MessagePortChannelProvider.h
@@ -53,7 +53,7 @@ public:
     virtual ~MessagePortChannelProvider() { }
 
     // Operations that WebProcesses perform
-    virtual void createNewMessagePortChannel(const MessagePortIdentifier& local, const MessagePortIdentifier& remote) = 0;
+    virtual void createNewMessagePortChannel(const MessagePortIdentifier& local, const MessagePortIdentifier& remote, bool siteIsolationEnabled) = 0;
     virtual void entangleLocalPortInThisProcessToRemote(const MessagePortIdentifier& local, const MessagePortIdentifier& remote) = 0;
     virtual void messagePortDisentangled(const MessagePortIdentifier& local) = 0;
     virtual void messagePortClosed(const MessagePortIdentifier& local) = 0;

--- a/Source/WebCore/dom/messageports/MessagePortChannelProviderImpl.cpp
+++ b/Source/WebCore/dom/messageports/MessagePortChannelProviderImpl.cpp
@@ -39,7 +39,7 @@ MessagePortChannelProviderImpl::~MessagePortChannelProviderImpl()
     ASSERT_NOT_REACHED();
 }
 
-void MessagePortChannelProviderImpl::createNewMessagePortChannel(const MessagePortIdentifier& local, const MessagePortIdentifier& remote)
+void MessagePortChannelProviderImpl::createNewMessagePortChannel(const MessagePortIdentifier& local, const MessagePortIdentifier& remote, bool)
 {
     ensureOnMainThread([weakRegistry = WeakPtr { m_registry }, local, remote] {
         if (CheckedPtr registry = weakRegistry.get())

--- a/Source/WebCore/dom/messageports/MessagePortChannelProviderImpl.h
+++ b/Source/WebCore/dom/messageports/MessagePortChannelProviderImpl.h
@@ -36,7 +36,7 @@ public:
     ~MessagePortChannelProviderImpl() final;
 
 private:
-    void createNewMessagePortChannel(const MessagePortIdentifier& local, const MessagePortIdentifier& remote) final;
+    void createNewMessagePortChannel(const MessagePortIdentifier& local, const MessagePortIdentifier& remote, bool siteIsolationEnabled) final;
     void entangleLocalPortInThisProcessToRemote(const MessagePortIdentifier& local, const MessagePortIdentifier& remote) final;
     void messagePortDisentangled(const MessagePortIdentifier& local) final;
     void messagePortClosed(const MessagePortIdentifier& local) final;

--- a/Source/WebCore/dom/messageports/WorkerMessagePortChannelProvider.cpp
+++ b/Source/WebCore/dom/messageports/WorkerMessagePortChannelProvider.cpp
@@ -50,10 +50,10 @@ WorkerMessagePortChannelProvider::~WorkerMessagePortChannelProvider()
     }
 }
 
-void WorkerMessagePortChannelProvider::createNewMessagePortChannel(const MessagePortIdentifier& local, const MessagePortIdentifier& remote)
+void WorkerMessagePortChannelProvider::createNewMessagePortChannel(const MessagePortIdentifier& local, const MessagePortIdentifier& remote, bool siteIsolationEnabled)
 {
-    callOnMainThread([local, remote] {
-        MessagePortChannelProvider::singleton().createNewMessagePortChannel(local, remote);
+    callOnMainThread([local, remote, siteIsolationEnabled] {
+        MessagePortChannelProvider::singleton().createNewMessagePortChannel(local, remote, siteIsolationEnabled);
     });
 }
 

--- a/Source/WebCore/dom/messageports/WorkerMessagePortChannelProvider.h
+++ b/Source/WebCore/dom/messageports/WorkerMessagePortChannelProvider.h
@@ -43,7 +43,7 @@ public:
     ~WorkerMessagePortChannelProvider();
 
 private:
-    void createNewMessagePortChannel(const MessagePortIdentifier& local, const MessagePortIdentifier& remote) final;
+    void createNewMessagePortChannel(const MessagePortIdentifier& local, const MessagePortIdentifier& remote, bool siteIsolationEnabled) final;
     void entangleLocalPortInThisProcessToRemote(const MessagePortIdentifier& local, const MessagePortIdentifier& remote) final;
     void messagePortDisentangled(const MessagePortIdentifier& local) final;
     void messagePortClosed(const MessagePortIdentifier& local) final;

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebMessagePortChannelProvider.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebMessagePortChannelProvider.cpp
@@ -59,12 +59,14 @@ static inline IPC::Connection& networkProcessConnection()
     return WebProcess::singleton().ensureNetworkProcessConnection().connection();
 }
 
-void WebMessagePortChannelProvider::createNewMessagePortChannel(const MessagePortIdentifier& port1, const MessagePortIdentifier& port2)
+void WebMessagePortChannelProvider::createNewMessagePortChannel(const MessagePortIdentifier& port1, const MessagePortIdentifier& port2, bool siteIsolationEnabled)
 {
-    ASSERT(!m_inProcessPortMessages.contains(port1));
-    ASSERT(!m_inProcessPortMessages.contains(port2));
-    m_inProcessPortMessages.add(port1, Vector<MessageWithMessagePorts> { });
-    m_inProcessPortMessages.add(port2, Vector<MessageWithMessagePorts> { });
+    if (!siteIsolationEnabled) {
+        ASSERT(!m_inProcessPortMessages.contains(port1));
+        ASSERT(!m_inProcessPortMessages.contains(port2));
+        m_inProcessPortMessages.add(port1, Vector<MessageWithMessagePorts> { });
+        m_inProcessPortMessages.add(port2, Vector<MessageWithMessagePorts> { });
+    }
 
     networkProcessConnection().send(Messages::NetworkConnectionToWebProcess::CreateNewMessagePortChannel { port1, port2 }, 0);
 }

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebMessagePortChannelProvider.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebMessagePortChannelProvider.h
@@ -43,7 +43,7 @@ private:
     WebMessagePortChannelProvider();
     ~WebMessagePortChannelProvider() final;
 
-    void createNewMessagePortChannel(const WebCore::MessagePortIdentifier& local, const WebCore::MessagePortIdentifier& remote) final;
+    void createNewMessagePortChannel(const WebCore::MessagePortIdentifier& local, const WebCore::MessagePortIdentifier& remote, bool siteIsolationEnabled) final;
     void entangleLocalPortInThisProcessToRemote(const WebCore::MessagePortIdentifier& local, const WebCore::MessagePortIdentifier& remote) final;
     void messagePortDisentangled(const WebCore::MessagePortIdentifier& local) final;
     void messagePortClosed(const WebCore::MessagePortIdentifier& local) final;


### PR DESCRIPTION
#### facee632ca540dd4cabc522903c54418b326656f
<pre>
Fix MessageChannel with site isolation enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=293822">https://bugs.webkit.org/show_bug.cgi?id=293822</a>

Reviewed by Sihui Liu.

In 255948@main we introduced a performance optimization to avoid IPC when a MessagePort
is in the same process as its other port.  However, with site isolation enabled we don&apos;t
know that the MessagePort will continue to only be used in the same process so this
performance optimization caused messages to be dropped when sent by the same process that
created the MessageChannel.  Skip the perf optimization when site isolation is enabled.
This is one of at least 2 fixes needed to fix <a href="https://rdar.apple.com/145004235">rdar://145004235</a>

* Source/WebCore/dom/MessageChannel.cpp:
(WebCore::MessageChannel::MessageChannel):
* Source/WebCore/dom/messageports/MessagePortChannelProvider.h:
* Source/WebCore/dom/messageports/MessagePortChannelProviderImpl.cpp:
(WebCore::MessagePortChannelProviderImpl::createNewMessagePortChannel):
* Source/WebCore/dom/messageports/MessagePortChannelProviderImpl.h:
* Source/WebCore/dom/messageports/WorkerMessagePortChannelProvider.cpp:
(WebCore::WorkerMessagePortChannelProvider::createNewMessagePortChannel):
* Source/WebCore/dom/messageports/WorkerMessagePortChannelProvider.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebMessagePortChannelProvider.cpp:
(WebKit::WebMessagePortChannelProvider::createNewMessagePortChannel):
* Source/WebKit/WebProcess/WebCoreSupport/WebMessagePortChannelProvider.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm:
(TestWebKitAPI::TEST(SiteIsolation, PostMessageWithMessagePorts)):

Canonical link: <a href="https://commits.webkit.org/295627@main">https://commits.webkit.org/295627@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e289d952a89abd9291b92d8e99ea508e35640c30

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105671 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25422 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15815 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110868 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/56266 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/107712 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/25896 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33925 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80252 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/56266 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108677 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/20247 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95363 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60559 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/19980 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13452 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55706 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/89699 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13495 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/113717 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32811 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/24191 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/89334 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33175 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91586 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88994 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33873 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11670 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/28271 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17141 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32736 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/38128 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32482 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35831 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34080 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->