### PR TITLE
Use more C++ Concepts in WebCore

### DIFF
--- a/Source/WebCore/dom/ScriptExecutionContext.h
+++ b/Source/WebCore/dom/ScriptExecutionContext.h
@@ -241,7 +241,8 @@ public:
     public:
         enum CleanupTaskTag { CleanupTask };
 
-        template<typename T, typename = typename std::enable_if<!std::is_base_of<Task, T>::value && std::is_convertible<T, Function<void(ScriptExecutionContext&)>>::value>::type>
+        template<typename T>
+            requires (!std::derived_from<T, Task> && std::convertible_to<T, Function<void(ScriptExecutionContext&)>>)
         Task(T task)
             : m_task(WTFMove(task))
             , m_isCleanupTask(false)
@@ -254,7 +255,8 @@ public:
         {
         }
 
-        template<typename T, typename = typename std::enable_if<std::is_convertible<T, Function<void(ScriptExecutionContext&)>>::value>::type>
+        template<typename T>
+            requires std::convertible_to<T, Function<void(ScriptExecutionContext&)>>
         Task(CleanupTaskTag, T task)
             : m_task(WTFMove(task))
             , m_isCleanupTask(true)

--- a/Source/WebCore/platform/graphics/ColorTypes.h
+++ b/Source/WebCore/platform/graphics/ColorTypes.h
@@ -136,15 +136,16 @@ template<typename ColorType, typename T, typename Alpha> constexpr auto makeFrom
 
 #if ASSERT_ENABLED
 
-template<typename ColorType, typename std::enable_if_t<std::is_same_v<typename ColorType::ComponentType, float>>* = nullptr>
+template<typename ColorType>
 constexpr void assertInRange(ColorType color)
+    requires std::same_as<typename ColorType::ComponentType, float>
 {
     auto components = asColorComponents(color.unresolved());
     for (unsigned i = 0; i < 3; ++i) {
         if (isNaNConstExpr(components[i]))
             continue;
-        ASSERT_WITH_MESSAGE(components[i] >= ColorType::Model::componentInfo[i].min, "Component at index %d is %f and is less than the allowed minimum %f", i,  components[i], ColorType::Model::componentInfo[i].min);
-        ASSERT_WITH_MESSAGE(components[i] <= ColorType::Model::componentInfo[i].max, "Component at index %d is %f and is greater than the allowed maximum %f", i,  components[i], ColorType::Model::componentInfo[i].max);
+        ASSERT_WITH_MESSAGE(components[i] >= ColorType::Model::componentInfo[i].min, "Component at index %d is %f and is less than the allowed minimum %f", i, components[i], ColorType::Model::componentInfo[i].min);
+        ASSERT_WITH_MESSAGE(components[i] <= ColorType::Model::componentInfo[i].max, "Component at index %d is %f and is greater than the allowed maximum %f", i, components[i], ColorType::Model::componentInfo[i].max);
     }
     if (!isNaNConstExpr(components[3])) {
         ASSERT_WITH_MESSAGE(components[3] >= AlphaTraits<typename ColorType::ComponentType>::transparent, "Alpha is %f and is less than the allowed minimum (transparent) %f", components[3], AlphaTraits<typename ColorType::ComponentType>::transparent);
@@ -152,8 +153,9 @@ constexpr void assertInRange(ColorType color)
     }
 }
 
-template<typename ColorType, typename std::enable_if_t<std::is_same_v<typename ColorType::ComponentType, uint8_t>>* = nullptr>
+template<typename ColorType>
 constexpr void assertInRange(ColorType)
+    requires std::same_as<typename ColorType::ComponentType, uint8_t>
 {
 }
 
@@ -165,8 +167,11 @@ template<typename T> constexpr void assertInRange(T)
 
 #endif
 
-template<typename, typename = void> inline constexpr bool IsConvertibleToColorComponents = false;
-template<typename T> inline constexpr bool IsConvertibleToColorComponents<T, std::void_t<decltype(asColorComponents(std::declval<T>().unresolved()))>> = true;
+template<typename T>
+concept IsConvertibleToColorComponents = requires(T t)
+{
+    asColorComponents(t.unresolved());
+};
 
 template<typename, typename = void> inline constexpr bool HasComponentTypeMember = false;
 template<typename T> inline constexpr bool HasComponentTypeMember<T, std::void_t<typename T::ComponentType>> = true;
@@ -194,13 +199,11 @@ template<typename Parent> struct ColorWithAlphaHelper {
     }
 };
 
-
-template<typename ColorType, typename std::enable_if_t<IsConvertibleToColorComponents<ColorType>>* = nullptr>
+template<IsConvertibleToColorComponents ColorType>
 constexpr bool operator==(const ColorType& a, const ColorType& b)
 {
     return asColorComponents(a.unresolved()) == asColorComponents(b.unresolved());
 }
-
 
 // MARK: - RGB Color Types.
 

--- a/Source/WebCore/svg/properties/SVGPropertyOwnerRegistry.h
+++ b/Source/WebCore/svg/properties/SVGPropertyOwnerRegistry.h
@@ -355,21 +355,22 @@ private:
         attributeNameToAccessorMap().add(attributeName, &propertyAccessor);
     }
 
