### PR TITLE
[JSC] Implement `TypedArray#reduce` / `TypedArray#reduceRight` in C++

### DIFF
--- a/Source/JavaScriptCore/builtins/TypedArrayPrototype.js
+++ b/Source/JavaScriptCore/builtins/TypedArrayPrototype.js
@@ -52,58 +52,6 @@ function typedArraySpeciesConstructor(value)
     return constructor;
 }
 
-function reduce(callback /* [, initialValue] */)
-{
-    // 22.2.3.19
-    "use strict";
-
-    var length = @typedArrayLength(this);
-
-    if (!@isCallable(callback))
-        @throwTypeError("TypedArray.prototype.reduce callback must be a function");
-
-    var argumentCount = @argumentCount();
-    if (length === 0 && argumentCount < 2)
-        @throwTypeError("TypedArray.prototype.reduce of empty array with no initial value");
-
-    var accumulator, k = 0;
-    if (argumentCount > 1)
-        accumulator = @argument(1);
-    else
-        accumulator = this[k++];
-
-    for (; k < length; k++)
-        accumulator = callback.@call(@undefined, accumulator, this[k], k, this);
-
-    return accumulator;
-}
-
-function reduceRight(callback /* [, initialValue] */)
-{
-    // 22.2.3.20
-    "use strict";
-
-    var length = @typedArrayLength(this);
-
-    if (!@isCallable(callback))
-        @throwTypeError("TypedArray.prototype.reduceRight callback must be a function");
-
-    var argumentCount = @argumentCount();
-    if (length === 0 && argumentCount < 2)
-        @throwTypeError("TypedArray.prototype.reduceRight of empty array with no initial value");
-
-    var accumulator, k = length - 1;
-    if (argumentCount > 1)
-        accumulator = @argument(1);
-    else
-        accumulator = this[k--];
-
-    for (; k >= 0; k--)
-        accumulator = callback.@call(@undefined, accumulator, this[k], k, this);
-
-    return accumulator;
-}
-
 function map(callback /*, thisArg */)
 {
     // 22.2.3.18

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototypeFunctions.h
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototypeFunctions.h
@@ -1252,6 +1252,157 @@ ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoFuncSome(VM& vm, JSGlobal
 }
 
 template<typename ViewClass>
+ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoFuncReduce(VM& vm, JSGlobalObject* globalObject, CallFrame* callFrame)
+{
+    // https://tc39.es/ecma262/#sec-%typedarray%.prototype.reduce
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    auto* thisObject = jsCast<ViewClass*>(callFrame->thisValue());
+    validateTypedArray(globalObject, thisObject);
+    RETURN_IF_EXCEPTION(scope, { });
+
+    const size_t length = thisObject->length();
+
+    JSValue callback = callFrame->argument(0);
+    auto callData = JSC::getCallData(callback);
+    if (callData.type == CallData::Type::None) [[unlikely]]
+        return throwVMTypeError(globalObject, scope, "TypedArray.prototype.reduce callback must be a function"_s);
+
+    const bool hasInitialValue = callFrame->argumentCount() > 1;
+
+    if (!hasInitialValue && !length) [[unlikely]]
+        return throwVMTypeError(globalObject, scope, "TypedArray.prototype.reduce of empty array with no initial value"_s);
+
+    JSValue accumulator = hasInitialValue ? callFrame->uncheckedArgument(1) : jsUndefined();
+
+    bool initialized = hasInitialValue;
+    if (callData.type == CallData::Type::JS) [[likely]] {
+        CachedCall cachedCall(globalObject, jsCast<JSFunction*>(callback), 4);
+        RETURN_IF_EXCEPTION(scope, { });
+
+        scope.release();
+        typedArrayViewForEachImpl<ForEachDirection::Forward>(globalObject, vm, thisObject, length, [&](JSValue element, size_t index) -> IterationStatus {
+            if (!initialized) {
+                accumulator = element;
+                initialized  = true;
+                return IterationStatus::Continue;
+            }
+
+            accumulator = cachedCall.callWithArguments(globalObject, jsUndefined(), accumulator, element, jsNumber(index), thisObject);
+            return IterationStatus::Continue;
+        });
+        return JSValue::encode(accumulator);
+    }
+
+    MarkedArgumentBuffer args;
+
+    scope.release();
+
+    typedArrayViewForEachImpl<ForEachDirection::Forward>(globalObject, vm, thisObject, length, [&](JSValue element, size_t index) -> IterationStatus {
+        auto scope = DECLARE_THROW_SCOPE(vm);
+
+        if (!initialized) {
+            accumulator = element;
+            initialized  = true;
+            return IterationStatus::Continue;
+        }
+
+        args.clear();
+
+        args.append(accumulator);
+        args.append(element);
+        args.append(jsNumber(index));
+        args.append(thisObject);
+        if (args.hasOverflowed()) [[unlikely]] {
+            throwOutOfMemoryError(globalObject, scope);
+            return IterationStatus::Continue;
+        }
+
+        scope.release();
+        accumulator = call(globalObject, callback, callData, jsUndefined(), args);
+        return IterationStatus::Continue;
+    });
+
+    return JSValue::encode(accumulator);
+}
+
+template<typename ViewClass>
+ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoFuncReduceRight(VM& vm, JSGlobalObject* globalObject, CallFrame* callFrame)
+{
+    // https://tc39.es/ecma262/#sec-%typedarray%.prototype.reduceright
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    auto* thisObject = jsCast<ViewClass*>(callFrame->thisValue());
+    validateTypedArray(globalObject, thisObject);
+    RETURN_IF_EXCEPTION(scope, { });
+
+    const size_t length = thisObject->length();
+
+    JSValue callback = callFrame->argument(0);
+    auto callData = JSC::getCallData(callback);
+    if (callData.type == CallData::Type::None) [[unlikely]]
+        return throwVMTypeError(globalObject, scope, "TypedArray.prototype.reduceRight callback must be a function"_s);
+
+    const bool hasInitialValue = callFrame->argumentCount() > 1;
+
+    if (!hasInitialValue && !length) [[unlikely]]
+        return throwVMTypeError(globalObject, scope, "TypedArray.prototype.reduceRight of empty array with no initial value"_s);
+
+    JSValue accumulator = hasInitialValue ? callFrame->uncheckedArgument(1) : jsUndefined();
+
+    bool initialized = hasInitialValue;
+    if (callData.type == CallData::Type::JS) [[likely]] {
+        CachedCall cachedCall(globalObject, jsCast<JSFunction*>(callback), 4);
+        RETURN_IF_EXCEPTION(scope, { });
+
+        scope.release();
+        typedArrayViewForEachImpl<ForEachDirection::Backward>(globalObject, vm, thisObject, length, [&](JSValue element, size_t index) -> IterationStatus {
+            if (!initialized) {
+                accumulator = element;
+                initialized  = true;
+                return IterationStatus::Continue;
+            }
+
+            accumulator = cachedCall.callWithArguments(globalObject, jsUndefined(), accumulator, element, jsNumber(index), thisObject);
+            return IterationStatus::Continue;
+        });
+
+        return JSValue::encode(accumulator);
+    }
+
+    MarkedArgumentBuffer args;
+
+    scope.release();
+
+    typedArrayViewForEachImpl<ForEachDirection::Backward>(globalObject, vm, thisObject, length, [&](JSValue element, size_t index) -> IterationStatus {
+        auto scope = DECLARE_THROW_SCOPE(vm);
+
+        if (!initialized) {
+            accumulator = element;
+            initialized  = true;
+            return IterationStatus::Continue;
+        }
+
+        args.clear();
+
+        args.append(accumulator);
+        args.append(element);
+        args.append(jsNumber(index));
+        args.append(thisObject);
+        if (args.hasOverflowed()) [[unlikely]] {
+            throwOutOfMemoryError(globalObject, scope);
+            return IterationStatus::Continue;
+        }
+
+        scope.release();
+        accumulator = call(globalObject, callback, callData, jsUndefined(), args);
+        return IterationStatus::Continue;
+    });
+
+    return JSValue::encode(accumulator);
+}
+
+template<typename ViewClass>
 ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoFuncReverse(VM& vm, JSGlobalObject* globalObject, CallFrame* callFrame)
 {
     auto scope = DECLARE_THROW_SCOPE(vm);

--- a/Source/JavaScriptCore/runtime/JSTypedArrayViewPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/JSTypedArrayViewPrototype.cpp
@@ -66,6 +66,8 @@ static JSC_DECLARE_HOST_FUNCTION(typedArrayViewProtoGetterFuncToStringTag);
 static JSC_DECLARE_HOST_FUNCTION(typedArrayViewProtoFuncToReversed);
 static JSC_DECLARE_HOST_FUNCTION(typedArrayViewProtoFuncToSorted);
 static JSC_DECLARE_HOST_FUNCTION(typedArrayViewProtoFuncWith);
+static JSC_DECLARE_HOST_FUNCTION(typedArrayViewProtoFuncReduce);
+static JSC_DECLARE_HOST_FUNCTION(typedArrayViewProtoFuncReduceRight);
 
 #define CALL_GENERIC_TYPEDARRAY_PROTOTYPE_FUNCTION_ON_TYPE(type, functionName) do {             \
     switch ((type)) {                                                                             \
@@ -545,6 +547,28 @@ JSC_DEFINE_HOST_FUNCTION(typedArrayViewProtoFuncWith, (JSGlobalObject* globalObj
     CALL_GENERIC_TYPEDARRAY_PROTOTYPE_FUNCTION(genericTypedArrayViewProtoFuncWith);
 }
 
+JSC_DEFINE_HOST_FUNCTION(typedArrayViewProtoFuncReduce, (JSGlobalObject* globalObject, CallFrame* callFrame))
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    JSValue thisValue = callFrame->thisValue();
+    if (!thisValue.isObject()) [[unlikely]]
+        return throwVMTypeError(globalObject, scope, "Receiver should be a typed array view but was not an object"_s);
+    scope.release();
+    CALL_GENERIC_TYPEDARRAY_PROTOTYPE_FUNCTION(genericTypedArrayViewProtoFuncReduce);
+}
+
+JSC_DEFINE_HOST_FUNCTION(typedArrayViewProtoFuncReduceRight, (JSGlobalObject* globalObject, CallFrame* callFrame))
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    JSValue thisValue = callFrame->thisValue();
+    if (!thisValue.isObject()) [[unlikely]]
+        return throwVMTypeError(globalObject, scope, "Receiver should be a typed array view but was not an object"_s);
+    scope.release();
+    CALL_GENERIC_TYPEDARRAY_PROTOTYPE_FUNCTION(genericTypedArrayViewProtoFuncReduceRight);
+}
+
 #undef CALL_GENERIC_TYPEDARRAY_PROTOTYPE_FUNCTION
 
 JSTypedArrayViewPrototype::JSTypedArrayViewPrototype(VM& vm, Structure* structure)
@@ -585,8 +609,8 @@ void JSTypedArrayViewPrototype::finishCreation(VM& vm, JSGlobalObject* globalObj
     putDirectNonIndexAccessorWithoutTransition(vm, vm.propertyNames->length, lengthGetterSetter, PropertyAttribute::DontEnum | PropertyAttribute::ReadOnly | PropertyAttribute::Accessor);
 
     JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION("map"_s, typedArrayPrototypeMapCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
-    JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION("reduce"_s, typedArrayPrototypeReduceCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
-    JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION("reduceRight"_s, typedArrayPrototypeReduceRightCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
+    JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().reducePublicName(), typedArrayViewProtoFuncReduce, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public);
+    JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().reduceRightPublicName(), typedArrayViewProtoFuncReduceRight, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public);
     JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION("reverse"_s, typedArrayViewProtoFuncReverse, static_cast<unsigned>(PropertyAttribute::DontEnum), 0, ImplementationVisibility::Public);
     JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->set, typedArrayViewProtoFuncSet, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public);
     JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->slice, typedArrayViewProtoFuncSlice, static_cast<unsigned>(PropertyAttribute::DontEnum), 2, ImplementationVisibility::Public);


### PR DESCRIPTION
#### b06d050e97e294790cae96707a3f6b1c0447ac34
<pre>
[JSC] Implement `TypedArray#reduce` / `TypedArray#reduceRight` in C++
<a href="https://bugs.webkit.org/show_bug.cgi?id=293873">https://bugs.webkit.org/show_bug.cgi?id=293873</a>

Reviewed by Yusuke Suzuki.

This patch implements `TypedArray#reduce` and `TypedArray#reduceRight`
in C++. See <a href="https://commits.webkit.org/293911@main">https://commits.webkit.org/293911@main</a> for the rationale
for this patch.

Canonical link: <a href="https://commits.webkit.org/295684@main">https://commits.webkit.org/295684@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a7c5eca1fefc012826a67679cf7471eefb555210

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105890 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25641 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/16034 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/111087 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/56488 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/26258 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34144 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80430 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108896 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/20677 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95559 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60748 "Found 143 new API test failures: /WPE/TestUIClient:/webkit/WebKitWebView/query-permission-requests, /WPE/TestWebsiteData:/webkit/WebKitWebsiteData/deviceidhashsalt, /WPE/TestLoaderClient:/webkit/WebKitWebView/load-twice-and-reload, /WPE/TestCookieManager:/webkit/WebKitCookieManager/ephemeral, /WPE/TestWebKitWebView:/webkit/WebKitWebView/is-playing-audio, /WPE/TestConsoleMessage:/webkit/WebKitConsoleMessage/network-error, /WPE/TestWebsiteData:/webkit/WebKitWebsiteData/configuration, /WPE/TestCookieManager:/webkit/WebKitCookieManager/delete-cookies, /WPE/TestWebKitWebView:/webkit/WebKitWebView/terminate-unresponsive-web-process, /WPE/TestSSL:/webkit/WebKitWebView/insecure-content ... (failure)") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/20324 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13657 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55925 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/98531 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/90067 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13693 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/113937 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/104509 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33030 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24361 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/89509 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33394 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91788 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89181 "Found 100 new API test failures: /TestWebKit:WebKit.PageLoadDidChangeLocationWithinPage, /TestWebKit:WebKit.AboutBlankLoad, /TestWebKit:WebKit.PreventEmptyUserAgent, /TestWebKit:WebKit.PrivateBrowsingPushStateNoHistoryCallback, /WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/content-type, /WebKitGTK/TestUIClient:/webkit/WebKitWebView/pointer-lock-permission-request, /TestWebKit:WebKit.HitTestResultNodeHandle, /TestWebKit:WebKit2TextFieldBeginAndEditEditingTest.TextFieldDidBeginShouldNotBeDispatchedForAlreadyFocusedField, /TestWebKit:WebKit.Find, /WebKitGTK/TestWebProcessExtensions:/webkit/WebKitWebProcessExtension/dom-input-element-is-user-edited ... (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22722 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34052 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11862 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/28566 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32955 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/38366 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/128821 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32701 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/35154 "Found 1 new JSC stress test failure: wasm.yaml/wasm/gc/ref-i31-eq.js.wasm-collect-continuously (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/36050 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34299 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->