### PR TITLE
[Web Inspector] Fix Need to press Tab twice to apply suggestion in Console

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Controllers/CodeMirrorCompletionController.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/CodeMirrorCompletionController.js
@@ -844,7 +844,7 @@ WI.CodeMirrorCompletionController = class CodeMirrorCompletionController extends
             var completion = this._completions[i];
             var lastIndex = Math.min(commonPrefix.length, completion.length);
             for (var j = prefixLength; j < lastIndex; ++j) {
-                if (commonPrefix[j] !== completion[j]) {
+                if (commonPrefix[j].toLowerCase() !== completion[j].toLowerCase()) {
                     commonPrefix = commonPrefix.substr(0, j);
                     break;
                 }


### PR DESCRIPTION
#### f04d1b70a3a96dc2f044c3b39d13b44f3343e431
<pre>
[Web Inspector] Fix Need to press Tab twice to apply suggestion in Console
<a href="https://bugs.webkit.org/show_bug.cgi?id=293704">https://bugs.webkit.org/show_bug.cgi?id=293704</a>

Reviewed by NOBODY (OOPS!).

Autocompletion sometimes required pressing the Tab key twice to work.
This happened because, when matching the prefix with possible completions,
Rhe code did not normalize the prefix and completion values to either uppercase or lowercase.
So, while typing doc, for example, the Doc prefix from Document was being treated as a different prefix.
To fix this bug, this patch apply lowercase to prefix and completions before comparing them.

* Source/WebInspectorUI/UserInterface/Controllers/CodeMirrorCompletionController.js:
(WI.CodeMirrorCompl etionController.prototype._generateJavaScriptCompletions):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f04d1b70a3a96dc2f044c3b39d13b44f3343e431

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105979 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25728 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/16122 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/111175 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/56575 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/26372 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34231 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80502 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108983 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/20795 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95642 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60822 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/20417 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13739 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/56013 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/90177 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13775 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/114029 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33117 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24436 "Found 3 new test failures: imported/w3c/web-platform-tests/mimesniff/media/media-sniff.window.html platform/mac/fast/text/line-break-locale.html svg/zoom/page/text-with-non-scaling-stroke.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89582 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33481 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91870 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89263 "Found 99 new API test failures: /TestWebKit:WebKit.PageLoadDidChangeLocationWithinPage, /TestWebKit:WebKit.AboutBlankLoad, /TestWebKit:WebKit.PreventEmptyUserAgent, /TestWebKit:WebKit.PrivateBrowsingPushStateNoHistoryCallback, /WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/content-type, /WebKitGTK/TestUIClient:/webkit/WebKitWebView/pointer-lock-permission-request, /TestWebKit:WebKit.HitTestResultNodeHandle, /TestWebKit:WebKit2TextFieldBeginAndEditEditingTest.TextFieldDidBeginShouldNotBeDispatchedForAlreadyFocusedField, /TestWebKit:WebKit.Find, /WebKitGTK/TestWebProcessExtensions:/webkit/WebKitWebProcessExtension/dom-input-element-is-user-edited ... (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34128 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11942 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/28656 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/33042 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/38453 "Build is in progress. Recent messages:OS: Sequoia (15.5), Xcode: 16.4; Checked out pull request; Found 79528 issues") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32788 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/36137 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34386 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->