### PR TITLE
[JSC] string.slice(-1) should be lowered to string.charAt(string.length - 1)

### DIFF
--- a/JSTests/stress/string-slice-negative-one.js
+++ b/JSTests/stress/string-slice-negative-one.js
@@ -1,0 +1,10 @@
+function test(string) {
+    return string.slice(-1);
+}
+noInline(test);
+
+for (var i = 0; i < testLoopCount; ++i) {
+    test('Hello', 'o');
+    test('', '');
+    test('こんにちは', 'は');
+}

--- a/Source/JavaScriptCore/dfg/DFGMayExit.cpp
+++ b/Source/JavaScriptCore/dfg/DFGMayExit.cpp
@@ -123,6 +123,7 @@ ExitMode mayExitImpl(Graph& graph, Node* node, StateType& state)
     case CompareBelow:
     case CompareBelowEq:
     case CompareEqPtr:
+    case StringCharAt:
         break;
 
     case Int52Rep:
@@ -277,6 +278,10 @@ ExitMode mayExitImpl(Graph& graph, Node* node, StateType& state)
             break;
         if (node->isBinaryUseKind(OtherUse) || node->isSymmetricBinaryUseKind(OtherUse, UntypedUse))
             break;
+        if (node->isBinaryUseKind(StringUse)) {
+            result = ExitsForExceptions;
+            break;
+        }
         [[fallthrough]];
     case CompareEq:
     case CompareLess:
@@ -350,7 +355,8 @@ ExitMode mayExitImpl(Graph& graph, Node* node, StateType& state)
         }
         break;
 
-    case MakeRope: {
+    case MakeRope:
+    case ResolveRope: {
         result = ExitsForExceptions;
         break;
     }

--- a/Source/JavaScriptCore/dfg/DFGOperations.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOperations.cpp
@@ -3464,14 +3464,12 @@ JSC_DEFINE_JIT_OPERATION(operationNewBoundFunction, JSBoundFunction*, (JSGlobalO
     OPERATION_RETURN(scope, JSBoundFunction::createRaw(vm, globalObject, function, boundArgsLength, boundThis, arg0, arg1, arg2));
 }
 
-JSC_DEFINE_JIT_OPERATION(operationSingleCharacterString, JSString*, (VM* vmPointer, int32_t character))
+JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationSingleCharacterString, JSString*, (VM* vmPointer, int32_t character))
 {
     VM& vm = *vmPointer;
     CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
     JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
-    auto scope = DECLARE_THROW_SCOPE(vm);
-    
-    OPERATION_RETURN(scope, jsSingleCharacterString(vm, static_cast<UChar>(character)));
+    return jsSingleCharacterString(vm, static_cast<UChar>(character));
 }
 
 JSC_DEFINE_JIT_OPERATION(operationNewSymbol, Symbol*, (VM* vmPointer))

--- a/Source/JavaScriptCore/dfg/DFGOperations.h
+++ b/Source/JavaScriptCore/dfg/DFGOperations.h
@@ -265,7 +265,7 @@ JSC_DECLARE_JIT_OPERATION(operationEnsureContiguous, Butterfly*, (VM*, JSCell*))
 JSC_DECLARE_JIT_OPERATION(operationEnsureArrayStorage, Butterfly*, (VM*, JSCell*));
 JSC_DECLARE_JIT_OPERATION(operationResolveRope, StringImpl*, (JSGlobalObject*, JSString*));
 JSC_DECLARE_JIT_OPERATION(operationResolveRopeString, JSString*, (JSGlobalObject*, JSRopeString*));
-JSC_DECLARE_JIT_OPERATION(operationSingleCharacterString, JSString*, (VM*, int32_t));
+JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationSingleCharacterString, JSString*, (VM*, int32_t));
 
 JSC_DECLARE_JIT_OPERATION(operationStringSubstr, JSCell*, (JSGlobalObject*, JSCell*, int32_t, int32_t));
 JSC_DECLARE_JIT_OPERATION(operationStringSlice, JSString*, (JSGlobalObject*, JSString*, int32_t));

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -1759,7 +1759,7 @@ void SpeculativeJIT::compileStringSlice(Node* node)
     addPtr(TrustedImmPtr(vm.smallStrings.singleCharacterStrings()), tempGPR);
     loadPtr(Address(tempGPR), tempGPR);
 
