### PR TITLE
ANGLE: Typo in valdiatePixmap

### DIFF
--- a/Source/ThirdParty/ANGLE/src/libANGLE/Display.cpp
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/Display.cpp
@@ -2289,7 +2289,7 @@ Error Display::validateImageClientBuffer(const gl::Context *context,
     return mImplementation->validateImageClientBuffer(context, target, clientBuffer, attribs);
 }
 
-Error Display::valdiatePixmap(const Config *config,
+Error Display::validatePixmap(const Config *config,
                               EGLNativePixmapType pixmap,
                               const AttributeMap &attributes) const
 {

--- a/Source/ThirdParty/ANGLE/src/libANGLE/Display.h
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/Display.h
@@ -217,7 +217,7 @@ class Display final : public LabeledObject,
                                     EGLenum target,
                                     EGLClientBuffer clientBuffer,
                                     const egl::AttributeMap &attribs) const;
-    Error valdiatePixmap(const Config *config,
+    Error validatePixmap(const Config *config,
                          EGLNativePixmapType pixmap,
                          const AttributeMap &attributes) const;
 

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/DisplayImpl.cpp
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/DisplayImpl.cpp
@@ -102,7 +102,7 @@ egl::Error DisplayImpl::validatePixmap(const egl::Config *config,
                                        const egl::AttributeMap &attributes) const
 {
     UNREACHABLE();
-    return egl::Error(EGL_BAD_DISPLAY, "DisplayImpl::valdiatePixmap unimplemented.");
+    return egl::Error(EGL_BAD_DISPLAY, "DisplayImpl::validatePixmap unimplemented.");
 }
 
 const egl::Caps &DisplayImpl::getCaps() const

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/TextureMtl.h
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/TextureMtl.h
@@ -313,7 +313,7 @@ class TextureMtl : public TextureImpl
                                       const uint8_t *pixels,
                                       const mtl::TextureRef &image);
 
-    // Convert pixels to suported format before uploading to texture
+    // Convert pixels to supported format before uploading to texture.
     angle::Result convertAndSetPerSliceSubImage(const gl::Context *context,
                                                 int slice,
                                                 const MTLRegion &mtlArea,

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/vulkan/vk_format_utils.cpp
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/vulkan/vk_format_utils.cpp
@@ -341,7 +341,7 @@ angle::FormatID ExternalFormatTable::getOrAllocExternalFormatID(uint64_t externa
 
     if (mExternalYuvFormats.size() >= kMaxExternalFormatCountSupported)
     {
-        ERR() << "ANGLE only suports maximum " << kMaxExternalFormatCountSupported
+        ERR() << "ANGLE only supports maximum " << kMaxExternalFormatCountSupported
               << " external renderable formats";
         return angle::FormatID::NONE;
     }

--- a/Source/ThirdParty/ANGLE/src/libANGLE/validationEGL.cpp
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/validationEGL.cpp
@@ -3459,11 +3459,11 @@ bool ValidateCreatePixmapSurface(const ValidationContext *val,
 
     if (!(config->surfaceType & EGL_PIXMAP_BIT))
     {
-        val->setError(EGL_BAD_MATCH, "Congfig does not suport pixmaps.");
+        val->setError(EGL_BAD_MATCH, "Config does not support pixmaps.");
         return false;
     }
 
-    ANGLE_EGL_TRY_RETURN(val->eglThread, display->valdiatePixmap(config, pixmap, attributes),
+    ANGLE_EGL_TRY_RETURN(val->eglThread, display->validatePixmap(config, pixmap, attributes),
                          val->entryPoint, val->labeledObject, false);
 
     return true;


### PR DESCRIPTION
#### 169e33b1792a01b853174c2b3d5ec8ff6dc61d43
<pre>
ANGLE: Typo in valdiatePixmap
<a href="https://bugs.webkit.org/show_bug.cgi?id=293940">https://bugs.webkit.org/show_bug.cgi?id=293940</a>
<a href="https://rdar.apple.com/150885464">rdar://150885464</a>

Reviewed by Mike Wyrzykowski.

Fix typo in Display::valdiatePixmap and adjacent typos.

* Source/ThirdParty/ANGLE/src/libANGLE/Display.cpp:
(egl::Display::validatePixmap const):
(egl::Display::valdiatePixmap const): Deleted.
* Source/ThirdParty/ANGLE/src/libANGLE/Display.h:
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/DisplayImpl.cpp:
(rx::DisplayImpl::validatePixmap const):
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/TextureMtl.h:
* Source/ThirdParty/ANGLE/src/libANGLE/validationEGL.cpp:
(egl::ValidateCreatePixmapSurface):

Canonical link: <a href="https://commits.webkit.org/295806@main">https://commits.webkit.org/295806@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fb82daff874a8fbbeb9c9329312da6dbb8157566

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/106012 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25761 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/16155 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/111208 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/56608 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/26415 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34264 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80527 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/109016 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/20848 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95674 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60848 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/20450 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13771 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/56046 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/90223 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13807 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/114064 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33150 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24462 "Found 3 new test failures: imported/w3c/web-platform-tests/mimesniff/media/media-sniff.window.html platform/mac/fast/text/line-break-locale.html svg/zoom/page/text-with-non-scaling-stroke.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89606 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33514 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91902 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89290 "Found 101 new API test failures: /TestWebKit:WebKit.PageLoadDidChangeLocationWithinPage, /TestWebKit:WebKit.AboutBlankLoad, /TestWebKit:WebKit.PreventEmptyUserAgent, /TestWebKit:WebKit.PrivateBrowsingPushStateNoHistoryCallback, /WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/content-type, /WebKitGTK/TestUIClient:/webkit/WebKitWebView/pointer-lock-permission-request, /TestWebKit:WebKit.HitTestResultNodeHandle, /TestWebKit:WebKit2TextFieldBeginAndEditEditingTest.TextFieldDidBeginShouldNotBeDispatchedForAlreadyFocusedField, /TestWebKit:WebKit.Find, /WebKitGTK/TestWebProcessExtensions:/webkit/WebKitWebProcessExtension/dom-input-element-is-user-edited ... (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22805 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34158 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11974 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/28709 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/33075 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32821 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/36170 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34419 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->