### PR TITLE
Draft: cleaning up Font::applyTransforms

### DIFF
--- a/Source/WebCore/platform/graphics/Font.cpp
+++ b/Source/WebCore/platform/graphics/Font.cpp
@@ -578,7 +578,7 @@ RefPtr<Font> Font::createHalfWidthFont() const
 }
 
 #if !USE(CORE_TEXT)
-GlyphBufferAdvance Font::applyTransforms(GlyphBuffer&, unsigned, unsigned, bool, bool, const AtomString&, StringView, TextDirection) const
+GlyphBufferAdvance Font::applyTransforms(GlyphBuffer&, unsigned, bool, bool, const AtomString&, StringView, TextDirection) const
 {
     return makeGlyphBufferAdvance();
 }

--- a/Source/WebCore/platform/graphics/Font.h
+++ b/Source/WebCore/platform/graphics/Font.h
@@ -240,7 +240,7 @@ public:
 #endif
 
     bool canRenderCombiningCharacterSequence(StringView) const;
-    GlyphBufferAdvance applyTransforms(GlyphBuffer&, unsigned beginningGlyphIndex, unsigned beginningStringIndex, bool enableKerning, bool requiresShaping, const AtomString& locale, StringView text, TextDirection) const;
+    GlyphBufferAdvance applyTransforms(GlyphBuffer&, unsigned beginningGlyphIndex, bool enableKerning, bool requiresShaping, const AtomString& locale, StringView text, TextDirection) const;
 
     // Returns nullopt if none of the glyphs are OT-SVG glyphs.
     std::optional<BitVector> findOTSVGGlyphs(std::span<const GlyphBufferGlyph>) const;

