### PR TITLE
Media playback can fail on some sites on Intel

### DIFF
--- a/Source/WebKit/GPUProcess/mac/com.apple.WebKit.GPUProcess.sb.in
+++ b/Source/WebKit/GPUProcess/mac/com.apple.WebKit.GPUProcess.sb.in
@@ -212,7 +212,7 @@
                     iokit-external-method
                     iokit-external-trap)
                 (allow iokit-external-method
-                    (iokit-method-number 1 2 114 115 120 132 133 144))))
+                    (iokit-method-number 1 2 3 4 5 6 114 115 120 132 133 144))))
         ;; else
         (allow IOKIT_OPEN_USER_CLIENT
             (iokit-user-client-class "AppleIntelMEUserClient")))
@@ -768,7 +768,9 @@
             (GPU_PROCESS_IOKIT_DEFAULT_FILTER_OPERATION (with telemetry)
                 iokit-async-external-method
                 iokit-external-method
-                iokit-external-trap)))
+                iokit-external-trap)
+            (allow iokit-external-method
+                (iokit-method-number 0 1))))
     ;; else
     (allow IOKIT_OPEN_USER_CLIENT
         (iokit-user-client-class "AppleUpstreamUserClient")))


### PR DESCRIPTION
#### e05edb1e995909e161be2835c6646eea6b8e11da
<pre>
Media playback can fail on some sites on Intel
<a href="https://bugs.webkit.org/show_bug.cgi?id=293861">https://bugs.webkit.org/show_bug.cgi?id=293861</a>
<a href="https://rdar.apple.com/152320491">rdar://152320491</a>

Reviewed by Sihui Liu.

Media playback can fail on some sites on Intel due to a sandbox restriction in the GPU process.

* Source/WebKit/GPUProcess/mac/com.apple.WebKit.GPUProcess.sb.in:

Canonical link: <a href="https://commits.webkit.org/295659@main">https://commits.webkit.org/295659@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d35082a0f5e0b58f5cb54fbace2b21517a3f014b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105809 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25560 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15953 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/111006 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/56405 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/26098 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34063 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80356 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108815 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/20465 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95483 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60669 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/20142 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55844 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/89885 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13619 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/113855 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32949 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24283 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89434 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33313 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91714 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89105 "Found 100 new API test failures: /TestWebKit:WebKit.PageLoadDidChangeLocationWithinPage, /TestWebKit:WebKit.AboutBlankLoad, /TestWebKit:WebKit.PreventEmptyUserAgent, /TestWebKit:WebKit.PrivateBrowsingPushStateNoHistoryCallback, /WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/content-type, /WebKitGTK/TestUIClient:/webkit/WebKitWebView/pointer-lock-permission-request, /TestWebKit:WebKit.HitTestResultNodeHandle, /TestWebKit:WebKit2TextFieldBeginAndEditEditingTest.TextFieldDidBeginShouldNotBeDispatchedForAlreadyFocusedField, /TestWebKit:WebKit.Find, /WebKitGTK/TestWebProcessExtensions:/webkit/WebKitWebProcessExtension/dom-input-element-is-user-edited ... (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33977 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11788 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/28438 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17162 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32874 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/38285 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32620 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35969 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34218 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->