### PR TITLE
Stop using some deprecated methods in WebKitLegacy

### DIFF
--- a/Source/WebKitLegacy/mac/WebInspector/WebNodeHighlight.mm
+++ b/Source/WebKitLegacy/mac/WebInspector/WebNodeHighlight.mm
@@ -268,9 +268,7 @@ using namespace WebCore;
     ASSERT([_targetView window]);
 
     NSRect highlightWindowFrame = [_targetView convertRect:[_targetView visibleRect] toView:nil];
-ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    highlightWindowFrame.origin = [[_targetView window] convertBaseToScreen:highlightWindowFrame.origin];
-ALLOW_DEPRECATED_DECLARATIONS_END
+    highlightWindowFrame.origin = [[_targetView window] convertPointToScreen:highlightWindowFrame.origin];
 
     return highlightWindowFrame;
 }

--- a/Source/WebKitLegacy/mac/WebView/WebFrame.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebFrame.mm
@@ -464,9 +464,7 @@ static NSURL *createUniqueWebDataURL();
         if (auto* view = frame->view()) {
             view->setTransparent(!drawsBackground);
 #if !PLATFORM(IOS_FAMILY)
-ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-            auto color = WebCore::colorFromCocoaColor([backgroundColor colorUsingColorSpaceName:NSDeviceRGBColorSpace]);
-ALLOW_DEPRECATED_DECLARATIONS_END
+            auto color = WebCore::colorFromCocoaColor([backgroundColor colorUsingColorSpace:NSColorSpace.deviceRGBColorSpace]);
 #else
             WebCore::Color color(WebCore::roundAndClampToSRGBALossy(backgroundColor));
 #endif

--- a/Source/WebKitLegacy/mac/WebView/WebFullScreenController.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebFullScreenController.mm
@@ -208,9 +208,7 @@ static NSRect convertRectToScreen(NSWindow *window, NSRect rect)
     webViewFrame.origin.y = NSMaxY([[[NSScreen screens] objectAtIndex:0] frame]) - NSMaxY(webViewFrame);
     
     CGWindowID windowID = [[_webView window] windowNumber];
-ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     RetainPtr webViewContents = WebCore::cgWindowListCreateImage(NSRectToCGRect(webViewFrame), kCGWindowListOptionIncludingWindow, windowID, kCGWindowImageShouldBeOpaque);
-ALLOW_DEPRECATED_DECLARATIONS_END
 
     // Screen updates to be re-enabled in beganEnterFullScreenWithInitialFrame:finalFrame:
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
@@ -500,9 +498,7 @@ static NSRect windowFrameFromApparentFrames(NSRect screenFrame, NSRect initialFr
     
     // setClipRectForWindow takes window coordinates, so convert from screen coordinates here:
     NSRect finalBounds = _finalFrame;
-ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    finalBounds.origin = [[self window] convertScreenToBase:finalBounds.origin];
-ALLOW_DEPRECATED_DECLARATIONS_END
+    finalBounds.origin = [[self window] convertPointFromScreen:finalBounds.origin];
     setClipRectForWindow(self.window, finalBounds);
     
     [[self window] makeKeyAndOrderFront:self];
@@ -571,9 +567,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     
     // setClipRectForWindow takes window coordinates, so convert from screen coordinates here:
     NSRect finalBounds = _finalFrame;
-ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    finalBounds.origin = [[self window] convertScreenToBase:finalBounds.origin];
-ALLOW_DEPRECATED_DECLARATIONS_END
+    finalBounds.origin = [[self window] convertPointFromScreen:finalBounds.origin];
     setClipRectForWindow(self.window, finalBounds);
     
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN

--- a/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
@@ -1503,9 +1503,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 {
     NSEvent *fakeEvent = [NSEvent mouseEventWithType:NSEventTypeMouseMoved
         location:[[self window]
-ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-        convertScreenToBase:[NSEvent mouseLocation]]
-ALLOW_DEPRECATED_DECLARATIONS_END
+        convertPointFromScreen:[NSEvent mouseLocation]]
         modifierFlags:[[NSApp currentEvent] modifierFlags]
         timestamp:[NSDate timeIntervalSinceReferenceDate]
         windowNumber:[[self window] windowNumber]
@@ -2084,9 +2082,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 
     NSEvent *fakeEvent = [NSEvent mouseEventWithType:NSEventTypeLeftMouseDragged
         location:[[self window]
-ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-        convertScreenToBase:[NSEvent mouseLocation]]
-ALLOW_DEPRECATED_DECLARATIONS_END
+        convertPointFromScreen:[NSEvent mouseLocation]]
         modifierFlags:[[NSApp currentEvent] modifierFlags]
         timestamp:[NSDate timeIntervalSinceReferenceDate]
         windowNumber:[[self window] windowNumber]
@@ -5044,9 +5040,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 #if PLATFORM(IOS_FAMILY)
         return [accTree accessibilityHitTest:point];
 #else
-ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-        NSPoint windowCoord = [[self window] convertScreenToBase:point];
-ALLOW_DEPRECATED_DECLARATIONS_END
+        NSPoint windowCoord = [[self window] convertPointFromScreen:point];
         return [accTree accessibilityHitTest:[self convertPoint:windowCoord fromView:nil]];
 #endif
     }
@@ -5108,9 +5102,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 - (NSString *)_colorAsString:(NSColor *)color
 {
-ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    NSColor *rgbColor = [color colorUsingColorSpaceName:NSDeviceRGBColorSpace];
-ALLOW_DEPRECATED_DECLARATIONS_END
+    NSColor *rgbColor = [color colorUsingColorSpace:NSColorSpace.deviceRGBColorSpace];
     // FIXME: If color is non-nil and rgbColor is nil, that means we got some kind
     // of fancy color that can't be converted to RGB. Changing that to "transparent"
     // might not be great, but it's probably OK.

--- a/Source/WebKitLegacy/mac/WebView/WebTextCompletionController.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebTextCompletionController.mm
@@ -83,10 +83,9 @@ using namespace WebCore;
 - (void)_buildUI
 {
     NSRect scrollFrame = NSMakeRect(0, 0, 100, 100);
-    NSRect tableFrame = NSZeroRect;    
-ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    tableFrame.size = [NSScrollView contentSizeForFrameSize:scrollFrame.size hasHorizontalScroller:NO hasVerticalScroller:YES borderType:NSNoBorder];
-ALLOW_DEPRECATED_DECLARATIONS_END
+    NSRect tableFrame = NSZeroRect;
+    tableFrame.size = [NSScrollView contentSizeForFrameSize:scrollFrame.size horizontalScrollerClass:nil verticalScrollerClass:[NSScroller class] borderType:NSNoBorder
+        controlSize:NSControlSizeRegular scrollerStyle:[NSScroller preferredScrollerStyle]];
     auto column = adoptNS([[NSTableColumn alloc] init]);
     [column setWidth:tableFrame.size.width];
     [column setEditable:NO];
@@ -127,9 +126,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
     NSRect windowFrame;
     NSPoint wordStart = topLeft;
-ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    windowFrame.origin = [[_view window] convertBaseToScreen:[_htmlView convertPoint:wordStart toView:nil]];
-ALLOW_DEPRECATED_DECLARATIONS_END
+    windowFrame.origin = [[_view window] convertPointToScreen:[_htmlView convertPoint:wordStart toView:nil]];
     windowFrame.size.height = numberToShow * [_tableView rowHeight] + (numberToShow + 1) * [_tableView intercellSpacing].height;
     windowFrame.origin.y -= windowFrame.size.height;
     NSDictionary *attributes = @{ NSFontAttributeName: [NSFont systemFontOfSize:12.0f] };


### PR DESCRIPTION
#### 56def202fc3c2585e0be1c8eeecbb5cfd408e1a8
<pre>
Stop using some deprecated methods in WebKitLegacy
<a href="https://bugs.webkit.org/show_bug.cgi?id=293929">https://bugs.webkit.org/show_bug.cgi?id=293929</a>
<a href="https://rdar.apple.com/152461747">rdar://152461747</a>

Reviewed by Sam Weinig.

This patch builds on Bug 293059, and switches from deprecated AppKit methods to the
modern equivalents. There is no change in behavior.

* Source/WebKitLegacy/mac/WebInspector/WebNodeHighlight.mm:
* Source/WebKitLegacy/mac/WebView/WebFrame.mm:
(-[WebFrame _updateBackgroundAndUpdatesWhileOffscreen]):
* Source/WebKitLegacy/mac/WebView/WebFullScreenController.mm:
(-[WebFullScreenController enterFullScreen:willEnterFullscreen:didEnterFullscreen:]):
(-[WebFullScreenController _startEnterFullScreenAnimationWithDuration:]):
(-[WebFullScreenController _startExitFullScreenAnimationWithDuration:]):
* Source/WebKitLegacy/mac/WebView/WebHTMLView.mm:
(-[WebHTMLView _updateMouseoverWithFakeEvent]):
(-[WebHTMLView _autoscroll]):
(-[WebHTMLView accessibilityHitTest:]):
(-[WebHTMLView _colorAsString:]):
* Source/WebKitLegacy/mac/WebView/WebTextCompletionController.mm:
(-[WebTextCompletionController _buildUI]):
(-[WebTextCompletionController _placePopupWindow:]):

Canonical link: <a href="https://commits.webkit.org/295827@main">https://commits.webkit.org/295827@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e832d81ce5b2cec5bed81ab94939fe3ac96024e3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/106098 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25847 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/16241 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/111295 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/56694 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/26503 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34350 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80590 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/109102 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/20942 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95746 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60912 "Found 1 new API test failure: /WPE/TestCookieManager:/webkit/WebKitCookieManager/persistent-storage (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/20517 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13844 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/56132 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/90309 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13879 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/114151 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33236 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/24636 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89672 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33600 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91974 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89361 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34225 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/12041 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/28809 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17220 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/33161 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/38573 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32907 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/36257 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34505 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->