### PR TITLE
[GTK][WPE] Add API to Damage to iterate and get the non-empty rectangles

### DIFF
--- a/Source/WebCore/platform/graphics/texmap/TextureMapperDamageVisualizer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperDamageVisualizer.cpp
@@ -52,8 +52,9 @@ void TextureMapperDamageVisualizer::paintDamage(TextureMapper& textureMapper, co
         return;
 
     const auto color = Color::red.colorWithAlphaByte(200);
-    for (const auto& rect : damage->rects())
+    damage->forEachNonEmptyRect([&](const auto& rect) {
         textureMapper.drawSolidColor(rect + m_margin, { }, color, true);
+    });
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.cpp
@@ -511,17 +511,15 @@ void TextureMapperLayer::collectDamageSelf(TextureMapperPaintOptions& options, D
     // layer-level operations such as resizes, transformations, etc.
     const auto& clipBounds = options.textureMapper.clipBounds();
     if (m_damageInGlobalCoordinateSpace) {
-        for (const auto& rect : m_damageInGlobalCoordinateSpace->rects()) {
-            if (!rect.isEmpty())
-                damage.add(intersection(rect, clipBounds));
-        }
+        m_damageInGlobalCoordinateSpace->forEachNonEmptyRect([&](const auto& rect) {
+            damage.add(intersection(rect, clipBounds));
+        });
     }
 
     if (m_damageInLayerCoordinateSpace) {
-        for (const auto& rect : m_damageInLayerCoordinateSpace->rects()) {
-            if (!rect.isEmpty())
-                damage.add(intersection(transformRectFromLayerToGlobalCoordinateSpace(rect, transform, options), clipBounds));
-        }
+        m_damageInLayerCoordinateSpace->forEachNonEmptyRect([&](const auto& rect) {
+            damage.add(intersection(transformRectFromLayerToGlobalCoordinateSpace(rect, transform, options), clipBounds));
+        });
     }
 }
 

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp
@@ -553,12 +553,7 @@ void CoordinatedPlatformLayer::setContentsTilePhase(const FloatSize& contentsTil
 void CoordinatedPlatformLayer::setDirtyRegion(Damage&& damage)
 {
     ASSERT(m_lock.isHeld());
-    // FIXME: add a way to remove the empty rects from Damage class.
-    auto dirtyRegion = WTF::compactMap(damage.rects(), [](const auto& value) -> std::optional<IntRect> {
-        if (value.isEmpty())
-            return std::nullopt;
-        return value;
-    });
+    auto dirtyRegion = damage.nonEmptyRects();
     if (m_dirtyRegion != dirtyRegion) {
         m_dirtyRegion = WTFMove(dirtyRegion);
         notifyCompositionRequired();

--- a/Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.cpp
+++ b/Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.cpp
@@ -681,7 +681,7 @@ void AcceleratedSurfaceDMABuf::didRenderFrame()
 #if ENABLE(DAMAGE_TRACKING)
     m_target->setDamage(WebCore::Damage(m_size));
     if (m_frameDamage) {
-        damageRects = m_frameDamage->rects();
+        damageRects = m_frameDamage->nonEmptyRects();
         m_frameDamage = std::nullopt;
     }
 #endif

--- a/Tools/TestWebKitAPI/Tests/WebCore/glib/Damage.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/glib/Damage.cpp
@@ -36,7 +36,7 @@ TEST(Damage, Basics)
 {
     Damage damage(IntSize { 2048, 1024 });
     EXPECT_TRUE(damage.isEmpty());
-    EXPECT_EQ(damage.rects().size(), 0);
+    EXPECT_EQ(damage.size(), 0);
 }
 
 TEST(Damage, Mode)
@@ -47,11 +47,12 @@ TEST(Damage, Mode)
     EXPECT_TRUE(rectsDamage.add(IntRect { 100, 100, 200, 200 }));
     EXPECT_TRUE(rectsDamage.add(IntRect { 300, 300, 200, 200 }));
     EXPECT_FALSE(rectsDamage.isEmpty());
-    EXPECT_EQ(rectsDamage.rects().size(), 2);
+    EXPECT_EQ(rectsDamage.size(), 2);
     EXPECT_EQ(rectsDamage.bounds().x(), 100);
     EXPECT_EQ(rectsDamage.bounds().y(), 100);
     EXPECT_EQ(rectsDamage.bounds().width(), 400);
     EXPECT_EQ(rectsDamage.bounds().height(), 400);
+    EXPECT_EQ(rectsDamage.nonEmptyRects().size(), 2);
 
     // BoundingBox always unite damage in bounds.
     Damage bboxDamage(IntSize { 1024, 768 }, Damage::Mode::BoundingBox);
@@ -59,12 +60,13 @@ TEST(Damage, Mode)
     EXPECT_TRUE(bboxDamage.add(IntRect { 100, 100, 200, 200 }));
     EXPECT_TRUE(bboxDamage.add(IntRect { 300, 300, 200, 200 }));
     EXPECT_FALSE(bboxDamage.isEmpty());
-    EXPECT_EQ(bboxDamage.rects().size(), 1);
+    EXPECT_EQ(bboxDamage.size(), 1);
     EXPECT_EQ(bboxDamage.rects()[0], bboxDamage.bounds());
     EXPECT_EQ(bboxDamage.bounds().x(), 100);
     EXPECT_EQ(bboxDamage.bounds().y(), 100);
     EXPECT_EQ(bboxDamage.bounds().width(), 400);
     EXPECT_EQ(bboxDamage.bounds().height(), 400);
+    EXPECT_EQ(bboxDamage.nonEmptyRects().size(), 1);
 
     // Full ignores any adds and always reports the whole area.
     Damage fullDamage(IntSize { 1024, 768 }, Damage::Mode::Full);
@@ -72,12 +74,13 @@ TEST(Damage, Mode)
     EXPECT_FALSE(fullDamage.add(IntRect { 100, 100, 200, 200 }));
     EXPECT_FALSE(fullDamage.add(IntRect { 300, 300, 200, 200 }));
     EXPECT_FALSE(fullDamage.isEmpty());
-    EXPECT_EQ(fullDamage.rects().size(), 1);
+    EXPECT_EQ(fullDamage.size(), 1);
     EXPECT_EQ(fullDamage.rects()[0], fullDamage.bounds());
     EXPECT_EQ(fullDamage.bounds().x(), 0);
     EXPECT_EQ(fullDamage.bounds().y(), 0);
     EXPECT_EQ(fullDamage.bounds().width(), 1024);
     EXPECT_EQ(fullDamage.bounds().height(), 768);
+    EXPECT_EQ(fullDamage.nonEmptyRects().size(), 1);
 
     // We can make a Damage full.
     fullDamage = rectsDamage;
@@ -85,7 +88,7 @@ TEST(Damage, Mode)
     fullDamage.makeFull();
     EXPECT_TRUE(fullDamage.mode() == Damage::Mode::Full);
     EXPECT_FALSE(fullDamage.isEmpty());
-    EXPECT_EQ(fullDamage.rects().size(), 1);
+    EXPECT_EQ(fullDamage.size(), 1);
     EXPECT_EQ(fullDamage.rects()[0], fullDamage.bounds());
     EXPECT_EQ(fullDamage.bounds().x(), 0);
     EXPECT_EQ(fullDamage.bounds().y(), 0);
@@ -98,7 +101,7 @@ TEST(Damage, Mode)
     EXPECT_TRUE(fullDamage.add(IntRect { 0, 0, 1024, 768 }));
     EXPECT_TRUE(fullDamage.mode() == Damage::Mode::Full);
     EXPECT_FALSE(fullDamage.isEmpty());
-    EXPECT_EQ(fullDamage.rects().size(), 1);
+    EXPECT_EQ(fullDamage.size(), 1);
     EXPECT_EQ(fullDamage.bounds().x(), 0);
     EXPECT_EQ(fullDamage.bounds().y(), 0);
     EXPECT_EQ(fullDamage.bounds().width(), 1024);
@@ -110,7 +113,7 @@ TEST(Damage, Mode)
     EXPECT_TRUE(fullDamage.add(IntRect { 0, 0, 2048, 1024 }));
     EXPECT_TRUE(fullDamage.mode() == Damage::Mode::Full);
     EXPECT_FALSE(fullDamage.isEmpty());
-    EXPECT_EQ(fullDamage.rects().size(), 1);
+    EXPECT_EQ(fullDamage.size(), 1);
     EXPECT_EQ(fullDamage.bounds().x(), 0);
     EXPECT_EQ(fullDamage.bounds().y(), 0);
     EXPECT_EQ(fullDamage.bounds().width(), 1024);
@@ -126,7 +129,7 @@ TEST(Damage, Mode)
     }));
     EXPECT_TRUE(fullDamage.mode() == Damage::Mode::Full);
     EXPECT_FALSE(fullDamage.isEmpty());
-    EXPECT_EQ(fullDamage.rects().size(), 1);
+    EXPECT_EQ(fullDamage.size(), 1);
     EXPECT_EQ(fullDamage.bounds().x(), 0);
     EXPECT_EQ(fullDamage.bounds().y(), 0);
     EXPECT_EQ(fullDamage.bounds().width(), 1024);
@@ -145,7 +148,7 @@ TEST(Damage, Mode)
     }));
     EXPECT_TRUE(fullDamage.mode() == Damage::Mode::Full);
     EXPECT_FALSE(fullDamage.isEmpty());
