### PR TITLE
Reduce incorrect usage of protectedX() in dom and editing

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -212,7 +212,6 @@ dom/ViewTransition.cpp
 dom/WindowEventLoop.cpp
 dom/mac/ImageControlsMac.cpp
 editing/AlternativeTextController.cpp
-editing/AppendNodeCommand.cpp
 editing/ApplyBlockElementCommand.cpp
 editing/ApplyStyleCommand.cpp
 editing/BreakBlockquoteCommand.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -544,7 +544,6 @@ dom/VisitedLinkState.cpp
 dom/WindowOrWorkerGlobalScopeTrustedTypes.cpp
 dom/mac/ImageControlsMac.cpp
 editing/AlternativeTextController.cpp
-editing/AppendNodeCommand.cpp
 editing/ApplyBlockElementCommand.cpp
 editing/ApplyStyleCommand.cpp
 editing/BreakBlockquoteCommand.cpp

--- a/Source/WebCore/dom/DocumentMarkerController.cpp
+++ b/Source/WebCore/dom/DocumentMarkerController.cpp
@@ -3,7 +3,7 @@
  *           (C) 1999 Antti Koivisto (koivisto@kde.org)
  *           (C) 2001 Dirk Mueller (mueller@kde.org)
  *           (C) 2006 Alexey Proskuryakov (ap@webkit.org)
