### PR TITLE
[css-anchor-position-1] Support ::before and ::after as anchor-positioned elements

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7614,7 +7614,6 @@ imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-chained-00
 imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-chained-fallback.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-fixedpos.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-012.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-to-sticky-002.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-to-sticky-003.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-to-sticky-004.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-update-003.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-function-pseudo-element-basic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-function-pseudo-element-basic-expected.txt
@@ -1,0 +1,4 @@
+
+PASS Initial anchored position
+PASS Anchored position after moving
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-function-pseudo-element-basic.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-function-pseudo-element-basic.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<title>Positioning pseudo-elements using anchor functions</title>
+<link rel="help" href="https://drafts.csswg.org/css-anchor-position-1/#positioning">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+body { margin: 0 }
+#anchor, #target::before, #target::after {
+    width: 100px;
+    height: 100px;
+    position: absolute;
+}
+#anchor.moved {
+    left: 200px;
+    top: 200px;
+}
+#anchor {
+    left: 50px;
+    top: 100px;
+    anchor-name: --a;
+    background: blue;
+}
+#target::before {
+    position-anchor: --a;
+    left: anchor(right);
+    top: anchor(top);
+    background: green;
+    content:'';
+}
+#target::after {
+    position-anchor: --a;
+    left: anchor(left);
+    top: anchor(bottom);
+    background: green;
+    content:'';
+}
+</style>
+<div id=anchor></div>
+<div id=target></div>
+<script>
+test(() => {
+    assert_equals(getComputedStyle(target, '::before').top, '100px', "#target::before top is positioned against anchor");
+    assert_equals(getComputedStyle(target, '::before').left, '150px', "#target::before left is positioned against anchor");
+    assert_equals(getComputedStyle(target, '::after').top, '200px', "#target::after top is positioned against anchor");
+    assert_equals(getComputedStyle(target, '::after').left, '50px', "#target::after left is positioned against anchor");
+}, "Initial anchored position");
+
+test(() => {
+    anchor.classList.add("moved");
+    assert_equals(getComputedStyle(target, '::before').top, '200px', "#target::before top is positioned against anchor");
+    assert_equals(getComputedStyle(target, '::before').left, '300px', "#target::before left is positioned against anchor");
+    assert_equals(getComputedStyle(target, '::after').top, '300px', "#target::after top is positioned against anchor");
+    assert_equals(getComputedStyle(target, '::after').left, '200px', "#target::after left is positioned against anchor");
+}, "Anchored position after moving");
+</script>

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -4784,6 +4784,20 @@ PseudoElement* Element::afterPseudoElement() const
     return hasRareData() ? elementRareData()->afterPseudoElement() : nullptr;
 }
 
