### PR TITLE
Improve error message when detecting a duplicate in contributors.json

### DIFF
--- a/Tools/Scripts/webkitpy/common/config/committers.py
+++ b/Tools/Scripts/webkitpy/common/config/committers.py
@@ -312,7 +312,7 @@ class CommitterList(object):
         if not len(self._contributors_by_name):
             for contributor in self._contributors:
                 assert contributor.full_name
-                assert contributor.full_name.lower() not in self._contributors_by_name  # We should never have duplicate names.
+                assert contributor.full_name.lower() not in self._contributors_by_name, f'Duplicate name: {contributor.full_name}'  # We should never have duplicate names.
                 self._contributors_by_name[contributor.full_name.lower()] = contributor
                 if contributor.aliases is None:
                     continue
@@ -325,7 +325,7 @@ class CommitterList(object):
         if not len(self._accounts_by_email):
             for account in self._contributors:
                 for email in account.emails:
-                    assert(email not in self._accounts_by_email)  # We should never have duplicate emails.
+                    assert email not in self._accounts_by_email, f'Duplicate email: {email}'  # We should never have duplicate emails.
                     self._accounts_by_email[email] = account
         return self._accounts_by_email
 


### PR DESCRIPTION
#### e3e5308657d41602f331ad0b8353a4ee480a12cd
<pre>
Improve error message when detecting a duplicate in contributors.json
<a href="https://bugs.webkit.org/show_bug.cgi?id=293961">https://bugs.webkit.org/show_bug.cgi?id=293961</a>

Reviewed by Ryan Haddad and Brianna Fan.

Add a custom error message which includes the name of duplicate entry.

* Tools/Scripts/webkitpy/common/config/committers.py:
(CommitterList._name_to_contributor_map):
(CommitterList._email_to_account_map):

Canonical link: <a href="https://commits.webkit.org/295756@main">https://commits.webkit.org/295756@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5520839f9d309053adf58c2ffea288a020192195

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/106061 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25810 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/138/builds/16204 "Build was cancelled. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/111258 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/56657 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/108100 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/26466 "Build was cancelled. Recent messages:OS: Sequoia (15.5), Xcode: 16.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34313 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/111258 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/56657 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/109065 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/130/builds/26466 "Build was cancelled. Recent messages:OS: Sequoia (15.5), Xcode: 16.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/138/builds/16204 "Build was cancelled. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/111258 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [❌ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/105538 "webkitpy-tests (failure)") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/130/builds/26466 "Build was cancelled. Recent messages:OS: Sequoia (15.5), Xcode: 16.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/138/builds/16204 "Build was cancelled. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/56095 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/130/builds/26466 "Build was cancelled. Recent messages:OS: Sequoia (15.5), Xcode: 16.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/138/builds/16204 "Build was cancelled. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/114113 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/33199 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/24498 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/114113 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/33563 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/138/builds/16204 "Build was cancelled. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/114113 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/138/builds/16204 "Build was cancelled. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/28770 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17201 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/33124 "Build was cancelled. Recent messages:OS: Sequoia (15.5), Xcode: 16.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/32870 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/36220 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34468 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->