-    EXPECT_EQ(fullDamage.rects().size(), 1);
+    EXPECT_EQ(fullDamage.size(), 1);
     EXPECT_EQ(fullDamage.bounds().x(), 0);
     EXPECT_EQ(fullDamage.bounds().y(), 0);
     EXPECT_EQ(fullDamage.bounds().width(), 512);
@@ -158,7 +161,7 @@ TEST(Damage, Mode)
     EXPECT_TRUE(fullDamage.add(fullDamage2));
     EXPECT_TRUE(fullDamage.mode() == Damage::Mode::Full);
     EXPECT_FALSE(fullDamage.isEmpty());
-    EXPECT_EQ(fullDamage.rects().size(), 1);
+    EXPECT_EQ(fullDamage.size(), 1);
     EXPECT_EQ(fullDamage.bounds().x(), 0);
     EXPECT_EQ(fullDamage.bounds().y(), 0);
     EXPECT_EQ(fullDamage.bounds().width(), 1024);
@@ -171,7 +174,7 @@ TEST(Damage, Move)
     EXPECT_TRUE(damage.add(IntRect { 100, 100, 200, 200 }));
     EXPECT_TRUE(damage.add(IntRect { 300, 300, 200, 200 }));
     EXPECT_FALSE(damage.isEmpty());
-    EXPECT_EQ(damage.rects().size(), 2);
+    EXPECT_EQ(damage.size(), 2);
     EXPECT_EQ(damage.bounds().x(), 100);
     EXPECT_EQ(damage.bounds().y(), 100);
     EXPECT_EQ(damage.bounds().width(), 400);
