### PR TITLE
Reduce unsafeness in various node collections

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -120,7 +120,6 @@ bindings/js/JSIntersectionObserverEntryCustom.cpp
 bindings/js/JSLazyEventListener.cpp
 bindings/js/JSNavigatorCustom.cpp
 bindings/js/JSNodeCustom.cpp
-bindings/js/JSNodeListCustom.cpp
 bindings/js/JSPluginElementFunctions.cpp
 bindings/js/JSSVGViewSpecCustom.cpp
 bindings/js/JSStylePropertyMapReadOnlyCustom.cpp
@@ -179,7 +178,6 @@ dom/IdleCallbackController.cpp
 dom/ImageOverlay.cpp
 dom/InlineStyleSheetOwner.cpp
 dom/KeyboardEvent.cpp
-dom/LiveNodeList.h
 dom/LiveNodeListInlines.h
 dom/MouseRelatedEvent.cpp
 dom/MutationObserver.cpp
@@ -282,8 +280,6 @@ html/HTMLBaseElement.cpp
 html/HTMLBodyElement.cpp
 html/HTMLButtonElement.cpp
 html/HTMLCanvasElement.cpp
-html/HTMLCollection.cpp
-html/HTMLCollectionInlines.h
 html/HTMLDialogElement.cpp
 html/HTMLFieldSetElement.cpp
 html/HTMLFormControlElement.cpp
@@ -323,7 +319,6 @@ html/HTMLVideoElement.cpp
 html/HTMLWBRElement.cpp
 html/ImageBitmap.cpp
 html/ImageDocument.cpp
-html/LabelsNodeList.cpp
 html/LazyLoadFrameObserver.cpp
 html/LazyLoadImageObserver.cpp
 html/MediaDocument.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
@@ -193,12 +193,10 @@ html/CustomPaintImage.cpp
 html/FormAssociatedCustomElement.cpp
 html/FormListedElement.cpp
 html/HTMLAttachmentElement.cpp
-html/HTMLCollection.cpp
 html/HTMLDialogElement.cpp
 html/HTMLDocument.cpp
 html/HTMLEmbedElement.cpp
 html/HTMLFormControlElement.cpp
-html/HTMLFormControlsCollection.cpp
 html/HTMLFormElement.cpp
 html/HTMLFrameElement.cpp
 html/HTMLFrameElementBase.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -518,7 +518,6 @@ dom/IdleDeadline.cpp
 dom/ImageOverlay.cpp
 dom/InlineStyleSheetOwner.cpp
 dom/KeyboardEvent.cpp
-dom/LiveNodeList.h
 dom/LiveNodeListInlines.h
 dom/MouseRelatedEvent.cpp
 dom/MutationObserver.cpp
@@ -548,7 +547,6 @@ dom/ShadowRoot.h
 dom/SimpleRange.cpp
 dom/SimulatedClick.cpp
 dom/SpaceSplitString.h
-dom/StaticNodeList.cpp
 dom/StaticRange.cpp
 dom/StyledElement.cpp
 dom/Subscriber.cpp
@@ -628,8 +626,6 @@ html/HTMLBaseElement.cpp
 html/HTMLBodyElement.cpp
 html/HTMLButtonElement.cpp
 html/HTMLCanvasElement.cpp
-html/HTMLCollection.cpp
-html/HTMLCollectionInlines.h
 html/HTMLFieldSetElement.cpp
 html/HTMLFormControlElement.cpp
 html/HTMLFormControlsCollection.cpp
@@ -662,7 +658,6 @@ html/HTMLTrackElement.cpp
 html/HTMLVideoElement.cpp
 html/ImageBitmap.cpp
 html/ImageDocument.cpp
-html/LabelsNodeList.cpp
 html/LazyLoadFrameObserver.cpp
 html/LazyLoadImageObserver.cpp
 html/LinkIconCollector.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -336,11 +336,9 @@ html/FormAssociatedCustomElement.cpp
 html/FormListedElement.cpp
 html/HTMLAnchorElement.cpp
 html/HTMLAttachmentElement.cpp
-html/HTMLCollection.cpp
 html/HTMLDocument.cpp
 html/HTMLEmbedElement.cpp
 html/HTMLFieldSetElement.cpp
