### PR TITLE
RenderSlider cannot have generated content.

### DIFF
--- a/LayoutTests/fast/css/input-before-pseudo-crash-expected.txt
+++ b/LayoutTests/fast/css/input-before-pseudo-crash-expected.txt
@@ -1,0 +1,2 @@
+
+Test passes if it does not crash.

--- a/LayoutTests/fast/css/input-before-pseudo-crash.html
+++ b/LayoutTests/fast/css/input-before-pseudo-crash.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script>
+if (window.testRunner)
+  testRunner.dumpAsText();
+</script>
+<style>
+.one::before {
+  float: left;
+  content: "B";
+}
+.two::before {
+  float: left;
+  content: "A";
+}
+</style>
+</head>
+<body>
+<input style="flex-direction: column;" class="one" type="range">
+</body>
+<script>
+for (let i = 0; i < 100; ++i) {
+  (i % 2) ? document.querySelector("input").classList = "one" : document.querySelector("input").classList = "two";
+  document.body.offsetHeight;
+}
+</script>
+<body>
+<p>Test passes if it does not crash.</p>
+</body>
+</html>

--- a/Source/WebCore/rendering/RenderSlider.h
+++ b/Source/WebCore/rendering/RenderSlider.h
@@ -39,6 +39,8 @@ public:
     HTMLInputElement& element() const;
     Ref<HTMLInputElement> protectedElement() const;
 
+    bool canHaveGeneratedChildren() const override { return false; }
+
     bool inDragMode() const;
 
     double valueRatio() const;


### PR DESCRIPTION
#### 3360d015ac9a20b8357f6a3bf100082cded0d325
<pre>
RenderSlider cannot have generated content.
<a href="https://bugs.webkit.org/show_bug.cgi?id=294047">https://bugs.webkit.org/show_bug.cgi?id=294047</a>
<a href="https://rdar.apple.com/144403747">rdar://144403747</a>

Reviewed by Alan Baradlay.

&lt;input type=&quot;range&quot;&gt; creates a RenderSlider which inherits from
RenderFlexibleBox. If you add some before/after floating pseudo content
and then mutate the content, this can result in a crash via a
RELEASE_ASSERT in WeakRef. This is because we fail to clean up some
caches in RenderFlexibleBox since that is an unexpected state for us to
be in.

Other renderers based on input elements, such as RenderTextControl,
override canHaveGeneratedChildren to indicate whether or not they
can have pseudo content. It seems like we do not typically allow
generated content on inputs with buttons being the sole exception. This
makes RenderSlider consistent with the other types of content/renderers.

Canonical link: <a href="https://commits.webkit.org/295904@main">https://commits.webkit.org/295904@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e8938516360bcedf0bdb0e2496520f3bcc22644e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/106408 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/26157 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/16555 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/111609 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/57004 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/108447 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/26824 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34660 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80822 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/109412 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/21273 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/96031 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/61150 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/20752 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/14130 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/56445 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/90604 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/14165 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/114471 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33546 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24737 "Found 1 new test failure: svg/zoom/page/text-with-non-scaling-stroke.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89894 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33910 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/92260 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89597 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22883 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34488 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/12310 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/29153 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/33471 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/38883 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/33217 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/36570 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34815 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->