### PR TITLE
[css-anchor-position-1] Anchor functions fail to invalidate on container resize

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-positioned-containing-block-resize-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-positioned-containing-block-resize-expected.txt
@@ -1,0 +1,4 @@
+
+PASS Initial anchored position
+PASS Anchored position after resizing the containing block
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-positioned-containing-block-resize.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-positioned-containing-block-resize.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<title>Containing block size change correctly invalidates styles with anchor functions</title>
+<link rel="help" href="https://drafts.csswg.org/css-anchor-position-1/#anchor-pos">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+.anchor, .anchored {
+    width: 100px;
+    height: 100px;
+    position: absolute;
+}
+.anchor {
+    left: 300px;
+    top: 200px;
+    anchor-name: --a;
+    background: blue;
+}
+.anchored {
+    position-anchor: --a;
+    right: anchor(left);
+    bottom: anchor(top);
+    background: green;
+    content:'';
+}
+.container {
+    position: relative;
+    width: 500px;
+    height: 500px;
+    border: 2px solid red;
+}
+.resize {
+    width: 400px;
+    height: 400px;
+}
+</style>
+<div id=container class=container>
+    <div class=anchor></div>
+    <div>
+        <div id=anchored class=anchored></div>
+    </div>
+</div>
+<script>
+test(() => {
+    assert_equals(anchored.offsetTop, 100);
+    assert_equals(anchored.offsetLeft, 200);
+    assert_equals(getComputedStyle(anchored).bottom, '300px');
+    assert_equals(getComputedStyle(anchored).right, '200px');
+}, "Initial anchored position");
+
+test(() => {
+    container.classList.add("resize");
+    assert_equals(anchored.offsetTop, 100);
+    assert_equals(anchored.offsetLeft, 200);
+    assert_equals(getComputedStyle(anchored).bottom, '200px');
+    assert_equals(getComputedStyle(anchored).right, '100px');
+}, "Anchored position after resizing the containing block");
+</script>

--- a/Source/WebCore/style/StyleScope.h
+++ b/Source/WebCore/style/StyleScope.h
@@ -28,6 +28,7 @@
 #pragma once
 
 #include "AnchorPositionEvaluator.h"
+#include "LayoutRect.h"
 #include "LayoutSize.h"
 #include "StyleScopeIdentifier.h"
 #include "StyleScopeOrdinal.h"
@@ -259,7 +260,13 @@ private:
     std::optional<MediaQueryViewportState> m_viewportStateOnPreviousMediaQueryEvaluation;
     WeakHashMap<Element, LayoutSize, WeakPtrImplWithEventTargetData> m_queryContainerDimensionsOnLastUpdate;
 
-    SingleThreadWeakHashMap<const RenderBoxModelObject, LayoutRect> m_anchorRectsOnLastUpdate;
+    struct AnchorPosition {
+        LayoutRect absoluteRect;
+        Vector<LayoutSize, 2> containingBlockSizes;
+
+        bool operator==(const AnchorPosition&) const = default;
+    };
+    SingleThreadWeakHashMap<const RenderBoxModelObject, AnchorPosition> m_anchorPositionsOnLastUpdate;
 
     std::unique_ptr<MatchResultCache> m_matchResultCache;
 


### PR DESCRIPTION
#### 8fca573e62a4b035bf358ed11c9d7eb07fddb6ba
<pre>
[css-anchor-position-1] Anchor functions fail to invalidate on container resize
<a href="https://bugs.webkit.org/show_bug.cgi?id=294009">https://bugs.webkit.org/show_bug.cgi?id=294009</a>
<a href="https://rdar.apple.com/problem/152560741">rdar://problem/152560741</a>

Reviewed by Alan Baradlay.

Resizing a container may not change the position of the anchors but the anchor functions referencing bottom/right
insets may still need to be recomputed.

* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-positioned-containing-block-resize-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-positioned-containing-block-resize.html: Added.
* Source/WebCore/style/StyleScope.cpp:
(WebCore::Style::Scope::invalidateForAnchorDependencies):

Besides saving the previous anchor rect also save the containing block sizes for boxes that can host anchored elements.

* Source/WebCore/style/StyleScope.h:

Canonical link: <a href="https://commits.webkit.org/295807@main">https://commits.webkit.org/295807@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9929aaa7705faed5df108c667243be30aae8f660

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/106210 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25959 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/16353 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/111407 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/56806 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/108249 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/26619 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34462 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80676 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/109214 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/21039 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95844 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/61002 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/20585 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13947 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/56246 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/90399 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13982 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/114268 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33348 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24590 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89749 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33712 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/92077 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89450 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22806 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34317 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/12132 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/28924 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/33273 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/38685 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/33019 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/36369 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34617 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->