### PR TITLE
[Page Color Sampling] Top sampled color changes after focusing search field in Confluence

### DIFF
--- a/LayoutTests/fast/page-color-sampling/color-sampling-fixed-popup-expected.txt
+++ b/LayoutTests/fast/page-color-sampling/color-sampling-fixed-popup-expected.txt
@@ -1,7 +1,7 @@
 PASS edgeColorsBeforeUnparenting.top is "rgb(100, 100, 100)"
-PASS edgeColorsBeforeUnparenting.left is "rgb(100, 100, 100)"
-PASS edgeColorsBeforeUnparenting.right is "rgb(100, 100, 100)"
-PASS edgeColorsBeforeUnparenting.bottom is "rgb(100, 100, 100)"
+PASS edgeColorsBeforeUnparenting.left is null
+PASS edgeColorsBeforeUnparenting.right is null
+PASS edgeColorsBeforeUnparenting.bottom is null
 PASS edgeColorsAfterUnparenting.top is null
 PASS edgeColorsAfterUnparenting.left is null
 PASS edgeColorsAfterUnparenting.right is null

--- a/LayoutTests/fast/page-color-sampling/color-sampling-fixed-popup.html
+++ b/LayoutTests/fast/page-color-sampling/color-sampling-fixed-popup.html
@@ -11,15 +11,15 @@
             font-family: system-ui;
         }
 
