### PR TITLE
REGRESSION(281090@main): Grid layout can be slow on pages with deeply nested grid and subgrid content.

### DIFF
--- a/PerformanceTests/Layout/grid-with-nested-grid-and-subgrid-columns.html
+++ b/PerformanceTests/Layout/grid-with-nested-grid-and-subgrid-columns.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../resources/runner.js"></script>
+<script>
+function startTest() {
+  document.body.offsetHeight;
+  var index = 0;
+  PerfTestRunner.measureRunsPerSecond({run: function() {
+      document.body.style.width = ++index % 2 ? "99%" : "98%";
+      document.body.offsetHeight;
+  }});
+}
+</script>
+<style>
+.grid {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+}
+.subgrid {
+  display: grid;
+  grid-template-columns: subgrid;
+}
+</style>
+</head>
+<body onload="startTest()">
+  <div class="grid">
+    <div class="subgrid">
+      <div class="grid">
+        <div class="subgrid">
+          <div class="grid">
+            <div class="subgrid">
+              <div class="grid">
+                <div class="subgrid">
+                  <div class="grid">
+                    <div class="subgrid">
+                      <div class="grid">
+                        <div class="subgrid">
+                          <div class="grid">
+                            <div class="subgrid">
+                              <div class="grid">
+                                <div class="subgrid">
+                                  <div class="grid">
+                                    <div class="subgrid">
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/Source/WebCore/rendering/RenderGrid.cpp
+++ b/Source/WebCore/rendering/RenderGrid.cpp
@@ -2752,15 +2752,20 @@ bool RenderGrid::canCreateIntrinsicLogicalHeightsForRowSizingFirstPassCache() co
     if (isMasonry())
         return false;
 
-    if (isSubgrid())
+    if (isSubgridRows())
         return false;
 
     if (enclosingFragmentedFlow())
         return false;
 
     for (auto& gridItem : childrenOfType<RenderBox>(*this)) {
-        if (auto* renderGrid = dynamicDowncast<RenderGrid>(gridItem); renderGrid && renderGrid->isSubgrid())
-            return false;
+        if (auto* renderGrid = dynamicDowncast<RenderGrid>(gridItem)) {
+            if (renderGrid->isSubgridRows())
+                return false;
+
+            if (renderGrid->isSubgridColumns() && GridLayoutFunctions::isOrthogonalGridItem(*this, *renderGrid))
+                return false;
+        }
 
         if (isBaselineAlignmentForGridItem(gridItem))
             return false;


### PR DESCRIPTION
#### 8af27c463fdd50a252381bdaf154c7008a6a7257
<pre>
REGRESSION(281090@main): Grid layout can be slow on pages with deeply nested grid and subgrid content.
<a href="https://bugs.webkit.org/show_bug.cgi?id=291827">https://bugs.webkit.org/show_bug.cgi?id=291827</a>
<a href="https://rdar.apple.com/149704403">rdar://149704403</a>

Reviewed by Alan Baradlay.

In 287890@main, we introduced a new cache for grid layout to use by
storing the intrinsic logical height of its grid items. That commit
message gives the explanation for the cause of the performance
regression, but the TLDR is:

We can experience some thrashing when we have deeply nested grid content
that is also stretching. This is because the track sizing algorithm will
query its item for its intrinsic logical height, and on relayout, we will
setNeedsLayout on those items to get that information. This behavior can
become pathological if those items are grid themselves.

The cache in 287890@main stores those sizes for grid to use without
needing to perform layout on those items. However, we restricted the
availability of this cache to limit the scope and risk of the initial
implementation. One of these restrictions was to not create that cache
in the presence of subgrids. As a result, any pages with subgrids and a
similar content structure of nested grids/subgrids can experience the
same performance problem that 287890@main attempted to address.

It seems like at one point, lobste.rs experienced this issue when the
website changed. This content structure no longer appears on the site at
this point, although that state is still accessible via the
Wayback Machine (see the link in the bugzilla).

The content seems to have been of the form:
&lt;grid&gt;
  &lt;subgrid column/&gt;
  &lt;subgrid columns/&gt;
  &lt;grid&gt;
    ...
  &lt;/grid&gt;
&lt;/grid&gt;

which was used in the comments section.

In this patch, we expand the availability of this cache to include when
the RenderGrid is subgridded in the columns or has a grid item which is
a subgrid columns. This should be okay for the following reason:

1.) A grid with subgridded columns and *not* rows will create its own
rows that are independent from the root grid. As a result, it will
perform track sizing on those rows and will need the cache for the exact
same reason.
2.) The shared columns should not impose a restriction on the cache
since the only time it should be used is for the first pass of row
sizing.

However, we impose an additional restriction to limit the cache if there
are any orthogonal subgrids. This is mostly just as a simplification to
not have to worry about dealing with the writing mode flips.

This mostly resolves the issue on lobste.rs as we can now load the page,
but there are still some visual glitches when resizing the viewport quickly.
This is because there are some row subgrids on the page, although not as
many, in which we still experience some slowness. I plan to address this
in a follow-up patch as this will require some additional logic to
handle it.

The performance test that was added went from ~3 runs/s -&gt; 55k runs/s
on my M1 Ultra Studio.

Canonical link: <a href="https://commits.webkit.org/295826@main">https://commits.webkit.org/295826@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2c7b548980bd57a8b597ae2fbe4658972c863457

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/106122 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25871 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/16265 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/111319 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/56718 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/108161 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/26527 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34374 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80606 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/109126 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/20960 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95765 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60928 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/20533 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13868 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/56157 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/90326 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13903 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/114175 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33260 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24539 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89687 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33624 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91998 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89378 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22822 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34243 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/12059 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/28833 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/33185 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/38597 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32931 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/36281 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34529 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->