- * Copyright (C) 2004-2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2004-2025 Apple Inc. All rights reserved.
  * Copyright (C) 2008, 2009 Torch Mobile Inc. All rights reserved. (http://www.torchmobile.com/)
  * Copyright (C) Research In Motion Limited 2010. All rights reserved.
  *
@@ -114,8 +114,8 @@ void DocumentMarkerController::addTransparentContentMarker(const SimpleRange& ra
         //
         // Otherwise, this information would be lost if the original range is collapsed, so this prevents that from happening.
 
-        DocumentMarker::TransparentContentData markerData { { range.protectedStartContainer().ptr() }, uuid };
-        Ref node = range.protectedStartContainer();
+        Ref node = range.startContainer();
+        DocumentMarker::TransparentContentData markerData { { node.ptr() }, uuid };
         addMarker(node.get(), { DocumentMarkerType::TransparentContent, { range.startOffset(), range.endOffset() }, WTFMove(markerData) });
 
         return;
@@ -543,7 +543,7 @@ void DocumentMarkerController::applyToCollapsedRangeMarker(const SimpleRange& ra
     if (!range.collapsed())
         return;
 
-    Ref node = range.protectedStartContainer();
+    Ref node = range.startContainer();
     if (auto list = m_markers.get(node.ptr())) {
         auto offsetRange = characterDataOffsetRange(range, node.get());
         for (auto& marker : *list) {

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -4,7 +4,7 @@
  *           (C) 2001 Peter Kelly (pmk@post.com)
  *           (C) 2001 Dirk Mueller (mueller@kde.org)
  *           (C) 2007 David Smith (catfish.man@gmail.com)
- * Copyright (C) 2004-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2004-2025 Apple Inc. All rights reserved.
  *           (C) 2007 Eric Seidel (eric@webkit.org)
  *
  * This library is free software; you can redistribute it and/or
@@ -237,7 +237,7 @@ static Attr* findAttrNodeInList(Vector<RefPtr<Attr>>& attrNodeList, const Qualif
 static bool shouldAutofocus(const Element& element)
 {
     Ref document = element.document();
-    RefPtr page = document->protectedPage();
+    RefPtr page = document->page();
     if (!page || page->autofocusProcessed())
         return false;
 

--- a/Source/WebCore/dom/Position.cpp
+++ b/Source/WebCore/dom/Position.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2004-2025 Apple Inc. All rights reserved.
  * Copyright (C) 2015-2018 Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -351,7 +351,7 @@ RefPtr<Element> Position::anchorElementAncestor() const
 
 Position Position::previous(PositionMoveType moveType) const
 {
-    auto node = protectedDeprecatedNode();
+    RefPtr node = deprecatedNode();
     if (!node)
         return *this;
 
@@ -408,7 +408,7 @@ Position Position::next(PositionMoveType moveType) const
 {
     ASSERT(moveType != BackwardDeletion);
 
-    auto node = protectedDeprecatedNode();
+    RefPtr node = deprecatedNode();
     if (!node)
         return *this;
 
@@ -1203,7 +1203,7 @@ InlineBoxAndOffset Position::inlineBoxAndOffset(Affinity affinity, TextDirection
 {
     auto caretOffset = static_cast<unsigned>(deprecatedEditingOffset());
 
-    auto node = protectedDeprecatedNode();
+    RefPtr node = deprecatedNode();
     if (!node)
         return { { }, caretOffset };
     auto renderer = node->renderer();

--- a/Source/WebCore/dom/PositionIterator.cpp
+++ b/Source/WebCore/dom/PositionIterator.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2007, 2008 Apple Inc. All rights reserved.
+ * Copyright (C) 2007-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -50,7 +50,7 @@ PositionIterator::PositionIterator(const Position& pos)
 
 PositionIterator::operator Position() const
 {
-    auto anchorNode = protectedNode();
+    RefPtr anchorNode = node();
     if (m_nodeAfterPositionInAnchor) {
         ASSERT(m_nodeAfterPositionInAnchor->parentNode() == anchorNode.get());
         // FIXME: This check is inadaquete because any ancestor could be ignored by editing
@@ -77,7 +77,7 @@ void PositionIterator::increment()
         return;
     }
 
-    auto anchorNode = protectedNode();
+    RefPtr anchorNode = node();
     if (anchorNode->renderer() && !anchorNode->hasChildNodes() && m_offsetInAnchor < lastOffsetForEditing(*anchorNode))
         m_offsetInAnchor = Position::uncheckedNextOffset(anchorNode.get(), m_offsetInAnchor);
     else {
@@ -130,7 +130,7 @@ bool PositionIterator::atStart() const
 
 bool PositionIterator::atEnd() const
 {
-    auto anchorNode = protectedNode();
+    RefPtr anchorNode = node();
     if (!anchorNode)
         return true;
     if (m_nodeAfterPositionInAnchor)
@@ -149,7 +149,7 @@ bool PositionIterator::atStartOfNode() const
 
 bool PositionIterator::atEndOfNode() const
 {
-    auto anchorNode = protectedNode();
+    RefPtr anchorNode = node();
     if (!anchorNode)
         return true;
     if (m_nodeAfterPositionInAnchor)
@@ -160,7 +160,7 @@ bool PositionIterator::atEndOfNode() const
 // This function should be kept in sync with Position::isCandidate().
 bool PositionIterator::isCandidate() const
 {
-    auto anchorNode = protectedNode();
+    RefPtr anchorNode = node();
     if (!anchorNode)
         return false;
 

--- a/Source/WebCore/dom/ScriptElement.cpp
+++ b/Source/WebCore/dom/ScriptElement.cpp
@@ -2,7 +2,7 @@
  * Copyright (C) 1999 Lars Knoll (knoll@kde.org)
  *           (C) 1999 Antti Koivisto (koivisto@kde.org)
  *           (C) 2001 Dirk Mueller (mueller@kde.org)
- * Copyright (C) 2003-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2003-2025 Apple Inc. All rights reserved.
  * Copyright (C) 2008 Nikolas Zimmermann <zimmermann@kde.org>
  *
  * This library is free software; you can redistribute it and/or
@@ -326,7 +326,7 @@ void ScriptElement::updateTaintedOriginFromSourceURL()
 
 bool ScriptElement::requestClassicScript(const String& sourceURL)
 {
-    auto element = protectedElement();
+    Ref element = this->element();
     ASSERT(element->isConnected());
     ASSERT(!m_loadableScript);
     Ref document = element->document();

--- a/Source/WebCore/dom/SimpleRange.cpp
+++ b/Source/WebCore/dom/SimpleRange.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2020-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -131,7 +131,7 @@ void IntersectingNodeIterator::advance()
 
 void IntersectingNodeIterator::advanceSkippingChildren()
 {
-    auto node = protectedNode();
+    RefPtr node = m_node;
     ASSERT(node);
     m_node = node->contains(m_pastLastNode.get()) ? nullptr : NodeTraversal::nextSkippingChildren(*node);
     enforceEndInvariant();

--- a/Source/WebCore/dom/TreeScope.cpp
+++ b/Source/WebCore/dom/TreeScope.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2011 Google Inc. All Rights Reserved.
- * Copyright (C) 2006-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2006-2025 Apple Inc. All rights reserved.
  * Copyright (C) 2006 Nikolas Zimmermann <zimmermann@kde.org>
  * Copyright (C) 2007 Rob Buis <buis@kde.org>
  *
@@ -408,7 +408,7 @@ static std::optional<LayoutPoint> absolutePointIfNotClipped(Document& document, 
 
 RefPtr<Node> TreeScope::nodeFromPoint(const LayoutPoint& clientPoint, LayoutPoint* localPoint, HitTestSource source)
 {
-    Ref document = protectedDocumentScope();
+    Ref document = documentScope();
     auto absolutePoint = absolutePointIfNotClipped(document, clientPoint);
     if (!absolutePoint)
         return nullptr;
@@ -444,7 +444,7 @@ Vector<RefPtr<Element>> TreeScope::elementsFromPoint(double clientX, double clie
 {
     Vector<RefPtr<Element>> elements;
 
-    Ref document = protectedDocumentScope();
+    Ref document = documentScope();
     if (!document->hasLivingRenderTree())
         return elements;
 
@@ -543,7 +543,7 @@ static Element* focusedFrameOwnerElement(Frame* focusedFrame, LocalFrame* curren
 
 Element* TreeScope::focusedElementInScope()
 {
-    Ref document = protectedDocumentScope();
+    Ref document = documentScope();
     RefPtr element = document->focusedElement();
 
     if (!element && document->page())

--- a/Source/WebCore/editing/AppendNodeCommand.cpp
+++ b/Source/WebCore/editing/AppendNodeCommand.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005, 2006, 2008 Apple Inc. All rights reserved.
+ * Copyright (C) 2005-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -46,11 +46,10 @@ AppendNodeCommand::AppendNodeCommand(Ref<ContainerNode>&& parent, Ref<Node>&& no
 
 void AppendNodeCommand::doApply()
 {
-    auto parent = protectedParent();
-    if (!parent->hasEditableStyle() && parent->renderer())
+    if (!m_parent->hasEditableStyle() && m_parent->renderer())
         return;
 
-    parent->appendChild(m_node);
+    m_parent->appendChild(m_node);
 }
 
 void AppendNodeCommand::doUnapply()
@@ -58,7 +57,7 @@ void AppendNodeCommand::doUnapply()
     if (!m_parent->hasEditableStyle())
         return;
 
-    protectedNode()->remove();
+    m_node->remove();
 }
 
 #ifndef NDEBUG

--- a/Source/WebCore/editing/AppendNodeCommand.h
+++ b/Source/WebCore/editing/AppendNodeCommand.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005, 2006, 2008 Apple Inc. All rights reserved.
+ * Copyright (C) 2005-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -46,11 +46,8 @@ private:
     void getNodesInCommand(NodeSet&) override;
 #endif
 
-    Ref<ContainerNode> protectedParent() const { return m_parent; }
-    Ref<Node> protectedNode() const { return m_node; }
-
-    Ref<ContainerNode> m_parent;
-    Ref<Node> m_node;
+    const Ref<ContainerNode> m_parent;
+    const Ref<Node> m_node;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/editing/ApplyStyleCommand.cpp
+++ b/Source/WebCore/editing/ApplyStyleCommand.cpp
@@ -349,7 +349,7 @@ void ApplyStyleCommand::applyRelativeFontStyleChange(EditingStyle* style)
         beyondEnd = NodeTraversal::next(*end.deprecatedNode());
     
     start = start.upstream(); // Move upstream to ensure we do not add redundant spans.
-    auto startNode = start.protectedDeprecatedNode();
+    RefPtr startNode = start.deprecatedNode();
 
     if (!startNode)
         return;
@@ -700,7 +700,7 @@ void ApplyStyleCommand::applyInlineStyle(EditingStyle& style)
 
 void ApplyStyleCommand::fixRangeAndApplyInlineStyle(EditingStyle& style, const Position& start, const Position& end)
 {
-    auto startNode = start.protectedDeprecatedNode();
+    RefPtr startNode = start.deprecatedNode();
 
     if (start.deprecatedEditingOffset() >= caretMaxOffset(*startNode)) {
         startNode = NodeTraversal::next(*startNode);
@@ -708,7 +708,7 @@ void ApplyStyleCommand::fixRangeAndApplyInlineStyle(EditingStyle& style, const P
             return;
     }
 
-    auto pastEndNode = end.protectedDeprecatedNode();
+    RefPtr pastEndNode = end.deprecatedNode();
     if (end.deprecatedEditingOffset() >= caretMaxOffset(*pastEndNode))
         pastEndNode = NodeTraversal::nextSkippingChildren(*pastEndNode);
 
@@ -1126,7 +1126,7 @@ void ApplyStyleCommand::removeInlineStyle(EditingStyle& style, const Position& s
     Position s = start.isNull() || start.isOrphan() ? pushDownStart : start;
     Position e = end.isNull() || end.isOrphan() ? pushDownEnd : end;
 
-    auto node = start.protectedDeprecatedNode();
+    RefPtr node = start.deprecatedNode();
     while (node) {
         RefPtr<Node> next;
         if (editingIgnoresContent(*node)) {

--- a/Source/WebCore/editing/BreakBlockquoteCommand.cpp
+++ b/Source/WebCore/editing/BreakBlockquoteCommand.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005 Apple Inc.  All rights reserved.
+ * Copyright (C) 2005-2025 Apple Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -124,7 +124,7 @@ void BreakBlockquoteCommand::doApply()
         pos = pos.previous();
     
     // startNode is the first node that we need to move to the new blockquote.
-    auto startNode = pos.protectedDeprecatedNode();
+    RefPtr startNode = pos.deprecatedNode();
     ASSERT(startNode);
     // Split at pos if in the middle of a text node.
     if (RefPtr textNode = dynamicDowncast<Text>(*startNode)) {

--- a/Source/WebCore/editing/CompositeEditCommand.cpp
+++ b/Source/WebCore/editing/CompositeEditCommand.cpp
@@ -600,7 +600,7 @@ void CompositeEditCommand::insertNodeAt(Ref<Node>&& insertChild, const Position&
     // For editing positions like [table, 0], insert before the table,
     // likewise for replaced elements, brs, etc.
     Position p = editingPosition.parentAnchoredEquivalent();
-    auto refChild = p.protectedDeprecatedNode();
+    RefPtr refChild = p.deprecatedNode();
     int offset = p.deprecatedEditingOffset();
     
     if (canHaveChildrenForEditing(*refChild)) {
@@ -1113,7 +1113,7 @@ void CompositeEditCommand::deleteInsignificantText(const Position& start, const 
         return;
 
     Vector<Ref<Text>> nodes;
-    for (RefPtr node = start.protectedDeprecatedNode(); node; node = NodeTraversal::next(*node)) {
+    for (RefPtr node = start.deprecatedNode(); node; node = NodeTraversal::next(*node)) {
         if (RefPtr textNode = dynamicDowncast<Text>(*node))
             nodes.append(*textNode);
         if (node == end.deprecatedNode())
@@ -1311,7 +1311,7 @@ void CompositeEditCommand::cloneParagraphUnderNewElement(const Position& start, 
         Vector<RefPtr<Node>> ancestors;
         
         // Insert each node from innerNode to outerNode (excluded) in a list.
-        for (RefPtr n = start.protectedDeprecatedNode(); n && n != outerNode; n = n->parentNode())
+        for (RefPtr n = start.deprecatedNode(); n && n != outerNode; n = n->parentNode())
             ancestors.append(n);
 
         // Clone every node between start.deprecatedNode() and outerBlock.
@@ -1337,7 +1337,7 @@ void CompositeEditCommand::cloneParagraphUnderNewElement(const Position& start, 
         while (!end.deprecatedNode()->isDescendantOf(outerNode.get()) && outerNode->parentNode())
             outerNode = outerNode->parentNode();
 
-        auto startNode = start.protectedDeprecatedNode();
+        RefPtr startNode = start.deprecatedNode();
         for (RefPtr<Node> node = NodeTraversal::nextSkippingChildren(*startNode, outerNode.get()); node; node = NodeTraversal::nextSkippingChildren(*node, outerNode.get())) {
             // Move lastNode up in the tree as much as node was moved up in the
             // tree by NodeTraversal::nextSkippingChildren, so that the relative depth between
@@ -1369,7 +1369,7 @@ void CompositeEditCommand::cleanupAfterDeletion(VisiblePosition destination)
     if (!caretAfterDelete.equals(destination) && isStartOfParagraph(caretAfterDelete) && isEndOfParagraph(caretAfterDelete)) {
         // Note: We want the rightmost candidate.
         Position position = caretAfterDelete.deepEquivalent().downstream();
-        auto node = position.protectedDeprecatedNode();
+        RefPtr node = position.deprecatedNode();
         ASSERT(node);
         // Normally deletion will leave a br as a placeholder.
         if (is<HTMLBRElement>(*node))

--- a/Source/WebCore/editing/DeleteFromTextNodeCommand.cpp
+++ b/Source/WebCore/editing/DeleteFromTextNodeCommand.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005, 2008, 2015 Apple Inc. All rights reserved.
+ * Copyright (C) 2005-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -45,36 +45,29 @@ DeleteFromTextNodeCommand::DeleteFromTextNodeCommand(Ref<Text>&& node, unsigned 
 
 void DeleteFromTextNodeCommand::doApply()
 {
-    auto node = protectedNode();
-    if (!isEditableNode(node))
+    if (!isEditableNode(m_node))
         return;
 
-    auto result = node->substringData(m_offset, m_count);
+    auto result = m_node->substringData(m_offset, m_count);
     if (result.hasException())
         return;
     m_text = result.releaseReturnValue();
-    node->deleteData(m_offset, m_count);
+    m_node->deleteData(m_offset, m_count);
 }
 
 void DeleteFromTextNodeCommand::doUnapply()
 {
-    auto node = protectedNode();
-    if (!node->hasEditableStyle())
+    if (!m_node->hasEditableStyle())
         return;
 
-    node->insertData(m_offset, m_text);
+    m_node->insertData(m_offset, m_text);
 }
 
 #ifndef NDEBUG
 void DeleteFromTextNodeCommand::getNodesInCommand(NodeSet& nodes)
 {
-    addNodeAndDescendants(protectedNode().ptr(), nodes);
+    addNodeAndDescendants(m_node.ptr(), nodes);
 }
 #endif
-
-inline Ref<Text> DeleteFromTextNodeCommand::protectedNode() const
-{
-    return m_node;
-}
 
 } // namespace WebCore

--- a/Source/WebCore/editing/DeleteFromTextNodeCommand.h
+++ b/Source/WebCore/editing/DeleteFromTextNodeCommand.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005, 2006, 2008, 2015 Apple Inc. All rights reserved.
+ * Copyright (C) 2005-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -49,9 +49,7 @@ private:
     void getNodesInCommand(NodeSet&) override;
 #endif
 
-    Ref<Text> protectedNode() const;
-    
-    Ref<Text> m_node;
+    const Ref<Text> m_node;
     unsigned m_offset;
     unsigned m_count;
     String m_text;

--- a/Source/WebCore/editing/DeleteSelectionCommand.cpp
+++ b/Source/WebCore/editing/DeleteSelectionCommand.cpp
@@ -425,7 +425,7 @@ void DeleteSelectionCommand::saveTypingStyleState()
         return;
     }
 
-    auto startNode = m_selectionToDelete.start().protectedDeprecatedNode();
+    RefPtr startNode = m_selectionToDelete.start().deprecatedNode();
     if (!startNode->isTextNode() && !startNode->hasTagName(imgTag) && !startNode->hasTagName(brTag))
         return;
 
@@ -628,7 +628,7 @@ void DeleteSelectionCommand::handleGeneralDelete()
         return;
 
     int startOffset = m_upstreamStart.deprecatedEditingOffset();
-    auto startNode = m_upstreamStart.protectedDeprecatedNode();
+    RefPtr startNode = m_upstreamStart.deprecatedNode();
 
     makeStylingElementsDirectChildrenOfEditableRootToPreventStyleLoss();
 
@@ -739,7 +739,7 @@ void DeleteSelectionCommand::handleGeneralDelete()
                 } else if (!(startNodeWasDescendantOfEndNode && !m_upstreamStart.anchorNode()->isConnected())) {
                     unsigned offset = 0;
                     if (m_upstreamStart.deprecatedNode()->isDescendantOf(m_downstreamEnd.deprecatedNode())) {
-                        auto n = m_upstreamStart.protectedDeprecatedNode();
+                        RefPtr n = m_upstreamStart.deprecatedNode();
                         while (n && n->parentNode() != m_downstreamEnd.deprecatedNode())
                             n = n->parentNode();
                         if (n)
@@ -829,7 +829,7 @@ void DeleteSelectionCommand::mergeParagraphs()
     // FIXME: Consider RTL.
     if (!m_startsAtEmptyLine && isStartOfParagraph(mergeDestination) && startOfParagraphToMove.absoluteCaretBounds().x() > mergeDestination.absoluteCaretBounds().x()) {
         if (mergeDestination.deepEquivalent().downstream().deprecatedNode()->hasTagName(brTag)) {
-            auto nodeToRemove = mergeDestination.deepEquivalent().downstream().protectedDeprecatedNode();
+            RefPtr nodeToRemove = mergeDestination.deepEquivalent().downstream().deprecatedNode();
             removeNodeAndPruneAncestors(*nodeToRemove);
             m_endingPosition = startOfParagraphToMove.deepEquivalent();
             return;
@@ -891,7 +891,7 @@ void DeleteSelectionCommand::removePreviouslySelectedEmptyTableRows()
         }
     }
 
-    auto endTableRow = protectedEndTableRow();
+    RefPtr endTableRow = m_startTableRow;
     if (endTableRow && endTableRow->isConnected() && endTableRow != m_startTableRow) {
         if (isTableRowEmpty(*endTableRow)) {
             // Don't remove m_endTableRow if it's where we're putting the ending selection.

--- a/Source/WebCore/editing/Editing.cpp
+++ b/Source/WebCore/editing/Editing.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2004-2025 Apple Inc. All rights reserved.
  * Copyright (C) 2015 Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -425,7 +425,7 @@ const String& nonBreakingSpaceString()
 RefPtr<Element> isFirstPositionAfterTable(const VisiblePosition& position)
 {
     Position upstream(position.deepEquivalent().upstream());
-    auto node = upstream.protectedDeprecatedNode();
+    RefPtr node = upstream.deprecatedNode();
     if (!node)
         return nullptr;
     auto* renderer = node->renderer();
@@ -437,7 +437,7 @@ RefPtr<Element> isFirstPositionAfterTable(const VisiblePosition& position)
 RefPtr<Element> isLastPositionBeforeTable(const VisiblePosition& position)
 {
     Position downstream(position.deepEquivalent().downstream());
-    auto node = downstream.protectedDeprecatedNode();
+    RefPtr node = downstream.deprecatedNode();
     if (!node)
         return nullptr;
     auto* renderer = node->renderer();
@@ -504,7 +504,7 @@ bool isListItem(const Node& node)
 Element* enclosingElementWithTag(const Position& position, const QualifiedName& tagName)
 {
     auto root = highestEditableRoot(position);
-    for (RefPtr node = position.protectedDeprecatedNode(); node; node = node->parentNode()) {
+    for (RefPtr node = position.deprecatedNode(); node; node = node->parentNode()) {
         if (root && !node->hasEditableStyle())
             continue;
         auto* element = dynamicDowncast<Element>(*node);
@@ -523,7 +523,7 @@ RefPtr<Node> enclosingNodeOfType(const Position& position, bool (*nodeIsOfType)(
     // FIXME: support CanSkipCrossEditingBoundary
     ASSERT(rule == CanCrossEditingBoundary || rule == CannotCrossEditingBoundary);
     auto root = rule == CannotCrossEditingBoundary ? highestEditableRoot(position) : nullptr;
-    for (auto n = position.protectedDeprecatedNode(); n; n = n->parentNode()) {
+    for (RefPtr n = position.deprecatedNode(); n; n = n->parentNode()) {
         // Don't return a non-editable node if the input position was editable, since
         // the callers from editing will no doubt want to perform editing inside the returned node.
         if (root && !n->hasEditableStyle())
@@ -586,7 +586,7 @@ RefPtr<Element> enclosingTableCell(const Position& position)
 
 RefPtr<Element> enclosingAnchorElement(const Position& p)
 {
-    for (auto node = p.protectedDeprecatedNode(); node; node = node->parentNode()) {
+    for (RefPtr node = p.deprecatedNode(); node; node = node->parentNode()) {
         if (RefPtr element = dynamicDowncast<Element>(*node); element && element->isLink())
             return element;
     }
@@ -831,7 +831,7 @@ Ref<Element> createTabSpanElement(Document& document)
 unsigned numEnclosingMailBlockquotes(const Position& position)
 {
     unsigned count = 0;
-    for (auto node = position.protectedDeprecatedNode(); node; node = node->parentNode()) {
+    for (RefPtr node = position.deprecatedNode(); node; node = node->parentNode()) {
         if (isMailBlockquote(*node))
             ++count;
     }

--- a/Source/WebCore/editing/EditingStyle.cpp
+++ b/Source/WebCore/editing/EditingStyle.cpp
@@ -904,7 +904,7 @@ TriState EditingStyle::triStateOfStyle(const VisibleSelection& selection) const
 
     TriState state = TriState::False;
     bool nodeIsStart = true;
-    for (auto node = selection.start().protectedDeprecatedNode(); node; node = NodeTraversal::next(*node)) {
+    for (RefPtr node = selection.start().deprecatedNode(); node; node = NodeTraversal::next(*node)) {
         if (node->renderer() && node->hasEditableStyle()) {
             Style::Extractor computedStyle(node.get());
             TriState nodeState = triStateOfStyle(computedStyle, node->isTextNode() ? EditingStyle::DoNotIgnoreTextOnlyProperties : EditingStyle::IgnoreTextOnlyProperties);
@@ -1691,7 +1691,7 @@ WritingDirection EditingStyle::textDirectionForSelection(const VisibleSelection&
 
     Position position = selection.start().downstream();
 
-    auto node = position.protectedDeprecatedNode();
+    RefPtr node = position.deprecatedNode();
     if (!node)
         return WritingDirection::Natural;
 
@@ -1714,7 +1714,7 @@ WritingDirection EditingStyle::textDirectionForSelection(const VisibleSelection&
                 return *direction;
             }
         }
-        node = selection.visibleStart().deepEquivalent().protectedDeprecatedNode();
+        node = selection.visibleStart().deepEquivalent().deprecatedNode();
     }
 
     // The selection is either a caret with no typing attributes or a range in which no embedding is added, so just use the start position

--- a/Source/WebCore/editing/Editor.cpp
+++ b/Source/WebCore/editing/Editor.cpp
@@ -830,7 +830,7 @@ bool Editor::shouldInsertText(const String& text, const std::optional<SimpleRang
 void Editor::respondToChangedContents(const VisibleSelection& endingSelection)
 {
     if (AXObjectCache::accessibilityEnabled()) {
-        auto node = endingSelection.start().protectedDeprecatedNode();
+        RefPtr node = endingSelection.start().deprecatedNode();
         if (AXObjectCache* cache = document().existingAXObjectCache())
             cache->postNotification(node.get(), AXNotification::ValueChanged, PostTarget::ObservableParent);
     }
@@ -849,12 +849,12 @@ bool Editor::hasBidiSelection() const
 
     RefPtr<Node> startNode;
     if (document->selection().isRange()) {
-        startNode = document->selection().selection().start().downstream().protectedDeprecatedNode();
-        auto endNode = document->selection().selection().end().upstream().protectedDeprecatedNode();
+        startNode = document->selection().selection().start().downstream().deprecatedNode();
+        RefPtr endNode = document->selection().selection().end().upstream().deprecatedNode();
         if (enclosingBlock(startNode.get()) != enclosingBlock(endNode.get()))
             return false;
     } else
-        startNode = document->selection().selection().visibleStart().deepEquivalent().protectedDeprecatedNode();
+        startNode = document->selection().selection().visibleStart().deepEquivalent().deprecatedNode();
 
     if (!startNode || !startNode->renderer())
         return false;
@@ -2183,7 +2183,7 @@ WritingDirection Editor::baseWritingDirectionForSelectionStart() const
     auto result = WritingDirection::LeftToRight;
 
     Position pos = document().selection().selection().visibleStart().deepEquivalent();
-    auto node = pos.protectedDeprecatedNode();
+    RefPtr node = pos.deprecatedNode();
     if (!node)
         return result;
 
@@ -2550,9 +2550,9 @@ void Editor::setComposition(const String& text, const Vector<CompositionUnderlin
         // Find out what node has the composition now.
         Position base = document->selection().selection().base().downstream();
         Position extent = document->selection().selection().extent();
-        auto baseNode = base.protectedDeprecatedNode();
+        RefPtr baseNode = base.deprecatedNode();
         unsigned baseOffset = base.deprecatedEditingOffset();
-        auto extentNode = extent.protectedDeprecatedNode();
+        RefPtr extentNode = extent.deprecatedNode();
         unsigned extentOffset = extent.deprecatedEditingOffset();
 
         if (is<Text>(baseNode) && baseNode == extentNode && baseOffset + text.length() == extentOffset) {
@@ -4890,7 +4890,7 @@ const RenderStyle* Editor::styleForSelectionStart(RefPtr<Node>& nodeToRemove)
 
     styleElement->appendChild(document->createEditingTextNode(String { emptyString() }));
 
-    auto positionNode = position.protectedDeprecatedNode();
+    RefPtr positionNode = position.deprecatedNode();
     ASSERT(positionNode);
     RefPtr parent { positionNode->parentNode() };
     if (!parent || parent->appendChild(styleElement.get()).hasException())

--- a/Source/WebCore/editing/IndentOutdentCommand.cpp
+++ b/Source/WebCore/editing/IndentOutdentCommand.cpp
@@ -61,7 +61,7 @@ IndentOutdentCommand::IndentOutdentCommand(Ref<Document>&& document, EIndentType
 bool IndentOutdentCommand::tryIndentingAsListItem(const Position& start, const Position& end)
 {
     // If our selection is not inside a list, bail out.
-    auto lastNodeInSelectedParagraph = start.protectedDeprecatedNode();
+    RefPtr lastNodeInSelectedParagraph = start.deprecatedNode();
     RefPtr<Element> listNode = enclosingList(lastNodeInSelectedParagraph.get());
     if (!listNode)
         return false;
@@ -187,7 +187,7 @@ void IndentOutdentCommand::outdentParagraph()
         return;
     }
 
-    auto startOfParagraphNode = visibleStartOfParagraph.deepEquivalent().protectedDeprecatedNode();
+    RefPtr startOfParagraphNode = visibleStartOfParagraph.deepEquivalent().deprecatedNode();
     RefPtr enclosingBlockFlow = enclosingBlock(startOfParagraphNode.get());
     RefPtr<Node> splitBlockquoteNode = enclosingNode;
     if (enclosingBlockFlow != enclosingNode)

--- a/Source/WebCore/editing/InsertIntoTextNodeCommand.cpp
+++ b/Source/WebCore/editing/InsertIntoTextNodeCommand.cpp
@@ -58,42 +58,38 @@ void InsertIntoTextNodeCommand::doApply()
     if (passwordEchoEnabled)
         document().updateLayoutIgnorePendingStylesheets();
 
-    auto node = protectedNode();
-    if (!node->hasEditableStyle())
+    if (!m_node->hasEditableStyle())
         return;
 
     if (passwordEchoEnabled) {
-        if (CheckedPtr renderText = node->renderer())
+        if (CheckedPtr renderText = m_node->renderer())
             renderText->momentarilyRevealLastTypedCharacter(m_offset + m_text.length());
     }
     
-    node->insertData(m_offset, m_text);
+    m_node->insertData(m_offset, m_text);
 }
 
 void InsertIntoTextNodeCommand::doReapply()
 {
-    auto node = protectedNode();
-    if (!node->hasEditableStyle())
+    if (!m_node->hasEditableStyle())
         return;
 
-    node->insertData(m_offset, m_text);
+    m_node->insertData(m_offset, m_text);
 }
 
 void InsertIntoTextNodeCommand::doUnapply()
 {
-    auto node = protectedNode();
-    if (!node->hasEditableStyle())
+    if (!m_node->hasEditableStyle())
         return;
 
-    node->deleteData(m_offset, m_text.length());
+    m_node->deleteData(m_offset, m_text.length());
 }
 
 #ifndef NDEBUG
 
 void InsertIntoTextNodeCommand::getNodesInCommand(NodeSet& nodes)
 {
-    auto node = protectedNode();
-    addNodeAndDescendants(node.ptr(), nodes);
+    addNodeAndDescendants(m_node.ptr(), nodes);
 }
 
 #endif

--- a/Source/WebCore/editing/InsertIntoTextNodeCommand.h
+++ b/Source/WebCore/editing/InsertIntoTextNodeCommand.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005, 2006, 2008 Apple Inc. All rights reserved.
+ * Copyright (C) 2005-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -48,13 +48,11 @@ private:
     void doUnapply() override;
     void doReapply() override;
 
-    Ref<Text> protectedNode() const { return m_node.get(); }
-    
 #ifndef NDEBUG
     void getNodesInCommand(NodeSet&) override;
 #endif
     
-    Ref<Text> m_node;
+    const Ref<Text> m_node;
     unsigned m_offset;
     String m_text;
 };

--- a/Source/WebCore/editing/InsertLineBreakCommand.cpp
+++ b/Source/WebCore/editing/InsertLineBreakCommand.cpp
@@ -60,7 +60,7 @@ bool InsertLineBreakCommand::shouldUseBreakElement(const Position& position)
     // An editing position like [input, 0] actually refers to the position before
     // the input element, and in that case we need to check the input element's
     // parent's renderer.
-    auto node = position.parentAnchoredEquivalent().protectedDeprecatedNode();
+    RefPtr node = position.parentAnchoredEquivalent().deprecatedNode();
     return node && node->renderer() && !node->renderer()->style().preserveNewline();
 }
 

--- a/Source/WebCore/editing/InsertListCommand.cpp
+++ b/Source/WebCore/editing/InsertListCommand.cpp
@@ -224,7 +224,7 @@ void InsertListCommand::doApplyForSingleParagraph(bool forceCreateList, const HT
     // FIXME: This will produce unexpected results for a selection that starts just before a
     // table and ends inside the first cell, selectionForParagraphIteration should probably
     // be renamed and deployed inside setEndingSelection().
-    auto selectionNode = endingSelection().start().protectedDeprecatedNode();
+    RefPtr selectionNode = endingSelection().start().deprecatedNode();
     RefPtr listChildNode = enclosingListChild(selectionNode.get());
     bool switchListType = false;
     if (listChildNode) {

--- a/Source/WebCore/editing/InsertNodeBeforeCommand.cpp
+++ b/Source/WebCore/editing/InsertNodeBeforeCommand.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005, 2008 Apple Inc. All rights reserved.
+ * Copyright (C) 2005-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -53,16 +53,15 @@ void InsertNodeBeforeCommand::doApply()
         return;
     ASSERT(isEditableNode(*parent));
 
-    parent->insertBefore(protectedInsertChild(), m_refChild.copyRef());
+    parent->insertBefore(m_insertChild, m_refChild.copyRef());
 }
 
 void InsertNodeBeforeCommand::doUnapply()
 {
-    auto insertChild = protectedInsertChild();
-    if (!isEditableNode(insertChild))
+    if (!isEditableNode(m_insertChild))
         return;
 
-    insertChild->remove();
+    m_insertChild->remove();
 }
 
 #ifndef NDEBUG

--- a/Source/WebCore/editing/InsertNodeBeforeCommand.h
+++ b/Source/WebCore/editing/InsertNodeBeforeCommand.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005, 2006, 2008 Apple Inc. All rights reserved.
+ * Copyright (C) 2005-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -48,10 +48,8 @@ private:
     void getNodesInCommand(NodeSet&) override;
 #endif
 
-    Ref<Node> protectedInsertChild() const { return m_insertChild; }
-
-    Ref<Node> m_insertChild;
-    Ref<Node> m_refChild;
+    const Ref<Node> m_insertChild;
+    const Ref<Node> m_refChild;
     ShouldAssumeContentIsAlwaysEditable m_shouldAssumeContentIsAlwaysEditable;
 };
 

--- a/Source/WebCore/editing/InsertParagraphSeparatorCommand.cpp
+++ b/Source/WebCore/editing/InsertParagraphSeparatorCommand.cpp
@@ -97,7 +97,7 @@ void InsertParagraphSeparatorCommand::applyStyleAfterInsertion(Node* originalEnc
         originalEnclosingBlock->hasTagName(h5Tag))
         return;
 
-    auto style = protectedStyle();
+    RefPtr style = m_style;
     if (!style)
         return;
 

--- a/Source/WebCore/editing/MergeIdenticalElementsCommand.cpp
+++ b/Source/WebCore/editing/MergeIdenticalElementsCommand.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005, 2008 Apple Inc. All rights reserved.
+ * Copyright (C) 2005-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -40,42 +40,38 @@ MergeIdenticalElementsCommand::MergeIdenticalElementsCommand(Ref<Element>&& firs
 
 void MergeIdenticalElementsCommand::doApply()
 {
-    Ref element1 = protectedElement1();
-    Ref element2 = protectedElement2();
-    if (element1->nextSibling() != element2.ptr() || !element1->hasEditableStyle() || !element2->hasEditableStyle())
+    if (m_element1->nextSibling() != m_element2.ptr() || !m_element1->hasEditableStyle() || !m_element2->hasEditableStyle())
         return;
 
-    m_atChild = element2->firstChild();
+    m_atChild = m_element2->firstChild();
 
     Vector<Ref<Node>> children;
-    for (Node* child = element1->firstChild(); child; child = child->nextSibling())
+    for (Node* child = m_element1->firstChild(); child; child = child->nextSibling())
         children.append(*child);
 
     for (auto& child : children)
-        element2->insertBefore(child, m_atChild.copyRef());
+        m_element2->insertBefore(child, m_atChild.copyRef());
 
-    element1->remove();
+    m_element1->remove();
 }
 
 void MergeIdenticalElementsCommand::doUnapply()
 {
     RefPtr<Node> atChild = WTFMove(m_atChild);
 
-    Ref element2 = protectedElement2();
-    RefPtr parent = element2->parentNode();
+    RefPtr parent = m_element2->parentNode();
     if (!parent || !parent->hasEditableStyle())
         return;
 
-    Ref element1 = protectedElement1();
-    if (parent->insertBefore(element1, element2.copyRef()).hasException())
+    if (parent->insertBefore(m_element1, m_element2.copyRef()).hasException())
         return;
 
     Vector<Ref<Node>> children;
-    for (Node* child = element2->firstChild(); child && child != atChild; child = child->nextSibling())
+    for (Node* child = m_element2->firstChild(); child && child != atChild; child = child->nextSibling())
         children.append(*child);
 
     for (auto& child : children)
-        element1->appendChild(child);
+        m_element1->appendChild(child);
 }
 
 #ifndef NDEBUG

--- a/Source/WebCore/editing/MergeIdenticalElementsCommand.h
+++ b/Source/WebCore/editing/MergeIdenticalElementsCommand.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005, 2006, 2008 Apple Inc. All rights reserved.
+ * Copyright (C) 2005-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -46,11 +46,8 @@ private:
     void getNodesInCommand(NodeSet&) override;
 #endif
 
-    Ref<Element> protectedElement1() const { return m_element1; }
-    Ref<Element> protectedElement2() const { return m_element2; }
-    
-    Ref<Element> m_element1;
-    Ref<Element> m_element2;
+    const Ref<Element> m_element1;
+    const Ref<Element> m_element2;
     RefPtr<Node> m_atChild;
 };
 

--- a/Source/WebCore/editing/RemoveNodeCommand.cpp
+++ b/Source/WebCore/editing/RemoveNodeCommand.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005, 2008 Apple Inc. All rights reserved.
+ * Copyright (C) 2005-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -44,17 +44,16 @@ RemoveNodeCommand::RemoveNodeCommand(Ref<Node>&& node, ShouldAssumeContentIsAlwa
 
 void RemoveNodeCommand::doApply()
 {
-    auto node = protectedNode();
-    RefPtr parent = node->parentNode();
+    RefPtr parent = m_node->parentNode();
     if (!parent || (m_shouldAssumeContentIsAlwaysEditable == DoNotAssumeContentIsAlwaysEditable
         && !isEditableNode(*parent) && parent->renderer()))
         return;
     ASSERT(isEditableNode(*parent) || !parent->renderer());
 
     m_parent = WTFMove(parent);
-    m_refChild = node->nextSibling();
+    m_refChild = m_node->nextSibling();
 
-    node->remove();
+    m_node->remove();
 }
 
 void RemoveNodeCommand::doUnapply()
@@ -64,7 +63,7 @@ void RemoveNodeCommand::doUnapply()
     if (!parent || !parent->hasEditableStyle())
         return;
 
-    parent->insertBefore(protectedNode(), WTFMove(refChild));
+    parent->insertBefore(m_node, WTFMove(refChild));
 }
 
 #ifndef NDEBUG

--- a/Source/WebCore/editing/RemoveNodeCommand.h
+++ b/Source/WebCore/editing/RemoveNodeCommand.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005, 2006, 2008 Apple Inc. All rights reserved.
+ * Copyright (C) 2005-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -46,9 +46,7 @@ private:
     void getNodesInCommand(NodeSet&) override;
 #endif
 
-    Ref<Node> protectedNode() const { return m_node; }
-
-    Ref<Node> m_node;
+    const Ref<Node> m_node;
     RefPtr<ContainerNode> m_parent;
     RefPtr<Node> m_refChild;
     ShouldAssumeContentIsAlwaysEditable m_shouldAssumeContentIsAlwaysEditable;

--- a/Source/WebCore/editing/RemoveNodePreservingChildrenCommand.cpp
+++ b/Source/WebCore/editing/RemoveNodePreservingChildrenCommand.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005, 2008 Apple Inc. All rights reserved.
+ * Copyright (C) 2005-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -42,21 +42,20 @@ RemoveNodePreservingChildrenCommand::RemoveNodePreservingChildrenCommand(Ref<Nod
 void RemoveNodePreservingChildrenCommand::doApply()
 {
     Vector<Ref<Node>> children;
-    auto node = protectedNode();
-    RefPtr parent { node->parentNode() };
+    RefPtr parent { m_node->parentNode() };
     if (!parent || (m_shouldAssumeContentIsAlwaysEditable == DoNotAssumeContentIsAlwaysEditable && !isEditableNode(*parent)))
         return;
 
-    for (Node* child = node->firstChild(); child; child = child->nextSibling())
+    for (Node* child = m_node->firstChild(); child; child = child->nextSibling())
         children.append(*child);
 
     size_t size = children.size();
     for (size_t i = 0; i < size; ++i) {
         auto child = WTFMove(children[i]);
         removeNode(child, m_shouldAssumeContentIsAlwaysEditable);
-        insertNodeBefore(WTFMove(child), node, m_shouldAssumeContentIsAlwaysEditable);
+        insertNodeBefore(WTFMove(child), m_node, m_shouldAssumeContentIsAlwaysEditable);
     }
-    removeNode(node, m_shouldAssumeContentIsAlwaysEditable);
+    removeNode(m_node, m_shouldAssumeContentIsAlwaysEditable);
 }
 
 }

--- a/Source/WebCore/editing/RemoveNodePreservingChildrenCommand.h
+++ b/Source/WebCore/editing/RemoveNodePreservingChildrenCommand.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005, 2006, 2008 Apple Inc. All rights reserved.
+ * Copyright (C) 2005-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -40,9 +40,8 @@ private:
     explicit RemoveNodePreservingChildrenCommand(Ref<Node>&&, ShouldAssumeContentIsAlwaysEditable, EditAction);
 
     void doApply() override;
-    Ref<Node> protectedNode() const { return m_node; }
 
-    Ref<Node> m_node;
+    const Ref<Node> m_node;
     ShouldAssumeContentIsAlwaysEditable m_shouldAssumeContentIsAlwaysEditable;
 };
 

--- a/Source/WebCore/editing/ReplaceNodeWithSpanCommand.cpp
+++ b/Source/WebCore/editing/ReplaceNodeWithSpanCommand.cpp
@@ -65,15 +65,15 @@ void ReplaceNodeWithSpanCommand::doApply()
         return;
     if (!m_spanElement)
         m_spanElement = HTMLSpanElement::create(m_elementToReplace->document());
-    swapInNodePreservingAttributesAndChildren(protectedSpanElement().releaseNonNull(), protectedElementToReplace());
+    swapInNodePreservingAttributesAndChildren(protectedSpanElement().releaseNonNull(), m_elementToReplace);
 }
 
 void ReplaceNodeWithSpanCommand::doUnapply()
 {
-    RefPtr spanElement = protectedSpanElement();
+    RefPtr spanElement = m_spanElement;
     if (!spanElement || !spanElement->isConnected())
         return;
-    swapInNodePreservingAttributesAndChildren(protectedElementToReplace(), *spanElement);
+    swapInNodePreservingAttributesAndChildren(m_elementToReplace, *spanElement);
 }
 
 #ifndef NDEBUG

--- a/Source/WebCore/editing/ReplaceNodeWithSpanCommand.h
+++ b/Source/WebCore/editing/ReplaceNodeWithSpanCommand.h
@@ -53,13 +53,12 @@ private:
     void doUnapply() override;
 
     RefPtr<HTMLElement> protectedSpanElement() const { return m_spanElement; }
-    Ref<HTMLElement> protectedElementToReplace() const { return m_elementToReplace; }
     
 #ifndef NDEBUG
     void getNodesInCommand(NodeSet&) override;
 #endif
 
-    Ref<HTMLElement> m_elementToReplace;
+    const Ref<HTMLElement> m_elementToReplace;
     RefPtr<HTMLElement> m_spanElement;
 };
 

--- a/Source/WebCore/editing/ReplaceSelectionCommand.cpp
+++ b/Source/WebCore/editing/ReplaceSelectionCommand.cpp
@@ -175,7 +175,7 @@ ReplacementFragment::ReplacementFragment(RefPtr<DocumentFragment>&& inputFragmen
     , m_hasInterchangeNewlineAtStart(false)
     , m_hasInterchangeNewlineAtEnd(false)
 {
-    auto fragment = protectedFragment();
+    RefPtr fragment = m_fragment;
     if (!fragment)
         return;
     if (!fragment->firstChild())
@@ -1446,7 +1446,7 @@ void ReplaceSelectionCommand::doApply()
         // We need to handle the case where we need to merge the end
         // but our destination node is inside an inline that is the last in the block.
         // We insert a placeholder before the newly inserted content to avoid being merged into the inline.
-        auto destinationNode = destination.deepEquivalent().protectedDeprecatedNode();
+        RefPtr destinationNode = destination.deepEquivalent().deprecatedNode();
         if (m_shouldMergeEnd && destinationNode != enclosingInline(destinationNode.get()) && enclosingInline(destinationNode.get())->nextSibling())
             insertNodeBefore(HTMLBRElement::create(document()), *refNode);
         
@@ -1528,7 +1528,7 @@ void ReplaceSelectionCommand::doApply()
 String ReplaceSelectionCommand::inputEventData() const
 {
     if (isEditingTextAreaOrTextInput())
-        return protectedDocumentFragment()->textContent();
+        return m_documentFragment->textContent();
 
     return CompositeEditCommand::inputEventData();
 }

--- a/Source/WebCore/editing/ReplaceSelectionCommand.h
+++ b/Source/WebCore/editing/ReplaceSelectionCommand.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2005-2025 Apple Inc. All rights reserved.
  * Copyright (C) 2014 Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -138,7 +138,7 @@ private:
     bool m_selectReplacement;
     bool m_smartReplace;
     bool m_matchStyle;
-    RefPtr<DocumentFragment> m_documentFragment;
+    const RefPtr<DocumentFragment> m_documentFragment;
     std::unique_ptr<ReplacementFragment> m_replacementFragment;
     String m_documentFragmentHTMLMarkup;
     String m_documentFragmentPlainText;

--- a/Source/WebCore/editing/SetNodeAttributeCommand.cpp
+++ b/Source/WebCore/editing/SetNodeAttributeCommand.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005, 2008 Apple Inc. All rights reserved.
+ * Copyright (C) 2005-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -42,21 +42,20 @@ SetNodeAttributeCommand::SetNodeAttributeCommand(Ref<Element>&& element, const Q
 
 void SetNodeAttributeCommand::doApply()
 {
-    auto element = protectedElement();
-    m_oldValue = element->getAttribute(m_attribute);
-    element->setAttribute(m_attribute, m_value);
+    m_oldValue = m_element->getAttribute(m_attribute);
+    m_element->setAttribute(m_attribute, m_value);
 }
 
 void SetNodeAttributeCommand::doUnapply()
 {
-    protectedElement()->setAttribute(m_attribute, m_oldValue);
+    m_element->setAttribute(m_attribute, m_oldValue);
     m_oldValue = { };
 }
 
 #ifndef NDEBUG
 void SetNodeAttributeCommand::getNodesInCommand(NodeSet& nodes)
 {
-    addNodeAndDescendants(protectedElement().ptr(), nodes);
+    addNodeAndDescendants(m_element.ptr(), nodes);
 }
 #endif
 

--- a/Source/WebCore/editing/SetNodeAttributeCommand.h
+++ b/Source/WebCore/editing/SetNodeAttributeCommand.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005, 2006, 2008 Apple Inc. All rights reserved.
+ * Copyright (C) 2005-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -47,9 +47,7 @@ private:
     void getNodesInCommand(NodeSet&) override;
 #endif
 
-    Ref<Element> protectedElement() const { return m_element; }
-
-    Ref<Element> m_element;
+    const Ref<Element> m_element;
     QualifiedName m_attribute;
     AtomString m_value;
     AtomString m_oldValue;

--- a/Source/WebCore/editing/VisiblePosition.cpp
+++ b/Source/WebCore/editing/VisiblePosition.cpp
@@ -567,8 +567,8 @@ Position VisiblePosition::canonicalPosition(const Position& passedPosition)
     // blocks or enter new ones), we search forward and backward until we find one.
     Position next = canonicalizeCandidate(nextCandidate(position));
     Position prev = canonicalizeCandidate(previousCandidate(position));
-    auto nextNode = next.protectedDeprecatedNode();
-    auto prevNode = prev.protectedDeprecatedNode();
+    RefPtr nextNode = next.deprecatedNode();
+    RefPtr prevNode = prev.deprecatedNode();
 
     // The new position must be in the same editable element. Enforce that first.
     // Unless the descent is from a non-editable html element to an editable body.

--- a/Source/WebCore/editing/VisibleUnits.cpp
+++ b/Source/WebCore/editing/VisibleUnits.cpp
@@ -963,7 +963,7 @@ static Element* rootEditableOrDocumentElement(Node& node, EditableType editableT
 VisiblePosition previousLinePosition(const VisiblePosition& visiblePosition, LayoutUnit lineDirectionPoint, EditableType editableType)
 {
     Position p = visiblePosition.deepEquivalent();
-    auto node = p.protectedDeprecatedNode();
+    RefPtr node = p.deprecatedNode();
 
     if (!node)
         return VisiblePosition();
@@ -1020,7 +1020,7 @@ VisiblePosition previousLinePosition(const VisiblePosition& visiblePosition, Lay
 VisiblePosition nextLinePosition(const VisiblePosition& visiblePosition, LayoutUnit lineDirectionPoint, EditableType editableType)
 {
     Position p = visiblePosition.deepEquivalent();
-    auto node = p.protectedDeprecatedNode();
+    RefPtr node = p.deprecatedNode();
     if (!node)
         return VisiblePosition();
     
@@ -1244,7 +1244,7 @@ RefPtr<Node> findEndOfParagraph(Node* startNode, Node* highestRoot, Node* stayIn
 VisiblePosition startOfParagraph(const VisiblePosition& c, EditingBoundaryCrossingRule boundaryCrossingRule)
 {
     auto p = c.deepEquivalent();
-    auto startNode = p.protectedDeprecatedNode();
+    RefPtr startNode = p.deprecatedNode();
 
     if (!startNode)
         return VisiblePosition();
@@ -1277,7 +1277,7 @@ VisiblePosition endOfParagraph(const VisiblePosition& c, EditingBoundaryCrossing
         return VisiblePosition();
 
     auto p = c.deepEquivalent();
-    auto startNode = p.protectedDeprecatedNode();
+    RefPtr startNode = p.deprecatedNode();
 
     if (isRenderedAsNonInlineTableImageOrHR(startNode.get()))
         return positionAfterNode(startNode.get());

--- a/Source/WebCore/editing/WebCorePasteboardFileReader.cpp
+++ b/Source/WebCore/editing/WebCorePasteboardFileReader.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -36,13 +36,12 @@ WebCorePasteboardFileReader::~WebCorePasteboardFileReader() = default;
 
 void WebCorePasteboardFileReader::readFilename(const String& filename)
 {
-    files.append(File::create(protectedContext().get(), filename));
+    files.append(File::create(context.get(), filename));
 }
 
 void WebCorePasteboardFileReader::readBuffer(const String& filename, const String& type, Ref<SharedBuffer>&& buffer)
 {
-    auto protectedContext = this->protectedContext();
-    files.append(File::create(protectedContext.get(), Blob::create(protectedContext.get(), buffer->extractData(), type), filename));
+    files.append(File::create(context.get(), Blob::create(context.get(), buffer->extractData(), type), filename));
 }
 
 }

--- a/Source/WebCore/editing/WebCorePasteboardFileReader.h
+++ b/Source/WebCore/editing/WebCorePasteboardFileReader.h
@@ -43,9 +43,7 @@ struct WebCorePasteboardFileReader final : PasteboardFileReader {
     void readFilename(const String&) final;
     void readBuffer(const String& filename, const String& type, Ref<SharedBuffer>&&) final;
 
-    RefPtr<ScriptExecutionContext> protectedContext() const { return context; }
-
-    RefPtr<ScriptExecutionContext> context;
+    const RefPtr<ScriptExecutionContext> context;
     Vector<Ref<File>> files;
 };
 

--- a/Source/WebCore/editing/WrapContentsInDummySpanCommand.cpp
+++ b/Source/WebCore/editing/WrapContentsInDummySpanCommand.cpp
@@ -39,15 +39,14 @@ WrapContentsInDummySpanCommand::WrapContentsInDummySpanCommand(Element& element)
 void WrapContentsInDummySpanCommand::executeApply()
 {
     Vector<Ref<Node>> children;
-    Ref element = protectedElement();
-    for (RefPtr child = element->firstChild(); child; child = child->nextSibling())
+    for (RefPtr child = m_element->firstChild(); child; child = child->nextSibling())
         children.append(*child);
 
-    auto dummySpan = protectedDummySpan();
+    RefPtr dummySpan = m_dummySpan;
     for (auto& child : children)
         dummySpan->appendChild(child);
 
-    element->appendChild(*dummySpan);
+    m_element->appendChild(*dummySpan);
 }
 
 void WrapContentsInDummySpanCommand::doApply()
@@ -62,24 +61,23 @@ void WrapContentsInDummySpanCommand::doUnapply()
     if (!m_dummySpan)
         return;
 
-    Ref element = protectedElement();
-    if (!element->hasEditableStyle())
+    if (!m_element->hasEditableStyle())
         return;
 
     Vector<Ref<Node>> children;
-    auto dummySpan = protectedDummySpan();
+    RefPtr dummySpan = m_dummySpan;
     for (RefPtr child = dummySpan->firstChild(); child; child = child->nextSibling())
         children.append(*child);
 
     for (auto& child : children)
-        element->appendChild(child);
+        m_element->appendChild(child);
 
     dummySpan->remove();
 }
 
 void WrapContentsInDummySpanCommand::doReapply()
 {
-    if (!m_dummySpan || !protectedElement()->hasEditableStyle())
+    if (!m_dummySpan || !m_element->hasEditableStyle())
         return;
 
     executeApply();
@@ -88,9 +86,9 @@ void WrapContentsInDummySpanCommand::doReapply()
 #ifndef NDEBUG
 void WrapContentsInDummySpanCommand::getNodesInCommand(NodeSet& nodes)
 {
-    addNodeAndDescendants(protectedElement().ptr(), nodes);
+    addNodeAndDescendants(m_element.ptr(), nodes);
     addNodeAndDescendants(protectedDummySpan().get(), nodes);
 }
 #endif
-    
+
 } // namespace WebCore

--- a/Source/WebCore/editing/WrapContentsInDummySpanCommand.h
+++ b/Source/WebCore/editing/WrapContentsInDummySpanCommand.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005, 2006, 2008 Apple Inc. All rights reserved.
+ * Copyright (C) 2005-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -47,13 +47,12 @@ private:
     void executeApply();
 
     RefPtr<HTMLElement> protectedDummySpan() const { return m_dummySpan; }
-    Ref<Element> protectedElement() const { return m_element; }
 
 #ifndef NDEBUG
     void getNodesInCommand(NodeSet&) override;
 #endif
 
-    Ref<Element> m_element;
+    const Ref<Element> m_element;
     RefPtr<HTMLElement> m_dummySpan;
 };
 

--- a/Source/WebCore/editing/markup.cpp
+++ b/Source/WebCore/editing/markup.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2004-2025 Apple Inc. All rights reserved.
  * Copyright (C) 2008, 2009, 2010, 2011 Google Inc. All rights reserved.
  * Copyright (C) 2011 Igalia S.L.
  * Copyright (C) 2011 Motorola Mobility. All rights reserved.
@@ -1358,7 +1358,7 @@ bool isPlainTextMarkup(Node* node)
 
 static bool contextPreservesNewline(const SimpleRange& context)
 {
-    auto container = VisiblePosition(makeDeprecatedLegacyPosition(context.start)).deepEquivalent().protectedContainerNode();
+    RefPtr container = VisiblePosition(makeDeprecatedLegacyPosition(context.start)).deepEquivalent().containerNode();
     return container && container->renderer() && container->renderer()->style().preserveNewline();
 }
 

--- a/Source/WebCore/html/canvas/WebGLRenderingContext.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContext.cpp
@@ -330,7 +330,7 @@ GCGLint WebGLRenderingContext::maxDrawBuffers()
 {
     if (!supportsDrawBuffers())
         return 0;
-    RefPtr graphicsContext = protectedGraphicsContextGL();
+    RefPtr graphicsContext = graphicsContextGL();
     if (!m_maxDrawBuffers)
         m_maxDrawBuffers = graphicsContext->getInteger(GraphicsContextGL::MAX_DRAW_BUFFERS_EXT);
     if (!m_maxColorAttachments)


### PR DESCRIPTION
#### f20d920da025ef028f9cc686e32a38e291a03633
<pre>
Reduce incorrect usage of protectedX() in dom and editing
<a href="https://bugs.webkit.org/show_bug.cgi?id=293959">https://bugs.webkit.org/show_bug.cgi?id=293959</a>
<a href="https://rdar.apple.com/152502777">rdar://152502777</a>

Reviewed by Chris Dumez.

Apply <a href="https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines">https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines</a> more
strictly to existing code so bad patterns have less of a chance of
getting copied.

This is not exhaustive and will be followed by more patches.

Canonical link: <a href="https://commits.webkit.org/295798@main">https://commits.webkit.org/295798@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fa240e6a393d0ae25002825339436f867dbd27ab

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/106198 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25947 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/16341 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/111395 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/56794 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/108237 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/26607 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34450 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80665 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/109202 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/21029 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95831 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60991 "Found 1 new API test failure: /WPE/TestCookieManager:/webkit/WebKitCookieManager/replace-get-all-cookies (failure)") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/20579 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13934 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/56234 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/90388 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13969 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/114256 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33336 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/24583 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89738 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33700 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/92064 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89439 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22799 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34309 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/12120 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/28912 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/33261 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/38673 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/33007 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/36357 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34605 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->