### PR TITLE
MediaRecorder's MediaRecorderPrivateWriterWebM can still be instantiated in the GPUP process from CoreIPC

### DIFF
--- a/Source/WebCore/platform/MediaStrategy.cpp
+++ b/Source/WebCore/platform/MediaStrategy.cpp
@@ -80,7 +80,7 @@ void MediaStrategy::addMockMediaSourceEngine()
 #endif
 
 #if PLATFORM(COCOA) && ENABLE(MEDIA_RECORDER)
-std::unique_ptr<MediaRecorderPrivateWriter> MediaStrategy::createMediaRecorderPrivateWriter(const String&, MediaRecorderPrivateWriterListener&) const
+std::unique_ptr<MediaRecorderPrivateWriter> MediaStrategy::createMediaRecorderPrivateWriter(MediaRecorderContainerType, MediaRecorderPrivateWriterListener&) const
 {
     return nullptr;
 }

--- a/Source/WebCore/platform/MediaStrategy.h
+++ b/Source/WebCore/platform/MediaStrategy.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#if PLATFORM(COCOA) && ENABLE(MEDIA_RECORDER)
+#include "MediaRecorderPrivateWriter.h"
+#endif
 #include "NativeImage.h"
 #include "NowPlayingManager.h"
 #include <wtf/CompletionHandler.h>
@@ -35,8 +38,6 @@ namespace WebCore {
 class AudioDestination;
 class AudioIOCallback;
 class CDMFactory;
-class MediaRecorderPrivateWriter;
-class MediaRecorderPrivateWriterListener;
 class NowPlayingManager;
 class VideoFrame;
 
@@ -56,7 +57,7 @@ public:
     static void addMockMediaSourceEngine();
 #endif
 #if PLATFORM(COCOA) && ENABLE(MEDIA_RECORDER)
-    virtual std::unique_ptr<MediaRecorderPrivateWriter> createMediaRecorderPrivateWriter(const String&, MediaRecorderPrivateWriterListener&) const;
+    virtual std::unique_ptr<MediaRecorderPrivateWriter> createMediaRecorderPrivateWriter(MediaRecorderContainerType, MediaRecorderPrivateWriterListener&) const;
 #endif
 
 #if ENABLE(VIDEO)

--- a/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateWriter.h
+++ b/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateWriter.h
@@ -49,10 +49,16 @@ public:
     virtual ~MediaRecorderPrivateWriterListener() = default;
 };
 
+enum class MediaRecorderContainerType : uint8_t {
+    Mp4,
+    WebM
+};
+
 class MediaRecorderPrivateWriter {
     WTF_MAKE_TZONE_ALLOCATED(MediaRecorderPrivateWriter);
 public:
     WEBCORE_EXPORT static std::unique_ptr<MediaRecorderPrivateWriter> create(String type, MediaRecorderPrivateWriterListener&);
+    WEBCORE_EXPORT static std::unique_ptr<MediaRecorderPrivateWriter> create(MediaRecorderContainerType, MediaRecorderPrivateWriterListener&);
 
     WEBCORE_EXPORT MediaRecorderPrivateWriter();
     WEBCORE_EXPORT virtual ~MediaRecorderPrivateWriter();

--- a/Source/WebKit/GPUProcess/media/RemoteMediaRecorderPrivateWriterManager.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaRecorderPrivateWriterManager.cpp
@@ -51,7 +51,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteMediaRecorderPrivateWriterManager);
 class RemoteMediaRecorderPrivateWriterProxy : public WebCore::MediaRecorderPrivateWriterListener {
     WTF_MAKE_TZONE_ALLOCATED(RemoteMediaRecorderPrivateWriterProxy);
 public:
-    static Ref<RemoteMediaRecorderPrivateWriterProxy> create(const String& mimeType) { return adoptRef(*new RemoteMediaRecorderPrivateWriterProxy(mimeType)); }
+    static Ref<RemoteMediaRecorderPrivateWriterProxy> create() { return adoptRef(*new RemoteMediaRecorderPrivateWriterProxy()); }
 
     std::optional<uint8_t> addAudioTrack(const AudioInfo& description)
     {
@@ -85,8 +85,8 @@ public:
     }
 
 private:
-    RemoteMediaRecorderPrivateWriterProxy(const String& mimeType)
-        : m_writer(makeUniqueRefFromNonNullUniquePtr(MediaRecorderPrivateWriter::create(mimeType, *this)))
+    RemoteMediaRecorderPrivateWriterProxy()
+        : m_writer(makeUniqueRefFromNonNullUniquePtr(MediaRecorderPrivateWriter::create(MediaRecorderContainerType::Mp4, *this)))
     {
     }
 
@@ -120,11 +120,11 @@ void RemoteMediaRecorderPrivateWriterManager::deref() const
     m_gpuConnectionToWebProcess.get()->deref();
 }
 
