### PR TITLE
Event::composedPath should include closed shadow roots when the DOM wrapper world is allowed access

### DIFF
--- a/Source/WebCore/dom/Event.cpp
+++ b/Source/WebCore/dom/Event.cpp
@@ -161,10 +161,12 @@ void Event::setEventPath(const EventPath& path)
     m_eventPath = &path;
 }
 
-Vector<Ref<EventTarget>> Event::composedPath() const
+Vector<Ref<EventTarget>> Event::composedPath(JSC::JSGlobalObject& lexicalGlobalObject) const
 {
     if (!m_eventPath)
         return Vector<Ref<EventTarget>>();
+    if (JSC::jsCast<JSDOMGlobalObject*>(&lexicalGlobalObject)->world().shadowRootIsAlwaysOpen())
+        return m_eventPath->computePathTreatingAllShadowRootsAsOpen();
     return m_eventPath->computePathUnclosedToTarget(*protectedCurrentTarget());
 }
 

--- a/Source/WebCore/dom/Event.h
+++ b/Source/WebCore/dom/Event.h
@@ -38,6 +38,10 @@ namespace WTF {
 class TextStream;
 }
 
+namespace JSC {
+class JSGlobalObject;
+}
+
 namespace WebCore {
 
 class EventPath;
@@ -94,7 +98,7 @@ public:
     MonotonicTime timeStamp() const { return m_createTime; }
 
     void setEventPath(const EventPath&);
-    Vector<Ref<EventTarget>> composedPath() const;
+    Vector<Ref<EventTarget>> composedPath(JSC::JSGlobalObject&) const;
 
     void stopPropagation() { m_propagationStopped = true; }
     void stopImmediatePropagation() { m_immediatePropagationStopped = true; }

--- a/Source/WebCore/dom/Event.idl
+++ b/Source/WebCore/dom/Event.idl
@@ -32,7 +32,7 @@ typedef double DOMHighResTimeStamp;
     readonly attribute DOMString type;
     readonly attribute EventTarget? target;
     readonly attribute EventTarget? currentTarget;
-    sequence<EventTarget> composedPath();
+    [CallWith=CurrentGlobalObject] sequence<EventTarget> composedPath();
 
     const unsigned short NONE = 0;
     const unsigned short CAPTURING_PHASE = 1;

--- a/Source/WebCore/dom/EventPath.cpp
+++ b/Source/WebCore/dom/EventPath.cpp
@@ -281,6 +281,17 @@ Vector<Ref<EventTarget>> EventPath::computePathUnclosedToTarget(const EventTarge
     return path;
 }
 
+Vector<Ref<EventTarget>> EventPath::computePathTreatingAllShadowRootsAsOpen() const
+{
+    Vector<Ref<EventTarget>> path;
+    auto pathSize = m_path.size();
+    RELEASE_ASSERT(pathSize);
+    path.reserveInitialCapacity(pathSize);
+    for (auto& currentContext : m_path)
+        path.append(*currentContext.currentTarget());
+    return path;
+}
+
 EventPath::EventPath(std::span<EventTarget* const> targets)
 {
     m_path = WTF::map(targets, [&](auto* target) {

--- a/Source/WebCore/dom/EventPath.h
+++ b/Source/WebCore/dom/EventPath.h
@@ -55,6 +55,7 @@ public:
     void adjustForDisabledFormControl();
 
     Vector<Ref<EventTarget>> computePathUnclosedToTarget(const EventTarget&) const;
+    Vector<Ref<EventTarget>> computePathTreatingAllShadowRootsAsOpen() const;
 
     static Node* eventTargetRespectingTargetRules(Node&);
 


### PR DESCRIPTION
#### c179521d89edddfe5f1ec2cb3c2b23bdf9701ff9
<pre>
Event::composedPath should include closed shadow roots when the DOM wrapper world is allowed access
<a href="https://bugs.webkit.org/show_bug.cgi?id=293915">https://bugs.webkit.org/show_bug.cgi?id=293915</a>

Reviewed by Wenson Hsieh.

When a DOM wrapper world has the option to allow access to closed shadow roots, Event::composedPath
should include closed shadow roots in its results. To implement this new behavior, the function now
takes a lexical global object and calls computePathTreatingAllShadowRootsAsOpen when the flag is set.

* Source/WebCore/dom/Event.cpp:
(WebCore::Event::composedPath const):
* Source/WebCore/dom/Event.h:
* Source/WebCore/dom/Event.idl:
* Source/WebCore/dom/EventPath.cpp:
(WebCore::EventPath::computePathTreatingAllShadowRootsAsOpen const):
* Source/WebCore/dom/EventPath.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/UserContentController.mm:
(TEST(WKUserContentController, AllowAccessToClosedShadowRoots)):

Canonical link: <a href="https://commits.webkit.org/295751@main">https://commits.webkit.org/295751@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2d67e668dc9c969e17d7a039322a24efbc2c7ddd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105930 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25681 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/16075 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/111128 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/56528 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/107971 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/26374 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34184 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80471 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108936 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/20799 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95598 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60791 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/20418 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13696 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55966 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/90181 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13732 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/113980 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33070 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24400 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89548 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33434 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91827 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89227 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34085 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11901 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/28608 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17197 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32995 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/38406 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32741 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/36090 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34339 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->