### PR TITLE
Compile the swift-refined WebKit API on a bunch more configurations

### DIFF
--- a/Source/WebKit/Shared/AuxiliaryProcessExtensions/GPUProcessExtension.swift
+++ b/Source/WebKit/Shared/AuxiliaryProcessExtensions/GPUProcessExtension.swift
@@ -1,27 +1,25 @@
-/*
- * Copyright (C) 2023 Apple Inc. All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in the
- *    documentation and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
- * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
- * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
- * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
- * THE POSSIBILITY OF SUCH DAMAGE.
- */
+// Copyright (C) 2023 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
 
 import BrowserEngineKit
 

--- a/Source/WebKit/Shared/AuxiliaryProcessExtensions/NetworkingProcessExtension.swift
+++ b/Source/WebKit/Shared/AuxiliaryProcessExtensions/NetworkingProcessExtension.swift
@@ -1,27 +1,25 @@
-/*
- * Copyright (C) 2023 Apple Inc. All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in the
- *    documentation and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
- * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
- * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
- * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
- * THE POSSIBILITY OF SUCH DAMAGE.
- */
+// Copyright (C) 2023 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
 
 import BrowserEngineKit
 

--- a/Source/WebKit/Shared/AuxiliaryProcessExtensions/WebContentProcessExtension.swift
+++ b/Source/WebKit/Shared/AuxiliaryProcessExtensions/WebContentProcessExtension.swift
@@ -1,27 +1,25 @@
-/*
- * Copyright (C) 2023 Apple Inc. All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in the
- *    documentation and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
- * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
- * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
- * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
- * THE POSSIBILITY OF SUCH DAMAGE.
- */
+// Copyright (C) 2023 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
 
 import BrowserEngineKit
 

--- a/Source/WebKit/UIProcess/API/Cocoa/ObjectiveCBlockConversions.swift
+++ b/Source/WebKit/UIProcess/API/Cocoa/ObjectiveCBlockConversions.swift
@@ -1,27 +1,25 @@
-/*
- * Copyright (C) 2020 Apple Inc. All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in the
- *    documentation and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
- * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
- * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
- * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
- * THE POSSIBILITY OF SUCH DAMAGE.
- */
+// Copyright (C) 2020 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
 
 /// A family of conversions for translating between Swift blocks expecting a `Result<V, Error>` and
 /// Objective-C callbacks of the form `(T?, Error?)`.

--- a/Source/WebKit/UIProcess/API/Cocoa/WKContextMenuElementInfoAdapter.swift
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKContextMenuElementInfoAdapter.swift
@@ -26,8 +26,12 @@
 public import Foundation
 internal import WebKit_Internal
 
+// SPI for the cross-import overlay.
+// swift-format-ignore: AllPublicDeclarationsHaveDocumentation
 @_spi(CrossImportOverlay)
 public struct WKContextMenuElementInfoAdapter {
+    // SPI for the cross-import overlay.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public let linkURL: URL?
 }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WebKitSwiftOverlay.swift
+++ b/Source/WebKit/UIProcess/API/Cocoa/WebKitSwiftOverlay.swift
@@ -23,8 +23,6 @@
 
 // FIXME: Eliminate this file since the refined API can now just go with the rest of the normal API where it belongs.
 
-#if !os(tvOS) && !os(watchOS)
-
 // Older versions of the Swift compiler fail to import WebKit_Private. Can be
 // removed when WebKit drops support for macOS Sonoma.
 #if ENABLE_WK_WEB_EXTENSIONS && compiler(>=6.1)
@@ -33,9 +31,13 @@ internal import WebKit_Private.WKWebExtensionPrivate
 
 #if USE_APPLE_INTERNAL_SDK
 @_spi(CTypeConversion) import Network
+#else
+import Network
 #endif
 
-@available(iOS 14.0, macOS 10.16, *)
+@available(iOS 14.0, macOS 10.16, visionOS 1.0, *)
+@available(watchOS, unavailable)
+@available(tvOS, unavailable)
 extension WKPDFConfiguration {
     // This is pre-existing API whose documentation does not use the source code.
     // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
@@ -45,7 +47,9 @@ extension WKPDFConfiguration {
     }
 }
 
-@available(iOS 14.0, macOS 10.16, *)
+@available(iOS 14.0, macOS 10.16, visionOS 1.0, *)
+@available(watchOS, unavailable)
+@available(tvOS, unavailable)
 extension WKWebView {
     // This is pre-existing API whose documentation does not use the source code.
     // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
@@ -103,7 +107,9 @@ extension WKWebView {
     }
 }
 
