### PR TITLE
Address uncounted lambda captures in WebResourceLoadStatisticsStore

### DIFF
--- a/Source/WebKit/NetworkProcess/Classifier/WebResourceLoadStatisticsStore.h
+++ b/Source/WebKit/NetworkProcess/Classifier/WebResourceLoadStatisticsStore.h
@@ -232,7 +232,7 @@ public:
 private:
     explicit WebResourceLoadStatisticsStore(NetworkSession&, const String&, ShouldIncludeLocalhost, WebCore::ResourceLoadStatistics::IsEphemeral);
 
-    void postTask(WTF::Function<void()>&&);
+    void postTask(WTF::Function<void(WebResourceLoadStatisticsStore&)>&&);
     static void postTaskReply(WTF::Function<void()>&&);
 
     void performDailyTasks();

--- a/Source/WebKit/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
@@ -1,4 +1,3 @@
-NetworkProcess/Classifier/WebResourceLoadStatisticsStore.cpp
 NetworkProcess/cocoa/NetworkSessionCocoa.mm
 Platform/IPC/StreamClientConnection.h
 Shared/Cocoa/AuxiliaryProcessCocoa.mm


### PR DESCRIPTION
#### 402c92d0335f8bc82014b8742f03ee6a3fa29dde
<pre>
Address uncounted lambda captures in WebResourceLoadStatisticsStore
<a href="https://bugs.webkit.org/show_bug.cgi?id=293958">https://bugs.webkit.org/show_bug.cgi?id=293958</a>

Reviewed by Chris Dumez.

