### PR TITLE
Save memory by moving more RenderStyle Vectors to FixedVector

### DIFF
--- a/LayoutTests/ipc/serialized-type-info.html
+++ b/LayoutTests/ipc/serialized-type-info.html
@@ -64,7 +64,8 @@
             "KeyValuePair",
             "Markable",
             "RetainPtr",
-            "HashCountedSet"
+            "HashCountedSet",
+            "FixedVector",
         ];
         if (window.testRunner && !testRunner.haveSecureCodingRequest) {
             containerTypes.push("IPC::CoreIPCRetainPtr");

--- a/Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp
+++ b/Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp
@@ -7586,10 +7586,7 @@ AccessGenerationResult InlineCacheCompiler::compileOneAccessCaseHandler(const Ve
 
     ASSERT(m_success.empty());
 
-    auto keys = FixedVector<Ref<AccessCase>>::createWithSizeFromGenerator(1,
-        [&](unsigned) {
-            return Ref { accessCase };
-        });
+    auto keys = FixedVector<Ref<AccessCase>> { Ref { accessCase } };
     dataLogLnIf(InlineCacheCompilerInternal::verbose, FullCodeOrigin(codeBlock, m_stubInfo.codeOrigin), ": Generating polymorphic access stub for ", listDump(keys));
 
     MacroAssemblerCodeRef<JITStubRoutinePtrTag> code = FINALIZE_CODE_FOR(codeBlock, linkBuffer, JITStubRoutinePtrTag, categoryName(m_stubInfo.accessType), "%s", toCString("Access stub for ", *codeBlock, " ", m_stubInfo.codeOrigin, "with start: ", m_stubInfo.startLocation, ": ", listDump(keys)).data());

--- a/Source/WTF/wtf/FixedVector.h
+++ b/Source/WTF/wtf/FixedVector.h
@@ -34,7 +34,6 @@ template<typename T, typename Malloc>
 class FixedVector {
     WTF_MAKE_CONFIGURABLE_ALLOCATED(Malloc);
 public:
-
     using Storage = EmbeddedFixedVector<T, Malloc>;
     using Self = FixedVector<T, Malloc>;
     using value_type = typename Storage::value_type;
@@ -56,13 +55,13 @@ public:
     FixedVector(FixedVector&& other) = default;
 
     FixedVector(std::initializer_list<T> initializerList)
-        : m_storage(initializerList.size() ? Storage::create(initializerList.size()).moveToUniquePtr() : nullptr)
+        : m_storage(initializerList.size() ? Storage::create(initializerList).moveToUniquePtr() : nullptr)
     {
-        size_t index = 0;
-        for (const auto& element : initializerList) {
-            m_storage->at(index) = element;
-            index++;
-        }
+    }
+
+    template<typename U, size_t Extent> FixedVector(std::span<U, Extent> span)
+        : m_storage(span.empty() ? nullptr : Storage::create(span).moveToUniquePtr())
+    {
     }
 
     template<typename InputIterator> FixedVector(InputIterator begin, InputIterator end)
@@ -134,13 +133,20 @@ public:
     template<std::invocable<size_t> Generator>
     static FixedVector createWithSizeFromGenerator(size_t size, NOESCAPE Generator&& generator)
     {
-        return Self { Storage::createWithSizeFromGenerator(size, std::forward<Generator>(generator)) };
+        return Self { size ? Storage::createWithSizeFromGenerator(size, std::forward<Generator>(generator)).moveToUniquePtr() : std::unique_ptr<Storage> { nullptr } };
     }
 
     template<std::invocable<size_t> FailableGenerator>
     static FixedVector createWithSizeFromFailableGenerator(size_t size, NOESCAPE FailableGenerator&& generator)
     {
-        return Self { Storage::createWithSizeFromFailableGenerator(size, std::forward<FailableGenerator>(generator)) };
+        return Self { size ? Storage::createWithSizeFromFailableGenerator(size, std::forward<FailableGenerator>(generator)) : std::unique_ptr<Storage> { nullptr } };
+    }
+
+    template<typename SizedRange, typename Mapper>
+    static FixedVector map(SizedRange&& range, NOESCAPE Mapper&& mapper)
+    {
+        auto size = std::size(range);
+        return Self { size ? Storage::map(size, std::forward<SizedRange>(range), std::forward<Mapper>(mapper)).moveToUniquePtr() : std::unique_ptr<Storage> { nullptr } };
     }
 
     size_t size() const { return m_storage ? m_storage->size() : 0; }
@@ -190,9 +196,12 @@ public:
         return *m_storage == *other.m_storage;
     }
 
-    template<typename U> bool contains(const U&) const;
-    template<typename U> size_t find(const U&) const;
-    template<typename MatchFunction> size_t findIf(const MatchFunction&) const;
+    bool contains(const auto&) const;
+    bool containsIf(NOESCAPE const Invocable<bool(const T&)> auto&) const;
+    size_t find(const auto&) const;
+    size_t findIf(NOESCAPE const Invocable<bool(const T&)> auto&) const;
+    size_t reverseFind(const auto&) const;
+    size_t reverseFindIf(NOESCAPE const Invocable<bool(const T&)> auto&) const;
 
     void swap(Self& other)
     {
@@ -229,15 +238,19 @@ private:
 static_assert(sizeof(FixedVector<int>) == sizeof(int*));
 
 template<typename T, typename Malloc>
-template<typename U>
-bool FixedVector<T, Malloc>::contains(const U& value) const
+bool FixedVector<T, Malloc>::containsIf(NOESCAPE const Invocable<bool(const T&)> auto& matches) const
+{
+    return findIf(matches) != notFound;
+}
+
+template<typename T, typename Malloc>
+bool FixedVector<T, Malloc>::contains(const auto& value) const
 {
     return find(value) != notFound;
 }
 
 template<typename T, typename Malloc>
-template<typename MatchFunction>
-size_t FixedVector<T, Malloc>::findIf(const MatchFunction& matches) const
+size_t FixedVector<T, Malloc>::findIf(NOESCAPE const Invocable<bool(const T&)> auto& matches) const
 {
     for (size_t i = 0; i < size(); ++i) {
         if (matches(at(i)))
@@ -247,10 +260,28 @@ size_t FixedVector<T, Malloc>::findIf(const MatchFunction& matches) const
 }
 
 template<typename T, typename Malloc>
-template<typename U>
-size_t FixedVector<T, Malloc>::find(const U& value) const
+size_t FixedVector<T, Malloc>::find(const auto& value) const
 {
     return findIf([&](auto& item) {
+        return item == value;
+    });
+}
+
+template<typename T, typename Malloc>
+size_t FixedVector<T, Malloc>::reverseFindIf(NOESCAPE const Invocable<bool(const T&)> auto& matches) const
+{
+    for (size_t i = 1; i <= size(); ++i) {
+        const size_t index = size() - i;
+        if (matches(at(index)))
+            return index;
+    }
+    return notFound;
+}
+
+template<typename T, typename Malloc>
+size_t FixedVector<T, Malloc>::reverseFind(const auto& value) const
+{
+    return reverseFindIf([&](auto& item) {
         return item == value;
     });
 }
@@ -261,18 +292,10 @@ inline void swap(FixedVector<T, Malloc>& a, FixedVector<T, Malloc>& b)
     a.swap(b);
 }
 
-template<typename T, typename MapFunction, typename Malloc, typename ReturnType = typename std::invoke_result<MapFunction, const T&>::type>
-FixedVector<ReturnType, Malloc> map(const FixedVector<T, Malloc>& source, MapFunction&& mapFunction)
+template<typename T, typename Mapper, typename Malloc, typename ReturnType = typename std::invoke_result<Mapper, const T&>::type>
+FixedVector<ReturnType, Malloc> map(const FixedVector<T, Malloc>& source, Mapper&& mapper)
 {
-    FixedVector<ReturnType, Malloc> result(source.size());
-
-    size_t resultIndex = 0;
-    for (const auto& item : source) {
-        result[resultIndex] = mapFunction(item);
-        resultIndex++;
-    }
-
-    return result;
+    return FixedVector<ReturnType, Malloc>::map(source, std::forward<Mapper>(mapper));
 }
 
 } // namespace WTF

--- a/Source/WTF/wtf/Vector.h
+++ b/Source/WTF/wtf/Vector.h
@@ -887,11 +887,11 @@ public:
     }
     
     bool contains(const auto&) const;
+    bool containsIf(NOESCAPE const Invocable<bool(const T&)> auto&) const;
     size_t find(const auto&) const;
-    size_t findIf(NOESCAPE const Invocable<bool(const T&)> auto& matches) const;
+    size_t findIf(NOESCAPE const Invocable<bool(const T&)> auto&) const;
     size_t reverseFind(const auto&) const;
-    size_t reverseFindIf(NOESCAPE const Invocable<bool(const T&)> auto& matches) const;
-    bool containsIf(NOESCAPE const Invocable<bool(const T&)> auto& matches) const { return findIf(matches) != notFound; }
+    size_t reverseFindIf(NOESCAPE const Invocable<bool(const T&)> auto&) const;
 
     bool appendIfNotContains(const auto&);
 
@@ -1157,6 +1157,12 @@ inline Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>& Vector<T
 }
 
 template<typename T, size_t inlineCapacity, typename OverflowHandler, size_t minCapacity, typename Malloc>