-@available(iOS 15.0, macOS 12.0, *)
+@available(iOS 15.0, macOS 12.0, visionOS 1.0, *)
+@available(watchOS, unavailable)
+@available(tvOS, unavailable)
 extension WKWebView {
     // This is pre-existing API whose documentation does not use the source code.
     // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
@@ -212,11 +218,9 @@ extension WKWebExtensionContext {
 }
 #endif
 
-// FIXME: Need to declare ProxyConfiguration SPI in order to build and test
-// this with public SDKs (https://bugs.webkit.org/show_bug.cgi?id=280911).
-#if USE_APPLE_INTERNAL_SDK
-#if canImport(Network, _version: "3623.0.0.0")
-@available(iOS 17.0, macOS 14.0, *)
+@available(iOS 17.0, macOS 14.0, visionOS 1.0, *)
+@available(watchOS, unavailable)
+@available(tvOS, unavailable)
 extension WKWebsiteDataStore {
     /// Gets or sets the proxy configurations to be used to override networking in all WKWebViews that use this WKWebsiteDataStore.
     ///
@@ -227,7 +231,3 @@ extension WKWebsiteDataStore {
         set { __proxyConfigurations = newValue.map(\.nw) }
     }
 }
-#endif
-#endif
-
-#endif // !os(tvOS) && !os(watchOS)

--- a/Source/WebKit/UIProcess/API/Cocoa/WebKitSwiftOverlay.swift
+++ b/Source/WebKit/UIProcess/API/Cocoa/WebKitSwiftOverlay.swift
@@ -1,27 +1,27 @@
-/*
- * Copyright (C) 2020 Apple Inc. All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in the
- *    documentation and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
- * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
- * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
- * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
- * THE POSSIBILITY OF SUCH DAMAGE.
- */
+// Copyright (C) 2020 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+
+// FIXME: Eliminate this file since the refined API can now just go with the rest of the normal API where it belongs.
 
 #if !os(tvOS) && !os(watchOS)
 
@@ -37,14 +37,18 @@ internal import WebKit_Private.WKWebExtensionPrivate
 
 @available(iOS 14.0, macOS 10.16, *)
 extension WKPDFConfiguration {
+    // This is pre-existing API whose documentation does not use the source code.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public var rect: CGRect? {
         get { __rect == .null ? nil : __rect }
-        set { __rect = newValue == nil ? .null : newValue! }
+        set { __rect = newValue ?? .null }
     }
 }
 
 @available(iOS 14.0, macOS 10.16, *)
 extension WKWebView {
+    // This is pre-existing API whose documentation does not use the source code.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     @preconcurrency
     public func callAsyncJavaScript(
         _ functionBody: String,
@@ -57,6 +61,8 @@ extension WKWebView {
         __callAsyncJavaScript(functionBody, arguments: arguments, inFrame: frame, in: contentWorld, completionHandler: thunk)
     }
 
+    // This is pre-existing API whose documentation does not use the source code.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     @preconcurrency
     public func createPDF(
         configuration: WKPDFConfiguration = .init(),
@@ -65,11 +71,15 @@ extension WKWebView {
         __createPDF(with: configuration, completionHandler: ObjCBlockConversion.exclusive(completionHandler))
     }
 
+    // This is pre-existing API whose documentation does not use the source code.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     @preconcurrency
     public func createWebArchiveData(completionHandler: @MainActor @escaping (Result<Data, Error>) -> Void) {
         __createWebArchiveData(completionHandler: ObjCBlockConversion.exclusive(completionHandler))
     }
 
+    // This is pre-existing API whose documentation does not use the source code.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     @preconcurrency
     public func evaluateJavaScript(
         _ javaScript: String,
@@ -81,6 +91,8 @@ extension WKWebView {
         __evaluateJavaScript(javaScript, inFrame: frame, in: contentWorld, completionHandler: thunk)
     }
 
+    // This is pre-existing API whose documentation does not use the source code.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     @preconcurrency
     public func find(
         _ string: String,
@@ -93,6 +105,8 @@ extension WKWebView {
 
 @available(iOS 15.0, macOS 12.0, *)
 extension WKWebView {
+    // This is pre-existing API whose documentation does not use the source code.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public func callAsyncJavaScript(
         _ functionBody: String,
         arguments: [String: Any] = [:],
@@ -102,14 +116,20 @@ extension WKWebView {
         try await __callAsyncJavaScript(functionBody, arguments: arguments, inFrame: frame, in: contentWorld)
     }
 
+    // This is pre-existing API whose documentation does not use the source code.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public func pdf(configuration: WKPDFConfiguration = .init()) async throws -> Data {
         try await __createPDF(with: configuration)
     }
 
+    // This is pre-existing API whose documentation does not use the source code.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public func evaluateJavaScript(_ javaScript: String, in frame: WKFrameInfo? = nil, contentWorld: WKContentWorld) async throws -> Any? {
         try await __evaluateJavaScript(javaScript, inFrame: frame, in: contentWorld)
     }
 
+    // This is pre-existing API whose documentation does not use the source code.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public func find(_ string: String, configuration: WKFindConfiguration = .init()) async throws -> WKFindResult {
         await __find(string, with: configuration)
     }
@@ -120,11 +140,25 @@ extension WKWebView {
 @available(watchOS, unavailable)
 @available(tvOS, unavailable)
 extension WKWebExtension {
+    /// Creates a web extension initialized with a specified app extension bundle.
+    ///
+    /// The app extension bundle must contain a `manifest.json` file in its resources directory.
+    /// If the manifest is invalid or missing, or the bundle is otherwise improperly configured, an error will be thrown.
+    ///
+    /// - Parameter appExtensionBundle: The bundle to use for the new web extension.
+    /// - Throws: An error if the manifest is invalid or missing, or the bundle is otherwise improperly configured.
     public convenience init(appExtensionBundle: Bundle) async throws {
         // FIXME: <https://webkit.org/b/276194> Make the WebExtension class load data on a background thread.
         try self.init(appExtensionBundle: appExtensionBundle, resourceBaseURL: nil)
     }
 
+    /// Creates a web extension initialized with a specified resource base URL, which can point to either a directory or a ZIP archive.
+    ///
+    /// The URL must be a file URL that points to either a directory with a `manifest.json` file or a ZIP archive containing a `manifest.json` file.
+    /// If the manifest is invalid or missing, or the URL points to an unsupported format or invalid archive, an error will be returned.
+    ///
+    /// - Parameter resourceBaseURL: The file URL to use for the new web extension.
+    /// - Throws: An error If the manifest is invalid or missing, or the URL points to an unsupported format or invalid archive.
     public convenience init(resourceBaseURL: URL) async throws {
         // FIXME: <https://webkit.org/b/276194> Make the WebExtension class load data on a background thread.
         try self.init(appExtensionBundle: nil, resourceBaseURL: resourceBaseURL)
@@ -135,14 +169,20 @@ extension WKWebExtension {
 @available(watchOS, unavailable)
 @available(tvOS, unavailable)
 extension WKWebExtensionController {
+    // This is pre-existing API whose documentation does not use the source code.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public func didCloseTab(_ closedTab: WKWebExtensionTab, windowIsClosing: Bool = false) {
         __didClose(closedTab, windowIsClosing: windowIsClosing)
     }
 
+    // This is pre-existing API whose documentation does not use the source code.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public func didActivateTab(_ activatedTab: any WKWebExtensionTab, previousActiveTab previousTab: (any WKWebExtensionTab)? = nil) {
         __didActivate(activatedTab, previousActiveTab: previousTab)
     }
 
+    // This is pre-existing API whose documentation does not use the source code.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public func didMoveTab(_ movedTab: any WKWebExtensionTab, from index: Int, in oldWindow: (any WKWebExtensionWindow)? = nil) {
         __didMove(movedTab, from: index, in: oldWindow)
     }
@@ -152,14 +192,20 @@ extension WKWebExtensionController {
 @available(watchOS, unavailable)
 @available(tvOS, unavailable)
 extension WKWebExtensionContext {
+    // This is pre-existing API whose documentation does not use the source code.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public func didCloseTab(_ closedTab: WKWebExtensionTab, windowIsClosing: Bool = false) {
         __didClose(closedTab, windowIsClosing: windowIsClosing)
     }
 
+    // This is pre-existing API whose documentation does not use the source code.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public func didActivateTab(_ activatedTab: any WKWebExtensionTab, previousActiveTab previousTab: (any WKWebExtensionTab)? = nil) {
         __didActivate(activatedTab, previousActiveTab: previousTab)
     }
 
+    // This is pre-existing API whose documentation does not use the source code.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public func didMoveTab(_ movedTab: any WKWebExtensionTab, from index: Int, in oldWindow: (any WKWebExtensionWindow)? = nil) {
         __didMove(movedTab, from: index, in: oldWindow)
     }
@@ -172,6 +218,10 @@ extension WKWebExtensionContext {
 #if canImport(Network, _version: "3623.0.0.0")
 @available(iOS 17.0, macOS 14.0, *)
 extension WKWebsiteDataStore {
+    /// Gets or sets the proxy configurations to be used to override networking in all WKWebViews that use this WKWebsiteDataStore.
+    ///
+    /// Changing the proxy configurations might interrupt current networking operations in any WKWebView that use this WKWebsiteDataStore,
+    /// so it is encouraged to finish setting the proxy configurations before starting any page loads.
     public var proxyConfigurations: [ProxyConfiguration] {
         get { __proxyConfigurations?.map(ProxyConfiguration.init(_:)) ?? [] }
         set { __proxyConfigurations = newValue.map(\.nw) }

--- a/Source/WebKit/UIProcess/API/Swift/URLSchemeHandler.swift
+++ b/Source/WebKit/UIProcess/API/Swift/URLSchemeHandler.swift
@@ -53,6 +53,7 @@ public struct URLScheme: Hashable, Sendable {
     public let rawValue: String
 }
 
+/// A value used as part of a sequence of results from a ``URLSchemeHandler``, which can either be a `Data` or a `URLResponse`.
 @available(WK_IOS_TBA, WK_MAC_TBA, WK_XROS_TBA, *)
 @available(watchOS, unavailable)
 @available(tvOS, unavailable)

--- a/Source/WebKit/UIProcess/API/Swift/WebPage+BackForwardList.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WebPage+BackForwardList.swift
@@ -39,6 +39,7 @@ extension WebPage {
         ///
         /// Two items with equal titles, urls, and initial urls may not necessarily be equal to one another.
         public struct Item: Equatable, Identifiable, Sendable {
+            /// An opaque type representing the identifier for an item.
             public struct ID: Hashable, Sendable {
                 private let value = UUID()
             }
@@ -63,7 +64,7 @@ extension WebPage {
             /// The url of the page this item represents, after having resolved all redirects.
             public let url: URL
 
-            /// The source URL that originally asked to load the resource
+            /// The source URL that originally asked to load the resource.
             public let initialURL: URL
 
             @MainActor

--- a/Source/WebKit/UIProcess/API/Swift/WebPage+Configuration.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WebPage+Configuration.swift
@@ -27,6 +27,7 @@ import Foundation
 internal import WebKit_Internal
 
 extension WebPage {
+    /// A configuration type that specifies the preferences and behaviors of a webpage.
     @MainActor
     @available(WK_IOS_TBA, WK_MAC_TBA, WK_XROS_TBA, *)
     @available(watchOS, unavailable)
@@ -104,17 +105,17 @@ extension WebPage {
         /// If `true`, they are inserted with the full adaptive sizing behavior.
         public var supportsAdaptiveImageGlyph: Bool = false
 
+        private var backingShowsSystemScreenTimeBlockingView = true
+
         /// Indicates whether the webpage should use the system Screen Time blocking view.
         ///
         /// The default value is `true`. If `true`, the system Screen Time blocking view is shown when blocked by Screen Time.
         /// If `false`, a blurred view of the web content is shown instead.
         @available(visionOS, unavailable)
         public var showsSystemScreenTimeBlockingView: Bool {
-            get { _showsSystemScreenTimeBlockingView }
-            set { _showsSystemScreenTimeBlockingView = newValue }
+            get { backingShowsSystemScreenTimeBlockingView }
+            set { backingShowsSystemScreenTimeBlockingView = newValue }
         }
-
-        private var _showsSystemScreenTimeBlockingView = true
 
         #if os(iOS)
         /// The types of data detectors to apply to the webpage's content.

--- a/Source/WebKit/UIProcess/API/Swift/WebPage+DialogPresenting.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WebPage+DialogPresenting.swift
@@ -111,7 +111,8 @@ extension WebPage {
 
         /// Returns the result of handling a JavaScript request to open files.
         ///
-        /// - Parameter parameters: The options to use for the file dialog.
+        /// - Parameters:
+        ///   - parameters: The options to use for the file dialog.
         ///   - frame: Information about the frame whose JavaScript process initiated this call.
         /// - Returns: The result of handling the invocation; if the result is affirmative, the response will include a set of files returned to JavaScript.
         @MainActor

--- a/Source/WebKit/UIProcess/API/Swift/WebPage+Navigation.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WebPage+Navigation.swift
@@ -66,6 +66,8 @@ extension WebPage {
             case failed(underlyingError: any Error)
         }
 
+        // SPI for testing.
+        // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
         @_spi(Testing)
         public init(kind: Kind, navigationID: NavigationID) {
             self.kind = kind
@@ -75,7 +77,9 @@ extension WebPage {
         /// The type of this navigation event.
         public let kind: Kind
 
-        /// The ID of the navigation that triggered this event. Multiple sequential events will have the same navigation identifier.
+        /// The ID of the navigation that triggered this event.
+        ///
+        /// Multiple sequential events will have the same navigation identifier.
         public let navigationID: NavigationID
     }
 }

--- a/Source/WebKit/UIProcess/API/Swift/WebPage+NavigationDeciding.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WebPage+NavigationDeciding.swift
@@ -64,6 +64,8 @@ extension WebPage {
         public var buttonNumber: Int { wrapped.buttonNumber }
         #endif
 
+        // SPI for the cross-import overlay.
+        // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
         @_spi(CrossImportOverlay)
         public var wrapped: WKNavigationAction
     }
@@ -81,6 +83,8 @@ extension WebPage {
             self.wrapped = wrapped
         }
 
+        // FIXME: This needs to be made API.
+        // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
         @_spi(Private)
         public var isForMainFrame: Bool { wrapped.isForMainFrame }
 

--- a/Source/WebKit/UIProcess/API/Swift/WebPage+NavigationPreferences.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WebPage+NavigationPreferences.swift
@@ -86,15 +86,15 @@ extension WebPage {
         /// The `WebPage.Configuration.upgradeKnownHostsToHTTPS` property supersedes this property for known hosts.
         public var preferredHTTPSNavigationPolicy: UpgradeToHTTPSPolicy = .keepAsRequested
 
-        var _isLockdownModeEnabled: Bool? = nil
+        var backingIsLockdownModeEnabled: Bool? = nil
 
         /// A Boolean value that indicates whether to use Lockdown Mode in the web page.
         ///
         /// By default, this reflects whether the user has enabled Lockdown Mode on the device. Update this preference to
         /// override the device setting when you implement a per-website or similar setting.
         public var isLockdownModeEnabled: Bool {
-            get { _isLockdownModeEnabled ?? false }
-            set { _isLockdownModeEnabled = newValue }
+            get { backingIsLockdownModeEnabled ?? false }
+            set { backingIsLockdownModeEnabled = newValue }
         }
     }
 }

--- a/Source/WebKit/UIProcess/API/Swift/WebPage.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WebPage.swift
@@ -49,7 +49,10 @@ final public class WebPage {
         /// Corresponds to the "print" media type.
         public static let print = CSSMediaType(rawValue: "print")
 
-        /// Create a media type with an arbitrary value. Use the static type properties for the defined canonical CSS media type options.
+        /// Create a media type with an arbitrary value.
+        ///
+        /// Use the static type properties for the defined canonical CSS media type options.
+        ///
         /// - Parameter rawValue: The raw value of the media type.
         public init(rawValue: String) {
             self.rawValue = rawValue
@@ -80,9 +83,9 @@ final public class WebPage {
     // MARK: Initializers
 
     private init(
-        _configuration: Configuration,
-        _navigationDecider navigationDecider: (any NavigationDeciding)?,
-        _dialogPresenter dialogPresenter: (any DialogPresenting)?,
+        internalHelperWithConfiguration configuration: Configuration,
+        navigationDecider navigationDecider: (any NavigationDeciding)?,
+        dialogPresenter dialogPresenter: (any DialogPresenting)?,
     ) {
         self.configuration = _configuration
 
@@ -97,32 +100,51 @@ final public class WebPage {
         backingNavigationDelegate.owner = self
     }
 
+    /// Create a new WebPage.
+    ///
+    /// - Parameters:
+    ///   - configuration: A ``WebPage/Configuration`` value to use when initializing the page.
+    ///   - navigationDecider: A navigation decider used to customize navigations that happen within the page.
+    ///   - dialogPresenter: A dialog presenter which controls how JS dialogs are handled.
     public convenience init(
         configuration: Configuration = Configuration(),
         navigationDecider: some NavigationDeciding,
         dialogPresenter: some DialogPresenting
     ) {
-        self.init(_configuration: configuration, _navigationDecider: navigationDecider, _dialogPresenter: dialogPresenter)
+        self.init(internalHelperWithConfiguration: configuration, navigationDecider: navigationDecider, dialogPresenter: dialogPresenter)
     }
 
+    /// Create a new WebPage.
+    ///
+    /// - Parameters:
+    ///   - configuration: A ``WebPage/Configuration`` value to use when initializing the page.
+    ///   - dialogPresenter: A dialog presenter which controls how JS dialogs are handled.
     public convenience init(
         configuration: Configuration = Configuration(),
         dialogPresenter: some DialogPresenting
     ) {
-        self.init(_configuration: configuration, _navigationDecider: nil, _dialogPresenter: dialogPresenter)
+        self.init(internalHelperWithConfiguration: configuration, navigationDecider: nil, dialogPresenter: dialogPresenter)
     }
 
+    /// Create a new WebPage.
+    ///
+    /// - Parameters:
+    ///   - configuration: A ``WebPage/Configuration`` value to use when initializing the page.
+    ///   - navigationDecider: A navigation decider used to customize navigations that happen within the page.
     public convenience init(
         configuration: Configuration = Configuration(),
         navigationDecider: some NavigationDeciding
     ) {
-        self.init(_configuration: configuration, _navigationDecider: navigationDecider, _dialogPresenter: nil)
+        self.init(internalHelperWithConfiguration: configuration, navigationDecider: navigationDecider, dialogPresenter: nil)
     }
 
+    /// Create a new WebPage.
+    ///
+    /// - Parameter configuration: A ``WebPage/Configuration`` value to use when initializing the page.
     public convenience init(
         configuration: Configuration = Configuration(),
     ) {
-        self.init(_configuration: configuration, _navigationDecider: nil, _dialogPresenter: nil)
+        self.init(internalHelperWithConfiguration: configuration, navigationDecider: nil, dialogPresenter: nil)
     }
 
     // MARK: Properties
@@ -153,6 +175,7 @@ final public class WebPage {
     public var title: String {
         backingProperty(\.title, backedBy: \.title) { backingValue in
             // The title property is annotated as optional in WKWebView, but is never actually `nil`.
+            // swift-format-ignore: NeverForceUnwrap
             backingValue!
         }
     }
@@ -254,6 +277,8 @@ final public class WebPage {
     private let backingNavigationDelegate: WKNavigationDelegateAdapter
 
     #if os(macOS)
+    // SPI for the cross-import overlay.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     @_spi(CrossImportOverlay)
     public func setMenuBuilder(_ menuBuilder: ((WKContextMenuElementInfoAdapter) -> NSMenu)?) {
         backingUIDelegate.menuBuilder = menuBuilder
@@ -263,10 +288,14 @@ final public class WebPage {
     @ObservationIgnored
     private var observations = KeyValueObservations()
 
+    // SPI for the cross-import overlay.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     @ObservationIgnored
     @_spi(CrossImportOverlay)
     public var isBoundToWebView = false
 
+    // SPI for the cross-import overlay.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     @ObservationIgnored
     @_spi(CrossImportOverlay)
     public lazy var backingWebView: WebPageWebView = {
@@ -303,7 +332,7 @@ final public class WebPage {
     /// - Parameters:
     ///   - data: The data to use as the contents of the webpage.
     ///   - mimeType: The MIME type of the information in the data parameter. This parameter must not contain an empty string.
-    ///   - encoding: The data's character encoding.
+    ///   - characterEncoding: The data's character encoding.
     ///   - baseURL: A URL that you use to resolve relative URLs within the document.
     /// - Returns: A navigation identifier you use to track the loading progress of the request.
     @discardableResult
@@ -368,8 +397,7 @@ final public class WebPage {
 
     /// Navigates to an item from the back-forward list and sets it as the current item.
     ///
-    /// - Parameters:
-    ///   - item: The item to navigate to. The item must be in the webpage's back-forward list.
+    /// - Parameter item: The item to navigate to. The item must be in the webpage's back-forward list.
     /// - Returns: A navigation identifier you use to track the loading progress of the request.
     @discardableResult
     public func load(_ item: BackForwardList.Item) -> NavigationID? {
@@ -436,8 +464,8 @@ final public class WebPage {
     ///   you make in the underlying web content, such as the document's DOM structure. Those changes remain visible to
     ///   all scripts, regardless of which content world you specify. For more information about content worlds, see `WKContentWorld`.
     ///
-    /// - Returns: The result of the script evaluation. If your function body doesn't return an explicit value, `nil` is returned.
-    ///  If your function body explicitly returns `null`, then `NSNull` is returned.
+    /// - Returns: The result of the script evaluation. If your function body doesn't return an explicit value, `nil` is returned. If your function body explicitly returns `null`, then `NSNull` is returned.
+    /// - Throws: An error if a problem occurred while evaluating the JabaScript.
     @discardableResult
     public func callJavaScript(
         _ functionBody: String,
@@ -456,12 +484,16 @@ final public class WebPage {
             return nil
         }
 
+        // Safe force-unwrap because all plist types are Sendable.
+        // swift-format-ignore: NeverForceUnwrap
         return result as! any Sendable
     }
 
-    /// Generates PDF data from the webpage's contents
+    /// Generates PDF data from the webpage's contents.
+    ///
     /// - Parameter configuration: The object that specifies the portion of the web view to capture as PDF data.
     /// - Returns: A data object that contains the PDF data to use for rendering the contents of the webpage.
+    /// - Throws: An error if a problem occurred.
     public func pdf(configuration: WKPDFConfiguration = .init()) async throws -> Data {
         try await backingWebView.pdf(configuration: configuration)
     }
@@ -530,6 +562,8 @@ final public class WebPage {
         }
     }
 
+    // SPI for the cross-import overlay.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     @_spi(CrossImportOverlay)
     public func backingProperty<Value, BackingValue>(
         _ keyPath: KeyPath<WebPage, Value>,
@@ -546,6 +580,8 @@ final public class WebPage {
         return transform(backingValue)
     }
 
+    // SPI for the cross-import overlay.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     @_spi(CrossImportOverlay)
     public func backingProperty<Value>(_ keyPath: KeyPath<WebPage, Value>, backedBy backingKeyPath: KeyPath<WebPageWebView, Value>) -> Value
     {

--- a/Source/WebKit/UIProcess/Cocoa/RunLoopQueue.swift
+++ b/Source/WebKit/UIProcess/Cocoa/RunLoopQueue.swift
@@ -66,6 +66,7 @@ public final class RunLoopQueue {
     private var pendingChanges: [Change] = []
     private var processingTask: Task<Void, Never>?
 
+    /// Creates an empty queue.
     public init() {
     }
 

--- a/Source/WebKit/UIProcess/Cocoa/TextExtraction/WKTextExtractionItem.swift
+++ b/Source/WebKit/UIProcess/Cocoa/TextExtraction/WKTextExtractionItem.swift
@@ -106,15 +106,15 @@ extension WKTextExtractionLink {
     // Used to workaround the fact that `@_objcImplementation` does not support stored properties whose size can change
     // due to Library Evolution. Do not use this property directly.
     @nonobjc
-    private let _url: NSURL
+    private let backingURL: NSURL
 
-    var url: URL { _url as URL }
+    var url: URL { backingURL as URL }
 
     let range: NSRange
 
     @objc(initWithURL:range:)
     init(url: URL, range: NSRange) {
-        self._url = url as NSURL
+        self.backingURL = url as NSURL
         self.range = range
     }
 

--- a/Source/WebKit/UIProcess/Cocoa/TextExtraction/WKWebView+TextExtraction.swift
+++ b/Source/WebKit/UIProcess/Cocoa/TextExtraction/WKWebView+TextExtraction.swift
@@ -80,10 +80,12 @@ private func createIntelligenceElement(item: WKTextExtractionItem) -> Intelligen
 
 @_spi(WKIntelligenceSupport)
 extension WKWebView {
+    // swift-format-ignore: NoLeadingUnderscores
     open override var _intelligenceBaseClass: AnyClass {
         WKWebView.self
     }
 
+    // swift-format-ignore: NoLeadingUnderscores
     open override func _intelligenceCollectContent(in visibleRect: CGRect, collector: UIIntelligenceElementCollector) {
         #if canImport(UIIntelligenceSupport, _version: 9007)
         let context = collector.context.createRemoteContext(description: "WKWebView")
@@ -93,6 +95,7 @@ extension WKWebView {
         collector.collect(.remote(context))
     }
 
+    // swift-format-ignore: NoLeadingUnderscores
     open override func _intelligenceCollectRemoteContent(
         in visibleRect: CGRect,
         remoteContextWrapper: UIIntelligenceCollectionRemoteContextWrapper

--- a/Source/WebKit/UIProcess/Cocoa/WKNavigationDelegateAdapter.swift
+++ b/Source/WebKit/UIProcess/Cocoa/WKNavigationDelegateAdapter.swift
@@ -76,6 +76,7 @@ final class WKNavigationDelegateAdapter: NSObject, WKNavigationDelegate {
 
     // MARK: Back-forward list support
 
+    // swift-format-ignore: NoLeadingUnderscores
     @objc(_webView:backForwardListItemAdded:removed:)
     func _webView(
         _ webView: WKWebView!,

--- a/Source/WebKit/UIProcess/Cocoa/WKScrollGeometryAdapter.swift
+++ b/Source/WebKit/UIProcess/Cocoa/WKScrollGeometryAdapter.swift
@@ -26,18 +26,30 @@
 public import Foundation
 internal import WebKit_Internal
 
+// SPI for the cross-import overlay.
+// swift-format-ignore: AllPublicDeclarationsHaveDocumentation
 @_spi(CrossImportOverlay)
 public struct WKScrollGeometryAdapter {
+    // SPI for the cross-import overlay.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public let containerSize: CGSize
 
     #if canImport(UIKit)
+    // SPI for the cross-import overlay.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public let contentInsets: UIEdgeInsets
     #else
+    // SPI for the cross-import overlay.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public let contentInsets: NSEdgeInsets
     #endif
 
+    // SPI for the cross-import overlay.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public let contentOffset: CGPoint
 
+    // SPI for the cross-import overlay.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public let contentSize: CGSize
 
     init(_ geometry: WKScrollGeometry) {

--- a/Source/WebKit/UIProcess/Cocoa/WKUIDelegateAdapter.swift
+++ b/Source/WebKit/UIProcess/Cocoa/WKUIDelegateAdapter.swift
@@ -125,6 +125,7 @@ final class WKUIDelegateAdapter: NSObject, WKUIDelegatePrivate {
     // MARK: Context menu support
 
     #if os(macOS)
+    // swift-format-ignore: NoLeadingUnderscores
     @objc(_webView:getContextMenuFromProposedMenu:forElement:userInfo:completionHandler:)
     func _webView(
         _ webView: WKWebView!,
@@ -141,6 +142,7 @@ final class WKUIDelegateAdapter: NSObject, WKUIDelegatePrivate {
     }
     #endif
 
+    // swift-format-ignore: NoLeadingUnderscores
     @objc(_webView:geometryDidChange:)
     func _webView(_ webView: WKWebView!, geometryDidChange geometry: WKScrollGeometry) {
         owner?.backingWebView.geometryDidChange(WKScrollGeometryAdapter(geometry))

--- a/Source/WebKit/UIProcess/Cocoa/WebPageWebView.swift
+++ b/Source/WebKit/UIProcess/Cocoa/WebPageWebView.swift
@@ -26,9 +26,13 @@
 import Foundation
 internal import WebKit_Internal
 
+// SPI for the cross-import overlay.
+// swift-format-ignore: AllPublicDeclarationsHaveDocumentation
 @MainActor
 @_spi(CrossImportOverlay)
 public final class WebPageWebView: WKWebView {
+    // SPI for the cross-import overlay.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public weak var delegate: (any Delegate)? = nil
 
     #if os(iOS)
@@ -57,6 +61,8 @@ public final class WebPageWebView: WKWebView {
 }
 
 extension WebPageWebView {
+    // SPI for the cross-import overlay.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     @MainActor
     public protocol Delegate: AnyObject {
         #if os(iOS)
@@ -75,31 +81,44 @@ extension WebPageWebView {
     // MARK: Platform-agnostic scrolling capabilities
 
     #if canImport(UIKit)
+
+    // SPI for the cross-import overlay.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public var alwaysBounceVertical: Bool {
         get { scrollView.alwaysBounceVertical }
         set { scrollView.alwaysBounceVertical = newValue }
     }
 
+    // SPI for the cross-import overlay.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public var alwaysBounceHorizontal: Bool {
         get { scrollView.alwaysBounceHorizontal }
         set { scrollView.alwaysBounceHorizontal = newValue }
     }
 
+    // SPI for the cross-import overlay.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public var bouncesVertically: Bool {
         get { scrollView.bouncesVertically }
         set { scrollView.bouncesVertically = newValue }
     }
 
+    // SPI for the cross-import overlay.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public var bouncesHorizontally: Bool {
         get { scrollView.bouncesHorizontally }
         set { scrollView.bouncesHorizontally = newValue }
     }
 
+    // SPI for the cross-import overlay.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public var allowsMagnification: Bool {
         get { self._allowsMagnification }
         set { self._allowsMagnification = newValue }
     }
 
+    // SPI for the cross-import overlay.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public func setContentOffset(x: Double?, y: Double?, animated: Bool) {
         let currentOffset = scrollView.contentOffset
         let newOffset = CGPoint(x: x ?? currentOffset.x, y: y ?? currentOffset.y)
@@ -107,37 +126,54 @@ extension WebPageWebView {
         scrollView.setContentOffset(newOffset, animated: animated)
     }
 
+    // SPI for the cross-import overlay.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public func scrollTo(edge: NSDirectionalRectEdge, animated: Bool) {
         self._scroll(to: _WKRectEdge(edge), animated: animated)
     }
+
     #else
+
+    // SPI for the cross-import overlay.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public var alwaysBounceVertical: Bool {
         get { self._alwaysBounceVertical }
         set { self._alwaysBounceVertical = newValue }
     }
 
+    // SPI for the cross-import overlay.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public var alwaysBounceHorizontal: Bool {
         get { self._alwaysBounceHorizontal }
         set { self._alwaysBounceHorizontal = newValue }
     }
 
+    // SPI for the cross-import overlay.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public var bouncesVertically: Bool {
         get { self._rubberBandingEnabled.contains(.top) && self._rubberBandingEnabled.contains(.bottom) }
         set { self._rubberBandingEnabled.formUnion([.top, .bottom]) }
     }
 
+    // SPI for the cross-import overlay.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public var bouncesHorizontally: Bool {
         get { self._rubberBandingEnabled.contains(.left) && self._rubberBandingEnabled.contains(.right) }
         set { self._rubberBandingEnabled.formUnion([.left, .right]) }
     }
 
+    // SPI for the cross-import overlay.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public func setContentOffset(x: Double?, y: Double?, animated: Bool) {
         self._setContentOffset(x: x.map(NSNumber.init(value:)), y: y.map(NSNumber.init(value:)), animated: animated)
     }
 
+    // SPI for the cross-import overlay.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public func scrollTo(edge: NSDirectionalRectEdge, animated: Bool) {
         self._scroll(to: _WKRectEdge(edge), animated: animated)
     }
+
     #endif
 }
 


### PR DESCRIPTION
#### f8a5da0ecc4d71fea73d11efa5fdb0e3a332b2bd
<pre>
Compile the swift-refined WebKit API on a bunch more configurations
Need the bug URL (OOPS!).
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

Draft for EWS

* Source/WebKit/UIProcess/API/Cocoa/WebKitSwiftOverlay.swift:
</pre>
----------------------------------------------------------------------
#### 4110ada6322f85a640b024d0675f5c1458fdf2db
<pre>
[Swift in WebKit] Use swift-format to lint WebKit code
<a href="https://bugs.webkit.org/show_bug.cgi?id=293842">https://bugs.webkit.org/show_bug.cgi?id=293842</a>
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

Work towards having consistently formatted and linted Swift code; lint the WebKit codebase
for improved correctness and readability.

This is excluding WebKitSwift for now.

* Source/WebKit/Shared/AuxiliaryProcessExtensions/GPUProcessExtension.swift:
* Source/WebKit/Shared/AuxiliaryProcessExtensions/NetworkingProcessExtension.swift:
* Source/WebKit/Shared/AuxiliaryProcessExtensions/WebContentProcessExtension.swift:
* Source/WebKit/UIProcess/API/Cocoa/ObjectiveCBlockConversions.swift:

- Replace block quotes.

* Source/WebKit/UIProcess/API/Cocoa/WKContextMenuElementInfoAdapter.swift:

- Ignore AllPublicDeclarationsHaveDocumentation due to SPI.

* Source/WebKit/UIProcess/API/Cocoa/WebKitSwiftOverlay.swift:

- Replace block quotes.
- Ignore AllPublicDeclarationsHaveDocumentation due to pre-existing API documentation.
- Use null coalescing instead of force-unwrapping
- Add missing documentation for some WKWebExtension initializers, based on their Objective-C documentation.
- Add missing documentation for `WKWebsiteDataStore.proxyConfigurations` based on its Objective-C documentation.

* Source/WebKit/UIProcess/API/Swift/URLSchemeHandler.swift:

- Add missing docs.

* Source/WebKit/UIProcess/API/Swift/WebPage+BackForwardList.swift:

- Add missing docs.

* Source/WebKit/UIProcess/API/Swift/WebPage+Configuration.swift:

- Add missing docs.
- Fix variable naming.

* Source/WebKit/UIProcess/API/Swift/WebPage+DialogPresenting.swift:

- Fix doc format.

* Source/WebKit/UIProcess/API/Swift/WebPage+Navigation.swift:

- Fix doc format.
- Ignore AllPublicDeclarationsHaveDocumentation due to SPI.

* Source/WebKit/UIProcess/API/Swift/WebPage+NavigationDeciding.swift:

- Ignore AllPublicDeclarationsHaveDocumentation due to SPI.
- Add a FIXME to SPI that should be API.

* Source/WebKit/UIProcess/API/Swift/WebPage+NavigationPreferences.swift:

- Fix variable naming

* Source/WebKit/UIProcess/API/Swift/WebPage.swift:

- Fix doc format
- Fix parameter and variable naming
- Add missing docs
- Ignore AllPublicDeclarationsHaveDocumentation in some places due to SPI.

* Source/WebKit/UIProcess/Cocoa/GroupActivities/WKGroupSession.swift:

- Fix variable naming
- Justify force-unwrapping

* Source/WebKit/UIProcess/Cocoa/RunLoopQueue.swift:

- Add documentation (even though this is SPI).

* Source/WebKit/UIProcess/Cocoa/TextExtraction/WKTextExtractionItem.swift:

- Fix variable naming.

* Source/WebKit/UIProcess/Cocoa/TextExtraction/WKWebView+TextExtraction.swift:

- Ignore NoLeadingUnderscores because it is a false-positive.

* Source/WebKit/UIProcess/Cocoa/WKNavigationDelegateAdapter.swift:

- Ignore NoLeadingUnderscores because it is a false-positive.

* Source/WebKit/UIProcess/Cocoa/WKScrollGeometryAdapter.swift:
* Source/WebKit/UIProcess/Cocoa/WKUIDelegateAdapter.swift:
* Source/WebKit/UIProcess/Cocoa/WebPageWebView.swift:

- Ignore AllPublicDeclarationsHaveDocumentation due to SPI.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f8a5da0ecc4d71fea73d11efa5fdb0e3a332b2bd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105748 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25499 "Hash f8a5da0e for PR 46158 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15892 "Hash f8a5da0e for PR 46158 does not build (failure)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110945 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/56344 "Built successfully") 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/25986 "Hash f8a5da0e for PR 46158 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34002 "Hash f8a5da0e for PR 46158 does not build (failure)") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80307 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108754 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/130/builds/25986 "Hash f8a5da0e for PR 46158 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/138/builds/15892 "Hash f8a5da0e for PR 46158 does not build (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60618 "Found 142 new API test failures: /WPE/TestUIClient:/webkit/WebKitWebView/query-permission-requests, /WPE/TestWebsiteData:/webkit/WebKitWebsiteData/deviceidhashsalt, /WPE/TestLoaderClient:/webkit/WebKitWebView/load-twice-and-reload, /WPE/TestCookieManager:/webkit/WebKitCookieManager/ephemeral, /WPE/TestWebKitWebView:/webkit/WebKitWebView/is-playing-audio, /WPE/TestConsoleMessage:/webkit/WebKitConsoleMessage/network-error, /WPE/TestWebsiteData:/webkit/WebKitWebsiteData/configuration, /WPE/TestCookieManager:/webkit/WebKitCookieManager/delete-cookies, /WPE/TestWebKitWebView:/webkit/WebKitWebView/terminate-unresponsive-web-process, /WPE/TestSSL:/webkit/WebKitWebView/insecure-content ... (failure)") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/130/builds/25986 "Hash f8a5da0e for PR 46158 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/138/builds/15892 "Hash f8a5da0e for PR 46158 does not build (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55783 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/130/builds/25986 "Hash f8a5da0e for PR 46158 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/138/builds/15892 "Hash f8a5da0e for PR 46158 does not build (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/113794 "Built successfully") | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32888 "Hash f8a5da0e for PR 46158 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/123/builds/34002 "Hash f8a5da0e for PR 46158 does not build (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89381 "Passed tests") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33252 "Hash f8a5da0e for PR 46158 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/138/builds/15892 "Hash f8a5da0e for PR 46158 does not build (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89050 "Passed tests") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/138/builds/15892 "Hash f8a5da0e for PR 46158 does not build (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/28348 "Built successfully") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32813 "Hash f8a5da0e for PR 46158 does not build (failure)") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/38223 "Failed to build and analyze WebKit") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32559 "Hash f8a5da0e for PR 46158 does not build (failure)") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35908 "Hash f8a5da0e for PR 46158 does not build (failure)") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34157 "Hash f8a5da0e for PR 46158 does not build (failure)") | | | 
<!--EWS-Status-Bubble-End-->