### PR TITLE
[Swift in WebKit] The Swift implementation of intelligence text effects code is slightly incorrect

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -2540,7 +2540,7 @@ static _WKSelectionAttributes selectionAttributes(const WebKit::EditorState& edi
     // It's possible that the selection has already been restored by this point if the entire animation has already
     // finished, but this is not guaranteed.
 
-    [_intelligenceTextEffectCoordinator flushReplacementsWithCompletion:makeBlockPtr([webSession, accepted, weakSelf = WeakObjCPtr<WKWebView>(self)] {
+    [_intelligenceTextEffectCoordinator flushReplacementsWithCompletionHandler:makeBlockPtr([webSession, accepted, weakSelf = WeakObjCPtr<WKWebView>(self)] {
         auto strongSelf = weakSelf.get();
         if (!strongSelf)
             return;
@@ -2558,7 +2558,7 @@ static _WKSelectionAttributes selectionAttributes(const WebKit::EditorState& edi
             if (accepted)
                 weakSelf.get()->_page->didEndWritingToolsSession(*webSession, accepted);
             else {
-                [weakSelf.get()->_intelligenceTextEffectCoordinator restoreSelectionAcceptedReplacements:accepted completion:makeBlockPtr([webSession, accepted, weakSelf] {
+                [weakSelf.get()->_intelligenceTextEffectCoordinator restoreSelectionAcceptedReplacements:accepted completionHandler:makeBlockPtr([webSession, accepted, weakSelf] {
                     weakSelf.get()->_page->didEndWritingToolsSession(*webSession, accepted);
                 }).get()];
             }

--- a/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
+++ b/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
@@ -1292,14 +1292,14 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 - (void)_web_suppressContentRelativeChildViews
 {
 #if ENABLE(WRITING_TOOLS)
-    [_intelligenceTextEffectCoordinator hideEffectsWithCompletion:^{ }];
+    [_intelligenceTextEffectCoordinator hideEffectsWithCompletionHandler:^{ }];
 #endif
 }
 
 - (void)_web_restoreContentRelativeChildViews
 {
 #if ENABLE(WRITING_TOOLS)
-    [_intelligenceTextEffectCoordinator showEffectsWithCompletion:^{ }];
+    [_intelligenceTextEffectCoordinator showEffectsWithCompletionHandler:^{ }];
 #endif
 }
 

--- a/Source/WebKit/WebKitSwift/WritingTools/PlatformIntelligenceTextEffectView.swift
+++ b/Source/WebKit/WebKitSwift/WritingTools/PlatformIntelligenceTextEffectView.swift
@@ -80,23 +80,26 @@ protocol PlatformIntelligenceTextEffectChunk: Identifiable {
 }
 
 /// Either a pondering or replacement effect.
-@MainActor protocol PlatformIntelligenceTextEffect<Chunk>: Equatable, Identifiable where ID == PlatformIntelligenceTextEffectID {
+@MainActor
+protocol PlatformIntelligenceTextEffect<Chunk>: Equatable, Identifiable where ID == PlatformIntelligenceTextEffectID {
     associatedtype Chunk: PlatformIntelligenceTextEffectChunk
 
     var chunk: Chunk { get }
 
     // Clients should not invoke this function directly.
-    func _add<Source>(to view: PlatformIntelligenceTextEffectView<Source>) async where Source: PlatformIntelligenceTextEffectViewSource, Source.Chunk == Chunk
+    func internalAdd<Source>(to view: PlatformIntelligenceTextEffectView<Source>) async
+    where Source: PlatformIntelligenceTextEffectViewSource, Source.Chunk == Chunk
 }
 
 extension PlatformIntelligenceTextEffect {
-    nonisolated static func ==(lhs: Self, rhs: Self) -> Bool {
+    nonisolated static func == (lhs: Self, rhs: Self) -> Bool {
         lhs.id == rhs.id
     }
 }
 
 /// A combination source+delegate protocol that clients conform to to control behavior and yield information to the effect view.
-@MainActor protocol PlatformIntelligenceTextEffectViewSource: AnyObject {
+@MainActor
+protocol PlatformIntelligenceTextEffectViewSource: AnyObject {
     associatedtype Chunk: PlatformIntelligenceTextEffectChunk
 
     /// Transforms an arbitrary chunk into a text preview.
@@ -110,7 +113,10 @@ extension PlatformIntelligenceTextEffect {
     ///
     /// Clients must also take the responsibility of animating the remaining text away from the replaced text if needed, using
     /// the provided animation parameters.
-    func performReplacementAndGeneratePreview(for chunk: Chunk, effect: PlatformIntelligenceReplacementTextEffect<Chunk>) async -> (PlatformTextPreview?, remainder: PlatformContentPreview?)
+    func performReplacementAndGeneratePreview(
+        for chunk: Chunk,
+        effect: PlatformIntelligenceReplacementTextEffect<Chunk>
+    ) async -> (PlatformTextPreview?, remainder: PlatformContentPreview?)
 
     /// This function is invoked after preparing the replacement effect, but before the effect is added.
     func replacementEffectWillBegin(_ effect: PlatformIntelligenceReplacementTextEffect<Chunk>) async
@@ -123,7 +129,9 @@ extension PlatformIntelligenceTextEffect {
 
 #if canImport(UIKit)
 
-@MainActor private final class UITextEffectViewSourceAdapter<Wrapped>: NSObject, UITextEffectViewSource where Wrapped: PlatformIntelligenceTextEffectViewSource {
+@MainActor
+private final class UITextEffectViewSourceAdapter<Wrapped>: NSObject, UITextEffectViewSource
+where Wrapped: PlatformIntelligenceTextEffectViewSource {
     private var wrapped: Wrapped
 
     init(wrapping wrapped: Wrapped) {
@@ -135,7 +143,8 @@ extension PlatformIntelligenceTextEffect {
     // This is because internally, UIKit creates a type with a default conformance to this protocol, and a default implementation of this method.
     // The default implementation ostensibly requires the real conforming type to be an `NSObject`, and if not will return `true`. And then, if
     // it is an `NSObject`, it performs a selector check, which requires an `@objc` implementation, else it will fail and once again return `true`.
-    @objc func canGenerateTargetedPreviewForChunk(_ chunk: UITextEffectTextChunk) async -> Bool {
+    @objc
+    func canGenerateTargetedPreviewForChunk(_ chunk: UITextEffectTextChunk) async -> Bool {
         if let chunk = chunk as? UIPonderingTextEffectTextChunkAdapter<Wrapped.Chunk> {
             return true
         }
@@ -155,6 +164,7 @@ extension PlatformIntelligenceTextEffect {
         if let chunk = chunk as? UIReplacementTextEffectTextChunkAdapter<Wrapped.Chunk> {
             // The chunk source may be `nil` in the case of a replacement whose source range is an empty range.
             // This force unwrap is safe because UIKit invokes `canGenerateTargetedPreviewForChunk` prior to this call.
+            // swift-format-ignore: NeverForceUnwrap
             return chunk.source!
         }
 
@@ -172,7 +182,9 @@ extension PlatformIntelligenceTextEffect {
     }
 }
 
-@MainActor private final class UIReplacementTextEffectDelegateAdapter<Wrapped>: UITextEffectView.ReplacementTextEffect.Delegate where Wrapped: PlatformIntelligenceTextEffectViewSource {
+@MainActor
+private final class UIReplacementTextEffectDelegateAdapter<Wrapped>: UITextEffectView.ReplacementTextEffect.Delegate
+where Wrapped: PlatformIntelligenceTextEffectViewSource {
     private let wrapped: Wrapped
     private weak var view: PlatformIntelligenceTextEffectView<Wrapped>?
 
@@ -187,7 +199,8 @@ extension PlatformIntelligenceTextEffect {
             return
         }
 
-        guard let effect = view.wrappedEffectIDToPlatformEffects[effect.id] as? PlatformIntelligenceReplacementTextEffect<Wrapped.Chunk> else {
+        guard let effect = view.wrappedEffectIDToPlatformEffects[effect.id] as? PlatformIntelligenceReplacementTextEffect<Wrapped.Chunk>
+        else {
             assertionFailure("Failed to handle completion of replacement effect: effect was unexpectedly nil.")
             return
         }
@@ -197,7 +210,11 @@ extension PlatformIntelligenceTextEffect {
         }
     }
 
-    func performReplacementAndGeneratePreview(for chunk: UITextEffectTextChunk, effect: UITextEffectView.ReplacementTextEffect, animation: UITextEffectView.ReplacementTextEffect.AnimationParameters) async -> UITargetedPreview? {
+    func performReplacementAndGeneratePreview(
+        for chunk: UITextEffectTextChunk,
+        effect: UITextEffectView.ReplacementTextEffect,
+        animation: UITextEffectView.ReplacementTextEffect.AnimationParameters
+    ) async -> UITargetedPreview? {
         guard let chunk = chunk as? UIReplacementTextEffectTextChunkAdapter<Wrapped.Chunk> else {
             fatalError("Failed to perform replacement and generate preview: parameter was of unexpected type \(type(of: chunk)).")
         }
@@ -206,7 +223,8 @@ extension PlatformIntelligenceTextEffect {
     }
 }
 
-private final class UIPonderingTextEffectTextChunkAdapter<Wrapped>: UITextEffectTextChunk where Wrapped: PlatformIntelligenceTextEffectChunk {
+private final class UIPonderingTextEffectTextChunkAdapter<Wrapped>: UITextEffectTextChunk
+where Wrapped: PlatformIntelligenceTextEffectChunk {
     let wrapped: Wrapped
     let preview: UITargetedPreview
 
@@ -216,7 +234,8 @@ private final class UIPonderingTextEffectTextChunkAdapter<Wrapped>: UITextEffect
     }
 }
 
-private final class UIReplacementTextEffectTextChunkAdapter<Wrapped>: UITextEffectTextChunk where Wrapped: PlatformIntelligenceTextEffectChunk {
+private final class UIReplacementTextEffectTextChunkAdapter<Wrapped>: UITextEffectTextChunk
+where Wrapped: PlatformIntelligenceTextEffectChunk {
     let wrapped: Wrapped
     let source: UITargetedPreview?
     let destination: UITargetedPreview
@@ -230,7 +249,9 @@ private final class UIReplacementTextEffectTextChunkAdapter<Wrapped>: UITextEffe
 
 #else
 
-@MainActor private final class WTTextPreviewAsyncSourceAdapter<Wrapped>: NSObject, _WTTextPreviewAsyncSource where Wrapped: PlatformIntelligenceTextEffectViewSource {
+@MainActor
+private final class WTTextPreviewAsyncSourceAdapter<Wrapped>: NSObject, _WTTextPreviewAsyncSource
+where Wrapped: PlatformIntelligenceTextEffectViewSource {
     private let wrapped: Wrapped
 
     init(wrapping wrapped: Wrapped) {
@@ -244,7 +265,7 @@ private final class UIReplacementTextEffectTextChunkAdapter<Wrapped>: UITextEffe
 
         return chunk.preview
     }
-    
+
     func textPreview(for rect: CGRect) async -> _WTTextPreview? {
         // This is implemented manually by the system instead of relying on the WTUI interface.
         nil
@@ -284,27 +305,28 @@ struct PlatformIntelligenceTextEffectID: Hashable {
 }
 
 /// A platform-agnostic view to control intelligence text effects given a particular source.
-@MainActor final class PlatformIntelligenceTextEffectView<Source>: CocoaView where Source: PlatformIntelligenceTextEffectViewSource {
-#if canImport(UIKit)
+@MainActor
+final class PlatformIntelligenceTextEffectView<Source>: CocoaView where Source: PlatformIntelligenceTextEffectViewSource {
+    #if canImport(UIKit)
     fileprivate typealias SourceAdapter = UITextEffectViewSourceAdapter<Source>
     fileprivate typealias Wrapped = UITextEffectView
-#else
+    #else
     fileprivate typealias SourceAdapter = WTTextPreviewAsyncSourceAdapter<Source>
     fileprivate typealias Wrapped = _WTTextEffectView
-#endif
+    #endif
 
     fileprivate let source: Source
     fileprivate let wrapped: Wrapped
 
     private let viewSource: SourceAdapter
 
-#if canImport(UIKit)
-    fileprivate var wrappedEffectIDToPlatformEffects: [UITextEffectView.EffectID : any PlatformIntelligenceTextEffect] = [:]
-    fileprivate var platformEffectIDToWrappedEffectIDs: [PlatformIntelligenceTextEffectID : UITextEffectView.EffectID] = [:]
-#else
-    fileprivate var wrappedEffectIDToPlatformEffects: [UUID : any PlatformIntelligenceTextEffect<Source.Chunk>] = [:]
-    fileprivate var platformEffectIDToWrappedEffectIDs: [PlatformIntelligenceTextEffectID : Set<UUID>] = [:]
-#endif
+    #if canImport(UIKit)
+    fileprivate var wrappedEffectIDToPlatformEffects: [UITextEffectView.EffectID: any PlatformIntelligenceTextEffect] = [:]
+    fileprivate var platformEffectIDToWrappedEffectIDs: [PlatformIntelligenceTextEffectID: UITextEffectView.EffectID] = [:]
+    #else
+    fileprivate var wrappedEffectIDToPlatformEffects: [UUID: any PlatformIntelligenceTextEffect<Source.Chunk>] = [:]
+    fileprivate var platformEffectIDToWrappedEffectIDs: [PlatformIntelligenceTextEffectID: Set<UUID>] = [:]
+    #endif
 
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
@@ -315,11 +337,11 @@ struct PlatformIntelligenceTextEffectID: Hashable {
         self.source = source
         self.viewSource = SourceAdapter(wrapping: self.source)
 
-#if canImport(UIKit)
+        #if canImport(UIKit)
         self.wrapped = Wrapped(source: self.viewSource)
-#else
+        #else
         self.wrapped = Wrapped(asyncSource: self.viewSource)
-#endif
+        #endif
 
         self.wrapped.clipsToBounds = true
 
@@ -332,8 +354,9 @@ struct PlatformIntelligenceTextEffectID: Hashable {
     }
 
     /// Prepares and adds an effect to be presented within the view.
-    @discardableResult func addEffect<Effect>(_ effect: Effect) async -> Effect.ID where Effect: PlatformIntelligenceTextEffect, Effect.Chunk == Source.Chunk {
-        await effect._add(to: self)
+    @discardableResult
+    func addEffect<Effect>(_ effect: Effect) async -> Effect.ID where Effect: PlatformIntelligenceTextEffect, Effect.Chunk == Source.Chunk {
+        await effect.internalAdd(to: self)
         return effect.id
     }
 
@@ -343,12 +366,14 @@ struct PlatformIntelligenceTextEffectID: Hashable {
             return
         }
 
-#if canImport(UIKit)
+        #if canImport(UIKit)
         self.wrappedEffectIDToPlatformEffects[wrappedEffectIDs] = nil
         self.wrapped.removeEffect(wrappedEffectIDs)
-#else
+        #else
         for wrappedEffectID in wrappedEffectIDs {
-            if let platformEffect = self.wrappedEffectIDToPlatformEffects.removeValue(forKey: wrappedEffectID), platformEffect is PlatformIntelligencePonderingTextEffect<Source.Chunk> {
+            if let platformEffect = self.wrappedEffectIDToPlatformEffects.removeValue(forKey: wrappedEffectID),
+                platformEffect is PlatformIntelligencePonderingTextEffect<Source.Chunk>
+            {
                 // When WTUI starts a pondering effect, it creates a 0.75s opacity CA animation to fade out the text, so it is possible
                 // that this is still ongoing by the time `removeEffect` is called. This may lead to issues if subsequent effects start
                 // immediately after the effect is removed and the animation has yet to stop.
@@ -363,7 +388,7 @@ struct PlatformIntelligenceTextEffectID: Hashable {
             self.wrappedEffectIDToPlatformEffects[wrappedEffectID] = nil
             self.wrapped.removeEffect(wrappedEffectID)
         }
-#endif
+        #endif
     }
 
     /// Removes all currently active effects.
@@ -376,7 +401,9 @@ struct PlatformIntelligenceTextEffectID: Hashable {
 
 /// An effect which shifts the remaining text (the text after the currently replaced text) either up or down,
 /// depending on if the newly replaced text is taller than the source text.
-@MainActor class PlatformIntelligenceRemainderAffordanceTextEffect<Chunk>: PlatformIntelligenceTextEffect where Chunk: PlatformIntelligenceTextEffectChunk {
+@MainActor
+class PlatformIntelligenceRemainderAffordanceTextEffect<Chunk>: PlatformIntelligenceTextEffect
+where Chunk: PlatformIntelligenceTextEffectChunk {
     private enum AnimationKind {
         case contract
         case expand
@@ -407,12 +434,12 @@ struct PlatformIntelligenceTextEffectID: Hashable {
     }
 
     private func heightDelta() -> Double {
-#if canImport(UIKit)
+        #if canImport(UIKit)
         let sourceRect = previews.source?.size ?? .zero
         let destRect = previews.destination.size
 
         let delta = destRect.height - sourceRect.height
-#else
+        #else
         let sourceRect = (previews.source ?? [])
             .map(\.presentationFrame)
             .reduce(CGRect.zero) { $0.union($1) }
@@ -422,12 +449,13 @@ struct PlatformIntelligenceTextEffectID: Hashable {
             .reduce(CGRect.zero) { $0.union($1) }
 
         let delta = destRect.size.height - sourceRect.size.height
-#endif
+        #endif
 
         return delta
     }
 
-    func _add<Source>(to view: PlatformIntelligenceTextEffectView<Source>) async where Source : PlatformIntelligenceTextEffectViewSource, Source.Chunk == Chunk {
+    func internalAdd<Source>(to view: PlatformIntelligenceTextEffectView<Source>) async
+    where Source: PlatformIntelligenceTextEffectViewSource, Source.Chunk == Chunk {
         guard let remainderPreviewImage = previews.remainder.previewImage else {
             return
         }
@@ -443,12 +471,12 @@ struct PlatformIntelligenceTextEffectID: Hashable {
 
         let remainderRect = previews.remainder.presentationFrame
 
-#if canImport(UIKit)
+        #if canImport(UIKit)
         let remainderViewSourceFrameY = remainderRect.origin.y
-#else
+        #else
         // origin-y-coordinate is flipped in AppKit
         let remainderViewSourceFrameY = view.frame.size.height - remainderRect.size.height - remainderRect.origin.y
-#endif
+        #endif
 
         let remainderViewSourceFrame = CGRect(
             x: remainderRect.origin.x,
@@ -457,13 +485,13 @@ struct PlatformIntelligenceTextEffectID: Hashable {
             height: remainderRect.size.height
         )
 
-#if canImport(UIKit)
+        #if canImport(UIKit)
         // shift down if the replaced text is taller than the source text
         let remainderViewDestFrameY = remainderViewSourceFrame.origin.y + delta
-#else
+        #else
         // shift down if the replaced text is taller than the source text
         let remainderViewDestFrameY = remainderViewSourceFrame.origin.y - delta
-#endif
+        #endif
 
         let remainderViewDestinationFrame = CGRect(
             x: remainderViewSourceFrame.origin.x,
@@ -477,12 +505,14 @@ struct PlatformIntelligenceTextEffectID: Hashable {
 
         let remainderView = CocoaView(frame: remainderViewSourceFrame)
 
-#if canImport(UIKit)
+        #if canImport(UIKit)
         remainderView.layer.contents = remainderPreviewImage
-#else
+        #else
         remainderView.wantsLayer = true
+        // Safe force unwrap because AppKit creates a layer when `wantsLayer` is `true`.
+        // swift-format-ignore: NeverForceUnwrap
         remainderView.layer!.contents = remainderPreviewImage
-#endif
+        #endif
 
         // Add the newly created view as a subview to the effect view.
 
@@ -496,16 +526,17 @@ struct PlatformIntelligenceTextEffectID: Hashable {
             remainderView.frame = remainderViewDestinationFrame
         }
 
-#if canImport(UIKit)
+        #if canImport(UIKit)
         UIView.animate(animation, changes: changes)
-#else
+        #else
         NSAnimationContext.animate(animation, changes: changes)
-#endif
+        #endif
     }
 }
 
 /// A replacement effect, which essentially involves the original text fading away while at the same time the new text fades in right above it.
-@MainActor class PlatformIntelligenceReplacementTextEffect<Chunk>: PlatformIntelligenceTextEffect where Chunk: PlatformIntelligenceTextEffectChunk {
+@MainActor
+class PlatformIntelligenceReplacementTextEffect<Chunk>: PlatformIntelligenceTextEffect where Chunk: PlatformIntelligenceTextEffectChunk {
     let id = PlatformIntelligenceTextEffectID()
     let chunk: Chunk
 
@@ -518,8 +549,9 @@ struct PlatformIntelligenceTextEffectID: Hashable {
         self.chunk = chunk
     }
 
-#if canImport(AppKit) && !targetEnvironment(macCatalyst)
-    private func didCompletePartialWrappedEffect<Source>(for source: Source) where Source: PlatformIntelligenceTextEffectViewSource, Source.Chunk == Chunk {
+    #if canImport(AppKit) && !targetEnvironment(macCatalyst)
+    private func didCompletePartialWrappedEffect<Source>(for source: Source)
+    where Source: PlatformIntelligenceTextEffectViewSource, Source.Chunk == Chunk {
         if self.hasCompletedPartialWrappedEffect {
             Task { @MainActor in
                 await source.replacementEffectDidComplete(self)
@@ -528,9 +560,10 @@ struct PlatformIntelligenceTextEffectID: Hashable {
 
         self.hasCompletedPartialWrappedEffect = true
     }
-#endif
+    #endif
 
-    func _add<Source>(to view: PlatformIntelligenceTextEffectView<Source>) async where Source : PlatformIntelligenceTextEffectViewSource, Source.Chunk == Chunk {
+    func internalAdd<Source>(to view: PlatformIntelligenceTextEffectView<Source>) async
+    where Source: PlatformIntelligenceTextEffectViewSource, Source.Chunk == Chunk {
         // The WT interfaces expect the replacement operation to be performed synchronously, else the source
         // and destination effects become disjoint and begin at different times.
         //
@@ -550,8 +583,12 @@ struct PlatformIntelligenceTextEffectID: Hashable {
             return
         }
 
-#if canImport(UIKit)
-        let chunkAdapter = UIReplacementTextEffectTextChunkAdapter(wrapping: self.chunk, source: sourcePreview, destination: destinationPreview)
+        #if canImport(UIKit)
+        let chunkAdapter = UIReplacementTextEffectTextChunkAdapter(
+            wrapping: self.chunk,
+            source: sourcePreview,
+            destination: destinationPreview
+        )
 
         let delegateAdapter = UIReplacementTextEffectDelegateAdapter(wrapping: view.source, view: view)
         let wrappedEffect = UITextEffectView.ReplacementTextEffect(chunk: chunkAdapter, view: view.wrapped, delegate: delegateAdapter)
@@ -561,7 +598,7 @@ struct PlatformIntelligenceTextEffectID: Hashable {
         view.wrapped.addEffect(wrappedEffect)
         view.wrappedEffectIDToPlatformEffects[wrappedEffect.id] = self
         view.platformEffectIDToWrappedEffectIDs[self.id] = wrappedEffect.id
-#else
+        #else
         // The WTUI interface on macOS exposes the replacement effect as two separate effects, a source effect
         // and a destination effect. To abstract this disparity between the platforms, the effects are modeled
         // as a single replacement effect, to match the iOS interface and provide a cohesive API.
@@ -585,6 +622,8 @@ struct PlatformIntelligenceTextEffectID: Hashable {
             // This block is invoked after the source effect has been prepared, but before it actually begins.
             // It's intended for the destination effect to be added here, synchronously.
 
+            // Misannotated WritingToolsUI symbol which never actually returns `nil`.
+            // swift-format-ignore: NeverForceUnwrap
             let destinationEffectID = view.wrapped.add(wrappedDestinationEffect)!
             view.wrappedEffectIDToPlatformEffects[destinationEffectID] = self
             view.platformEffectIDToWrappedEffectIDs[self.id, default: []].insert(destinationEffectID)
@@ -597,28 +636,31 @@ struct PlatformIntelligenceTextEffectID: Hashable {
 
         await view.source.replacementEffectWillBegin(self)
 
+        // Misannotated WritingToolsUI symbol which never actually returns `nil`.
+        // swift-format-ignore: NeverForceUnwrap
         let sourceEffectID = view.wrapped.add(wrappedSourceEffect)!
         view.wrappedEffectIDToPlatformEffects[sourceEffectID] = self
         view.platformEffectIDToWrappedEffectIDs[self.id, default: []].insert(sourceEffectID)
-#endif
+        #endif
 
         guard let remainderPreview else {
             return
         }
 
-        let previews = PlatformIntelligenceRemainderAffordanceTextEffect<Chunk>.Previews(source: sourcePreview, destination: destinationPreview, remainder: remainderPreview)
+        let previews = PlatformIntelligenceRemainderAffordanceTextEffect<Chunk>
+            .Previews(source: sourcePreview, destination: destinationPreview, remainder: remainderPreview)
         let remainderEffect = PlatformIntelligenceRemainderAffordanceTextEffect(chunk: chunk, previews: previews)
-        await remainderEffect._add(to: view)
+        await remainderEffect.internalAdd(to: view)
     }
 }
 
 /// An effect which adds a shimmer animation to some text, intended to indicate that some operation is pending.
 class PlatformIntelligencePonderingTextEffect<Chunk>: PlatformIntelligenceTextEffect where Chunk: PlatformIntelligenceTextEffectChunk {
-#if canImport(UIKit)
+    #if canImport(UIKit)
     private typealias ChunkAdapter = UIPonderingTextEffectTextChunkAdapter
-#else
+    #else
     private typealias ChunkAdapter = WTTextChunkAdapter
-#endif
+    #endif
 
     let id = PlatformIntelligenceTextEffectID()
     let chunk: Chunk
@@ -627,26 +669,27 @@ class PlatformIntelligencePonderingTextEffect<Chunk>: PlatformIntelligenceTextEf
         self.chunk = chunk
     }
 
-    func _add<Source>(to view: PlatformIntelligenceTextEffectView<Source>) async where Source : PlatformIntelligenceTextEffectViewSource, Source.Chunk == Chunk {
+    func internalAdd<Source>(to view: PlatformIntelligenceTextEffectView<Source>) async
+    where Source: PlatformIntelligenceTextEffectViewSource, Source.Chunk == Chunk {
         guard let preview = await view.source.textPreview(for: self.chunk) else {
             return
         }
 
         let chunkAdapter = ChunkAdapter(wrapping: self.chunk, preview: preview)
 
-#if canImport(UIKit)
+        #if canImport(UIKit)
         let wrappedEffect = UITextEffectView.PonderingEffect(chunk: chunkAdapter, view: view.wrapped)
         view.wrapped.addEffect(wrappedEffect)
 
         view.wrappedEffectIDToPlatformEffects[wrappedEffect.id] = self
         view.platformEffectIDToWrappedEffectIDs[self.id] = wrappedEffect.id
-#else
+        #else
         let wrappedEffect = _WTSweepTextEffect(chunk: chunkAdapter, effectView: view.wrapped)
         view.wrapped.add(wrappedEffect)
 
         view.wrappedEffectIDToPlatformEffects[wrappedEffect.identifier] = self
         view.platformEffectIDToWrappedEffectIDs[self.id] = [wrappedEffect.identifier]
-#endif
+        #endif
     }
 }
 

--- a/Source/WebKit/WebKitSwift/WritingTools/WKIntelligenceReplacementTextEffectCoordinator.h
+++ b/Source/WebKit/WebKitSwift/WritingTools/WKIntelligenceReplacementTextEffectCoordinator.h
@@ -39,6 +39,20 @@ NS_SWIFT_UI_ACTOR
 
 + (NSInteger)characterDeltaForReceivedSuggestions:(NSArray<WTTextSuggestion *> *)suggestions;
 
+// FIXME: (rdar://142275772) Remove these duplicate protocol method declarations when Swift is able to properly synthesize their Swift names.
+
+- (void)startAnimationForRange:(NSRange)range completion:(NS_SWIFT_UI_ACTOR void (^)(void))completion;
+
+- (void)requestReplacementWithProcessedRange:(NSRange)range finished:(BOOL)finished characterDelta:(NSInteger)characterDelta operation:(NS_SWIFT_UI_ACTOR void (^)(NS_SWIFT_UI_ACTOR void (^)(void)))operation completion:(NS_SWIFT_UI_ACTOR void (^)(void))completion;
+
+- (void)flushReplacementsWithCompletionHandler:(NS_SWIFT_UI_ACTOR void (^)(void))completionHandler;
+
+- (void)restoreSelectionAcceptedReplacements:(BOOL)acceptedReplacements completionHandler:(NS_SWIFT_UI_ACTOR void (^)(void))completionHandler;
+
+- (void)hideEffectsWithCompletionHandler:(NS_SWIFT_UI_ACTOR void (^)(void))completionHandler;
+
+- (void)showEffectsWithCompletionHandler:(NS_SWIFT_UI_ACTOR void (^)(void))completionHandler;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Source/WebKit/WebKitSwift/WritingTools/WKIntelligenceSmartReplyTextEffectCoordinator.h
+++ b/Source/WebKit/WebKitSwift/WritingTools/WKIntelligenceSmartReplyTextEffectCoordinator.h
@@ -37,6 +37,20 @@ NS_ASSUME_NONNULL_BEGIN
 NS_SWIFT_UI_ACTOR
 @interface WKIntelligenceSmartReplyTextEffectCoordinator : NSObject <WKIntelligenceTextEffectCoordinating>
 
+// FIXME: (rdar://142275772) Remove these duplicate protocol method declarations when Swift is able to properly synthesize their Swift names.
+
+- (void)startAnimationForRange:(NSRange)range completion:(NS_SWIFT_UI_ACTOR void (^)(void))completion;
+
+- (void)requestReplacementWithProcessedRange:(NSRange)range finished:(BOOL)finished characterDelta:(NSInteger)characterDelta operation:(NS_SWIFT_UI_ACTOR void (^)(NS_SWIFT_UI_ACTOR void (^)(void)))operation completion:(NS_SWIFT_UI_ACTOR void (^)(void))completion;
+
+- (void)flushReplacementsWithCompletionHandler:(NS_SWIFT_UI_ACTOR void (^)(void))completionHandler;
+
+- (void)restoreSelectionAcceptedReplacements:(BOOL)acceptedReplacements completionHandler:(NS_SWIFT_UI_ACTOR void (^)(void))completionHandler;
+
+- (void)hideEffectsWithCompletionHandler:(NS_SWIFT_UI_ACTOR void (^)(void))completionHandler;
+
+- (void)showEffectsWithCompletionHandler:(NS_SWIFT_UI_ACTOR void (^)(void))completionHandler;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Source/WebKit/WebKitSwift/WritingTools/WKIntelligenceTextEffectCoordinator.h
+++ b/Source/WebKit/WebKitSwift/WritingTools/WKIntelligenceTextEffectCoordinator.h
@@ -76,17 +76,17 @@ NS_SWIFT_UI_ACTOR
 
 - (instancetype)initWithDelegate:(id<WKIntelligenceTextEffectCoordinatorDelegate>)delegate;
 
-- (void)startAnimationForRange:(NSRange)range completion:(void (^)(void))completion;
+- (void)startAnimationForRange:(NSRange)range completion:(NS_SWIFT_UI_ACTOR void (^)(void))completion;
 
-- (void)requestReplacementWithProcessedRange:(NSRange)range finished:(BOOL)finished characterDelta:(NSInteger)characterDelta operation:(void (^)(void (^)(void)))operation completion:(void (^)(void))completion;
+- (void)requestReplacementWithProcessedRange:(NSRange)range finished:(BOOL)finished characterDelta:(NSInteger)characterDelta operation:(NS_SWIFT_UI_ACTOR void (^)(NS_SWIFT_UI_ACTOR void (^)(void)))operation completion:(NS_SWIFT_UI_ACTOR void (^)(void))completion;
 
-- (void)flushReplacementsWithCompletion:(void (^)(void))completion;
+- (void)flushReplacementsWithCompletionHandler:(NS_SWIFT_UI_ACTOR void (^)(void))completionHandler;
 
-- (void)restoreSelectionAcceptedReplacements:(BOOL)acceptedReplacements completion:(void (^)(void))completion;
+- (void)restoreSelectionAcceptedReplacements:(BOOL)acceptedReplacements completionHandler:(NS_SWIFT_UI_ACTOR void (^)(void))completionHandler;
 
-- (void)hideEffectsWithCompletion:(void (^)(void))completion;
+- (void)hideEffectsWithCompletionHandler:(NS_SWIFT_UI_ACTOR void (^)(void))completionHandler;
 
-- (void)showEffectsWithCompletion:(void (^)(void))completion;
+- (void)showEffectsWithCompletionHandler:(NS_SWIFT_UI_ACTOR void (^)(void))completionHandler;
 
 @end
 


### PR DESCRIPTION
#### 1243db2d3cef54f8258b2ace6c8dd71476efe8c7
<pre>
[Swift in WebKit] The Swift implementation of intelligence text effects code is slightly incorrect
<a href="https://bugs.webkit.org/show_bug.cgi?id=293856">https://bugs.webkit.org/show_bug.cgi?id=293856</a>
<a href="https://rdar.apple.com/152373241">rdar://152373241</a>

Reviewed by Aditya Keerthi.

Properly use `@objc @implementation` and address all the errors it exposes.

Also apply formatting and linting.

* Source/WebKit/WebKitSwift/WritingTools/IntelligenceTextEffectViewManager.swift:
* Source/WebKit/WebKitSwift/WritingTools/PlatformIntelligenceTextEffectView.swift:
* Source/WebKit/WebKitSwift/WritingTools/WKIntelligenceReplacementTextEffectCoordinator.swift:
* Source/WebKit/WebKitSwift/WritingTools/WKIntelligenceSmartReplyTextEffectCoordinator.swift:
* Source/WebKit/WebKitSwift/WritingTools/WKIntelligenceTextEffectCoordinator.h:

- Format code
- Remove needless `public`
- Replace force-unwrap with optional-unwrap
- Justify other force-unwraps

Canonical link: <a href="https://commits.webkit.org/295726@main">https://commits.webkit.org/295726@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1858c7a14effececd615282fa71a78a0da96f2e8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105965 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25715 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/16109 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/111162 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/56562 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/108005 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/26355 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34218 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80497 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108970 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/20777 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95625 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60817 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/20393 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13722 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/56000 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/90158 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13758 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/114014 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33104 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/24425 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89569 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33468 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91853 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89249 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22748 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34112 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11926 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/28643 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/33029 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/38440 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32775 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/36124 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34373 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->