### PR TITLE
AX: Implement support for NSAccessibilityStringForRangeParameterizedAttribute off the main-thread

### DIFF
--- a/LayoutTests/accessibility/insert-newline-expected.txt
+++ b/LayoutTests/accessibility/insert-newline-expected.txt
@@ -1,10 +1,12 @@
-hello
-world
-PASS text.selectedTextRange became '{5, 0}'
-There must be only one [newline] between hello and world: hello[newline]world
-PASS text.selectedTextRange became '{6, 0}'
-The text after the newline should be world: world
+This test exercises a combination of selectedTextRange, stringForRange, and newline manipulation.
+
+PASS: contenteditable.selectedTextRange === '{5, 0}'
+PASS: contenteditable.stringForRange(0, 11).replace(new RegExp('(?:\r\n|\r|\n)', 'g'), '[newline]') === 'hello[newline]world'
+PASS: contenteditable.selectedTextRange === '{6, 0}'
+PASS: contenteditable.stringForRange(6, 5) === 'world'
+
 PASS successfullyParsed is true
 
 TEST COMPLETE
-
+hello
+world

--- a/LayoutTests/accessibility/insert-newline.html
+++ b/LayoutTests/accessibility/insert-newline.html
@@ -1,39 +1,36 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../resources/js-test-pre.js"></script>
+<script src="../resources/accessibility-helper.js"></script>
+<script src="../resources/js-test.js"></script>
 </head>
 <body>
 
-<div id="content" contenteditable tabindex="0">helloworld</div>
-
-<div id="console"></div>
+<div id="contenteditable" contenteditable tabindex="0">helloworld</div>
 
 <script>