-    addSlowPathGenerator(slowPathCall(bigCharacter, this, operationSingleCharacterString, tempGPR, TrustedImmPtr(&vm), tempGPR));
+    addSlowPathGenerator(slowPathCall(bigCharacter, this, operationSingleCharacterString, NeedToSpill, ExceptionCheckRequirement::CheckNotNeeded, tempGPR, TrustedImmPtr(&vm), tempGPR));
 
     addSlowPathGenerator(slowPathCall(slowCases, this, operationStringSubstr, tempGPR, LinkableConstant::globalObject(*this, node), stringGPR, startIndexGPR, tempGPR));
 
@@ -2618,7 +2618,7 @@ void SpeculativeJIT::compileGetByValOnString(Node* node, const ScopedLambda<std:
 
     addSlowPathGenerator(
         slowPathCall(
-            bigCharacter, this, operationSingleCharacterString, scratchReg, TrustedImmPtr(&vm), scratchReg));
+            bigCharacter, this, operationSingleCharacterString, NeedToSpill, ExceptionCheckRequirement::CheckNotNeeded, scratchReg, TrustedImmPtr(&vm), scratchReg));
 
     if (node->op() != StringCharAt && node->op() != StringAt && node->arrayMode().isOutOfBounds()) {
         ASSERT(format == DataFormatJS);

--- a/Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp
@@ -1247,8 +1247,20 @@ private:
             }
 
             String string = stringNode->tryGetString(m_graph);
-            if (!string)
+            if (!string) {
+                if (m_node->op() == StringSlice && !m_node->child3() && startValue == -1) {
+                    m_changed = true;
+                    m_insertionSet.insertNode(m_nodeIndex, SpecNone, Check, m_node->origin, m_node->children.justChecks());
+                    stringNode = m_insertionSet.insertNode(m_nodeIndex, SpecNone, ResolveRope, m_node->origin, Edge(stringNode, KnownStringUse));
+                    Node* length = m_insertionSet.insertNode(m_nodeIndex, SpecNone, GetArrayLength, m_node->origin, OpInfo(ArrayMode(Array::String, Array::Read).asWord()), Edge(stringNode, KnownCellUse));
+                    Node* negativeOne = m_insertionSet.insertConstant(m_nodeIndex, m_node->origin, jsNumber(-1));
+                    Node* index = m_insertionSet.insertNode(m_nodeIndex, SpecNone, ArithAdd, m_node->origin, OpInfo(Arith::Unchecked), Edge(length, Int32Use), Edge(negativeOne, Int32Use));
+
+                    Node* result = m_insertionSet.insertNode(m_nodeIndex, SpecNone, StringCharAt, m_node->origin, OpInfo(ArrayMode(Array::String, Array::Read).asWord()), Edge(stringNode, KnownStringUse), Edge(index, Int32Use));
+                    m_node->convertToIdentityOn(result);
+                }
                 break;
+            }
 
             int32_t length = string.length();
             int32_t start = 0;


### PR DESCRIPTION
#### befba3750cd7048e78a6d816290dee55475c03d8
<pre>
[JSC] string.slice(-1) should be lowered to string.charAt(string.length - 1)
<a href="https://bugs.webkit.org/show_bug.cgi?id=293985">https://bugs.webkit.org/show_bug.cgi?id=293985</a>
<a href="https://rdar.apple.com/152530069">rdar://152530069</a>

Reviewed by NOBODY (OOPS!).

Add DFG lowering for string.slice(-1). This can be converted to
string.charAt(string.length - 1).

* JSTests/stress/string-slice-negative-one.js: Added.
(test):
* Source/JavaScriptCore/dfg/DFGMayExit.cpp:
* Source/JavaScriptCore/dfg/DFGOperations.cpp:
(JSC::DFG::JSC_DEFINE_NOEXCEPT_JIT_OPERATION):
* Source/JavaScriptCore/dfg/DFGOperations.h:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
(JSC::DFG::SpeculativeJIT::compileStringSlice):
(JSC::DFG::SpeculativeJIT::compileGetByValOnString):
* Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp:
(JSC::DFG::StrengthReductionPhase::handleNode):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/befba3750cd7048e78a6d816290dee55475c03d8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/106254 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/26003 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/16399 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/111452 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/56850 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/26666 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34506 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80712 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/109258 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/21095 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95883 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/61039 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/20626 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13982 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/56290 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/98893 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/90450 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/14017 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/114312 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/104871 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33392 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24623 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89787 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33756 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/92112 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89488 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34356 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/12167 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/28975 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/33317 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/38729 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/129183 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/33063 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/35202 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/36416 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34661 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->