### PR TITLE
Adds Quirks for converting HEIC images to JPEG on canva.com

### DIFF
--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -713,6 +713,10 @@ bool Quirks::shouldTranscodeHeicImagesForURL(const URL& url)
     if (quirksDomain.string() == "zillow.com"_s)
         return true;
 
+    // canva.com https://webkit.org/b/293886
+    if (quirksDomain.string() == "canva.com"_s)
+        return true;
+
     return false;
 }
 


### PR DESCRIPTION
#### 7c351be901dd5d98663ad065d87121959bbaa3a5
<pre>
Adds Quirks for converting HEIC images to JPEG on canva.com
<a href="https://bugs.webkit.org/show_bug.cgi?id=293886">https://bugs.webkit.org/show_bug.cgi?id=293886</a>
<a href="https://rdar.apple.com/150489476">rdar://150489476</a>

Reviewed by Brent Fulgham.

canva.com allows uploading images with any format. After uploading
the HEIC images, the canva.com Web application transcodes them. In some
cases, this transcoding results in corrupted images. In the better case,
the images are correctly displayed in a canvas element in the Web
application, filters can be applied to the image in the browser but then
users are unable to download the image on their computer or save the
image in the web application. These issues are not happening when the
image is JPEG.

WebKit added the possibility to automatically convert the HEIC image
format to one that the site accepts.
see <a href="https://github.com/WebKit/WebKit/commit/1fd3fe3f407ad3cbc9fde83b03a9a0641e6d3e58">https://github.com/WebKit/WebKit/commit/1fd3fe3f407ad3cbc9fde83b03a9a0641e6d3e58</a>

The current input on the canva.com website is

    &lt;input type=&quot;file&quot; class=&quot;VVvG5A&quot; tabindex=&quot;-1&quot; aria-hidden=&quot;true&quot; accept=&quot;image/*&quot;&gt;

To benefit from WebKit capability to auto-convert the file
to the format of website choice, it is necessary to specify
in the accept attribute, the accepted format, for example:

    accept=&quot;image/jpeg, image/png, image/gif&quot;

This quirk will allow WebKit to transcode the HEIC images to correct
JPEG images before uploading them to canva.com.

* Source/WebCore/page/Quirks.cpp:
(WebCore::Quirks::shouldTranscodeHeicImagesForURL):

Canonical link: <a href="https://commits.webkit.org/295722@main">https://commits.webkit.org/295722@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/836c44bd10b8910fe5e795d68eb432c16db97439

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105961 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25711 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/16105 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/111158 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/56558 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/108001 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/26351 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34214 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/80489 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108966 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/20776 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95626 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60809 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/20392 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13723 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55996 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/90157 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13759 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/114010 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33100 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/24421 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/89567 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33464 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91854 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89246 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34110 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11927 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/28639 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17185 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/33025 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/38436 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32771 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/36120 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34369 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->