### PR TITLE
[WebGPU] Implement copyBufferToBuffer overload from https://github.com/gpuweb/gpuweb/pull/5098

### DIFF
--- a/Source/WebCore/Modules/WebGPU/GPUCommandEncoder.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUCommandEncoder.cpp
@@ -67,12 +67,20 @@ ExceptionOr<Ref<GPUComputePassEncoder>> GPUCommandEncoder::beginComputePass(cons
 
 void GPUCommandEncoder::copyBufferToBuffer(
     const GPUBuffer& source,
+    const GPUBuffer& destination,
+    std::optional<GPUSize64> size)
+{
+    return copyBufferToBuffer(source, 0u, destination, 0u, size);
+}
+
+void GPUCommandEncoder::copyBufferToBuffer(
+    const GPUBuffer& source,
     GPUSize64 sourceOffset,
     const GPUBuffer& destination,
     GPUSize64 destinationOffset,
-    GPUSize64 size)
+    std::optional<GPUSize64> size)
 {
-    m_backing->copyBufferToBuffer(source.backing(), sourceOffset, destination.backing(), destinationOffset, size);
+    m_backing->copyBufferToBuffer(source.backing(), sourceOffset, destination.backing(), destinationOffset, size.value_or(sourceOffset < source.size() ? source.size() - sourceOffset : 0u));
 }
 
 void GPUCommandEncoder::copyBufferToTexture(

--- a/Source/WebCore/Modules/WebGPU/GPUCommandEncoder.h
+++ b/Source/WebCore/Modules/WebGPU/GPUCommandEncoder.h
@@ -65,10 +65,15 @@ public:
 
     void copyBufferToBuffer(
         const GPUBuffer& source,
+        const GPUBuffer& destination,
+        std::optional<GPUSize64>);
+
+    void copyBufferToBuffer(
+        const GPUBuffer& source,
         GPUSize64 sourceOffset,
         const GPUBuffer& destination,
         GPUSize64 destinationOffset,
-        GPUSize64);
+        std::optional<GPUSize64>);
 
     void copyBufferToTexture(
         const GPUImageCopyBuffer& source,

--- a/Source/WebCore/Modules/WebGPU/GPUCommandEncoder.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUCommandEncoder.idl
@@ -42,10 +42,15 @@ interface GPUCommandEncoder {
 
     undefined copyBufferToBuffer(
         GPUBuffer source,
+        GPUBuffer destination,
+        optional GPUSize64 size);
+
+    undefined copyBufferToBuffer(
+        GPUBuffer source,
         GPUSize64 sourceOffset,
         GPUBuffer destination,
         GPUSize64 destinationOffset,
-        GPUSize64 size);
+        optional GPUSize64 size);
 
     undefined copyBufferToTexture(
         GPUImageCopyBuffer source,


### PR DESCRIPTION
#### b297fe6ceb7d6a120cd0e8aa028912c84bb42487
<pre>
[WebGPU] Implement copyBufferToBuffer overload from <a href="https://github.com/gpuweb/gpuweb/pull/5098">https://github.com/gpuweb/gpuweb/pull/5098</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=293905">https://bugs.webkit.org/show_bug.cgi?id=293905</a>
<a href="https://rdar.apple.com/152435677">rdar://152435677</a>

Reviewed by Tadeu Zagallo.

The CTS plans to use this, so add the overloads which are trivial
to add so tests continue passing after auto-import.

* Source/WebCore/Modules/WebGPU/GPUCommandEncoder.cpp:
(WebCore::GPUCommandEncoder::copyBufferToBuffer):
* Source/WebCore/Modules/WebGPU/GPUCommandEncoder.h:
* Source/WebCore/Modules/WebGPU/GPUCommandEncoder.idl:

Canonical link: <a href="https://commits.webkit.org/295757@main">https://commits.webkit.org/295757@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/61c473db6a20813fc18f78defa001ee5cda05eae

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105931 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25682 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/16076 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/111129 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/56529 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/107972 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/26316 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34185 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80464 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108937 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/20741 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95596 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60784 "Found 145 new API test failures: /WPE/TestUIClient:/webkit/WebKitWebView/query-permission-requests, /WPE/TestWebsiteData:/webkit/WebKitWebsiteData/deviceidhashsalt, /WPE/TestLoaderClient:/webkit/WebKitWebView/load-twice-and-reload, /WPE/TestCookieManager:/webkit/WebKitCookieManager/ephemeral, /WPE/TestWebKitWebView:/webkit/WebKitWebView/is-playing-audio, /WPE/TestWebsiteData:/webkit/WebKitWebsiteData/configuration, /WPE/TestCookieManager:/webkit/WebKitCookieManager/delete-cookies, /WPE/TestWebKitWebView:/webkit/WebKitWebView/terminate-unresponsive-web-process, /WPE/TestSSL:/webkit/WebKitWebView/insecure-content, /WPE/TestAuthentication:/webkit/Authentication/authentication-storage ... (failure)") | 
| | [💥 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/20368 "An unexpected error occured. Recent messages:OS: Sequoia (15.5), Xcode: 16.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-layout-tests-in-stress-mode; layout-tests (failure); Uploaded test results; layout-tests (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13694 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55967 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/90125 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13730 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/113981 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33071 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24399 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89550 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33435 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91825 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89229 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22764 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34086 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11899 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/28609 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32996 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/38407 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32742 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/36091 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34340 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->