### PR TITLE
[Site Isolation] Escape doesn't exit fullscreen with site isolated fullscreen content

### DIFF
--- a/LayoutTests/http/tests/site-isolation/fullscreen-escape-key-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/fullscreen-escape-key-expected.txt
@@ -1,0 +1,7 @@
+supportsFullScreen() == true
+enterFullScreenForElement()
+beganEnterFullScreen() - initialRect.size: {800, 600}, finalRect.size: {800, 600}
+exitFullScreenForElement()
+beganExitFullScreen() - initialRect.size: {800, 600}, finalRect.size: {800, 600}
+
+

--- a/LayoutTests/http/tests/site-isolation/fullscreen-escape-key.html
+++ b/LayoutTests/http/tests/site-isolation/fullscreen-escape-key.html
@@ -1,0 +1,21 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<script>
+    addEventListener("message", (event) => {                
+        if (event.data.startsWith("Entered") && window.testRunner) { eventSender.keyDown("escape"); }
+        if (event.data.startsWith("Exited") && window.testRunner) { testRunner.notifyDone(); }
+    });
+
+    testRunner.dumpFullScreenCallbacks();
+
+    function test() {
+        document.getElementById("frame").focus();
+        if (window.testRunner) {
+            testRunner.waitUntilDone();
+            testRunner.dumpAsText()
+        }
+    }
+
+</script>
+<iframe onload="test()" id="frame" allowfullscreen src="http://localhost:8000/site-isolation/resources/fullscreen-escape-key.html" frameborder=0></iframe>
+<div id=mylog>
+</div>

--- a/LayoutTests/http/tests/site-isolation/resources/fullscreen-escape-key.html
+++ b/LayoutTests/http/tests/site-isolation/resources/fullscreen-escape-key.html
@@ -1,0 +1,16 @@
+<script>
+    async function enterFullScreen() {
+        await document.documentElement.requestFullscreen();
+        if (window.testRunner) { await testRunner.updatePresentation() }
+    }
+
+    document.documentElement.addEventListener("fullscreenchange", () => { if (!document.fullscreenElement) { window.parent.postMessage("Exited",  "*"); }});
+
+    if (window.internals) {
+        internals.withUserGesture(async () => {
+            await enterFullScreen();
+            window.parent.postMessage("Entered", "*");
+        });
+    }
+</script>
+<button onclick="enterFullScreen()">Enter</button>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -7854,6 +7854,8 @@ webkit.org/b/291456 fast/forms/state-restore-per-form.html [ Pass Timeout ]
 
 webkit.org/b/291459 imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-image/shape-image-018.html [ Pass Failure ]
 
+http/tests/site-isolation/fullscreen-escape-key.html [ Skip ]
+
 # webkit.org/b/268568 [iOS] Assertion failure causing fast/forms/ios/file-upload-panel-capture.html to consistently crash. (268568) -[DOCWeakProxy forwardingTargetForSelector:]
 fast/forms/ios/file-upload-panel-accept.html [ Pass Crash ]
 fast/forms/ios/file-upload-panel-capture.html [ Pass Crash ]

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1950,7 +1950,8 @@ editing/input/scroll-viewport-page-up-down.html [ Pass Failure ]
 
 # webkit.org/b/282046 REGRESSION(285592@main): [ macOS iOS wk2 ] http/tests/site-isolation/load-event.html are near constant failures.
 http/tests/site-isolation/load-event.html [ Pass Failure ]
-http/tests/site-isolation/fullscreen.html [ Pass Failure ]
+webkit.org/b/289347 http/tests/site-isolation/fullscreen.html [ Pass Failure ]
+webkit.org/b/289347 http/tests/site-isolation/fullscreen-escape-key.html [ Pass Failure ]
 
 # webkit.org/b/282051 REGRESSION(285577@main): [ macOS iOS wk2 ] imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/back-204-205-download.html is a constant timeout
 # webkit.org/b/286584 REGRESSION (286180@main): [ macOS wk2 debug ] imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/back-204-205-download.html is a flaky failure


### PR DESCRIPTION
#### c9c6fd9ba28a57dc52e30138802cf87fd282f3ce
<pre>
[Site Isolation] Escape doesn&apos;t exit fullscreen with site isolated fullscreen content
<a href="https://bugs.webkit.org/show_bug.cgi?id=293989">https://bugs.webkit.org/show_bug.cgi?id=293989</a>
<a href="https://rdar.apple.com/150307508">rdar://150307508</a>

Reviewed by Tim Nguyen.

Hitting escape routes the key event to the correct process and eventually calls down into
DocumentFullscreen::fullyExitFullscreen, which currently doesn&apos;t work for subframe processes,
as mainFrameDocument() will return null. Instead use the root frame&apos;s document for this case.

* LayoutTests/http/tests/site-isolation/fullscreen-escape-key-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/fullscreen-escape-key.html: Added.
* LayoutTests/http/tests/site-isolation/resources/fullscreen-escape-key.html: Added.
* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/mac-wk2/TestExpectations:
* Source/WebCore/dom/DocumentFullscreen.cpp:
(WebCore::DocumentFullscreen::fullyExitFullscreen):

Canonical link: <a href="https://commits.webkit.org/296004@main">https://commits.webkit.org/296004@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/434b0c0e6c8451d109dc0425339f1e22896ed442

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/106655 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/26406 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/16803 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/111864 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/57253 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/108694 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/27076 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34908 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80990 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/109659 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/21474 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/96234 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/61326 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/20927 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/14341 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/56707 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/90814 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/14370 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/114739 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33793 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24916 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/90055 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/34157 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/92465 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89763 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34681 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/29420 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17303 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/33718 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/39131 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/33464 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/36817 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/35063 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->