### PR TITLE
[Swift in WebKit] Support compiling `WKWebsiteDataStore.proxyConfigurations` in more configurations

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore+SwiftOverlay.swift
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore+SwiftOverlay.swift
@@ -1,0 +1,39 @@
+// Copyright (C) 2025 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+
+import Network
+
+extension WKWebsiteDataStore {
+    /// Gets or sets the proxy configurations to be used to override networking in all WKWebViews that use this WKWebsiteDataStore.
+    ///
+    /// Changing the proxy configurations might interrupt current networking operations in any WKWebView that use this WKWebsiteDataStore,
+    /// so it is encouraged to finish setting the proxy configurations before starting any page loads.
+    @available(iOS 17.0, macOS 14.0, visionOS 1.0, *)
+    @available(watchOS, unavailable)
+    @available(tvOS, unavailable)
+    public var proxyConfigurations: [ProxyConfiguration] {
+        get { __proxyConfigurations?.map(ProxyConfiguration.init(_nw:)) ?? [] }
+        set { __proxyConfigurations = newValue.map(\._nw) }
+    }
+}
+

--- a/Source/WebKit/UIProcess/API/Cocoa/WebKitSwiftOverlay.swift
+++ b/Source/WebKit/UIProcess/API/Cocoa/WebKitSwiftOverlay.swift
@@ -31,10 +31,6 @@
 internal import WebKit_Private.WKWebExtensionPrivate
 #endif
 
-#if USE_APPLE_INTERNAL_SDK
-@_spi(CTypeConversion) import Network
-#endif
-
 @available(iOS 14.0, macOS 10.16, *)
 extension WKPDFConfiguration {
     public var rect: CGRect? {
@@ -164,20 +160,6 @@ extension WKWebExtensionContext {
         __didMove(movedTab, from: index, in: oldWindow)
     }
 }
-#endif
-
-// FIXME: Need to declare ProxyConfiguration SPI in order to build and test
-// this with public SDKs (https://bugs.webkit.org/show_bug.cgi?id=280911).
-#if USE_APPLE_INTERNAL_SDK
-#if canImport(Network, _version: "3623.0.0.0")
-@available(iOS 17.0, macOS 14.0, *)
-extension WKWebsiteDataStore {
-    public var proxyConfigurations: [ProxyConfiguration] {
-        get { __proxyConfigurations?.map(ProxyConfiguration.init(_:)) ?? [] }
-        set { __proxyConfigurations = newValue.map(\.nw) }
-    }
-}
-#endif
 #endif
 
 #endif // !os(tvOS) && !os(watchOS)

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -172,6 +172,7 @@
 		0753932C2DC94A2B0002EBCD /* WKGroupSession.h in Headers */ = {isa = PBXBuildFile; fileRef = 0753932A2DC94A2B0002EBCD /* WKGroupSession.h */; };
 		075A9CF326169BAB006DFA3A /* MediaSessionCoordinatorProxyPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 077BA570260E8F630072F19F /* MediaSessionCoordinatorProxyPrivate.h */; };
 		075C079A2D92125D00B3E900 /* WKContextMenuElementInfoAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 075C07992D9211F700B3E900 /* WKContextMenuElementInfoAdapter.swift */; };
+		07642AEF2DEABBA100561888 /* WKWebsiteDataStore+SwiftOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07642AEE2DEABB7300561888 /* WKWebsiteDataStore+SwiftOverlay.swift */; };
 		076867FF2D4C283E004DA801 /* WebViewRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 076867F72D4C26A8004DA801 /* WebViewRepresentable.swift */; };
 		076868022D4C285B004DA801 /* WebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 076867F62D4C26A8004DA801 /* WebView.swift */; };
 		076868032D4C2867004DA801 /* View+WebViewModifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 078B04B52CF2B4D300B453A6 /* View+WebViewModifiers.swift */; };
