### PR TITLE
Update style script to mention m_foo as other alternative to protectedFoo()

### DIFF
--- a/Tools/Scripts/webkitpy/style/checkers/cpp.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp.py
@@ -3649,10 +3649,10 @@ def check_safer_cpp(clean_lines, line_number, error):
         error(line_number, 'safercpp/sqlite3_column_blob', 4, "Use sqliteColumnBlob() instead of sqlite3_column_blob().")
 
     if search(r'= [a-zA-Z0-9_.(),\s\->]*protected[a-zA-Z0-9]+\(\)[;\)]', line):
-        error(line_number, 'safercpp/protected_getter_for_init', 4, "Use foo() instead of protectedFoo() for variable initialization.")
+        error(line_number, 'safercpp/protected_getter_for_init', 4, "Use m_foo or foo() instead of protectedFoo() for variable initialization.")
 
     if search(r'= [a-zA-Z0-9_.(),\s\->]*checked[a-zA-Z0-9]+\(\)[;\)]', line):
-        error(line_number, 'safercpp/checked_getter_for_init', 4, "Use foo() instead of checkedFoo() for variable initialization.")
+        error(line_number, 'safercpp/checked_getter_for_init', 4, "Use m_foo or foo() instead of checkedFoo() for variable initialization.")
 
 def check_style(clean_lines, line_number, file_extension, class_state, file_state, enum_state, error):
     """Checks rules from the 'C++ style rules' section of cppguide.html.

--- a/Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py
@@ -6382,122 +6382,122 @@ class WebKitStyleTest(CppStyleTestBase):
 
         self.assert_lint(
             'auto foo = protectedFoo();',
-            'Use foo() instead of protectedFoo() for variable initialization.  [safercpp/protected_getter_for_init] [4]',
+            'Use m_foo or foo() instead of protectedFoo() for variable initialization.  [safercpp/protected_getter_for_init] [4]',
             'foo.cpp')
 
         self.assert_lint(
             'auto foo = checkedFoo();',
-            'Use foo() instead of checkedFoo() for variable initialization.  [safercpp/checked_getter_for_init] [4]',
+            'Use m_foo or foo() instead of checkedFoo() for variable initialization.  [safercpp/checked_getter_for_init] [4]',
             'foo.cpp')
 
         self.assert_lint(
             'Ref foo = protectedFoo();',
-            'Use foo() instead of protectedFoo() for variable initialization.  [safercpp/protected_getter_for_init] [4]',
+            'Use m_foo or foo() instead of protectedFoo() for variable initialization.  [safercpp/protected_getter_for_init] [4]',
             'foo.cpp')
 
         self.assert_lint(
             'CheckedRef foo = checkedFoo();',
-            'Use foo() instead of checkedFoo() for variable initialization.  [safercpp/checked_getter_for_init] [4]',
+            'Use m_foo or foo() instead of checkedFoo() for variable initialization.  [safercpp/checked_getter_for_init] [4]',
             'foo.cpp')
 
         self.assert_lint(
             'RefPtr foo = protectedFoo();',
-            'Use foo() instead of protectedFoo() for variable initialization.  [safercpp/protected_getter_for_init] [4]',
+            'Use m_foo or foo() instead of protectedFoo() for variable initialization.  [safercpp/protected_getter_for_init] [4]',
             'foo.cpp')
 
         self.assert_lint(
             'CheckedPtr foo = checkedFoo();',
-            'Use foo() instead of checkedFoo() for variable initialization.  [safercpp/checked_getter_for_init] [4]',
+            'Use m_foo or foo() instead of checkedFoo() for variable initialization.  [safercpp/checked_getter_for_init] [4]',
             'foo.cpp')
 
         self.assert_lint(
             'RefPtr bar = foo()->protectedBar();',
-            'Use foo() instead of protectedFoo() for variable initialization.  [safercpp/protected_getter_for_init] [4]',
+            'Use m_foo or foo() instead of protectedFoo() for variable initialization.  [safercpp/protected_getter_for_init] [4]',
             'foo.cpp')
 
         self.assert_lint(
             'CheckedPtr bar = foo()->checkedBar();',
-            'Use foo() instead of checkedFoo() for variable initialization.  [safercpp/checked_getter_for_init] [4]',
+            'Use m_foo or foo() instead of checkedFoo() for variable initialization.  [safercpp/checked_getter_for_init] [4]',
             'foo.cpp')
 
         self.assert_lint(
             'RefPtr bar = foo().protectedBar();',
-            'Use foo() instead of protectedFoo() for variable initialization.  [safercpp/protected_getter_for_init] [4]',
+            'Use m_foo or foo() instead of protectedFoo() for variable initialization.  [safercpp/protected_getter_for_init] [4]',
             'foo.cpp')
 
         self.assert_lint(
             'CheckedPtr bar = foo().checkedBar();',
-            'Use foo() instead of checkedFoo() for variable initialization.  [safercpp/checked_getter_for_init] [4]',
+            'Use m_foo or foo() instead of checkedFoo() for variable initialization.  [safercpp/checked_getter_for_init] [4]',
             'foo.cpp')
 
         self.assert_lint(
             'RefPtr bar = m_foo->protectedBar();',
-            'Use foo() instead of protectedFoo() for variable initialization.  [safercpp/protected_getter_for_init] [4]',
+            'Use m_foo or foo() instead of protectedFoo() for variable initialization.  [safercpp/protected_getter_for_init] [4]',
             'foo.cpp')
 
         self.assert_lint(
             'CheckedPtr bar = m_foo->checkedBar();',
-            'Use foo() instead of checkedFoo() for variable initialization.  [safercpp/checked_getter_for_init] [4]',
+            'Use m_foo or foo() instead of checkedFoo() for variable initialization.  [safercpp/checked_getter_for_init] [4]',
             'foo.cpp')
 
         self.assert_lint(
             'RefPtr bar = foo(1, 2)->protectedBar();',
-            'Use foo() instead of protectedFoo() for variable initialization.  [safercpp/protected_getter_for_init] [4]',
+            'Use m_foo or foo() instead of protectedFoo() for variable initialization.  [safercpp/protected_getter_for_init] [4]',
             'foo.cpp')
 
         self.assert_lint(
             'CheckedPtr bar = foo(1, 2)->checkedBar();',
-            'Use foo() instead of checkedFoo() for variable initialization.  [safercpp/checked_getter_for_init] [4]',
+            'Use m_foo or foo() instead of checkedFoo() for variable initialization.  [safercpp/checked_getter_for_init] [4]',
             'foo.cpp')
 
         self.assert_lint(
             'if (RefPtr bar = protectedBar())',
-            'Use foo() instead of protectedFoo() for variable initialization.  [safercpp/protected_getter_for_init] [4]',
+            'Use m_foo or foo() instead of protectedFoo() for variable initialization.  [safercpp/protected_getter_for_init] [4]',
             'foo.cpp')
 
         self.assert_lint(
             'if (CheckedPtr bar = checkedBar())',
-            'Use foo() instead of checkedFoo() for variable initialization.  [safercpp/checked_getter_for_init] [4]',
+            'Use m_foo or foo() instead of checkedFoo() for variable initialization.  [safercpp/checked_getter_for_init] [4]',
             'foo.cpp')
 
         self.assert_lint(
             'if (RefPtr bar = foo()->protectedBar())',
-            'Use foo() instead of protectedFoo() for variable initialization.  [safercpp/protected_getter_for_init] [4]',
+            'Use m_foo or foo() instead of protectedFoo() for variable initialization.  [safercpp/protected_getter_for_init] [4]',
             'foo.cpp')
 
         self.assert_lint(
             'if (CheckedPtr bar = foo()->checkedBar())',
-            'Use foo() instead of checkedFoo() for variable initialization.  [safercpp/checked_getter_for_init] [4]',
+            'Use m_foo or foo() instead of checkedFoo() for variable initialization.  [safercpp/checked_getter_for_init] [4]',
             'foo.cpp')
 
         self.assert_lint(
             'if (RefPtr bar = protectedBar()) {',
-            'Use foo() instead of protectedFoo() for variable initialization.  [safercpp/protected_getter_for_init] [4]',
+            'Use m_foo or foo() instead of protectedFoo() for variable initialization.  [safercpp/protected_getter_for_init] [4]',
             'foo.cpp')
 
         self.assert_lint(
             'if (CheckedPtr bar = checkedBar()) {',
-            'Use foo() instead of checkedFoo() for variable initialization.  [safercpp/checked_getter_for_init] [4]',
+            'Use m_foo or foo() instead of checkedFoo() for variable initialization.  [safercpp/checked_getter_for_init] [4]',
             'foo.cpp')
 
         self.assert_lint(
             'if (RefPtr bar = foo()->protectedBar()) {',
-            'Use foo() instead of protectedFoo() for variable initialization.  [safercpp/protected_getter_for_init] [4]',
+            'Use m_foo or foo() instead of protectedFoo() for variable initialization.  [safercpp/protected_getter_for_init] [4]',
             'foo.cpp')
 
         self.assert_lint(
             'if (CheckedPtr bar = foo()->checkedBar()) {',
-            'Use foo() instead of checkedFoo() for variable initialization.  [safercpp/checked_getter_for_init] [4]',
+            'Use m_foo or foo() instead of checkedFoo() for variable initialization.  [safercpp/checked_getter_for_init] [4]',
             'foo.cpp')
 
         self.assert_lint(
             'if (RefPtr bar = foo().protectedBar()) {',
-            'Use foo() instead of protectedFoo() for variable initialization.  [safercpp/protected_getter_for_init] [4]',
+            'Use m_foo or foo() instead of protectedFoo() for variable initialization.  [safercpp/protected_getter_for_init] [4]',
             'foo.cpp')
 
         self.assert_lint(
             'if (CheckedPtr bar = foo().checkedBar()) {',
-            'Use foo() instead of checkedFoo() for variable initialization.  [safercpp/checked_getter_for_init] [4]',
+            'Use m_foo or foo() instead of checkedFoo() for variable initialization.  [safercpp/checked_getter_for_init] [4]',
             'foo.cpp')
 
         self.assert_lint('auto foo = protectedFoo()->bar();', '')


### PR DESCRIPTION
#### d0428feaa2ed2b98a749ec5460076402c9b39a6c
<pre>
Update style script to mention m_foo as other alternative to protectedFoo()
<a href="https://bugs.webkit.org/show_bug.cgi?id=294024">https://bugs.webkit.org/show_bug.cgi?id=294024</a>

Reviewed by Tim Nguyen.

Also covers checkedFoo().

Canonical link: <a href="https://commits.webkit.org/295842@main">https://commits.webkit.org/295842@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b9e7b06aaff00a92d1a54e790f567e8a8e3f9231

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/106244 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25993 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/16388 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/111442 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/56840 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/108283 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/26656 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34496 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80705 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/109248 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/21091 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95873 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/61032 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/105721 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/20622 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13974 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/56280 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/90446 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/14009 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/114302 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33382 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24616 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89775 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33746 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/92104 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89476 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34347 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/12159 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/28964 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17229 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/33307 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/33053 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/36404 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34651 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->