### PR TITLE
Content inset fill view obscures media controls in element fullscreen

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -138,6 +138,10 @@ class WebViewImpl;
 #if PLATFORM(IOS_FAMILY)
 class ViewGestureController;
 #endif
+enum class HideContentInsetFillReason : uint8_t {
+    FullScreen      = 1 << 0,
+    ScrolledToTop   = 1 << 1,
+};
 }
 
 @class WKColorExtensionView;
@@ -458,6 +462,7 @@ struct PerWebProcessState {
 
 #if ENABLE(CONTENT_INSET_BACKGROUND_FILL)
     WebCore::RectEdges<RetainPtr<WKColorExtensionView>> _fixedColorExtensionViews;
+    OptionSet<WebKit::HideContentInsetFillReason> _reasonsToHideTopContentInsetFill;
 #endif
 }
 
@@ -530,6 +535,8 @@ struct PerWebProcessState {
 #if ENABLE(CONTENT_INSET_BACKGROUND_FILL)
 - (void)_updateFixedColorExtensionViewFrames;
 - (BOOL)_hasVisibleColorExtensionView:(WebCore::BoxSide)side;
+- (void)_addReasonToHideTopContentInsetFill:(WebKit::HideContentInsetFillReason)reason;
+- (void)_removeReasonToHideTopContentInsetFill:(WebKit::HideContentInsetFillReason)reason;
 #endif
 
 #if ENABLE(GAMEPAD)

--- a/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
+++ b/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
@@ -1568,7 +1568,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     _usesAutomaticContentInsetBackgroundFill = value;
 
 #if ENABLE(CONTENT_INSET_BACKGROUND_FILL)
-    _impl->updateContentInsetFillViews();
+    _impl->updateTopContentInsetFillDueToScrolling();
 #endif
 }
 

--- a/Source/WebKit/UIProcess/Cocoa/FullscreenClient.mm
+++ b/Source/WebKit/UIProcess/Cocoa/FullscreenClient.mm
@@ -77,6 +77,10 @@ void FullscreenClient::willEnterFullscreen(WebPageProxy*)
     if (m_delegateMethods.webViewWillEnterElementFullscreen)
         [m_delegate.get() _webViewWillEnterElementFullscreen:webView.get()];
 #endif
+
+#if ENABLE(CONTENT_INSET_BACKGROUND_FILL)
+    [webView _addReasonToHideTopContentInsetFill:HideContentInsetFillReason::FullScreen];
+#endif
 }
 
 void FullscreenClient::didEnterFullscreen(WebPageProxy*)
@@ -112,6 +116,10 @@ void FullscreenClient::willExitFullscreen(WebPageProxy*)
 #else
     if (m_delegateMethods.webViewWillExitElementFullscreen)
         [m_delegate.get() _webViewWillExitElementFullscreen:webView.get()];
+#endif
+
+#if ENABLE(CONTENT_INSET_BACKGROUND_FILL)
+    [webView _removeReasonToHideTopContentInsetFill:HideContentInsetFillReason::FullScreen];
 #endif
 }
 

--- a/Source/WebKit/UIProcess/ios/WKScrollView.h
+++ b/Source/WebKit/UIProcess/ios/WKScrollView.h
@@ -44,7 +44,7 @@
 - (void)_setDecelerationRateInternal:(UIScrollViewDecelerationRate)rate;
 
 #if ENABLE(CONTENT_INSET_BACKGROUND_FILL)
-- (void)_setFixedColorExtensionEdges:(UIRectEdge)edges;
+@property (nonatomic, setter=_setHiddenContentInsetFillEdges:) UIRectEdge _hiddenContentInsetFillEdges;
 #endif
 
 - (void)_resetContentInset;

--- a/Source/WebKit/UIProcess/ios/WKScrollView.mm
+++ b/Source/WebKit/UIProcess/ios/WKScrollView.mm
@@ -137,7 +137,7 @@ static BOOL shouldForwardScrollViewDelegateMethodToExternalDelegate(SEL selector
     BOOL _indicatorStyleSetByClient;
     BOOL _decelerationRateSetByClient;
 #if ENABLE(CONTENT_INSET_BACKGROUND_FILL)
-    BOOL _fixedColorExtensionEdgesSetByClient;
+    BOOL _hiddenContentInsetFillEdgesSetByClient;
 #endif
 // FIXME: Likely we can remove this special case for watchOS.
 #if !PLATFORM(WATCHOS)

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -792,6 +792,7 @@ public:
     WKNSContentInsetFillView *topContentInsetFillView() const { return m_topContentInsetFillView.get(); }
     void registerViewAboveTopContentInsetArea(NSView *);
     void unregisterViewAboveTopContentInsetArea(NSView *);
+    void updateTopContentInsetFillDueToScrolling();
 #endif
 
 private:

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -2364,11 +2364,24 @@ void WebViewImpl::pageDidScroll(const IntPoint& scrollPosition)
     m_pageIsScrolledToTop = pageIsScrolledToTop;
 
 #if ENABLE(CONTENT_INSET_BACKGROUND_FILL)
-    updateContentInsetFillViews();
+    updateTopContentInsetFillDueToScrolling();
 #endif
 
     [m_view didChangeValueForKey:@"hasScrolledContentsUnderTitlebar"];
 }
