### PR TITLE
[SaferCPP] Use checked pointers in RenderLayerFilters

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/NoUncheckedPtrMemberCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/NoUncheckedPtrMemberCheckerExpectations
@@ -82,7 +82,6 @@ rendering/RenderLayerBacking.cpp
 rendering/RenderLayerBacking.h
 rendering/RenderLayerCompositor.cpp
 rendering/RenderLayerCompositor.h
-rendering/RenderLayerFilters.h
 rendering/RenderLayerScrollableArea.h
 rendering/RenderLayoutState.h
 rendering/RenderMarquee.h

--- a/Source/WebCore/rendering/RenderLayerFilters.cpp
+++ b/Source/WebCore/rendering/RenderLayerFilters.cpp
@@ -34,6 +34,7 @@
 #include "CSSFilter.h"
 #include "CachedSVGDocument.h"
 #include "CachedSVGDocumentReference.h"
+#include "ContainerNodeInlines.h"
 #include "GraphicsContextSwitcher.h"
 #include "LegacyRenderSVGResourceFilter.h"
 #include "Logging.h"
@@ -76,9 +77,9 @@ void RenderLayerFilters::notifyFinished(CachedResource&, const NetworkLoadMetric
 {
     // FIXME: This really shouldn't have to invalidate layer composition,
     // but tests like css3/filters/effect-reference-delete.html fail if that doesn't happen.
-    if (auto* enclosingElement = m_layer.enclosingElement())
+    if (auto* enclosingElement = m_layer->enclosingElement())
         enclosingElement->invalidateStyleAndLayerComposition();
-    m_layer.renderer().repaint();
+    m_layer->renderer().repaint();
 }
 
 void RenderLayerFilters::updateReferenceFilterClients(const FilterOperations& operations)
@@ -97,7 +98,7 @@ void RenderLayerFilters::updateReferenceFilterClients(const FilterOperations& op
             m_externalSVGReferences.append(cachedSVGDocument);
         } else {
             // Reference is internal; add layer as a client so we can trigger filter repaint on SVG attribute change.
-            RefPtr filterElement = m_layer.renderer().document().getElementById(referenceOperation->fragment());
+            RefPtr filterElement = m_layer->renderer().document().getElementById(referenceOperation->fragment());
             if (!filterElement)
                 continue;
             CheckedPtr renderer = dynamicDowncast<LegacyRenderSVGResourceFilter>(filterElement->renderer());
@@ -117,7 +118,7 @@ void RenderLayerFilters::removeReferenceFilterClients()
     m_externalSVGReferences.clear();
 
     for (auto& filterElement : m_internalSVGReferences) {
-        if (auto* renderer = filterElement->renderer())
+        if (CheckedPtr renderer = filterElement->renderer())
             downcast<LegacyRenderSVGResourceContainer>(*renderer).removeClientRenderLayer(m_layer);
     }
     m_internalSVGReferences.clear();

--- a/Source/WebCore/rendering/RenderLayerFilters.h
+++ b/Source/WebCore/rendering/RenderLayerFilters.h
@@ -78,7 +78,7 @@ private:
     void notifyFinished(CachedResource&, const NetworkLoadMetrics&, LoadWillContinueInAnotherProcess) final;
     void resetDirtySourceRect() { m_dirtySourceRect = LayoutRect(); }
 
-    RenderLayer& m_layer;
+    const CheckedRef<RenderLayer> m_layer;
     Vector<RefPtr<Element>> m_internalSVGReferences;
     Vector<CachedResourceHandle<CachedSVGDocument>> m_externalSVGReferences;
 


### PR DESCRIPTION
#### 98c8c30bedec8804137e612adf69e49ceaf0d920
<pre>
[SaferCPP] Use checked pointers in RenderLayerFilters
<a href="https://bugs.webkit.org/show_bug.cgi?id=293869">https://bugs.webkit.org/show_bug.cgi?id=293869</a>
<a href="https://rdar.apple.com/152381542">rdar://152381542</a>

Reviewed by Charlie Wolfe.

Use checked pointers in RenderLayerFilters

* Source/WebCore/rendering/RenderLayerFilters.cpp:
(WebCore::RenderLayerFilters::notifyFinished):
(WebCore::RenderLayerFilters::updateReferenceFilterClients):
(WebCore::RenderLayerFilters::removeReferenceFilterClients):
* Source/WebCore/rendering/RenderLayerFilters.h:

Canonical link: <a href="https://commits.webkit.org/295766@main">https://commits.webkit.org/295766@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/48d5f30026a35c6f425ad5331addf3befb37a5d1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/106050 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25799 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/16193 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/111247 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/56646 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/108089 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/26455 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34302 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80559 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/109054 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/20893 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95707 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60882 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/20489 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13805 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/56084 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/90264 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13840 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/114102 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33188 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/24495 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89639 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33552 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91935 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89328 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34191 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/12005 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/28759 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17206 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/33113 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/38525 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32859 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/36209 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34457 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->