### PR TITLE
Link preconnect and DNS prefetch ignores content extension rules

### DIFF
--- a/LayoutTests/http/tests/contentextensions/dns-prefetch-blocked-expected.txt
+++ b/LayoutTests/http/tests/contentextensions/dns-prefetch-blocked-expected.txt
@@ -1,0 +1,4 @@
+CONSOLE MESSAGE: Content blocker prevented frame displaying http://127.0.0.1:8000/contentextensions/dns-prefetch-blocked.html from loading a resource from http://127.0.0.1:8000/contentextensions/resources/should-not-load.html
+This page prefetches a Document.
+The prefetch should be blocked by the content extension filter
+

--- a/LayoutTests/http/tests/contentextensions/dns-prefetch-blocked.html
+++ b/LayoutTests/http/tests/contentextensions/dns-prefetch-blocked.html
@@ -1,0 +1,8 @@
+This page prefetches a Document.<br>
+The prefetch should be blocked by the content extension filter<br>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+}
+</script>
+<link rel="dns-prefetch" href="resources/should-not-load.html">

--- a/LayoutTests/http/tests/contentextensions/dns-prefetch-blocked.html.json
+++ b/LayoutTests/http/tests/contentextensions/dns-prefetch-blocked.html.json
@@ -1,0 +1,11 @@
+[
+    {
+        "action": {
+            "type": "block"
+        },
+        "trigger": {
+            "url-filter": "should-not-load",
+            "resource-type": ["ping"]
+        }
+    }
+]

--- a/LayoutTests/http/tests/contentextensions/preconnect-blocked-expected.txt
+++ b/LayoutTests/http/tests/contentextensions/preconnect-blocked-expected.txt
@@ -1,0 +1,4 @@
+CONSOLE MESSAGE: Content blocker prevented frame displaying http://127.0.0.1:8000/contentextensions/preconnect-blocked.html from loading a resource from http://127.0.0.1:8000/contentextensions/resources/should-not-load.html
+This page preconnects a Document.
+The preconnect should be blocked by the content extension filter
+

--- a/LayoutTests/http/tests/contentextensions/preconnect-blocked.html
+++ b/LayoutTests/http/tests/contentextensions/preconnect-blocked.html
@@ -1,0 +1,8 @@
+This page preconnects a Document.<br>
+The preconnect should be blocked by the content extension filter<br>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+}
+</script>
+<link rel="preconnect" href="resources/should-not-load.html">

--- a/LayoutTests/http/tests/contentextensions/preconnect-blocked.html.json
+++ b/LayoutTests/http/tests/contentextensions/preconnect-blocked.html.json
@@ -1,0 +1,11 @@
+[
+    {
+        "action": {
+            "type": "block"
+        },
+        "trigger": {
+            "url-filter": "should-not-load",
+            "resource-type": ["ping"]
+        }
+    }
+]

--- a/Source/WebCore/html/HTMLAnchorElement.cpp
+++ b/Source/WebCore/html/HTMLAnchorElement.cpp
@@ -599,7 +599,7 @@ void HTMLAnchorElement::handleClick(Event& event)
     // Preconnect to the link's target for improved page load time.
     if (completedURL.protocolIsInHTTPFamily() && document->settings().linkPreconnectEnabled() && ((frame->isMainFrame() && isSelfTargetFrameName(effectiveTarget)) || isBlankTargetFrameName(effectiveTarget))) {
         auto storageCredentialsPolicy = frame->page() && frame->page()->canUseCredentialStorage() ? StoredCredentialsPolicy::Use : StoredCredentialsPolicy::DoNotUse;
-        platformStrategies()->loaderStrategy()->preconnectTo(frame->loader(), completedURL, storageCredentialsPolicy, LoaderStrategy::ShouldPreconnectAsFirstParty::Yes, [] (ResourceError) { });
+        platformStrategies()->loaderStrategy()->preconnectTo(frame->loader(), ResourceRequest { WTFMove(completedURL) }, storageCredentialsPolicy, LoaderStrategy::ShouldPreconnectAsFirstParty::Yes, [] (ResourceError) { });
     }
 }
 

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -4841,6 +4841,26 @@ RefPtr<DocumentLoader> FrameLoader::loaderForWebsitePolicies(CanIncludeCurrentDo
     return loader;
 }
 
+void FrameLoader::prefetchDNSIfNeeded(const URL& url)
+{
+#if ENABLE(CONTENT_EXTENSIONS)
+    RefPtr page = m_frame->page();
+    if (!page)
+        return;
+
+    RefPtr documentLoader = m_documentLoader;
+    if (!documentLoader)
+        return;
+
+    auto results = page->protectedUserContentProvider()->processContentRuleListsForLoad(*page, url, ContentExtensions::ResourceType::Ping, *documentLoader);
+    if (results.summary.blockedLoad)
+        return;
+#endif
+
+    if (url.isValid() && !url.isEmpty() && url.protocolIsInHTTPFamily())
+        client().prefetchDNS(url.host().toString());
+}
+
 } // namespace WebCore
 
 #undef PAGE_ID

