### PR TITLE
Null pointer dereference in JavaScriptCore llint_op_call.

### DIFF
--- a/JSTests/stress/dfg-ai-should-reduce-new-array-with-spread-structures.js
+++ b/JSTests/stress/dfg-ai-should-reduce-new-array-with-spread-structures.js
@@ -1,0 +1,11 @@
+//@ runDefault("--thresholdForFTLOptimizeAfterWarmUp=1000", "--useConcurrentJIT=0")
+for (let i = 0; i < 1000; ++i) {
+    (() => {
+        for (let v8 = 0; v8 < 25; v8++) {}
+        const v10 = [...[1,2,3,4,5]];
+        v10[2] = 3;
+        function f11(a12) { return a12;}
+        class C13 extends f11 {}
+        v10.at(3745);
+    })();
+}


### PR DESCRIPTION
#### ac09d743b1828ad9f6e86626db9b4bd3cf00e285
<pre>
Null pointer dereference in JavaScriptCore llint_op_call.
<a href="https://bugs.webkit.org/show_bug.cgi?id=288814">https://bugs.webkit.org/show_bug.cgi?id=288814</a>
<a href="https://rdar.apple.com/145826169">rdar://145826169</a>

Reviewed by Keith Miller.

DFG AI should continuously reduce the abstract value&apos;s possibility,
otherwise the constant folding will remove some nodes based on the
previous decision. NewArrayWithSpread says that it returns CoW array
with one argument (Spread for example), but later, when it gets
converted to PhantomSpread and PhantomNewArrayBuffer with non contiguous
CoW immutable butterfly, then it starts saying that it returns non-CoW
array. It is possible that we already removed some of DFG nodes based on
the previous assumption, and changing this causes a bug that we may miss
the necessary checks. This patch makes this node return CoW contiguous
array for PhantomSpread(PhantomNewArrayBuffer) case regardless so that
we can avoid this problem.

* JSTests/stress/dfg-ai-should-reduce-new-array-with-spread-structures.js: Added.
(i.f11):
(i.C13):
* Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h:
(JSC::DFG::AbstractInterpreter&lt;AbstractStateType&gt;::executeEffects):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileNewArrayWithSpread):
(JSC::FTL::DFG::LowerDFGToB3::createContiguousImmutableButterflyFromPhantomNewArrayBuffer):
(JSC::FTL::DFG::LowerDFGToB3::createContiguousImmutableButterflyFromPhantomCreateRest):
(JSC::FTL::DFG::LowerDFGToB3::compileSpread):

Originally-landed-as: 289651.293@safari-7621-branch (4c7737fa3c68). <a href="https://rdar.apple.com/151710409">rdar://151710409</a>
Canonical link: <a href="https://commits.webkit.org/295832@main">https://commits.webkit.org/295832@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/abd13d5e1b70605c7f5a73bf18417b5cfaf8f4c5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/106272 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/26021 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/16417 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/111470 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/56868 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/26684 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34524 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80724 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/109276 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/21114 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95896 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/61051 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/20636 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13995 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/56308 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/98911 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/90465 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/14030 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/114330 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/104889 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33410 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/24635 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89796 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33774 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/92125 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89497 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34373 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/12180 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/28994 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17222 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/33335 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/38747 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/129201 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/33081 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/35205 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/36434 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34679 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->