+RefPtr<PseudoElement> Element::pseudoElementIfExists(Style::PseudoElementIdentifier pseudoElementIdentifier)
+{
+    if (pseudoElementIdentifier.pseudoId == PseudoId::Before)
+        return beforePseudoElement();
+    if (pseudoElementIdentifier.pseudoId == PseudoId::After)
+        return afterPseudoElement();
+    return nullptr;
+}
+
+RefPtr<const PseudoElement> Element::pseudoElementIfExists(Style::PseudoElementIdentifier pseudoElementIdentifier) const
+{
+    return const_cast<Element&>(*this).pseudoElementIfExists(pseudoElementIdentifier);
+}
+
 static void disconnectPseudoElement(PseudoElement* pseudoElement)
 {
     if (!pseudoElement)

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -591,6 +591,9 @@ public:
     PseudoElement& ensurePseudoElement(PseudoId);
     WEBCORE_EXPORT PseudoElement* beforePseudoElement() const;
     WEBCORE_EXPORT PseudoElement* afterPseudoElement() const;
+    RefPtr<PseudoElement> pseudoElementIfExists(Style::PseudoElementIdentifier);
+    RefPtr<const PseudoElement> pseudoElementIfExists(Style::PseudoElementIdentifier) const;
+
     bool childNeedsShadowWalker() const;
     void didShadowTreeAwareChildrenChange();
 

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -469,7 +469,7 @@ RenderStyle* RenderStyle::addCachedPseudoStyle(std::unique_ptr<RenderStyle> pseu
     if (!m_cachedPseudoStyles)
         m_cachedPseudoStyles = makeUnique<PseudoStyleCache>();
 
-    m_cachedPseudoStyles->styles.add(Style::PseudoElementIdentifier { result->pseudoElementType(), result->pseudoElementNameArgument() }, WTFMove(pseudo));
+    m_cachedPseudoStyles->styles.add(*result->pseudoElementIdentifier(), WTFMove(pseudo));
 
     return result;
 }
@@ -3935,6 +3935,13 @@ const FixedVector<Style::PositionTryFallback>& RenderStyle::positionTryFallbacks
 void RenderStyle::setPositionTryFallbacks(FixedVector<Style::PositionTryFallback>&& fallbacks)
 {
     SET_NESTED_VAR(m_nonInheritedData, rareData, positionTryFallbacks, WTFMove(fallbacks));
+}
+
+std::optional<Style::PseudoElementIdentifier> RenderStyle::pseudoElementIdentifier() const
+{
+    if (pseudoElementType() == PseudoId::None)
+        return { };
+    return Style::PseudoElementIdentifier { pseudoElementType(), pseudoElementNameArgument() };
 }
 
 void RenderStyle::adjustScrollTimelines()

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -377,6 +377,8 @@ public:
     const AtomString& pseudoElementNameArgument() const;
     void setPseudoElementNameArgument(const AtomString&);
 
+    std::optional<Style::PseudoElementIdentifier> pseudoElementIdentifier() const;
+
     RenderStyle* getCachedPseudoStyle(const Style::PseudoElementIdentifier&) const;
     RenderStyle* addCachedPseudoStyle(std::unique_ptr<RenderStyle>);
 

--- a/Source/WebCore/rendering/updating/RenderTreeUpdater.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeUpdater.cpp
@@ -390,8 +390,7 @@ static bool pseudoStyleCacheIsInvalid(RenderElement* renderer, RenderStyle* newS
         return false;
 
     for (auto& [key, value] : pseudoStyleCache->styles) {
-        Style::PseudoElementIdentifier pseudoElementIdentifier { value->pseudoElementType(), value->pseudoElementNameArgument() };
-        auto newPseudoStyle = renderer->getUncachedPseudoStyle(pseudoElementIdentifier, newStyle, newStyle);
+        auto newPseudoStyle = renderer->getUncachedPseudoStyle(*value->pseudoElementIdentifier(), newStyle, newStyle);
         if (!newPseudoStyle)
             return true;
         if (*newPseudoStyle != *value) {

--- a/Source/WebCore/style/AnchorPositionEvaluator.h
+++ b/Source/WebCore/style/AnchorPositionEvaluator.h
@@ -28,6 +28,7 @@
 #include "EventTarget.h"
 #include "LayoutUnit.h"
 #include "PositionTryOrder.h"
+#include "PseudoElementIdentifier.h"
 #include "ResolvedScopedName.h"
 #include "ScopedName.h"
 #include "WritingMode.h"
@@ -64,12 +65,15 @@ enum class AnchorPositionResolutionStage : uint8_t {
 using AnchorElements = HashMap<ResolvedScopedName, WeakPtr<Element, WeakPtrImplWithEventTargetData>>;
 
 struct AnchorPositionedState {
-    WTF_MAKE_TZONE_ALLOCATED(AnchorPositionedState);
-public:
     AnchorElements anchorElements;
     UncheckedKeyHashSet<ResolvedScopedName> anchorNames;
     AnchorPositionResolutionStage stage;
+
+    WTF_MAKE_STRUCT_TZONE_ALLOCATED(AnchorPositionedState);
 };
+
+using AnchorPositionedKey = std::pair<RefPtr<const Element>, std::optional<PseudoElementIdentifier>>;
+using AnchorPositionedStates = HashMap<AnchorPositionedKey, std::unique_ptr<AnchorPositionedState>>;
 
 using AnchorsForAnchorName = HashMap<ResolvedScopedName, Vector<SingleThreadWeakRef<const RenderBoxModelObject>>>;
 
@@ -82,8 +86,6 @@ enum class AnchorSizeDimension : uint8_t {
     SelfBlock,
     SelfInline
 };
-
-using AnchorPositionedStates = WeakHashMap<Element, std::unique_ptr<AnchorPositionedState>, WeakPtrImplWithEventTargetData>;
 
 using AnchorPositionedToAnchorMap = WeakHashMap<Element, Vector<SingleThreadWeakPtr<RenderBoxModelObject>>, WeakPtrImplWithEventTargetData>;
 using AnchorToAnchorPositionedMap = SingleThreadWeakHashMap<const RenderBoxModelObject, Vector<Ref<Element>>>;
@@ -118,6 +120,8 @@ public:
 
 private:
     static AnchorElements findAnchorsForAnchorPositionedElement(const Element&, const UncheckedKeyHashSet<ResolvedScopedName>& anchorNames, const AnchorsForAnchorName&);
+    static RefPtr<const Element> anchorPositionedElementOrPseudoElement(BuilderState&);
+    static AnchorPositionedKey keyForElementOrPseudoElement(const Element&);
 };
 
 } // namespace Style

--- a/Source/WebCore/style/StyleBuilderState.cpp
+++ b/Source/WebCore/style/StyleBuilderState.cpp
@@ -317,15 +317,9 @@ void BuilderState::setUsesContainerUnits()
 
 double BuilderState::lookupCSSRandomBaseValue(const CSSCalc::RandomCachingKey& key, std::optional<CSS::Keyword::ElementShared> elementShared) const
 {
-    if (!elementShared) {
-        ASSERT(element());
+    if (!elementShared)
+        return element()->lookupCSSRandomBaseValue(style().pseudoElementIdentifier(), key);
 
-        std::optional<Style::PseudoElementIdentifier> pseudoElementIdentifier;
-        if (style().pseudoElementType() != PseudoId::None)
-            pseudoElementIdentifier = Style::PseudoElementIdentifier { style().pseudoElementType(), style().pseudoElementNameArgument() };
-
-        return element()->lookupCSSRandomBaseValue(pseudoElementIdentifier, key);
-    }
     return document().lookupCSSRandomBaseValue(key);
 }
 

--- a/Source/WebCore/style/StyleResolver.cpp
+++ b/Source/WebCore/style/StyleResolver.cpp
@@ -412,7 +412,7 @@ std::unique_ptr<RenderStyle> Resolver::styleForKeyframe(Element& element, const 
     ElementRuleCollector collector(element, m_ruleSets, context.selectorMatchingState);
 
     if (elementStyle.pseudoElementType() != PseudoId::None)
-        collector.setPseudoElementRequest(Style::PseudoElementIdentifier { elementStyle.pseudoElementType(), elementStyle.pseudoElementNameArgument() });
+        collector.setPseudoElementRequest(elementStyle.pseudoElementIdentifier());
 
     if (hasRevert) {
         // In the animation origin, 'revert' rolls back the cascaded value to the user level.
@@ -560,7 +560,7 @@ void Resolver::keyframeStylesForAnimation(Element& element, const RenderStyle& e
 
 std::optional<ResolvedStyle> Resolver::styleForPseudoElement(Element& element, const PseudoElementRequest& pseudoElementRequest, const ResolutionContext& context)
 {
-    auto state = State(element, context.parentStyle, context.documentElementStyle, nullptr);
+    auto state = State(element, context.parentStyle, context.documentElementStyle, context.treeResolutionState.get());
 
     if (state.parentStyle()) {
         state.setStyle(RenderStyle::createPtrWithRegisteredInitialValues(document().customPropertyRegistry()));

--- a/Source/WebCore/style/StyleTreeResolver.h
+++ b/Source/WebCore/style/StyleTreeResolver.h
@@ -181,8 +181,8 @@ private:
     const RenderStyle* beforeResolutionStyle(const Element&, std::optional<PseudoElementIdentifier>);
     void saveBeforeResolutionStyleForInterleaving(const Element&);
 
-    bool hasUnresolvedAnchorPosition(const Element&) const;
-    bool hasResolvedAnchorPosition(const Element&) const;
+    bool hasUnresolvedAnchorPosition(const Styleable&) const;
+    bool hasResolvedAnchorPosition(const Styleable&) const;
 
     CheckedRef<Document> m_document;
     std::unique_ptr<RenderStyle> m_computedDocumentElementStyle;

--- a/Source/WebCore/style/Styleable.cpp
+++ b/Source/WebCore/style/Styleable.cpp
@@ -89,7 +89,7 @@ const std::optional<const Styleable> Styleable::fromRenderer(const RenderElement
     case PseudoId::ViewTransitionNew:
     case PseudoId::ViewTransitionOld:
         if (auto* documentElement = renderer.document().documentElement())
-            return Styleable(*documentElement, Style::PseudoElementIdentifier { renderer.style().pseudoElementType(), renderer.style().pseudoElementNameArgument() });
+            return Styleable(*documentElement, renderer.style().pseudoElementIdentifier());
         break;
     case PseudoId::ViewTransition:
         if (auto* documentElement = renderer.document().documentElement())


### PR DESCRIPTION
#### e7804dbd6d4128ea5a9795bb7e7d4056fa7bd065
<pre>
[css-anchor-position-1] Support ::before and ::after as anchor-positioned elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=293625">https://bugs.webkit.org/show_bug.cgi?id=293625</a>
<a href="https://rdar.apple.com/152097389">rdar://152097389</a>

Reviewed by Alan Baradlay.

Basic support for ::before and ::after (but not ::marker).

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-function-pseudo-element-basic-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-function-pseudo-element-basic.html: Added.

Add a test. There were none.

* Source/WebCore/dom/Element.cpp:
(WebCore::Element::pseudoElementIfExists):
(WebCore::Element::pseudoElementIfExists const):

Add helpers.

* Source/WebCore/dom/Element.h:
* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::RenderStyle::addCachedPseudoStyle):
(WebCore::RenderStyle::pseudoElementIdentifier const):

Add a helper to move towards using PseudoElementIdentifier everywhere instead of PseudoId.

* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/updating/RenderTreeUpdater.cpp:
(WebCore::pseudoStyleCacheIsInvalid):

Use the helper.

* Source/WebCore/style/AnchorPositionEvaluator.cpp:
(WebCore::Style::AnchorPositionEvaluator::findAnchorForAnchorFunctionAndAttemptResolution):

Use host/PseudoElementIdentifier pair as the state map key.

(WebCore::Style::AnchorPositionEvaluator::evaluate):
(WebCore::Style::AnchorPositionEvaluator::evaluateSize):
(WebCore::Style::AnchorPositionEvaluator::updateAnchorPositioningStatesAfterInterleavedLayout):
(WebCore::Style::AnchorPositionEvaluator::updateAnchorPositionedStateForLayoutTimePositioned):

Adopt host/PseudoElementIdentifier key pair.

(WebCore::Style::AnchorPositionEvaluator::anchorPositionedElementOrPseudoElement):
(WebCore::Style::AnchorPositionEvaluator::keyForElementOrPseudoElement):

Add some helpers.

* Source/WebCore/style/AnchorPositionEvaluator.h:
* Source/WebCore/style/StyleBuilderState.cpp:
(WebCore::Style::BuilderState::lookupCSSRandomBaseValue const):

Use Style::pseudoElementIdentifier helper.

* Source/WebCore/style/StyleResolver.cpp:
(WebCore::Style::Resolver::styleForKeyframe):
(WebCore::Style::Resolver::styleForPseudoElement):

Pass the tree resolution state for pseudo elements too.

* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::createAnimatedElementUpdate):
(WebCore::Style::TreeResolver::resolve):
(WebCore::Style::TreeResolver::updateAnchorPositioningState):
(WebCore::Style::TreeResolver::generatePositionOptionsIfNeeded):

Adopt host/PseudoElementIdentifier key pair.

(WebCore::Style::TreeResolver::tryChoosePositionOption):
(WebCore::Style::TreeResolver::updateForPositionVisibility):
(WebCore::Style::TreeResolver::hasUnresolvedAnchorPosition const):
(WebCore::Style::TreeResolver::hasResolvedAnchorPosition const):

Use Styleable as argument instead of Element.

* Source/WebCore/style/StyleTreeResolver.h:
* Source/WebCore/style/Styleable.cpp:
(WebCore::Styleable::fromRenderer):

Canonical link: <a href="https://commits.webkit.org/295686@main">https://commits.webkit.org/295686@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/39477cddd882e37d79890183e5f22a21a15cf09f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105879 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25630 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/16023 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/111076 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/56477 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/107920 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/26236 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34133 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80423 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108885 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/20652 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95548 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60739 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/20302 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13647 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55914 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/90046 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13683 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/113926 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33019 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24350 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89503 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33383 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91778 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89175 "Found 101 new API test failures: /TestWebKit:WebKit.PageLoadDidChangeLocationWithinPage, /TestWebKit:WebKit.AboutBlankLoad, /TestWebKit:WebKit.PreventEmptyUserAgent, /TestWebKit:WebKit.PrivateBrowsingPushStateNoHistoryCallback, /WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/content-type, /WebKitGTK/TestUIClient:/webkit/WebKitWebView/pointer-lock-permission-request, /TestWebKit:WebKit.HitTestResultNodeHandle, /TestWebKit:WebKit2TextFieldBeginAndEditEditingTest.TextFieldDidBeginShouldNotBeDispatchedForAlreadyFocusedField, /TestWebKit:WebKit.Find, /WebKitGTK/TestWebProcessExtensions:/webkit/WebKitWebProcessExtension/dom-input-element-is-user-edited ... (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22723 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34042 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11852 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/28551 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32944 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/38355 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32690 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/36039 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34288 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->