### PR TITLE
Sync `html/browsers/browsing-the-web/unloading-documents` from WPT upstream

### DIFF
--- a/LayoutTests/imported/w3c/resources/resource-files.json
+++ b/LayoutTests/imported/w3c/resources/resource-files.json
@@ -9333,8 +9333,6 @@
         "web-platform-tests/html/browsers/browsing-the-web/unloading-documents/unload/007-2.html",
         "web-platform-tests/html/browsers/browsing-the-web/unloading-documents/unload/008-1.html",
         "web-platform-tests/html/browsers/browsing-the-web/unloading-documents/unload/009-1.html",
-        "web-platform-tests/html/browsers/browsing-the-web/unloading-documents/unload/manual-001-1.html",
-        "web-platform-tests/html/browsers/browsing-the-web/unloading-documents/unload/manual-001.html",
         "web-platform-tests/html/browsers/browsing-the-web/unloading-documents/unload/pagehide-manual-1.html",
         "web-platform-tests/html/browsers/history/joint-session-history/joint-session-history-child1.html",
         "web-platform-tests/html/browsers/history/joint-session-history/joint-session-history-child2.html",

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/unloading-documents/001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/unloading-documents/001-expected.txt
@@ -1,6 +1,5 @@
 main frame - has 1 onunload handler(s)
 frame "<!--frame1-->" - has 1 onunload handler(s)
-CONSOLE MESSAGE: TypeError: do_test is not a function. (In 'do_test()', 'do_test' is undefined)
 
-FAIL document.open in unload assert_equals: expected "0123456789" but got "012389"
+PASS document.open in unload
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/unloading-documents/002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/unloading-documents/002-expected.txt
@@ -1,5 +1,5 @@
 main frame - has 1 onunload handler(s)
 frame "<!--frame1-->" - has 1 onunload handler(s)
 
-FAIL document.open in unload assert_equals: expected "0123456789Z" but got "016789Z"
+PASS document.open in unload
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/unloading-documents/beforeunload-canceling-1.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/unloading-documents/beforeunload-canceling-1.html
@@ -7,8 +7,12 @@
 <script>
 "use strict";
 
