### PR TITLE
getBoundingClientRect returns inconsistent (decimal) values for sticky element

### DIFF
--- a/LayoutTests/fast/scrolling/ios/bounding-client-rect-on-fixed-expected.txt
+++ b/LayoutTests/fast/scrolling/ios/bounding-client-rect-on-fixed-expected.txt
@@ -1,0 +1,10 @@
+Verifies that getBoundingClientRect() on a fixedpos always returns the layout value.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS unexpectedValue is undefined
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/scrolling/ios/bounding-client-rect-on-fixed.html
+++ b/LayoutTests/fast/scrolling/ios/bounding-client-rect-on-fixed.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../resources/js-test.js"></script>
+<script src="../../../resources/ui-helper.js"></script>
+<style>
+body {
+    height: 2000px;
+}
+
+#target {
+    position: fixed;
+    top: 100px;
+    width: 100px;
+    height: 200px;
+    background-color: silver;
+}
+</style>
+
+<body onload="runTest()">
+    <div id="target"></div>
+</body>
+
+<script>
+jsTestIsAsync = true;
+
+let unexpectedValue = undefined;
+
+async function runTest()
+{
+    description("Verifies that getBoundingClientRect() on a fixedpos always returns the layout value.");
+
+    window.addEventListener('scroll', () => {
+        if (unexpectedValue !== undefined)
+            return;
+
+        const targetTop = document.getElementById('target').getBoundingClientRect().top;
+        
+        if (targetTop != 100)
+            unexpectedValue = targetTop;
+    }, false);
+
+    if (!window.testRunner)
+        return;
+
+    await UIHelper.dragFromPointToPoint(150, 300, 150, 50, 0.1);
+    await UIHelper.waitForTargetScrollAnimationToSettle(document.scrollingElement);
+    shouldBe("unexpectedValue", "undefined");
+
+   finishJSTest();
+}
+</script>
+</html>

--- a/Source/WebCore/platform/graphics/FloatPoint.h
+++ b/Source/WebCore/platform/graphics/FloatPoint.h
@@ -315,9 +315,9 @@ inline FloatPoint toFloatPoint(const FloatSize& a)
     return FloatPoint(a.width(), a.height());
 }
 
-inline bool areEssentiallyEqual(const FloatPoint& a, const FloatPoint& b)
+inline bool areEssentiallyEqual(const FloatPoint& a, const FloatPoint& b, float epsilon = std::numeric_limits<float>::epsilon())
 {
-    return WTF::areEssentiallyEqual(a.x(), b.x()) && WTF::areEssentiallyEqual(a.y(), b.y());
+    return WTF::areEssentiallyEqual(a.x(), b.x(), epsilon) && WTF::areEssentiallyEqual(a.y(), b.y(), epsilon);
 }
 
 inline void add(Hasher& hasher, const FloatPoint& point)


### PR DESCRIPTION
#### 4be483e6f8458ff2bb70bfe97201f9cea0afe33f
<pre>
getBoundingClientRect returns inconsistent (decimal) values for sticky element
<a href="https://bugs.webkit.org/show_bug.cgi?id=289431">https://bugs.webkit.org/show_bug.cgi?id=289431</a>
<a href="https://rdar.apple.com/147163986">rdar://147163986</a>

Reviewed by Abrar Rahman Protyasha.

getBoundingClientRect() on fixed and sticky elements could give results off by fractional
pixels on iOS while scrolling. If JS does math on those values and uses them to toggle
`position:fixed`, as some fake-sticky JS libraries do, then this can cause fixed elements
to jump around (see on gearspace.com, <a href="https://rdar.apple.com/45975461">rdar://45975461</a>).

The cause was fractional differences between the `layoutViewportRect` in
`VisibleContentRectUpdateInfo`, and the `unobscuredContentRect`, which stemmed from
`-[WKContentView didUpdateVisibleRect:...]` using
`WebPageProxy::computeLayoutViewportRect()`, which calls into a `LocalFrameView` function
that does math in LayoutUnits. The returned value is converted back to FloatRect, which
contained values rounded to 1/64 pixel values (the LayoutUnit denominator).

`WebPage::updateVisibleContentRects()` would then push down two rects with slightly
different origins into the `VisualViewportOverrideRect` (this contributes to
scrollPosition computations), and the layout viewport rect (which is used to lay out fixed
and sticky renderers). So layout runs using the layout viewport, and then
`getBoundingClientRect` runs which uses the scroll position to compute client coordinates,
and we end up with slightly wrong client coords.

One possible fix is to convert `LocalFrameView::computeLayoutViewportOrigin()` and callers
to do math in FloatRects, but this is an extensive change. It also doesn&apos;t handle the
issue that scroll positions in WebCore are represented as IntPoint. So instead, fix
`WebPage::updateVisibleContentRects()` to set the layoutViewportRect origin to the rounded
scroll position (which is the origin of the visual viewport).

Note that this does not fix the issue while rubberbanding, which will be fixed separately.

* LayoutTests/fast/scrolling/ios/bounding-client-rect-on-fixed-expected.txt: Added.
* LayoutTests/fast/scrolling/ios/bounding-client-rect-on-fixed.html: Added.
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::updateVisibleContentRects):

Canonical link: <a href="https://commits.webkit.org/295783@main">https://commits.webkit.org/295783@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/169720366b1b976628762dd45d02977f8985a9dd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/106110 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25859 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/16253 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/111307 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/56706 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/108149 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/26515 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34362 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/80615 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/56706 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/109114 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/20946 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95755 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60938 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/20521 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13858 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/56144 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/90314 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13893 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/114163 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33248 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/24532 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89678 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33612 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91988 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89368 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22785 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34236 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/12050 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/28821 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/33173 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/38585 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32919 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/36269 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34517 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->