### PR TITLE
[macOS] Safari AutoFill should not trigger text replacement

### DIFF
--- a/LayoutTests/editing/input/cocoa/untrusted-text-event-does-not-trigger-text-replacement-expected.txt
+++ b/LayoutTests/editing/input/cocoa/untrusted-text-event-does-not-trigger-text-replacement-expected.txt
@@ -1,0 +1,9 @@
+This test verifies that dispatching untrusted TextEvents does not trigger system text replacements. Requires WebKitTestRunner
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+PASS editor.textContent is "foo@bar.com"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/editing/input/cocoa/untrusted-text-event-does-not-trigger-text-replacement.html
+++ b/LayoutTests/editing/input/cocoa/untrusted-text-event-does-not-trigger-text-replacement.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+<head>
+    <meta name="viewport" content="initial-scale=1.0, width=device-width, user-scalable=no">
+    <script src="../../../resources/ui-helper.js"></script>
+    <script src="../../../resources/js-test.js"></script>
+    <style>
+    div[contenteditable] {
+        width: 200px;
+        height: 100px;
+        font-size: 24px;
+        border: 1px solid tomato;
+        margin: 10px;
+    }
+    </style>
+</head>
+<body>
+    <div contenteditable></div>
+    <pre id="description"></pre>
+    <pre id="console"></pre>
+    <script>
+    const stringToType = "foo@bar.com";
+    window.jsTestIsAsync = true;
+    description("This test verifies that dispatching untrusted TextEvents does not trigger system text replacements. Requires WebKitTestRunner");
+
+    addEventListener("load", async () => {
+        if (window.testRunner) {
+            await UIHelper.setContinuousSpellCheckingEnabled(true);
+            const textReplacementData = {
+                "replacement": "foo@bar.com",
+                "type": "replacement",
+                "from": 0,
+                "to": 4
+            };
+            await UIHelper.setSpellCheckerResults({
+                "foo@": [textReplacementData],
+                "foo@b": [textReplacementData]
+            });
+
+            internals.setAutomaticTextReplacementEnabled(true);
+            internals.setAutomaticSpellingCorrectionEnabled(true);
+        }
+
+        editor = document.querySelector("div[contenteditable]");
+        editor.focus();
+
+        for (let character of [...stringToType]) {
+            const event = document.createEvent("TextEvent");
+            event.initTextEvent("textInput", true, true, null, character);
+            editor.dispatchEvent(event);
+            await UIHelper.ensurePresentationUpdate();
+        }
+
+        shouldBeEqualToString("editor.textContent", "foo@bar.com");
+
+        editor.remove();
+        finishJSTest();
+    });
+    </script>
+</body>
+</html>

--- a/LayoutTests/editing/inserting/typing-space-to-trigger-smart-link.html
+++ b/LayoutTests/editing/inserting/typing-space-to-trigger-smart-link.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+<script src="../../resources/ui-helper.js"></script>
 <script>
 function runTest()
 {
@@ -12,7 +13,7 @@ function runTest()
     var testTypeSpaceDiv = document.getElementById('testTypeSpace');
     var targetText = testTypeSpaceDiv.firstChild;
     window.getSelection().setPosition(targetText, 15);
-    pressKey(" ");
+    UIHelper.keyDown(" ");
     var expectedContents = "The <a href=\"http://www.foo.com\">www.foo.com</a> should be underlined and there is an anchor node created for it.";
     if (expectedContents == testTypeSpaceDiv.innerHTML)
         document.getElementById('log').textContent = "PASS: the anchor for 'www.foo.com' has been created.\n"
@@ -22,18 +23,18 @@ function runTest()
     var testTypeLinkDiv = document.getElementById('testTypeLink');
     targetText = testTypeLinkDiv.firstChild;
     window.getSelection().setPosition(targetText, 4);
-    pressKey("w");
-    pressKey("w");
-    pressKey("w");
-    pressKey(".");
-    pressKey("b");
-    pressKey("a");
-    pressKey("r");
-    pressKey(".");
-    pressKey("c");
-    pressKey("o");
-    pressKey("m");
-    pressKey(" ");
+    UIHelper.keyDown("w");
+    UIHelper.keyDown("w");
+    UIHelper.keyDown("w");
+    UIHelper.keyDown(".");
+    UIHelper.keyDown("b");
+    UIHelper.keyDown("a");
+    UIHelper.keyDown("r");
+    UIHelper.keyDown(".");
+    UIHelper.keyDown("c");
+    UIHelper.keyDown("o");
+    UIHelper.keyDown("m");
+    UIHelper.keyDown(" ");
     expectedContents = "The <a href=\"http://www.bar.com\">www.bar.com</a> should be underlined and there is an anchor node created for it.";
     if (expectedContents == testTypeLinkDiv.innerHTML)
         document.getElementById('log').textContent += "PASS: the anchor for 'www.bar.com' has been created."
@@ -42,19 +43,6 @@ function runTest()
 
     if (window.internals)
         internals.setAutomaticLinkDetectionEnabled(false);
-}
-
-function pressKey(key)
-{
-    if (window.KeyEvent) {
-        var ev = document.createEvent("KeyboardEvent");
-        ev.initKeyEvent("keypress", true, true, window,  0,0,0,0, 0, key.charCodeAt(0));
-        document.body.dispatchEvent(ev);
-    } else {
-        var ev = document.createEvent("TextEvent");
-        ev.initTextEvent('textInput', true, true, null, key.charAt(0));
-        document.body.dispatchEvent(ev);
-    }
 }
 </script>
 </head>