-        .popup {
+        .banner {
             position: fixed;
             top: 0;
-            bottom: 0;
             left: 0;
+            height: 100px;
             right: 0;
         }
 
-        .popup-content {
+        .banner-content {
             background: rgb(100, 100, 100);
             width: 100%;
             height: 100%;
@@ -35,11 +35,11 @@
         await UIHelper.ensurePresentationUpdate();
         edgeColorsBeforeUnparenting = await UIHelper.fixedContainerEdgeColors();
         shouldBeEqualToString("edgeColorsBeforeUnparenting.top", "rgb(100, 100, 100)");
-        shouldBeEqualToString("edgeColorsBeforeUnparenting.left", "rgb(100, 100, 100)");
-        shouldBeEqualToString("edgeColorsBeforeUnparenting.right", "rgb(100, 100, 100)");
-        shouldBeEqualToString("edgeColorsBeforeUnparenting.bottom", "rgb(100, 100, 100)");
+        shouldBeNull("edgeColorsBeforeUnparenting.left");
+        shouldBeNull("edgeColorsBeforeUnparenting.right");
+        shouldBeNull("edgeColorsBeforeUnparenting.bottom");
 
-        document.querySelector(".popup").remove();
+        document.querySelector(".banner").remove();
         edgeColorsAfterUnparenting = await UIHelper.fixedContainerEdgeColors();
         shouldBeNull("edgeColorsAfterUnparenting.top");
         shouldBeNull("edgeColorsAfterUnparenting.left");
@@ -51,8 +51,8 @@
     </script>
 </head>
 <body>
-<div class="popup">
-    <div class="popup-content"></div>
+<div class="banner">
+    <div class="banner-content"></div>
 </div>
 <div class="tall"></div>
 </body>

--- a/LayoutTests/fast/page-color-sampling/color-sampling-ignores-modal-popup-expected.txt
+++ b/LayoutTests/fast/page-color-sampling/color-sampling-ignores-modal-popup-expected.txt
@@ -1,0 +1,12 @@
+PASS edgeColorsBeforeShowingPopup.top is "rgb(255, 0, 0)"
+PASS edgeColorsBeforeShowingPopup.left is "rgb(0, 128, 0)"
+PASS edgeColorsBeforeShowingPopup.right is "rgb(0, 0, 255)"
+PASS edgeColorsBeforeShowingPopup.bottom is null
+PASS edgeColorsAfterShowingPopup.top is "rgb(255, 0, 0)"
+PASS edgeColorsAfterShowingPopup.left is "rgb(0, 128, 0)"
+PASS edgeColorsAfterShowingPopup.right is "rgb(0, 0, 255)"
+PASS edgeColorsAfterShowingPopup.bottom is null
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/page-color-sampling/color-sampling-ignores-modal-popup.html
+++ b/LayoutTests/fast/page-color-sampling/color-sampling-ignores-modal-popup.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true pageTopColorSamplingEnabled=true useFlexibleViewport=true ] -->
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <style>
+        body, html {
+            width: 100%;
+            height: 100%;
+            margin: 0;
+            font-family: system-ui;
+        }
+
+        .top {
+            position: fixed;
+            top: 0;
+            height: 60px;
+            left: 0;
+            right: 0;
+        }
+
+        .left {
+            position: fixed;
+            top: 0;
+            width: 60px;
+            left: 0;
+            bottom: 0;
+        }
+
+        .right {
+            position: fixed;
+            top: 0;
+            width: 60px;
+            right: 0;
+            bottom: 0;
+        }
+
+        .content {
+            width: 100%;
+            height: 100%;
+        }
+
+        .top > .content {
+            background: red;
+        }
+
+        .left > .content {
+            background: green;
+        }
+
+        .right > .content {
+            background: blue;
+        }
+
+        .popup {
+            position: fixed;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            opacity: 0.6;
+            background-color: gray;
+            display: none;
+            z-index: 100;
+        }
+    </style>
+    <script src="../../resources/js-test.js"></script>
+    <script src="../../resources/ui-helper.js"></script>
+    <script>
+    jsTestIsAsync = true;
+
+    addEventListener("load", async () => {
+        await UIHelper.setObscuredInsets(50, 50, 50, 50);
+        await UIHelper.ensurePresentationUpdate();
+        edgeColorsBeforeShowingPopup = await UIHelper.fixedContainerEdgeColors();
+        shouldBeEqualToString("edgeColorsBeforeShowingPopup.top", "rgb(255, 0, 0)");
+        shouldBeEqualToString("edgeColorsBeforeShowingPopup.left", "rgb(0, 128, 0)");
+        shouldBeEqualToString("edgeColorsBeforeShowingPopup.right", "rgb(0, 0, 255)");
+        shouldBeNull("edgeColorsBeforeShowingPopup.bottom");
+
+        document.querySelector(".popup").style.display = "block";
+        await UIHelper.ensurePresentationUpdate();
+
+        edgeColorsAfterShowingPopup = await UIHelper.fixedContainerEdgeColors();
+        shouldBeEqualToString("edgeColorsAfterShowingPopup.top", "rgb(255, 0, 0)");
+        shouldBeEqualToString("edgeColorsAfterShowingPopup.left", "rgb(0, 128, 0)");
+        shouldBeEqualToString("edgeColorsAfterShowingPopup.right", "rgb(0, 0, 255)");
+        shouldBeNull("edgeColorsAfterShowingPopup.bottom");
+
+        finishJSTest();
+    });
+    </script>
+</head>
+<body>
+    <div class="right"><div class="content"></div></div>
+    <div class="left"><div class="content"></div></div>
+    <div class="top"><div class="content"></div></div>
+    <div class="popup"></div>
+    <div class="tall"></div>
+</body>
+</html>

--- a/LayoutTests/fast/page-color-sampling/color-sampling-ignores-transparent-pointer-events-none-container-expected.txt
+++ b/LayoutTests/fast/page-color-sampling/color-sampling-ignores-transparent-pointer-events-none-container-expected.txt
@@ -3,9 +3,9 @@ PASS colorsBeforeShowingPopup.left is null
 PASS colorsBeforeShowingPopup.right is null
 PASS colorsBeforeShowingPopup.bottom is "rgb(0, 122, 255)"
 PASS colorsAfterShowingPopup.top is "rgb(255, 59, 48)"
-PASS colorsAfterShowingPopup.left is "rgb(255, 59, 48)"
-PASS colorsAfterShowingPopup.right is "rgb(255, 59, 48)"
-PASS colorsAfterShowingPopup.bottom is "rgb(255, 59, 48)"
+PASS colorsAfterShowingPopup.left is null
+PASS colorsAfterShowingPopup.right is null
+PASS colorsAfterShowingPopup.bottom is "rgb(0, 122, 255)"
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/page-color-sampling/color-sampling-ignores-transparent-pointer-events-none-container.html
+++ b/LayoutTests/fast/page-color-sampling/color-sampling-ignores-transparent-pointer-events-none-container.html
@@ -11,16 +11,6 @@
             margin: 0;
         }
 
-        .content {
-            position: fixed;
-            bottom: 0;
-            left: 0;
-            right: 0;
-            top: 0;
-            overflow-y: scroll;
-            padding: 0 1em;
-        }
-
         .box {
             width: 100%;
             height: 100px;
@@ -49,7 +39,7 @@
             top: 0;
             left: 0;
             right: 0;
-            bottom: 0;
+            height: 50px;
             color: white;
             text-align: center;
             line-height: 100vh;
@@ -81,9 +71,9 @@
 
         colorsAfterShowingPopup = await UIHelper.fixedContainerEdgeColors();
         shouldBeEqualToString("colorsAfterShowingPopup.top", "rgb(255, 59, 48)");
-        shouldBeEqualToString("colorsAfterShowingPopup.left", "rgb(255, 59, 48)");
-        shouldBeEqualToString("colorsAfterShowingPopup.right", "rgb(255, 59, 48)");
-        shouldBeEqualToString("colorsAfterShowingPopup.bottom", "rgb(255, 59, 48)");
+        shouldBeNull("colorsAfterShowingPopup.left");
+        shouldBeNull("colorsAfterShowingPopup.right");
+        shouldBeEqualToString("colorsAfterShowingPopup.bottom", "rgb(0, 122, 255)");
 
         finishJSTest();
     });


