### PR TITLE
[Swift in WebKit] Fix concurrency issues in WKRKEntity

### DIFF
--- a/Source/WebKit/WebKitSwift/RealityKit/WKRKEntity.h
+++ b/Source/WebKit/WebKitSwift/RealityKit/WKRKEntity.h
@@ -43,11 +43,13 @@ typedef struct {
 
 @class WKRKEntity;
 
+NS_SWIFT_UI_ACTOR
 @protocol WKRKEntityDelegate <NSObject>
 @optional
 - (void)entityAnimationPlaybackStateDidUpdate:(WKRKEntity *)entity;
 @end
 
+NS_SWIFT_UI_ACTOR
 @interface WKRKEntity : NSObject
 @property (nonatomic, weak) id <WKRKEntityDelegate> delegate;
 @property (nonatomic, copy) NSString *name;
@@ -69,7 +71,7 @@ typedef struct {
 - (instancetype)initWithCoreEntity:(REEntityRef)coreEntity;
 - (void)setParentCoreEntity:(REEntityRef)parentCoreEntity preservingWorldTransform:(BOOL)preservingWorldTransform;
 - (void)setUpAnimationWithAutoPlay:(BOOL)autoPlay;
-- (void)applyIBLData:(NSData *)data attributionHandler:(void (^)(REAssetRef coreEnvironmentResourceAsset))attributionHandler withCompletion:(NS_SWIFT_UI_ACTOR void (^)(BOOL success))completion;
+- (void)applyIBLData:(NSData *)data attributionHandler:(NS_SWIFT_UI_ACTOR void (^)(REAssetRef coreEnvironmentResourceAsset))attributionHandler withCompletion:(NS_SWIFT_UI_ACTOR void (^)(BOOL success))completion;
 - (void)interactionContainerDidRecenterFromTransform:(simd_float4x4)transform;
 - (void)recenterEntityAtTransform:(WKEntityTransform)transform;
 - (void)applyDefaultIBL;


### PR DESCRIPTION
#### 4ef8db60ef01a873c9e788e571a55083e6e18070
<pre>
[Swift in WebKit] Fix concurrency issues in WKRKEntity
<a href="https://bugs.webkit.org/show_bug.cgi?id=294004">https://bugs.webkit.org/show_bug.cgi?id=294004</a>
<a href="https://rdar.apple.com/152553932">rdar://152553932</a>

Reviewed by Ada Chan.

Fix some concurrency issues in WKRKEntity and improve concurrency patterns used.

* Source/WebKit/WebKitSwift/RealityKit/WKRKEntity.h:

- Properly annotate all symbols with their respective actor
- Add a completion hander to `setUpAnimationWithAutoPlay` to facilitate using structured concurrency

* Source/WebKit/WebKitSwift/RealityKit/WKRKEntity.swift:

- Remove an import that wasn&apos;t needed
- Drive-by fix: use consistent style for implicit `return`s and `self`s
- Use structured concurrency where applicable
- Drive-by fix: Simplify some trivial expressions for more consistency
- Use an async sequence instead of a Combine subscription to stream events

Canonical link: <a href="https://commits.webkit.org/295879@main">https://commits.webkit.org/295879@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ee04b9862c5f4f2b66a00c7deb9d83ee657eb847

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/106351 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/26100 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/16498 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/111551 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/56947 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/26766 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34603 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80780 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/109355 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/21199 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95979 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/61108 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/20699 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/56387 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/90542 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/14113 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/114411 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33489 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24689 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89853 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33853 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/92208 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89557 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22865 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34440 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/12259 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/29075 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/33414 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/38826 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/33160 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/36513 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34758 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->