@@ -179,13 +182,13 @@ TEST(Damage, Move)
 
     Damage other = WTFMove(damage);
     EXPECT_FALSE(other.isEmpty());
-    EXPECT_EQ(other.rects().size(), 2);
+    EXPECT_EQ(other.size(), 2);
     EXPECT_EQ(other.bounds().x(), 100);
     EXPECT_EQ(other.bounds().y(), 100);
     EXPECT_EQ(other.bounds().width(), 400);
     EXPECT_EQ(other.bounds().height(), 400);
     EXPECT_TRUE(damage.isEmpty());
-    EXPECT_EQ(damage.rects().size(), 0);
+    EXPECT_EQ(damage.size(), 0);
     EXPECT_EQ(damage.bounds().x(), 100);
     EXPECT_EQ(damage.bounds().y(), 100);
     EXPECT_EQ(damage.bounds().width(), 400);
@@ -196,7 +199,7 @@ TEST(Damage, AddRect)
 {
     Damage damage(IntSize { 2048, 1024 });
     EXPECT_TRUE(damage.add(IntRect { 100, 100, 200, 200 }));
-    EXPECT_EQ(damage.rects().size(), 1);
+    EXPECT_EQ(damage.size(), 1);
 
     // When there's only one rect, that should be the bounds.
     EXPECT_EQ(damage.bounds().x(), 100);
@@ -207,15 +210,15 @@ TEST(Damage, AddRect)
     // When there's only one rect, adding a rect already contained
     // by the bounding box does nothing.
     EXPECT_FALSE(damage.add(IntRect { 150, 150, 100, 100 }));
-    EXPECT_EQ(damage.rects().size(), 1);
+    EXPECT_EQ(damage.size(), 1);
 
     // Adding an empty rect does nothing.
     EXPECT_FALSE(damage.add(IntRect { }));
-    EXPECT_EQ(damage.rects().size(), 1);
+    EXPECT_EQ(damage.size(), 1);
 
     // Adding a new rect not contained by previous one adds it to the list.
     EXPECT_TRUE(damage.add(IntRect { 300, 300, 200, 200 }));
-    EXPECT_EQ(damage.rects().size(), 2);
+    EXPECT_EQ(damage.size(), 2);
 
     // Now the bounding box contains the two rectangles.
     EXPECT_EQ(damage.bounds().x(), 100);
@@ -225,7 +228,7 @@ TEST(Damage, AddRect)
 
     // Adding a rect containing the bounds makes it the only rect.
     EXPECT_TRUE(damage.add(IntRect { 50, 50, 500, 500 }));
-    EXPECT_EQ(damage.rects().size(), 1);
+    EXPECT_EQ(damage.size(), 1);
     EXPECT_EQ(damage.bounds().x(), 50);
     EXPECT_EQ(damage.bounds().y(), 50);
     EXPECT_EQ(damage.bounds().width(), 500);
@@ -233,7 +236,7 @@ TEST(Damage, AddRect)
 
     // Adding FloatRect takes the enclosingIntRect
     EXPECT_TRUE(damage.add(FloatRect { 1024.50, 1024.25, 50.32, 25.75 }));
-    EXPECT_EQ(damage.rects().size(), 2);
+    EXPECT_EQ(damage.size(), 2);
     EXPECT_EQ(damage.rects().last().x(), 1024);
     EXPECT_EQ(damage.rects().last().y(), 1024);
     EXPECT_EQ(damage.rects().last().width(), 51);
@@ -241,23 +244,23 @@ TEST(Damage, AddRect)
 
     // Adding an empty FloatRect does nothing.
     EXPECT_FALSE(damage.add(FloatRect { 1024.50, 1024.25, 0, 0 }));
-    EXPECT_EQ(damage.rects().size(), 2);
+    EXPECT_EQ(damage.size(), 2);
 }
 
 TEST(Damage, AddRects)
 {
     Damage damage(IntSize { 2048, 1024 });
     EXPECT_TRUE(damage.add(Vector<IntRect, 1> { { 100, 100, 200, 200 } }));
-    EXPECT_EQ(damage.rects().size(), 1);
+    EXPECT_EQ(damage.size(), 1);
     EXPECT_EQ(damage.bounds(), IntRect(100, 100, 200, 200));
 
     // Adding an empty Vector does nothing.
     EXPECT_FALSE(damage.add(Vector<IntRect, 1> { }));
-    EXPECT_EQ(damage.rects().size(), 1);
+    EXPECT_EQ(damage.size(), 1);
 
     // Adding a Vector with empty rets does nothing.
     EXPECT_FALSE(damage.add(Vector<IntRect, 1> { { }, { } }));
-    EXPECT_EQ(damage.rects().size(), 1);
+    EXPECT_EQ(damage.size(), 1);
 
     // Adding more than 4 rectangles will unite.
     damage = Damage(IntSize { 512, 512 });
@@ -268,7 +271,7 @@ TEST(Damage, AddRects)
         { 200, 200, 4, 4 },
         { 128, 128, 4, 4 }
     }));
-    EXPECT_EQ(damage.rects().size(), 4);
+    EXPECT_EQ(damage.size(), 4);
     EXPECT_EQ(damage.rects()[0], damage.bounds());
 
     // Adding more than 4 rectangles to a non empty damage should unite too.
@@ -280,20 +283,20 @@ TEST(Damage, AddRects)
         { 500, 200, 4, 4 },
         { 384, 128, 4, 4 }
     }));