--- a/Source/WebCore/loader/FrameLoader.h
+++ b/Source/WebCore/loader/FrameLoader.h
@@ -361,6 +361,8 @@ public:
     void setRequiredCookiesVersion(uint64_t version) { m_requiredCookiesVersion = version; }
     uint64_t requiredCookiesVersion() const { return m_requiredCookiesVersion; }
 
+    WEBCORE_EXPORT void prefetchDNSIfNeeded(const URL&);
+
 private:
     enum FormSubmissionCacheLoadPolicy {
         MayAttemptCacheOnlyLoadForFormSubmissionItem,

--- a/Source/WebCore/loader/LinkLoader.cpp
+++ b/Source/WebCore/loader/LinkLoader.cpp
@@ -62,6 +62,7 @@
 #include "Settings.h"
 #include "SizesAttributeParser.h"
 #include "StyleResolver.h"
+#include "UserContentProvider.h"
 #include <wtf/text/MakeString.h>
 
 namespace WebCore {
@@ -277,15 +278,32 @@ bool LinkLoader::isSupportedType(CachedResource::Type resourceType, const String
 
 void LinkLoader::preconnectIfNeeded(const LinkLoadParameters& params, Document& document)
 {
-    const URL href = params.href;
-    if (!params.relAttribute.isLinkPreconnect || !href.isValid() || !params.href.protocolIsInHTTPFamily() || !document.frame())
+    if (!params.relAttribute.isLinkPreconnect || !params.href.isValid() || !params.href.protocolIsInHTTPFamily() || !document.frame())
         return;
+
+    ResourceRequest request { URL { params.href } };
+#if ENABLE(CONTENT_EXTENSIONS)
+    RefPtr page = document.page();
+    if (!page)
+        return;
+
+    RefPtr documentLoader = document.loader();
+    if (!documentLoader)
+        return;
+
+    auto results = page->protectedUserContentProvider()->processContentRuleListsForLoad(*page, params.href, ContentExtensions::ResourceType::Ping, *documentLoader);
+    if (results.summary.blockedLoad)
+        return;
+
+    ContentExtensions::applyResultsToRequest(WTFMove(results), page.get(), request);
+#endif
+
     ASSERT(document.settings().linkPreconnectEnabled());
     StoredCredentialsPolicy storageCredentialsPolicy = StoredCredentialsPolicy::Use;
-    if (equalLettersIgnoringASCIICase(params.crossOrigin, "anonymous"_s) && !document.protectedSecurityOrigin()->isSameOriginDomain(SecurityOrigin::create(href)))
+    if (equalLettersIgnoringASCIICase(params.crossOrigin, "anonymous"_s) && !document.protectedSecurityOrigin()->isSameOriginDomain(SecurityOrigin::create(params.href)))
         storageCredentialsPolicy = StoredCredentialsPolicy::DoNotUse;
     ASSERT(document.frame()->loader().networkingContext());
-    platformStrategies()->loaderStrategy()->preconnectTo(document.protectedFrame()->protectedLoader(), href, storageCredentialsPolicy, LoaderStrategy::ShouldPreconnectAsFirstParty::No, [weakDocument = WeakPtr { document }, href](ResourceError error) {
+    platformStrategies()->loaderStrategy()->preconnectTo(document.protectedFrame()->protectedLoader(), WTFMove(request), storageCredentialsPolicy, LoaderStrategy::ShouldPreconnectAsFirstParty::No, [weakDocument = WeakPtr { document }, href = params.href](ResourceError error) {
         RefPtr document = weakDocument.get();
         if (!document)
             return;
@@ -417,13 +435,11 @@ void LinkLoader::cancelLoad()
 void LinkLoader::loadLink(const LinkLoadParameters& params, Document& document)
 {
     if (params.relAttribute.isDNSPrefetch) {
-        if (params.href.isValid() && !params.href.isEmpty() && params.href.protocolIsInHTTPFamily() && document.frame())
-            document.protectedFrame()->protectedLoader()->client().prefetchDNS(params.href.host().toString());
-    }
-
-    preconnectIfNeeded(params, document);
-
-    if (params.relAttribute.isLinkPrefetch) {
+        if (RefPtr frame = document.frame())
+            frame->loader().prefetchDNSIfNeeded(params.href);
+    } else if (params.relAttribute.isLinkPreconnect)
+        preconnectIfNeeded(params, document);
+    else if (params.relAttribute.isLinkPrefetch) {
         prefetchIfNeeded(params, document);
         return;
     }

--- a/Source/WebCore/loader/LoaderStrategy.h
+++ b/Source/WebCore/loader/LoaderStrategy.h
@@ -80,7 +80,7 @@ public:
 
     using PreconnectCompletionHandler = Function<void(const ResourceError&)>;
     enum class ShouldPreconnectAsFirstParty : bool { No, Yes };
-    virtual void preconnectTo(FrameLoader&, const URL&, StoredCredentialsPolicy, ShouldPreconnectAsFirstParty, PreconnectCompletionHandler&&) = 0;
+    virtual void preconnectTo(FrameLoader&, ResourceRequest&&, StoredCredentialsPolicy, ShouldPreconnectAsFirstParty, PreconnectCompletionHandler&&) = 0;
 
     virtual void setCaptureExtraNetworkLoadMetricsEnabled(bool) = 0;
 

--- a/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
+++ b/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
@@ -942,17 +942,17 @@ void WebLoaderStrategy::didFinishPingLoad(WebCore::ResourceLoaderIdentifier ping
         completionHandler(WTFMove(error), WTFMove(response));
 }
 
-void WebLoaderStrategy::preconnectTo(FrameLoader& frameLoader, const URL& url, StoredCredentialsPolicy storedCredentialsPolicy, ShouldPreconnectAsFirstParty shouldPreconnectAsFirstParty, PreconnectCompletionHandler&& completionHandler)
+void WebLoaderStrategy::preconnectTo(FrameLoader& frameLoader, ResourceRequest&& request, StoredCredentialsPolicy storedCredentialsPolicy, ShouldPreconnectAsFirstParty shouldPreconnectAsFirstParty, PreconnectCompletionHandler&& completionHandler)
 {
     RefPtr webFrame = WebProcess::singleton().webFrame(frameLoader.frameID());
     if (!webFrame)
-        return completionHandler(internalError(url));
+        return completionHandler(internalError(request.url()));
 
     RefPtr webPage = webFrame->page();
     if (!webPage)
-        return completionHandler(internalError(url));
+        return completionHandler(internalError(request.url()));
 
-    preconnectTo(ResourceRequest { URL { url } }, *webPage, *webFrame, storedCredentialsPolicy, shouldPreconnectAsFirstParty, WTFMove(completionHandler));
+    preconnectTo(WTFMove(request), *webPage, *webFrame, storedCredentialsPolicy, shouldPreconnectAsFirstParty, WTFMove(completionHandler));
 }
 
 void WebLoaderStrategy::preconnectTo(WebCore::ResourceRequest&& request, WebPage& webPage, WebFrame& webFrame, WebCore::StoredCredentialsPolicy storedCredentialsPolicy, ShouldPreconnectAsFirstParty shouldPreconnectAsFirstParty, PreconnectCompletionHandler&& completionHandler)

--- a/Source/WebKit/WebProcess/Network/WebLoaderStrategy.h
+++ b/Source/WebKit/WebProcess/Network/WebLoaderStrategy.h
@@ -78,7 +78,7 @@ public:
     void didFinishPingLoad(WebCore::ResourceLoaderIdentifier pingLoadIdentifier, WebCore::ResourceError&&, WebCore::ResourceResponse&&);
 
     void preconnectTo(WebCore::ResourceRequest&&, WebPage&, WebFrame&, WebCore::StoredCredentialsPolicy, ShouldPreconnectAsFirstParty, PreconnectCompletionHandler&& = nullptr);
-    void preconnectTo(WebCore::FrameLoader&, const URL&, WebCore::StoredCredentialsPolicy, ShouldPreconnectAsFirstParty, PreconnectCompletionHandler&&) final;
+    void preconnectTo(WebCore::FrameLoader&, WebCore::ResourceRequest&&, WebCore::StoredCredentialsPolicy, ShouldPreconnectAsFirstParty, PreconnectCompletionHandler&&) final;
     void didFinishPreconnection(WebCore::ResourceLoaderIdentifier preconnectionIdentifier, WebCore::ResourceError&&);
 
     void setCaptureExtraNetworkLoadMetricsEnabled(bool) final;

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -1281,10 +1281,7 @@ void WebPage::sendTapHighlightForNodeIfNecessary(WebKit::TapIdentifier requestID
 
     if (RefPtr element = dynamicDowncast<Element>(*node)) {
         ASSERT(m_page);
-        auto linkURL = element->absoluteLinkURL();
-        if (!linkURL.protocolIsInHTTPFamily())
-            return;
-        localMainFrame->loader().client().prefetchDNS(linkURL.host().toString());
+        localMainFrame->loader().prefetchDNSIfNeeded(element->absoluteLinkURL());
     }
 
     if (RefPtr area = dynamicDowncast<HTMLAreaElement>(*node)) {

--- a/Source/WebKitLegacy/WebCoreSupport/WebResourceLoadScheduler.cpp
+++ b/Source/WebKitLegacy/WebCoreSupport/WebResourceLoadScheduler.cpp
@@ -415,6 +415,6 @@ void WebResourceLoadScheduler::addOnlineStateChangeListener(WTF::Function<void(b
     NetworkStateNotifier::singleton().addListener(WTFMove(listener));
 }
 
-void WebResourceLoadScheduler::preconnectTo(FrameLoader&, const URL&, StoredCredentialsPolicy, ShouldPreconnectAsFirstParty, PreconnectCompletionHandler&&)
+void WebResourceLoadScheduler::preconnectTo(FrameLoader&, ResourceRequest&&, StoredCredentialsPolicy, ShouldPreconnectAsFirstParty, PreconnectCompletionHandler&&)
 {
 }

--- a/Source/WebKitLegacy/WebCoreSupport/WebResourceLoadScheduler.h
+++ b/Source/WebKitLegacy/WebCoreSupport/WebResourceLoadScheduler.h
@@ -64,7 +64,7 @@ public:
 
     void startPingLoad(WebCore::LocalFrame&, WebCore::ResourceRequest&, const WebCore::HTTPHeaderMap&, const WebCore::FetchOptions&, WebCore::ContentSecurityPolicyImposition, PingLoadCompletionHandler&&) final;
 
-    void preconnectTo(WebCore::FrameLoader&, const URL&, WebCore::StoredCredentialsPolicy, ShouldPreconnectAsFirstParty, PreconnectCompletionHandler&&) final;
+    void preconnectTo(WebCore::FrameLoader&, WebCore::ResourceRequest&&, WebCore::StoredCredentialsPolicy, ShouldPreconnectAsFirstParty, PreconnectCompletionHandler&&) final;
 
     void setCaptureExtraNetworkLoadMetricsEnabled(bool) final { }
 


### PR DESCRIPTION
#### ce84da3fd2d634040f3197d526b4ac914e45d2e6
<pre>
Link preconnect and DNS prefetch ignores content extension rules
<a href="https://bugs.webkit.org/show_bug.cgi?id=289572">https://bugs.webkit.org/show_bug.cgi?id=289572</a>
<a href="https://rdar.apple.com/144699810">rdar://144699810</a>

Reviewed by Alex Christensen.

Make content extension rules apply to DNS prefetch and preconnect, just as they already do for prefetch
and normal loads.

* LayoutTests/http/tests/contentextensions/dns-prefetch-blocked-expected.txt: Added.
* LayoutTests/http/tests/contentextensions/dns-prefetch-blocked.html: Added.
* LayoutTests/http/tests/contentextensions/dns-prefetch-blocked.html.json: Added.
* LayoutTests/http/tests/contentextensions/preconnect-blocked-expected.txt: Added.
* LayoutTests/http/tests/contentextensions/preconnect-blocked.html: Added.
* LayoutTests/http/tests/contentextensions/preconnect-blocked.html.json: Added.
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::prefetchDNSIfNeeded):
* Source/WebCore/loader/FrameLoader.h:
* Source/WebCore/loader/LinkLoader.cpp:
(WebCore::LinkLoader::preconnectIfNeeded):
(WebCore::LinkLoader::loadLink):
* Source/WebCore/loader/LoaderStrategy.h:
* Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp:
(WebKit::WebLoaderStrategy::preconnectTo):
* Source/WebKit/WebProcess/Network/WebLoaderStrategy.h:
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::sendTapHighlightForNodeIfNecessary):
* Source/WebKitLegacy/WebCoreSupport/WebResourceLoadScheduler.cpp:
(WebResourceLoadScheduler::preconnectTo):
* Source/WebKitLegacy/WebCoreSupport/WebResourceLoadScheduler.h:

Originally-landed-as: 289651.274@safari-7621-branch (3af4bf0136a9). <a href="https://rdar.apple.com/151707262">rdar://151707262</a>
Canonical link: <a href="https://commits.webkit.org/295844@main">https://commits.webkit.org/295844@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/38acec2b08e5e5b2c8c94589e68d0f6b58edfe26

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/106290 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/26039 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/16435 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/111488 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/56886 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/108329 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/26702 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34542 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80745 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/109294 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/21134 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95924 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/61072 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/20652 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/14022 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/56326 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/90484 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/14057 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/114358 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33428 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24652 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89817 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33792 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/92152 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89518 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22834 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34391 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/12206 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/29012 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/33353 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/38765 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/33099 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/36452 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34697 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->