### PR TITLE
[Extractor] Support direct serialization and conversion to CSSValue from Style value objects

### DIFF
--- a/Source/WebCore/css/parser/CSSPropertyParserCustom.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserCustom.h
@@ -726,10 +726,10 @@ inline bool PropertyParserCustom::consumeBorderRadiusShorthand(CSSParserTokenRan
     if (!borderRadius)
         return false;
 
-    result.addPropertyForCurrentShorthand(state, CSSPropertyBorderTopLeftRadius, WebCore::CSS::createCSSValue(borderRadius->topLeft()));
-    result.addPropertyForCurrentShorthand(state, CSSPropertyBorderTopRightRadius, WebCore::CSS::createCSSValue(borderRadius->topRight()));
-    result.addPropertyForCurrentShorthand(state, CSSPropertyBorderBottomRightRadius, WebCore::CSS::createCSSValue(borderRadius->bottomRight()));
-    result.addPropertyForCurrentShorthand(state, CSSPropertyBorderBottomLeftRadius, WebCore::CSS::createCSSValue(borderRadius->bottomLeft()));
+    result.addPropertyForCurrentShorthand(state, CSSPropertyBorderTopLeftRadius, WebCore::CSS::createCSSValue(state.pool, borderRadius->topLeft()));
+    result.addPropertyForCurrentShorthand(state, CSSPropertyBorderTopRightRadius, WebCore::CSS::createCSSValue(state.pool, borderRadius->topRight()));
+    result.addPropertyForCurrentShorthand(state, CSSPropertyBorderBottomRightRadius, WebCore::CSS::createCSSValue(state.pool, borderRadius->bottomRight()));
+    result.addPropertyForCurrentShorthand(state, CSSPropertyBorderBottomLeftRadius, WebCore::CSS::createCSSValue(state.pool, borderRadius->bottomLeft()));
     return true;
 }
 
@@ -739,10 +739,10 @@ inline bool PropertyParserCustom::consumeWebkitBorderRadiusShorthand(CSSParserTo
     if (!borderRadius)
         return false;
 
-    result.addPropertyForCurrentShorthand(state, CSSPropertyBorderTopLeftRadius, WebCore::CSS::createCSSValue(borderRadius->topLeft()));
-    result.addPropertyForCurrentShorthand(state, CSSPropertyBorderTopRightRadius, WebCore::CSS::createCSSValue(borderRadius->topRight()));
-    result.addPropertyForCurrentShorthand(state, CSSPropertyBorderBottomRightRadius, WebCore::CSS::createCSSValue(borderRadius->bottomRight()));
-    result.addPropertyForCurrentShorthand(state, CSSPropertyBorderBottomLeftRadius, WebCore::CSS::createCSSValue(borderRadius->bottomLeft()));
+    result.addPropertyForCurrentShorthand(state, CSSPropertyBorderTopLeftRadius, WebCore::CSS::createCSSValue(state.pool, borderRadius->topLeft()));
+    result.addPropertyForCurrentShorthand(state, CSSPropertyBorderTopRightRadius, WebCore::CSS::createCSSValue(state.pool, borderRadius->topRight()));
+    result.addPropertyForCurrentShorthand(state, CSSPropertyBorderBottomRightRadius, WebCore::CSS::createCSSValue(state.pool, borderRadius->bottomRight()));
+    result.addPropertyForCurrentShorthand(state, CSSPropertyBorderBottomLeftRadius, WebCore::CSS::createCSSValue(state.pool, borderRadius->bottomLeft()));
     return true;
 }
 

--- a/Source/WebCore/css/values/CSSValueTypes.cpp
+++ b/Source/WebCore/css/values/CSSValueTypes.cpp
@@ -25,7 +25,12 @@
 #include "config.h"
 #include "CSSValueTypes.h"
 
+#include "CSSFunctionValue.h"
 #include "CSSMarkup.h"