-    EXPECT_EQ(damage.rects().size(), 4);
+    EXPECT_EQ(damage.size(), 4);
     EXPECT_EQ(damage.rects()[1], damage.bounds());
 
     // Adding more than 4 empty rectangles does nothing.
     damage = Damage(IntSize { 512, 512 });
     EXPECT_FALSE(damage.add(Vector<IntRect, 1> { { }, { }, { }, { }, { } }));
-    EXPECT_EQ(damage.rects().size(), 0);
+    EXPECT_EQ(damage.size(), 0);
 
     // Adding more than 4 empty rectangles to a non empty damage does nothing too.
     damage = Damage(IntSize { 512, 512 });
     EXPECT_TRUE(damage.add(IntRect { 300, 0, 4, 4 }));
-    EXPECT_EQ(damage.rects().size(), 1);
+    EXPECT_EQ(damage.size(), 1);
     EXPECT_FALSE(damage.add(Vector<IntRect, 1> { { }, { }, { }, { }, { } }));
-    EXPECT_EQ(damage.rects().size(), 1);
+    EXPECT_EQ(damage.size(), 1);
 
     // Adding a Vector to damage in BoundingBox mode always unite damage in bounds.
     damage = Damage(IntSize { 1024, 768 }, Damage::Mode::BoundingBox);
@@ -301,7 +304,7 @@ TEST(Damage, AddRects)
         { 100, 100, 200, 200 },
         { 300, 300, 200, 200 }
     }));
-    EXPECT_EQ(damage.rects().size(), 1);
+    EXPECT_EQ(damage.size(), 1);
     EXPECT_EQ(damage.rects()[0], damage.bounds());
     EXPECT_EQ(damage.bounds(), IntRect(100, 100, 400, 400));
 
@@ -311,7 +314,7 @@ TEST(Damage, AddRects)
         { 100, 100, 200, 200 },
         { 300, 300, 200, 200 }
     }));
-    EXPECT_EQ(damage.rects().size(), 1);
+    EXPECT_EQ(damage.size(), 1);
     EXPECT_EQ(damage.rects()[0], damage.bounds());
     EXPECT_EQ(damage.bounds(), IntRect(0, 0, 1024, 768));
 }
@@ -320,18 +323,18 @@ TEST(Damage, AddDamage)
 {
     Damage damage(IntSize { 2048, 1024 });
     EXPECT_TRUE(damage.add(IntRect { 100, 100, 200, 200 }));
-    EXPECT_EQ(damage.rects().size(), 1);
+    EXPECT_EQ(damage.size(), 1);
 
     // Adding empty Damage does nothing.
     Damage other(IntSize { 2048, 1024 });
     EXPECT_FALSE(damage.add(other));
-    EXPECT_EQ(damage.rects().size(), 1);
+    EXPECT_EQ(damage.size(), 1);
 
     // Adding a valid Damage adds its rectangles.
     EXPECT_TRUE(other.add(IntRect { 300, 300, 200, 200 }));
-    EXPECT_EQ(other.rects().size(), 1);
+    EXPECT_EQ(other.size(), 1);
     EXPECT_TRUE(damage.add(other));
-    EXPECT_EQ(damage.rects().size(), 2);
+    EXPECT_EQ(damage.size(), 2);
     EXPECT_EQ(damage.bounds().x(), 100);
     EXPECT_EQ(damage.bounds().y(), 100);
     EXPECT_EQ(damage.bounds().width(), 400);
@@ -340,12 +343,12 @@ TEST(Damage, AddDamage)
     // It's possible to add one Damage to another with different rectangle.
     damage = Damage(IntSize { 1024, 768 });
     EXPECT_TRUE(damage.add(IntRect { 100, 100, 200, 200 }));
-    EXPECT_EQ(damage.rects().size(), 1);
+    EXPECT_EQ(damage.size(), 1);
     other = Damage(IntSize { 800, 600 });
     EXPECT_TRUE(other.add(IntRect { 300, 300, 200, 200 }));
-    EXPECT_EQ(other.rects().size(), 1);
+    EXPECT_EQ(other.size(), 1);
     EXPECT_TRUE(damage.add(other));
-    EXPECT_EQ(damage.rects().size(), 2);
+    EXPECT_EQ(damage.size(), 2);
     EXPECT_EQ(damage.rects()[0], IntRect(100, 100, 200, 200));
     EXPECT_EQ(damage.rects()[1], IntRect(300, 300, 200, 200));
 
@@ -358,7 +361,7 @@ TEST(Damage, AddDamage)
         { 300, 300, 4, 4 },
         { 128, 128, 4, 4 }
     }));
-    EXPECT_EQ(damage.rects().size(), 4);
+    EXPECT_EQ(damage.size(), 4);
     EXPECT_EQ(damage.rects()[0], IntRect(0, 0, 132, 132));
     EXPECT_EQ(damage.rects()[1], IntRect(300, 0, 4, 4));
     EXPECT_EQ(damage.rects()[2], IntRect(0, 300, 4, 4));
@@ -371,13 +374,13 @@ TEST(Damage, AddDamage)
         { 310, 310, 4, 4 },
         { 384, 384, 4, 4 }
     }));
-    EXPECT_EQ(other.rects().size(), 4);
+    EXPECT_EQ(other.size(), 4);
     EXPECT_EQ(other.rects()[0], IntRect(10, 10, 4, 4));
     EXPECT_EQ(other.rects()[1], IntRect(310, 10, 4, 4));
     EXPECT_EQ(other.rects()[2], IntRect(10, 310, 4, 4));
     EXPECT_EQ(other.rects()[3], IntRect(310, 310, 78, 78));
     EXPECT_TRUE(damage.add(other));
