### PR TITLE
[SwiftUI] SwiftBrowser should support a URL CLI argument

### DIFF
--- a/Tools/Scripts/webkitpy/swiftbrowser/run_webkit_app.py
+++ b/Tools/Scripts/webkitpy/swiftbrowser/run_webkit_app.py
@@ -34,7 +34,7 @@ from webkitcorepy.string_utils import decode
 
 
 def main(argv):
-    option_parser = argparse.ArgumentParser(formatter_class=argparse.RawDescriptionHelpFormatter, usage="%(prog)s")
+    option_parser = argparse.ArgumentParser(formatter_class=argparse.RawDescriptionHelpFormatter, usage="%(prog)s [options] [url]")
     groups = [("Platform options", platform_options()), ("Configuration options", configuration_options())]
 
     # Convert options to argparse, so that we can use parse_known_args() which is not supported in optparse.
@@ -51,17 +51,15 @@ def main(argv):
                 option_group.add_argument(option.get_opt_string(), action=option.action, dest=option.dest,
                                           help=option.help, const=option.const, default=default)
 
-    options, args = option_parser.parse_known_args(argv)
+    option_parser.add_argument('url', metavar='url', type=lambda s: decode(s, 'utf8'), nargs='?', help='Website URL to load')
+    options, _ = option_parser.parse_known_args(argv)
 
     if not options.platform:
         options.platform = "mac"
 
-    # Make this a well-formed arg list if SwiftBrowser ever supports command line arguments.
-    browser_args = []
-
     try:
         port = factory.PortFactory(Host()).get(options.platform, options=options)
-        return port.run_swiftbrowser(browser_args)
+        return port.run_swiftbrowser(["--url", options.url] if options.url else [])
     except BaseException as e:
         if isinstance(e, Exception):
             print('\n%s raised: %s' % (e.__class__.__name__, str(e)), file=sys.stderr)

--- a/Tools/SwiftBrowser/Source/Extensions/CommandLine+Extras.swift
+++ b/Tools/SwiftBrowser/Source/Extensions/CommandLine+Extras.swift
@@ -1,0 +1,37 @@
+// Copyright (C) 2025 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+
+extension CommandLine {
+    static func value(for flag: String) -> String? {
+        guard let flagIndex = arguments.firstIndex(of: flag) else {
+            return nil
+        }
+
+        let valueIndex = arguments.index(after: flagIndex)
+        guard valueIndex < arguments.endIndex else {
+            return nil
+        }
+
+        return arguments[valueIndex]
+    }
+}

--- a/Tools/SwiftBrowser/SwiftBrowser.xcodeproj/project.pbxproj
+++ b/Tools/SwiftBrowser/SwiftBrowser.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		07A58C0E2D04DD4700CAB4ED /* WebKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 07A58C0D2D04DD4700CAB4ED /* WebKit.framework */; };
 		07A58C482D05651C00CAB4ED /* AppStorageKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07A58C472D05651C00CAB4ED /* AppStorageKeys.swift */; };
 		07A58C4A2D0567A100CAB4ED /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07A58C492D0567A100CAB4ED /* SettingsView.swift */; };
+		330FBEE22DEAD07600C266CA /* CommandLine+Extras.swift in Sources */ = {isa = PBXBuildFile; fileRef = 330FBEE12DEAD05F00C266CA /* CommandLine+Extras.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -58,6 +59,7 @@
 		07A58C0D2D04DD4700CAB4ED /* WebKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = WebKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		07A58C472D05651C00CAB4ED /* AppStorageKeys.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStorageKeys.swift; sourceTree = "<group>"; };
 		07A58C492D0567A100CAB4ED /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
+		330FBEE12DEAD05F00C266CA /* CommandLine+Extras.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CommandLine+Extras.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -97,6 +99,7 @@
 		07259B372D1F978200B45C4E /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				330FBEE12DEAD05F00C266CA /* CommandLine+Extras.swift */,
 				078F11842D288FAC00B3582D /* URLRequest+Codable.swift */,
 				07259B382D1F97A500B45C4E /* URLResponse+Extras.swift */,
 			);
@@ -256,6 +259,7 @@
 				07A58C482D05651C00CAB4ED /* AppStorageKeys.swift in Sources */,
 				07A58C022D04111900CAB4ED /* BrowserView.swift in Sources */,
 				07A58C002D040E3400CAB4ED /* BrowserViewModel.swift in Sources */,
+				330FBEE22DEAD07600C266CA /* CommandLine+Extras.swift in Sources */,
 				07A58BEE2D04013100CAB4ED /* ContentView.swift in Sources */,
 				07259B2E2D1F308500B45C4E /* DialogPresenter.swift in Sources */,
 				07A4CE9F2D08C06400764F5E /* Empty.swift in Sources */,


### PR DESCRIPTION
#### 0a0952a23ca4359a04d380456efc0a7693da44db
<pre>
[SwiftUI] SwiftBrowser should support a URL CLI argument
<a href="https://bugs.webkit.org/show_bug.cgi?id=293826">https://bugs.webkit.org/show_bug.cgi?id=293826</a>
<a href="https://rdar.apple.com/152332512">rdar://152332512</a>

Reviewed by Richard Robinson.

This patch imbues SwiftBrowser with the ability to process a `--url`
CLI argument instead of defaulting to webkit.org as a landing page.

* Tools/Scripts/webkitpy/swiftbrowser/run_webkit_app.py:
(main):
* Tools/SwiftBrowser/Source/Extensions/CommandLine+Extras.swift:
(CommandLine.value(for:)):
  Introduce an extension to CommandLine that allows callers to retrieve
  the `--url` argument value with `CommandLine.value(for: &quot;--url&quot;)`.
* Tools/SwiftBrowser/Source/SwiftBrowser.swift:
(SwiftBrowserApp.addProtocolIfNecessary(to:)):
  Defaults to http if a scheme is missing, but accepts about: and data:
  URLs as-is.
(SwiftBrowserApp.body):
* Tools/SwiftBrowser/SwiftBrowser.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/295657@main">https://commits.webkit.org/295657@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/146fe93ffb43d724964238d9007ec2febedba700

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105793 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25544 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15937 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110990 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/56389 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/107834 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/26074 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34047 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80340 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108799 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/20438 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95467 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60653 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/105271 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/20122 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13564 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55828 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/89861 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13603 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/113839 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32933 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24268 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/89422 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33297 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91698 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89092 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22709 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33964 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11772 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/28415 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32858 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32604 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35953 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34202 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->