### PR TITLE
Stop using Vector::data() in WebCore/

### DIFF
--- a/Source/WTF/wtf/ParallelJobs.h
+++ b/Source/WTF/wtf/ParallelJobs.h
@@ -87,7 +87,7 @@ public:
 
     void execute()
     {
-        m_parallelEnvironment.execute(reinterpret_cast<unsigned char*>(m_parameters.data()));
+        m_parallelEnvironment.execute(reinterpret_cast<unsigned char*>(m_parameters.mutableSpan().data()));
     }
 
 private:

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUAdapterImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUAdapterImpl.cpp
@@ -56,7 +56,7 @@ static Ref<SupportedFeatures> supportedFeatures(WGPUAdapter adapter)
 {
     auto featureCount = wgpuAdapterEnumerateFeatures(adapter, nullptr);
     Vector<WGPUFeatureName> features(featureCount);
-    wgpuAdapterEnumerateFeatures(adapter, features.data());
+    wgpuAdapterEnumerateFeatures(adapter, features.mutableSpan().data());
 
     return supportedFeatures(features);
 }
@@ -248,7 +248,7 @@ void AdapterImpl::requestDevice(const DeviceDescriptor& descriptor, CompletionHa
         .nextInChain = nullptr,
         .label = label.data(),
         .requiredFeatureCount = features.size(),
-        .requiredFeatures = features.size() ? features.data() : nullptr,
+        .requiredFeatures = features.size() ? features.span().data() : nullptr,
         .requiredLimits = &requiredLimits,
         .defaultQueue = {
             { },

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUCommandEncoderImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUCommandEncoderImpl.cpp
@@ -112,7 +112,7 @@ RefPtr<RenderPassEncoder> CommandEncoderImpl::beginRenderPass(const RenderPassDe
         .nextInChain = descriptor.maxDrawCount ? &maxDrawCount.chain : nullptr,
         .label = label.data(),
         .colorAttachmentCount = colorAttachments.size(),
-        .colorAttachments = colorAttachments.size() ? colorAttachments.data() : nullptr,
+        .colorAttachments = colorAttachments.size() ? colorAttachments.span().data() : nullptr,
         .depthStencilAttachment = depthStencilAttachment ? &depthStencilAttachment.value() : nullptr,
         .occlusionQuerySet = descriptor.occlusionQuerySet ? convertToBackingContext->convertToBacking(*descriptor.protectedOcclusionQuerySet()) : nullptr,
         .timestampWrites = timestampWrites.querySet ? &timestampWrites : nullptr

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUDeviceImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUDeviceImpl.cpp
@@ -142,7 +142,7 @@ RefPtr<Texture> DeviceImpl::createTexture(const TextureDescriptor& descriptor)
         descriptor.mipLevelCount,
         descriptor.sampleCount,
         backingTextureFormats.size(),
-        backingTextureFormats.size() ? backingTextureFormats.data() : nullptr,
+        backingTextureFormats.size() ? backingTextureFormats.span().data() : nullptr,
     };
 
     return TextureImpl::create(adoptWebGPU(wgpuDeviceCreateTexture(m_backing.get(), &backingDescriptor)), descriptor.format, descriptor.dimension, convertToBackingContext);
@@ -239,7 +239,7 @@ RefPtr<BindGroupLayout> DeviceImpl::createBindGroupLayout(const BindGroupLayoutD
         nullptr,
         label.data(),
         backingEntries.size(),
-        backingEntries.size() ? backingEntries.data() : nullptr,
+        backingEntries.size() ? backingEntries.span().data() : nullptr,
     };
 
     return BindGroupLayoutImpl::create(adoptWebGPU(wgpuDeviceCreateBindGroupLayout(m_backing.get(), &backingDescriptor)), m_convertToBackingContext);
@@ -260,7 +260,7 @@ RefPtr<PipelineLayout> DeviceImpl::createPipelineLayout(const PipelineLayoutDesc
         nullptr,
         label.data(),
         descriptor.bindGroupLayouts ? backingBindGroupLayouts.size() : 0,
-        descriptor.bindGroupLayouts ? backingBindGroupLayouts.data() : nullptr,
+        descriptor.bindGroupLayouts ? backingBindGroupLayouts.span().data() : nullptr,
     };
 
     return PipelineLayoutImpl::create(adoptWebGPU(wgpuDeviceCreatePipelineLayout(m_backing.get(), &backingDescriptor)), m_convertToBackingContext);
@@ -297,7 +297,7 @@ RefPtr<BindGroup> DeviceImpl::createBindGroup(const BindGroupDescriptor& descrip
         label.data(),
         convertToBackingContext->convertToBacking(descriptor.protectedLayout().get()),
         backingEntries.size(),
-        backingEntries.size() ? backingEntries.data() : nullptr,
+        backingEntries.size() ? backingEntries.span().data() : nullptr,
     };
 
     return BindGroupImpl::create(adoptWebGPU(wgpuDeviceCreateBindGroup(m_backing.get(), &backingDescriptor)), convertToBackingContext);
@@ -378,7 +378,7 @@ static auto convertToBacking(const ComputePipelineDescriptor& descriptor, Conver
             convertToBackingContext.convertToBacking(descriptor.compute.protectedModule().get()),
             entryPoint ? entryPoint->data() : nullptr,
             backingConstantEntries.size(),
-            backingConstantEntries.size() ? backingConstantEntries.data() : nullptr,
+            backingConstantEntries.size() ? backingConstantEntries.span().data() : nullptr,
         }
     };
 
@@ -437,7 +437,7 @@ static auto convertToBacking(const RenderPipelineDescriptor& descriptor, Convert
             buffer ? buffer->arrayStride : WGPU_COPY_STRIDE_UNDEFINED,
             buffer ? convertToBackingContext.convertToBacking(buffer->stepMode) : WGPUVertexStepMode_Vertex,
             backingAttributes[i].size(),
-            backingAttributes[i].size() ? backingAttributes[i].data() : nullptr,
+            backingAttributes[i].size() ? backingAttributes[i].span().data() : nullptr,
         };
     });
 
@@ -537,9 +537,9 @@ static auto convertToBacking(const RenderPipelineDescriptor& descriptor, Convert
         descriptor.fragment ? convertToBackingContext.convertToBacking(descriptor.fragment->protectedModule().get()) : nullptr,
         fragmentEntryPoint ? fragmentEntryPoint->data() : nullptr,
         fragmentConstantEntries.size(),
-        fragmentConstantEntries.size() ? fragmentConstantEntries.data() : nullptr,
+        fragmentConstantEntries.size() ? fragmentConstantEntries.span().data() : nullptr,
         colorTargets.size(),
-        colorTargets.size() ? colorTargets.data() : nullptr,
+        colorTargets.size() ? colorTargets.span().data() : nullptr,
     };
 
     WGPUPrimitiveDepthClipControl depthClipControl = {
@@ -559,9 +559,9 @@ static auto convertToBacking(const RenderPipelineDescriptor& descriptor, Convert
             convertToBackingContext.convertToBacking(descriptor.vertex.protectedModule().get()),
             vertexEntryPoint ? vertexEntryPoint->data() : nullptr,
             vertexConstantEntries.size(),
-            vertexConstantEntries.size() ? vertexConstantEntries.data() : nullptr,
+            vertexConstantEntries.size() ? vertexConstantEntries.span().data() : nullptr,
             backingBuffers.size(),
-            backingBuffers.size() ? backingBuffers.data() : nullptr,
+            backingBuffers.size() ? backingBuffers.span().data() : nullptr,
         },
         .primitive = {
             descriptor.primitive && descriptor.primitive->unclippedDepth ? &depthClipControl.chain : nullptr,
@@ -655,7 +655,7 @@ RefPtr<RenderBundleEncoder> DeviceImpl::createRenderBundleEncoder(const RenderBu
         nullptr,
         label.data(),
         backingColorFormats.size(),
-        backingColorFormats.size() ? backingColorFormats.data() : nullptr,
+        backingColorFormats.size() ? backingColorFormats.span().data() : nullptr,
         descriptor.depthStencilFormat ? convertToBackingContext->convertToBacking(*descriptor.depthStencilFormat) : WGPUTextureFormat_Undefined,
         descriptor.sampleCount,
         descriptor.depthReadOnly,

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUQueueImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUQueueImpl.cpp
@@ -54,7 +54,7 @@ void QueueImpl::submit(Vector<Ref<WebGPU::CommandBuffer>>&& commandBuffers)
         return Ref { m_convertToBackingContext }->convertToBacking(commandBuffer);
     });
 
-    wgpuQueueSubmit(m_backing.get(), backingCommandBuffers.size(), backingCommandBuffers.data());
+    wgpuQueueSubmit(m_backing.get(), backingCommandBuffers.size(), backingCommandBuffers.span().data());
 }
 
 static void onSubmittedWorkDoneCallback(WGPUQueueWorkDoneStatus status, void* userdata)

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPURenderPassEncoderImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPURenderPassEncoderImpl.cpp
@@ -155,7 +155,7 @@ void RenderPassEncoderImpl::executeBundles(Vector<Ref<RenderBundle>>&& renderBun
         return protectedConvertToBackingContext()->convertToBacking(renderBundle.get());
     });
 
-    wgpuRenderPassEncoderExecuteBundles(m_backing.get(), backingBundles.size(), backingBundles.data());
+    wgpuRenderPassEncoderExecuteBundles(m_backing.get(), backingBundles.size(), backingBundles.span().data());
 }
 
 void RenderPassEncoderImpl::end()

