### PR TITLE
Further reduce use of Vector::data() in the codebase

### DIFF
--- a/Source/WTF/wtf/StreamBuffer.h
+++ b/Source/WTF/wtf/StreamBuffer.h
@@ -94,7 +94,7 @@ public:
         if (!m_size)
             return 0;
         ASSERT(m_buffer.size() > 0);
-        return &m_buffer.first()->data()[m_readOffset];
+        return &m_buffer.first()->at(m_readOffset);
     }
 
     size_t firstBlockSize() const

--- a/Source/WTF/wtf/cocoa/SpanCocoa.h
+++ b/Source/WTF/wtf/cocoa/SpanCocoa.h
@@ -27,6 +27,7 @@
 
 #import <dispatch/dispatch.h>
 #import <span>
+#import <wtf/RetainPtr.h>
 
 namespace WTF {
 

--- a/Source/WebCore/page/ios/FrameIOS.mm
+++ b/Source/WebCore/page/ios/FrameIOS.mm
@@ -789,7 +789,7 @@ NSArray *LocalFrame::interpretationsForCurrentRoot() const
     }
 
     return createNSArray(interpretations, [] (auto& interpretation) {
-        return adoptNS([[NSString alloc] initWithCharacters:reinterpret_cast<const unichar*>(interpretation.data()) length:interpretation.size()]);
+        return adoptNS([[NSString alloc] initWithCharacters:reinterpret_cast<const unichar*>(interpretation.span().data()) length:interpretation.size()]);
     }).autorelease();
 }
 

--- a/Source/WebCore/platform/graphics/GCGLSpan.h
+++ b/Source/WebCore/platform/graphics/GCGLSpan.h
@@ -44,7 +44,7 @@ struct GCGLSpanTuple {
                 RELEASE_ASSERT(((otherVectors.size() == size) && ...));
                 return size;
             }(dataVectors...))
-        , dataTuple { dataVectors.data()... }
+        , dataTuple { dataVectors.span().data()... }
     { }
 
     template<unsigned I>

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.cpp
@@ -404,7 +404,7 @@ void RemoteGraphicsContextGL::multiDrawElementsANGLE(uint32_t mode, IPC::ArrayRe
     const Vector<GCGLsizei> counts = vectorCopyCast<GCGLsizei, 0>(countsAndOffsets);
     // Currently offsets are copied in the m_context.
     const GCGLsizei* offsets = reinterpret_cast<const GCGLsizei*>(countsAndOffsets.data<1>());
-    protectedContext()->multiDrawElementsANGLE(mode, GCGLSpanTuple { counts.data(), offsets, counts.size() }, type);
+    protectedContext()->multiDrawElementsANGLE(mode, GCGLSpanTuple { counts.span().data(), offsets, counts.size() }, type);
 }
 
 void RemoteGraphicsContextGL::multiDrawElementsInstancedANGLE(uint32_t mode, IPC::ArrayReferenceTuple<int32_t, int32_t, int32_t>&& countsOffsetsAndInstanceCounts, uint32_t type)
@@ -415,7 +415,7 @@ void RemoteGraphicsContextGL::multiDrawElementsInstancedANGLE(uint32_t mode, IPC
     // Currently offsets are copied in the m_context.
     const GCGLsizei* offsets = reinterpret_cast<const GCGLsizei*>(countsOffsetsAndInstanceCounts.data<1>());
     const Vector<GCGLsizei> instanceCounts = vectorCopyCast<GCGLsizei, 2>(countsOffsetsAndInstanceCounts);
-    protectedContext()->multiDrawElementsInstancedANGLE(mode, GCGLSpanTuple { counts.data(), offsets, instanceCounts.data(), counts.size() }, type);
+    protectedContext()->multiDrawElementsInstancedANGLE(mode, GCGLSpanTuple { counts.span().data(), offsets, instanceCounts.span().data(), counts.size() }, type);
 }
 
 void RemoteGraphicsContextGL::multiDrawArraysInstancedBaseInstanceANGLE(uint32_t mode, IPC::ArrayReferenceTuple<int32_t, int32_t, int32_t, uint32_t>&& firstsCountsInstanceCountsAndBaseInstances)
@@ -439,7 +439,7 @@ void RemoteGraphicsContextGL::multiDrawElementsInstancedBaseVertexBaseInstanceAN
     const Vector<GCGLsizei> instanceCounts = vectorCopyCast<GCGLsizei, 2>(countsOffsetsInstanceCountsBaseVerticesAndBaseInstances);
     const Vector<GCGLint> baseVertices = vectorCopyCast<GCGLint, 3>(countsOffsetsInstanceCountsBaseVerticesAndBaseInstances);
     const Vector<GCGLuint> baseInstances = vectorCopyCast<GCGLuint, 4>(countsOffsetsInstanceCountsBaseVerticesAndBaseInstances);
