### PR TITLE
[JSC] Implement `AsyncDisposableStack` prototype methods

### DIFF
--- a/JSTests/stress/async-disposable-stack-prototype-methods.js
+++ b/JSTests/stress/async-disposable-stack-prototype-methods.js
@@ -1,0 +1,225 @@
+//@ requireOptions("--useExplicitResourceManagement=1")
+
+function shouldBe(a, b) {
+    if (a !== b)
+        throw new Error(`Expected ${b} but got ${a}`);
+}
+
+function shouldThrow(run, errorType, message) {
+    let error;
+    let threw = false;
+    try {
+        run();
+    } catch (e) {
+        threw = true;
+        error = e;
+    }
+    if (!threw)
+        throw new Error(`Expected to throw ${errorType.name}, but did not throw.`);
+    if (!(error instanceof errorType))
+        throw new Error(`Expected to throw ${errorType.name}, but threw '${error}'`);
+    if (message !== void 0 && error.message !== message)
+        throw new Error(`Expected to throw '${message}', but threw '${error.message}'`);
+}
+
+function shouldThrowAsync(run, errorType, message) {
+    let actual;
+    let hadError = false;
+    run().then(v => { actual = v; },
+               e => { hadError = true; actual = e; });
+    drainMicrotasks();
+    if (!hadError)
+        throw new Error("Expected async throw, but promise fulfilled.");
+    if (!(actual instanceof errorType))
+        throw new Error(`Expected to throw ${errorType.name}, but threw '${actual}'`);
+    if (message !== void 0 && actual.message !== message)
+        throw new Error(`Expected to throw '${message}', but threw '${actual.message}'`);
+}
+
+/* adopt */
+
+{
+    const stack = new AsyncDisposableStack();
+    const value = { x: 1 };
+    let called = 0;
+    let captured;
+    shouldBe(stack.adopt(value, v => { called++; captured = v; }), value);
+    const p = stack.disposeAsync();
+    shouldBe(p instanceof Promise, true);
+    drainMicrotasks();
+    shouldBe(called, 1);
+    shouldBe(captured, value);
+}
+
+{
+    const stack = new AsyncDisposableStack();
+    shouldThrow(() => stack.adopt(0, 1), TypeError);
+}
+
+{
+    const stack = new AsyncDisposableStack();
+    stack.disposeAsync();
+    shouldThrow(() => stack.adopt({}, () => {}), ReferenceError);
+}
+
+/* defer */
+
+{
+    const stack = new AsyncDisposableStack();
+    let called = 0;
+    shouldBe(stack.defer(() => { called++; }), undefined);
+    const p = stack.disposeAsync();
+    shouldBe(p instanceof Promise, true);
+    drainMicrotasks();
+    shouldBe(called, 1);
+}
+
+{
+    const stack = new AsyncDisposableStack();
+    shouldThrow(() => stack.defer(1), TypeError);
+}
+
+{
+    const stack = new AsyncDisposableStack();
+    stack.disposeAsync();
+    shouldThrow(() => stack.defer(() => {}), ReferenceError);
+}
+
+/* use */
+
+{
+    const stack = new AsyncDisposableStack();
+    let disposed = 0;
+    const resource = {
+        async [Symbol.asyncDispose]() { disposed++; }
+    };
+    shouldBe(stack.use(resource), resource);
+    const p = stack.disposeAsync();
+    shouldBe(p instanceof Promise, true);
+    drainMicrotasks();
+    shouldBe(disposed, 1);
+}
+
+{
+    const stack = new AsyncDisposableStack();
+    shouldThrow(() => stack.use({}), TypeError);
+}
+
+{
+    const stack = new AsyncDisposableStack();
+    stack.disposeAsync();
+    shouldThrow(() => stack.use({ async [Symbol.asyncDispose]() {} }), ReferenceError);
+}
+
+/* move */
+
+{
+    const stack = new AsyncDisposableStack();
+    let disposed = 0;
+    stack.defer(() => { disposed++; });
+    const moved = stack.move();
+    const p1 = stack.disposeAsync();
+    let fulfilled1 = 0;
+    p1.then(() => fulfilled1++);
+    drainMicrotasks();
+    shouldBe(fulfilled1, 1);
+    shouldBe(disposed, 0);
+
+    const p2 = moved.disposeAsync();
+    p2.then(() => {});
+    drainMicrotasks();
+    shouldBe(disposed, 1);
+}
+
+{
+    const stack = new AsyncDisposableStack();
+    stack.disposeAsync();
+    shouldThrow(() => stack.move(), ReferenceError);
+}
+
+/* disposeAsync */
+
+{
+    const stack = new AsyncDisposableStack();
+    let fulfilled = 0;
+    const p = stack.disposeAsync();
+    p.then(v => { fulfilled++; shouldBe(v, undefined); });
+    drainMicrotasks();
+    shouldBe(fulfilled, 1);
+}
+
+{
+    const stack = new AsyncDisposableStack();
+    let first = 0;
+    let second = 0;
+    stack.disposeAsync().then(() => first++);
+    drainMicrotasks();
+    shouldBe(first, 1);
+    stack.disposeAsync().then(() => second++);
+    drainMicrotasks();
+    shouldBe(second, 1);
+}
+
+{
+    shouldThrowAsync(
+        () => AsyncDisposableStack.prototype.disposeAsync.call({}),
+        TypeError
+    );
+}
+
+{
+    const order = [];
+    const stack = new AsyncDisposableStack();
+    stack.defer(() => order.push(1));
+    stack.defer(() => order.push(2));
+    stack.disposeAsync();
+    drainMicrotasks();
+    shouldBe(order.join(','), '2,1');
+}
+
+{
+    const order = [];
+    let resolver;
+    const stack = new AsyncDisposableStack();
+    stack.defer(() => order.push('b'));
+    stack.defer(() => {
+        order.push('a-start');
+        return new Promise(r => { resolver = () => { order.push('a-end'); r(); }; });
+    });
+    let fulfilled = 0;
+    const p = stack.disposeAsync();
+    p.then(() => fulfilled++);
+    drainMicrotasks();
+    shouldBe(order.join(','), 'a-start');
+    shouldBe(fulfilled, 0);
+    resolver();
+    drainMicrotasks();
+    shouldBe(order.join(','), 'a-start,a-end,b');
+    shouldBe(fulfilled, 1);
+}
+
+{
+    function E1() {}
+    const stack = new AsyncDisposableStack();
+    stack.defer(() => {});
+    stack.defer(() => Promise.reject(new E1()));
+    shouldThrowAsync(() => stack.disposeAsync(), E1);
+}
+
+{
+    const stack = new AsyncDisposableStack();
+    function E1() {}
+    function E2() {}
+    stack.defer(() => { throw new E1(); });
+    stack.defer(() => { throw new E2(); });
+    shouldThrowAsync(() => stack.disposeAsync(), SuppressedError);
+}
+
+{
+    function E1() {}
+    function E2() {}
+    const stack = new AsyncDisposableStack();
+    stack.defer(() => { throw new E2(); });
+    stack.defer(() => Promise.reject(new E1()));
+    shouldThrowAsync(() => stack.disposeAsync(), SuppressedError);
+}

