### PR TITLE
[SwiftUI] SwiftBrowser target misconfigured in some WebKit.xcworkspace xcshemes

### DIFF
--- a/WebKit.xcworkspace/xcshareddata/xcschemes/All WebKit Tools.xcscheme
+++ b/WebKit.xcworkspace/xcshareddata/xcschemes/All WebKit Tools.xcscheme
@@ -56,8 +56,8 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "07A58BCC2D0400B300CAB4ED"
-               BuildableName = "SwiftBrowser"
+               BlueprintIdentifier = "07A58BD32D0400B300CAB4ED"
+               BuildableName = "SwiftBrowser.app"
                BlueprintName = "SwiftBrowser"
                ReferencedContainer = "container:Tools/SwiftBrowser/SwiftBrowser.xcodeproj">
             </BuildableReference>

--- a/WebKit.xcworkspace/xcshareddata/xcschemes/Everything up to WebKit + Tools.xcscheme
+++ b/WebKit.xcworkspace/xcshareddata/xcschemes/Everything up to WebKit + Tools.xcscheme
@@ -196,8 +196,8 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "07A58BCC2D0400B300CAB4ED"
-               BuildableName = "SwiftBrowser"
+               BlueprintIdentifier = "07A58BD32D0400B300CAB4ED"
+               BuildableName = "SwiftBrowser.app"
                BlueprintName = "SwiftBrowser"
                ReferencedContainer = "container:Tools/SwiftBrowser/SwiftBrowser.xcodeproj">
             </BuildableReference>


### PR DESCRIPTION
#### 776d905df641face821ec89cab3e7dd5594aa3ea
<pre>
[SwiftUI] SwiftBrowser target misconfigured in some WebKit.xcworkspace xcshemes
<a href="https://bugs.webkit.org/show_bug.cgi?id=293987">https://bugs.webkit.org/show_bug.cgi?id=293987</a>
<a href="https://rdar.apple.com/152531237">rdar://152531237</a>

Reviewed by NOBODY (OOPS!).

A couple of the WebKit.xcworkspace xcschemes were mis-identifying the
SwiftBrowser.app target. This patch fixes the issue by using the correct
identifier.

* WebKit.xcworkspace/xcshareddata/xcschemes/All WebKit Tools.xcscheme:
* WebKit.xcworkspace/xcshareddata/xcschemes/Everything up to WebKit + Tools.xcscheme:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/776d905df641face821ec89cab3e7dd5594aa3ea

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/106127 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25876 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/16270 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/111324 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/56723 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/108166 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/26532 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34379 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80610 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/109131 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/20965 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95770 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60932 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/20536 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13873 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/56162 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/90331 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13908 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/114180 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33265 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24544 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89690 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33629 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/92003 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89383 "Passed tests") | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22829 "Failed to checkout and rebase branch from PR 46283") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34248 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/12063 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/28838 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/33190 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32936 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/36286 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34534 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->