### PR TITLE
[WebGPU] abort() called during render bundle replay path

### DIFF
--- a/LayoutTests/fast/webgpu/nocrash/fuzz-293854-expected.txt
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-293854-expected.txt
@@ -1,0 +1,5 @@
+CONSOLE MESSAGE: promises created
+CONSOLE MESSAGE: the end
+CONSOLE MESSAGE: fuzz-293854.html
+CONSOLE MESSAGE: Pass
+

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-293854.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-293854.html
@@ -1,0 +1,262 @@
+<style>
+  :root { background: #102030e0; color: #99ddbbcc; font-size: 15px; }
+</style>
+<script id="shared">
+const log = console.log;
+
+</script>
+<script>
+globalThis.testRunner?.waitUntilDone();
+
+async function window0() {
+let adapter0 = await navigator.gpu.requestAdapter();
+let device0 = await adapter0.requestDevice();
+// START
+c = device0.createTexture({
+  size : [],
+  format : 'depth24plus-stencil8',
+  usage : GPUTextureUsage.TEXTURE_BINDING
+})
+d = device0.createTexture(
+    {
+      size : [ 4, 4, 20 ],
+      format : 'rgba32sint',
+      usage : GPUTextureUsage.STORAGE_BINDING
+    })
+e = device0.createTexture({
+  size : {width : 1},
+  format : 'r32sint',
+  usage : GPUTextureUsage.STORAGE_BINDING
+})
+f = e.createView()
+h = device0.createTexture({
+  size : {width : 5},
+  dimension : '1d',
+  format : 'r32uint',
+  usage : GPUTextureUsage.STORAGE_BINDING
+})
+i = device0.createBuffer({size : 4, usage : GPUBufferUsage.UNIFORM})
+j = device0.createBindGroupLayout({
+  entries : [
+    {
+      binding : 2,
+      visibility : GPUShaderStage.COMPUTE,
+      buffer : {type : 'storage', hasDynamicOffset : true}
+    },
+    {binding : 111, visibility : GPUShaderStage.COMPUTE, buffer : {}}, {
+      binding : 264,
+      visibility : GPUShaderStage.COMPUTE,
+      buffer : {type : 'storage'}
+    }
+  ]
+})
+k = device0.createRenderBundleEncoder({colorFormats : [ 'rgba8uint' ]})
+l = d.createView()
+m = device0.createTexture({
+  size : [ 2, 5, 67 ],
+  dimension : '3d',
+  format : 'rgba8uint',
+  usage : GPUTextureUsage.RENDER_ATTACHMENT
+})
+n = m.createView()
+o = device0.createBindGroupLayout({
+  entries : [
+    {
+      binding : 0,
+      visibility : GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture :
+          {format : 'r32uint', access : 'read-write', viewDimension : '1d'}
+    },
+    {
+      binding : 5,
+      visibility :
+          GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage,
+      buffer : {type : 'read-only-storage', hasDynamicOffset : true}
+    },
+    {
+      binding : 13,
+      visibility : GPUShaderStage.FRAGMENT,
+      buffer : {type : 'storage', hasDynamicOffset : true}
+    },
+    {
+      binding : 15,
+      visibility : GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture : {format : 'r32sint', access : 'read-write'}
+    },
+    {
+      binding : 43,
+      visibility :
+          GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage,
+      texture : {sampleType : 'depth'}
+    },
+    {
+      binding : 45,
+      visibility : GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture : {format : 'rgba32sint', viewDimension : '2d-array'}
+    }
+  ]
+})
+q = device0.createBuffer({size : 5763, usage : GPUBufferUsage.STORAGE})
+s = c.createView()
+aa = device0.createPipelineLayout({bindGroupLayouts : [ o ]})
+t = device0.createShaderModule({
+  code : ` 
+           struct ab {
+           @location(0) ac: vec4u}
+           @id(39156) override u: i32;
+           @fragment fn v() -> ab {
+           var ad: ab;
+           return ad;
+           _ = u;
+         }
+           `
+})
+w = device0.createBuffer({size : 60, usage : GPUBufferUsage.STORAGE})
+ae = h.createView()
+x = device0.createBindGroupLayout({
+  entries : [
+    {
+      binding : 0,
+      visibility : GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture :
+          {format : 'r32uint', access : 'read-write', viewDimension : '1d'}
+    },
+    {
+      binding : 5,
+      visibility :
+          GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage,
+      buffer : {type : 'read-only-storage', hasDynamicOffset : true}
+    },
+    {
+      binding : 13,
+      visibility : GPUShaderStage.FRAGMENT,
+      buffer : {type : 'storage', hasDynamicOffset : true}
+    },
+    {
+      binding : 15,
+      visibility : GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture : {format : 'r32sint', access : 'read-write'}
+    },
+    {
+      binding : 43,
+      visibility :
+          GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage,
+      texture : {sampleType : 'depth'}
+    },
+    {
+      binding : 45,
+      visibility : GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture : {format : 'rgba32sint', viewDimension : '2d-array'}
+    }
+  ]
+})
+y = device0.createShaderModule({
+  code : `  
+           struct z {
+           @builtin(position) position: vec4f}
+           @vertex fn af() -> z {
+           var ad: z;
+           return ad;
+         }
+           `
+})
+ag = device0.createCommandEncoder()
+ah = ag.beginRenderPass({
+  colorAttachments :
+      [ {view : n, depthSlice : 7, loadOp : 'load', storeOp : 'discard'} ]
+})
+aj = device0.createBindGroup({
+  layout : x,
+  entries : [
+    {binding : 15, resource : f}, {binding : 0, resource : ae},
+    {binding : 5, resource : {buffer : w}},
+    {binding : 13, resource : {buffer : q, size : 4}},
+    {binding : 45, resource : l}, {binding : 43, resource : s}
+  ]
+})
+ak = device0.createRenderPipeline({
+  layout : aa,
+  fragment : {
+    module : t,
+    constants : {39_156 : 1},
+    targets : [ {format : 'rgba8uint'} ]
+  },
+  vertex : {module : y}
+})
+try {
+  k.setPipeline(ak)
+} catch {
+}
+al = device0.createBindGroup({
+  layout : j,
+  entries : [
+    {binding : 111, resource : {buffer : i}},
+    {binding : 2, resource : {buffer : q, size : 36}},
+    {binding : 264, resource : {buffer : q, size : 12}}
+  ]
+})
+try {
+  k.setBindGroup(0, aj, new Uint32Array(91), 9, 2)
+k.draw(3)
+k.setBindGroup(0, al, new Uint32Array(6), 1, 1)
+} catch {
+}
+am = k.finish()
+try {
+  ah.executeBundles([ am ])
+} catch {
+}
+// END
+await device0.queue.onSubmittedWorkDone();
+}
+
+onload = async () => {
+  try {
+  let sharedScript = document.querySelector('#shared').textContent;
+
+  let workers = [
+
+  ];
+  let promises = [ window0() ];
+  log('promises created');
+  let results = await Promise.allSettled(promises);
+  for (let result of results) {
+    if (result.status === 'rejected') { throw result.reason; }
+  }
+  log('the end')
+  log(location);
+  } catch (e) {
+    log('error');
+    log(e);
+    log(e[Symbol.toStringTag]);
+    log(e.stack);
+    if (e instanceof GPUPipelineError) {
+      log(`${e} - ${e.reason}`);
+      
+    } else if (e instanceof DOMException) {
+      if (e.name === 'OperationError') {
+      log(e.message);
+      
+      } else if (e.name === 'InvalidStateError') {
+      } else {
+        log(e);
+        
+      }
+    } else if (e instanceof GPUValidationError) {
+      
+    } else if (e instanceof GPUOutOfMemoryError) {
+      
+    } else if (e instanceof TypeError) {
+      log(e);
+      
+    } else {
+      log('unexpected error type');
+      log(e);
+      
+    }
+  }
+  log('Pass');
+  globalThis.testRunner?.dumpAsText();
+  globalThis.testRunner?.notifyDone();
+};
+</script>

--- a/Source/WebGPU/WebGPU/RenderBundleEncoder.mm
+++ b/Source/WebGPU/WebGPU/RenderBundleEncoder.mm
@@ -298,6 +298,7 @@ bool RenderBundleEncoder::executePreDrawCommands(bool needsValidationLayerWorkar
         makeInvalid(@"Pipeline was not set prior to draw command");
         return false;
     }
+    m_requiresCommandReplay = m_requiresCommandReplay || !pipeline->vertexShaderBindingCount();
 
     auto pipelineLayout = pipeline->protectedPipelineLayout();
     auto vertexDynamicOffsetSum = checkedSum<uint64_t>(m_vertexDynamicOffset, sizeof(uint32_t) * pipelineLayout->sizeOfVertexDynamicOffsets());
@@ -373,7 +374,6 @@ bool RenderBundleEncoder::executePreDrawCommands(bool needsValidationLayerWorkar
         if (protectedGroup && (protectedGroup->makeSubmitInvalid(ShaderStage::Vertex, pipelineOptionalBindGroupLayout) || protectedGroup->makeSubmitInvalid(ShaderStage::Fragment, pipelineOptionalBindGroupLayout)))
             m_makeSubmitInvalid = true;
     }
-    m_requiresCommandReplay = m_requiresCommandReplay || !pipeline->vertexShaderBindingCount();
 
     if (NSString* error = pipeline->protectedPipelineLayout()->errorValidatingBindGroupCompatibility(m_bindGroups)) {
         makeInvalid(error);


### PR DESCRIPTION
#### bd6d1a65ebbfa2b6fc3409579a689aaca8aaa296
<pre>
[WebGPU] abort() called during render bundle replay path
<a href="https://bugs.webkit.org/show_bug.cgi?id=293854">https://bugs.webkit.org/show_bug.cgi?id=293854</a>
<a href="https://rdar.apple.com/152334151">rdar://152334151</a>

Reviewed by Tadeu Zagallo.

To workaround radar://150861687 we need to ensure we make the decision
to replay or not replay at recording time, otherwise we end up with
a bundle which contains an ICB and then later decides to replay all the commands.

We only support all ICBs or all replay. Replay should be required in fewer and
fewer instances once we support indirect calls in ICBs.

* LayoutTests/fast/webgpu/nocrash/fuzz-293854-expected.txt: Added.
* LayoutTests/fast/webgpu/nocrash/fuzz-293854.html: Added.
Add regression test.

* Source/WebGPU/WebGPU/RenderBundleEncoder.mm:
(WebGPU::RenderBundleEncoder::executePreDrawCommands):
Need to record that replay will be taken prior to command replay.

Canonical link: <a href="https://commits.webkit.org/295692@main">https://commits.webkit.org/295692@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4b8318a3cd2d86c3f6321d7b118e3ba687242177

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105826 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25577 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15970 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/111023 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/56422 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/26141 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34080 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80373 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108832 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/20518 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95496 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60687 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/20189 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13593 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55861 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/89932 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13631 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/113873 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32966 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24297 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89453 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33330 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91726 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89124 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22728 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33993 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11800 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/28467 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32891 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/38302 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32637 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35986 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34235 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->