### PR TITLE
[Safe CPP] Re-land Address Warnings in RenderTableCol.cpp

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -700,7 +700,6 @@ rendering/RenderTable.h
 rendering/RenderTableCaption.cpp
 rendering/RenderTableCell.cpp
 rendering/RenderTableCellInlines.h
-rendering/RenderTableCol.cpp
 rendering/RenderTableRow.cpp
 rendering/RenderTableRowInlines.h
 rendering/RenderTableSection.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
@@ -475,7 +475,6 @@ rendering/RenderTable.cpp
 rendering/RenderTableCaption.cpp
 rendering/RenderTableCell.cpp
 rendering/RenderTableCellInlines.h
-rendering/RenderTableCol.cpp
 rendering/RenderTableRow.cpp
 rendering/RenderTableSection.cpp
 rendering/RenderText.cpp

--- a/Source/WebCore/rendering/RenderElement.h
+++ b/Source/WebCore/rendering/RenderElement.h
@@ -27,6 +27,7 @@
 #include "RenderObject.h"
 #include "RenderPtr.h"
 #include "RenderStyle.h"
+#include <wtf/CheckedRef.h>
 #include <wtf/MonotonicTime.h>
 #include <wtf/Packed.h>
 
@@ -68,6 +69,8 @@ public:
     bool hasInitializedStyle() const { return m_hasInitializedStyle; }
 
     const RenderStyle& style() const { return m_style; }
+    // FIXME: Remove checkedStyle once https://github.com/llvm/llvm-project/pull/142485 lands. This is a false positive.
+    const CheckedRef<const RenderStyle> checkedStyle() const { return m_style; }
     const RenderStyle* parentStyle() const { return !m_parent ? nullptr : &m_parent->style(); }
     const RenderStyle& firstLineStyle() const;
 

--- a/Source/WebCore/rendering/RenderTableCol.cpp
+++ b/Source/WebCore/rendering/RenderTableCol.cpp
@@ -38,6 +38,8 @@
 #include "RenderTable.h"
 #include "RenderTableCaption.h"
 #include "RenderTableCell.h"
