### PR TITLE
Tabbing in a scroll container with scroll-padding set does not scroll focused element into view

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/scroll-padding-focus-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/scroll-padding-focus-expected.txt
@@ -1,0 +1,5 @@
+Other focus
+
+PASS Avoid left scroll-padding
+PASS Avoid right scroll-padding
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/scroll-padding-focus.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/scroll-padding-focus.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-scroll-snap-1/#scroll-padding">
+<title>Scroll into view for focus respects scroll padding</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+#scroller {
+  height: 200px;
+  width: 600px;
+  margin: 50px;
+  scroll-padding: 0 120px;
+  scrollbar-width: none;
+  overflow: auto;
+  border: 1px solid black;
+}
+.wide {
+  width: 2000px;
+}
+#target {
+  width: 100px;
+  height: 100px;
+  margin: 10px;
+  margin-left: 600px;
+  background-color: silver;
+}
+</style>
+
+<div id="scroller">
+  <div class="wide">
+      <div id="target" tabindex="-1" style="background-color: green"></div>
+  </div>
+</div>
+<div id="other-focus" tabindex="-1">Other focus</div>
+<script>
+function tick() {
+  return new Promise(resolve => {
+    requestAnimationFrame(() => requestAnimationFrame(resolve));
+  });
+}
+
+function reset()
+{
+  document.getElementById('other-focus').focus();
+}
+
+let scroller = document.getElementById("scroller");
+promise_test(async t => {
+  reset();
+  scroller.scrollTo(100, 0);
+  await tick();
+  const target = document.getElementById("target");
+  target.focus();
+  await tick(); // Work around WebKit bug.
+  assert_equals(scroller.scrollLeft, 350, "Focus should scroll the target from out under the left scrollpadding");
+}, 'Avoid left scroll-padding');
+
+promise_test(async t => {
+  reset();
+  scroller.scrollTo(600, 0);
+  await tick();
+  const target = document.getElementById("target");
+  target.focus();
+  await tick(); // Work around WebKit bug.
+  assert_equals(scroller.scrollLeft, 350, "Focus should scroll the target from out under the right scrollpadding");
+}, 'Avoid right scroll-padding');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/scroll-padding-percentage-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/scroll-padding-percentage-expected.txt
@@ -1,0 +1,5 @@
+Other focus
+
+PASS No need to scroll to avoid percentage scroll padding left
+PASS No need to scroll to avoid percentage scroll padding right
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/scroll-padding-percentage.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/scroll-padding-percentage.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-scroll-snap-1/#scroll-padding">
+<title>Scroll padding percentage is computed relative to the scrollport</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+.container {
+  position: relative;
+  height: 400px;
+  width: 800px;
+  margin: 50px;
+  outline: 1px solid black;
+}
+
+#scroller {
+  height: 100%;
+  width: 100%;
+  border: 100px solid silver;
+  padding: 20px;
+  scroll-padding: 0 20%;
+  scrollbar-width: none;
+  overflow: auto;
+  box-sizing: border-box;
+}
+
+.scroll-padding-indicator {
+  position: absolute;
+  background-color: rgba(128, 0, 0, 0.2);
+  top: 0;
+  width: calc(600px * 0.2);
+  height: 100%;
+  pointer-events: none;
+}
+
+.scroll-padding-indicator.left {
+  left: 100px;
+}
+
+.scroll-padding-indicator.right {
+  right: 100px;  
+}
+
+.wide {
+  width: 2000px;
+}
+
+#target {
+  width: 10px;
+  height: 10px;
+  margin: 10px;
+  margin-left: 600px;
+  background-color: silver;
+}
+</style>
+
+<div class="container">
+  <div class="scroll-padding-indicator left"></div>
+  <div class="scroll-padding-indicator right"></div>
+  <div id="scroller">
+    <div class="wide">
+        <div id="target" tabindex="-1" style="background-color: green"></div>
+    </div>
+  </div>
+</div>
+<div id="other-focus" tabindex="-1">Other focus</div>
+<script>
+function tick() {
+  return new Promise(resolve => {
+    requestAnimationFrame(() => requestAnimationFrame(resolve));
+  });
+}
+
+function reset()
+{
+  document.getElementById('other-focus').focus();
+}
+
+let scroller = document.getElementById("scroller");
+promise_test(async t => {
+  scroller.scrollTo(160, 0);
+  reset();
+  await tick();
+  const target = document.getElementById("target");
+  target.focus();
+  await tick(); // Work around WebKit bug.
+  assert_equals(scroller.scrollLeft, 160, "The target should aleady be outside the left scrollpardding area");
+}, 'No need to scroll to avoid percentage scroll padding left');
+
+promise_test(async t => {
+  scroller.scrollTo(490, 0);
+  reset();
+  await tick();
+  const target = document.getElementById("target");
+  target.focus();
+  await tick(); // Work around WebKit bug.
+  assert_equals(scroller.scrollLeft, 490, "The target should aleady be outside the right scrollpardding area");
+}, 'No need to scroll to avoid percentage scroll padding right');
+</script>

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/cssom-view/scrollIntoView-stuck.tentative-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/cssom-view/scrollIntoView-stuck.tentative-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL CSSOM View - scrollIntoView doesn't consider scroll-padding when target is stuck assert_equals: Shouldn't have scrolled expected 2323 but got 2422
+FAIL CSSOM View - scrollIntoView doesn't consider scroll-padding when target is stuck assert_equals: Shouldn't have scrolled expected 2324 but got 2422
 

