### PR TITLE
[JSC] Improve Performance of `Math.sumPrecise` for Large Inputs

### DIFF
--- a/JSTests/stress/math-sum-precise.js
+++ b/JSTests/stress/math-sum-precise.js
@@ -8,7 +8,7 @@ function shouldBe(actual, expected) {
         throw new Error(`Bad value: ${actual}!`);
 }
 
-for (var i = 0; i < 1e4; i++) {
+for (var i = 0; i < testLoopCount; i++) {
     shouldBe(Math.sumPrecise([1, 2, 3]), 6);
     shouldBe(Math.sumPrecise([1e308]), 1e308);
     shouldBe(Math.sumPrecise([1e308, -1e308]), 0);

--- a/Source/WTF/wtf/PreciseSum.cpp
+++ b/Source/WTF/wtf/PreciseSum.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2024-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -68,6 +68,7 @@ namespace WTF {
 
 namespace {
 
+// CONSTANTS DEFINING THE FLOATING POINT FORMAT
 constexpr int64_t XSUM_MANTISSA_BITS = 52; // Bits in fp mantissa, excludes implict 1
 constexpr int64_t XSUM_EXP_BITS = 11; // Bits in fp exponent
 constexpr int64_t XSUM_MANTISSA_MASK = (static_cast<int64_t>(1) << XSUM_MANTISSA_BITS) - 1; // Mask for mantissa bits
@@ -75,6 +76,8 @@ constexpr int64_t XSUM_EXP_MASK = (1 << XSUM_EXP_BITS) - 1; // Mask for exponent
 constexpr int64_t XSUM_EXP_BIAS = (1 << (XSUM_EXP_BITS - 1)) - 1; // Bias added to signed exponent
 constexpr int64_t XSUM_SIGN_BIT = XSUM_MANTISSA_BITS + XSUM_EXP_BITS; // Position of sign bit
 constexpr uint64_t XSUM_SIGN_MASK = static_cast<uint64_t>(1) << XSUM_SIGN_BIT; // Mask for sign bit
+
+// CONSTANTS DEFINING THE SMALL ACCUMULATOR FORMAT
 constexpr int64_t XSUM_SCHUNK_BITS = 64; // Bits in chunk of the small accumulator
 constexpr int64_t XSUM_LOW_EXP_BITS = 5; // # of low bits of exponent, in one chunk
 constexpr int64_t XSUM_LOW_EXP_MASK = (1 << XSUM_LOW_EXP_BITS) - 1; // Mask for low-order exponent bits
@@ -85,38 +88,354 @@ constexpr int64_t XSUM_LOW_MANTISSA_MASK = (static_cast<int64_t>(1) << XSUM_LOW_
 constexpr int64_t XSUM_SMALL_CARRY_BITS = (XSUM_SCHUNK_BITS - 1) - XSUM_MANTISSA_BITS; // Bits sums can carry into
 constexpr int64_t XSUM_SMALL_CARRY_TERMS = (1 << XSUM_SMALL_CARRY_BITS) - 1; // # terms can add before need prop.
 
+// CONSTANTS DEFINING THE LARGE ACCUMULATOR FORMAT
+constexpr int64_t XSUM_LCOUNT_BITS = 64 - XSUM_MANTISSA_BITS; // # of bits in count
+constexpr int64_t XSUM_LCHUNKS = 1 << (XSUM_EXP_BITS + 1); // # of chunks in large accumulator
+
 } // anonymous namespace
 
 namespace Xsum {
 
+// SmallAccumulator
+
+SmallAccumulator::SmallAccumulator()
+    : chunk(XSUM_SCHUNKS, 0LL), addsUntilPropagate { XSUM_SMALL_CARRY_TERMS }, inf { 0 }, nan { 0 },
+    sizeCount { 0 }, hasPosNumber { false } { }
+
 SmallAccumulator::SmallAccumulator(
-    int addsUntilPropagate,
-    int64_t inf,
-    int64_t nan
-) : chunk(XSUM_SCHUNKS, 0LL), addsUntilPropagate { addsUntilPropagate }, inf { inf }, nan { nan } { }
+    Vector<int64_t> &&chunk, const int addsUntilPropagate, const int64_t inf, const int64_t nan,
+    const size_t sizeCount, const bool hasPosNumber)
+: chunk(WTFMove(chunk)), addsUntilPropagate { addsUntilPropagate }, inf { inf }, nan { nan },
+    sizeCount { sizeCount }, hasPosNumber { hasPosNumber } { }
 
-} // namespace Xsum
+/*
+ADD AN INF OR NAN TO A SMALL ACCUMULATOR. This only changes the flags,
+not the chunks in the accumulator, which retains the sum of the finite
+terms (which is perhaps sometimes useful to access, though no function
+to do so is defined at present). A nan with larger payload (seen as a
+52-bit unsigned integer) takes precedence, with the sign of the nan always
+being positive. This ensures that the order of summing nan values doesn't
+matter.
+*/
+void SmallAccumulator::addInfNan(int64_t ivalue)
+{
+    const int64_t mantissa = ivalue & XSUM_MANTISSA_MASK;
+    if (!mantissa) {
+        if (!inf)
+            inf = ivalue;
+        else if (inf != ivalue) {
+            double fltv = std::bit_cast<double>(ivalue);
+            fltv = fltv - fltv;
+            inf = std::bit_cast<int64_t>(fltv);
+        }
+    } else {
+        if ((nan & XSUM_MANTISSA_MASK) <= mantissa)
+            nan = ivalue & ~XSUM_SIGN_MASK;
+    }
+}
 
-PreciseSum::PreciseSum()
-: m_smallAccumulator { XSUM_SMALL_CARRY_TERMS, 0, 0 }, m_sizeCount { 0 }, m_hasPosNumber { false } { }
+/*
+PROPAGATE CARRIES TO NEXT CHUNK IN A SMALL ACCUMULATOR. Needs to
+be called often enough that accumulated carries don't overflow out
+the top, as indicated by addsUntilPropagate.  
+Returns the index of the uppermost non-zero chunk (0 if number is zero).
+
+After carry propagation, the uppermost non-zero chunk will indicate
+the sign of the number, and will not be -1 (all 1s). It will be in
+the range -2^XSUM_LOW_MANTISSA_BITS to 2^XSUM_LOW_MANTISSA_BITS - 1.
+Lower chunks will be non-negative, and in the range from 0 up to
+2^XSUM_LOW_MANTISSA_BITS - 1.
+*/
+int SmallAccumulator::carryPropagate()
+{
+    int u = XSUM_SCHUNKS - 1;
+    while (0 <= u && !chunk[u]) {
+        if (!u) {
+            addsUntilPropagate = XSUM_SMALL_CARRY_TERMS - 1;
+            return 0;
+        }
+        --u;
+    }
+
+    int i = 0;
+    int uix = -1;
+    do {
+        int64_t c;
+        do {
+            c = chunk[i];
+            if (c)
+                break;
+            i += 1;
+        } while (i <= u);
+
+        if (i > u)
+            break;
+
+        const int64_t chigh = c >> XSUM_LOW_MANTISSA_BITS;
+        if (!chigh) {
+            uix = i;
+            i += 1;
+            continue;
+        }
+
+        if (u == i) {
+            if (chigh == -1) {
+                uix = i;
+                break;
+            }
+            u = i + 1;
+        }
+
+        const int64_t clow = c & XSUM_LOW_MANTISSA_MASK;
+        if (clow)
+            uix = i;
+
+        chunk[i] = clow;
+        if (i + 1 >= XSUM_SCHUNKS) {
+            this->addInfNan(
+                (static_cast<int64_t>(XSUM_EXP_MASK) << XSUM_MANTISSA_BITS) | XSUM_MANTISSA_MASK
+            );
+            u = i;
+        } else
+            chunk[i + 1] += chigh;
+        i += 1;
+    } while (i <= u);
+
+    if (uix < 0) {
+        uix = 0;
+        addsUntilPropagate = XSUM_SMALL_CARRY_TERMS - 1;
+        return uix;
+    }
+
+    while (chunk[uix] == -1 && uix > 0) {
+        chunk[uix - 1] += -(static_cast<int64_t>(1) << XSUM_LOW_MANTISSA_BITS);
+        chunk[uix] = 0;
+        uix -= 1;
+    }
+    addsUntilPropagate = XSUM_SMALL_CARRY_TERMS - 1;
+    return uix;
+}
+
+/*
+ADD ONE NUMBER TO A SMALL ACCUMULATOR ASSUMING NO CARRY PROPAGATION REQ'D.
+*/
+inline void SmallAccumulator::add1NoCarry(double value)
+{
+    const int64_t ivalue = std::bit_cast<int64_t>(value);
+    const int_fast16_t exp = (ivalue >> XSUM_MANTISSA_BITS) & XSUM_EXP_MASK;
+    int64_t mantissa = ivalue & XSUM_MANTISSA_MASK;
+    const int_fast16_t highExp = exp >> XSUM_LOW_EXP_BITS;
+    int_fast16_t lowExp = exp & XSUM_LOW_EXP_MASK;
+
+    if (!exp) {
+        if (!mantissa)
+            return;
+        lowExp = 1;
+    } else if (exp == XSUM_EXP_MASK) {
+        this->addInfNan(ivalue);
+        return;
+    } else
+        mantissa |= static_cast<int64_t>(1) << XSUM_MANTISSA_BITS;
+
+    const std::array<int64_t, 2> splitMantissa {
+        static_cast<int64_t>((static_cast<uint64_t>(mantissa) << lowExp) & XSUM_LOW_MANTISSA_MASK),
+        mantissa >> (XSUM_LOW_MANTISSA_BITS - lowExp)
+    };
+
+    if (ivalue < 0) {
+        chunk[highExp] -= splitMantissa[0];
+        chunk[highExp + 1] -= splitMantissa[1];
+    } else {
+        chunk[highExp] += splitMantissa[0];
+        chunk[highExp + 1] += splitMantissa[1];
+    }
+}
+
+/*
+Increment sizeCount and check positive value every time when value is added.
+This is needed to return -0 (negative zero) if applicable.
+*/
+ALWAYS_INLINE void SmallAccumulator::incrementWhenValueAdded(double value)
+{
+    sizeCount++;
+    hasPosNumber = hasPosNumber || !std::signbit(value);
+}
+
+// LargeAccumulator
+
+LargeAccumulator::LargeAccumulator()
+    : chunk(XSUM_LCHUNKS), count(XSUM_LCHUNKS, -1), chunksUsed(XSUM_LCHUNKS / 64, 0), usedUsed { 0 }, sacc { } { }
+
+/*
+ADD CHUNK FROM A LARGE ACCUMULATOR TO THE SMALL ACCUMULATOR WITHIN IT.
+The large accumulator chunk to add is indexed by ix.  This chunk will
+be cleared to zero and its count reset after it has been added to the
+small accumulator (except no add is done for a new chunk being initialized).
+This procedure should not be called for the special chunks correspnding to
+Inf or NaN, whose counts should always remain at -1.
+*/
+void LargeAccumulator::addLchunkToSmall(int_fast16_t ix)
+{
+    const int_fast16_t countElement = count[ix];
+
+    if (countElement >= 0) {
+        if (!sacc.addsUntilPropagate)
+            sacc.carryPropagate();
+
+        uint64_t chunkElement = chunk[ix];
+        if (countElement > 0)
+            chunkElement += static_cast<uint64_t>(countElement * ix) << XSUM_MANTISSA_BITS;
+
+        const int_fast16_t exp = ix & XSUM_EXP_MASK;
+        int_fast16_t lowExp = exp & XSUM_LOW_EXP_MASK;
+        int_fast16_t highExp = exp >> XSUM_LOW_EXP_BITS;
+        if (!exp) {
+            lowExp = 1;
+            highExp = 0;
+        }
+
+        const uint64_t lowChunk = (chunkElement << lowExp) & XSUM_LOW_MANTISSA_MASK;
+        uint64_t midChunk = chunkElement >> (XSUM_LOW_MANTISSA_BITS - lowExp);
+        if (exp) {
+            midChunk += static_cast<uint64_t>((1 << XSUM_LCOUNT_BITS) - countElement)
+                << (XSUM_MANTISSA_BITS - XSUM_LOW_MANTISSA_BITS + lowExp);
+        }
+
+        const uint64_t highChunk = midChunk >> XSUM_LOW_MANTISSA_BITS;
+        midChunk &= XSUM_LOW_MANTISSA_MASK;
+        if (ix & (1 << XSUM_EXP_BITS)) {
+            sacc.chunk[highExp] -= lowChunk;
+            sacc.chunk[highExp + 1] -= midChunk;
+            sacc.chunk[highExp + 2] -= highChunk;
+        } else {
+            sacc.chunk[highExp] += lowChunk;
+            sacc.chunk[highExp + 1] += midChunk;
+            sacc.chunk[highExp + 2] += highChunk;
+        }
+        sacc.addsUntilPropagate -= 1;
+    }
+    chunk[ix] = 0;
+    count[ix] = 1 << XSUM_LCOUNT_BITS;
+    chunksUsed[ix >> 6] |= static_cast<uint64_t>(1) << (ix & 0x3f);
+    usedUsed |= static_cast<uint64_t>(1) << (ix >> 6);
+}
+
+/*
+ADD A CHUNK TO THE LARGE ACCUMULATOR OR PROCESS NAN OR INF.  This routine
+is called when the count for a chunk is negative after decrementing, which
+indicates either inf/nan, or that the chunk has not been initialized, or
+that the chunk needs to be transferred to the small accumulator.
+*/
+void LargeAccumulator::largeAddValueInfNan(int_fast16_t ix, uint64_t uintv)
+{
+    if ((ix & XSUM_EXP_MASK) == XSUM_EXP_MASK)
+        sacc.addInfNan(uintv);
+    else {
+        this->addLchunkToSmall(ix);
+        count[ix] -= 1;
+        chunk[ix] += uintv;
+    }
+}
+
+/*
+TRANSFER ALL CHUNKS IN LARGE ACCUMULATOR TO ITS SMALL ACCUMULATOR.
+*/
+void LargeAccumulator::transferToSmall()
+{
+    const size_t chunksUsedSize = chunksUsed.size();
+    size_t p = 0;
+    uint64_t uu = usedUsed;
+
+    if (!(uu & 0xffffffff)) {
+        uu >>= 32;
+        p += 32;
+    }
+    if (!(uu & 0xffff)) {
+        uu >>= 16;
+        p += 16;
+    }
+    if (!(uu & 0xff))
+        p += 8;
+
+    uint64_t u = chunksUsed[p];
+    do {
+        for (;;) {
+            u = chunksUsed[p];
+            if (u)
+                break;
+            p += 1;
+            if (p == chunksUsedSize)
+                return;
+            u = chunksUsed[p];
+            if (u)
+                break;
+            p += 1;
+            if (p == chunksUsedSize)
+                return;
+            u = chunksUsed[p];
+            if (u)
+                break;
+            p += 1;
+            if (p == chunksUsedSize)
+                return;
+            u = chunksUsed[p];
+            if (u)
+                break;
+            p += 1;
+            if (p == chunksUsedSize)
+                return;
+        }
+
+        int ix = p << 6;
+        if (!(u & 0xffffffff)) {
+            u >>= 32;
+            ix += 32;
+        }
+        if (!(u & 0xffff)) {
+            u >>= 16;
+            ix += 16;
+        }
+        if (!(u & 0xff)) {
+            u >>= 8;
+            ix += 8;
+        }
+        do {
+            if (count[ix] >= 0)
+                this->addLchunkToSmall(ix);
+            ix += 1;
+            u >>= 1;
+        } while (u);
+        p += 1;
+    } while (p < chunksUsedSize);
+}
+
+// XsumSmall
+
+XsumSmall::XsumSmall()
+    : m_smallAccumulator { } { }
+
+XsumSmall::XsumSmall(SmallAccumulator sacc)
+    : m_smallAccumulator {
+        WTFMove(sacc.chunk), sacc.addsUntilPropagate, sacc.inf, sacc.nan, sacc.sizeCount, sacc.hasPosNumber
+    } { }
 
 /*
 ADD A VECTOR OF FLOATING-POINT NUMBERS TO A SMALL ACCUMULATOR. Mixes
-calls of xsumCarryPropagate with calls of xsumAdd1NoCarry.
+calls of carryPropagate with calls of add1NoCarry.
 */
-void PreciseSum::addList(const std::span<const double> vec)
+void XsumSmall::addList(const std::span<const double> vec)
 {
     size_t offset = 0;
     size_t n = vec.size();
 
     while (0 < n) {
         if (!m_smallAccumulator.addsUntilPropagate)
-            xsumCarryPropagate();
+            m_smallAccumulator.carryPropagate();
         size_t m = std::min(static_cast<int>(n), m_smallAccumulator.addsUntilPropagate);
         for (size_t i = 0; i < m; i++) {
             const double value = vec[offset + i];
-            incrementWhenValueAdded(value);
-            xsumAdd1NoCarry(value);
+            m_smallAccumulator.incrementWhenValueAdded(value);
+            m_smallAccumulator.add1NoCarry(value);
         }
         m_smallAccumulator.addsUntilPropagate -= m;
         offset += m;
@@ -125,16 +444,14 @@ void PreciseSum::addList(const std::span<const double> vec)
 }
 
 /*
-ADD ONE DOUBLE TO A SMALL ACCUMULATOR. This is equivalent to, but
-somewhat faster than, calling xsum_small_addv with a vector of one
-value.
+Add one double to a small accumulator.
 */
-void PreciseSum::add(double value)
+void XsumSmall::add(double value)
 {
-    incrementWhenValueAdded(value);
+    m_smallAccumulator.incrementWhenValueAdded(value);
     if (!m_smallAccumulator.addsUntilPropagate)
-        xsumCarryPropagate();
-    xsumAdd1NoCarry(value);
+        m_smallAccumulator.carryPropagate();
+    m_smallAccumulator.add1NoCarry(value);
     m_smallAccumulator.addsUntilPropagate -= 1;
 }
 
@@ -144,21 +461,21 @@ is to nearest, with ties to even. The small accumulator may be modified
 by this operation (by carry propagation being done), but the value it
 represents should not change.
 */
-double PreciseSum::compute()
+double XsumSmall::compute()
 {
-    if (m_smallAccumulator.nan)
+    if (m_smallAccumulator.nan) [[unlikely]]
         return std::bit_cast<double>(m_smallAccumulator.nan);
-    if (m_smallAccumulator.inf)
+    if (m_smallAccumulator.inf) [[unlikely]]
         return std::bit_cast<double>(m_smallAccumulator.inf);
-    if (!m_sizeCount)
+    if (!m_smallAccumulator.sizeCount) [[unlikely]]
         return -0.0;
 
-    const int i = xsumCarryPropagate();
+    const int i = m_smallAccumulator.carryPropagate();
     int64_t ivalue = m_smallAccumulator.chunk[i];
     int64_t intv = 0;
     if (i <= 1) {
-        if (!ivalue)
-            return !m_hasPosNumber ? -0.0 : 0.0;
+        if (!ivalue) [[unlikely]]
+            return !m_smallAccumulator.hasPosNumber ? -0.0 : 0.0;
         if (!i) {
             intv = 0 <= ivalue ? ivalue : -ivalue;
             intv >>= 1;
@@ -220,7 +537,7 @@ double PreciseSum::compute()
         }
     } else {
         if (!((-ivalue) & (static_cast<int64_t>(1) << (XSUM_MANTISSA_BITS + 2)))) {
-            int pos = (int64_t)1 << (XSUM_LOW_MANTISSA_BITS - 1 - more);
+            const int pos = static_cast<int64_t>(1) << (XSUM_LOW_MANTISSA_BITS - 1 - more);
             ivalue *= 2;
             if (lower & pos) {
                 ivalue += 1;
@@ -257,167 +574,59 @@ double PreciseSum::compute()
     ivalue >>= 2;
     e += (i << XSUM_LOW_EXP_BITS) - XSUM_EXP_BIAS - XSUM_MANTISSA_BITS;
     if (e >= XSUM_EXP_MASK) {
-        intv |= static_cast<int64_t>(XSUM_EXP_MASK) << XSUM_MANTISSA_BITS;
+        intv |= XSUM_EXP_MASK << XSUM_MANTISSA_BITS;
         return std::bit_cast<double>(intv);
     }
     intv += (static_cast<int64_t>(e) << XSUM_MANTISSA_BITS) + (ivalue & XSUM_MANTISSA_MASK);
     return std::bit_cast<double>(intv);
 }
 
+// XsumLarge
+
+XsumLarge::XsumLarge()
+    : m_largeAccumulator { } { }
+
 /*
-ADD AN INF OR NAN TO A SMALL ACCUMULATOR. This only changes the flags,
-not the chunks in the accumulator, which retains the sum of the finite
-terms (which is perhaps sometimes useful to access, though no function
-to do so is defined at present). A nan with larger payload (seen as a
-52-bit unsigned integer) takes precedence, with the sign of the nan always
-being positive. This ensures that the order of summing nan values doesn't
-matter.
+ADD A VECTOR OF FLOATING-POINT NUMBERS TO A LARGE ACCUMULATOR.
 */
-void PreciseSum::xsumSmallAddInfNan(int64_t ivalue)
+void XsumLarge::addList(const std::span<const double> vec)
 {
-    const int64_t mantissa = ivalue & XSUM_MANTISSA_MASK;
-    if (!mantissa) {
-        if (!m_smallAccumulator.inf)
-            m_smallAccumulator.inf = ivalue;
-        else if (m_smallAccumulator.inf != ivalue) {
-            double fltv = std::bit_cast<double>(ivalue);
-            fltv = fltv - fltv;
-            m_smallAccumulator.inf = std::bit_cast<int64_t>(fltv);
-        }
-    } else {
-        if ((m_smallAccumulator.nan & XSUM_MANTISSA_MASK) <= mantissa)
-            m_smallAccumulator.nan = ivalue & ~XSUM_SIGN_MASK;
+    for (const auto value : vec)
+        this->add(value);
+}
+
+/*
+ADD ONE DOUBLE TO A LARGE ACCUMULATOR.
+*/
+void XsumLarge::add(double value)
+{
+    const uint64_t uintv = std::bit_cast<uint64_t>(value);
+    const int_fast16_t ix = uintv >> XSUM_MANTISSA_BITS;
+    const int_least16_t count = m_largeAccumulator.count[ix] - 1;
+
+    m_largeAccumulator.sacc.incrementWhenValueAdded(value);
+
+    if (count < 0)
+        m_largeAccumulator.largeAddValueInfNan(ix, uintv);
+    else {
+        m_largeAccumulator.count[ix] = count;
+        m_largeAccumulator.chunk[ix] += uintv;
     }
 }
 
 /*
-ADD ONE NUMBER TO A SMALL ACCUMULATOR ASSUMING NO CARRY PROPAGATION REQ'D.
-This function is declared INLINE regardless of the setting of INLINE_SMALL
-and for good performance it must be inlined by the compiler (otherwise the
-procedure call overhead will result in substantial inefficiency).
+RETURN RESULT OF ROUNDING A LARGE ACCUMULATOR.  Rounding mode is to nearest,
+with ties to even.
+This is done by adding all the chunks in the large accumulator to the
+small accumulator, and then calling its rounding procedure.
 */
-inline void PreciseSum::xsumAdd1NoCarry(double value)
+double XsumLarge::compute()
 {
-    const int64_t ivalue = std::bit_cast<int64_t>(value);
-    int_fast16_t exp = (ivalue >> XSUM_MANTISSA_BITS) & XSUM_EXP_MASK;
-    int64_t mantissa = ivalue & XSUM_MANTISSA_MASK;
-    const int_fast16_t highExp = exp >> XSUM_LOW_EXP_BITS;
-    int_fast16_t lowExp = exp & XSUM_LOW_EXP_MASK;
-
-    if (!exp) {
-        if (!mantissa)
-            return;
-        exp = lowExp = 1;
-    } else if (exp == XSUM_EXP_MASK) {
-        xsumSmallAddInfNan(ivalue);
-        return;
-    } else
-        mantissa |= static_cast<int64_t>(1) << XSUM_MANTISSA_BITS;
-
-    const std::array<int64_t, 2> splitMantissa {
-        static_cast<int64_t>((static_cast<uint64_t>(mantissa) << lowExp) & XSUM_LOW_MANTISSA_MASK),
-        mantissa >> (XSUM_LOW_MANTISSA_BITS - lowExp)
-    };
-
-    if (ivalue < 0) {
-        m_smallAccumulator.chunk[highExp] -= splitMantissa[0];
-        m_smallAccumulator.chunk[highExp + 1] -= splitMantissa[1];
-    } else {
-        m_smallAccumulator.chunk[highExp] += splitMantissa[0];
-        m_smallAccumulator.chunk[highExp + 1] += splitMantissa[1];
-    }
+    m_largeAccumulator.transferToSmall();
+    XsumSmall xsumSmall { m_largeAccumulator.sacc };
+    return xsumSmall.compute();
 }
 
-/*
-PROPAGATE CARRIES TO NEXT CHUNK IN A SMALL ACCUMULATOR. Needs to
-be called often enough that accumulated carries don't overflow out
-the top, as indicated by m_smallAccumulator.addsUntilPropagate.  
-Returns the index of the uppermost non-zero chunk (0 if number is zero).
-
-After carry propagation, the uppermost non-zero chunk will indicate
-the sign of the number, and will not be -1 (all 1s). It will be in
-the range -2^XSUM_LOW_MANTISSA_BITS to 2^XSUM_LOW_MANTISSA_BITS - 1.
-Lower chunks will be non-negative, and in the range from 0 up to
-2^XSUM_LOW_MANTISSA_BITS - 1.
-*/
-int PreciseSum::xsumCarryPropagate()
-{
-    int u = XSUM_SCHUNKS - 1;
-    while (0 <= u && !m_smallAccumulator.chunk[u]) {
-        if (!u) {
-            m_smallAccumulator.addsUntilPropagate = XSUM_SMALL_CARRY_TERMS - 1;
-            return 0;
-        }
-        --u;
-    }
-
-    int i = 0;
-    int uix = -1;
-    do {
-        int64_t c;
-        int64_t clow;
-        int64_t chigh;
-        do {
-            c = m_smallAccumulator.chunk[i];
-            if (c)
-                break;
-            i += 1;
-        } while (i <= u);
-
-        if (i > u)
-            break;
-
-        chigh = c >> XSUM_LOW_MANTISSA_BITS;
-        if (!chigh) {
-            uix = i;
-            i += 1;
-            continue;
-        }
-
-        if (u == i) {
-            if (chigh == -1) {
-                uix = i;
-                break;
-            }
-            u = i + 1;
-        }
-
-        clow = c & XSUM_LOW_MANTISSA_MASK;
-        if (clow)
-            uix = i;
-
-        m_smallAccumulator.chunk[i] = clow;
-        if (i + 1 >= XSUM_SCHUNKS) {
-            xsumSmallAddInfNan((static_cast<int64_t>(XSUM_EXP_MASK) << XSUM_MANTISSA_BITS) | XSUM_MANTISSA_MASK);
-            u = i;
-        } else
-            m_smallAccumulator.chunk[i + 1] += chigh;
-        i += 1;
-    } while (i <= u);
-
-    if (uix < 0) {
-        uix = 0;
-        m_smallAccumulator.addsUntilPropagate = XSUM_SMALL_CARRY_TERMS - 1;
-        return uix;
-    }
-
-    while (m_smallAccumulator.chunk[uix] == -1 && uix > 0) {
-        m_smallAccumulator.chunk[uix - 1] += static_cast<int64_t>(-1) * (static_cast<int64_t>(1) << XSUM_LOW_MANTISSA_BITS);
-        m_smallAccumulator.chunk[uix] = 0;
-        uix -= 1;
-    }
-    m_smallAccumulator.addsUntilPropagate = XSUM_SMALL_CARRY_TERMS - 1;
-    return uix;
-}
-
-/*
-Increment m_sizeCount and check positive value every time when value is added.
-This is needed to return -0 (negative zero) if applicable.
-*/
-ALWAYS_INLINE void PreciseSum::incrementWhenValueAdded(double value)
-{
-    m_sizeCount++;
-    m_hasPosNumber = m_hasPosNumber || !std::signbit(value);
-}
+} // namespace Xsum
 
 } // namespace WTF

--- a/Source/WTF/wtf/PreciseSum.h
+++ b/Source/WTF/wtf/PreciseSum.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2024-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -32,35 +32,108 @@ namespace WTF {
 namespace Xsum {
 
 struct SmallAccumulator final {
-    explicit SmallAccumulator(const int addsUntilPropagate, const int64_t inf, const int64_t nan);
+    explicit SmallAccumulator();
+    explicit SmallAccumulator(
+        Vector<int64_t> &&chunk, const int addsUntilPropagate, const int64_t inf,
+        const int64_t nan, const size_t sizeCount, const bool hasPosNumber
+    );
     ~SmallAccumulator() = default;
 
     Vector<int64_t> chunk; // Chunks making up small accumulator
     int addsUntilPropagate; // Number of remaining adds before carry
     int64_t inf; // If non-zero, +Inf, -Inf, or NaN
     int64_t nan; // If non-zero, a NaN value with payload
+    size_t sizeCount; // number of added values
+    bool hasPosNumber; // check if added values have at least one positive number
+
+    int carryPropagate();
+    void addInfNan(int64_t ivalue);
+    inline void add1NoCarry(double value);
+    ALWAYS_INLINE void incrementWhenValueAdded(double value);
+};
+
+struct LargeAccumulator final {
+    Vector<uint64_t> chunk; // Chunks making up large accumulator
+    Vector<int_least16_t> count; // Counts of # adds remaining for chunks, or -1 if not used yet or special
+    Vector<uint64_t> chunksUsed; // Bits indicate chunks in use
+    uint64_t usedUsed; // Bits indicate chunk_used entries not 0
+    SmallAccumulator sacc; // The small accumulator to condense into
+
+    explicit LargeAccumulator();
+    ~LargeAccumulator() = default;
+
+    void addLchunkToSmall(int_fast16_t ix);
+    void largeAddValueInfNan(int_fast16_t ix, uint64_t uintv);
+    void transferToSmall();
+};
+
+class XsumInterface {
+public:
+    virtual ~XsumInterface() = default;
+
+    virtual void addList(const std::span<const double> vec) = 0;
+    virtual void add(double value) = 0;
+    virtual double compute() = 0;
+};
+
+class XsumSmall final : public XsumInterface {
+public:
+    explicit XsumSmall();
+    explicit XsumSmall(SmallAccumulator sacc);
+    ~XsumSmall() = default;
+
+    void addList(const std::span<const double> vec) override;
+    void add(double value) override;
+    double compute() override;
+
+private:
+    SmallAccumulator m_smallAccumulator;
+};
+
+class XsumLarge final : public XsumInterface {
+public:
+    explicit XsumLarge();
+    ~XsumLarge() = default;
+
+    void addList(const std::span<const double> vec) override;
+    void add(double value) override;
+    double compute() override;
+
+private:
+    LargeAccumulator m_largeAccumulator;
 };
 
 } // namespace Xsum
 
+// Threshold for PreciseSum to determine whether to use XsumSmall or XsumLarge
+// if expected array size if more than PRECISE_SUM_THRESHOLD, use Xsum::XsumLarge
+// otherwise, use Xsum::XsumSmall
+constexpr uint64_t PRECISE_SUM_THRESHOLD = 1'000;
+
+template<std::derived_from<Xsum::XsumInterface> T = Xsum::XsumSmall>
 class PreciseSum final {
 public:
-    explicit PreciseSum();
+    explicit PreciseSum()
+        : m_xsum { T { } } { }
     ~PreciseSum() = default;
 
-    WTF_EXPORT_PRIVATE void addList(const std::span<const double> vec);
-    WTF_EXPORT_PRIVATE void add(double value);
-    WTF_EXPORT_PRIVATE double compute();
+    void addList(const std::span<const double> vec)
+    {
+        m_xsum.addList(vec);
+    }
+
+    void add(double value)
+    {
+        m_xsum.add(value);
+    }
+
+    double compute()
+    {
+        return m_xsum.compute();
+    }
 
 private:
-    Xsum::SmallAccumulator m_smallAccumulator;
-    size_t m_sizeCount;
-    bool m_hasPosNumber;
-
-    void xsumSmallAddInfNan(int64_t ivalue);
-    inline void xsumAdd1NoCarry(double value);
-    int xsumCarryPropagate();
-    ALWAYS_INLINE void incrementWhenValueAdded(double value);
+    T m_xsum;
 };
 
 } // namespace WTF


### PR DESCRIPTION
#### d95d6a80355e27cd4091e806e21019e4bc557a1e
<pre>
[JSC] Improve Performance of `Math.sumPrecise` for Large Inputs
<a href="https://bugs.webkit.org/show_bug.cgi?id=293866">https://bugs.webkit.org/show_bug.cgi?id=293866</a>

Reviewed by Yusuke Suzuki.

Math.sumPrecise may be used in scientific calculations, charting, and statistical analysis,
where it is crucial to handle large inputs precisely and efficiently.
This patch improves performance for large inputs by implementing Radford M. Neal&apos;s xsum
algorithm using the large superaccumulator[1].
The large superaccumulator is used when the input is an array and its size exceeds
PRECISE_SUM_THRESHOLD (1,000); otherwise, the small superaccumulator is used.
The original implementation of xsum large superaccumulator is in C [2]; a C++ translation
by Keita Nonaka was referenced for integration [3].
This patch also refactors the previous implementation[4] of xsum using the small
superaccumulator to align with the xsum large superaccumulator design.

                                TipOfTree              Patched                Ratio
math-sumPrecise-10              2.6139+-0.1125         2.6545+-0.1376         0.0152x slower
math-sumPrecise-100             17.9892+-0.0930        18.0620+-0.1747        0.0040x slower
math-sumPrecise-1000            172.3968+-1.8629       155.9089+-1.3315       1.1057x faster
math-sumPrecise-10000           1709.5876+-4.2845      1530.4218+-5.2034      1.1170x faster

[1]: <a href="https://arxiv.org/abs/1505.05571">https://arxiv.org/abs/1505.05571</a>
[2]: <a href="https://gitlab.com/radfordneal/xsum">https://gitlab.com/radfordneal/xsum</a>
[3]: <a href="https://github.com/Gumichocopengin8/xsum.cpp">https://github.com/Gumichocopengin8/xsum.cpp</a>
[4]: <a href="https://github.com/WebKit/WebKit/commit/2682d2ab17a40851f7e6bcff35126e810b0646fd">https://github.com/WebKit/WebKit/commit/2682d2ab17a40851f7e6bcff35126e810b0646fd</a>

* JSTests/stress/math-sum-precise.js:
* Source/JavaScriptCore/runtime/MathObject.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/WTF/wtf/PreciseSum.cpp:
(WTF::Xsum::SmallAccumulator::SmallAccumulator):
(WTF::Xsum::SmallAccumulator::addInfNan):
(WTF::Xsum::SmallAccumulator::carryPropagate):
(WTF::Xsum::SmallAccumulator::add1NoCarry):
(WTF::Xsum::SmallAccumulator::incrementWhenValueAdded):
(WTF::Xsum::LargeAccumulator::LargeAccumulator):
(WTF::Xsum::LargeAccumulator::addLchunkToSmall):
(WTF::Xsum::LargeAccumulator::largeAddValueInfNan):
(WTF::Xsum::LargeAccumulator::transferToSmall):
(WTF::Xsum::XsumSmall::XsumSmall):
(WTF::Xsum::XsumSmall::addList):
(WTF::Xsum::XsumSmall::add):
(WTF::Xsum::XsumSmall::compute):
(WTF::Xsum::XsumLarge::XsumLarge):
(WTF::Xsum::XsumLarge::addList):
(WTF::Xsum::XsumLarge::add):
(WTF::Xsum::XsumLarge::compute):
(WTF::PreciseSum::PreciseSum): Deleted.
(WTF::PreciseSum::addList): Deleted.
(WTF::PreciseSum::add): Deleted.
(WTF::PreciseSum::compute): Deleted.
(WTF::PreciseSum::xsumSmallAddInfNan): Deleted.
(WTF::PreciseSum::xsumAdd1NoCarry): Deleted.
(WTF::PreciseSum::xsumCarryPropagate): Deleted.
(WTF::PreciseSum::incrementWhenValueAdded): Deleted.
* Source/WTF/wtf/PreciseSum.h:

Canonical link: <a href="https://commits.webkit.org/296157@main">https://commits.webkit.org/296157@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5f5546f2af7684fad49e40813f8a7d5cfa9e62fe

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/107528 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27210 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/17619 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/112744 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/58067 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/27901 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/35712 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/81633 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/110457 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22109 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/96917 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62014 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/21548 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/15055 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/57508 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/100120 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/91478 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15088 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/115844 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/106077 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/34595 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/25510 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/90670 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/34972 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93167 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/90411 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23059 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35331 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13107 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/30356 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/34516 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/40073 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/130391 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34263 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/35457 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/37622 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/35926 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->