### PR TITLE
[Page color sampling] Fixed element detection may incorrectly ignore subframes

### DIFF
--- a/LayoutTests/fast/page-color-sampling/color-sampling-includes-subframes-expected.txt
+++ b/LayoutTests/fast/page-color-sampling/color-sampling-includes-subframes-expected.txt
@@ -1,5 +1,6 @@
-PASS Loaded iframe
+PASS Loaded iframes
 PASS color.top is "rgb(255, 100, 0)"
+PASS color.bottom is "rgb(0, 100, 250)"
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/page-color-sampling/color-sampling-includes-subframes.html
+++ b/LayoutTests/fast/page-color-sampling/color-sampling-includes-subframes.html
@@ -20,7 +20,14 @@
 
         iframe {
             width: 100%;
-            height: 250px;
+            height: 100px;
+        }
+
+        iframe.bottom {
+            position: fixed;
+            bottom: 0;
+            left: 0;
+            right: 0;
         }
 
         .tall {
@@ -34,28 +41,48 @@
     jsTestIsAsync = true;
 
     addEventListener("load", async () => {
-        await UIHelper.setObscuredInsets(100, 0, 0, 0);
+        await UIHelper.setObscuredInsets(100, 0, 100, 0);
 
-        let frame = document.querySelector("iframe");
+        let topFrame = document.querySelector("iframe.top");
         await UIHelper.callFunctionAndWaitForEvent(() => {
-            frame.srcdoc = `
+            topFrame.srcdoc = `
                 <body style='margin: 0; width: 100%; height: 100%; background: rgb(255, 100, 0);'>
                     <p>Hello world</p>
                 </body>`;
-        }, frame, "load");
+        }, topFrame, "load");
 
-        testPassed("Loaded iframe");
+        let bottomFrame = document.querySelector("iframe.bottom");
+        await UIHelper.callFunctionAndWaitForEvent(() => {
+            bottomFrame.srcdoc = `<!DOCTYPE html>
+            <html>
+                <head>
+                    <style>
+                    body, html {
+                        margin: 0;
+                        width: 100%;
+                        height: 100%;
+                        background: rgb(0, 100, 250);
+                    }
+                    </style>
+                </head>
+                <body></body>
+            </html>`
+        }, bottomFrame, "load");
+
+        testPassed("Loaded iframes");
 
         await UIHelper.ensurePresentationUpdate();
         color = await UIHelper.fixedContainerEdgeColors();
 
         shouldBeEqualToString("color.top", "rgb(255, 100, 0)");
+        shouldBeEqualToString("color.bottom", "rgb(0, 100, 250)");
         finishJSTest();
     });
     </script>
 </head>
 <body>
-<header><iframe frameborder="0"></iframe></header>
+<header><iframe class="top" frameborder="0"></iframe></header>
 <div class="tall"></div>
+<iframe class="bottom" frameborder="0"></iframe>
 </body>
 </html>

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -1922,7 +1922,7 @@ static bool isHiddenOrNearlyTransparent(const RenderBox& box)
     if (box.opacity() < PageColorSampler::nearlyTransparentAlphaThreshold)
         return true;
 
-    if (!box.hasBackground() && !box.firstChild())
+    if (!box.hasBackground() && !box.firstChild() && !is<RenderReplaced>(box))
         return true;
 
     return false;


### PR DESCRIPTION
#### bba8d155dff7ddba32eda78e56d0bafdda239f68
<pre>
[Page color sampling] Fixed element detection may incorrectly ignore subframes
<a href="https://bugs.webkit.org/show_bug.cgi?id=293883">https://bugs.webkit.org/show_bug.cgi?id=293883</a>
<a href="https://rdar.apple.com/151981818">rdar://151981818</a>

Reviewed by Richard Robinson.

The heuristic in `isHiddenOrNearlyTransparent` is currently too restrictive, in the case where the
hit-tested element is a subframe. In particular, `!box.hasBackground() &amp;&amp; !box.firstChild()` check
was intended to avoid color-sampling fixed containers without backgrounds or any rendered children,
but in the case where the hit-tested element is a fixed-position subframe, the frame owner element
won&apos;t have any children in the render tree (despite the fact that it may have a content document/
frame with rendered children).

Fix this by simply adding `!is&lt;RenderReplaced&gt;` as an additional constraint to this check, to ensure
that we correctly detect and sample content inside fixed subframes (and other renderer types like
images or videos, which may be visually non-empty).

* LayoutTests/fast/page-color-sampling/color-sampling-includes-subframes-expected.txt:
* LayoutTests/fast/page-color-sampling/color-sampling-includes-subframes.html:

Augment an existing layout test, to also cover the case where the `iframe` itself is fixed (as
opposed to being contained in a fixed-position container).

* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::isHiddenOrNearlyTransparent):

See above.

Canonical link: <a href="https://commits.webkit.org/295667@main">https://commits.webkit.org/295667@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1ccc112573e44d35d9a9851e3f0768f4704593b8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105852 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25603 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15996 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/111049 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/56449 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/107893 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/26195 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34106 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80396 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108858 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/20597 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95520 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60711 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/20258 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13618 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55887 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/89996 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13655 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/113899 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32992 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24322 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89478 "Found 2 new test failures: compositing/patterns/direct-pattern-compositing-size.html imported/w3c/web-platform-tests/service-workers/service-worker/redirected-response.https.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33356 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91750 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/89149 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22718 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34017 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11824 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/29995 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32917 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/38328 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32663 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/36012 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34261 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->