-    if (window.accessibilityController) {
-        window.jsTestIsAsync = true;
+var output = "This test exercises a combination of selectedTextRange, stringForRange, and newline manipulation.\n\n";
 
-        var content = document.getElementById("content");
-        content.focus();
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
 
-        var text = accessibilityController.focusedElement;
-        text.setSelectedTextRange(5, 0);
-        shouldBecomeEqual("text.selectedTextRange", "'{5, 0}'", function() {
-            text.insertText("\n");
+    var contenteditable;
+    setTimeout(async function() {
+        contenteditable = await waitForFocus("contenteditable");
+        contenteditable.setSelectedTextRange(5, 0);
 
-            var t = text.stringForRange(0, 11);
-            t = t.replace(/(?:\r\n|\r|\n)/g, '[newline]');
-            debug("There must be only one [newline] between hello and world: " + t);
+        output += await expectAsync("contenteditable.selectedTextRange", "'{5, 0}'");
+        contenteditable.insertText("\n");
+        output += await expectAsync("contenteditable.stringForRange(0, 11).replace(new RegExp('(?:\\r\\n|\\r|\\n)', 'g'), '[newline]')", "'hello[newline]world'");
 
-            shouldBecomeEqual("text.selectedTextRange", "'{6, 0}'", function() {
-                var t = text.stringForRange(6, 5);
-                t = t.replace(/(?:\r\n|\r|\n)/g, '[newline]');
-                debug("The text after the newline should be world: " + t);
+        output += await expectAsync("contenteditable.selectedTextRange", "'{6, 0}'");
+        output += await expectAsync("contenteditable.stringForRange(6, 5)", "'world'");
 
-                finishJSTest();
-            });
-        });
-    }
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
 </script>
-<script src="../resources/js-test-post.js"></script>
 </body>
 </html>
+

--- a/LayoutTests/accessibility/set-selected-text-range-after-newline-expected.txt
+++ b/LayoutTests/accessibility/set-selected-text-range-after-newline-expected.txt
@@ -1,13 +1,15 @@
-hello
+This test exercises a combination of selectedTextRange, stringForRange, and newline manipulation.
 
-world
-PASS text.selectedTextRange became '{5, 0}'
-There must be only one [newline] between hello and world: hello[newline]world
-PASS text.selectedTextRange became '{6, 0}'
-There must be two [newline] between hello and world: hello[newline][newline]world
-PASS text.selectedTextRange became '{7, 0}'
-The text after the newline should be world: world
+PASS: contenteditable.selectedTextRange === '{5, 0}'
+PASS: contenteditable.stringForRange(0, 11).replace(newlineRegex, '[newline]') === 'hello[newline]world'
+PASS: contenteditable.selectedTextRange === '{6, 0}'
+PASS: contenteditable.stringForRange(0, 12).replace(newlineRegex, '[newline]') === 'hello[newline][newline]world'
+PASS: contenteditable.selectedTextRange === '{7, 0}'
+PASS: contenteditable.stringForRange(7, 5) === 'world'
+
 PASS successfullyParsed is true
 
 TEST COMPLETE
+hello
 
+world

--- a/LayoutTests/accessibility/set-selected-text-range-after-newline.html
+++ b/LayoutTests/accessibility/set-selected-text-range-after-newline.html
@@ -1,51 +1,45 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../resources/js-test-pre.js"></script>
+<script src="../resources/accessibility-helper.js"></script>
+<script src="../resources/js-test.js"></script>
 </head>
 <body>
 
-<div id="content" contenteditable tabindex="0">helloworld</div>
-
-<div id="console"></div>
+<div id="contenteditable" contenteditable tabindex="0">helloworld</div>
 
 <script>
-    if (window.accessibilityController) {
-        window.jsTestIsAsync = true;
+var output = "This test exercises a combination of selectedTextRange, stringForRange, and newline manipulation.\n\n";
 
-        var content = document.getElementById("content");
-        content.focus();
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
 
-        var text = accessibilityController.focusedElement;
-        text.setSelectedTextRange(5, 0);
-        shouldBecomeEqual("text.selectedTextRange", "'{5, 0}'", function() {
-            // Insert a linebreak between "hello" and "world".
-            text.replaceTextInRange("\n", 5, 0);
+    var newlineRegex = new RegExp('(?:\\r\\n|\\r|\\n)', 'g');
+    var contenteditable;
+    setTimeout(async function() {
+        contenteditable = await waitForFocus("contenteditable");
+        contenteditable.setSelectedTextRange(5, 0);
+        output += await expectAsync("contenteditable.selectedTextRange", "'{5, 0}'");
 
-            var t = text.stringForRange(0, 11);
-            t = t.replace(/(?:\r\n|\r|\n)/g, '[newline]');
-            debug("There must be only one [newline] between hello and world: " + t);
+        // Insert a linebreak between "hello" and "world".
+        contenteditable.replaceTextInRange("\n", 5, 0);
+        output += await expectAsync("contenteditable.stringForRange(0, 11).replace(newlineRegex, '[newline]')", "'hello[newline]world'");
 
-            text.setSelectedTextRange(6, 0);
-            shouldBecomeEqual("text.selectedTextRange", "'{6, 0}'", function() {
-                // Insert another linebreak before "world".
-                text.replaceTextInRange("\n", 6, 0);
+        contenteditable.setSelectedTextRange(6, 0);
+        output += await expectAsync("contenteditable.selectedTextRange", "'{6, 0}'");
+        // Insert another linebreak before "world".
+        contenteditable.replaceTextInRange("\n", 6, 0);
 
-                var t = text.stringForRange(0, 12);
-                t = t.replace(/(?:\r\n|\r|\n)/g, '[newline]');
-                debug("There must be two [newline] between hello and world: " + t);
+        output += await expectAsync("contenteditable.stringForRange(0, 12).replace(newlineRegex, '[newline]')", "'hello[newline][newline]world'");
+        contenteditable.setSelectedTextRange(7, 0);
+        output += await expectAsync("contenteditable.selectedTextRange", "'{7, 0}'");
+        output += await expectAsync("contenteditable.stringForRange(7, 5)", "'world'");
 
-                text.setSelectedTextRange(7, 0);
-                shouldBecomeEqual("text.selectedTextRange", "'{7, 0}'", function() {
-                    var t = text.stringForRange(7, 5);
-                    t = t.replace(/(?:\r\n|\r|\n)/g, '[newline]');
-                    debug("The text after the newline should be world: " + t);
-
-                    finishJSTest();
-                });
-            });
-        });
-    }
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
 </script>
-<script src="../resources/js-test-post.js"></script>
 </body>
 </html>
+

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
@@ -1310,11 +1310,16 @@ CharacterRange AXIsolatedObject::doAXRangeForLine(unsigned lineIndex) const
     });
 }
 
-String AXIsolatedObject::doAXStringForRange(const CharacterRange& axRange) const
+String AXIsolatedObject::doAXStringForRange(const CharacterRange& range) const
 {
-    return Accessibility::retrieveValueFromMainThread<String>([&axRange, this] () -> String {
+#if ENABLE(AX_THREAD_TEXT_APIS)
+    if (AXObjectCache::useAXThreadTextApis())
+        return textMarkerRange().toString().substring(range.location, range.length);
+#endif // ENABLE(AX_THREAD_TEXT_APIS)
+
+    return Accessibility::retrieveValueFromMainThread<String>([&range, this] () -> String {
         if (auto* object = associatedAXObject())
-            return object->doAXStringForRange(axRange).isolatedCopy();
+            return object->doAXStringForRange(range).isolatedCopy();
         return { };
     });
 }


### PR DESCRIPTION
#### 9ce888f87b027c593caad79000972faa1ac595cf
<pre>
AX: Implement support for NSAccessibilityStringForRangeParameterizedAttribute off the main-thread
<a href="https://bugs.webkit.org/show_bug.cgi?id=293917">https://bugs.webkit.org/show_bug.cgi?id=293917</a>
<a href="https://rdar.apple.com/152449191">rdar://152449191</a>

Reviewed by Joshua Hoffman.

If we convert the NSRange to an AXTextMarkerRange, we can implement NSAccessibilityStringForRangeParameterizedAttribute
off the main-thread -- this commit does so. A few tests needed to be modified to wait for accessibility tree updates
after corresponding main-thread page changes.

* LayoutTests/accessibility/insert-newline-expected.txt:
* LayoutTests/accessibility/insert-newline.html:
* LayoutTests/accessibility/set-selected-text-range-after-newline-expected.txt:
* LayoutTests/accessibility/set-selected-text-range-after-newline.html:
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp:
(WebCore::AXIsolatedObject::doAXStringForRange const):
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm:
(markerRangeFrom):
(computeTextBoundsForRange):
(-[WebAccessibilityObjectWrapper accessibilityAttributeValue:forParameter:]):

Canonical link: <a href="https://commits.webkit.org/295725@main">https://commits.webkit.org/295725@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/06a5b0e4528a23ceb7f4473e0bffcbdd31bf5f36

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105949 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25700 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/16094 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/111147 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/56547 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/107990 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/26337 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34203 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80480 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108955 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/20760 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95614 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60800 "Passed tests") | 
| | [💥 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/20381 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13712 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55985 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/90144 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13748 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/113999 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33089 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24413 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89559 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33453 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91843 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89238 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22747 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34102 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11917 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/28627 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/33014 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/38425 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32760 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/36109 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34358 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->