### PR TITLE
Add Web Inspector description and auto-completion for dynamic-range-limit

### DIFF
--- a/Source/WebInspectorUI/UserInterface/External/CSSDocumentation/CSSDocumentation-overrides.json
+++ b/Source/WebInspectorUI/UserInterface/External/CSSDocumentation/CSSDocumentation-overrides.json
@@ -9,6 +9,10 @@
         "description": "Changes the appearance of buttons and other controls to resemble native controls.",
         "syntax": "none | button | checkbox | listbox | menulist | menulist-button | meter | progress-bar | push-button | radio | searchfield | slider-horizontal | slider-vertical | square-button | textarea | textfield | -apple-pay-button"
     },
+    "dynamic-range-limit": {
+        "description": "Controls the maximum brightness of high dynamic range (HDR) content.",
+        "syntax": "standard | no-limit"
+    },
     "overlay": {
         "description": "The overlay CSS property specifies whether an element appearing in the top layer (for example, a shown popover or modal <dialog> element) is actually rendered in the top layer. This property is only relevant within a list of transition-property values, and only if allow-discrete is set as the transition-behavior."
     },

--- a/Source/WebInspectorUI/UserInterface/External/CSSDocumentation/CSSDocumentation.js
+++ b/Source/WebInspectorUI/UserInterface/External/CSSDocumentation/CSSDocumentation.js
@@ -1110,6 +1110,10 @@ CSSDocumentation = {
         "syntax": "auto | text-bottom | alphabetic | ideographic | middle | central | mathematical | hanging | text-top",
         "url": "https://developer.mozilla.org/docs/Web/CSS/dominant-baseline"
     },
+    "dynamic-range-limit": {
+        "description": "Controls the maximum brightness of high dynamic range (HDR) content.",
+        "syntax": "standard | no-limit"
+    },
     "empty-cells": {
         "description": "In the separated borders model, this property controls the rendering of borders and backgrounds around cells that have no visible content.",
         "syntax": "show | hide",

--- a/Source/WebInspectorUI/UserInterface/Models/CSSKeywordCompletions.js
+++ b/Source/WebInspectorUI/UserInterface/Models/CSSKeywordCompletions.js
@@ -1233,6 +1233,9 @@ WI.CSSKeywordCompletions._propertyKeywordMap = {
     "dominant-baseline": [
         "middle", "auto", "alphabetic", "central", "text-before-edge", "text-after-edge", "ideographic", "hanging", "mathematical", "use-script", "no-change", "reset-size",
     ],
+    "dynamic-range-limit": [
+        "standard", "no-limit",
+    ],
     "empty-cells": [
         "hide", "show",
     ],


### PR DESCRIPTION
#### ab6af93cf9e272e418ae414d4590a008f1b9c940
<pre>
Add Web Inspector description and auto-completion for dynamic-range-limit
<a href="https://bugs.webkit.org/show_bug.cgi?id=293938">https://bugs.webkit.org/show_bug.cgi?id=293938</a>
<a href="https://rdar.apple.com/152481438">rdar://152481438</a>

Reviewed by BJ Burg.

* Source/WebInspectorUI/UserInterface/External/CSSDocumentation/CSSDocumentation-overrides.json:
There is currently no external documentation for `dynamic-range-limit`,
so this is added to the overrides file for now.

* Source/WebInspectorUI/UserInterface/External/CSSDocumentation/CSSDocumentation.js:
Manually added to CSSDocumentation.js, as update-inspector-css-documentation
would have done for just this override; but without updating everything
else, which should happen closer to the release.

* Source/WebInspectorUI/UserInterface/Models/CSSKeywordCompletions.js:
`dynamic-range-limit` is not fast-path eligible, so keywords have to be
manually added to this special completion list.

Canonical link: <a href="https://commits.webkit.org/295780@main">https://commits.webkit.org/295780@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dd059444a16afbf1e83bbc74cfe8e931d34806ab

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/106006 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25755 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/16149 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/111202 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/56602 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/26409 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34258 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80523 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/109010 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/20838 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95667 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60844 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/20445 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13764 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/56040 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/90216 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13800 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/114058 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33144 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24457 "Found 3 new test failures: imported/w3c/web-platform-tests/mimesniff/media/media-sniff.window.html platform/mac/fast/text/line-break-locale.html svg/zoom/page/text-with-non-scaling-stroke.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89602 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33508 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91895 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89286 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22783 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34153 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11968 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/28702 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/33069 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/38481 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32815 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/36164 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34413 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->