### PR TITLE
[JSC] Fix parsing unreachable `ref.null`

### DIFF
--- a/JSTests/wasm/stress/parse-unreachable-ref-null.js
+++ b/JSTests/wasm/stress/parse-unreachable-ref-null.js
@@ -1,0 +1,56 @@
+function shouldThrow(run, errorType, message) {
+    let error;
+    let threw = false;
+    try {
+        run();
+    } catch (e) {
+        threw = true;
+        error = e;
+    }
+    if (!threw)
+        throw new Error(`Expected to throw ${errorType.name}, but did not throw.`);
+    if (!(error instanceof errorType))
+        throw new Error(`Expected to throw ${errorType.name}, but threw '${error}'`);
+    if (message !== void 0 && error.message !== message)
+        throw new Error(`Expected to throw '${message}', but threw '${error.message}'`);
+}
+
+{
+    // (module
+    //   (type $0 (func))
+    //   (type $1 (func))
+    //   (type $2 (func))
+    //   (func
+    //     (return)
+    //     (ref.null $2)
+    //     (drop)
+    //   )
+    // )
+    const wasm = new Uint8Array([
+      0, 97, 115, 109, 1, 0, 0, 0, 1, 10, 3, 96, 0, 0, 96, 0, 0, 96, 0, 0, 3, 2, 1,
+      0, 10, 8, 1, 6, 0, 15, 208, 2, 26, 11, 0, 17, 4, 110, 97, 109, 101, 4, 10, 3,
+      0, 1, 48, 1, 1, 49, 2, 1, 50,
+    ]);
+    new WebAssembly.Module(wasm);
+}
+
+{
+    // (module
+    //   (type $0 (func))
+    //   (type $1 (func))
+    //   (type $2 (func))
+    //   (func
+    //     (return)
+    //     (ref.null)
+    //     (drop)
+    //   )
+    // )
+    const wasm = new Uint8Array([
+      0, 97, 115, 109, 1, 0, 0, 0, 1, 10, 3, 96, 0, 0, 96, 0, 0, 96, 0, 0, 3, 2, 1,
+      0, 10, 7, 1, 5, 0, 15, 208, 26, 11, 0, 17, 4, 110, 97, 109, 101, 4, 10, 3, 0,
+      1, 48, 1, 1, 49, 2, 1, 50,
+    ]);
+    shouldThrow(() => {
+        new WebAssembly.Module(wasm);
+    }, WebAssembly.CompileError, "WebAssembly.Module doesn't parse at byte 4: can't get heap type for RefNull in unreachable context, in function at index 0 (evaluating 'new WebAssembly.Module(wasm)')")
+}

--- a/Source/JavaScriptCore/wasm/WasmFunctionParser.h
+++ b/Source/JavaScriptCore/wasm/WasmFunctionParser.h
@@ -4099,8 +4099,13 @@ auto FunctionParser<Context>::parseUnreachableExpression() -> PartialResult
         WASM_PARSER_FAIL_IF(!parseVarUInt32(tableIndex), "can't parse table index"_s);
         [[fallthrough]];
     }
-    case RefIsNull:
+    case RefIsNull: {
+        return { };
+    }
+
     case RefNull: {
+        int32_t unused;
+        WASM_PARSER_FAIL_IF(!parseHeapType(m_info, unused), "can't get heap type for "_s, m_currentOpcode, " in unreachable context"_s);
         return { };
     }
 


### PR DESCRIPTION
#### d8a5f39bad4fec5d966dda7496c7f0fefcf7d3f2
<pre>
[JSC] Fix parsing unreachable `ref.null`
<a href="https://bugs.webkit.org/show_bug.cgi?id=293107">https://bugs.webkit.org/show_bug.cgi?id=293107</a>

Reviewed by Yusuke Suzuki.

WasmFunctionParser has a separate path for parsing known unreachable
code. However, this segment missed `ref.null` handling.

* JSTests/wasm/stress/parse-unreachable-ref-null.js: Added.
* Source/JavaScriptCore/wasm/WasmFunctionParser.h:
(JSC::Wasm::FunctionParser&lt;Context&gt;::parseUnreachableExpression):

Canonical link: <a href="https://commits.webkit.org/295644@main">https://commits.webkit.org/295644@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b86ee3ebaf72dd875310836fb52abb51abfed53b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105771 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25522 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15915 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110968 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/56367 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/26019 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34025 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80324 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/56367 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108777 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/20365 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95445 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60637 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/20072 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13542 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55806 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/98412 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/89802 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13581 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/113817 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/104390 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32911 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/24249 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89402 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33275 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91676 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89071 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22698 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33946 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11750 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/28384 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32836 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/38247 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/128702 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32582 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/35130 "Found 2 new JSC stress test failures: wasm.yaml/wasm/gc/ref-i31-eq.js.default-wasm, wasm.yaml/wasm/gc/ref-i31-eq.js.wasm-slow-memory (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35931 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34180 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->