-html/HTMLFormControlsCollection.cpp
 html/HTMLFormElement.cpp
 html/HTMLFrameElement.cpp
 html/HTMLFrameElementBase.cpp

--- a/Source/WebCore/dom/ClassCollection.cpp
+++ b/Source/WebCore/dom/ClassCollection.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2007-2008, 2014, 2015 Apple Inc. All rights reserved.
+ * Copyright (C) 2007-2025 Apple Inc. All rights reserved.
  * Copyright (C) 2007 David Smith (catfish.man@gmail.com)
  *
  * Redistribution and use in source and binary forms, with or without
@@ -46,7 +46,7 @@ Ref<ClassCollection> ClassCollection::create(ContainerNode& rootNode, Collection
 
 ClassCollection::~ClassCollection()
 {
-    protectedOwnerNode()->nodeLists()->removeCachedCollection(this, m_originalClassNames);
+    ownerNode().nodeLists()->removeCachedCollection(this, m_originalClassNames);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/dom/LiveNodeList.h
+++ b/Source/WebCore/dom/LiveNodeList.h
@@ -2,7 +2,7 @@
  * Copyright (C) 1999 Lars Knoll (knoll@kde.org)
  *           (C) 1999 Antti Koivisto (koivisto@kde.org)
  *           (C) 2001 Dirk Mueller (mueller@kde.org)
- * Copyright (C) 2004-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2004-2025 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -48,10 +48,9 @@ public:
 
     NodeListInvalidationType invalidationType() const { return m_invalidationType; }
     ContainerNode& ownerNode() const { return m_ownerNode; }
-    Ref<ContainerNode> protectedOwnerNode() const { return m_ownerNode; }
     void invalidateCacheForAttribute(const QualifiedName& attributeName) const;
     virtual void invalidateCacheForDocument(Document&) const = 0;
-    void invalidateCache() const { invalidateCacheForDocument(document()); }
+    void invalidateCache() const { invalidateCacheForDocument(protectedDocument().get()); }
 
     bool isRegisteredForInvalidationAtDocument() const { return m_isRegisteredForInvalidationAtDocument; }
     void setRegisteredForInvalidationAtDocument(bool isRegistered) { m_isRegisteredForInvalidationAtDocument = isRegistered; }
@@ -66,7 +65,7 @@ protected:
 private:
     bool isLiveNodeList() const final { return true; }
 
-    Ref<ContainerNode> m_ownerNode;
+    const Ref<ContainerNode> m_ownerNode;
 
     const NodeListInvalidationType m_invalidationType;
     bool m_isRegisteredForInvalidationAtDocument { false };
@@ -120,7 +119,7 @@ template <class NodeListType>
 CachedLiveNodeList<NodeListType>::~CachedLiveNodeList()
 {
     if (m_indexCache.hasValidCache())
-        document().unregisterNodeListForInvalidation(*this);
+        protectedDocument()->unregisterNodeListForInvalidation(*this);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/dom/NameNodeList.cpp
+++ b/Source/WebCore/dom/NameNodeList.cpp
@@ -2,7 +2,7 @@
  * Copyright (C) 1999 Lars Knoll (knoll@kde.org)
  *           (C) 1999 Antti Koivisto (koivisto@kde.org)
  *           (C) 2001 Dirk Mueller (mueller@kde.org)
- * Copyright (C) 2004-2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2004-2025 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -47,7 +47,7 @@ Ref<NameNodeList> NameNodeList::create(ContainerNode& rootNode, const AtomString
 
 NameNodeList::~NameNodeList()
 {
-    protectedOwnerNode()->nodeLists()->removeCacheWithAtomName(*this, m_name);
+    ownerNode().nodeLists()->removeCacheWithAtomName(*this, m_name);
 }
 
 bool NameNodeList::elementMatches(Element& element) const

--- a/Source/WebCore/dom/NodeRareData.h
+++ b/Source/WebCore/dom/NodeRareData.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2008-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2008-2025 Apple Inc. All rights reserved.
  * Copyright (C) 2008 David Smith <catfish.man@gmail.com>
  *
  * This library is free software; you can redistribute it and/or
@@ -165,7 +165,7 @@ public:
     void removeCacheWithAtomName(NodeListType& list, const AtomString& name)
     {
         ASSERT(&list == m_atomNameCaches.get(namedNodeListKey<NodeListType>(name)));
-        if (deleteThisAndUpdateNodeRareDataIfAboutToRemoveLastList(list.protectedOwnerNode()))
+        if (deleteThisAndUpdateNodeRareDataIfAboutToRemoveLastList(list.ownerNode()))
             return;
         m_atomNameCaches.remove(namedNodeListKey<NodeListType>(name));
     }
@@ -174,7 +174,7 @@ public:
     {
         QualifiedName name(nullAtom(), localName, namespaceURI);
         ASSERT(&collection == m_tagCollectionNSCache.get(name));
-        if (deleteThisAndUpdateNodeRareDataIfAboutToRemoveLastList(collection.protectedOwnerNode()))
+        if (deleteThisAndUpdateNodeRareDataIfAboutToRemoveLastList(collection.ownerNode()))
             return;
         m_tagCollectionNSCache.remove(name);
     }

--- a/Source/WebCore/dom/NodeRareDataInlines.h
+++ b/Source/WebCore/dom/NodeRareDataInlines.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2023-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -53,7 +53,7 @@ inline void NodeListsNodeData::adoptDocument(Document& oldDocument, Document& ne
 void NodeListsNodeData::removeCachedCollection(HTMLCollection* collection, const AtomString& name)
 {
     ASSERT(collection == m_cachedCollections.get(namedCollectionKey(collection->type(), name)));
-    if (deleteThisAndUpdateNodeRareDataIfAboutToRemoveLastList(collection->protectedOwnerNode()))
+    if (deleteThisAndUpdateNodeRareDataIfAboutToRemoveLastList(collection->ownerNode()))
         return;
     m_cachedCollections.remove(namedCollectionKey(collection->type(), name));
 }

--- a/Source/WebCore/dom/StaticNodeList.h
+++ b/Source/WebCore/dom/StaticNodeList.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2007, 2008 Apple Inc. All rights reserved.
+ * Copyright (C) 2007-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -68,7 +68,7 @@ private:
         : m_nodeList(nodeList)
     { }
 
-    Ref<NodeList>  m_nodeList;
+    const Ref<NodeList> m_nodeList;
 };
 
 class StaticElementList final : public NodeList {
@@ -87,7 +87,7 @@ private:
         : m_elements(WTFMove(elements))
     { }
 
-    Vector<Ref<Element>> m_elements;
+    const Vector<Ref<Element>> m_elements;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/dom/TagCollection.cpp
+++ b/Source/WebCore/dom/TagCollection.cpp
@@ -2,7 +2,7 @@
  * Copyright (C) 1999 Lars Knoll (knoll@kde.org)
  *           (C) 1999 Antti Koivisto (koivisto@kde.org)
  *           (C) 2001 Dirk Mueller (mueller@kde.org)
- * Copyright (C) 2004-2007, 2014-2016 Apple Inc. All rights reserved.
+ * Copyright (C) 2004-2025 Apple Inc. All rights reserved.
  * Copyright (C) 2008 Nokia Corporation and/or its subsidiary(-ies)
  *
  * This library is free software; you can redistribute it and/or
@@ -44,7 +44,7 @@ TagCollectionNS::TagCollectionNS(ContainerNode& rootNode, const AtomString& name
 
 TagCollectionNS::~TagCollectionNS()
 {
-    protectedOwnerNode()->nodeLists()->removeCachedTagCollectionNS(*this, m_namespaceURI, m_localName);
+    ownerNode().nodeLists()->removeCachedTagCollectionNS(*this, m_namespaceURI, m_localName);
 }
 
 TagCollection::TagCollection(ContainerNode& rootNode, const AtomString& qualifiedName)
@@ -56,7 +56,7 @@ TagCollection::TagCollection(ContainerNode& rootNode, const AtomString& qualifie
 
 TagCollection::~TagCollection()
 {
-    protectedOwnerNode()->nodeLists()->removeCachedCollection(this, m_qualifiedName);
+    ownerNode().nodeLists()->removeCachedCollection(this, m_qualifiedName);
 }
 
 HTMLTagCollection::HTMLTagCollection(ContainerNode& rootNode, const AtomString& qualifiedName)
@@ -69,7 +69,7 @@ HTMLTagCollection::HTMLTagCollection(ContainerNode& rootNode, const AtomString& 
 
 HTMLTagCollection::~HTMLTagCollection()
 {
-    protectedOwnerNode()->nodeLists()->removeCachedCollection(this, m_qualifiedName);
+    ownerNode().nodeLists()->removeCachedCollection(this, m_qualifiedName);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/html/HTMLCollection.cpp
+++ b/Source/WebCore/html/HTMLCollection.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 1999 Lars Knoll (knoll@kde.org)
  *           (C) 1999 Antti Koivisto (koivisto@kde.org)
- * Copyright (C) 2003-2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2003-2025 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -127,7 +127,7 @@ HTMLCollection::HTMLCollection(ContainerNode& ownerNode, CollectionType type)
 HTMLCollection::~HTMLCollection()
 {
     if (hasNamedElementCache())
-        document().collectionWillClearIdNameMap(*this);
+        protectedDocument()->collectionWillClearIdNameMap(*this);
 
     // HTMLNameCollection & ClassCollection remove cache by themselves.
     // FIXME: We need a cleaner way to handle this.
@@ -210,16 +210,16 @@ void HTMLCollection::updateNamedElementCache() const
 
     unsigned size = length();
     for (unsigned i = 0; i < size; ++i) {
-        Element& element = *item(i);
-        const AtomString& id = element.getIdAttribute();
+        Ref element = *item(i);
+        auto& id = element->getIdAttribute();
         if (!id.isEmpty())
-            cache->appendToIdCache(id, element);
-        auto* htmlElement = dynamicDowncast<HTMLElement>(element);
+            cache->appendToIdCache(id, element.get());
+        RefPtr htmlElement = dynamicDowncast<HTMLElement>(element);
         if (!htmlElement)
             continue;
-        const AtomString& name = element.getNameAttribute();
+        auto& name = htmlElement->getNameAttribute();
         if (!name.isEmpty() && id != name && (type() != CollectionType::DocAll || nameShouldBeVisibleInDocumentAll(*htmlElement)))
-            cache->appendToNameCache(name, element);
+            cache->appendToNameCache(name, *htmlElement);
     }
 
     setNamedItemCache(WTFMove(cache));

--- a/Source/WebCore/html/HTMLCollection.h
+++ b/Source/WebCore/html/HTMLCollection.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 1999 Lars Knoll (knoll@kde.org)
  *           (C) 1999 Antti Koivisto (koivisto@kde.org)
- * Copyright (C) 2003-2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2003-2025 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -78,7 +78,6 @@ public:
     inline NodeListInvalidationType invalidationType() const;
     inline CollectionType type() const;
     inline ContainerNode& ownerNode() const;
-    inline Ref<ContainerNode> protectedOwnerNode() const;
     inline ContainerNode& rootNode() const;
     inline void invalidateCacheForAttribute(const QualifiedName& attributeName);
     WEBCORE_EXPORT virtual void invalidateCacheForDocument(Document&);
@@ -96,6 +95,7 @@ protected:
     inline const CollectionNamedElementCache& namedItemCaches() const;
 
     inline Document& document() const;
+    inline Ref<Document> protectedDocument() const;
 
     void invalidateNamedElementCache(Document&) const;
 
@@ -121,11 +121,6 @@ inline size_t CollectionNamedElementCache::memoryCost() const
 }
 
 inline ContainerNode& HTMLCollection::ownerNode() const
-{
-    return m_ownerNode;
-}
-
-inline Ref<ContainerNode> HTMLCollection::protectedOwnerNode() const
 {
     return m_ownerNode;
 }

--- a/Source/WebCore/html/HTMLCollectionInlines.h
+++ b/Source/WebCore/html/HTMLCollectionInlines.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2023-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -101,17 +101,22 @@ inline Document& HTMLCollection::document() const
     return m_ownerNode->document();
 }
 
+inline Ref<Document> HTMLCollection::protectedDocument() const
+{
+    return document();
+}
+
 inline void HTMLCollection::invalidateCacheForAttribute(const QualifiedName& attributeName)
 {
     if (shouldInvalidateTypeOnAttributeChange(invalidationType(), attributeName))
         invalidateCache();
     else if (hasNamedElementCache() && (attributeName == HTMLNames::idAttr || attributeName == HTMLNames::nameAttr))
-        invalidateNamedElementCache(document());
+        invalidateNamedElementCache(protectedDocument().get());
 }
 
 inline void HTMLCollection::invalidateCache()
 {
-    invalidateCacheForDocument(document());
+    invalidateCacheForDocument(protectedDocument().get());
 }
 
 inline bool HTMLCollection::hasNamedElementCache() const
@@ -128,7 +133,7 @@ inline void HTMLCollection::setNamedItemCache(std::unique_ptr<CollectionNamedEle
         Locker locker { m_namedElementCacheAssignmentLock };
         m_namedElementCache = WTFMove(cache);
     }
-    document().collectionCachedIdNameMap(*this);
+    protectedDocument()->collectionCachedIdNameMap(*this);
 }
 
 inline const CollectionNamedElementCache& HTMLCollection::namedItemCaches() const

--- a/Source/WebCore/html/HTMLFormControlsCollection.cpp
+++ b/Source/WebCore/html/HTMLFormControlsCollection.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 1999 Lars Knoll (knoll@kde.org)
  *           (C) 1999 Antti Koivisto (koivisto@kde.org)
- * Copyright (C) 2003, 2004, 2005, 2006, 2007, 2010, 2011, 2012 Apple Inc. All rights reserved.
+ * Copyright (C) 2003-2025 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -70,7 +70,7 @@ static unsigned findFormListedElement(const Vector<WeakPtr<HTMLElement, WeakPtrI
     for (unsigned i = 0; i < elements.size(); ++i) {
         RefPtr currentElement = elements[i].get();
         ASSERT(currentElement);
-        auto* listedElement = currentElement->asFormListedElement();
+        RefPtr listedElement = currentElement->asFormListedElement();
         ASSERT(listedElement);
         if (listedElement->isEnumeratable() && currentElement == &element)
             return i;
@@ -119,17 +119,17 @@ void HTMLFormControlsCollection::updateNamedElementCache() const
 
     ScriptDisallowedScope::InMainThread scriptDisallowedScope;
     for (auto& weakElement : ownerNode().unsafeListedElements()) {
-        RefPtr element { weakElement.get() };
+        RefPtr element = weakElement.get();
         ASSERT(element);
-        auto* associatedElement = element->asFormListedElement();
+        RefPtr associatedElement = element->asFormListedElement();
         ASSERT(associatedElement);
         if (associatedElement->isEnumeratable()) {
-            const AtomString& id = element->getIdAttribute();
+            auto& id = element->getIdAttribute();
             if (!id.isEmpty()) {
                 cache->appendToIdCache(id, *element);
                 foundInputElements.add(id);
             }
-            const AtomString& name = element->getNameAttribute();
+            auto& name = element->getNameAttribute();
             if (!name.isEmpty() && id != name) {
                 cache->appendToNameCache(name, *element);
                 foundInputElements.add(name);
@@ -137,16 +137,16 @@ void HTMLFormControlsCollection::updateNamedElementCache() const
         }
     }
 
-    for (auto& elementPtr : ownerNode().imageElements()) {
-        if (!elementPtr)
+    for (auto& weakElement : ownerNode().imageElements()) {
+        RefPtr element = weakElement.get();
+        if (!element)
             continue;
-        HTMLImageElement& element = *elementPtr;
-        const AtomString& id = element.getIdAttribute();
+        auto& id = element->getIdAttribute();
         if (!id.isEmpty() && !foundInputElements.contains(id))
-            cache->appendToIdCache(id, element);
-        const AtomString& name = element.getNameAttribute();
+            cache->appendToIdCache(id, *element);
+        auto& name = element->getNameAttribute();
         if (!name.isEmpty() && id != name && !foundInputElements.contains(name))
-            cache->appendToNameCache(name, element);
+            cache->appendToNameCache(name, *element);
     }
 
     setNamedItemCache(WTFMove(cache));

--- a/Source/WebCore/html/HTMLTableRowsCollection.cpp
+++ b/Source/WebCore/html/HTMLTableRowsCollection.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2008, 2011, 2012, 2013 Apple Inc. All rights reserved.
+ * Copyright (C) 2008-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -166,7 +166,7 @@ Ref<HTMLTableRowsCollection> HTMLTableRowsCollection::create(HTMLTableElement& t
 
 Element* HTMLTableRowsCollection::customElementAfter(Element* previous) const
 {
-    return rowAfter(const_cast<HTMLTableElement&>(tableElement()), downcast<HTMLTableRowElement>(previous));
+    return rowAfter(tableElement(), downcast<HTMLTableRowElement>(previous));
 }
 
 }

--- a/Source/WebCore/html/HTMLTableRowsCollection.h
+++ b/Source/WebCore/html/HTMLTableRowsCollection.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2008, 2013 Apple Inc. All rights reserved.
+ * Copyright (C) 2008-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -40,8 +40,7 @@ class HTMLTableRowsCollection final : public CachedHTMLCollection<HTMLTableRowsC
 public:
     static Ref<HTMLTableRowsCollection> create(HTMLTableElement&, CollectionType);
 
-    HTMLTableElement& tableElement() { return downcast<HTMLTableElement>(ownerNode()); }
-    const HTMLTableElement& tableElement() const { return downcast<HTMLTableElement>(ownerNode()); }
+    HTMLTableElement& tableElement() const { return downcast<HTMLTableElement>(ownerNode()); }
 
     static HTMLTableRowElement* rowAfter(HTMLTableElement&, HTMLTableRowElement*);
     static HTMLTableRowElement* lastRow(HTMLTableElement&);

--- a/Source/WebCore/html/LabelsNodeList.cpp
+++ b/Source/WebCore/html/LabelsNodeList.cpp
@@ -2,7 +2,7 @@
  * Copyright (C) 1999 Lars Knoll (knoll@kde.org)
  *           (C) 1999 Antti Koivisto (koivisto@kde.org)
  *           (C) 2001 Dirk Mueller (mueller@kde.org)
- * Copyright (C) 2004-2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2004-2025 Apple Inc. All rights reserved.
  * Copyright (C) 2010 Nokia Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
@@ -54,7 +54,7 @@ LabelsNodeList::~LabelsNodeList()
     
 bool LabelsNodeList::elementMatches(Element& testNode) const
 {
-    auto* label = dynamicDowncast<HTMLLabelElement>(testNode);
+    RefPtr label = dynamicDowncast<HTMLLabelElement>(testNode);
     return label && label->control() == &ownerNode();
 }
 


### PR DESCRIPTION
#### 5df479c28a655ee36d5682ef6c90fea085824915
<pre>
Reduce unsafeness in various node collections
<a href="https://bugs.webkit.org/show_bug.cgi?id=293874">https://bugs.webkit.org/show_bug.cgi?id=293874</a>
<a href="https://rdar.apple.com/152388343">rdar://152388343</a>

Reviewed by Chris Dumez.

Apply <a href="https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines">https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines</a>

One observation here is that m_ownerNode can always be const and thus
there is no need for protectedOwnerNode().

Canonical link: <a href="https://commits.webkit.org/295739@main">https://commits.webkit.org/295739@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cf1fb6ee659def903a1b1f5a042fd1f5a38907d4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/106000 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25749 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/16143 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/111196 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/56596 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/108039 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/26402 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34252 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80519 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/109004 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/20830 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95663 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60840 "Found 138 new API test failures: /WPE/TestUIClient:/webkit/WebKitWebView/query-permission-requests, /WPE/TestWebsiteData:/webkit/WebKitWebsiteData/deviceidhashsalt, /WPE/TestLoaderClient:/webkit/WebKitWebView/load-twice-and-reload, /WPE/TestCookieManager:/webkit/WebKitCookieManager/ephemeral, /WPE/TestWebKitWebView:/webkit/WebKitWebView/is-playing-audio, /WPE/TestWebsiteData:/webkit/WebKitWebsiteData/configuration, /WPE/TestCookieManager:/webkit/WebKitCookieManager/delete-cookies, /WPE/TestWebKitWebView:/webkit/WebKitWebView/terminate-unresponsive-web-process, /WPE/TestSSL:/webkit/WebKitWebView/insecure-content, /WPE/TestAuthentication:/webkit/Authentication/authentication-storage ... (failure)") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/20439 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13760 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/56034 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/90208 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13796 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-pseudo/highlight-custom-properties-dynamic-001.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/114055 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33138 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24452 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89599 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33502 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91891 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89283 "Passed tests") | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22752 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-conditional/container-queries/canvas-as-container-002.html (failure)") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34147 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11963 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/28692 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17191 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/33063 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/38475 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32809 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/36158 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34407 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->