### PR TITLE
[JSC] Fix MultiGetByVal's condition for supported arrays

### DIFF
--- a/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
@@ -4535,7 +4535,7 @@ private:
 
         NodeFlags flags = NodeResultJS;
         if (!node->arrayMode().isOutOfBounds()) {
-            if ((arrayModes & preferDoubleResult) == arrayModes)
+            if (!(arrayModes & ~preferDoubleResult))
                 flags = NodeResultDouble;
         }
 

--- a/Source/JavaScriptCore/dfg/DFGValueRepReductionPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGValueRepReductionPhase.cpp
@@ -124,10 +124,10 @@ private:
                             | Uint32ArrayMode
                             | 0;
 
-                        if (!(child1->arrayModes() & supportedArrays))
+                        if (child1->arrayModes() & ~supportedArrays)
                             break;
 
-                        if (child1.useKind() == AnyIntUse) {
+                        if (child1.useKind() == AnyIntUse || child1.useKind() == RealNumberUse) {
                             if (child1->origin.exitOK)
                                 candidates.add(child1.node());
                             break;
@@ -174,7 +174,7 @@ private:
                             | Uint32ArrayMode
                             | 0;
 
-                        if (!(child1->arrayModes() & supportedArrays))
+                        if (child1->arrayModes() & ~supportedArrays)
                             break;
 
                         if (child1->origin.exitOK)
@@ -445,6 +445,7 @@ private:
                         }
                         switch (user->child1().useKind()) {
                         case AnyIntUse:
+                        case RealNumberUse:
                             break;
                         default: {
                             ok = false;


### PR DESCRIPTION
#### 53cc09c25e129b5ac996efac9d326ab69b4bd82c
<pre>
[JSC] Fix MultiGetByVal&apos;s condition for supported arrays
<a href="https://bugs.webkit.org/show_bug.cgi?id=293841">https://bugs.webkit.org/show_bug.cgi?id=293841</a>
<a href="https://rdar.apple.com/149168442">rdar://149168442</a>

Reviewed by Daniel Liu.

Bit ops for supportedArrays are wrong. We are including Contiguous array
for these Int52 / Int32 cases. This patch fixes them.

* Source/JavaScriptCore/dfg/DFGFixupPhase.cpp:
(JSC::DFG::FixupPhase::refineArrayModesForMultiGetByVal):
* Source/JavaScriptCore/dfg/DFGValueRepReductionPhase.cpp:
(JSC::DFG::ValueRepReductionPhase::convertValueRepsToUnboxed):

Canonical link: <a href="https://commits.webkit.org/295694@main">https://commits.webkit.org/295694@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e6d18c815556bce3b979abf256f8464dd6631107

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105757 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25508 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15901 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110954 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/56353 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/26151 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34011 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80311 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108763 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/20533 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95431 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60623 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/20199 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13528 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55792 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/98398 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/89943 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13567 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/113803 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/104376 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32897 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24240 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89386 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33261 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91662 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89055 "Found 96 new API test failures: /TestWebKit:WebKit.PageLoadDidChangeLocationWithinPage, /TestWebKit:WebKit.AboutBlankLoad, /TestWebKit:WebKit.PreventEmptyUserAgent, /TestWebKit:WebKit.PrivateBrowsingPushStateNoHistoryCallback, /WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/content-type, /WebKitGTK/TestUIClient:/webkit/WebKitWebView/pointer-lock-permission-request, /TestWebKit:WebKit.HitTestResultNodeHandle, /TestWebKit:WebKit2TextFieldBeginAndEditEditingTest.TextFieldDidBeginShouldNotBeDispatchedForAlreadyFocusedField, /TestWebKit:WebKit.Find, /WebKitGTK/TestWebProcessExtensions:/webkit/WebKitWebProcessExtension/dom-input-element-is-user-edited ... (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33928 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11736 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/28361 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17173 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32822 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/38232 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/128687 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32568 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/35127 "Found 2 new JSC stress test failures: wasm.yaml/wasm/gc/ref-i31-eq.js.default-wasm, wasm.yaml/wasm/gc/ref-i31-eq.js.wasm-eager (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35917 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34166 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->