-void RemoteMediaRecorderPrivateWriterManager::create(RemoteMediaRecorderPrivateWriterIdentifier identifier, const String& mimeType)
+void RemoteMediaRecorderPrivateWriterManager::create(RemoteMediaRecorderPrivateWriterIdentifier identifier)
 {
     MESSAGE_CHECK(!m_remoteMediaRecorderPrivateWriters.contains(identifier));
 
-    m_remoteMediaRecorderPrivateWriters.add(identifier, Writer { RemoteMediaRecorderPrivateWriterProxy::create(mimeType) });
+    m_remoteMediaRecorderPrivateWriters.add(identifier, Writer { RemoteMediaRecorderPrivateWriterProxy::create() });
 }
 
 void RemoteMediaRecorderPrivateWriterManager::addAudioTrack(RemoteMediaRecorderPrivateWriterIdentifier identifier, RemoteAudioInfo info, CompletionHandler<void(std::optional<uint8_t>)>&& completionHandler)

--- a/Source/WebKit/GPUProcess/media/RemoteMediaRecorderPrivateWriterManager.h
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaRecorderPrivateWriterManager.h
@@ -75,7 +75,7 @@ public:
     bool allowsExitUnderMemoryPressure() { return m_remoteMediaRecorderPrivateWriters.isEmpty(); }
 
     // Messages.
-    void create(RemoteMediaRecorderPrivateWriterIdentifier, const String&);
+    void create(RemoteMediaRecorderPrivateWriterIdentifier);
     void addMediaRecorderPrivateWriter(RemoteMediaRecorderPrivateWriterIdentifier);
     void addAudioTrack(RemoteMediaRecorderPrivateWriterIdentifier, RemoteAudioInfo, CompletionHandler<void(std::optional<uint8_t>)>&&);
     void addVideoTrack(RemoteMediaRecorderPrivateWriterIdentifier, RemoteVideoInfo, std::optional<CGAffineTransform>, CompletionHandler<void(std::optional<uint8_t>)>&&);

