### PR TITLE
[WebGPU] swift/bridging not found when using different toolchains

### DIFF
--- a/Source/WTF/WTF.xcodeproj/project.pbxproj
+++ b/Source/WTF/WTF.xcodeproj/project.pbxproj
@@ -171,6 +171,7 @@
 		93E4A13728F6B75A006AD994 /* UUIDCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 93E4A13628F6B75A006AD994 /* UUIDCocoa.mm */; };
 		93F1993E19D7958D00C2390B /* StringView.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 93F1993D19D7958D00C2390B /* StringView.cpp */; };
 		941C64A72CA5A2A000A63214 /* RetainReleaseSwift.h in Headers */ = {isa = PBXBuildFile; fileRef = 941C64A62CA5A29400A63214 /* RetainReleaseSwift.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		9758E8F02DDCA639004434FD /* SwiftBridging.h in Headers */ = {isa = PBXBuildFile; fileRef = 9758E8EF2DDCA639004434FD /* SwiftBridging.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		9785729929FAC2BB00350CBA /* ReferenceWrapperVector.h in Headers */ = {isa = PBXBuildFile; fileRef = 9785729829FAC2BB00350CBA /* ReferenceWrapperVector.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		9B5605902D9691ED00FCE33E /* NoVirtualDestructorBase.h in Headers */ = {isa = PBXBuildFile; fileRef = 9B56058F2D9691ED00FCE33E /* NoVirtualDestructorBase.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		9BC70F05176C379D00101DEC /* AtomStringTable.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9BC70F04176C379D00101DEC /* AtomStringTable.cpp */; };
@@ -1436,6 +1437,7 @@
 		93F1993D19D7958D00C2390B /* StringView.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = StringView.cpp; sourceTree = "<group>"; };
 		941C64A62CA5A29400A63214 /* RetainReleaseSwift.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RetainReleaseSwift.h; sourceTree = "<group>"; };
 		974CFC8D16A4F327006D5404 /* WeakPtr.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WeakPtr.h; sourceTree = "<group>"; };
+		9758E8EF2DDCA639004434FD /* SwiftBridging.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SwiftBridging.h; sourceTree = "<group>"; };
 		9785729829FAC2BB00350CBA /* ReferenceWrapperVector.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ReferenceWrapperVector.h; sourceTree = "<group>"; };
 		996B17841EBA441C007E10EB /* DebugUtilities.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DebugUtilities.h; sourceTree = "<group>"; };
 		9B56058F2D9691ED00FCE33E /* NoVirtualDestructorBase.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NoVirtualDestructorBase.h; sourceTree = "<group>"; };
@@ -2628,6 +2630,7 @@
 				E3260E972DA0E508003FC93F /* StructDump.h */,
 				93B07ED726B8715B00A09B34 /* SuspendableWorkQueue.cpp */,
 				93B07ED626B86BB500A09B34 /* SuspendableWorkQueue.h */,
+				9758E8EF2DDCA639004434FD /* SwiftBridging.h */,
 				5C12460D2DC25A130077D423 /* SwiftCXXThunk.h */,
 				5597F82C1D94B9970066BC21 /* SynchronizedFixedQueue.h */,
 				E3E158251EADA53C004A079D /* SystemFree.h */,
@@ -3761,6 +3764,7 @@
 				FF8CB4012A88C0D3004AF498 /* SuperFastHash.h in Headers */,
 				DD3DC89A27A4BF8E007E5B61 /* SuspendableWorkQueue.h in Headers */,
 				E396C11E2BE885D9000CBAE1 /* sve.h in Headers */,
+				9758E8F02DDCA639004434FD /* SwiftBridging.h in Headers */,
 				5C12460E2DC25A130077D423 /* SwiftCXXThunk.h in Headers */,
 				DDF307DA27C086DF006A526F /* SymbolImpl.h in Headers */,
 				DDF307EC27C086DF006A526F /* SymbolRegistry.h in Headers */,

--- a/Source/WTF/wtf/RetainReleaseSwift.h
+++ b/Source/WTF/wtf/RetainReleaseSwift.h
@@ -26,7 +26,7 @@
 #pragma once
 
 #if HAVE(SWIFT_CPP_INTEROP) // FIXME: rdar://136787800
-#include <swift/bridging>
+#include <wtf/SwiftBridging.h>
 #else
 
 #ifndef SWIFT_SHARED_REFERENCE // FIXME: rdar://136787800

--- a/Source/WTF/wtf/SwiftBridging.h
+++ b/Source/WTF/wtf/SwiftBridging.h
@@ -1,0 +1,309 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if __has_include(<swift/bridging>)
+
+#include <swift/bridging>
+
+#else
+
+// Copied from https://github.com/swiftlang/swift/blob/ff8b9f145320b02bc6de75163d78528f210bdba6/lib/ClangImporter/SwiftBridging/swift/bridging
+
+// -*- C++ -*-
+//===------------------ bridging - C++ and Swift Interop --------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This file provides common utilities and annotations that are useful for C++
+// codebases that interoperate with Swift.
+//
+//===----------------------------------------------------------------------===//
+#ifndef SWIFT_CLANGIMPORTER_SWIFT_INTEROP_SUPPORT_H
+#define SWIFT_CLANGIMPORTER_SWIFT_INTEROP_SUPPORT_H
+
+#ifdef __has_attribute
+#define _CXX_INTEROP_HAS_ATTRIBUTE(x) __has_attribute(x)
+#else
+#define _CXX_INTEROP_HAS_ATTRIBUTE(x) 0
+#endif
+
+#if _CXX_INTEROP_HAS_ATTRIBUTE(swift_attr)
+
+/// Specifies that a C++ `class` or `struct` owns and controls the lifetime of all
+/// of the objects it references. Such type should not reference any objects whose
+/// lifetime is controlled externally. This annotation allows Swift to import methods
+/// that return a `class` or `struct` type that is annotated with this macro.
+#define SWIFT_SELF_CONTAINED __attribute__((swift_attr("import_owned")))
+
+/// Specifies that a C++ method returns a value that is presumed to contain
+/// objects whose lifetime is not dependent on `this` or other parameters passed
+/// to the method.
+#define SWIFT_RETURNS_INDEPENDENT_VALUE __attribute__((swift_attr("import_unsafe")))
+
+#define _CXX_INTEROP_STRINGIFY(_x) #_x
+
+#define _CXX_INTEROP_CONCAT_(a,b,c,d,e,f,g,i,j,k,l,m,n,o,p,...)         \
+  #a "," #b "," #c "," #d "," #e "," #f "," #g "," #i "," #j "," #k "," \
+  #l "," #m "," #n "," #o "," #p
+#define _CXX_INTEROP_CONCAT(...) \
+  _CXX_INTEROP_CONCAT_(__VA_ARGS__,,,,,,,,,,,,,,,,,)
+
+/// Specifies that a C++ `class` or `struct` is reference-counted using
+/// the given `retain` and `release` functions. This annotation lets Swift import
+/// such a type as reference counted type in Swift, taking advantage of Swift's
+/// automatic reference counting.
+///
+/// This example shows how to use this macro to let Swift know that
+/// a non-copyable reference counted C++ class can be imported as a reference counted type in Swift:
+///  ```c++
+///    class SWIFT_SHARED_REFERENCE(retainSharedObject, releaseSharedObject)
+///    SharedObject : NonCopyable, IntrusiveReferenceCounted<SharedObject> {
+///    public:
+///      static SharedObject* create();
+///      void doSomething();
+///    };
+///
+///    void retainSharedObject(SharedObject *);
+///    void releaseSharedObject(SharedObject *);
+///  ```
+///
+///  Then, the Swift programmer would be able to use it in the following manner:
+///
+///  ```swift
+///    let object = SharedObject.create()
+///    object.doSomething()
+///    // The Swift compiler will release object here.
+///  ```
+#define SWIFT_SHARED_REFERENCE(_retain, _release)                                \
+  __attribute__((swift_attr("import_reference")))                          \
+  __attribute__((swift_attr(_CXX_INTEROP_STRINGIFY(retain:_retain))))      \
+  __attribute__((swift_attr(_CXX_INTEROP_STRINGIFY(release:_release))))
+
+/// Specifies that a C++ `class` or `struct` is a reference type whose lifetime
+/// is presumed to be immortal, i.e. the reference to such object is presumed to
+/// always be valid. This annotation lets Swift import such a type as a reference
+/// type in Swift.
+////
+/// This example shows how to use this macro to let Swift know that
+/// a non-copyable singleton C++ class can be imported as a reference type in Swift:
+///  ```c++
+///    class SWIFT_IMMORTAL_REFERENCE
+///    LoggerSingleton : NonCopyable {
+///    public:
+///      static LoggerSingleton &getInstance();
+///      void log(int x);
+///    };
+///  ```
+///
+///  Then, the Swift programmer would be able to use it in the following manner:
+///
+///  ```swift
+///    let logger = LoggerSingleton.getInstance()
+///    logger.log(123)
+///  ```
+#define SWIFT_IMMORTAL_REFERENCE                                                \
+  __attribute__((swift_attr("import_reference")))                         \
+  __attribute__((swift_attr(_CXX_INTEROP_STRINGIFY(retain:immortal))))    \
+  __attribute__((swift_attr(_CXX_INTEROP_STRINGIFY(release:immortal))))
+
+/// Specifies that a C++ `class` or `struct` is a reference type whose lifetime
+/// is not managed automatically. The programmer must validate that any reference
+/// to such object is valid themselves. This annotation lets Swift import such a type as a reference type in Swift.
+#define SWIFT_UNSAFE_REFERENCE                                                  \
+  __attribute__((swift_attr("import_reference")))                         \
+  __attribute__((swift_attr(_CXX_INTEROP_STRINGIFY(retain:immortal))))    \
+  __attribute__((swift_attr(_CXX_INTEROP_STRINGIFY(release:immortal))))   \
+  __attribute__((swift_attr("unsafe")))
+
+/// Specifies a name that will be used in Swift for this declaration instead of its original name.
+#define SWIFT_NAME(_name) __attribute__((swift_name(#_name)))
+
+/// Specifies that a specific C++ `class` or `struct` conforms to a
+/// a specific Swift protocol.
+///
+/// This example shows how to use this macro to conform a class template to a Swift protocol:
+///  ```
+///    template<class T>
+///    class SWIFT_CONFORMS_TO_PROTOCOL(SwiftModule.ProtocolName)
+///    CustomClass {};
+///  ```
+#define SWIFT_CONFORMS_TO_PROTOCOL(_moduleName_protocolName) \
+  __attribute__((swift_attr(_CXX_INTEROP_STRINGIFY(conforms_to:_moduleName_protocolName))))
+
+/// Specifies that a specific C++ method should be imported as a computed
+/// property. If this macro is specified on a getter, a getter will be
+/// synthesized. If this macro is specified on a setter, both a getter and
+/// setter will be synthesized.
+///
+/// For example:
+///  ```
+///    int getX() SWIFT_COMPUTED_PROPERTY;
+///  ```
+/// Will be imported as `var x: CInt {...}`.
+#define SWIFT_COMPUTED_PROPERTY \
+  __attribute__((swift_attr("import_computed_property")))
+
+/// Specifies that a specific **constant** C++ member function should be imported as
+/// `mutating` Swift method. This annotation should be added to constant C++ member functions
+/// that mutate `mutable` fields in a C++ object, to let Swift know that this function is still mutating
+/// and thus that it should become a `mutating` method in Swift.
+#define SWIFT_MUTATING \
+  __attribute__((swift_attr("mutating")))
+
+/// Specifies that a specific c++ type such class or struct should be imported as type marked 
+/// as `@unchecked Sendable` type in swift. If this annotation is used, the type is therefore allowed to
+/// use safely across async contexts.
+///
+/// For example 
+/// ```
+///   class SWIFT_UNCHECKED_SENDABLE CustomUserType
+///   { ... } 
+/// ``` 
+/// Will be imported as `struct CustomUserType: @unchecked Sendable`
+#define SWIFT_UNCHECKED_SENDABLE \
+  __attribute__((swift_attr("@Sendable")))
+
+/// Specifies that a specific c++ type such class or struct should be imported
+/// as a non-copyable Swift value type.
+#define SWIFT_NONCOPYABLE \
+  __attribute__((swift_attr("~Copyable")))
+
+/// Specifies that a specific c++ type such class or struct should be imported
+/// as a non-escapable Swift value type when the non-escapable language feature
+/// is enabled.
+#define SWIFT_NONESCAPABLE \
+  __attribute__((swift_attr("~Escapable")))
+
+/// Specifies that a specific c++ type such class or struct should be imported
+/// as a escapable Swift value. While this matches the default behavior,
+/// in safe mode interop mode it ensures that the type is not marked as
+/// unsafe.
+#define SWIFT_ESCAPABLE \
+  __attribute__((swift_attr("Escapable")))
+
+/// Specifies that a C++ `class` or `struct` should be imported as a escapable
+/// Swift value if all of the specified template arguments are escapable.
+#define SWIFT_ESCAPABLE_IF(...) \
+  __attribute__((swift_attr("escapable_if:" _CXX_INTEROP_CONCAT(__VA_ARGS__))))
+
+/// Specifies that the return value is passed as owned for C++ functions and
+/// methods returning types annotated as `SWIFT_SHARED_REFERENCE`
+#define SWIFT_RETURNS_RETAINED __attribute__((swift_attr("returns_retained")))
+/// Specifies that the return value is passed as unowned for C++ functions and
+/// methods returning types annotated as `SWIFT_SHARED_REFERENCE`
+#define SWIFT_RETURNS_UNRETAINED                                               \
+  __attribute__((swift_attr("returns_unretained")))
+
+/// Applied to a C++ foreign reference type annotated with
+/// SWIFT_SHARED_REFERENCE. Indicates that C++ APIs returning this type are
+/// assumed to return an unowned (+0) value by default, unless explicitly annotated
+/// with SWIFT_RETURNS_RETAINED.
+///
+/// For example:
+/// ```c++
+/// struct SWIFT_SHARED_REFERENCE(retainBar, releaseBar)
+/// SWIFT_RETURNED_AS_UNRETAINED_BY_DEFAULT
+/// Bar { ... };
+/// ```
+///
+/// In Swift, C++ APIs returning `Bar*` will be assumed to return an unowned
+/// value.
+#define SWIFT_RETURNED_AS_UNRETAINED_BY_DEFAULT                                    \
+  __attribute__((swift_attr("returned_as_unretained_by_default")))
+
+/// Specifies that the non-public members of a C++ class, struct, or union can
+/// be accessed from extensions of that type, in the given file ID.
+///
+/// In other words, Swift's access controls will behave as if the non-public
+/// members of the annotated C++ class were privated declared in the specified
+/// Swift source file, rather than in a C++ header file/Clang module.
+///
+/// For example, we can annotate a C++ class definition like this:
+///
+/// ```c++
+/// class SWIFT_PRIVATE_FILEID("MySwiftModule/MySwiftFile.swift")
+/// MyCxxClass {
+/// private:
+///   void privateMethod();
+///   int  privateStorage;
+/// };
+/// ```
+///
+/// Then, Swift extensions of `MyCxxClass` in `MySwiftModule/MySwiftFile.swift`
+/// are allowed to access `privateMethod()` and `privateStorage`:
+///
+/// ```swift
+/// //-- MySwiftModule/SwiftFile.swift
+/// extension MyCxxClass {
+///     func ext() {
+///         privateMethod()
+///         print("\(privateStorage)")
+///     }
+/// }
+/// ```
+///
+/// Non-public access is still forbidden outside of extensions and outside of
+/// the designated file ID.
+#define SWIFT_PRIVATE_FILEID(_fileID) \
+  __attribute__((swift_attr("private_fileid:" _fileID)))
+
+#else  // #if _CXX_INTEROP_HAS_ATTRIBUTE(swift_attr)
+
+// Empty defines for compilers that don't support `attribute(swift_attr)`.
+#define SWIFT_SELF_CONTAINED
+#define SWIFT_RETURNS_INDEPENDENT_VALUE
+#define SWIFT_SHARED_REFERENCE(_retain, _release)
+#define SWIFT_IMMORTAL_REFERENCE
+#define SWIFT_UNSAFE_REFERENCE
+#define SWIFT_NAME(_name)
+#define SWIFT_CONFORMS_TO_PROTOCOL(_moduleName_protocolName)
+#define SWIFT_COMPUTED_PROPERTY
+#define SWIFT_MUTATING 
+#define SWIFT_UNCHECKED_SENDABLE
+#define SWIFT_NONCOPYABLE
+#define SWIFT_NONESCAPABLE
+#define SWIFT_ESCAPABLE
+#define SWIFT_ESCAPABLE_IF(...)
+#define SWIFT_RETURNS_RETAINED
+#define SWIFT_RETURNS_UNRETAINED
+#define SWIFT_PRIVATE_FILEID(_fileID)
+
+#endif // #if _CXX_INTEROP_HAS_ATTRIBUTE(swift_attr)
+
+#undef _CXX_INTEROP_HAS_ATTRIBUTE
+
+#endif // SWIFT_CLANGIMPORTER_SWIFT_INTEROP_SUPPORT_H
+
+#endif

--- a/Source/WebGPU/WebGPU/Buffer.swift
+++ b/Source/WebGPU/WebGPU/Buffer.swift
@@ -82,6 +82,6 @@ extension WebGPU.Buffer {
             return SpanUInt8()
         }
 
-        return getBufferContents().subspan(offset, stdDynamicExtent)
+        return getBufferContents().subspan(offset, rangeSize)
     }
 }

--- a/Tools/Scripts/webkitpy/style/checkers/cpp.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp.py
@@ -134,6 +134,9 @@ _AUTO_GENERATED_FILES = [
     # VisualStudio resource files
     'Tools/MiniBrowser/win/MiniBrowserLibResource.h',
 
+    # Swift bridging header
+    'Source/WTF/wtf/SwiftBridging.h',
+
     # Generated Test Results
     'Source/WebCore/css/scripts/test/TestCSSPropertiesResults/CSSPropertyNames.gperf',
     'Source/WebCore/css/scripts/test/TestCSSPropertiesResults/CSSPropertyNames.h',


### PR DESCRIPTION
#### 04b145579526f622e26806ea4959f64dee8c9d49
<pre>
[WebGPU] swift/bridging not found when using different toolchains
<a href="https://bugs.webkit.org/show_bug.cgi?id=293963">https://bugs.webkit.org/show_bug.cgi?id=293963</a>
<a href="https://rdar.apple.com/152511571">rdar://152511571</a>

Reviewed by Mike Wyrzykowski.

When compiling with a different toolchain, the Swift compiler doesn&apos;t find the
the `swift/bridging` header under the toolchain&apos;s `usr/include` folder. That
issue has been raised, but in the mean time we work around this by checking in
a copy of the header from Swift&apos;s open source repo.

* Source/WTF/WTF.xcodeproj/project.pbxproj:
* Source/WTF/wtf/RetainReleaseSwift.h:
* Source/WTF/wtf/SwiftBridging.h: Added.
* Source/WebGPU/WebGPU/Buffer.swift:

Canonical link: <a href="https://commits.webkit.org/295811@main">https://commits.webkit.org/295811@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e36a9e5610848b49105e0480a377c6612eb6965f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/106080 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25829 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/16223 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/111277 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/56676 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/108119 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/26485 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34332 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80578 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/109084 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/20919 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95731 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60901 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/105557 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/20500 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13829 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/56114 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/98719 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/90287 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13864 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/114132 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/104697 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33218 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24513 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89659 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33582 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91959 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89348 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22811 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34213 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/12027 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/28791 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/33143 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/38555 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/129009 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32889 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/35172 "Found 2 new JSC stress test failures: wasm.yaml/wasm/gc/ref-i31-eq.js.wasm-collect-continuously, wasm.yaml/wasm/gc/ref-i31-eq.js.wasm-eager (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/36239 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34487 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->