### PR TITLE
REGRESSION(295182@main): Broke test-webkitpy

### DIFF
--- a/Tools/Scripts/webkitpy/tool/commands/upload_unittest.py
+++ b/Tools/Scripts/webkitpy/tool/commands/upload_unittest.py
@@ -34,6 +34,7 @@ from webkitpy.thirdparty.mock import Mock
 from webkitpy.tool.commands.commandtest import CommandsTest
 from webkitpy.tool.commands.upload import *
 from webkitpy.tool.mocktool import MockOptions, MockTool
+from webkitscmpy import mocks as wmocks
 
 
 class MockIssue(object):
@@ -43,6 +44,8 @@ class MockIssue(object):
 
 
 class UploadCommandsTest(CommandsTest):
+    path = '/mock-checkout'
+
     def test_post(self):
         options = MockOptions()
         options.cc = None
@@ -144,7 +147,8 @@ MOCK reassign_bug: bug_id=50000, assignee=None
 MOCK add_patch_to_bug: bug_id=50000, description=MOCK description, mark_for_review=True, mark_for_commit_queue=False, mark_for_landing=False
 MOCK: user.open_url: http://example.com/50000
 """
-        self.assert_execute_outputs(Upload(), [50000], options=options, expected_logs=expected_logs)
+        with wmocks.local.Git(self.path):
+            self.assert_execute_outputs(Upload(), [50000], options=options, expected_logs=expected_logs)
 
     def test_upload_fast_cq(self):
         options = MockOptions()
@@ -168,7 +172,8 @@ MOCK reassign_bug: bug_id=50000, assignee=None
 MOCK add_patch_to_bug: bug_id=50000, description=[fast-cq] MOCK description, mark_for_review=True, mark_for_commit_queue=False, mark_for_landing=False
 MOCK: user.open_url: http://example.com/50000
 """
-        self.assert_execute_outputs(Upload(), [50000], options=options, expected_logs=expected_logs)
+        with wmocks.local.Git(self.path):
+            self.assert_execute_outputs(Upload(), [50000], options=options, expected_logs=expected_logs)
 
     def test_upload_with_no_review_and_ews(self):
         options = MockOptions()
@@ -193,7 +198,8 @@ MOCK add_patch_to_bug: bug_id=50000, description=MOCK description, mark_for_revi
 MOCK: user.open_url: http://example.com/50000
 MOCK: submit_to_ews: 10001
 """
-        self.assert_execute_outputs(Upload(), [50000], options=options, expected_logs=expected_logs)
+        with wmocks.local.Git(self.path):
+            self.assert_execute_outputs(Upload(), [50000], options=options, expected_logs=expected_logs)
 
     def test_mark_bug_fixed(self):
         tool = MockTool()
@@ -219,7 +225,7 @@ Committed r9876 (5@main): <https://commits.webkit.org/5@main>
                 identifier='5@main',
                 revision=9876,
             )),
-        }):
+        }), wmocks.local.Git(self.path):
             self.assert_execute_outputs(MarkBugFixed(), [], expected_logs=expected_logs, tool=tool, options=options)
 
     def test_edit_changelog(self):
@@ -280,4 +286,5 @@ MOCK reassign_bug: bug_id=50000, assignee=None
 MOCK add_patch_to_bug: bug_id=50000, description=MOCK description, mark_for_review=True, mark_for_commit_queue=False, mark_for_landing=False
 MOCK: user.open_url: http://example.com/50000
 """
-        self.assert_execute_outputs(Upload(), [50000], options=options, expected_logs=expected_logs)
+        with wmocks.local.Git(self.path):
+            self.assert_execute_outputs(Upload(), [50000], options=options, expected_logs=expected_logs)

--- a/Tools/Scripts/webkitpy/w3c/test_exporter.py
+++ b/Tools/Scripts/webkitpy/w3c/test_exporter.py
@@ -63,10 +63,12 @@ class WebPlatformTestExporter(object):
 
         self._WPTGitHubClass = WPTGitHubClass
         self._gitClass = gitClass  # FIXME: Move git operations to webkitscmpy
-        self._repository = repository or local.Git(os.path.abspath(os.getcwd()))
         self._bugzilla = bugzillaClass()
         self._bug_id = options.bug_id
         self._bug = None