--- a/Source/WebKit/GPUProcess/media/RemoteMediaRecorderPrivateWriterManager.messages.in
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaRecorderPrivateWriterManager.messages.in
@@ -25,7 +25,7 @@
 
 [EnabledBy=MediaRecorderEnabled]
 messages -> RemoteMediaRecorderPrivateWriterManager {
-    Create(WebKit::RemoteMediaRecorderPrivateWriterIdentifier identifier, String type)
+    Create(WebKit::RemoteMediaRecorderPrivateWriterIdentifier identifier)
     AddAudioTrack(WebKit::RemoteMediaRecorderPrivateWriterIdentifier identifier, struct WebKit::RemoteAudioInfo trackInfo) -> (std::optional<uint8_t> trackNumber) Synchronous
     AddVideoTrack(WebKit::RemoteMediaRecorderPrivateWriterIdentifier identifier, struct WebKit::RemoteVideoInfo trackInfo, std::optional<CGAffineTransform> transform) -> (std::optional<uint8_t> trackNumber) Synchronous
     AllTracksAdded(WebKit::RemoteMediaRecorderPrivateWriterIdentifier identifier) -> (bool success) Synchronous

--- a/Source/WebKit/WebProcess/GPU/media/RemoteMediaRecorderPrivateWriter.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteMediaRecorderPrivateWriter.cpp
@@ -49,18 +49,18 @@ namespace WebKit {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteMediaRecorderPrivateWriter);
 
-std::unique_ptr<WebCore::MediaRecorderPrivateWriter> RemoteMediaRecorderPrivateWriter::create(GPUProcessConnection& gpuProcessConnection, const String& type, MediaRecorderPrivateWriterListener& listener)
+std::unique_ptr<WebCore::MediaRecorderPrivateWriter> RemoteMediaRecorderPrivateWriter::create(GPUProcessConnection& gpuProcessConnection, MediaRecorderPrivateWriterListener& listener)
 {
-    return std::unique_ptr<MediaRecorderPrivateWriter> { new RemoteMediaRecorderPrivateWriter(gpuProcessConnection, type, listener) };
+    return std::unique_ptr<MediaRecorderPrivateWriter> { new RemoteMediaRecorderPrivateWriter(gpuProcessConnection, listener) };
 }
 
-RemoteMediaRecorderPrivateWriter::RemoteMediaRecorderPrivateWriter(GPUProcessConnection& gpuProcessConnection, const String& type, MediaRecorderPrivateWriterListener& listener)
+RemoteMediaRecorderPrivateWriter::RemoteMediaRecorderPrivateWriter(GPUProcessConnection& gpuProcessConnection, MediaRecorderPrivateWriterListener& listener)
     : m_gpuProcessConnection(gpuProcessConnection)
     , m_listener(listener)
     , m_remoteMediaRecorderPrivateWriterIdentifier(RemoteMediaRecorderPrivateWriterIdentifier::generate())
 {
     if (RefPtr gpuProcessConnection = m_gpuProcessConnection.get())
-        gpuProcessConnection->protectedConnection()->send(Messages::RemoteMediaRecorderPrivateWriterManager::Create(m_remoteMediaRecorderPrivateWriterIdentifier, type), 0);
+        gpuProcessConnection->protectedConnection()->send(Messages::RemoteMediaRecorderPrivateWriterManager::Create(m_remoteMediaRecorderPrivateWriterIdentifier), 0);
 }
 
 std::optional<uint8_t> RemoteMediaRecorderPrivateWriter::addAudioTrack(const AudioInfo& info)

--- a/Source/WebKit/WebProcess/GPU/media/RemoteMediaRecorderPrivateWriter.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteMediaRecorderPrivateWriter.h
@@ -43,10 +43,10 @@ class GPUProcessConnection;
 class RemoteMediaRecorderPrivateWriter final : public WebCore::MediaRecorderPrivateWriter {
     WTF_MAKE_TZONE_ALLOCATED(RemoteMediaRecorderPrivateWriter);
 public:
-    static std::unique_ptr<MediaRecorderPrivateWriter> create(GPUProcessConnection&, const String& type, WebCore::MediaRecorderPrivateWriterListener&);
+    static std::unique_ptr<MediaRecorderPrivateWriter> create(GPUProcessConnection&, WebCore::MediaRecorderPrivateWriterListener&);
 
 private:
-    RemoteMediaRecorderPrivateWriter(GPUProcessConnection&, const String& type, WebCore::MediaRecorderPrivateWriterListener&);
+    RemoteMediaRecorderPrivateWriter(GPUProcessConnection&, WebCore::MediaRecorderPrivateWriterListener&);
     std::optional<uint8_t> addAudioTrack(const WebCore::AudioInfo&) final;
     std::optional<uint8_t> addVideoTrack(const WebCore::VideoInfo&, const std::optional<CGAffineTransform>&) final;
     bool allTracksAdded() final;

--- a/Source/WebKit/WebProcess/GPU/media/WebMediaStrategy.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/WebMediaStrategy.cpp
@@ -123,12 +123,16 @@ void WebMediaStrategy::enableMockMediaSource()
 #endif
 
 #if PLATFORM(COCOA) && ENABLE(MEDIA_RECORDER)
-std::unique_ptr<MediaRecorderPrivateWriter> WebMediaStrategy::createMediaRecorderPrivateWriter(const String& type, WebCore::MediaRecorderPrivateWriterListener& listener) const
+std::unique_ptr<MediaRecorderPrivateWriter> WebMediaStrategy::createMediaRecorderPrivateWriter(MediaRecorderContainerType type, WebCore::MediaRecorderPrivateWriterListener& listener) const
 {
     ASSERT(isMainRunLoop());
 #if ENABLE(GPU_PROCESS)
-    if (m_useGPUProcess && (equalLettersIgnoringASCIICase(type, "video/mp4"_s) || equalLettersIgnoringASCIICase(type, "audio/mp4"_s)))
-        return RemoteMediaRecorderPrivateWriter::create(WebProcess::singleton().ensureProtectedGPUProcessConnection(), type, listener);
+    if (type != MediaRecorderContainerType::Mp4)
+        return nullptr;
+    if (m_useGPUProcess) {
+        Ref connection = WebProcess::singleton().ensureGPUProcessConnection();
+        return RemoteMediaRecorderPrivateWriter::create(connection, listener);
+    }
 #else
     UNUSED_PARAM(type);
     UNUSED_PARAM(listener);

--- a/Source/WebKit/WebProcess/GPU/media/WebMediaStrategy.h
+++ b/Source/WebKit/WebProcess/GPU/media/WebMediaStrategy.h
@@ -50,7 +50,7 @@ private:
     void enableMockMediaSource() final;
 #endif
 #if PLATFORM(COCOA) && ENABLE(MEDIA_RECORDER)
-    std::unique_ptr<WebCore::MediaRecorderPrivateWriter> createMediaRecorderPrivateWriter(const String&, WebCore::MediaRecorderPrivateWriterListener&) const final;
+    std::unique_ptr<WebCore::MediaRecorderPrivateWriter> createMediaRecorderPrivateWriter(WebCore::MediaRecorderContainerType, WebCore::MediaRecorderPrivateWriterListener&) const final;
 #endif
 #if PLATFORM(COCOA) && ENABLE(VIDEO)
     void nativeImageFromVideoFrame(const WebCore::VideoFrame&, CompletionHandler<void(std::optional<RefPtr<WebCore::NativeImage>>&&)>&&) final;


### PR DESCRIPTION
#### 9cc8bff81bf14bd60dc2d4ebee4b15f7fe074507
<pre>
MediaRecorder&apos;s MediaRecorderPrivateWriterWebM can still be instantiated in the GPUP process from CoreIPC
<a href="https://rdar.apple.com/147740597">rdar://147740597</a>

Reviewed by Youenn Fablet.

We remove the content type argument that allowed to control which container
would be used in the GPU process.
Instead we always assume it will be MP4.

We also stop using strings to define the content type, and instead use
an enum.

No change in users observable behaviour. Covered by existing tests.

* Source/WebCore/platform/MediaStrategy.cpp:
(WebCore::MediaStrategy::createMediaRecorderPrivateWriter const):
* Source/WebCore/platform/MediaStrategy.h:
* Source/WebCore/platform/mediarecorder/MediaRecorderPrivateWriter.cpp:
(WebCore::MediaRecorderPrivateWriter::create):
* Source/WebCore/platform/mediarecorder/MediaRecorderPrivateWriter.h:
* Source/WebKit/GPUProcess/media/RemoteMediaRecorderPrivateWriterManager.cpp:
(WebKit::RemoteMediaRecorderPrivateWriterProxy::create):
(WebKit::RemoteMediaRecorderPrivateWriterProxy::RemoteMediaRecorderPrivateWriterProxy):
(WebKit::RemoteMediaRecorderPrivateWriterManager::create):
* Source/WebKit/GPUProcess/media/RemoteMediaRecorderPrivateWriterManager.h:
* Source/WebKit/GPUProcess/media/RemoteMediaRecorderPrivateWriterManager.messages.in:
* Source/WebKit/WebProcess/GPU/media/RemoteMediaRecorderPrivateWriter.cpp:
(WebKit::RemoteMediaRecorderPrivateWriter::create):
(WebKit::RemoteMediaRecorderPrivateWriter::RemoteMediaRecorderPrivateWriter):
* Source/WebKit/WebProcess/GPU/media/RemoteMediaRecorderPrivateWriter.h:
* Source/WebKit/WebProcess/GPU/media/WebMediaStrategy.cpp:
(WebKit::WebMediaStrategy::createMediaRecorderPrivateWriter const):
* Source/WebKit/WebProcess/GPU/media/WebMediaStrategy.h:

Originally-landed-as: 289651.347@safari-7621-branch (31bf16344c0d). <a href="https://rdar.apple.com/151714059">rdar://151714059</a>
Canonical link: <a href="https://commits.webkit.org/295800@main">https://commits.webkit.org/295800@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dd19d6ead779da705e9477c4c7b0fcaeadc5c0e9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/106181 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25930 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/16324 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/111378 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/56777 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/108220 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/26588 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34433 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80653 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/109185 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/21015 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95813 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60978 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/20574 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13916 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/56217 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/90376 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13951 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/114238 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33319 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24577 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89727 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33683 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/92046 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89426 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22800 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34292 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/12102 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/28895 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/33244 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/38656 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32990 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/36340 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34588 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->