+#include <wtf/CheckedPtr.h>
+#include <wtf/CheckedRef.h>
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
@@ -67,21 +69,21 @@ RenderTableCol::~RenderTableCol() = default;
 void RenderTableCol::styleDidChange(StyleDifference diff, const RenderStyle* oldStyle)
 {
     RenderBox::styleDidChange(diff, oldStyle);
-    RenderTable* table = this->table();
+    CheckedPtr table = this->table();
     if (!table)
         return;
     // If border was changed, notify table.
     if (!oldStyle)
         return;
-    table->invalidateCollapsedBordersAfterStyleChangeIfNeeded(*oldStyle, style());
+    table->invalidateCollapsedBordersAfterStyleChangeIfNeeded(*oldStyle, checkedStyle());
     if (oldStyle->width() != style().width()) {
         table->recalcSectionsIfNeeded();
-        for (auto& section : childrenOfType<RenderTableSection>(*table)) {
+        for (CheckedRef section : childrenOfType<RenderTableSection>(*table)) {
             unsigned nEffCols = table->numEffCols();
             for (unsigned j = 0; j < nEffCols; j++) {
-                unsigned rowCount = section.numRows();
+                unsigned rowCount = section->numRows();
                 for (unsigned i = 0; i < rowCount; i++) {
-                    RenderTableCell* cell = section.primaryCellAt(i, j);
+                    CheckedPtr cell = section->primaryCellAt(i, j);
                     if (!cell)
                         continue;
                     cell->setNeedsPreferredWidthsUpdate();
@@ -103,7 +105,7 @@ void RenderTableCol::updateFromElement()
     if (m_span != oldSpan && parent()) {
         if (hasInitializedStyle())
             setNeedsLayoutAndPrefWidthsRecalc();
-        if (RenderTable* table = this->table())
+        if (CheckedPtr table = this->table())
             table->invalidateColumns();
     }
 }
@@ -111,13 +113,13 @@ void RenderTableCol::updateFromElement()
 void RenderTableCol::insertedIntoTree()
 {
     RenderBox::insertedIntoTree();
-    table()->addColumn(this);
+    checkedTable()->addColumn(this);
 }
 
 void RenderTableCol::willBeRemovedFromTree()
 {
     RenderBox::willBeRemovedFromTree();
-    if (auto* table = this->table()) {
+    if (CheckedPtr table = this->table()) {
         // We only need to invalidate the column cache when only individual columns are being removed (as opposed to when the entire table is being collapsed).
         table->invalidateColumns();
     }
@@ -143,7 +145,7 @@ LayoutRect RenderTableCol::clippedOverflowRect(const RenderLayerModelObject* rep
     // might have propagated a background color or borders into.
     // FIXME: check for repaintContainer each time here?
 
-    auto* parentTable = table();
+    CheckedPtr parentTable = table();
     if (!parentTable)
         return { };
 
@@ -168,8 +170,8 @@ void RenderTableCol::clearNeedsPreferredLogicalWidthsUpdate()
 {
     clearNeedsPreferredWidthsUpdate();
 
-    for (auto& child : childrenOfType<RenderObject>(*this))
-        child.clearNeedsPreferredWidthsUpdate();
+    for (CheckedRef child : childrenOfType<RenderObject>(*this))
+        child->clearNeedsPreferredWidthsUpdate();
 }
 
 RenderTable* RenderTableCol::table() const
@@ -178,6 +180,11 @@ RenderTable* RenderTableCol::table() const
     if (table && !is<RenderTable>(*table))
         table = table->parent();
     return dynamicDowncast<RenderTable>(table);
+}
+
+CheckedPtr<RenderTable> RenderTableCol::checkedTable() const
+{
+    return table();
 }
 
 RenderTableCol* RenderTableCol::enclosingColumnGroup() const
@@ -194,15 +201,15 @@ RenderTableCol* RenderTableCol::enclosingColumnGroup() const
 RenderTableCol* RenderTableCol::nextColumn() const
 {
     // If |this| is a column-group, the next column is the colgroup's first child column.
-    if (RenderObject* firstChild = this->firstChild())
-        return downcast<RenderTableCol>(firstChild);
+    if (CheckedPtr firstChild = this->firstChild())
+        return downcast<RenderTableCol>(firstChild.get());
 
     // Otherwise it's the next column along.
-    RenderObject* next = nextSibling();
+    CheckedPtr next = nextSibling();
 
     // Failing that, the child is the last column in a column-group, so the next column is the next column/column-group after its column-group.
     if (!next && is<RenderTableCol>(*parent()))
-        next = parent()->nextSibling();
+        next = checkedParent()->nextSibling();
 
     for (; next; next = next->nextSibling()) {
         if (auto* column = dynamicDowncast<RenderTableCol>(*next))
@@ -214,44 +221,46 @@ RenderTableCol* RenderTableCol::nextColumn() const
 
 const BorderValue& RenderTableCol::borderAdjoiningCellStartBorder() const
 {
-    return style().borderStart(table()->writingMode());
+    return checkedStyle()->borderStart(table()->writingMode());
 }
 
 const BorderValue& RenderTableCol::borderAdjoiningCellEndBorder() const
 {
-    return style().borderEnd(table()->writingMode());
+    return checkedStyle()->borderEnd(table()->writingMode());
 }
 
 const BorderValue& RenderTableCol::borderAdjoiningCellBefore(const RenderTableCell& cell) const
 {
-    ASSERT_UNUSED(cell, table()->colElement(cell.col() + cell.colSpan()) == this);
-    return style().borderStart(table()->writingMode());
+    CheckedPtr table = this->table();
+    ASSERT_UNUSED(cell, table->colElement(cell.col() + cell.colSpan()) == this);
+    return checkedStyle()->borderStart(table->writingMode());
 }
 
 const BorderValue& RenderTableCol::borderAdjoiningCellAfter(const RenderTableCell& cell) const
 {
-    ASSERT_UNUSED(cell, table()->colElement(cell.col() - 1) == this);
-    return style().borderEnd(table()->writingMode());
+    CheckedPtr table = this->table();
+    ASSERT_UNUSED(cell, table->colElement(cell.col() - 1) == this);
+    return checkedStyle()->borderEnd(table->writingMode());
 }
 
 LayoutUnit RenderTableCol::offsetLeft() const
 {
-    return table()->offsetLeftForColumn(*this);
+    return checkedTable()->offsetLeftForColumn(*this);
 }
 
 LayoutUnit RenderTableCol::offsetTop() const
 {
-    return table()->offsetTopForColumn(*this);
+    return checkedTable()->offsetTopForColumn(*this);
 }
 
 LayoutUnit RenderTableCol::offsetWidth() const
 {
-    return table()->offsetWidthForColumn(*this);
+    return checkedTable()->offsetWidthForColumn(*this);
 }
 
 LayoutUnit RenderTableCol::offsetHeight() const
 {
-    return table()->offsetHeightForColumn(*this);
+    return checkedTable()->offsetHeightForColumn(*this);
 }
 
 }

--- a/Source/WebCore/rendering/RenderTableCol.h
+++ b/Source/WebCore/rendering/RenderTableCol.h
@@ -88,6 +88,7 @@ private:
     void paint(PaintInfo&, const LayoutPoint&) override { }
 
     RenderTable* table() const;
+    CheckedPtr<RenderTable> checkedTable() const;
 
     unsigned m_span { 1 };
 };


### PR DESCRIPTION
#### 4767bd89fe19b3ab7f1cad692110b244051bad0e
<pre>
[Safe CPP] Re-land Address Warnings in RenderTableCol.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=294030">https://bugs.webkit.org/show_bug.cgi?id=294030</a>
<a href="https://rdar.apple.com/problem/152583157">rdar://problem/152583157</a>

Reviewed by Chris Dumez.

Re-land Address Warnings in RenderTableCol.cpp.

* Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations:
* Source/WebCore/rendering/RenderElement.h:
(WebCore::RenderElement::checkedStyle const):
* Source/WebCore/rendering/RenderTableCol.cpp:
(WebCore::RenderTableCol::styleDidChange):
(WebCore::RenderTableCol::updateFromElement):
(WebCore::RenderTableCol::insertedIntoTree):
(WebCore::RenderTableCol::willBeRemovedFromTree):
(WebCore::RenderTableCol::clippedOverflowRect const):
(WebCore::RenderTableCol::clearNeedsPreferredLogicalWidthsUpdate):
(WebCore::RenderTableCol::checkedTable const):
(WebCore::RenderTableCol::nextColumn const):
(WebCore::RenderTableCol::borderAdjoiningCellStartBorder const):
(WebCore::RenderTableCol::borderAdjoiningCellEndBorder const):
(WebCore::RenderTableCol::borderAdjoiningCellBefore const):
(WebCore::RenderTableCol::borderAdjoiningCellAfter const):
(WebCore::RenderTableCol::offsetLeft const):
(WebCore::RenderTableCol::offsetTop const):
(WebCore::RenderTableCol::offsetWidth const):
(WebCore::RenderTableCol::offsetHeight const):
* Source/WebCore/rendering/RenderTableCol.h:

Canonical link: <a href="https://commits.webkit.org/295850@main">https://commits.webkit.org/295850@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d36c8de9c84fc0e3ca1178ba89aaed9d109c5040

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/106273 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/26022 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/16418 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/111471 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/56869 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/108312 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/26685 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34525 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80726 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/109277 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/21116 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95902 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/61053 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/20638 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/14001 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/56309 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/90468 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/14036 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/114331 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33411 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24638 "Found 2 new test failures: platform/mac/fast/text/line-break-locale.html svg/zoom/page/text-with-non-scaling-stroke.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89798 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33775 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/92131 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89499 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22836 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34374 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/12186 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/28995 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/33336 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/38748 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/33082 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/36435 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34680 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->