+
+        repo_path = WebKitFinder(self._filesystem).webkit_base()
+        self._repository = repository or local.Git(repo_path)
 
         issue = None
         if not self._bug_id:

--- a/Tools/Scripts/webkitpy/w3c/test_exporter_unittest.py
+++ b/Tools/Scripts/webkitpy/w3c/test_exporter_unittest.py
@@ -238,32 +238,34 @@ class TestExporterTest(testing.PathTestCase):
         host = TestExporterTest.MyMockHost()
         host.web.responses.append({'status_code': 401})
         options = parse_args(['test_exporter.py', '-g', 'HEAD', '-b', '1', '-c', '-n', 'USER', '-t', 'TOKEN'])
-        exporter = WebPlatformTestExporter(host, options, TestExporterTest.MockGit, TestExporterTest.MockBugzilla, MockWPTGitHub, TestExporterTest.MockWPTLinter)
-        with self.assertRaises(Exception) as context:
+        with mocks.local.Git(self.path) as repo, self.assertRaises(Exception) as context:
+            exporter = WebPlatformTestExporter(host, options, TestExporterTest.MockGit, TestExporterTest.MockBugzilla, MockWPTGitHub, TestExporterTest.MockWPTLinter, repo)
             exporter.do_export()
-        self.assertIn('OAuth token is not valid', str(context.exception))
+            self.assertIn('OAuth token is not valid', str(context.exception))
 
     def test_export_wrong_token(self):
         host = TestExporterTest.MyMockHost()
         host.web.responses.append({'status_code': 200, 'body': '{"login": "DIFF_USER"}'})
         options = parse_args(['test_exporter.py', '-g', 'HEAD', '-b', '1', '-c', '-n', 'USER', '-t', 'TOKEN'])
-        exporter = WebPlatformTestExporter(host, options, TestExporterTest.MockGit, TestExporterTest.MockBugzilla, MockWPTGitHub, TestExporterTest.MockWPTLinter)
-        with self.assertRaises(Exception) as context:
+        with mocks.local.Git(self.path) as repo, self.assertRaises(Exception) as context:
+            exporter = WebPlatformTestExporter(host, options, TestExporterTest.MockGit, TestExporterTest.MockBugzilla, MockWPTGitHub, TestExporterTest.MockWPTLinter, repo)
             exporter.do_export()
-        self.assertIn('OAuth token does not match the provided username', str(context.exception))
+            self.assertIn('OAuth token does not match the provided username', str(context.exception))
 
     def test_has_wpt_changes(self):
         host = TestExporterTest.MyMockHost()
         options = parse_args(['test_exporter.py', '-g', 'HEAD', '-b', '1', '-c', '-n', 'USER', '-t', 'TOKEN'])
-        exporter = WebPlatformTestExporter(host, options, TestExporterTest.MockGit, TestExporterTest.MockBugzilla, MockWPTGitHub, TestExporterTest.MockWPTLinter)
-        self.assertTrue(exporter.has_wpt_changes())
+        with mocks.local.Git(self.path) as repo:
+            exporter = WebPlatformTestExporter(host, options, TestExporterTest.MockGit, TestExporterTest.MockBugzilla, MockWPTGitHub, TestExporterTest.MockWPTLinter, repo)
+            self.assertTrue(exporter.has_wpt_changes())
 
     def test_has_no_wpt_changes_for_no_diff(self):
         host = TestExporterTest.MyMockHost()
         host._mockSCM.mock_format_patch_result = None
         options = parse_args(['test_exporter.py', '-g', 'HEAD', '-b', '1', '-c', '-n', 'USER', '-t', 'TOKEN'])
-        exporter = WebPlatformTestExporter(host, options, TestExporterTest.MockGit, TestExporterTest.MockBugzilla, MockWPTGitHub, TestExporterTest.MockWPTLinter)
-        self.assertFalse(exporter.has_wpt_changes())
+        with mocks.local.Git(self.path) as repo:
+            exporter = WebPlatformTestExporter(host, options, TestExporterTest.MockGit, TestExporterTest.MockBugzilla, MockWPTGitHub, TestExporterTest.MockWPTLinter, repo)
+            self.assertFalse(exporter.has_wpt_changes())
 
     def test_ignore_changes_to_expected_file(self):
         host = TestExporterTest.MyMockHost()
