### PR TITLE
Address unchecked variable CPP warnings in WebResourceLoadStatisticsStore

### DIFF
--- a/Source/WebKit/NetworkProcess/Classifier/WebResourceLoadStatisticsStore.cpp
+++ b/Source/WebKit/NetworkProcess/Classifier/WebResourceLoadStatisticsStore.cpp
@@ -232,8 +232,8 @@ void WebResourceLoadStatisticsStore::setResourceLoadStatisticsDebugMode(bool val
         return;
     }
 
-    if (m_networkSession) {
-        if (auto* storageSession = m_networkSession->networkStorageSession())
+    if (CheckedPtr networkSession = m_networkSession.get()) {
+        if (CheckedPtr storageSession = networkSession->networkStorageSession())
             storageSession->setTrackingPreventionDebugLoggingEnabled(value);
     }
 
@@ -326,8 +326,8 @@ void WebResourceLoadStatisticsStore::hasStorageAccess(RegistrableDomain&& subFra
         return hasStorageAccessEphemeral(WTFMove(subFrameDomain), WTFMove(topFrameDomain), frameID, pageID, WTFMove(completionHandler));
 
     CanRequestStorageAccessWithoutUserInteraction canRequestStorageAccessWithoutUserInteraction { CanRequestStorageAccessWithoutUserInteraction::No };
-    if (m_networkSession) {
-        if (auto* storageSession = m_networkSession->networkStorageSession())
+    if (CheckedPtr networkSession = m_networkSession.get()) {
+        if (CheckedPtr storageSession = networkSession->networkStorageSession())
             canRequestStorageAccessWithoutUserInteraction = storageSession->canRequestStorageAccessForLoginOrCompatibilityPurposesWithoutPriorUserInteraction(subFrameDomain, topFrameDomain) ? CanRequestStorageAccessWithoutUserInteraction::Yes : CanRequestStorageAccessWithoutUserInteraction::No;
     }
 
@@ -352,8 +352,8 @@ void WebResourceLoadStatisticsStore::hasStorageAccessEphemeral(const Registrable
 {
     ASSERT(isEphemeral());
 
-    if (m_networkSession) {
-        if (auto* storageSession = m_networkSession->networkStorageSession()) {
+    if (CheckedPtr networkSession = m_networkSession.get()) {
+        if (CheckedPtr storageSession = networkSession->networkStorageSession()) {
             completionHandler(storageSession->hasStorageAccess(subFrameDomain, topFrameDomain, frameID, pageID));
             return;
         }
@@ -365,11 +365,10 @@ bool WebResourceLoadStatisticsStore::hasStorageAccessForFrame(const RegistrableD
 {
     ASSERT(RunLoop::isMain());
 
-    if (!m_networkSession)
-        return false;
-
-    if (auto* storageSession = m_networkSession->networkStorageSession())
-        return storageSession->hasStorageAccess(resourceDomain, firstPartyDomain, frameID, pageID);
+    if (CheckedPtr networkSession = m_networkSession.get()) {
+        if (CheckedPtr storageSession = networkSession->networkStorageSession())
+            return storageSession->hasStorageAccess(resourceDomain, firstPartyDomain, frameID, pageID);
+    }
 
     return false;
 }
@@ -378,8 +377,8 @@ void WebResourceLoadStatisticsStore::callHasStorageAccessForFrameHandler(const R
 {
     ASSERT(RunLoop::isMain());
 
-    if (m_networkSession) {
-        if (auto* storageSession = m_networkSession->networkStorageSession()) {
+    if (CheckedPtr networkSession = m_networkSession.get()) {
+        if (CheckedPtr storageSession = networkSession->networkStorageSession()) {
             callback(storageSession->hasStorageAccess(resourceDomain, firstPartyDomain, frameID, pageID));
             return;
         }
@@ -399,8 +398,8 @@ void WebResourceLoadStatisticsStore::requestStorageAccess(RegistrableDomain&& su
 
     CanRequestStorageAccessWithoutUserInteraction canRequestStorageAccessWithoutUserInteraction { CanRequestStorageAccessWithoutUserInteraction::No };
     std::optional<OrganizationStorageAccessPromptQuirk> storageAccessQuirk;
-    if (m_networkSession) {
-        if (auto* storageSession = m_networkSession->networkStorageSession()) {
+    if (CheckedPtr networkSession = m_networkSession.get()) {
+        if (CheckedPtr storageSession = networkSession->networkStorageSession()) {
             canRequestStorageAccessWithoutUserInteraction = storageSession->canRequestStorageAccessForLoginOrCompatibilityPurposesWithoutPriorUserInteraction(subFrameDomain, topFrameDomain) ? CanRequestStorageAccessWithoutUserInteraction::Yes : CanRequestStorageAccessWithoutUserInteraction::No;
             storageAccessQuirk = storageSession->storageAccessQuirkForDomainPair(topFrameDomain, subFrameDomain);
         }
@@ -501,8 +500,8 @@ void WebResourceLoadStatisticsStore::requestStorageAccessUnderOpener(Registrable
         return requestStorageAccessUnderOpenerEphemeral(WTFMove(domainInNeedOfStorageAccess), openerPageID, WTFMove(openerDomain));
 
     CanRequestStorageAccessWithoutUserInteraction canRequestStorageAccessWithoutUserInteraction { CanRequestStorageAccessWithoutUserInteraction::No };
-    if (m_networkSession) {
-        if (auto* storageSession = m_networkSession->networkStorageSession())
+    if (CheckedPtr networkSession = m_networkSession.get()) {
+        if (CheckedPtr storageSession = networkSession->networkStorageSession())
             canRequestStorageAccessWithoutUserInteraction = storageSession->canRequestStorageAccessForLoginOrCompatibilityPurposesWithoutPriorUserInteraction(domainInNeedOfStorageAccess, openerDomain) ? CanRequestStorageAccessWithoutUserInteraction::Yes : CanRequestStorageAccessWithoutUserInteraction::No;
     }
 
@@ -519,8 +518,8 @@ void WebResourceLoadStatisticsStore::requestStorageAccessUnderOpenerEphemeral(Re
 {
     ASSERT(isEphemeral());
 
-    if (m_networkSession) {
-        if (auto* storageSession = m_networkSession->networkStorageSession())
+    if (CheckedPtr networkSession = m_networkSession.get()) {
+        if (CheckedPtr storageSession = networkSession->networkStorageSession())
             storageSession->grantStorageAccess(WTFMove(domainInNeedOfStorageAccess), WTFMove(openerDomain), std::nullopt, openerPageID);
     }
 }
@@ -554,8 +553,8 @@ void WebResourceLoadStatisticsStore::grantStorageAccessEphemeral(const Registrab
 {
     ASSERT(isEphemeral());
 
-    if (m_networkSession) {
-        if (auto* storageSession = m_networkSession->networkStorageSession()) {
+    if (CheckedPtr networkSession = m_networkSession.get()) {
+        if (CheckedPtr storageSession = networkSession->networkStorageSession()) {
             storageSession->grantStorageAccess(subFrameDomain, topFrameDomain, frameID, pageID);
             completionHandler({ storageAccessWasGrantedValueForFrame(frameID, subFrameDomain), promptWasShown, scope, topFrameDomain, subFrameDomain });
             return;
@@ -570,8 +569,8 @@ StorageAccessWasGranted WebResourceLoadStatisticsStore::grantStorageAccessInStor
 
     bool isStorageGranted = false;
 
-    if (m_networkSession) {
-        if (auto* storageSession = m_networkSession->networkStorageSession()) {
+    if (CheckedPtr networkSession = m_networkSession.get()) {
+        if (CheckedPtr storageSession = networkSession->networkStorageSession()) {
             storageSession->grantStorageAccess(resourceDomain, firstPartyDomain, (scope == StorageAccessScope::PerFrame ? frameID : std::nullopt), pageID);
             ASSERT(storageSession->hasStorageAccess(resourceDomain, firstPartyDomain, frameID, pageID));
             isStorageGranted = true;
@@ -598,8 +597,8 @@ void WebResourceLoadStatisticsStore::hasCookies(const RegistrableDomain& domain,
 {
     ASSERT(RunLoop::isMain());
 
-    if (m_networkSession) {
-        if (auto* storageSession = m_networkSession->networkStorageSession()) {
+    if (CheckedPtr networkSession = m_networkSession.get()) {
+        if (CheckedPtr storageSession = networkSession->networkStorageSession()) {
             storageSession->hasCookies(domain, WTFMove(completionHandler));
             return;
         }
@@ -612,8 +611,8 @@ void WebResourceLoadStatisticsStore::setThirdPartyCookieBlockingMode(ThirdPartyC
 {
     ASSERT(RunLoop::isMain());
 
-    if (m_networkSession) {
-        if (auto* storageSession = m_networkSession->networkStorageSession())
+    if (CheckedPtr networkSession = m_networkSession.get()) {
+        if (CheckedPtr storageSession = networkSession->networkStorageSession())
             storageSession->setThirdPartyCookieBlockingMode(blockingMode);
         else
             ASSERT_NOT_REACHED();
@@ -707,8 +706,8 @@ void WebResourceLoadStatisticsStore::setAppBoundDomains(HashSet<RegistrableDomai
 
     auto domainsCopy = crossThreadCopy(domains);
 
-    if (m_networkSession) {
-        if (auto* storageSession = m_networkSession->networkStorageSession()) {
+    if (CheckedPtr networkSession = m_networkSession.get()) {
+        if (CheckedPtr storageSession = networkSession->networkStorageSession()) {
             storageSession->setAppBoundDomains(WTFMove(domains));
             storageSession->setThirdPartyCookieBlockingMode(ThirdPartyCookieBlockingMode::AllExceptBetweenAppBoundDomains);
         }
@@ -736,8 +735,8 @@ void WebResourceLoadStatisticsStore::setManagedDomains(HashSet<RegistrableDomain
 
     auto domainsCopy = crossThreadCopy(domains);
 
-    if (m_networkSession) {
-        if (auto* storageSession = m_networkSession->networkStorageSession()) {
+    if (CheckedPtr networkSession = m_networkSession.get()) {
+        if (CheckedPtr storageSession = networkSession->networkStorageSession()) {
             storageSession->setManagedDomains(WTFMove(domains));
             storageSession->setThirdPartyCookieBlockingMode(ThirdPartyCookieBlockingMode::AllExceptManagedDomains);
         }
@@ -767,8 +766,8 @@ void WebResourceLoadStatisticsStore::removeAllStorageAccess(CompletionHandler<vo
 {
     ASSERT(RunLoop::isMain());
 
-    if (m_networkSession) {
-        if (auto* storageSession = m_networkSession->networkStorageSession())
+    if (CheckedPtr networkSession = m_networkSession.get()) {
+        if (CheckedPtr storageSession = networkSession->networkStorageSession())
             storageSession->removeAllStorageAccess();
     }
 
@@ -1237,9 +1236,12 @@ void WebResourceLoadStatisticsStore::scheduleClearInMemoryAndPersistent(WallTime
 void WebResourceLoadStatisticsStore::clearInMemoryEphemeral(CompletionHandler<void()>&& completionHandler)
 {
     m_domainsWithEphemeralUserInteraction.clear();
-    if (auto* storageSession = m_networkSession->networkStorageSession())
-        storageSession->removeAllStorageAccess();
-    
+
+    if (CheckedPtr networkSession = m_networkSession.get()) {
+        if (CheckedPtr storageSession = networkSession->networkStorageSession())
+            storageSession->removeAllStorageAccess();
+    }
+
     completionHandler();
 }
 
@@ -1297,8 +1299,8 @@ void WebResourceLoadStatisticsStore::setCacheMaxAgeCap(Seconds seconds, Completi
     ASSERT(RunLoop::isMain());
     ASSERT(seconds >= 0_s);
     
-    if (m_networkSession) {
-        if (auto* storageSession = m_networkSession->networkStorageSession())
+    if (CheckedPtr networkSession = m_networkSession.get()) {
+        if (CheckedPtr storageSession = networkSession->networkStorageSession())
             storageSession->setCacheMaxAgeCapForPrevalentResources(seconds);
     }
 
@@ -1322,7 +1324,7 @@ void WebResourceLoadStatisticsStore::callUpdatePrevalentDomainsToBlockCookiesFor
     ASSERT(RunLoop::isMain());
 
     if (CheckedPtr networkSession = m_networkSession.get()) {
-        if (auto* storageSession = networkSession->networkStorageSession()) {
+        if (CheckedPtr storageSession = networkSession->networkStorageSession()) {
             storageSession->setPrevalentDomainsToBlockAndDeleteCookiesFor(domainsToBlock.domainsToBlockAndDeleteCookiesFor);
             storageSession->setPrevalentDomainsToBlockButKeepCookiesFor(domainsToBlock.domainsToBlockButKeepCookiesFor);
             storageSession->setDomainsWithUserInteractionAsFirstParty(domainsToBlock.domainsWithUserInteractionAsFirstParty);
@@ -1348,7 +1350,7 @@ void WebResourceLoadStatisticsStore::callUpdatePrevalentDomainsToBlockCookiesFor
         }
 
         if (m_domainsWithCrossPageStorageAccessQuirk != domainsWithStorageAccessQuirk) {
-            if (auto* storageSession = networkSession->networkStorageSession())
+            if (CheckedPtr storageSession = networkSession->networkStorageSession())
                 storageSession->setDomainsWithCrossPageStorageAccess(domainsWithStorageAccessQuirk);
             networkSession->protectedNetworkProcess()->protectedParentProcessConnection()->sendWithAsyncReply(Messages::NetworkProcessProxy::SetDomainsWithCrossPageStorageAccess(domainsWithStorageAccessQuirk), [this, protectedThis = Ref { *this }, domainsWithStorageAccessQuirk] () mutable {
                 m_domainsWithCrossPageStorageAccessQuirk = domainsWithStorageAccessQuirk;
@@ -1392,15 +1394,15 @@ void WebResourceLoadStatisticsStore::resetParametersToDefaultValues(CompletionHa
     }
 
 #if ENABLE(APP_BOUND_DOMAINS)
-    if (m_networkSession) {
-        if (auto* storageSession = m_networkSession->networkStorageSession())
+    if (CheckedPtr networkSession = m_networkSession.get()) {
+        if (CheckedPtr storageSession = networkSession->networkStorageSession())
             storageSession->resetAppBoundDomains();
     }
 #endif
 
 #if ENABLE(MANAGED_DOMAINS)
-    if (m_networkSession) {
-        if (auto* storageSession = m_networkSession->networkStorageSession())
+    if (CheckedPtr networkSession = m_networkSession.get()) {
+        if (CheckedPtr storageSession = networkSession->networkStorageSession())
             storageSession->resetManagedDomains();
     }
 #endif
@@ -1504,8 +1506,8 @@ void WebResourceLoadStatisticsStore::deleteAndRestrictWebsiteDataForRegistrableD
 {
     ASSERT(RunLoop::isMain());
     
-    if (m_networkSession) {
-        m_networkSession->deleteAndRestrictWebsiteDataForRegistrableDomains(dataTypes, WTFMove(domainsToDeleteAndRestrictWebsiteDataFor), WTFMove(completionHandler));
+    if (CheckedPtr networkSession = m_networkSession.get()) {
+        networkSession->deleteAndRestrictWebsiteDataForRegistrableDomains(dataTypes, WTFMove(domainsToDeleteAndRestrictWebsiteDataFor), WTFMove(completionHandler));
         return;
     }
 
@@ -1516,8 +1518,8 @@ void WebResourceLoadStatisticsStore::registrableDomainsWithWebsiteData(OptionSet
 {
     ASSERT(RunLoop::isMain());
     
-    if (m_networkSession) {
-        m_networkSession->registrableDomainsWithWebsiteData(dataTypes, WTFMove(completionHandler));
+    if (CheckedPtr networkSession = m_networkSession.get()) {
+        networkSession->registrableDomainsWithWebsiteData(dataTypes, WTFMove(completionHandler));
         return;
     }
 

--- a/Source/WebKit/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -1,6 +1,5 @@
 EventDispatcherMessages.h
 NetworkProcess/Classifier/ResourceLoadStatisticsStore.cpp
-NetworkProcess/Classifier/WebResourceLoadStatisticsStore.cpp
 NetworkProcess/CustomProtocols/LegacyCustomProtocolManager.cpp
 NetworkProcess/DatabaseUtilities.cpp
 NetworkProcess/NetworkConnectionToWebProcess.cpp

--- a/Source/WebKit/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
@@ -1,6 +1,5 @@
 NetworkProcess/BackgroundFetchLoad.cpp
 NetworkProcess/Classifier/ResourceLoadStatisticsStore.cpp
-NetworkProcess/Classifier/WebResourceLoadStatisticsStore.cpp
 NetworkProcess/Cookies/WebCookieManager.cpp
 NetworkProcess/Cookies/mac/WebCookieManagerMac.mm
 NetworkProcess/Downloads/cocoa/DownloadCocoa.mm


### PR DESCRIPTION
#### 62158fd73c37d53af3283611f7cb1079076bab2a
<pre>
Address unchecked variable CPP warnings in WebResourceLoadStatisticsStore
<a href="https://bugs.webkit.org/show_bug.cgi?id=294028">https://bugs.webkit.org/show_bug.cgi?id=294028</a>

Reviewed by Chris Dumez.

* Source/WebKit/NetworkProcess/Classifier/WebResourceLoadStatisticsStore.cpp:
(WebKit::WebResourceLoadStatisticsStore::setResourceLoadStatisticsDebugMode):
(WebKit::WebResourceLoadStatisticsStore::hasStorageAccess):
(WebKit::WebResourceLoadStatisticsStore::hasStorageAccessEphemeral):
(WebKit::WebResourceLoadStatisticsStore::hasStorageAccessForFrame):
(WebKit::WebResourceLoadStatisticsStore::callHasStorageAccessForFrameHandler):
(WebKit::WebResourceLoadStatisticsStore::requestStorageAccess):
(WebKit::WebResourceLoadStatisticsStore::requestStorageAccessUnderOpener):
(WebKit::WebResourceLoadStatisticsStore::requestStorageAccessUnderOpenerEphemeral):
(WebKit::WebResourceLoadStatisticsStore::grantStorageAccessEphemeral):
(WebKit::WebResourceLoadStatisticsStore::grantStorageAccessInStorageSession):
(WebKit::WebResourceLoadStatisticsStore::hasCookies):
(WebKit::WebResourceLoadStatisticsStore::setThirdPartyCookieBlockingMode):
(WebKit::WebResourceLoadStatisticsStore::setAppBoundDomains):
(WebKit::WebResourceLoadStatisticsStore::setManagedDomains):
(WebKit::WebResourceLoadStatisticsStore::removeAllStorageAccess):
(WebKit::WebResourceLoadStatisticsStore::clearInMemoryEphemeral):
(WebKit::WebResourceLoadStatisticsStore::setCacheMaxAgeCap):
(WebKit::WebResourceLoadStatisticsStore::callUpdatePrevalentDomainsToBlockCookiesForHandler):
(WebKit::WebResourceLoadStatisticsStore::resetParametersToDefaultValues):
(WebKit::WebResourceLoadStatisticsStore::deleteAndRestrictWebsiteDataForRegistrableDomains):
(WebKit::WebResourceLoadStatisticsStore::registrableDomainsWithWebsiteData):
* Source/WebKit/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations:

Canonical link: <a href="https://commits.webkit.org/295870@main">https://commits.webkit.org/295870@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7e2071a70e67f84c63eda784cb904a41c186df0e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/106382 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/26131 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/16529 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/111583 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/56978 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/26798 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34634 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80800 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/109386 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/21236 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/96007 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/61128 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/20727 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/56418 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/90573 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/14141 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/114442 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33520 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24712 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89873 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33884 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/92236 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89576 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22858 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34462 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/12286 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/29115 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/33445 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/38857 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/33191 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/36544 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34789 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->