--- a/JSTests/test262/config.yaml
+++ b/JSTests/test262/config.yaml
@@ -48,17 +48,9 @@ skip:
     - test/staging/sm/Temporal
     # Explicit Resource Management
     - test/staging/explicit-resource-management
-    - test/built-ins/AsyncDisposableStack/prototype
     - test/language/statements/using
     - test/language/statements/await-using
   files:
-    # Depends on AsyncDisposableStack
-    - test/built-ins/DisposableStack/prototype/use/this-does-not-have-internal-disposablestate-throws.js
-    - test/built-ins/DisposableStack/prototype/dispose/this-does-not-have-internal-disposablestate-throws.js
-    - test/built-ins/DisposableStack/prototype/adopt/this-does-not-have-internal-disposablestate-throws.js
-    - test/built-ins/DisposableStack/prototype/move/this-does-not-have-internal-disposablestate-throws.js
-    - test/built-ins/DisposableStack/prototype/defer/this-does-not-have-internal-disposablestate-throws.js
-
     # https://github.com/claudepache/es-legacy-function-reflection
     - test/built-ins/ThrowTypeError/unique-per-realm-function-proto.js
     - test/built-ins/Function/prototype/restricted-property-arguments.js

--- a/Source/JavaScriptCore/CMakeLists.txt
+++ b/Source/JavaScriptCore/CMakeLists.txt
@@ -339,6 +339,7 @@ set(JavaScriptCore_BUILTINS_SOURCES
     ${JAVASCRIPTCORE_DIR}/builtins/ArrayConstructor.js
     ${JAVASCRIPTCORE_DIR}/builtins/ArrayIteratorPrototype.js
     ${JAVASCRIPTCORE_DIR}/builtins/ArrayPrototype.js
+    ${JAVASCRIPTCORE_DIR}/builtins/AsyncDisposableStackPrototype.js
     ${JAVASCRIPTCORE_DIR}/builtins/AsyncFunctionPrototype.js
     ${JAVASCRIPTCORE_DIR}/builtins/AsyncGeneratorPrototype.js
     ${JAVASCRIPTCORE_DIR}/builtins/AsyncIteratorPrototype.js

--- a/Source/JavaScriptCore/DerivedSources-input.xcfilelist
+++ b/Source/JavaScriptCore/DerivedSources-input.xcfilelist
@@ -39,6 +39,7 @@ $(PROJECT_DIR)/b3/air/opcode_generator.rb
 $(PROJECT_DIR)/builtins/ArrayConstructor.js
 $(PROJECT_DIR)/builtins/ArrayIteratorPrototype.js
 $(PROJECT_DIR)/builtins/ArrayPrototype.js
+$(PROJECT_DIR)/builtins/AsyncDisposableStackPrototype.js
 $(PROJECT_DIR)/builtins/AsyncFromSyncIteratorPrototype.js
 $(PROJECT_DIR)/builtins/AsyncFunctionPrototype.js
 $(PROJECT_DIR)/builtins/AsyncGeneratorPrototype.js

--- a/Source/JavaScriptCore/DerivedSources.make
+++ b/Source/JavaScriptCore/DerivedSources.make
@@ -108,6 +108,7 @@ JavaScriptCore_BUILTINS_SOURCES = \
     $(JavaScriptCore)/builtins/ArrayConstructor.js \
     $(JavaScriptCore)/builtins/ArrayIteratorPrototype.js \
     $(JavaScriptCore)/builtins/ArrayPrototype.js \
+    $(JavaScriptCore)/builtins/AsyncDisposableStackPrototype.js \
     $(JavaScriptCore)/builtins/AsyncFunctionPrototype.js \
     $(JavaScriptCore)/builtins/AsyncGeneratorPrototype.js \
     $(JavaScriptCore)/builtins/AsyncIteratorPrototype.js \

--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -4811,6 +4811,7 @@
 		8BC064931E1D828B00B2B8CA /* AsyncIteratorPrototype.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AsyncIteratorPrototype.cpp; sourceTree = "<group>"; };
 		8BC064941E1D828B00B2B8CA /* AsyncIteratorPrototype.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AsyncIteratorPrototype.h; sourceTree = "<group>"; };
 		8C469C292D8EBC8A008C6403 /* StringReplaceCache.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = StringReplaceCache.cpp; sourceTree = "<group>"; };
+		8C7B16342DEAD8FC00BF0920 /* AsyncDisposableStackPrototype.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = AsyncDisposableStackPrototype.js; sourceTree = "<group>"; };
 		8C9F78BF2DC8836D00868239 /* AsyncIteratorPrototype.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = AsyncIteratorPrototype.js; sourceTree = "<group>"; };
 		8C9F78D82DCF65EB00868239 /* DisposableStackConstructor.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = DisposableStackConstructor.cpp; sourceTree = "<group>"; };
 		8C9F78D92DCF65F400868239 /* DisposableStackConstructor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DisposableStackConstructor.h; sourceTree = "<group>"; };
@@ -9981,6 +9982,7 @@
 				7CF9BC581B65D9A3009DB1EF /* ArrayConstructor.js */,
 				7CF9BC591B65D9A3009DB1EF /* ArrayIteratorPrototype.js */,
 				A7D801A01880D66E0026C39B /* ArrayPrototype.js */,
+				8C7B16342DEAD8FC00BF0920 /* AsyncDisposableStackPrototype.js */,
 				8B1735EF1E92E52900369054 /* AsyncFromSyncIteratorPrototype.js */,
 				5B8243041DB7AA4900EA6384 /* AsyncFunctionPrototype.js */,
 				8BC064821E180B4A00B2B8CA /* AsyncGeneratorPrototype.js */,

--- a/Source/JavaScriptCore/builtins/AsyncDisposableStackPrototype.js
+++ b/Source/JavaScriptCore/builtins/AsyncDisposableStackPrototype.js
@@ -1,0 +1,159 @@
+/*
+ * Copyright (C) 2025 Sosuke Suzuki <aosukeke@gmail.com>.
+ *
+ * Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// https://tc39.es/proposal-explicit-resource-management/#sec-asyncdisposablestack.prototype.adopt
+function adopt(value, onAsyncDispose)
+{
+    'use strict';
+
+    if (!@isAsyncDisposableStack(this))
+        @throwTypeError("AsyncDisposableStack.prototype.adopt requires that |this| be a AsyncDisposableStack object");
+
+    if (@getAsyncDisposableStackInternalField(this, @asyncDisposableStackFieldState) === @AsyncDisposableStackStateDisposed)
+        throw new @ReferenceError("AsyncDisposableStack.prototype.adopt requires that |this| be a pending AsyncDisposableStack object");
+
+    if (!@isCallable(onAsyncDispose))
+        @throwTypeError("AsyncDisposableStack.prototype.adopt requires that onAsyncDispose argument be a callable");
+
+    var closure = () => { onAsyncDispose.@call(@undefined, value); }
+    @addDisposableResource(@getAsyncDisposableStackInternalField(this, @asyncDisposableStackFieldCapability), @undefined, /* isAsync */ true, closure);
+
+    return value;
+}
+
+// https://tc39.es/proposal-explicit-resource-management/#sec-asyncdisposablestack.prototype.defer
+@overriddenName="defer"
+function deferMethod(onAsyncDispose)
+{
+    'use strict';
+
+    if (!@isAsyncDisposableStack(this))
+        @throwTypeError("AsyncDisposableStack.prototype.defer requires that |this| be a AsyncDisposableStack object");
+
+    if (@getAsyncDisposableStackInternalField(this, @asyncDisposableStackFieldState) === @AsyncDisposableStackStateDisposed)
+        throw new @ReferenceError("AsyncDisposableStack.prototype.defer requires that |this| be a pending AsyncDisposableStack object");
+
+    if (!@isCallable(onAsyncDispose))
+        @throwTypeError("AsyncDisposableStack.prototype.defer requires that onAsyncDispose argument be a callable");
+
+    @addDisposableResource(@getAsyncDisposableStackInternalField(this, @asyncDisposableStackFieldCapability), @undefined, /* isAsync */ true, onAsyncDispose);
+
+    return @undefined;
+}
+
+// https://tc39.es/proposal-explicit-resource-management/#sec-asyncdisposablestack.prototype.disposeAsync
+function disposeAsync()
+{
+    'use strict';
+
+    var promiseCapability = @newPromiseCapability(@Promise);
+
+    if (!@isAsyncDisposableStack(this)) {
+        @rejectPromiseWithFirstResolvingFunctionCallCheck(promiseCapability.promise, @makeTypeError("AsyncDisposableStack.prototype.disposeAsync requires that |this| be a AsyncDisposableStack object"));
+        return promiseCapability.promise;
+    }
+
+    if (@getAsyncDisposableStackInternalField(this, @asyncDisposableStackFieldState) === @AsyncDisposableStackStateDisposed) {
+        @resolvePromiseWithFirstResolvingFunctionCallCheck(promiseCapability.promise, @undefined);
+        return promiseCapability.promise;
+    }
+
+    @putAsyncDisposableStackInternalField(this, @asyncDisposableStackFieldState, @AsyncDisposableStackStateDisposed);
+
+    var stack = @getAsyncDisposableStackInternalField(this, @asyncDisposableStackFieldCapability);
+    @assert(@isArray(stack));
+
+    var i = stack.length;
+    var thrown = false;
+    var suppressed;
+
+    var handleError = (result) => {
+        if (thrown)
+            suppressed = new @SuppressedError(result, suppressed);
+        else {
+            thrown = true;
+            suppressed = result;
+        }
+        loop();
+    };
+
+    var loop = () => {
+        if (i) {
+            var resource = stack[--i];
+            try {
+                @Promise.@resolve(resource.method.@call(resource.value)).@then(loop, handleError);
+            } catch (error) {
+                handleError(error);
+            }
+        } else {
+            if (thrown)
+                @rejectPromiseWithFirstResolvingFunctionCallCheck(promiseCapability.promise, suppressed);
+            else
+               @resolvePromiseWithFirstResolvingFunctionCallCheck(promiseCapability.promise, @undefined);
+        }
+    };
+
+    loop();
+
+    @putAsyncDisposableStackInternalField(this, @asyncDisposableStackFieldCapability, []);
+
+    return promiseCapability.promise;
+}
+
+// https://tc39.es/proposal-explicit-resource-management/#sec-asyncdisposablestack.prototype.move
+function move()
+{
+    'use strict';
+
+    if (!@isAsyncDisposableStack(this))
+        @throwTypeError("AsyncDisposableStack.prototype.move requires that |this| be a AsyncDisposableStack object");
+
+    if (@getAsyncDisposableStackInternalField(this, @asyncDisposableStackFieldState) === @AsyncDisposableStackStateDisposed)
+        throw new @ReferenceError("AsyncDisposableStack.prototype.move requires that |this| be a pending AsyncDisposableStack object");
+
+    var newAsyncDisposableStack = new @AsyncDisposableStack();
+    @putAsyncDisposableStackInternalField(newAsyncDisposableStack, @asyncDisposableStackFieldCapability, @getAsyncDisposableStackInternalField(this, @asyncDisposableStackFieldCapability));
+
+    @putAsyncDisposableStackInternalField(this, @asyncDisposableStackFieldCapability, []);
+    @putAsyncDisposableStackInternalField(this, @asyncDisposableStackFieldState, @AsyncDisposableStackStateDisposed);
+
+    return newAsyncDisposableStack;
+}
+
+// https://tc39.es/proposal-explicit-resource-management/#sec-asyncdisposablestack.prototype.use
+function use(value)
+{
+    'use strict';
+
+    if (!@isAsyncDisposableStack(this))
+        @throwTypeError("AsyncDisposableStack.prototype.use requires that |this| be a AsyncDisposableStack object");
+
+    if (@getAsyncDisposableStackInternalField(this, @asyncDisposableStackFieldState) === @AsyncDisposableStackStateDisposed)
+        throw new @ReferenceError("AsyncDisposableStack.prototype.use requires that |this| be a pending AsyncDisposableStack object");
+
+    @addDisposableResource(@getDisposableStackInternalField(this, @disposableStackFieldCapability), value, /* isAsync */ true);
+
+    return value;
+}