+
+#if ENABLE(CONTENT_INSET_BACKGROUND_FILL)
+
+void WebViewImpl::updateTopContentInsetFillDueToScrolling()
+{
+    RetainPtr view = m_view.get();
+    if ([view _usesAutomaticContentInsetBackgroundFill] && m_pageIsScrolledToTop)
+        [view _addReasonToHideTopContentInsetFill:HideContentInsetFillReason::ScrolledToTop];
+    else
+        [view _removeReasonToHideTopContentInsetFill:HideContentInsetFillReason::ScrolledToTop];
+}
+
+#endif // ENABLE(CONTENT_INSET_BACKGROUND_FILL)
 
 NSRect WebViewImpl::scrollViewFrame()
 {


### PR DESCRIPTION
#### fdce102465d769a6932598d2815c0024a2598870
<pre>
Content inset fill view obscures media controls in element fullscreen
<a href="https://bugs.webkit.org/show_bug.cgi?id=293833">https://bugs.webkit.org/show_bug.cgi?id=293833</a>
<a href="https://rdar.apple.com/152166931">rdar://152166931</a>

Reviewed by Abrar Rahman Protyasha, Megan Gardner, and Tim Horton.

Refactor logic for hiding content inset fill views, such that we can hide them in element fullscreen
mode. To do this, we introduce a new options enum — `HideContentInsetFillReason` — to keep track of
reasons for suppressing visibility for the content inset fill. We then use this mechanism to hide
the view when we&apos;re about to enter element fullscreen, and show it again when we&apos;re about to exit.

Using an option set of reason flags here allows us to both:

1.  Reconcile logic for hiding the top inset fill view in element fullscreen with existing logic to
    hide the inset fill view when automatic appearance is enabled on macOS.

2.  Allows us to easily add more reasons in the future.

See below for more details.

* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _updateFixedColorExtensionEdges]):

Rename `-_setFixedColorExtensionEdges:` to `-_setHiddenContentInsetFillEdges:`, which better
encapsulates the underlying behavior. Also check for `_reasonsToHideTopContentInsetFill` when
determining whether we need to suppress the inset fill view along the top edge.

(-[WKWebView _addReasonToHideTopContentInsetFill:]):
(-[WKWebView _removeReasonToHideTopContentInsetFill:]):

Add the two new helper methods to (respectively) add or remove `HideContentInsetFillReason`s.

(-[WKWebView _setTopContentInsetFillHidden:]):

Called when the reasons `OptionSet` goes from being empty to non-empty, or vice versa.

* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:
* Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm:
(-[WKWebView _setUsesAutomaticContentInsetBackgroundFill:]):

Call into `updateTopContentInsetFillDueToScrolling()`. This is called here because whether or not we
should suppress the top content inset fill view when we&apos;re scrolled to the top also depends on
whether or not the client is opting into the automatic content inset fill appearance.

* Source/WebKit/UIProcess/Cocoa/FullscreenClient.mm:
(WebKit::FullscreenClient::willEnterFullscreen):
(WebKit::FullscreenClient::willExitFullscreen):

Add or remove `HideContentInsetFillReason::FullScreen` when entering or exiting fullscreen.

* Source/WebKit/UIProcess/ios/WKScrollView.h:
* Source/WebKit/UIProcess/ios/WKScrollView.mm:
* Source/WebKit/UIProcess/mac/WebViewImpl.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::pageDidScroll):
(WebKit::WebViewImpl::updateTopContentInsetFillDueToScrolling):

Canonical link: <a href="https://commits.webkit.org/295638@main">https://commits.webkit.org/295638@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5ae00568737f2a007bcdb8dd3827455471155484

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105734 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25485 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15878 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110931 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/56329 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/25966 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33988 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80295 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/56329 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108740 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/20308 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95412 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60606 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/20030 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55769 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/89754 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13548 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/113780 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32874 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/24229 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89370 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33238 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91643 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89038 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22694 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33913 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11718 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/28334 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32799 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/38209 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32545 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35894 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34143 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->