-    EXPECT_EQ(damage.rects().size(), 4);
+    EXPECT_EQ(damage.size(), 4);
     EXPECT_EQ(damage.rects()[0], IntRect(0, 0, 132, 132));
     EXPECT_EQ(damage.rects()[1], IntRect(300, 0, 14, 14));
     EXPECT_EQ(damage.rects()[2], IntRect(0, 300, 14, 14));
@@ -389,85 +392,95 @@ TEST(Damage, Unite)
     // Add several rects to the first tile.
     Damage damage(IntSize { 512, 512 });
     EXPECT_TRUE(damage.add(IntRect { 0, 0, 4, 4 }));
-    EXPECT_EQ(damage.rects().size(), 1);
+    EXPECT_EQ(damage.size(), 1);
     EXPECT_TRUE(damage.add(IntRect { 200, 0, 4, 4 }));
-    EXPECT_EQ(damage.rects().size(), 2);
+    EXPECT_EQ(damage.size(), 2);
     EXPECT_TRUE(damage.add(IntRect { 0, 200, 4, 4 }));
-    EXPECT_EQ(damage.rects().size(), 3);
+    EXPECT_EQ(damage.size(), 3);
     EXPECT_TRUE(damage.add(IntRect { 200, 200, 4, 4 }));
-    EXPECT_EQ(damage.rects().size(), 4);
+    EXPECT_EQ(damage.size(), 4);
     EXPECT_TRUE(damage.add(IntRect { 128, 128, 4, 4 }));
-    EXPECT_EQ(damage.rects().size(), 4);
+    EXPECT_EQ(damage.size(), 4);
     EXPECT_FALSE(damage.rects()[0].isEmpty());
     EXPECT_TRUE(damage.rects()[1].isEmpty());
     EXPECT_TRUE(damage.rects()[2].isEmpty());
     EXPECT_TRUE(damage.rects()[3].isEmpty());
+    EXPECT_EQ(damage.nonEmptyRects().size(), 1);
     EXPECT_EQ(damage.rects()[0], damage.bounds());
 
     // Add several rects to the second tile.
     damage = Damage(IntSize { 512, 512 });
     EXPECT_TRUE(damage.add(IntRect { 300, 0, 4, 4 }));
-    EXPECT_EQ(damage.rects().size(), 1);
+    EXPECT_EQ(damage.size(), 1);
     EXPECT_TRUE(damage.add(IntRect { 500, 0, 4, 4 }));
-    EXPECT_EQ(damage.rects().size(), 2);
+    EXPECT_EQ(damage.size(), 2);
     EXPECT_TRUE(damage.add(IntRect { 300, 200, 4, 4 }));
-    EXPECT_EQ(damage.rects().size(), 3);
+    EXPECT_EQ(damage.size(), 3);
     EXPECT_TRUE(damage.add(IntRect { 500, 200, 4, 4 }));
-    EXPECT_EQ(damage.rects().size(), 4);
+    EXPECT_EQ(damage.size(), 4);
     EXPECT_TRUE(damage.add(IntRect { 384, 128, 4, 4 }));
-    EXPECT_EQ(damage.rects().size(), 4);
+    EXPECT_EQ(damage.size(), 4);
     EXPECT_TRUE(damage.rects()[0].isEmpty());
     EXPECT_FALSE(damage.rects()[1].isEmpty());
     EXPECT_TRUE(damage.rects()[2].isEmpty());
     EXPECT_TRUE(damage.rects()[3].isEmpty());
+    EXPECT_EQ(damage.nonEmptyRects().size(), 1);
+    damage.forEachNonEmptyRect([&](const auto& rect) {
+        EXPECT_EQ(rect, damage.bounds());
+    });
     EXPECT_EQ(damage.rects()[1], damage.bounds());
 
     // Add several rects to the third tile.
     damage = Damage(IntSize { 512, 512 });
     EXPECT_TRUE(damage.add(IntRect { 0, 300, 4, 4 }));
-    EXPECT_EQ(damage.rects().size(), 1);
+    EXPECT_EQ(damage.size(), 1);
     EXPECT_TRUE(damage.add(IntRect { 200, 300, 4, 4 }));
-    EXPECT_EQ(damage.rects().size(), 2);
+    EXPECT_EQ(damage.size(), 2);
     EXPECT_TRUE(damage.add(IntRect { 0, 500, 4, 4 }));
-    EXPECT_EQ(damage.rects().size(), 3);
+    EXPECT_EQ(damage.size(), 3);
     EXPECT_TRUE(damage.add(IntRect { 200, 500, 4, 4 }));
-    EXPECT_EQ(damage.rects().size(), 4);
+    EXPECT_EQ(damage.size(), 4);
     EXPECT_TRUE(damage.add(IntRect { 128, 384, 4, 4 }));
-    EXPECT_EQ(damage.rects().size(), 4);
+    EXPECT_EQ(damage.size(), 4);
     EXPECT_TRUE(damage.rects()[0].isEmpty());
     EXPECT_TRUE(damage.rects()[1].isEmpty());
     EXPECT_FALSE(damage.rects()[2].isEmpty());
     EXPECT_TRUE(damage.rects()[3].isEmpty());
+    EXPECT_EQ(damage.nonEmptyRects().size(), 1);
     EXPECT_EQ(damage.rects()[2], damage.bounds());
 
     // Add several rects to the fourth tile.
     damage = Damage(IntSize { 512, 512 });
     EXPECT_TRUE(damage.add(IntRect { 300, 300, 4, 4 }));