* Source/WebKit/NetworkProcess/Classifier/WebResourceLoadStatisticsStore.cpp:
(WebKit::WebResourceLoadStatisticsStore::setIsRunningTest):
(WebKit::WebResourceLoadStatisticsStore::setShouldClassifyResourcesBeforeDataRecordsRemoval):
(WebKit::WebResourceLoadStatisticsStore::WebResourceLoadStatisticsStore):
(WebKit::WebResourceLoadStatisticsStore::postTask):
(WebKit::WebResourceLoadStatisticsStore::destroyResourceLoadStatisticsStore):
(WebKit::WebResourceLoadStatisticsStore::populateMemoryStoreFromDisk):
(WebKit::WebResourceLoadStatisticsStore::setResourceLoadStatisticsDebugMode):
(WebKit::WebResourceLoadStatisticsStore::setPrevalentResourceForDebugMode):
(WebKit::WebResourceLoadStatisticsStore::scheduleStatisticsAndDataRecordsProcessing):
(WebKit::WebResourceLoadStatisticsStore::statisticsDatabaseHasAllTables):
(WebKit::WebResourceLoadStatisticsStore::resourceLoadStatisticsUpdated):
(WebKit::WebResourceLoadStatisticsStore::hasStorageAccess):
(WebKit::WebResourceLoadStatisticsStore::requestStorageAccess):
(WebKit::WebResourceLoadStatisticsStore::requestStorageAccessUnderOpener):
(WebKit::WebResourceLoadStatisticsStore::grantStorageAccess):
(WebKit::WebResourceLoadStatisticsStore::setThirdPartyCookieBlockingMode):
(WebKit::WebResourceLoadStatisticsStore::setSameSiteStrictEnforcementEnabled):
(WebKit::WebResourceLoadStatisticsStore::setFirstPartyWebsiteDataRemovalMode):
(WebKit::WebResourceLoadStatisticsStore::setPersistedDomains):
(WebKit::WebResourceLoadStatisticsStore::setStandaloneApplicationDomain):
(WebKit::WebResourceLoadStatisticsStore::setAppBoundDomains):
(WebKit::WebResourceLoadStatisticsStore::setManagedDomains):
(WebKit::WebResourceLoadStatisticsStore::didCreateNetworkProcess):
(WebKit::WebResourceLoadStatisticsStore::performDailyTasks):
(WebKit::WebResourceLoadStatisticsStore::logFrameNavigation):
(WebKit::WebResourceLoadStatisticsStore::logUserInteraction):
(WebKit::WebResourceLoadStatisticsStore::logCrossSiteLoadWithLinkDecoration):
(WebKit::WebResourceLoadStatisticsStore::clearUserInteraction):
(WebKit::WebResourceLoadStatisticsStore::setTimeAdvanceForTesting):
(WebKit::WebResourceLoadStatisticsStore::hasHadUserInteraction):
(WebKit::WebResourceLoadStatisticsStore::setLastSeen):
(WebKit::WebResourceLoadStatisticsStore::mergeStatisticForTesting):
(WebKit::WebResourceLoadStatisticsStore::isRelationshipOnlyInDatabaseOnce):
(WebKit::WebResourceLoadStatisticsStore::setPrevalentResource):
(WebKit::WebResourceLoadStatisticsStore::setVeryPrevalentResource):
(WebKit::WebResourceLoadStatisticsStore::setMostRecentWebPushInteractionTime):
(WebKit::WebResourceLoadStatisticsStore::dumpResourceLoadStatistics):
(WebKit::WebResourceLoadStatisticsStore::isPrevalentResource):
(WebKit::WebResourceLoadStatisticsStore::isVeryPrevalentResource):
(WebKit::WebResourceLoadStatisticsStore::isRegisteredAsSubresourceUnder):
(WebKit::WebResourceLoadStatisticsStore::isRegisteredAsSubFrameUnder):
(WebKit::WebResourceLoadStatisticsStore::isRegisteredAsRedirectingTo):
(WebKit::WebResourceLoadStatisticsStore::clearPrevalentResource):
(WebKit::WebResourceLoadStatisticsStore::setGrandfathered):
(WebKit::WebResourceLoadStatisticsStore::isGrandfathered):
(WebKit::WebResourceLoadStatisticsStore::setSubframeUnderTopFrameDomain):
(WebKit::WebResourceLoadStatisticsStore::setSubresourceUnderTopFrameDomain):
(WebKit::WebResourceLoadStatisticsStore::setSubresourceUniqueRedirectTo):
(WebKit::WebResourceLoadStatisticsStore::setSubresourceUniqueRedirectFrom):
(WebKit::WebResourceLoadStatisticsStore::setTopFrameUniqueRedirectTo):
(WebKit::WebResourceLoadStatisticsStore::setTopFrameUniqueRedirectFrom):
(WebKit::WebResourceLoadStatisticsStore::scheduleCookieBlockingUpdate):
(WebKit::WebResourceLoadStatisticsStore::scheduleClearInMemoryAndPersistent):
(WebKit::WebResourceLoadStatisticsStore::domainIDExistsInDatabase):
(WebKit::WebResourceLoadStatisticsStore::setTimeToLiveUserInteraction):
(WebKit::WebResourceLoadStatisticsStore::setMinimumTimeBetweenDataRecordsRemoval):
(WebKit::WebResourceLoadStatisticsStore::setGrandfatheringTime):
(WebKit::WebResourceLoadStatisticsStore::callUpdatePrevalentDomainsToBlockCookiesForHandler):
(WebKit::WebResourceLoadStatisticsStore::setMaxStatisticsEntries):
(WebKit::WebResourceLoadStatisticsStore::setPruneEntriesDownTo):
(WebKit::WebResourceLoadStatisticsStore::resetParametersToDefaultValues):
(WebKit::WebResourceLoadStatisticsStore::removeDataForDomain):
(WebKit::WebResourceLoadStatisticsStore::registrableDomains):
(WebKit::WebResourceLoadStatisticsStore::registrableDomainsWithLastAccessedTime):
(WebKit::WebResourceLoadStatisticsStore::registrableDomainsExemptFromWebsiteDataDeletion):
(WebKit::WebResourceLoadStatisticsStore::aggregatedThirdPartyData):
(WebKit::WebResourceLoadStatisticsStore::insertExpiredStatisticForTesting):
* Source/WebKit/NetworkProcess/Classifier/WebResourceLoadStatisticsStore.h:
* Source/WebKit/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations:

Canonical link: <a href="https://commits.webkit.org/295837@main">https://commits.webkit.org/295837@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/31c690a1931e0afce7c6365a5d312d2c80cab2f2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/106248 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25997 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/16392 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/111446 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/56844 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/26660 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34500 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80708 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/109252 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/21087 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95885 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/61035 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/20619 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/56284 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/90440 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/14019 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/114306 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33386 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24618 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89781 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33750 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/92114 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89482 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22827 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34353 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/12169 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/28968 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/33311 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/38723 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/33057 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/36408 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34655 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->