### PR TITLE
Update style script to catch variable initializations using `protectedFoo()` functions

### DIFF
--- a/Tools/Scripts/webkitpy/style/checkers/cpp.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp.py
@@ -3645,6 +3645,11 @@ def check_safer_cpp(clean_lines, line_number, error):
     if search(r'sqlite3_column_blob\(', line):
         error(line_number, 'safercpp/sqlite3_column_blob', 4, "Use sqliteColumnBlob() instead of sqlite3_column_blob().")
 
+    if search(r'= [a-zA-Z0-9_.(),\s\->]*protected[a-zA-Z0-9]+\(\)[;\)]', line):
+        error(line_number, 'safercpp/protected_getter_for_init', 4, "Use foo() instead of protectedFoo() for variable initialization.")
+
+    if search(r'= [a-zA-Z0-9_.(),\s\->]*checked[a-zA-Z0-9]+\(\)[;\)]', line):
+        error(line_number, 'safercpp/checked_getter_for_init', 4, "Use foo() instead of checkedFoo() for variable initialization.")
 
 def check_style(clean_lines, line_number, file_extension, class_state, file_state, enum_state, error):
     """Checks rules from the 'C++ style rules' section of cppguide.html.
@@ -4983,6 +4988,7 @@ class CppChecker(object):
         'runtime/wtf_move',
         'runtime/wtf_never_destroyed',
         'safercpp/atoi',
+        'safercpp/checked_getter_for_init',
         'safercpp/memchr',
         'safercpp/memcmp',
         'safercpp/memcpy',
@@ -4994,6 +5000,7 @@ class CppChecker(object):
         'safercpp/strcmp',
         'safercpp/strncmp',
         'safercpp/printf',
+        'safercpp/protected_getter_for_init',
         'safercpp/strchr',
         'safercpp/strstr',
         'safercpp/timer_exception',

--- a/Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py
@@ -6377,6 +6377,140 @@ class WebKitStyleTest(CppStyleTestBase):
             'Use xpcStringGetString() instead of xpc_string_get_string_ptr().  [safercpp/xpc_string_get_string_ptr] [4]',
             'foo.cpp')
 
+        self.assert_lint(
+            'auto foo = protectedFoo();',
+            'Use foo() instead of protectedFoo() for variable initialization.  [safercpp/protected_getter_for_init] [4]',
+            'foo.cpp')
+
+        self.assert_lint(
+            'auto foo = checkedFoo();',
+            'Use foo() instead of checkedFoo() for variable initialization.  [safercpp/checked_getter_for_init] [4]',
+            'foo.cpp')
+
+        self.assert_lint(
+            'Ref foo = protectedFoo();',
+            'Use foo() instead of protectedFoo() for variable initialization.  [safercpp/protected_getter_for_init] [4]',
+            'foo.cpp')
+
+        self.assert_lint(
+            'CheckedRef foo = checkedFoo();',
+            'Use foo() instead of checkedFoo() for variable initialization.  [safercpp/checked_getter_for_init] [4]',
+            'foo.cpp')
+
+        self.assert_lint(
+            'RefPtr foo = protectedFoo();',
+            'Use foo() instead of protectedFoo() for variable initialization.  [safercpp/protected_getter_for_init] [4]',
+            'foo.cpp')
+
+        self.assert_lint(
+            'CheckedPtr foo = checkedFoo();',
+            'Use foo() instead of checkedFoo() for variable initialization.  [safercpp/checked_getter_for_init] [4]',
+            'foo.cpp')
+
+        self.assert_lint(
+            'RefPtr bar = foo()->protectedBar();',
+            'Use foo() instead of protectedFoo() for variable initialization.  [safercpp/protected_getter_for_init] [4]',
+            'foo.cpp')
+
+        self.assert_lint(
+            'CheckedPtr bar = foo()->checkedBar();',
+            'Use foo() instead of checkedFoo() for variable initialization.  [safercpp/checked_getter_for_init] [4]',
+            'foo.cpp')
+
+        self.assert_lint(
+            'RefPtr bar = foo().protectedBar();',
+            'Use foo() instead of protectedFoo() for variable initialization.  [safercpp/protected_getter_for_init] [4]',
+            'foo.cpp')
+
+        self.assert_lint(
+            'CheckedPtr bar = foo().checkedBar();',
+            'Use foo() instead of checkedFoo() for variable initialization.  [safercpp/checked_getter_for_init] [4]',
+            'foo.cpp')
+
+        self.assert_lint(
+            'RefPtr bar = m_foo->protectedBar();',
+            'Use foo() instead of protectedFoo() for variable initialization.  [safercpp/protected_getter_for_init] [4]',
+            'foo.cpp')
+
+        self.assert_lint(
+            'CheckedPtr bar = m_foo->checkedBar();',
+            'Use foo() instead of checkedFoo() for variable initialization.  [safercpp/checked_getter_for_init] [4]',
+            'foo.cpp')
+
+        self.assert_lint(
+            'RefPtr bar = foo(1, 2)->protectedBar();',
+            'Use foo() instead of protectedFoo() for variable initialization.  [safercpp/protected_getter_for_init] [4]',
+            'foo.cpp')
+
+        self.assert_lint(
+            'CheckedPtr bar = foo(1, 2)->checkedBar();',
+            'Use foo() instead of checkedFoo() for variable initialization.  [safercpp/checked_getter_for_init] [4]',
+            'foo.cpp')
+
+        self.assert_lint(
+            'if (RefPtr bar = protectedBar())',
+            'Use foo() instead of protectedFoo() for variable initialization.  [safercpp/protected_getter_for_init] [4]',
+            'foo.cpp')
+
+        self.assert_lint(
+            'if (CheckedPtr bar = checkedBar())',
+            'Use foo() instead of checkedFoo() for variable initialization.  [safercpp/checked_getter_for_init] [4]',
+            'foo.cpp')
+
+        self.assert_lint(
+            'if (RefPtr bar = foo()->protectedBar())',
+            'Use foo() instead of protectedFoo() for variable initialization.  [safercpp/protected_getter_for_init] [4]',
+            'foo.cpp')
+
+        self.assert_lint(
+            'if (CheckedPtr bar = foo()->checkedBar())',
+            'Use foo() instead of checkedFoo() for variable initialization.  [safercpp/checked_getter_for_init] [4]',
+            'foo.cpp')
+
+        self.assert_lint(
+            'if (RefPtr bar = protectedBar()) {',
+            'Use foo() instead of protectedFoo() for variable initialization.  [safercpp/protected_getter_for_init] [4]',
+            'foo.cpp')
+
+        self.assert_lint(
+            'if (CheckedPtr bar = checkedBar()) {',
+            'Use foo() instead of checkedFoo() for variable initialization.  [safercpp/checked_getter_for_init] [4]',
+            'foo.cpp')
+
+        self.assert_lint(
+            'if (RefPtr bar = foo()->protectedBar()) {',
+            'Use foo() instead of protectedFoo() for variable initialization.  [safercpp/protected_getter_for_init] [4]',
+            'foo.cpp')
+
+        self.assert_lint(
+            'if (CheckedPtr bar = foo()->checkedBar()) {',
+            'Use foo() instead of checkedFoo() for variable initialization.  [safercpp/checked_getter_for_init] [4]',
+            'foo.cpp')
+
+        self.assert_lint(
+            'if (RefPtr bar = foo().protectedBar()) {',
+            'Use foo() instead of protectedFoo() for variable initialization.  [safercpp/protected_getter_for_init] [4]',
+            'foo.cpp')
+
+        self.assert_lint(
+            'if (CheckedPtr bar = foo().checkedBar()) {',
+            'Use foo() instead of checkedFoo() for variable initialization.  [safercpp/checked_getter_for_init] [4]',
+            'foo.cpp')
+
+        self.assert_lint('auto foo = protectedFoo()->bar();', '')
+        self.assert_lint('postTask([foo = protectedFoo()] {', '')
+        self.assert_lint('postTask([foo = protectedFoo(), bar] {', '')
+        self.assert_lint('postTask([foo = protectedFoo(), bar]() {', '')
+        self.assert_lint('postTask([foo = protectedFoo(), bar](ScriptExecutionContext& context) {', '')
+        self.assert_lint('postTask([foo = bar().protectedFoo(), bar](ScriptExecutionContext& context) {', '')
+
+        self.assert_lint('auto foo = checkedFoo()->bar();', '')
+        self.assert_lint('postTask([foo = checkedFoo()] {', '')
+        self.assert_lint('postTask([foo = checkedFoo(), bar] {', '')
+        self.assert_lint('postTask([foo = checkedFoo(), bar]() {', '')
+        self.assert_lint('postTask([foo = checkedFoo(), bar](ScriptExecutionContext& context) {', '')
+        self.assert_lint('postTask([foo = bar().checkedFoo(), bar](ScriptExecutionContext& context) {', '')
+
     def test_ctype_fucntion(self):
         self.assert_lint(
             'int i = isascii(8);',


### PR DESCRIPTION
#### a0f950c437560811912adf933ae1265dceed34d5
<pre>
Update style script to catch variable initializations using `protectedFoo()` functions
<a href="https://bugs.webkit.org/show_bug.cgi?id=293977">https://bugs.webkit.org/show_bug.cgi?id=293977</a>

Reviewed by Tim Nguyen.

Also cover initializations using `checkedFoo()` functions.

* Tools/Scripts/webkitpy/style/checkers/cpp.py:
(check_safer_cpp):
(CppChecker):
* Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py:
(WebKitStyleTest.test_safer_cpp):

Canonical link: <a href="https://commits.webkit.org/295768@main">https://commits.webkit.org/295768@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/23c99a368c1edbeb0056d83514ee3b3afea84cf8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/106105 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25854 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/16248 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/111302 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/56701 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/108144 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/26510 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34357 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/80593 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/56701 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/109109 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-WK2-Tests-EWS "Waiting to run tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/60915 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/105582 "Passed tests") | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13850 "Passed tests") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/56139 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/90306 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13885 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/114158 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33243 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/24527 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/89675 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33607 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91980 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89364 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22773 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34229 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/28816 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/33168 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32914 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/36264 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/34512 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->