-    EXPECT_EQ(damage.rects().size(), 1);
+    EXPECT_EQ(damage.size(), 1);
     EXPECT_TRUE(damage.add(IntRect { 500, 300, 4, 4 }));
-    EXPECT_EQ(damage.rects().size(), 2);
+    EXPECT_EQ(damage.size(), 2);
     EXPECT_TRUE(damage.add(IntRect { 300, 500, 4, 4 }));
-    EXPECT_EQ(damage.rects().size(), 3);
+    EXPECT_EQ(damage.size(), 3);
     EXPECT_TRUE(damage.add(IntRect { 500, 500, 4, 4 }));
-    EXPECT_EQ(damage.rects().size(), 4);
+    EXPECT_EQ(damage.size(), 4);
     EXPECT_TRUE(damage.add(IntRect { 384, 384, 4, 4 }));
-    EXPECT_EQ(damage.rects().size(), 4);
+    EXPECT_EQ(damage.size(), 4);
     EXPECT_TRUE(damage.rects()[0].isEmpty());
     EXPECT_TRUE(damage.rects()[1].isEmpty());
     EXPECT_TRUE(damage.rects()[2].isEmpty());
     EXPECT_FALSE(damage.rects()[3].isEmpty());
+    EXPECT_EQ(damage.nonEmptyRects().size(), 1);
+    damage.forEachNonEmptyRect([&](const auto& rect) {
+        EXPECT_EQ(rect, damage.bounds());
+    });
     EXPECT_EQ(damage.rects()[3], damage.bounds());
 
     // Add one rect per tile.
     damage = Damage(IntSize { 512, 512 });
     EXPECT_TRUE(damage.add(IntRect { 0, 0, 4, 4 }));
-    EXPECT_EQ(damage.rects().size(), 1);
+    EXPECT_EQ(damage.size(), 1);
     EXPECT_TRUE(damage.add(IntRect { 300, 0, 4, 4 }));
-    EXPECT_EQ(damage.rects().size(), 2);
+    EXPECT_EQ(damage.size(), 2);
     EXPECT_TRUE(damage.add(IntRect { 0, 300, 4, 4 }));
-    EXPECT_EQ(damage.rects().size(), 3);
+    EXPECT_EQ(damage.size(), 3);
     EXPECT_TRUE(damage.add(IntRect { 300, 300, 4, 4 }));
-    EXPECT_EQ(damage.rects().size(), 4);
+    EXPECT_EQ(damage.size(), 4);
     EXPECT_FALSE(damage.rects()[0].isEmpty());
     EXPECT_EQ(damage.rects()[0].x(), 0);
     EXPECT_EQ(damage.rects()[0].y(), 0);
@@ -488,25 +501,26 @@ TEST(Damage, Unite)
     EXPECT_EQ(damage.rects()[3].y(), 300);
     EXPECT_EQ(damage.rects()[3].width(), 4);
     EXPECT_EQ(damage.rects()[3].height(), 4);
+    EXPECT_EQ(damage.nonEmptyRects().size(), 4);
 
     // Add rects with points off the grid area.
     damage = Damage(IntSize { 512, 512 });
     EXPECT_TRUE(damage.add(IntRect { -2, 0, 4, 4 }));
-    EXPECT_EQ(damage.rects().size(), 1);
+    EXPECT_EQ(damage.size(), 1);
     EXPECT_TRUE(damage.add(IntRect { 50, -2, 4, 4 }));
-    EXPECT_EQ(damage.rects().size(), 2);
+    EXPECT_EQ(damage.size(), 2);
     EXPECT_TRUE(damage.add(IntRect { 550, 0, 4, 4 }));
-    EXPECT_EQ(damage.rects().size(), 3);
+    EXPECT_EQ(damage.size(), 3);
     EXPECT_TRUE(damage.add(IntRect { 300, -2, 4, 4 }));
-    EXPECT_EQ(damage.rects().size(), 4);
+    EXPECT_EQ(damage.size(), 4);
     EXPECT_TRUE(damage.add(IntRect { -2, 300, 4, 4 }));
-    EXPECT_EQ(damage.rects().size(), 4);
+    EXPECT_EQ(damage.size(), 4);
     EXPECT_TRUE(damage.add(IntRect { 50, 550, 4, 4 }));
-    EXPECT_EQ(damage.rects().size(), 4);
+    EXPECT_EQ(damage.size(), 4);
     EXPECT_TRUE(damage.add(IntRect { 300, 550, 4, 4 }));
-    EXPECT_EQ(damage.rects().size(), 4);
+    EXPECT_EQ(damage.size(), 4);
     EXPECT_TRUE(damage.add(IntRect { 550, 300, 4, 4 }));
-    EXPECT_EQ(damage.rects().size(), 4);
+    EXPECT_EQ(damage.size(), 4);
     EXPECT_FALSE(damage.rects()[0].isEmpty());
     EXPECT_EQ(damage.rects()[0].x(), -2);
     EXPECT_EQ(damage.rects()[0].y(), -2);
@@ -527,21 +541,23 @@ TEST(Damage, Unite)
     EXPECT_EQ(damage.rects()[3].y(), 300);
     EXPECT_EQ(damage.rects()[3].width(), 254);
     EXPECT_EQ(damage.rects()[3].height(), 254);