-    // This is a template function with parameter 'I' whose default value = 0. So you can call it without any parameter
-    // from enumerateRecursively(). It returns true and is enable_if<I == sizeof...(BaseTypes)>. So it is mainly for
-    // breaking the recursion.
     template<typename Functor, size_t I = 0>
-    static typename std::enable_if<I == sizeof...(BaseTypes), bool>::type enumerateRecursivelyBaseTypes(NOESCAPE const Functor&) { return true; }
-
-    // This version of animatedTypesBaseTypes() is enable_if<I < sizeof...(BaseTypes)>.
-    template<typename Functor, size_t I = 0>
-    static typename std::enable_if<I < sizeof...(BaseTypes), bool>::type enumerateRecursivelyBaseTypes(NOESCAPE const Functor& functor)
+    static bool enumerateRecursivelyBaseTypes(NOESCAPE const Functor&)
+        requires (I == sizeof...(BaseTypes))
     {
-        // Get the base type at index 'I' using std::tuple and std::tuple_element.
-        using BaseType = typename std::tuple_element<I, typename std::tuple<BaseTypes...>>::type;
+        return true;
+    }
+
+    template<typename Functor, size_t I = 0>
+    static bool enumerateRecursivelyBaseTypes(NOESCAPE const Functor& functor)
+        requires (I < sizeof...(BaseTypes))
+    {
+        using BaseType = std::tuple_element_t<I, std::tuple<BaseTypes...>>;
+
         if (!BaseType::PropertyRegistry::enumerateRecursively(functor))
             return false;
-        // BaseType does not want to break the recursion. So recurse to the next BaseType.
+
         return enumerateRecursivelyBaseTypes<Functor, I + 1>(functor);
     }
 
@@ -380,16 +381,21 @@ private:
     }
 
     template<typename Functor, size_t I = 0>
-    static typename std::enable_if<I == sizeof...(BaseTypes), bool>::type lookupRecursivelyAndApplyBaseTypes(const QualifiedName&, NOESCAPE const Functor&) { return false; }
+    static bool lookupRecursivelyAndApplyBaseTypes(const QualifiedName&, NOESCAPE const Functor&)
+        requires (I == sizeof...(BaseTypes))
+    {
+        return false;
+    }
 
     template<typename Functor, size_t I = 0>
-    static typename std::enable_if<I < sizeof...(BaseTypes), bool>::type lookupRecursivelyAndApplyBaseTypes(const QualifiedName& attributeName, NOESCAPE const Functor& functor)
+    static bool lookupRecursivelyAndApplyBaseTypes(const QualifiedName& attributeName, NOESCAPE const Functor& functor)
+        requires (I < sizeof...(BaseTypes))
     {
-        // Get the base type at index 'I' using std::tuple and std::tuple_element.
-        using BaseType = typename std::tuple_element<I, typename std::tuple<BaseTypes...>>::type;
+        using BaseType = std::tuple_element_t<I, std::tuple<BaseTypes...>>;
+
         if (BaseType::PropertyRegistry::lookupRecursivelyAndApply(attributeName, functor))
             return true;
-        // BaseType does not want to break the recursion. So recurse to the next BaseType.
+
         return lookupRecursivelyAndApplyBaseTypes<Functor, I + 1>(attributeName, functor);
     }
 


### PR DESCRIPTION
#### 47bcffeb6d9aa11082e4da3a31065883bbd3d1dc
<pre>
Use more C++ Concepts in WebCore
<a href="https://bugs.webkit.org/show_bug.cgi?id=293995">https://bugs.webkit.org/show_bug.cgi?id=293995</a>
<a href="https://rdar.apple.com/problem/152545943">rdar://problem/152545943</a>

Reviewed by Sam Weinig.

Replace std::enable_if with C++20 requires clauses and require clauses for template constraints.
This should provide better readability and better compile-time performance by utilizing
more core language features.

* Source/WebCore/dom/ScriptExecutionContext.h:
* Source/WebCore/platform/graphics/ColorTypes.h:
(WebCore::requires):
* Source/WebCore/svg/properties/SVGPropertyOwnerRegistry.h:
(WebCore::SVGPropertyOwnerRegistry::requires):
(WebCore::SVGPropertyOwnerRegistry::enumerateRecursivelyBaseTypes): Deleted.
(WebCore::SVGPropertyOwnerRegistry::lookupRecursivelyAndApplyBaseTypes): Deleted.

Canonical link: <a href="https://commits.webkit.org/295856@main">https://commits.webkit.org/295856@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c8d68e39d2a897f6643f51345308bd8c8ca801e9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/106304 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/26053 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/16449 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/111502 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/56900 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/108343 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/26717 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34556 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80752 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/109308 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/21154 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95935 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/61079 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/20667 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/14033 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/56340 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/90500 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/14068 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/114364 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33442 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24661 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89831 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33806 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/92163 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89534 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22844 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34403 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/12217 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/29027 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/33367 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/38779 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/33113 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/36466 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34711 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->