--- a/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
+++ b/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
@@ -1874,54 +1874,58 @@ void RenderLayerScrollableArea::panScrollFromPoint(const IntPoint& sourcePoint)
     scrollByRecursively(adjustedScrollDelta(delta));
 }
 
-static LayoutRect getLocalExposeRect(const LayoutRect& absoluteRect, RenderBox* box, int verticalScrollbarWidth, const LayoutRect& layerBounds)
+static LayoutRect computeLocalExposeRect(const LayoutRect& absoluteRect, RenderBox* box)
 {
-    LayoutRect localExposeRect(box->absoluteToLocalQuad(FloatQuad(FloatRect(absoluteRect))).boundingBox());
-
-    // localExposedRect is now the absolute rect in local coordinates, but relative to the
-    // border edge. Make the rectangle relative to the scrollable area.
-    localExposeRect.moveBy(-LayoutPoint(box->borderLeft(), box->borderTop()));
-
-    if (box->shouldPlaceVerticalScrollbarOnLeft()) {
-        // For `direction: rtl; writing-mode: horizontal-{tb,bt}` and `writing-mode: vertical-rl`
-        // boxes, the scroll bar is on the left side. The visible rect starts from the right side
-        // of the scroll bar. So the x of localExposeRect should start from the same position too.
-        localExposeRect.moveBy(LayoutPoint(-verticalScrollbarWidth, 0));
-    }
-
-    // scroll-padding applies to the scroll container, but expand the rectangle that we want to expose in order
-    // simulate padding the scroll container. This rectangle is passed up the tree of scrolling elements to
-    // ensure that the padding on this scroll container is maintained.
-    localExposeRect.expand(box->scrollPaddingForViewportRect(layerBounds));
-    return localExposeRect;
+    return LayoutRect { box->absoluteToLocalQuad(FloatQuad(FloatRect(absoluteRect))).boundingBox() };
 }
 
 LayoutRect RenderLayerScrollableArea::scrollRectToVisible(const LayoutRect& absoluteRect, const ScrollRectToVisibleOptions& options)
 {
     RenderBox* box = layer().renderBox();
     ASSERT(box);
-    
-    LayoutRect layerBounds(0_lu, 0_lu, box->clientWidth(), box->clientHeight());
 
-    LayoutRect localExposeRect = getLocalExposeRect(absoluteRect, box, verticalScrollbarWidth(), layerBounds);
+    auto scrollingViewport = box->paddingBoxRect();
+
+    auto scrollPadding = box->scrollPaddingForViewportRect(scrollingViewport);
+    if ((scrollPadding.left() + scrollPadding.right()) > scrollingViewport.width()) {
+        auto shrinkFactor = static_cast<float>(scrollingViewport.width()) / (scrollPadding.left() + scrollPadding.right());
+        scrollPadding.left() *= shrinkFactor;
+        scrollPadding.right() *= shrinkFactor;
+    }
+
+    if ((scrollPadding.top() + scrollPadding.bottom()) > scrollingViewport.height()) {
+        auto shrinkFactor = static_cast<float>(scrollingViewport.height()) / (scrollPadding.top() + scrollPadding.bottom());
+        scrollPadding.top() *= shrinkFactor;
+        scrollPadding.bottom() *= shrinkFactor;
+    }
+
+    auto scrollingViewportWithPadding = scrollingViewport;
+    scrollingViewportWithPadding.contract(scrollPadding);
+
+    auto localExposeRect = computeLocalExposeRect(absoluteRect, box);
     std::optional<LayoutRect> localVisiblityRect;
     if (options.visibilityCheckRect)
-        localVisiblityRect = getLocalExposeRect(*options.visibilityCheckRect, box, verticalScrollbarWidth(), layerBounds);
+        localVisiblityRect = computeLocalExposeRect(*options.visibilityCheckRect, box);
 
-    auto revealRect = getRectToExposeForScrollIntoView(layerBounds, localExposeRect, options.alignX, options.alignY, localVisiblityRect);
+    auto revealRect = getRectToExposeForScrollIntoView(scrollingViewportWithPadding, localExposeRect, options.alignX, options.alignY, localVisiblityRect);
+    revealRect.move(-scrollingViewportWithPadding.x(), -scrollingViewportWithPadding.y());
+
     auto scrollPositionOptions = ScrollPositionChangeOptions::createProgrammatic();
     if (!box->frame().eventHandler().autoscrollInProgress() && box->element() && useSmoothScrolling(options.behavior, protect(box->element()).get()))
         scrollPositionOptions.animated = ScrollIsAnimated::Yes;
-    if (auto result = updateScrollPositionForScrollIntoView(scrollPositionOptions, revealRect, localExposeRect))
+
+    if (auto result = updateScrollPositionForScrollIntoView(scrollPositionOptions, toLayoutSize(revealRect.location()), localExposeRect))
         return result.value();
+
     return absoluteRect;
 }
