### PR TITLE
[libpas] Fix the libpas tests build

### DIFF
--- a/Source/bmalloc/libpas/libpas.xcodeproj/project.pbxproj
+++ b/Source/bmalloc/libpas/libpas.xcodeproj/project.pbxproj
@@ -331,8 +331,8 @@
 		0F9E945923452262009FAFDD /* pas_log.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F9E945723452262009FAFDD /* pas_log.h */; };
 		0F9E9466234660D4009FAFDD /* pas_dyld_state.c in Sources */ = {isa = PBXBuildFile; fileRef = 0F9E9464234660D3009FAFDD /* pas_dyld_state.c */; };
 		0F9E9467234660D4009FAFDD /* pas_dyld_state.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F9E9465234660D3009FAFDD /* pas_dyld_state.h */; };
+		0FA18546236B3C82003609A7 /* ScavengerExternalWorkTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FA18545236B3C82003609A7 /* ScavengerExternalWorkTests.cpp */; };
 		0FA18546236B3C82003609AD /* IsoHeapChaosTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FA18545236B3C82003609AD /* IsoHeapChaosTests.cpp */; };
-		0FA18546236B3C82003609A7 /* ScavengerExternalWorkTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FA18545236B3C82003609A7 /* ScavengerExternalWorkTests.cpp.cpp */; };
 		0FA5E4562492D5BA00CE962A /* pas_thread_local_cache_layout_node.c in Sources */ = {isa = PBXBuildFile; fileRef = 0FA5E4512492D5B900CE962A /* pas_thread_local_cache_layout_node.c */; };
 		0FA5E4572492D5BA00CE962A /* pas_redundant_local_allocator_node.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FA5E4522492D5B900CE962A /* pas_redundant_local_allocator_node.h */; };
 		0FA5E4582492D5BA00CE962A /* pas_thread_local_cache_layout_node.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FA5E4532492D5B900CE962A /* pas_thread_local_cache_layout_node.h */; };
@@ -595,6 +595,8 @@
 		2CB9B15B278F85EE003A8C1B /* pas_lenient_compact_ptr_inlines.h in Headers */ = {isa = PBXBuildFile; fileRef = 2CB9B157278F85EE003A8C1B /* pas_lenient_compact_ptr_inlines.h */; };
 		2CB9B15D278F861B003A8C1B /* LotsOfHeapsAndThreads.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2CB9B15C278F861B003A8C1B /* LotsOfHeapsAndThreads.cpp */; };
 		2CE2AE35275A953E00D02BBC /* BitfitTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2CE2AE34275A953E00D02BBC /* BitfitTests.cpp */; };
+		A4203F4A2DEF5D8300F67514 /* pas_thread.h in Headers */ = {isa = PBXBuildFile; fileRef = A4203F492DEF5D8300F67514 /* pas_thread.h */; };
+		A4203F4C2DEF5E8600F67514 /* pas_thread.c in Sources */ = {isa = PBXBuildFile; fileRef = A4203F4B2DEF5E8600F67514 /* pas_thread.c */; };
 		E3096D4C2A82357800BC4CA0 /* pas_allocation_result.c in Sources */ = {isa = PBXBuildFile; fileRef = E3096D4B2A82357800BC4CA0 /* pas_allocation_result.c */; };
 		E3AA9B8328C724D8005DF9D6 /* pas_darwin_spi.h in Headers */ = {isa = PBXBuildFile; fileRef = E3AA9B8228C724D8005DF9D6 /* pas_darwin_spi.h */; };
 /* End PBXBuildFile section */
@@ -1041,8 +1043,8 @@
 		0F9E945723452262009FAFDD /* pas_log.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pas_log.h; sourceTree = "<group>"; };
 		0F9E9464234660D3009FAFDD /* pas_dyld_state.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pas_dyld_state.c; sourceTree = "<group>"; };
 		0F9E9465234660D3009FAFDD /* pas_dyld_state.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pas_dyld_state.h; sourceTree = "<group>"; };
-		0FA18545236B3C82003609AD /* IsoHeapChaosTests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = IsoHeapChaosTests.cpp; sourceTree = "<group>"; };
 		0FA18545236B3C82003609A7 /* ScavengerExternalWorkTests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ScavengerExternalWorkTests.cpp; sourceTree = "<group>"; };
+		0FA18545236B3C82003609AD /* IsoHeapChaosTests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = IsoHeapChaosTests.cpp; sourceTree = "<group>"; };
 		0FA5E4512492D5B900CE962A /* pas_thread_local_cache_layout_node.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pas_thread_local_cache_layout_node.c; sourceTree = "<group>"; };
 		0FA5E4522492D5B900CE962A /* pas_redundant_local_allocator_node.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pas_redundant_local_allocator_node.h; sourceTree = "<group>"; };
 		0FA5E4532492D5B900CE962A /* pas_thread_local_cache_layout_node.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pas_thread_local_cache_layout_node.h; sourceTree = "<group>"; };
@@ -1313,6 +1315,8 @@
 		2CB9B157278F85EE003A8C1B /* pas_lenient_compact_ptr_inlines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pas_lenient_compact_ptr_inlines.h; sourceTree = "<group>"; };
 		2CB9B15C278F861B003A8C1B /* LotsOfHeapsAndThreads.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LotsOfHeapsAndThreads.cpp; sourceTree = "<group>"; };
 		2CE2AE34275A953E00D02BBC /* BitfitTests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = BitfitTests.cpp; sourceTree = "<group>"; };
+		A4203F492DEF5D8300F67514 /* pas_thread.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = pas_thread.h; sourceTree = "<group>"; };
+		A4203F4B2DEF5E8600F67514 /* pas_thread.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = pas_thread.c; sourceTree = "<group>"; };
 		E3096D4B2A82357800BC4CA0 /* pas_allocation_result.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pas_allocation_result.c; sourceTree = "<group>"; };
 		E3AA9B8228C724D8005DF9D6 /* pas_darwin_spi.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pas_darwin_spi.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -1930,6 +1934,8 @@
 				0FC6821921253627003C6A13 /* pas_stream.h */,
 				0FC4EC2E234A91E200B710A3 /* pas_string_stream.c */,
 				0FC4EC33234A91E200B710A3 /* pas_string_stream.h */,