+#include "CSSPrimitiveValue.h"
+#include "CSSValueList.h"
+#include "CSSValuePair.h"
+#include "CSSValuePool.h"
 
 namespace WebCore {
 namespace CSS {
@@ -35,9 +40,59 @@ void Serialize<CustomIdentifier>::operator()(StringBuilder& builder, const Seria
     serializeIdentifier(value.value, builder);
 }
 
+void Serialize<WTF::AtomString>::operator()(StringBuilder& builder, const SerializationContext&, const WTF::AtomString& value)
+{
+    serializeString(value, builder);
+}
+
 void Serialize<WTF::String>::operator()(StringBuilder& builder, const SerializationContext&, const WTF::String& value)
 {
     serializeString(value, builder);
+}
+
+Ref<CSSValue> makePrimitiveCSSValue(CSSValueID value)
+{
+    return CSSPrimitiveValue::create(value);
+}
+
+Ref<CSSValue> makePrimitiveCSSValue(const CustomIdentifier& value)
+{
+    return CSSPrimitiveValue::createCustomIdent(value.value);
+}
+
+Ref<CSSValue> makePrimitiveCSSValue(const WTF::AtomString& value)
+{
+    return CSSPrimitiveValue::create(value);
+}
+
+Ref<CSSValue> makePrimitiveCSSValue(const WTF::String& value)
+{
+    return CSSPrimitiveValue::create(value);
+}
+
+Ref<CSSValue> makeFunctionCSSValue(CSSValueID name, Ref<CSSValue>&& value)
+{
+    return CSSFunctionValue::create(name, WTFMove(value));
+}
+
+Ref<CSSValue> makeSpaceSeparatedCoalescingPairCSSValue(Ref<CSSValue>&& first, Ref<CSSValue>&& second)
+{
+    return CSSValuePair::create(WTFMove(first), WTFMove(second));
+}
+
+template<> Ref<CSSValue> makeListCSSValue<SerializationSeparatorType::Space>(CSSValueListBuilder&& builder)
+{
+    return CSSValueList::createSpaceSeparated(WTFMove(builder));
+}
+
+template<> Ref<CSSValue> makeListCSSValue<SerializationSeparatorType::Comma>(CSSValueListBuilder&& builder)
+{
+    return CSSValueList::createCommaSeparated(WTFMove(builder));
+}
+
+template<> Ref<CSSValue> makeListCSSValue<SerializationSeparatorType::Slash>(CSSValueListBuilder&& builder)
+{
+    return CSSValueList::createSlashSeparated(WTFMove(builder));
 }
 
 } // namespace CSS

--- a/Source/WebCore/css/values/CSSValueTypes.h
+++ b/Source/WebCore/css/values/CSSValueTypes.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Samuel Weinig <sam@webkit.org>
+ * Copyright (C) 2024-2025 Samuel Weinig <sam@webkit.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -24,13 +24,15 @@
 
 #pragma once
 
+#include "CSSValue.h"
 #include "CSSValueAggregates.h"
 #include "ComputedStyleDependencies.h"
 #include <wtf/text/StringBuilder.h>
 
 namespace WebCore {
 
-class CSSValue;
+class CSSValuePool;
+using CSSValueListBuilder = Vector<Ref<CSSValue>, 4>;
 
 namespace CSS {
 
@@ -39,7 +41,7 @@ namespace CSS {
 // All leaf types must implement the following conversions:
 //
 //    template<> struct WebCore::CSS::Serialize<CSSType> {
-//        void operator()(StringBuilder&, const SerializationContext&, const SerializationContext&, const CSSType&);
+//        void operator()(StringBuilder&, const SerializationContext&, const CSSType&);
 //    };
 
 struct SerializationContext;
@@ -124,7 +126,7 @@ template<OptionalLike CSSType> struct Serialize<CSSType> {
 template<TupleLike CSSType> struct Serialize<CSSType> {
     void operator()(StringBuilder& builder, const SerializationContext& context, const CSSType& value)
     {
-        serializationForCSSOnTupleLike(builder, context, value, SerializationSeparator<CSSType>);
+        serializationForCSSOnTupleLike(builder, context, value, SerializationSeparatorString<CSSType>);
     }
 };
 
@@ -132,7 +134,7 @@ template<TupleLike CSSType> struct Serialize<CSSType> {
 template<RangeLike CSSType> struct Serialize<CSSType> {
     void operator()(StringBuilder& builder, const SerializationContext& context, const CSSType& value)
     {
-        serializationForCSSOnRangeLike(builder, context, value, SerializationSeparator<CSSType>);
+        serializationForCSSOnRangeLike(builder, context, value, SerializationSeparatorString<CSSType>);
     }
 };
 
@@ -157,6 +159,11 @@ template<> struct Serialize<CustomIdentifier> {
     void operator()(StringBuilder&, const SerializationContext&, const CustomIdentifier&);
 };
 
+// Specialization for `WTF::AtomString`.
+template<> struct Serialize<WTF::AtomString> {
+    void operator()(StringBuilder&, const SerializationContext&, const WTF::AtomString&);
+};
+
 // Specialization for `WTF::String`.
 template<> struct Serialize<WTF::String> {
     void operator()(StringBuilder&, const SerializationContext&, const WTF::String&);
@@ -172,11 +179,25 @@ template<CSSValueID Name, typename CSSType> struct Serialize<FunctionNotation<Na
     }
 };
 
+// Specialization for `MinimallySerializingSpaceSeparatedSize`.
+template<typename CSSType> struct Serialize<MinimallySerializingSpaceSeparatedSize<CSSType>> {
+    void operator()(StringBuilder& builder, const SerializationContext& context, const MinimallySerializingSpaceSeparatedSize<CSSType>& value)
+    {
+        constexpr auto separator = SerializationSeparatorString<MinimallySerializingSpaceSeparatedSize<CSSType>>;
+
+        if (get<0>(value) != get<1>(value)) {
+            serializationForCSSOnTupleLike(builder, context, std::tuple { get<0>(value), get<1>(value) }, separator);
+            return;
+        }
+        serializationForCSS(builder, context, get<0>(value));
+    }
+};
+
 // Specialization for `MinimallySerializingSpaceSeparatedRectEdges`.
 template<typename CSSType> struct Serialize<MinimallySerializingSpaceSeparatedRectEdges<CSSType>> {
     void operator()(StringBuilder& builder, const SerializationContext& context, const MinimallySerializingSpaceSeparatedRectEdges<CSSType>& value)
     {
-        constexpr auto separator = SerializationSeparator<MinimallySerializingSpaceSeparatedRectEdges<CSSType>>;
+        constexpr auto separator = SerializationSeparatorString<MinimallySerializingSpaceSeparatedRectEdges<CSSType>>;
 
         if (value.left() != value.right()) {
             serializationForCSSOnTupleLike(builder, context, std::tuple { value.top(), value.right(), value.bottom(), value.left() }, separator);
@@ -292,6 +313,14 @@ template<CSSValueID C> struct ComputedStyleDependenciesCollector<Constant<C>> {
 // Specialization for `CustomIdentifier`.
 template<> struct ComputedStyleDependenciesCollector<CustomIdentifier> {
     constexpr void operator()(ComputedStyleDependencies&, const CustomIdentifier&)
+    {
+        // Nothing to do.
+    }
+};
+
+// Specialization for `WTF::AtomString`.
+template<> struct ComputedStyleDependenciesCollector<WTF::AtomString> {
+    constexpr void operator()(ComputedStyleDependencies&, const WTF::AtomString&)
     {
         // Nothing to do.
     }
@@ -420,6 +449,14 @@ template<> struct CSSValueChildrenVisitor<CustomIdentifier> {
     }
 };
 
+// Specialization for `WTF::AtomString`.
+template<> struct CSSValueChildrenVisitor<WTF::AtomString> {
+    constexpr IterationStatus operator()(NOESCAPE const Function<IterationStatus(CSSValue&)>&, const WTF::AtomString&)
+    {
+        return IterationStatus::Continue;
+    }
+};
+
 // Specialization for `WTF::String`.
 template<> struct CSSValueChildrenVisitor<WTF::String> {
     constexpr IterationStatus operator()(NOESCAPE const Function<IterationStatus(CSSValue&)>&, const WTF::String&)
@@ -433,6 +470,125 @@ template<> struct CSSValueChildrenVisitor<WTF::URL> {
     constexpr IterationStatus operator()(NOESCAPE const Function<IterationStatus(CSSValue&)>&, const WTF::URL&)
     {
         return IterationStatus::Continue;
+    }
+};
+
+// MARK: - CSSValue Creation
+
+template<typename CSSType> struct CSSValueCreation;
+
+template<typename CSSType> Ref<CSSValue> createCSSValue(CSSValuePool& pool, const CSSType& value)
+{
+    return CSSValueCreation<CSSType>{}(pool, value);
+}
+
+Ref<CSSValue> makePrimitiveCSSValue(CSSValueID);
+Ref<CSSValue> makePrimitiveCSSValue(const CustomIdentifier&);
+Ref<CSSValue> makePrimitiveCSSValue(const WTF::AtomString&);
+Ref<CSSValue> makePrimitiveCSSValue(const WTF::String&);
+Ref<CSSValue> makeFunctionCSSValue(CSSValueID, Ref<CSSValue>&&);
+Ref<CSSValue> makeSpaceSeparatedCoalescingPairCSSValue(Ref<CSSValue>&&, Ref<CSSValue>&&);
+template<SerializationSeparatorType> Ref<CSSValue> makeListCSSValue(CSSValueListBuilder&&);
+template<> Ref<CSSValue> makeListCSSValue<SerializationSeparatorType::Space>(CSSValueListBuilder&&);
+template<> Ref<CSSValue> makeListCSSValue<SerializationSeparatorType::Comma>(CSSValueListBuilder&&);
+template<> Ref<CSSValue> makeListCSSValue<SerializationSeparatorType::Slash>(CSSValueListBuilder&&);
+
+// Constrained for `TreatAsVariantLike`.
+template<VariantLike CSSType> struct CSSValueCreation<CSSType> {
+    Ref<CSSValue> operator()(CSSValuePool& pool, const CSSType& value)
+    {
+        return WTF::switchOn(value, [&](const auto& alternative) { return createCSSValue(pool, alternative); });
+    }
+};
+
+// Constrained for `TreatAsTupleLike`
+template<TupleLike CSSType> struct CSSValueCreation<CSSType> {
+    Ref<CSSValue> operator()(CSSValuePool& pool, const CSSType& value)
+    {
+        if constexpr (std::tuple_size_v<CSSType> == 1 && SerializationSeparator<CSSType> == SerializationSeparatorType::None) {
+            return createCSSValue(pool, get<0>(value));
+        } else {
+            CSSValueListBuilder list;
+
+            auto caller = WTF::makeVisitor(
+                [&]<typename T>(const std::optional<T>& element) {
+                    if (!element)
+                        return;
+                    list.append(createCSSValue(pool, *element));
+                },
+                [&]<typename T>(const Markable<T>& element) {
+                    if (!element)
+                        return;
+                    list.append(createCSSValue(pool, *element));
+                },
+                [&](const auto& element) {
+                    list.append(createCSSValue(pool, element));
+                }
+            );
+            WTF::apply([&](const auto& ...x) { (..., caller(x)); }, value);
+
+            return makeListCSSValue<SerializationSeparator<CSSType>>(WTFMove(list));
+        }
+    }
+};
+
+// Constrained for `TreatAsRangeLike`
+template<RangeLike CSSType> struct CSSValueCreation<CSSType> {
+    Ref<CSSValue> operator()(CSSValuePool& pool, const CSSType& value)
+    {
+        CSSValueListBuilder list;
+        for (const auto& element : value)
+            list.append(createCSSValue(pool, element));
+
+        return makeListCSSValue<SerializationSeparator<CSSType>>(WTFMove(list));
+    }
+};
+
+// Specialization for `Constant`.
+template<CSSValueID Id> struct CSSValueCreation<Constant<Id>> {
+    Ref<CSSValue> operator()(CSSValuePool&, const Constant<Id>&)
+    {
+        return makePrimitiveCSSValue(Id);
+    }
+};
+
+// Specialization for `CustomIdentifier`.
+template<> struct CSSValueCreation<CustomIdentifier> {
+    Ref<CSSValue> operator()(CSSValuePool&, const CustomIdentifier& customIdentifier)
+    {
+        return makePrimitiveCSSValue(customIdentifier);
+    }
+};
+
+// Specialization for `WTF::AtomString`.
+template<> struct CSSValueCreation<WTF::AtomString> {
+    Ref<CSSValue> operator()(CSSValuePool&, const WTF::AtomString& string)
+    {
+        return makePrimitiveCSSValue(string);
+    }
+};
+
+// Specialization for `WTF::String`.
+template<> struct CSSValueCreation<WTF::String> {
+    Ref<CSSValue> operator()(CSSValuePool&, const WTF::String& string)
+    {
+        return makePrimitiveCSSValue(string);
+    }
+};
+
+// Specialization for `FunctionNotation`.
+template<CSSValueID Name, typename CSSType> struct CSSValueCreation<FunctionNotation<Name, CSSType>> {
+    Ref<CSSValue> operator()(CSSValuePool& pool, const FunctionNotation<Name, CSSType>& value)
+    {
+        return makeFunctionCSSValue(value.name, createCSSValue(pool, value.parameters));
+    }
+};
+
+// Specialization for `MinimallySerializingSpaceSeparatedSize`.
+template<typename CSSType> struct CSSValueCreation<MinimallySerializingSpaceSeparatedSize<CSSType>> {
+    Ref<CSSValue> operator()(CSSValuePool& pool, const MinimallySerializingSpaceSeparatedSize<CSSType>& value)
+    {
+        return makeSpaceSeparatedCoalescingPairCSSValue(createCSSValue(pool, get<0>(value)), createCSSValue(pool, get<1>(value)));
     }
 };
 

--- a/Source/WebCore/css/values/borders/CSSBorderRadius.h
+++ b/Source/WebCore/css/values/borders/CSSBorderRadius.h
@@ -33,7 +33,7 @@ namespace CSS {
 // https://drafts.csswg.org/css-backgrounds-3/#propdef-border-radius
 struct BorderRadius {
     using Axis = SpaceSeparatedArray<LengthPercentage<Nonnegative>, 4>;
-    using Corner = SpaceSeparatedSize<LengthPercentage<Nonnegative>>;
+    using Corner = MinimallySerializingSpaceSeparatedSize<LengthPercentage<Nonnegative>>;
 
     static BorderRadius defaultValue();
 

--- a/Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes+CSSValueCreation.h
+++ b/Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes+CSSValueCreation.h
@@ -26,74 +26,25 @@
 
 #include "CSSPrimitiveNumericTypes.h"
 #include "CSSPrimitiveValue.h"
-#include "CSSPrimitiveValueMappings.h"
-#include "CSSValuePair.h"
 #include "CSSValuePool.h"
+#include "CSSValueTypes.h"
 
 namespace WebCore {
 namespace CSS {
 
 // MARK: - Conversion from strongly typed `CSS::` value types to `WebCore::CSSValue` types.
 
-template<typename CSSType> struct CSSValueCreation;
-
-template<typename CSSType> Ref<CSSValue> createCSSValue(const CSSType& value)
-{
-    return CSSValueCreation<CSSType>{}(value);
-}
-
-template<CSSValueID Id> struct CSSValueCreation<Constant<Id>> {
-    Ref<CSSValue> operator()(const Constant<Id>&)
-    {
-        return CSSPrimitiveValue::create(Id);
-    }
-};
-
-template<VariantLike CSSType> struct CSSValueCreation<CSSType> {
-    Ref<CSSValue> operator()(const CSSType& value)
-    {
-        return WTF::switchOn(value, [](const auto& alternative) { return createCSSValue(alternative); });
-    }
-};
-
-template<TupleLike CSSType> requires (std::tuple_size_v<CSSType> == 1) struct CSSValueCreation<CSSType> {
-    Ref<CSSValue> operator()(const CSSType& value)
-    {
-        return createCSSValue(get<0>(value));;
-    }
-};
-
 template<NumericRaw CSSType> struct CSSValueCreation<CSSType> {
-    Ref<CSSValue> operator()(const CSSType& raw)
+    Ref<CSSValue> operator()(CSSValuePool&, const CSSType& raw)
     {
         return CSSPrimitiveValue::create(raw.value, toCSSUnitType(raw.unit));
     }
 };
 
 template<Calc CSSType> struct CSSValueCreation<CSSType> {
-    Ref<CSSValue> operator()(const CSSType& calc)
+    Ref<CSSValue> operator()(CSSValuePool&, const CSSType& calc)
     {
         return CSSPrimitiveValue::create(calc.protectedCalc());
-    }
-};
-
-template<typename CSSType> struct CSSValueCreation<SpaceSeparatedPoint<CSSType>> {
-    Ref<CSSValue> operator()(const SpaceSeparatedPoint<CSSType>& value)
-    {
-        return CSSValuePair::create(
-            createCSSValue(value.x()),
-            createCSSValue(value.y())
-        );
-    }
-};
-
-template<typename CSSType> struct CSSValueCreation<SpaceSeparatedSize<CSSType>> {
-    Ref<CSSValue> operator()(const SpaceSeparatedSize<CSSType>& value)
-    {
-        return CSSValuePair::create(
-            createCSSValue(value.width()),
-            createCSSValue(value.height())
-        );
     }
 };
 

--- a/Source/WebCore/css/values/shapes/CSSShapeFunction.h
+++ b/Source/WebCore/css/values/shapes/CSSShapeFunction.h
@@ -310,7 +310,7 @@ struct ArcCommand {
     using By = ByCoordinatePair;
     Variant<To, By> toBy;
 
-    using SizeOfEllipse = SpaceSeparatedSize<LengthPercentage<>>;
+    using SizeOfEllipse = MinimallySerializingSpaceSeparatedSize<LengthPercentage<>>;
     SizeOfEllipse size;
 
     ArcSweep arcSweep;

--- a/Source/WebCore/style/StyleExtractorConverter.h
+++ b/Source/WebCore/style/StyleExtractorConverter.h
@@ -36,9 +36,7 @@
 #include "CSSBorderImage.h"
 #include "CSSBorderImageSliceValue.h"
 #include "CSSBoxShadowPropertyValue.h"
-#include "CSSColorSchemeValue.h"
 #include "CSSCounterValue.h"
-#include "CSSDynamicRangeLimitValue.h"
 #include "CSSEasingFunctionValue.h"
 #include "CSSFilterPropertyValue.h"
 #include "CSSFontFeatureValue.h"
@@ -97,6 +95,7 @@
 #include "SkewTransformOperation.h"
 #include "StyleAppleColorFilterProperty.h"
 #include "StyleBoxShadow.h"
+#include "StyleColor.h"
 #include "StyleColorScheme.h"
 #include "StyleCornerShapeValue.h"
 #include "StyleDynamicRangeLimit.h"
@@ -105,6 +104,7 @@
 #include "StyleFilterProperty.h"
 #include "StyleLineBoxContain.h"
 #include "StylePathData.h"
+#include "StylePrimitiveNumericTypes+CSSValueCreation.h"
 #include "StylePrimitiveNumericTypes+Conversions.h"
 #include "StyleReflection.h"
 #include "StyleScrollMargin.h"
@@ -119,6 +119,13 @@
 
 namespace WebCore {
 namespace Style {
+
+template<typename T> requires std::is_enum_v<T> struct CSSValueCreation<T> {
+    Ref<CSSValue> operator()(CSSValuePool&, const RenderStyle&, T value)
+    {
+        return CSSPrimitiveValue::create(toCSSValueID(value));
+    }
+};
 
 class ExtractorConverter {
 public:
@@ -163,9 +170,19 @@ public:
     static RefPtr<CSSValue> convertTransformOperation(ExtractorState&, const TransformOperation&);
     static RefPtr<CSSValue> convertTransformOperation(const RenderStyle&, const TransformOperation&);
 
-    // MARK: Shared conversions
+    // MARK: Strong value conversions
 
     static Ref<CSSValue> convertColor(ExtractorState&, const Color&);
+    static Ref<CSSValue> convertScrollMarginEdge(ExtractorState&, const ScrollMarginEdge&);
+    static Ref<CSSValue> convertScrollPaddingEdge(ExtractorState&, const ScrollPaddingEdge&);
+    static Ref<CSSValue> convertCornerShapeValue(ExtractorState&, const CornerShapeValue&);
+    static Ref<CSSValue> convertDynamicRangeLimit(ExtractorState&, const DynamicRangeLimit&);
+#if ENABLE(DARK_MODE_CSS)
+    static Ref<CSSValue> convertColorScheme(ExtractorState&, const ColorScheme&);
+#endif
+
+    // MARK: Shared conversions
+
     static Ref<CSSValue> convertOpacity(ExtractorState&, float);
     static Ref<CSSValue> convertImageOrNone(ExtractorState&, const StyleImage*);
     static Ref<CSSValue> convertGlyphOrientation(ExtractorState&, GlyphOrientation);
@@ -181,10 +198,6 @@ public:
     static Ref<CSSValue> convertTextStrokeWidth(ExtractorState&, float);
     static Ref<CSSValue> convertFilterOperations(ExtractorState&, const FilterOperations&);
     static Ref<CSSValue> convertAppleColorFilterOperations(ExtractorState&, const FilterOperations&);
-    static Ref<CSSValue> convertScrollMarginEdge(ExtractorState&, const ScrollMarginEdge&);
-    static Ref<CSSValue> convertScrollPaddingEdge(ExtractorState&, const ScrollPaddingEdge&);
-    static Ref<CSSValue> convertCornerShapeValue(ExtractorState&, const CornerShapeValue&);
-    static Ref<CSSValue> convertDynamicRangeLimit(ExtractorState&, const DynamicRangeLimit&);
     static Ref<CSSValue> convertWebkitTextCombine(ExtractorState&, TextCombine);
     static Ref<CSSValue> convertImageOrientation(ExtractorState&, ImageOrientation);
     static Ref<CSSValue> convertLineClamp(ExtractorState&, const LineClampValue&);
@@ -247,9 +260,6 @@ public:
     static Ref<CSSValue> convertSingleViewTimelineInsets(ExtractorState&, const ViewTimelineInsets&);
     static Ref<CSSValue> convertViewTimelineInsets(ExtractorState&, const FixedVector<ViewTimelineInsets>&);
     static Ref<CSSValue> convertPositionVisibility(ExtractorState&, OptionSet<PositionVisibility>);
-#if ENABLE(DARK_MODE_CSS)
-    static Ref<CSSValue> convertColorScheme(ExtractorState&, const ColorScheme&);
-#endif
 #if ENABLE(TEXT_AUTOSIZING)
     static Ref<CSSValue> convertWebkitTextSizeAdjust(ExtractorState&, const TextSizeAdjustment&);
 #endif
@@ -610,12 +620,41 @@ inline RefPtr<CSSValue> ExtractorConverter::convertTransformOperation(const Rend
     return nullptr;
 }
 
-// MARK: - Shared conversions
+// MARK: - Strong value conversions
 
-inline Ref<CSSValue> ExtractorConverter::convertColor(ExtractorState& state, const Color& color)
+inline Ref<CSSValue> ExtractorConverter::convertColor(ExtractorState& state, const Color& value)
 {
-    return state.pool.createColorValue(state.style.colorResolvingCurrentColor(color));
+    return createCSSValue(state.pool, state.style, value);
 }
+
+inline Ref<CSSValue> ExtractorConverter::convertScrollMarginEdge(ExtractorState& state, const ScrollMarginEdge& value)
+{
+    return createCSSValue(state.pool, state.style, value);
+}
+
+inline Ref<CSSValue> ExtractorConverter::convertScrollPaddingEdge(ExtractorState& state, const ScrollPaddingEdge& value)
+{
+    return createCSSValue(state.pool, state.style, value);
+}
+
+inline Ref<CSSValue> ExtractorConverter::convertCornerShapeValue(ExtractorState& state, const CornerShapeValue& value)
+{
+    return createCSSValue(state.pool, state.style, value);
+}
+
+inline Ref<CSSValue> ExtractorConverter::convertDynamicRangeLimit(ExtractorState& state, const DynamicRangeLimit& value)
+{
+    return createCSSValue(state.pool, state.style, value);
+}
+
+#if ENABLE(DARK_MODE_CSS)
+inline Ref<CSSValue> ExtractorConverter::convertColorScheme(ExtractorState& state, const ColorScheme& value)
+{
+    return createCSSValue(state.pool, state.style, value);
+}
+#endif
+
+// MARK: - Shared conversions
 
 inline Ref<CSSValue> ExtractorConverter::convertOpacity(ExtractorState& state, float opacity)
 {
@@ -799,26 +838,6 @@ inline Ref<CSSValue> ExtractorConverter::convertFilterOperations(ExtractorState&
 inline Ref<CSSValue> ExtractorConverter::convertAppleColorFilterOperations(ExtractorState& state, const FilterOperations& filterOperations)
 {
     return CSSAppleColorFilterPropertyValue::create(toCSSAppleColorFilterProperty(filterOperations, state.style));
-}
-
-inline Ref<CSSValue> ExtractorConverter::convertScrollMarginEdge(ExtractorState& state, const ScrollMarginEdge& edge)
-{
-    return edge.toCSS(state);
-}
-
-inline Ref<CSSValue> ExtractorConverter::convertScrollPaddingEdge(ExtractorState& state, const ScrollPaddingEdge& edge)
-{
-    return edge.toCSS(state);
-}
-
-inline Ref<CSSValue> ExtractorConverter::convertCornerShapeValue(ExtractorState& state, const CornerShapeValue& cornerShape)
-{
-    return toCSSValue(cornerShape, state.style);
-}
-
-inline Ref<CSSValue> ExtractorConverter::convertDynamicRangeLimit(ExtractorState& state, const DynamicRangeLimit& dynamicRangeLimit)
-{
-    return CSSDynamicRangeLimitValue::create(toCSS(dynamicRangeLimit, state.style));
 }
 
 inline Ref<CSSValue> ExtractorConverter::convertWebkitTextCombine(ExtractorState& state, TextCombine textCombine)
@@ -1798,13 +1817,6 @@ inline Ref<CSSValue> ExtractorConverter::convertPositionVisibility(ExtractorStat
 
     return CSSValueList::createSpaceSeparated(WTFMove(list));
 }
-
-#if ENABLE(DARK_MODE_CSS)
-inline Ref<CSSValue> ExtractorConverter::convertColorScheme(ExtractorState& state, const ColorScheme& colorScheme)
-{
-    return CSSColorSchemeValue::create(toCSS(colorScheme, state.style));
-}
-#endif
 
 #if ENABLE(TEXT_AUTOSIZING)
 inline Ref<CSSValue> ExtractorConverter::convertWebkitTextSizeAdjust(ExtractorState&, const TextSizeAdjustment& textSizeAdjust)

--- a/Source/WebCore/style/values/borders/StyleBorderRadius.h
+++ b/Source/WebCore/style/values/borders/StyleBorderRadius.h
@@ -34,7 +34,7 @@ namespace Style {
 // <'border-radius'> = <length-percentage [0,∞]>{1,4} [ / <length-percentage [0,∞]>{1,4} ]?
 // https://drafts.csswg.org/css-backgrounds-3/#propdef-border-radius
 struct BorderRadius {
-    using Corner = SpaceSeparatedSize<LengthPercentage<CSS::Nonnegative>>;
+    using Corner = MinimallySerializingSpaceSeparatedSize<LengthPercentage<CSS::Nonnegative>>;
 
     constexpr bool operator==(const BorderRadius&) const = default;
 

--- a/Source/WebCore/style/values/borders/StyleCornerShapeValue.cpp
+++ b/Source/WebCore/style/values/borders/StyleCornerShapeValue.cpp
@@ -29,28 +29,10 @@
 #include "CSSPrimitiveValue.h"
 #include "CSSValuePool.h"
 #include "StylePrimitiveNumericTypes+Blending.h"
+#include "StylePrimitiveNumericTypes+CSSValueCreation.h"
 
 namespace WebCore {
 namespace Style {
-
-// MARK: - Conversion
-
-Ref<CSSValue> toCSSValue(const CornerShapeValue& cornerShapeValue, const RenderStyle&)
-{
-    if (cornerShapeValue == CornerShapeValue::round())
-        return CSSPrimitiveValue::create(CSSValueRound);
-    if (cornerShapeValue == CornerShapeValue::scoop())
-        return CSSPrimitiveValue::create(CSSValueScoop);
-    if (cornerShapeValue == CornerShapeValue::bevel())
-        return CSSPrimitiveValue::create(CSSValueBevel);
-    if (cornerShapeValue == CornerShapeValue::notch())
-        return CSSPrimitiveValue::create(CSSValueNotch);
-    if (cornerShapeValue == CornerShapeValue::straight())
-        return CSSPrimitiveValue::create(CSSValueStraight);
-    if (cornerShapeValue == CornerShapeValue::squircle())
-        return CSSPrimitiveValue::create(CSSValueSquircle);
-    return CSSFunctionValue::create(cornerShapeValue.superellipse.name, CSSPrimitiveValue::create(cornerShapeValue.superellipse->value));
-}
 
 // MARK: - Blending
 

--- a/Source/WebCore/style/values/borders/StyleCornerShapeValue.h
+++ b/Source/WebCore/style/values/borders/StyleCornerShapeValue.h
@@ -47,13 +47,25 @@ struct CornerShapeValue {
     static constexpr CornerShapeValue straight() { return { SuperellipseFunction { std::numeric_limits<double>::infinity() } }; }
     static constexpr CornerShapeValue squircle() { return { SuperellipseFunction { 4.0 } }; }
 
+    template<typename F> decltype(auto) switchOn(F&& functor) const
+    {
+        if (*this == CornerShapeValue::round())
+            return functor(CSS::Keyword::Round { });
+        if (*this == CornerShapeValue::scoop())
+            return functor(CSS::Keyword::Scoop { });
+        if (*this == CornerShapeValue::bevel())
+            return functor(CSS::Keyword::Bevel { });
+        if (*this == CornerShapeValue::notch())
+            return functor(CSS::Keyword::Notch { });
+        if (*this == CornerShapeValue::straight())
+            return functor(CSS::Keyword::Straight { });
+        if (*this == CornerShapeValue::squircle())
+            return functor(CSS::Keyword::Squircle { });
+        return functor(superellipse);
+    }
+
     bool operator==(const CornerShapeValue&) const = default;
 };
-DEFINE_TYPE_WRAPPER_GET(CornerShapeValue, superellipse);
-
-// MARK: - Conversion
-
-Ref<CSSValue> toCSSValue(const CornerShapeValue&, const RenderStyle&);
 
 // MARK: - Blending
 
@@ -65,4 +77,4 @@ template<> struct Blending<CornerShapeValue> {
 } // namespace Style
 } // namespace WebCore
 
-DEFINE_TUPLE_LIKE_CONFORMANCE_FOR_TYPE_WRAPPER(WebCore::Style::CornerShapeValue)
+template<> inline constexpr auto WebCore::TreatAsVariantLike<WebCore::Style::CornerShapeValue> = true;

--- a/Source/WebCore/style/values/color-adjust/StyleColorScheme.cpp
+++ b/Source/WebCore/style/values/color-adjust/StyleColorScheme.cpp
@@ -27,6 +27,7 @@
 
 #if ENABLE(DARK_MODE_CSS)
 
+#include "CSSColorSchemeValue.h"
 #include "CSSToLengthConversionData.h"
 #include "CSSValueKeywords.h"
 #include <wtf/text/TextStream.h>
@@ -44,6 +45,25 @@ OptionSet<WebCore::ColorScheme> ColorScheme::colorScheme() const
             result.add(WebCore::ColorScheme::Dark);
     }
     return result;
+}
+
+Ref<CSSValue> CSSValueCreation<ColorScheme>::operator()(CSSValuePool&, const RenderStyle& style, const ColorScheme& value)
+{
+    return CSSColorSchemeValue::create(toCSS(value, style));
+}
+
+void Serialize<ColorScheme>::operator()(StringBuilder& builder, const CSS::SerializationContext& context, const RenderStyle& style, const ColorScheme& value)
+{
+    if (value.isNormal()) {
+        serializationForCSS(builder, context, style, CSS::Keyword::Normal { });
+        return;
+    }
+
+    serializationForCSS(builder, context, style, value.schemes);
+    if (value.only) {
+        builder.append(' ');
+        serializationForCSS(builder, context, style, *value.only);
+    }
 }
 
 WTF::TextStream& operator<<(WTF::TextStream& ts, const ColorScheme& value)

--- a/Source/WebCore/style/values/color-adjust/StyleColorScheme.h
+++ b/Source/WebCore/style/values/color-adjust/StyleColorScheme.h
@@ -60,6 +60,11 @@ template<size_t I> const auto& get(const ColorScheme& colorScheme)
 
 DEFINE_TYPE_MAPPING(CSS::ColorScheme, ColorScheme)
 
+// `ColorScheme` is special-cased to return a `CSSColorSchemeValue`.
+template<> struct CSSValueCreation<ColorScheme> { Ref<CSSValue> operator()(CSSValuePool&, const RenderStyle&, const ColorScheme&); };
+
+template<> struct Serialize<ColorScheme> { void operator()(StringBuilder&, const CSS::SerializationContext&, const RenderStyle&, const ColorScheme&); };
+
 TextStream& operator<<(TextStream&, const ColorScheme&);
 
 } // namespace Style

--- a/Source/WebCore/style/values/color/StyleColor.cpp
+++ b/Source/WebCore/style/values/color/StyleColor.cpp
@@ -308,7 +308,13 @@ String serializationForCSS(const CSS::SerializationContext& context, const Color
 
 void serializationForCSS(StringBuilder& builder, const CSS::SerializationContext& context, const Color& value)
 {
-    return WTF::switchOn(value, [&](const auto& kind) { WebCore::Style::serializationForCSS(builder, context, kind); });
+    WTF::switchOn(value, [&](const auto& kind) { WebCore::Style::serializationForCSS(builder, context, kind); });
+}
+
+void Serialize<Color>::operator()(StringBuilder& builder, const CSS::SerializationContext&, const RenderStyle& style, const Color& value)
+{
+    // NOTE: The specialization of Style::Serialize is used for computed value serialization, so the resolved "used" value is used.
+    builder.append(serializationForCSS(style.colorResolvingCurrentColor(value)));
 }
 
 // MARK: - TextStream.
@@ -353,6 +359,11 @@ auto ToStyle<CSS::Color>::operator()(const CSS::Color& value, const BuilderState
 auto ToStyle<CSS::Color>::operator()(const CSS::Color& value, const BuilderState& builderState) -> Color
 {
     return toStyle(value, builderState, ForVisitedLink::No);
+}
+
+Ref<CSSValue> CSSValueCreation<Color>::operator()(CSSValuePool& pool, const RenderStyle& style, const Color& value)
+{
+    return pool.createColorValue(style.colorResolvingCurrentColor(value));
 }
 
 } // namespace Style

--- a/Source/WebCore/style/values/color/StyleColor.h
+++ b/Source/WebCore/style/values/color/StyleColor.h
@@ -170,6 +170,10 @@ bool containsCurrentColor(const Color&);
 void serializationForCSS(StringBuilder&, const CSS::SerializationContext&, const Color&);
 WEBCORE_EXPORT String serializationForCSS(const CSS::SerializationContext&, const Color&);
 
+template<> struct Serialize<Color> {
+    void operator()(StringBuilder&, const CSS::SerializationContext&, const RenderStyle&, const Color&);
+};
+
 WTF::TextStream& operator<<(WTF::TextStream&, const Color&);
 
 // MARK: - Conversion
@@ -183,6 +187,10 @@ template<> struct ToCSS<Color> {
 template<> struct ToStyle<CSS::Color> {
     auto operator()(const CSS::Color&, const BuilderState&, ForVisitedLink) -> Color;
     auto operator()(const CSS::Color&, const BuilderState&) -> Color;
+};
+
+template<> struct CSSValueCreation<Color> {
+    Ref<CSSValue> operator()(CSSValuePool&, const RenderStyle&, const Color&);
 };
 
 template<typename... F> decltype(auto) Color::switchOn(F&&... f) const

--- a/Source/WebCore/style/values/color/StyleDynamicRangeLimit.cpp
+++ b/Source/WebCore/style/values/color/StyleDynamicRangeLimit.cpp
@@ -29,6 +29,7 @@
 #include "AnimationUtilities.h"
 #include "CSSDynamicRangeLimit.h"
 #include "CSSDynamicRangeLimitMix.h"
+#include "CSSDynamicRangeLimitValue.h"
 #include "PlatformDynamicRangeLimit.h"
 #include "StyleDynamicRangeLimitMix.h"
 
@@ -75,6 +76,16 @@ auto ToStyle<CSS::DynamicRangeLimit>::operator()(const CSS::DynamicRangeLimit& l
             return resolve(toStyle(mix, state));
         }
     );
+}
+
+Ref<CSSValue> CSSValueCreation<DynamicRangeLimit>::operator()(CSSValuePool&, const RenderStyle& style, const DynamicRangeLimit& value)
+{
+    return CSSDynamicRangeLimitValue::create(toCSS(value, style));
+}
+
+void Serialize<DynamicRangeLimit>::operator()(StringBuilder& builder, const CSS::SerializationContext& context, const RenderStyle& style, const DynamicRangeLimit& value)
+{
+    CSS::serializationForCSS(builder, context, toCSS(value, style));
 }
 
 // MARK: - Blending

--- a/Source/WebCore/style/values/color/StyleDynamicRangeLimit.h
+++ b/Source/WebCore/style/values/color/StyleDynamicRangeLimit.h
@@ -136,6 +136,13 @@ inline DynamicRangeLimit::Kind DynamicRangeLimit::copyKind(const Kind& other)
 template<> struct ToCSS<DynamicRangeLimit> { auto operator()(const DynamicRangeLimit&, const RenderStyle&) -> CSS::DynamicRangeLimit; };
 template<> struct ToStyle<CSS::DynamicRangeLimit> { auto operator()(const CSS::DynamicRangeLimit&, const BuilderState&) -> DynamicRangeLimit; };
 
+// `DynamicRangeLimit` is special-cased to return a `CSSDynamicRangeLimitValue`.
+template<> struct CSSValueCreation<DynamicRangeLimit> { Ref<CSSValue> operator()(CSSValuePool&, const RenderStyle&, const DynamicRangeLimit&); };
+
+// MARK: Serialization
+
+template<> struct Serialize<DynamicRangeLimit> { void operator()(StringBuilder&, const CSS::SerializationContext&, const RenderStyle&, const DynamicRangeLimit&); };
+
 // MARK: Blending
 
 template<> struct Blending<DynamicRangeLimit> {

--- a/Source/WebCore/style/values/primitives/StylePrimitiveNumeric.h
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveNumeric.h
@@ -37,6 +37,13 @@ namespace Style {
 
 template<typename> struct DimensionPercentageMapping;
 
+struct PrimitiveNumericEmptyToken { constexpr bool operator==(const PrimitiveNumericEmptyToken&) const = default; };
+
+template<typename T> struct PrimitiveNumericMarkableTraits {
+    static bool isEmptyValue(const T& value) { return value.isEmpty(); }
+    static T emptyValue() { return T(PrimitiveNumericEmptyToken { }); }
+};
+
 // Default implementation of `PrimitiveNumeric` for non-composite numeric types.
 template<CSS::Numeric CSSType> struct PrimitiveNumeric {
     using CSS = CSSType;
@@ -64,6 +71,20 @@ template<CSS::Numeric CSSType> struct PrimitiveNumeric {
 
     constexpr bool operator==(const PrimitiveNumeric&) const = default;
     constexpr bool operator==(ResolvedValueType other) const { return value == other; };
+
+private:
+    template<typename> friend struct PrimitiveNumericMarkableTraits;
+
+    PrimitiveNumeric(PrimitiveNumericEmptyToken) requires std::floating_point<ResolvedValueType>
+        : value { std::numeric_limits<ResolvedValueType>::quiet_NaN() }
+    {
+    }
+
+    bool isEmpty() const
+        requires std::floating_point<ResolvedValueType>
+    {
+        return std::isnan(value);
+    }
 };
 
 // Specialization of `PrimitiveNumeric` for composite dimension-percentage types.
@@ -168,6 +189,7 @@ template<CSS::Range R = CSS::All, typename V = int> struct Integer : PrimitiveNu
 template<CSS::Range R = CSS::All, typename V = double> struct Number : PrimitiveNumeric<CSS::Number<R, V>> {
     using Base = PrimitiveNumeric<CSS::Number<R, V>>;
     using Base::Base;
+    using MarkableTraits = PrimitiveNumericMarkableTraits<Number>;
 };
 
 // MARK: Percentage Primitive
@@ -175,6 +197,7 @@ template<CSS::Range R = CSS::All, typename V = double> struct Number : Primitive
 template<CSS::Range R = CSS::All, typename V = double> struct Percentage : PrimitiveNumeric<CSS::Percentage<R, V>> {
     using Base = PrimitiveNumeric<CSS::Percentage<R, V>>;
     using Base::Base;
+    using MarkableTraits = PrimitiveNumericMarkableTraits<Percentage>;
 };
 
 // MARK: Dimension Primitives
@@ -182,26 +205,32 @@ template<CSS::Range R = CSS::All, typename V = double> struct Percentage : Primi
 template<CSS::Range R = CSS::All, typename V = double> struct Angle : PrimitiveNumeric<CSS::Angle<R, V>> {
     using Base = PrimitiveNumeric<CSS::Angle<R, V>>;
     using Base::Base;
+    using MarkableTraits = PrimitiveNumericMarkableTraits<Angle>;
 };
 template<CSS::Range R = CSS::All, typename V = float> struct Length : PrimitiveNumeric<CSS::Length<R, V>> {
     using Base = PrimitiveNumeric<CSS::Length<R, V>>;
     using Base::Base;
+    using MarkableTraits = PrimitiveNumericMarkableTraits<Length>;
 };
 template<CSS::Range R = CSS::All, typename V = double> struct Time : PrimitiveNumeric<CSS::Time<R, V>> {
     using Base = PrimitiveNumeric<CSS::Time<R, V>>;
     using Base::Base;
+    using MarkableTraits = PrimitiveNumericMarkableTraits<Time>;
 };
 template<CSS::Range R = CSS::All, typename V = double> struct Frequency : PrimitiveNumeric<CSS::Frequency<R, V>> {
     using Base = PrimitiveNumeric<CSS::Frequency<R, V>>;
     using Base::Base;
+    using MarkableTraits = PrimitiveNumericMarkableTraits<Frequency>;
 };
 template<CSS::Range R = CSS::Nonnegative, typename V = double> struct Resolution : PrimitiveNumeric<CSS::Resolution<R, V>> {
     using Base = PrimitiveNumeric<CSS::Resolution<R, V>>;
     using Base::Base;
+    using MarkableTraits = PrimitiveNumericMarkableTraits<Resolution>;
 };
 template<CSS::Range R = CSS::All, typename V = double> struct Flex : PrimitiveNumeric<CSS::Flex<R, V>> {
     using Base = PrimitiveNumeric<CSS::Flex<R, V>>;
     using Base::Base;
+    using MarkableTraits = PrimitiveNumericMarkableTraits<Flex>;
 };
 
 // MARK: Dimension + Percentage Primitives

--- a/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+CSSValueCreation.h
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+CSSValueCreation.h
@@ -24,53 +24,27 @@
 
 #pragma once
 
-#include "CSSURL.h"
+#include "CSSPrimitiveNumericTypes+CSSValueCreation.h"
+#include "StylePrimitiveNumericTypes+Conversions.h"
+#include "StylePrimitiveNumericTypes.h"
 #include "StyleValueTypes.h"
 
 namespace WebCore {
-
-class ScriptExecutionContext;
-
 namespace Style {
 
-struct URL {
-    WTF::URL resolved;
-    CSS::URLModifiers modifiers;
-
-    static URL none() { return { .resolved = { }, .modifiers = { } }; }
-    bool isNone() const { return resolved.isNull(); }
-
-    bool operator==(const URL&) const = default;
+template<Numeric StyleType> struct CSSValueCreation<StyleType> {
+    Ref<CSSValue> operator()(CSSValuePool& pool, const RenderStyle& style, const StyleType& value)
+    {
+        return CSS::createCSSValue(pool, toCSS(value, style));
+    }
 };
 
-template<size_t I> const auto& get(const URL& value)
-{
-    if constexpr (!I)
-        return value.resolved;
-    if constexpr (I == 1)
-        return value.modifiers;
-}
-
-// MARK: Conversion
-
-// Special conversion function for use by filters and font-face code.
-URL toStyleWithScriptExecutionContext(const CSS::URL&, const ScriptExecutionContext&);
-
-template<> struct ToCSS<URL> { auto operator()(const URL&, const RenderStyle&) -> CSS::URL; };
-template<> struct ToStyle<CSS::URL> { auto operator()(const CSS::URL&, const BuilderState&) -> URL; };
-
-// `URL` is special-cased to return a `CSSURLValue`.
-template<> struct CSSValueCreation<URL> { Ref<CSSValue> operator()(CSSValuePool&, const RenderStyle&, const URL&); };
-
-// MARK: Serialization
-
-template<> struct Serialize<URL> { void operator()(StringBuilder&, const CSS::SerializationContext&, const RenderStyle&, const URL&); };
-
-// MARK: Logging
-
-TextStream& operator<<(TextStream&, const URL&);
+template<Calc StyleType> struct CSSValueCreation<StyleType> {
+    Ref<CSSValue> operator()(CSSValuePool& pool, const RenderStyle& style, const StyleType& value)
+    {
+        return CSS::createCSSValue(pool, toCSS(value, style));
+    }
+};
 
 } // namespace Style
 } // namespace WebCore
-
-DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::Style::URL, 2)

--- a/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Conversions.h
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Conversions.h
@@ -246,14 +246,14 @@ template<auto R, typename V> struct ToCSS<Length<R, V>> {
 template<auto R, typename V> struct ToCSS<UnevaluatedCalculation<CSS::AnglePercentage<R, V>>> {
     auto operator()(const UnevaluatedCalculation<CSS::AnglePercentage<R, V>>& value, const RenderStyle& style) -> typename CSS::AnglePercentage<R, V>::Calc
     {
-        return typename CSS::AnglePercentage<R, V>::Calc { makeCalc(value.protectedCalculation(), style) };
+        return typename CSS::AnglePercentage<R, V>::Calc { CSSCalcValue::create(value.protectedCalculation(), style) };
     }
 };
 
 template<auto R, typename V> struct ToCSS<UnevaluatedCalculation<CSS::LengthPercentage<R, V>>> {
     auto operator()(const UnevaluatedCalculation<CSS::LengthPercentage<R, V>>& value, const RenderStyle& style) -> typename CSS::LengthPercentage<R, V>::Calc
     {
-        return typename CSS::LengthPercentage<R, V>::Calc { makeCalc(value.protectedCalculation(), style) };
+        return typename CSS::LengthPercentage<R, V>::Calc { CSSCalcValue::create(value.protectedCalculation(), style) };
     }
 };
 

--- a/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Evaluation.h
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Evaluation.h
@@ -111,6 +111,18 @@ template<typename T> struct Evaluation<SpaceSeparatedSize<T>> {
     }
 };
 
+// MARK: - MinimallySerializingSpaceSeparatedSize
+
+template<typename T> struct Evaluation<MinimallySerializingSpaceSeparatedSize<T>> {
+    FloatSize operator()(const MinimallySerializingSpaceSeparatedSize<T>& value, FloatSize referenceBox)
+    {
+        return {
+            evaluate(value.width(), referenceBox.width()),
+            evaluate(value.height(), referenceBox.height())
+        };
+    }
+};
+
 // MARK: - VariantLike
 
 template<VariantLike CSSType, typename... Rest> decltype(auto) evaluate(const CSSType& value, Rest&& ...rest)

--- a/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Logging.h
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Logging.h
@@ -34,7 +34,7 @@ namespace Style {
 
 WTF::TextStream& operator<<(WTF::TextStream& ts, Calc auto const& value)
 {
-    return ts << value.get();
+    return ts << value.protectedCalculation().get();
 }
 
 WTF::TextStream& operator<<(WTF::TextStream& ts, Numeric auto const& value)
@@ -63,6 +63,11 @@ template<typename T> WTF::TextStream& operator<<(WTF::TextStream& ts, const Spac
 }
 
 template<typename T> WTF::TextStream& operator<<(WTF::TextStream& ts, const SpaceSeparatedSize<T>& value)
+{
+    return ts << value.width() << ' ' << value.height();
+}
+
+template<typename T> WTF::TextStream& operator<<(WTF::TextStream& ts, const MinimallySerializingSpaceSeparatedSize<T>& value)
 {
     return ts << value.width() << ' ' << value.height();
 }

--- a/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes.h
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes.h
@@ -143,6 +143,8 @@ using LengthPercentageSpaceSeparatedPointNonnegative = SpaceSeparatedPoint<Lengt
 // Standard Sizes
 using LengthPercentageSpaceSeparatedSizeAll = SpaceSeparatedSize<LengthPercentageAll>;
 using LengthPercentageSpaceSeparatedSizeNonnegative = SpaceSeparatedSize<LengthPercentageNonnegative>;
+using LengthPercentageMinimallySerializingSpaceSeparatedSizeAll = MinimallySerializingSpaceSeparatedSize<LengthPercentageAll>;
+using LengthPercentageMinimallySerializingSpaceSeparatedSizeNonnegative = MinimallySerializingSpaceSeparatedSize<LengthPercentageNonnegative>;
 
 // MARK: CSS -> Style
 

--- a/Source/WebCore/style/values/primitives/StyleURL.cpp
+++ b/Source/WebCore/style/values/primitives/StyleURL.cpp
@@ -25,6 +25,7 @@
 #include "config.h"
 #include "StyleURL.h"
 
+#include "CSSURLValue.h"
 #include "Document.h"
 #include "StyleBuilderState.h"
 #include <wtf/text/TextStream.h>
@@ -77,6 +78,18 @@ auto ToCSS<URL>::operator()(const URL& url, const RenderStyle&) -> CSS::URL
 auto ToStyle<CSS::URL>::operator()(const CSS::URL& url, const BuilderState& state) -> URL
 {
     return toStyleWithScriptExecutionContext(url, state.protectedDocument());
+}
+
+Ref<CSSValue> CSSValueCreation<URL>::operator()(CSSValuePool&, const RenderStyle& style, const URL& value)
+{
+    return CSSURLValue::create(toCSS(value, style));
+}
+
+// MARK: - Serialization
+
+void Serialize<URL>::operator()(StringBuilder& builder, const CSS::SerializationContext& context, const RenderStyle& style, const URL& value)
+{
+    CSS::serializationForCSS(builder, context, toCSS(value, style));
 }
 
 // MARK: - Logging

--- a/Source/WebCore/style/values/scroll-snap/StyleScrollMargin.h
+++ b/Source/WebCore/style/values/scroll-snap/StyleScrollMargin.h
@@ -47,16 +47,11 @@ struct ScrollMarginEdge {
     ScrollMarginEdge(WebCore::Length&& value)
         : m_value { WTFMove(value) }
     {
-        RELEASE_ASSERT(m_value.isSpecified());
+        RELEASE_ASSERT(m_value.isFixed());
     }
 
     ScrollMarginEdge(CSS::ValueLiteral<CSS::LengthUnit::Px> pixels)
         : m_value { pixels.value, WebCore::LengthType::Fixed }
-    {
-    }
-
-    ScrollMarginEdge(CSS::ValueLiteral<CSS::PercentageUnit::Percentage> percentage)
-        : m_value { percentage.value, WebCore::LengthType::Percent }
     {
     }
 
@@ -66,6 +61,11 @@ struct ScrollMarginEdge {
     Ref<CSSValue> toCSS(ExtractorState&) const;
 
     bool isZero() const { return m_value.isZero(); }
+
+    template<typename F> decltype(auto) switchOn(F&& functor) const
+    {
+        return functor(Style::Length<> { m_value.value() });
+    }
 
     bool operator==(const ScrollMarginEdge&) const = default;
 
@@ -113,5 +113,7 @@ WTF::TextStream& operator<<(WTF::TextStream&, const ScrollMarginEdge&);
 
 } // namespace Style
 } // namespace WebCore
+
+template<> inline constexpr auto WebCore::TreatAsVariantLike<WebCore::Style::ScrollMarginEdge> = true;
 
 DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::Style::ScrollMargin, 4)

--- a/Source/WebCore/style/values/scroll-snap/StyleScrollPadding.h
+++ b/Source/WebCore/style/values/scroll-snap/StyleScrollPadding.h
@@ -72,6 +72,23 @@ struct ScrollPaddingEdge {
 
     bool isZero() const { return m_value.isZero(); }
 
+    template<typename F> decltype(auto) switchOn(F&& functor) const
+    {
+        switch (m_value.type()) {
+        case WebCore::LengthType::Auto:
+            return functor(CSS::Keyword::Auto { });
+        case WebCore::LengthType::Fixed:
+            return functor(LengthPercentage<CSS::Nonnegative>::Dimension { m_value.value() });
+        case WebCore::LengthType::Percent:
+            return functor(LengthPercentage<CSS::Nonnegative>::Percentage { m_value.value() });
+        case WebCore::LengthType::Calculated:
+            return functor(LengthPercentage<CSS::Nonnegative>::Calc { m_value.protectedCalculationValue() });
+        default:
+            break;
+        }
+        RELEASE_ASSERT_NOT_REACHED();
+    }
+
     bool operator==(const ScrollPaddingEdge&) const = default;
 
 private:
@@ -119,4 +136,5 @@ WTF::TextStream& operator<<(WTF::TextStream&, const ScrollPaddingEdge&);
 } // namespace Style
 } // namespace WebCore
 
+template<> inline constexpr auto WebCore::TreatAsVariantLike<WebCore::Style::ScrollPaddingEdge> = true;
 DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::Style::ScrollPadding, 4)

--- a/Source/WebCore/style/values/shapes/StyleShapeFunction.h
+++ b/Source/WebCore/style/values/shapes/StyleShapeFunction.h
@@ -327,7 +327,7 @@ struct ArcCommand {
     using By = ByCoordinatePair;
     Variant<To, By> toBy;
 
-    using SizeOfEllipse = SpaceSeparatedSize<LengthPercentage<>>;
+    using SizeOfEllipse = MinimallySerializingSpaceSeparatedSize<LengthPercentage<>>;
     SizeOfEllipse size;
 
     ArcSweep arcSweep;

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -3181,6 +3181,13 @@ using WebCore::Style::LengthPercentageAll = WebCore::Style::LengthPercentage<Web
     WebCore::SpaceSeparatedPair<WebCore::Style::LengthPercentageAll> value;
 };
 
+[CustomHeader, Nested] struct WebCore::MinimallySerializingSpaceSeparatedSize<WebCore::Style::LengthPercentageNonnegative> {
+    WebCore::SpaceSeparatedPair<WebCore::Style::LengthPercentageNonnegative> value;
+};
+[CustomHeader, Nested] struct WebCore::MinimallySerializingSpaceSeparatedSize<WebCore::Style::LengthPercentageAll> {
+    WebCore::SpaceSeparatedPair<WebCore::Style::LengthPercentageAll> value;
+};
+
 using WebCore::Style::LengthPercentageSpaceSeparatedPointAll = WebCore::SpaceSeparatedPoint<WebCore::Style::LengthPercentageAll>;
 using WebCore::Style::LengthPercentageSpaceSeparatedPointNonnegative = WebCore::SpaceSeparatedPoint<WebCore::Style::LengthPercentageNonnegative>;
 
@@ -3405,19 +3412,19 @@ using WebCore::Style::CloseCommand = WebCore::Constant<WebCore::CSSValueClose>;
 };
 [CustomHeader, Nested] struct WebCore::Style::ArcCommand {
     Variant<WebCore::Style::ToPosition, WebCore::Style::ByCoordinatePair> toBy;
-    WebCore::Style::LengthPercentageSpaceSeparatedSizeAll size;
+    WebCore::Style::LengthPercentageMinimallySerializingSpaceSeparatedSizeAll size;
     Variant<WebCore::CSS::Keyword::Cw, WebCore::CSS::Keyword::Ccw> arcSweep;
     Variant<WebCore::CSS::Keyword::Large, WebCore::CSS::Keyword::Small> arcSize;
     WebCore::Style::Angle<WebCore::CSS::All> rotation;
 };
-using WebCore::Style::LengthPercentageSpaceSeparatedSizeAll = WebCore::SpaceSeparatedSize<WebCore::Style::LengthPercentageAll>
+using WebCore::Style::LengthPercentageMinimallySerializingSpaceSeparatedSizeAll = WebCore::MinimallySerializingSpaceSeparatedSize<WebCore::Style::LengthPercentageAll>
 
 header: <WebCore/StyleBorderRadius.h>
 [CustomHeader, Nested] struct WebCore::Style::BorderRadius {
-    WebCore::SpaceSeparatedSize<WebCore::Style::LengthPercentageNonnegative> topLeft;
-    WebCore::SpaceSeparatedSize<WebCore::Style::LengthPercentageNonnegative> topRight;
-    WebCore::SpaceSeparatedSize<WebCore::Style::LengthPercentageNonnegative> bottomRight;
-    WebCore::SpaceSeparatedSize<WebCore::Style::LengthPercentageNonnegative> bottomLeft;
+    WebCore::MinimallySerializingSpaceSeparatedSize<WebCore::Style::LengthPercentageNonnegative> topLeft;
+    WebCore::MinimallySerializingSpaceSeparatedSize<WebCore::Style::LengthPercentageNonnegative> topRight;
+    WebCore::MinimallySerializingSpaceSeparatedSize<WebCore::Style::LengthPercentageNonnegative> bottomRight;
+    WebCore::MinimallySerializingSpaceSeparatedSize<WebCore::Style::LengthPercentageNonnegative> bottomLeft;
 };
 
 header: <WebCore/StyleRayFunction.h>


### PR DESCRIPTION
#### dc119b7139d872ff07841d797dbd6122ebdcfa2a
<pre>
[Extractor] Support direct serialization and conversion to CSSValue from Style value objects
<a href="https://bugs.webkit.org/show_bug.cgi?id=293877">https://bugs.webkit.org/show_bug.cgi?id=293877</a>

Reviewed by Darin Adler.

To serialize a Style value object for getComputedStyle purposes, adds a new `Style::serializationForCSS`
function and corresponding `Style::Serializer` specializable struct interface. This
interface differs from `CSS::serializationForCSS` in that it takes a `RenderStyle`
in addition to the existing arguments.

To convert a Style value object to a CSSValue for getComputedStyle purposes, adds a
new `Style::createCSSValue` function and corresponding `Style::CSSValueCreation`
specializable struct interface. This interface differs from `CSS::createCSSValue`
in the same way as above, in that it takes a `RenderStyle` in addition to the
existing arguments. Additionally, `CSS::CSSValueCreation` has been moved to
CSSValueTypes.h, been given a `CSSValuePool` argument and made to work generally
with ranged, tuple and variant value types.

To avoid ambiguity, a new `MinimallySerializingSpaceSeparatedSize` type has been
added for use in places where coalescing is needed. It is specialized to return
a coalescing `CSSValuePair`. All other non-&quot;MinimallySerializing&quot; tuple types
convert to a `CSSValueList`.

* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/css/values/CSSValueAggregates.h:
* Source/WebCore/css/values/CSSValueTypes.cpp:
* Source/WebCore/css/values/CSSValueTypes.h:
* Source/WebCore/css/values/borders/CSSBorderRadius.h:
* Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes+CSSValueCreation.h:
* Source/WebCore/css/values/shapes/CSSShapeFunction.h:
* Source/WebCore/style/StyleExtractorConverter.h:
* Source/WebCore/style/StyleExtractorSerializer.h:
* Source/WebCore/style/values/StyleValueTypes.h:
* Source/WebCore/style/values/borders/StyleBorderRadius.h:
* Source/WebCore/style/values/borders/StyleCornerShapeValue.cpp:
* Source/WebCore/style/values/borders/StyleCornerShapeValue.h:
* Source/WebCore/style/values/color-adjust/StyleColorScheme.cpp:
* Source/WebCore/style/values/color-adjust/StyleColorScheme.h:
* Source/WebCore/style/values/color/StyleColor.cpp:
* Source/WebCore/style/values/color/StyleColor.h:
* Source/WebCore/style/values/color/StyleDynamicRangeLimit.cpp:
* Source/WebCore/style/values/color/StyleDynamicRangeLimit.h:
* Source/WebCore/style/values/primitives/StylePrimitiveNumeric.h:
* Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+CSSValueCreation.h: Added.
* Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Conversions.h:
* Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Evaluation.h:
* Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Logging.h:
* Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Serialization.h: Added.
* Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes.h:
* Source/WebCore/style/values/primitives/StyleURL.cpp:
* Source/WebCore/style/values/primitives/StyleURL.h:
* Source/WebCore/style/values/scroll-snap/StyleScrollMargin.h:
* Source/WebCore/style/values/scroll-snap/StyleScrollPadding.h:
* Source/WebCore/style/values/shapes/StyleShapeFunction.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/295702@main">https://commits.webkit.org/295702@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/da609753661ba545ce99ba760b26cba71deb134e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105911 "31 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25662 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/16056 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/111109 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/56509 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/107952 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/26289 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34165 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/80453 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108917 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/20715 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95580 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60773 "Found 1 new API test failure: /WPE/TestSSL:/webkit/WebKitWebView/ephemeral-tls-errors (failure)") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/20351 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13678 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55947 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/90103 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/13714 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/113960 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33051 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/24382 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/89530 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33415 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91809 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89209 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22734 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34073 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11883 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/28589 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32976 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/38387 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32722 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/36071 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34320 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->