-std::optional<LayoutRect> RenderLayerScrollableArea::updateScrollPositionForScrollIntoView(const ScrollPositionChangeOptions& options, const LayoutRect& revealRect, const LayoutRect& localExposeRect)
+
+std::optional<LayoutRect> RenderLayerScrollableArea::updateScrollPositionForScrollIntoView(const ScrollPositionChangeOptions& options, const LayoutSize& revealOffset, const LayoutRect& localExposeRect)
 {
     RenderBox* box = m_layer.renderBox();
     ASSERT(box);
 
-    ScrollOffset clampedScrollOffset = clampScrollOffset(scrollOffset() + toIntSize(roundedIntRect(revealRect).location()));
+    ScrollOffset clampedScrollOffset = clampScrollOffset(scrollOffset() + roundedIntSize(revealOffset));
     if (clampedScrollOffset == scrollOffset() && scrollAnimationStatus() == ScrollAnimationStatus::NotAnimating)
         return std::nullopt;
 

--- a/Source/WebCore/rendering/RenderLayerScrollableArea.h
+++ b/Source/WebCore/rendering/RenderLayerScrollableArea.h
@@ -259,7 +259,7 @@ public:
     bool isVisibleToHitTesting() const final;
     void animatedScrollDidEnd() final;
     LayoutRect scrollRectToVisible(const LayoutRect& absoluteRect, const ScrollRectToVisibleOptions&);
-    std::optional<LayoutRect> updateScrollPositionForScrollIntoView(const ScrollPositionChangeOptions&, const LayoutRect& revealRect, const LayoutRect& localExposeRect);
+    std::optional<LayoutRect> updateScrollPositionForScrollIntoView(const ScrollPositionChangeOptions&, const LayoutSize& revealOffset, const LayoutRect& localExposeRect);
 
     ScrollAnchoringController* scrollAnchoringController() const final { return m_scrollAnchoringController.get(); }
 


### PR DESCRIPTION
#### 079d6409fe009b33b2863648e519dc6af2d7f7cc
<pre>
Tabbing in a scroll container with scroll-padding set does not scroll focused element into view
<a href="https://bugs.webkit.org/show_bug.cgi?id=290096">https://bugs.webkit.org/show_bug.cgi?id=290096</a>
<a href="https://rdar.apple.com/147513379">rdar://147513379</a>

Reviewed by Alan Baradlay.

The existing code took scroll-padding into account by inflating the `localExposeRect`, but this doesn&apos;t
have the correct behavior because it makes this rect wider. The correct approach is to shrink the
the scrolling viewport. We can also simplify the code by keeping all the rects in coordinates local
to the RenderBox, so `paddingBoxRect()` gives the correct scroll viewport with the left scrollbar
taken into account.

Also handle the case of the scroll padding being larger than the scrollport by proportionally shrinking
it; this behavior is not specified, but seems reasonable.

* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/scroll-padding-focus-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/scroll-padding-focus.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/scroll-padding-percentage-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/scroll-padding-percentage.html: Added.
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/cssom-view/scrollIntoView-stuck.tentative-expected.txt:
* Source/WebCore/rendering/RenderLayerScrollableArea.cpp:
(WebCore::computeLocalExposeRect):
(WebCore::RenderLayerScrollableArea::scrollRectToVisible):
(WebCore::RenderLayerScrollableArea::updateScrollPositionForScrollIntoView): This only needs the offset to
reveal, not the entire rect.
(WebCore::getLocalExposeRect): Deleted.
* Source/WebCore/rendering/RenderLayerScrollableArea.h:

Canonical link: <a href="https://commits.webkit.org/311512@main">https://commits.webkit.org/311512@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/14e79e2658b85b57af0b2853aa7ed845a3fa08ab

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157146 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30483 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23673 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165969 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111228 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/31d0de95-6065-447e-b8fc-b5c4cf80df9c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/159017 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30618 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30485 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121699 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/85445 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e6908a58-b8eb-4a21-9410-b7d2673066c7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160104 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23940 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141104 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102367 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0786c1cf-504c-4110-b4b5-a15edbdf97d2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22995 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21232 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13741 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132675 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18932 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168454 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/12613 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20552 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129829 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30084 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25310 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129937 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35210 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30007 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140726 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87828 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24760 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17530 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29718 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/93732 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29240 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29470 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29367 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->