-    protectedContext()->multiDrawElementsInstancedBaseVertexBaseInstanceANGLE(mode, GCGLSpanTuple { counts.data(), offsets, instanceCounts.data(), baseVertices.data(), baseInstances.data(), counts.size() }, type);
+    protectedContext()->multiDrawElementsInstancedBaseVertexBaseInstanceANGLE(mode, GCGLSpanTuple { counts.span().data(), offsets, instanceCounts.span().data(), baseVertices.span().data(), baseInstances.span().data(), counts.size() }, type);
 }
 
 RefPtr<RemoteGraphicsContextGL::GCGLContext> RemoteGraphicsContextGL::protectedContext()

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
@@ -2369,7 +2369,7 @@ void NetworkSessionCocoa::setProxyConfigData(const Vector<std::pair<Vector<uint8
         else
             zeroBytes(identifier);
 
-        auto nwProxyConfig = adoptNS(createProxyConfig(config.first.data(), config.first.size(), identifier));
+        auto nwProxyConfig = adoptNS(createProxyConfig(config.first.span().data(), config.first.size(), identifier));
 
         if (requiresHTTPProtocols(nwProxyConfig.get()))
             recreateSessions = true;

--- a/Source/WebKit/Platform/IPC/cocoa/ConnectionCocoa.mm
+++ b/Source/WebKit/Platform/IPC/cocoa/ConnectionCocoa.mm
@@ -467,7 +467,7 @@ static mach_msg_header_t* readFromMachPort(mach_port_t machPort, ReceiveBuffer& 
 
     buffer.resize(receiveBufferSize);
 
-    mach_msg_header_t* header = reinterpret_cast<mach_msg_header_t*>(buffer.data());
+    auto* header = &reinterpretCastSpanStartTo<mach_msg_header_t>(buffer.mutableSpan());
     kern_return_t kr = mach_msg(header, MACH_RCV_MSG | MACH_RCV_LARGE | MACH_RCV_TIMEOUT | MACH_RCV_VOUCHER, 0, buffer.size(), machPort, 0, MACH_PORT_NULL);
     if (kr == MACH_RCV_TIMED_OUT)
         return nullptr;
@@ -478,7 +478,7 @@ static mach_msg_header_t* readFromMachPort(mach_port_t machPort, ReceiveBuffer& 
         if (newBufferSize.hasOverflowed())
             return nullptr;
         buffer.resize(newBufferSize);
-        header = reinterpret_cast<mach_msg_header_t*>(buffer.data());
+        header = &reinterpretCastSpanStartTo<mach_msg_header_t>(buffer.mutableSpan());
 
         kr = mach_msg(header, MACH_RCV_MSG | MACH_RCV_LARGE | MACH_RCV_TIMEOUT | MACH_RCV_VOUCHER, 0, buffer.size(), machPort, 0, MACH_PORT_NULL);
         ASSERT(kr != MACH_RCV_TOO_LARGE);

--- a/Source/WebKit/Platform/classifier/cocoa/ResourceLoadStatisticsClassifierCocoa.cpp
+++ b/Source/WebKit/Platform/classifier/cocoa/ResourceLoadStatisticsClassifierCocoa.cpp
@@ -54,7 +54,7 @@ bool ResourceLoadStatisticsClassifierCocoa::classify(unsigned subresourceUnderTo
     features.append({-1, -1});
 
     double score;
-    int classification = svm_predict_values(singletonPredictionModel(), features.data(), &score);
+    int classification = svm_predict_values(singletonPredictionModel(), features.span().data(), &score);
     LOG(ResourceLoadStatistics, "ResourceLoadStatisticsClassifierCocoa::classify(): Classified with CorePrediction.");
     return classification < 0;
 }

--- a/Source/WebKit/Shared/ApplePay/cocoa/WebPaymentCoordinatorProxyCocoa.mm
+++ b/Source/WebKit/Shared/ApplePay/cocoa/WebPaymentCoordinatorProxyCocoa.mm
@@ -125,7 +125,7 @@ static RetainPtr<NSSet> toPKContactFields(const WebCore::ApplePaySessionPaymentR
     if (contactFields.phoneticName)
         result.append(PKContactFieldPhoneticName);
 
-    return adoptNS([[NSSet alloc] initWithObjects:result.data() count:result.size()]);
+    return adoptNS([[NSSet alloc] initWithObjects:result.span().data() count:result.size()]);
 }
 
 PKMerchantCapability toPKMerchantCapabilities(const WebCore::ApplePaySessionPaymentRequest::MerchantCapabilities& merchantCapabilities)

--- a/Source/WebKit/Shared/Cocoa/CoreIPCCFURL.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCCFURL.mm
@@ -38,7 +38,7 @@ std::optional<CoreIPCCFURL> CoreIPCCFURL::createWithBaseURLAndBytes(std::optiona
     }
 
     RetainPtr baseCFURL = baseURL ? baseURL->m_cfURL.get() : nullptr;
-    if (RetainPtr newCFURL = adoptCF(CFURLCreateAbsoluteURLWithBytes(nullptr, bytes.data(), bytes.size(), kCFStringEncodingUTF8, baseCFURL.get(), true)))
+    if (RetainPtr newCFURL = adoptCF(CFURLCreateAbsoluteURLWithBytes(nullptr, bytes.span().data(), bytes.size(), kCFStringEncodingUTF8, baseCFURL.get(), true)))
         return CoreIPCCFURL { WTFMove(newCFURL) };
 
     return std::nullopt;
@@ -56,7 +56,7 @@ Vector<uint8_t> CoreIPCCFURL::toVector() const
     auto bytesLength = CFURLGetBytes(m_cfURL.get(), nullptr, 0);
     RELEASE_ASSERT(bytesLength != -1);
     Vector<uint8_t> result(bytesLength);
-    CFURLGetBytes(m_cfURL.get(), result.data(), bytesLength);
+    CFURLGetBytes(m_cfURL.get(), result.mutableSpan().data(), bytesLength);
 
     return result;
 }

--- a/Source/WebKit/Shared/Extensions/WebExtensionUtilities.cpp
+++ b/Source/WebKit/Shared/Extensions/WebExtensionUtilities.cpp
@@ -139,7 +139,7 @@ ALLOW_NONLITERAL_FORMAT_BEGIN
     Vector<char, 256> buffer;
     buffer.grow(result + 1);
 
-    vsnprintf(buffer.data(), buffer.size(), format, args);
+    vsnprintf(buffer.mutableSpan().data(), buffer.size(), format, args);
     va_end(args);
 
     return StringImpl::create(buffer.subspan(0, buffer.size() - 1));

--- a/Source/WebKit/Shared/RTCNetwork.cpp
+++ b/Source/WebKit/Shared/RTCNetwork.cpp
@@ -49,7 +49,7 @@ RTCNetwork::RTCNetwork(Vector<char>&& name, Vector<char>&& description, IPAddres
 
 rtc::Network RTCNetwork::value() const
 {
-    rtc::Network network({ name.data(), name.size() }, { description.data(), description.size() }, prefix.rtcAddress(), prefixLength, rtc::AdapterType(type));
+    rtc::Network network({ name.span().data(), name.size() }, { description.span().data(), description.size() }, prefix.rtcAddress(), prefixLength, rtc::AdapterType(type));
     network.set_id(id);
     network.set_preference(preference);
     network.set_active(active);
@@ -89,7 +89,7 @@ rtc::SocketAddress SocketAddress::rtcAddress() const
     rtc::SocketAddress result;
     result.SetPort(port);
     result.SetScopeID(scopeID);
-    result.SetIP({ hostname.data(), hostname.size() });
+    result.SetIP({ hostname.span().data(), hostname.size() });
     if (ipAddress)
         result.SetResolvedIP(ipAddress->rtcAddress());
     return result;

--- a/Source/WebKit/Shared/cf/CookieStorageUtilsCF.mm
+++ b/Source/WebKit/Shared/cf/CookieStorageUtilsCF.mm
@@ -37,8 +37,8 @@ RetainPtr<CFHTTPCookieStorageRef> cookieStorageFromIdentifyingData(const Vector<
     ASSERT(!data.isEmpty());
     ASSERT(hasProcessPrivilege(ProcessPrivilege::CanAccessRawCookies));
 
-    auto cookieStorageData = adoptCF(CFDataCreate(kCFAllocatorDefault, data.data(), data.size()));
-    auto cookieStorage = adoptCF(CFHTTPCookieStorageCreateFromIdentifyingData(kCFAllocatorDefault, cookieStorageData.get()));
+    RetainPtr cookieStorageData = toCFData(data.span());
+    RetainPtr cookieStorage = adoptCF(CFHTTPCookieStorageCreateFromIdentifyingData(kCFAllocatorDefault, cookieStorageData.get()));
     ASSERT(cookieStorage);
 
     CFHTTPCookieStorageScheduleWithRunLoop(cookieStorage.get(), [NSURLConnection resourceLoaderRunLoop], kCFRunLoopCommonModes);

--- a/Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm
+++ b/Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm
@@ -551,7 +551,7 @@ static bool compileAndApplySandboxSlowCase(const String& profileOrProfilePath, b
     uint64_t flags = isProfilePath ? SANDBOX_NAMED_EXTERNAL : 0;
 
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    if (sandbox_init_with_parameters(temp.data(), flags, parameters.namedParameterVector().data(), &errorBuf)) {
+    if (sandbox_init_with_parameters(temp.data(), flags, parameters.namedParameterVector().span().data(), &errorBuf)) {
 ALLOW_DEPRECATED_DECLARATIONS_END
         WTFLogAlways("%s: Could not initialize sandbox profile [%s], error '%s'\n", getprogname(), temp.data(), errorBuf);
         for (size_t i = 0, count = parameters.count(); i != count; ++i)

--- a/Source/WebKit/UIProcess/API/C/WKPage.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKPage.cpp
@@ -2901,7 +2901,7 @@ void WKPageComputePagesForPrinting(WKPageRef pageRef, WKFrameRef frame, WKPrintI
         Vector<WKRect> wkRects(rects.size());
         for (size_t i = 0; i < rects.size(); ++i)
             wkRects[i] = toAPI(rects[i]);
-        callback(wkRects.data(), wkRects.size(), scaleFactor, nullptr, context);
+        callback(wkRects.mutableSpan().data(), wkRects.size(), scaleFactor, nullptr, context);
     });
 }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTouchEventGenerator.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTouchEventGenerator.mm
@@ -284,7 +284,7 @@ static void delayBetweenMove(int eventIndex, double elapsed)
 - (void)touchDown:(CGPoint)location touchCount:(NSUInteger)touchCount window:(UIWindow *)window
 {
     Vector<CGPoint, HIDMaxTouchCount> locations(std::min(touchCount, HIDMaxTouchCount), location);
-    [self touchDownAtPoints:locations.data() touchCount:locations.size() window:window];
+    [self touchDownAtPoints:locations.mutableSpan().data() touchCount:locations.size() window:window];
 }
 
 - (void)liftUpAtPoints:(CGPoint*)rawLocations touchCount:(NSUInteger)touchCount window:(UIWindow *)window
@@ -307,7 +307,7 @@ static void delayBetweenMove(int eventIndex, double elapsed)
 - (void)liftUp:(CGPoint)location touchCount:(NSUInteger)touchCount window:(UIWindow *)window
 {
     Vector<CGPoint, HIDMaxTouchCount> locations(std::min(touchCount, HIDMaxTouchCount), location);
-    [self liftUpAtPoints:locations.data() touchCount:locations.size() window:window];
+    [self liftUpAtPoints:locations.mutableSpan().data() touchCount:locations.size() window:window];
 }
 
 - (void)moveToPoints:(CGPoint*)rawNewLocations touchCount:(NSUInteger)touchCount duration:(NSTimeInterval)seconds window:(UIWindow *)window

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalAuthenticator.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalAuthenticator.mm
@@ -548,9 +548,9 @@ void LocalAuthenticator::continueMakeCredentialAfterUserVerification(SecAccessCo
     {
         // COSE Encoding
         Vector<uint8_t> x(ES256FieldElementLength);
-        [nsPublicKeyData getBytes: x.data() range:NSMakeRange(1, ES256FieldElementLength)];
+        [nsPublicKeyData getBytes:x.mutableSpan().data() range:NSMakeRange(1, ES256FieldElementLength)];
         Vector<uint8_t> y(ES256FieldElementLength);
-        [nsPublicKeyData getBytes: y.data() range:NSMakeRange(1 + ES256FieldElementLength, ES256FieldElementLength)];
+        [nsPublicKeyData getBytes:y.mutableSpan().data() range:NSMakeRange(1 + ES256FieldElementLength, ES256FieldElementLength)];
         cosePublicKey = encodeES256PublicKeyAsCBOR(WTFMove(x), WTFMove(y));
     }
 
@@ -712,8 +712,8 @@ void LocalAuthenticator::continueGetAssertionAfterUserVerification(Ref<WebCore::
         }
         auto privateKey = adoptCF(privateKeyRef);
 
-        RetainPtr dataToSign = adoptNS([[NSMutableData alloc] initWithBytes:authData.data() length:authData.size()]);
-        [dataToSign appendBytes:requestData().hash.data() length:requestData().hash.size()];
+        RetainPtr dataToSign = adoptNS([[NSMutableData alloc] initWithBytes:authData.span().data() length:authData.size()]);
+        [dataToSign appendBytes:requestData().hash.span().data() length:requestData().hash.size()];
 
         CFErrorRef errorRef = nullptr;
         // FIXME: Converting CFTypeRef to SecKeyRef is quite subtle here.

--- a/Source/WebKit/UIProcess/WebAuthentication/Virtual/VirtualAuthenticatorUtils.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Virtual/VirtualAuthenticatorUtils.mm
@@ -88,9 +88,9 @@ std::pair<Vector<uint8_t>, Vector<uint8_t>> credentialIdAndCosePubKeyForPrivateK
     {
         // COSE Encoding
         Vector<uint8_t> x(ES256FieldElementLength);
-        [nsPublicKeyData getBytes: x.data() range:NSMakeRange(1, ES256FieldElementLength)];
+        [nsPublicKeyData getBytes:x.mutableSpan().data() range:NSMakeRange(1, ES256FieldElementLength)];
         Vector<uint8_t> y(ES256FieldElementLength);
-        [nsPublicKeyData getBytes: y.data() range:NSMakeRange(1 + ES256FieldElementLength, ES256FieldElementLength)];
+        [nsPublicKeyData getBytes:y.mutableSpan().data() range:NSMakeRange(1 + ES256FieldElementLength, ES256FieldElementLength)];
         cosePublicKey = encodeES256PublicKeyAsCBOR(WTFMove(x), WTFMove(y));
     }
     return std::pair { credentialId, cosePublicKey };
@@ -128,8 +128,8 @@ RetainPtr<SecKeyRef> privateKeyFromBase64(const String& base64PrivateKey)
 
 Vector<uint8_t> signatureForPrivateKey(RetainPtr<SecKeyRef> privateKey, const Vector<uint8_t>& authData, const Vector<uint8_t>& clientDataHash)
 {
-    RetainPtr dataToSign = adoptNS([[NSMutableData alloc] initWithBytes:authData.data() length:authData.size()]);
-    [dataToSign appendBytes:clientDataHash.data() length:clientDataHash.size()];
+    RetainPtr dataToSign = adoptNS([[NSMutableData alloc] initWithBytes:authData.span().data() length:authData.size()]);
+    [dataToSign appendBytes:clientDataHash.span().data() length:clientDataHash.size()];
     RetainPtr<CFDataRef> signature;
     {
         CFErrorRef errorRef = nullptr;

--- a/Source/WebKit/UIProcess/mac/LegacySessionStateCoding.cpp
+++ b/Source/WebKit/UIProcess/mac/LegacySessionStateCoding.cpp
@@ -419,7 +419,7 @@ static RetainPtr<CFDictionaryRef> createDictionary(std::initializer_list<std::pa
         values.append(keyValuePair.second);
     }
 
-    return adoptCF(CFDictionaryCreate(kCFAllocatorDefault, keys.data(), values.data(), keyValuePairs.size(), &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
+    return adoptCF(CFDictionaryCreate(kCFAllocatorDefault, keys.mutableSpan().data(), values.mutableSpan().data(), keyValuePairs.size(), &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
 }
 
 static RetainPtr<CFDictionaryRef> encodeSessionHistory(const BackForwardListState& backForwardListState)

--- a/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp
+++ b/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp
@@ -92,7 +92,7 @@ static JSObjectRef toJSArray(JSContextRef context, const Vector<T>& data, JSValu
         return convertedValue;
     });
 
-    JSObjectRef array = JSObjectMakeArray(context, convertedData.size(), convertedData.data(), exception);
+    JSObjectRef array = JSObjectMakeArray(context, convertedData.size(), convertedData.span().data(), exception);
 
     for (auto& convertedValue : convertedData)
         JSValueUnprotect(context, convertedValue);

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBufferProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBufferProxy.cpp
@@ -72,7 +72,7 @@ void RemoteBufferProxy::getMappedRange(WebCore::WebGPU::Size64 offset, std::opti
     auto sendResult = sendSync(Messages::RemoteBuffer::GetMappedRange(offset, size));
     auto [data] = sendResult.takeReplyOr(std::nullopt);
 
-    if (!data || !data->data() || offsetOrSizeExceedsBounds(data->size(), offset, size)) {
+    if (!data || !data->span().data() || offsetOrSizeExceedsBounds(data->size(), offset, size)) {
         callback({ });
         return;
     }

--- a/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKDOMTextIterator.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKDOMTextIterator.mm
@@ -85,7 +85,7 @@
         _upconvertedText.appendRange(characters.begin(), characters.end());
     }
     ASSERT(_upconvertedText.size() == text.length());
-    return _upconvertedText.data();
+    return _upconvertedText.span().data();
 }
 
 - (NSUInteger)currentTextLength

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDataDetectorOverlayController.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDataDetectorOverlayController.mm
@@ -112,7 +112,7 @@ static RetainPtr<DDHighlightRef> createPlatformDataDetectorHighlight(Vector<Floa
     BOOL drawFlipped = YES;
     float targetSurfaceBackingScaleFactor = 0;
 
-    return adoptCF(PAL::softLink_DataDetectors_DDHighlightCreateWithRectsInVisibleRectWithStyleScaleAndDirection(nullptr, highlightBoundsCG.data(), highlightBounds.size(), visibleContentRect, style, drawButton, writingDirection, endsWithEOL, drawFlipped, targetSurfaceBackingScaleFactor));
+    return adoptCF(PAL::softLink_DataDetectors_DDHighlightCreateWithRectsInVisibleRectWithStyleScaleAndDirection(nullptr, highlightBoundsCG.mutableSpan().data(), highlightBounds.size(), visibleContentRect, style, drawButton, writingDirection, endsWithEOL, drawFlipped, targetSurfaceBackingScaleFactor));
 }
 
 RetainPtr<DDHighlightRef> PDFDataDetectorOverlayController::createPlatformDataDetectorHighlight(PDFDataDetectorItem& dataDetectorItem) const

--- a/Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp
+++ b/Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp
@@ -2797,7 +2797,7 @@ JSValueRef JSIPC::serializedEnumInfo(JSContextRef context, JSObjectRef thisObjec
         auto validValuesArray = WTF::map(enumeration.validValues, [&](auto& validValue) -> JSValueRef {
             return JSValueMakeNumber(context, validValue);
         });
-        JSObjectRef jsValidValues = JSObjectMakeArray(context, enumeration.validValues.size(), validValuesArray.data(), exception);
+        JSObjectRef jsValidValues = JSObjectMakeArray(context, enumeration.validValues.size(), validValuesArray.span().data(), exception);
         if (*exception)
             return JSValueMakeUndefined(context);
 

--- a/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
+++ b/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
@@ -343,7 +343,7 @@ static void setVideoDecoderBehaviors(OptionSet<VideoDecoderBehavior> videoDecode
     flags |= kVTRestrictions_RegisterLimitedSystemDecodersWithoutValidation;
 #endif
 
-    PAL::softLinkVideoToolboxVTRestrictVideoDecoders(flags, allowedCodecTypeList.data(), allowedCodecTypeList.size());
+    PAL::softLinkVideoToolboxVTRestrictVideoDecoders(flags, allowedCodecTypeList.span().data(), allowedCodecTypeList.size());
 }
 
 void WebProcess::platformInitializeWebProcess(WebProcessCreationParameters& parameters)

--- a/Source/WebKitLegacy/WebCoreSupport/SocketStreamHandleImpl.cpp
+++ b/Source/WebKitLegacy/WebCoreSupport/SocketStreamHandleImpl.cpp
@@ -117,7 +117,7 @@ void SocketStreamHandleImpl::platformSendHandshake(std::span<const uint8_t> data
             return completionHandler(false, secureCookiesAccessed);
         }
         m_buffer.append(data);
-        m_buffer.append(cookieData.data(), cookieData.size());
+        m_buffer.append(cookieData.span());
         m_client.didUpdateBufferedAmount(*this, bufferedAmount());
         return completionHandler(true, secureCookiesAccessed);
     }
@@ -144,7 +144,7 @@ void SocketStreamHandleImpl::platformSendHandshake(std::span<const uint8_t> data
             m_buffer.append(data.subspan(bytesWritten));
         else
             cookieBytesWritten = bytesWritten - data.size();
-        m_buffer.append(cookieData.data() + cookieBytesWritten, cookieData.size() - cookieBytesWritten);
+        m_buffer.append(cookieData.subspan(cookieBytesWritten));
         m_client.didUpdateBufferedAmount(static_cast<SocketStreamHandle&>(*this), bufferedAmount());
     }
     return completionHandler(true, secureCookiesAccessed);

--- a/Source/WebKitLegacy/WebCoreSupport/WebSocketChannel.cpp
+++ b/Source/WebKitLegacy/WebCoreSupport/WebSocketChannel.cpp
@@ -539,8 +539,8 @@ bool WebSocketChannel::processFrame()
         return false;
     }
 
-    ASSERT(m_buffer.data() < frameEnd);
-    ASSERT(frameEnd <= m_buffer.data() + m_buffer.size());
+    ASSERT(m_buffer.begin() < frameEnd);
+    ASSERT(frameEnd <= m_buffer.end());
 
     auto inflateResult = m_deflateFramer.inflate(frame);
     if (!inflateResult->succeeded()) {
@@ -594,7 +594,7 @@ bool WebSocketChannel::processFrame()
             return false;
         }
         m_continuousFrameData.append(frame.payload);
-        skipBuffer(frameEnd - m_buffer.data());
+        skipBuffer(frameEnd - m_buffer.begin());
         if (frame.final) {
             // onmessage handler may eventually call the other methods of this channel,
             // so we should pretend that we have finished to read this frame and
@@ -624,7 +624,7 @@ bool WebSocketChannel::processFrame()
                 message = String::fromUTF8(frame.payload);
             else
                 message = emptyString();
-            skipBuffer(frameEnd - m_buffer.data());
+            skipBuffer(frameEnd - m_buffer.begin());
             if (message.isNull())
                 fail("Could not decode a text frame as UTF-8."_s);
             else
@@ -634,21 +634,21 @@ bool WebSocketChannel::processFrame()
             m_continuousFrameOpCode = WebSocketFrame::OpCodeText;
             ASSERT(m_continuousFrameData.isEmpty());
             m_continuousFrameData.append(frame.payload);
-            skipBuffer(frameEnd - m_buffer.data());
+            skipBuffer(frameEnd - m_buffer.begin());
         }
         break;
 
     case WebSocketFrame::OpCodeBinary:
         if (frame.final) {
             Vector<uint8_t> binaryData(frame.payload);
-            skipBuffer(frameEnd - m_buffer.data());
+            skipBuffer(frameEnd - m_buffer.begin());
             protectedClient()->didReceiveBinaryData(WTFMove(binaryData));
         } else {
             m_hasContinuousFrame = true;
             m_continuousFrameOpCode = WebSocketFrame::OpCodeBinary;
             ASSERT(m_continuousFrameData.isEmpty());
             m_continuousFrameData.append(frame.payload);
-            skipBuffer(frameEnd - m_buffer.data());
+            skipBuffer(frameEnd - m_buffer.begin());
         }
         break;
 
@@ -671,7 +671,7 @@ bool WebSocketChannel::processFrame()
             m_closeEventReason = String::fromUTF8({ &frame.payload[2], frame.payload.size() - 2 });
         else
             m_closeEventReason = emptyString();
-        skipBuffer(frameEnd - m_buffer.data());
+        skipBuffer(frameEnd - m_buffer.begin());
         m_receivedClosingHandshake = true;
         startClosingHandshake(m_closeEventCode, m_closeEventReason);
         if (m_closing) {
@@ -683,19 +683,19 @@ bool WebSocketChannel::processFrame()
 
     case WebSocketFrame::OpCodePing:
         enqueueRawFrame(WebSocketFrame::OpCodePong, frame.payload);
-        skipBuffer(frameEnd - m_buffer.data());
+        skipBuffer(frameEnd - m_buffer.begin());
         processOutgoingFrameQueue();
         break;
 
     case WebSocketFrame::OpCodePong:
         // A server may send a pong in response to our ping, or an unsolicited pong which is not associated with
         // any specific ping. Either way, there's nothing to do on receipt of pong.
-        skipBuffer(frameEnd - m_buffer.data());
+        skipBuffer(frameEnd - m_buffer.begin());
         break;
 
     default:
         ASSERT_NOT_REACHED();
-        skipBuffer(frameEnd - m_buffer.data());
+        skipBuffer(frameEnd - m_buffer.begin());
         break;
     }
 

--- a/Source/WebKitLegacy/mac/Misc/WebKitNSStringExtras.mm
+++ b/Source/WebKitLegacy/mac/Misc/WebKitNSStringExtras.mm
@@ -65,7 +65,7 @@ static bool canUseFastRenderer(std::span<const UniChar> buffer)
 
     unsigned length = [self length];
     Vector<UniChar, 2048> buffer(length);
-    [self getCharacters:buffer.data()];
+    [self getCharacters:buffer.mutableSpan().data()];
 
     if (canUseFastRenderer(buffer)) {
         FontCascade webCoreFont(FontPlatformData((__bridge CTFontRef)font, [font pointSize]));
@@ -105,7 +105,7 @@ static bool canUseFastRenderer(std::span<const UniChar> buffer)
 {
     unsigned length = [self length];
     Vector<UniChar, 2048> buffer(length);
-    [self getCharacters:buffer.data()];
+    [self getCharacters:buffer.mutableSpan().data()];
 
     if (canUseFastRenderer(buffer)) {
         FontCascade webCoreFont(FontPlatformData((__bridge CTFontRef)font, [font pointSize]));

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebVisitedLinkStore.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebVisitedLinkStore.mm
@@ -91,9 +91,9 @@ void WebVisitedLinkStore::addVisitedLink(NSString *urlString)
     }
 
     Vector<UniChar, 512> buffer(length);
-    [urlString getCharacters:buffer.data()];
+    [urlString getCharacters:buffer.mutableSpan().data()];
 
-    addVisitedLinkHash(computeSharedStringHash(std::span { reinterpret_cast<const UChar*>(buffer.data()), length }));
+    addVisitedLinkHash(computeSharedStringHash(spanReinterpretCast<const UChar>(buffer.span())));
 }
 
 void WebVisitedLinkStore::removeVisitedLink(NSString *urlString)

--- a/Source/WebKitLegacy/mac/WebView/WebTextIterator.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebTextIterator.mm
@@ -115,7 +115,7 @@
         _private->_upconvertedText.appendRange(characters.begin(), characters.end());
     }
     ASSERT(_private->_upconvertedText.size() == text.length());
-    return _private->_upconvertedText.data();
+    return _private->_upconvertedText.span().data();
 }
 
 - (NSUInteger)currentTextLength

--- a/Tools/DumpRenderTree/PixelDumpSupport.cpp
+++ b/Tools/DumpRenderTree/PixelDumpSupport.cpp
@@ -120,7 +120,7 @@ void printPNG(const unsigned char* data, const size_t dataLength, const char* ch
     size_t insertOffset = offsetAfterIHDRChunk(data, dataLength);
 
     fwrite(data, 1, insertOffset, testResult);
-    fwrite(bytesToAdd.data(), 1, bytesToAdd.size(), testResult);
+    fwrite(bytesToAdd.span().data(), 1, bytesToAdd.size(), testResult);
 
     const size_t bytesToWriteInOneChunk = 1 << 15;
     data += insertOffset;

--- a/Tools/DumpRenderTree/ios/AccessibilityUIElementIOS.mm
+++ b/Tools/DumpRenderTree/ios/AccessibilityUIElementIOS.mm
@@ -137,15 +137,15 @@ AccessibilityUIElement::AccessibilityUIElement(id element)
 static JSRetainPtr<JSStringRef> concatenateAttributeAndValue(NSString *attribute, NSString *value)
 {
     Vector<UniChar> buffer([attribute length]);
-    [attribute getCharacters:buffer.data()];
+    [attribute getCharacters:buffer.mutableSpan().data()];
     buffer.append(':');
     buffer.append(' ');
     
     Vector<UniChar> valueBuffer([value length]);
-    [value getCharacters:valueBuffer.data()];
+    [value getCharacters:valueBuffer.mutableSpan().data()];
     buffer.appendVector(valueBuffer);
 
-    return adopt(JSStringCreateWithCharacters(buffer.data(), buffer.size()));
+    return adopt(JSStringCreateWithCharacters(buffer.span().data(), buffer.size()));
 }
 
 bool AccessibilityUIElement::isEqual(AccessibilityUIElement* otherElement)

--- a/Tools/DumpRenderTree/mac/AccessibilityUIElementMac.mm
+++ b/Tools/DumpRenderTree/mac/AccessibilityUIElementMac.mm
@@ -191,15 +191,15 @@ static NSString* attributesOfElement(id accessibilityObject)
 static JSRetainPtr<JSStringRef> concatenateAttributeAndValue(NSString *attribute, NSString *value)
 {
     Vector<UniChar> buffer([attribute length]);
-    [attribute getCharacters:buffer.data()];
+    [attribute getCharacters:buffer.mutableSpan().data()];
     buffer.append(':');
     buffer.append(' ');
 
     Vector<UniChar> valueBuffer([value length]);
-    [value getCharacters:valueBuffer.data()];
+    [value getCharacters:valueBuffer.mutableSpan().data()];
     buffer.appendVector(valueBuffer);
 
-    return adopt(JSStringCreateWithCharacters(buffer.data(), buffer.size()));
+    return adopt(JSStringCreateWithCharacters(buffer.span().data(), buffer.size()));
 }
 
 static JSRetainPtr<JSStringRef> descriptionOfElements(Vector<AccessibilityUIElement>& elementVector)

--- a/Tools/TestWebKitAPI/Tests/IPC/ArgumentCoderTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/IPC/ArgumentCoderTests.cpp
@@ -97,7 +97,7 @@ public:
 
     std::unique_ptr<IPC::Decoder> createDecoder() const
     {
-        auto decoder = makeUnique<IPC::Decoder>(std::span { m_impl->buffer.data(), m_impl->buffer.size() }, 0);
+        auto decoder = makeUnique<IPC::Decoder>(m_impl->buffer.span(), 0);
         return decoder;
     }
 

--- a/Tools/TestWebKitAPI/Tests/WTF/IntegerToStringConversion.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/IntegerToStringConversion.cpp
@@ -75,13 +75,13 @@ void testBoundaries()
 
     const IntegerType min = std::numeric_limits<IntegerType>::min();
     CString minStringData = String::number(min).latin1();
-    snprintf(buffer.data(), bufferSize, PrintfFormatTrait<IntegerType>::format, min);
-    ASSERT_STREQ(buffer.data(), minStringData.data());
+    snprintf(buffer.mutableSpan().data(), bufferSize, PrintfFormatTrait<IntegerType>::format, min);
+    ASSERT_STREQ(buffer.span().data(), minStringData.data());
 
     const IntegerType max = std::numeric_limits<IntegerType>::max();
     CString maxStringData = String::number(max).latin1();
-    snprintf(buffer.data(), bufferSize, PrintfFormatTrait<IntegerType>::format, max);
-    ASSERT_STREQ(buffer.data(), maxStringData.data());
+    snprintf(buffer.mutableSpan().data(), bufferSize, PrintfFormatTrait<IntegerType>::format, max);
+    ASSERT_STREQ(buffer.span().data(), maxStringData.data());
 }
 
 template<typename IntegerType>
@@ -94,8 +94,8 @@ void testNumbers()
     for (int i = -100; i < 100; ++i) {
         const IntegerType number = static_cast<IntegerType>(i);
         CString numberStringData = String::number(number).latin1();
-        snprintf(buffer.data(), bufferSize, PrintfFormatTrait<IntegerType>::format, number);
-        ASSERT_STREQ(buffer.data(), numberStringData.data());
+        snprintf(buffer.mutableSpan().data(), bufferSize, PrintfFormatTrait<IntegerType>::format, number);
+        ASSERT_STREQ(buffer.span().data(), numberStringData.data());
     }
 }
 

--- a/Tools/TestWebKitAPI/Tests/WTF/StdLibExtrasTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/StdLibExtrasTests.cpp
@@ -253,7 +253,7 @@ TEST(WTF_StdLibExtras, SpanReinterpretCast_DynamicExtent_ManualRuntimeErrors)
 TEST(WTF_StdLibExtras, SpanReinterpretCast_NonDynamicExtent)
 {
     Vector<int32_t> signedInt { -3, -2, -1, 0, 1, 2 };
-    std::span<const int32_t, 6> signedIntSpan { signedInt.data(), signedInt.size() };
+    std::span<const int32_t, 6> signedIntSpan { signedInt.span() };
     static_assert(std::same_as<std::span<const int32_t, 6>, decltype(signedIntSpan)>);
 
     // Cast from 4 bytes to 1 byte per item.

--- a/Tools/TestWebKitAPI/Tests/WTF/StringCommon.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/StringCommon.cpp
@@ -45,26 +45,26 @@ TEST(WTF_StringCommon, Find8NonASCII)
     EXPECT_FALSE(WTF::find8NonASCII(vector.subspan(0, 4096)));
 
     vector[4095] = 0x80;
-    EXPECT_EQ(WTF::find8NonASCII(vector.subspan(0, 4096)) - vector.data(), 4095);
+    EXPECT_EQ(WTF::find8NonASCII(vector.subspan(0, 4096)) - vector.span().data(), 4095);
     for (unsigned i = 0; i < 16; ++i)
         EXPECT_FALSE(WTF::find8NonASCII(vector.subspan(0, 4095 - i)));
 
     vector[1024] = 0x80;
-    EXPECT_EQ(WTF::find8NonASCII(vector.subspan(0, 4096)) - vector.data(), 1024);
+    EXPECT_EQ(WTF::find8NonASCII(vector.subspan(0, 4096)) - vector.span().data(), 1024);
     EXPECT_FALSE(WTF::find8NonASCII(vector.subspan(0, 1023)));
 
     vector[1024] = 0xff;
-    EXPECT_EQ(WTF::find8NonASCII(vector.subspan(0, 4096)) - vector.data(), 1024);
+    EXPECT_EQ(WTF::find8NonASCII(vector.subspan(0, 4096)) - vector.span().data(), 1024);
     EXPECT_FALSE(WTF::find8NonASCII(vector.subspan(0, 1023)));
 
     vector[1024] = 0x7f;
-    EXPECT_EQ(WTF::find8NonASCII(vector.subspan(0, 4096)) - vector.data(), 4095);
+    EXPECT_EQ(WTF::find8NonASCII(vector.subspan(0, 4096)) - vector.span().data(), 4095);
 
     vector[0] = 0xff;
-    EXPECT_EQ(WTF::find8NonASCII(vector.subspan(0, 4096)) - vector.data(), 0);
+    EXPECT_EQ(WTF::find8NonASCII(vector.subspan(0, 4096)) - vector.span().data(), 0);
     for (int i = 0; i < 16; ++i) {
         vector[i] = 0xff;
-        EXPECT_EQ(WTF::find8NonASCII(vector.subspan(i, 4096 - i)) - vector.data(), i);
+        EXPECT_EQ(WTF::find8NonASCII(vector.subspan(i, 4096 - i)) - vector.span().data(), i);
     }
 }
 
@@ -76,26 +76,26 @@ TEST(WTF_StringCommon, Find16NonASCII)
     EXPECT_FALSE(WTF::find16NonASCII(vector.subspan(0, 4096)));
 
     vector[4095] = 0x80;
-    EXPECT_EQ(WTF::find16NonASCII(vector.subspan(0, 4096)) - vector.data(), 4095);
+    EXPECT_EQ(WTF::find16NonASCII(vector.subspan(0, 4096)) - vector.span().data(), 4095);
     for (unsigned i = 0; i < 16; ++i)
         EXPECT_FALSE(WTF::find16NonASCII(vector.subspan(0, 4095 - i)));
 
     vector[1024] = 0x80;
-    EXPECT_EQ(WTF::find16NonASCII(vector.subspan(0, 4096)) - vector.data(), 1024);
+    EXPECT_EQ(WTF::find16NonASCII(vector.subspan(0, 4096)) - vector.span().data(), 1024);
     EXPECT_FALSE(WTF::find16NonASCII(vector.subspan(0, 1023)));
 
     vector[1024] = 0xff;
-    EXPECT_EQ(WTF::find16NonASCII(vector.subspan(0, 4096)) - vector.data(), 1024);
+    EXPECT_EQ(WTF::find16NonASCII(vector.subspan(0, 4096)) - vector.span().data(), 1024);
     EXPECT_FALSE(WTF::find16NonASCII(vector.subspan(0, 1023)));
 
     vector[1024] = 0x7f;
-    EXPECT_EQ(WTF::find16NonASCII(vector.subspan(0, 4096)) - vector.data(), 4095);
+    EXPECT_EQ(WTF::find16NonASCII(vector.subspan(0, 4096)) - vector.span().data(), 4095);
 
     vector[0] = 0xff;
-    EXPECT_EQ(WTF::find16NonASCII(vector.subspan(0, 4096)) - vector.data(), 0);
+    EXPECT_EQ(WTF::find16NonASCII(vector.subspan(0, 4096)) - vector.span().data(), 0);
     for (int i = 0; i < 16; ++i) {
         vector[i] = 0xff;
-        EXPECT_EQ(WTF::find16NonASCII(vector.subspan(i, 4096 - i)) - vector.data(), i);
+        EXPECT_EQ(WTF::find16NonASCII(vector.subspan(i, 4096 - i)) - vector.span().data(), i);
     }
 }
 #endif

--- a/Tools/TestWebKitAPI/Tests/WTF/StringHasher.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/StringHasher.cpp
@@ -74,47 +74,45 @@ TEST(WTF, StringHasher_SuperFastHash_VS_WYHash)
     size_t sum = 0;
     dataLogLn("UChar");
     for (size_t size = 2; size < (1 << 16); size *= 2) {
-        Vector<UChar> vector;
-        vector.resize(size);
-        for (unsigned i = 0; i < size; ++i)
-            vector[i] = i & 0x7f;
-        sum += SuperFastHash::computeHashAndMaskTop8Bits(std::span<const UChar> { vector.data(), size });
-        sum += WYHash::computeHashAndMaskTop8Bits(std::span<const UChar> { vector.data(), size });
-        sum += StringHasher::computeHashAndMaskTop8Bits(std::span<const UChar> { vector.data(), size });
+        Vector<UChar> vector(size, [](size_t index) {
+            return index & 0x7f;
+        });
+        sum += SuperFastHash::computeHashAndMaskTop8Bits(vector.span());
+        sum += WYHash::computeHashAndMaskTop8Bits(vector.span());
+        sum += StringHasher::computeHashAndMaskTop8Bits(vector.span());
         auto start = MonotonicTime::now();
         for (unsigned i = 0; i < 1e5; ++i)
-            sum += SuperFastHash::computeHashAndMaskTop8Bits(std::span<const UChar> { vector.data(), size });
+            sum += SuperFastHash::computeHashAndMaskTop8Bits(vector.span());
         dataLogLn("SFH ", size, " -> ", MonotonicTime::now() - start);
         start = MonotonicTime::now();
         for (unsigned i = 0; i < 1e5; ++i)
-            sum += WYHash::computeHashAndMaskTop8Bits(std::span<const UChar> { vector.data(), size });
+            sum += WYHash::computeHashAndMaskTop8Bits(vector.span());
         dataLogLn("WYH ", size, " -> ", MonotonicTime::now() - start);
         start = MonotonicTime::now();
         for (unsigned i = 0; i < 1e5; ++i)
-            sum += StringHasher::computeHashAndMaskTop8Bits(std::span<const UChar> { vector.data(), size });
+            sum += StringHasher::computeHashAndMaskTop8Bits(vector.span());
         dataLogLn("STH ", size, " -> ", MonotonicTime::now() - start);
     }
 
     dataLogLn("LChar");
     for (size_t size = 2; size < (1 << 16); size *= 2) {
-        Vector<LChar> vector;
-        vector.resize(size);
-        for (unsigned i = 0; i < size; ++i)
-            vector[i] = i & 0x7f;
-        sum += SuperFastHash::computeHashAndMaskTop8Bits(std::span<const LChar> { vector.data(), size });
-        sum += WYHash::computeHashAndMaskTop8Bits(std::span<const LChar> { vector.data(), size });
-        sum += StringHasher::computeHashAndMaskTop8Bits(std::span<const LChar> { vector.data(), size });
+        Vector<LChar> vector(size, [](size_t index) {
+            return index & 0x7f;
+        });
+        sum += SuperFastHash::computeHashAndMaskTop8Bits(vector.span());
+        sum += WYHash::computeHashAndMaskTop8Bits(vector.span());
+        sum += StringHasher::computeHashAndMaskTop8Bits(vector.span());
         auto start = MonotonicTime::now();
         for (unsigned i = 0; i < 1e5; ++i)
-            sum += SuperFastHash::computeHashAndMaskTop8Bits(std::span<const LChar> { vector.data(), size });
+            sum += SuperFastHash::computeHashAndMaskTop8Bits(vector.span());
         dataLogLn("SFH ", size, " -> ", MonotonicTime::now() - start);
         start = MonotonicTime::now();
         for (unsigned i = 0; i < 1e5; ++i)
-            sum += WYHash::computeHashAndMaskTop8Bits(std::span<const LChar> { vector.data(), size });
+            sum += WYHash::computeHashAndMaskTop8Bits(vector.span());
         dataLogLn("WYH ", size, " -> ", MonotonicTime::now() - start);
         start = MonotonicTime::now();
         for (unsigned i = 0; i < 1e5; ++i)
-            sum += StringHasher::computeHashAndMaskTop8Bits(std::span<const LChar> { vector.data(), size });
+            sum += StringHasher::computeHashAndMaskTop8Bits(vector.span());
         dataLogLn("STH ", size, " -> ", MonotonicTime::now() - start);
     }
     dataLogLn(sum);

--- a/Tools/TestWebKitAPI/Tests/WTF/Vector.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/Vector.cpp
@@ -42,7 +42,7 @@ TEST(WTF_Vector, Basic)
 {
     Vector<int> intVector;
     EXPECT_TRUE(intVector.isEmpty());
-    EXPECT_EQ(nullptr, intVector.data());
+    EXPECT_EQ(nullptr, intVector.span().data());
     EXPECT_EQ(0U, intVector.size());
     EXPECT_EQ(0U, intVector.capacity());
 
@@ -56,7 +56,7 @@ TEST(WTF_Vector, ZeroSize)
 {
     Vector<int> intVector(0);
     EXPECT_TRUE(intVector.isEmpty());
-    EXPECT_EQ(nullptr, intVector.data());
+    EXPECT_EQ(nullptr, intVector.span().data());
     EXPECT_EQ(0U, intVector.size());
     EXPECT_EQ(0U, intVector.capacity());
 
@@ -68,7 +68,7 @@ TEST(WTF_Vector, ZeroSize)
     intVector.append(0);
     intVector.removeLast();
     EXPECT_TRUE(intVector.isEmpty());
-    EXPECT_NE(nullptr, intVector.data());
+    EXPECT_NE(nullptr, intVector.span().data());
     EXPECT_EQ(0U, intVector.size());
     EXPECT_NE(0U, intVector.capacity());
 

--- a/Tools/TestWebKitAPI/Tests/WebCore/CBORWriterTest.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/CBORWriterTest.cpp
@@ -33,6 +33,7 @@
 
 #include <WebCore/CBORWriter.h>
 #include <limits>
+#include <wtf/StdLibExtras.h>
 
 // Leveraging RFC 7049 examples from https://github.com/cbor/test-vectors/blob/master/appendix_a.json.
 namespace TestWebKitAPI {
@@ -41,16 +42,12 @@ using namespace cbor;
 
 bool eq(const Vector<uint8_t>& cbor, const CString& expect)
 {
-    if (cbor.size() != expect.length())
-        return false;
-    return !memcmp(cbor.data(), expect.data(), cbor.size());
+    return equalSpans(cbor.span(), expect.span());
 }
 
-bool eq(const Vector<uint8_t>& cbor, const uint8_t* expect, const size_t expectLength)
+bool eq(const Vector<uint8_t>& cbor, std::span<const uint8_t> expect)
 {
-    if (cbor.size() != expectLength)
-        return false;
-    return !memcmp(cbor.data(), expect, expectLength);
+    return equalSpans(cbor.span(), expect);
 }
 
 TEST(CBORWriterTest, TestWriteUint)
@@ -169,7 +166,7 @@ TEST(CBORWriterTest, TestWriteArray)
         array.append(CBORValue(i));
     auto cbor = CBORWriter::write(CBORValue(array));
     ASSERT_TRUE(cbor.has_value());
-    EXPECT_TRUE(eq(cbor.value(), kArrayTestCaseCbor, sizeof(kArrayTestCaseCbor)));
+    EXPECT_TRUE(eq(cbor.value(), std::span { kArrayTestCaseCbor }));
 }
 
 TEST(CBORWriterTest, TestWriteMapWithMapValue)
@@ -279,7 +276,7 @@ TEST(CBORWriterTest, TestWriteMapWithMapValue)
     map[CBORValue(std::numeric_limits<int64_t>::max())] = CBORValue("j");
     auto cbor = CBORWriter::write(CBORValue(map));
     ASSERT_TRUE(cbor.has_value());
-    EXPECT_TRUE(eq(cbor.value(), kMapTestCaseCbor, sizeof(kMapTestCaseCbor)));
+    EXPECT_TRUE(eq(cbor.value(), std::span { kMapTestCaseCbor }));
 }
 
 TEST(CBORWriterTest, TestWriteMapWithArray)
@@ -302,7 +299,7 @@ TEST(CBORWriterTest, TestWriteMapWithArray)
     map[CBORValue("b")] = CBORValue(array);
     auto cbor = CBORWriter::write(CBORValue(map));
     ASSERT_TRUE(cbor.has_value());
-    EXPECT_TRUE(eq(cbor.value(), kMapArrayTestCaseCbor, sizeof(kMapArrayTestCaseCbor)));
+    EXPECT_TRUE(eq(cbor.value(), std::span { kMapArrayTestCaseCbor }));
 }
 
 TEST(CBORWriterTest, TestWriteNestedMap)
@@ -328,7 +325,7 @@ TEST(CBORWriterTest, TestWriteNestedMap)
     map[CBORValue("b")] = CBORValue(nestedMap);
     auto cbor = CBORWriter::write(CBORValue(map));
     ASSERT_TRUE(cbor.has_value());
-    EXPECT_TRUE(eq(cbor.value(), kNestedMapTestCase, sizeof(kNestedMapTestCase)));
+    EXPECT_TRUE(eq(cbor.value(), std::span { kNestedMapTestCase }));
 }
 
 TEST(CBORWriterTest, TestWriteSimpleValue)

--- a/Tools/TestWebKitAPI/Tests/WebCore/ContentExtensions.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/ContentExtensions.cpp
@@ -154,10 +154,10 @@ public:
     const CompiledContentExtensionData& data() { return m_data; };
 
 private:
-    std::span<const uint8_t> serializedActions() const final { return { m_data.actions.data(), m_data.actions.size() }; }
-    std::span<const uint8_t> urlFiltersBytecode() const final { return { m_data.urlFilters.data(), m_data.urlFilters.size() }; }
-    std::span<const uint8_t> topURLFiltersBytecode() const final { return { m_data.topURLFilters.data(), m_data.topURLFilters.size() }; }
-    std::span<const uint8_t> frameURLFiltersBytecode() const final { return { m_data.frameURLFilters.data(), m_data.frameURLFilters.size() }; }
+    std::span<const uint8_t> serializedActions() const final { return m_data.actions.span(); }
+    std::span<const uint8_t> urlFiltersBytecode() const final { return m_data.urlFilters.span(); }
+    std::span<const uint8_t> topURLFiltersBytecode() const final { return m_data.topURLFilters.span(); }
+    std::span<const uint8_t> frameURLFiltersBytecode() const final { return m_data.frameURLFilters.span(); }
 
     InMemoryCompiledContentExtension(CompiledContentExtensionData&& data)
         : m_data(WTFMove(data))
@@ -579,7 +579,7 @@ TEST_F(ContentExtensionTest, SearchSuffixesWithIdenticalActionAreMerged)
     Vector<ContentExtensions::DFABytecode> bytecode;
     ContentExtensions::DFABytecodeCompiler compiler(dfa, bytecode);
     compiler.compile();
-    DFABytecodeInterpreter interpreter({ bytecode.data(), bytecode.size() });
+    DFABytecodeInterpreter interpreter(bytecode.span());
     compareContents(interpreter.interpret("foo.org"_s, 0), { 0 });
     compareContents(interpreter.interpret("ba.org"_s, 0), { 0 });
     compareContents(interpreter.interpret("bar.org"_s, 0), { });
@@ -605,7 +605,7 @@ TEST_F(ContentExtensionTest, SearchSuffixesWithDistinguishableActionAreNotMerged
     Vector<ContentExtensions::DFABytecode> bytecode;
     ContentExtensions::DFABytecodeCompiler compiler(dfa, bytecode);
     compiler.compile();
-    DFABytecodeInterpreter interpreter({ bytecode.data(), bytecode.size() });
+    DFABytecodeInterpreter interpreter(bytecode.span());
     compareContents(interpreter.interpret("foo.org"_s, 0), { 0 });
     compareContents(interpreter.interpret("ba.org"_s, 0), { 1 });
     compareContents(interpreter.interpret("bar.org"_s, 0), { });
@@ -1125,7 +1125,7 @@ TEST_F(ContentExtensionTest, UselessTermsMatchingEverythingAreEliminated)
     Vector<ContentExtensions::DFABytecode> bytecode;
     ContentExtensions::DFABytecodeCompiler compiler(dfa, bytecode);
     compiler.compile();
-    DFABytecodeInterpreter interpreter({ bytecode.data(), bytecode.size() });
+    DFABytecodeInterpreter interpreter(bytecode.span());
     compareContents(interpreter.interpret("eb"_s, 0), { });
     compareContents(interpreter.interpret("we"_s, 0), { });
     compareContents(interpreter.interpret("weeb"_s, 0), { });
@@ -1752,7 +1752,7 @@ TEST_F(ContentExtensionTest, SplittingLargeNFAs)
             combinedBytecode.appendVector(bytecode);
         }
         
-        DFABytecodeInterpreter interpreter({ combinedBytecode.data(), combinedBytecode.size() });
+        DFABytecodeInterpreter interpreter(combinedBytecode.span());
         
         EXPECT_EQ(interpreter.interpret("ABBBX"_s, 0).size(), 1ull);
         EXPECT_EQ(interpreter.interpret("ACCCX"_s, 0).size(), 1ull);
@@ -3065,7 +3065,7 @@ TEST_F(ContentExtensionTest, Serialization)
         Vector<uint8_t> buffer;
         action.serialize(buffer);
         EXPECT_EQ(expectedSerializedBufferLength, buffer.size());
-        auto deserialized = RedirectAction::deserialize({ buffer.data(), buffer.size() });
+        auto deserialized = RedirectAction::deserialize(buffer.span());
         EXPECT_EQ(deserialized, action);
     };
     checkRedirectActionSerialization({ { RedirectAction::ExtensionPathAction { "extensionPath"_s } } }, 18);
@@ -3095,7 +3095,7 @@ TEST_F(ContentExtensionTest, Serialization)
     Vector<uint8_t> modifyHeadersBuffer;
     modifyHeaders.serialize(modifyHeadersBuffer);
     EXPECT_EQ(modifyHeadersBuffer.size(), 59u);
-    auto deserializedModifyHeaders = ModifyHeadersAction::deserialize({ modifyHeadersBuffer.data(), modifyHeadersBuffer.size() });
+    auto deserializedModifyHeaders = ModifyHeadersAction::deserialize(modifyHeadersBuffer.span());
     EXPECT_EQ(modifyHeaders, deserializedModifyHeaders);
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebCore/RTCRtpSFrameTransformerTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/RTCRtpSFrameTransformerTests.cpp
@@ -200,11 +200,11 @@ TEST(RTCRtpSFrameTransformer, EncryptDecrypt)
     auto decryptor = createVideoTransformer(false);
     auto frame = Vector<uint8_t>::from(135, 89, 51, 166, 248, 129, 157, 111, 190, 134, 220);
 
-    auto encryptedResult = encryptor->transform({ frame.data(), frame.size() });
+    auto encryptedResult = encryptor->transform(frame.span());
     EXPECT_TRUE(encryptedResult.has_value());
 
     auto encrypted = WTFMove(encryptedResult.value());
-    auto decryptedResult = decryptor->transform({ encrypted.data(), encrypted.size() });
+    auto decryptedResult = decryptor->transform(encrypted.span());
     EXPECT_TRUE(decryptedResult.has_value());
 
     checkVectorsAreEqual(decryptedResult.value(), frame);
@@ -220,11 +220,11 @@ TEST(RTCRtpSFrameTransformer, EncryptDecryptKeyID0)
 
     auto frame = Vector<uint8_t>::from(135, 89, 51, 166, 248, 129, 157, 111, 190, 134, 220);
 
-    auto encryptedResult = encryptor->transform({ frame.data(), frame.size() });
+    auto encryptedResult = encryptor->transform(frame.span());
     EXPECT_TRUE(encryptedResult.has_value());
 
     auto encrypted = WTFMove(encryptedResult.value());
-    auto decryptedResult = decryptor->transform({ encrypted.data(), encrypted.size() });
+    auto decryptedResult = decryptor->transform(encrypted.span());
     EXPECT_TRUE(decryptedResult.has_value());
 
     checkVectorsAreEqual(decryptedResult.value(), frame);
@@ -242,11 +242,11 @@ TEST(RTCRtpSFrameTransformer, EncryptDecryptAudio)
 
     auto frame = Vector<uint8_t>::from(135, 89, 51, 166, 248, 129, 157, 111, 190, 134, 220, 56);
 
-    auto encryptedResult = encryptor->transform({ frame.data(), frame.size() });
+    auto encryptedResult = encryptor->transform(frame.span());
     EXPECT_TRUE(encryptedResult.has_value());
 
     auto encrypted = WTFMove(encryptedResult.value());
-    auto decryptedResult = decryptor->transform({ encrypted.data(), encrypted.size() });
+    auto decryptedResult = decryptor->transform(encrypted.span());
     EXPECT_TRUE(decryptedResult.has_value());
 
     checkVectorsAreEqual(decryptedResult.value(), frame);

--- a/Tools/TestWebKitAPI/Tests/WebCore/cocoa/PrivateClickMeasurementCocoa.mm
+++ b/Tools/TestWebKitAPI/Tests/WebCore/cocoa/PrivateClickMeasurementCocoa.mm
@@ -71,7 +71,7 @@ TEST(PrivateClickMeasurement, ValidBlindedSecret)
 
     size_t exportSize = ccder_encode_rsa_pub_size(rsaPublicKey);
     Vector<uint8_t> rawKeyBytes(exportSize);
-    ccder_encode_rsa_pub(rsaPublicKey, rawKeyBytes.data(), rawKeyBytes.data() + exportSize);
+    ccder_encode_rsa_pub(rsaPublicKey, rawKeyBytes.begin(), rawKeyBytes.end());
 
     auto wrappedKeyBytes = wrapPublicKeyWithRSAPSSOID(WTFMove(rawKeyBytes));
 
@@ -90,7 +90,7 @@ TEST(PrivateClickMeasurement, ValidBlindedSecret)
     auto blindedMessage = base64URLDecode(sourceUnlinkableToken->getString("source_unlinkable_token"_s));
 
     RetainPtr blindedSignature = adoptNS([[NSMutableData alloc] initWithLength:modulusNBytes]);
-    ccrsabssa_sign_blinded_message(ciphersuite, rsaPrivateKey, blindedMessage->data(), blindedMessage->size(), static_cast<uint8_t *>([blindedSignature mutableBytes]), [blindedSignature length], rng);
+    ccrsabssa_sign_blinded_message(ciphersuite, rsaPrivateKey, blindedMessage->span().data(), blindedMessage->size(), static_cast<uint8_t *>([blindedSignature mutableBytes]), [blindedSignature length], rng);
 
     // Continue the test.
     errorMessage = pcm.calculateAndUpdateSourceSecretToken(base64URLEncodeToString(span(blindedSignature.get())));

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/Download.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/Download.mm
@@ -59,6 +59,7 @@
 #import <wtf/MainThread.h>
 #import <wtf/MonotonicTime.h>
 #import <wtf/RetainPtr.h>
+#import <wtf/StdLibExtras.h>
 #import <wtf/WeakObjCPtr.h>
 #import <wtf/text/MakeString.h>
 #import <wtf/text/WTFString.h>
@@ -1262,7 +1263,7 @@ static TestWebKitAPI::HTTPServer downloadTestServer(IncludeETag includeETag = In
             break;
         case 2:
             connection.receiveHTTPRequest([=](Vector<char>&& request) {
-                EXPECT_TRUE(strnstr(request.data(), "Range: bytes=5000-\r\n", request.size()));
+                EXPECT_TRUE(contains(request.span(), "Range: bytes=5000-\r\n"_span));
                 connection.send(makeString(
                     "HTTP/1.1 206 Partial Content\r\n"
                     "ETag: test\r\n"
@@ -1945,7 +1946,7 @@ TEST(WKDownload, ResumeWithoutInitialDataOnDisk)
             break;
         case 2:
             connection.receiveHTTPRequest([=](Vector<char>&& request) {
-                EXPECT_FALSE(strnstr(request.data(), "Range", request.size()));
+                EXPECT_FALSE(contains(request.span(), "Range"_span));
                 connection.send(makeString(
                     "HTTP/1.1 200 OK\r\n"
                     "ETag: test\r\n"
@@ -1988,7 +1989,7 @@ TEST(WKDownload, ResumeWithExtraInitialDataOnDisk)
             break;
         case 2:
             connection.receiveHTTPRequest([=](Vector<char>&& request) {
-                EXPECT_TRUE(strnstr(request.data(), "Range: bytes=5000-\r\n", request.size()));
+                EXPECT_TRUE(contains(request.span(), "Range: bytes=5000-\r\n"_span));
                 connection.send(makeString(
                     "HTTP/1.1 206 Partial Content\r\n"
                     "ETag: test\r\n"

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/EventAttribution.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/EventAttribution.mm
@@ -143,13 +143,13 @@ void runBasicPCMTest(WKWebViewConfiguration *configuration, Function<void(WKWebV
         switch (++connectionCount) {
         case 1:
             connection.receiveHTTPRequest([connection] (Vector<char>&& request1) {
-                EXPECT_TRUE(strnstr(request1.data(), "GET /conversionRequestBeforeRedirect HTTP/1.1\r\n", request1.size()));
+                EXPECT_TRUE(contains(request1.span(), "GET /conversionRequestBeforeRedirect HTTP/1.1\r\n"_span));
                 constexpr auto redirect = "HTTP/1.1 302 Found\r\n"
                     "Location: /.well-known/private-click-measurement/trigger-attribution/12\r\n"
                     "Content-Length: 0\r\n\r\n"_s;
                 connection.send(redirect, [connection] {
                     connection.receiveHTTPRequest([connection] (Vector<char>&& request2) {
-                        EXPECT_TRUE(strnstr(request2.data(), "GET /.well-known/private-click-measurement/trigger-attribution/12 HTTP/1.1\r\n", request2.size()));
+                        EXPECT_TRUE(contains(request2.span(), "GET /.well-known/private-click-measurement/trigger-attribution/12 HTTP/1.1\r\n"_span));
                         constexpr auto response = "HTTP/1.1 200 OK\r\n"
                             "Content-Length: 0\r\n\r\n"_s;
                         connection.send(response);
@@ -159,10 +159,9 @@ void runBasicPCMTest(WKWebViewConfiguration *configuration, Function<void(WKWebV
             break;
         case 2:
             connection.receiveHTTPRequest([&done] (Vector<char>&& request3) {
-                request3.append('\0');
-                EXPECT_TRUE(strnstr(request3.data(), "POST / HTTP/1.1\r\n", request3.size()));
-                const char* bodyBegin = strnstr(request3.data(), "\r\n\r\n", request3.size()) + strlen("\r\n\r\n");
-                EXPECT_STREQ(bodyBegin, "{\"source_engagement_type\":\"click\",\"source_site\":\"127.0.0.1\",\"source_id\":42,\"attributed_on_site\":\"example.com\",\"trigger_data\":12,\"version\":3}");
+                EXPECT_TRUE(contains(request3.span(), "POST / HTTP/1.1\r\n"_span));
+                size_t bodyBegin = find(request3.span(), "\r\n\r\n"_span) + strlen("\r\n\r\n");
+                EXPECT_TRUE(equalSpans(request3.subspan(bodyBegin), "{\"source_engagement_type\":\"click\",\"source_site\":\"127.0.0.1\",\"source_id\":42,\"attributed_on_site\":\"example.com\",\"trigger_data\":12,\"version\":3}"_span));
                 done = true;
             });
             break;
@@ -204,12 +203,12 @@ static void triggerAttributionWithSubresourceRedirect(Connection& connection, co
     auto optionalQueryString = attributionDestinationNonce.isEmpty() ? attributionDestinationNonce : makeString("?attributionDestinationNonce="_s, attributionDestinationNonce);
     auto location = makeString("/.well-known/private-click-measurement/trigger-attribution/12"_s, optionalQueryString);
     connection.receiveHTTPRequest([connection, location] (Vector<char>&& request1) {
-        EXPECT_TRUE(strnstr(request1.data(), "GET /conversionRequestBeforeRedirect HTTP/1.1\r\n", request1.size()));
+        EXPECT_TRUE(contains(request1.span(), "GET /conversionRequestBeforeRedirect HTTP/1.1\r\n"_span));
         auto redirect = makeString("HTTP/1.1 302 Found\r\nLocation: "_s, location, "\r\nContent-Length: 0\r\n\r\n"_s);
         connection.send(WTFMove(redirect), [connection, location] {
             connection.receiveHTTPRequest([connection, location] (Vector<char>&& request2) {
                 auto expectedHttpGetString = makeString("GET "_s, location, " HTTP/1.1\r\n"_s).utf8();
-                EXPECT_TRUE(strnstr(request2.data(), expectedHttpGetString.data(), request2.size()));
+                EXPECT_TRUE(contains(request2.span(), expectedHttpGetString.span()));
                 constexpr auto response = "HTTP/1.1 200 OK\r\n"
                     "Content-Length: 0\r\n\r\n"_s;
                 connection.send(response);
@@ -272,7 +271,7 @@ static void signUnlinkableTokenAndSendSecretToken(TokenSigningParty signingParty
             break;
         case 2:
             connection.receiveHTTPRequest([signingParty, connection, &rsaPrivateKey, &modulusNBytes, &rng, &keyData, &done, &secKey] (Vector<char>&& request1) {
-                EXPECT_TRUE(strnstr(request1.data(), "GET / HTTP/1.1\r\n", request1.size()));
+                EXPECT_TRUE(contains(request1.span(), "GET / HTTP/1.1\r\n"_span));
 
                 // Example response: { "token_public_key": "ABCD" }. "ABCD" should be Base64URL encoded.
                 auto response = makeString("HTTP/1.1 200 OK\r\n"
@@ -281,7 +280,7 @@ static void signUnlinkableTokenAndSendSecretToken(TokenSigningParty signingParty
                     "{\"token_public_key\": \""_s, keyData, "\"}"_s);
                 connection.send(WTFMove(response), [signingParty, connection, &rsaPrivateKey, &modulusNBytes, &rng, &keyData, &done, &secKey] {
                     connection.receiveHTTPRequest([signingParty, connection, &rsaPrivateKey, &modulusNBytes, &rng, &keyData, &done, &secKey] (Vector<char>&& request2) {
-                        EXPECT_TRUE(strnstr(request2.data(), "POST / HTTP/1.1\r\n", request2.size()));
+                        EXPECT_TRUE(contains(request2.span(), "POST / HTTP/1.1\r\n"_span));
 
                         auto request2String = String(request2.span());
                         auto key = signingParty == TokenSigningParty::Source ? "source_unlinkable_token"_s : "destination_unlinkable_token"_s;
@@ -294,7 +293,7 @@ static void signUnlinkableTokenAndSendSecretToken(TokenSigningParty signingParty
 
                         const struct ccrsabssa_ciphersuite *ciphersuite = &ccrsabssa_ciphersuite_rsa4096_sha384;
                         auto blindedSignature = adoptNS([[NSMutableData alloc] initWithLength:modulusNBytes]);
-                        ccrsabssa_sign_blinded_message(ciphersuite, rsaPrivateKey, blindedMessage->data(), blindedMessage->size(), static_cast<uint8_t *>([blindedSignature mutableBytes]), [blindedSignature length], rng);
+                        ccrsabssa_sign_blinded_message(ciphersuite, rsaPrivateKey, blindedMessage->span().data(), blindedMessage->size(), static_cast<uint8_t *>([blindedSignature mutableBytes]), [blindedSignature length], rng);
                         auto unlinkableToken = base64URLEncodeToString(span(blindedSignature.get()));
 
                         // Example response: { "unlinkable_token": "ABCD" }. "ABCD" should be Base64URL encoded.
@@ -304,7 +303,7 @@ static void signUnlinkableTokenAndSendSecretToken(TokenSigningParty signingParty
                             "{\"unlinkable_token\": \""_s, unlinkableToken, "\"}"_s);
                         connection.send(WTFMove(response), [signingParty, connection, &keyData, &done, unlinkableToken, token, &secKey] {
                             connection.receiveHTTPRequest([signingParty, connection, &keyData, &done, unlinkableToken, token, &secKey] (Vector<char>&& request3) {
-                                EXPECT_TRUE(strnstr(request3.data(), "GET / HTTP/1.1\r\n", request3.size()));
+                                EXPECT_TRUE(contains(request3.span(), "GET / HTTP/1.1\r\n"_span));
 
                                 // Example response: { "token_public_key": "ABCD" }. "ABCD" should be Base64URL encoded.
                                 auto response = makeString("HTTP/1.1 200 OK\r\n"
@@ -313,12 +312,11 @@ static void signUnlinkableTokenAndSendSecretToken(TokenSigningParty signingParty
                                     "{\"token_public_key\": \""_s, keyData, "\"}"_s);
                                 connection.send(WTFMove(response), [signingParty, connection, &done, unlinkableToken, token, &secKey] {
                                     connection.receiveHTTPRequest([signingParty, connection, &done, unlinkableToken, token, &secKey] (Vector<char>&& request4) {
-                                        EXPECT_TRUE(strnstr(request4.data(), "POST / HTTP/1.1\r\n", request4.size()));
-                                        EXPECT_TRUE(strnstr(request4.data(), "{\"source_engagement_type\":\"click\",\"source_site\":\"127.0.0.1\",\"source_id\":42,\"attributed_on_site\":\"example.com\",\"trigger_data\":12,\"version\":3,",
-                                            request4.size()));
+                                        EXPECT_TRUE(contains(request4.span(), "POST / HTTP/1.1\r\n"_span));
+                                        EXPECT_TRUE(contains(request4.span(), "{\"source_engagement_type\":\"click\",\"source_site\":\"127.0.0.1\",\"source_id\":42,\"attributed_on_site\":\"example.com\",\"trigger_data\":12,\"version\":3,"_span));
 
-                                        EXPECT_FALSE(strnstr(request4.data(), token.utf8().data(), request4.size()));
-                                        EXPECT_FALSE(strnstr(request4.data(), unlinkableToken.utf8().data(), request4.size()));
+                                        EXPECT_FALSE(contains(request4.span(), token.utf8().span()));
+                                        EXPECT_FALSE(contains(request4.span(), unlinkableToken.utf8().span()));
 
                                         auto request4String = String(request4.span());
 
@@ -328,7 +326,7 @@ static void signUnlinkableTokenAndSendSecretToken(TokenSigningParty signingParty
                                         auto end = request4String.find('"', start);
                                         auto token = request4String.substring(start, end - start);
                                         auto tokenVector = base64URLDecode(token);
-                                        auto tokenData = adoptNS([[NSData alloc] initWithBytes:tokenVector->data() length:tokenVector->size()]);
+                                        RetainPtr tokenData = toNSData(tokenVector->span());
 
                                         key = signingParty == TokenSigningParty::Source ? "source_secret_token_signature"_s : "destination_secret_token_signature"_s;
                                         start = request4String.find(key);
@@ -336,7 +334,7 @@ static void signUnlinkableTokenAndSendSecretToken(TokenSigningParty signingParty
                                         end = request4String.find('"', start);
                                         auto signature = request4String.substring(start, end - start);
                                         auto signatureVector = base64URLDecode(signature);
-                                        auto signatureData = adoptNS([[NSData alloc] initWithBytes:signatureVector->data() length:signatureVector->size()]);
+                                        RetainPtr signatureData = toNSData(signatureVector->span());
 
                                         EXPECT_TRUE(SecKeyVerifySignature(secKey.get(), kSecKeyAlgorithmRSASignatureMessagePSSSHA384, (__bridge CFDataRef)tokenData.get(), (__bridge CFDataRef)signatureData.get(), NULL));
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/LoadAlternateHTMLString.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/LoadAlternateHTMLString.mm
@@ -34,6 +34,7 @@
 #import <WebKit/WKFoundation.h>
 #import <WebKit/WKWebViewPrivate.h>
 #import <wtf/RetainPtr.h>
+#import <wtf/StdLibExtras.h>
 #import <wtf/cocoa/NSURLExtras.h>
 #import <wtf/cocoa/VectorCocoa.h>
 
@@ -175,7 +176,7 @@ TEST(WKWebView, LoadHTMLStringOrigin)
     bool done = false;
     HTTPServer server([&](Connection connection) {
         connection.receiveHTTPRequest([&](Vector<char>&& request) {
-            EXPECT_TRUE(strnstr(request.data(), "Origin: custom-scheme://\r\n", request.size()));
+            EXPECT_TRUE(contains(request.span(), "Origin: custom-scheme://\r\n"_span));
             done = true;
         });
     });

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/Proxy.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/Proxy.mm
@@ -38,6 +38,7 @@
 #import <pal/spi/cf/CFNetworkSPI.h>
 #import <wtf/RetainPtr.h>
 #import <wtf/SoftLinking.h>
+#import <wtf/StdLibExtras.h>
 #import <wtf/text/MakeString.h>
 
 @interface ProxyDelegate : NSObject <WKNavigationDelegate, WKUIDelegate>
@@ -453,7 +454,7 @@ TEST(WebKit, RelaxThirdPartyCookieBlocking)
                 "</script>"_s;
                 switch (connectionCount) {
                 case 1: {
-                    EXPECT_TRUE(strnstr(request.data(), "GET http://www.webkit.org/path1 HTTP/1.1\r\n", request.size()));
+                    EXPECT_TRUE(contains(request.span(), "GET http://www.webkit.org/path1 HTTP/1.1\r\n"_span));
                     reply = makeString(
                         "HTTP/1.1 200 OK\r\n"
                         "Content-Length: "_s, strlen(body), "\r\n"
@@ -464,7 +465,7 @@ TEST(WebKit, RelaxThirdPartyCookieBlocking)
                     break;
                 }
                 case 3: {
-                    EXPECT_TRUE(strnstr(request.data(), "GET http://example.com/path2 HTTP/1.1\r\n", request.size()));
+                    EXPECT_TRUE(contains(request.span(), "GET http://example.com/path2 HTTP/1.1\r\n"_span));
                     reply = makeString(
                         "HTTP/1.1 200 OK\r\n"
                         "Content-Type: text/html\r\n"
@@ -477,10 +478,10 @@ TEST(WebKit, RelaxThirdPartyCookieBlocking)
                 case 2:
                 case 4:
                     if (connectionCount == 2 || shouldRelaxThirdPartyCookieBlocking)
-                        EXPECT_TRUE(strnstr(request.data(), "Cookie: a=b\r\n", request.size()));
+                        EXPECT_TRUE(contains(request.span(), "Cookie: a=b\r\n"_span));
                     else
-                        EXPECT_FALSE(strnstr(request.data(), "Cookie: a=b\r\n", request.size()));
-                    EXPECT_TRUE(strnstr(request.data(), "GET http://www.webkit.org/path3 HTTP/1.1\r\n", request.size()));
+                        EXPECT_FALSE(contains(request.span(), "Cookie: a=b\r\n"_span));
+                    EXPECT_TRUE(contains(request.span(), "GET http://www.webkit.org/path3 HTTP/1.1\r\n"_span));
                     reply =
                         "HTTP/1.1 200 OK\r\n"
                         "Content-Length: 0\r\n"

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/SOAuthorizationTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/SOAuthorizationTests.mm
@@ -41,6 +41,7 @@
 #import <pal/spi/cocoa/AuthKitSPI.h>
 #import <wtf/BlockPtr.h>
 #import <wtf/RetainPtr.h>
+#import <wtf/StdLibExtras.h>
 #import <wtf/StringPrintStream.h>
 #import <wtf/URL.h>
 #import <wtf/text/MakeString.h>
@@ -887,9 +888,9 @@ TEST(SOAuthorizationRedirect, InterceptionSucceedWith307Simple)
             auto path = HTTPServer::parsePath(request);
             if (path == "/simple2.html"_s) {
                 request.append(0);
-                EXPECT_TRUE(strnstr(request.data(), "POST /simple2.html HTTP/1.1\r\n", request.size()));
-                EXPECT_TRUE(strnstr(request.data(), "\r\nContent-Type: application/x-www-form-urlencoded\r\n", request.size()));
-                EXPECT_TRUE(strnstr(request.data(), "\r\n\r\nname=test", request.size()));
+                EXPECT_TRUE(contains(request.span(), "POST /simple2.html HTTP/1.1\r\n"_span));
+                EXPECT_TRUE(contains(request.span(), "\r\nContent-Type: application/x-www-form-urlencoded\r\n"_span));
+                EXPECT_TRUE(contains(request.span(), "\r\n\r\nname=test"_span));
             }
             co_await connection.awaitableSend(HTTPResponse(SimpleHtml).serialize());
         }
@@ -944,9 +945,9 @@ TEST(SOAuthorizationRedirect, InterceptionSucceedWith307CrossOrigin)
             auto path = HTTPServer::parsePath(request);
             if (path == "/simple2.html"_s) {
                 request.append(0);
-                EXPECT_TRUE(strnstr(request.data(), "POST /simple2.html HTTP/1.1\r\n", request.size()));
-                EXPECT_TRUE(strnstr(request.data(), "\r\nContent-Type: application/x-www-form-urlencoded\r\n", request.size()));
-                EXPECT_TRUE(strnstr(request.data(), "\r\n\r\nname=test", request.size()));
+                EXPECT_TRUE(contains(request.span(), "POST /simple2.html HTTP/1.1\r\n"_span));
+                EXPECT_TRUE(contains(request.span(), "\r\nContent-Type: application/x-www-form-urlencoded\r\n"_span));
+                EXPECT_TRUE(contains(request.span(), "\r\n\r\nname=test"_span));
             }
             co_await connection.awaitableSend(HTTPResponse(SimpleHtml).serialize());
         }
@@ -1002,9 +1003,9 @@ TEST(SOAuthorizationRedirect, InterceptionFailedWith307PUT)
             auto path = HTTPServer::parsePath(request);
             if (path == "/simple2.html"_s) {
                 request.append(0);
-                EXPECT_TRUE(strnstr(request.data(), "POST /simple2.html HTTP/1.1\r\n", request.size()));
-                EXPECT_TRUE(strnstr(request.data(), "\r\nContent-Type: application/x-www-form-urlencoded\r\n", request.size()));
-                EXPECT_TRUE(strnstr(request.data(), "\r\n\r\nname=test", request.size()));
+                EXPECT_TRUE(contains(request.span(), "POST /simple2.html HTTP/1.1\r\n"_span));
+                EXPECT_TRUE(contains(request.span(), "\r\nContent-Type: application/x-www-form-urlencoded\r\n"_span));
+                EXPECT_TRUE(contains(request.span(), "\r\n\r\nname=test"_span));
             }
             co_await connection.awaitableSend(HTTPResponse(SimpleHtml).serialize());
         }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ServiceWorkerBasic.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ServiceWorkerBasic.mm
@@ -65,6 +65,7 @@
 #import <wtf/HashMap.h>
 #import <wtf/RetainPtr.h>
 #import <wtf/Scope.h>
+#import <wtf/StdLibExtras.h>
 #import <wtf/URL.h>
 #import <wtf/Vector.h>
 #import <wtf/cocoa/SpanCocoa.h>
@@ -2551,7 +2552,7 @@ TEST(ServiceWorkers, ContentRuleList)
                 connection.receiveHTTPRequest([=](Vector<char>&&) {
                     connection.send(HTTPResponse({ { "Content-Type"_s, "application/javascript"_s } }, contentRuleListWorkerScript).serialize(), [=] {
                         connection.receiveHTTPRequest([=](Vector<char>&& lastRequest) {
-                            EXPECT_TRUE(strnstr((const char*)lastRequest.data(), "allowedsubresource", lastRequest.size()));
+                            EXPECT_TRUE(contains(lastRequest.span(), "allowedsubresource"_span));
                             connection.send(HTTPResponse("successful fetch"_s).serialize());
                         });
                     });

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm
@@ -228,9 +228,9 @@ static Vector<char> indentation(size_t count)
 static void printTree(_WKFrameTreeNode *n, size_t indent = 0)
 {
     if (n.info._isLocalFrame)
-        WTFLogAlways("%s%@://%@ (pid %d)", indentation(indent).data(), n.info.securityOrigin.protocol, n.info.securityOrigin.host, n.info._processIdentifier);
+        WTFLogAlways("%s%@://%@ (pid %d)", indentation(indent).span().data(), n.info.securityOrigin.protocol, n.info.securityOrigin.host, n.info._processIdentifier);
     else
-        WTFLogAlways("%s(remote) (pid %d)", indentation(indent).data(), n.info._processIdentifier);
+        WTFLogAlways("%s(remote) (pid %d)", indentation(indent).span().data(), n.info._processIdentifier);
     for (_WKFrameTreeNode *c in n.childFrames)
         printTree(c, indent + 1);
 }
@@ -238,9 +238,9 @@ static void printTree(_WKFrameTreeNode *n, size_t indent = 0)
 static void printTree(const ExpectedFrameTree& n, size_t indent = 0)
 {
     if (auto* s = std::get_if<String>(&n.remoteOrOrigin))
-        WTFLogAlways("%s%s", indentation(indent).data(), s->utf8().data());
+        WTFLogAlways("%s%s", indentation(indent).span().data(), s->utf8().data());
     else
-        WTFLogAlways("%s(remote)", indentation(indent).data());
+        WTFLogAlways("%s(remote)", indentation(indent).span().data());
     for (const auto& c : n.children)
         printTree(c, indent + 1);
 }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/UploadDirectory.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/UploadDirectory.mm
@@ -34,6 +34,7 @@
 #import "Utilities.h"
 #import <WebKit/WebKit.h>
 #import <wtf/RetainPtr.h>
+#import <wtf/StdLibExtras.h>
 #import <wtf/text/WTFString.h>
 
 @interface UploadDelegate : NSObject <WKUIDelegate>
@@ -89,10 +90,10 @@ TEST(WebKit, UploadDirectory)
                 "<form id='form' action='/upload.php' method='post' enctype='multipart/form-data'><input type='file' name='testname'></form>"_s;
                 connection.send(response, [=] {
                     connection.receiveHTTPRequest([=](Vector<char>&& request) {
-                        EXPECT_TRUE(strnstr(request.data(), "Content-Length: 543\r\n", request.size()));
-                        auto* headerEnd = strnstr(request.data(), "\r\n\r\n", request.size());
-                        EXPECT_TRUE(headerEnd);
-                        EXPECT_EQ(request.end() - (headerEnd + + strlen("\r\n\r\n")), 543);
+                        EXPECT_TRUE(contains(request.span(), "Content-Length: 543\r\n"_span));
+                        size_t headerEnd = find(request.span(), "\r\n\r\n"_span);
+                        EXPECT_TRUE(headerEnd != notFound);
+                        EXPECT_EQ(request.size() - (headerEnd + strlen("\r\n\r\n")), 543u);
                         constexpr auto secondResponse =
                         "HTTP/1.1 200 OK\r\n"
                         "Content-Length: 0\r\n\r\n"_s;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKContentExtensionStore.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKContentExtensionStore.mm
@@ -42,6 +42,7 @@
 #import <WebKit/_WKContentRuleListAction.h>
 #import <WebKit/_WKWebsiteDataStoreConfiguration.h>
 #import <wtf/RetainPtr.h>
+#import <wtf/StdLibExtras.h>
 #import <wtf/Vector.h>
 #import <wtf/text/WTFString.h>
 
@@ -372,8 +373,7 @@ TEST_F(WKContentRuleListStoreTest, CrossOriginCookieBlocking)
                     if (path == "/org"_s)
                         return HTTPResponse("<script>fetch('https://example.com/cookie-check', {credentials: 'include'})</script>"_s);
                     if (path == "/cookie-check"_s) {
-                        auto cookieHeader = "Cookie: testCookie=42";
-                        requestHadCookieResult = memmem(request.data(), request.size(), cookieHeader, strlen(cookieHeader));
+                        requestHadCookieResult = contains(request.span(), "Cookie: testCookie=42"_span);
                         return HTTPResponse("hi"_s);
                     }
                     RELEASE_ASSERT_NOT_REACHED();

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKRequestActivatedElementInfo.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKRequestActivatedElementInfo.mm
@@ -160,7 +160,7 @@ TEST(_WKActivatedElementInfo, InfoForRotatedImage)
 IGNORE_WARNINGS_BEGIN("deprecated-enum-enum-conversion")
         CGBitmapInfo bitmapInfo = kCGImageAlphaPremultipliedFirst | kCGImageByteOrder32Little;
 IGNORE_WARNINGS_END
-        RetainPtr<CGContextRef> context = adoptCF(CGBitmapContextCreate(pixels.data(), width, height, bitsPerComponent, bytesPerRow, colorSpace.get(), bitmapInfo));
+        RetainPtr<CGContextRef> context = adoptCF(CGBitmapContextCreate(pixels.mutableSpan().data(), width, height, bitsPerComponent, bytesPerRow, colorSpace.get(), bitmapInfo));
 
         CGContextDrawImage(context.get(), CGRectMake(0, 0, width, height), image);
         return pixels;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKURLSchemeHandler-1.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKURLSchemeHandler-1.mm
@@ -49,6 +49,7 @@
 #import <wtf/HashMap.h>
 #import <wtf/RetainPtr.h>
 #import <wtf/RunLoop.h>
+#import <wtf/StdLibExtras.h>
 #import <wtf/Threading.h>
 #import <wtf/Vector.h>
 #import <wtf/WeakObjCPtr.h>
@@ -1206,7 +1207,7 @@ TEST(WebKit, OriginHeaderWithCORSDisablingPatternsInUnrelatedWebView)
                 auto html = "<head><link rel='modulepreload' href='https://webkit.org/module'></head>"_s;
                 connection.send(HTTPResponse(html).serialize());
             } else if (path == "/module"_s) {
-                EXPECT_TRUE(strnstr(requestBytes.data(), "Origin: https://example.com\r\n", requestBytes.size()));
+                EXPECT_TRUE(contains(requestBytes.span(), "Origin: https://example.com\r\n"_span));
                 done = true;
             }
         });

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewConfiguration.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewConfiguration.mm
@@ -184,7 +184,7 @@ TEST(WebKit, ConfigurationHTTPSUpgrade)
         if (requestBytes.size() <= strlen(string))
             return;
         requestBytes[strlen(string)] = 0;
-        EXPECT_WK_STREQ(requestBytes.data(), string);
+        EXPECT_WK_STREQ(requestBytes.span().data(), string);
     };
 
     runTest(true);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebsiteDatastore.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebsiteDatastore.mm
@@ -508,7 +508,7 @@ TEST(WKWebsiteDataStore, ClearCustomDataStoreNoWebViews)
                     "Hello"_s);
                 break;
             case 2:
-                EXPECT_FALSE(strnstr(request.data(), "Cookie: a=b\r\n", request.size()));
+                EXPECT_FALSE(contains(request.span(), "Cookie: a=b\r\n"_span));
                 connection.send(
                     "HTTP/1.1 200 OK\r\n"
                     "Content-Length: 5\r\n"

--- a/Tools/TestWebKitAPI/cocoa/DaemonTestUtilities.mm
+++ b/Tools/TestWebKitAPI/cocoa/DaemonTestUtilities.mm
@@ -68,9 +68,9 @@ static RetainPtr<NSURL> currentExecutableLocation()
     _NSGetExecutablePath(nullptr, &size);
     Vector<char> buffer;
     buffer.resize(size + 1);
-    _NSGetExecutablePath(buffer.data(), &size);
+    _NSGetExecutablePath(buffer.mutableSpan().data(), &size);
     buffer[size] = '\0';
-    auto pathString = adoptNS([[NSString alloc] initWithUTF8String:buffer.data()]);
+    auto pathString = adoptNS([[NSString alloc] initWithUTF8String:buffer.span().data()]);
     return adoptNS([[NSURL alloc] initFileURLWithPath:pathString.get() isDirectory:NO]);
 }
 

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
@@ -117,7 +117,7 @@ static WKRetainPtr<WKDictionaryRef> createWKDictionary(std::initializer_list<std
         values.append(pair.second.get());
         strings.append(WTFMove(key));
     }
-    return adoptWK(WKDictionaryCreate(keys.data(), values.data(), keys.size()));
+    return adoptWK(WKDictionaryCreate(keys.span().data(), values.span().data(), keys.size()));
 }
 
 template<typename T> static WKRetainPtr<WKTypeRef> postSynchronousMessageWithReturnValue(const char* name, const WKRetainPtr<T>& value)
@@ -1609,7 +1609,7 @@ static WKRetainPtr<WKDictionaryRef> captureDeviceProperties(JSContextRef context
         JSPropertyNameArrayRelease(propertyNameArray);
     }
 
-    return adoptWK(WKDictionaryCreate(keys.data(), values.data(), keys.size()));
+    return adoptWK(WKDictionaryCreate(keys.span().data(), values.span().data(), keys.size()));
 }
 
 void TestRunner::addMockCameraDevice(JSContextRef context, JSStringRef persistentId, JSStringRef label, JSValueRef properties)

--- a/Tools/WebKitTestRunner/InjectedBundle/ios/AccessibilityUIElementIOS.mm
+++ b/Tools/WebKitTestRunner/InjectedBundle/ios/AccessibilityUIElementIOS.mm
@@ -164,15 +164,15 @@ namespace WTR {
 static JSRetainPtr<JSStringRef> concatenateAttributeAndValue(NSString *attribute, NSString *value)
 {
     Vector<UniChar> buffer([attribute length]);
-    [attribute getCharacters:buffer.data()];
+    [attribute getCharacters:buffer.mutableSpan().data()];
     buffer.append(':');
     buffer.append(' ');
 
     Vector<UniChar> valueBuffer([value length]);
-    [value getCharacters:valueBuffer.data()];
+    [value getCharacters:valueBuffer.mutableSpan().data()];
     buffer.appendVector(valueBuffer);
 
-    return adopt(JSStringCreateWithCharacters(buffer.data(), buffer.size()));
+    return adopt(JSStringCreateWithCharacters(buffer.span().data(), buffer.size()));
 }
     
 AccessibilityUIElement::AccessibilityUIElement(PlatformUIElement element)

--- a/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.mm
+++ b/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.mm
@@ -269,15 +269,15 @@ RetainPtr<NSString> AccessibilityUIElement::descriptionOfValue(id valueObject) c
 static JSRetainPtr<JSStringRef> concatenateAttributeAndValue(NSString* attribute, NSString* value)
 {
     Vector<UniChar> buffer([attribute length]);
-    [attribute getCharacters:buffer.data()];
+    [attribute getCharacters:buffer.mutableSpan().data()];
     buffer.append(':');
     buffer.append(' ');
 
     Vector<UniChar> valueBuffer([value length]);
-    [value getCharacters:valueBuffer.data()];
+    [value getCharacters:valueBuffer.mutableSpan().data()];
     buffer.appendVector(valueBuffer);
 
-    return adopt(JSStringCreateWithCharacters(buffer.data(), buffer.size()));
+    return adopt(JSStringCreateWithCharacters(buffer.span().data(), buffer.size()));
 }
 
 static JSRetainPtr<JSStringRef> descriptionOfElements(const Vector<RefPtr<AccessibilityUIElement>>& elements)

--- a/Tools/WebKitTestRunner/PixelDumpSupport.cpp
+++ b/Tools/WebKitTestRunner/PixelDumpSupport.cpp
@@ -78,7 +78,7 @@ void printPNG(const unsigned char* data, const size_t dataLength, const char* ch
     size_t insertOffset = offsetAfterIHDRChunk(data, dataLength);
 
     fwrite(data, 1, insertOffset, stdout);
-    fwrite(bytesToAdd.data(), 1, bytesToAdd.size(), stdout);
+    fwrite(bytesToAdd.span().data(), 1, bytesToAdd.size(), stdout);
 
     const size_t bytesToWriteInOneChunk = 1 << 15;
     data += insertOffset;

--- a/Tools/WebKitTestRunner/ios/HIDEventGenerator.mm
+++ b/Tools/WebKitTestRunner/ios/HIDEventGenerator.mm
@@ -618,7 +618,7 @@ static InterpolationType interpolationFromString(NSString *string)
     for (NSUInteger index = 0; index < touchCount; ++index)
         locations[index] = location;
     
-    [self touchDownAtPoints:(locations.isEmpty() ? nullptr : locations.data()) touchCount:touchCount];
+    [self touchDownAtPoints:(locations.isEmpty() ? nullptr : locations.mutableSpan().data()) touchCount:touchCount];
 }
 
 - (void)touchDown:(CGPoint)location
@@ -654,7 +654,7 @@ static InterpolationType interpolationFromString(NSString *string)
     for (NSUInteger index = 0; index < touchCount; ++index)
         locations[index] = location;
     
-    [self liftUpAtPoints:(locations.isEmpty() ? nullptr : locations.data()) touchCount:touchCount];
+    [self liftUpAtPoints:(locations.isEmpty() ? nullptr : locations.mutableSpan().data()) touchCount:touchCount];
 }
 
 - (void)liftUp:(CGPoint)location
@@ -683,7 +683,7 @@ static InterpolationType interpolationFromString(NSString *string)
 
             nextLocations[i] = calculateNextCurveLocation(startLocations[i], newLocations[i], interval);
         }
-        [self _updateTouchPoints:(nextLocations.isEmpty() ? nullptr : nextLocations.data()) count:touchCount];
+        [self _updateTouchPoints:(nextLocations.isEmpty() ? nullptr : nextLocations.mutableSpan().data()) count:touchCount];
 
         delayBetweenMove(eventIndex++, elapsed);
     }


### PR DESCRIPTION
#### 56f70884724fb1a8ca99e5e2d043aa3016c5baf3
<pre>
Further reduce use of Vector::data() in the codebase
<a href="https://bugs.webkit.org/show_bug.cgi?id=293934">https://bugs.webkit.org/show_bug.cgi?id=293934</a>

Reviewed by Justin Michaud.

Further reduce use of Vector::data() in the codebase, in favor of using
Vector::span(). This is a step towards dropping Vector::data() and encouraging
developers to use spans.

* Source/JavaScriptCore/jsc.cpp:
(currentWorkingDirectory):
(fillBufferWithContentsOfFile):
(JSC_DEFINE_HOST_FUNCTION):
* Source/WTF/wtf/StreamBuffer.h:
(WTF::StreamBuffer::firstBlockData const):
* Source/WTF/wtf/Vector.h:
* Source/WTF/wtf/cocoa/SpanCocoa.h:
* Source/WebCore/platform/graphics/GCGLSpan.h:
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.cpp:
(WebKit::RemoteGraphicsContextGL::multiDrawElementsANGLE):
(WebKit::RemoteGraphicsContextGL::multiDrawElementsInstancedANGLE):
(WebKit::RemoteGraphicsContextGL::multiDrawElementsInstancedBaseVertexBaseInstanceANGLE):
* Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm:
(WebKit::NetworkSessionCocoa::setProxyConfigData):
* Source/WebKit/Platform/IPC/cocoa/ConnectionCocoa.mm:
(IPC::readFromMachPort):
* Source/WebKit/Platform/classifier/cocoa/ResourceLoadStatisticsClassifierCocoa.cpp:
(WebKit::ResourceLoadStatisticsClassifierCocoa::classify):
* Source/WebKit/Shared/ApplePay/cocoa/WebPaymentCoordinatorProxyCocoa.mm:
(WebKit::toPKContactFields):
* Source/WebKit/Shared/Cocoa/CoreIPCCFURL.mm:
(WebKit::CoreIPCCFURL::createWithBaseURLAndBytes):
(WebKit::CoreIPCCFURL::toVector const):
* Source/WebKit/Shared/Cocoa/SandboxExtensionCocoa.mm:
(WebKit::SandboxExtension::createHandleForTemporaryFile):
* Source/WebKit/Shared/Extensions/WebExtensionUtilities.cpp:
(WebKit::formatString):
* Source/WebKit/Shared/RTCNetwork.cpp:
(WebKit::RTCNetwork::value const):
(WebKit::RTC::Network::SocketAddress::rtcAddress const):
* Source/WebKit/Shared/cf/CookieStorageUtilsCF.mm:
(WebKit::cookieStorageFromIdentifyingData):
* Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm:
(WebKit::compileAndApplySandboxSlowCase):
* Source/WebKit/UIProcess/API/C/WKPage.cpp:
(WKPageComputePagesForPrinting):
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/HidConnection.mm:
(WebKit::HidConnection::initialize):
(WebKit::HidConnection::terminate):
(WebKit::HidConnection::sendSync):
(WebKit::HidConnection::send):
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalAuthenticator.mm:
(WebKit::LocalAuthenticator::continueMakeCredentialAfterUserVerification):
(WebKit::LocalAuthenticator::continueGetAssertionAfterUserVerification):
* Source/WebKit/UIProcess/WebAuthentication/Virtual/VirtualAuthenticatorUtils.mm:
(WebKit::credentialIdAndCosePubKeyForPrivateKey):
(WebKit::signatureForPrivateKey):
* Source/WebKit/UIProcess/mac/LegacySessionStateCoding.cpp:
(WebKit::createDictionary):
* Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp:
(WebKit::toJSArray):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBufferProxy.cpp:
(WebKit::WebGPU::RemoteBufferProxy::getMappedRange):
* Source/WebKit/WebProcess/InjectedBundle/API/mac/WKDOMTextIterator.mm:
(-[WKDOMTextIterator currentTextPointer]):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDataDetectorOverlayController.mm:
(WebKit::createPlatformDataDetectorHighlight):
* Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp:
(WebKit::IPCTestingAPI::JSIPC::serializedEnumInfo):
* Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm:
(WebKit::setVideoDecoderBehaviors):
* Source/WebKitLegacy/WebCoreSupport/SocketStreamHandleImpl.cpp:
(WebCore::SocketStreamHandleImpl::platformSendHandshake):
* Source/WebKitLegacy/WebCoreSupport/WebSocketChannel.cpp:
(WebCore::WebSocketChannel::processFrame):
* Source/WebKitLegacy/mac/Misc/WebKitNSStringExtras.mm:
(-[NSString _web_drawAtPoint:font:textColor:]):
(-[NSString _web_widthWithFont:]):
* Source/WebKitLegacy/mac/Plugins/WebBasePluginPackage.mm:
(swapIntsInHeader):
(-[WebBasePluginPackage isNativeLibraryData:]):
* Source/WebKitLegacy/mac/WebCoreSupport/WebVisitedLinkStore.mm:
(WebVisitedLinkStore::addVisitedLink):
* Source/WebKitLegacy/mac/WebView/WebTextIterator.mm:
(-[WebTextIterator currentTextPointer]):
* Tools/DumpRenderTree/PixelDumpSupport.cpp:
(printPNG):
* Tools/DumpRenderTree/mac/AccessibilityUIElementMac.mm:
(concatenateAttributeAndValue):
* Tools/TestWebKitAPI/NetworkConnection.mm:
(TestWebKitAPI::Connection::receiveHTTPRequest const):
(TestWebKitAPI::Connection::webSocketHandshake):
* Tools/TestWebKitAPI/Tests/IPC/ArgumentCoderTests.cpp:
(TestWebKitAPI::ArgumentCoderEncoderDecoderTest&lt;IPC::StreamConnectionEncoder&gt;::createDecoder const):
* Tools/TestWebKitAPI/Tests/WTF/IntegerToStringConversion.cpp:
(testBoundaries):
(testNumbers):
* Tools/TestWebKitAPI/Tests/WTF/StdLibExtrasTests.cpp:
(TestWebKitAPI::TEST(WTF_StdLibExtras, SpanReinterpretCast_NonDynamicExtent)):
* Tools/TestWebKitAPI/Tests/WTF/StringCommon.cpp:
(TestWebKitAPI::TEST(WTF_StringCommon, Find8NonASCII)):
(TestWebKitAPI::TEST(WTF_StringCommon, Find16NonASCII)):
* Tools/TestWebKitAPI/Tests/WTF/StringHasher.cpp:
(TestWebKitAPI::TEST(WTF, StringHasher_SuperFastHash_VS_WYHash)):
* Tools/TestWebKitAPI/Tests/WTF/Vector.cpp:
(TestWebKitAPI::TEST(WTF_Vector, Basic)):
(TestWebKitAPI::TEST(WTF_Vector, ZeroSize)):
* Tools/TestWebKitAPI/Tests/WebCore/CBORWriterTest.cpp:
(TestWebKitAPI::eq):
(TestWebKitAPI::TEST(CBORWriterTest, TestWriteArray)):
(TestWebKitAPI::TEST(CBORWriterTest, TestWriteMapWithMapValue)):
(TestWebKitAPI::TEST(CBORWriterTest, TestWriteMapWithArray)):
(TestWebKitAPI::TEST(CBORWriterTest, TestWriteNestedMap)):
* Tools/TestWebKitAPI/Tests/WebCore/ContentExtensions.cpp:
(TestWebKitAPI::TEST_F(ContentExtensionTest, SearchSuffixesWithIdenticalActionAreMerged)):
(TestWebKitAPI::TEST_F(ContentExtensionTest, SearchSuffixesWithDistinguishableActionAreNotMerged)):
(TestWebKitAPI::TEST_F(ContentExtensionTest, UselessTermsMatchingEverythingAreEliminated)):
(TestWebKitAPI::TEST_F(ContentExtensionTest, SplittingLargeNFAs)):
(TestWebKitAPI::TEST_F(ContentExtensionTest, Serialization)):
* Tools/TestWebKitAPI/Tests/WebCore/RTCRtpSFrameTransformerTests.cpp:
(TestWebKitAPI::TEST(RTCRtpSFrameTransformer, EncryptDecrypt)):
(TestWebKitAPI::TEST(RTCRtpSFrameTransformer, EncryptDecryptKeyID0)):
(TestWebKitAPI::TEST(RTCRtpSFrameTransformer, EncryptDecryptAudio)):
* Tools/TestWebKitAPI/Tests/WebCore/cocoa/PrivateClickMeasurementCocoa.mm:
(TestWebKitAPI::TEST(PrivateClickMeasurement, ValidBlindedSecret)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/Challenge.mm:
(testCertificate):
(createTestIdentity):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/CookieAcceptPolicy.mm:
(TEST(WKHTTPCookieStore, CookiePolicy)):
(TEST(WKHTTPCookieStore, CookiePolicyAllowIsOnlyFromMainDocumentDomain)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/Download.mm:
(downloadTestServer):
(TestWebKitAPI::ResumeWithoutInitialDataOnDisk)):
(TestWebKitAPI::ResumeWithExtraInitialDataOnDisk)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/EventAttribution.mm:
(TestWebKitAPI::runBasicPCMTest):
(TestWebKitAPI::triggerAttributionWithSubresourceRedirect):
(TestWebKitAPI::signUnlinkableTokenAndSendSecretToken):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/LoadAlternateHTMLString.mm:
(TEST(WKWebView, LoadHTMLStringOrigin)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/NetworkProcess.mm:
(TEST(WebKit, HTTPReferer)):
(TEST(NetworkProcess, CORSPreflightCachePartitioned)):
(TEST(_WKDataTask, Basic)):
(TEST(WKWebView, CrossOriginDoubleRedirectAuthentication)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/Proxy.mm:
(TestWebKitAPI::TEST(WebKit, RelaxThirdPartyCookieBlocking)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SOAuthorizationTests.mm:
(TestWebKitAPI::TEST(SOAuthorizationRedirect, InterceptionSucceedWith307Simple)):
(TestWebKitAPI::TEST(SOAuthorizationRedirect, InterceptionSucceedWith307CrossOrigin)):
(TestWebKitAPI::TEST(SOAuthorizationRedirect, InterceptionFailedWith307PUT)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ServiceWorkerBasic.mm:
((ServiceWorkers, ContentRuleList)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm:
(TestWebKitAPI::printTree):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/UploadDirectory.mm:
(TEST(WebKit, UploadDirectory)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKContentExtensionStore.mm:
(TEST_F(WKContentRuleListStoreTest, CrossOriginCookieBlocking)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKHTTPCookieStore.mm:
(TEST(WKHTTPCookieStore, WebSocketCookies)):
(TEST(WKHTTPCookieStore, WebSocketCookiesFromRedirect)):
(TEST(WKHTTPCookieStore, WebSocketCookiesThroughRedirect)):
(TEST(WKHTTPCookieStore, WebSocketSetCookiesThroughFirstPartyRedirect)):
(TEST(WKHTTPCookieStore, WebSocketSetCookiesThroughRedirectToThirdParty)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKURLSchemeHandler-1.mm:
((WebKit, OriginHeaderWithCORSDisablingPatternsInUnrelatedWebView)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewConfiguration.mm:
(TEST(WebKit, ConfigurationHTTPSUpgrade)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebsiteDatastore.mm:
(TestWebKitAPI::(WKWebsiteDataStore, ClearCustomDataStoreNoWebViews)):
* Tools/TestWebKitAPI/cocoa/DaemonTestUtilities.mm:
(TestWebKitAPI::currentExecutableLocation):
* Tools/TestWebKitAPI/cocoa/HTTPServer.mm:
(TestWebKitAPI::HTTPServer::parsePath):
(TestWebKitAPI::HTTPServer::parseBody):
(TestWebKitAPI::H2::Connection::receive const):
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp:
(WTR::createWKDictionary):
(WTR::captureDeviceProperties):
* Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.mm:
(WTR::concatenateAttributeAndValue):
* Tools/WebKitTestRunner/PixelDumpSupport.cpp:
(printPNG):

Canonical link: <a href="https://commits.webkit.org/295795@main">https://commits.webkit.org/295795@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f4d85df01415b0a17ebb7636b86750a069e20c30

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/106161 "9 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25910 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/16304 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/111358 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/56757 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/108200 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/26568 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34413 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80637 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/109165 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/20992 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95799 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60962 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/20556 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13902 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/56196 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/98800 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/90354 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13937 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/114216 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/104778 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33299 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24563 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89712 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33663 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/92032 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89411 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22795 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34275 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/12088 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/28875 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/33224 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/38636 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/129090 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32970 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/35184 "Found 1 new JSC stress test failure: wasm.yaml/wasm/gc/ref-i31-eq.js.wasm-eager (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/36320 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34568 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->