### PR TITLE
Various build errors, notably "implicit instantiation of undefined template 'std::numeric_limits<unsigned int>'"

### DIFF
--- a/Source/JavaScriptCore/bytecode/SourceID.h
+++ b/Source/JavaScriptCore/bytecode/SourceID.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <limits>
+
 namespace JSC {
 
 using SourceID = uint32_t;

--- a/Source/JavaScriptCore/jit/GdbJIT.cpp
+++ b/Source/JavaScriptCore/jit/GdbJIT.cpp
@@ -28,7 +28,8 @@
 
 #include <wtf/TZoneMallocInlines.h>
 
-#if ENABLE(ASSEMBLER) && (OS(DARWIN) || OS(LINUX))
+#if ENABLE(ASSEMBLER)
+#if OS(DARWIN) || OS(LINUX)
 
 #include "CallFrame.h"
 #include "CallFrameInlines.h"
@@ -1492,4 +1493,5 @@ void GdbJIT::log(const CString&, MacroAssemblerCodeRef<LinkBufferPtrTag>) { }
 
 } // namespace JSC
 
-#endif // ENABLE(ASSEMBLER) && (OS(DARWIN) || OS(LINUX))
+#endif // OS(DARWIN) || OS(LINUX)
+#endif // ENABLE(ASSEMBLER)

--- a/Source/JavaScriptCore/runtime/PureNaN.h
+++ b/Source/JavaScriptCore/runtime/PureNaN.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <bit>
+#include <limits>
 #include <wtf/Assertions.h>
 #include <wtf/StdLibExtras.h>
 

--- a/Source/JavaScriptCore/yarr/Yarr.h
+++ b/Source/JavaScriptCore/yarr/Yarr.h
@@ -27,7 +27,7 @@
 
 #pragma once
 
-#include <limits.h>
+#include <limits>
 #include "YarrErrorCode.h"
 
 namespace JSC { namespace Yarr {

--- a/Source/WTF/wtf/WeakRandom.h
+++ b/Source/WTF/wtf/WeakRandom.h
@@ -30,7 +30,7 @@
 
 #pragma once
 
-#include <limits.h>
+#include <limits>
 #include <wtf/CryptographicallyRandomNumber.h>
 #include <wtf/StdLibExtras.h>
 

--- a/Source/WTF/wtf/text/icu/UTextProvider.h
+++ b/Source/WTF/wtf/text/icu/UTextProvider.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <limits>
 #include <unicode/utext.h>
 
 namespace WTF {

--- a/Source/WebCore/platform/DateComponents.h
+++ b/Source/WebCore/platform/DateComponents.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include <limits>
 #include <optional>
 #include <unicode/utypes.h>
 #include <wtf/Forward.h>


### PR DESCRIPTION
#### bdd2c53befeb0f121bb757753624b6251098ad37
<pre>
Various build errors, notably &quot;implicit instantiation of undefined template &apos;std::numeric_limits&lt;unsigned int&gt;&apos;&quot;
<a href="https://bugs.webkit.org/show_bug.cgi?id=293853">https://bugs.webkit.org/show_bug.cgi?id=293853</a>

Unreviewed build fixes.

Add missing includes in various places, and fix guards in GdbJIT.cpp.

* Source/JavaScriptCore/bytecode/SourceID.h:
* Source/JavaScriptCore/jit/GdbJIT.cpp:
* Source/JavaScriptCore/runtime/PureNaN.h:
* Source/JavaScriptCore/yarr/Yarr.h:
* Source/WTF/wtf/WeakRandom.h:
* Source/WTF/wtf/text/icu/UTextProvider.h:
* Source/WebCore/platform/DateComponents.h:

Canonical link: <a href="https://commits.webkit.org/295723@main">https://commits.webkit.org/295723@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e2ef689d4be8d8eded742d6320f5e4b4f0c34f5c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105960 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25710 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/16104 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/111157 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/56557 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/108000 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/26350 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34213 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/80492 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108965 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-WK2-Tests-EWS "Waiting to run tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/95628 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60812 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13725 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55995 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/98600 "Built successfully and passed tests") | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13761 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/114018 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/104578 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33099 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Debug-WK2-Tests-EWS "Waiting to run tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/89575 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33463 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91856 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89255 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22744 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34114 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11929 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/28638 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/33024 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/38435 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/128890 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32770 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/35162 "Found 3 new JSC stress test failures: wasm.yaml/wasm/gc/ref-i31-eq.js.default-wasm, wasm.yaml/wasm/gc/ref-i31-eq.js.wasm-collect-continuously, wasm.yaml/wasm/gc/ref-i31-eq.js.wasm-eager (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/36119 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34368 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->