### PR TITLE
Remove redundant RenderStyle::isInVisibilityAdjustmentSubtree bit

### DIFF
--- a/Source/WebCore/page/ElementTargetingController.cpp
+++ b/Source/WebCore/page/ElementTargetingController.cpp
@@ -1041,7 +1041,7 @@ static Element* searchForElementContainingText(ContainerNode& container, const S
         }
 
         CheckedPtr renderer = target->renderer();
-        if (!renderer || renderer->style().isInVisibilityAdjustmentSubtree()) {
+        if (!renderer || renderer->style().isForceHidden()) {
             remainingRange.start = foundRange.end;
             continue;
         }

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -1174,9 +1174,6 @@ public:
     inline void setBlendMode(BlendMode);
     inline bool isInSubtreeWithBlendMode() const;
 
-    inline void setIsInVisibilityAdjustmentSubtree();
-    inline bool isInVisibilityAdjustmentSubtree() const;
-
     inline void setIsForceHidden();
     inline bool isForceHidden() const;
 

--- a/Source/WebCore/rendering/style/RenderStyleInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleInlines.h
@@ -856,16 +856,13 @@ inline BlendMode RenderStyle::blendMode() const { return static_cast<BlendMode>(
 constexpr BlendMode RenderStyle::initialBlendMode() { return BlendMode::Normal; }
 constexpr Isolation RenderStyle::initialIsolation() { return Isolation::Auto; }
 inline bool RenderStyle::isInSubtreeWithBlendMode() const { return m_rareInheritedData->isInSubtreeWithBlendMode; }
-inline bool RenderStyle::isInVisibilityAdjustmentSubtree() const { return m_rareInheritedData->isInVisibilityAdjustmentSubtree; }
 inline bool RenderStyle::isForceHidden() const { return m_rareInheritedData->isForceHidden; }
 inline Isolation RenderStyle::isolation() const { return static_cast<Isolation>(m_nonInheritedData->rareData->isolation); }
 inline bool RenderStyle::usesAnchorFunctions() const { return m_nonInheritedData->rareData->usesAnchorFunctions; }
 
 inline Visibility RenderStyle::usedVisibility() const
 {
-    if (isInVisibilityAdjustmentSubtree()) [[unlikely]]
-        return Visibility::Hidden;
-    if (isForceHidden())
+    if (isForceHidden()) [[unlikely]]
         return Visibility::Hidden;
     return static_cast<Visibility>(m_inheritedFlags.visibility);
 }

--- a/Source/WebCore/rendering/style/RenderStyleSetters.h
+++ b/Source/WebCore/rendering/style/RenderStyleSetters.h
@@ -676,7 +676,6 @@ inline void RenderStyle::setBlendMode(BlendMode mode)
     SET(m_rareInheritedData, isInSubtreeWithBlendMode, mode != BlendMode::Normal);
 }
 
-inline void RenderStyle::setIsInVisibilityAdjustmentSubtree() { SET(m_rareInheritedData, isInVisibilityAdjustmentSubtree, true); }
 inline void RenderStyle::setIsForceHidden() { SET(m_rareInheritedData, isForceHidden, true); }
 inline void RenderStyle::setIsolation(Isolation isolation) { SET_NESTED(m_nonInheritedData, rareData, isolation, static_cast<unsigned>(isolation)); }
 

--- a/Source/WebCore/rendering/style/StyleRareInheritedData.cpp
+++ b/Source/WebCore/rendering/style/StyleRareInheritedData.cpp
@@ -143,7 +143,6 @@ StyleRareInheritedData::StyleRareInheritedData()
     , hasAutoAccentColor(true)
     , effectiveInert(false)
     , isInSubtreeWithBlendMode(false)
-    , isInVisibilityAdjustmentSubtree(false)
     , isForceHidden(false)
     , usedContentVisibility(static_cast<unsigned>(ContentVisibility::Visible))
     , insideDefaultButton(false)
@@ -245,7 +244,6 @@ inline StyleRareInheritedData::StyleRareInheritedData(const StyleRareInheritedDa
     , hasAutoAccentColor(o.hasAutoAccentColor)
     , effectiveInert(o.effectiveInert)
     , isInSubtreeWithBlendMode(o.isInSubtreeWithBlendMode)
-    , isInVisibilityAdjustmentSubtree(o.isInVisibilityAdjustmentSubtree)
     , isForceHidden(o.isForceHidden)
     , usedContentVisibility(o.usedContentVisibility)
     , insideDefaultButton(o.insideDefaultButton)
@@ -378,7 +376,6 @@ bool StyleRareInheritedData::operator==(const StyleRareInheritedData& o) const
         && hasVisitedLinkAutoCaretColor == o.hasVisitedLinkAutoCaretColor
         && hasAutoAccentColor == o.hasAutoAccentColor
         && isInSubtreeWithBlendMode == o.isInSubtreeWithBlendMode
-        && isInVisibilityAdjustmentSubtree == o.isInVisibilityAdjustmentSubtree
         && isForceHidden == o.isForceHidden
         && usedTouchActions == o.usedTouchActions
         && eventListenerRegionTypes == o.eventListenerRegionTypes
@@ -506,7 +503,6 @@ void StyleRareInheritedData::dumpDifferences(TextStream& ts, const StyleRareInhe
     LOG_IF_DIFFERENT_WITH_CAST(bool, hasAutoAccentColor);
     LOG_IF_DIFFERENT_WITH_CAST(bool, effectiveInert);
     LOG_IF_DIFFERENT_WITH_CAST(bool, isInSubtreeWithBlendMode);
-    LOG_IF_DIFFERENT_WITH_CAST(bool, isInVisibilityAdjustmentSubtree);
     LOG_IF_DIFFERENT_WITH_CAST(bool, isForceHidden);
 
     LOG_IF_DIFFERENT_WITH_CAST(ContentVisibility, usedContentVisibility);

--- a/Source/WebCore/rendering/style/StyleRareInheritedData.h
+++ b/Source/WebCore/rendering/style/StyleRareInheritedData.h
@@ -179,7 +179,6 @@ public:
 
     unsigned isInSubtreeWithBlendMode : 1;
 
-    unsigned isInVisibilityAdjustmentSubtree : 1;
     unsigned isForceHidden : 1;
 
     unsigned usedContentVisibility : 2; // ContentVisibility

--- a/Source/WebCore/style/StyleAdjuster.cpp
+++ b/Source/WebCore/style/StyleAdjuster.cpp
@@ -643,8 +643,8 @@ void Adjuster::adjust(RenderStyle& style) const
                 style.setHeight(WebCore::Length(200, LengthType::Fixed));
         }
 
-        if (m_element->visibilityAdjustment().contains(VisibilityAdjustment::Subtree) || m_parentStyle.isInVisibilityAdjustmentSubtree()) [[unlikely]]
-            style.setIsInVisibilityAdjustmentSubtree();
+        if (m_element->visibilityAdjustment().contains(VisibilityAdjustment::Subtree)) [[unlikely]]
+            style.setIsForceHidden();
     }
 
     if (shouldInheritTextDecorationsInEffect(style, m_element.get()))
@@ -1236,7 +1236,7 @@ void Adjuster::adjustVisibilityForPseudoElement(RenderStyle& style, const Elemen
 {
     if ((style.pseudoElementType() == PseudoId::After && host.visibilityAdjustment().contains(VisibilityAdjustment::AfterPseudo))
         || (style.pseudoElementType() == PseudoId::Before && host.visibilityAdjustment().contains(VisibilityAdjustment::BeforePseudo)))
-        style.setIsInVisibilityAdjustmentSubtree();
+        style.setIsForceHidden();
 }
 
 }


### PR DESCRIPTION
#### 5c5b1af25d9afa0f066b093afb681451328efdf3
<pre>
Remove redundant RenderStyle::isInVisibilityAdjustmentSubtree bit
<a href="https://bugs.webkit.org/show_bug.cgi?id=294020">https://bugs.webkit.org/show_bug.cgi?id=294020</a>
<a href="https://rdar.apple.com/problem/152572297">rdar://problem/152572297</a>

Reviewed by Wenson Hsieh.

The existing RenderStyle::isForceHidden covers the same functionality with a more generic name.

* Source/WebCore/page/ElementTargetingController.cpp:
(WebCore::searchForElementContainingText):
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/style/RenderStyleInlines.h:
(WebCore::RenderStyle::isInSubtreeWithBlendMode const):
(WebCore::RenderStyle::usedVisibility const):
(WebCore::RenderStyle::isInVisibilityAdjustmentSubtree const): Deleted.
* Source/WebCore/rendering/style/RenderStyleSetters.h:
(WebCore::RenderStyle::setIsInVisibilityAdjustmentSubtree): Deleted.
* Source/WebCore/rendering/style/StyleRareInheritedData.cpp:
(WebCore::StyleRareInheritedData::StyleRareInheritedData):
(WebCore::StyleRareInheritedData::operator== const):
(WebCore::StyleRareInheritedData::dumpDifferences const):
* Source/WebCore/rendering/style/StyleRareInheritedData.h:
* Source/WebCore/style/StyleAdjuster.cpp:
(WebCore::Style::Adjuster::adjust const):

No need to inherit the bit explicitly, it gets implicitly inherited.

(WebCore::Style::Adjuster::adjustVisibilityForPseudoElement):

Canonical link: <a href="https://commits.webkit.org/295813@main">https://commits.webkit.org/295813@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/61367ee975a81fc53901809ef93bc774db63ec33

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/106235 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25984 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/16379 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/111433 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/56831 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/108274 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/26646 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34487 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80699 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/109239 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/21072 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95869 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/61026 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/20613 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13970 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/56271 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/90428 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/14005 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/114293 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33373 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/24610 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89772 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33737 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/92100 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89473 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22812 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34341 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/12155 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/28953 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/33298 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/38710 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/33044 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/36394 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34642 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->