+				A4203F4B2DEF5E8600F67514 /* pas_thread.c */,
+				A4203F492DEF5D8300F67514 /* pas_thread.h */,
 				0FC681C9210F7C9F003C6A13 /* pas_thread_local_cache.c */,
 				0FC681C4210F7C9E003C6A13 /* pas_thread_local_cache.h */,
 				0FC681C2210F7C9E003C6A13 /* pas_thread_local_cache_layout.c */,
@@ -2396,6 +2402,7 @@
 				0FC4EC3D234A91E300B710A3 /* pas_status_reporter.h in Headers */,
 				0FE7EE3322960142004F4166 /* pas_stream.h in Headers */,
 				0FC4EC3C234A91E300B710A3 /* pas_string_stream.h in Headers */,
+				A4203F4A2DEF5D8300F67514 /* pas_thread.h in Headers */,
 				0FE7EE3522960142004F4166 /* pas_thread_local_cache.h in Headers */,
 				0FE7EE3422960142004F4166 /* pas_thread_local_cache_layout.h in Headers */,
 				0FA5E4582492D5BA00CE962A /* pas_thread_local_cache_layout_node.h in Headers */,
@@ -2859,6 +2866,7 @@
 				0FC4EC3B234A91E300B710A3 /* pas_status_reporter.c in Sources */,
 				0FE7EDD322960142004F4166 /* pas_stream.c in Sources */,
 				0FC4EC37234A91E300B710A3 /* pas_string_stream.c in Sources */,
+				A4203F4C2DEF5E8600F67514 /* pas_thread.c in Sources */,
 				0FE7EDD522960142004F4166 /* pas_thread_local_cache.c in Sources */,
 				0FE7EDD422960142004F4166 /* pas_thread_local_cache_layout.c in Sources */,
 				0FA5E4562492D5BA00CE962A /* pas_thread_local_cache_layout_node.c in Sources */,

--- a/Source/bmalloc/libpas/src/libpas/pas_segregated_shared_view.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_segregated_shared_view.h
@@ -133,7 +133,7 @@ pas_segregated_shared_view_compute_minimum_size_for_bump_with_aligned_padding(
     unsigned trailing_padding_size,
     unsigned trailing_padding_alignment)
 {
-    return pas_round_up_to_power_of_2(allocation_size, trailing_padding_alignment)
+    return (unsigned)pas_round_up_to_power_of_2(allocation_size, trailing_padding_alignment)
         + trailing_padding_size;
 }
 


### PR DESCRIPTION
#### 8f3d6b367eb5893dd4a9f2cab616732fc1e80bdf
<pre>
[libpas] Fix the libpas tests build
<a href="https://bugs.webkit.org/show_bug.cgi?id=293960">https://bugs.webkit.org/show_bug.cgi?id=293960</a>
<a href="https://rdar.apple.com/152507524">rdar://152507524</a>

Reviewed by Yijia Huang.

* Source/bmalloc/libpas/libpas.xcodeproj/project.pbxproj:

pas_thread.{c,h} was added in 295497@main so add it to the
xcode project so that the tests can be built on darwin.

* Source/bmalloc/libpas/src/libpas/pas_segregated_shared_view.h:
(pas_segregated_shared_view_compute_minimum_size_for_bump_with_aligned_padding):

This function was added in 293476@main. The compiler complains about the
implicit conversion when building the tests but not when building the product.
Add the cast to silence the warning  (promoted to error), like we do in other places.

OpenSource/Source/bmalloc/libpas/src/libpas/pas_segregated_shared_view.h:137:9: error:
      implicit conversion loses integer precision: &apos;uintptr_t&apos; (aka &apos;unsigned long&apos;) to &apos;unsigned int&apos;
      [-Werror,-Wshorten-64-to-32]
  136 |     return pas_round_up_to_power_of_2(allocation_size, trailing_padding_alignment)
      |     ~~~~~~ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  137 |         + trailing_padding_size;
      |         ^~~~~~~~~~~~~~~~~~~~~~~

Canonical link: <a href="https://commits.webkit.org/295762@main">https://commits.webkit.org/295762@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1a388703a256aa0da7075d54d93e1c66a527b4ed

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/106060 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25809 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/16203 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/111257 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/56656 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/26465 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34312 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/80573 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/109064 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/20904 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95718 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60895 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/20487 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13816 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/56094 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/98699 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/90273 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13851 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/114112 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/104677 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33198 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/24501 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/89654 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33562 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91946 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89343 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22769 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34202 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/12014 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/28769 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/33123 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/128989 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32869 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/35168 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/36219 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34467 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->