### PR TITLE
[macOS] Unified field incorrectly gets focused if you click on a bookmark from the favorites bar

### DIFF
--- a/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
+++ b/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
@@ -1568,6 +1568,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     _usesAutomaticContentInsetBackgroundFill = value;
 
 #if ENABLE(CONTENT_INSET_BACKGROUND_FILL)
+    _impl->updateTopContentInsetFillStyle();
     _impl->updateTopContentInsetFillDueToScrolling();
 #endif
 }

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -794,6 +794,7 @@ public:
     void unregisterViewAboveTopContentInsetArea(NSView *);
     void updateTopContentInsetFillDueToScrolling();
     void updateTopContentInsetFillCaptureColor();
+    void updateTopContentInsetFillStyle();
 #endif
 
 private:


### PR DESCRIPTION
#### 985743a6f41c83e97e204a58302a13068ab28923
<pre>
[macOS] Unified field incorrectly gets focused if you click on a bookmark from the favorites bar
<a href="https://bugs.webkit.org/show_bug.cgi?id=294031">https://bugs.webkit.org/show_bug.cgi?id=294031</a>
<a href="https://rdar.apple.com/152196672">rdar://152196672</a>

Reviewed by Abrar Rahman Protyasha, Aditya Keerthi, and Megan Gardner.

Add a new method declaration; see the corresponding paired change for more details.

* Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm:
(-[WKWebView _setUsesAutomaticContentInsetBackgroundFill:]):
* Source/WebKit/UIProcess/mac/WebViewImpl.h:

Canonical link: <a href="https://commits.webkit.org/295828@main">https://commits.webkit.org/295828@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/12dd4599327f85418c9e6882b21aef20fb2538b6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/106259 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/26008 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/16404 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/111457 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/56855 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/26671 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34511 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80716 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/109263 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/21108 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95890 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/61043 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/20631 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/56295 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/90456 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/14024 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/114317 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33397 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24628 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89788 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33761 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/92119 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89489 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22823 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34362 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/12174 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/28981 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/33322 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/38734 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/33068 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/36421 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34666 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->