### PR TITLE
Replace hard coded @"NSErrorFailingURLKey" in favor of the framework NSURLErrorFailingURLErrorKey symbol

### DIFF
--- a/Source/WebCore/platform/network/mac/ResourceErrorMac.mm
+++ b/Source/WebCore/platform/network/mac/ResourceErrorMac.mm
@@ -104,8 +104,8 @@ static RetainPtr<NSError> createNSErrorFromResourceErrorBase(const ResourceError
 
     if (!resourceError.failingURL().isEmpty()) {
         [userInfo setValue:resourceError.failingURL().string().createNSString().get() forKey:@"NSErrorFailingURLStringKey"];
-        if (RetainPtr cocoaURL = (NSURL *)resourceError.failingURL().createNSURL())
-            [userInfo setValue:cocoaURL.get() forKey:@"NSErrorFailingURLKey"];
+        if (RetainPtr cocoaURL = resourceError.failingURL().createNSURL())
+            [userInfo setValue:cocoaURL.get() forKey:NSURLErrorFailingURLErrorKey];
     }
 
     return adoptNS([[NSError alloc] initWithDomain:resourceError.domain().createNSString().get() code:resourceError.errorCode() userInfo:userInfo.get()]);
@@ -229,7 +229,7 @@ void ResourceError::platformLazyInit()
     RetainPtr userInfo = [m_platformError userInfo];
     if (auto *failingURLString = dynamic_objc_cast<NSString>([userInfo valueForKey:@"NSErrorFailingURLStringKey"]))
         m_failingURL = URL { failingURLString };
-    else if (auto *failingURL = dynamic_objc_cast<NSURL>([userInfo valueForKey:@"NSErrorFailingURLKey"]))
+    else if (auto *failingURL = dynamic_objc_cast<NSURL>([userInfo valueForKey:NSURLErrorFailingURLErrorKey]))
         m_failingURL = URL { failingURL };
     // Workaround for <rdar://problem/6554067>
     m_localizedDescription = m_failingURL.string();
@@ -316,7 +316,7 @@ String ResourceError::blockedTrackerHostName() const
 
 bool ResourceError::hasMatchingFailingURLKeys() const
 {
-    if (RetainPtr<id> nsErrorFailingURL = [nsError().userInfo objectForKey:@"NSErrorFailingURLKey"]) {
+    if (RetainPtr<id> nsErrorFailingURL = [nsError().userInfo objectForKey:NSURLErrorFailingURLErrorKey]) {
         RetainPtr failingURL = dynamic_objc_cast<NSURL>(nsErrorFailingURL.get());
         if (!failingURL)
             return false;

--- a/Source/WebKit/Shared/Cocoa/WebErrorsCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/WebErrorsCocoa.mm
@@ -38,7 +38,7 @@ using namespace WebCore;
 static RetainPtr<NSError> createNSError(NSString* domain, int code, NSURL *URL)
 {
     RetainPtr<NSDictionary> userInfo = [NSDictionary dictionaryWithObjectsAndKeys:
-        URL, @"NSErrorFailingURLKey",
+        URL, NSURLErrorFailingURLErrorKey,
         [URL absoluteString], @"NSErrorFailingURLStringKey",
         nil];
 

--- a/Source/WebKitLegacy/mac/Misc/WebKitErrors.m
+++ b/Source/WebKitLegacy/mac/Misc/WebKitErrors.m
@@ -73,8 +73,8 @@ static NSMutableDictionary *descriptions = nil;
     NSString *localizedDescription = [[descriptions objectForKey:domain] objectForKey:@(code)];
     ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     NSDictionary *userInfo = [NSDictionary dictionaryWithObjectsAndKeys:
-        URL, @"NSErrorFailingURLKey",
-        [URL absoluteString], NSURLErrorFailingURLStringErrorKey,
+        URL, NSURLErrorFailingURLErrorKey,
+        [URL absoluteString], @"NSErrorFailingURLStringKey",
         localizedDescription, NSLocalizedDescriptionKey,
         nil];
     ALLOW_DEPRECATED_DECLARATIONS_END
@@ -145,7 +145,7 @@ static NSMutableDictionary *descriptions = nil;
         [userInfo setObject:localizedDescription forKey:NSLocalizedDescriptionKey];
     ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     if (contentURL) {
-        [userInfo setObject:contentURL forKey:@"NSErrorFailingURLKey"];
+        [userInfo setObject:contentURL forKey:NSURLErrorFailingURLErrorKey];
         [userInfo setObject:[contentURL _web_userVisibleString] forKey:NSURLErrorFailingURLStringErrorKey];
     }
     ALLOW_DEPRECATED_DECLARATIONS_END

--- a/Tools/DumpRenderTree/mac/ResourceLoadDelegate.mm
+++ b/Tools/DumpRenderTree/mac/ResourceLoadDelegate.mm
@@ -60,7 +60,7 @@
     NSString *str = [NSString stringWithFormat:@"<NSError domain %@, code %ld", [self domain], static_cast<long>([self code])];
     NSURL *failingURL;
 
-    if ((failingURL = [[self userInfo] objectForKey:@"NSErrorFailingURLKey"]))
+    if ((failingURL = [[self userInfo] objectForKey:NSURLErrorFailingURLErrorKey]))
         str = [str stringByAppendingFormat:@", failing URL \"%@\"", [failingURL _drt_descriptionSuitableForTestResult]];
 
     str = [str stringByAppendingFormat:@">"];
@@ -271,7 +271,7 @@ BOOL canAuthenticateServerTrustAgainstProtectionSpace(NSString *host)
 -(void)webView: (WebView *)wv resource:identifier didFailLoadingWithError:(NSError *)error fromDataSource:(WebDataSource *)dataSource
 {
     if (!gUsingServerMode && done) {
-        NSURL *failingURL = [error.userInfo[@"NSErrorFailingURLKey"] _webkit_canonicalize_with_wtf];
+        NSURL *failingURL = [error.userInfo[NSURLErrorFailingURLErrorKey] _webkit_canonicalize_with_wtf];
         if ([self.mainResourceURL isEqual:failingURL]) {
             NSString *string = [NSString stringWithFormat:@"Failed to load %@\n%@", identifier, [error _drt_descriptionSuitableForTestResult]];
             printf("%s\n", string.UTF8String);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/LoadAlternateHTMLString.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/LoadAlternateHTMLString.mm
@@ -48,7 +48,7 @@ static int provisionalLoadCount;
 - (void)webView:(WKWebView *)webView didFailProvisionalNavigation:(WKNavigation *)navigation withError:(NSError *)error
 {
     if (error.code != NSURLErrorCancelled)
-        [webView _loadAlternateHTMLString:@"error page" baseURL:nil forUnreachableURL:error.userInfo[@"NSErrorFailingURLKey"]];
+        [webView _loadAlternateHTMLString:@"error page" baseURL:nil forUnreachableURL:error.userInfo[NSURLErrorFailingURLErrorKey]];
 }
 
 - (void)webView:(WKWebView *)webView didFinishNavigation:(WKNavigation *)navigation

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/LoadInvalidURLRequest.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/LoadInvalidURLRequest.mm
@@ -59,7 +59,7 @@ static NSURL *literalURL(const char* literal)
 {
     EXPECT_WK_STREQ(error.domain, @"WebKitErrorDomain");
     EXPECT_EQ(error.code, 101);
-    EXPECT_NULL(error.userInfo[@"NSErrorFailingURLKey"]);
+    EXPECT_NULL(error.userInfo[NSURLErrorFailingURLErrorKey]);
 
     didFailProvisionalLoad = true;
     didFinishTest = true;
@@ -113,7 +113,7 @@ TEST(WebKit, LoadInvalidURLRequestNonASCII)
     delegate.get().didFailProvisionalNavigation = ^(WKWebView *, WKNavigation *, NSError *error) {
         EXPECT_WK_STREQ(error.domain, @"WebKitErrorDomain");
         EXPECT_EQ(error.code, WebKitErrorCannotShowURL);
-        EXPECT_WK_STREQ([error.userInfo[@"NSErrorFailingURLKey"] absoluteString], "");
+        EXPECT_WK_STREQ([error.userInfo[NSURLErrorFailingURLErrorKey] absoluteString], "");
         done = true;
     };
     auto webView = adoptNS([WKWebView new]);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/Navigation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/Navigation.mm
@@ -2272,8 +2272,8 @@ TEST(WKNavigation, HTTPSOnlyWithSameSiteBypass)
 
     delegate.get().didFailProvisionalNavigation = ^(WKWebView *, WKNavigation *, NSError *error) {
         EXPECT_NOT_NULL(error);
-        EXPECT_NOT_NULL(error.userInfo[@"NSErrorFailingURLKey"]);
-        EXPECT_WK_STREQ(@"https://site.example/secure", ((NSURL *)error.userInfo[@"NSErrorFailingURLKey"]).absoluteString);
+        EXPECT_NOT_NULL(error.userInfo[NSURLErrorFailingURLErrorKey]);
+        EXPECT_WK_STREQ(@"https://site.example/secure", ((NSURL *)error.userInfo[NSURLErrorFailingURLErrorKey]).absoluteString);
         errorCode = error.code;
         didFailNavigation = true;
     };
@@ -2361,8 +2361,8 @@ TEST(WKNavigation, HTTPSOnlyWithSameSiteBypass)
     // Step 4: Attempt cross-site http load with HTTPS-bypass enabled
     delegate.get().didFailProvisionalNavigation = ^(WKWebView *, WKNavigation *, NSError *error) {
         EXPECT_NOT_NULL(error);
-        EXPECT_NOT_NULL(error.userInfo[@"NSErrorFailingURLKey"]);
-        EXPECT_WK_STREQ(@"https://site2.example/secure", ((NSURL *)error.userInfo[@"NSErrorFailingURLKey"]).absoluteString);
+        EXPECT_NOT_NULL(error.userInfo[NSURLErrorFailingURLErrorKey]);
+        EXPECT_WK_STREQ(@"https://site2.example/secure", ((NSURL *)error.userInfo[NSURLErrorFailingURLErrorKey]).absoluteString);
         errorCode = error.code;
         didFailNavigation = true;
     };
@@ -2448,8 +2448,8 @@ TEST(WKNavigation, HTTPSOnlyWithHTTPRedirect)
 
     delegate.get().didFailProvisionalNavigation = ^(WKWebView *, WKNavigation *, NSError *error) {
         EXPECT_NOT_NULL(error);
-        EXPECT_NOT_NULL(error.userInfo[@"NSErrorFailingURLKey"]);
-        EXPECT_WK_STREQ(@"https://site.example/secure", ((NSURL *)error.userInfo[@"NSErrorFailingURLKey"]).absoluteString);
+        EXPECT_NOT_NULL(error.userInfo[NSURLErrorFailingURLErrorKey]);
+        EXPECT_WK_STREQ(@"https://site.example/secure", ((NSURL *)error.userInfo[NSURLErrorFailingURLErrorKey]).absoluteString);
         errorCode = error.code;
         didFailNavigation = true;
     };
@@ -2474,8 +2474,8 @@ TEST(WKNavigation, HTTPSOnlyWithHTTPRedirect)
 
     delegate.get().didFailProvisionalNavigation = ^(WKWebView *, WKNavigation *, NSError *error) {
         EXPECT_NOT_NULL(error);
-        EXPECT_NOT_NULL(error.userInfo[@"NSErrorFailingURLKey"]);
-        EXPECT_WK_STREQ(@"https://site2.example/secure2", ((NSURL *)error.userInfo[@"NSErrorFailingURLKey"]).absoluteString);
+        EXPECT_NOT_NULL(error.userInfo[NSURLErrorFailingURLErrorKey]);
+        EXPECT_WK_STREQ(@"https://site2.example/secure2", ((NSURL *)error.userInfo[NSURLErrorFailingURLErrorKey]).absoluteString);
         errorCode = error.code;
         didFailNavigation = true;
     };
@@ -3467,8 +3467,8 @@ TEST(WKNavigation, PreferredHTTPSPolicyUserMediatedHTTPFallbackWithHTTPRedirect)
 
     delegate.get().didFailProvisionalNavigation = ^(WKWebView *, WKNavigation *, NSError *error) {
         EXPECT_NOT_NULL(error);
-        EXPECT_NOT_NULL(error.userInfo[@"NSErrorFailingURLKey"]);
-        EXPECT_WK_STREQ(@"https://site.example/secure", ((NSURL *)error.userInfo[@"NSErrorFailingURLKey"]).absoluteString);
+        EXPECT_NOT_NULL(error.userInfo[NSURLErrorFailingURLErrorKey]);
+        EXPECT_WK_STREQ(@"https://site.example/secure", ((NSURL *)error.userInfo[NSURLErrorFailingURLErrorKey]).absoluteString);
         errorCode = error.code;
         didFailNavigation = true;
     };
@@ -3493,8 +3493,8 @@ TEST(WKNavigation, PreferredHTTPSPolicyUserMediatedHTTPFallbackWithHTTPRedirect)
 
     delegate.get().didFailProvisionalNavigation = ^(WKWebView *, WKNavigation *, NSError *error) {
         EXPECT_NOT_NULL(error);
-        EXPECT_NOT_NULL(error.userInfo[@"NSErrorFailingURLKey"]);
-        EXPECT_WK_STREQ(@"https://site2.example/secure2", ((NSURL *)error.userInfo[@"NSErrorFailingURLKey"]).absoluteString);
+        EXPECT_NOT_NULL(error.userInfo[NSURLErrorFailingURLErrorKey]);
+        EXPECT_WK_STREQ(@"https://site2.example/secure2", ((NSURL *)error.userInfo[NSURLErrorFailingURLErrorKey]).absoluteString);
         errorCode = error.code;
         didFailNavigation = true;
     };

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/SafeBrowsing.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/SafeBrowsing.mm
@@ -35,6 +35,7 @@
 #import "TestResourceLoadDelegate.h"
 #import "TestWKWebView.h"
 #import "WKWebViewConfigurationExtras.h"
+#import <Foundation/NSURLError.h>
 #import <WebKit/WKNavigationDelegate.h>
 #import <WebKit/WKPreferencesPrivate.h>
 #import <WebKit/WKUIDelegatePrivate.h>
@@ -513,8 +514,10 @@ TEST(SafeBrowsing, WKWebViewGoBackIFrame)
     __block bool navigationFinished = false;
     delegate.get().didFailProvisionalLoadInSubframeWithError = ^(WKWebView *, WKFrameInfo *frame, NSError *error) {
         EXPECT_NOT_NULL(error);
-        auto failingURL = (NSString *)[error.userInfo valueForKey:@"NSErrorFailingURLStringKey"];
-        EXPECT_TRUE([failingURL hasSuffix:@"/simple.html"]);
+        auto failingURL = (NSURL *)[error.userInfo valueForKey:NSURLErrorFailingURLErrorKey];
+        EXPECT_TRUE([failingURL.lastPathComponent isEqualToString:@"simple.html"]);
+        auto failingURLString = (NSString *)[error.userInfo valueForKey:@"NSErrorFailingURLStringKey"];
+        EXPECT_TRUE([failingURLString hasSuffix:@"/simple.html"]);
         navigationFailed = true;
     };
     delegate.get().didFinishNavigation = ^(WKWebView *, WKNavigation *navigation) {
@@ -628,8 +631,10 @@ TEST(SafeBrowsing, PostResponseIframe)
     __block bool navigationFinished = false;
     delegate.get().didFailProvisionalLoadInSubframeWithError = ^(WKWebView *, WKFrameInfo *frame, NSError *error) {
         EXPECT_NOT_NULL(error);
-        auto failingURL = (NSString *)[error.userInfo valueForKey:@"NSErrorFailingURLStringKey"];
-        EXPECT_TRUE([failingURL hasSuffix:@"/simple.html"]);
+        auto failingURL = (NSURL *)[error.userInfo valueForKey:NSURLErrorFailingURLErrorKey];
+        EXPECT_TRUE([failingURL.lastPathComponent isEqualToString:@"simple.html"]);
+        auto failingURLString = (NSString *)[error.userInfo valueForKey:@"NSErrorFailingURLStringKey"];
+        EXPECT_TRUE([failingURLString hasSuffix:@"/simple.html"]);
         navigationFailed = true;
     };
     delegate.get().didFinishNavigation = ^(WKWebView *, WKNavigation *navigation) {

--- a/Tools/TestWebKitAPI/Tests/mac/LoadInvalidURLRequest.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/LoadInvalidURLRequest.mm
@@ -52,7 +52,7 @@ static bool didFailProvisionalLoad;
 
     static char literal[] = "https://www.example.com$/";
     NSURL *failedURL = WTF::URLWithData([NSData dataWithBytes:literal length:strlen(literal)], nil);
-    EXPECT_TRUE([error.userInfo[@"NSErrorFailingURLKey"] isEqual:failedURL]);
+    EXPECT_TRUE([error.userInfo[NSURLErrorFailingURLErrorKey] isEqual:failedURL]);
 
     didFailProvisionalLoad = true;
     didFinishTest = true;


### PR DESCRIPTION
#### 174717c86b5434d55ecabc5077aa191ef10b4a0d
<pre>
Replace hard coded @&quot;NSErrorFailingURLKey&quot; in favor of the framework NSURLErrorFailingURLErrorKey symbol
<a href="https://bugs.webkit.org/show_bug.cgi?id=293978">https://bugs.webkit.org/show_bug.cgi?id=293978</a>
<a href="https://rdar.apple.com/152520483">rdar://152520483</a>

Reviewed by Tim Nguyen.

This change replaces some hard-coded string literals with the official Foundation framework
symbols with the same values. There is no change in behavior.

* Source/WebCore/platform/network/mac/ResourceErrorMac.mm:
(WebCore::createNSErrorFromResourceErrorBase):
(WebCore::ResourceError::platformLazyInit):
(WebCore::ResourceError::hasMatchingFailingURLKeys const):
* Source/WebKit/Shared/Cocoa/WebErrorsCocoa.mm:
(WebKit::createNSError):
* Source/WebKitLegacy/mac/Misc/WebKitErrors.m:
(-[NSError _webkit_initWithDomain:code:URL:]):
(-[NSError _initWithPluginErrorCode:contentURL:pluginPageURL:pluginName:MIMEType:]):
* Tools/DumpRenderTree/mac/ResourceLoadDelegate.mm:
(-[NSError _drt_descriptionSuitableForTestResult]):
(-[ResourceLoadDelegate webView:resource:didFailLoadingWithError:fromDataSource:]):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/LoadAlternateHTMLString.mm:
(-[LoadAlternateHTMLStringFromProvisionalLoadErrorController webView:didFailProvisionalNavigation:withError:]):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/LoadInvalidURLRequest.mm:
(-[LoadInvalidURLNavigationActionDelegate webView:didFailProvisionalNavigation:withError:]):
(TestWebKitAPI::TEST(WebKit, LoadInvalidURLRequestNonASCII)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/Navigation.mm:
(TEST(WKNavigation, HTTPSOnlyWithSameSiteBypass)):
(TEST(WKNavigation, HTTPSOnlyWithHTTPRedirect)):
(TEST(WKNavigation, PreferredHTTPSPolicyUserMediatedHTTPFallbackWithHTTPRedirect)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SafeBrowsing.mm:
(TEST(SafeBrowsing, WKWebViewGoBackIFrame)):
(TEST(SafeBrowsing, PostResponseIframe)):
* Tools/TestWebKitAPI/Tests/mac/LoadInvalidURLRequest.mm:
(-[LoadInvalidURLWebFrameLoadDelegate webView:didFailProvisionalLoadWithError:forFrame:]):

Canonical link: <a href="https://commits.webkit.org/295919@main">https://commits.webkit.org/295919@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8c046e01b9c6a399b5751610024581a82c11adbc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/106276 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/26025 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/16421 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/111474 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/56872 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/108315 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/26688 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34528 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80730 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/109280 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/21117 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95904 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/61057 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/20639 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/14003 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/56312 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/90469 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/14038 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/114334 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33414 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24639 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89799 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33778 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/92133 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89500 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34376 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/12188 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/28998 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17265 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/33339 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/38751 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/33085 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/36438 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34683 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->