### PR TITLE
Fix repaint artifacts for animated SVG images with srcset descriptors

### DIFF
--- a/LayoutTests/svg/repaint/image-srcset-transform-animation-expected.html
+++ b/LayoutTests/svg/repaint/image-srcset-transform-animation-expected.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<style>
+    body { margin: 0; padding: 0; }
+</style>
+<html>
+<body>
+    <picture>
+        <source srcset="../../resources/square-translate.svg 2x"></source>
+        <img id="svgImg" alt="" />
+    </picture>
+</body>
+</html>

--- a/LayoutTests/svg/repaint/image-srcset-transform-animation-zoom-expected.html
+++ b/LayoutTests/svg/repaint/image-srcset-transform-animation-zoom-expected.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<style>
+    body { zoom: 2; margin: 0; padding: 0; }
+</style>
+<html>
+<body>
+    <picture>
+        <source srcset="../../resources/square-translate.svg 2x"></source>
+        <img id="svgImg" alt="" />
+    </picture>
+</body>
+</html>

--- a/LayoutTests/svg/repaint/image-srcset-transform-animation-zoom.html
+++ b/LayoutTests/svg/repaint/image-srcset-transform-animation-zoom.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<style>
+    body { zoom: 2; margin: 0; padding: 0; }
+</style>
+<body>
+    <picture>
+        <source srcset="../../resources/square-translate.svg 2x"></source>
+        <img id="svgImg" alt="" />
+    </picture>
+</body>
+<script>
+    if (window.testRunner) {
+        testRunner.waitUntilDone();
+        if (testRunner.dontForceRepaint)
+            testRunner.dontForceRepaint();
+    }
+
+    async function main() {
+        // Wait 250ms to ensure 100ms SVG animation completes
+        setTimeout(() => {
+            if (window.testRunner)
+                testRunner.notifyDone();
+        }, 250);
+    }
+
+    window.addEventListener('load', main, false);
+</script>
+</html>

--- a/LayoutTests/svg/repaint/image-srcset-transform-animation.html
+++ b/LayoutTests/svg/repaint/image-srcset-transform-animation.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<style>
+    body { margin: 0; padding: 0; }
+</style>
+<body>
+    <picture>
+        <source srcset="../../resources/square-translate.svg 2x"></source>
+        <img id="svgImg" alt="" />
+    </picture>
+</body>
+<script>
+    if (window.testRunner) {
+        testRunner.waitUntilDone();
+        if (testRunner.dontForceRepaint)
+            testRunner.dontForceRepaint();
+    }
+
+    async function main() {
+        // Wait 250ms to ensure 100ms SVG animation completes
+        setTimeout(() => {
+            if (window.testRunner)
+                testRunner.notifyDone();
+        }, 250);
+    }
+
+    window.addEventListener('load', main, false);
+</script>
+</html>

--- a/LayoutTests/svg/resources/square-translate.svg
+++ b/LayoutTests/svg/resources/square-translate.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="250" height="250">
+  <rect id="rect" x="10" y="10" width="50" height="50" fill="red">
+    <animateTransform
+      attributeName="transform"
+      type="translate"
+      values="0,0; 30,0"
+      keyTimes="0; 0.5"
+      dur="0.1s"
+      begin="0s"
+      fill="freeze"
+      calcMode="discrete"
+    />
+  </rect>
+</svg>

--- a/Source/WebCore/rendering/RenderImage.cpp
+++ b/Source/WebCore/rendering/RenderImage.cpp
@@ -410,7 +410,9 @@ void RenderImage::repaintOrMarkForLayout(ImageSizeChangeType imageSizeChange, co
         if (rect) {
             // The image changed rect is in source image coordinates (pre-zooming),
             // so map from the bounds of the image to the contentsBox.
-            repaintRect.intersect(enclosingIntRect(mapRect(*rect, FloatRect(FloatPoint(), imageResource().imageSize(1.0f)), repaintRect)));
+            RefPtr<Image> srcImg = imageResource().image(flooredIntSize(contentBoxSize()));
+            FloatSize sourceSize = srcImg->size() / style().usedZoom();
+            repaintRect.intersect(enclosingIntRect(mapRect(*rect, FloatRect(FloatPoint(), sourceSize), repaintRect)));
         }
         repaintRectangle(repaintRect);
     }


### PR DESCRIPTION
#### b223af795341c3d435824a2adfe269f9e600f6f9
<pre>
Fix repaint artifacts for animated SVG images with srcset descriptors
<a href="https://rdar.apple.com/130617653">rdar://130617653</a>

Reviewed by Simon Fraser.

This patch fixes the coordinate mapping issue when
animated SVG images use srcset descriptors.

When an SVG with animations is displayed via an &lt;img&gt; element with
srcset descriptors, the repaint rectangles incorrectly mapped,
causing only a portion of the rectangle being repainted.

* Source/WebCore/rendering/RenderImage.cpp:
(WebCore::RenderImage::repaintOrMarkForLayout):

Canonical link: <a href="https://commits.webkit.org/295859@main">https://commits.webkit.org/295859@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/931152c96d55c517057f1e3d81df7b8edf055d97

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/106322 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/26071 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/16467 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/111520 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/56918 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/108361 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/26736 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34574 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80757 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/109326 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/21162 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95943 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/61084 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/20673 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/14041 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/56358 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/90511 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/14076 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/114382 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33460 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24670 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89828 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33824 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/92171 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89530 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22849 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34411 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/29045 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/33385 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/38797 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/33131 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/36484 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34729 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->