### PR TITLE
[Swift in WebKit] Fix Swift 6 concurrency issues in WKPreviewWindowController

### DIFF
--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
@@ -946,7 +946,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
             UIWindowScene *scene = [window windowScene];
             _previewWindowController = adoptNS([WebKit::allocWKPreviewWindowControllerInstance() initWithURL:url.createNSURL().get() sceneID:scene._sceneIdentifier]);
             [_previewWindowController setDelegate:self];
-            [_previewWindowController presentWindow];
+            [_previewWindowController presentWindowWithCompletionHandler:^{ }];
             _fullScreenState = WebKit::InFullScreen;
 
             OBJC_ALWAYS_LOG(logIdentifier, "(QL) presentation completed");
@@ -1111,7 +1111,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         return;
 
     manager->prepareQuickLookImageURL([strongSelf = retainPtr(self), self, window = retainPtr([webView window]), logIdentifier = OBJC_LOGIDENTIFIER](URL&& url) mutable {
-        [_previewWindowController updateImage:url.createNSURL().get()];
+        [_previewWindowController updateImage:url.createNSURL().get() completionHandler:^{ }];
     });
 }
 #endif
@@ -1289,7 +1289,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         _fullScreenState = WebKit::NotInFullScreen;
 
         if (_previewWindowController) {
-            [_previewWindowController dismissWindow];
+            [_previewWindowController dismissWindowWithCompletionHandler:^{ }];
             [_previewWindowController setDelegate:nil];
             _previewWindowController = nil;
         }

--- a/Source/WebKit/WebKitSwift/Preview/WKPreviewWindowController.h
+++ b/Source/WebKit/WebKitSwift/Preview/WKPreviewWindowController.h
@@ -31,17 +31,19 @@ NS_ASSUME_NONNULL_BEGIN
 
 @class WKPreviewWindowController;
 
+NS_SWIFT_UI_ACTOR
 @protocol WKPreviewWindowControllerDelegate <NSObject>
 - (void)previewWindowControllerDidClose:(WKPreviewWindowController *)previewWindowController;
 @end
 
+NS_SWIFT_UI_ACTOR
 @interface WKPreviewWindowController : NSObject
 @property (nonatomic, weak, nullable) id <WKPreviewWindowControllerDelegate> delegate;
 
 - (instancetype)initWithURL:(NSURL *)url sceneID:(NSString *)sceneID NS_DESIGNATED_INITIALIZER;
-- (void)presentWindow;
-- (void)updateImage:(NSURL *)url;
-- (void)dismissWindow;
+- (void)presentWindowWithCompletionHandler:(NS_SWIFT_UI_ACTOR void(^)(void))completionHandler;
+- (void)updateImage:(NSURL *)url completionHandler:(NS_SWIFT_UI_ACTOR void(^)(void))completionHandler;
+- (void)dismissWindowWithCompletionHandler:(NS_SWIFT_UI_ACTOR void(^)(void))completionHandler;
 @end
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
#### d313a33c5a4ead1d8740d1ee552c42582a265127
<pre>
[Swift in WebKit] Fix Swift 6 concurrency issues in WKPreviewWindowController
<a href="https://bugs.webkit.org/show_bug.cgi?id=293850">https://bugs.webkit.org/show_bug.cgi?id=293850</a>
<a href="https://rdar.apple.com/152356775">rdar://152356775</a>

Reviewed by Aditya Keerthi.

Fix some concurrency issues by removing an unnecessary `DisaptchQueue.main.async`,
and using structured instead of unstructured concurrency where applicable.

* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm:
(-[WKFullScreenWindowController updateImageSource]):
(-[WKFullScreenWindowController exitFullScreen:]):
* Source/WebKit/WebKitSwift/Preview/WKPreviewWindowController.h:
* Source/WebKit/WebKitSwift/Preview/WKPreviewWindowController.swift:
(presentWindow):
(updateImage(_:)):
(dismissWindow):

Canonical link: <a href="https://commits.webkit.org/295781@main">https://commits.webkit.org/295781@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7b3e91725e9de3c615624a463bf4f1da02ce8dc3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/106131 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25880 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/16274 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/111328 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/56727 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/26536 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34383 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/80612 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/56727 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/109135 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/20966 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95773 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60935 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/20537 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [❌ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/56166 "Failed to checkout and rebase branch from PR 46162") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/90332 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13912 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/114186 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33269 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/24547 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/89693 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33633 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/92007 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89386 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22784 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34251 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/12066 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/28842 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/33194 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/38606 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32940 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/36290 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/34538 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->