### PR TITLE
Fix switch-over point for implicit discrete 'to'-animations

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -2163,7 +2163,6 @@ imported/w3c/web-platform-tests/svg/animations/conditional-processing-01.html [ 
 imported/w3c/web-platform-tests/svg/animations/stop-animation-01.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/svg/animations/switch-animation-01.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/svg/animations/switch-animation-02.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/svg/animations/animate-display-to-none-001.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/svg/embedded/image-crossorigin.sub.html [ Skip ]
 imported/w3c/web-platform-tests/svg/embedded/image-embedding-svg-with-near-integral-width.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/svg/embedded/image-fractional-width-vertical-fidelity.svg [ ImageOnlyFailure ]

--- a/LayoutTests/platform/gtk/svg/W3C-SVG-1.1/animate-elem-41-t-expected.txt
+++ b/LayoutTests/platform/gtk/svg/W3C-SVG-1.1/animate-elem-41-t-expected.txt
@@ -94,11 +94,11 @@ layer at (0,0) size 480x360
             RenderSVGContainer {g} at (385,92) size 50x18
               RenderSVGPath {polyline} at (385,92) size 20x18 [fill={[type=SOLID] [color=#CCCCCC]}] [points="20 10 0 10 15 20 10 2 5 20 20 10"]
               RenderSVGPath {polyline} at (415,92) size 20x18 [transform={m=((1.00,0.00)(0.00,1.00)) t=(30.00,0.00)}] [fill={[type=SOLID] [color=#CCCCCC] [fill rule=EVEN-ODD]}] [points="20 10 0 10 15 20 10 2 5 20 20 10"]
-          RenderSVGPath {polyline} at (163,90) size 23x22 [stroke={[type=SOLID] [color=#CC0066]}] [fill={[type=SOLID] [color=#CC0066] [fill rule=EVEN-ODD]}] [points="20 10 0 10 15 20 10 2 5 20 20 10"]
+          RenderSVGPath {polyline} at (163,90) size 23x22 [stroke={[type=SOLID] [color=#CC0066]}] [fill={[type=SOLID] [color=#CC0066]}] [points="20 10 0 10 15 20 10 2 5 20 20 10"]
           RenderSVGContainer {g} at (273,90) size 23x22 [transform={m=((1.00,0.00)(0.00,1.00)) t=(110.00,0.00)}]
-            RenderSVGPath {polyline} at (273,90) size 23x22 [stroke={[type=SOLID] [color=#CC0066]}] [fill={[type=SOLID] [color=#CC0066] [fill rule=EVEN-ODD]}] [points="20 10 0 10 15 20 10 2 5 20 20 10"]
+            RenderSVGPath {polyline} at (273,90) size 23x22 [stroke={[type=SOLID] [color=#CC0066]}] [fill={[type=SOLID] [color=#CC0066]}] [points="20 10 0 10 15 20 10 2 5 20 20 10"]
           RenderSVGContainer {a} at (383,90) size 23x22 [transform={m=((1.00,0.00)(0.00,1.00)) t=(220.00,0.00)}]
-            RenderSVGPath {polyline} at (383,90) size 23x22 [stroke={[type=SOLID] [color=#CC0066]}] [fill={[type=SOLID] [color=#CC0066] [fill rule=EVEN-ODD]}] [points="20 10 0 10 15 20 10 2 5 20 20 10"]
+            RenderSVGPath {polyline} at (383,90) size 23x22 [stroke={[type=SOLID] [color=#CC0066]}] [fill={[type=SOLID] [color=#CC0066]}] [points="20 10 0 10 15 20 10 2 5 20 20 10"]
         RenderSVGContainer {g} at (168,118) size 262x12 [transform={m=((1.00,0.00)(0.00,1.00)) t=(0.00,45.00)}]
           RenderSVGHiddenContainer {defs} at (0,0) size 0x0
             RenderSVGContainer {g} at (168,118) size 42x12

--- a/LayoutTests/platform/ios/svg/W3C-SVG-1.1/animate-elem-41-t-expected.txt
+++ b/LayoutTests/platform/ios/svg/W3C-SVG-1.1/animate-elem-41-t-expected.txt
@@ -94,11 +94,11 @@ layer at (0,0) size 480x360
             RenderSVGContainer {g} at (385,92) size 50x18
               RenderSVGPath {polyline} at (385,92) size 20x18 [fill={[type=SOLID] [color=#CCCCCC]}] [points="20 10 0 10 15 20 10 2 5 20 20 10"]
               RenderSVGPath {polyline} at (415,92) size 20x18 [transform={m=((1.00,0.00)(0.00,1.00)) t=(30.00,0.00)}] [fill={[type=SOLID] [color=#CCCCCC] [fill rule=EVEN-ODD]}] [points="20 10 0 10 15 20 10 2 5 20 20 10"]
-          RenderSVGPath {polyline} at (163,90) size 23x22 [stroke={[type=SOLID] [color=#CC0066]}] [fill={[type=SOLID] [color=#CC0066] [fill rule=EVEN-ODD]}] [points="20 10 0 10 15 20 10 2 5 20 20 10"]
+          RenderSVGPath {polyline} at (163,90) size 23x22 [stroke={[type=SOLID] [color=#CC0066]}] [fill={[type=SOLID] [color=#CC0066]}] [points="20 10 0 10 15 20 10 2 5 20 20 10"]
           RenderSVGContainer {g} at (273,90) size 23x22 [transform={m=((1.00,0.00)(0.00,1.00)) t=(110.00,0.00)}]
-            RenderSVGPath {polyline} at (273,90) size 23x22 [stroke={[type=SOLID] [color=#CC0066]}] [fill={[type=SOLID] [color=#CC0066] [fill rule=EVEN-ODD]}] [points="20 10 0 10 15 20 10 2 5 20 20 10"]
+            RenderSVGPath {polyline} at (273,90) size 23x22 [stroke={[type=SOLID] [color=#CC0066]}] [fill={[type=SOLID] [color=#CC0066]}] [points="20 10 0 10 15 20 10 2 5 20 20 10"]
           RenderSVGContainer {a} at (383,90) size 23x22 [transform={m=((1.00,0.00)(0.00,1.00)) t=(220.00,0.00)}]
-            RenderSVGPath {polyline} at (383,90) size 23x22 [stroke={[type=SOLID] [color=#CC0066]}] [fill={[type=SOLID] [color=#CC0066] [fill rule=EVEN-ODD]}] [points="20 10 0 10 15 20 10 2 5 20 20 10"]
+            RenderSVGPath {polyline} at (383,90) size 23x22 [stroke={[type=SOLID] [color=#CC0066]}] [fill={[type=SOLID] [color=#CC0066]}] [points="20 10 0 10 15 20 10 2 5 20 20 10"]
         RenderSVGContainer {g} at (168,118) size 262x12 [transform={m=((1.00,0.00)(0.00,1.00)) t=(0.00,45.00)}]
           RenderSVGHiddenContainer {defs} at (0,0) size 0x0
             RenderSVGContainer {g} at (168,118) size 42x12

--- a/LayoutTests/platform/mac/svg/W3C-SVG-1.1/animate-elem-41-t-expected.txt
+++ b/LayoutTests/platform/mac/svg/W3C-SVG-1.1/animate-elem-41-t-expected.txt
@@ -94,11 +94,11 @@ layer at (0,0) size 480x360
             RenderSVGContainer {g} at (385,92) size 50x18
               RenderSVGPath {polyline} at (385,92) size 20x18 [fill={[type=SOLID] [color=#CCCCCC]}] [points="20 10 0 10 15 20 10 2 5 20 20 10"]
               RenderSVGPath {polyline} at (415,92) size 20x18 [transform={m=((1.00,0.00)(0.00,1.00)) t=(30.00,0.00)}] [fill={[type=SOLID] [color=#CCCCCC] [fill rule=EVEN-ODD]}] [points="20 10 0 10 15 20 10 2 5 20 20 10"]
-          RenderSVGPath {polyline} at (163,90) size 23x22 [stroke={[type=SOLID] [color=#CC0066]}] [fill={[type=SOLID] [color=#CC0066] [fill rule=EVEN-ODD]}] [points="20 10 0 10 15 20 10 2 5 20 20 10"]
+          RenderSVGPath {polyline} at (163,90) size 23x22 [stroke={[type=SOLID] [color=#CC0066]}] [fill={[type=SOLID] [color=#CC0066]}] [points="20 10 0 10 15 20 10 2 5 20 20 10"]
           RenderSVGContainer {g} at (273,90) size 23x22 [transform={m=((1.00,0.00)(0.00,1.00)) t=(110.00,0.00)}]
-            RenderSVGPath {polyline} at (273,90) size 23x22 [stroke={[type=SOLID] [color=#CC0066]}] [fill={[type=SOLID] [color=#CC0066] [fill rule=EVEN-ODD]}] [points="20 10 0 10 15 20 10 2 5 20 20 10"]
+            RenderSVGPath {polyline} at (273,90) size 23x22 [stroke={[type=SOLID] [color=#CC0066]}] [fill={[type=SOLID] [color=#CC0066]}] [points="20 10 0 10 15 20 10 2 5 20 20 10"]
           RenderSVGContainer {a} at (383,90) size 23x22 [transform={m=((1.00,0.00)(0.00,1.00)) t=(220.00,0.00)}]
-            RenderSVGPath {polyline} at (383,90) size 23x22 [stroke={[type=SOLID] [color=#CC0066]}] [fill={[type=SOLID] [color=#CC0066] [fill rule=EVEN-ODD]}] [points="20 10 0 10 15 20 10 2 5 20 20 10"]
+            RenderSVGPath {polyline} at (383,90) size 23x22 [stroke={[type=SOLID] [color=#CC0066]}] [fill={[type=SOLID] [color=#CC0066]}] [points="20 10 0 10 15 20 10 2 5 20 20 10"]
         RenderSVGContainer {g} at (168,118) size 262x12 [transform={m=((1.00,0.00)(0.00,1.00)) t=(0.00,45.00)}]
           RenderSVGHiddenContainer {defs} at (0,0) size 0x0
             RenderSVGContainer {g} at (168,118) size 42x12

--- a/LayoutTests/platform/win/svg/W3C-SVG-1.1/animate-elem-41-t-expected.txt
+++ b/LayoutTests/platform/win/svg/W3C-SVG-1.1/animate-elem-41-t-expected.txt
@@ -94,11 +94,11 @@ layer at (0,0) size 480x360
             RenderSVGContainer {g} at (385,92) size 50x18
               RenderSVGPath {polyline} at (385,92) size 20x18 [fill={[type=SOLID] [color=#CCCCCC]}] [points="20 10 0 10 15 20 10 2 5 20 20 10"]
               RenderSVGPath {polyline} at (415,92) size 20x18 [transform={m=((1.00,0.00)(0.00,1.00)) t=(30.00,0.00)}] [fill={[type=SOLID] [color=#CCCCCC] [fill rule=EVEN-ODD]}] [points="20 10 0 10 15 20 10 2 5 20 20 10"]
-          RenderSVGPath {polyline} at (163,90) size 23x22 [stroke={[type=SOLID] [color=#CC0066]}] [fill={[type=SOLID] [color=#CC0066] [fill rule=EVEN-ODD]}] [points="20 10 0 10 15 20 10 2 5 20 20 10"]
+          RenderSVGPath {polyline} at (163,90) size 23x22 [stroke={[type=SOLID] [color=#CC0066]}] [fill={[type=SOLID] [color=#CC0066]}] [points="20 10 0 10 15 20 10 2 5 20 20 10"]
           RenderSVGContainer {g} at (273,90) size 23x22 [transform={m=((1.00,0.00)(0.00,1.00)) t=(110.00,0.00)}]
-            RenderSVGPath {polyline} at (273,90) size 23x22 [stroke={[type=SOLID] [color=#CC0066]}] [fill={[type=SOLID] [color=#CC0066] [fill rule=EVEN-ODD]}] [points="20 10 0 10 15 20 10 2 5 20 20 10"]
+            RenderSVGPath {polyline} at (273,90) size 23x22 [stroke={[type=SOLID] [color=#CC0066]}] [fill={[type=SOLID] [color=#CC0066]}] [points="20 10 0 10 15 20 10 2 5 20 20 10"]
           RenderSVGContainer {a} at (383,90) size 23x22 [transform={m=((1.00,0.00)(0.00,1.00)) t=(220.00,0.00)}]
-            RenderSVGPath {polyline} at (383,90) size 23x22 [stroke={[type=SOLID] [color=#CC0066]}] [fill={[type=SOLID] [color=#CC0066] [fill rule=EVEN-ODD]}] [points="20 10 0 10 15 20 10 2 5 20 20 10"]
+            RenderSVGPath {polyline} at (383,90) size 23x22 [stroke={[type=SOLID] [color=#CC0066]}] [fill={[type=SOLID] [color=#CC0066]}] [points="20 10 0 10 15 20 10 2 5 20 20 10"]
         RenderSVGContainer {g} at (168,118) size 262x12 [transform={m=((1.00,0.00)(0.00,1.00)) t=(0.00,45.00)}]
           RenderSVGHiddenContainer {defs} at (0,0) size 0x0
             RenderSVGContainer {g} at (168,118) size 42x12

--- a/LayoutTests/platform/wpe/svg/W3C-SVG-1.1/animate-elem-41-t-expected.txt
+++ b/LayoutTests/platform/wpe/svg/W3C-SVG-1.1/animate-elem-41-t-expected.txt
@@ -94,11 +94,11 @@ layer at (0,0) size 800x600
             RenderSVGContainer {g} at (641,153) size 84x31
               RenderSVGPath {polyline} at (641,153) size 34x31 [fill={[type=SOLID] [color=#CCCCCC]}] [points="20 10 0 10 15 20 10 2 5 20 20 10"]
               RenderSVGPath {polyline} at (691,153) size 34x31 [transform={m=((1.00,0.00)(0.00,1.00)) t=(30.00,0.00)}] [fill={[type=SOLID] [color=#CCCCCC] [fill rule=EVEN-ODD]}] [points="20 10 0 10 15 20 10 2 5 20 20 10"]
-          RenderSVGPath {polyline} at (272,150) size 37x36 [stroke={[type=SOLID] [color=#CC0066]}] [fill={[type=SOLID] [color=#CC0066] [fill rule=EVEN-ODD]}] [points="20 10 0 10 15 20 10 2 5 20 20 10"]
+          RenderSVGPath {polyline} at (272,150) size 37x36 [stroke={[type=SOLID] [color=#CC0066]}] [fill={[type=SOLID] [color=#CC0066]}] [points="20 10 0 10 15 20 10 2 5 20 20 10"]
           RenderSVGContainer {g} at (455,150) size 38x36 [transform={m=((1.00,0.00)(0.00,1.00)) t=(110.00,0.00)}]
-            RenderSVGPath {polyline} at (455,150) size 38x36 [stroke={[type=SOLID] [color=#CC0066]}] [fill={[type=SOLID] [color=#CC0066] [fill rule=EVEN-ODD]}] [points="20 10 0 10 15 20 10 2 5 20 20 10"]
+            RenderSVGPath {polyline} at (455,150) size 38x36 [stroke={[type=SOLID] [color=#CC0066]}] [fill={[type=SOLID] [color=#CC0066]}] [points="20 10 0 10 15 20 10 2 5 20 20 10"]
           RenderSVGContainer {a} at (638,150) size 38x36 [transform={m=((1.00,0.00)(0.00,1.00)) t=(220.00,0.00)}]
-            RenderSVGPath {polyline} at (638,150) size 38x36 [stroke={[type=SOLID] [color=#CC0066]}] [fill={[type=SOLID] [color=#CC0066] [fill rule=EVEN-ODD]}] [points="20 10 0 10 15 20 10 2 5 20 20 10"]
+            RenderSVGPath {polyline} at (638,150) size 38x36 [stroke={[type=SOLID] [color=#CC0066]}] [fill={[type=SOLID] [color=#CC0066]}] [points="20 10 0 10 15 20 10 2 5 20 20 10"]
         RenderSVGContainer {g} at (280,196) size 437x21 [transform={m=((1.00,0.00)(0.00,1.00)) t=(0.00,45.00)}]
           RenderSVGHiddenContainer {defs} at (0,0) size 0x0
             RenderSVGContainer {g} at (280,196) size 70x21

--- a/Source/WebCore/svg/properties/SVGAnimationDiscreteFunction.h
+++ b/Source/WebCore/svg/properties/SVGAnimationDiscreteFunction.h
@@ -49,7 +49,7 @@ public:
 
     void animate(SVGElement&, float progress, unsigned, ValueType& animated)
     {
-        if ((m_animationMode == AnimationMode::FromTo && progress > 0.5) || m_animationMode == AnimationMode::To || progress == 1)
+        if (((m_animationMode == AnimationMode::FromTo || m_animationMode == AnimationMode::To) && progress > 0.5) || progress == 1)
             animated = m_to;
         else
             animated = m_from;


### PR DESCRIPTION
#### 4923841d8c930238c18627cdd55ddee11490828d
<pre>
Fix switch-over point for implicit discrete &apos;to&apos;-animations
<a href="https://bugs.webkit.org/show_bug.cgi?id=293862">https://bugs.webkit.org/show_bug.cgi?id=293862</a>
<a href="https://rdar.apple.com/problem/152376446">rdar://problem/152376446</a>

Reviewed by Simon Fraser.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

Merge: <a href="https://source.chromium.org/chromium/chromium/src/+/39d072be004bf3fc4a5f534c0d926293255ec74f">https://source.chromium.org/chromium/chromium/src/+/39d072be004bf3fc4a5f534c0d926293255ec74f</a>

SMIL Animation (3.2.3) [1] says:

 &quot;For the shorthand form to animation, there is only 1 value; a discrete
  to animation will simply set the &quot;to&quot; value for the simple duration.&quot;

SVG Animation (2.10) [2] says:

 &quot;...the behavior of discrete to-animation in SVG deviates from the
  definition in SMIL Animation. As with a discrete from-to animation, a
  discrete to animation will set the underlying value for the first half
  of the simple duration ... and the ‘to’ value for the remainder of the
  simple duration.&quot;

For calcMode != &quot;discrete&quot; and non-interpolable types we were
implementing the former and not the latter. This patch changes it.

[1] <a href="https://www.w3.org/TR/2001/REC-smil-animation-20010904/">https://www.w3.org/TR/2001/REC-smil-animation-20010904/</a>
[2] <a href="https://svgwg.org/specs/animations/#ValueAttributes">https://svgwg.org/specs/animations/#ValueAttributes</a>

* Source/WebCore/svg/properties/SVGAnimationDiscreteFunction.h:
(WebCore::SVGAnimationDiscreteFunction::animate):
* LayoutTests/TestExpectations: WPT progression
* LayoutTests/platform/gtk/svg/W3C-SVG-1.1/animate-elem-41-t-expected.txt: Matches other browser
* LayoutTests/platform/ios/svg/W3C-SVG-1.1/animate-elem-41-t-expected.txt: Ditto
* LayoutTests/platform/mac/svg/W3C-SVG-1.1/animate-elem-41-t-expected.txt: Ditto
* LayoutTests/platform/win/svg/W3C-SVG-1.1/animate-elem-41-t-expected.txt: Ditto
* LayoutTests/platform/wpe/svg/W3C-SVG-1.1/animate-elem-41-t-expected.txt: Ditto

Canonical link: <a href="https://commits.webkit.org/295662@main">https://commits.webkit.org/295662@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7805886fe4107d0f0fbc99016ab3cfc8489d76fa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105799 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25550 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15943 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110996 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/56395 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/107840 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/26149 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34053 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80347 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108805 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/20534 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95470 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60660 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/20200 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13567 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55834 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/89944 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13606 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/113845 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32939 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24273 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89426 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33303 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91701 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89096 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22713 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33969 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11775 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/28424 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32864 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/38275 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32610 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35959 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34208 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->