--- a/Source/JavaScriptCore/builtins/BuiltinNames.h
+++ b/Source/JavaScriptCore/builtins/BuiltinNames.h
@@ -223,6 +223,7 @@ namespace JSC {
     macro(ReferenceError) \
     macro(SuppressedError) \
     macro(DisposableStack) \
+    macro(AsyncDisposableStack) \
 
 
 namespace Symbols {

--- a/Source/JavaScriptCore/bytecode/BytecodeIntrinsicRegistry.cpp
+++ b/Source/JavaScriptCore/bytecode/BytecodeIntrinsicRegistry.cpp
@@ -34,6 +34,7 @@
 #include "IdentifierInlines.h"
 #include "IterationKind.h"
 #include "JSArrayIterator.h"
+#include "JSAsyncDisposableStack.h"
 #include "JSAsyncFromSyncIterator.h"
 #include "JSAsyncGenerator.h"
 #include "JSDisposableStack.h"
@@ -144,6 +145,11 @@ BytecodeIntrinsicRegistry::BytecodeIntrinsicRegistry(VM& vm)
     m_disposableStackFieldCapability.set(m_vm, jsNumber(static_cast<int32_t>(JSDisposableStack::Field::Capability)));
     m_DisposableStackStatePending.set(m_vm, jsNumber(static_cast<int32_t>(JSDisposableStack::State::Pending)));
     m_DisposableStackStateDisposed.set(m_vm, jsNumber(static_cast<int32_t>(JSDisposableStack::State::Disposed)));
+    m_asyncDisposableStackFieldState.set(m_vm, jsNumber(static_cast<int32_t>(JSAsyncDisposableStack::Field::State)));
+    m_asyncDisposableStackFieldCapability.set(m_vm, jsNumber(static_cast<int32_t>(JSAsyncDisposableStack::Field::Capability)));
+    m_AsyncDisposableStackStatePending.set(m_vm, jsNumber(static_cast<int32_t>(JSAsyncDisposableStack::State::Pending)));
+    m_AsyncDisposableStackStateDisposed.set(m_vm, jsNumber(static_cast<int32_t>(JSAsyncDisposableStack::State::Disposed)));
+
 }
 
 std::optional<BytecodeIntrinsicRegistry::Entry> BytecodeIntrinsicRegistry::lookup(const Identifier& ident) const

--- a/Source/JavaScriptCore/bytecode/BytecodeIntrinsicRegistry.h
+++ b/Source/JavaScriptCore/bytecode/BytecodeIntrinsicRegistry.h
@@ -51,6 +51,7 @@ enum class LinkTimeConstant : int32_t;
     macro(getPromiseInternalField) \
     macro(getGeneratorInternalField) \
     macro(getIteratorHelperInternalField) \
+    macro(getAsyncDisposableStackInternalField) \
     macro(getAsyncFromSyncIteratorInternalField) \
     macro(getAsyncGeneratorInternalField) \
     macro(getAbstractModuleRecordInternalField) \
@@ -63,6 +64,7 @@ enum class LinkTimeConstant : int32_t;
     macro(getWrapForValidIteratorInternalField) \
     macro(getDisposableStackInternalField) \
     macro(idWithProfile) \
+    macro(isAsyncDisposableStack) \
     macro(isAsyncFromSyncIterator) \
     macro(isObject) \
     macro(isCallable) \
@@ -99,6 +101,7 @@ enum class LinkTimeConstant : int32_t;
     macro(putByValWithThisStrict) \
     macro(putPromiseInternalField) \
     macro(putGeneratorInternalField) \
+    macro(putAsyncDisposableStackInternalField) \
     macro(putAsyncGeneratorInternalField) \
     macro(putArrayIteratorInternalField) \
     macro(putStringIteratorInternalField) \
@@ -205,6 +208,10 @@ enum class LinkTimeConstant : int32_t;
     macro(disposableStackFieldCapability) \
     macro(DisposableStackStatePending) \
     macro(DisposableStackStateDisposed) \
+    macro(asyncDisposableStackFieldState) \
+    macro(asyncDisposableStackFieldCapability) \
+    macro(AsyncDisposableStackStatePending) \
+    macro(AsyncDisposableStackStateDisposed) \
 
 
 #define JSC_COMMON_BYTECODE_INTRINSIC_CONSTANTS_CUSTOM_EACH_NAME(macro) \

--- a/Source/JavaScriptCore/bytecode/LinkTimeConstant.h
+++ b/Source/JavaScriptCore/bytecode/LinkTimeConstant.h
@@ -154,6 +154,7 @@ class JSGlobalObject;
     v(ReferenceError, nullptr) \
     v(SuppressedError, nullptr) \
     v(DisposableStack, nullptr) \
+    v(AsyncDisposableStack, nullptr) \
 
 
 #define DECLARE_LINK_TIME_CONSTANT(name, code) name,

--- a/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h
+++ b/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h
@@ -945,6 +945,7 @@ namespace JSC {
         RegisterID* emitIsDerivedArray(RegisterID* dst, RegisterID* src) { return emitIsCellWithType(dst, src, DerivedArrayType); }
         RegisterID* emitIsAsyncFromSyncIterator(RegisterID* dst, RegisterID* src) { return emitIsCellWithType(dst, src, JSAsyncFromSyncIteratorType); }
         RegisterID* emitIsDisposableStack(RegisterID* dst, RegisterID* src) { return emitIsCellWithType(dst, src, DisposableStackType); }
+        RegisterID* emitIsAsyncDisposableStack(RegisterID* dst, RegisterID* src) { return emitIsCellWithType(dst, src, AsyncDisposableStackType); }
         void emitRequireObjectCoercible(RegisterID* value, ASCIILiteral error);
 
         void emitIteratorOpen(RegisterID* iterator, RegisterID* nextOrIndex, RegisterID* symbolIterator, CallArguments& iterable, const ThrowableExpressionData*);

--- a/Source/JavaScriptCore/runtime/CommonIdentifiers.h
+++ b/Source/JavaScriptCore/runtime/CommonIdentifiers.h
@@ -325,7 +325,8 @@
     macro(dispose) \
     macro(use) \
     macro(move) \
-    macro(AsyncDisposableStack)
+    macro(AsyncDisposableStack) \
+    macro(disposeAsync) \
 
 #define JSC_COMMON_IDENTIFIERS_EACH_PRIVATE_FIELD(macro) \
     macro(constructor)

--- a/Source/JavaScriptCore/runtime/JSAsyncDisposableStack.cpp
+++ b/Source/JavaScriptCore/runtime/JSAsyncDisposableStack.cpp
@@ -57,6 +57,11 @@ void JSAsyncDisposableStack::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     Base::visitChildren(thisObject, visitor);
 }
 
+bool JSAsyncDisposableStack::disposed()
+{
+    return internalField(Field::State).get().asInt32() == static_cast<int32_t>(State::Disposed);
+}
+
 DEFINE_VISIT_CHILDREN(JSAsyncDisposableStack);
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/JSAsyncDisposableStack.h
+++ b/Source/JavaScriptCore/runtime/JSAsyncDisposableStack.h
@@ -71,6 +71,8 @@ public:
     static JSAsyncDisposableStack* createWithInitialValues(VM&);
     static JSAsyncDisposableStack* create(VM&, Structure*);
 
+    bool disposed();
+
 private:
     JSAsyncDisposableStack(VM& vm, Structure* structure)
         : Base(vm, structure)

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -1712,6 +1712,10 @@ capitalName ## Constructor* lowerName ## Constructor = featureFlag ? capitalName
         JSGlobalObject* globalObject = jsCast<JSGlobalObject*>(init.owner);
         init.set(globalObject->m_disposableStackStructure.constructor(globalObject));
     });
