### PR TITLE
Handle word-spacing for leading white space on SVG text

### DIFF
--- a/LayoutTests/svg/text/word-spacing-leading-ws-expected.html
+++ b/LayoutTests/svg/text/word-spacing-leading-ws-expected.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<div style="width: 100px; height: 100px; background-color: green"></div>

--- a/LayoutTests/svg/text/word-spacing-leading-ws.html
+++ b/LayoutTests/svg/text/word-spacing-leading-ws.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<script src="../../resources/ahem.js"></script>
+<svg>
+  <rect width="100" height="100" fill="red"/>
+  <g fill="green" style="font-size: 50px; font-family: Ahem; word-spacing: 50px">
+    <text x="-100" y="40" style="white-space: pre"> XX</text>
+    <text x="-100" y="90" style="white-space: pre"><tspan> XX</tspan></text>
+  </g>
+</svg>

--- a/Source/WebCore/rendering/svg/SVGTextLayoutEngine.cpp
+++ b/Source/WebCore/rendering/svg/SVGTextLayoutEngine.cpp
@@ -539,7 +539,7 @@ void SVGTextLayoutEngine::layoutTextOnLineOrPath(InlineIterator::SVGTextBoxItera
         updateRelativePositionAdjustmentsIfNeeded(data.dx, data.dy);
 
         // Calculate CSS 'letter-spacing' and 'word-spacing' for next character, if needed.
-        float spacing = spacingLayout.calculateCSSSpacing(currentCharacter);
+        float spacing = spacingLayout.calculateCSSSpacing(currentCharacter ? *currentCharacter : '\0');
 
         float textPathOffset = 0;
         if (m_inPathLayout) {

--- a/Source/WebCore/rendering/svg/SVGTextLayoutEngineSpacing.cpp
+++ b/Source/WebCore/rendering/svg/SVGTextLayoutEngineSpacing.cpp
@@ -34,20 +34,14 @@ SVGTextLayoutEngineSpacing::SVGTextLayoutEngineSpacing(const FontCascade& font)
 {
 }
 
-float SVGTextLayoutEngineSpacing::calculateCSSSpacing(const char16_t* currentCharacter)
+float SVGTextLayoutEngineSpacing::calculateCSSSpacing(char16_t currentCharacter)
 {
-    const char16_t* lastCharacter = m_lastCharacter;
-    m_lastCharacter = currentCharacter;
-
-    if (!m_font->letterSpacing() && !m_font->wordSpacing())
-        return 0;
-
     float spacing = m_font->letterSpacing();
-    if (currentCharacter && lastCharacter && m_font->wordSpacing()) {
-        if (FontCascade::treatAsSpace(*currentCharacter) && !FontCascade::treatAsSpace(*lastCharacter))
-            spacing += m_font->wordSpacing();
-    }
 
+    if (m_font->wordSpacing() && FontCascade::treatAsSpace(currentCharacter) && !FontCascade::treatAsSpace(m_lastCharacter))
+        spacing += m_font->wordSpacing();
+
+    m_lastCharacter = currentCharacter;
     return spacing;
 }
 

--- a/Source/WebCore/rendering/svg/SVGTextLayoutEngineSpacing.h
+++ b/Source/WebCore/rendering/svg/SVGTextLayoutEngineSpacing.h
@@ -35,11 +35,11 @@ class SVGTextLayoutEngineSpacing {
 public:
     SVGTextLayoutEngineSpacing(const FontCascade&);
 
-    float calculateCSSSpacing(const char16_t* currentCharacter);
+    float calculateCSSSpacing(char16_t);
 
 private:
     const CheckedRef<const FontCascade> m_font;
-    const char16_t* m_lastCharacter;
+    char16_t m_lastCharacter { '\0' };
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 81b3e77c1b84125f95be7bd4372d269310d6bb92
<pre>
Handle word-spacing for leading white space on SVG text
<a href="https://bugs.webkit.org/show_bug.cgi?id=278523">https://bugs.webkit.org/show_bug.cgi?id=278523</a>
<a href="https://rdar.apple.com/problem/134941299">rdar://problem/134941299</a>

Reviewed by Said Abou-Hallawa and Brent Fulgham.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

Merge: <a href="https://chromium.googlesource.com/chromium/src.git/+/56aec4bdbfb7f81b00009aa702be81ace6a20665">https://chromium.googlesource.com/chromium/src.git/+/56aec4bdbfb7f81b00009aa702be81ace6a20665</a>

SVGTextLayoutEngineSpacing checking if the current and last characters
were non-nulls before attempting to apply word-spacing. This would mean
that we would never add word-spacing at the beginning of a text box.

* Source/WebCore/rendering/svg/SVGTextLayoutEngine.cpp:
(WebCore::SVGTextLayoutEngine::layoutTextOnLineOrPath):
* Source/WebCore/rendering/svg/SVGTextLayoutEngineSpacing.cpp:
(WebCore::SVGTextLayoutEngineSpacing::calculateCSSSpacing):
* Source/WebCore/rendering/svg/SVGTextLayoutEngineSpacing.h:
* LayoutTests/svg/text/word-spacing-leading-ws.html:
* LayoutTests/svg/text/word-spacing-leading-ws-expected.html:

Canonical link: <a href="https://commits.webkit.org/299066@main">https://commits.webkit.org/299066@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c275a9e93117554cb99683d358df8743f29010c8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/117582 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37259 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/27883 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/123694 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/69589 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/35ba5f8a-2fc3-4900-98f3-da3b7605badd) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/119460 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/37952 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/45842 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89231 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-transforms/transform-box/cssbox-content-box-002.html (failure)") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/45043 "Build is in progress. Recent messages:") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3fbcfe79-cd80-4182-a2bf-ce0135212c67) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/120534 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30204 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105421 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/69733 "Build was cancelled. Recent messages:Printed configuration; Running apply-patch; Failed to checkout and rebase branch from PR 46311") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ac0d9f76-1e4c-4afd-9ee3-55fb14360fa9) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29266 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/23537 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/67363 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99619 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23719 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/126807 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/44485 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33464 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97894 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/44843 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101650 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97682 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24878 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43057 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21006 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/40843 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44356 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/50031 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/43814 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/47162 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/45506 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->