### PR TITLE
[WPE] WPE Platform: add API tests to check WebKitWebView display and wpe-view

### DIFF
--- a/Tools/TestWebKitAPI/wpe/mock-platform/CMakeLists.txt
+++ b/Tools/TestWebKitAPI/wpe/mock-platform/CMakeLists.txt
@@ -2,6 +2,7 @@ set_property(DIRECTORY . PROPERTY FOLDER "mock-platform")
 
 add_library(WPEMockPlatform MODULE
     WPEDisplayMock.cpp
+    WPEViewMock.cpp
 )
 
 set_target_properties(WPEMockPlatform PROPERTIES

--- a/Tools/TestWebKitAPI/wpe/mock-platform/WPEDisplayMock.cpp
+++ b/Tools/TestWebKitAPI/wpe/mock-platform/WPEDisplayMock.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "WPEDisplayMock.h"
 
+#include "WPEViewMock.h"
 #include <gio/gio.h>
 #include <gmodule.h>
 
@@ -57,7 +58,7 @@ static gboolean wpeDisplayMockConnect(WPEDisplay* display, GError** error)
 
 static WPEView* wpeDisplayMockCreateView(WPEDisplay* display)
 {
-    return nullptr;
+    return WPE_VIEW(g_object_new(WPE_TYPE_VIEW_MOCK, "display", display, nullptr));
 }
 
 static WPEInputMethodContext* wpeDisplayMockCreateInputMethodContext(WPEDisplay* display, WPEView*)

--- a/Tools/TestWebKitAPI/wpe/mock-platform/WPEViewMock.cpp
+++ b/Tools/TestWebKitAPI/wpe/mock-platform/WPEViewMock.cpp
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2025 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WPEViewMock.h"
+
+#include <wtf/glib/GRefPtr.h>
+#include <wtf/glib/WTFGType.h>
+
+struct _WPEViewMockPrivate {
+    GRefPtr<WPEBuffer> pendingBuffer;
+    GRefPtr<WPEBuffer> committedBuffer;
+    guint frameTimerID;
+};
+WEBKIT_DEFINE_FINAL_TYPE(WPEViewMock, wpe_view_mock, WPE_TYPE_VIEW, WPEView)
+
+static void wpeViewMockDispose(GObject* object)
+{
+    auto* priv = WPE_VIEW_MOCK(object)->priv;
+    g_clear_handle_id(&priv->frameTimerID, g_source_remove);
+
+    G_OBJECT_CLASS(wpe_view_mock_parent_class)->dispose(object);
+}
+
+static gboolean wpeViewMockRenderBuffer(WPEView* view, WPEBuffer* buffer, const WPERectangle*, guint, GError**)
+{
+    auto* priv = WPE_VIEW_MOCK(view)->priv;
+    priv->pendingBuffer = buffer;
+    priv->frameTimerID = g_timeout_add(1000 / 60, +[](gpointer userData) -> gboolean {
+        auto* priv = WPE_VIEW_MOCK(userData)->priv;
+        priv->frameTimerID = 0;
+
+        auto* view = WPE_VIEW(userData);
+        if (priv->committedBuffer)
+            wpe_view_buffer_released(view, priv->committedBuffer.get());
+        priv->committedBuffer = WTFMove(priv->pendingBuffer);
+        wpe_view_buffer_rendered(view, priv->committedBuffer.get());
+
+        return G_SOURCE_REMOVE;
+    }, view);
+
+    return TRUE;
+}
+
+static void wpe_view_mock_class_init(WPEViewMockClass* viewMockClass)
+{
+    GObjectClass* objectClass = G_OBJECT_CLASS(viewMockClass);
+    objectClass->dispose = wpeViewMockDispose;
+
+    WPEViewClass* viewClass = WPE_VIEW_CLASS(viewMockClass);
+    viewClass->render_buffer = wpeViewMockRenderBuffer;
+}

--- a/Tools/TestWebKitAPI/wpe/mock-platform/WPEViewMock.h
+++ b/Tools/TestWebKitAPI/wpe/mock-platform/WPEViewMock.h
@@ -30,7 +30,7 @@
 
 G_BEGIN_DECLS
 
-#define WPE_TYPE_DISPLAY_MOCK (wpe_display_mock_get_type())
-G_DECLARE_FINAL_TYPE(WPEDisplayMock, wpe_display_mock, WPE, DISPLAY_MOCK, WPEDisplay)
+#define WPE_TYPE_VIEW_MOCK (wpe_view_mock_get_type())
+G_DECLARE_FINAL_TYPE(WPEViewMock, wpe_view_mock, WPE, VIEW_MOCK, WPEView)
 
 G_END_DECLS


### PR DESCRIPTION
#### 7c58566fb8cadc7541cb72f7c5a15b9c9ac4ad73
<pre>
[WPE] WPE Platform: add API tests to check WebKitWebView display and wpe-view
<a href="https://bugs.webkit.org/show_bug.cgi?id=293941">https://bugs.webkit.org/show_bug.cgi?id=293941</a>

Reviewed by Patrick Griffis.

This adds WPEViewMock since we can&apos;t create a WebKitWebView without a
WPEView.

Canonical link: <a href="https://commits.webkit.org/295866@main">https://commits.webkit.org/295866@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9a5ca473ea56cb0ef4d2f246d9c2d33057dcdae4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/106371 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/26120 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/16518 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/111572 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/56967 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/108410 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/26787 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34623 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/80795 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/109375 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/21221 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95995 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/61123 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/20718 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/14094 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/56407 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/90559 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/14129 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/114431 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33509 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/24704 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/89866 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33873 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/92224 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89570 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34453 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/12274 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/29100 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17236 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/33434 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/33180 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/36533 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34778 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->