-window.runTest = (t, { valueToReturn, expectCancelation, setReturnValue, expectedReturnValue }) => {
+window.runTest = (t, { valueToReturn, expectCancelation, setReturnValue, expectedReturnValue, cancel }) => {
   window.onbeforeunload = t.step_func(e => {
+    if (cancel) {
+      e.preventDefault();
+    }
+
     if (setReturnValue !== undefined) {
       e.returnValue = setReturnValue;
     }

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/unloading-documents/beforeunload-canceling-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/unloading-documents/beforeunload-canceling-expected.txt
@@ -15,4 +15,10 @@ PASS Returning  with a real iframe unloading; setting returnValue to foo
 PASS Returning false with a real iframe unloading; setting returnValue to foo
 PASS Returning true with a real iframe unloading; setting returnValue to foo
 PASS Returning 0 with a real iframe unloading; setting returnValue to foo
+PASS Returning undefined with a real iframe unloading; setting returnValue to
+PASS Returning undefined with a real iframe unloading; calling preventDefault()
+PASS Returning undefined with a real iframe unloading; setting returnValue to foo; calling preventDefault()
+PASS Returning foo with a real iframe unloading; calling preventDefault()
+PASS Returning foo with a real iframe unloading; setting returnValue to foo; calling preventDefault()
+PASS Returning true with a real iframe unloading; setting returnValue to ; calling preventDefault()
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/unloading-documents/beforeunload-canceling.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/unloading-documents/beforeunload-canceling.html
@@ -154,6 +154,42 @@ const testCases = [
     expectCancelation: true,
     setReturnValue: "foo",
     expectedReturnValue: "foo"
+  },
+  {
+    setReturnValue: "",
+    expectedReturnValue: "",
+    expectCancelation: false,
+  },
+  {
+    expectCancelation: true,
+    expectedReturnValue: "",
+    cancel: true
+  },
+  {
+    setReturnValue: "foo",
+    expectCancelation: true,
+    expectedReturnValue: "foo",
+    cancel: true
+  },
+  {
+    valueToReturn: "foo",
+    expectedReturnValue: "foo",
+    expectCancelation: true,
+    cancel: true
+  },
+  {
+    valueToReturn: "foo",
+    setReturnValue: "foo",
+    expectedReturnValue: "foo",
+    expectCancelation: true,
+    cancel: true
+  },
+  {
+    valueToReturn: true,
+    setReturnValue: "",
+    expectedReturnValue: "true",
+    expectCancelation: true,
+    cancel: true
   }
 ];
 
@@ -163,6 +199,11 @@ function runNextTest() {
 
   const labelAboutReturnValue = testCase.setReturnValue === undefined ? "" :
     `; setting returnValue to ${testCase.setReturnValue}`;
+
+  const labelAboutCancel = testCase.cancel === undefined ? "" :
+    "; calling preventDefault()";
+
+  const suffixLabels = labelAboutReturnValue + labelAboutCancel;
 
   async_test(t => {
     const iframe = document.createElement("iframe");
@@ -174,7 +215,7 @@ function runNextTest() {
 
     iframe.src = "beforeunload-canceling-1.html";
     document.body.appendChild(iframe);
-  }, `Returning ${testCase.valueToReturn} with a real iframe unloading${labelAboutReturnValue}`);
+  }, `Returning ${testCase.valueToReturn} with a real iframe unloading${suffixLabels}`);
 }
 
 runNextTest();

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/unloading-documents/prompt/004-1.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/unloading-documents/prompt/004-1.html
@@ -23,6 +23,6 @@ onload = function() {
 }
 </script>
 // child frame with no onbeforeunload listener. Should leave the parent as unsalvageable.
-// Adding the iframe prevents potential implementation bugs where the the recursive steps of #prompt-to-unload-a-document
+// Adding the iframe prevents potential implementation bugs where the recursive steps of #prompt-to-unload-a-document
 // would overwrite the salvageable state of the parent.
 <iframe></iframe>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/unloading-documents/support/001-1.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/unloading-documents/support/001-1.html
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML>
 <script>
  t = opener.t;
- do_test = t.step(function () {
+ do_test = t.step_func(function () {
    localStorage.test6564729 += '4';
    var d = document;
    var e = document.open(); // has no effect (ignore-opens-during-unload > 0)

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/unloading-documents/support/002-1.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/unloading-documents/support/002-1.html
@@ -5,7 +5,11 @@
  var do_test = t.step_func(function() {
    localStorage.test6564729 += '1';
    var d = document;
-   var e = document.open(); // unload triggered here - beforeunload 2, 3 in 002b; pagehide 4, unload 5, pagehide 6 in 002b, unload 7 in 002b
+   // This document's unload not triggered here because `document.open` erases
+   // all of the document's handlers. However the iframe's event handlers (002b)
+   // will fire. The `beforeunload` event handler will not fire because this is
+   // not a navigation resulting from a user interaction.
+   var e = document.open();
    localStorage.test6564729 += (e == d) ? '8' : 'X';
    var s = 'FAIL if you see this | ' + localStorage.test6564729;
    document.write(s);

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/unloading-documents/support/002a.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/unloading-documents/support/002a.html
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML>
 <script>
  opener.t.step(function() {
-   opener.assert_equals(localStorage.test6564729, '0123456789Z');
+   opener.assert_equals(localStorage.test6564729, '016789Z');
    opener.t.done();
  });
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/unloading-documents/unload/unload-main-frame-cross-origin.window.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/unloading-documents/unload/unload-main-frame-cross-origin.window.js
@@ -3,8 +3,6 @@
 // META: script=/common/get-host-info.sub.js
 // META: script=/common/utils.js
 // META: script=/html/browsers/browsing-the-web/remote-context-helper/resources/remote-context-helper.js
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 
 promise_test(async t => {
   const rcHelper = new RemoteContextHelper();

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/unloading-documents/unload/unload-main-frame-same-origin.window.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/unloading-documents/unload/unload-main-frame-same-origin.window.js
@@ -3,8 +3,6 @@
 // META: script=/common/get-host-info.sub.js
 // META: script=/common/utils.js
 // META: script=/html/browsers/browsing-the-web/remote-context-helper/resources/remote-context-helper.js
-// META: script=/resources/testharness.js
-// META: script=/resources/testharnessreport.js
 
 promise_test(async t => {
   const rcHelper = new RemoteContextHelper();


### PR DESCRIPTION
#### 63484b31c08bb06dad35118c29e3a53782afec25
<pre>
Sync `html/browsers/browsing-the-web/unloading-documents` from WPT upstream
<a href="https://bugs.webkit.org/show_bug.cgi?id=293984">https://bugs.webkit.org/show_bug.cgi?id=293984</a>

Reviewed by Tim Nguyen.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/9dd67fb047650c4e394dc9d3bfbe78b98efbabef">https://github.com/web-platform-tests/wpt/commit/9dd67fb047650c4e394dc9d3bfbe78b98efbabef</a>

* LayoutTests/imported/w3c/resources/resource-files.json:
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/unloading-documents/001-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/unloading-documents/002-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/unloading-documents/beforeunload-canceling-1.html:
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/unloading-documents/beforeunload-canceling-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/unloading-documents/beforeunload-canceling.html:
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/unloading-documents/prompt/004-1.html:
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/unloading-documents/support/001-1.html:
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/unloading-documents/support/002-1.html:
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/unloading-documents/support/002a.html:
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/unloading-documents/unload/unload-main-frame-cross-origin.window.js:
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/unloading-documents/unload/unload-main-frame-same-origin.window.js:

Canonical link: <a href="https://commits.webkit.org/295797@main">https://commits.webkit.org/295797@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e22af520a4377ace3024c65a78d9e24b6053baad

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/106120 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25869 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/16263 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/111317 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/56716 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/26525 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34372 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80605 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/109124 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/20956 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95766 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60927 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/20529 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13869 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/56155 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/90322 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13904 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/114173 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33258 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24538 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89686 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33622 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91999 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89377 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22797 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34244 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/12060 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/28831 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/33183 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32929 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/36279 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34527 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->