+bool Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::containsIf(NOESCAPE const Invocable<bool(const T&)> auto& matches) const
+{
+    return findIf(matches) != notFound;
+}
+
+template<typename T, size_t inlineCapacity, typename OverflowHandler, size_t minCapacity, typename Malloc>
 bool Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::contains(const auto& value) const
 {
     return find(value) != notFound;
@@ -1181,17 +1187,6 @@ size_t Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::find(con
 }
 
 template<typename T, size_t inlineCapacity, typename OverflowHandler, size_t minCapacity, typename Malloc>
-size_t Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::reverseFind(const auto& value) const
-{
-    for (size_t i = 1; i <= size(); ++i) {
-        const size_t index = size() - i;
-        if (at(index) == value)
-            return index;
-    }
-    return notFound;
-}
-
-template<typename T, size_t inlineCapacity, typename OverflowHandler, size_t minCapacity, typename Malloc>
 size_t Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::reverseFindIf(NOESCAPE const Invocable<bool(const T&)> auto& matches) const
 {
     for (size_t i = 1; i <= size(); ++i) {
@@ -1200,6 +1195,14 @@ size_t Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::reverseF
             return index;
     }
     return notFound;
+}
+
+template<typename T, size_t inlineCapacity, typename OverflowHandler, size_t minCapacity, typename Malloc>
+size_t Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::reverseFind(const auto& value) const
+{
+    return reverseFindIf([&](auto& item) {
+        return item == value;
+    });
 }
 
 template<typename T, size_t inlineCapacity, typename OverflowHandler, size_t minCapacity, typename Malloc>

--- a/Source/WTF/wtf/text/TextStream.h
+++ b/Source/WTF/wtf/text/TextStream.h
@@ -374,6 +374,9 @@ struct supports_text_stream_insertion<T, std::void_t<decltype(std::declval<TextS
 template<typename ItemType, size_t inlineCapacity>
 struct supports_text_stream_insertion<Vector<ItemType, inlineCapacity>> : supports_text_stream_insertion<ItemType> { };
 
+template<typename ItemType>
+struct supports_text_stream_insertion<FixedVector<ItemType>> : supports_text_stream_insertion<ItemType> { };
+
 template<typename ValueArg, typename HashArg, typename TraitsArg>
 struct supports_text_stream_insertion<HashSet<ValueArg, HashArg, TraitsArg>> : supports_text_stream_insertion<ValueArg> { };
 

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -761,7 +761,7 @@
                 {
                     "enable-if": "ENABLE_VARIATION_FONTS",
                     "aliases": ["font-stretch"],
-                    "animation-wrapper": "Wrapper<FontSelectionValue>",
+                    "animation-wrapper": "Wrapper",
                     "animation-wrapper-requires-render-style": true,
                     "font-description-name-for-methods": "Width",
                     "font-property": true,
@@ -772,7 +772,7 @@
                 {
                     "enable-if": "!ENABLE_VARIATION_FONTS",
                     "aliases": ["font-stretch"],
-                    "animation-wrapper": "Wrapper<FontSelectionValue>",
+                    "animation-wrapper": "Wrapper",
                     "animation-wrapper-requires-render-style": true,
                     "font-description-name-for-methods": "Width",
                     "font-property": true,
@@ -4471,7 +4471,7 @@
             "inherited": true,
             "initial": "1",
             "codegen-properties": {
-                "animation-wrapper": "Wrapper<float>",
+                "animation-wrapper": "Wrapper",
                 "animation-wrapper-requires-render-style": true,
                 "style-converter": "Opacity",
                 "svg": true,
@@ -4545,7 +4545,7 @@
             "animation-type": "by computed value",
             "initial": "1",
             "codegen-properties": {
-                "animation-wrapper": "Wrapper<float>",
+                "animation-wrapper": "Wrapper",
                 "animation-wrapper-requires-render-style": true,
                 "style-converter": "Opacity",
                 "svg": true,
@@ -6592,7 +6592,7 @@
                 "aliases": [
                     "-webkit-opacity"
                 ],
-                "animation-wrapper": "Wrapper<float>",
+                "animation-wrapper": "Wrapper",
                 "animation-wrapper-acceleration": "always",
                 "style-converter": "Opacity",
                 "parser-grammar": "<alpha-value>"
@@ -6656,7 +6656,7 @@
             "animation-type": "by computed value",
             "initial": "0",
             "codegen-properties": {
-                "animation-wrapper": "Wrapper<float>",
+                "animation-wrapper": "Wrapper",
                 "style-converter": "ComputedLength<float>",
                 "parser-grammar": "<length>"
             },
@@ -7520,7 +7520,7 @@
             "animation-type": "by computed value",
             "initial": "1",
             "codegen-properties": {
-                "animation-wrapper": "Wrapper<float>",
+                "animation-wrapper": "Wrapper",
                 "animation-wrapper-requires-render-style": true,
                 "style-converter": "Opacity",
                 "svg": true,
@@ -7570,8 +7570,7 @@
                 "none"
             ],
             "codegen-properties": {
-                "animation-wrapper": "StrokeDashArrayWrapper",
-                "animation-wrapper-requires-override-parameters": [],
+                "animation-wrapper": "Wrapper",
                 "animation-wrapper-requires-render-style": true,
                 "animation-wrapper-requires-non-additive-or-cumulative-interpolation": true,
                 "render-style-name-for-methods": "StrokeDashArray",
@@ -7653,7 +7652,7 @@
             "inherited": true,
             "initial": "4",
             "codegen-properties": {
-                "animation-wrapper": "Wrapper<float>",
+                "animation-wrapper": "Wrapper",
                 "render-style-name-for-methods": "StrokeMiterLimit",
                 "style-converter": "Number<float>",
                 "parser-grammar": "<number [0,inf]>"
@@ -7671,7 +7670,7 @@
             "inherited": true,
             "initial": "1",
             "codegen-properties": {
-                "animation-wrapper": "Wrapper<float>",
+                "animation-wrapper": "Wrapper",
                 "animation-wrapper-requires-render-style": true,
                 "style-converter": "Opacity",
                 "svg": true,
@@ -9343,7 +9342,7 @@
                 "aliases": [
                     "-webkit-column-rule-width"
                 ],
-                "animation-wrapper": "Wrapper<unsigned short>",
+                "animation-wrapper": "Wrapper",
                 "style-converter": "LineWidth<unsigned short>",
                 "parser-grammar": "<line-width>"
             },
@@ -10662,7 +10661,7 @@
                 "aliases": [
                     "-webkit-order"
                 ],
-                "animation-wrapper": "Wrapper<int>",
+                "animation-wrapper": "Wrapper",
                 "parser-grammar": "<integer>"
             },
             "specification": {
@@ -11289,7 +11288,7 @@
                 "aliases": [
                     "-webkit-transform-origin-z"
                 ],
-                "animation-wrapper": "Wrapper<float>",
+                "animation-wrapper": "Wrapper",
                 "skip-style-extractor": true,
                 "style-converter": "ComputedLength<float>",
                 "parser-grammar": "<length>"
@@ -12096,7 +12095,7 @@
                 "aliases": [
                     "-webkit-shape-image-threshold"
                 ],
-                "animation-wrapper": "Wrapper<float>",
+                "animation-wrapper": "Wrapper",
                 "style-converter": "Number<float>",
                 "parser-grammar": "<number>"
             },

--- a/Source/WebCore/css/scripts/process-css-properties.py
+++ b/Source/WebCore/css/scripts/process-css-properties.py
@@ -3933,9 +3933,9 @@ class GenerateStyleBuilderGenerated:
 
     def _generate_color_property_inherit_value_setter(self, to, property):
         to.write(f"if (builderState.applyPropertyToRegularStyle())")
-        to.write(f"    builderState.style().{property.codegen_properties.render_style_setter}(builderState.parentStyle().{property.codegen_properties.render_style_getter}());")
+        to.write(f"    builderState.style().{property.codegen_properties.render_style_setter}(forwardInheritedValue(builderState.parentStyle().{property.codegen_properties.render_style_getter}()));")
         to.write(f"if (builderState.applyPropertyToVisitedLinkStyle())")
-        to.write(f"    builderState.style().setVisitedLink{property.codegen_properties.render_style_name_for_methods}(builderState.parentStyle().{property.codegen_properties.render_style_getter}());")
+        to.write(f"    builderState.style().setVisitedLink{property.codegen_properties.render_style_name_for_methods}(forwardInheritedValue(builderState.parentStyle().{property.codegen_properties.render_style_getter}()));")
 
     def _generate_color_property_value_setter(self, to, property, value):
         to.write(f"if (builderState.applyPropertyToRegularStyle())")

--- a/Source/WebCore/css/scripts/test/TestCSSPropertiesResults/StyleBuilderGenerated.cpp
+++ b/Source/WebCore/css/scripts/test/TestCSSPropertiesResults/StyleBuilderGenerated.cpp
@@ -290,9 +290,9 @@ public:
     static void applyInheritTestColorPropertyWithVisitedLinkSupport(BuilderState& builderState)
     {
         if (builderState.applyPropertyToRegularStyle())
-            builderState.style().setTestColorPropertyWithVisitedLinkSupport(builderState.parentStyle().testColorPropertyWithVisitedLinkSupport());
+            builderState.style().setTestColorPropertyWithVisitedLinkSupport(forwardInheritedValue(builderState.parentStyle().testColorPropertyWithVisitedLinkSupport()));
         if (builderState.applyPropertyToVisitedLinkStyle())
-            builderState.style().setVisitedLinkTestColorPropertyWithVisitedLinkSupport(builderState.parentStyle().testColorPropertyWithVisitedLinkSupport());
+            builderState.style().setVisitedLinkTestColorPropertyWithVisitedLinkSupport(forwardInheritedValue(builderState.parentStyle().testColorPropertyWithVisitedLinkSupport()));
     }
     static void applyValueTestColorPropertyWithVisitedLinkSupport(BuilderState& builderState, CSSValue& value)
     {

--- a/Source/WebCore/dom/ViewTransition.cpp
+++ b/Source/WebCore/dom/ViewTransition.cpp
@@ -347,7 +347,7 @@ static AtomString effectiveViewTransitionName(RenderLayerModelObject& renderer, 
     if (renderer.isSkippedContent())
         return nullAtom();
 
-    auto transitionName = renderer.style().viewTransitionName();
+    auto& transitionName = renderer.style().viewTransitionName();
     if (transitionName.isNone())
         return nullAtom();
 

--- a/Source/WebCore/platform/graphics/DashArray.h
+++ b/Source/WebCore/platform/graphics/DashArray.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2008 Dirk Schulze <vbs85@gmx.de>
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,7 +26,7 @@
 
 #pragma once
 
-#include <wtf/Vector.h>
+#include <wtf/FixedVector.h>
 
 #if USE(CG)
 #include <CoreGraphics/CoreGraphics.h>
@@ -43,6 +44,6 @@ using DashArrayElement = float;
 
 // DashArray is array of lengths along a path, with elements alternating on, off, on, off state.
 // The array is applied circularly mod path length.
-using DashArray = Vector<DashArrayElement>;
+using DashArray = FixedVector<DashArrayElement>;
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/cairo/CairoOperations.cpp
+++ b/Source/WebCore/platform/graphics/cairo/CairoOperations.cpp
@@ -615,8 +615,10 @@ void setLineDash(GraphicsContextCairo& platformContext, const DashArray& dashes,
 {
     if (std::all_of(dashes.begin(), dashes.end(), [](auto& dash) { return !dash; }))
         cairo_set_dash(platformContext.cr(), 0, 0, 0);
-    else
-        cairo_set_dash(platformContext.cr(), dashes.data(), dashes.size(), dashOffset);
+    else {
+        auto dashesSpan = dashes.span();
+        cairo_set_dash(platformContext.cr(), dashesSpan.data(), dashesSpan.size(), dashOffset);
+    }
 }
 
 void setLineJoin(GraphicsContextCairo& platformContext, LineJoin lineJoin)

--- a/Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp
@@ -1317,7 +1317,8 @@ void GraphicsContextCG::setLineDash(const DashArray& dashes, float dashOffset)
         if (length)
             dashOffset = fmod(dashOffset, length) + length;
     }
-    CGContextSetLineDash(platformContext(), dashOffset, dashes.data(), dashes.size());
+    auto dashesSpan = dashes.span();
+    CGContextSetLineDash(platformContext(), dashOffset, dashesSpan.data(), dashesSpan.size());
 }
 
 void GraphicsContextCG::setLineJoin(LineJoin join)

--- a/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.cpp
@@ -857,11 +857,15 @@ void GraphicsContextSkia::setLineDash(const DashArray& dashArray, float dashOffs
 
     if (dashArray.size() % 2 == 1) {
         // Repeat the array to ensure even number of dash array elements, see e.g. 'stroke-dasharray' spec.
-        DashArray repeatedDashArray(dashArray);
-        repeatedDashArray.appendVector(dashArray);
-        m_skiaState.m_stroke.dash = SkDashPathEffect::Make(repeatedDashArray.data(), repeatedDashArray.size(), dashOffset);
-    } else
-        m_skiaState.m_stroke.dash = SkDashPathEffect::Make(dashArray.data(), dashArray.size(), dashOffset);
+        auto repeatedDashArray = DashArray::createWithSizeFromGenerator(dashArray.size() * 2, [&](auto i) {
+            return dashArray[i % dashArray.size()];
+        });
+        auto repeatedDashArraySpan = repeatedDashArray.span();
+        m_skiaState.m_stroke.dash = SkDashPathEffect::Make(repeatedDashArraySpan.data(), repeatedDashArraySpan.size(), dashOffset);
+    } else {
+        auto dashArraySpan = dashArray.span();
+        m_skiaState.m_stroke.dash = SkDashPathEffect::Make(dashArraySpan.data(), dashArraySpan.size(), dashOffset);
+    }
 }
 
 void GraphicsContextSkia::setLineJoin(LineJoin lineJoin)

--- a/Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp
+++ b/Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp
@@ -153,7 +153,7 @@ MockRealtimeVideoSource::MockRealtimeVideoSource(String&& deviceID, AtomString&&
     ASSERT(device);
     m_device = *device;
 
-    m_dashWidths.appendList({ 6, 6 });
+    m_dashWidths = { 6, 6 };
 
     if (mockDisplay()) {
         auto& properties = std::get<MockDisplayProperties>(m_device.properties);

--- a/Source/WebCore/rendering/BorderPainter.cpp
+++ b/Source/WebCore/rendering/BorderPainter.cpp
@@ -857,8 +857,7 @@ void BorderPainter::drawBoxSideFromPath(const BorderShape& borderShape, const Pa
                 gapLength += (dashLength  / numberOfGaps);
             }
 
-            auto lineDash = DashArray::from(dashLength, gapLength);
-            graphicsContext.setLineDash(WTFMove(lineDash), dashLength);
+            graphicsContext.setLineDash(DashArray { dashLength, gapLength }, dashLength);
         }
 
         // FIXME: stroking the border path causes issues with tight corners:

--- a/Source/WebCore/rendering/ios/RenderThemeIOS.mm
+++ b/Source/WebCore/rendering/ios/RenderThemeIOS.mm
@@ -907,9 +907,9 @@ void RenderThemeIOS::adjustButtonLikeControlStyle(RenderStyle& style, const Elem
     if (!style.hasAutoAccentColor()) {
         auto tintColor = style.usedAccentColor(element.document().styleColorOptions(&style));
         if (isSubmitStyleButton(element))
-            style.setBackgroundColor(tintColor);
+            style.setBackgroundColor(WTFMove(tintColor));
         else
-            style.setColor(tintColor);
+            style.setColor(WTFMove(tintColor));
     }
 
     if (!element.active())

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -31,6 +31,7 @@
 #include <unicode/utypes.h>
 #include <wtf/CheckedRef.h>
 #include <wtf/DataRef.h>
+#include <wtf/FixedVector.h>
 #include <wtf/OptionSet.h>
 #include <wtf/Vector.h>
 
@@ -794,7 +795,7 @@ public:
     inline bool containsPaint() const;
     inline bool containsLayoutOrPaint() const;
     inline ContainerType containerType() const;
-    inline const Vector<Style::ScopedName>& containerNames() const;
+    inline const FixedVector<Style::ScopedName>& containerNames() const;
     inline bool containerTypeAndNamesEqual(const RenderStyle&) const;
 
     inline ContentVisibility contentVisibility() const;
@@ -1036,21 +1037,21 @@ public:
     PointerEvents pointerEvents() const { return static_cast<PointerEvents>(m_inheritedFlags.pointerEvents); }
     inline PointerEvents usedPointerEvents() const;
 
-    inline const Vector<Ref<ScrollTimeline>>& scrollTimelines() const;
-    inline const Vector<ScrollAxis>& scrollTimelineAxes() const;
-    inline const Vector<AtomString>& scrollTimelineNames() const;
+    inline const FixedVector<Ref<ScrollTimeline>>& scrollTimelines() const;
+    inline const FixedVector<ScrollAxis>& scrollTimelineAxes() const;
+    inline const FixedVector<AtomString>& scrollTimelineNames() const;
     inline bool hasScrollTimelines() const;
-    inline void setScrollTimelineAxes(const Vector<ScrollAxis>&);
-    inline void setScrollTimelineNames(const Vector<AtomString>&);
+    inline void setScrollTimelineAxes(FixedVector<ScrollAxis>&&);
+    inline void setScrollTimelineNames(FixedVector<AtomString>&&);
 
-    inline const Vector<Ref<ViewTimeline>>& viewTimelines() const;
-    inline const Vector<ScrollAxis>& viewTimelineAxes() const;
-    inline const Vector<ViewTimelineInsets>& viewTimelineInsets() const;
-    inline const Vector<AtomString>& viewTimelineNames() const;
+    inline const FixedVector<Ref<ViewTimeline>>& viewTimelines() const;
+    inline const FixedVector<ScrollAxis>& viewTimelineAxes() const;
+    inline const FixedVector<ViewTimelineInsets>& viewTimelineInsets() const;
+    inline const FixedVector<AtomString>& viewTimelineNames() const;
     inline bool hasViewTimelines() const;
-    inline void setViewTimelineAxes(const Vector<ScrollAxis>&);
-    inline void setViewTimelineInsets(const Vector<ViewTimelineInsets>&);
-    inline void setViewTimelineNames(const Vector<AtomString>&);
+    inline void setViewTimelineAxes(FixedVector<ScrollAxis>&&);
+    inline void setViewTimelineInsets(FixedVector<ViewTimelineInsets>&&);
+    inline void setViewTimelineNames(FixedVector<AtomString>&&);
 
     static inline const NameScope initialTimelineScope();
     inline const NameScope& timelineScope() const;
@@ -1205,8 +1206,8 @@ public:
 
     inline MathStyle mathStyle() const;
 
-    inline const Vector<Style::ScopedName>& viewTransitionClasses() const;
-    inline Style::ViewTransitionName viewTransitionName() const;
+    inline const FixedVector<Style::ScopedName>& viewTransitionClasses() const;
+    inline const Style::ViewTransitionName& viewTransitionName() const;
 
     void setDisplay(DisplayType value)
     {
@@ -1251,7 +1252,7 @@ public:
     inline void resetBorderBottomLeftRadius();
     inline void resetBorderBottomRightRadius();
 
-    inline void setBackgroundColor(const Style::Color&);
+    inline void setBackgroundColor(Style::Color&&);
     inline void setBackgroundAttachment(FillAttachment);
     inline void setBackgroundClip(FillBox);
     inline void setBackgroundOrigin(FillBox);
@@ -1282,21 +1283,21 @@ public:
 
     inline void setBorderLeftWidth(float);
     inline void setBorderLeftStyle(BorderStyle);
-    inline void setBorderLeftColor(const Style::Color&);
+    inline void setBorderLeftColor(Style::Color&&);
     inline void setBorderRightWidth(float);
     inline void setBorderRightStyle(BorderStyle);
-    inline void setBorderRightColor(const Style::Color&);
+    inline void setBorderRightColor(Style::Color&&);
     inline void setBorderTopWidth(float);
     inline void setBorderTopStyle(BorderStyle);
-    inline void setBorderTopColor(const Style::Color&);
+    inline void setBorderTopColor(Style::Color&&);
     inline void setBorderBottomWidth(float);
     inline void setBorderBottomStyle(BorderStyle);
-    inline void setBorderBottomColor(const Style::Color&);
+    inline void setBorderBottomColor(Style::Color&&);
 
     inline void setOutlineWidth(float);
     inline void setOutlineStyle(BorderStyle);
     inline void setHasAutoOutlineStyle();
-    inline void setOutlineColor(const Style::Color&);
+    inline void setOutlineColor(Style::Color&&);
 
     void setOverflowX(Overflow v) { m_nonInheritedFlags.overflowX =  static_cast<unsigned>(v); }
     void setOverflowY(Overflow v) { m_nonInheritedFlags.overflowY = static_cast<unsigned>(v); }
@@ -1335,7 +1336,7 @@ public:
     void setFontItalic(std::optional<FontSelectionValue>);
     void setFontPalette(const FontPalette&);
 
-    void setColor(const Color&);
+    void setColor(Color&&);
     inline void setTextIndent(Length&&);
     void setTextAlign(TextAlignMode v) { m_inheritedFlags.textAlign = static_cast<unsigned>(v); }
     inline void setTextAlignLast(TextAlignLast);
@@ -1418,7 +1419,7 @@ public:
 
     inline void setContain(OptionSet<Containment>);
     inline void setContainerType(ContainerType);
-    inline void setContainerNames(const Vector<Style::ScopedName>&);
+    inline void setContainerNames(FixedVector<Style::ScopedName>&&);
 
     inline void setContainIntrinsicWidthType(ContainIntrinsicSizeType);
     inline void setContainIntrinsicHeightType(ContainIntrinsicSizeType);
@@ -1491,12 +1492,12 @@ public:
 
     inline void setOutlineOffset(float);
     inline void setTextShadow(FixedVector<Style::TextShadow>&&);
-    inline void setTextStrokeColor(const Style::Color&);
+    inline void setTextStrokeColor(Style::Color&&);
     inline void setTextStrokeWidth(float);
-    inline void setTextFillColor(const Style::Color&);
-    inline void setCaretColor(const Style::Color&);
+    inline void setTextFillColor(Style::Color&&);
+    inline void setCaretColor(Style::Color&&);
     inline void setHasAutoCaretColor();
-    inline void setAccentColor(const Style::Color&);
+    inline void setAccentColor(Style::Color&&);
     inline void setHasAutoAccentColor();
     inline void setOpacity(float);
     inline void setAppearance(StyleAppearance);
@@ -1533,8 +1534,8 @@ public:
 
     inline void setGridColumnList(const GridTrackList&);
     inline void setGridRowList(const GridTrackList&);
-    inline void setGridAutoColumns(const Vector<GridTrackSize>&);
-    inline void setGridAutoRows(const Vector<GridTrackSize>&);
+    inline void setGridAutoColumns(Vector<GridTrackSize>&&);
+    inline void setGridAutoRows(Vector<GridTrackSize>&&);
     inline void setImplicitNamedGridColumnLines(const NamedGridLinesMap&);
     inline void setImplicitNamedGridRowLines(const NamedGridLinesMap&);
     inline void setNamedGridArea(const NamedGridAreaMap&);
@@ -1574,7 +1575,7 @@ public:
     inline void setColumnFill(ColumnFill);
     inline void setColumnGap(GapLength&&);
     inline void setRowGap(GapLength&&);
-    inline void setColumnRuleColor(const Style::Color&);
+    inline void setColumnRuleColor(Style::Color&&);
     inline void setColumnRuleStyle(BorderStyle);
     inline void setColumnRuleWidth(unsigned short);
     inline void resetColumnRule();
@@ -1593,8 +1594,8 @@ public:
 
     inline void setSpeakAs(OptionSet<SpeakAs>);
     inline void setTextCombine(TextCombine);
-    inline void setTextDecorationColor(const Style::Color&);
-    inline void setTextEmphasisColor(const Style::Color&);
+    inline void setTextDecorationColor(Style::Color&&);
+    inline void setTextEmphasisColor(Style::Color&&);
     inline void setTextEmphasisFill(TextEmphasisFill);
     inline void setTextEmphasisMark(TextEmphasisMark);
     inline void setTextEmphasisCustomMark(const AtomString&);
@@ -1683,13 +1684,13 @@ public:
     void setScrollSnapStop(ScrollSnapStop);
 
     inline void setScrollbarColor(const std::optional<ScrollbarColor>&);
-    inline void setScrollbarThumbColor(const Style::Color&);
-    inline void setScrollbarTrackColor(const Style::Color&);
+    inline void setScrollbarThumbColor(Style::Color&&);
+    inline void setScrollbarTrackColor(Style::Color&&);
     void setScrollbarGutter(ScrollbarGutter);
     inline void setScrollbarWidth(ScrollbarWidth);
 
 #if ENABLE(TOUCH_EVENTS)
-    inline void setTapHighlightColor(const Style::Color&);
+    inline void setTapHighlightColor(Style::Color&&);
 #endif
 
 #if PLATFORM(IOS_FAMILY)
@@ -1748,8 +1749,8 @@ public:
     bool hasPositiveStrokeWidth() const;
     
     inline const Style::Color& strokeColor() const;
-    inline void setStrokeColor(const Style::Color&);
-    inline void setVisitedLinkStrokeColor(const Style::Color&);
+    inline void setStrokeColor(Style::Color&&);
+    inline void setVisitedLinkStrokeColor(Style::Color&&);
     inline const Style::Color& visitedLinkStrokeColor() const;
     inline void setHasExplicitlySetStrokeColor(bool);
     inline bool hasExplicitlySetStrokeColor() const;
@@ -1768,8 +1769,8 @@ public:
     inline SVGPaintType visitedFillPaintType() const;
     inline const Style::Color& fillPaintColor() const;
     inline const Style::Color& visitedFillPaintColor() const;
-    inline void setFillPaintColor(const Style::Color&);
-    inline void setVisitedFillPaintColor(const Style::Color&);
+    inline void setFillPaintColor(Style::Color&&);
+    inline void setVisitedFillPaintColor(Style::Color&&);
     inline void setHasExplicitlySetColor(bool);
     inline bool hasExplicitlySetColor() const;
     inline float fillOpacity() const;
@@ -1779,12 +1780,12 @@ public:
     inline SVGPaintType visitedStrokePaintType() const;
     inline const Style::Color& strokePaintColor() const;
     inline const Style::Color& visitedStrokePaintColor() const;
-    inline void setStrokePaintColor(const Style::Color&);
-    inline void setVisitedStrokePaintColor(const Style::Color&);
+    inline void setStrokePaintColor(Style::Color&&);
+    inline void setVisitedStrokePaintColor(Style::Color&&);
     inline float strokeOpacity() const;
     inline void setStrokeOpacity(float);
-    inline const Vector<Length>& strokeDashArray() const;
-    inline void setStrokeDashArray(Vector<Length>&&);
+    inline const FixedVector<Length>& strokeDashArray() const;
+    inline void setStrokeDashArray(FixedVector<Length>&&);
     inline const Length& strokeDashOffset() const;
     inline void setStrokeDashOffset(Length&&);
 
@@ -1813,9 +1814,9 @@ public:
     inline float stopOpacity() const;
     inline void setStopOpacity(float);
 
-    inline void setStopColor(const Style::Color&);
-    inline void setFloodColor(const Style::Color&);
-    inline void setLightingColor(const Style::Color&);
+    inline void setStopColor(Style::Color&&);
+    inline void setFloodColor(Style::Color&&);
+    inline void setLightingColor(Style::Color&&);
 
     inline const Length& baselineShiftValue() const;
     inline void setBaselineShiftValue(Length&&);
@@ -1861,8 +1862,8 @@ public:
     inline QuotesData* quotes() const;
     void setQuotes(RefPtr<QuotesData>&&);
 
-    inline void setViewTransitionClasses(const Vector<Style::ScopedName>&);
-    inline void setViewTransitionName(Style::ViewTransitionName);
+    inline void setViewTransitionClasses(FixedVector<Style::ScopedName>&&);
+    inline void setViewTransitionName(Style::ViewTransitionName&&);
 
     inline WillChangeData* willChange() const;
     void setWillChange(RefPtr<WillChangeData>&&);
@@ -1975,7 +1976,7 @@ public:
     static constexpr ListStylePosition initialListStylePosition();
     static inline ListStyleType initialListStyleType();
     static constexpr OptionSet<TextTransform> initialTextTransform();
-    static inline Vector<Style::ScopedName> initialViewTransitionClasses();
+    static inline FixedVector<Style::ScopedName> initialViewTransitionClasses();
     static inline Style::ViewTransitionName initialViewTransitionName();
     static constexpr Visibility initialVisibility();
     static constexpr WhiteSpaceCollapse initialWhiteSpaceCollapse();
@@ -2072,7 +2073,7 @@ public:
     static constexpr OptionSet<Containment> contentContainment();
     static constexpr ContainerType initialContainerType();
     static constexpr ContentVisibility initialContentVisibility();
-    static Vector<Style::ScopedName> initialContainerNames();
+    static FixedVector<Style::ScopedName> initialContainerNames();
     static double initialAspectRatioWidth() { return 1.0; }
     static double initialAspectRatioHeight() { return 1.0; }
 
@@ -2151,12 +2152,12 @@ public:
     static ScrollSnapAlign initialScrollSnapAlign();
     static ScrollSnapStop initialScrollSnapStop();
 
-    static Vector<ScrollAxis> initialScrollTimelineAxes() { return { }; }
-    static Vector<AtomString> initialScrollTimelineNames() { return { }; }
+    static FixedVector<ScrollAxis> initialScrollTimelineAxes() { return { }; }
+    static FixedVector<AtomString> initialScrollTimelineNames() { return { }; }
 
-    static Vector<ScrollAxis> initialViewTimelineAxes() { return { }; }
-    static Vector<ViewTimelineInsets> initialViewTimelineInsets();
-    static Vector<AtomString> initialViewTimelineNames() { return { }; }
+    static FixedVector<ScrollAxis> initialViewTimelineAxes() { return { }; }
+    static FixedVector<ViewTimelineInsets> initialViewTimelineInsets();
+    static FixedVector<AtomString> initialViewTimelineNames() { return { }; }
 
     static inline std::optional<ScrollbarColor> initialScrollbarColor();
     static ScrollbarGutter initialScrollbarGutter();
@@ -2240,19 +2241,19 @@ public:
 
     static constexpr MathStyle initialMathStyle();
 
-    void setVisitedLinkColor(const Color&);
-    inline void setVisitedLinkBackgroundColor(const Style::Color&);
-    inline void setVisitedLinkBorderLeftColor(const Style::Color&);
-    inline void setVisitedLinkBorderRightColor(const Style::Color&);
-    inline void setVisitedLinkBorderBottomColor(const Style::Color&);
-    inline void setVisitedLinkBorderTopColor(const Style::Color&);
-    inline void setVisitedLinkOutlineColor(const Style::Color&);
-    inline void setVisitedLinkColumnRuleColor(const Style::Color&);
-    inline void setVisitedLinkTextDecorationColor(const Style::Color&);
-    inline void setVisitedLinkTextEmphasisColor(const Style::Color&);
-    inline void setVisitedLinkTextFillColor(const Style::Color&);
-    inline void setVisitedLinkTextStrokeColor(const Style::Color&);
-    inline void setVisitedLinkCaretColor(const Style::Color&);
+    void setVisitedLinkColor(Color&&);
+    inline void setVisitedLinkBackgroundColor(Style::Color&&);
+    inline void setVisitedLinkBorderLeftColor(Style::Color&&);
+    inline void setVisitedLinkBorderRightColor(Style::Color&&);
+    inline void setVisitedLinkBorderBottomColor(Style::Color&&);
+    inline void setVisitedLinkBorderTopColor(Style::Color&&);
+    inline void setVisitedLinkOutlineColor(Style::Color&&);
+    inline void setVisitedLinkColumnRuleColor(Style::Color&&);
+    inline void setVisitedLinkTextDecorationColor(Style::Color&&);
+    inline void setVisitedLinkTextEmphasisColor(Style::Color&&);
+    inline void setVisitedLinkTextFillColor(Style::Color&&);
+    inline void setVisitedLinkTextStrokeColor(Style::Color&&);
+    inline void setVisitedLinkCaretColor(Style::Color&&);
     inline void setHasVisitedLinkAutoCaretColor();
 
     void inheritUnicodeBidiFrom(const RenderStyle* parent) { m_nonInheritedFlags.unicodeBidi = parent->m_nonInheritedFlags.unicodeBidi; }
@@ -2345,9 +2346,9 @@ public:
     bool scrollAnchoringSuppressionStyleDidChange(const RenderStyle*) const;
     bool outOfFlowPositionStyleDidChange(const RenderStyle*) const;
 
-    static Vector<Style::ScopedName> initialAnchorNames();
-    inline const Vector<Style::ScopedName>& anchorNames() const;
-    inline void setAnchorNames(const Vector<Style::ScopedName>&);
+    static FixedVector<Style::ScopedName> initialAnchorNames();
+    inline const FixedVector<Style::ScopedName>& anchorNames() const;
+    inline void setAnchorNames(FixedVector<Style::ScopedName>&&);
 
     static inline NameScope initialAnchorScope();
     inline const NameScope& anchorScope() const;
@@ -2365,9 +2366,9 @@ public:
     inline Style::PositionTryOrder positionTryOrder() const;
     inline void setPositionTryOrder(Style::PositionTryOrder);
 
-    static Vector<Style::PositionTryFallback> initialPositionTryFallbacks();
-    const Vector<Style::PositionTryFallback>& positionTryFallbacks() const;
-    void setPositionTryFallbacks(const Vector<Style::PositionTryFallback>&);
+    static FixedVector<Style::PositionTryFallback> initialPositionTryFallbacks();
+    const FixedVector<Style::PositionTryFallback>& positionTryFallbacks() const;
+    void setPositionTryFallbacks(FixedVector<Style::PositionTryFallback>&&);
 
     static constexpr OptionSet<PositionVisibility> initialPositionVisibility();
     inline OptionSet<PositionVisibility> positionVisibility() const;

--- a/Source/WebCore/rendering/style/RenderStyleInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleInlines.h
@@ -82,7 +82,7 @@ inline const StyleSelfAlignmentData& RenderStyle::alignSelf() const { return m_n
 constexpr auto RenderStyle::allTransformOperations() -> OptionSet<TransformOperationOption> { return { TransformOperationOption::TransformOrigin, TransformOperationOption::Translate, TransformOperationOption::Rotate, TransformOperationOption::Scale, TransformOperationOption::Offset }; }
 inline const AnimationList* RenderStyle::animations() const { return m_nonInheritedData->miscData->animations.get(); }
 inline AnimationList* RenderStyle::animations() { return m_nonInheritedData->miscData->animations.get(); }
-inline const Vector<Style::ScopedName>& RenderStyle::anchorNames() const { return m_nonInheritedData->rareData->anchorNames; }
+inline const FixedVector<Style::ScopedName>& RenderStyle::anchorNames() const { return m_nonInheritedData->rareData->anchorNames; }
 inline const NameScope& RenderStyle::anchorScope() const { return m_nonInheritedData->rareData->anchorScope; }
 inline StyleAppearance RenderStyle::appearance() const { return static_cast<StyleAppearance>(m_nonInheritedData->miscData->appearance); }
 inline const FilterOperations& RenderStyle::appleColorFilter() const { return m_rareInheritedData->appleColorFilter->operations; }
@@ -204,7 +204,7 @@ inline bool RenderStyle::containIntrinsicWidthHasLength() const { return contain
 inline bool RenderStyle::containIntrinsicLogicalWidthHasAuto() const { return writingMode().isHorizontal() ? containIntrinsicWidthHasAuto() : containIntrinsicHeightHasAuto(); }
 inline std::optional<Length> RenderStyle::containIntrinsicWidth() const { return m_nonInheritedData->rareData->containIntrinsicWidth; }
 inline ContainIntrinsicSizeType RenderStyle::containIntrinsicWidthType() const { return static_cast<ContainIntrinsicSizeType>(m_nonInheritedData->rareData->containIntrinsicWidthType); }
-inline const Vector<Style::ScopedName>& RenderStyle::containerNames() const { return m_nonInheritedData->rareData->containerNames; }
+inline const FixedVector<Style::ScopedName>& RenderStyle::containerNames() const { return m_nonInheritedData->rareData->containerNames; }
 inline ContainerType RenderStyle::containerType() const { return static_cast<ContainerType>(m_nonInheritedData->rareData->containerType); }
 inline bool RenderStyle::containsInlineSize() const { return usedContain().contains(Containment::InlineSize); }
 inline bool RenderStyle::containsLayout() const { return usedContain().contains(Containment::Layout); }
@@ -361,7 +361,7 @@ inline const NamedGridLinesMap& RenderStyle::implicitNamedGridColumnLines() cons
 inline const NamedGridLinesMap& RenderStyle::implicitNamedGridRowLines() const { return m_nonInheritedData->rareData->grid->implicitNamedGridRowLines; }
 constexpr auto RenderStyle::individualTransformOperations() -> OptionSet<TransformOperationOption> { return { TransformOperationOption::Translate, TransformOperationOption::Rotate, TransformOperationOption::Scale, TransformOperationOption::Offset }; }
 inline const StyleCustomPropertyData& RenderStyle::inheritedCustomProperties() const { return m_rareInheritedData->customProperties.get(); }
-inline Vector<Style::ScopedName> RenderStyle::initialAnchorNames() { return { }; }
+inline FixedVector<Style::ScopedName> RenderStyle::initialAnchorNames() { return { }; }
 inline NameScope RenderStyle::initialAnchorScope() { return { }; }
 constexpr StyleAppearance RenderStyle::initialAppearance() { return StyleAppearance::None; }
 #if HAVE(CORE_MATERIAL)
@@ -401,7 +401,7 @@ inline std::optional<Length> RenderStyle::initialContainIntrinsicHeight() { retu
 constexpr ContainIntrinsicSizeType RenderStyle::initialContainIntrinsicHeightType() { return ContainIntrinsicSizeType::None; }
 inline std::optional<Length> RenderStyle::initialContainIntrinsicWidth() { return std::nullopt; }
 constexpr ContainIntrinsicSizeType RenderStyle::initialContainIntrinsicWidthType() { return ContainIntrinsicSizeType::None; }
-inline Vector<Style::ScopedName> RenderStyle::initialContainerNames() { return { }; }
+inline FixedVector<Style::ScopedName> RenderStyle::initialContainerNames() { return { }; }
 constexpr ContainerType RenderStyle::initialContainerType() { return ContainerType::Normal; }
 constexpr OptionSet<Containment> RenderStyle::initialContainment() { return { }; }
 constexpr StyleContentAlignmentData RenderStyle::initialContentAlignment() { return { }; }
@@ -487,7 +487,7 @@ constexpr PointerEvents RenderStyle::initialPointerEvents() { return PointerEven
 constexpr PositionType RenderStyle::initialPosition() { return PositionType::Static; }
 inline std::optional<Style::ScopedName> RenderStyle::initialPositionAnchor() { return { }; }
 inline std::optional<PositionArea> RenderStyle::initialPositionArea() { return { }; }
-inline Vector<Style::PositionTryFallback> RenderStyle::initialPositionTryFallbacks() { return { }; }
+inline FixedVector<Style::PositionTryFallback> RenderStyle::initialPositionTryFallbacks() { return { }; }
 constexpr Style::PositionTryOrder RenderStyle::initialPositionTryOrder() { return Style::PositionTryOrder::Normal; }
 constexpr OptionSet<PositionVisibility> RenderStyle::initialPositionVisibility() { return PositionVisibility::AnchorsVisible; }
 constexpr PrintColorAdjust RenderStyle::initialPrintColorAdjust() { return PrintColorAdjust::Economy; }
@@ -553,8 +553,8 @@ constexpr UserDrag RenderStyle::initialUserDrag() { return UserDrag::Auto; }
 constexpr UserModify RenderStyle::initialUserModify() { return UserModify::ReadOnly; }
 constexpr UserSelect RenderStyle::initialUserSelect() { return UserSelect::Text; }
 constexpr VerticalAlign RenderStyle::initialVerticalAlign() { return VerticalAlign::Baseline; }
-inline Vector<ViewTimelineInsets> RenderStyle::initialViewTimelineInsets() { return { }; }
-inline Vector<Style::ScopedName> RenderStyle::initialViewTransitionClasses() { return { }; }
+inline FixedVector<ViewTimelineInsets> RenderStyle::initialViewTimelineInsets() { return { }; }
+inline FixedVector<Style::ScopedName> RenderStyle::initialViewTransitionClasses() { return { }; }
 inline Style::ViewTransitionName RenderStyle::initialViewTransitionName() { return Style::ViewTransitionName::createWithNone(); }
 constexpr Visibility RenderStyle::initialVisibility() { return Visibility::Visible; }
 inline const NameScope RenderStyle::initialTimelineScope() { return { }; }
@@ -727,14 +727,14 @@ inline RubyPosition RenderStyle::rubyPosition() const { return static_cast<RubyP
 inline RubyAlign RenderStyle::rubyAlign() const { return static_cast<RubyAlign>(m_rareInheritedData->rubyAlign); }
 inline RubyOverhang RenderStyle::rubyOverhang() const { return static_cast<RubyOverhang>(m_rareInheritedData->rubyOverhang); }
 inline ScaleTransformOperation* RenderStyle::scale() const { return m_nonInheritedData->rareData->scale.get(); }
-inline const Vector<Ref<ScrollTimeline>>& RenderStyle::scrollTimelines() const { return m_nonInheritedData->rareData->scrollTimelines; }
-inline const Vector<ScrollAxis>& RenderStyle::scrollTimelineAxes() const { return m_nonInheritedData->rareData->scrollTimelineAxes; }
-inline const Vector<AtomString>& RenderStyle::scrollTimelineNames() const { return m_nonInheritedData->rareData->scrollTimelineNames; }
+inline const FixedVector<Ref<ScrollTimeline>>& RenderStyle::scrollTimelines() const { return m_nonInheritedData->rareData->scrollTimelines; }
+inline const FixedVector<ScrollAxis>& RenderStyle::scrollTimelineAxes() const { return m_nonInheritedData->rareData->scrollTimelineAxes; }
+inline const FixedVector<AtomString>& RenderStyle::scrollTimelineNames() const { return m_nonInheritedData->rareData->scrollTimelineNames; }
 inline bool RenderStyle::hasScrollTimelines() const { return m_nonInheritedData->rareData->hasScrollTimelines(); }
-inline const Vector<Ref<ViewTimeline>>& RenderStyle::viewTimelines() const { return m_nonInheritedData->rareData->viewTimelines; }
-inline const Vector<ScrollAxis>& RenderStyle::viewTimelineAxes() const { return m_nonInheritedData->rareData->viewTimelineAxes; }
-inline const Vector<ViewTimelineInsets>& RenderStyle::viewTimelineInsets() const { return m_nonInheritedData->rareData->viewTimelineInsets; }
-inline const Vector<AtomString>& RenderStyle::viewTimelineNames() const { return m_nonInheritedData->rareData->viewTimelineNames; }
+inline const FixedVector<Ref<ViewTimeline>>& RenderStyle::viewTimelines() const { return m_nonInheritedData->rareData->viewTimelines; }
+inline const FixedVector<ScrollAxis>& RenderStyle::viewTimelineAxes() const { return m_nonInheritedData->rareData->viewTimelineAxes; }
+inline const FixedVector<ViewTimelineInsets>& RenderStyle::viewTimelineInsets() const { return m_nonInheritedData->rareData->viewTimelineInsets; }
+inline const FixedVector<AtomString>& RenderStyle::viewTimelineNames() const { return m_nonInheritedData->rareData->viewTimelineNames; }
 inline bool RenderStyle::hasViewTimelines() const { return m_nonInheritedData->rareData->hasViewTimelines(); }
 inline const NameScope& RenderStyle::timelineScope() const { return m_nonInheritedData->rareData->timelineScope; }
 inline std::optional<ScrollbarColor> RenderStyle::scrollbarColor() const { return m_rareInheritedData->scrollbarColor.asOptional(); }
@@ -808,8 +808,8 @@ inline UserModify RenderStyle::userModify() const { return static_cast<UserModif
 inline UserSelect RenderStyle::userSelect() const { return static_cast<UserSelect>(m_rareInheritedData->userSelect); }
 inline VerticalAlign RenderStyle::verticalAlign() const { return m_nonInheritedData->boxData->verticalAlign(); }
 inline const Length& RenderStyle::verticalAlignLength() const { return m_nonInheritedData->boxData->verticalAlignLength(); }
-inline const Vector<Style::ScopedName>& RenderStyle::viewTransitionClasses() const { return m_nonInheritedData->rareData->viewTransitionClasses; }
-inline Style::ViewTransitionName RenderStyle::viewTransitionName() const { return m_nonInheritedData->rareData->viewTransitionName; }
+inline const FixedVector<Style::ScopedName>& RenderStyle::viewTransitionClasses() const { return m_nonInheritedData->rareData->viewTransitionClasses; }
+inline const Style::ViewTransitionName& RenderStyle::viewTransitionName() const { return m_nonInheritedData->rareData->viewTransitionName; }
 inline const Style::Color& RenderStyle::visitedLinkBackgroundColor() const { return m_nonInheritedData->miscData->visitedLinkColor->background; }
 inline const Style::Color& RenderStyle::visitedLinkBorderBottomColor() const { return m_nonInheritedData->miscData->visitedLinkColor->borderBottom; }
 inline const Style::Color& RenderStyle::visitedLinkBorderLeftColor() const { return m_nonInheritedData->miscData->visitedLinkColor->borderLeft; }

--- a/Source/WebCore/rendering/style/RenderStyleSetters.h
+++ b/Source/WebCore/rendering/style/RenderStyleSetters.h
@@ -72,13 +72,13 @@ inline void RenderStyle::resetColumnRule() { SET_DOUBLY_NESTED(m_nonInheritedDat
 inline void RenderStyle::resetMargin() { SET_NESTED(m_nonInheritedData, surroundData, margin, LengthBox(LengthType::Fixed)); }
 inline void RenderStyle::resetPadding() { SET_NESTED(m_nonInheritedData, surroundData, padding, LengthBox { 0 }); }
 inline void RenderStyle::resetPageSizeType() { SET_NESTED(m_nonInheritedData, rareData, pageSizeType, static_cast<unsigned>(PageSizeType::Auto)); }
-inline void RenderStyle::setAccentColor(const Style::Color& color) { SET_PAIR(m_rareInheritedData, accentColor, color, hasAutoAccentColor, false); }
+inline void RenderStyle::setAccentColor(Style::Color&& color) { SET_PAIR(m_rareInheritedData, accentColor, WTFMove(color), hasAutoAccentColor, false); }
 inline void RenderStyle::setAlignContent(const StyleContentAlignmentData& data) { SET_NESTED(m_nonInheritedData, miscData, alignContent, data); }
 inline void RenderStyle::setAlignItems(const StyleSelfAlignmentData& data) { SET_NESTED(m_nonInheritedData, miscData, alignItems, data); }
 inline void RenderStyle::setAlignItemsPosition(ItemPosition position) { m_nonInheritedData.access().miscData.access().alignItems.setPosition(position); }
 inline void RenderStyle::setAlignSelf(const StyleSelfAlignmentData& data) { SET_NESTED(m_nonInheritedData, miscData, alignSelf, data); }
 inline void RenderStyle::setAlignSelfPosition(ItemPosition position) { m_nonInheritedData.access().miscData.access().alignSelf.setPosition(position); }
-inline void RenderStyle::setAnchorNames(const Vector<Style::ScopedName>& names) { SET_NESTED(m_nonInheritedData, rareData, anchorNames, names); }
+inline void RenderStyle::setAnchorNames(FixedVector<Style::ScopedName>&& names) { SET_NESTED(m_nonInheritedData, rareData, anchorNames, WTFMove(names)); }
 inline void RenderStyle::setAnchorScope(const NameScope& scope) { SET_NESTED(m_nonInheritedData, rareData, anchorScope, scope); }
 inline void RenderStyle::setAppearance(StyleAppearance appearance) { SET_NESTED_PAIR(m_nonInheritedData, miscData, appearance, static_cast<unsigned>(appearance), usedAppearance, static_cast<unsigned>(appearance)); }
 inline void RenderStyle::setAppleColorFilter(FilterOperations&& ops) { SET_NESTED(m_rareInheritedData, appleColorFilter, operations, WTFMove(ops)); }
@@ -92,7 +92,7 @@ inline void RenderStyle::setBackfaceVisibility(BackfaceVisibility b) { SET_NESTE
 inline void RenderStyle::setBackgroundAttachment(FillAttachment attachment) { SET_DOUBLY_NESTED_PAIR(m_nonInheritedData, backgroundData, background, m_attachment, static_cast<unsigned>(attachment), m_attachmentSet, true); }
 inline void RenderStyle::setBackgroundBlendMode(BlendMode blendMode) { SET_DOUBLY_NESTED_PAIR(m_nonInheritedData, backgroundData, background, m_blendMode, static_cast<unsigned>(blendMode), m_blendModeSet, true); }
 inline void RenderStyle::setBackgroundClip(FillBox fillBox) { SET_DOUBLY_NESTED_PAIR(m_nonInheritedData, backgroundData, background, m_clip, static_cast<unsigned>(fillBox), m_clipSet, true); }
-inline void RenderStyle::setBackgroundColor(const Style::Color& value) { SET_NESTED(m_nonInheritedData, backgroundData, color, value); }
+inline void RenderStyle::setBackgroundColor(Style::Color&& value) { SET_NESTED(m_nonInheritedData, backgroundData, color, WTFMove(value)); }
 inline void RenderStyle::setBackgroundOrigin(FillBox fillBox) { SET_DOUBLY_NESTED_PAIR(m_nonInheritedData, backgroundData, background, m_origin, static_cast<unsigned>(fillBox), m_originSet, true); }
 inline void RenderStyle::setBackgroundRepeat(FillRepeatXY fillRepeat) { SET_DOUBLY_NESTED_PAIR(m_nonInheritedData, backgroundData, background, m_repeat, fillRepeat, m_repeatSet, true); }
 inline void RenderStyle::setBlockEllipsis(const BlockEllipsis& value) { SET(m_rareInheritedData, blockEllipsis, value); }
@@ -100,20 +100,20 @@ inline void RenderStyle::setBlockStepAlign(BlockStepAlign value) { SET_NESTED(m_
 inline void RenderStyle::setBlockStepInsert(BlockStepInsert value) { SET_NESTED(m_nonInheritedData, rareData, blockStepInsert, static_cast<unsigned>(value)); }
 inline void RenderStyle::setBlockStepRound(BlockStepRound value) { SET_NESTED(m_nonInheritedData, rareData, blockStepRound, static_cast<unsigned>(value)); }
 inline void RenderStyle::setBlockStepSize(std::optional<Length> length) { SET_NESTED(m_nonInheritedData, rareData, blockStepSize, WTFMove(length)); }
-inline void RenderStyle::setBorderBottomColor(const Style::Color& value) { SET_NESTED_BORDER_COLOR(m_nonInheritedData, surroundData, border.m_edges.bottom(), value); }
+inline void RenderStyle::setBorderBottomColor(Style::Color&& value) { SET_NESTED_BORDER_COLOR(m_nonInheritedData, surroundData, border.m_edges.bottom(), WTFMove(value)); }
 inline void RenderStyle::setBorderBottomLeftRadius(LengthSize&& size) { SET_NESTED(m_nonInheritedData, surroundData, border.m_radii.bottomLeft(), WTFMove(size)); }
 inline void RenderStyle::setBorderBottomRightRadius(LengthSize&& size) { SET_NESTED(m_nonInheritedData, surroundData, border.m_radii.bottomRight(), WTFMove(size)); }
 inline void RenderStyle::setBorderBottomStyle(BorderStyle value) { SET_NESTED(m_nonInheritedData, surroundData, border.m_edges.bottom().m_style, static_cast<unsigned>(value)); }
 inline void RenderStyle::setBorderBottomWidth(float value) { SET_NESTED(m_nonInheritedData, surroundData, border.m_edges.bottom().m_width, value); }
 inline void RenderStyle::setBorderImage(const NinePieceImage& image) { SET_NESTED(m_nonInheritedData, surroundData, border.m_image, image); }
-inline void RenderStyle::setBorderLeftColor(const Style::Color& value) { SET_NESTED_BORDER_COLOR(m_nonInheritedData, surroundData, border.m_edges.left(), value); }
+inline void RenderStyle::setBorderLeftColor(Style::Color&& value) { SET_NESTED_BORDER_COLOR(m_nonInheritedData, surroundData, border.m_edges.left(), WTFMove(value)); }
 inline void RenderStyle::setBorderLeftStyle(BorderStyle value) { SET_NESTED(m_nonInheritedData, surroundData, border.m_edges.left().m_style, static_cast<unsigned>(value)); }
 inline void RenderStyle::setBorderLeftWidth(float value) { SET_NESTED(m_nonInheritedData, surroundData, border.m_edges.left().m_width, value); }
 inline void RenderStyle::setBorderRadius(const IntSize& size) { setBorderRadius({ { size.width(), LengthType::Fixed }, { size.height(), LengthType::Fixed } }); }
-inline void RenderStyle::setBorderRightColor(const Style::Color& value) { SET_NESTED_BORDER_COLOR(m_nonInheritedData, surroundData, border.m_edges.right(), value); }
+inline void RenderStyle::setBorderRightColor(Style::Color&& value) { SET_NESTED_BORDER_COLOR(m_nonInheritedData, surroundData, border.m_edges.right(), WTFMove(value)); }
 inline void RenderStyle::setBorderRightStyle(BorderStyle value) { SET_NESTED(m_nonInheritedData, surroundData, border.m_edges.right().m_style, static_cast<unsigned>(value)); }
 inline void RenderStyle::setBorderRightWidth(float value) { SET_NESTED(m_nonInheritedData, surroundData, border.m_edges.right().m_width, value); }
-inline void RenderStyle::setBorderTopColor(const Style::Color& value) { SET_NESTED_BORDER_COLOR(m_nonInheritedData, surroundData, border.m_edges.top(), value); }
+inline void RenderStyle::setBorderTopColor(Style::Color&& value) { SET_NESTED_BORDER_COLOR(m_nonInheritedData, surroundData, border.m_edges.top(), WTFMove(value)); }
 inline void RenderStyle::setBorderTopLeftRadius(LengthSize&& size) { SET_NESTED(m_nonInheritedData, surroundData, border.m_radii.topLeft(), WTFMove(size)); }
 inline void RenderStyle::setBorderTopRightRadius(LengthSize&& size) { SET_NESTED(m_nonInheritedData, surroundData, border.m_radii.topRight(), WTFMove(size)); }
 inline void RenderStyle::setBorderTopStyle(BorderStyle value) { SET_NESTED(m_nonInheritedData, surroundData, border.m_edges.top().m_style, static_cast<unsigned>(value)); }
@@ -133,7 +133,7 @@ inline void RenderStyle::setBreakAfter(BreakBetween behavior) { SET_NESTED(m_non
 inline void RenderStyle::setBreakBefore(BreakBetween behavior) { SET_NESTED(m_nonInheritedData, rareData, breakBefore, static_cast<unsigned>(behavior)); }
 inline void RenderStyle::setBreakInside(BreakInside behavior) { SET_NESTED(m_nonInheritedData, rareData, breakInside, static_cast<unsigned>(behavior)); }
 inline void RenderStyle::setCapStyle(LineCap style) { SET(m_rareInheritedData, capStyle, static_cast<unsigned>(style)); }
-inline void RenderStyle::setCaretColor(const Style::Color& color) { SET_PAIR(m_rareInheritedData, caretColor, color, hasAutoCaretColor, false); }
+inline void RenderStyle::setCaretColor(Style::Color&& color) { SET_PAIR(m_rareInheritedData, caretColor, WTFMove(color), hasAutoCaretColor, false); }
 inline void RenderStyle::setClip(LengthBox&& box) { SET_NESTED(m_nonInheritedData, rareData, clip, WTFMove(box)); }
 inline void RenderStyle::setClipBottom(Length&& length) { SET_NESTED(m_nonInheritedData, rareData, clip.bottom(), WTFMove(length)); }
 inline void RenderStyle::setClipLeft(Length&& length) { SET_NESTED(m_nonInheritedData, rareData, clip.left(), WTFMove(length)); }
@@ -143,7 +143,7 @@ inline void RenderStyle::setColumnAxis(ColumnAxis axis) { SET_DOUBLY_NESTED(m_no
 inline void RenderStyle::setColumnFill(ColumnFill fill) { SET_DOUBLY_NESTED(m_nonInheritedData, miscData, multiCol, fill, static_cast<unsigned>(fill)); }
 inline void RenderStyle::setColumnGap(GapLength&& length) { SET_NESTED(m_nonInheritedData, rareData, columnGap, WTFMove(length)); }
 inline void RenderStyle::setColumnProgression(ColumnProgression progression) { SET_DOUBLY_NESTED(m_nonInheritedData, miscData, multiCol, progression, static_cast<unsigned>(progression)); }
-inline void RenderStyle::setColumnRuleColor(const Style::Color& c) { SET_BORDER_COLOR(m_nonInheritedData.access().miscData.access().multiCol, rule, c); }
+inline void RenderStyle::setColumnRuleColor(Style::Color&& c) { SET_BORDER_COLOR(m_nonInheritedData.access().miscData.access().multiCol, rule, WTFMove(c)); }
 inline void RenderStyle::setColumnRuleStyle(BorderStyle b) { SET_DOUBLY_NESTED(m_nonInheritedData, miscData, multiCol, rule.m_style, static_cast<unsigned>(b)); }
 inline void RenderStyle::setColumnRuleWidth(unsigned short w) { SET_DOUBLY_NESTED(m_nonInheritedData, miscData, multiCol, rule.m_width, w); }
 inline void RenderStyle::setColumnSpan(ColumnSpan span) { SET_DOUBLY_NESTED(m_nonInheritedData, miscData, multiCol, columnSpan, static_cast<unsigned>(span)); }
@@ -153,7 +153,7 @@ inline void RenderStyle::setContainIntrinsicHeight(std::optional<Length> height)
 inline void RenderStyle::setContainIntrinsicHeightType(ContainIntrinsicSizeType containIntrinsicHeightType) { SET_NESTED(m_nonInheritedData, rareData, containIntrinsicHeightType, static_cast<unsigned>(containIntrinsicHeightType)); }
 inline void RenderStyle::setContainIntrinsicWidth(std::optional<Length> width) { SET_NESTED(m_nonInheritedData, rareData, containIntrinsicWidth, width); }
 inline void RenderStyle::setContainIntrinsicWidthType(ContainIntrinsicSizeType containIntrinsicWidthType) { SET_NESTED(m_nonInheritedData, rareData, containIntrinsicWidthType, static_cast<unsigned>(containIntrinsicWidthType)); }
-inline void RenderStyle::setContainerNames(const Vector<Style::ScopedName>& names) { SET_NESTED(m_nonInheritedData, rareData, containerNames, names); }
+inline void RenderStyle::setContainerNames(FixedVector<Style::ScopedName>&& names) { SET_NESTED(m_nonInheritedData, rareData, containerNames, WTFMove(names)); }
 inline void RenderStyle::setContainerType(ContainerType type) { SET_NESTED(m_nonInheritedData, rareData, containerType, static_cast<unsigned>(type)); }
 inline void RenderStyle::setContentVisibility(ContentVisibility value) { SET_NESTED(m_nonInheritedData, rareData, contentVisibility, static_cast<unsigned>(value)); }
 inline void RenderStyle::setUsedAppearance(StyleAppearance a) { SET_NESTED(m_nonInheritedData, miscData, usedAppearance, static_cast<unsigned>(a)); }
@@ -165,9 +165,9 @@ inline void RenderStyle::setFilter(FilterOperations&& ops) { SET_DOUBLY_NESTED(m
 inline void RenderStyle::setFlexBasis(Length&& length) { SET_DOUBLY_NESTED(m_nonInheritedData, miscData, flexibleBox, flexBasis, WTFMove(length)); }
 inline void RenderStyle::setFlexDirection(FlexDirection direction) { SET_DOUBLY_NESTED(m_nonInheritedData, miscData, flexibleBox, flexDirection, static_cast<unsigned>(direction)); }
 inline void RenderStyle::setFlexWrap(FlexWrap wrap) { SET_DOUBLY_NESTED(m_nonInheritedData, miscData, flexibleBox, flexWrap, static_cast<unsigned>(wrap)); }
-inline void RenderStyle::setGridAutoColumns(const Vector<GridTrackSize>& trackSizeList) { SET_DOUBLY_NESTED(m_nonInheritedData, rareData, grid, gridAutoColumns, trackSizeList); }
+inline void RenderStyle::setGridAutoColumns(Vector<GridTrackSize>&& trackSizeList) { SET_DOUBLY_NESTED(m_nonInheritedData, rareData, grid, gridAutoColumns, WTFMove(trackSizeList)); }
 inline void RenderStyle::setGridAutoFlow(GridAutoFlow flow) { SET_DOUBLY_NESTED(m_nonInheritedData, rareData, grid, gridAutoFlow, flow); }
-inline void RenderStyle::setGridAutoRows(const Vector<GridTrackSize>& trackSizeList) { SET_DOUBLY_NESTED(m_nonInheritedData, rareData, grid, gridAutoRows, trackSizeList); }
+inline void RenderStyle::setGridAutoRows(Vector<GridTrackSize>&& trackSizeList) { SET_DOUBLY_NESTED(m_nonInheritedData, rareData, grid, gridAutoRows, WTFMove(trackSizeList)); }
 inline void RenderStyle::setGridItemColumnEnd(const GridPosition& columnEndPosition) { SET_DOUBLY_NESTED(m_nonInheritedData, rareData, gridItem, gridColumnEnd, columnEndPosition); }
 inline void RenderStyle::setGridItemColumnStart(const GridPosition& columnStartPosition) { SET_DOUBLY_NESTED(m_nonInheritedData, rareData, gridItem, gridColumnStart, columnStartPosition); }
 inline void RenderStyle::setGridItemRowEnd(const GridPosition& rowEndPosition) { SET_DOUBLY_NESTED(m_nonInheritedData, rareData, gridItem, gridRowEnd, rowEndPosition); }
@@ -256,7 +256,7 @@ inline void RenderStyle::setOffsetPath(RefPtr<PathOperation>&& path) { SET_NESTE
 inline void RenderStyle::setOffsetPosition(LengthPoint position) { SET_NESTED(m_nonInheritedData, rareData, offsetPosition, WTFMove(position)); }
 inline void RenderStyle::setOffsetRotate(OffsetRotation&& rotation) { SET_NESTED(m_nonInheritedData, rareData, offsetRotate, WTFMove(rotation)); }
 inline void RenderStyle::setOrder(int o) { SET_NESTED(m_nonInheritedData, miscData, order, o); }
-inline void RenderStyle::setOutlineColor(const Style::Color& color) { SET_NESTED_BORDER_COLOR(m_nonInheritedData, backgroundData, outline, color); }
+inline void RenderStyle::setOutlineColor(Style::Color&& color) { SET_NESTED_BORDER_COLOR(m_nonInheritedData, backgroundData, outline, WTFMove(color)); }
 inline void RenderStyle::setOutlineOffset(float offset) { SET_NESTED(m_nonInheritedData, backgroundData, outline.m_offset, offset); }
 inline void RenderStyle::setOutlineStyle(BorderStyle style) { SET_NESTED_PAIR(m_nonInheritedData, backgroundData, outline.m_isAuto, static_cast<unsigned>(false), outline.m_style, static_cast<unsigned>(style)); }
 inline void RenderStyle::setHasAutoOutlineStyle() { SET_NESTED_PAIR(m_nonInheritedData, backgroundData, outline.m_isAuto, static_cast<unsigned>(true), outline.m_style, static_cast<unsigned>(BorderStyle::Dotted)); }
@@ -287,39 +287,39 @@ inline void RenderStyle::setRowGap(GapLength&& gapLength) { SET_NESTED(m_nonInhe
 inline void RenderStyle::setRubyPosition(RubyPosition position) { SET(m_rareInheritedData, rubyPosition, static_cast<unsigned>(position)); }
 inline void RenderStyle::setRubyAlign(RubyAlign alignment) { SET(m_rareInheritedData, rubyAlign, static_cast<unsigned>(alignment)); }
 inline void RenderStyle::setRubyOverhang(RubyOverhang overhang) { SET(m_rareInheritedData, rubyOverhang, static_cast<unsigned>(overhang)); }
-inline void RenderStyle::setScrollTimelineAxes(const Vector<ScrollAxis>& axes) { SET_NESTED(m_nonInheritedData, rareData, scrollTimelineAxes, axes); }
-inline void RenderStyle::setScrollTimelineNames(const Vector<AtomString>& names) { SET_NESTED(m_nonInheritedData, rareData, scrollTimelineNames, names); }
-inline void RenderStyle::setViewTimelineAxes(const Vector<ScrollAxis>& axes) { SET_NESTED(m_nonInheritedData, rareData, viewTimelineAxes, axes); }
-inline void RenderStyle::setViewTimelineInsets(const Vector<ViewTimelineInsets>& insets) { SET_NESTED(m_nonInheritedData, rareData, viewTimelineInsets, insets); }
-inline void RenderStyle::setViewTimelineNames(const Vector<AtomString>& names) { SET_NESTED(m_nonInheritedData, rareData, viewTimelineNames, names); }
+inline void RenderStyle::setScrollTimelineAxes(FixedVector<ScrollAxis>&& axes) { SET_NESTED(m_nonInheritedData, rareData, scrollTimelineAxes, WTFMove(axes)); }
+inline void RenderStyle::setScrollTimelineNames(FixedVector<AtomString>&& names) { SET_NESTED(m_nonInheritedData, rareData, scrollTimelineNames, WTFMove(names)); }
+inline void RenderStyle::setViewTimelineAxes(FixedVector<ScrollAxis>&& axes) { SET_NESTED(m_nonInheritedData, rareData, viewTimelineAxes, WTFMove(axes)); }
+inline void RenderStyle::setViewTimelineInsets(FixedVector<ViewTimelineInsets>&& insets) { SET_NESTED(m_nonInheritedData, rareData, viewTimelineInsets, WTFMove(insets)); }
+inline void RenderStyle::setViewTimelineNames(FixedVector<AtomString>&& names) { SET_NESTED(m_nonInheritedData, rareData, viewTimelineNames, WTFMove(names)); }
 inline void RenderStyle::setTimelineScope(const NameScope& scope) { SET_NESTED(m_nonInheritedData, rareData, timelineScope, scope); }
 inline void RenderStyle::setScrollbarColor(const std::optional<ScrollbarColor>& color) { SET(m_rareInheritedData, scrollbarColor, color); }
-inline void RenderStyle::setScrollbarThumbColor(const Style::Color& color) { m_rareInheritedData.access().scrollbarColor->thumbColor = color; }
-inline void RenderStyle::setScrollbarTrackColor(const Style::Color& color) { m_rareInheritedData.access().scrollbarColor->trackColor = color; }
+inline void RenderStyle::setScrollbarThumbColor(Style::Color&& color) { m_rareInheritedData.access().scrollbarColor->thumbColor = WTFMove(color); }
+inline void RenderStyle::setScrollbarTrackColor(Style::Color&& color) { m_rareInheritedData.access().scrollbarColor->trackColor = WTFMove(color); }
 inline void RenderStyle::setScrollbarWidth(ScrollbarWidth width) { SET_NESTED(m_nonInheritedData, rareData, scrollbarWidth, static_cast<unsigned>(width)); }
 inline void RenderStyle::setShapeMargin(Length&& margin) { SET_NESTED(m_nonInheritedData, rareData, shapeMargin, WTFMove(margin)); }
 inline void RenderStyle::setUsedContentVisibility(ContentVisibility usedContentVisibility) { SET(m_rareInheritedData, usedContentVisibility, static_cast<unsigned>(usedContentVisibility)); }
 inline void RenderStyle::setSpeakAs(OptionSet<SpeakAs> style) { SET(m_rareInheritedData, speakAs, style.toRaw()); }
 inline void RenderStyle::setSpecifiedZIndex(int value) { SET_NESTED_PAIR(m_nonInheritedData, boxData, m_hasAutoSpecifiedZIndex, false, m_specifiedZIndex, value); }
-inline void RenderStyle::setStrokeColor(const Style::Color& color) { SET(m_rareInheritedData, strokeColor, color); }
+inline void RenderStyle::setStrokeColor(Style::Color&& color) { SET(m_rareInheritedData, strokeColor, WTFMove(color)); }
 inline void RenderStyle::setStrokeMiterLimit(float value) { SET(m_rareInheritedData, miterLimit, value); }
 inline void RenderStyle::setStrokeWidth(Length&& width) { SET(m_rareInheritedData, strokeWidth, WTFMove(width)); }
 inline void RenderStyle::setTabSize(const TabSize& size) { SET(m_rareInheritedData, tabSize, size); }
 inline void RenderStyle::setTextAlignLast(TextAlignLast value) { SET(m_rareInheritedData, textAlignLast, static_cast<unsigned>(value)); }
 inline void RenderStyle::setTextBoxTrim(TextBoxTrim value) { SET_NESTED(m_nonInheritedData, rareData, textBoxTrim, static_cast<unsigned>(value)); }
 inline void RenderStyle::setTextCombine(TextCombine value) { SET(m_rareInheritedData, textCombine, static_cast<unsigned>(value)); }
-inline void RenderStyle::setTextDecorationColor(const Style::Color& color) { SET_NESTED(m_nonInheritedData, rareData, textDecorationColor, color); }
+inline void RenderStyle::setTextDecorationColor(Style::Color&& color) { SET_NESTED(m_nonInheritedData, rareData, textDecorationColor, WTFMove(color)); }
 inline void RenderStyle::setTextDecorationLine(OptionSet<TextDecorationLine> value) { m_nonInheritedFlags.textDecorationLine = value.toRaw(); }
 inline void RenderStyle::setTextDecorationSkipInk(TextDecorationSkipInk skipInk) { SET(m_rareInheritedData, textDecorationSkipInk, static_cast<unsigned>(skipInk)); }
 inline void RenderStyle::setTextDecorationStyle(TextDecorationStyle value) { SET_NESTED(m_nonInheritedData, rareData, textDecorationStyle, static_cast<unsigned>(value)); }
 inline void RenderStyle::setTextDecorationThickness(TextDecorationThickness textDecorationThickness) { SET_NESTED(m_nonInheritedData, rareData, textDecorationThickness, textDecorationThickness); }
 inline void RenderStyle::setTextDecorationLineInEffect(OptionSet<TextDecorationLine> value) { m_inheritedFlags.textDecorationLineInEffect = value.toRaw(); }
-inline void RenderStyle::setTextEmphasisColor(const Style::Color& c) { SET(m_rareInheritedData, textEmphasisColor, c); }
+inline void RenderStyle::setTextEmphasisColor(Style::Color&& c) { SET(m_rareInheritedData, textEmphasisColor, WTFMove(c)); }
 inline void RenderStyle::setTextEmphasisCustomMark(const AtomString& mark) { SET(m_rareInheritedData, textEmphasisCustomMark, mark); }
 inline void RenderStyle::setTextEmphasisFill(TextEmphasisFill fill) { SET(m_rareInheritedData, textEmphasisFill, static_cast<unsigned>(fill)); }
 inline void RenderStyle::setTextEmphasisMark(TextEmphasisMark mark) { SET(m_rareInheritedData, textEmphasisMark, static_cast<unsigned>(mark)); }
 inline void RenderStyle::setTextEmphasisPosition(OptionSet<TextEmphasisPosition> position) { SET(m_rareInheritedData, textEmphasisPosition, static_cast<unsigned>(position.toRaw())); }
-inline void RenderStyle::setTextFillColor(const Style::Color& color) { SET(m_rareInheritedData, textFillColor, color); }
+inline void RenderStyle::setTextFillColor(Style::Color&& color) { SET(m_rareInheritedData, textFillColor, WTFMove(color)); }
 inline void RenderStyle::setHasExplicitlySetColor(bool value) { m_inheritedFlags.hasExplicitlySetColor = value; }
 inline void RenderStyle::setTableLayout(TableLayoutType value) { SET_NESTED(m_nonInheritedData, miscData, tableLayout, static_cast<unsigned>(value)); }
 inline void RenderStyle::setTextGroupAlign(TextGroupAlign value) { SET_NESTED(m_nonInheritedData, rareData, textGroupAlign, static_cast<unsigned>(value)); }
@@ -330,7 +330,7 @@ inline void RenderStyle::setTextJustify(TextJustify value) { SET(m_rareInherited
 inline void RenderStyle::setTextOverflow(TextOverflow overflow) { SET_NESTED(m_nonInheritedData, miscData, textOverflow, static_cast<unsigned>(overflow)); }
 inline void RenderStyle::setTextSecurity(TextSecurity security) { SET(m_rareInheritedData, textSecurity, static_cast<unsigned>(security)); }
 inline void RenderStyle::setTextShadow(FixedVector<Style::TextShadow>&& textShadow) { SET(m_rareInheritedData, textShadow, WTFMove(textShadow)); }
-inline void RenderStyle::setTextStrokeColor(const Style::Color& c) { SET(m_rareInheritedData, textStrokeColor, c); }
+inline void RenderStyle::setTextStrokeColor(Style::Color&& c) { SET(m_rareInheritedData, textStrokeColor, WTFMove(c)); }
 inline void RenderStyle::setTextStrokeWidth(float value) { SET(m_rareInheritedData, textStrokeWidth, value); }
 inline void RenderStyle::setTextTransform(OptionSet<TextTransform> value) { m_inheritedFlags.textTransform = value.toRaw(); }
 inline void RenderStyle::setTextUnderlineOffset(TextUnderlineOffset textUnderlineOffset) { SET(m_rareInheritedData, textUnderlineOffset, textUnderlineOffset); }
@@ -351,21 +351,21 @@ inline void RenderStyle::setUsedZIndex(int index) { SET_NESTED_PAIR(m_nonInherit
 inline void RenderStyle::setUserDrag(UserDrag value) { SET_NESTED(m_nonInheritedData, miscData, userDrag, static_cast<unsigned>(value)); }
 inline void RenderStyle::setUserModify(UserModify value) { SET(m_rareInheritedData, userModify, static_cast<unsigned>(value)); }
 inline void RenderStyle::setUserSelect(UserSelect value) { SET(m_rareInheritedData, userSelect, static_cast<unsigned>(value)); }
-inline void RenderStyle::setViewTransitionClasses(const Vector<Style::ScopedName>& value) { SET_NESTED(m_nonInheritedData, rareData, viewTransitionClasses, value); }
-inline void RenderStyle::setViewTransitionName(Style::ViewTransitionName value) { SET_NESTED(m_nonInheritedData, rareData, viewTransitionName, value); }
-inline void RenderStyle::setVisitedLinkBackgroundColor(const Style::Color& value) { SET_DOUBLY_NESTED(m_nonInheritedData, miscData, visitedLinkColor, background, value); }
-inline void RenderStyle::setVisitedLinkBorderBottomColor(const Style::Color& value) { SET_DOUBLY_NESTED(m_nonInheritedData, miscData, visitedLinkColor, borderBottom, value); }
-inline void RenderStyle::setVisitedLinkBorderLeftColor(const Style::Color& value) { SET_DOUBLY_NESTED(m_nonInheritedData, miscData, visitedLinkColor, borderLeft, value); }
-inline void RenderStyle::setVisitedLinkBorderRightColor(const Style::Color& value) { SET_DOUBLY_NESTED(m_nonInheritedData, miscData, visitedLinkColor, borderRight, value); }
-inline void RenderStyle::setVisitedLinkBorderTopColor(const Style::Color& value) { SET_DOUBLY_NESTED(m_nonInheritedData, miscData, visitedLinkColor, borderTop, value); }
-inline void RenderStyle::setVisitedLinkCaretColor(const Style::Color& value) { SET_PAIR(m_rareInheritedData, visitedLinkCaretColor, value, hasVisitedLinkAutoCaretColor, false); }
-inline void RenderStyle::setVisitedLinkColumnRuleColor(const Style::Color& value) { SET_DOUBLY_NESTED(m_nonInheritedData, miscData, multiCol, visitedLinkColumnRuleColor, value); }
-inline void RenderStyle::setVisitedLinkOutlineColor(const Style::Color& value) { SET_DOUBLY_NESTED(m_nonInheritedData, miscData, visitedLinkColor, outline, value); }
-inline void RenderStyle::setVisitedLinkStrokeColor(const Style::Color& value) { SET(m_rareInheritedData, visitedLinkStrokeColor, value); }
-inline void RenderStyle::setVisitedLinkTextDecorationColor(const Style::Color& value) { SET_DOUBLY_NESTED(m_nonInheritedData, miscData, visitedLinkColor, textDecoration, value); }
-inline void RenderStyle::setVisitedLinkTextEmphasisColor(const Style::Color& value) { SET(m_rareInheritedData, visitedLinkTextEmphasisColor, value); }
-inline void RenderStyle::setVisitedLinkTextFillColor(const Style::Color& value) { SET(m_rareInheritedData, visitedLinkTextFillColor, value); }
-inline void RenderStyle::setVisitedLinkTextStrokeColor(const Style::Color& value) { SET(m_rareInheritedData, visitedLinkTextStrokeColor, value); }
+inline void RenderStyle::setViewTransitionClasses(FixedVector<Style::ScopedName>&& value) { SET_NESTED(m_nonInheritedData, rareData, viewTransitionClasses, WTFMove(value)); }
+inline void RenderStyle::setViewTransitionName(Style::ViewTransitionName&& value) { SET_NESTED(m_nonInheritedData, rareData, viewTransitionName, value); }
+inline void RenderStyle::setVisitedLinkBackgroundColor(Style::Color&& value) { SET_DOUBLY_NESTED(m_nonInheritedData, miscData, visitedLinkColor, background, WTFMove(value)); }
+inline void RenderStyle::setVisitedLinkBorderBottomColor(Style::Color&& value) { SET_DOUBLY_NESTED(m_nonInheritedData, miscData, visitedLinkColor, borderBottom, WTFMove(value)); }
+inline void RenderStyle::setVisitedLinkBorderLeftColor(Style::Color&& value) { SET_DOUBLY_NESTED(m_nonInheritedData, miscData, visitedLinkColor, borderLeft, WTFMove(value)); }
+inline void RenderStyle::setVisitedLinkBorderRightColor(Style::Color&& value) { SET_DOUBLY_NESTED(m_nonInheritedData, miscData, visitedLinkColor, borderRight, WTFMove(value)); }
+inline void RenderStyle::setVisitedLinkBorderTopColor(Style::Color&& value) { SET_DOUBLY_NESTED(m_nonInheritedData, miscData, visitedLinkColor, borderTop, WTFMove(value)); }
+inline void RenderStyle::setVisitedLinkCaretColor(Style::Color&& value) { SET_PAIR(m_rareInheritedData, visitedLinkCaretColor, WTFMove(value), hasVisitedLinkAutoCaretColor, false); }
+inline void RenderStyle::setVisitedLinkColumnRuleColor(Style::Color&& value) { SET_DOUBLY_NESTED(m_nonInheritedData, miscData, multiCol, visitedLinkColumnRuleColor, WTFMove(value)); }
+inline void RenderStyle::setVisitedLinkOutlineColor(Style::Color&& value) { SET_DOUBLY_NESTED(m_nonInheritedData, miscData, visitedLinkColor, outline, WTFMove(value)); }
+inline void RenderStyle::setVisitedLinkStrokeColor(Style::Color&& value) { SET(m_rareInheritedData, visitedLinkStrokeColor, WTFMove(value)); }
+inline void RenderStyle::setVisitedLinkTextDecorationColor(Style::Color&& value) { SET_DOUBLY_NESTED(m_nonInheritedData, miscData, visitedLinkColor, textDecoration, WTFMove(value)); }
+inline void RenderStyle::setVisitedLinkTextEmphasisColor(Style::Color&& value) { SET(m_rareInheritedData, visitedLinkTextEmphasisColor, WTFMove(value)); }
+inline void RenderStyle::setVisitedLinkTextFillColor(Style::Color&& value) { SET(m_rareInheritedData, visitedLinkTextFillColor, WTFMove(value)); }
+inline void RenderStyle::setVisitedLinkTextStrokeColor(Style::Color&& value) { SET(m_rareInheritedData, visitedLinkTextStrokeColor, WTFMove(value)); }
 inline void RenderStyle::setWidth(Length&& length) { SET_NESTED(m_nonInheritedData, boxData, m_width, WTFMove(length)); }
 inline void RenderStyle::setWordBreak(WordBreak rule) { SET(m_rareInheritedData, wordBreak, static_cast<unsigned>(rule)); }
 
@@ -405,7 +405,7 @@ inline void RenderStyle::setTextSizeAdjust(TextSizeAdjustment adjustment) { SET(
 #endif
 
 #if ENABLE(TOUCH_EVENTS)
-inline void RenderStyle::setTapHighlightColor(const Style::Color& color) { SET(m_rareInheritedData, tapHighlightColor, color); }
+inline void RenderStyle::setTapHighlightColor(Style::Color&& color) { SET(m_rareInheritedData, tapHighlightColor, WTFMove(color)); }
 #endif
 
 inline void RenderStyle::setInsideDefaultButton(bool value) { SET(m_rareInheritedData, insideDefaultButton, value); }

--- a/Source/WebCore/rendering/style/SVGRenderStyle.h
+++ b/Source/WebCore/rendering/style/SVGRenderStyle.h
@@ -83,7 +83,7 @@ public:
     static SVGPaintType initialStrokePaintType() { return SVGPaintType::None; }
     static Style::Color initialStrokePaintColor() { /* No initial value per spec. */ return Color { }; }
     static Style::URL initialStrokePaintUri() { return Style::URL::none(); }
-    static Vector<Length> initialStrokeDashArray() { return { }; }
+    static FixedVector<Length> initialStrokeDashArray() { return { }; }
     static float initialStopOpacity() { return 1; }
     static Style::Color initialStopColor() { return Color::black; }
     static float initialFloodOpacity() { return 1; }
@@ -110,32 +110,32 @@ public:
     void setGlyphOrientationHorizontal(GlyphOrientation val) { m_inheritedFlags.glyphOrientationHorizontal = static_cast<unsigned>(val); }
     void setGlyphOrientationVertical(GlyphOrientation val) { m_inheritedFlags.glyphOrientationVertical = static_cast<unsigned>(val); }
     void setMaskType(MaskType val) { m_nonInheritedFlags.flagBits.maskType = static_cast<unsigned>(val); }
-    void setCx(const Length&);
-    void setCy(const Length&);
-    void setR(const Length&);
-    void setRx(const Length&);
-    void setRy(const Length&);
-    void setX(const Length&);
-    void setY(const Length&);
+    void setCx(Length&&);
+    void setCy(Length&&);
+    void setR(Length&&);
+    void setRx(Length&&);
+    void setRy(Length&&);
+    void setX(Length&&);
+    void setY(Length&&);
     void setD(RefPtr<StylePathData>&&);
     void setFillOpacity(float);
-    void setFillPaint(SVGPaintType, const Style::Color&, const Style::URL&, bool applyToRegularStyle, bool applyToVisitedLinkStyle);
+    void setFillPaint(SVGPaintType, Style::Color&&, Style::URL&&, bool applyToRegularStyle, bool applyToVisitedLinkStyle);
     void setStrokeOpacity(float);
-    void setStrokePaint(SVGPaintType, const Style::Color&, const Style::URL&, bool applyToRegularStyle, bool applyToVisitedLinkStyle);
+    void setStrokePaint(SVGPaintType, Style::Color&&, Style::URL&&, bool applyToRegularStyle, bool applyToVisitedLinkStyle);
 
-    void setStrokeDashArray(const Vector<Length>&);
-    void setStrokeDashOffset(const Length&);
+    void setStrokeDashArray(FixedVector<Length>&&);
+    void setStrokeDashOffset(Length&&);
     void setStopOpacity(float);
-    void setStopColor(const Style::Color&);
+    void setStopColor(Style::Color&&);
     void setFloodOpacity(float);
-    void setFloodColor(const Style::Color&);
-    void setLightingColor(const Style::Color&);
-    void setBaselineShiftValue(const Length&);
+    void setFloodColor(Style::Color&&);
+    void setLightingColor(Style::Color&&);
+    void setBaselineShiftValue(Length&&);
 
     // Setters for inherited resources
-    void setMarkerStartResource(const Style::URL&);
-    void setMarkerMidResource(const Style::URL&);
-    void setMarkerEndResource(const Style::URL&);
+    void setMarkerStartResource(Style::URL&&);
+    void setMarkerMidResource(Style::URL&&);
+    void setMarkerEndResource(Style::URL&&);
 
     // Read accessors for all the properties
     AlignmentBaseline alignmentBaseline() const { return static_cast<AlignmentBaseline>(m_nonInheritedFlags.flagBits.alignmentBaseline); }
@@ -159,7 +159,7 @@ public:
     SVGPaintType strokePaintType() const { return static_cast<SVGPaintType>(m_strokeData->paintType); }
     const Style::Color& strokePaintColor() const { return m_strokeData->paintColor; }
     const Style::URL& strokePaintUri() const { return m_strokeData->paintUri; }
-    const Vector<Length>& strokeDashArray() const { return m_strokeData->dashArray; }
+    const FixedVector<Length>& strokeDashArray() const { return m_strokeData->dashArray; }
     const Length& strokeDashOffset() const { return m_strokeData->dashOffset; }
     float stopOpacity() const { return m_stopData->opacity; }
     const Style::Color& stopColor() const { return m_stopData->color; }
@@ -279,27 +279,26 @@ inline void RenderStyle::setCx(Length&& cx) { accessSVGStyle().setCx(WTFMove(cx)
 inline void RenderStyle::setCy(Length&& cy) { accessSVGStyle().setCy(WTFMove(cy)); }
 inline void RenderStyle::setD(RefPtr<StylePathData>&& d) { accessSVGStyle().setD(WTFMove(d)); }
 inline void RenderStyle::setFillOpacity(float f) { accessSVGStyle().setFillOpacity(f); }
-inline void RenderStyle::setFillPaintColor(const Style::Color& color) { accessSVGStyle().setFillPaint(SVGPaintType::RGBColor, color, Style::URL::none(), true, false); }
-inline void RenderStyle::setVisitedFillPaintColor(const Style::Color& color) { accessSVGStyle().setFillPaint(SVGPaintType::RGBColor, color, Style::URL::none(), false, true); }
-
-inline void RenderStyle::setFloodColor(const Style::Color& c) { accessSVGStyle().setFloodColor(c); }
+inline void RenderStyle::setFillPaintColor(Style::Color&& color) { accessSVGStyle().setFillPaint(SVGPaintType::RGBColor, WTFMove(color), Style::URL::none(), true, false); }
+inline void RenderStyle::setVisitedFillPaintColor(Style::Color&& color) { accessSVGStyle().setFillPaint(SVGPaintType::RGBColor, WTFMove(color), Style::URL::none(), false, true); }
+inline void RenderStyle::setFloodColor(Style::Color&& c) { accessSVGStyle().setFloodColor(WTFMove(c)); }
 inline void RenderStyle::setFloodOpacity(float f) { accessSVGStyle().setFloodOpacity(f); }
-inline void RenderStyle::setLightingColor(const Style::Color& c) { accessSVGStyle().setLightingColor(c); }
+inline void RenderStyle::setLightingColor(Style::Color&& c) { accessSVGStyle().setLightingColor(WTFMove(c)); }
 inline void RenderStyle::setR(Length&& r) { accessSVGStyle().setR(WTFMove(r)); }
 inline void RenderStyle::setRx(Length&& rx) { accessSVGStyle().setRx(WTFMove(rx)); }
 inline void RenderStyle::setRy(Length&& ry) { accessSVGStyle().setRy(WTFMove(ry)); }
-inline void RenderStyle::setStopColor(const Style::Color& c) { accessSVGStyle().setStopColor(c); }
+inline void RenderStyle::setStopColor(Style::Color&& c) { accessSVGStyle().setStopColor(WTFMove(c)); }
 inline void RenderStyle::setStopOpacity(float f) { accessSVGStyle().setStopOpacity(f); }
-inline void RenderStyle::setStrokeDashArray(Vector<Length>&& array) { accessSVGStyle().setStrokeDashArray(WTFMove(array)); }
+inline void RenderStyle::setStrokeDashArray(FixedVector<Length>&& array) { accessSVGStyle().setStrokeDashArray(WTFMove(array)); }
 inline void RenderStyle::setStrokeDashOffset(Length&& d) { accessSVGStyle().setStrokeDashOffset(WTFMove(d)); }
 inline void RenderStyle::setStrokeOpacity(float f) { accessSVGStyle().setStrokeOpacity(f); }
-inline void RenderStyle::setStrokePaintColor(const Style::Color& color) { accessSVGStyle().setStrokePaint(SVGPaintType::RGBColor, color, Style::URL::none(), true, false); }
-inline void RenderStyle::setVisitedStrokePaintColor(const Style::Color& color) { accessSVGStyle().setStrokePaint(SVGPaintType::RGBColor, color, Style::URL::none(), false, true); }
+inline void RenderStyle::setStrokePaintColor(Style::Color&& color) { accessSVGStyle().setStrokePaint(SVGPaintType::RGBColor, WTFMove(color), Style::URL::none(), true, false); }
+inline void RenderStyle::setVisitedStrokePaintColor(Style::Color&& color) { accessSVGStyle().setStrokePaint(SVGPaintType::RGBColor, WTFMove(color), Style::URL::none(), false, true); }
 inline void RenderStyle::setX(Length&& x) { accessSVGStyle().setX(WTFMove(x)); }
 inline void RenderStyle::setY(Length&& y) { accessSVGStyle().setY(WTFMove(y)); }
 inline const Style::Color& RenderStyle::stopColor() const { return svgStyle().stopColor(); }
 inline float RenderStyle::stopOpacity() const { return svgStyle().stopOpacity(); }
-inline const Vector<Length>& RenderStyle::strokeDashArray() const { return svgStyle().strokeDashArray(); }
+inline const FixedVector<Length>& RenderStyle::strokeDashArray() const { return svgStyle().strokeDashArray(); }
 inline const Length& RenderStyle::strokeDashOffset() const { return svgStyle().strokeDashOffset(); }
 inline float RenderStyle::strokeOpacity() const { return svgStyle().strokeOpacity(); }
 inline const Style::Color& RenderStyle::strokePaintColor() const { return svgStyle().strokePaintColor(); }
@@ -310,52 +309,52 @@ inline const Length& RenderStyle::strokeWidth() const { return m_rareInheritedDa
 inline const Length& RenderStyle::x() const { return svgStyle().x(); }
 inline const Length& RenderStyle::y() const { return svgStyle().y(); }
 
-inline void SVGRenderStyle::setCx(const Length& length)
+inline void SVGRenderStyle::setCx(Length&& length)
 {
     if (!(m_layoutData->cx == length))
-        m_layoutData.access().cx = length;
+        m_layoutData.access().cx = WTFMove(length);
 }
 
-inline void SVGRenderStyle::setCy(const Length& length)
+inline void SVGRenderStyle::setCy(Length&& length)
 {
     if (!(m_layoutData->cy == length))
-        m_layoutData.access().cy = length;
+        m_layoutData.access().cy = WTFMove(length);
 }
 
-inline void SVGRenderStyle::setR(const Length& length)
+inline void SVGRenderStyle::setR(Length&& length)
 {
     if (!(m_layoutData->r == length))
-        m_layoutData.access().r = length;
+        m_layoutData.access().r = WTFMove(length);
 }
 
-inline void SVGRenderStyle::setRx(const Length& length)
+inline void SVGRenderStyle::setRx(Length&& length)
 {
     if (!(m_layoutData->rx == length))
-        m_layoutData.access().rx = length;
+        m_layoutData.access().rx = WTFMove(length);
 }
 
-inline void SVGRenderStyle::setRy(const Length& length)
+inline void SVGRenderStyle::setRy(Length&& length)
 {
     if (!(m_layoutData->ry == length))
-        m_layoutData.access().ry = length;
+        m_layoutData.access().ry = WTFMove(length);
 }
 
-inline void SVGRenderStyle::setX(const Length& length)
+inline void SVGRenderStyle::setX(Length&& length)
 {
     if (!(m_layoutData->x == length))
-        m_layoutData.access().x = length;
+        m_layoutData.access().x = WTFMove(length);
 }
 
-inline void SVGRenderStyle::setY(const Length& length)
+inline void SVGRenderStyle::setY(Length&& length)
 {
     if (!(m_layoutData->y == length))
-        m_layoutData.access().y = length;
+        m_layoutData.access().y = WTFMove(length);
 }
 
 inline void SVGRenderStyle::setD(RefPtr<StylePathData>&& d)
 {
     if (!(m_layoutData->d == d))
-        m_layoutData.access().d = d;
+        m_layoutData.access().d = WTFMove(d);
 }
 
 inline void SVGRenderStyle::setFillOpacity(float opacity)
@@ -365,7 +364,7 @@ inline void SVGRenderStyle::setFillOpacity(float opacity)
         m_fillData.access().opacity = clampedOpacity;
 }
 
-inline void SVGRenderStyle::setFillPaint(SVGPaintType type, const Style::Color& color, const Style::URL& uri, bool applyToRegularStyle, bool applyToVisitedLinkStyle)
+inline void SVGRenderStyle::setFillPaint(SVGPaintType type, Style::Color&& color, Style::URL&& uri, bool applyToRegularStyle, bool applyToVisitedLinkStyle)
 {
     if (applyToRegularStyle) {
         if (!(m_fillData->paintType == type))
@@ -379,9 +378,9 @@ inline void SVGRenderStyle::setFillPaint(SVGPaintType type, const Style::Color& 
         if (!(m_fillData->visitedLinkPaintType == type))
             m_fillData.access().visitedLinkPaintType = type;
         if (!(m_fillData->visitedLinkPaintColor == color))
-            m_fillData.access().visitedLinkPaintColor = color;
+            m_fillData.access().visitedLinkPaintColor = WTFMove(color);
         if (!(m_fillData->visitedLinkPaintUri == uri))
-            m_fillData.access().visitedLinkPaintUri = uri;
+            m_fillData.access().visitedLinkPaintUri = WTFMove(uri);
     }
 }
 
@@ -392,7 +391,7 @@ inline void SVGRenderStyle::setStrokeOpacity(float opacity)
         m_strokeData.access().opacity = clampedOpacity;
 }
 
-inline void SVGRenderStyle::setStrokePaint(SVGPaintType type, const Style::Color& color, const Style::URL& uri, bool applyToRegularStyle, bool applyToVisitedLinkStyle)
+inline void SVGRenderStyle::setStrokePaint(SVGPaintType type, Style::Color&& color, Style::URL&& uri, bool applyToRegularStyle, bool applyToVisitedLinkStyle)
 {
     if (applyToRegularStyle) {
         if (!(m_strokeData->paintType == type))
@@ -406,22 +405,22 @@ inline void SVGRenderStyle::setStrokePaint(SVGPaintType type, const Style::Color
         if (!(m_strokeData->visitedLinkPaintType == type))
             m_strokeData.access().visitedLinkPaintType = type;
         if (!(m_strokeData->visitedLinkPaintColor == color))
-            m_strokeData.access().visitedLinkPaintColor = color;
+            m_strokeData.access().visitedLinkPaintColor = WTFMove(color);
         if (!(m_strokeData->visitedLinkPaintUri == uri))
-            m_strokeData.access().visitedLinkPaintUri = uri;
+            m_strokeData.access().visitedLinkPaintUri = WTFMove(uri);
     }
 }
 
-inline void SVGRenderStyle::setStrokeDashArray(const Vector<Length>& array)
+inline void SVGRenderStyle::setStrokeDashArray(FixedVector<Length>&& array)
 {
     if (!(m_strokeData->dashArray == array))
-        m_strokeData.access().dashArray = array;
+        m_strokeData.access().dashArray = WTFMove(array);
 }
 
-inline void SVGRenderStyle::setStrokeDashOffset(const Length& offset)
+inline void SVGRenderStyle::setStrokeDashOffset(Length&& offset)
 {
     if (!(m_strokeData->dashOffset == offset))
-        m_strokeData.access().dashOffset = offset;
+        m_strokeData.access().dashOffset = WTFMove(offset);
 }
 
 inline void SVGRenderStyle::setStopOpacity(float opacity)
@@ -431,10 +430,10 @@ inline void SVGRenderStyle::setStopOpacity(float opacity)
         m_stopData.access().opacity = clampedOpacity;
 }
 
-inline void SVGRenderStyle::setStopColor(const Style::Color& color)
+inline void SVGRenderStyle::setStopColor(Style::Color&& color)
 {
     if (!(m_stopData->color == color))
-        m_stopData.access().color = color;
+        m_stopData.access().color = WTFMove(color);
 }
 
 inline void SVGRenderStyle::setFloodOpacity(float opacity)
@@ -444,40 +443,40 @@ inline void SVGRenderStyle::setFloodOpacity(float opacity)
         m_miscData.access().floodOpacity = clampedOpacity;
 }
 
-inline void SVGRenderStyle::setFloodColor(const Style::Color& color)
+inline void SVGRenderStyle::setFloodColor(Style::Color&& color)
 {
     if (!(m_miscData->floodColor == color))
-        m_miscData.access().floodColor = color;
+        m_miscData.access().floodColor = WTFMove(color);
 }
 
-inline void SVGRenderStyle::setLightingColor(const Style::Color& color)
+inline void SVGRenderStyle::setLightingColor(Style::Color&& color)
 {
     if (!(m_miscData->lightingColor == color))
-        m_miscData.access().lightingColor = color;
+        m_miscData.access().lightingColor = WTFMove(color);
 }
 
-inline void SVGRenderStyle::setBaselineShiftValue(const Length& shiftValue)
+inline void SVGRenderStyle::setBaselineShiftValue(Length&& shiftValue)
 {
     if (!(m_miscData->baselineShiftValue == shiftValue))
-        m_miscData.access().baselineShiftValue = shiftValue;
+        m_miscData.access().baselineShiftValue = WTFMove(shiftValue);
 }
 
-inline void SVGRenderStyle::setMarkerStartResource(const Style::URL& resource)
+inline void SVGRenderStyle::setMarkerStartResource(Style::URL&& resource)
 {
     if (!(m_inheritedResourceData->markerStart == resource))
-        m_inheritedResourceData.access().markerStart = resource;
+        m_inheritedResourceData.access().markerStart = WTFMove(resource);
 }
 
-inline void SVGRenderStyle::setMarkerMidResource(const Style::URL& resource)
+inline void SVGRenderStyle::setMarkerMidResource(Style::URL&& resource)
 {
     if (!(m_inheritedResourceData->markerMid == resource))
-        m_inheritedResourceData.access().markerMid = resource;
+        m_inheritedResourceData.access().markerMid = WTFMove(resource);
 }
 
-inline void SVGRenderStyle::setMarkerEndResource(const Style::URL& resource)
+inline void SVGRenderStyle::setMarkerEndResource(Style::URL&& resource)
 {
     if (!(m_inheritedResourceData->markerEnd == resource))
-        m_inheritedResourceData.access().markerEnd = resource;
+        m_inheritedResourceData.access().markerEnd = WTFMove(resource);
 }
 
 inline void SVGRenderStyle::setBitDefaults()

--- a/Source/WebCore/rendering/style/SVGRenderStyleDefs.h
+++ b/Source/WebCore/rendering/style/SVGRenderStyleDefs.h
@@ -192,7 +192,7 @@ public:
     Style::URL visitedLinkPaintUri;
 
     Length dashOffset;
-    Vector<Length> dashArray;
+    FixedVector<Length> dashArray;
 
     SVGPaintType paintType;
     SVGPaintType visitedLinkPaintType;

--- a/Source/WebCore/rendering/style/StyleGridData.h
+++ b/Source/WebCore/rendering/style/StyleGridData.h
@@ -29,6 +29,7 @@
 #include "GridTrackSize.h"
 #include "RenderStyleConstants.h"
 #include "StyleContentAlignmentData.h"
+#include <wtf/FixedVector.h>
 #include <wtf/Ref.h>
 #include <wtf/RefCounted.h>
 #include <wtf/Vector.h>

--- a/Source/WebCore/rendering/style/StyleRareNonInheritedData.h
+++ b/Source/WebCore/rendering/style/StyleRareNonInheritedData.h
@@ -55,9 +55,9 @@
 #include "ViewTransitionName.h"
 #include <memory>
 #include <wtf/DataRef.h>
+#include <wtf/FixedVector.h>
 #include <wtf/Markable.h>
 #include <wtf/OptionSet.h>
-#include <wtf/Vector.h>
 
 namespace WTF {
 class TextStream;
@@ -191,9 +191,9 @@ public:
     RefPtr<TranslateTransformOperation> translate;
     RefPtr<PathOperation> offsetPath;
 
-    Vector<Style::ScopedName> containerNames;
+    FixedVector<Style::ScopedName> containerNames;
 
-    Vector<Style::ScopedName> viewTransitionClasses;
+    FixedVector<Style::ScopedName> viewTransitionClasses;
     Style::ViewTransitionName viewTransitionName;
 
     GapLength columnGap;
@@ -206,14 +206,14 @@ public:
 
     TextDecorationThickness textDecorationThickness;
 
-    Vector<Ref<ScrollTimeline>> scrollTimelines;
-    Vector<ScrollAxis> scrollTimelineAxes;
-    Vector<AtomString> scrollTimelineNames;
+    FixedVector<Ref<ScrollTimeline>> scrollTimelines;
+    FixedVector<ScrollAxis> scrollTimelineAxes;
+    FixedVector<AtomString> scrollTimelineNames;
 
-    Vector<Ref<ViewTimeline>> viewTimelines;
-    Vector<ScrollAxis> viewTimelineAxes;
-    Vector<ViewTimelineInsets> viewTimelineInsets;
-    Vector<AtomString> viewTimelineNames;
+    FixedVector<Ref<ViewTimeline>> viewTimelines;
+    FixedVector<ScrollAxis> viewTimelineAxes;
+    FixedVector<ViewTimelineInsets> viewTimelineInsets;
+    FixedVector<AtomString> viewTimelineNames;
 
     NameScope timelineScope;
 
@@ -225,11 +225,11 @@ public:
 
     AtomString pseudoElementNameArgument;
 
-    Vector<Style::ScopedName> anchorNames;
+    FixedVector<Style::ScopedName> anchorNames;
     NameScope anchorScope;
     std::optional<Style::ScopedName> positionAnchor;
     std::optional<PositionArea> positionArea;
-    Vector<Style::PositionTryFallback> positionTryFallbacks;
+    FixedVector<Style::PositionTryFallback> positionTryFallbacks;
 
     std::optional<Length> blockStepSize;
     unsigned blockStepAlign : 2; // BlockStepAlign

--- a/Source/WebCore/rendering/svg/SVGRenderSupport.cpp
+++ b/Source/WebCore/rendering/svg/SVGRenderSupport.cpp
@@ -7,6 +7,7 @@
  * Copyright (C) Research In Motion Limited 2009-2010. All rights reserved.
  * Copyright (C) 2018 Adobe Systems Incorporated. All rights reserved.
  * Copyright (C) 2020-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public

--- a/Source/WebCore/rendering/svg/SVGRenderTreeAsText.cpp
+++ b/Source/WebCore/rendering/svg/SVGRenderTreeAsText.cpp
@@ -208,7 +208,7 @@ static void writeSVGStrokePaintingResource(TextStream& ts, const RenderElement& 
     SVGLengthContext lengthContext(&shape);
     double dashOffset = lengthContext.valueForLength(svgStyle.strokeDashOffset());
     double strokeWidth = lengthContext.valueForLength(style.strokeWidth());
-    auto dashArray = svgStyle.strokeDashArray().map([&](auto& length) -> DashArrayElement {
+    auto dashArray = WTF::map(svgStyle.strokeDashArray(), [&](auto& length) -> DashArrayElement {
         return lengthContext.valueForLength(length);
     });
 

--- a/Source/WebCore/style/StyleBuilderConverter.h
+++ b/Source/WebCore/style/StyleBuilderConverter.h
@@ -178,7 +178,7 @@ public:
     static std::optional<GridTrackList> convertGridTrackList(BuilderState&, const CSSValue&);
     static GridPosition convertGridPosition(BuilderState&, const CSSValue&);
     static GridAutoFlow convertGridAutoFlow(BuilderState&, const CSSValue&);
-    static Vector<StyleContentAlignmentData> convertContentAlignmentDataList(BuilderState&, const CSSValue&);
+    static FixedVector<StyleContentAlignmentData> convertContentAlignmentDataList(BuilderState&, const CSSValue&);
     static std::optional<float> convertPerspective(BuilderState&, const CSSValue&);
     static std::optional<WebCore::Length> convertMarqueeIncrement(BuilderState&, const CSSValue&);
     static FilterOperations convertFilterOperations(BuilderState&, const CSSValue&);
@@ -203,7 +203,7 @@ public:
     static FontSelectionValue convertFontStyle(BuilderState&, const CSSValue&);
     static FontFeatureSettings convertFontFeatureSettings(BuilderState&, const CSSValue&);
     static FontVariationSettings convertFontVariationSettings(BuilderState&, const CSSValue&);
-    static Vector<WebCore::Length> convertStrokeDashArray(BuilderState&, const CSSValue&);
+    static FixedVector<WebCore::Length> convertStrokeDashArray(BuilderState&, const CSSValue&);
     static PaintOrder convertPaintOrder(BuilderState&, const CSSValue&);
     static float convertOpacity(BuilderState&, const CSSValue&);
     static Style::URL convertSVGURIReference(BuilderState&, const CSSValue&);
@@ -228,7 +228,7 @@ public:
     static OffsetRotation convertOffsetRotate(BuilderState&, const CSSValue&);
 
     static OptionSet<Containment> convertContain(BuilderState&, const CSSValue&);
-    static Vector<ScopedName> convertContainerNames(BuilderState&, const CSSValue&);
+    static FixedVector<ScopedName> convertContainerNames(BuilderState&, const CSSValue&);
 
     static OptionSet<MarginTrimType> convertMarginTrim(BuilderState&, const CSSValue&);
 
@@ -237,15 +237,15 @@ public:
 
     static std::optional<WebCore::Length> convertBlockStepSize(BuilderState&, const CSSValue&);
 
-    static Vector<ScopedName> convertViewTransitionClasses(BuilderState&, const CSSValue&);
+    static FixedVector<ScopedName> convertViewTransitionClasses(BuilderState&, const CSSValue&);
     static ViewTransitionName convertViewTransitionName(BuilderState&, const CSSValue&);
     static RefPtr<WillChangeData> convertWillChange(BuilderState&, const CSSValue&);
     
-    static Vector<AtomString> convertScrollTimelineNames(BuilderState&, const CSSValue&);
-    static Vector<ScrollAxis> convertScrollTimelineAxes(BuilderState&, const CSSValue&);
-    static Vector<ViewTimelineInsets> convertViewTimelineInsets(BuilderState&, const CSSValue&);
+    static FixedVector<AtomString> convertScrollTimelineNames(BuilderState&, const CSSValue&);
+    static FixedVector<ScrollAxis> convertScrollTimelineAxes(BuilderState&, const CSSValue&);
+    static FixedVector<ViewTimelineInsets> convertViewTimelineInsets(BuilderState&, const CSSValue&);
 
-    static Vector<ScopedName> convertAnchorNames(BuilderState&, const CSSValue&);
+    static FixedVector<ScopedName> convertAnchorNames(BuilderState&, const CSSValue&);
     static std::optional<ScopedName> convertPositionAnchor(BuilderState&, const CSSValue&);
     static std::optional<PositionArea> convertPositionArea(BuilderState&, const CSSValue&);
     static OptionSet<PositionVisibility> convertPositionVisibility(BuilderState&, const CSSValue&);
@@ -267,7 +267,7 @@ public:
     static Style::DynamicRangeLimit convertDynamicRangeLimit(BuilderState&, const CSSValue&);
     static Style::CornerShapeValue convertCornerShapeValue(BuilderState&, const CSSValue&);
 
-    static Vector<PositionTryFallback> convertPositionTryFallbacks(BuilderState&, const CSSValue&);
+    static FixedVector<PositionTryFallback> convertPositionTryFallbacks(BuilderState&, const CSSValue&);
 
     template<class ValueType> static const ValueType* requiredDowncast(BuilderState&, const CSSValue&);
     template<class ValueType> static std::optional<std::pair<const ValueType&, const ValueType&>> requiredPairDowncast(BuilderState&, const CSSValue&);
@@ -1616,13 +1616,13 @@ inline GridAutoFlow BuilderConverter::convertGridAutoFlow(BuilderState& builderS
     return autoFlow;
 }
 
-inline Vector<StyleContentAlignmentData> BuilderConverter::convertContentAlignmentDataList(BuilderState& builderState, const CSSValue& value)
+inline FixedVector<StyleContentAlignmentData> BuilderConverter::convertContentAlignmentDataList(BuilderState& builderState, const CSSValue& value)
 {
     auto list = requiredListDowncast<CSSValueList, CSSContentDistributionValue>(builderState, value);
     if (!list)
         return { };
 
-    return WTF::map(*list, [&](auto& value) {
+    return FixedVector<StyleContentAlignmentData>::map(*list, [&](auto& value) {
         return convertContentAlignmentData(builderState, value);
     });
 }
@@ -1791,21 +1791,21 @@ inline bool BuilderConverter::convertSmoothScrolling(BuilderState&, const CSSVal
     return value.valueID() == CSSValueSmooth;
 }
 
-inline Vector<WebCore::Length> BuilderConverter::convertStrokeDashArray(BuilderState& builderState, const CSSValue& value)
+inline FixedVector<WebCore::Length> BuilderConverter::convertStrokeDashArray(BuilderState& builderState, const CSSValue& value)
 {
     if (auto* primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value)) {
         if (primitiveValue->valueID() == CSSValueNone)
             return SVGRenderStyle::initialStrokeDashArray();
 
         // Values coming from CSS-Typed-OM may not have been converted to a CSSValueList yet.
-        return Vector { convertLengthAllowingNumber(builderState, *primitiveValue) };
+        return FixedVector<WebCore::Length> { convertLengthAllowingNumber(builderState, *primitiveValue) };
     }
 
     auto list = requiredListDowncast<CSSValueList, CSSPrimitiveValue>(builderState, value);
     if (!list)
         return { };
 
-    return WTF::map(*list, [&](auto& item) {
+    return FixedVector<WebCore::Length>::map(*list, [&](auto& item) {
         return convertLengthAllowingNumber(builderState, item);
     });
 }
@@ -2126,7 +2126,7 @@ inline OffsetRotation BuilderConverter::convertOffsetRotate(BuilderState& builde
     return OffsetRotation(hasAuto, angleInDegrees);
 }
 
-inline Vector<Style::ScopedName> BuilderConverter::convertContainerNames(BuilderState& builderState, const CSSValue& value)
+inline FixedVector<ScopedName> BuilderConverter::convertContainerNames(BuilderState& builderState, const CSSValue& value)
 {
     if (is<CSSPrimitiveValue>(value)) {
         ASSERT(value.valueID() == CSSValueNone);
@@ -2136,8 +2136,11 @@ inline Vector<Style::ScopedName> BuilderConverter::convertContainerNames(Builder
     if (!list)
         return { };
 
-    return WTF::map(*list, [&](auto& item) {
-        return Style::ScopedName { AtomString { item.stringValue() }, builderState.styleScopeOrdinal() };
+    return FixedVector<ScopedName>::map(*list, [&](auto& item) {
+        return ScopedName {
+            .name = AtomString { item.stringValue() },
+            .scopeOrdinal = builderState.styleScopeOrdinal()
+        };
     });
 }
 
@@ -2275,20 +2278,29 @@ inline OptionSet<Containment> BuilderConverter::convertContain(BuilderState& bui
     return containment;
 }
 
-inline Vector<Style::ScopedName> BuilderConverter::convertViewTransitionClasses(BuilderState& builderState, const CSSValue& value)
+inline FixedVector<ScopedName> BuilderConverter::convertViewTransitionClasses(BuilderState& builderState, const CSSValue& value)
 {
     if (auto* primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value)) {
         if (value.valueID() == CSSValueNone)
             return { };
-        return { Style::ScopedName { AtomString { primitiveValue->stringValue() }, builderState.styleScopeOrdinal() } };
+
+        return {
+            ScopedName {
+                .name = AtomString { primitiveValue->stringValue() },
+                .scopeOrdinal = builderState.styleScopeOrdinal()
+            }
+        };
     }
 
     auto list = requiredListDowncast<CSSValueList, CSSPrimitiveValue>(builderState, value);
     if (!list)
         return { };
 
-    return WTF::map(*list, [&](auto& item) {
-        return Style::ScopedName { AtomString { item.stringValue() }, builderState.styleScopeOrdinal() };
+    return FixedVector<ScopedName>::map(*list, [&](auto& item) {
+        return ScopedName {
+            .name = AtomString { item.stringValue() },
+            .scopeOrdinal = builderState.styleScopeOrdinal()
+        };
     });
 }
 
@@ -2344,7 +2356,7 @@ inline RefPtr<WillChangeData> BuilderConverter::convertWillChange(BuilderState& 
     return willChange;
 }
 
-inline Vector<AtomString> BuilderConverter::convertScrollTimelineNames(BuilderState& builderState, const CSSValue& value)
+inline FixedVector<AtomString> BuilderConverter::convertScrollTimelineNames(BuilderState& builderState, const CSSValue& value)
 {
     if (auto* primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value)) {
         if (value.valueID() == CSSValueNone)
@@ -2356,12 +2368,12 @@ inline Vector<AtomString> BuilderConverter::convertScrollTimelineNames(BuilderSt
     if (!list)
         return { };
 
-    return WTF::map(*list, [&](auto& item) {
+    return FixedVector<AtomString>::map(*list, [&](auto& item) {
         return AtomString { item.stringValue() };
     });
 }
 
-inline Vector<ScrollAxis> BuilderConverter::convertScrollTimelineAxes(BuilderState& builderState, const CSSValue& value)
+inline FixedVector<ScrollAxis> BuilderConverter::convertScrollTimelineAxes(BuilderState& builderState, const CSSValue& value)
 {
     if (is<CSSPrimitiveValue>(value))
         return { fromCSSValueID<ScrollAxis>(value.valueID()) };
@@ -2370,19 +2382,19 @@ inline Vector<ScrollAxis> BuilderConverter::convertScrollTimelineAxes(BuilderSta
     if (!list)
         return { };
 
-    return WTF::map(*list, [&](auto& item) {
+    return FixedVector<ScrollAxis>::map(*list, [&](auto& item) {
         return fromCSSValueID<ScrollAxis>(item.valueID());
     });
 }
 
-inline Vector<ViewTimelineInsets> BuilderConverter::convertViewTimelineInsets(BuilderState& builderState, const CSSValue& value)
+inline FixedVector<ViewTimelineInsets> BuilderConverter::convertViewTimelineInsets(BuilderState& builderState, const CSSValue& value)
 {
     // While parsing, consumeViewTimelineInset() and consumeViewTimelineShorthand() yield a CSSValueList exclusively.
     auto list = requiredListDowncast<CSSValueList, CSSValue>(builderState, value);
     if (!list)
         return { };
 
-    return WTF::map(*list, [&](auto& item) -> ViewTimelineInsets {
+    return FixedVector<ViewTimelineInsets>::map(*list, [&](auto& item) -> ViewTimelineInsets {
         // Each item is either a single value or a CSSValuePair.
         if (auto* pair = dynamicDowncast<CSSValuePair>(item))
             return { convertLengthOrAuto(builderState, pair->first()), convertLengthOrAuto(builderState, pair->second()) };
@@ -2392,25 +2404,25 @@ inline Vector<ViewTimelineInsets> BuilderConverter::convertViewTimelineInsets(Bu
     });
 }
 
-inline Vector<ScopedName> BuilderConverter::convertAnchorNames(BuilderState& builderState, const CSSValue& value)
+inline FixedVector<ScopedName> BuilderConverter::convertAnchorNames(BuilderState& builderState, const CSSValue& value)
 {
     if (auto* primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value)) {
         if (value.valueID() == CSSValueNone)
             return { };
 
-        ScopedName scopedName {
-            .name = AtomString { primitiveValue->stringValue() },
-            .scopeOrdinal = builderState.styleScopeOrdinal()
+        return {
+            ScopedName {
+                .name = AtomString { primitiveValue->stringValue() },
+                .scopeOrdinal = builderState.styleScopeOrdinal()
+            }
         };
-
-        return { scopedName };
     }
 
     auto list = requiredListDowncast<CSSValueList, CSSPrimitiveValue>(builderState, value);
     if (!list)
         return { };
 
-    return WTF::map(*list, [&](auto& item) {
+    return FixedVector<ScopedName>::map(*list, [&](auto& item) {
         return ScopedName {
             .name = AtomString { item.stringValue() },
             .scopeOrdinal = builderState.styleScopeOrdinal()
@@ -2846,7 +2858,7 @@ inline NameScope BuilderConverter::convertNameScope(BuilderState& builderState, 
     return { NameScope::Type::Ident, WTFMove(nameHashSet) };
 }
 
-inline Vector<PositionTryFallback> BuilderConverter::convertPositionTryFallbacks(BuilderState& builderState, const CSSValue& value)
+inline FixedVector<PositionTryFallback> BuilderConverter::convertPositionTryFallbacks(BuilderState& builderState, const CSSValue& value)
 {
     auto convertFallback = [&](const CSSValue& fallbackValue) -> std::optional<PositionTryFallback> {
         auto* valueList = dynamicDowncast<CSSValueList>(fallbackValue);
@@ -2889,7 +2901,7 @@ inline Vector<PositionTryFallback> BuilderConverter::convertPositionTryFallbacks
     if (!list)
         return { };
 
-    return WTF::map(*list, [&](auto& item) {
+    return FixedVector<PositionTryFallback>::map(*list, [&](auto& item) {
         auto fallback = convertFallback(item);
         return fallback ? *fallback : PositionTryFallback { };
     });

--- a/Source/WebCore/style/StyleBuilderCustom.h
+++ b/Source/WebCore/style/StyleBuilderCustom.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2013-2014 Google Inc. All rights reserved.
  * Copyright (C) 2014-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -73,6 +74,8 @@ namespace Style {
     static void applyValue##property(BuilderState&, CSSValue&)
 
 template<typename T> inline T forwardInheritedValue(T&& value) { return std::forward<T>(value); }
+inline WebCore::Color forwardInheritedValue(const WebCore::Color& value) { auto copy = value; return copy; }
+inline Color forwardInheritedValue(const Color& value) { auto copy = value; return copy; }
 inline WebCore::Length forwardInheritedValue(const WebCore::Length& value) { auto copy = value; return copy; }
 inline LengthSize forwardInheritedValue(const LengthSize& value) { auto copy = value; return copy; }
 inline LengthBox forwardInheritedValue(const LengthBox& value) { auto copy = value; return copy; }
@@ -83,8 +86,19 @@ inline ScrollMarginEdge forwardInheritedValue(const ScrollMarginEdge& value) { a
 inline ScrollPaddingEdge forwardInheritedValue(const ScrollPaddingEdge& value) { auto copy = value; return copy; }
 inline DynamicRangeLimit forwardInheritedValue(const DynamicRangeLimit& value) { auto copy = value; return copy; }
 inline CornerShapeValue forwardInheritedValue(const CornerShapeValue& value) { auto copy = value; return copy; }
+inline URL forwardInheritedValue(const URL& value) { auto copy = value; return copy; }
+inline ViewTransitionName forwardInheritedValue(const ViewTransitionName& value) { auto copy = value; return copy; }
+inline FixedVector<WebCore::Length> forwardInheritedValue(const FixedVector<WebCore::Length>& value) { auto copy = value; return copy; }
 inline FixedVector<BoxShadow> forwardInheritedValue(const FixedVector<BoxShadow>& value) { auto copy = value; return copy; }
 inline FixedVector<TextShadow> forwardInheritedValue(const FixedVector<TextShadow>& value) { auto copy = value; return copy; }
+inline FixedVector<ScopedName> forwardInheritedValue(const FixedVector<ScopedName>& value) { auto copy = value; return copy; }
+inline FixedVector<PositionTryFallback> forwardInheritedValue(const FixedVector<PositionTryFallback>& value) { auto copy = value; return copy; }
+inline FixedVector<Ref<ScrollTimeline>> forwardInheritedValue(const FixedVector<Ref<ScrollTimeline>>& value) { auto copy = value; return copy; }
+inline FixedVector<Ref<ViewTimeline>> forwardInheritedValue(const FixedVector<Ref<ViewTimeline>>& value) { auto copy = value; return copy; }
+inline FixedVector<AtomString> forwardInheritedValue(const FixedVector<AtomString>& value) { auto copy = value; return copy; }
+inline FixedVector<ScrollAxis> forwardInheritedValue(const FixedVector<ScrollAxis>& value) { auto copy = value; return copy; }
+inline FixedVector<ViewTimelineInsets> forwardInheritedValue(const FixedVector<ViewTimelineInsets>& value) { auto copy = value; return copy; }
+inline Vector<GridTrackSize> forwardInheritedValue(const Vector<GridTrackSize>& value) { auto copy = value; return copy; }
 
 // Note that we assume the CSS parser only allows valid CSSValue types.
 class BuilderCustom {
@@ -202,7 +216,7 @@ inline void BuilderCustom::applyInitialZoom(BuilderState& builderState)
 inline void BuilderCustom::applyInheritZoom(BuilderState& builderState)
 {
     resetUsedZoom(builderState);
-    builderState.setZoom(builderState.parentStyle().zoom());
+    builderState.setZoom(forwardInheritedValue(builderState.parentStyle().zoom()));
 }
 
 inline void BuilderCustom::applyValueZoom(BuilderState& builderState, CSSValue& value)
@@ -245,9 +259,9 @@ inline void BuilderCustom::applyValueVerticalAlign(BuilderState& builderState, C
 
 inline void BuilderCustom::applyInheritTextIndent(BuilderState& builderState)
 {
-    builderState.style().setTextIndent(WebCore::Length { builderState.parentStyle().textIndent() });
-    builderState.style().setTextIndentLine(builderState.parentStyle().textIndentLine());
-    builderState.style().setTextIndentType(builderState.parentStyle().textIndentType());
+    builderState.style().setTextIndent(forwardInheritedValue(builderState.parentStyle().textIndent()));
+    builderState.style().setTextIndentLine(forwardInheritedValue(builderState.parentStyle().textIndentLine()));
+    builderState.style().setTextIndentType(forwardInheritedValue(builderState.parentStyle().textIndentType()));
 }
 
 inline void BuilderCustom::applyInitialTextIndent(BuilderState& builderState)
@@ -400,12 +414,12 @@ DEFINE_BORDER_IMAGE_MODIFIER_HANDLER(MaskBorder, Width)
 
 inline void BuilderCustom::applyInheritWordSpacing(BuilderState& builderState)
 {
-    builderState.style().setWordSpacing(WebCore::Length { builderState.parentStyle().computedWordSpacing() });
+    builderState.style().setWordSpacing(forwardInheritedValue(builderState.parentStyle().computedWordSpacing()));
 }
 
 inline void BuilderCustom::applyInheritLetterSpacing(BuilderState& builderState)
 {
-    builderState.style().setLetterSpacing(WebCore::Length { builderState.parentStyle().computedLetterSpacing() });
+    builderState.style().setLetterSpacing(forwardInheritedValue(builderState.parentStyle().computedLetterSpacing()));
 }
 
 inline void BuilderCustom::applyInitialLetterSpacing(BuilderState& builderState)
@@ -450,8 +464,8 @@ inline void BuilderCustom::applyValueLetterSpacing(BuilderState& builderState, C
 
 inline void BuilderCustom::applyInheritLineHeight(BuilderState& builderState)
 {
-    builderState.style().setLineHeight(WebCore::Length { builderState.parentStyle().lineHeight() });
-    builderState.style().setSpecifiedLineHeight(WebCore::Length { builderState.parentStyle().specifiedLineHeight() });
+    builderState.style().setLineHeight(forwardInheritedValue(builderState.parentStyle().lineHeight()));
+    builderState.style().setSpecifiedLineHeight(forwardInheritedValue(builderState.parentStyle().specifiedLineHeight()));
 }
 
 inline void BuilderCustom::applyInitialLineHeight(BuilderState& builderState)
@@ -539,7 +553,7 @@ inline void BuilderCustom::applyInheritOutlineStyle(BuilderState& builderState)
     if (builderState.parentStyle().hasAutoOutlineStyle())
         builderState.style().setHasAutoOutlineStyle();
     else
-        builderState.style().setOutlineStyle(builderState.parentStyle().outlineStyle());
+        builderState.style().setOutlineStyle(forwardInheritedValue(builderState.parentStyle().outlineStyle()));
 }
 
 inline void BuilderCustom::applyInitialOutlineStyle(BuilderState& builderState)
@@ -565,18 +579,18 @@ inline void BuilderCustom::applyInitialCaretColor(BuilderState& builderState)
 
 inline void BuilderCustom::applyInheritCaretColor(BuilderState& builderState)
 {
-    auto color = builderState.parentStyle().caretColor();
+    auto& color = builderState.parentStyle().caretColor();
     if (builderState.applyPropertyToRegularStyle()) {
         if (builderState.parentStyle().hasAutoCaretColor())
             builderState.style().setHasAutoCaretColor();
         else
-            builderState.style().setCaretColor(color);
+            builderState.style().setCaretColor(forwardInheritedValue(color));
     }
     if (builderState.applyPropertyToVisitedLinkStyle()) {
         if (builderState.parentStyle().hasVisitedLinkAutoCaretColor())
             builderState.style().setHasVisitedLinkAutoCaretColor();
         else
-            builderState.style().setVisitedLinkCaretColor(color);
+            builderState.style().setVisitedLinkCaretColor(forwardInheritedValue(color));
     }
 }
 
@@ -970,9 +984,9 @@ inline void BuilderCustom::applyInitialTextEmphasisStyle(BuilderState& builderSt
 
 inline void BuilderCustom::applyInheritTextEmphasisStyle(BuilderState& builderState)
 {
-    builderState.style().setTextEmphasisFill(builderState.parentStyle().textEmphasisFill());
-    builderState.style().setTextEmphasisMark(builderState.parentStyle().textEmphasisMark());
-    builderState.style().setTextEmphasisCustomMark(builderState.parentStyle().textEmphasisCustomMark());
+    builderState.style().setTextEmphasisFill(forwardInheritedValue(builderState.parentStyle().textEmphasisFill()));
+    builderState.style().setTextEmphasisMark(forwardInheritedValue(builderState.parentStyle().textEmphasisMark()));
+    builderState.style().setTextEmphasisCustomMark(forwardInheritedValue(builderState.parentStyle().textEmphasisCustomMark()));
 }
 
 inline void BuilderCustom::applyInitialAspectRatio(BuilderState& builderState)
@@ -1164,8 +1178,8 @@ inline void BuilderCustom::applyInitialCursor(BuilderState& builderState)
 
 inline void BuilderCustom::applyInheritCursor(BuilderState& builderState)
 {
-    builderState.style().setCursor(builderState.parentStyle().cursor());
-    builderState.style().setCursorList(builderState.parentStyle().cursors());
+    builderState.style().setCursor(forwardInheritedValue(builderState.parentStyle().cursor()));
+    builderState.style().setCursorList(forwardInheritedValue(builderState.parentStyle().cursors()));
 }
 
 inline void BuilderCustom::applyValueCursor(BuilderState& builderState, CSSValue& value)
@@ -1227,7 +1241,7 @@ inline void BuilderCustom::applyInheritFill(BuilderState& builderState)
 {
     auto& svgStyle = builderState.style().accessSVGStyle();
     auto& svgParentStyle = builderState.parentStyle().svgStyle();
-    svgStyle.setFillPaint(svgParentStyle.fillPaintType(), svgParentStyle.fillPaintColor(), svgParentStyle.fillPaintUri(), builderState.applyPropertyToRegularStyle(), builderState.applyPropertyToVisitedLinkStyle());
+    svgStyle.setFillPaint(forwardInheritedValue(svgParentStyle.fillPaintType()), forwardInheritedValue(svgParentStyle.fillPaintColor()), forwardInheritedValue(svgParentStyle.fillPaintUri()), builderState.applyPropertyToRegularStyle(), builderState.applyPropertyToVisitedLinkStyle());
 }
 
 inline void BuilderCustom::applyValueFill(BuilderState& builderState, CSSValue& value)
@@ -1246,7 +1260,7 @@ inline void BuilderCustom::applyValueFill(BuilderState& builderState, CSSValue& 
             return;
     }
     auto [color, paintType] = colorAndSVGPaintType(builderState, localValue ? *localValue : value, url);
-    svgStyle.setFillPaint(paintType, color, url, builderState.applyPropertyToRegularStyle(), builderState.applyPropertyToVisitedLinkStyle());
+    svgStyle.setFillPaint(paintType, WTFMove(color), WTFMove(url), builderState.applyPropertyToRegularStyle(), builderState.applyPropertyToVisitedLinkStyle());
 }
 
 inline void BuilderCustom::applyInitialStroke(BuilderState& builderState)
@@ -1259,7 +1273,7 @@ inline void BuilderCustom::applyInheritStroke(BuilderState& builderState)
 {
     auto& svgStyle = builderState.style().accessSVGStyle();
     auto& svgParentStyle = builderState.parentStyle().svgStyle();
-    svgStyle.setStrokePaint(svgParentStyle.strokePaintType(), svgParentStyle.strokePaintColor(), svgParentStyle.strokePaintUri(), builderState.applyPropertyToRegularStyle(), builderState.applyPropertyToVisitedLinkStyle());
+    svgStyle.setStrokePaint(forwardInheritedValue(svgParentStyle.strokePaintType()), forwardInheritedValue(svgParentStyle.strokePaintColor()), forwardInheritedValue(svgParentStyle.strokePaintUri()), builderState.applyPropertyToRegularStyle(), builderState.applyPropertyToVisitedLinkStyle());
 }
 
 inline void BuilderCustom::applyValueStroke(BuilderState& builderState, CSSValue& value)
@@ -1279,7 +1293,7 @@ inline void BuilderCustom::applyValueStroke(BuilderState& builderState, CSSValue
     }
 
     auto [color, paintType] = colorAndSVGPaintType(builderState, localValue ? *localValue : value, url);
-    svgStyle.setStrokePaint(paintType, color, url, builderState.applyPropertyToRegularStyle(), builderState.applyPropertyToVisitedLinkStyle());
+    svgStyle.setStrokePaint(paintType, WTFMove(color), WTFMove(url), builderState.applyPropertyToRegularStyle(), builderState.applyPropertyToVisitedLinkStyle());
 }
 
 inline void BuilderCustom::applyInitialContent(BuilderState& builderState)
@@ -1759,9 +1773,9 @@ inline void BuilderCustom::applyInitialColor(BuilderState& builderState)
 inline void BuilderCustom::applyInheritColor(BuilderState& builderState)
 {
     if (builderState.applyPropertyToRegularStyle())
-        builderState.style().setColor(builderState.parentStyle().color());
+        builderState.style().setColor(forwardInheritedValue(builderState.parentStyle().color()));
     if (builderState.applyPropertyToVisitedLinkStyle())
-        builderState.style().setVisitedLinkColor(builderState.parentStyle().color());
+        builderState.style().setVisitedLinkColor(forwardInheritedValue(builderState.parentStyle().color()));
 
     builderState.style().setDisallowsFastPathInheritance();
     builderState.style().setHasExplicitlySetColor(builderState.isAuthorOrigin());
@@ -1775,8 +1789,8 @@ inline void BuilderCustom::applyInitialContainIntrinsicWidth(BuilderState& build
 
 inline void BuilderCustom::applyInheritContainIntrinsicWidth(BuilderState& builderState)
 {
-    builderState.style().setContainIntrinsicWidthType(builderState.parentStyle().containIntrinsicWidthType());
-    builderState.style().setContainIntrinsicWidth(builderState.parentStyle().containIntrinsicWidth());
+    builderState.style().setContainIntrinsicWidthType(forwardInheritedValue(builderState.parentStyle().containIntrinsicWidthType()));
+    builderState.style().setContainIntrinsicWidth(forwardInheritedValue(builderState.parentStyle().containIntrinsicWidth()));
 }
 
 inline void BuilderCustom::applyValueContainIntrinsicWidth(BuilderState& builderState, CSSValue& value)
@@ -1819,8 +1833,8 @@ inline void BuilderCustom::applyInitialContainIntrinsicHeight(BuilderState& buil
 
 inline void BuilderCustom::applyInheritContainIntrinsicHeight(BuilderState& builderState)
 {
-    builderState.style().setContainIntrinsicHeightType(builderState.parentStyle().containIntrinsicHeightType());
-    builderState.style().setContainIntrinsicHeight(builderState.parentStyle().containIntrinsicHeight());
+    builderState.style().setContainIntrinsicHeightType(forwardInheritedValue(builderState.parentStyle().containIntrinsicHeightType()));
+    builderState.style().setContainIntrinsicHeight(forwardInheritedValue(builderState.parentStyle().containIntrinsicHeight()));
 }
 
 inline void BuilderCustom::applyValueContainIntrinsicHeight(BuilderState& builderState, CSSValue& value)

--- a/Source/WebCore/style/StyleExtractorConverter.h
+++ b/Source/WebCore/style/StyleExtractorConverter.h
@@ -177,7 +177,7 @@ public:
     static Ref<CSSValue> convertPathOperation(ExtractorState&, const PathOperation*, PathConversion = PathConversion::None);
     static Ref<CSSValue> convertPathOperationForceAbsolute(ExtractorState&, const PathOperation*);
     static Ref<CSSValue> convertDPath(ExtractorState&, const StylePathData*);
-    static Ref<CSSValue> convertStrokeDashArray(ExtractorState&, const Vector<WebCore::Length>&);
+    static Ref<CSSValue> convertStrokeDashArray(ExtractorState&, const FixedVector<WebCore::Length>&);
     static Ref<CSSValue> convertTextStrokeWidth(ExtractorState&, float);
     static Ref<CSSValue> convertFilterOperations(ExtractorState&, const FilterOperations&);
     static Ref<CSSValue> convertAppleColorFilterOperations(ExtractorState&, const FilterOperations&);
@@ -199,12 +199,12 @@ public:
     static Ref<CSSValue> convertTextBoxEdge(ExtractorState&, const TextEdge&);
     static Ref<CSSValue> convertQuotes(ExtractorState&, const QuotesData*);
     static Ref<CSSValue> convertBorderRadiusCorner(ExtractorState&, const LengthSize&);
-    static Ref<CSSValue> convertContainerNames(ExtractorState&, const Vector<ScopedName>&);
-    static Ref<CSSValue> convertViewTransitionClasses(ExtractorState&, const Vector<ScopedName>&);
+    static Ref<CSSValue> convertContainerNames(ExtractorState&, const FixedVector<ScopedName>&);
+    static Ref<CSSValue> convertViewTransitionClasses(ExtractorState&, const FixedVector<ScopedName>&);
     static Ref<CSSValue> convertViewTransitionName(ExtractorState&, const ViewTransitionName&);
     static Ref<CSSValue> convertBoxShadow(ExtractorState&, const FixedVector<BoxShadow>&);
     static Ref<CSSValue> convertTextShadow(ExtractorState&, const FixedVector<TextShadow>&);
-    static Ref<CSSValue> convertPositionTryFallbacks(ExtractorState&, const Vector<PositionTryFallback>&);
+    static Ref<CSSValue> convertPositionTryFallbacks(ExtractorState&, const FixedVector<PositionTryFallback>&);
     static Ref<CSSValue> convertWillChange(ExtractorState&, const WillChangeData*);
     static Ref<CSSValue> convertBlockEllipsis(ExtractorState&, const BlockEllipsis&);
     static Ref<CSSValue> convertBlockStepSize(ExtractorState&, std::optional<WebCore::Length>);
@@ -237,15 +237,15 @@ public:
     static Ref<CSSValue> convertContentAlignmentData(ExtractorState&, const StyleContentAlignmentData&);
     static Ref<CSSValue> convertOffsetRotate(ExtractorState&, const OffsetRotation&);
     static Ref<CSSValue> convertPaintOrder(ExtractorState&, PaintOrder);
-    static Ref<CSSValue> convertScrollTimelineAxes(ExtractorState&, const Vector<ScrollAxis>&);
-    static Ref<CSSValue> convertScrollTimelineNames(ExtractorState&, const Vector<AtomString>&);
-    static Ref<CSSValue> convertAnchorNames(ExtractorState&, const Vector<ScopedName>&);
+    static Ref<CSSValue> convertScrollTimelineAxes(ExtractorState&, const FixedVector<ScrollAxis>&);
+    static Ref<CSSValue> convertScrollTimelineNames(ExtractorState&, const FixedVector<AtomString>&);
+    static Ref<CSSValue> convertAnchorNames(ExtractorState&, const FixedVector<ScopedName>&);
     static Ref<CSSValue> convertPositionAnchor(ExtractorState&, const std::optional<ScopedName>&);
     static Ref<CSSValue> convertPositionArea(ExtractorState&, const PositionArea&);
     static Ref<CSSValue> convertPositionArea(ExtractorState&, const std::optional<PositionArea>&);
     static Ref<CSSValue> convertNameScope(ExtractorState&, const NameScope&);
     static Ref<CSSValue> convertSingleViewTimelineInsets(ExtractorState&, const ViewTimelineInsets&);
-    static Ref<CSSValue> convertViewTimelineInsets(ExtractorState&, const Vector<ViewTimelineInsets>&);
+    static Ref<CSSValue> convertViewTimelineInsets(ExtractorState&, const FixedVector<ViewTimelineInsets>&);
     static Ref<CSSValue> convertPositionVisibility(ExtractorState&, OptionSet<PositionVisibility>);
 #if ENABLE(DARK_MODE_CSS)
     static Ref<CSSValue> convertColorScheme(ExtractorState&, const ColorScheme&);
@@ -776,7 +776,7 @@ inline Ref<CSSValue> ExtractorConverter::convertDPath(ExtractorState& state, con
     return CSSPathValue::create(overrideToCSS(Ref { *path }->path(), state.style, PathConversion::ForceAbsolute));
 }
 
-inline Ref<CSSValue> ExtractorConverter::convertStrokeDashArray(ExtractorState& state, const Vector<WebCore::Length>& dashes)
+inline Ref<CSSValue> ExtractorConverter::convertStrokeDashArray(ExtractorState& state, const FixedVector<WebCore::Length>& dashes)
 {
     if (dashes.isEmpty())
         return CSSPrimitiveValue::create(CSSValueNone);
@@ -1013,7 +1013,7 @@ inline Ref<CSSValue> ExtractorConverter::convertBorderRadiusCorner(ExtractorStat
     return CSSValuePair::create(WTFMove(x), WTFMove(y));
 }
 
-inline Ref<CSSValue> ExtractorConverter::convertContainerNames(ExtractorState& state, const Vector<ScopedName>& containerNames)
+inline Ref<CSSValue> ExtractorConverter::convertContainerNames(ExtractorState& state, const FixedVector<ScopedName>& containerNames)
 {
     if (containerNames.isEmpty())
         return CSSPrimitiveValue::create(CSSValueNone);
@@ -1024,7 +1024,7 @@ inline Ref<CSSValue> ExtractorConverter::convertContainerNames(ExtractorState& s
     return CSSValueList::createSpaceSeparated(WTFMove(list));
 }
 
-inline Ref<CSSValue> ExtractorConverter::convertViewTransitionClasses(ExtractorState& state, const Vector<ScopedName>& classList)
+inline Ref<CSSValue> ExtractorConverter::convertViewTransitionClasses(ExtractorState& state, const FixedVector<ScopedName>& classList)
 {
     if (classList.isEmpty())
         return CSSPrimitiveValue::create(CSSValueNone);
@@ -1072,7 +1072,7 @@ inline Ref<CSSValue> ExtractorConverter::convertTextShadow(ExtractorState& state
     return CSSTextShadowPropertyValue::create(CSS::TextShadowProperty { WTFMove(list) });
 }
 
-inline Ref<CSSValue> ExtractorConverter::convertPositionTryFallbacks(ExtractorState& state, const Vector<PositionTryFallback>& fallbacks)
+inline Ref<CSSValue> ExtractorConverter::convertPositionTryFallbacks(ExtractorState& state, const FixedVector<PositionTryFallback>& fallbacks)
 {
     if (fallbacks.isEmpty())
         return CSSPrimitiveValue::create(CSSValueNone);
@@ -1552,7 +1552,7 @@ inline Ref<CSSValue> ExtractorConverter::convertPaintOrder(ExtractorState&, Pain
     return CSSValueList::createSpaceSeparated(WTFMove(paintOrderList));
 }
 
-inline Ref<CSSValue> ExtractorConverter::convertScrollTimelineAxes(ExtractorState& state, const Vector<ScrollAxis>& axes)
+inline Ref<CSSValue> ExtractorConverter::convertScrollTimelineAxes(ExtractorState& state, const FixedVector<ScrollAxis>& axes)
 {
     if (axes.isEmpty())
         return CSSPrimitiveValue::create(CSSValueBlock);
@@ -1563,7 +1563,7 @@ inline Ref<CSSValue> ExtractorConverter::convertScrollTimelineAxes(ExtractorStat
     return CSSValueList::createCommaSeparated(WTFMove(list));
 }
 
-inline Ref<CSSValue> ExtractorConverter::convertScrollTimelineNames(ExtractorState&, const Vector<AtomString>& names)
+inline Ref<CSSValue> ExtractorConverter::convertScrollTimelineNames(ExtractorState&, const FixedVector<AtomString>& names)
 {
     if (names.isEmpty())
         return CSSPrimitiveValue::create(CSSValueNone);
@@ -1578,7 +1578,7 @@ inline Ref<CSSValue> ExtractorConverter::convertScrollTimelineNames(ExtractorSta
     return CSSValueList::createCommaSeparated(WTFMove(list));
 }
 
-inline Ref<CSSValue> ExtractorConverter::convertAnchorNames(ExtractorState& state, const Vector<ScopedName>& anchorNames)
+inline Ref<CSSValue> ExtractorConverter::convertAnchorNames(ExtractorState& state, const FixedVector<ScopedName>& anchorNames)
 {
     if (anchorNames.isEmpty())
         return CSSPrimitiveValue::create(CSSValueNone);
@@ -1772,7 +1772,7 @@ inline Ref<CSSValue> ExtractorConverter::convertSingleViewTimelineInsets(Extract
     return CSSPrimitiveValue::create(*insets.start, state.style);
 }
 
-inline Ref<CSSValue> ExtractorConverter::convertViewTimelineInsets(ExtractorState& state, const Vector<ViewTimelineInsets>& insets)
+inline Ref<CSSValue> ExtractorConverter::convertViewTimelineInsets(ExtractorState& state, const FixedVector<ViewTimelineInsets>& insets)
 {
     if (insets.isEmpty())
         return CSSPrimitiveValue::create(CSSValueAuto);

--- a/Source/WebCore/style/StyleExtractorSerializer.h
+++ b/Source/WebCore/style/StyleExtractorSerializer.h
@@ -93,7 +93,7 @@ public:
     static void serializePathOperation(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const PathOperation*, PathConversion = PathConversion::None);
     static void serializePathOperationForceAbsolute(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const PathOperation*);
     static void serializeDPath(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const StylePathData*);
-    static void serializeStrokeDashArray(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const Vector<WebCore::Length>&);
+    static void serializeStrokeDashArray(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const FixedVector<WebCore::Length>&);
     static void serializeTextStrokeWidth(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, float);
     static void serializeFilterOperations(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const FilterOperations&);
     static void serializeAppleColorFilterOperations(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const FilterOperations&);
@@ -115,12 +115,12 @@ public:
     static void serializeTextBoxEdge(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const TextEdge&);
     static void serializeQuotes(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const QuotesData*);
     static void serializeBorderRadiusCorner(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const LengthSize&);
-    static void serializeContainerNames(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const Vector<ScopedName>&);
-    static void serializeViewTransitionClasses(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const Vector<ScopedName>&);
+    static void serializeContainerNames(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const FixedVector<ScopedName>&);
+    static void serializeViewTransitionClasses(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const FixedVector<ScopedName>&);
     static void serializeViewTransitionName(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const ViewTransitionName&);
     static void serializeBoxShadow(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const FixedVector<BoxShadow>&);
     static void serializeTextShadow(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const FixedVector<TextShadow>&);
-    static void serializePositionTryFallbacks(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const Vector<PositionTryFallback>&);
+    static void serializePositionTryFallbacks(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const FixedVector<PositionTryFallback>&);
     static void serializeWillChange(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const WillChangeData*);
     static void serializeBlockEllipsis(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const BlockEllipsis&);
     static void serializeBlockStepSize(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, std::optional<WebCore::Length>);
@@ -153,14 +153,14 @@ public:
     static void serializeContentAlignmentData(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const StyleContentAlignmentData&);
     static void serializeOffsetRotate(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const OffsetRotation&);
     static void serializePaintOrder(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, PaintOrder);
-    static void serializeScrollTimelineAxes(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const Vector<ScrollAxis>&);
-    static void serializeScrollTimelineNames(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const Vector<AtomString>&);
-    static void serializeAnchorNames(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const Vector<ScopedName>&);
+    static void serializeScrollTimelineAxes(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const FixedVector<ScrollAxis>&);
+    static void serializeScrollTimelineNames(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const FixedVector<AtomString>&);
+    static void serializeAnchorNames(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const FixedVector<ScopedName>&);
     static void serializePositionAnchor(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const std::optional<ScopedName>&);
     static void serializePositionArea(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const std::optional<PositionArea>&);
     static void serializeNameScope(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const NameScope&);
     static void serializeSingleViewTimelineInsets(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const ViewTimelineInsets&);
-    static void serializeViewTimelineInsets(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const Vector<ViewTimelineInsets>&);
+    static void serializeViewTimelineInsets(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const FixedVector<ViewTimelineInsets>&);
     static void serializePositionVisibility(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, OptionSet<PositionVisibility>);
 #if ENABLE(DARK_MODE_CSS)
     static void serializeColorScheme(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const ColorScheme&);
@@ -952,7 +952,7 @@ inline void ExtractorSerializer::serializeDPath(ExtractorState& state, StringBui
     CSS::serializationForCSS(builder, context, overrideToCSS(Ref { *path }->path(), state.style, PathConversion::ForceAbsolute));
 }
 
-inline void ExtractorSerializer::serializeStrokeDashArray(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context, const Vector<WebCore::Length>& dashes)
+inline void ExtractorSerializer::serializeStrokeDashArray(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context, const FixedVector<WebCore::Length>& dashes)
 {
     if (dashes.isEmpty()) {
         CSS::serializationForCSS(builder, context, CSS::Keyword::None { });
@@ -1259,7 +1259,7 @@ inline void ExtractorSerializer::serializeBorderRadiusCorner(ExtractorState& sta
     serializeLength(state, builder, context, radius.height);
 }
 
-inline void ExtractorSerializer::serializeContainerNames(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context, const Vector<ScopedName>& containerNames)
+inline void ExtractorSerializer::serializeContainerNames(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context, const FixedVector<ScopedName>& containerNames)
 {
     if (containerNames.isEmpty()) {
         CSS::serializationForCSS(builder, context, CSS::Keyword::None { });
@@ -1271,7 +1271,7 @@ inline void ExtractorSerializer::serializeContainerNames(ExtractorState& state, 
     }, ' '));
 }
 
-inline void ExtractorSerializer::serializeViewTransitionClasses(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context, const Vector<ScopedName>& classList)
+inline void ExtractorSerializer::serializeViewTransitionClasses(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context, const FixedVector<ScopedName>& classList)
 {
     if (classList.isEmpty()) {
         CSS::serializationForCSS(builder, context, CSS::Keyword::None { });
@@ -1328,7 +1328,7 @@ inline void ExtractorSerializer::serializeTextShadow(ExtractorState& state, Stri
     CSS::serializationForCSS(builder, context, CSS::TextShadowProperty { WTFMove(list) });
 }
 
-inline void ExtractorSerializer::serializePositionTryFallbacks(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context, const Vector<PositionTryFallback>& fallbacks)
+inline void ExtractorSerializer::serializePositionTryFallbacks(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context, const FixedVector<PositionTryFallback>& fallbacks)
 {
     if (fallbacks.isEmpty()) {
         CSS::serializationForCSS(builder, context, CSS::Keyword::None { });
@@ -1941,7 +1941,7 @@ inline void ExtractorSerializer::serializePaintOrder(ExtractorState&, StringBuil
     RELEASE_ASSERT_NOT_REACHED();
 }
 
-inline void ExtractorSerializer::serializeScrollTimelineAxes(ExtractorState&, StringBuilder& builder, const CSS::SerializationContext& context, const Vector<ScrollAxis>& axes)
+inline void ExtractorSerializer::serializeScrollTimelineAxes(ExtractorState&, StringBuilder& builder, const CSS::SerializationContext& context, const FixedVector<ScrollAxis>& axes)
 {
     if (axes.isEmpty()) {
         CSS::serializationForCSS(builder, context, CSS::Keyword::Block { });
@@ -1953,7 +1953,7 @@ inline void ExtractorSerializer::serializeScrollTimelineAxes(ExtractorState&, St
     }, ", "_s));
 }
 
-inline void ExtractorSerializer::serializeScrollTimelineNames(ExtractorState&, StringBuilder& builder, const CSS::SerializationContext& context, const Vector<AtomString>& names)
+inline void ExtractorSerializer::serializeScrollTimelineNames(ExtractorState&, StringBuilder& builder, const CSS::SerializationContext& context, const FixedVector<AtomString>& names)
 {
     if (names.isEmpty()) {
         CSS::serializationForCSS(builder, context, CSS::Keyword::None { });
@@ -1968,7 +1968,7 @@ inline void ExtractorSerializer::serializeScrollTimelineNames(ExtractorState&, S
     }, ", "_s));
 }
 
-inline void ExtractorSerializer::serializeAnchorNames(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context, const Vector<ScopedName>& anchorNames)
+inline void ExtractorSerializer::serializeAnchorNames(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context, const FixedVector<ScopedName>& anchorNames)
 {
     if (anchorNames.isEmpty()) {
         CSS::serializationForCSS(builder, context, CSS::Keyword::None { });
@@ -2039,7 +2039,7 @@ inline void ExtractorSerializer::serializeSingleViewTimelineInsets(ExtractorStat
     serializeLength(state, builder, context, *insets.end);
 }
 
-inline void ExtractorSerializer::serializeViewTimelineInsets(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context, const Vector<ViewTimelineInsets>& insets)
+inline void ExtractorSerializer::serializeViewTimelineInsets(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context, const FixedVector<ViewTimelineInsets>& insets)
 {
     if (insets.isEmpty()) {
         CSS::serializationForCSS(builder, context, CSS::Keyword::Auto { });

--- a/Source/WebCore/style/StyleInterpolationFunctions.h
+++ b/Source/WebCore/style/StyleInterpolationFunctions.h
@@ -409,17 +409,13 @@ inline LengthBox blendFunc(const LengthBox& from, const LengthBox& to, const Con
     };
 }
 
-inline SVGLengthValue blendFunc(const SVGLengthValue& from, const SVGLengthValue& to, const Context& context)
-{
-    return SVGLengthValue::blend(from, to, narrowPrecisionToFloat(context.progress));
-}
-
-inline Vector<WebCore::Length> blendFunc(const Vector<WebCore::Length>& from, const Vector<WebCore::Length>& to, const Context& context)
+inline FixedVector<WebCore::Length> blendFunc(const FixedVector<WebCore::Length>& from, const FixedVector<WebCore::Length>& to, const Context& context)
 {
     size_t fromLength = from.size();
     size_t toLength = to.size();
     if (!fromLength || !toLength)
         return context.progress < 0.5 ? from : to;
+
     size_t resultLength = fromLength;
     if (fromLength != toLength) {
         if (!remainder(std::max(fromLength, toLength), std::min(fromLength, toLength)))
@@ -427,10 +423,9 @@ inline Vector<WebCore::Length> blendFunc(const Vector<WebCore::Length>& from, co
         else
             resultLength = fromLength * toLength;
     }
-    Vector<WebCore::Length> result(resultLength);
-    for (size_t i = 0; i < resultLength; ++i)
-        result[i] = blendFunc(from[i % fromLength], to[i % toLength], context);
-    return result;
+    return FixedVector<WebCore::Length>::createWithSizeFromGenerator(resultLength, [&](auto i) {
+        return blendFunc(from[i % fromLength], to[i % toLength], context);
+    });
 }
 
 inline RefPtr<StyleImage> crossfadeBlend(StyleCachedImage& fromStyleImage, StyleCachedImage& toStyleImage, const Context& context)

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -8811,13 +8811,13 @@ enum class WebCore::PlatformMediaError : uint8_t {
 #endif
 
 #if USE(CG)
-using WebCore::DashArray = Vector<CGFloat>;
+using WebCore::DashArray = FixedVector<CGFloat>;
 #endif
 #if USE(CAIRO)
-using WebCore::DashArray = Vector<double>;
+using WebCore::DashArray = FixedVector<double>;
 #endif
 #if !USE(CG) && !USE(CAIRO)
-using WebCore::DashArray = Vector<float>;
+using WebCore::DashArray = FixedVector<float>;
 #endif
 
 [WebKitPlatform] enum class WebCore::NotificationDirection : uint8_t {


### PR DESCRIPTION
#### 7a8e21f8b0bd5d0377eb851f7f090086c34ad473
<pre>
Save memory by moving more RenderStyle Vectors to FixedVector
<a href="https://bugs.webkit.org/show_bug.cgi?id=293855">https://bugs.webkit.org/show_bug.cgi?id=293855</a>

Reviewed by Darin Adler.

Moves an initial set of RenderStyle Vectors to FixedVector.

* Source/WTF/wtf/EmbeddedFixedVector.h:
* Source/WTF/wtf/FixedVector.h:
* Source/WTF/wtf/TrailingArray.h:
    - Add support for construction via std::initializer_list, std::span and
      mapped sized range.
    - Add search functions matching those in Vector.

* Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp:
    - Replace use of createWithSizeFromGenerator with direct std::initializer_list use.

* Source/WTF/wtf/text/TextStream.h:
    - Match Vector, defining supports_text_stream_insertion for FixedVector.

* Source/WebCore/css/CSSProperties.json:
    - Remove a bunch of now unnecessary explicit template parameters to interpolation wrapper types.

* Source/WebCore/css/scripts/process-css-properties.py:
    - Add missing to forwardInheritedValue for color properties (needed now due to setters taking
      r-values instead of const references).

* Source/WebCore/dom/ViewTransition.cpp:
    - Update to avoid copy now that viewTransitionName() returns a const reference.

* Source/WebCore/rendering/style/RenderStyle.cpp:
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/style/RenderStyleInlines.h:
* Source/WebCore/rendering/style/RenderStyleSetters.h:
* Source/WebCore/rendering/style/SVGRenderStyle.h:
* Source/WebCore/rendering/style/SVGRenderStyleDefs.h:
* Source/WebCore/rendering/style/StyleGridData.h:
* Source/WebCore/rendering/style/StyleRareNonInheritedData.h:
* Source/WebCore/rendering/svg/SVGRenderSupport.cpp:
* Source/WebCore/rendering/svg/SVGRenderTreeAsText.cpp:
* Source/WebCore/style/StyleBuilderConverter.h:
* Source/WebCore/style/StyleBuilderCustom.h:
* Source/WebCore/style/StyleExtractorConverter.h:
* Source/WebCore/style/StyleExtractorSerializer.h:
* Source/WebCore/style/StyleInterpolationFunctions.h:
* Source/WebCore/style/StyleInterpolationWrappers.h:
    - Update setters/getters to use FixedVector instead of Vector.
    - Update setters/getters to return const reference and take r-value reference
      for non-trivial types.

* Source/WebCore/platform/graphics/DashArray.h:
* Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp:
* Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp:
* Source/WebCore/rendering/BorderPainter.cpp:
    - Switch DashArray to use a FixedVector.

* Source/WebKit/Platform/IPC/ArgumentCoders.h:
    - Add coder for FixedVector.

* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
    - Switch DashArray to FixedVector definition.

Canonical link: <a href="https://commits.webkit.org/295663@main">https://commits.webkit.org/295663@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5f4e962af9d401b5187fecea35feecc91530d6dd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105842 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25593 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15986 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/111039 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/56439 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/107883 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/26175 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34096 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80391 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108848 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/20570 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95511 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60706 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/20233 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13608 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55877 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/98483 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/89974 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13646 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/113889 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/104461 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32982 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24313 "Found 3 new test failures: imported/w3c/web-platform-tests/mimesniff/media/media-sniff.window.html platform/mac/fast/text/line-break-locale.html svg/zoom/page/text-with-non-scaling-stroke.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89469 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33346 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91741 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89140 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22714 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34008 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11815 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/28499 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32907 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/38318 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/128773 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32653 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/35148 "Found 1 new JSC stress test failure: wasm.yaml/wasm/gc/ref-i31-eq.js.wasm-eager-jettison (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/36002 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34251 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->