### PR TITLE
[Safe CPP] Address Warnings in Quad.h

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -425,7 +425,6 @@ css/CSSViewValue.cpp
 css/CSSViewValue.h
 css/DeprecatedCSSOMPrimitiveValue.h
 css/DeprecatedCSSOMRGBColor.h
-css/DeprecatedCSSOMRect.h
 css/FontFace.cpp
 css/FontFaceSet.cpp
 css/ImmutableStyleProperties.cpp
@@ -433,8 +432,6 @@ css/MediaList.cpp
 css/MediaQueryList.cpp
 css/MediaQueryMatcher.cpp
 css/MutableStyleProperties.cpp
-css/Quad.h
-css/Rect.h
 css/SelectorChecker.cpp
 css/SelectorCheckerTestFunctions.h
 css/SelectorFilter.cpp

--- a/Source/WebCore/css/CSSPropertyInitialValues.cpp
+++ b/Source/WebCore/css/CSSPropertyInitialValues.cpp
@@ -473,10 +473,10 @@ static bool isNumber(const CSSValue& value, double number, CSSUnitType type)
 
 static bool isNumber(const RectBase& quad, double number, CSSUnitType type)
 {
-    return isNumber(quad.protectedTop(), number, type)
-        && isNumber(quad.protectedRight(), number, type)
-        && isNumber(quad.protectedBottom(), number, type)
-        && isNumber(quad.protectedLeft(), number, type);
+    return isNumber(quad.top(), number, type)
+        && isNumber(quad.right(), number, type)
+        && isNumber(quad.bottom(), number, type)
+        && isNumber(quad.left(), number, type);
 }
 
 static bool isValueID(const RectBase& quad, CSSValueID valueID)

--- a/Source/WebCore/css/RectBase.h
+++ b/Source/WebCore/css/RectBase.h
@@ -30,10 +30,6 @@ public:
     const CSSValue& right() const { return m_right.get(); }
     const CSSValue& bottom() const { return m_bottom.get(); }
     const CSSValue& left() const { return m_left.get(); }
-    Ref<const CSSValue> protectedTop() const { return m_top; }
-    Ref<const CSSValue> protectedRight() const { return m_right; }
-    Ref<const CSSValue> protectedBottom() const { return m_bottom; }
-    Ref<const CSSValue> protectedLeft() const { return m_left; }
 
     bool equals(const RectBase& other) const
     {
@@ -59,10 +55,10 @@ protected:
     ~RectBase() = default;
 
 private:
-    Ref<const CSSValue> m_top;
-    Ref<const CSSValue> m_right;
-    Ref<const CSSValue> m_bottom;
-    Ref<const CSSValue> m_left;
+    const Ref<const CSSValue> m_top;
+    const Ref<const CSSValue> m_right;
+    const Ref<const CSSValue> m_bottom;
+    const Ref<const CSSValue> m_left;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### f56307b11b40ab389f4acf8cb24a532284a430e2
<pre>
[Safe CPP] Address Warnings in Quad.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=294000">https://bugs.webkit.org/show_bug.cgi?id=294000</a>
<a href="https://rdar.apple.com/problem/152549205">rdar://problem/152549205</a>

Reviewed by Charlie Wolfe.

Address safe cpp warnings in Quad.h. This also fixes css/DeprecatedCSSOMRect.h and css/Rect.h.

 * Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
 * Source/WebCore/css/CSSPropertyInitialValues.cpp:
 (WebCore::isNumber):
 * Source/WebCore/css/RectBase.h:
 (WebCore::RectBase::left const):
 (WebCore::RectBase::protectedTop const): Deleted.
 (WebCore::RectBase::protectedRight const): Deleted.
 (WebCore::RectBase::protectedBottom const): Deleted.
 (WebCore::RectBase::protectedLeft const): Deleted.

Canonical link: <a href="https://commits.webkit.org/295818@main">https://commits.webkit.org/295818@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7c14b7c26cfa2c8301a4af9cb0f8403aeac09b5a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/106232 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25981 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/16376 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/111430 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/56828 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/108271 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/26643 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34484 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80694 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/109236 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/21070 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95863 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/61021 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/20607 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13964 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/56268 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/90426 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13999 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/114290 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33370 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24605 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89766 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33734 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/92094 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89467 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22815 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34337 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/12149 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/28950 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/33295 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/38707 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/33041 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/36391 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34639 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->