--- a/Source/WebCore/platform/graphics/FontCascade.cpp
+++ b/Source/WebCore/platform/graphics/FontCascade.cpp
@@ -361,7 +361,7 @@ NEVER_INLINE float FontCascade::widthForSimpleTextSlow(StringView text, TextDire
     else
         addGlyphsFromText(glyphBuffer, font, text.span16());
 
-    auto initialAdvance = font->applyTransforms(glyphBuffer, 0, 0, enableKerning(), requiresShaping(), fontDescription().computedLocale(), text, textDirection);
+    auto initialAdvance = font->applyTransforms(glyphBuffer, 0, enableKerning(), requiresShaping(), fontDescription().computedLocale(), text, textDirection);
     auto width = 0.f;
     for (size_t i = 0; i < glyphBuffer.size(); ++i)
         width += WebCore::width(glyphBuffer.advanceAt(i));

--- a/Source/WebCore/platform/graphics/WidthIterator.cpp
+++ b/Source/WebCore/platform/graphics/WidthIterator.cpp
@@ -92,7 +92,7 @@ inline auto WidthIterator::applyFontTransforms(GlyphBuffer& glyphBuffer, unsigne
     for (unsigned i = lastGlyphCount; i < glyphBufferSize; ++i)
         beforeWidth += width(advances[i]);
 
-    auto initialAdvance = font.applyTransforms(glyphBuffer, lastGlyphCount, m_currentCharacterIndex, m_enableKerning, m_requiresShaping, m_fontCascade->fontDescription().computedLocale(), m_run->text(), direction());
+    auto initialAdvance = font.applyTransforms(glyphBuffer, lastGlyphCount, m_enableKerning, m_requiresShaping, m_fontCascade->fontDescription().computedLocale(), m_run->text(), direction());
 
     glyphBufferSize = glyphBuffer.size();
     advances = glyphBuffer.advances();

--- a/Source/WebCore/platform/graphics/coretext/FontCoreText.cpp
+++ b/Source/WebCore/platform/graphics/coretext/FontCoreText.cpp
@@ -596,7 +596,7 @@ float Font::platformWidthForGlyph(Glyph glyph) const
     return advance.width;
 }
 
-GlyphBufferAdvance Font::applyTransforms(GlyphBuffer& glyphBuffer, unsigned beginningGlyphIndex, unsigned beginningStringIndex, bool enableKerning, bool requiresShaping, const AtomString& locale, StringView text, TextDirection textDirection) const
+GlyphBufferAdvance Font::applyTransforms(GlyphBuffer& glyphBuffer, unsigned beginningGlyphIndex, bool enableKerning, bool requiresShaping, const AtomString& locale, StringView text, TextDirection textDirection) const
 {
     UNUSED_PARAM(requiresShaping);
 
@@ -619,19 +619,14 @@ GlyphBufferAdvance Font::applyTransforms(GlyphBuffer& glyphBuffer, unsigned begi
         *newIndicesPointer = glyphBuffer.offsetsInString(beginningGlyphIndex).data();
     };
 
-    auto substring = text.substring(beginningStringIndex);
     constexpr unsigned bufferSize = 256;
-    auto upconvertedCharacters = substring.upconvertedCharacters<bufferSize>();
+    auto upconvertedCharacters = text.upconvertedCharacters<bufferSize>();
     auto localeString = locale.isNull() ? nullptr : LocaleCocoa::canonicalLanguageIdentifierFromString(locale);
     auto numberOfInputGlyphs = glyphBuffer.size() - beginningGlyphIndex;
     // FIXME: Enable kerning for single glyphs when rdar://82195405 is fixed
     CTFontShapeOptions options = kCTFontShapeWithClusterComposition
         | (enableKerning && numberOfInputGlyphs ? kCTFontShapeWithKerning : 0)
         | (textDirection == TextDirection::RTL ? kCTFontShapeRightToLeft : 0);
-
-    // FIXME: This shouldn't actually be necessary, if we pass in a pointer to the base of the string.
-    for (unsigned i = 0; i < glyphBuffer.size() - beginningGlyphIndex; ++i)
-        glyphBuffer.offsetsInString(beginningGlyphIndex)[i] -= beginningStringIndex;
 
     LOG_WITH_STREAM(TextShaping,
         stream << "Simple shaping " << numberOfInputGlyphs << " glyphs in font " << String(adoptCF(CTFontCopyPostScriptName(getCTFont())).get()) << ".\n";
@@ -703,9 +698,6 @@ GlyphBufferAdvance Font::applyTransforms(GlyphBuffer& glyphBuffer, unsigned begi
 
     ASSERT(numberOfInputGlyphs || glyphBuffer.size() == beginningGlyphIndex);
     ASSERT(numberOfInputGlyphs || (!initialAdvance.width && !initialAdvance.height));
-
-    for (unsigned i = 0; i < glyphBuffer.size() - beginningGlyphIndex; ++i)
-        glyphBuffer.offsetsInString(beginningGlyphIndex)[i] += beginningStringIndex;
 
     if (textDirection == TextDirection::RTL)
         glyphBuffer.reverse(beginningGlyphIndex, glyphBuffer.size() - beginningGlyphIndex);


### PR DESCRIPTION
#### b065d8b799e5ffc0b0dc600dc6cbd98a1be5456f
<pre>
Draft: cleaning up Font::applyTransforms
Need the bug URL (OOPS!).
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

* Source/WebCore/platform/graphics/Font.cpp:
(WebCore::Font::applyTransforms const):
* Source/WebCore/platform/graphics/Font.h:
* Source/WebCore/platform/graphics/FontCascade.cpp:
(WebCore::FontCascade::widthForSimpleText const):
* Source/WebCore/platform/graphics/WidthIterator.cpp:
(WebCore::WidthIterator::applyFontTransforms):
* Source/WebCore/platform/graphics/coretext/FontCoreText.cpp:
(WebCore::Font::applyTransforms const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b065d8b799e5ffc0b0dc600dc6cbd98a1be5456f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105725 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25476 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15869 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110922 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/56320 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/107766 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/26062 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33979 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80292 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108731 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/20425 "Found 6 new test failures: fast/attachment/cocoa/wide-attachment-rendering.html fast/text/capitalize-content-with-outside-bmp-characters.html fast/text/capitalize-content-with-outside-bmp-previous-characters.html fast/text/fallback-font-and-zero-width-glyph.html fast/text/international/bidi-explicit-embedding.html fast/text/international/old-turkic-direction.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95407 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60603 "Found 139 new API test failures: /WPE/TestUIClient:/webkit/WebKitWebView/query-permission-requests, /WPE/TestWebsiteData:/webkit/WebKitWebsiteData/deviceidhashsalt, /WPE/TestLoaderClient:/webkit/WebKitWebView/load-twice-and-reload, /WPE/TestWebKitWebView:/webkit/WebKitWebView/is-playing-audio, /WPE/TestWebsiteData:/webkit/WebKitWebsiteData/configuration, /WPE/TestCookieManager:/webkit/WebKitCookieManager/delete-cookies, /WPE/TestWebKitWebView:/webkit/WebKitWebView/terminate-unresponsive-web-process, /WPE/TestSSL:/webkit/WebKitWebView/insecure-content, /WPE/TestAuthentication:/webkit/Authentication/authentication-storage, /WPE/TestWebKitWebContext:/webkit/WebKitWebContext/timezone-worker ... (failure)") | 
| | [💥 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/20113 "An unexpected error occured. Recent messages:Printed configuration") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13501 "Found 60 new test failures: compositing/transforms/transformed-replaced-with-shadow-children.html fast/dom/52776.html fast/text/capitalize-content-with-outside-bmp-characters.html fast/text/capitalize-content-with-outside-bmp-previous-characters.html fast/text/drawBidiText.html fast/text/fallback-font-and-zero-width-glyph.html fast/text/international/bdi-dir-default-to-auto.html fast/text/international/bdi-neutral-wrapped.html fast/text/international/bidi-LDB-2-formatting-characters.html fast/text/international/bidi-neutral-run.html ... (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55760 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/89850 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13540 "Found 60 new test failures: compositing/transforms/transformed-replaced-with-shadow-children.html fast/attachment/cocoa/wide-attachment-rendering.html fast/attachment/mac/wide-attachment-title-with-rtl.html fast/dom/52776.html fast/text/capitalize-content-with-outside-bmp-characters.html fast/text/capitalize-content-with-outside-bmp-previous-characters.html fast/text/drawBidiText.html fast/text/fallback-font-and-zero-width-glyph.html fast/text/international/bdi-dir-default-to-auto.html fast/text/international/bdi-neutral-wrapped.html ... (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/113771 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32865 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24225 "Found 60 new test failures: fast/attachment/cocoa/wide-attachment-rendering.html fast/attachment/mac/wide-attachment-title-with-rtl.html fast/dom/52776.html fast/forms/switch/click-animation-twice.html fast/text/capitalize-content-with-outside-bmp-characters.html fast/text/capitalize-content-with-outside-bmp-previous-characters.html fast/text/drawBidiText.html fast/text/fallback-font-and-zero-width-glyph.html fast/text/international/bdi-dir-default-to-auto.html fast/text/international/bdi-neutral-wrapped.html ... (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89372 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33229 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91635 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89040 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33909 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11713 "Found 60 new test failures: compositing/reflections/opacity-in-reflection.html css2.1/20110323/outline-color-applies-to-010.htm css3/calc/simple-composited-mask.html fast/attachment/cocoa/wide-attachment-rendering.html fast/attachment/mac/wide-attachment-title-with-rtl.html fast/css/direct-adjacent-style-sharing-2.html fast/dom/52776.html fast/media/media-type-syntax-01.html fast/text/capitalize-content-with-outside-bmp-characters.html fast/text/capitalize-content-with-outside-bmp-previous-characters.html ... (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/28325 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32790 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/38200 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32536 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35885 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34134 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->