### PR TITLE
Revert "[Safe CPP] Address Warnings in RenderTableCol.cpp"

### DIFF
--- a/Source/WTF/wtf/CheckedPtr.h
+++ b/Source/WTF/wtf/CheckedPtr.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2021 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -212,62 +212,6 @@ inline bool is(const CheckedPtr<ArgType, ArgPtrTraits>& source)
     return is<ExpectedType>(source.get());
 }
 
-template<typename Target, typename Source, typename PtrTraits>
-inline CheckedPtr<match_constness_t<Source, Target>> uncheckedDowncast(CheckedPtr<Source, PtrTraits>& source)
-{
-    static_assert(!std::is_same_v<Source, Target>, "Unnecessary cast to same type");
-    static_assert(std::is_base_of_v<Source, Target>, "Should be a downcast");
-    RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(!source || is<Target>(*source));
-    return CheckedPtr<match_constness_t<Source, Target>>(static_cast<Target*>(source.get()));
-}
-
-template<typename Target, typename Source, typename PtrTraits>
-inline CheckedPtr<match_constness_t<Source, Target>> uncheckedDowncast(CheckedPtr<Source, PtrTraits>&& source)
-{
-    static_assert(!std::is_same_v<Source, Target>, "Unnecessary cast to same type");
-    static_assert(std::is_base_of_v<Source, Target>, "Should be a downcast");
-    RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(!source || is<Target>(*source));
-    return CheckedPtr<match_constness_t<Source, Target>>(static_cast<Target*>(WTFMove(source)));
-}
-
-template<typename Target, typename Source, typename PtrTraits>
-inline CheckedPtr<match_constness_t<Source, Target>> downcast(CheckedPtr<Source, PtrTraits>& source)
-{
-    static_assert(!std::is_same_v<Source, Target>, "Unnecessary cast to same type");
-    static_assert(std::is_base_of_v<Source, Target>, "Should be a downcast");
-    RELEASE_ASSERT(!source || is<Target>(*source));
-    return CheckedPtr<match_constness_t<Source, Target>>(static_cast<Target*>(source.get()));
-}
-
-template<typename Target, typename Source, typename PtrTraits>
-inline CheckedPtr<match_constness_t<Source, Target>> downcast(CheckedPtr<Source, PtrTraits>&& source)
-{
-    static_assert(!std::is_same_v<Source, Target>, "Unnecessary cast to same type");
-    static_assert(std::is_base_of_v<Source, Target>, "Should be a downcast");
-    RELEASE_ASSERT(!source || is<Target>(*source));
-    return CheckedPtr<match_constness_t<Source, Target>>(static_cast<Target*>(WTFMove(source)));
-}
-
-template<typename Target, typename Source, typename TargetPtrTraits = RawPtrTraits<Target>, typename SourcePtrTraits>
-inline CheckedPtr<match_constness_t<Source, Target>, TargetPtrTraits> dynamicDowncast(CheckedPtr<Source, SourcePtrTraits>& source)
-{
-    static_assert(!std::is_same_v<Source, Target>, "Unnecessary cast to same type");
-    static_assert(std::is_base_of_v<Source, Target>, "Should be a downcast");
-    if (!is<Target>(source))
-        return nullptr;
-    return CheckedPtr<match_constness_t<Source, Target>, TargetPtrTraits>(static_cast<Target*>(source.get()));
-}
-
-template<typename Target, typename Source, typename TargetPtrTraits = RawPtrTraits<Target>, typename SourcePtrTraits>
-inline CheckedPtr<match_constness_t<Source, Target>, TargetPtrTraits> dynamicDowncast(CheckedPtr<Source, SourcePtrTraits>&& source)
-{
-    static_assert(!std::is_same_v<Source, Target>, "Unnecessary cast to same type");
-    static_assert(std::is_base_of_v<Source, Target>, "Should be a downcast");
-    if (!is<Target>(source))
-        return nullptr;
-    return CheckedPtr<match_constness_t<Source, Target>, TargetPtrTraits>(static_cast<Target*>(WTFMove(source)));
-}
-
 template<typename P> struct HashTraits<CheckedPtr<P>> : SimpleClassHashTraits<CheckedPtr<P>> {
     static P* emptyValue() { return nullptr; }
     static bool isEmptyValue(const CheckedPtr<P>& value) { return !value; }
@@ -294,3 +238,4 @@ template<typename T> using PackedCheckedPtr = CheckedPtr<T, PackedPtrTraits<T>>;
 
 using WTF::CheckedPtr;
 using WTF::PackedCheckedPtr;
+

--- a/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -704,6 +704,7 @@ rendering/RenderTable.h
 rendering/RenderTableCaption.cpp
 rendering/RenderTableCell.cpp
 rendering/RenderTableCellInlines.h
+rendering/RenderTableCol.cpp
 rendering/RenderTableRow.cpp
 rendering/RenderTableRowInlines.h
 rendering/RenderTableSection.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
@@ -477,6 +477,7 @@ rendering/RenderTable.cpp
 rendering/RenderTableCaption.cpp
 rendering/RenderTableCell.cpp
 rendering/RenderTableCellInlines.h
+rendering/RenderTableCol.cpp
 rendering/RenderTableRow.cpp
 rendering/RenderTableSection.cpp
 rendering/RenderText.cpp

--- a/Source/WebCore/rendering/AutoTableLayout.cpp
+++ b/Source/WebCore/rendering/AutoTableLayout.cpp
@@ -32,7 +32,6 @@
 #include "RenderTableInlines.h"
 #include "RenderTableSection.h"
 #include "RenderView.h"
-#include <wtf/CheckedPtr.h>
 
 namespace WebCore {
 
@@ -158,7 +157,7 @@ void AutoTableLayout::fullRecalc()
 
     Length groupLogicalWidth;
     unsigned currentColumn = 0;
-    for (CheckedPtr column = m_table->firstColumn(); column; column = column->nextColumn()) {
+    for (RenderTableCol* column = m_table->firstColumn(); column; column = column->nextColumn()) {
         if (column->isTableColumnGroupWithColumnChildren())
             groupLogicalWidth = column->style().logicalWidth();
         else {

--- a/Source/WebCore/rendering/FixedTableLayout.cpp
+++ b/Source/WebCore/rendering/FixedTableLayout.cpp
@@ -27,7 +27,6 @@
 #include "RenderTableCol.h"
 #include "RenderTableInlines.h"
 #include "RenderTableSection.h"
-#include <wtf/CheckedPtr.h>
 
 /*
   The text below is from the CSS 2.1 specs.
@@ -88,7 +87,7 @@ float FixedTableLayout::calcWidthArray()
     m_width.fill(Length(LengthType::Auto));
 
     unsigned currentEffectiveColumn = 0;
-    for (CheckedPtr col = m_table->firstColumn(); col; col = col->nextColumn()) {
+    for (RenderTableCol* col = m_table->firstColumn(); col; col = col->nextColumn()) {
         // RenderTableCols don't have the concept of preferred logical width, but we need to clear their dirty bits
         // so that if we call setPreferredWidthsDirty(true) on a col or one of its descendants, we'll mark it's
         // ancestors as dirty.

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -710,7 +710,7 @@ void RenderBlockFlow::dirtyForLayoutFromPercentageHeightDescendants()
 
         for (CheckedPtr<RenderElement> renderer = &descendant; renderer && renderer != this && !renderer->normalChildNeedsLayout(); renderer = renderer->container()) {
             renderer->setChildNeedsLayout(MarkOnlyThis);
-            if (CheckedPtr renderBox = dynamicDowncast<RenderBox>(renderer)) {
+            if (CheckedPtr renderBox = dynamicDowncast<RenderBox>(renderer.get())) {
                 // If the width of an image is affected by the height of a child (e.g., an image with an aspect ratio),
                 // then we have to dirty preferred widths, since even enclosing blocks can become dirty as a result.
                 // (A horizontal flexbox that contains an inline image wrapped in an anonymous block for example.)

--- a/Source/WebCore/rendering/RenderElement.h
+++ b/Source/WebCore/rendering/RenderElement.h
@@ -27,7 +27,6 @@
 #include "RenderObject.h"
 #include "RenderPtr.h"
 #include "RenderStyle.h"
-#include <wtf/CheckedRef.h>
 #include <wtf/MonotonicTime.h>
 #include <wtf/Packed.h>
 
@@ -69,7 +68,6 @@ public:
     bool hasInitializedStyle() const { return m_hasInitializedStyle; }
 
     const RenderStyle& style() const { return m_style; }
-    CheckedRef<const RenderStyle> protectedStyle() const { return m_style; }
     const RenderStyle* parentStyle() const { return !m_parent ? nullptr : &m_parent->style(); }
     const RenderStyle& firstLineStyle() const;
 

--- a/Source/WebCore/rendering/RenderTable.cpp
+++ b/Source/WebCore/rendering/RenderTable.cpp
@@ -59,7 +59,6 @@
 #include "RenderView.h"
 #include "StyleBoxShadow.h"
 #include "StyleInheritedData.h"
-#include <wtf/CheckedPtr.h>
 #include <wtf/SetForScope.h>
 #include <wtf/StackStats.h>
 #include <wtf/TZoneMallocInlines.h>
@@ -1049,10 +1048,10 @@ void RenderTable::updateColumnCache() const
     ASSERT(!m_columnRenderersValid);
 
     unsigned columnIndex = 0;
-    for (CheckedPtr columnRenderer = firstColumn(); columnRenderer; columnRenderer = columnRenderer->nextColumn()) {
+    for (RenderTableCol* columnRenderer = firstColumn(); columnRenderer; columnRenderer = columnRenderer->nextColumn()) {
         if (columnRenderer->isTableColumnGroupWithColumnChildren())
             continue;
-        m_columnRenderers.append(*columnRenderer);
+        m_columnRenderers.append(columnRenderer);
         // FIXME: We should look to compute the effective column index successively from previous values instead of
         // calling colToEffCol(), which is in O(numEffCols()). Although it's unlikely that this is a hot function.
         m_effectiveColumnIndexMap.add(*columnRenderer, colToEffCol(columnIndex));
@@ -1065,10 +1064,10 @@ unsigned RenderTable::effectiveIndexOfColumn(const RenderTableCol& column) const
 {
     if (!m_columnRenderersValid)
         updateColumnCache();
-    CheckedPtr<const RenderTableCol> columnToUse = &column;
+    const RenderTableCol* columnToUse = &column;
     if (columnToUse->isTableColumnGroupWithColumnChildren())
         columnToUse = columnToUse->nextColumn(); // First column in column-group
-    auto it = m_effectiveColumnIndexMap.find(columnToUse.get());
+    auto it = m_effectiveColumnIndexMap.find(columnToUse);
     ASSERT(it != m_effectiveColumnIndexMap.end());
     if (it == m_effectiveColumnIndexMap.end())
         return std::numeric_limits<unsigned>::max();
@@ -1097,7 +1096,7 @@ LayoutUnit RenderTable::offsetLeftForColumn(const RenderTableCol& column) const
 
 LayoutUnit RenderTable::offsetWidthForColumn(const RenderTableCol& column) const
 {
-    CheckedPtr<const RenderTableCol> currentColumn = &column;
+    const RenderTableCol* currentColumn = &column;
     bool hasColumnChildren;
     if ((hasColumnChildren = currentColumn->isTableColumnGroupWithColumnChildren()))
         currentColumn = currentColumn->nextColumn(); // First column in column-group

--- a/Source/WebCore/rendering/RenderTable.h
+++ b/Source/WebCore/rendering/RenderTable.h
@@ -29,7 +29,6 @@
 #include "CollapsedBorderValue.h"
 #include "RenderBlock.h"
 #include <memory>
-#include <wtf/CheckedPtr.h>
 #include <wtf/HashMap.h>
 #include <wtf/Vector.h>
 

--- a/Source/WebCore/rendering/RenderTableCell.cpp
+++ b/Source/WebCore/rendering/RenderTableCell.cpp
@@ -49,7 +49,6 @@
 #include "StyleProperties.h"
 #include "TransformState.h"
 #include <ranges>
-#include <wtf/CheckedPtr.h>
 #include <wtf/StackStats.h>
 #include <wtf/TZoneMallocInlines.h>
 
@@ -176,7 +175,7 @@ void RenderTableCell::colSpanOrRowSpanChanged()
 Length RenderTableCell::logicalWidthFromColumns(RenderTableCol* firstColForThisCell, Length widthFromStyle) const
 {
     ASSERT(firstColForThisCell && firstColForThisCell == table()->colElement(col()));
-    CheckedPtr tableCol = firstColForThisCell;
+    RenderTableCol* tableCol = firstColForThisCell;
 
     unsigned colSpanCount = colSpan();
     LayoutUnit colWidthSum;
@@ -671,7 +670,7 @@ CollapsedBorderValue RenderTableCell::computeCollapsedStartBorder(IncludeBorderC
             if (!result.exists())
                 return result;
             // Next, apply the start border of the enclosing colgroup but only if it is adjacent to the cell's edge.
-            if (CheckedPtr enclosingColumnGroup = colElt->enclosingColumnGroupIfAdjacentBefore()) {
+            if (RenderTableCol* enclosingColumnGroup = colElt->enclosingColumnGroupIfAdjacentBefore()) {
                 result = chooseBorder(result, CollapsedBorderValue(enclosingColumnGroup->borderAdjoiningCellStartBorder(), includeColor ? enclosingColumnGroup->style().visitedDependentColorWithColorFilter(startColorProperty) : Color(), BorderPrecedence::ColumnGroup));
                 if (!result.exists())
                     return result;
@@ -694,7 +693,7 @@ CollapsedBorderValue RenderTableCell::computeCollapsedStartBorder(IncludeBorderC
                     return result;
                 // Next, if the previous col has a parent colgroup then its end border should be applied
                 // but only if it is adjacent to the cell's edge.
-                if (CheckedPtr enclosingColumnGroup = colElt->enclosingColumnGroupIfAdjacentAfter()) {
+                if (RenderTableCol* enclosingColumnGroup = colElt->enclosingColumnGroupIfAdjacentAfter()) {
                     result = chooseBorder(CollapsedBorderValue(enclosingColumnGroup->borderAdjoiningCellEndBorder(), includeColor ? enclosingColumnGroup->style().visitedDependentColorWithColorFilter(endColorProperty) : Color(), BorderPrecedence::ColumnGroup), result);
                     if (!result.exists())
                         return result;
@@ -786,7 +785,7 @@ CollapsedBorderValue RenderTableCell::computeCollapsedEndBorder(IncludeBorderCol
             if (!result.exists())
                 return result;
             // Next, if it has a parent colgroup then we apply its end border but only if it is adjacent to the cell.
-            if (CheckedPtr enclosingColumnGroup = colElt->enclosingColumnGroupIfAdjacentAfter()) {
+            if (RenderTableCol* enclosingColumnGroup = colElt->enclosingColumnGroupIfAdjacentAfter()) {
                 result = chooseBorder(result, CollapsedBorderValue(enclosingColumnGroup->borderAdjoiningCellEndBorder(), includeColor ? enclosingColumnGroup->style().visitedDependentColorWithColorFilter(endColorProperty) : Color(), BorderPrecedence::ColumnGroup));
                 if (!result.exists())
                     return result;
@@ -808,7 +807,7 @@ CollapsedBorderValue RenderTableCell::computeCollapsedEndBorder(IncludeBorderCol
                 if (!result.exists())
                     return result;
                 // If we have a parent colgroup, resolve the border only if it is adjacent to the cell.
-                if (CheckedPtr enclosingColumnGroup = colElt->enclosingColumnGroupIfAdjacentBefore()) {
+                if (RenderTableCol* enclosingColumnGroup = colElt->enclosingColumnGroupIfAdjacentBefore()) {
                     result = chooseBorder(result, CollapsedBorderValue(enclosingColumnGroup->borderAdjoiningCellStartBorder(), includeColor ? enclosingColumnGroup->style().visitedDependentColorWithColorFilter(startColorProperty) : Color(), BorderPrecedence::ColumnGroup));
                     if (!result.exists())
                         return result;
@@ -908,7 +907,7 @@ CollapsedBorderValue RenderTableCell::computeCollapsedBeforeBorder(IncludeBorder
             result = chooseBorder(result, CollapsedBorderValue(colElt->style().borderBefore(tableWritingMode()), includeColor ? colElt->style().visitedDependentColorWithColorFilter(beforeColorProperty) : Color(), BorderPrecedence::Column));
             if (!result.exists())
                 return result;
-            if (CheckedPtr enclosingColumnGroup = colElt->enclosingColumnGroup()) {
+            if (RenderTableCol* enclosingColumnGroup = colElt->enclosingColumnGroup()) {
                 result = chooseBorder(result, CollapsedBorderValue(enclosingColumnGroup->style().borderBefore(tableWritingMode()), includeColor ? enclosingColumnGroup->style().visitedDependentColorWithColorFilter(beforeColorProperty) : Color(), BorderPrecedence::ColumnGroup));
                 if (!result.exists())
                     return result;
@@ -996,7 +995,7 @@ CollapsedBorderValue RenderTableCell::computeCollapsedAfterBorder(IncludeBorderC
         if (colElt) {
             result = chooseBorder(result, CollapsedBorderValue(colElt->style().borderAfter(tableWritingMode()), includeColor ? colElt->style().visitedDependentColorWithColorFilter(afterColorProperty) : Color(), BorderPrecedence::Column));
             if (!result.exists()) return result;
-            if (CheckedPtr enclosingColumnGroup = colElt->enclosingColumnGroup()) {
+            if (RenderTableCol* enclosingColumnGroup = colElt->enclosingColumnGroup()) {
                 result = chooseBorder(result, CollapsedBorderValue(enclosingColumnGroup->style().borderAfter(tableWritingMode()), includeColor ? enclosingColumnGroup->style().visitedDependentColorWithColorFilter(afterColorProperty) : Color(), BorderPrecedence::ColumnGroup));
                 if (!result.exists())
                     return result;

--- a/Source/WebCore/rendering/RenderTableCol.h
+++ b/Source/WebCore/rendering/RenderTableCol.h
@@ -26,8 +26,6 @@
 #pragma once
 
 #include "RenderBox.h"
-#include <wtf/CheckedPtr.h>
-#include <wtf/CheckedRef.h>
 
 namespace WebCore {
 
@@ -51,12 +49,12 @@ public:
     bool isTableColumn() const { return style().display() == DisplayType::TableColumn; }
     bool isTableColumnGroup() const { return style().display() == DisplayType::TableColumnGroup; }
 
-    CheckedPtr<RenderTableCol> enclosingColumnGroup() const;
-    CheckedPtr<RenderTableCol> enclosingColumnGroupIfAdjacentBefore() const;
-    CheckedPtr<RenderTableCol> enclosingColumnGroupIfAdjacentAfter() const;
+    RenderTableCol* enclosingColumnGroup() const;
+    RenderTableCol* enclosingColumnGroupIfAdjacentBefore() const;
+    RenderTableCol* enclosingColumnGroupIfAdjacentAfter() const;
 
     // Returns the next column or column-group.
-    CheckedPtr<RenderTableCol> nextColumn() const;
+    RenderTableCol* nextColumn() const;
 
     const BorderValue& borderAdjoiningCellStartBorder() const;
     const BorderValue& borderAdjoiningCellEndBorder() const;
@@ -89,19 +87,19 @@ private:
     void styleDidChange(StyleDifference, const RenderStyle* oldStyle) override;
     void paint(PaintInfo&, const LayoutPoint&) override { }
 
-    CheckedPtr<RenderTable> table() const;
+    RenderTable* table() const;
 
     unsigned m_span { 1 };
 };
 
-inline CheckedPtr<RenderTableCol> RenderTableCol::enclosingColumnGroupIfAdjacentBefore() const
+inline RenderTableCol* RenderTableCol::enclosingColumnGroupIfAdjacentBefore() const
 {
     if (previousSibling())
         return nullptr;
     return enclosingColumnGroup();
 }
 
-inline CheckedPtr<RenderTableCol> RenderTableCol::enclosingColumnGroupIfAdjacentAfter() const
+inline RenderTableCol* RenderTableCol::enclosingColumnGroupIfAdjacentAfter() const
 {
     if (nextSibling())
         return nullptr;

--- a/Source/WebCore/rendering/RenderTableSection.cpp
+++ b/Source/WebCore/rendering/RenderTableSection.cpp
@@ -986,8 +986,8 @@ void RenderTableSection::paintCell(RenderTableCell* cell, PaintInfo& paintInfo, 
         // Note that we deliberately ignore whether or not the cell has a layer, since these backgrounds paint "behind" the
         // cell.
         if (RenderTableCol* column = table()->colElement(cell->col())) {
-            if (CheckedPtr columnGroup = column->enclosingColumnGroup())
-                cell->paintBackgroundsBehindCell(paintInfo, cellPoint, columnGroup.get(), cellPoint);
+            if (RenderTableCol* columnGroup = column->enclosingColumnGroup())
+                cell->paintBackgroundsBehindCell(paintInfo, cellPoint, columnGroup, cellPoint);
             cell->paintBackgroundsBehindCell(paintInfo, cellPoint, column, cellPoint);
         }
 


### PR DESCRIPTION
#### 7e74145709820033b893cf6ca970711259b96a88
<pre>
Revert &quot;[Safe CPP] Address Warnings in RenderTableCol.cpp&quot;
<a href="https://bugs.webkit.org/show_bug.cgi?id=293964">https://bugs.webkit.org/show_bug.cgi?id=293964</a>
<a href="https://rdar.apple.com/problem/152512236">rdar://problem/152512236</a>

Reviewed by Chris Dumez.

Did not correctly meet style guides, and needed to make updates as it did not cleanly revert
without manual intervention.

Reverted Commit: <a href="https://commits.webkit.org/295455@main">https://commits.webkit.org/295455@main</a>

* Source/WTF/wtf/CheckedPtr.h:
(WTF::uncheckedDowncast): Deleted.
(WTF::downcast): Deleted.
(WTF::dynamicDowncast): Deleted.
* Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations:
* Source/WebCore/rendering/AutoTableLayout.cpp:
(WebCore::AutoTableLayout::fullRecalc):
* Source/WebCore/rendering/FixedTableLayout.cpp:
(WebCore::FixedTableLayout::calcWidthArray):
* Source/WebCore/rendering/RenderElement.h:
(WebCore::RenderElement::style const):
(WebCore::RenderElement::protectedStyle const): Deleted.
* Source/WebCore/rendering/RenderTable.cpp:
(WebCore::RenderTable::updateColumnCache const):
(WebCore::RenderTable::effectiveIndexOfColumn const):
(WebCore::RenderTable::offsetWidthForColumn const):
* Source/WebCore/rendering/RenderTable.h:
* Source/WebCore/rendering/RenderTableCell.cpp:
(WebCore::RenderTableCell::logicalWidthFromColumns const):
(WebCore::RenderTableCell::computeCollapsedStartBorder const):
(WebCore::RenderTableCell::computeCollapsedEndBorder const):
(WebCore::RenderTableCell::computeCollapsedBeforeBorder const):
(WebCore::RenderTableCell::computeCollapsedAfterBorder const):
* Source/WebCore/rendering/RenderTableCol.cpp:
(WebCore::RenderTableCol::styleDidChange):
(WebCore::RenderTableCol::updateFromElement):
(WebCore::RenderTableCol::willBeRemovedFromTree):
(WebCore::RenderTableCol::clippedOverflowRect const):
(WebCore::RenderTableCol::clearNeedsPreferredLogicalWidthsUpdate):
(WebCore::RenderTableCol::table const):
(WebCore::RenderTableCol::enclosingColumnGroup const):
(WebCore::RenderTableCol::nextColumn const):
(WebCore::RenderTableCol::borderAdjoiningCellStartBorder const):
(WebCore::RenderTableCol::borderAdjoiningCellEndBorder const):
(WebCore::RenderTableCol::borderAdjoiningCellBefore const):
(WebCore::RenderTableCol::borderAdjoiningCellAfter const):
* Source/WebCore/rendering/RenderTableCol.h:
(WebCore::RenderTableCol::enclosingColumnGroupIfAdjacentBefore const):
(WebCore::RenderTableCol::enclosingColumnGroupIfAdjacentAfter const):
* Source/WebCore/rendering/RenderTableSection.cpp:
(WebCore::RenderTableSection::paintCell):

Canonical link: <a href="https://commits.webkit.org/295791@main">https://commits.webkit.org/295791@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fdee7c8bd7afc48f5c0fea3025b9b0011e1e4e57

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/106072 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25821 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/16215 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/111269 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/56668 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/108111 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/26477 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34324 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80574 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/109076 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/20920 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95734 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60896 "Found 1 new API test failure: /WPE/TestCookieManager:/webkit/WebKitCookieManager/replace-get-all-cookies (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/20501 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13832 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/56106 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/98711 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/90288 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13867 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/114124 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/104689 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33210 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24507 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89656 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33574 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91962 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89345 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22790 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34214 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/12030 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/28783 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/33135 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/38547 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/129001 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32881 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/35171 "Found 1 new JSC stress test failure: wasm.yaml/wasm/gc/ref-i31-eq.js.wasm-collect-continuously (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/36231 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34479 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->