### PR TITLE
AX: Rename AXCoreObject::roleValue to AXCoreObject::role as the "Value" suffix is redundant

### DIFF
--- a/Source/WebCore/accessibility/AXCoreObject.cpp
+++ b/Source/WebCore/accessibility/AXCoreObject.cpp
@@ -37,15 +37,9 @@
 
 namespace WebCore {
 
-bool AXCoreObject::isLink() const
-{
-    auto role = roleValue();
-    return role == AccessibilityRole::Link;
-}
-
 bool AXCoreObject::isList() const
 {
-    auto role = roleValue();
+    auto role = this->role();
     return role == AccessibilityRole::List || role == AccessibilityRole::DescriptionList;
 }
 
@@ -57,7 +51,7 @@ bool AXCoreObject::isFileUploadButton() const
 
 bool AXCoreObject::isMenuRelated() const
 {
-    switch (roleValue()) {
+    switch (role()) {
     case AccessibilityRole::Menu:
     case AccessibilityRole::MenuBar:
     case AccessibilityRole::MenuItem:
@@ -71,7 +65,7 @@ bool AXCoreObject::isMenuRelated() const
 
 bool AXCoreObject::isMenuItem() const
 {
-    switch (roleValue()) {
+    switch (role()) {
     case AccessibilityRole::MenuItem:
     case AccessibilityRole::MenuItemRadio:
     case AccessibilityRole::MenuItemCheckbox:
@@ -83,7 +77,7 @@ bool AXCoreObject::isMenuItem() const
 
 bool AXCoreObject::isInputImage() const
 {
-    if (roleValue() != AccessibilityRole::Button)
+    if (role() != AccessibilityRole::Button)
         return false;
 
     std::optional type = inputType();
@@ -92,7 +86,7 @@ bool AXCoreObject::isInputImage() const
 
 bool AXCoreObject::isControl() const
 {
-    switch (roleValue()) {
+    switch (role()) {
     case AccessibilityRole::Button:
     case AccessibilityRole::Checkbox:
     case AccessibilityRole::ColorWell:
@@ -117,7 +111,7 @@ bool AXCoreObject::isControl() const
 
 bool AXCoreObject::isImplicitlyInteractive() const
 {
-    switch (roleValue()) {
+    switch (role()) {
     case AccessibilityRole::Button:
     case AccessibilityRole::Checkbox:
     case AccessibilityRole::ColorWell:
@@ -152,7 +146,7 @@ bool AXCoreObject::isImplicitlyInteractive() const
 
 bool AXCoreObject::isLandmark() const
 {
-    switch (roleValue()) {
+    switch (role()) {
     case AccessibilityRole::Form:
     case AccessibilityRole::LandmarkBanner:
     case AccessibilityRole::LandmarkComplementary:
@@ -170,7 +164,7 @@ bool AXCoreObject::isLandmark() const
 
 bool AXCoreObject::isGroup() const
 {
-    switch (roleValue()) {
+    switch (role()) {
     case AccessibilityRole::Group:
     case AccessibilityRole::TextGroup:
         return true;
@@ -190,19 +184,19 @@ bool AXCoreObject::hasHighlighting() const
 
 bool AXCoreObject::hasGridRole() const
 {
-    auto role = roleValue();
+    auto role = this->role();
     return role == AccessibilityRole::Grid || role == AccessibilityRole::TreeGrid;
 }
 
 bool AXCoreObject::hasCellRole() const
 {
-    auto role = roleValue();
+    auto role = this->role();
     return role == AccessibilityRole::Cell || role == AccessibilityRole::GridCell || role == AccessibilityRole::ColumnHeader || role == AccessibilityRole::RowHeader;
 }
 
 bool AXCoreObject::isButton() const
 {
-    switch (roleValue()) {
+    switch (role()) {
     case AccessibilityRole::Button:
     case AccessibilityRole::PopUpButton:
     case AccessibilityRole::ToggleButton:
@@ -214,7 +208,7 @@ bool AXCoreObject::isButton() const
 
 bool AXCoreObject::isTextControl() const
 {
-    switch (roleValue()) {
+    switch (role()) {
     case AccessibilityRole::ComboBox:
     case AccessibilityRole::SearchField:
     case AccessibilityRole::TextArea:
@@ -227,7 +221,7 @@ bool AXCoreObject::isTextControl() const
 
 bool AXCoreObject::isValidListBox() const
 {
-    if (roleValue() != AccessibilityRole::ListBox)
+    if (role() != AccessibilityRole::ListBox)
         return false;
 
     Deque<Ref<AXCoreObject>, /* inlineCapacity */ 100> queue;
@@ -258,7 +252,7 @@ bool AXCoreObject::isValidListBox() const
 
 AXCoreObject::AccessibilityChildrenVector AXCoreObject::tabChildren()
 {
-    if (roleValue() != AccessibilityRole::TabList)
+    if (role() != AccessibilityRole::TabList)
         return { };
 
     AXCoreObject::AccessibilityChildrenVector result;
@@ -272,7 +266,7 @@ AXCoreObject::AccessibilityChildrenVector AXCoreObject::tabChildren()
 #if ENABLE(INCLUDE_IGNORED_IN_CORE_AX_TREE)
 static bool isValidChildForTable(AXCoreObject& object)
 {
-    auto role = object.roleValue();
+    auto role = object.role();
     // Tables can only have these roles as exposed-to-AT children.
     return role == AccessibilityRole::Row || role == AccessibilityRole::Column || role == AccessibilityRole::TableHeaderContainer || role == AccessibilityRole::Caption;
 }
@@ -344,7 +338,7 @@ AXCoreObject* AXCoreObject::nextInPreOrder(bool updateChildrenIfNeeded, AXCoreOb
 {
     const auto& children = childrenIncludingIgnored(updateChildrenIfNeeded);
     if (!children.isEmpty()) {
-        auto role = roleValue();
+        auto role = this->role();
         if (role != AccessibilityRole::Column && role != AccessibilityRole::TableHeaderContainer) {
             // Table columns and header containers add cells despite not being their "true" parent (which are the rows).
             // Don't allow a pre-order traversal of these object types to return cells to avoid an infinite loop.
@@ -499,7 +493,7 @@ AXCoreObject::AccessibilityChildrenVector AXCoreObject::ariaTreeItemContent()
     AccessibilityChildrenVector result;
     // The content of a treeitem excludes other treeitems or their containing groups.
     for (const auto& child : unignoredChildren()) {
-        if (!child->isGroup() && child->roleValue() != AccessibilityRole::TreeItem)
+        if (!child->isGroup() && child->role() != AccessibilityRole::TreeItem)
             result.append(child);
     }
     return result;
@@ -531,7 +525,7 @@ AXCoreObject::AXValue AXCoreObject::value()
     if (supportsRangeValue())
         return valueForRange();
 
-    if (roleValue() == AccessibilityRole::SliderThumb) {
+    if (role() == AccessibilityRole::SliderThumb) {
         RefPtr parent = parentObject();
         return parent ? parent->valueForRange() : 0.0f;
     }
@@ -542,7 +536,7 @@ AXCoreObject::AXValue AXCoreObject::value()
     if (supportsCheckedState())
         return checkboxOrRadioValue();
 
-    if (roleValue() == AccessibilityRole::Summary)
+    if (role() == AccessibilityRole::Summary)
         return isExpanded();
 
     // Radio groups return the selected radio button as the AXValue.
@@ -578,7 +572,7 @@ AXCoreObject* AXCoreObject::selectedRadioButton()
 
     // Find the child radio button that is selected (ie. the intValue == 1).
     for (const auto& child : unignoredChildren()) {
-        if (child->roleValue() == AccessibilityRole::RadioButton && child->checkboxOrRadioValue() == AccessibilityButtonState::On)
+        if (child->role() == AccessibilityRole::RadioButton && child->checkboxOrRadioValue() == AccessibilityButtonState::On)
             return child.ptr();
     }
     return nullptr;
@@ -600,7 +594,7 @@ AXCoreObject* AXCoreObject::selectedTabItem()
 
 bool AXCoreObject::canHaveSelectedChildren() const
 {
-    switch (roleValue()) {
+    switch (role()) {
     // These roles are containers whose children support aria-selected:
     case AccessibilityRole::Grid:
     case AccessibilityRole::ListBox:
@@ -628,7 +622,7 @@ AXCoreObject::AccessibilityChildrenVector AXCoreObject::selectedChildren()
     if (!canHaveSelectedChildren())
         return { };
 
-    switch (roleValue()) {
+    switch (role()) {
     case AccessibilityRole::ComboBox:
         if (auto* descendant = activeDescendant())
             return { { *descendant } };
@@ -669,7 +663,7 @@ AXCoreObject::AccessibilityChildrenVector AXCoreObject::selectedChildren()
 
 AXCoreObject::AccessibilityChildrenVector AXCoreObject::listboxSelectedChildren()
 {
-    ASSERT(roleValue() == AccessibilityRole::ListBox);
+    ASSERT(role() == AccessibilityRole::ListBox);
 
     AccessibilityChildrenVector result;
     bool isMulti = isMultiSelectable();
@@ -686,7 +680,7 @@ AXCoreObject::AccessibilityChildrenVector AXCoreObject::listboxSelectedChildren(
 
 AXCoreObject::AccessibilityChildrenVector AXCoreObject::selectedRows()
 {
-    ASSERT(roleValue() == AccessibilityRole::Grid || roleValue() == AccessibilityRole::Tree || roleValue() == AccessibilityRole::TreeGrid);
+    ASSERT(role() == AccessibilityRole::Grid || role() == AccessibilityRole::Tree || role() == AccessibilityRole::TreeGrid);
 
     bool isMulti = isMultiSelectable();
 
@@ -718,7 +712,7 @@ AXCoreObject::AccessibilityChildrenVector AXCoreObject::selectedRows()
 
 AXCoreObject::AccessibilityChildrenVector AXCoreObject::selectedListItems()
 {
-    ASSERT(roleValue() == AccessibilityRole::List);
+    ASSERT(role() == AccessibilityRole::List);
 
     AccessibilityChildrenVector selectedListItems;
     for (const auto& child : unignoredChildren()) {
@@ -737,7 +731,7 @@ void AXCoreObject::ariaTreeRows(AccessibilityChildrenVector& rows, Accessibility
     // in aria-owns.
     for (const auto& child : unignoredChildren()) {
         // Add tree items as the rows.
-        if (child->roleValue() == AccessibilityRole::TreeItem) {
+        if (child->role() == AccessibilityRole::TreeItem) {
             // Child appears both as a direct child and aria-owns, we should use the ordering as
             // described in aria-owns for this child.
             if (ownedObjects.contains(child))
@@ -764,7 +758,7 @@ void AXCoreObject::ariaTreeRows(AccessibilityChildrenVector& rows, Accessibility
             continue;
 
         // Add tree items as the rows.
-        if (child->roleValue() == AccessibilityRole::TreeItem) {
+        if (child->role() == AccessibilityRole::TreeItem) {
             // Hopefully a flow that does not occur often in practice, but if someone were to include
             // the owned child ealier in the top level of the tree, then reference via aria-owns later,
             // move it to the right place.
@@ -803,7 +797,7 @@ bool AXCoreObject::isActiveDescendantOfFocusedContainer() const
 // ARIA spec: User agents must not expose the aria-roledescription property if the element to which aria-roledescription is applied does not have a valid WAI-ARIA role or does not have an implicit WAI-ARIA role semantic.
 bool AXCoreObject::supportsARIARoleDescription() const
 {
-    switch (roleValue()) {
+    switch (role()) {
     case AccessibilityRole::Generic:
     case AccessibilityRole::Unknown:
         return false;
@@ -824,7 +818,7 @@ bool AXCoreObject::supportsRangeValue() const
 
 bool AXCoreObject::supportsRequiredAttribute() const
 {
-    switch (roleValue()) {
+    switch (role()) {
     case AccessibilityRole::Button:
         return isFileUploadButton();
     case AccessibilityRole::Cell:
@@ -850,12 +844,12 @@ bool AXCoreObject::supportsRequiredAttribute() const
 
 bool AXCoreObject::isRootWebArea() const
 {
-    if (roleValue() != AccessibilityRole::WebArea)
+    if (role() != AccessibilityRole::WebArea)
         return false;
 
     RefPtr parent = parentObject();
     // If the parent is a scroll area, and the scroll area has no parent, we are at the root web area.
-    return parent && parent->roleValue() == AccessibilityRole::ScrollArea && !parent->parentObject();
+    return parent && parent->role() == AccessibilityRole::ScrollArea && !parent->parentObject();
 }
 
 bool AXCoreObject::isRadioInput() const
@@ -1063,7 +1057,7 @@ bool AXCoreObject::isTableCellInSameColGroup(AXCoreObject* tableCell)
 bool AXCoreObject::isReplacedElement() const
 {
     // FIXME: Should this include <legend> and form control elements like TextIterator::isRendererReplacedElement does?
-    switch (roleValue()) {
+    switch (role()) {
     case AccessibilityRole::Audio:
     case AccessibilityRole::Image:
     case AccessibilityRole::Meter:
@@ -1109,10 +1103,10 @@ String AXCoreObject::roleDescription()
     if (!roleDescription.isEmpty())
         return roleDescription;
 
-    if (roleValue() == AccessibilityRole::Figure)
+    if (role() == AccessibilityRole::Figure)
         return AXFigureText();
 
-    if (roleValue() == AccessibilityRole::Suggestion)
+    if (role() == AccessibilityRole::Suggestion)
         return AXSuggestionRoleDescriptionText();
 
     return { };
@@ -1120,7 +1114,7 @@ String AXCoreObject::roleDescription()
 
 String AXCoreObject::ariaLandmarkRoleDescription() const
 {
-    switch (roleValue()) {
+    switch (role()) {
     case AccessibilityRole::Form:
         return AXARIAContentGroupText("ARIALandmarkForm"_s);
     case AccessibilityRole::LandmarkBanner:
@@ -1175,7 +1169,7 @@ unsigned AXCoreObject::blockquoteLevel() const
 {
     unsigned level = 0;
     for (RefPtr ancestor = parentObject(); ancestor; ancestor = ancestor->parentObject()) {
-        if (ancestor->roleValue() == AccessibilityRole::Blockquote)
+        if (ancestor->role() == AccessibilityRole::Blockquote)
             ++level;
     }
     return level;
@@ -1212,14 +1206,14 @@ unsigned AXCoreObject::hierarchicalLevel() const
         return level;
 
     // Only tree item will calculate its level through the DOM currently.
-    if (roleValue() != AccessibilityRole::TreeItem)
+    if (role() != AccessibilityRole::TreeItem)
         return 0;
 
     // Hierarchy leveling starts at 1, to match the aria-level spec.
     // We measure tree hierarchy by the number of groups that the item is within.
     level = 1;
     for (RefPtr ancestor = parentObject(); ancestor; ancestor = ancestor->parentObject()) {
-        auto ancestorRole = ancestor->roleValue();
+        auto ancestorRole = ancestor->role();
         if (ancestorRole == AccessibilityRole::Group)
             level++;
         else if (ancestorRole == AccessibilityRole::Tree)
@@ -1231,7 +1225,7 @@ unsigned AXCoreObject::hierarchicalLevel() const
 
 bool AXCoreObject::supportsPressAction() const
 {
-    if (roleValue() == AccessibilityRole::Presentational)
+    if (role() == AccessibilityRole::Presentational)
         return false;
 
     if (isImplicitlyInteractive() || hasClickHandler())
@@ -1246,7 +1240,7 @@ bool AXCoreObject::supportsPressAction() const
             // Stop iterating if we walk over an implicitly interactive element on our way to the click handler, as
             // we can rely on the semantics of that element to imply pressability. Also stop when encountering the body
             // or main to avoid exposing pressability for everything in web apps that implement an event-delegation mechanism.
-            return ancestor.isImplicitlyInteractive() || ancestor.roleValue() == AccessibilityRole::LandmarkMain || ancestor.hasBodyTag();
+            return ancestor.isImplicitlyInteractive() || ancestor.role() == AccessibilityRole::LandmarkMain || ancestor.hasBodyTag();
         })) {
             unsigned matches = 0;
             unsigned candidatesChecked = 0;
@@ -1272,7 +1266,7 @@ bool AXCoreObject::supportsPressAction() const
 
 bool AXCoreObject::supportsActiveDescendant() const
 {
-    switch (roleValue()) {
+    switch (role()) {
     case AccessibilityRole::ComboBox:
     case AccessibilityRole::Grid:
     case AccessibilityRole::List:
@@ -1531,7 +1525,7 @@ void AXCoreObject::appendRadioButtonGroupMembers(AccessibilityChildrenVector& li
     } else {
         // If we didn't find any radio button siblings with the traditional naming, lets search for a radio group role and find its children.
         for (RefPtr parent = parentObject(); parent; parent = parent->parentObject()) {
-            if (parent->roleValue() == AccessibilityRole::RadioGroup) {
+            if (parent->role() == AccessibilityRole::RadioGroup) {
                 appendRadioButtonDescendants(*parent, linkedUIElements);
                 break;
             }
@@ -1541,7 +1535,7 @@ void AXCoreObject::appendRadioButtonGroupMembers(AccessibilityChildrenVector& li
 
 AXCoreObject* AXCoreObject::parentObjectUnignored() const
 {
-    if (roleValue() == AccessibilityRole::Row) {
+    if (role() == AccessibilityRole::Row) {
         if (auto* table = exposedTableAncestor())
             return table;
     }

--- a/Source/WebCore/accessibility/AXCoreObject.h
+++ b/Source/WebCore/accessibility/AXCoreObject.h
@@ -815,31 +815,31 @@ public:
     virtual bool isAXIsolatedObjectInstance() const = 0;
     virtual bool isAXRemoteFrame() const = 0;
 
-    bool isHeading() const { return roleValue() == AccessibilityRole::Heading; }
-    bool isLink() const;
-    bool isCode() const { return roleValue() == AccessibilityRole::Code; }
-    bool isImage() const { return roleValue() == AccessibilityRole::Image; }
-    bool isImageMap() const { return roleValue() == AccessibilityRole::ImageMap; }
-    bool isVideo() const { return roleValue() == AccessibilityRole::Video; }
+    bool isHeading() const { return role() == AccessibilityRole::Heading; }
+    bool isLink() const { return role() == AccessibilityRole::Link; };
+    bool isCode() const { return role() == AccessibilityRole::Code; }
+    bool isImage() const { return role() == AccessibilityRole::Image; }
+    bool isImageMap() const { return role() == AccessibilityRole::ImageMap; }
+    bool isVideo() const { return role() == AccessibilityRole::Video; }
     virtual bool isSecureField() const = 0;
     virtual bool isNativeTextControl() const = 0;
-    bool isWebArea() const { return roleValue() == AccessibilityRole::WebArea; }
+    bool isWebArea() const { return role() == AccessibilityRole::WebArea; }
     bool isRootWebArea() const;
-    bool isCheckbox() const { return roleValue() == AccessibilityRole::Checkbox; }
-    bool isRadioButton() const { return roleValue() == AccessibilityRole::RadioButton; }
-    bool isListBox() const { return roleValue() == AccessibilityRole::ListBox; }
+    bool isCheckbox() const { return role() == AccessibilityRole::Checkbox; }
+    bool isRadioButton() const { return role() == AccessibilityRole::RadioButton; }
+    bool isListBox() const { return role() == AccessibilityRole::ListBox; }
     // The children of listboxes must be of specific roles. Returns true if at least one of those is present.
     bool isValidListBox() const;
     bool isInvalidListBox() const { return isListBox() && !isValidListBox(); }
-    bool isListBoxOption() const { return roleValue() == AccessibilityRole::ListBoxOption; }
+    bool isListBoxOption() const { return role() == AccessibilityRole::ListBoxOption; }
     virtual bool isAttachment() const = 0;
     bool isMenuRelated() const;
-    bool isMenu() const { return roleValue() == AccessibilityRole::Menu; }
-    bool isMenuBar() const { return roleValue() == AccessibilityRole::MenuBar; }
+    bool isMenu() const { return role() == AccessibilityRole::Menu; }
+    bool isMenuBar() const { return role() == AccessibilityRole::MenuBar; }
     bool isMenuItem() const;
     bool isInputImage() const;
-    bool isProgressIndicator() const { return roleValue() == AccessibilityRole::ProgressIndicator || roleValue() == AccessibilityRole::Meter; }
-    bool isSlider() const { return roleValue() == AccessibilityRole::Slider; }
+    bool isProgressIndicator() const { return role() == AccessibilityRole::ProgressIndicator || role() == AccessibilityRole::Meter; }
+    bool isSlider() const { return role() == AccessibilityRole::Slider; }
     bool isControl() const;
     bool isRadioInput() const;
     // lists support (l, ul, ol, dl)
@@ -894,7 +894,7 @@ public:
     virtual std::optional<unsigned> axRowIndex() const = 0;
 
     // Table column support.
-    bool isTableColumn() const { return roleValue() == AccessibilityRole::Column; }
+    bool isTableColumn() const { return role() == AccessibilityRole::Column; }
     virtual unsigned columnIndex() const = 0;
     AXCoreObject* columnHeader();
 
@@ -916,49 +916,49 @@ public:
 #endif
 
     // Native spin buttons.
-    bool isSpinButton() const { return roleValue() == AccessibilityRole::SpinButton; }
+    bool isSpinButton() const { return role() == AccessibilityRole::SpinButton; }
     SpinButtonType spinButtonType();
     virtual AXCoreObject* incrementButton() = 0;
     virtual AXCoreObject* decrementButton() = 0;
 
     virtual bool isMockObject() const = 0;
-    bool isSwitch() const { return roleValue() == AccessibilityRole::Switch; }
-    bool isToggleButton() const { return roleValue() == AccessibilityRole::ToggleButton; }
+    bool isSwitch() const { return role() == AccessibilityRole::Switch; }
+    bool isToggleButton() const { return role() == AccessibilityRole::ToggleButton; }
     bool isTextControl() const;
     virtual bool isNonNativeTextControl() const = 0;
-    bool isTabList() const { return roleValue() == AccessibilityRole::TabList; }
-    bool isTabItem() const { return roleValue() == AccessibilityRole::Tab; }
-    bool isRadioGroup() const { return roleValue() == AccessibilityRole::RadioGroup; }
-    bool isComboBox() const { return roleValue() == AccessibilityRole::ComboBox; }
-    bool isDateTime() const { return roleValue() == AccessibilityRole::DateTime; }
-    bool isGrid() const { return roleValue() == AccessibilityRole::Grid; }
-    bool isTree() const { return roleValue() == AccessibilityRole::Tree; }
-    bool isTreeGrid() const { return roleValue() == AccessibilityRole::TreeGrid; }
-    bool isTreeItem() const { return roleValue() == AccessibilityRole::TreeItem; }
-    bool isScrollbar() const { return roleValue() == AccessibilityRole::ScrollBar; }
-    bool isRemoteFrame() const { return roleValue() == AccessibilityRole::RemoteFrame; }
+    bool isTabList() const { return role() == AccessibilityRole::TabList; }
+    bool isTabItem() const { return role() == AccessibilityRole::Tab; }
+    bool isRadioGroup() const { return role() == AccessibilityRole::RadioGroup; }
+    bool isComboBox() const { return role() == AccessibilityRole::ComboBox; }
+    bool isDateTime() const { return role() == AccessibilityRole::DateTime; }
+    bool isGrid() const { return role() == AccessibilityRole::Grid; }
+    bool isTree() const { return role() == AccessibilityRole::Tree; }
+    bool isTreeGrid() const { return role() == AccessibilityRole::TreeGrid; }
+    bool isTreeItem() const { return role() == AccessibilityRole::TreeItem; }
+    bool isScrollbar() const { return role() == AccessibilityRole::ScrollBar; }
+    bool isRemoteFrame() const { return role() == AccessibilityRole::RemoteFrame; }
 #if PLATFORM(COCOA)
     virtual RetainPtr<id> remoteFramePlatformElement() const = 0;
 #endif
     virtual bool hasRemoteFrameChild() const = 0;
 
     bool isButton() const;
-    bool isMeter() const { return roleValue() == AccessibilityRole::Meter; }
+    bool isMeter() const { return role() == AccessibilityRole::Meter; }
 
-    bool isListItem() const { return roleValue() == AccessibilityRole::ListItem; }
+    bool isListItem() const { return role() == AccessibilityRole::ListItem; }
     bool isCheckboxOrRadio() const { return isCheckbox() || isRadioButton(); }
-    bool isScrollView() const { return roleValue() == AccessibilityRole::ScrollArea; }
-    bool isCanvas() const { return roleValue() == AccessibilityRole::Canvas; }
-    bool isPopUpButton() const { return roleValue() == AccessibilityRole::PopUpButton; }
-    bool isColorWell() const { return roleValue() == AccessibilityRole::ColorWell; }
-    bool isSplitter() const { return roleValue() == AccessibilityRole::Splitter; }
-    bool isToolbar() const { return roleValue() == AccessibilityRole::Toolbar; }
-    bool isSummary() const { return roleValue() == AccessibilityRole::Summary; }
-    bool isBlockquote() const { return roleValue() == AccessibilityRole::Blockquote; }
+    bool isScrollView() const { return role() == AccessibilityRole::ScrollArea; }
+    bool isCanvas() const { return role() == AccessibilityRole::Canvas; }
+    bool isPopUpButton() const { return role() == AccessibilityRole::PopUpButton; }
+    bool isColorWell() const { return role() == AccessibilityRole::ColorWell; }
+    bool isSplitter() const { return role() == AccessibilityRole::Splitter; }
+    bool isToolbar() const { return role() == AccessibilityRole::Toolbar; }
+    bool isSummary() const { return role() == AccessibilityRole::Summary; }
+    bool isBlockquote() const { return role() == AccessibilityRole::Blockquote; }
 #if ENABLE(MODEL_ELEMENT)
-    bool isModel() const { return roleValue() == AccessibilityRole::Model; }
+    bool isModel() const { return role() == AccessibilityRole::Model; }
 #endif
-    bool isLineBreak() const { return roleValue() == AccessibilityRole::LineBreak; }
+    bool isLineBreak() const { return role() == AccessibilityRole::LineBreak; }
 
     bool isLandmark() const;
     virtual bool isKeyboardFocusable() const = 0;
@@ -999,7 +999,7 @@ public:
     virtual bool hasSameFont(AXCoreObject&) = 0;
     virtual bool hasSameFontColor(AXCoreObject&) = 0;
     virtual bool hasSameStyle(AXCoreObject&) = 0;
-    bool isStaticText() const { return roleValue() == AccessibilityRole::StaticText; }
+    bool isStaticText() const { return role() == AccessibilityRole::StaticText; }
     virtual bool hasUnderline() const = 0;
     bool hasHighlighting() const;
     virtual AXTextMarkerRange textInputMarkedTextMarkerRange() const = 0;
@@ -1012,7 +1012,7 @@ public:
     virtual bool canSetFocusAttribute() const = 0;
     bool canSetTextRangeAttributes() const;
     virtual bool canSetValueAttribute() const = 0;
-    bool canSetNumericValue() const { return roleValue() == AccessibilityRole::ScrollBar; }
+    bool canSetNumericValue() const { return role() == AccessibilityRole::ScrollBar; }
     virtual bool canSetSelectedAttribute() const = 0;
     bool canSetSelectedChildren() const;
     bool canSetExpandedAttribute() const;
@@ -1182,7 +1182,7 @@ public:
     // Only if isColorWell()
     virtual SRGBA<uint8_t> colorValue() const = 0;
 
-    AccessibilityRole roleValue() const { return m_role; }
+    AccessibilityRole role() const { return m_role; }
 #if PLATFORM(MAC)
     // Non-localized string associated with the object role.
     String rolePlatformString();
@@ -1304,7 +1304,7 @@ public:
         return children(updateChildrenIfNeeded);
     };
 #if ENABLE(INCLUDE_IGNORED_IN_CORE_AX_TREE)
-    bool onlyAddsUnignoredChildren() const { return isTableColumn() || roleValue() == AccessibilityRole::TableHeaderContainer; }
+    bool onlyAddsUnignoredChildren() const { return isTableColumn() || role() == AccessibilityRole::TableHeaderContainer; }
     AccessibilityChildrenVector unignoredChildren(bool updateChildrenIfNeeded = true);
     AXCoreObject* firstUnignoredChild();
 #else
@@ -1336,7 +1336,7 @@ public:
     }
     bool shouldSetChildIndexInParent() const
     {
-        auto role = roleValue();
+        auto role = this->role();
         // Columns and table header containers add cells as children, but are not their "true" parent
         // (the rows are), so these two roles should not update their children's index-in-parent.
         return role != AccessibilityRole::Column && role != AccessibilityRole::TableHeaderContainer;
@@ -1617,13 +1617,13 @@ void attributedStringSetElement(NSMutableAttributedString *, NSString *attribute
 inline bool AXCoreObject::shouldComputeDescriptionAttributeValue() const
 {
     // Static text objects shouldn't return a description. Their content is communicated via AXValue.
-    return roleValue() != AccessibilityRole::StaticText;
+    return role() != AccessibilityRole::StaticText;
 }
 
 inline bool AXCoreObject::shouldComputeTitleAttributeValue() const
 {
     // Static text objects shouldn't return a title. Their content is communicated via AXValue.
-    return roleValue() != AccessibilityRole::StaticText;
+    return role() != AccessibilityRole::StaticText;
 }
 #endif // PLATFORM(COCOA)
 
@@ -1659,7 +1659,7 @@ inline const String AXCoreObject::liveRegionRelevant() const
 inline const String AXCoreObject::liveRegionStatus() const
 {
     auto explicitStatus = explicitLiveRegionStatus();
-    return explicitStatus.isEmpty() ? defaultLiveRegionStatusForRole(roleValue()) : explicitStatus;
+    return explicitStatus.isEmpty() ? defaultLiveRegionStatusForRole(role()) : explicitStatus;
 }
 
 inline bool AXCoreObject::supportsLiveRegion(bool excludeIfOff) const
@@ -1775,7 +1775,7 @@ T* clickableSelfOrAncestor(const T& startObject, const F& shouldStop)
     }, shouldStop);
 
     // Presentational objects should not be allowed to be clicked.
-    if (ancestor && ancestor->roleValue() == AccessibilityRole::Presentational)
+    if (ancestor && ancestor->role() == AccessibilityRole::Presentational)
         return nullptr;
     return ancestor;
 }

--- a/Source/WebCore/accessibility/AXLogger.cpp
+++ b/Source/WebCore/accessibility/AXLogger.cpp
@@ -1289,7 +1289,7 @@ void streamAXCoreObject(TextStream& stream, const AXCoreObject& object, const Op
         stream << "objectID " << object.objectID();
 
     if (options & AXStreamOptions::Role)
-        stream.dumpProperty("role"_s, object.roleValue());
+        stream.dumpProperty("role"_s, object.role());
 
     auto* axObject = dynamicDowncast<AccessibilityObject>(object);
     if (axObject) {
@@ -1309,7 +1309,7 @@ void streamAXCoreObject(TextStream& stream, const AXCoreObject& object, const Op
         stream.dumpProperty("identifier"_s, WTFMove(id));
 
     if (options & AXStreamOptions::OuterHTML) {
-        auto role = object.roleValue();
+        auto role = object.role();
         auto* objectWithInterestingHTML = role == AccessibilityRole::Button ? // Add here other roles of interest.
             &object : nullptr;
 

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -367,7 +367,7 @@ bool AXObjectCache::modalElementHasAccessibleContent(Element& element)
                 // Its content is exposed by its parent.
                 // Treat such elements as having accessible content.
                 // FIXME: This may not be sufficient for visibility:hidden or inert (https://bugs.webkit.org/show_bug.cgi?id=280914).
-                if (axObject->roleValue() == AccessibilityRole::StaticText && !axObject->isAXHidden())
+                if (axObject->role() == AccessibilityRole::StaticText && !axObject->isAXHidden())
                     return true;
 #endif
             }
@@ -1249,7 +1249,7 @@ void AXObjectCache::handleTextChanged(AccessibilityObject* object)
 
         if (isText) {
             bool dependsOnTextUnderElement = ancestor->dependsOnTextUnderElement();
-            auto role = ancestor->roleValue();
+            auto role = ancestor->role();
             dependsOnTextUnderElement |= role == AccessibilityRole::Label || role == AccessibilityRole::TextField;
 
             // If the starting object is a static text, its underlying text has changed.
@@ -1694,7 +1694,7 @@ void AXObjectCache::notificationPostTimerFired()
         if (note.second == AXNotification::MenuOpened) {
             // Only notify if the object is in fact a menu.
             note.first->updateChildrenIfNecessary();
-            if (note.first->roleValue() != AccessibilityRole::Menu)
+            if (note.first->role() != AccessibilityRole::Menu)
                 continue;
         }
 
@@ -1838,7 +1838,7 @@ void AXObjectCache::handleTabPanelSelected(Element* oldElement, Element* newElem
     RefPtr<AccessibilityObject> oldFocusedControlledPanel;
     if (oldObject) {
         oldFocusedControlledPanel = Accessibility::findAncestor<AccessibilityObject>(*oldObject, false, [] (auto& ancestor) {
-            return ancestor.roleValue() == AccessibilityRole::TabPanel;
+            return ancestor.role() == AccessibilityRole::TabPanel;
         });
 
         updateTab(oldFocusedControlledPanel.get(), *oldElement);
@@ -1849,7 +1849,7 @@ void AXObjectCache::handleTabPanelSelected(Element* oldElement, Element* newElem
         return;
 
     RefPtr newFocusedControlledPanel = Accessibility::findAncestor<AccessibilityObject>(*newObject, false, [] (auto& ancestor) {
-        return ancestor.roleValue() == AccessibilityRole::TabPanel;
+        return ancestor.role() == AccessibilityRole::TabPanel;
     });
 
     if (oldFocusedControlledPanel != newFocusedControlledPanel)
@@ -2727,7 +2727,7 @@ void AXObjectCache::handleAriaExpandedChange(Element& element)
             handleRowCountChanged(ancestor, protectedDocument().get());
 
         // Post that the specific row either collapsed or expanded.
-        auto role = object->roleValue();
+        auto role = object->role();
         if (role == AccessibilityRole::Row || role == AccessibilityRole::TreeItem)
             postNotification(object.get(), protectedDocument().get(), object->isExpanded() ? AXNotification::RowExpanded : AXNotification::RowCollapsed);
         else
@@ -3114,7 +3114,7 @@ void AXObjectCache::handleAttributeChange(Element* element, const QualifiedName&
     else if (attrName == aria_multilineAttr) {
         if (auto* axObject = get(*element)) {
             // The role of textarea and textfield objects is dependent on whether they can span multiple lines, so recompute it here.
-            if (axObject->roleValue() == AccessibilityRole::TextArea || axObject->roleValue() == AccessibilityRole::TextField)
+            if (axObject->role() == AccessibilityRole::TextArea || axObject->role() == AccessibilityRole::TextField)
                 axObject->updateRole();
         }
     }
@@ -5034,7 +5034,7 @@ void AXObjectCache::updateIsolatedTree(const Vector<std::pair<Ref<AccessibilityO
             break;
         case AXNotification::TextUnderElementChanged:
             tree->queueNodeUpdate(notification.first->objectID(), { { AXProperty::AccessibilityText, AXProperty::Title } });
-            if (notification.first->isAccessibilityLabelInstance() || notification.first->roleValue() == AccessibilityRole::TextField)
+            if (notification.first->isAccessibilityLabelInstance() || notification.first->role() == AccessibilityRole::TextField)
                 tree->queueNodeUpdate(notification.first->objectID(), { AXProperty::StringValue });
             break;
 #if ENABLE(AX_THREAD_TEXT_APIS)

--- a/Source/WebCore/accessibility/AXSearchManager.cpp
+++ b/Source/WebCore/accessibility/AXSearchManager.cpp
@@ -56,7 +56,7 @@ bool AXSearchManager::matchForSearchKeyAtIndex(Ref<AXCoreObject> axObject, const
         // The AccessibilitySearchKey::AnyType matches any non-null AccessibilityObject.
         return true;
     case AccessibilitySearchKey::Article:
-        return axObject->roleValue() == AccessibilityRole::DocumentArticle;
+        return axObject->role() == AccessibilityRole::DocumentArticle;
     case AccessibilitySearchKey::BlockquoteSameLevel:
         return criteria.startObject
             && axObject->isBlockquote()
@@ -73,7 +73,7 @@ bool AXSearchManager::matchForSearchKeyAtIndex(Ref<AXCoreObject> axObject, const
         return axObject->isControl() || axObject->isSummary();
     case AccessibilitySearchKey::DifferentType:
         return criteria.startObject
-            && axObject->roleValue() != criteria.startObject->roleValue();
+            && axObject->role() != criteria.startObject->role();
     case AccessibilitySearchKey::FontChange:
         return criteria.startObject
             && !axObject->hasSameFont(*criteria.startObject);
@@ -137,7 +137,7 @@ bool AXSearchManager::matchForSearchKeyAtIndex(Ref<AXCoreObject> axObject, const
         return axObject->isRadioGroup() || isRadioButtonInDifferentAdhocGroup(axObject, criteria.startObject);
     case AccessibilitySearchKey::SameType:
         return criteria.startObject
-            && axObject->roleValue() == criteria.startObject->roleValue();
+            && axObject->role() == criteria.startObject->role();
     case AccessibilitySearchKey::StaticText:
         return axObject->isStaticText();
     case AccessibilitySearchKey::StyleChange:

--- a/Source/WebCore/accessibility/AccessibilityLabel.cpp
+++ b/Source/WebCore/accessibility/AccessibilityLabel.cpp
@@ -57,7 +57,7 @@ static bool childrenContainOnlyStaticText(const AccessibilityObject::Accessibili
     if (children.isEmpty())
         return false;
     for (const auto& child : children) {
-        if (child->roleValue() == AccessibilityRole::StaticText)
+        if (child->role() == AccessibilityRole::StaticText)
             continue;
         if (child->isGroup()) {
             if (!childrenContainOnlyStaticText(child->unignoredChildren()))

--- a/Source/WebCore/accessibility/AccessibilityList.cpp
+++ b/Source/WebCore/accessibility/AccessibilityList.cpp
@@ -170,7 +170,7 @@ AccessibilityRole AccessibilityList::determineAccessibilityRoleWithCleanChildren
         auto* axChild = dynamicDowncast<AccessibilityObject>(child.get());
         if (axChild && axChild->ariaRoleAttribute() == AccessibilityRole::ListItem)
             listItemCount++;
-        else if (child->roleValue() == AccessibilityRole::ListItem) {
+        else if (child->role() == AccessibilityRole::ListItem) {
             // Rendered list items always count.
             if (CheckedPtr renderListItem = dynamicDowncast<RenderListItem>(child->renderer())) {
                 if (!hasVisibleMarkers && (renderListItem->style().listStyleType().type != ListStyleType::Type::None || renderListItem->style().listStyleImage() || childHasPseudoVisibleListItemMarkers(renderListItem->element())))
@@ -196,7 +196,7 @@ AccessibilityRole AccessibilityList::determineAccessibilityRoleWithCleanChildren
             role = AccessibilityRole::Group;
     } else if (!hasVisibleMarkers) {
         // http://webkit.org/b/193382 lists inside of navigation hierarchies should still be considered lists.
-        if (Accessibility::findAncestor<AccessibilityObject>(*this, false, [] (auto& object) { return object.roleValue() == AccessibilityRole::LandmarkNavigation; }))
+        if (Accessibility::findAncestor<AccessibilityObject>(*this, false, [] (auto& object) { return object.role() == AccessibilityRole::LandmarkNavigation; }))
             role = AccessibilityRole::List;
         else
             role = AccessibilityRole::Group;

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
@@ -522,7 +522,7 @@ AccessibilityRole AccessibilityNodeObject::roleFromInputElement(const HTMLInputE
                 foundCombobox = true;
                 break;
             }
-            if (!ancestor->isGroup() && ancestor->roleValue() != AccessibilityRole::Generic)
+            if (!ancestor->isGroup() && ancestor->role() != AccessibilityRole::Generic)
                 break;
         }
         if (foundCombobox)
@@ -646,7 +646,7 @@ bool AccessibilityNodeObject::canHaveChildren() const
     // nodes, like scroll areas and css-generated text.
 
     // Elements that should not have children.
-    switch (roleValue()) {
+    switch (role()) {
     case AccessibilityRole::Button:
 #if !USE(ATSPI)
     // GTK/ATSPI layout tests expect popup buttons to have children.
@@ -718,7 +718,7 @@ bool AccessibilityNodeObject::computeIsIgnored() const
     if (decision == AccessibilityObjectInclusion::IgnoreObject)
         return true;
 
-    auto role = roleValue();
+    auto role = this->role();
     if (role == AccessibilityRole::Ignored || role == AccessibilityRole::Unknown)
         return true;
 
@@ -773,7 +773,7 @@ bool AccessibilityNodeObject::isSearchField() const
     if (!node)
         return false;
 
-    if (roleValue() == AccessibilityRole::SearchField)
+    if (role() == AccessibilityRole::SearchField)
         return true;
 
     RefPtr inputElement = dynamicDowncast<HTMLInputElement>(*node);
@@ -835,7 +835,7 @@ bool AccessibilityNodeObject::isEnabled() const
             break;
     }
 
-    if (roleValue() == AccessibilityRole::HorizontalRule)
+    if (role() == AccessibilityRole::HorizontalRule)
         return false;
 
     RefPtr element = dynamicDowncast<Element>(node());
@@ -1256,7 +1256,7 @@ Element* AccessibilityNodeObject::actionElement() const
     if (AccessibilityObject::isARIAInput(ariaRoleAttribute()))
         return downcast<Element>(node);
 
-    switch (roleValue()) {
+    switch (role()) {
     case AccessibilityRole::Button:
     case AccessibilityRole::PopUpButton:
     case AccessibilityRole::ToggleButton:
@@ -1303,7 +1303,7 @@ bool AccessibilityNodeObject::isDescendantOfBarrenParent() const
 
 void AccessibilityNodeObject::alterRangeValue(StepAction stepAction)
 {
-    if (roleValue() != AccessibilityRole::Slider && roleValue() != AccessibilityRole::SpinButton)
+    if (role() != AccessibilityRole::Slider && role() != AccessibilityRole::SpinButton)
         return;
 
     auto element = this->element();
@@ -1380,7 +1380,7 @@ bool AccessibilityNodeObject::postKeyboardKeysForValueChange(StepAction stepActi
     // `spinbutton` elements don't have an implicit orientation, but the spec does say:
     //     > Authors SHOULD also ensure the up and down arrows on a keyboard perform the increment and decrement functions
     // So let's force a vertical orientation for `spinbutton`s so we simulate the correct keypress (either up or down).
-    bool vertical = orientation() == AccessibilityOrientation::Vertical || roleValue() == AccessibilityRole::SpinButton;
+    bool vertical = orientation() == AccessibilityOrientation::Vertical || role() == AccessibilityRole::SpinButton;
 
     // The goal is to mimic existing keyboard dispatch completely, so that this is indistinguishable from a real key press.
     typedef enum { left = 37, up = 38, right = 39, down = 40 } keyCode;
@@ -1444,7 +1444,7 @@ bool AccessibilityNodeObject::liveRegionAtomic() const
         return false;
 
     // WAI-ARIA "alert" and "status" roles have an implicit aria-atomic value of true.
-    switch (roleValue()) {
+    switch (role()) {
     case AccessibilityRole::ApplicationAlert:
     case AccessibilityRole::ApplicationStatus:
         return true;
@@ -1552,7 +1552,7 @@ bool AccessibilityNodeObject::isGenericFocusableElement() const
     if (isControl())
         return false;
 
-    AccessibilityRole role = roleValue();
+    auto role = this->role();
     if (role == AccessibilityRole::Video || role == AccessibilityRole::Audio)
         return false;
 
@@ -2015,7 +2015,7 @@ String AccessibilityNodeObject::alternativeTextForWebArea() const
 String AccessibilityNodeObject::description() const
 {
     // Static text should not have a description, it should only have a stringValue.
-    if (roleValue() == AccessibilityRole::StaticText)
+    if (role() == AccessibilityRole::StaticText)
         return { };
 
     String ariaDescription = ariaAccessibilityDescription();
@@ -2057,7 +2057,7 @@ bool AccessibilityNodeObject::roleIgnoresTitle() const
     if (ariaRoleAttribute() != AccessibilityRole::Unknown)
         return false;
 
-    switch (roleValue()) {
+    switch (role()) {
     case AccessibilityRole::Generic:
     case AccessibilityRole::Unknown:
         return true;
@@ -2100,7 +2100,7 @@ String AccessibilityNodeObject::helpText() const
         // Only take help text from an ancestor element if its a group or an unknown role. If help was
         // added to those kinds of elements, it is likely it was meant for a child element.
         if (auto* axAncestor = cache->getOrCreate(*ancestor)) {
-            if (!axAncestor->isGroup() && axAncestor->roleValue() != AccessibilityRole::Unknown)
+            if (!axAncestor->isGroup() && axAncestor->role() != AccessibilityRole::Unknown)
                 break;
         }
     }
@@ -2356,10 +2356,10 @@ String AccessibilityNodeObject::title() const
 
     // For <select> elements, title should be empty if they are not rendered or have role PopUpButton.
     if (WebCore::elementName(*node) == ElementName::HTML_select
-        && (!isAccessibilityRenderObject() || roleValue() == AccessibilityRole::PopUpButton))
+        && (!isAccessibilityRenderObject() || role() == AccessibilityRole::PopUpButton))
         return { };
 
-    switch (roleValue()) {
+    switch (role()) {
     case AccessibilityRole::Button:
     case AccessibilityRole::Checkbox:
     case AccessibilityRole::ListBoxOption:
@@ -2403,7 +2403,7 @@ String AccessibilityNodeObject::text() const
             return textOrder[0].text;
     }
 
-    if (roleValue() == AccessibilityRole::StaticText)
+    if (role() == AccessibilityRole::StaticText)
         return textUnderElement();
 
     if (!isTextControl())
@@ -2684,7 +2684,7 @@ bool AccessibilityNodeObject::isFocused() const
 
     // A web area is represented by the Document node in the DOM tree which isn't focusable.
     // Instead, check if the frame's selection is focused.
-    if (roleValue() != AccessibilityRole::WebArea)
+    if (role() != AccessibilityRole::WebArea)
         return false;
 
     auto* frame = document.frame();
@@ -2881,7 +2881,7 @@ bool AccessibilityNodeObject::canSetSelectedAttribute() const
         return true;
 
     // Elements that can be selected
-    switch (roleValue()) {
+    switch (role()) {
     case AccessibilityRole::Cell:
     case AccessibilityRole::GridCell:
     case AccessibilityRole::Row:

--- a/Source/WebCore/accessibility/AccessibilityObject.h
+++ b/Source/WebCore/accessibility/AccessibilityObject.h
@@ -352,7 +352,7 @@ public:
 
     virtual AccessibilityRole ariaRoleAttribute() const { return AccessibilityRole::Unknown; }
     bool hasExplicitGenericRole() const { return ariaRoleAttribute() == AccessibilityRole::Generic; }
-    bool hasImplicitGenericRole() const { return roleValue() == AccessibilityRole::Generic && !hasExplicitGenericRole(); }
+    bool hasImplicitGenericRole() const { return role() == AccessibilityRole::Generic && !hasExplicitGenericRole(); }
     bool ariaRoleHasPresentationalChildren() const;
     bool inheritsPresentationalRole() const override { return false; }
 
@@ -980,7 +980,7 @@ inline unsigned AccessibilityObject::getLengthForTextRange() const { return text
 inline bool AccessibilityObject::hasTextContent() const
 {
     return isStaticText()
-        || roleValue() == AccessibilityRole::Link
+        || role() == AccessibilityRole::Link
         || isTextControl() || isTabItem();
 }
 
@@ -988,7 +988,7 @@ inline bool AccessibilityObject::hasTextContent() const
 inline bool AccessibilityObject::hasAttributedText() const
 {
     return (isStaticText() && !isARIAStaticText())
-        || roleValue() == AccessibilityRole::Link
+        || role() == AccessibilityRole::Link
         || isTextControl() || isTabItem();
 }
 #endif

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -654,7 +654,7 @@ String AccessibilityRenderObject::helpText() const
         // Only take help text from an ancestor element if its a group or an unknown role. If help was 
         // added to those kinds of elements, it is likely it was meant for a child element.
         if (auto* axAncestor = axObjectCache()->getOrCreate(*ancestor)) {
-            if (!axAncestor->isGroup() && axAncestor->roleValue() != AccessibilityRole::Unknown)
+            if (!axAncestor->isGroup() && axAncestor->role() != AccessibilityRole::Unknown)
                 break;
         }
     }
@@ -1048,7 +1048,7 @@ bool AccessibilityRenderObject::isAllowedChildOfTree() const
     bool isInTree = false;
     bool isTreeItemDescendant = false;
     while (axObj) {
-        if (axObj->roleValue() == AccessibilityRole::TreeItem)
+        if (axObj->role() == AccessibilityRole::TreeItem)
             isTreeItemDescendant = true;
         if (axObj->isTree()) {
             isInTree = true;
@@ -1059,7 +1059,7 @@ bool AccessibilityRenderObject::isAllowedChildOfTree() const
     
     // If the object is in a tree, only tree items should be exposed (and the children of tree items).
     if (isInTree) {
-        AccessibilityRole role = roleValue();
+        auto role = this->role();
         if (role != AccessibilityRole::TreeItem && role != AccessibilityRole::StaticText && !isTreeItemDescendant)
             return false;
     }
@@ -1107,7 +1107,7 @@ bool AccessibilityRenderObject::computeIsIgnored() const
     if (decision == AccessibilityObjectInclusion::IgnoreObject)
         return true;
 
-    if (roleValue() == AccessibilityRole::Ignored)
+    if (role() == AccessibilityRole::Ignored)
         return true;
 
     if (ignoredFromPresentationalRole())
@@ -1169,7 +1169,7 @@ bool AccessibilityRenderObject::computeIsIgnored() const
         for (RefPtr ancestor = parentObject(); ancestor; ancestor = ancestor->parentObject()) {
             // Static text beneath TextControls is reported along with the text control text so it's ignored.
             // FIXME: Why does this not check for the other text-control roles (e.g. textarea)?
-            if (ancestor->roleValue() == AccessibilityRole::TextField)
+            if (ancestor->role() == AccessibilityRole::TextField)
                 return true;
 
             if (checkForIgnored && !ancestor->isIgnored()) {
@@ -1200,7 +1200,7 @@ bool AccessibilityRenderObject::computeIsIgnored() const
     if (isFigureElement() || isSummary())
         return false;
 
-    switch (roleValue()) {
+    switch (role()) {
     case AccessibilityRole::Audio:
     case AccessibilityRole::DescriptionListTerm:
     case AccessibilityRole::DescriptionListDetail:
@@ -1275,7 +1275,7 @@ bool AccessibilityRenderObject::computeIsIgnored() const
     if (ariaRoleAttribute() != AccessibilityRole::Unknown)
         return false;
 
-    if (roleValue() == AccessibilityRole::HorizontalRule)
+    if (role() == AccessibilityRole::HorizontalRule)
         return false;
     
     // don't ignore labels, because they serve as TitleUIElements
@@ -1612,7 +1612,7 @@ AXTextRuns AccessibilityRenderObject::textRuns()
 
 AXTextRunLineID AccessibilityRenderObject::listMarkerLineID() const
 {
-    ASSERT(roleValue() == AccessibilityRole::ListMarker);
+    ASSERT(role() == AccessibilityRole::ListMarker);
     return { renderer() ? renderer()->containingBlock() : nullptr, 0 };
 }
 
@@ -2212,7 +2212,7 @@ String AccessibilityRenderObject::expandedTextValue() const
 
 bool AccessibilityRenderObject::supportsExpandedTextValue() const
 {
-    if (roleValue() == AccessibilityRole::StaticText) {
+    if (role() == AccessibilityRole::StaticText) {
         if (AccessibilityObject* parent = parentObject()) {
             auto parentName = parent->elementName();
             return parentName == ElementName::HTML_abbr || parentName == ElementName::HTML_acronym;
@@ -2348,7 +2348,7 @@ bool AccessibilityRenderObject::inheritsPresentationalRole() const
     // http://www.w3.org/WAI/PF/aria/complete#presentation
 
     std::span<decltype(aTag)* const> parentTags;
-    switch (roleValue()) {
+    switch (role()) {
     case AccessibilityRole::ListItem:
     case AccessibilityRole::ListMarker: {
         static constexpr std::array listItemParents { &dlTag, &menuTag, &olTag, &ulTag };
@@ -2379,7 +2379,7 @@ bool AccessibilityRenderObject::inheritsPresentationalRole() const
         // based on its presentational status.
         auto& name = node->tagQName();
         if (std::ranges::any_of(parentTags, [&name](auto* possibleName) { return possibleName->get() == name; }))
-            return parent->roleValue() == AccessibilityRole::Presentational;
+            return parent->role() == AccessibilityRole::Presentational;
     }
 
     return false;
@@ -2484,7 +2484,7 @@ void AccessibilityRenderObject::addRemoteSVGChildren()
     // in this case, as it will create an invalid parent-child relationship in the accessibility tree.
     // If it's parent is a WebArea, that is just the default value given when the object was created, so still add the child in that case.
     RefPtr parent = root->parentObject();
-    if (parent && parent->roleValue() != AccessibilityRole::WebArea)
+    if (parent && parent->role() != AccessibilityRole::WebArea)
         return;
 
     // In order to connect the AX hierarchy from the SVG root element from the loaded resource
@@ -2622,7 +2622,7 @@ RenderObject* AccessibilityRenderObject::markerRenderer() const
 void AccessibilityRenderObject::updateRoleAfterChildrenCreation()
 {
     // If a menu does not have valid menuitem children, it should not be exposed as a menu.
-    auto role = roleValue();
+    auto role = this->role();
     if (role == AccessibilityRole::Menu) {
         // Elements marked as menus must have at least one menu item child.
         bool hasMenuItemDescendant = false;

--- a/Source/WebCore/accessibility/AccessibilitySVGObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilitySVGObject.cpp
@@ -263,13 +263,13 @@ bool AccessibilitySVGObject::inheritsPresentationalRole() const
     if (canSetFocusAttribute())
         return false;
 
-    AccessibilityRole role = roleValue();
+    auto role = this->role();
     if (role != AccessibilityRole::SVGTextPath && role != AccessibilityRole::SVGTSpan)
         return false;
 
     for (AccessibilityObject* parent = parentObject(); parent; parent = parent->parentObject()) {
         if (is<AccessibilityRenderObject>(*parent) && parent->hasElementName(ElementName::SVG_text))
-            return parent->roleValue() == AccessibilityRole::Presentational;
+            return parent->role() == AccessibilityRole::Presentational;
     }
 
     return false;

--- a/Source/WebCore/accessibility/AccessibilityTable.cpp
+++ b/Source/WebCore/accessibility/AccessibilityTable.cpp
@@ -194,7 +194,7 @@ bool AccessibilityTable::isDataTable() const
 
         // If the top section has any non-group role, then don't make this a data table. The author probably wants to use the role on the section.
         if (auto* axTableSection = cache->getOrCreate(*tableSectionElement)) {
-            auto role = axTableSection->roleValue();
+            auto role = axTableSection->role();
             if (!axTableSection->isGroup() && role != AccessibilityRole::Unknown && role != AccessibilityRole::Ignored)
                 return true;
         }
@@ -553,7 +553,7 @@ unsigned AccessibilityTable::computeCellSlots()
             return;
         processedRows.add(row);
 
-        if (row->roleValue() != AccessibilityRole::Unknown && row->isIgnored()) {
+        if (row->role() != AccessibilityRole::Unknown && row->isIgnored()) {
             // Skip ignored rows (except for those ignored because they have an unknown role, which will happen after a table has become un-exposed but is potentially becoming re-exposed).
             // This is an addition on top of the HTML algorithm because the computed AX table has extra restrictions (e.g. cannot contain aria-hidden or role="presentation" rows).
             return;

--- a/Source/WebCore/accessibility/AccessibilityTableCell.cpp
+++ b/Source/WebCore/accessibility/AccessibilityTableCell.cpp
@@ -175,7 +175,7 @@ bool AccessibilityTableCell::isTableHeaderCell() const
 
 bool AccessibilityTableCell::isColumnHeader() const
 {
-    if (roleValue() == AccessibilityRole::ColumnHeader)
+    if (role() == AccessibilityRole::ColumnHeader)
         return true;
     const AtomString& scope = getAttribute(scopeAttr);
     if (scope == "col"_s || scope == "colgroup"_s)
@@ -206,7 +206,7 @@ bool AccessibilityTableCell::isColumnHeader() const
 
 bool AccessibilityTableCell::isRowHeader() const
 {
-    if (roleValue() == AccessibilityRole::RowHeader)
+    if (role() == AccessibilityRole::RowHeader)
         return true;
     const AtomString& scope = getAttribute(scopeAttr);
     if (scope == "row"_s || scope == "rowgroup"_s)

--- a/Source/WebCore/accessibility/atspi/AXObjectCacheAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AXObjectCacheAtspi.cpp
@@ -240,7 +240,7 @@ void AXObjectCache::frameLoadingEventPlatformNotification(AccessibilityObject* c
     if (!coreObject)
         return;
 
-    if (coreObject->roleValue() != AccessibilityRole::WebArea)
+    if (coreObject->role() != AccessibilityRole::WebArea)
         return;
 
     auto* wrapper = coreObject->wrapper();

--- a/Source/WebCore/accessibility/atspi/AccessibilityObjectAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AccessibilityObjectAtspi.cpp
@@ -66,14 +66,14 @@ OptionSet<AccessibilityObjectAtspi::Interface> AccessibilityObjectAtspi::interfa
 
     auto* axObject = dynamicDowncast<AccessibilityObject>(coreObject);
     RenderObject* renderer = coreObject.isAccessibilityRenderObject() ? coreObject.renderer() : nullptr;
-    if (coreObject.roleValue() == AccessibilityRole::StaticText || coreObject.roleValue() == AccessibilityRole::ColorWell)
+    if (coreObject.role() == AccessibilityRole::StaticText || coreObject.role() == AccessibilityRole::ColorWell)
         interfaces.add(Interface::Text);
     else if (coreObject.isTextControl() || coreObject.isNonNativeTextControl())
         interfaces.add(Interface::Text);
     else if (!coreObject.isWebArea()) {
-        if (coreObject.roleValue() != AccessibilityRole::Table) {
+        if (coreObject.role() != AccessibilityRole::Table) {
             interfaces.add(Interface::Hypertext);
-            if ((renderer && renderer->childrenInline()) || roleIsTextType(coreObject.roleValue()) || coreObject.isMathToken())
+            if ((renderer && renderer->childrenInline()) || roleIsTextType(coreObject.role()) || coreObject.isMathToken())
                 interfaces.add(Interface::Text);
         }
     }
@@ -84,7 +84,7 @@ OptionSet<AccessibilityObjectAtspi::Interface> AccessibilityObjectAtspi::interfa
     if (coreObject.isLink() || (isRendererReplacedElement(renderer)))
         interfaces.add(Interface::Hyperlink);
 
-    if (coreObject.roleValue() == AccessibilityRole::WebArea)
+    if (coreObject.role() == AccessibilityRole::WebArea)
         interfaces.add(Interface::Document);
 
     if (coreObject.isImage())
@@ -96,13 +96,13 @@ OptionSet<AccessibilityObjectAtspi::Interface> AccessibilityObjectAtspi::interfa
     if (coreObject.isTable())
         interfaces.add(Interface::Table);
 
-    if (coreObject.roleValue() == AccessibilityRole::Cell
-        || coreObject.roleValue() == AccessibilityRole::GridCell
-        || coreObject.roleValue() == AccessibilityRole::ColumnHeader
-        || coreObject.roleValue() == AccessibilityRole::RowHeader)
+    if (coreObject.role() == AccessibilityRole::Cell
+        || coreObject.role() == AccessibilityRole::GridCell
+        || coreObject.role() == AccessibilityRole::ColumnHeader
+        || coreObject.role() == AccessibilityRole::RowHeader)
         interfaces.add(Interface::TableCell);
 
-    if (coreObject.roleValue() == AccessibilityRole::ListMarker && renderer) {
+    if (coreObject.role() == AccessibilityRole::ListMarker && renderer) {
         if (renderer->isImage())
             interfaces.add(Interface::Image);
         else
@@ -640,7 +640,7 @@ CString AccessibilityObjectAtspi::name() const
     if (!m_coreObject)
         return "";
 
-    if (m_coreObject->roleValue() == AccessibilityRole::ListBoxOption || m_coreObject->roleValue() == AccessibilityRole::MenuListOption) {
+    if (m_coreObject->role() == AccessibilityRole::ListBoxOption || m_coreObject->role() == AccessibilityRole::MenuListOption) {
         auto value = m_coreObject->stringValue();
         if (!value.isEmpty())
             return value.utf8();
@@ -767,9 +767,9 @@ OptionSet<Atspi::State> AccessibilityObjectAtspi::states() const
     if (m_coreObject->isRequired())
         states.add(Atspi::State::Required);
 
-    if (m_coreObject->roleValue() == AccessibilityRole::TextArea || (liveObject && liveObject->ariaIsMultiline()))
+    if (m_coreObject->role() == AccessibilityRole::TextArea || (liveObject && liveObject->ariaIsMultiline()))
         states.add(Atspi::State::MultiLine);
-    else if (m_coreObject->roleValue() == AccessibilityRole::TextField || m_coreObject->roleValue() == AccessibilityRole::SearchField)
+    else if (m_coreObject->role() == AccessibilityRole::TextField || m_coreObject->role() == AccessibilityRole::SearchField)
         states.add(Atspi::State::SingleLine);
 
     if (m_coreObject->isTextControl())
@@ -1032,7 +1032,7 @@ RelationMap AccessibilityObjectAtspi::relationMap() const
     if (m_coreObject->isControl() || m_coreObject->isFieldset()) {
         if (auto* label = m_coreObject->titleUIElement())
             ariaLabelledByElements.append(*label);
-    } else if (m_coreObject->roleValue() == AccessibilityRole::Legend) {
+    } else if (m_coreObject->role() == AccessibilityRole::Legend) {
         if (auto* renderFieldset = ancestorsOfType<RenderBlock>(*m_coreObject->renderer()).first()) {
             if (renderFieldset->isFieldset())
                 ariaLabelledByElements.append(*m_coreObject->axObjectCache()->getOrCreate(renderFieldset));
@@ -1174,7 +1174,7 @@ std::optional<Atspi::Role> AccessibilityObjectAtspi::effectiveRole() const
 
     RefPtr liveObject = dynamicDowncast<AccessibilityObject>(m_coreObject);
 
-    switch (m_coreObject->roleValue()) {
+    switch (m_coreObject->role()) {
     case AccessibilityRole::Form:
         if (liveObject && liveObject->ariaRoleAttribute() != AccessibilityRole::Unknown)
             return Atspi::Role::Landmark;
@@ -1236,7 +1236,7 @@ Atspi::Role AccessibilityObjectAtspi::role() const
     if (auto effective = effectiveRole())
         return *effective;
 
-    return atspiRole(m_coreObject->roleValue());
+    return atspiRole(m_coreObject->role());
 }
 
 String AccessibilityObjectAtspi::effectiveRoleName() const
@@ -1345,7 +1345,7 @@ const char* AccessibilityObjectAtspi::localizedRoleName() const
     if (const auto* effective = effectiveLocalizedRoleName())
         return effective;
 
-    return AccessibilityAtspi::localizedRoleName(m_coreObject->roleValue());
+    return AccessibilityAtspi::localizedRoleName(m_coreObject->role());
 }
 
 void AccessibilityObjectAtspi::updateBackingStore()
@@ -1391,11 +1391,11 @@ AccessibilityObjectInclusion AccessibilityObject::accessibilityPlatformIncludesO
 
     // Never expose an unknown object, since AT's won't know what to
     // do with them. This is what is done on the Mac as well.
-    if (roleValue() == AccessibilityRole::Unknown)
+    if (role() == AccessibilityRole::Unknown)
         return AccessibilityObjectInclusion::IgnoreObject;
 
     // The object containing the text should implement org.a11y.atspi.Text itself.
-    if (roleValue() == AccessibilityRole::StaticText)
+    if (role() == AccessibilityRole::StaticText)
         return AccessibilityObjectInclusion::IgnoreObject;
 
     // Entries and password fields have extraneous children which we want to ignore.
@@ -1403,13 +1403,13 @@ AccessibilityObjectInclusion AccessibilityObject::accessibilityPlatformIncludesO
         return AccessibilityObjectInclusion::IgnoreObject;
 
     // We expose the slider as a whole but not its value indicator.
-    if (roleValue() == AccessibilityRole::SliderThumb)
+    if (role() == AccessibilityRole::SliderThumb)
         return AccessibilityObjectInclusion::IgnoreObject;
 
     // List items inheriting presentational are ignored, but their content exposed.
     // Since we expose text in the parent, we need to expose presentational list items
     // with a different role (section).
-    if (roleValue() == AccessibilityRole::ListItem && inheritsPresentationalRole())
+    if (role() == AccessibilityRole::ListItem && inheritsPresentationalRole())
         return AccessibilityObjectInclusion::IncludeObject;
 
     RenderObject* renderObject = renderer();
@@ -1418,7 +1418,7 @@ AccessibilityObjectInclusion AccessibilityObject::accessibilityPlatformIncludesO
 
     // We always want to include paragraphs that have rendered content.
     // WebCore Accessibility does so unless there is a RenderBlock child.
-    if (roleValue() == AccessibilityRole::Paragraph) {
+    if (role() == AccessibilityRole::Paragraph) {
         auto child = childrenOfType<RenderBlock>(downcast<RenderElement>(*renderObject)).first();
         return child ? AccessibilityObjectInclusion::IncludeObject : AccessibilityObjectInclusion::DefaultBehavior;
     }
@@ -1452,7 +1452,7 @@ AccessibilityObjectInclusion AccessibilityObject::accessibilityPlatformIncludesO
         // FIXME: This next one needs some further consideration. But paragraphs are not
         // typically huge (like divs). And ignoring anonymous block children of paragraphs
         // will preserve existing behavior.
-        if (parent->roleValue() == AccessibilityRole::Paragraph)
+        if (parent->role() == AccessibilityRole::Paragraph)
             return AccessibilityObjectInclusion::IgnoreObject;
 
         return AccessibilityObjectInclusion::DefaultBehavior;

--- a/Source/WebCore/accessibility/atspi/AccessibilityObjectTextAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AccessibilityObjectTextAtspi.cpp
@@ -276,7 +276,7 @@ String AccessibilityObjectAtspi::text() const
 
     m_hasListMarkerAtStart = false;
 
-    if (m_coreObject->roleValue() == AccessibilityRole::ColorWell) {
+    if (m_coreObject->role() == AccessibilityRole::ColorWell) {
         auto color = convertColor<SRGBA<float>>(m_coreObject->colorValue()).resolved();
         GUniquePtr<char> colorString(g_strdup_printf("rgb %7.5f %7.5f %7.5f 1", color.red, color.green, color.blue));
         return String::fromUTF8(colorString.get());

--- a/Source/WebCore/accessibility/cocoa/AXCoreObjectCocoa.mm
+++ b/Source/WebCore/accessibility/cocoa/AXCoreObjectCocoa.mm
@@ -230,7 +230,7 @@ RetainPtr<NSMutableAttributedString> AXCoreObject::createAttributedString(String
         if (ancestor->hasMarkTag())
             attributedStringSetNumber(string.get(), NSAccessibilityHighlightAttribute, @YES, range);
 
-        switch (ancestor->roleValue()) {
+        switch (ancestor->role()) {
         case AccessibilityRole::Insertion:
             attributedStringSetNumber(string.get(), NSAccessibilityIsSuggestedInsertionAttribute, @YES, range);
             break;
@@ -257,7 +257,7 @@ RetainPtr<NSMutableAttributedString> AXCoreObject::createAttributedString(String
             }
         }
 
-        if (ancestor->roleValue() == AccessibilityRole::Blockquote)
+        if (ancestor->role() == AccessibilityRole::Blockquote)
             ++blockquoteLevel;
     }
     if (blockquoteLevel)
@@ -323,7 +323,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         if (!ariaLandmarkRoleDescription.isEmpty())
             return ariaLandmarkRoleDescription;
 
-        switch (roleValue()) {
+        switch (role()) {
         case AccessibilityRole::Audio:
             return localizedMediaControlElementString("AudioElement"_s);
         case AccessibilityRole::Definition:
@@ -400,7 +400,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     if (isDescriptionList())
         return AXDescriptionListText();
 
-    if (roleValue() == AccessibilityRole::HorizontalRule)
+    if (role() == AccessibilityRole::HorizontalRule)
         return AXHorizontalRuleDescriptionText();
 
     // AppKit also returns AXTab for the role description for a tab item.
@@ -423,7 +423,7 @@ ALLOW_DEPRECATED_DECLARATIONS_BEGIN
         return [remoteFramePlatformElement().get() accessibilityAttributeValue:NSAccessibilityRoleAttribute];
 ALLOW_DEPRECATED_DECLARATIONS_END
 
-    auto role = roleValue();
+    auto role = this->role();
     if (role == AccessibilityRole::Label) {
         // Labels that only contain static text should just be mapped to static text.
         if (containsOnlyStaticText())

--- a/Source/WebCore/accessibility/ios/AccessibilityObjectIOS.mm
+++ b/Source/WebCore/accessibility/ios/AccessibilityObjectIOS.mm
@@ -123,7 +123,7 @@ bool AccessibilityObject::accessibilityIgnoreAttachment() const
     
 AccessibilityObjectInclusion AccessibilityObject::accessibilityPlatformIncludesObject() const
 {
-    if (roleValue() == AccessibilityRole::Unknown)
+    if (role() == AccessibilityRole::Unknown)
         return AccessibilityObjectInclusion::IgnoreObject;
     return AccessibilityObjectInclusion::DefaultBehavior;
 }

--- a/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
+++ b/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
@@ -302,7 +302,7 @@ static AccessibilityObjectWrapper* AccessibilityUnignoredAncestor(AccessibilityO
     if (![self _prepareAccessibilityCall])
         return false;
     
-    AccessibilityRole role = self.axBackingObject->roleValue();
+    AccessibilityRole role = self.axBackingObject->role();
     // Elements that can be returned when performing fuzzy hit testing.
     switch (role) {
     case AccessibilityRole::Button:
@@ -497,7 +497,7 @@ static AccessibilityObjectWrapper* AccessibilityUnignoredAncestor(AccessibilityO
     if (![self _prepareAccessibilityCall])
         return nil;
 
-    return accessibilityRoleToString(self.axBackingObject->roleValue()).createNSString().autorelease();
+    return accessibilityRoleToString(self.axBackingObject->role()).createNSString().autorelease();
 }
 
 - (BOOL)accessibilityHasPopup
@@ -572,14 +572,14 @@ static AccessibilityObjectWrapper* AccessibilityUnignoredAncestor(AccessibilityO
     if (![self _prepareAccessibilityCall])
         return NO;
 
-    AccessibilityRole roleValue = self.axBackingObject->roleValue();
+    AccessibilityRole roleValue = self.axBackingObject->role();
     return roleValue == AccessibilityRole::ApplicationDialog || roleValue == AccessibilityRole::ApplicationAlertDialog;
 }
 
 static AccessibilityObjectWrapper *ancestorWithRole(const AXCoreObject& descendant, const AccessibilityRoleSet& roles)
 {
     auto* ancestor = Accessibility::findAncestor(descendant, false, [&roles] (const auto& object) {
-        return roles.contains(object.roleValue());
+        return roles.contains(object.role());
     });
     return ancestor ? ancestor->wrapper() : nil;
 }
@@ -664,7 +664,7 @@ static AccessibilityObjectWrapper *ancestorWithRole(const AXCoreObject& descenda
     // Trait information also needs to be gathered from the parents above the object.
     // The parentObject is needed instead of the unignoredParentObject, because a table might be ignored, but information still needs to be gathered from it.
     for (auto* parent = backingObject->parentObject(); parent; parent = parent->parentObject()) {
-        auto parentRole = parent->roleValue();
+        auto parentRole = parent->role();
         if (parentRole == AccessibilityRole::WebArea)
             break;
 
@@ -698,7 +698,7 @@ static AccessibilityObjectWrapper *ancestorWithRole(const AXCoreObject& descenda
     if (![self _prepareAccessibilityCall])
         return NO;
 
-    if (self.axBackingObject->roleValue() != AccessibilityRole::Video)
+    if (self.axBackingObject->role() != AccessibilityRole::Video)
         return NO;
 
     // Convey the video object as interactive if auto-play is not enabled.
@@ -758,7 +758,7 @@ static AccessibilityObjectWrapper *ancestorWithRole(const AXCoreObject& descenda
     if (backingObject->isSecureField())
         traits |= [self _axSecureTextFieldTrait];
 
-    switch (backingObject->roleValue()) {
+    switch (backingObject->role()) {
     case AccessibilityRole::SearchField:
         traits |= [self _axSearchFieldTrait];
         break;
@@ -777,7 +777,7 @@ static AccessibilityObjectWrapper *ancestorWithRole(const AXCoreObject& descenda
     if (![self _prepareAccessibilityCall])
         return 0;
 
-    AccessibilityRole role = self.axBackingObject->roleValue();
+    AccessibilityRole role = self.axBackingObject->role();
     uint64_t traits = [self _axWebContentTrait];
     switch (role) {
     case AccessibilityRole::Link:
@@ -886,7 +886,7 @@ static AccessibilityObjectWrapper *ancestorWithRole(const AXCoreObject& descenda
 
     backingObject->updateBackingStore();
 
-    switch (backingObject->roleValue()) {
+    switch (backingObject->role()) {
     case AccessibilityRole::TextField:
     case AccessibilityRole::TextArea:
     case AccessibilityRole::Button:
@@ -1163,10 +1163,10 @@ static void appendStringToResult(NSMutableString *result, NSString *string)
     // text, in which case, that alternative text is returned here.
     // The reason is that the string value for static text inside a heading is
     // used to convey the heading level instead.
-    if (backingObject->roleValue() == AccessibilityRole::StaticText
+    if (backingObject->role() == AccessibilityRole::StaticText
         && self.accessibilityTraits & self._axHeaderTrait) {
         auto* heading = Accessibility::findAncestor(*backingObject, false, [] (const auto& ancestor) {
-            return ancestor.roleValue() == AccessibilityRole::Heading;
+            return ancestor.role() == AccessibilityRole::Heading;
         });
 
         if (heading) {
@@ -1189,11 +1189,11 @@ static void appendStringToResult(NSMutableString *result, NSString *string)
         title = ""_s;
 
     // Footer is not considered a landmark, but we want the role description.
-    if (backingObject->roleValue() == AccessibilityRole::Footer)
+    if (backingObject->role() == AccessibilityRole::Footer)
         landmarkDescription = AXFooterRoleDescriptionText().createNSString();
 
     NSMutableString *result = [NSMutableString string];
-    if (backingObject->roleValue() == AccessibilityRole::HorizontalRule)
+    if (backingObject->role() == AccessibilityRole::HorizontalRule)
         appendStringToResult(result, AXHorizontalRuleDescriptionText().createNSString().get());
 
     appendStringToResult(result, title.createNSString().get());
@@ -1410,7 +1410,7 @@ static void appendStringToResult(NSMutableString *result, NSString *string)
 
         // Only expose positional information for the first non-list-marker child in a list item.
         for (const auto& child : listItemChildren) {
-            if (child->roleValue() != AccessibilityRole::ListMarker) {
+            if (child->role() != AccessibilityRole::ListMarker) {
                 if (child.ptr() == self.axBackingObject)
                     break;
                 return NSMakeRange(NSNotFound, 0);
@@ -1521,7 +1521,7 @@ static void appendStringToResult(NSMutableString *result, NSString *string)
     // If self has the header trait, value should be the heading level.
     if (self.accessibilityTraits & self._axHeaderTrait) {
         auto* heading = Accessibility::findAncestor(backingObject.get(), true, [] (const auto& ancestor) {
-            return ancestor.roleValue() == AccessibilityRole::Heading;
+            return ancestor.role() == AccessibilityRole::Heading;
         });
         ASSERT(heading);
 
@@ -1608,7 +1608,7 @@ static void appendStringToResult(NSMutableString *result, NSString *string)
     if (![self _prepareAccessibilityCall])
         return NO;
 
-    return self.axBackingObject->roleValue() == AccessibilityRole::ComboBox;
+    return self.axBackingObject->role() == AccessibilityRole::ComboBox;
 }
 
 - (NSString *)accessibilityHint
@@ -1767,7 +1767,7 @@ static void appendStringToResult(NSMutableString *result, NSString *string)
     if (!self.axBackingObject)
         return NO;
     
-    AccessibilityRole role = self.axBackingObject->roleValue();
+    AccessibilityRole role = self.axBackingObject->role();
     if (role != AccessibilityRole::Link)
         return NO;
     
@@ -1779,7 +1779,7 @@ static void appendStringToResult(NSMutableString *result, NSString *string)
         return NO;
     
     for (unsigned i = 0; i < childrenSize; ++i) {
-        AccessibilityRole role = children[i]->roleValue();
+        AccessibilityRole role = children[i]->role();
         if (role != AccessibilityRole::StaticText && role != AccessibilityRole::Image && !children[i]->isGroup())
             return NO;
     }
@@ -1974,7 +1974,7 @@ static NSArray *accessibleElementsForObjects(const AXCoreObject::AccessibilityCh
 
     // If this static text inside of a link, it should use its parent's linked element.
     auto* backingObject = self.axBackingObject;
-    if (backingObject->roleValue() == AccessibilityRole::StaticText && backingObject->parentObjectUnignored()->isLink())
+    if (backingObject->role() == AccessibilityRole::StaticText && backingObject->parentObjectUnignored()->isLink())
         backingObject = backingObject->parentObjectUnignored();
 
     auto linkedObjects = backingObject->linkedObjects();
@@ -2126,7 +2126,7 @@ static RenderObject* rendererForView(WAKView* view)
 {
     // Use this to check if an object is inside a treeitem object.
     if (AXCoreObject* parent = Accessibility::findAncestor<AXCoreObject>(*object, true, [] (const AXCoreObject& object) {
-        return object.roleValue() == AccessibilityRole::TreeItem;
+        return object.role() == AccessibilityRole::TreeItem;
     }))
         return parent;
     return nil;
@@ -2817,7 +2817,7 @@ static RenderObject* rendererForView(WAKView* view)
         return NO;
     
     return Accessibility::findAncestor(*self.axBackingObject, false, [] (const auto& object) {
-        return object.roleValue() == AccessibilityRole::Insertion;
+        return object.role() == AccessibilityRole::Insertion;
     }) != nullptr;
 }
 
@@ -2827,7 +2827,7 @@ static RenderObject* rendererForView(WAKView* view)
         return NO;
     
     return Accessibility::findAncestor(*self.axBackingObject, false, [] (const auto& object) {
-        return object.roleValue() == AccessibilityRole::Deletion;
+        return object.role() == AccessibilityRole::Deletion;
     }) != nullptr;
 }
 
@@ -2843,7 +2843,7 @@ static RenderObject* rendererForView(WAKView* view)
         const auto& children = parent->unignoredChildren();
         if (children.isEmpty() || children[0].ptr() != object)
             return NO;
-        if (parent->roleValue() == AccessibilityRole::Suggestion)
+        if (parent->role() == AccessibilityRole::Suggestion)
             return YES;
         object = parent;
         parent = object->parentObjectUnignored();
@@ -2863,7 +2863,7 @@ static RenderObject* rendererForView(WAKView* view)
         const auto& children = parent->unignoredChildren();
         if (children.isEmpty() || children.last().ptr() != object)
             return NO;
-        if (parent->roleValue() == AccessibilityRole::Suggestion)
+        if (parent->role() == AccessibilityRole::Suggestion)
             return YES;
         object = parent;
         parent = object->parentObjectUnignored();
@@ -3134,7 +3134,7 @@ static RenderObject* rendererForView(WAKView* view)
     if (![self _prepareAccessibilityCall])
         return NO;
 
-    return self.axBackingObject->roleValue() == AccessibilityRole::DocumentMath;
+    return self.axBackingObject->role() == AccessibilityRole::DocumentMath;
 }
 
 - (NSInteger)accessibilityMathLineThickness
@@ -3150,7 +3150,7 @@ static RenderObject* rendererForView(WAKView* view)
     if (![self _prepareAccessibilityCall])
         return nil;
 
-    if (self.axBackingObject->roleValue() == AccessibilityRole::MathElement) {
+    if (self.axBackingObject->role() == AccessibilityRole::MathElement) {
         if (self.axBackingObject->isMathFraction())
             return @"AXMathFraction";
         if (self.axBackingObject->isMathFenced())

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
@@ -77,7 +77,7 @@ String AXIsolatedObject::dbgInternal(bool verbose, OptionSet<AXDebugStringOption
 {
     StringBuilder result;
     result.append("{"_s);
-    result.append("role: "_s, accessibilityRoleToString(roleValue()));
+    result.append("role: "_s, accessibilityRoleToString(role()));
     result.append(", ID "_s, objectID().loggingString());
 
     if (verbose || debugOptions & AXDebugStringOption::Ignored)
@@ -302,7 +302,7 @@ void AXIsolatedObject::setSelectedChildren(const AccessibilityChildrenVector& se
 bool AXIsolatedObject::isInDescriptionListTerm() const
 {
     return Accessibility::findAncestor<AXIsolatedObject>(*this, false, [&] (const auto& ancestor) {
-        return ancestor.roleValue() == AccessibilityRole::DescriptionListTerm;
+        return ancestor.role() == AccessibilityRole::DescriptionListTerm;
     });
 }
 
@@ -1097,7 +1097,7 @@ FloatRect AXIsolatedObject::relativeFrame() const
         // a rect at the position of the nearest render tree ancestor with some made-up size (AccessibilityNodeObject::boundingBoxRect does this).
         // However, we don't have access to the render tree in this context (only the AX isolated tree, which is too sparse for this purpose), so
         // until we cache the necessary information let's go to the main-thread.
-    } else if (roleValue() == AccessibilityRole::Column || roleValue() == AccessibilityRole::TableHeaderContainer)
+    } else if (role() == AccessibilityRole::Column || role() == AccessibilityRole::TableHeaderContainer)
         relativeFrame = exposedTableAncestor() ? relativeFrameFromChildren() : FloatRect();
 
     // Mock objects and SVG objects need use the main thread since they do not have render nodes and are not painted with layers, respectively.
@@ -1854,7 +1854,7 @@ AXCoreObject::AccessibilityChildrenVector AXIsolatedObject::rowHeaders()
 AXIsolatedObject* AXIsolatedObject::headerContainer()
 {
     for (const auto& child : unignoredChildren()) {
-        if (child->roleValue() == AccessibilityRole::TableHeaderContainer)
+        if (child->role() == AccessibilityRole::TableHeaderContainer)
             return downcast<AXIsolatedObject>(child.ptr());
     }
     return nullptr;

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
@@ -1044,7 +1044,7 @@ void AXIsolatedTree::updateChildren(AccessibilityObject& axObject, ResolveNodeCh
     };
 
     // Also queue updates to the target node itself and any properties that depend on children().
-    if (childrenChanged || unconditionallyUpdate(axAncestor->roleValue())) {
+    if (childrenChanged || unconditionallyUpdate(axAncestor->role())) {
         queueNodeUpdate(axAncestor->objectID(), NodeUpdateOptions::nodeUpdate());
         updateDependentProperties(*axAncestor);
     }
@@ -1717,7 +1717,7 @@ IsolatedObjectData createIsolatedObjectData(const Ref<AccessibilityObject>& axOb
 #if ENABLE(AX_THREAD_TEXT_APIS)
         setProperty(AXProperty::TextRuns, std::make_shared<AXTextRuns>(object.textRuns()));
         setProperty(AXProperty::TextEmissionBehavior, object.textEmissionBehavior());
-        if (object.roleValue() == AccessibilityRole::ListMarker) {
+        if (object.role() == AccessibilityRole::ListMarker) {
             setProperty(AXProperty::ListMarkerText, object.listMarkerText().isolatedCopy());
             setProperty(AXProperty::ListMarkerLineID, object.listMarkerLineID());
         }
@@ -2074,7 +2074,7 @@ IsolatedObjectData createIsolatedObjectData(const Ref<AccessibilityObject>& axOb
         WTFMove(tree),
         parentID,
         object.objectID(),
-        object.roleValue(),
+        object.role(),
         propertyFlags,
         getsGeometryFromChildren
     };

--- a/Source/WebCore/accessibility/mac/AccessibilityObjectMac.mm
+++ b/Source/WebCore/accessibility/mac/AccessibilityObjectMac.mm
@@ -143,15 +143,15 @@ AccessibilityObjectInclusion AccessibilityObject::accessibilityPlatformIncludesO
     if (isMenuListPopup() || isMenuListOption())
         return AccessibilityObjectInclusion::IgnoreObject;
 
-    if (roleValue() == AccessibilityRole::Mark)
+    if (role() == AccessibilityRole::Mark)
         return AccessibilityObjectInclusion::IncludeObject;
 
     // Never expose an unknown object on the Mac. Clients of the AX API will not know what to do with it.
     // Special case is when the unknown object is actually an attachment.
-    if (roleValue() == AccessibilityRole::Unknown && !isAttachment())
+    if (role() == AccessibilityRole::Unknown && !isAttachment())
         return AccessibilityObjectInclusion::IgnoreObject;
     
-    if (roleValue() == AccessibilityRole::Inline && !isStyleFormatGroup())
+    if (role() == AccessibilityRole::Inline && !isStyleFormatGroup())
         return AccessibilityObjectInclusion::IgnoreObject;
 
     if (RenderObject* renderer = this->renderer()) {
@@ -219,7 +219,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         return "AXModel"_s;
 #endif
 
-    AccessibilityRole role = roleValue();
+    auto role = this->role();
     if (role == AccessibilityRole::HorizontalRule)
         return "AXContentSeparator"_s;
     if (role == AccessibilityRole::ToggleButton)

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.mm
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.mm
@@ -632,7 +632,7 @@ std::optional<SimpleRange> makeDOMRange(Document* document, NSRange range)
                     continue;
 
                 RetainPtr<NSString> label;
-                switch (object->roleValue()) {
+                switch (object->role()) {
                 case AccessibilityRole::StaticText:
                     label = object->stringValue().createNSString();
                     break;

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
@@ -444,7 +444,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
         || backingObject->isRadioGroup()
         || backingObject->isSplitter()
         || backingObject->isToolbar()
-        || backingObject->roleValue() == AccessibilityRole::HorizontalRule)
+        || backingObject->role() == AccessibilityRole::HorizontalRule)
         [additional addObject:NSAccessibilityOrientationAttribute];
 
     if (backingObject->supportsDragging())
@@ -931,7 +931,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
     else if (backingObject->isControl())
         objectAttributes = controlAttrs.get().get();
 
-    else if (backingObject->isGroup() || backingObject->isListItem() || backingObject->roleValue() == AccessibilityRole::Figure)
+    else if (backingObject->isGroup() || backingObject->isListItem() || backingObject->role() == AccessibilityRole::Figure)
         objectAttributes = groupAttrs.get().get();
     else if (backingObject->isTabList())
         objectAttributes = tabListAttrs.get().get();
@@ -2354,7 +2354,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         return;
     }
 
-    if (backingObject->roleValue() == AccessibilityRole::ComboBox) {
+    if (backingObject->role() == AccessibilityRole::ComboBox) {
         backingObject->setIsExpanded(true);
         return;
     }


### PR DESCRIPTION
#### 2ecfb728b19297fbf48ef4bcf1da4a01919bee8d
<pre>
AX: Rename AXCoreObject::roleValue to AXCoreObject::role as the &quot;Value&quot; suffix is redundant
<a href="https://bugs.webkit.org/show_bug.cgi?id=293967">https://bugs.webkit.org/show_bug.cgi?id=293967</a>
<a href="https://rdar.apple.com/152514020">rdar://152514020</a>

Reviewed by Joshua Hoffman.

* Source/WebCore/accessibility/AXCoreObject.cpp:
(WebCore::AXCoreObject::isList const):
(WebCore::AXCoreObject::isMenuRelated const):
(WebCore::AXCoreObject::isMenuItem const):
(WebCore::AXCoreObject::isInputImage const):
(WebCore::AXCoreObject::isControl const):
(WebCore::AXCoreObject::isImplicitlyInteractive const):
(WebCore::AXCoreObject::isLandmark const):
(WebCore::AXCoreObject::isGroup const):
(WebCore::AXCoreObject::hasGridRole const):
(WebCore::AXCoreObject::hasCellRole const):
(WebCore::AXCoreObject::isButton const):
(WebCore::AXCoreObject::isTextControl const):
(WebCore::AXCoreObject::isValidListBox const):
(WebCore::AXCoreObject::tabChildren):
(WebCore::isValidChildForTable):
(WebCore::AXCoreObject::nextInPreOrder):
(WebCore::AXCoreObject::ariaTreeItemContent):
(WebCore::AXCoreObject::value):
(WebCore::AXCoreObject::selectedRadioButton):
(WebCore::AXCoreObject::canHaveSelectedChildren const):
(WebCore::AXCoreObject::selectedChildren):
(WebCore::AXCoreObject::listboxSelectedChildren):
(WebCore::AXCoreObject::selectedRows):
(WebCore::AXCoreObject::selectedListItems):
(WebCore::AXCoreObject::ariaTreeRows):
(WebCore::AXCoreObject::supportsARIARoleDescription const):
(WebCore::AXCoreObject::supportsRequiredAttribute const):
(WebCore::AXCoreObject::isRootWebArea const):
(WebCore::AXCoreObject::isReplacedElement const):
(WebCore::AXCoreObject::roleDescription):
(WebCore::AXCoreObject::ariaLandmarkRoleDescription const):
(WebCore::AXCoreObject::blockquoteLevel const):
(WebCore::AXCoreObject::hierarchicalLevel const):
(WebCore::AXCoreObject::supportsPressAction const):
(WebCore::AXCoreObject::supportsActiveDescendant const):
(WebCore::AXCoreObject::appendRadioButtonGroupMembers const):
(WebCore::AXCoreObject::parentObjectUnignored const):
(WebCore::AXCoreObject::isLink const): Deleted.
* Source/WebCore/accessibility/AXCoreObject.h:
(WebCore::AXCoreObject::isHeading const):
(WebCore::AXCoreObject::isLink const):
(WebCore::AXCoreObject::isCode const):
(WebCore::AXCoreObject::isImage const):
(WebCore::AXCoreObject::isImageMap const):
(WebCore::AXCoreObject::isVideo const):
(WebCore::AXCoreObject::isWebArea const):
(WebCore::AXCoreObject::isCheckbox const):
(WebCore::AXCoreObject::isRadioButton const):
(WebCore::AXCoreObject::isListBox const):
(WebCore::AXCoreObject::isListBoxOption const):
(WebCore::AXCoreObject::isMenu const):
(WebCore::AXCoreObject::isMenuBar const):
(WebCore::AXCoreObject::isProgressIndicator const):
(WebCore::AXCoreObject::isSlider const):
(WebCore::AXCoreObject::isTableColumn const):
(WebCore::AXCoreObject::isSpinButton const):
(WebCore::AXCoreObject::isSwitch const):
(WebCore::AXCoreObject::isToggleButton const):
(WebCore::AXCoreObject::isTabList const):
(WebCore::AXCoreObject::isTabItem const):
(WebCore::AXCoreObject::isRadioGroup const):
(WebCore::AXCoreObject::isComboBox const):
(WebCore::AXCoreObject::isDateTime const):
(WebCore::AXCoreObject::isGrid const):
(WebCore::AXCoreObject::isTree const):
(WebCore::AXCoreObject::isTreeGrid const):
(WebCore::AXCoreObject::isTreeItem const):
(WebCore::AXCoreObject::isScrollbar const):
(WebCore::AXCoreObject::isRemoteFrame const):
(WebCore::AXCoreObject::isMeter const):
(WebCore::AXCoreObject::isListItem const):
(WebCore::AXCoreObject::isScrollView const):
(WebCore::AXCoreObject::isCanvas const):
(WebCore::AXCoreObject::isPopUpButton const):
(WebCore::AXCoreObject::isColorWell const):
(WebCore::AXCoreObject::isSplitter const):
(WebCore::AXCoreObject::isToolbar const):
(WebCore::AXCoreObject::isSummary const):
(WebCore::AXCoreObject::isBlockquote const):
(WebCore::AXCoreObject::isModel const):
(WebCore::AXCoreObject::isLineBreak const):
(WebCore::AXCoreObject::isStaticText const):
(WebCore::AXCoreObject::canSetNumericValue const):
(WebCore::AXCoreObject::role const):
(WebCore::AXCoreObject::onlyAddsUnignoredChildren const):
(WebCore::AXCoreObject::shouldSetChildIndexInParent const):
(WebCore::AXCoreObject::shouldComputeDescriptionAttributeValue const):
(WebCore::AXCoreObject::shouldComputeTitleAttributeValue const):
(WebCore::AXCoreObject::liveRegionStatus const):
(WebCore::Accessibility::clickableSelfOrAncestor):
(WebCore::AXCoreObject::roleValue const): Deleted.
* Source/WebCore/accessibility/AXLogger.cpp:
(WebCore::streamAXCoreObject):
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::modalElementHasAccessibleContent):
(WebCore::AXObjectCache::handleTextChanged):
(WebCore::AXObjectCache::notificationPostTimerFired):
(WebCore::AXObjectCache::handleTabPanelSelected):
(WebCore::AXObjectCache::handleAriaExpandedChange):
(WebCore::AXObjectCache::handleAttributeChange):
(WebCore::AXObjectCache::updateIsolatedTree):
* Source/WebCore/accessibility/AXSearchManager.cpp:
(WebCore::AXSearchManager::matchForSearchKeyAtIndex):
* Source/WebCore/accessibility/AXTextMarker.cpp:
(WebCore::AXTextMarker::debugDescription const):
(WebCore::listMarkerTextOnSameLine):
(WebCore::AXTextMarker::findMarker const):
(WebCore::AXTextMarker::findLine const):
(WebCore::AXTextMarker::findParagraph const):
(WebCore::AXTextMarker::findWordOrSentence const):
(WebCore::AXTextMarker::previousParagraphStart const):
(WebCore::AXTextMarker::nextParagraphEnd const):
(WebCore::Accessibility::findObjectWithRuns):
* Source/WebCore/accessibility/AccessibilityLabel.cpp:
(WebCore::childrenContainOnlyStaticText):
* Source/WebCore/accessibility/AccessibilityList.cpp:
(WebCore::AccessibilityList::determineAccessibilityRoleWithCleanChildren):
* Source/WebCore/accessibility/AccessibilityNodeObject.cpp:
(WebCore::AccessibilityNodeObject::roleFromInputElement const):
(WebCore::AccessibilityNodeObject::canHaveChildren const):
(WebCore::AccessibilityNodeObject::computeIsIgnored const):
(WebCore::AccessibilityNodeObject::isSearchField const):
(WebCore::AccessibilityNodeObject::isEnabled const):
(WebCore::AccessibilityNodeObject::actionElement const):
(WebCore::AccessibilityNodeObject::alterRangeValue):
(WebCore::AccessibilityNodeObject::postKeyboardKeysForValueChange):
(WebCore::AccessibilityNodeObject::liveRegionAtomic const):
(WebCore::AccessibilityNodeObject::isGenericFocusableElement const):
(WebCore::AccessibilityNodeObject::description const):
(WebCore::AccessibilityNodeObject::roleIgnoresTitle const):
(WebCore::AccessibilityNodeObject::helpText const):
(WebCore::AccessibilityNodeObject::title const):
(WebCore::AccessibilityNodeObject::text const):
(WebCore::AccessibilityNodeObject::isFocused const):
(WebCore::AccessibilityNodeObject::canSetSelectedAttribute const):
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::dbgInternal const):
(WebCore::AccessibilityObject::detachRemoteParts):
(WebCore::AccessibilityObject::matchesAncestorFlag const):
(WebCore::AccessibilityObject::accessibleNameDerivesFromContent const):
(WebCore::AccessibilityObject::accessibleNameDerivesFromHeading const):
(WebCore::AccessibilityObject::isDescendantOfRole const):
(WebCore::AccessibilityObject::insertChild):
(WebCore::AccessibilityObject::isRangeControl const):
(WebCore::AccessibilityObject::dependsOnTextUnderElement const):
(WebCore::AccessibilityObject::supportsReadOnly const):
(WebCore::AccessibilityObject::supportsCheckedState const):
(WebCore::AccessibilityObject::headingElementForNode):
(WebCore::AccessibilityObject::disclosedRows):
(WebCore::AccessibilityObject::localizedActionVerb const):
(WebCore::AccessibilityObject::actionVerb const):
(WebCore::AccessibilityObject::computedRoleString const):
(WebCore::AccessibilityObject::isTabItemSelected const):
(WebCore::AccessibilityObject::setSelectedRows):
(WebCore::AccessibilityObject::supportsExpanded const):
(WebCore::AccessibilityObject::supportsChecked const):
(WebCore::AccessibilityObject::supportsRowCountChange const):
(WebCore::AccessibilityObject::ignoredFromPresentationalRole const):
(WebCore::AccessibilityObject::defaultObjectInclusion const):
* Source/WebCore/accessibility/AccessibilityObject.h:
(WebCore::AccessibilityObject::hasImplicitGenericRole const):
(WebCore::AccessibilityObject::hasTextContent const):
(WebCore::AccessibilityObject::hasAttributedText const):
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::AccessibilityRenderObject::helpText const):
(WebCore::AccessibilityRenderObject::isAllowedChildOfTree const):
(WebCore::AccessibilityRenderObject::computeIsIgnored const):
(WebCore::AccessibilityRenderObject::listMarkerLineID const):
(WebCore::AccessibilityRenderObject::supportsExpandedTextValue const):
(WebCore::AccessibilityRenderObject::inheritsPresentationalRole const):
(WebCore::AccessibilityRenderObject::addRemoteSVGChildren):
(WebCore::AccessibilityRenderObject::updateRoleAfterChildrenCreation):
* Source/WebCore/accessibility/AccessibilitySVGObject.cpp:
(WebCore::AccessibilitySVGObject::inheritsPresentationalRole const):
* Source/WebCore/accessibility/AccessibilityTable.cpp:
(WebCore::AccessibilityTable::isDataTable const):
(WebCore::AccessibilityTable::computeCellSlots):
* Source/WebCore/accessibility/AccessibilityTableCell.cpp:
(WebCore::AccessibilityTableCell::isColumnHeader const):
(WebCore::AccessibilityTableCell::isRowHeader const):
* Source/WebCore/accessibility/atspi/AXObjectCacheAtspi.cpp:
(WebCore::AXObjectCache::frameLoadingEventPlatformNotification):
* Source/WebCore/accessibility/atspi/AccessibilityObjectAtspi.cpp:
(WebCore::AccessibilityObjectAtspi::interfacesForObject):
(WebCore::AccessibilityObjectAtspi::name const):
(WebCore::AccessibilityObjectAtspi::states const):
(WebCore::AccessibilityObjectAtspi::relationMap const):
(WebCore::AccessibilityObjectAtspi::effectiveRole const):
(WebCore::AccessibilityObjectAtspi::role const):
(WebCore::AccessibilityObjectAtspi::localizedRoleName const):
(WebCore::AccessibilityObject::accessibilityPlatformIncludesObject const):
* Source/WebCore/accessibility/atspi/AccessibilityObjectTextAtspi.cpp:
(WebCore::AccessibilityObjectAtspi::text const):
* Source/WebCore/accessibility/cocoa/AXCoreObjectCocoa.mm:
(WebCore::AXCoreObject::createAttributedString const):
(WebCore::AXCoreObject::rolePlatformDescription):
(WebCore::AXCoreObject::rolePlatformString):
* Source/WebCore/accessibility/ios/AccessibilityObjectIOS.mm:
(WebCore::AccessibilityObject::accessibilityPlatformIncludesObject const):
* Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm:
(-[WebAccessibilityObjectWrapper accessibilityCanFuzzyHitTest]):
(-[WebAccessibilityObjectWrapper _accessibilityWebRoleAsString]):
(-[WebAccessibilityObjectWrapper accessibilityIsDialog]):
(ancestorWithRole):
(-[WebAccessibilityObjectWrapper _accessibilityTraitsFromAncestors]):
(-[WebAccessibilityObjectWrapper accessibilityIsWebInteractiveVideo]):
(-[WebAccessibilityObjectWrapper _accessibilityTextEntryTraits]):
(-[WebAccessibilityObjectWrapper accessibilityTraits]):
(-[WebAccessibilityObjectWrapper determineIsAccessibilityElement]):
(-[WebAccessibilityObjectWrapper accessibilityLabel]):
(-[WebAccessibilityObjectWrapper accessibilityRowRange]):
(-[WebAccessibilityObjectWrapper accessibilityValue]):
(-[WebAccessibilityObjectWrapper accessibilityIsComboBox]):
(-[WebAccessibilityObjectWrapper containsUnnaturallySegmentedChildren]):
(-[WebAccessibilityObjectWrapper accessibilityLinkedElement]):
(-[WebAccessibilityObjectWrapper treeItemParentForObject:]):
(-[WebAccessibilityObjectWrapper accessibilityIsInsertion]):
(-[WebAccessibilityObjectWrapper accessibilityIsDeletion]):
(-[WebAccessibilityObjectWrapper accessibilityIsFirstItemInSuggestion]):
(-[WebAccessibilityObjectWrapper accessibilityIsLastItemInSuggestion]):
(-[WebAccessibilityObjectWrapper accessibilityIsMathTopObject]):
(-[WebAccessibilityObjectWrapper accessibilityMathType]):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp:
(WebCore::AXIsolatedObject::dbgInternal const):
(WebCore::AXIsolatedObject::isInDescriptionListTerm const):
(WebCore::AXIsolatedObject::relativeFrame const):
(WebCore::AXIsolatedObject::headerContainer):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp:
(WebCore::AXIsolatedTree::updateChildren):
(WebCore::createIsolatedObjectData):
* Source/WebCore/accessibility/mac/AccessibilityObjectMac.mm:
(WebCore::AccessibilityObject::accessibilityPlatformIncludesObject const):
(WebCore::AccessibilityObject::subrolePlatformString const):
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.mm:
(-[WebAccessibilityObjectWrapperBase lineRectsAndText]):
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm:
(-[WebAccessibilityObjectWrapper _additionalAccessibilityAttributeNames:]):
(-[WebAccessibilityObjectWrapper ALLOW_DEPRECATED_IMPLEMENTATIONS_END]):
(-[WebAccessibilityObjectWrapper accessibilityPerformShowMenuAction]):

Canonical link: <a href="https://commits.webkit.org/295777@main">https://commits.webkit.org/295777@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d8cee076106876575c12d55bf48114a414987a11

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/106074 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25823 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/16217 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/111271 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/56670 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/108113 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/26479 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34326 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80577 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/109078 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/20922 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95725 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60899 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/20502 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13823 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/56108 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/90290 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13858 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/114126 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33212 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24511 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89661 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33576 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91953 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89350 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22781 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34207 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/12021 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/28785 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/33137 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/38549 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32883 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/36233 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34481 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->