### PR TITLE
Parsing stop-color with invalid values (i.e., "1234" - hashless color value)

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/pservers/parsing/stop-color-invalid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/pservers/parsing/stop-color-invalid-expected.txt
@@ -1,6 +1,6 @@
 
 PASS e.style['stop-color'] = "auto" should not set the property value
-FAIL e.style['stop-color'] = "123" should not set the property value assert_equals: expected "" but got "rgb(17, 34, 51)"
+PASS e.style['stop-color'] = "123" should not set the property value
 PASS e.style['stop-color'] = "#12" should not set the property value
 PASS e.style['stop-color'] = "#123456789" should not set the property value
 PASS e.style['stop-color'] = "rgb" should not set the property value

--- a/Source/WebCore/css/parser/CSSParserFastPaths.cpp
+++ b/Source/WebCore/css/parser/CSSParserFastPaths.cpp
@@ -603,7 +603,7 @@ static std::optional<SRGBA<uint8_t>> parseNumericColor(std::span<const Character
             return *hexColor;
     }
 
-    if (isQuirksModeBehavior(context.mode) && (characters.size() == 3 || characters.size() == 6)) {
+    if (isQuirksModeBehavior(context.mode) && !isStrictParserMode(context.mode) && (characters.size() == 3 || characters.size() == 6)) {
         if (auto hexColor = parseHexColorInternal(characters))
             return *hexColor;
     }


### PR DESCRIPTION
#### 63a81d8845f28637c6c6a563d1a21ecd027ce5fe
<pre>
Parsing stop-color with invalid values (i.e., &quot;1234&quot; - hashless color value)
<a href="https://bugs.webkit.org/show_bug.cgi?id=265420">https://bugs.webkit.org/show_bug.cgi?id=265420</a>

Reviewed by NOBODY (OOPS!).

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

Currently, while trying to parse &apos;stop-color&apos;, we trip in &apos;parseNumericColor&apos;
function, where Quirk Mode behavior lead to inadverently applying quirky
color to &apos;stop-color&apos; in SVG attribute mode as well.

This patch adds additional check to ensure that we are not in &apos;StrictMode&apos;,
which also cover &apos;SVG&apos; attribute mode.

* LayoutTests/imported/w3c/web-platform-tests/svg/pservers/parsing/stop-color-invalid-expected.txt:
* Source/WebCore/css/parser/CSSParserFastPaths.cpp:
(WebCore::parseNumericColor):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/63a81d8845f28637c6c6a563d1a21ecd027ce5fe

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/107996 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27661 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18080 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/113207 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/58519 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/109959 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/28356 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/36210 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/81979 "Found 1 new test failure: imported/w3c/web-platform-tests/svg/pservers/parsing/stop-color-invalid.svg (failure)") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/110944 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22470 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97297 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62410 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/21882 "Found 1 new test failure: imported/w3c/web-platform-tests/svg/pservers/parsing/stop-color-invalid.svg (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/15430 "Found 1 new test failure: imported/w3c/web-platform-tests/svg/pservers/parsing/stop-color-invalid.svg (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/57954 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/91823 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15496 "Found 1 new test failure: imported/w3c/web-platform-tests/svg/pservers/parsing/stop-color-invalid.svg (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/116334 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35068 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/25813 "Found 1 new test failure: imported/w3c/web-platform-tests/svg/pservers/parsing/stop-color-invalid.svg (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91014 "Found 1 new test failure: imported/w3c/web-platform-tests/svg/pservers/parsing/stop-color-invalid.svg (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/35444 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93575 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/90808 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35709 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13462 "Found 1 new test failure: imported/w3c/web-platform-tests/svg/pservers/parsing/stop-color-invalid.svg (failure)") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/30951 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Failed to compile WebKit; Compiled WebKit (cancelled)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/34966 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/40520 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34710 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38069 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/36370 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->