+    m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::AsyncDisposableStack)].initLater([] (const Initializer<JSCell>& init) {
+        JSGlobalObject* globalObject = jsCast<JSGlobalObject*>(init.owner);
+        init.set(globalObject->m_asyncDisposableStackStructure.constructor(globalObject));
+    });
 
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::typedArrayLength)].initLater([] (const Initializer<JSCell>& init) {
             init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 0, "typedArrayViewLength"_s, typedArrayViewPrivateFuncLength, ImplementationVisibility::Private));


### PR DESCRIPTION
#### 524caf808d1981a6f729d29622b7435383d1d3f9
<pre>
[JSC] Implement `AsyncDisposableStack` prototype methods
<a href="https://bugs.webkit.org/show_bug.cgi?id=293849">https://bugs.webkit.org/show_bug.cgi?id=293849</a>

Reviewed by Yusuke Suzuki.

This patch implements following `AsyncDisposableStack`&apos;s prototype methods
from Explicit Resource Management Proposal[1]:

- `adopt`[2]
- `defer`[3]
- `disposeAsync`[4]
- `disposed`[5]
- `move`[6]
- `use`[7]

[1]: <a href="https://github.com/tc39/proposal-explicit-resource-management">https://github.com/tc39/proposal-explicit-resource-management</a>
[2]: <a href="https://tc39.es/proposal-explicit-resource-management/#sec-asyncdisposablestack.prototype.adopt">https://tc39.es/proposal-explicit-resource-management/#sec-asyncdisposablestack.prototype.adopt</a>
[3]: <a href="https://tc39.es/proposal-explicit-resource-management/#sec-asyncdisposablestack.prototype.defer">https://tc39.es/proposal-explicit-resource-management/#sec-asyncdisposablestack.prototype.defer</a>
[4]: <a href="https://tc39.es/proposal-explicit-resource-management/#sec-asyncdisposablestack.prototype.disposeAsync">https://tc39.es/proposal-explicit-resource-management/#sec-asyncdisposablestack.prototype.disposeAsync</a>
[5]: <a href="https://tc39.es/proposal-explicit-resource-management/#sec-get-asyncdisposablestack.prototype.disposed">https://tc39.es/proposal-explicit-resource-management/#sec-get-asyncdisposablestack.prototype.disposed</a>
[6]: <a href="https://tc39.es/proposal-explicit-resource-management/#sec-asyncdisposablestack.prototype.move">https://tc39.es/proposal-explicit-resource-management/#sec-asyncdisposablestack.prototype.move</a>
[7]: <a href="https://tc39.es/proposal-explicit-resource-management/#sec-asyncdisposablestack.prototype.use">https://tc39.es/proposal-explicit-resource-management/#sec-asyncdisposablestack.prototype.use</a>