--- a/Source/WebCore/editing/Editor.cpp
+++ b/Source/WebCore/editing/Editor.cpp
@@ -2908,7 +2908,7 @@ void Editor::markMisspellingsAndBadGrammar(const VisibleSelection &movingSelecti
     markMisspellingsAndBadGrammar(movingSelection, isContinuousSpellCheckingEnabled() && isGrammarCheckingEnabled(), movingSelection);
 }
 
-void Editor::markMisspellingsAfterTypingToWord(const VisiblePosition& wordStart, const VisibleSelection& selectionAfterTyping, bool doReplacement)
+void Editor::markMisspellingsAfterTypingToWord(const VisiblePosition& wordStart, const VisibleSelection& selectionAfterTyping, AllowTextReplacement allowTextReplacement)
 {
     Ref document = this->document();
 
@@ -2917,7 +2917,7 @@ void Editor::markMisspellingsAfterTypingToWord(const VisiblePosition& wordStart,
 
 #if PLATFORM(IOS_FAMILY)
     UNUSED_PARAM(selectionAfterTyping);
-    UNUSED_PARAM(doReplacement);
+    UNUSED_PARAM(allowTextReplacement);
     OptionSet<TextCheckingType> textCheckingOptions;
     if (isContinuousSpellCheckingEnabled())
         textCheckingOptions.add(TextCheckingType::Spelling);
@@ -2946,7 +2946,7 @@ void Editor::markMisspellingsAfterTypingToWord(const VisiblePosition& wordStart,
     }
 #else
 #if !USE(AUTOMATIC_TEXT_REPLACEMENT)
-    UNUSED_PARAM(doReplacement);
+    UNUSED_PARAM(allowTextReplacement);
 #endif
 
     if (unifiedTextCheckerEnabled()) {
@@ -2958,7 +2958,7 @@ void Editor::markMisspellingsAfterTypingToWord(const VisiblePosition& wordStart,
             textCheckingOptions.add(TextCheckingType::Spelling);
 
 #if USE(AUTOMATIC_TEXT_REPLACEMENT)
-        if (doReplacement
+        if (allowTextReplacement == AllowTextReplacement::Yes
             && (isAutomaticQuoteSubstitutionEnabled()
                 || isAutomaticLinkDetectionEnabled()
                 || isAutomaticDashSubstitutionEnabled()

--- a/Source/WebCore/editing/Editor.h
+++ b/Source/WebCore/editing/Editor.h
@@ -114,6 +114,8 @@ enum class MailBlockquoteHandling : bool {
     IgnoreBlockquote,
 };
 
+enum class AllowTextReplacement : bool { No, Yes };
+
 #if ENABLE(ATTACHMENT_ELEMENT)
 class AttachmentAssociatedElement;
 class HTMLAttachmentElement;
@@ -360,7 +362,7 @@ public:
     TextCheckingGuesses guessesForMisspelledOrUngrammatical();
     bool isSpellCheckingEnabledInFocusedNode() const;
     bool isSpellCheckingEnabledFor(Node*) const;
-    WEBCORE_EXPORT void markMisspellingsAfterTypingToWord(const VisiblePosition& wordStart, const VisibleSelection& selectionAfterTyping, bool doReplacement);
+    WEBCORE_EXPORT void markMisspellingsAfterTypingToWord(const VisiblePosition& wordStart, const VisibleSelection& selectionAfterTyping, AllowTextReplacement);
     std::optional<SimpleRange> markMisspellings(const VisibleSelection&); // Returns first misspelling range.
     void markBadGrammar(const VisibleSelection&);
     void markMisspellingsAndBadGrammar(const VisibleSelection& spellingSelection, bool markGrammar, const VisibleSelection& grammarSelection);

--- a/Source/WebCore/editing/TypingCommand.cpp
+++ b/Source/WebCore/editing/TypingCommand.cpp
@@ -475,7 +475,8 @@ void TypingCommand::markMisspellingsAfterTyping(Type commandType)
             String trimmedPreviousWord;
             if (range && (commandType == TypingCommand::Type::InsertText || commandType == TypingCommand::Type::InsertLineBreak || commandType == TypingCommand::Type::InsertParagraphSeparator || commandType == TypingCommand::Type::InsertParagraphSeparatorInQuotedContent))
                 trimmedPreviousWord = plainText(*range).trim(deprecatedIsSpaceOrNewline);
-            document().editor().markMisspellingsAfterTypingToWord(p1, endingSelection(), !trimmedPreviousWord.isEmpty());
+            auto allowTextReplacement = !trimmedPreviousWord.isEmpty() && !triggeringEventIsUntrusted() ? AllowTextReplacement::Yes : AllowTextReplacement::No;
+            document().editor().markMisspellingsAfterTypingToWord(p1, endingSelection(), allowTextReplacement);
         } else if (commandType == TypingCommand::Type::InsertText)
             document().editor().startAlternativeTextUITimer();
 #else
@@ -492,7 +493,7 @@ void TypingCommand::markMisspellingsAfterTyping(Type commandType)
         VisiblePosition p1 = startOfWord(previous, startWordSide);
         VisiblePosition p2 = startOfWord(start, startWordSide);
         if (p1 != p2)
-            document().editor().markMisspellingsAfterTypingToWord(p1, endingSelection(), false);
+            document().editor().markMisspellingsAfterTypingToWord(p1, endingSelection(), AllowTextReplacement::No);
 #endif // !PLATFORM(IOS_FAMILY)
     }
 }


### PR DESCRIPTION
#### a90b28a5b1a806efdff51cf6d8420cf7b4852ba4
<pre>
[macOS] Safari AutoFill should not trigger text replacement
<a href="https://bugs.webkit.org/show_bug.cgi?id=293957">https://bugs.webkit.org/show_bug.cgi?id=293957</a>
<a href="https://rdar.apple.com/151984377">rdar://151984377</a>

Reviewed by Aditya Keerthi and Abrar Rahman Protyasha.

Safari AutoFill works by dispatching `TextEvent`s to simulate user-triggered editing; however, this
means that it can also trigger text replacements on macOS — for instance, if the user has mapped the
string `name@` to `name@apple.com` and AutoFill attempts to fill in login credentials using this
email address, we&apos;ll end up with `name@apple.comapple.com` instead of just `name@apple.com`, due to
fact that text replacement triggers immediately upon typing the `a` in `apple.com`.

To fix this, we prevent any untrusted `TextEvent` (i.e. created and dispatched via bindings) from
triggering text replacements when applying the edit command.

* LayoutTests/editing/input/cocoa/untrusted-text-event-does-not-trigger-text-replacement-expected.txt: Added.
* LayoutTests/editing/input/cocoa/untrusted-text-event-does-not-trigger-text-replacement.html: Added.

Add a layout test to exercise this fix; before the fix, we end up with `foo@bar.combar.com`.

* LayoutTests/editing/inserting/typing-space-to-trigger-smart-link.html:

Adjust an existing test to work with this new behavior by using key events to exercise typing,
instead of creating and dispatching key/text events in JavaScript.

* Source/WebCore/editing/Editor.cpp:
(WebCore::Editor::markMisspellingsAfterTypingToWord):

Drive-by refactoring: also replace the `bool doReplacement` argument here with a strongly typed enum
class, to help clarify the intent of this parameter.

* Source/WebCore/editing/Editor.h:
* Source/WebCore/editing/TypingCommand.cpp:
(WebCore::TypingCommand::markMisspellingsAfterTyping):

Additionally check `!triggeringEventIsUntrusted()` when determining whether we should allow text
replacement (this is plumbed down from the result of `TextEvent::isTrusted()`).

Canonical link: <a href="https://commits.webkit.org/295758@main">https://commits.webkit.org/295758@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d4bbca52b66b12e83bf7ce9f48c34bba6fa25b14

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/106052 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25801 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/16195 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/111249 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/56648 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/108091 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/26457 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34304 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80561 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/109056 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/20899 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95713 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60884 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/20484 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13811 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/56086 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/90269 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13846 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/114104 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33190 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/24496 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/89644 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33554 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91941 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89333 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22765 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34195 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/12010 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/28761 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/33115 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/38527 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32861 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/36211 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34459 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->