### PR TITLE
[Swift in WebKit] The Swift implementation of intelligence text effects code is slightly incorrect (follow-up)

### DIFF
--- a/Source/WebKit/WebKitSwift/WritingTools/WKIntelligenceSmartReplyTextEffectCoordinator.swift
+++ b/Source/WebKit/WebKitSwift/WritingTools/WKIntelligenceSmartReplyTextEffectCoordinator.swift
@@ -100,17 +100,8 @@ extension WKIntelligenceSmartReplyTextEffectCoordinator {
         self.delegate = delegate
     }
 
-    // FIXME: Remove this and the other shims when upgrading WKS to Swift 6.
     @objc(startAnimationForRange:completion:)
-    func startAnimation(for range: NSRange, completion: @MainActor @Sendable @escaping () -> Void) {
-        Task {
-            await startAnimationAsync(for: range)
-            completion()
-        }
-    }
-
-    @nonobjc
-    private final func startAnimationAsync(for range: NSRange) async {
+    func startAnimation(for range: NSRange) async {
         self.viewManager.assertPonderingEffectIsInactive()
         self.viewManager.assertReplacementEffectIsInactive()
 
@@ -125,26 +116,8 @@ extension WKIntelligenceSmartReplyTextEffectCoordinator {
         await self.viewManager.setActivePonderingEffect(effect)
     }
 
+    @objc(requestReplacementWithProcessedRange:finished:characterDelta:operation:completion:)
     func requestReplacement(
-        withProcessedRange processedRange: NSRange,
-        finished: Bool,
-        characterDelta: Int,
-        operation: @MainActor @Sendable @escaping (@MainActor @Sendable @escaping () -> Void) -> Void,
-        completion: @MainActor @Sendable @escaping () -> Void
-    ) {
-        Task {
-            await requestReplacementAsync(
-                withProcessedRange: processedRange,
-                finished: finished,
-                characterDelta: characterDelta,
-                operation: operation
-            )
-            completion()
-        }
-    }
-
-    @nonobjc
-    private final func requestReplacementAsync(
         withProcessedRange processedRange: NSRange,
         finished: Bool,
         characterDelta: Int,


### PR DESCRIPTION
#### 77955478883efde92ce71e7c590dfa24fbb1532b
<pre>
[Swift in WebKit] The Swift implementation of intelligence text effects code is slightly incorrect (follow-up)
<a href="https://bugs.webkit.org/show_bug.cgi?id=294001">https://bugs.webkit.org/show_bug.cgi?id=294001</a>
<a href="https://rdar.apple.com/152550042">rdar://152550042</a>

Reviewed by Aditya Keerthi.

In 295726@main, I forgot to clean up WKIntelligenceSmartReplyTextEffectCoordinator in a few place
as I did with WKIntelligenceReplacementTextEffectCoordinator.swift.

* Source/WebKit/WebKitSwift/WritingTools/WKIntelligenceSmartReplyTextEffectCoordinator.swift:
(startAnimation(for:)):
(startAnimation(for:completion:)): Deleted.
(startAnimationAsync(for:)): Deleted.

Canonical link: <a href="https://commits.webkit.org/295821@main">https://commits.webkit.org/295821@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/38f27e7d6eb64dd501d601153738ec422c02ecb5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/106175 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25924 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/16318 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/111372 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/56771 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/108214 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/26582 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34427 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80647 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/109179 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/21004 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95811 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60972 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/20563 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13914 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/56211 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/90366 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13949 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/114232 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33313 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24570 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89721 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33677 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/92044 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89420 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22818 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34286 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/12100 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/28889 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/33238 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/38650 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32984 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/36334 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34582 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->