### PR DESCRIPTION
#### fc70d62e654cd0d5654ce0273c36f7e339146df6
<pre>
[Page Color Sampling] Top sampled color changes after focusing search field in Confluence
<a href="https://bugs.webkit.org/show_bug.cgi?id=293924">https://bugs.webkit.org/show_bug.cgi?id=293924</a>
<a href="https://rdar.apple.com/151744926">rdar://151744926</a>

Reviewed by Abrar Rahman Protyasha.

Make more adjustments to the color sampling heuristic, to avoid applying fixed color extension to
containers docked to the top/bottom or left/right edges, if they also cover most of the left/right
or top/bottom edges (respectively). Importantly, this allows us to avoid thrashing sampled color in
the case where a popup that obscures the entire viewport is temporarily shown (in the case of
Confluence, in response to the user focusing a search field).

By avoiding detection for these containers, we simply fall back to the previously sampled result, as
long as those previously sampled elements are still in the render tree (see 295099@main).

* LayoutTests/fast/page-color-sampling/color-sampling-fixed-popup-expected.txt:
* LayoutTests/fast/page-color-sampling/color-sampling-fixed-popup.html:

Adjust this layout test by making turning the popup into a (short) banner that doesn&apos;t cover the
whole viewport, since this now causes the sampling heuristic to avoid detecting it as a candidate
for color extension.

* LayoutTests/fast/page-color-sampling/color-sampling-ignores-modal-popup-expected.txt: Added.
* LayoutTests/fast/page-color-sampling/color-sampling-ignores-modal-popup.html: Added.

Add a new layout test to verify that sampled fixed-position container colors remain stable after
showing a modal popup that covers the page.

* LayoutTests/fast/page-color-sampling/color-sampling-ignores-transparent-pointer-events-none-container-expected.txt:
* LayoutTests/fast/page-color-sampling/color-sampling-ignores-transparent-pointer-events-none-container.html:

Adjust this layout test in the same way (see `color-sampling-fixed-popup.html` above).

* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::fixedContainerEdges const):

Canonical link: <a href="https://commits.webkit.org/295724@main">https://commits.webkit.org/295724@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/78503aedc0aabd4f0b4e2dc1c619392cf9b02291

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105950 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25701 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/16095 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/111148 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/56548 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/107991 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/26338 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34204 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80482 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108956 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/20768 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95617 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60802 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/20386 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13715 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55986 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/90150 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13751 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/114000 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33090 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24414 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89561 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33454 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91846 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89240 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22746 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34101 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11920 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/28628 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/33015 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/38426 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32761 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/36110 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34359 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->