### PR TITLE
[build-webkit] Clean up smart-pointer-result-archive from worker after uploading results

### DIFF
--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -46,7 +46,7 @@ import socket
 import sys
 import time
 
-from Shared.steps import ShellMixin
+from Shared.steps import ShellMixin, SetBuildSummary
 
 if sys.version_info < (3, 9):  # noqa: UP036
     print('ERROR: Minimum supported Python version for this code is Python 3.9')
@@ -6110,31 +6110,6 @@ class ApplyWatchList(shell.ShellCommandNewStyle):
         if self.results != SUCCESS:
             return {'step': 'Failed to apply watchlist'}
         return super().getResultSummary()
-
-
-class SetBuildSummary(buildstep.BuildStep):
-    name = 'set-build-summary'
-    descriptionDone = ['Set build summary']
-    alwaysRun = True
-    haltOnFailure = False
-    flunkOnFailure = False
-
-    def doStepIf(self, step):
-        return self.getProperty('build_summary', False)
-
-    def hideStepIf(self, results, step):
-        return not self.doStepIf(step)
-
-    def start(self):
-        build_summary = self.getProperty('build_summary', 'build successful')
-        self.finished(SUCCESS)
-        previous_build_summary = self.getProperty('build_summary', '')
-        if RunWebKitTestsInStressMode.FAILURE_MSG_IN_STRESS_MODE in previous_build_summary:
-            self.build.results = FAILURE
-        elif any(s in previous_build_summary for s in ('Committed ', '@', 'Passed', 'Ignored pre-existing failure')):
-            self.build.results = SUCCESS
-        self.build.buildFinished([build_summary], self.build.results)
-        return defer.succeed(None)
 
 
 class PushCommitToWebKitRepo(shell.ShellCommand):


### PR DESCRIPTION
#### 3353e5ee1407fe48cf39357c8f2fac5d6b027da9
<pre>
[build-webkit] Clean up smart-pointer-result-archive from worker after uploading results
<a href="https://bugs.webkit.org/show_bug.cgi?id=293930">https://bugs.webkit.org/show_bug.cgi?id=293930</a>
<a href="https://rdar.apple.com/147597769">rdar://147597769</a>

Reviewed by Aakash Jain.

Delete the archive dir from the current build.

* Tools/CISupport/Shared/steps.py: Move SetBuildSummary to Shared.
(SetBuildSummary):
(SetBuildSummary.doStepIf):
(SetBuildSummary.hideStepIf):
(SetBuildSummary.start):

* Tools/CISupport/build-webkit-org/steps.py:
(ScanBuild.run): Add CleanSaferCPPArchive in steps to add after completing a build.
(ParseStaticAnalyzerResults.run): Use SAFER_CPP_ARCHIVE_DIR.
(FindUnexpectedStaticAnalyzerResults.run): Use SAFER_CPP_ARCHIVE_DIR.
(DisplaySaferCPPResults):
(DisplaySaferCPPResults.getResultSummary):
(UpdateSaferCPPBaseline.run): Use SAFER_CPP_ARCHIVE_DIR.
(CleanSaferCPPArchive):
(CleanSaferCPPArchive.__init__):
(CleanSaferCPPArchive.run): Remove SAFER_CPP_ARCHIVE_DIR.
* Tools/CISupport/build-webkit-org/steps_unittest.py:
* Tools/CISupport/ews-build/steps.py:
(SetBuildSummary): Deleted.
(SetBuildSummary.doStepIf): Deleted.
(SetBuildSummary.hideStepIf): Deleted.
(SetBuildSummary.start): Deleted.

Canonical link: <a href="https://commits.webkit.org/296324@main">https://commits.webkit.org/296324@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6b6fafd2760b6a420575d7900752cedd74b84065

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108058 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27723 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18142 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/113268 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/58571 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/110021 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/28417 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/36272 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82035 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111006 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22519 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97354 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62467 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/21931 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/15489 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58014 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/91871 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15553 "Found 2 new test failures: imported/w3c/web-platform-tests/url/IdnaTestV2.window.html imported/w3c/web-platform-tests/url/toascii.window.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/116393 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35127 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/25867 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91063 "Passed tests") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/107554 "Passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/35503 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93632 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/90857 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35756 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13519 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/30969 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17473 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35027 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34767 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38125 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/36429 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->