### PR TITLE
Switch to TextIndicator for InteractionInformationAtPosition.

### DIFF
--- a/Source/WebKit/Shared/ios/InteractionInformationAtPosition.h
+++ b/Source/WebKit/Shared/ios/InteractionInformationAtPosition.h
@@ -109,7 +109,7 @@ struct InteractionInformationAtPosition {
 
     CursorContext cursorContext;
 
-    WebCore::TextIndicatorData linkIndicator;
+    RefPtr<WebCore::TextIndicator> textIndicator;
 #if ENABLE(DATA_DETECTION)
     String dataDetectorIdentifier;
     RetainPtr<NSArray> dataDetectorResults;

--- a/Source/WebKit/Shared/ios/InteractionInformationAtPosition.mm
+++ b/Source/WebKit/Shared/ios/InteractionInformationAtPosition.mm
@@ -42,7 +42,7 @@ void InteractionInformationAtPosition::mergeCompatibleOptionalInformation(const 
         image = oldInformation.image;
 
     if (oldInformation.request.includeLinkIndicator && !request.includeLinkIndicator)
-        linkIndicator = oldInformation.linkIndicator;
+        textIndicator = oldInformation.textIndicator;
 }
 
 #endif // PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/Shared/ios/InteractionInformationAtPosition.serialization.in
+++ b/Source/WebKit/Shared/ios/InteractionInformationAtPosition.serialization.in
@@ -82,7 +82,7 @@ struct WebKit::InteractionInformationAtPosition {
 
     WebKit::CursorContext cursorContext;
 
-    WebCore::TextIndicatorData linkIndicator;
+    RefPtr<WebCore::TextIndicator> textIndicator;
 #if ENABLE(DATA_DETECTION)
     String dataDetectorIdentifier;
     [SecureCodingAllowed=[NSArray.class, PAL::getDDScannerResultClass()]] RetainPtr<NSArray> dataDetectorResults;

--- a/Source/WebKit/UIProcess/ios/WKActionSheetAssistant.mm
+++ b/Source/WebKit/UIProcess/ios/WKActionSheetAssistant.mm
@@ -203,13 +203,13 @@ static const CGFloat presentationElementRectPadding = 15;
     if (!view || !delegate || !_positionInformation)
         return CGRectZero;
 
-    auto indicator = _positionInformation->linkIndicator;
-    if (indicator.textRectsInBoundingRectCoordinates.isEmpty())
+    RefPtr textIndicator = _positionInformation->textIndicator;
+    if (textIndicator->textRectsInBoundingRectCoordinates().isEmpty())
         return CGRectZero;
 
     WebCore::FloatPoint touchLocation = _positionInformation->request.point;
-    WebCore::FloatPoint linkElementLocation = indicator.textBoundingRectInRootViewCoordinates.location();
-    auto indicatedRects = indicator.textRectsInBoundingRectCoordinates.map([&](auto rect) {
+    WebCore::FloatPoint linkElementLocation = textIndicator->textBoundingRectInRootViewCoordinates().location();
+    auto indicatedRects = textIndicator->textRectsInBoundingRectCoordinates().map([&](auto rect) {
         rect.inflate(2);
         rect.moveBy(linkElementLocation);
         return rect;
@@ -466,7 +466,7 @@ static bool isJavaScriptURL(NSURL *url)
     if (std::max(leftInset, rightInset) <= minimumAvailableWidthOrHeightRatio * CGRectGetWidth(visibleRect) && std::max(topInset, bottomInset) <= minimumAvailableWidthOrHeightRatio * CGRectGetHeight(visibleRect))
         return WKActionSheetPresentAtTouchLocation;
 
-    if (elementInfo.type == _WKActivatedElementTypeLink && positionInfo.linkIndicator.textRectsInBoundingRectCoordinates.size())
+    if (elementInfo.type == _WKActivatedElementTypeLink && positionInfo.textIndicator->textRectsInBoundingRectCoordinates().size())
         return WKActionSheetPresentAtClosestIndicatorRect;
 
     return WKActionSheetPresentAtElementRect;
@@ -927,7 +927,7 @@ static NSMutableArray<UIMenuElement *> *menuElementsFromDefaultActions(RetainPtr
 
         CGRect sourceRect;
         if (_positionInformation->isLink)
-            sourceRect = _positionInformation->linkIndicator.textBoundingRectInRootViewCoordinates;
+            sourceRect = _positionInformation->textIndicator->textBoundingRectInRootViewCoordinates();
         else
             sourceRect = _positionInformation->bounds;
 

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -10024,7 +10024,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
     CGRect sourceRect;
     if (positionInformation.isLink)
-        sourceRect = positionInformation.linkIndicator.textBoundingRectInRootViewCoordinates;
+        sourceRect = positionInformation.textIndicator->textBoundingRectInRootViewCoordinates();
     else if (!positionInformation.dataDetectorBounds.isEmpty())
         sourceRect = positionInformation.dataDetectorBounds;
     else
@@ -11656,11 +11656,11 @@ static RetainPtr<UITargetedPreview> createFallbackTargetedPreview(UIView *rootVi
 {
     RetainPtr<UITargetedPreview> targetedPreview;
 
-    if (_positionInformation.isLink && _positionInformation.linkIndicator.contentImage) {
-        auto indicator = _positionInformation.linkIndicator;
-        _positionInformationLinkIndicator = indicator;
+    if (_positionInformation.isLink && _positionInformation.textIndicator->contentImage()) {
+        RefPtr indicator = _positionInformation.textIndicator;
+        _positionInformationLinkIndicator = indicator ? std::optional { indicator->data() } : std::nullopt;
 
-        targetedPreview = [self _createTargetedPreviewFromTextIndicator:indicator previewContainer:self.containerForContextMenuHintPreviews];
+        targetedPreview = [self _createTargetedPreviewFromTextIndicator:indicator->data() previewContainer:self.containerForContextMenuHintPreviews];
     } else if ((_positionInformation.isAttachment || _positionInformation.isImage) && _positionInformation.image) {
         auto cgImage = _positionInformation.image->makeCGImageCopy();
         auto image = adoptNS([[UIImage alloc] initWithCGImage:cgImage.get()]);
@@ -15621,10 +15621,10 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 - (UIImage *)_presentationSnapshotForPreviewItemController:(UIPreviewItemController *)controller
 {
-    if (!_positionInformation.linkIndicator.contentImage)
+    if (!_positionInformation.textIndicator->contentImage())
         return nullptr;
 
-    auto nativeImage = _positionInformation.linkIndicator.contentImage->nativeImage();
+    auto nativeImage = _positionInformation.textIndicator->contentImage()->nativeImage();
     if (!nativeImage)
         return nullptr;
 
@@ -15633,9 +15633,9 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 - (NSArray *)_presentationRectsForPreviewItemController:(UIPreviewItemController *)controller
 {
-    if (_positionInformation.linkIndicator.contentImage) {
-        auto origin = _positionInformation.linkIndicator.textBoundingRectInRootViewCoordinates.location();
-        return createNSArray(_positionInformation.linkIndicator.textRectsInBoundingRectCoordinates, [&] (CGRect rect) {
+    if (_positionInformation.textIndicator->contentImage()) {
+        auto origin = _positionInformation.textIndicator->textBoundingRectInRootViewCoordinates().location();
+        return createNSArray(_positionInformation.textIndicator->textRectsInBoundingRectCoordinates(), [&] (CGRect rect) {
             return [NSValue valueWithCGRect:CGRectOffset(rect, origin.x(), origin.y())];
         }).autorelease();
     } else {

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -3449,7 +3449,7 @@ static void linkIndicatorPositionInformation(WebPage& page, Element& linkElement
     auto textIndicator = TextIndicator::createWithRange(linkRange, textIndicatorOptions, TextIndicatorPresentationTransition::None, FloatSize(marginInPoints * deviceScaleFactor, marginInPoints * deviceScaleFactor));
 
     if (textIndicator)
-        info.linkIndicator = textIndicator->data();
+        info.textIndicator = textIndicator;
 }
     
 #if ENABLE(DATA_DETECTION)
@@ -3984,7 +3984,7 @@ InteractionInformationAtPosition WebPage::positionInformation(const InteractionI
             info.isLink = true;
             info.url = WTFMove(url);
             info.bounds = enclosingIntRect(bounds);
-            info.linkIndicator = textIndicator->data();
+            info.textIndicator = textIndicator;
         }
         info.isInPlugin = true;
     }


### PR DESCRIPTION
#### 0fe7f6034ba4e2d6eeadde09e0a6d6fd2d292d52
<pre>
Switch to TextIndicator for InteractionInformationAtPosition.
<a href="https://bugs.webkit.org/show_bug.cgi?id=293825">https://bugs.webkit.org/show_bug.cgi?id=293825</a>
<a href="https://rdar.apple.com/152332238">rdar://152332238</a>

Reviewed by Aditya Keerthi and Tim Horton.

Continuing to switch to TextIndicator in more places.

* Source/WebKit/Shared/ios/InteractionInformationAtPosition.h:
* Source/WebKit/Shared/ios/InteractionInformationAtPosition.mm:
(WebKit::InteractionInformationAtPosition::mergeCompatibleOptionalInformation):
* Source/WebKit/Shared/ios/InteractionInformationAtPosition.serialization.in:
* Source/WebKit/UIProcess/ios/WKActionSheetAssistant.mm:
(-[WKActionSheetAssistant presentationRectForElementUsingClosestIndicatedRect]):
(-[WKActionSheetAssistant _presentationStyleForPositionInfo:elementInfo:]):
(-[WKActionSheetAssistant contextMenuInteraction:configurationForMenuAtLocation:]):
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView dataDetectionContextForPositionInformation:]):
(-[WKContentView _createTargetedContextMenuHintPreviewIfPossible]):
(-[WKContentView _presentationSnapshotForPreviewItemController:]):
(-[WKContentView _presentationRectsForPreviewItemController:]):
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::linkIndicatorPositionInformation):
(WebKit::WebPage::positionInformation):

Canonical link: <a href="https://commits.webkit.org/295634@main">https://commits.webkit.org/295634@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8f92c145a045cbeedeb84d91ee622be2a52ac87f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105718 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25469 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15862 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110915 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/56313 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/25949 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33972 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80283 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/56313 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108724 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/20294 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95404 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60593 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/20014 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55753 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/89742 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13536 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/113764 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32858 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/24219 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/89361 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33222 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91631 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89025 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/22691 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33902 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11710 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/28318 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17149 "Built successfully and passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32783 "Build is in progress. Recent messages:OS: Sequoia (15.5), Xcode: 16.4; Running apply-patch; Checked out pull request; Compiled WebKit (warnings)") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/38192 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32529 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35878 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34127 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->