### PR TITLE
tabs.sendMessage() also sends the message to the tab's opener.

### DIFF
--- a/Source/WebKit/Shared/Extensions/WebExtensionMessageTargetParameters.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionMessageTargetParameters.h
@@ -34,6 +34,7 @@
 namespace WebKit {
 
 struct WebExtensionMessageTargetParameters {
+    std::optional<WebPageProxyIdentifier> pageProxyIdentifier;
     std::optional<WebExtensionFrameIdentifier> frameIdentifier;
     Markable<WTF::UUID> documentIdentifier;
 };

--- a/Source/WebKit/Shared/Extensions/WebExtensionMessageTargetParameters.serialization.in
+++ b/Source/WebKit/Shared/Extensions/WebExtensionMessageTargetParameters.serialization.in
@@ -23,6 +23,7 @@
 #if ENABLE(WK_WEB_EXTENSIONS)
 
 struct WebKit::WebExtensionMessageTargetParameters {
+    std::optional<WebKit::WebPageProxyIdentifier> pageProxyIdentifier;
     std::optional<WebKit::WebExtensionFrameIdentifier> frameIdentifier;
     Markable<WTF::UUID> documentIdentifier;
 };

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIRuntimeCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIRuntimeCocoa.mm
@@ -599,7 +599,11 @@ static bool matches(WebFrame& frame, const std::optional<WebExtensionMessageTarg
     if (!targetParameters)
         return true;
 
-    // Skip all frames / documents that don't match the target parameters.
+    // Skip all pages / frames / documents that don't match the target parameters.
+    auto& pageProxyIdentifier = targetParameters.value().pageProxyIdentifier;
+    if (pageProxyIdentifier && pageProxyIdentifier != frame.protectedPage()->webPageProxyIdentifier())
+        return false;
+
     auto& frameIdentifier = targetParameters.value().frameIdentifier;
     if (frameIdentifier && !matchesFrame(frameIdentifier.value(), frame))
         return false;

--- a/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.h
+++ b/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.h
@@ -111,7 +111,7 @@
 - (instancetype)initWithExtensionController:(WKWebExtensionController *)extensionController usesPrivateBrowsing:(BOOL)usesPrivateBrowsing NS_DESIGNATED_INITIALIZER;
 
 @property (nonatomic, copy) NSArray<TestWebExtensionTab *> *tabs;
-@property (nonatomic, strong) TestWebExtensionTab * activeTab;
+@property (nonatomic, strong) TestWebExtensionTab *activeTab;
 
 - (TestWebExtensionTab *)openNewTab;
 - (TestWebExtensionTab *)openNewTabAtIndex:(NSUInteger)index;


### PR DESCRIPTION
#### 133ceaf9e9d8a2eee2cbb83827ab03975bbff8e2
<pre>
tabs.sendMessage() also sends the message to the tab&apos;s opener.
<a href="https://webkit.org/b/289640">https://webkit.org/b/289640</a>
<a href="https://rdar.apple.com/problem/146886179">rdar://problem/146886179</a>

Reviewed by Brian Weinstein.

Since window.open() web views share the same web process, tabs.sendMessage must include the target
web page’s identifier to ensure messages are delivered only to that specific page, avoiding
unintended delivery to other pages within the same process.

* Source/WebKit/Shared/Extensions/WebExtensionMessageTargetParameters.h: Add web page identifier.
* Source/WebKit/Shared/Extensions/WebExtensionMessageTargetParameters.serialization.in: Ditto.
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPITabsCocoa.mm:
(WebKit::WebExtensionContext::tabsSendMessage): Add the web page identifier for the tab
to a copy of the target parameters.
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIRuntimeCocoa.mm:
(WebKit::matches): Check the web page identifier if it is supplied.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIRuntime.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPITabs, SendMessageFromBackgroundToOpenedWindow)): Added.
* Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.h: Removed a stray space.

Canonical link: <a href="https://commits.webkit.org/295792@main">https://commits.webkit.org/295792@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/678fafab70de340adc2e8831b91cd52d23a6babd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/106153 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25902 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/16296 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/111350 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/56749 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/108192 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/26559 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34405 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80632 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/109157 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/20983 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95789 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60957 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/20550 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13892 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/56188 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/90346 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13927 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/114208 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33291 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/24560 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89708 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33655 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/92022 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89405 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34268 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/12078 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/28864 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17212 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/33216 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/38628 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32962 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/36312 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34560 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->