--- a/Source/WebCore/Modules/compression/CompressionStreamEncoder.cpp
+++ b/Source/WebCore/Modules/compression/CompressionStreamEncoder.cpp
@@ -130,7 +130,7 @@ ExceptionOr<Ref<JSC::ArrayBuffer>> CompressionStreamEncoder::compressZlib(std::s
 
         output.grow(allocateSize);
 
-        m_zstream.getPlatformStream().next_out = output.data();
+        m_zstream.getPlatformStream().next_out = output.mutableSpan().data();
         m_zstream.getPlatformStream().avail_out = output.size();
 
         result = deflate(&m_zstream.getPlatformStream(), m_didFinish ? Z_FINISH : Z_NO_FLUSH);

--- a/Source/WebCore/Modules/compression/DecompressionStreamDecoder.cpp
+++ b/Source/WebCore/Modules/compression/DecompressionStreamDecoder.cpp
@@ -133,7 +133,7 @@ ExceptionOr<Ref<JSC::ArrayBuffer>> DecompressionStreamDecoder::decompressZlib(st
 
         output.grow(allocateSize);
 
-        m_zstream.getPlatformStream().next_out = output.data();
+        m_zstream.getPlatformStream().next_out = output.mutableSpan().data();
         m_zstream.getPlatformStream().avail_out = output.size();
 
         result = inflate(&m_zstream.getPlatformStream(), m_didFinish ? Z_FINISH : Z_NO_FLUSH);

--- a/Source/WebCore/Modules/compression/cocoa/CompressionStreamEncoderCocoa.mm
+++ b/Source/WebCore/Modules/compression/cocoa/CompressionStreamEncoderCocoa.mm
@@ -66,7 +66,7 @@ ExceptionOr<Ref<JSC::ArrayBuffer>> CompressionStreamEncoder::compressAppleCompre
 
         output.grow(allocateSize);
 
-        m_compressionStream.getPlatformStream().dst_ptr = output.data();
+        m_compressionStream.getPlatformStream().dst_ptr = output.mutableSpan().data();
         m_compressionStream.getPlatformStream().dst_size = output.size();
 
         result = compression_stream_process(&m_compressionStream.getPlatformStream(), m_didFinish ? COMPRESSION_STREAM_FINALIZE : 0);

--- a/Source/WebCore/Modules/compression/cocoa/DecompressionStreamDecoderCocoa.mm
+++ b/Source/WebCore/Modules/compression/cocoa/DecompressionStreamDecoderCocoa.mm
@@ -66,7 +66,7 @@ ExceptionOr<Ref<JSC::ArrayBuffer>> DecompressionStreamDecoder::decompressAppleCo
 
         output.grow(allocateSize);
 
-        m_compressionStream.getPlatformStream().dst_ptr = output.data();
+        m_compressionStream.getPlatformStream().dst_ptr = output.mutableSpan().data();
         m_compressionStream.getPlatformStream().dst_size = output.size();
 
         result = compression_stream_process(&m_compressionStream.getPlatformStream(), m_didFinish ? COMPRESSION_STREAM_FINALIZE : 0);

--- a/Source/WebCore/Modules/encryptedmedia/legacy/LegacyCDMSessionClearKey.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/legacy/LegacyCDMSessionClearKey.cpp
@@ -175,7 +175,7 @@ RefPtr<JSC::ArrayBuffer> CDMSessionClearKey::cachedKeyForKeyID(const String& key
         return nullptr;
 
     auto keyData = m_cachedKeys.get(keyId);
-    auto keyDataArray = JSC::Uint8Array::create(keyData.data(), keyData.size());
+    auto keyDataArray = JSC::Uint8Array::create(keyData.span());
     return keyDataArray->unsharedBuffer();
 }
 

--- a/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransform.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransform.cpp
@@ -174,7 +174,7 @@ void RTCRtpSFrameTransform::initializeTransformer(RTCRtpTransformBackend& backen
         if (!result)
             return;
 
-        frame->setData({ result.value().data(), result.value().size() });
+        frame->setData(result.value().span());
 
         backend->processTransformedFrame(frame.get());
     });

--- a/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransformerCocoa.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransformerCocoa.cpp
@@ -79,13 +79,13 @@ Vector<uint8_t> RTCRtpSFrameTransformer::computeEncryptedDataSignature(const Vec
 
     Vector<uint8_t> result(CC_SHA256_DIGEST_LENGTH);
     CCHmacContext context;
-    CCHmacInit(&context, kCCHmacAlgSHA256, key.data(), key.size());
-    CCHmacUpdate(&context, headerLength.data(), headerLength.size());
-    CCHmacUpdate(&context, dataLength.data(), dataLength.size());
-    CCHmacUpdate(&context, nonce.data(), 12);
+    CCHmacInit(&context, kCCHmacAlgSHA256, key.span().data(), key.size());
+    CCHmacUpdate(&context, headerLength.span().data(), headerLength.size());
+    CCHmacUpdate(&context, dataLength.span().data(), dataLength.size());
+    CCHmacUpdate(&context, nonce.span().data(), 12);
     CCHmacUpdate(&context, header.data(), header.size());
     CCHmacUpdate(&context, data.data(), data.size());
-    CCHmacFinal(&context, result.data());
+    CCHmacFinal(&context, result.mutableSpan().data());
 
     return result;
 }

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpTransformableFrame.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpTransformableFrame.cpp
@@ -154,7 +154,7 @@ void LibWebRTCRtpTransformableFrame::setOptions(const RTCEncodedVideoFrameMetada
     if (newMetadata.frameId)
         rtcMetadata.SetFrameId(*newMetadata.frameId);
     if (newMetadata.dependencies)
-        rtcMetadata.SetFrameDependencies({ newMetadata.dependencies->data(), newMetadata.dependencies->size() });
+        rtcMetadata.SetFrameDependencies({ newMetadata.dependencies->span().data(), newMetadata.dependencies->size() });
     if (newMetadata.width)
         rtcMetadata.SetWidth(*newMetadata.width);
     if (newMetadata.height)

--- a/Source/WebCore/Modules/push-api/cocoa/PushCryptoCocoa.cpp
+++ b/Source/WebCore/Modules/push-api/cocoa/PushCryptoCocoa.cpp
@@ -120,7 +120,7 @@ std::optional<Vector<uint8_t>> decryptAES128GCM(std::span<const uint8_t> key, st
 
     Vector<uint8_t> plainText(cipherTextWithTag.size() - aes128GCMTagLength);
     auto nonTagCipherTextLength = cipherTextWithTag.size() - aes128GCMTagLength;
-    auto result = CCCryptorGCMOneshotDecrypt(kCCAlgorithmAES, key.data(), key.size(), iv.data(), iv.size(), nullptr /* additionalData */, 0 /* additionalDataLength */, cipherTextWithTag.data(), nonTagCipherTextLength, plainText.data(), cipherTextWithTag.subspan(nonTagCipherTextLength).data(), aes128GCMTagLength);
+    auto result = CCCryptorGCMOneshotDecrypt(kCCAlgorithmAES, key.data(), key.size(), iv.data(), iv.size(), nullptr /* additionalData */, 0 /* additionalDataLength */, cipherTextWithTag.data(), nonTagCipherTextLength, plainText.mutableSpan().data(), cipherTextWithTag.subspan(nonTagCipherTextLength).data(), aes128GCMTagLength);
     if (result != kCCSuccess)
         return std::nullopt;
 

--- a/Source/WebCore/Modules/webaudio/WaveShaperNode.cpp
+++ b/Source/WebCore/Modules/webaudio/WaveShaperNode.cpp
@@ -42,7 +42,7 @@ ExceptionOr<Ref<WaveShaperNode>> WaveShaperNode::create(BaseAudioContext& contex
 {
     RefPtr<Float32Array> curve;
     if (options.curve) {
-        curve = Float32Array::tryCreate(options.curve->data(), options.curve->size());
+        curve = Float32Array::tryCreate(options.curve->span());
         if (!curve)
             return Exception { ExceptionCode::InvalidStateError, "Invalid curve parameter"_s };
     }

--- a/Source/WebCore/PAL/pal/PALSwift/UnsafeOverlays.swift
+++ b/Source/WebCore/PAL/pal/PALSwift/UnsafeOverlays.swift
@@ -53,7 +53,7 @@ extension ContiguousBytes {
             let result = VectorUInt8(buf.count)
             buf.copyBytes(
                 to: UnsafeMutableRawBufferPointer(
-                    start: UnsafeMutableRawPointer(mutating: result.__dataUnsafe()),
+                    start: UnsafeMutableRawPointer(mutating: result.span().__dataUnsafe()),
                     count: result.size()), count: result.size())
             return result
         }

--- a/Source/WebCore/PAL/pal/cocoa/Gunzip.cpp
+++ b/Source/WebCore/PAL/pal/cocoa/Gunzip.cpp
@@ -49,7 +49,7 @@ Vector<LChar> gunzip(std::span<const uint8_t> data)
     ASSERT(status == COMPRESSION_STATUS_OK);
     if (status != COMPRESSION_STATUS_OK)
         return { };
-    stream.dst_ptr = result.data();
+    stream.dst_ptr = result.mutableSpan().data();
     stream.dst_size = result.size();
     stream.src_ptr = data.subspan(ignoredByteCount).data();
     stream.src_size = data.size() - ignoredByteCount;
@@ -74,7 +74,7 @@ Vector<LChar> gunzip(std::span<const uint8_t> data)
             status = compression_stream_destroy(&stream);
             ASSERT(status == COMPRESSION_STATUS_OK);
             if (status == COMPRESSION_STATUS_OK) {
-                result.shrink(stream.dst_ptr - result.data());
+                result.shrink(stream.dst_ptr - result.span().data());
                 return result;
             }
             return { };

--- a/Source/WebCore/bridge/objc/objc_class.mm
+++ b/Source/WebCore/bridge/objc/objc_class.mm
@@ -110,7 +110,7 @@ Method* ObjcClass::methodNamed(PropertyName propertyName, Instance*) const
     CString jsName = name.ascii();
     JSNameConversionBuffer buffer;
     convertJSMethodNameToObjc(jsName, buffer);
-    RetainPtr<NSString> methodName = adoptNS([[NSString alloc] initWithCString:buffer.data() encoding:NSASCIIStringEncoding]);
+    RetainPtr<NSString> methodName = adoptNS([[NSString alloc] initWithCString:buffer.span().data() encoding:NSASCIIStringEncoding]);
 
     Method* methodPtr = 0;
     ClassStructPtr thisClass = _isa;
@@ -133,7 +133,7 @@ Method* ObjcClass::methodNamed(PropertyName propertyName, Instance*) const
             if ([thisClass respondsToSelector:@selector(webScriptNameForSelector:)])
                 mappedName = [thisClass webScriptNameForSelector:objcMethodSelector];
 
-            if ((mappedName && [mappedName isEqual:methodName.get()]) || equalSpans(objcMethodSelectorName, unsafeSpan(buffer.data()))) {
+            if ((mappedName && [mappedName isEqual:methodName.get()]) || equalSpans(objcMethodSelectorName, unsafeSpan(buffer.span().data()))) {
                 auto method = makeUnique<ObjcMethod>(thisClass, objcMethodSelector);
                 methodPtr = method.get();
                 m_methodCache.add(name.impl(), WTFMove(method));

--- a/Source/WebCore/contentextensions/ContentExtensionActions.cpp
+++ b/Source/WebCore/contentextensions/ContentExtensionActions.cpp
@@ -445,8 +445,8 @@ void RedirectAction::RegexSubstitutionAction::applyToURL(URL& url) const
         auto string = adopt(JSValueToStringCopy(context, value, nullptr));
         size_t bufferSize = JSStringGetMaximumUTF8CStringSize(string.get());
         Vector<char> buffer(bufferSize);
-        JSStringGetUTF8CString(string.get(), buffer.data(), buffer.size());
-        return String::fromUTF8(buffer.data());
+        JSStringGetUTF8CString(string.get(), buffer.mutableSpan().data(), buffer.size());
+        return String::fromUTF8(buffer.span().data());
     };
 
     // Effectively execute this JavaScript:

--- a/Source/WebCore/contentextensions/HashableActionList.h
+++ b/Source/WebCore/contentextensions/HashableActionList.h
@@ -47,7 +47,7 @@ struct HashableActionList {
     {
         std::ranges::sort(actions);
         SuperFastHash hasher;
-        hasher.addCharactersAssumingAligned(reinterpret_cast<const UChar*>(actions.data()), actions.size() * sizeof(uint64_t) / sizeof(UChar));
+        hasher.addCharactersAssumingAligned(reinterpret_cast<const UChar*>(actions.span().data()), actions.size() * sizeof(uint64_t) / sizeof(UChar));
         hash = hasher.hash();
     }
 

--- a/Source/WebCore/crypto/cocoa/CryptoAlgorithmAESCBCMac.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoAlgorithmAESCBCMac.cpp
@@ -37,14 +37,14 @@ static ExceptionOr<Vector<uint8_t>> transformAESCBC(CCOperation operation, const
 {
     CCOptions options = padding == CryptoAlgorithmAESCBC::Padding::Yes ? kCCOptionPKCS7Padding : 0;
     CCCryptorRef cryptor;
-    CCCryptorStatus status = CCCryptorCreate(operation, kCCAlgorithmAES, options, key.data(), key.size(), iv.data(), &cryptor);
+    CCCryptorStatus status = CCCryptorCreate(operation, kCCAlgorithmAES, options, key.span().data(), key.size(), iv.span().data(), &cryptor);
     if (status)
         return Exception { ExceptionCode::OperationError };
 
     Vector<uint8_t> result(CCCryptorGetOutputLength(cryptor, data.size(), true));
 
     size_t bytesWritten;
-    status = CCCryptorUpdate(cryptor, data.data(), data.size(), result.data(), result.size(), &bytesWritten);
+    status = CCCryptorUpdate(cryptor, data.span().data(), data.size(), result.mutableSpan().data(), result.size(), &bytesWritten);
     if (status)
         return Exception { ExceptionCode::OperationError };
 

--- a/Source/WebCore/crypto/cocoa/CryptoAlgorithmAESCFBMac.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoAlgorithmAESCFBMac.cpp
@@ -35,14 +35,14 @@ namespace WebCore {
 static ExceptionOr<Vector<uint8_t>> transformAESCFB(CCOperation operation, const Vector<uint8_t>& iv, const Vector<uint8_t>& key, const Vector<uint8_t>& data)
 {
     CCCryptorRef cryptor;
-    CCCryptorStatus status = CCCryptorCreateWithMode(operation, kCCModeCFB8, kCCAlgorithmAES, ccNoPadding, iv.data(), key.data(), key.size(), 0, 0, 0, 0, &cryptor);
+    CCCryptorStatus status = CCCryptorCreateWithMode(operation, kCCModeCFB8, kCCAlgorithmAES, ccNoPadding, iv.span().data(), key.span().data(), key.size(), 0, 0, 0, 0, &cryptor);
     if (status)
         return Exception { ExceptionCode::OperationError };
 
     Vector<uint8_t> result(CCCryptorGetOutputLength(cryptor, data.size(), true));
 
     size_t bytesWritten;
-    status = CCCryptorUpdate(cryptor, data.data(), data.size(), result.data(), result.size(), &bytesWritten);
+    status = CCCryptorUpdate(cryptor, data.span().data(), data.size(), result.mutableSpan().data(), result.size(), &bytesWritten);
     if (status)
         return Exception { ExceptionCode::OperationError };
 

--- a/Source/WebCore/crypto/cocoa/CryptoAlgorithmAESGCMMac.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoAlgorithmAESGCMMac.cpp
@@ -44,7 +44,7 @@ static ExceptionOr<Vector<uint8_t>> encryptAESGCM(const Vector<uint8_t>& iv, con
     Vector<uint8_t> tag(desiredTagLengthInBytes);
     // tagLength is actual an input <rdar://problem/30660074>
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    CCCryptorStatus status = CCCryptorGCM(kCCEncrypt, kCCAlgorithmAES, key.data(), key.size(), iv.data(), iv.size(), additionalData.data(), additionalData.size(), plainText.data(), plainText.size(), cipherText.data(), tag.data(), &desiredTagLengthInBytes);
+    CCCryptorStatus status = CCCryptorGCM(kCCEncrypt, kCCAlgorithmAES, key.span().data(), key.size(), iv.span().data(), iv.size(), additionalData.span().data(), additionalData.size(), plainText.span().data(), plainText.size(), cipherText.mutableSpan().data(), tag.mutableSpan().data(), &desiredTagLengthInBytes);
 ALLOW_DEPRECATED_DECLARATIONS_END
     if (status)
         return Exception { ExceptionCode::OperationError };
@@ -70,7 +70,7 @@ static ExceptionOr<Vector<uint8_t>> decyptAESGCM(const Vector<uint8_t>& iv, cons
     size_t offset = cipherText.size() - desiredTagLengthInBytes;
     // tagLength is actual an input <rdar://problem/30660074>
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    CCCryptorStatus status = CCCryptorGCM(kCCDecrypt, kCCAlgorithmAES, key.data(), key.size(), iv.data(), iv.size(), additionalData.data(), additionalData.size(), cipherText.data(), offset, plainText.data(), tag.data(), &desiredTagLengthInBytes);
+    CCCryptorStatus status = CCCryptorGCM(kCCDecrypt, kCCAlgorithmAES, key.span().data(), key.size(), iv.span().data(), iv.size(), additionalData.span().data(), additionalData.size(), cipherText.span().data(), offset, plainText.mutableSpan().data(), tag.mutableSpan().data(), &desiredTagLengthInBytes);
 ALLOW_DEPRECATED_DECLARATIONS_END
     if (status)
         return Exception { ExceptionCode::OperationError };

--- a/Source/WebCore/crypto/cocoa/CryptoAlgorithmPBKDF2Mac.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoAlgorithmPBKDF2Mac.cpp
@@ -59,7 +59,8 @@ ExceptionOr<Vector<uint8_t>> CryptoAlgorithmPBKDF2::platformDeriveBits(const Cry
     Vector<uint8_t> result(length / 8);
     // CCKeyDerivationPBKDF returns an error if the key pointer is null, even if the key length is 0. For this reason, we need to make sure we pass the empty string
     // instead of a null pointer in this case.
-    if (CCKeyDerivationPBKDF(kCCPBKDF2, key.key().data() ? reinterpret_cast<const char *>(key.key().data()) : "", key.key().size(), parameters.saltVector().data(), parameters.saltVector().size(), CryptoAlgorithmPBKDF2MacInternal::commonCryptoHMACAlgorithm(parameters.hashIdentifier), parameters.iterations, result.data(), length / 8))
+    auto keySpan = spanReinterpretCast<const char>(key.key().span());
+    if (CCKeyDerivationPBKDF(kCCPBKDF2, keySpan.data() ? keySpan.data() : "", key.key().size(), parameters.saltVector().span().data(), parameters.saltVector().size(), CryptoAlgorithmPBKDF2MacInternal::commonCryptoHMACAlgorithm(parameters.hashIdentifier), parameters.iterations, result.mutableSpan().data(), length / 8))
         return Exception { ExceptionCode::OperationError };
     return WTFMove(result);
 }

--- a/Source/WebCore/crypto/cocoa/CryptoAlgorithmRSASSA_PKCS1_v1_5Mac.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoAlgorithmRSASSA_PKCS1_v1_5Mac.cpp
@@ -50,7 +50,7 @@ static ExceptionOr<Vector<uint8_t>> signRSASSA_PKCS1_v1_5(CryptoAlgorithmIdentif
     Vector<uint8_t> signature(keyLength / 8); // Per https://tools.ietf.org/html/rfc3447#section-8.2.1
     size_t signatureSize = signature.size();
 
-    CCCryptorStatus status = CCRSACryptorSign(key, ccPKCS1Padding, digestData.data(), digestData.size(), digestAlgorithm, 0, signature.data(), &signatureSize);
+    CCCryptorStatus status = CCRSACryptorSign(key, ccPKCS1Padding, digestData.span().data(), digestData.size(), digestAlgorithm, 0, signature.mutableSpan().data(), &signatureSize);
     if (status)
         return Exception { ExceptionCode::OperationError };
 
@@ -72,7 +72,7 @@ static ExceptionOr<bool> verifyRSASSA_PKCS1_v1_5(CryptoAlgorithmIdentifier hash,
     digest->addBytes(data.span());
     auto digestData = digest->computeHash();
 
-    auto status = CCRSACryptorVerify(key, ccPKCS1Padding, digestData.data(), digestData.size(), digestAlgorithm, 0, signature.data(), signature.size());
+    auto status = CCRSACryptorVerify(key, ccPKCS1Padding, digestData.span().data(), digestData.size(), digestAlgorithm, 0, signature.span().data(), signature.size());
     if (!status)
         return true;
     if (status == kCCDecodeError)

--- a/Source/WebCore/crypto/cocoa/CryptoAlgorithmRSA_OAEPMac.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoAlgorithmRSA_OAEPMac.cpp
@@ -40,7 +40,7 @@ static ExceptionOr<Vector<uint8_t>> encryptRSA_OAEP(CryptoAlgorithmIdentifier ha
 
     Vector<uint8_t> cipherText(keyLength / 8); // Per Step 3.c of https://tools.ietf.org/html/rfc3447#section-7.1.1
     size_t cipherTextLength = cipherText.size();
-    if (CCRSACryptorEncrypt(key, ccOAEPPadding, data.data(), data.size(), cipherText.data(), &cipherTextLength, label.data(), label.size(), digestAlgorithm))
+    if (CCRSACryptorEncrypt(key, ccOAEPPadding, data.span().data(), data.size(), cipherText.mutableSpan().data(), &cipherTextLength, label.span().data(), label.size(), digestAlgorithm))
         return Exception { ExceptionCode::OperationError };
 
     return WTFMove(cipherText);
@@ -54,7 +54,7 @@ static ExceptionOr<Vector<uint8_t>> decryptRSA_OAEP(CryptoAlgorithmIdentifier ha
 
     Vector<uint8_t> plainText(keyLength / 8); // Per Step 1.b of https://tools.ietf.org/html/rfc3447#section-7.1.1
     size_t plainTextLength = plainText.size();
-    if (CCRSACryptorDecrypt(key, ccOAEPPadding, data.data(), data.size(), plainText.data(), &plainTextLength, label.data(), label.size(), digestAlgorithm))
+    if (CCRSACryptorDecrypt(key, ccOAEPPadding, data.span().data(), data.size(), plainText.mutableSpan().data(), &plainTextLength, label.span().data(), label.size(), digestAlgorithm))
         return Exception { ExceptionCode::OperationError };
 
     plainText.resize(plainTextLength);

--- a/Source/WebCore/crypto/cocoa/CryptoAlgorithmRSA_PSSMac.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoAlgorithmRSA_PSSMac.cpp
@@ -53,7 +53,7 @@ static ExceptionOr<Vector<uint8_t>> signRSA_PSS(CryptoAlgorithmIdentifier hash, 
     Vector<uint8_t> signature(keyLength / 8); // Per https://tools.ietf.org/html/rfc3447#section-8.1.1
     size_t signatureSize = signature.size();
 
-    CCCryptorStatus status = CCRSACryptorSign(key, ccRSAPSSPadding, digestData.data(), digestData.size(), digestAlgorithm, saltLength, signature.data(), &signatureSize);
+    CCCryptorStatus status = CCRSACryptorSign(key, ccRSAPSSPadding, digestData.span().data(), digestData.size(), digestAlgorithm, saltLength, signature.mutableSpan().data(), &signatureSize);
     if (status)
         return Exception { ExceptionCode::OperationError };
 
@@ -75,7 +75,7 @@ static ExceptionOr<bool> verifyRSA_PSS(CryptoAlgorithmIdentifier hash, const Pla
     digest->addBytes(data.span());
     auto digestData = digest->computeHash();
 
-    auto status = CCRSACryptorVerify(key, ccRSAPSSPadding, digestData.data(), digestData.size(), digestAlgorithm, saltLength, signature.data(), signature.size());
+    auto status = CCRSACryptorVerify(key, ccRSAPSSPadding, digestData.span().data(), digestData.size(), digestAlgorithm, saltLength, signature.span().data(), signature.size());
     if (!status)
         return true;
     return false;

--- a/Source/WebCore/crypto/cocoa/CryptoKeyMac.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoKeyMac.cpp
@@ -33,7 +33,7 @@ namespace WebCore {
 Vector<uint8_t> CryptoKey::randomData(size_t size)
 {
     Vector<uint8_t> result(size);
-    auto rc = CCRandomGenerateBytes(result.data(), result.size());
+    auto rc = CCRandomGenerateBytes(result.mutableSpan().data(), result.size());
     RELEASE_ASSERT(rc == kCCSuccess);
     return result;
 }

--- a/Source/WebCore/dom/ElementData.h
+++ b/Source/WebCore/dom/ElementData.h
@@ -206,7 +206,7 @@ inline unsigned ElementData::length() const
 inline const Attribute* ElementData::attributeBase() const
 {
     if (auto* uniqueData = dynamicDowncast<UniqueElementData>(*this))
-        return uniqueData->m_attributeVector.data();
+        return uniqueData->m_attributeVector.span().data();
     return uncheckedDowncast<ShareableElementData>(*this).m_attributeArray;
 }
 

--- a/Source/WebCore/dom/TextEncoderStreamEncoder.cpp
+++ b/Source/WebCore/dom/TextEncoderStreamEncoder.cpp
@@ -69,8 +69,7 @@ RefPtr<Uint8Array> TextEncoderStreamEncoder::encode(const String& input)
     if (!bytesWritten)
         return nullptr;
 
-    bytes.shrink(bytesWritten);
-    return Uint8Array::tryCreate(bytes.data(), bytesWritten);
+    return Uint8Array::tryCreate(bytes.span().first(bytesWritten));
 }
 
 RefPtr<Uint8Array> TextEncoderStreamEncoder::flush()

--- a/Source/WebCore/editing/TextIterator.cpp
+++ b/Source/WebCore/editing/TextIterator.cpp
@@ -2329,7 +2329,7 @@ inline size_t SearchBuffer::search(size_t& start)
     UStringSearch* searcher = WebCore::searcher();
 
     UErrorCode status = U_ZERO_ERROR;
-    usearch_setText(searcher, m_buffer.data(), size, &status);
+    usearch_setText(searcher, m_buffer.span().data(), size, &status);
     ASSERT(U_SUCCESS(status));
 
     usearch_setOffset(searcher, m_prefixLength, &status);

--- a/Source/WebCore/html/canvas/WebGL2RenderingContext.cpp
+++ b/Source/WebCore/html/canvas/WebGL2RenderingContext.cpp
@@ -747,7 +747,7 @@ WebGLAny WebGL2RenderingContext::getInternalformatParameter(GCGLenum target, GCG
             return nullptr;
     }
 
-    return Int32Array::tryCreate(params.data(), params.size());
+    return Int32Array::tryCreate(params.span());
 }
 
 void WebGL2RenderingContext::invalidateFramebuffer(GCGLenum target, const Vector<GCGLenum>& attachments)
@@ -2480,7 +2480,7 @@ WebGLAny WebGL2RenderingContext::getActiveUniformBlockParameter(WebGLProgram& pr
         GCGLint size = m_context->getActiveUniformBlocki(program.object(), uniformBlockIndex, GraphicsContextGL::UNIFORM_BLOCK_ACTIVE_UNIFORMS);
         Vector<GCGLint> params(size, 0);
         m_context->getActiveUniformBlockiv(program.object(), uniformBlockIndex, pname, params);
-        return Uint32Array::tryCreate(reinterpret_cast<GCGLuint*>(params.data()), params.size());
+        return Uint32Array::tryCreate(spanReinterpretCast<const GCGLuint>(params.span()));
     }
     case GraphicsContextGL::UNIFORM_BLOCK_REFERENCED_BY_VERTEX_SHADER:
     case GraphicsContextGL::UNIFORM_BLOCK_REFERENCED_BY_FRAGMENT_SHADER:

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -1900,7 +1900,7 @@ WebGLAny WebGLRenderingContextBase::getParameter(GCGLenum pname)
     case GraphicsContextGL::COLOR_WRITEMASK:
         return getBooleanArrayParameter(pname);
     case GraphicsContextGL::COMPRESSED_TEXTURE_FORMATS:
-        return Uint32Array::tryCreate(m_compressedTextureFormats.data(), m_compressedTextureFormats.size());
+        return Uint32Array::tryCreate(m_compressedTextureFormats.span());
     case GraphicsContextGL::CULL_FACE:
         return getBooleanParameter(pname);
     case GraphicsContextGL::CULL_FACE_MODE:

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
@@ -354,7 +354,7 @@ public:
         {
             return WTF::switchOn(m_variant,
                 [] (const RefPtr<TypedArray>& typedArray) -> const DataType* { return typedArray->data(); },
-                [] (const Vector<DataType>& vector) -> const DataType* { return vector.data(); }
+                [] (const Vector<DataType>& vector) -> const DataType* { return vector.span().data(); }
             );
         }
 

--- a/Source/WebCore/html/parser/HTMLToken.h
+++ b/Source/WebCore/html/parser/HTMLToken.h
@@ -437,7 +437,7 @@ inline const HTMLToken::Attribute* findAttribute(const HTMLToken::AttributeList&
 {
     for (auto& attribute : attributes) {
         // FIXME: The one caller that uses this probably wants to ignore letter case.
-        if (attribute.name.size() == name.size() && equal(attribute.name.data(), name))
+        if (attribute.name.size() == name.size() && equal(attribute.name.span().data(), name))
             return &attribute;
     }
     return nullptr;

--- a/Source/WebCore/html/parser/HTMLTokenizer.cpp
+++ b/Source/WebCore/html/parser/HTMLTokenizer.cpp
@@ -1406,7 +1406,7 @@ inline bool HTMLTokenizer::temporaryBufferIs(ASCIILiteral expectedString)
 {
     if (m_temporaryBuffer.size() != expectedString.length())
         return false;
-    return equal(m_temporaryBuffer.data(), expectedString.span8());
+    return equal(m_temporaryBuffer.span().data(), expectedString.span8());
 }
 
 inline void HTMLTokenizer::appendToPossibleEndTag(UChar character)
@@ -1419,7 +1419,7 @@ inline bool HTMLTokenizer::isAppropriateEndTag() const
 {
     if (m_bufferedEndTagName.size() != m_appropriateEndTagName.size())
         return false;
-    return equal(m_bufferedEndTagName.data(), m_appropriateEndTagName.span());
+    return equal(m_bufferedEndTagName.span().data(), m_appropriateEndTagName.span());
 }
 
 inline void HTMLTokenizer::parseError()

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.cpp
@@ -110,7 +110,7 @@ static inline Vector<int32_t> computedVisualOrder(const Line::RunList& lineRuns,
     }
 
     visualOrderList.resizeToFit(runLevels.size());
-    ubidi_reorderVisual(runLevels.data(), runLevels.size(), visualOrderList.data());
+    ubidi_reorderVisual(runLevels.span().data(), runLevels.size(), visualOrderList.mutableSpan().data());
     if (hasOpaqueRun) {
         ASSERT(visualOrderList.size() == runIndexOffsetMap.size());
         for (size_t i = 0; i < runIndexOffsetMap.size(); ++i)

--- a/Source/WebCore/platform/Timer.cpp
+++ b/Source/WebCore/platform/Timer.cpp
@@ -149,8 +149,8 @@ inline void TimerHeapReference::swap(TimerHeapReference& other)
 inline void TimerHeapReference::updateHeapIndex()
 {
     auto& heap = m_reference->timerHeap();
-    if (&m_reference >= heap.data() && &m_reference < heap.end())
-        m_reference->setHeapIndex(&m_reference - heap.data());
+    if (&m_reference >= heap.begin() && &m_reference < heap.end())
+        m_reference->setHeapIndex(&m_reference - heap.begin());
 }
 
 inline void swap(TimerHeapReference a, TimerHeapReference b)
@@ -192,10 +192,10 @@ private:
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     void checkConsistency(ptrdiff_t offset = 0) const
     {
-        ASSERT(m_pointer >= threadGlobalTimerHeap().data());
-        ASSERT(m_pointer <= threadGlobalTimerHeap().data() + threadGlobalTimerHeap().size());
-        ASSERT_UNUSED(offset, m_pointer + offset >= threadGlobalTimerHeap().data());
-        ASSERT_UNUSED(offset, m_pointer + offset <= threadGlobalTimerHeap().data() + threadGlobalTimerHeap().size());
+        ASSERT(m_pointer >= threadGlobalTimerHeap().begin());
+        ASSERT(m_pointer <= threadGlobalTimerHeap().begin() + threadGlobalTimerHeap().size());
+        ASSERT_UNUSED(offset, m_pointer + offset >= threadGlobalTimerHeap().begin());
+        ASSERT_UNUSED(offset, m_pointer + offset <= threadGlobalTimerHeap().begin() + threadGlobalTimerHeap().size());
     }
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
@@ -364,7 +364,7 @@ void TimerBase::heapDecreaseKey()
     RefPtr item = m_heapItemWithBitfields.pointer();
     ASSERT(item);
     checkHeapIndex();
-    auto* heapData = item->timerHeap().data();
+    auto* heapData = item->timerHeap().mutableSpan().data();
     std::push_heap(TimerHeapIterator(heapData), TimerHeapIterator(heapData + item->heapIndex() + 1), TimerHeapLessThanFunction());
     checkHeapIndex();
 }
@@ -428,7 +428,7 @@ void TimerBase::heapPopMin()
     ASSERT(item == item->timerHeap().first());
     checkHeapIndex();
     auto& heap = item->timerHeap();
-    auto* heapData = heap.data();
+    auto* heapData = heap.mutableSpan().data();
     std::pop_heap(TimerHeapIterator(heapData), TimerHeapIterator(heapData + heap.size()), TimerHeapLessThanFunction());
     checkHeapIndex();
     ASSERT(item == item->timerHeap().last());
@@ -438,7 +438,7 @@ void TimerBase::heapDeleteNullMin(ThreadTimerHeap& heap)
 {
     RELEASE_ASSERT(!heap.first()->hasTimer());
     heap.first()->time = -MonotonicTime::infinity();
-    auto* heapData = heap.data();
+    auto* heapData = heap.mutableSpan().data();
     std::pop_heap(TimerHeapIterator(heapData), TimerHeapIterator(heapData + heap.size()), TimerHeapLessThanFunction());
     heap.removeLast();
 }

--- a/Source/WebCore/platform/audio/cocoa/AudioDecoderCocoa.cpp
+++ b/Source/WebCore/platform/audio/cocoa/AudioDecoderCocoa.cpp
@@ -272,7 +272,7 @@ String InternalAudioDecoderCocoa::initialize(const String& codecName, const Audi
         bool succeeded = false;
         if (config.description.size()) {
             UInt32 size = sizeof(asbd);
-            succeeded = PAL::AudioFormatGetProperty(kAudioFormatProperty_FormatInfo, config.description.size(), config.description.data(), &size, &asbd) == noErr;
+            succeeded = PAL::AudioFormatGetProperty(kAudioFormatProperty_FormatInfo, config.description.size(), config.description.span().data(), &size, &asbd) == noErr;
             if (codec == kAudioFormatOpus) {
                 if (auto cookie = parseOpusPrivateData(config.description, { }))
                     preSkip = cookie->preSkip;

--- a/Source/WebCore/platform/audio/cocoa/CARingBuffer.h
+++ b/Source/WebCore/platform/audio/cocoa/CARingBuffer.h
@@ -127,7 +127,7 @@ public:
 
 protected:
     WEBCORE_EXPORT InProcessCARingBuffer(size_t bytesPerFrame, size_t frameCount, uint32_t numChannelStreams, Vector<uint8_t>&& buffer);
-    void* data() final { return m_buffer.data(); }
+    void* data() final { return m_buffer.mutableSpan().data(); }
     TimeBoundsBuffer& timeBoundsBuffer() final { return m_timeBoundsBuffer; }
 
 private:

--- a/Source/WebCore/platform/cocoa/DragImageCocoa.mm
+++ b/Source/WebCore/platform/cocoa/DragImageCocoa.mm
@@ -247,7 +247,7 @@ LinkImageLayout::LinkImageLayout(URL& url, const String& titleString)
         Vector<CGPoint> origins(lineCount);
         CGRect lineBounds;
         CGFloat height = 0;
-        CTFrameGetLineOrigins(textFrame.get(), CFRangeMake(0, 0), origins.data());
+        CTFrameGetLineOrigins(textFrame.get(), CFRangeMake(0, 0), origins.mutableSpan().data());
         for (CFIndex lineIndex = 0; lineIndex < lineCount; ++lineIndex) {
             CTLineRef line = (CTLineRef)CFArrayGetValueAtIndex(ctLines, lineIndex);
 

--- a/Source/WebCore/platform/graphics/Region.cpp
+++ b/Source/WebCore/platform/graphics/Region.cpp
@@ -312,7 +312,7 @@ void Region::Shape::appendSpans(const Shape& shape, std::span<const Span> spans)
 
 std::span<const int> Region::Shape::segments(std::span<const Span> span) const
 {
-    ASSERT(span.data() >= m_spans.data());
+    ASSERT(span.data() >= std::to_address(m_spans.begin()));
     ASSERT(span.data() < std::to_address(m_spans.end()));
     ASSERT(std::to_address(span.end()) <= std::to_address(m_spans.end()));
 

--- a/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp
+++ b/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp
@@ -1062,7 +1062,7 @@ Vector<GCGLint> GraphicsContextGLANGLE::getActiveUniforms(PlatformGLObject progr
     if (!makeContextCurrent())
         return result;
 
-    GL_GetActiveUniformsiv(program, uniformIndices.size(), uniformIndices.data(), pname, result.data());
+    GL_GetActiveUniformsiv(program, uniformIndices.size(), uniformIndices.span().data(), pname, result.mutableSpan().data());
     return result;
 }
 
@@ -1317,7 +1317,7 @@ bool GraphicsContextGLANGLE::getActiveAttribImpl(PlatformGLObject program, GCGLu
     GLsizei nameLength = 0;
     GLint size = 0;
     GLenum type = 0;
-    GL_GetActiveAttrib(program, index, maxAttributeSize, &nameLength, &size, &type, name.data());
+    GL_GetActiveAttrib(program, index, maxAttributeSize, &nameLength, &size, &type, name.mutableSpan().data());
     if (!nameLength)
         return false;
 
@@ -1348,7 +1348,7 @@ bool GraphicsContextGLANGLE::getActiveUniformImpl(PlatformGLObject program, GCGL
     GLsizei nameLength = 0;
     GLint size = 0;
     GLenum type = 0;
-    GL_GetActiveUniform(program, index, maxUniformSize, &nameLength, &size, &type, name.data());
+    GL_GetActiveUniform(program, index, maxUniformSize, &nameLength, &size, &type, name.mutableSpan().data());
     if (!nameLength)
         return false;
 
@@ -2022,7 +2022,7 @@ String GraphicsContextGLANGLE::getProgramInfoLog(PlatformGLObject program)
 
     GLsizei size = 0;
     Vector<GLchar> info(length);
-    GL_GetProgramInfoLog(program, length, &size, info.data());
+    GL_GetProgramInfoLog(program, length, &size, info.mutableSpan().data());
     return info.subspan(0, static_cast<unsigned>(size));
 }
 
@@ -2059,7 +2059,7 @@ String GraphicsContextGLANGLE::getShaderInfoLog(PlatformGLObject shader)
 
     GLsizei size = 0;
     Vector<GLchar> info(length);
-    GL_GetShaderInfoLog(shader, length, &size, info.data());
+    GL_GetShaderInfoLog(shader, length, &size, info.mutableSpan().data());
     return info.subspan(0, static_cast<unsigned>(size));
 }
 
@@ -2309,7 +2309,7 @@ String GraphicsContextGLANGLE::getActiveUniformBlockName(PlatformGLObject progra
     }
     Vector<GLchar> buffer(maxLength);
     GLsizei length = 0;
-    GL_GetActiveUniformBlockName(program, uniformBlockIndex, buffer.size(), &length, buffer.data());
+    GL_GetActiveUniformBlockName(program, uniformBlockIndex, buffer.size(), &length, buffer.mutableSpan().data());
     if (!length)
         return String();
     return buffer.subspan(0, length);
@@ -2425,7 +2425,7 @@ void GraphicsContextGLANGLE::transformFeedbackVaryings(PlatformGLObject program,
         return varying.data();
     });
 
-    GL_TransformFeedbackVaryings(program, pointersToVaryings.size(), pointersToVaryings.data(), bufferMode);
+    GL_TransformFeedbackVaryings(program, pointersToVaryings.size(), pointersToVaryings.span().data(), bufferMode);
 }
 
 void GraphicsContextGLANGLE::getTransformFeedbackVarying(PlatformGLObject program, GCGLuint index, GraphicsContextGLActiveInfo& info)
@@ -2443,7 +2443,7 @@ void GraphicsContextGLANGLE::getTransformFeedbackVarying(PlatformGLObject progra
     GCGLenum type = 0;
     Vector<GCGLchar> name(bufSize);
 
-    GL_GetTransformFeedbackVarying(program, index, bufSize, &length, &size, &type, name.data());
+    GL_GetTransformFeedbackVarying(program, index, bufSize, &length, &size, &type, name.mutableSpan().data());
 
     info.name = name.subspan(0, length);
     info.size = size;
@@ -2917,7 +2917,7 @@ Vector<GCGLuint> GraphicsContextGLANGLE::getUniformIndices(PlatformGLObject prog
     Vector<CString> utf8 = uniformNames.map([](auto& x) { return x.utf8(); });
     Vector<const char*> cstr = utf8.map([](auto& x) { return x.data(); });
     Vector<GCGLuint> result(cstr.size(), 0);
-    GL_GetUniformIndices(program, cstr.size(), cstr.data(), result.data());
+    GL_GetUniformIndices(program, cstr.size(), cstr.span().data(), result.mutableSpan().data());
     return result;
 }
 
@@ -3001,7 +3001,7 @@ void GraphicsContextGLANGLE::multiDrawElementsANGLE(GCGLenum mode, GCGLSpanTuple
         return;
 
     prepareForDrawingBufferWriteIfBound();
-    GL_MultiDrawElementsANGLE(mode, countsAndOffsets.data<0>(), type, asPointers(countsAndOffsets.span<1>()).data(), countsAndOffsets.bufSize);
+    GL_MultiDrawElementsANGLE(mode, countsAndOffsets.data<0>(), type, asPointers(countsAndOffsets.span<1>()).span().data(), countsAndOffsets.bufSize);
     checkGPUStatus();
 }
 
@@ -3011,7 +3011,7 @@ void GraphicsContextGLANGLE::multiDrawElementsInstancedANGLE(GCGLenum mode, GCGL
         return;
 
     prepareForDrawingBufferWriteIfBound();
-    GL_MultiDrawElementsInstancedANGLE(mode, countsOffsetsAndInstanceCounts.data<0>(), type, asPointers(countsOffsetsAndInstanceCounts.span<1>()).data(), countsOffsetsAndInstanceCounts.data<2>(), countsOffsetsAndInstanceCounts.bufSize);
+    GL_MultiDrawElementsInstancedANGLE(mode, countsOffsetsAndInstanceCounts.data<0>(), type, asPointers(countsOffsetsAndInstanceCounts.span<1>()).span().data(), countsOffsetsAndInstanceCounts.data<2>(), countsOffsetsAndInstanceCounts.bufSize);
     checkGPUStatus();
 }
 
@@ -3046,7 +3046,7 @@ String GraphicsContextGLANGLE::getTranslatedShaderSourceANGLE(PlatformGLObject s
         return emptyString();
     Vector<GLchar> name(sourceLength); // GL_TRANSLATED_SHADER_SOURCE_LENGTH_ANGLE includes null termination.
     GCGLint returnedLength = 0;
-    GL_GetTranslatedShaderSourceANGLE(shader, sourceLength, &returnedLength, name.data());
+    GL_GetTranslatedShaderSourceANGLE(shader, sourceLength, &returnedLength, name.mutableSpan().data());
     if (!returnedLength)
         return emptyString();
     // returnedLength does not include the null terminator.
@@ -3241,7 +3241,7 @@ void GraphicsContextGLANGLE::multiDrawElementsInstancedBaseVertexBaseInstanceANG
         return;
 
     prepareForDrawingBufferWriteIfBound();
-    GL_MultiDrawElementsInstancedBaseVertexBaseInstanceANGLE(mode, countsOffsetsInstanceCountsBaseVerticesAndBaseInstances.data<0>(), type, asPointers(countsOffsetsInstanceCountsBaseVerticesAndBaseInstances.span<1>()).data(), countsOffsetsInstanceCountsBaseVerticesAndBaseInstances.data<2>(), countsOffsetsInstanceCountsBaseVerticesAndBaseInstances.data<3>(), countsOffsetsInstanceCountsBaseVerticesAndBaseInstances.data<4>(), countsOffsetsInstanceCountsBaseVerticesAndBaseInstances.bufSize);
+    GL_MultiDrawElementsInstancedBaseVertexBaseInstanceANGLE(mode, countsOffsetsInstanceCountsBaseVerticesAndBaseInstances.data<0>(), type, asPointers(countsOffsetsInstanceCountsBaseVerticesAndBaseInstances.span<1>()).span().data(), countsOffsetsInstanceCountsBaseVerticesAndBaseInstances.data<2>(), countsOffsetsInstanceCountsBaseVerticesAndBaseInstances.data<3>(), countsOffsetsInstanceCountsBaseVerticesAndBaseInstances.data<4>(), countsOffsetsInstanceCountsBaseVerticesAndBaseInstances.bufSize);
     checkGPUStatus();
 }
 

--- a/Source/WebCore/platform/graphics/avfoundation/InbandTextTrackPrivateAVF.cpp
+++ b/Source/WebCore/platform/graphics/avfoundation/InbandTextTrackPrivateAVF.cpp
@@ -122,7 +122,7 @@ Ref<InbandGenericCue> InbandTextTrackPrivateAVF::processCueAttributes(CFAttribut
         CFIndex attributeCount = CFDictionaryGetCount(attributes);
         Vector<const void*> keys(attributeCount);
         Vector<const void*> values(attributeCount);
-        CFDictionaryGetKeysAndValues(attributes, keys.data(), values.data());
+        CFDictionaryGetKeysAndValues(attributes, keys.mutableSpan().data(), values.mutableSpan().data());
 
         for (CFIndex i = 0; i < attributeCount; ++i) {
             auto key = dynamic_cf_cast<CFStringRef>(keys[i]);

--- a/Source/WebCore/platform/graphics/avfoundation/objc/AVAssetMIMETypeCache.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/AVAssetMIMETypeCache.mm
@@ -76,7 +76,7 @@ static bool isMultichannelOpusAvailable()
         size_t count = propertySize / sizeof(AudioChannelLayoutTag);
         Vector<AudioChannelLayoutTag> channelLayoutTags(count, { });
 
-        error = PAL::AudioFormatGetProperty(kAudioFormatProperty_AvailableDecodeChannelLayoutTags, sizeof(asbd), &asbd, &propertySize, channelLayoutTags.data());
+        error = PAL::AudioFormatGetProperty(kAudioFormatProperty_AvailableDecodeChannelLayoutTags, sizeof(asbd), &asbd, &propertySize, channelLayoutTags.mutableSpan().data());
         if (error != noErr)
             return false;
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm
@@ -1359,7 +1359,7 @@ RetainPtr<NSDictionary> CDMInstanceSessionFairPlayStreamingAVFObjC::optionsForKe
         seedData.insertFill(seedData.size(), 0, kMaximumDeviceIdentifierSeedSize - seedData.size());
 
     [options setValue:@YES forKey:AVContentKeyRequestShouldRandomizeDeviceIdentifierKey];
-    [options setValue:[NSData dataWithBytes:seedData.data() length:seedData.sizeInBytes()] forKey:AVContentKeyRequestRandomDeviceIdentifierSeedKey];
+    [options setValue:WTF::toNSData(seedData.span()).get() forKey:AVContentKeyRequestRandomDeviceIdentifierSeedKey];
 
     return options;
 }

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaSampleAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaSampleAVFObjC.mm
@@ -235,7 +235,7 @@ void MediaSampleAVFObjC::offsetTimestampsBy(const MediaTime& offset)
     
     Vector<CMSampleTimingInfo> timingInfoArray;
     timingInfoArray.grow(itemCount);
-    if (noErr != PAL::CMSampleBufferGetSampleTimingInfoArray(m_sample.get(), itemCount, timingInfoArray.data(), nullptr))
+    if (noErr != PAL::CMSampleBufferGetSampleTimingInfoArray(m_sample.get(), itemCount, timingInfoArray.mutableSpan().data(), nullptr))
         return;
     
     for (auto& timing : timingInfoArray) {
@@ -244,7 +244,7 @@ void MediaSampleAVFObjC::offsetTimestampsBy(const MediaTime& offset)
     }
     
     CMSampleBufferRef newSample;
-    if (noErr != PAL::CMSampleBufferCreateCopyWithNewTiming(kCFAllocatorDefault, m_sample.get(), itemCount, timingInfoArray.data(), &newSample))
+    if (noErr != PAL::CMSampleBufferCreateCopyWithNewTiming(kCFAllocatorDefault, m_sample.get(), itemCount, timingInfoArray.span().data(), &newSample))
         return;
     
     m_presentationTime += offset;
@@ -260,7 +260,7 @@ void MediaSampleAVFObjC::setTimestamps(const WTF::MediaTime &presentationTimesta
     
     Vector<CMSampleTimingInfo> timingInfoArray;
     timingInfoArray.grow(itemCount);
-    if (noErr != PAL::CMSampleBufferGetSampleTimingInfoArray(m_sample.get(), itemCount, timingInfoArray.data(), nullptr))
+    if (noErr != PAL::CMSampleBufferGetSampleTimingInfoArray(m_sample.get(), itemCount, timingInfoArray.mutableSpan().data(), nullptr))
         return;
     
     for (auto& timing : timingInfoArray) {
@@ -269,7 +269,7 @@ void MediaSampleAVFObjC::setTimestamps(const WTF::MediaTime &presentationTimesta
     }
     
     CMSampleBufferRef newSample;
-    if (noErr != PAL::CMSampleBufferCreateCopyWithNewTiming(kCFAllocatorDefault, m_sample.get(), itemCount, timingInfoArray.data(), &newSample))
+    if (noErr != PAL::CMSampleBufferCreateCopyWithNewTiming(kCFAllocatorDefault, m_sample.get(), itemCount, timingInfoArray.span().data(), &newSample))
         return;
     
     m_presentationTime = presentationTimestamp;

--- a/Source/WebCore/platform/graphics/cg/GradientRendererCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/GradientRendererCG.cpp
@@ -544,9 +544,9 @@ GradientRendererCG::Strategy GradientRendererCG::makeGradient(ColorInterpolation
     apply139572277Workaround();
 
 #if HAVE(CORE_GRAPHICS_GRADIENT_CREATE_WITH_OPTIONS)
-    return Gradient { adoptCF(CGGradientCreateWithColorComponentsAndOptions(cgColorSpace, colorComponents.data(), locations.data(), numberOfStops, gradientOptionsDictionary(colorInterpolationMethod))), destinationColorSpace };
+    return Gradient { adoptCF(CGGradientCreateWithColorComponentsAndOptions(cgColorSpace, colorComponents.span().data(), locations.span().data(), numberOfStops, gradientOptionsDictionary(colorInterpolationMethod))), destinationColorSpace };
 #else
-    return Gradient { adoptCF(CGGradientCreateWithColorComponents(cgColorSpace, colorComponents.data(), locations.data(), numberOfStops)), destinationColorSpace };
+    return Gradient { adoptCF(CGGradientCreateWithColorComponents(cgColorSpace, colorComponents.span().data(), locations.span().data(), numberOfStops)), destinationColorSpace };
 #endif
 }
 

--- a/Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp
@@ -1398,7 +1398,7 @@ void GraphicsContextCG::drawLinesForText(const FloatPoint& origin, float thickne
     bool changeFillColor = fillColor() != color;
     if (changeFillColor)
         setCGFillColor(platformContext(), color);
-    CGContextFillRects(platformContext(), rects.data(), rects.size());
+    CGContextFillRects(platformContext(), rects.span().data(), rects.size());
     if (changeFillColor)
         setCGFillColor(platformContext(), fillColor());
 }

--- a/Source/WebCore/platform/graphics/cocoa/CMUtilities.mm
+++ b/Source/WebCore/platform/graphics/cocoa/CMUtilities.mm
@@ -316,7 +316,7 @@ Expected<RetainPtr<CMSampleBufferRef>, CString> toCMSampleBuffer(const MediaSamp
     }
 
     CMSampleBufferRef rawSampleBuffer = nullptr;
-    if (PAL::CMSampleBufferCreateReady(kCFAllocatorDefault, completeBlockBuffers.get(), format.get(), packetSizes.size(), packetTimings.size(), packetTimings.data(), packetSizes.size(), packetSizes.data(), &rawSampleBuffer))
+    if (PAL::CMSampleBufferCreateReady(kCFAllocatorDefault, completeBlockBuffers.get(), format.get(), packetSizes.size(), packetTimings.size(), packetTimings.span().data(), packetSizes.size(), packetSizes.span().data(), &rawSampleBuffer))
         return makeUnexpected("CMSampleBufferCreateReady failed: OOM");
 
     if (samples.isVideo() && samples.size()) {
@@ -538,7 +538,7 @@ Vector<AudioStreamPacketDescription> getPacketDescriptions(CMSampleBufferRef sam
         return { };
     }
     Vector<AudioStreamPacketDescription> descriptions(numDescriptions);
-    if (PAL::CMSampleBufferGetAudioStreamPacketDescriptions(sampleBuffer, packetDescriptionsSize, descriptions.data(), nullptr) != noErr) {
+    if (PAL::CMSampleBufferGetAudioStreamPacketDescriptions(sampleBuffer, packetDescriptionsSize, descriptions.mutableSpan().data(), nullptr) != noErr) {
         RELEASE_LOG_FAULT(Media, "Unable to get packet description list");
         return { };
     }

--- a/Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.mm
@@ -141,7 +141,7 @@ static EGLDisplay initializeEGLDisplay(const GraphicsContextGLAttributes& attrs)
     displayAttributes.append(reinterpret_cast<EGLAttrib>(disabledANGLEMetalFeatures));
     displayAttributes.append(EGL_NONE);
 
-    EGLDisplay display = EGL_GetPlatformDisplay(EGL_PLATFORM_ANGLE_ANGLE, reinterpret_cast<void*>(EGL_DEFAULT_DISPLAY), displayAttributes.data());
+    EGLDisplay display = EGL_GetPlatformDisplay(EGL_PLATFORM_ANGLE_ANGLE, reinterpret_cast<void*>(EGL_DEFAULT_DISPLAY), displayAttributes.span().data());
     EGLint majorVersion = 0;
     EGLint minorVersion = 0;
     if (EGL_Initialize(display, &majorVersion, &minorVersion) == EGL_FALSE) {
@@ -270,7 +270,7 @@ bool GraphicsContextGLCocoa::platformInitializeContext()
 
     eglContextAttributes.append(EGL_NONE);
 
-    m_contextObj = EGL_CreateContext(m_displayObj, m_configObj, EGL_NO_CONTEXT, eglContextAttributes.data());
+    m_contextObj = EGL_CreateContext(m_displayObj, m_configObj, EGL_NO_CONTEXT, eglContextAttributes.span().data());
     if (m_contextObj == EGL_NO_CONTEXT || !makeCurrent(m_displayObj, m_contextObj)) {
         LOG(WebGL, "EGLContext Initialization failed.");
         return false;

--- a/Source/WebCore/platform/graphics/cocoa/H264UtilitiesCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/H264UtilitiesCocoa.mm
@@ -97,14 +97,14 @@ RefPtr<VideoInfo> createVideoInfoFromAVCC(std::span<const uint8_t> avcc)
     }
 
     Vector<const uint8_t*> paramSetPtrs { paramSets.size(), [&paramSets](auto index) {
-        return paramSets[index].data();
+        return paramSets[index].span().data();
     } };
     Vector<size_t> paramSetSizes { paramSets.size(), [&paramSets](auto index) {
         return paramSets[index].size();
     } };
 
     CMFormatDescriptionRef rawDescription = nullptr;
-    if (PAL::CMVideoFormatDescriptionCreateFromH264ParameterSets(kCFAllocatorDefault, paramSetPtrs.size(), paramSetPtrs.data(), paramSetSizes.data(), lengthSize, &rawDescription))
+    if (PAL::CMVideoFormatDescriptionCreateFromH264ParameterSets(kCFAllocatorDefault, paramSetPtrs.size(), paramSetPtrs.span().data(), paramSetSizes.span().data(), lengthSize, &rawDescription))
         return nullptr;
     RetainPtr description = adoptCF(rawDescription);
     auto dimensions = PAL::CMVideoFormatDescriptionGetDimensions(rawDescription);

--- a/Source/WebCore/platform/graphics/cocoa/WebMAudioUtilitiesCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/WebMAudioUtilitiesCocoa.mm
@@ -86,7 +86,7 @@ static RefPtr<AudioInfo> createAudioInfoForFormat(OSType formatID, Vector<uint8_
     AudioStreamBasicDescription asbd { };
     asbd.mFormatID = formatID;
     uint32_t size = sizeof(asbd);
-    auto error = PAL::AudioFormatGetProperty(kAudioFormatProperty_FormatInfo, magicCookie.size(), magicCookie.data(), &size, &asbd);
+    auto error = PAL::AudioFormatGetProperty(kAudioFormatProperty_FormatInfo, magicCookie.size(), magicCookie.span().data(), &size, &asbd);
     if (error) {
         RELEASE_LOG_ERROR(Media, "createAudioFormatDescriptionForFormat failed with error %d (%.4s)", error, (char *)&error);
         return nullptr;

--- a/Source/WebCore/platform/graphics/coretext/ComplexTextControllerCoreText.mm
+++ b/Source/WebCore/platform/graphics/coretext/ComplexTextControllerCoreText.mm
@@ -74,7 +74,7 @@ ComplexTextController::ComplexTextRun::ComplexTextRun(CTRunRef ctRun, const Font
     Vector<CFIndex> coreTextIndices;
     if (!coreTextIndicesSpan.data()) {
         coreTextIndices.grow(m_glyphCount);
-        CTRunGetStringIndices(ctRun, CFRangeMake(0, 0), coreTextIndices.data());
+        CTRunGetStringIndices(ctRun, CFRangeMake(0, 0), coreTextIndices.mutableSpan().data());
         coreTextIndicesSpan = coreTextIndices.span();
     }
     m_coreTextIndices = coreTextIndicesSpan;
@@ -83,13 +83,13 @@ ComplexTextController::ComplexTextRun::ComplexTextRun(CTRunRef ctRun, const Font
         m_glyphs = glyphsSpan;
     else {
         m_glyphs.grow(m_glyphCount);
-        CTRunGetGlyphs(ctRun, CFRangeMake(0, 0), m_glyphs.data());
+        CTRunGetGlyphs(ctRun, CFRangeMake(0, 0), m_glyphs.mutableSpan().data());
     }
 
     if (CTRunGetStatus(ctRun) & kCTRunStatusHasOrigins) {
         Vector<CGSize> baseAdvances(m_glyphCount);
         Vector<CGPoint> glyphOrigins(m_glyphCount);
-        CTRunGetBaseAdvancesAndOrigins(ctRun, CFRangeMake(0, 0), baseAdvances.data(), glyphOrigins.data());
+        CTRunGetBaseAdvancesAndOrigins(ctRun, CFRangeMake(0, 0), baseAdvances.mutableSpan().data(), glyphOrigins.mutableSpan().data());
         m_baseAdvances.reserveInitialCapacity(m_glyphCount);
         m_glyphOrigins.reserveInitialCapacity(m_glyphCount);
         for (unsigned i = 0; i < m_glyphCount; ++i) {
@@ -102,7 +102,7 @@ ComplexTextController::ComplexTextRun::ComplexTextRun(CTRunRef ctRun, const Font
         else {
             Vector<CGSize, 64> baseAdvancesVector;
             baseAdvancesVector.grow(m_glyphCount);
-            CTRunGetAdvances(ctRun, CFRangeMake(0, 0), baseAdvancesVector.data());
+            CTRunGetAdvances(ctRun, CFRangeMake(0, 0), baseAdvancesVector.mutableSpan().data());
             m_baseAdvances = BaseAdvancesVector(m_glyphCount, [&](size_t i) {
                 return baseAdvancesVector[i];
             });

--- a/Source/WebCore/platform/graphics/coretext/DrawGlyphsRecorder.cpp
+++ b/Source/WebCore/platform/graphics/coretext/DrawGlyphsRecorder.cpp
@@ -346,7 +346,7 @@ void DrawGlyphsRecorder::recordDrawGlyphs(CGRenderingStateRef, CGGStateRef gstat
     AdvancesAndInitialPosition advances;
     if (font->platformData().orientation() == FontOrientation::Vertical) {
         Vector<CGSize, 256> translations(glyphs.size());
-        CTFontGetVerticalTranslationsForGlyphs(font->platformData().ctFont(), glyphs.data(), translations.data(), glyphs.size());
+        CTFontGetVerticalTranslationsForGlyphs(font->platformData().ctFont(), glyphs.data(), translations.mutableSpan().data(), glyphs.size());
         auto ascentDelta = font->fontMetrics().ascent(IdeographicBaseline) - font->fontMetrics().ascent();
         advances = computeVerticalAdvancesFromPositions(translations.span(), positions, ascentDelta, textMatrix);
     } else

--- a/Source/WebCore/platform/graphics/coretext/FontCascadeCoreText.cpp
+++ b/Source/WebCore/platform/graphics/coretext/FontCascadeCoreText.cpp
@@ -275,14 +275,14 @@ static void showGlyphsWithAdvances(const FloatPoint& point, const Font& font, CG
 
         Vector<CGSize, 256> translations(glyphs.size());
         RetainPtr ctFont = platformData.ctFont();
-        CTFontGetVerticalTranslationsForGlyphs(ctFont.get(), glyphs.data(), translations.data(), glyphs.size());
+        CTFontGetVerticalTranslationsForGlyphs(ctFont.get(), glyphs.data(), translations.mutableSpan().data(), glyphs.size());
 
         auto ascentDelta = font.fontMetrics().ascent(IdeographicBaseline) - font.fontMetrics().ascent();
         fillVectorWithVerticalGlyphPositions(positions, translations, advances, point, ascentDelta, CGContextGetTextMatrix(context));
-        CTFontDrawGlyphs(ctFont.get(), glyphs.data(), positions.data(), glyphs.size(), context);
+        CTFontDrawGlyphs(ctFont.get(), glyphs.data(), positions.span().data(), glyphs.size(), context);
     } else {
         fillVectorWithHorizontalGlyphPositions(positions, context, advances, point);
-        CTFontDrawGlyphs(RetainPtr { platformData.ctFont() }.get(), glyphs.data(), positions.data(), glyphs.size(), context);
+        CTFontDrawGlyphs(RetainPtr { platformData.ctFont() }.get(), glyphs.data(), positions.span().data(), glyphs.size(), context);
     }
 }
 

--- a/Source/WebCore/platform/graphics/coretext/FontCoreText.cpp
+++ b/Source/WebCore/platform/graphics/coretext/FontCoreText.cpp
@@ -776,7 +776,7 @@ FloatRect Font::platformBoundsForGlyph(Glyph glyph) const
 Vector<FloatRect, Font::inlineGlyphRunCapacity> Font::platformBoundsForGlyphs(const Vector<Glyph, inlineGlyphRunCapacity>& glyphs) const
 {
     Vector<CGRect, inlineGlyphRunCapacity> rectsForGlyphs(glyphs.size());
-    CTFontGetBoundingRectsForGlyphs(getCTFont(), platformData().orientation() == FontOrientation::Vertical ? kCTFontOrientationVertical : kCTFontOrientationHorizontal, glyphs.data(), rectsForGlyphs.data(), rectsForGlyphs.size());
+    CTFontGetBoundingRectsForGlyphs(getCTFont(), platformData().orientation() == FontOrientation::Vertical ? kCTFontOrientationVertical : kCTFontOrientationHorizontal, glyphs.span().data(), rectsForGlyphs.mutableSpan().data(), rectsForGlyphs.size());
 
     return rectsForGlyphs.map<Vector<FloatRect, inlineGlyphRunCapacity>>([&](const auto& rect) -> auto {
         FloatRect boundingBox(rect);

--- a/Source/WebCore/platform/graphics/coretext/FontPlatformDataCoreText.cpp
+++ b/Source/WebCore/platform/graphics/coretext/FontPlatformDataCoreText.cpp
@@ -345,7 +345,7 @@ std::optional<FontPlatformSerializedAttributes> FontPlatformSerializedAttributes
         CFIndex count = CFDictionaryGetCount(dictionary);
         Vector<void*> keys(count);
         Vector<void*> values(count);
-        CFDictionaryGetKeysAndValues(dictionary, const_cast<const void**>(keys.data()), const_cast<const void**>(values.data()));
+        CFDictionaryGetKeysAndValues(dictionary, const_cast<const void**>(keys.span().data()), const_cast<const void**>(values.span().data()));
 
         for (CFIndex i = 0; i < count; ++i) {
             auto key = static_cast<CFNumberRef>(keys[i]);

--- a/Source/WebCore/platform/graphics/coretext/GlyphPageCoreText.cpp
+++ b/Source/WebCore/platform/graphics/coretext/GlyphPageCoreText.cpp
@@ -57,9 +57,9 @@ bool GlyphPage::fill(std::span<const UChar> buffer)
     unsigned glyphStep = buffer.size() / GlyphPage::size;
 
     if (shouldFillWithVerticalGlyphs(buffer, font))
-        CTFontGetVerticalGlyphsForCharacters(font->platformData().ctFont(), reinterpret_cast<const UniChar*>(buffer.data()), glyphs.data(), buffer.size());
+        CTFontGetVerticalGlyphsForCharacters(font->platformData().ctFont(), reinterpret_cast<const UniChar*>(buffer.data()), glyphs.mutableSpan().data(), buffer.size());
     else
-        CTFontGetGlyphsForCharacters(font->platformData().ctFont(), reinterpret_cast<const UniChar*>(buffer.data()), glyphs.data(), buffer.size());
+        CTFontGetGlyphsForCharacters(font->platformData().ctFont(), reinterpret_cast<const UniChar*>(buffer.data()), glyphs.mutableSpan().data(), buffer.size());
 
     bool haveGlyphs = false;
     for (unsigned i = 0; i < GlyphPage::size; ++i) {

--- a/Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterWebM.cpp
+++ b/Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterWebM.cpp
@@ -113,7 +113,7 @@ public:
         if (info.codecName == kAudioFormatOpus) {
             auto description = audioStreamDescriptionFromAudioInfo(info);
             auto opusHeader = createOpusPrivateData(description.streamDescription());
-            audioTrack->SetCodecPrivate(opusHeader.data(), opusHeader.size());
+            audioTrack->SetCodecPrivate(opusHeader.span().data(), opusHeader.size());
         }
         return trackIndex;
     }

--- a/Source/WebCore/platform/mediastream/RealtimeOutgoingAudioSource.cpp
+++ b/Source/WebCore/platform/mediastream/RealtimeOutgoingAudioSource.cpp
@@ -104,7 +104,7 @@ void RealtimeOutgoingAudioSource::RemoveSink(webrtc::AudioTrackSinkInterface* si
     m_sinks.remove(sink);
 }
 
-void RealtimeOutgoingAudioSource::sendAudioFrames(const void* audioData, int bitsPerSample, int sampleRate, size_t numberOfChannels, size_t numberOfFrames)
+void RealtimeOutgoingAudioSource::sendAudioFrames(std::span<const uint8_t> audioData, int bitsPerSample, int sampleRate, size_t numberOfChannels, size_t numberOfFrames)
 {
 #if !RELEASE_LOG_DISABLED
     if (!(++m_chunksSent % 200))
@@ -113,7 +113,7 @@ void RealtimeOutgoingAudioSource::sendAudioFrames(const void* audioData, int bit
 
     Locker locker { m_sinksLock };
     for (auto sink : m_sinks)
-        sink->OnData(audioData, bitsPerSample, sampleRate, numberOfChannels, numberOfFrames);
+        sink->OnData(audioData.data(), bitsPerSample, sampleRate, numberOfChannels, numberOfFrames);
 }
 
 #if !RELEASE_LOG_DISABLED

--- a/Source/WebCore/platform/mediastream/RealtimeOutgoingAudioSource.h
+++ b/Source/WebCore/platform/mediastream/RealtimeOutgoingAudioSource.h
@@ -81,7 +81,7 @@ protected:
 
     bool isSilenced() const { return m_muted || !m_enabled; }
 
-    void sendAudioFrames(const void* audioData, int bitsPerSample, int sampleRate, size_t numberOfChannels, size_t numberOfFrames);
+    void sendAudioFrames(std::span<const uint8_t> audioData, int bitsPerSample, int sampleRate, size_t numberOfChannels, size_t numberOfFrames);
 
 #if !RELEASE_LOG_DISABLED
     // LoggerHelper API

--- a/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/RealtimeOutgoingAudioSourceLibWebRTC.cpp
+++ b/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/RealtimeOutgoingAudioSourceLibWebRTC.cpp
@@ -125,7 +125,7 @@ void RealtimeOutgoingAudioSourceLibWebRTC::pullAudioData()
             }
         }
 
-        sendAudioFrames(m_audioBuffer.data(), LibWebRTCAudioFormat::sampleSize, GST_AUDIO_INFO_RATE(&m_outputStreamDescription),
+        sendAudioFrames(m_audioBuffer.span(), LibWebRTCAudioFormat::sampleSize, GST_AUDIO_INFO_RATE(&m_outputStreamDescription),
             GST_AUDIO_INFO_CHANNELS(&m_outputStreamDescription), outChunkSampleCount);
     }
 }

--- a/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureDevice.cpp
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureDevice.cpp
@@ -149,7 +149,7 @@ Vector<AudioDeviceID> CoreAudioCaptureDevice::relatedAudioDeviceIDs(AudioDeviceI
         return { };
 
     Vector<AudioDeviceID> devices(size / sizeof(AudioDeviceID));
-    error = AudioObjectGetPropertyData(deviceID, &property, 0, nullptr, &size, devices.data());
+    error = AudioObjectGetPropertyData(deviceID, &property, 0, nullptr, &size, devices.mutableSpan().data());
     if (error)
         return { };
     return devices;

--- a/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureDeviceManager.cpp
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureDeviceManager.cpp
@@ -267,7 +267,7 @@ static inline Vector<CoreAudioCaptureDevice> computeAudioDeviceList(bool filterT
 
     size_t deviceCount = dataSize / sizeof(AudioObjectID);
     Vector<AudioObjectID> deviceIDs(deviceCount);
-    err = AudioObjectGetPropertyData(kAudioObjectSystemObject, &address, 0, nullptr, &dataSize, deviceIDs.data());
+    err = AudioObjectGetPropertyData(kAudioObjectSystemObject, &address, 0, nullptr, &dataSize, deviceIDs.mutableSpan().data());
     if (err) {
         RELEASE_LOG(WebRTC, "computeAudioDeviceList failed to get device list %d (%.4s)", (int)err, (char*)&err);
         return { };

--- a/Source/WebCore/platform/mediastream/mac/RealtimeOutgoingAudioSourceCocoa.cpp
+++ b/Source/WebCore/platform/mediastream/mac/RealtimeOutgoingAudioSourceCocoa.cpp
@@ -150,14 +150,14 @@ void RealtimeOutgoingAudioSourceCocoa::pullAudioData()
     auto& firstBuffer = span(bufferList)[0];
     firstBuffer.mNumberChannels = numberOfChannels;
     firstBuffer.mDataByteSize = bufferSize;
-    firstBuffer.mData = m_audioBuffer.data();
+    firstBuffer.mData = m_audioBuffer.mutableSpan().data();
 
     if (isSilenced() != m_sampleConverter->muted())
         m_sampleConverter->setMuted(isSilenced());
 
     m_sampleConverter->pullAvailableSamplesAsChunks(bufferList, chunkSampleCount, m_readCount, [this, numberOfChannels] {
         m_readCount += chunkSampleCount;
-        sendAudioFrames(m_audioBuffer.data(), LibWebRTCAudioFormat::sampleSize, LibWebRTCAudioFormat::sampleRate, numberOfChannels, chunkSampleCount);
+        sendAudioFrames(m_audioBuffer.span(), LibWebRTCAudioFormat::sampleSize, LibWebRTCAudioFormat::sampleRate, numberOfChannels, chunkSampleCount);
     });
 }
 

--- a/Source/WebCore/platform/network/cf/FormDataStreamCFNet.cpp
+++ b/Source/WebCore/platform/network/cf/FormDataStreamCFNet.cpp
@@ -41,6 +41,7 @@
 #include <wtf/SchedulePair.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/Threading.h>
+#include <wtf/cf/VectorCF.h>
 
 static const SInt32 fileNotFoundError = -43;
 
@@ -386,7 +387,7 @@ void setHTTPBody(CFMutableURLRequestRef request, const RefPtr<FormData>& formDat
     auto& elements = formData->elements();
     if (elements.size() == 1 && !formData->alwaysStream()) {
         if (auto* vector = std::get_if<Vector<uint8_t>>(&elements[0].data)) {
-            auto data = adoptCF(CFDataCreate(nullptr, vector->data(), vector->size()));
+            RetainPtr data = toCFData(vector->span());
             CFURLRequestSetHTTPRequestBody(request, data.get());
             return;
         }

--- a/Source/WebCore/rendering/AttachmentLayout.mm
+++ b/Source/WebCore/rendering/AttachmentLayout.mm
@@ -365,7 +365,7 @@ void AttachmentLayout::buildWrappedLines(String& text, CTFontRef font, NSDiction
         return;
     
     origins.resize(lineCount);
-    CTFrameGetLineOrigins(textFrame.get(), CFRangeMake(0, 0), origins.data());
+    CTFrameGetLineOrigins(textFrame.get(), CFRangeMake(0, 0), origins.mutableSpan().data());
     // Lay out and record the first (maximumLineCount - 1) lines.
     CFIndex lineIndex = 0;
     auto nonTruncatedLineCount = std::min<CFIndex>(maximumLineCount - 1, lineCount);

--- a/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
+++ b/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
@@ -970,14 +970,14 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     va_end(preflightArgs);
 
     Vector<char, 1024> buffer(stringLength + 1);
-    vsnprintf(buffer.data(), stringLength + 1, message, args);
+    vsnprintf(buffer.mutableSpan().data(), stringLength + 1, message, args);
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     TextPosition position = textPosition();
     if (m_parserPaused)
-        m_pendingCallbacks->appendErrorCallback(type, reinterpret_cast<const xmlChar*>(buffer.data()), position.m_line, position.m_column);
+        m_pendingCallbacks->appendErrorCallback(type, reinterpret_cast<const xmlChar*>(buffer.span().data()), position.m_line, position.m_column);
     else
-        handleError(type, buffer.data(), textPosition());
+        handleError(type, buffer.span().data(), textPosition());
 }
 
 void XMLDocumentParser::processingInstruction(const xmlChar* target, const xmlChar* data)

--- a/Source/WebGPU/WebGPU/RenderBundleEncoder.mm
+++ b/Source/WebGPU/WebGPU/RenderBundleEncoder.mm
@@ -1184,12 +1184,12 @@ void RenderBundleEncoder::setBindGroup(uint32_t groupIndex, const BindGroup* gro
     if (auto vertexBindGroupBufferIndex = m_device->vertexBufferIndexForBindGroup(groupIndex); group.vertexArgumentBuffer() && m_vertexBuffers.size() > vertexBindGroupBufferIndex) {
         if (!addResource(m_resources, group.vertexArgumentBuffer(), MTLRenderStageVertex))
             return;
-        m_vertexBuffers[vertexBindGroupBufferIndex] = { .buffer = group.vertexArgumentBuffer(), .offset = 0, .dynamicOffsetCount = dynamicOffsetCount, .dynamicOffsets = dynamicOffsets->data(), .size = group.vertexArgumentBuffer().length };
+        m_vertexBuffers[vertexBindGroupBufferIndex] = { .buffer = group.vertexArgumentBuffer(), .offset = 0, .dynamicOffsetCount = dynamicOffsetCount, .dynamicOffsets = dynamicOffsets->span().data(), .size = group.vertexArgumentBuffer().length };
     }
     if (group.fragmentArgumentBuffer() && m_fragmentBuffers.size() > groupIndex) {
         if (!addResource(m_resources, group.fragmentArgumentBuffer(), MTLRenderStageFragment))
             return;
-        m_fragmentBuffers[groupIndex] = { .buffer = group.fragmentArgumentBuffer(), .offset = 0, .dynamicOffsetCount = dynamicOffsetCount, .dynamicOffsets = dynamicOffsets->data(), .size = group.fragmentArgumentBuffer().length };
+        m_fragmentBuffers[groupIndex] = { .buffer = group.fragmentArgumentBuffer(), .offset = 0, .dynamicOffsetCount = dynamicOffsetCount, .dynamicOffsets = dynamicOffsets->span().data(), .size = group.fragmentArgumentBuffer().length };
     }
 }
 


### PR DESCRIPTION
#### d231ec9725b1e94f2be9175b4ffa488900b0b15f
<pre>
Stop using Vector::data() in WebCore/
<a href="https://bugs.webkit.org/show_bug.cgi?id=293863">https://bugs.webkit.org/show_bug.cgi?id=293863</a>

Reviewed by Darin Adler.

Stop using Vector::data() in WebCore/, in favor of Vector::span(). This is a
step towards removing Vector::data() and encouraging people to use spans.

* Source/WTF/wtf/ParallelJobs.h:
(WTF::ParallelJobs::execute):
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUAdapterImpl.cpp:
(WebCore::WebGPU::supportedFeatures):
(WebCore::WebGPU::AdapterImpl::requestDevice):
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUCommandEncoderImpl.cpp:
(WebCore::WebGPU::CommandEncoderImpl::beginRenderPass):
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUDeviceImpl.cpp:
(WebCore::WebGPU::DeviceImpl::createTexture):
(WebCore::WebGPU::DeviceImpl::createBindGroupLayout):
(WebCore::WebGPU::DeviceImpl::createPipelineLayout):
(WebCore::WebGPU::DeviceImpl::createBindGroup):
(WebCore::WebGPU::convertToBacking):
(WebCore::WebGPU::DeviceImpl::createRenderBundleEncoder):
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUQueueImpl.cpp:
(WebCore::WebGPU::QueueImpl::submit):
* Source/WebCore/Modules/WebGPU/Implementation/WebGPURenderPassEncoderImpl.cpp:
(WebCore::WebGPU::RenderPassEncoderImpl::executeBundles):
* Source/WebCore/Modules/compression/CompressionStreamEncoder.cpp:
(WebCore::CompressionStreamEncoder::compressZlib):
* Source/WebCore/Modules/compression/DecompressionStreamDecoder.cpp:
(WebCore::DecompressionStreamDecoder::decompressZlib):
* Source/WebCore/Modules/compression/cocoa/CompressionStreamEncoderCocoa.mm:
(WebCore::CompressionStreamEncoder::compressAppleCompressionFramework):
* Source/WebCore/Modules/compression/cocoa/DecompressionStreamDecoderCocoa.mm:
(WebCore::DecompressionStreamDecoder::decompressAppleCompressionFramework):
* Source/WebCore/Modules/encryptedmedia/legacy/LegacyCDMSessionClearKey.cpp:
(WebCore::CDMSessionClearKey::cachedKeyForKeyID const):
* Source/WebCore/Modules/mediastream/RTCRtpSFrameTransform.cpp:
(WebCore::RTCRtpSFrameTransform::initializeTransformer):
* Source/WebCore/Modules/mediastream/RTCRtpSFrameTransformerCocoa.cpp:
(WebCore::RTCRtpSFrameTransformer::computeEncryptedDataSignature):
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpTransformableFrame.cpp:
(WebCore::LibWebRTCRtpTransformableFrame::setOptions):
* Source/WebCore/Modules/push-api/cocoa/PushCryptoCocoa.cpp:
(WebCore::PushCrypto::decryptAES128GCM):
* Source/WebCore/Modules/webaudio/WaveShaperNode.cpp:
(WebCore::WaveShaperNode::create):
* Source/WebCore/PAL/pal/PALSwift/UnsafeOverlays.swift:
(ContiguousBytes.copyToVectorUInt8):
* Source/WebCore/PAL/pal/cocoa/Gunzip.cpp:
(PAL::gunzip):
* Source/WebCore/bridge/objc/objc_class.mm:
(JSC::Bindings::ObjcClass::methodNamed const):
* Source/WebCore/contentextensions/ContentExtensionActions.cpp:
(WebCore::ContentExtensions::RedirectAction::RegexSubstitutionAction::applyToURL const):
* Source/WebCore/contentextensions/HashableActionList.h:
(WebCore::ContentExtensions::HashableActionList::HashableActionList):
* Source/WebCore/crypto/cocoa/CryptoAlgorithmAESCBCMac.cpp:
(WebCore::transformAESCBC):
* Source/WebCore/crypto/cocoa/CryptoAlgorithmAESCFBMac.cpp:
(WebCore::transformAESCFB):
* Source/WebCore/crypto/cocoa/CryptoAlgorithmAESGCMMac.cpp:
(WebCore::encryptAESGCM):
(WebCore::decyptAESGCM):
* Source/WebCore/crypto/cocoa/CryptoAlgorithmPBKDF2Mac.cpp:
(WebCore::CryptoAlgorithmPBKDF2::platformDeriveBits):
* Source/WebCore/crypto/cocoa/CryptoAlgorithmRSASSA_PKCS1_v1_5Mac.cpp:
(WebCore::signRSASSA_PKCS1_v1_5):
(WebCore::verifyRSASSA_PKCS1_v1_5):
* Source/WebCore/crypto/cocoa/CryptoAlgorithmRSA_OAEPMac.cpp:
(WebCore::encryptRSA_OAEP):
(WebCore::decryptRSA_OAEP):
* Source/WebCore/crypto/cocoa/CryptoAlgorithmRSA_PSSMac.cpp:
(WebCore::signRSA_PSS):
(WebCore::verifyRSA_PSS):
* Source/WebCore/crypto/cocoa/CryptoKeyMac.cpp:
(WebCore::CryptoKey::randomData):
* Source/WebCore/crypto/cocoa/CryptoKeyRSAMac.cpp:
(WebCore::getPublicKeyComponents):
(WebCore::getPrivateKeyComponents):
(WebCore::CryptoKeyRSA::create):
(WebCore::CryptoKeyRSA::algorithm const):
(WebCore::CryptoKeyRSA::exportSpki const):
(WebCore::CryptoKeyRSA::exportPkcs8 const):
* Source/WebCore/crypto/cocoa/CryptoUtilitiesCocoa.cpp:
(WebCore::transformAESCTR):
(WebCore::keyDerivationHMAC):
(WebCore::calculateHMACSignature):
* Source/WebCore/crypto/cocoa/SerializedCryptoKeyWrapMac.mm:
(WebCore::createAndStoreMasterKey):
(WebCore::wrapSerializedCryptoKey):
(WebCore::unwrapCryptoKey):
* Source/WebCore/dom/ElementData.h:
(WebCore::ElementData::attributeBase const):
* Source/WebCore/dom/TextEncoderStreamEncoder.cpp:
(WebCore::TextEncoderStreamEncoder::encode):
* Source/WebCore/editing/TextIterator.cpp:
(WebCore::SearchBuffer::search):
* Source/WebCore/html/canvas/WebGL2RenderingContext.cpp:
(WebCore::WebGL2RenderingContext::getInternalformatParameter):
(WebCore::WebGL2RenderingContext::getActiveUniformBlockParameter):
* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::getParameter):
* Source/WebCore/html/canvas/WebGLRenderingContextBase.h:
* Source/WebCore/html/parser/HTMLToken.h:
(WebCore::findAttribute):
* Source/WebCore/html/parser/HTMLTokenizer.cpp:
(WebCore::HTMLTokenizer::temporaryBufferIs):
(WebCore::HTMLTokenizer::isAppropriateEndTag const):
* Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.cpp:
(WebCore::Layout::computedVisualOrder):
* Source/WebCore/platform/Timer.cpp:
(WebCore::TimerHeapReference::updateHeapIndex):
(WebCore::TimerHeapIterator::checkConsistency const):
(WebCore::TimerBase::heapDecreaseKey):
(WebCore::TimerBase::heapPopMin):
(WebCore::TimerBase::heapDeleteNullMin):
* Source/WebCore/platform/audio/cocoa/AudioDecoderCocoa.cpp:
(WebCore::InternalAudioDecoderCocoa::initialize):
* Source/WebCore/platform/audio/cocoa/AudioSampleBufferConverter.mm:
(WebCore::AudioSampleBufferConverter::sampleBuffer):
(WebCore::AudioSampleBufferConverter::provideSourceDataNumOutputPackets):
(WebCore::AudioSampleBufferConverter::processSampleBuffers):
* Source/WebCore/platform/audio/cocoa/CARingBuffer.h:
* Source/WebCore/platform/cocoa/DragImageCocoa.mm:
(WebCore::LinkImageLayout::LinkImageLayout):
* Source/WebCore/platform/graphics/Region.cpp:
(WebCore::Region::Shape::segments const):
* Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp:
(WebCore::GraphicsContextGLANGLE::getActiveUniforms):
(WebCore::GraphicsContextGLANGLE::getActiveAttribImpl):
(WebCore::GraphicsContextGLANGLE::getActiveUniformImpl):
(WebCore::GraphicsContextGLANGLE::getProgramInfoLog):
(WebCore::GraphicsContextGLANGLE::getShaderInfoLog):
(WebCore::GraphicsContextGLANGLE::getActiveUniformBlockName):
(WebCore::GraphicsContextGLANGLE::transformFeedbackVaryings):
(WebCore::GraphicsContextGLANGLE::getTransformFeedbackVarying):
(WebCore::GraphicsContextGLANGLE::getUniformIndices):
(WebCore::GraphicsContextGLANGLE::multiDrawElementsANGLE):
(WebCore::GraphicsContextGLANGLE::multiDrawElementsInstancedANGLE):
(WebCore::GraphicsContextGLANGLE::getTranslatedShaderSourceANGLE):
(WebCore::GraphicsContextGLANGLE::multiDrawElementsInstancedBaseVertexBaseInstanceANGLE):
* Source/WebCore/platform/graphics/avfoundation/InbandTextTrackPrivateAVF.cpp:
(WebCore::InbandTextTrackPrivateAVF::processCueAttributes):
* Source/WebCore/platform/graphics/avfoundation/objc/AVAssetMIMETypeCache.mm:
(WebCore::isMultichannelOpusAvailable):
* Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm:
(WebCore::CDMInstanceSessionFairPlayStreamingAVFObjC::optionsForKeyRequestWithHashSalt):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaSampleAVFObjC.mm:
(WebCore::MediaSampleAVFObjC::offsetTimestampsBy):
(WebCore::MediaSampleAVFObjC::setTimestamps):
* Source/WebCore/platform/graphics/cg/GradientRendererCG.cpp:
(WebCore::GradientRendererCG::makeGradient const):
* Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp:
(WebCore::GraphicsContextCG::setLineDash):
(WebCore::GraphicsContextCG::drawLinesForText):
* Source/WebCore/platform/graphics/cocoa/CMUtilities.mm:
(WebCore::toCMSampleBuffer):
(WebCore::getPacketDescriptions):
* Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.mm:
(WebCore::initializeEGLDisplay):
(WebCore::GraphicsContextGLCocoa::platformInitializeContext):
* Source/WebCore/platform/graphics/cocoa/H264UtilitiesCocoa.mm:
(WebCore::createVideoInfoFromAVCC):
* Source/WebCore/platform/graphics/cocoa/WebMAudioUtilitiesCocoa.mm:
(WebCore::createAudioInfoForFormat):
* Source/WebCore/platform/graphics/coretext/ComplexTextControllerCoreText.mm:
(WebCore::ComplexTextController::ComplexTextRun::ComplexTextRun):
* Source/WebCore/platform/graphics/coretext/DrawGlyphsRecorder.cpp:
(WebCore::DrawGlyphsRecorder::recordDrawGlyphs):
* Source/WebCore/platform/graphics/coretext/FontCascadeCoreText.cpp:
(WebCore::showGlyphsWithAdvances):
* Source/WebCore/platform/graphics/coretext/FontCoreText.cpp:
(WebCore::Font::platformBoundsForGlyphs const):
* Source/WebCore/platform/graphics/coretext/FontPlatformDataCoreText.cpp:
(WebCore::FontPlatformSerializedAttributes::fromCF):
* Source/WebCore/platform/graphics/coretext/GlyphPageCoreText.cpp:
(WebCore::GlyphPage::fill):
* Source/WebCore/platform/graphics/cv/ImageTransferSessionVT.mm:
(WebCore::ImageTransferSessionVT::convertCMSampleBuffer):
* Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterWebM.cpp:
(WebCore::MediaRecorderPrivateWriterWebMDelegate::addAudioTrack):
* Source/WebCore/platform/mediastream/RealtimeOutgoingAudioSource.cpp:
(WebCore::RealtimeOutgoingAudioSource::sendAudioFrames):
* Source/WebCore/platform/mediastream/RealtimeOutgoingAudioSource.h:
* Source/WebCore/platform/mediastream/libwebrtc/gstreamer/RealtimeOutgoingAudioSourceLibWebRTC.cpp:
(WebCore::RealtimeOutgoingAudioSourceLibWebRTC::pullAudioData):
* Source/WebCore/platform/mediastream/mac/CoreAudioCaptureDevice.cpp:
(WebCore::CoreAudioCaptureDevice::relatedAudioDeviceIDs):
* Source/WebCore/platform/mediastream/mac/CoreAudioCaptureDeviceManager.cpp:
(WebCore::computeAudioDeviceList):
* Source/WebCore/platform/mediastream/mac/RealtimeOutgoingAudioSourceCocoa.cpp:
(WebCore::RealtimeOutgoingAudioSourceCocoa::pullAudioData):
* Source/WebCore/platform/network/cf/FormDataStreamCFNet.cpp:
(WebCore::setHTTPBody):
* Source/WebCore/rendering/AttachmentLayout.mm:
(WebCore::AttachmentLayout::buildWrappedLines):
* Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp:
(WebCore::XMLDocumentParser::error):
* Source/WebGPU/WebGPU/RenderBundleEncoder.mm:
(WebGPU::RenderBundleEncoder::setBindGroup):

Canonical link: <a href="https://commits.webkit.org/295666@main">https://commits.webkit.org/295666@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/73f36c496906bedee27fef181165bbd7247756da

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105849 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25600 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15993 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/111046 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/56446 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/107890 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/26177 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34103 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/80397 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108855 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/20574 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95518 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60712 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/20236 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/13616 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55884 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/98490 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/89977 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/13653 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/113896 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/104468 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32989 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/24320 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/89475 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33353 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91748 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89146 "Found 100 new API test failures: /TestWebKit:WebKit.PageLoadDidChangeLocationWithinPage, /TestWebKit:WebKit.AboutBlankLoad, /TestWebKit:WebKit.PreventEmptyUserAgent, /TestWebKit:WebKit.PrivateBrowsingPushStateNoHistoryCallback, /WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/content-type, /WebKitGTK/TestUIClient:/webkit/WebKitWebView/pointer-lock-permission-request, /TestWebKit:WebKit.HitTestResultNodeHandle, /TestWebKit:WebKit2TextFieldBeginAndEditEditingTest.TextFieldDidBeginShouldNotBeDispatchedForAlreadyFocusedField, /TestWebKit:WebKit.Find, /WebKitGTK/TestWebProcessExtensions:/webkit/WebKitWebProcessExtension/dom-input-element-is-user-edited ... (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22715 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34015 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11822 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/28508 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32914 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/38325 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/128780 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32660 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/35149 "Found 1 new JSC stress test failure: wasm.yaml/wasm/gc/ref-i31-eq.js.default-wasm (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/36009 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34258 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->