### PR TITLE
StructureTransitionStructureStubClearingWatchpoint and AdaptiveValueStructureStubClearingWatchpoint should hold an owner PolymorphicAccessJITStub and check if their owner is destroyed

### DIFF
--- a/Source/JavaScriptCore/bytecode/StructureStubClearingWatchpoint.cpp
+++ b/Source/JavaScriptCore/bytecode/StructureStubClearingWatchpoint.cpp
@@ -59,6 +59,9 @@ void StructureStubInfoClearingWatchpoint::fireInternal(VM&, const FireDetail&)
 
 void StructureTransitionStructureStubClearingWatchpoint::fireInternal(VM& vm, const FireDetail&)
 {
+    if (m_owner->ownerIsDead())
+        return;
+
     if (!m_key || !m_key.isWatchable(PropertyCondition::EnsureWatchability)) {
         StringFireDetail detail("IC has been invalidated");
         Ref { m_watchpointSet }->fireAll(vm, detail);
@@ -76,6 +79,9 @@ void StructureTransitionStructureStubClearingWatchpoint::fireInternal(VM& vm, co
 
 void AdaptiveValueStructureStubClearingWatchpoint::handleFire(VM& vm, const FireDetail&)
 {
+    if (m_owner->ownerIsDead())
+        return;
+
     StringFireDetail detail("IC has been invalidated");
     Ref { m_watchpointSet }->fireAll(vm, detail);
 }

--- a/Source/JavaScriptCore/bytecode/StructureStubClearingWatchpoint.h
+++ b/Source/JavaScriptCore/bytecode/StructureStubClearingWatchpoint.h
@@ -65,8 +65,9 @@ class StructureTransitionStructureStubClearingWatchpoint final : public Watchpoi
     WTF_MAKE_NONCOPYABLE(StructureTransitionStructureStubClearingWatchpoint);
     WTF_MAKE_TZONE_ALLOCATED(StructureTransitionStructureStubClearingWatchpoint);
 public:
-    StructureTransitionStructureStubClearingWatchpoint(const ObjectPropertyCondition& key, WatchpointSet& watchpointSet)
+    StructureTransitionStructureStubClearingWatchpoint(PolymorphicAccessJITStubRoutine* owner, const ObjectPropertyCondition& key, WatchpointSet& watchpointSet)
         : Watchpoint(Watchpoint::Type::StructureTransitionStructureStubClearing)
+        , m_owner(owner)
         , m_watchpointSet(watchpointSet)
         , m_key(key)
     {
@@ -75,6 +76,7 @@ public:
     void fireInternal(VM&, const FireDetail&);
 
 private:
+    PolymorphicAccessJITStubRoutine* m_owner;
     Ref<WatchpointSet> m_watchpointSet;
     ObjectPropertyCondition m_key;
 };
@@ -87,8 +89,9 @@ class AdaptiveValueStructureStubClearingWatchpoint final : public AdaptiveInferr
     void handleFire(VM&, const FireDetail&) final;
 
 public:
-    AdaptiveValueStructureStubClearingWatchpoint(const ObjectPropertyCondition& key, WatchpointSet& watchpointSet)
+    AdaptiveValueStructureStubClearingWatchpoint(PolymorphicAccessJITStubRoutine* owner, const ObjectPropertyCondition& key, WatchpointSet& watchpointSet)
         : Base(key)
+        , m_owner(owner)
         , m_watchpointSet(watchpointSet)
     {
         RELEASE_ASSERT(key.condition().kind() == PropertyCondition::Equivalence);
@@ -96,6 +99,7 @@ public:
 
 
 private:
+    PolymorphicAccessJITStubRoutine* m_owner;
     Ref<WatchpointSet> m_watchpointSet;
 };
 

--- a/Source/JavaScriptCore/jit/GCAwareJITStubRoutine.cpp
+++ b/Source/JavaScriptCore/jit/GCAwareJITStubRoutine.cpp
@@ -39,15 +39,15 @@
 
 namespace JSC {
 
-GCAwareJITStubRoutine::GCAwareJITStubRoutine(Type type, const MacroAssemblerCodeRef<JITStubRoutinePtrTag>& code, JSCell* owner)
+GCAwareJITStubRoutine::GCAwareJITStubRoutine(Type type, const MacroAssemblerCodeRef<JITStubRoutinePtrTag>& code, JSCell* owner, bool isCodeImmutable)
     : JITStubRoutine(type, code)
     , m_owner(owner)
+    , m_isCodeImmutable(isCodeImmutable)
 {
 }
 
-void GCAwareJITStubRoutine::makeGCAware(VM& vm, bool isCodeImmutable)
+void GCAwareJITStubRoutine::makeGCAware(VM& vm)
 {
-    m_isCodeImmutable = isCodeImmutable;
     vm.heap.m_jitStubRoutines->add(this);
     m_isGCAware = true;
 }
@@ -108,8 +108,8 @@ bool GCAwareJITStubRoutine::removeDeadOwners(VM& vm)
 
 #if ENABLE(JIT)
 
-PolymorphicAccessJITStubRoutine::PolymorphicAccessJITStubRoutine(Type type, const MacroAssemblerCodeRef<JITStubRoutinePtrTag>& code, VM& vm, FixedVector<Ref<AccessCase>>&& cases, FixedVector<StructureID>&& weakStructures, JSCell* owner)
-    : GCAwareJITStubRoutine(type, code, owner)
+PolymorphicAccessJITStubRoutine::PolymorphicAccessJITStubRoutine(Type type, const MacroAssemblerCodeRef<JITStubRoutinePtrTag>& code, VM& vm, FixedVector<Ref<AccessCase>>&& cases, FixedVector<StructureID>&& weakStructures, JSCell* owner, bool isCodeImmutable)
+    : GCAwareJITStubRoutine(type, code, owner, isCodeImmutable)
     , m_vm(vm)
     , m_cases(WTFMove(cases))
     , m_weakStructures(WTFMove(weakStructures))
@@ -152,6 +152,12 @@ unsigned PolymorphicAccessJITStubRoutine::computeHash(std::span<const Ref<Access
     return hasher.hash();
 }
 
+void PolymorphicAccessJITStubRoutine::addGCAwareWatchpoint()
+{
+    if (!m_isGCAware)
+        makeGCAware(m_vm);
+}
+
 void PolymorphicAccessJITStubRoutine::addedToSharedJITStubSet()
 {
     m_isInSharedJITStubSet = true;
@@ -159,8 +165,8 @@ void PolymorphicAccessJITStubRoutine::addedToSharedJITStubSet()
 
 MarkingGCAwareJITStubRoutine::MarkingGCAwareJITStubRoutine(
     Type type, const MacroAssemblerCodeRef<JITStubRoutinePtrTag>& code, VM& vm, FixedVector<Ref<AccessCase>>&& cases, FixedVector<StructureID>&& weakStructures, JSCell* owner,
-    const Vector<JSCell*>& cells, Vector<std::unique_ptr<OptimizingCallLinkInfo>, 16>&& callLinkInfos)
-    : PolymorphicAccessJITStubRoutine(type, code, vm, WTFMove(cases), WTFMove(weakStructures), owner)
+    const Vector<JSCell*>& cells, Vector<std::unique_ptr<OptimizingCallLinkInfo>, 16>&& callLinkInfos, bool isCodeImmutable)
+    : PolymorphicAccessJITStubRoutine(type, code, vm, WTFMove(cases), WTFMove(weakStructures), owner, isCodeImmutable)
     , m_cells(cells.size())
     , m_callLinkInfos(WTFMove(callLinkInfos))
 {
@@ -201,8 +207,8 @@ CallLinkInfo* MarkingGCAwareJITStubRoutine::callLinkInfoAtImpl(const ConcurrentJ
 }
 
 GCAwareJITStubRoutineWithExceptionHandler::GCAwareJITStubRoutineWithExceptionHandler(const MacroAssemblerCodeRef<JITStubRoutinePtrTag>& code, VM& vm, FixedVector<Ref<AccessCase>>&& cases, FixedVector<StructureID>&& weakStructures, JSCell* owner, const Vector<JSCell*>& cells, Vector<std::unique_ptr<OptimizingCallLinkInfo>, 16>&& callLinkInfos,
-    CodeBlock* codeBlockForExceptionHandlers, DisposableCallSiteIndex exceptionHandlerCallSiteIndex)
-    : MarkingGCAwareJITStubRoutine(JITStubRoutine::Type::GCAwareJITStubRoutineWithExceptionHandlerType, code, vm, WTFMove(cases), WTFMove(weakStructures), owner, cells, WTFMove(callLinkInfos))
+    CodeBlock* codeBlockForExceptionHandlers, DisposableCallSiteIndex exceptionHandlerCallSiteIndex, bool isCodeImmutable)
+    : MarkingGCAwareJITStubRoutine(JITStubRoutine::Type::GCAwareJITStubRoutineWithExceptionHandlerType, code, vm, WTFMove(cases), WTFMove(weakStructures), owner, cells, WTFMove(callLinkInfos), isCodeImmutable)
     , m_codeBlockWithExceptionHandler(codeBlockForExceptionHandlers)
 #if ENABLE(DFG_JIT)
     , m_codeOriginPool(&m_codeBlockWithExceptionHandler->codeOrigins())
@@ -256,17 +262,17 @@ Ref<PolymorphicAccessJITStubRoutine> createICJITStubRoutine(
         for (auto& callLinkInfo : callLinkInfos)
             ASSERT(!callLinkInfo);
 #endif
-        auto stub = adoptRef(*new PolymorphicAccessJITStubRoutine(JITStubRoutine::Type::PolymorphicAccessJITStubRoutineType, code, vm, WTFMove(cases), WTFMove(weakStructures), owner));
         constexpr bool isCodeImmutable = false;
-        stub->makeGCAware(vm, isCodeImmutable);
+        auto stub = adoptRef(*new PolymorphicAccessJITStubRoutine(JITStubRoutine::Type::PolymorphicAccessJITStubRoutineType, code, vm, WTFMove(cases), WTFMove(weakStructures), owner, isCodeImmutable));
+        stub->makeGCAware(vm);
         return stub;
     }
     
     if (codeBlockForExceptionHandlers) {
         RELEASE_ASSERT(JSC::JITCode::isOptimizingJIT(codeBlockForExceptionHandlers->jitType()));
-        auto stub = adoptRef(*new GCAwareJITStubRoutineWithExceptionHandler(code, vm, WTFMove(cases), WTFMove(weakStructures), owner, cells, WTFMove(callLinkInfos), codeBlockForExceptionHandlers, exceptionHandlerCallSiteIndex));
         constexpr bool isCodeImmutable = false;
-        stub->makeGCAware(vm, isCodeImmutable);
+        auto stub = adoptRef(*new GCAwareJITStubRoutineWithExceptionHandler(code, vm, WTFMove(cases), WTFMove(weakStructures), owner, cells, WTFMove(callLinkInfos), codeBlockForExceptionHandlers, exceptionHandlerCallSiteIndex, isCodeImmutable));
+        stub->makeGCAware(vm);
         return stub;
     }
 
@@ -279,21 +285,22 @@ Ref<PolymorphicAccessJITStubRoutine> createICJITStubRoutine(
     }
 
     if (cells.isEmpty() && !hasCallLinkInfo) {
-        auto stub = adoptRef(*new PolymorphicAccessJITStubRoutine(JITStubRoutine::Type::PolymorphicAccessJITStubRoutineType, code, vm, WTFMove(cases), WTFMove(weakStructures), owner));
         constexpr bool isCodeImmutable = false;
-        stub->makeGCAware(vm, isCodeImmutable);
+        auto stub = adoptRef(*new PolymorphicAccessJITStubRoutine(JITStubRoutine::Type::PolymorphicAccessJITStubRoutineType, code, vm, WTFMove(cases), WTFMove(weakStructures), owner, isCodeImmutable));
+        stub->makeGCAware(vm);
         return stub;
     }
     
-    auto stub = adoptRef(*new MarkingGCAwareJITStubRoutine(JITStubRoutine::Type::MarkingGCAwareJITStubRoutineType, code, vm, WTFMove(cases), WTFMove(weakStructures), owner, cells, WTFMove(callLinkInfos)));
     constexpr bool isCodeImmutable = false;
-    stub->makeGCAware(vm, isCodeImmutable);
+    auto stub = adoptRef(*new MarkingGCAwareJITStubRoutine(JITStubRoutine::Type::MarkingGCAwareJITStubRoutineType, code, vm, WTFMove(cases), WTFMove(weakStructures), owner, cells, WTFMove(callLinkInfos), isCodeImmutable));
+    stub->makeGCAware(vm);
     return stub;
 }
 
-Ref<PolymorphicAccessJITStubRoutine> createPreCompiledICJITStubRoutine(const MacroAssemblerCodeRef<JITStubRoutinePtrTag>& code, VM& vm)
+Ref<PolymorphicAccessJITStubRoutine> createPreCompiledICJITStubRoutine(const MacroAssemblerCodeRef<JITStubRoutinePtrTag>& code, VM& vm, JSCell* owner)
 {
-    return adoptRef(*new PolymorphicAccessJITStubRoutine(JITStubRoutine::Type::PolymorphicAccessJITStubRoutineType, code, vm, { }, { }, nullptr));
+    auto stub = adoptRef(*new PolymorphicAccessJITStubRoutine(JITStubRoutine::Type::PolymorphicAccessJITStubRoutineType, code, vm, { }, { }, owner, true));
+    return stub;
 }
 
 #endif // ENABLE(JIT)

--- a/Source/JavaScriptCore/jit/GCAwareJITStubRoutine.h
+++ b/Source/JavaScriptCore/jit/GCAwareJITStubRoutine.h
@@ -58,19 +58,18 @@ class GCAwareJITStubRoutine : public JITStubRoutine {
 public:
     using Base = JITStubRoutine;
     friend class JITStubRoutine;
-    GCAwareJITStubRoutine(Type, const MacroAssemblerCodeRef<JITStubRoutinePtrTag>&, JSCell* owner);
+    GCAwareJITStubRoutine(Type, const MacroAssemblerCodeRef<JITStubRoutinePtrTag>&, JSCell* owner, bool isCodeImmutable);
 
-    static Ref<JITStubRoutine> create(VM& vm, const MacroAssemblerCodeRef<JITStubRoutinePtrTag>& code, JSCell* owner)
+    static Ref<JITStubRoutine> create(VM& vm, const MacroAssemblerCodeRef<JITStubRoutinePtrTag>& code, JSCell* owner, bool isCodeImmutable)
     {
-        auto stub = adoptRef(*new GCAwareJITStubRoutine(Type::GCAwareJITStubRoutineType, code, owner));
-        constexpr bool isCodeImmutable = false;
-        stub->makeGCAware(vm, isCodeImmutable);
+        auto stub = adoptRef(*new GCAwareJITStubRoutine(Type::GCAwareJITStubRoutineType, code, owner, isCodeImmutable));
+        stub->makeGCAware(vm);
         return stub;
     }
 
     void deleteFromGC();
 
-    void makeGCAware(VM&, bool isCodeImmutable);
+    void makeGCAware(VM&);
 
     JSCell* owner() const { return m_owner; }
 
@@ -100,7 +99,7 @@ public:
 
     using Watchpoints = Bag<Variant<StructureTransitionStructureStubClearingWatchpoint, AdaptiveValueStructureStubClearingWatchpoint>>;
 
-    PolymorphicAccessJITStubRoutine(Type, const MacroAssemblerCodeRef<JITStubRoutinePtrTag>&, VM&, FixedVector<Ref<AccessCase>>&&, FixedVector<StructureID>&&, JSCell* owner);
+    PolymorphicAccessJITStubRoutine(Type, const MacroAssemblerCodeRef<JITStubRoutinePtrTag>&, VM&, FixedVector<Ref<AccessCase>>&&, FixedVector<StructureID>&&, JSCell* owner, bool isCodeImmutable);
     ~PolymorphicAccessJITStubRoutine();
 
     const FixedVector<Ref<AccessCase>>& cases() const { return m_cases; }
@@ -115,6 +114,7 @@ public:
 
     static unsigned computeHash(std::span<const Ref<AccessCase>>);
 
+    void addGCAwareWatchpoint();
     void addedToSharedJITStubSet();
 
     Watchpoints& watchpoints() { return m_watchpoints; }
@@ -128,6 +128,11 @@ public:
         if (!m_watchpointSet->isStillValid())
             return false;
         return !m_ownerIsDead;
+    }
+
+    bool ownerIsDead() const
+    {
+        return m_ownerIsDead;
     }
 
     void addOwner(CodeBlock* codeBlock)
@@ -162,7 +167,7 @@ public:
     using Base = PolymorphicAccessJITStubRoutine;
     friend class JITStubRoutine;
 
-    MarkingGCAwareJITStubRoutine(Type, const MacroAssemblerCodeRef<JITStubRoutinePtrTag>&, VM&, FixedVector<Ref<AccessCase>>&&, FixedVector<StructureID>&&, JSCell* owner, const Vector<JSCell*>&, Vector<std::unique_ptr<OptimizingCallLinkInfo>, 16>&&);
+    MarkingGCAwareJITStubRoutine(Type, const MacroAssemblerCodeRef<JITStubRoutinePtrTag>&, VM&, FixedVector<Ref<AccessCase>>&&, FixedVector<StructureID>&&, JSCell* owner, const Vector<JSCell*>&, Vector<std::unique_ptr<OptimizingCallLinkInfo>, 16>&&, bool isCodeImmutable);
 
     bool visitWeakImpl(VM&);
     CallLinkInfo* callLinkInfoAtImpl(const ConcurrentJSLocker&, unsigned);
@@ -186,7 +191,7 @@ public:
     using Base = MarkingGCAwareJITStubRoutine;
     friend class JITStubRoutine;
 
-    GCAwareJITStubRoutineWithExceptionHandler(const MacroAssemblerCodeRef<JITStubRoutinePtrTag>&, VM&, FixedVector<Ref<AccessCase>>&&, FixedVector<StructureID>&&, JSCell* owner, const Vector<JSCell*>&, Vector<std::unique_ptr<OptimizingCallLinkInfo>, 16>&&, CodeBlock*, DisposableCallSiteIndex);
+    GCAwareJITStubRoutineWithExceptionHandler(const MacroAssemblerCodeRef<JITStubRoutinePtrTag>&, VM&, FixedVector<Ref<AccessCase>>&&, FixedVector<StructureID>&&, JSCell* owner, const Vector<JSCell*>&, Vector<std::unique_ptr<OptimizingCallLinkInfo>, 16>&&, CodeBlock*, DisposableCallSiteIndex, bool isCodeImmutable);
     ~GCAwareJITStubRoutineWithExceptionHandler();
 
 
@@ -233,7 +238,7 @@ Ref<PolymorphicAccessJITStubRoutine> createICJITStubRoutine(
     const Vector<JSCell*>&, Vector<std::unique_ptr<OptimizingCallLinkInfo>, 16>&& callLinkInfos,
     CodeBlock* codeBlockForExceptionHandlers, DisposableCallSiteIndex exceptionHandlingCallSiteIndex);
 
-Ref<PolymorphicAccessJITStubRoutine> createPreCompiledICJITStubRoutine(const MacroAssemblerCodeRef<JITStubRoutinePtrTag>&, VM&);
+Ref<PolymorphicAccessJITStubRoutine> createPreCompiledICJITStubRoutine(const MacroAssemblerCodeRef<JITStubRoutinePtrTag>&, VM&, JSCell*);
 
 #endif // ENABLE(JIT)
 

--- a/Source/JavaScriptCore/jit/PolymorphicCallStubRoutine.cpp
+++ b/Source/JavaScriptCore/jit/PolymorphicCallStubRoutine.cpp
@@ -71,7 +71,7 @@ void PolymorphicCallCase::dump(PrintStream& out) const
 }
 
 PolymorphicCallStubRoutine::PolymorphicCallStubRoutine(unsigned headerSize, unsigned trailingSize, const MacroAssemblerCodeRef<JITStubRoutinePtrTag>& code, VM& vm, JSCell* owner, CallFrame* callerFrame, CallLinkInfo& callLinkInfo, const Vector<CallSlot, 16>& callSlots, bool notUsingCounting, bool isClosureCall)
-    : GCAwareJITStubRoutine(Type::PolymorphicCallStubRoutineType, code, owner)
+    : GCAwareJITStubRoutine(Type::PolymorphicCallStubRoutineType, code, owner, /* isCodeImmutable */ true)
     , ButterflyArray<PolymorphicCallStubRoutine, PolymorphicCallNode, CallSlot>(headerSize, trailingSize)
     , m_callLinkInfo(&callLinkInfo)
     , m_notUsingCounting(notUsingCounting)
@@ -93,8 +93,7 @@ PolymorphicCallStubRoutine::PolymorphicCallStubRoutine(unsigned headerSize, unsi
     }
 
     WTF::storeStoreFence();
-    bool isCodeImmutable = true;
-    makeGCAware(vm, isCodeImmutable);
+    makeGCAware(vm);
 }
 
 bool PolymorphicCallStubRoutine::upgradeIfPossible(VM&, CodeBlock* oldCodeBlock, CodeBlock* newCodeBlock, uint8_t index)


### PR DESCRIPTION
#### a22ff5314d9fc55cb59733dcc1e3dfeef1b7a4d8
<pre>
StructureTransitionStructureStubClearingWatchpoint and AdaptiveValueStructureStubClearingWatchpoint should hold an owner PolymorphicAccessJITStub and check if their owner is destroyed
<a href="https://bugs.webkit.org/show_bug.cgi?id=288985">https://bugs.webkit.org/show_bug.cgi?id=288985</a>
<a href="https://rdar.apple.com/144722637">rdar://144722637</a>

Reviewed by Yusuke Suzuki.

StructureTransitionStructureStubClearingWatchpoint and AdaptiveValueStructureStubClearingWatchpoint keep a
JSObject within their ObjectPropertyCondition. However, during program execution, we could no longer have
a live PolymorphicAccessJITStub associated with the watchpoint. Since these watchpoints don&apos;t check if the
owner JITStub is live, they may still attempt to fire. This means that they could attempt to access a dead
object, which was cleaned up during a GC pass. This patch ensures that these watchpoints don&apos;t fire and do
nothing if their owner JITStub is no longer alive, meaning that they can no longer UAF their key&apos;s object.

Additionally, we modify the PolymorphicAccessJITStub to separate isCodeImmutable and isGCAware. These
properties are not related, but the old code set them together since we would only care about immutability
if we were a GC-aware JIT stub. However, we can set immutability at the beginning, allowing us to only set
isGCAware when we add a watchpoint that requires GC awareness. This is required since the two StubClearing
watchpoints hold references to objects, meaning they need to be GC aware. With these fixes, we are able to
ensure that watchpoints are invalidated or silenced when objects they refer to are dead.

* Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp:
(JSC::addWatchpoint):
(JSC::ensureReferenceAndInstallWatchpoint):
(JSC::ensureReferenceAndAddWatchpoint):
(JSC::InlineCacheCompiler::compile):
(JSC::InlineCacheCompiler::compileOneAccessCaseHandler):
* Source/JavaScriptCore/bytecode/StructureStubClearingWatchpoint.cpp:
(JSC::StructureTransitionStructureStubClearingWatchpoint::fireInternal):
(JSC::AdaptiveValueStructureStubClearingWatchpoint::handleFire):
* Source/JavaScriptCore/bytecode/StructureStubClearingWatchpoint.h:
* Source/JavaScriptCore/jit/GCAwareJITStubRoutine.cpp:
(JSC::GCAwareJITStubRoutine::GCAwareJITStubRoutine):
(JSC::GCAwareJITStubRoutine::makeGCAware):
(JSC::PolymorphicAccessJITStubRoutine::PolymorphicAccessJITStubRoutine):
(JSC::PolymorphicAccessJITStubRoutine::addGCAwareWatchpoint):
(JSC::MarkingGCAwareJITStubRoutine::MarkingGCAwareJITStubRoutine):
(JSC::GCAwareJITStubRoutineWithExceptionHandler::GCAwareJITStubRoutineWithExceptionHandler):
(JSC::createICJITStubRoutine):
(JSC::createPreCompiledICJITStubRoutine):
* Source/JavaScriptCore/jit/GCAwareJITStubRoutine.h:
(JSC::GCAwareJITStubRoutine::create):
(JSC::PolymorphicAccessJITStubRoutine::ownerIsDead const):
* Source/JavaScriptCore/jit/PolymorphicCallStubRoutine.cpp:
(JSC::PolymorphicCallStubRoutine::PolymorphicCallStubRoutine):

Originally-landed-as: 289651.245@safari-7621-branch (be9f31f7acec). <a href="https://rdar.apple.com/151707889">rdar://151707889</a>
Canonical link: <a href="https://commits.webkit.org/295824@main">https://commits.webkit.org/295824@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2e1eab587dcd8f5bf40d5aa338d970c658454190

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/106138 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25887 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/16281 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/111335 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/56734 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/26543 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34390 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80625 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/109142 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/20974 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95780 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60949 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/20544 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13884 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/56173 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/98777 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/90339 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13919 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/114193 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/104755 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33276 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24553 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89701 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33640 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/92014 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89397 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34260 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/12072 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/28849 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17218 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/33201 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/38613 "Found 1 new failure in bytecode/StructureStubClearingWatchpoint.h") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/129067 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32947 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/35181 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/36297 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34545 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->