@@ -282,7 +284,8 @@ diff --git a/LayoutTests/imported/w3c/web-platform-tests/fetch/api/headers/heade
 +change to expected
 """
         options = parse_args(['test_exporter.py', '-g', 'HEAD', '-b', '1', '-c', '-n', 'USER', '-t', 'TOKEN'])
-        exporter = WebPlatformTestExporter(host, options, TestExporterTest.MockGit, TestExporterTest.MockBugzilla, MockWPTGitHub, TestExporterTest.MockWPTLinter)
+        with mocks.local.Git(self.path) as repo:
+            exporter = WebPlatformTestExporter(host, options, TestExporterTest.MockGit, TestExporterTest.MockBugzilla, MockWPTGitHub, TestExporterTest.MockWPTLinter, repo)
         self.assertFalse(exporter.has_wpt_changes())
 
     def test_ignore_changes_to_expected_mismatch_file(self):
@@ -294,7 +297,8 @@ diff --git a/LayoutTests/imported/w3c/web-platform-tests/css/css-counter-styles/
 +change to expected-mismatch
 """
         options = parse_args(['test_exporter.py', '-g', 'HEAD', '-b', '1', '-c', '-n', 'USER', '-t', 'TOKEN'])
-        exporter = WebPlatformTestExporter(host, options, TestExporterTest.MockGit, TestExporterTest.MockBugzilla, MockWPTGitHub, TestExporterTest.MockWPTLinter)
+        with mocks.local.Git(self.path) as repo:
+            exporter = WebPlatformTestExporter(host, options, TestExporterTest.MockGit, TestExporterTest.MockBugzilla, MockWPTGitHub, TestExporterTest.MockWPTLinter, repo)
         self.assertFalse(exporter.has_wpt_changes())
 
     def test_ignore_changes_to_w3c_import_log(self):
@@ -306,5 +310,6 @@ diff --git a/LayoutTests/imported/w3c/web-platform-tests/fetch/api/headers/w3c-i
 +change to w3c import
 """
         options = parse_args(['test_exporter.py', '-g', 'HEAD', '-b', '1', '-c', '-n', 'USER', '-t', 'TOKEN'])
-        exporter = WebPlatformTestExporter(host, options, TestExporterTest.MockGit, TestExporterTest.MockBugzilla, MockWPTGitHub, TestExporterTest.MockWPTLinter)
+        with mocks.local.Git(self.path) as repo:
+            exporter = WebPlatformTestExporter(host, options, TestExporterTest.MockGit, TestExporterTest.MockBugzilla, MockWPTGitHub, TestExporterTest.MockWPTLinter, repo)
         self.assertFalse(exporter.has_wpt_changes())


### PR DESCRIPTION
#### e6f56a695c32af5c0a404905150ce65f2bca8849
<pre>
REGRESSION(295182@main): Broke test-webkitpy
<a href="https://bugs.webkit.org/show_bug.cgi?id=293992">https://bugs.webkit.org/show_bug.cgi?id=293992</a>
<a href="https://rdar.apple.com/152536037">rdar://152536037</a>

Reviewed by Sam Sneddon.

Add mock repository to test_exporter unittests.
Find the WebKit repository using WebKitFinder and use
webkitscmpy mocks in upload unittests.

* Tools/Scripts/webkitpy/tool/commands/upload_unittest.py:
(UploadCommandsTest):
* Tools/Scripts/webkitpy/w3c/test_exporter.py:
(WebPlatformTestExporter.__init__):
* Tools/Scripts/webkitpy/w3c/test_exporter_unittest.py:
(TestExporterTest.test_export_invalid_token):
(TestExporterTest.test_export_wrong_token):
(TestExporterTest.test_has_wpt_changes):
(TestExporterTest.test_has_no_wpt_changes_for_no_diff):

Canonical link: <a href="https://commits.webkit.org/295829@main">https://commits.webkit.org/295829@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1d6dd801a5774db89b5b4a9aa9cd76964732a19d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/106265 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/26014 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/16410 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/111463 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/56861 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/108304 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/26677 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34517 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80719 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/109269 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/21110 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95893 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/61046 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/105742 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/20632 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13992 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/56301 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/90458 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/14027 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/114323 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33403 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24629 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89791 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33767 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/92122 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89492 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34363 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/12177 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/28987 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17221 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/33328 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/33074 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/36427 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34672 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->