+    EXPECT_EQ(damage.nonEmptyRects().size(), 4);
 
     // Add several rects and check that unite works for single tile grid.
     damage = Damage(IntSize { 128, 128 });
     EXPECT_TRUE(damage.add(IntRect { 10, 10, 4, 4 }));
-    EXPECT_EQ(damage.rects().size(), 1);
+    EXPECT_EQ(damage.size(), 1);
     EXPECT_TRUE(damage.add(IntRect { 60, 60, 4, 4 }));
-    EXPECT_EQ(damage.rects().size(), 1);
+    EXPECT_EQ(damage.size(), 1);
     EXPECT_TRUE(damage.add(IntRect { 70, 10, 4, 4 }));
-    EXPECT_EQ(damage.rects().size(), 1);
+    EXPECT_EQ(damage.size(), 1);
     EXPECT_TRUE(damage.add(IntRect { 120, 60, 4, 4 }));
-    EXPECT_EQ(damage.rects().size(), 1);
+    EXPECT_EQ(damage.size(), 1);
     EXPECT_TRUE(damage.add(IntRect { 10, 70, 4, 4 }));
-    EXPECT_EQ(damage.rects().size(), 1);
+    EXPECT_EQ(damage.size(), 1);
     EXPECT_TRUE(damage.add(IntRect { 120, 120, 4, 4 }));
-    EXPECT_EQ(damage.rects().size(), 1);
+    EXPECT_EQ(damage.size(), 1);
+    EXPECT_EQ(damage.nonEmptyRects().size(), 1);
 
     // Grid size should be ceiled.
     damage = Damage(IntSize { 512, 333 });
@@ -549,13 +565,15 @@ TEST(Damage, Unite)
     EXPECT_TRUE(damage.add(IntRect { 1, 1, 1, 1 }));
     EXPECT_TRUE(damage.add(IntRect { 2, 2, 1, 1 }));
     EXPECT_TRUE(damage.add(IntRect { 3, 3, 1, 1 }));
-    EXPECT_EQ(damage.rects().size(), 4);
+    EXPECT_EQ(damage.size(), 4);
+    EXPECT_EQ(damage.nonEmptyRects().size(), 4);
 
     // Grid size should be ceiled with high precision.
     damage = Damage(IntSize { 257, 50 });
     EXPECT_TRUE(damage.add(IntRect { 0, 0, 1, 1 }));
     EXPECT_TRUE(damage.add(IntRect { 1, 1, 1, 1 }));
-    EXPECT_EQ(damage.rects().size(), 2);
+    EXPECT_EQ(damage.size(), 2);
+    EXPECT_EQ(damage.nonEmptyRects().size(), 2);
 
     // Unification should work correctly when grid does not start and { 0, 0 }.
     damage = Damage(IntRect { 256, 256, 512, 512 });
@@ -563,28 +581,30 @@ TEST(Damage, Unite)
     EXPECT_TRUE(damage.add(IntRect { 600, 300, 1, 1 }));
     EXPECT_TRUE(damage.add(IntRect { 300, 600, 1, 1 }));
     EXPECT_TRUE(damage.add(IntRect { 600, 600, 1, 1 }));
-    EXPECT_EQ(damage.rects().size(), 4);
+    EXPECT_EQ(damage.size(), 4);
     EXPECT_TRUE(damage.add(IntRect { 301, 301, 1, 1 }));
-    EXPECT_EQ(damage.rects().size(), 4);
+    EXPECT_EQ(damage.size(), 4);
     EXPECT_EQ(damage.rects()[0], IntRect(300, 300, 2, 2));
     EXPECT_EQ(damage.rects()[1], IntRect(600, 300, 1, 1));
     EXPECT_EQ(damage.rects()[2], IntRect(300, 600, 1, 1));
     EXPECT_EQ(damage.rects()[3], IntRect(600, 600, 1, 1));
+    EXPECT_EQ(damage.nonEmptyRects().size(), 4);
 
     // Adding a rect covering the current bounding box makes the Damage no longer unified.
     damage = Damage(IntSize { 512, 512 });
     EXPECT_TRUE(damage.add(IntRect { 300, 0, 4, 4 }));
-    EXPECT_EQ(damage.rects().size(), 1);
+    EXPECT_EQ(damage.size(), 1);
     EXPECT_TRUE(damage.add(IntRect { 500, 0, 4, 4 }));
-    EXPECT_EQ(damage.rects().size(), 2);
+    EXPECT_EQ(damage.size(), 2);
     EXPECT_TRUE(damage.add(IntRect { 300, 200, 4, 4 }));
-    EXPECT_EQ(damage.rects().size(), 3);
+    EXPECT_EQ(damage.size(), 3);
     EXPECT_TRUE(damage.add(IntRect { 500, 200, 4, 4 }));
-    EXPECT_EQ(damage.rects().size(), 4);
+    EXPECT_EQ(damage.size(), 4);
     EXPECT_TRUE(damage.add(IntRect { 384, 128, 4, 4 }));
-    EXPECT_EQ(damage.rects().size(), 4);
+    EXPECT_EQ(damage.size(), 4);
     EXPECT_TRUE(damage.add(IntRect { 250, 0, 254, 254 }));
-    EXPECT_EQ(damage.rects().size(), 1);
+    EXPECT_EQ(damage.size(), 1);
+    EXPECT_EQ(damage.nonEmptyRects().size(), 1);
 }
 
 TEST(Damage, MaxRectangles)
@@ -596,9 +616,10 @@ TEST(Damage, MaxRectangles)
         { 0, 300, 4, 4 },
         { 300, 300, 4, 4 }
     }));