Canonical link: <a href="https://commits.webkit.org/295677@main">https://commits.webkit.org/295677@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/542c042261d0854fec133c21070e49e3e8c23f74

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105778 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25529 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15922 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110975 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/56374 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/26030 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34032 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80330 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108784 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/20380 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95453 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60643 "Found 142 new API test failures: /WPE/TestUIClient:/webkit/WebKitWebView/query-permission-requests, /WPE/TestWebsiteData:/webkit/WebKitWebsiteData/deviceidhashsalt, /WPE/TestLoaderClient:/webkit/WebKitWebView/load-twice-and-reload, /WPE/TestCookieManager:/webkit/WebKitCookieManager/ephemeral, /WPE/TestWebKitWebView:/webkit/WebKitWebView/is-playing-audio, /WPE/TestConsoleMessage:/webkit/WebKitConsoleMessage/network-error, /WPE/TestWebsiteData:/webkit/WebKitWebsiteData/configuration, /WPE/TestCookieManager:/webkit/WebKitCookieManager/delete-cookies, /WPE/TestWebKitWebView:/webkit/WebKitWebView/terminate-unresponsive-web-process, /WPE/TestSSL:/webkit/WebKitWebView/insecure-content ... (failure)") | 
| | [💥 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/20083 "An unexpected error occured. Recent messages:OS: Sequoia (15.5), Xcode: 16.4; Running apply-patch; Checked out pull request; Skipped layout-tests; layout-tests (failure); Uploaded test results") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13550 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55813 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/98419 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/89814 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13589 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/113824 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/104397 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32918 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24256 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89409 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33282 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91684 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89079 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22720 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33953 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11758 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/28392 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32843 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/38254 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/128709 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32589 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/35132 "Found 3 new JSC stress test failures: wasm.yaml/wasm/gc/ref-i31-eq.js.wasm-collect-continuously, wasm.yaml/wasm/gc/ref-i31-eq.js.wasm-eager-jettison, wasm.yaml/wasm/gc/ref-i31-eq.js.wasm-slow-memory (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35938 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34187 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->