@@ -3299,6 +3300,7 @@
 		074F34802CC5F7D500CA5301 /* WKIntelligenceTextEffectCoordinator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WKIntelligenceTextEffectCoordinator.h; sourceTree = "<group>"; };
 		0753932A2DC94A2B0002EBCD /* WKGroupSession.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WKGroupSession.h; sourceTree = "<group>"; };
 		075C07992D9211F700B3E900 /* WKContextMenuElementInfoAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WKContextMenuElementInfoAdapter.swift; sourceTree = "<group>"; };
+		07642AEE2DEABB7300561888 /* WKWebsiteDataStore+SwiftOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WKWebsiteDataStore+SwiftOverlay.swift"; sourceTree = "<group>"; };
 		076867F42D4C26A8004DA801 /* CocoaWebViewAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CocoaWebViewAdapter.swift; sourceTree = "<group>"; };
 		076867F52D4C26A8004DA801 /* PlatformTextSearching.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlatformTextSearching.swift; sourceTree = "<group>"; };
 		076867F62D4C26A8004DA801 /* WebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebView.swift; sourceTree = "<group>"; };
@@ -12406,6 +12408,7 @@
 				1A4832C91A9BC465008B4DFE /* WKWebsiteDataRecord.mm */,
 				1A4832CD1A9BC484008B4DFE /* WKWebsiteDataRecordInternal.h */,
 				1AA654D01B14F71400BF1D3E /* WKWebsiteDataRecordPrivate.h */,
+				07642AEE2DEABB7300561888 /* WKWebsiteDataStore+SwiftOverlay.swift */,
 				75A8D2C4187CCF9F00C39C9E /* WKWebsiteDataStore.h */,
 				75A8D2C5187CCF9F00C39C9E /* WKWebsiteDataStore.mm */,
 				75A8D2D4187D1C0100C39C9E /* WKWebsiteDataStoreInternal.h */,
@@ -21066,6 +21069,7 @@
 				1C5ACF902A955CB000C041C0 /* WKWebExtensionTabConfiguration.mm in Sources */,
 				1C5ACF8D2A955CA700C041C0 /* WKWebExtensionWindowConfiguration.mm in Sources */,
 				079A4DA52D72CE3F00CA387F /* WKWebpagePreferences+Extras.swift in Sources */,
+				07642AEF2DEABBA100561888 /* WKWebsiteDataStore+SwiftOverlay.swift in Sources */,
 				075369492DC589E1006446F8 /* WKWebView+TextExtraction.swift in Sources */,
 				079A4DA32D72CDB400CA387F /* WKWebViewConfiguration+Extras.swift in Sources */,
 				C14D306924B79BE000480387 /* XPCEndpoint.mm in Sources */,


### PR DESCRIPTION
#### 3718aac8cf4603d0f07eb2c9313a002a97d5a43e
<pre>
[Swift in WebKit] Support compiling `WKWebsiteDataStore.proxyConfigurations` in more configurations
<a href="https://bugs.webkit.org/show_bug.cgi?id=293848">https://bugs.webkit.org/show_bug.cgi?id=293848</a>
<a href="https://rdar.apple.com/152353674">rdar://152353674</a>

Reviewed by Abrar Rahman Protyasha.

- Use the API version of the Network interface instead of the SPI so that it can compile on the public SDK
- Enable compiling it on watchOS and tvOS, and just mark it unavailable there instead
- Explicitly specify visionOS availability
- Refactor into a more sensible file
- Add documentation

* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore+SwiftOverlay.swift: Added.
* Source/WebKit/UIProcess/API/Cocoa/WebKitSwiftOverlay.swift:
(WKWebsiteDataStore.proxyConfigurations): Deleted.
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* WebKit.xcworkspace/xcshareddata/xcschemes/All WebKit Tools.xcscheme:
* WebKit.xcworkspace/xcshareddata/xcschemes/Everything up to WebKit + Tools.xcscheme:

Canonical link: <a href="https://commits.webkit.org/295650@main">https://commits.webkit.org/295650@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/76c9caf854525f768bfe4ae9094130cf6d8b69fe

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105761 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25512 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15905 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110958 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/56357 "Built successfully") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/26054 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34015 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80316 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/transform-origin-view-transition-group.html (failure)") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108767 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/20346 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95437 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60629 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/20061 "Unexpected infrastructure issue, retrying build") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55796 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/89789 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13573 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/113807 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32901 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24244 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89392 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33265 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91668 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89061 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22702 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33935 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11742 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/28368 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32826 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/38236 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32572 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35921 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34170 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->