-    EXPECT_EQ(damage.rects().size(), 2);
+    EXPECT_EQ(damage.size(), 2);
     EXPECT_EQ(damage.rects()[0], IntRect(0, 0, 4, 304));
     EXPECT_EQ(damage.rects()[1], IntRect(300, 0, 4, 304));
+    EXPECT_EQ(damage.nonEmptyRects().size(), 2);
 
     damage = Damage(IntSize { 2048, 1024 }, Damage::Mode::Rectangles, 3);
     EXPECT_TRUE(damage.add(Vector<IntRect, 1> {
@@ -607,10 +628,11 @@ TEST(Damage, MaxRectangles)
         { 1400, 700, 200, 200 },
         { 1800, 800, 200, 200 }
     }));
-    EXPECT_EQ(damage.rects().size(), 3);
+    EXPECT_EQ(damage.size(), 3);
     EXPECT_EQ(damage.rects()[0], IntRect(100, 100, 200, 200));
     EXPECT_EQ(damage.rects()[1], IntRect(700, 500, 200, 200));
     EXPECT_EQ(damage.rects()[2], IntRect(1400, 700, 600, 300));
+    EXPECT_EQ(damage.nonEmptyRects().size(), 3);
 
     // Using MaxRectangles = 0 means no maximum so default fixed cell size is used
     damage = Damage(IntSize { 512, 512 }, Damage::Mode::Rectangles, 0);
@@ -621,11 +643,12 @@ TEST(Damage, MaxRectangles)
         { 300, 300, 4, 4 },
         { 384, 384, 4, 4 }
     }));
-    EXPECT_EQ(damage.rects().size(), 4);
+    EXPECT_EQ(damage.size(), 4);
     EXPECT_EQ(damage.rects()[0], IntRect(0, 0, 4, 4));
     EXPECT_EQ(damage.rects()[1], IntRect(300, 0, 4, 4));
     EXPECT_EQ(damage.rects()[2], IntRect(0, 300, 4, 4));
     EXPECT_EQ(damage.rects()[3], IntRect(300, 300, 88, 88));
+    EXPECT_EQ(damage.nonEmptyRects().size(), 4);
 
     // Passing MaxRectangles = 1 always unifies.
     damage = Damage(IntSize { 512, 512 }, Damage::Mode::Rectangles, 1);
@@ -636,9 +659,10 @@ TEST(Damage, MaxRectangles)
         { 300, 300, 4, 4 },
         { 384, 384, 4, 4 }
     }));
-    EXPECT_EQ(damage.rects().size(), 1);
+    EXPECT_EQ(damage.size(), 1);
     EXPECT_EQ(damage.rects()[0], damage.bounds());
     EXPECT_EQ(damage.bounds(), IntRect(0, 0, 388, 388));
+    EXPECT_EQ(damage.nonEmptyRects().size(), 1);
 
     // Passing MaxRectangles with BoundingBode mode ignores it.
     damage = Damage(IntSize { 1024, 768 }, Damage::Mode::BoundingBox, 2);
@@ -647,9 +671,10 @@ TEST(Damage, MaxRectangles)
         { 200, 200, 200, 200 },
         { 300, 300, 200, 200 }
     }));
-    EXPECT_EQ(damage.rects().size(), 1);
+    EXPECT_EQ(damage.size(), 1);
     EXPECT_EQ(damage.rects()[0], damage.bounds());
     EXPECT_EQ(damage.bounds(), IntRect(100, 100, 400, 400));
+    EXPECT_EQ(damage.nonEmptyRects().size(), 1);
 
     // Passing MaxRectangles with Full mode ignores it.
     damage = Damage(IntSize { 1024, 768 }, Damage::Mode::Full, 3);
@@ -657,9 +682,10 @@ TEST(Damage, MaxRectangles)
         { 100, 100, 200, 200 },
         { 300, 300, 200, 200 }
     }));
-    EXPECT_EQ(damage.rects().size(), 1);
+    EXPECT_EQ(damage.size(), 1);
     EXPECT_EQ(damage.rects()[0], damage.bounds());
     EXPECT_EQ(damage.bounds(), IntRect(0, 0, 1024, 768));
+    EXPECT_EQ(damage.nonEmptyRects().size(), 1);
 }
 
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### 4ccbfa1856505352185aa3dac2b5c154ba70aaa9
<pre>
[GTK][WPE] Add API to Damage to iterate and get the non-empty rectangles
<a href="https://bugs.webkit.org/show_bug.cgi?id=294015">https://bugs.webkit.org/show_bug.cgi?id=294015</a>

Reviewed by Adrian Perez de Castro.

This patch includes many of the changes added in 294236@main to make
Damage iterable that were reverted in 294557@main, but without making
Damage iterable again, since we need to investigate what caused the
artifacts. In the meantime we add nonEmptyRects() to get a copy of
the rects without the empty rectangles and forEachNonEmptyRect() to
iterate the rects skipping the empty ones.

Canonical link: <a href="https://commits.webkit.org/296137@main">https://commits.webkit.org/296137@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/42e343974ab99769d049a623be341deee76f98b5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/106871 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/26601 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/16998 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/112077 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/57452 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/108887 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/27269 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/35102 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/81158 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/109852 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/21652 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/96422 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/61499 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/21094 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/14531 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/56900 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/90993 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/14558 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/115056 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33987 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/25079 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/90217 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/34353 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/92653 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89927 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34854 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/12668 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/29686 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17382 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/33911 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/39346 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/33658 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/37011 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/35272 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->