### PR TITLE
Introduce ignore-following-rules action type in WebKit Content Blockers

### DIFF
--- a/Source/WebCore/contentextensions/ContentExtensionActions.h
+++ b/Source/WebCore/contentextensions/ContentExtensionActions.h
@@ -64,6 +64,7 @@ struct BlockCookiesAction : public ActionWithoutMetadata<BlockCookiesAction> { }
 struct CSSDisplayNoneSelectorAction : public ActionWithStringMetadata<CSSDisplayNoneSelectorAction> { };
 struct NotifyAction : public ActionWithStringMetadata<NotifyAction> { };
 struct IgnorePreviousRulesAction : public ActionWithoutMetadata<IgnorePreviousRulesAction> { };
+struct IgnoreFollowingRulesAction : public ActionWithoutMetadata<IgnoreFollowingRulesAction> { };
 struct MakeHTTPSAction : public ActionWithoutMetadata<MakeHTTPSAction> { };
 
 struct WEBCORE_EXPORT ModifyHeadersAction {
@@ -238,6 +239,7 @@ using ActionData = Variant<
     CSSDisplayNoneSelectorAction,
     NotifyAction,
     IgnorePreviousRulesAction,
+    IgnoreFollowingRulesAction,
     MakeHTTPSAction,
     ModifyHeadersAction,
     RedirectAction

--- a/Source/WebCore/contentextensions/ContentExtensionParser.cpp
+++ b/Source/WebCore/contentextensions/ContentExtensionParser.cpp
@@ -244,6 +244,8 @@ static std::optional<Expected<Action, std::error_code>> loadAction(const JSON::O
         return Action { BlockLoadAction() };
     if (actionType == "ignore-previous-rules"_s)
         return Action { IgnorePreviousRulesAction() };
+    if (actionType == "ignore-following-rules"_s)
+        return Action { IgnoreFollowingRulesAction() };
     if (actionType == "block-cookies"_s)
         return Action { BlockCookiesAction() };
     if (actionType == "css-display-none"_s) {

--- a/Tools/TestWebKitAPI/Tests/WebCore/ContentExtensions.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/ContentExtensions.cpp
@@ -509,9 +509,9 @@ TEST_F(ContentExtensionTest, DistinguishableActionInsidePrefixTree)
     testRequest(backend, mainDocumentRequest("http://prefix.org/"_s), { variantIndex<ContentExtensions::BlockLoadAction> });
     testRequest(backend, mainDocumentRequest("http://webkit.org/prefix"_s), { variantIndex<ContentExtensions::BlockLoadAction> });
     testRequest(backend, mainDocumentRequest("http://webkit.org/aaaprefixaaa"_s), { variantIndex<ContentExtensions::BlockLoadAction> });
-    testRequest(backend, mainDocumentRequest("http://prefixsuffix.org/"_s), { variantIndex<ContentExtensions::BlockCookiesAction>, variantIndex<ContentExtensions::BlockLoadAction> });
-    testRequest(backend, mainDocumentRequest("http://webkit.org/prefixsuffix"_s), { variantIndex<ContentExtensions::BlockCookiesAction>, variantIndex<ContentExtensions::BlockLoadAction> });
-    testRequest(backend, mainDocumentRequest("http://webkit.org/bbbprefixsuffixbbb"_s), { variantIndex<ContentExtensions::BlockCookiesAction>, variantIndex<ContentExtensions::BlockLoadAction> });
+    testRequest(backend, mainDocumentRequest("http://prefixsuffix.org/"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::BlockCookiesAction> });
+    testRequest(backend, mainDocumentRequest("http://webkit.org/prefixsuffix"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::BlockCookiesAction> });
+    testRequest(backend, mainDocumentRequest("http://webkit.org/bbbprefixsuffixbbb"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::BlockCookiesAction> });
 
     testRequest(backend, mainDocumentRequest("http://suffix.org/"_s), { });
     testRequest(backend, mainDocumentRequest("http://webkit.org/suffix"_s), { });
@@ -710,13 +710,13 @@ TEST_F(ContentExtensionTest, DomainTriggers)
     testRequest(combinedBackend2, mainDocumentRequest("http://webkit.org/test_block_load.html"_s), { variantIndex<ContentExtensions::BlockLoadAction> });
     testRequest(combinedBackend2, mainDocumentRequest("http://not_webkit.org/test_block_load.html"_s), { });
     testRequest(combinedBackend2, mainDocumentRequest("http://not_webkit.org/test_css.html"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
-    testRequest(combinedBackend2, mainDocumentRequest("http://webkit.org/TEST_CSS.hTmL/test_block_load.html"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction> });
+    testRequest(combinedBackend2, mainDocumentRequest("http://webkit.org/TEST_CSS.hTmL/test_block_load.html"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(combinedBackend2, mainDocumentRequest("http://w3c.org/test_css.html"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(combinedBackend2, mainDocumentRequest("http://w3c.org/test_block_load.html"_s), { });
     testRequest(combinedBackend2, mainDocumentRequest("http://w3c.org/test_block_cookies.html"_s), { });
     testRequest(combinedBackend2, mainDocumentRequest("http://w3c.org/test_css.html/test_block_cookies.html"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(combinedBackend2, mainDocumentRequest("http://not_w3c.org/test_block_cookies.html"_s), { variantIndex<ContentExtensions::BlockCookiesAction> });
-    testRequest(combinedBackend2, mainDocumentRequest("http://not_w3c.org/test_css.html/test_block_cookies.html"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockCookiesAction> });
+    testRequest(combinedBackend2, mainDocumentRequest("http://not_w3c.org/test_css.html/test_block_cookies.html"_s), { variantIndex<ContentExtensions::BlockCookiesAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
 
     auto ifDomainWithFlagsBackend = makeBackend("[{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"test\", \"if-domain\":[\"webkit.org\"],\"resource-type\":[\"image\"]}}]"_s);
     testRequest(ifDomainWithFlagsBackend, mainDocumentRequest("http://webkit.org/test.html"_s), { });
@@ -759,22 +759,22 @@ TEST_F(ContentExtensionTest, DomainTriggersAlongMergedActions)
         "{\"action\":{\"type\":\"block-cookies\"},\"trigger\":{\"url-filter\":\"except-this\"}}]"_s);
 
     testRequest(backend, mainDocumentRequest("http://webkit.org/test.htm"_s), { });
-    testRequest(backend, mainDocumentRequest("http://webkit.org/test.html"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::BlockCookiesAction> });
+    testRequest(backend, mainDocumentRequest("http://webkit.org/test.html"_s), { variantIndex<ContentExtensions::BlockCookiesAction>, variantIndex<ContentExtensions::BlockLoadAction> });
     testRequest(backend, mainDocumentRequest("http://notwebkit.org/test.html"_s), { variantIndex<ContentExtensions::BlockCookiesAction> });
 
     testRequest(backend, mainDocumentRequest("http://notwebkit.org/trigger-on-scripts.html"_s), { });
     testRequest(backend, mainDocumentRequest("http://webkit.org/trigger-on-scripts.html"_s), { });
     testRequest(backend, mainDocumentRequest("http://notwebkit.org/trigger-on-scripts.html"_s, ResourceType::Script), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(backend, mainDocumentRequest("http://webkit.org/trigger-on-scripts.html"_s, ResourceType::Script), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
-    testRequest(backend, mainDocumentRequest("http://notwebkit.org/trigger-on-scripts.html.test.html"_s, ResourceType::Script), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockCookiesAction> });
-    testRequest(backend, mainDocumentRequest("http://webkit.org/trigger-on-scripts.html.test.html"_s, ResourceType::Script), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::BlockCookiesAction> });
+    testRequest(backend, mainDocumentRequest("http://notwebkit.org/trigger-on-scripts.html.test.html"_s, ResourceType::Script), { variantIndex<ContentExtensions::BlockCookiesAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
+    testRequest(backend, mainDocumentRequest("http://webkit.org/trigger-on-scripts.html.test.html"_s, ResourceType::Script), { variantIndex<ContentExtensions::BlockCookiesAction>, variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>,  });
 
     testRequest(backend, mainDocumentRequest("http://notwebkit.org/ignore-previous-trigger-on-scripts.html"_s), { });
     testRequest(backend, mainDocumentRequest("http://webkit.org/ignore-previous-trigger-on-scripts.html"_s), { });
     testRequest(backend, mainDocumentRequest("http://notwebkit.org/ignore-previous-trigger-on-scripts.html"_s, ResourceType::Script), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(backend, mainDocumentRequest("http://webkit.org/ignore-previous-trigger-on-scripts.html"_s, ResourceType::Script), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
-    testRequest(backend, mainDocumentRequest("http://notwebkit.org/ignore-previous-trigger-on-scripts.html.test.html"_s, ResourceType::Script), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockCookiesAction> });
-    testRequest(backend, mainDocumentRequest("http://webkit.org/ignore-previous-trigger-on-scripts.html.test.html"_s, ResourceType::Script), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::BlockCookiesAction> });
+    testRequest(backend, mainDocumentRequest("http://notwebkit.org/ignore-previous-trigger-on-scripts.html.test.html"_s, ResourceType::Script), { variantIndex<ContentExtensions::BlockCookiesAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
+    testRequest(backend, mainDocumentRequest("http://webkit.org/ignore-previous-trigger-on-scripts.html.test.html"_s, ResourceType::Script), { variantIndex<ContentExtensions::BlockCookiesAction>, variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
 
     testRequest(backend, mainDocumentRequest("http://notwebkit.org/ignore-previous-trigger-on-scripts.html"_s, ResourceType::Image), { }, 0);
     testRequest(backend, mainDocumentRequest("http://webkit.org/ignore-previous-trigger-on-scripts.html"_s, ResourceType::Image), { }, 0);
@@ -784,15 +784,15 @@ TEST_F(ContentExtensionTest, DomainTriggersAlongMergedActions)
     testRequest(backend, mainDocumentRequest("http://notwebkit.org/except-this-ignore-previous-trigger-on-scripts.html"_s), { variantIndex<ContentExtensions::BlockCookiesAction> });
     testRequest(backend, mainDocumentRequest("http://webkit.org/except-this-ignore-previous-trigger-on-scripts.html"_s), { variantIndex<ContentExtensions::BlockCookiesAction> });
     testRequest(backend, mainDocumentRequest("http://notwebkit.org/except-this-ignore-previous-trigger-on-scripts.html.test.html"_s), { variantIndex<ContentExtensions::BlockCookiesAction>, variantIndex<ContentExtensions::BlockCookiesAction> });
-    testRequest(backend, mainDocumentRequest("http://webkit.org/except-this-ignore-previous-trigger-on-scripts.html.test.html"_s), { variantIndex<ContentExtensions::BlockCookiesAction>, variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::BlockCookiesAction> });
+    testRequest(backend, mainDocumentRequest("http://webkit.org/except-this-ignore-previous-trigger-on-scripts.html.test.html"_s), { variantIndex<ContentExtensions::BlockCookiesAction>, variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::BlockCookiesAction>  });
     testRequest(backend, mainDocumentRequest("http://notwebkit.org/except-this-ignore-previous-trigger-on-scripts.html"_s, ResourceType::Image), { variantIndex<ContentExtensions::BlockCookiesAction> }, 0);
     testRequest(backend, mainDocumentRequest("http://webkit.org/except-this-ignore-previous-trigger-on-scripts.html"_s, ResourceType::Image), { variantIndex<ContentExtensions::BlockCookiesAction> }, 0);
     testRequest(backend, mainDocumentRequest("http://notwebkit.org/except-this-ignore-previous-trigger-on-scripts.html.test.html"_s, ResourceType::Image), { variantIndex<ContentExtensions::BlockCookiesAction> }, 0);
     testRequest(backend, mainDocumentRequest("http://webkit.org/except-this-ignore-previous-trigger-on-scripts.html.test.html"_s, ResourceType::Image), { variantIndex<ContentExtensions::BlockCookiesAction> }, 0);
-    testRequest(backend, mainDocumentRequest("http://notwebkit.org/except-this-ignore-previous-trigger-on-scripts.html"_s, ResourceType::Script), { variantIndex<ContentExtensions::BlockCookiesAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
-    testRequest(backend, mainDocumentRequest("http://webkit.org/except-this-ignore-previous-trigger-on-scripts.html"_s, ResourceType::Script), { variantIndex<ContentExtensions::BlockCookiesAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
+    testRequest(backend, mainDocumentRequest("http://notwebkit.org/except-this-ignore-previous-trigger-on-scripts.html"_s, ResourceType::Script), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockCookiesAction> });
+    testRequest(backend, mainDocumentRequest("http://webkit.org/except-this-ignore-previous-trigger-on-scripts.html"_s, ResourceType::Script), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockCookiesAction> });
     testRequest(backend, mainDocumentRequest("http://notwebkit.org/except-this-ignore-previous-trigger-on-scripts.html.test.html"_s, ResourceType::Script), { variantIndex<ContentExtensions::BlockCookiesAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockCookiesAction> });
-    testRequest(backend, mainDocumentRequest("http://webkit.org/except-this-ignore-previous-trigger-on-scripts.html.test.html"_s, ResourceType::Script), { variantIndex<ContentExtensions::BlockCookiesAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::BlockCookiesAction> });
+    testRequest(backend, mainDocumentRequest("http://webkit.org/except-this-ignore-previous-trigger-on-scripts.html.test.html"_s, ResourceType::Script), { variantIndex<ContentExtensions::BlockCookiesAction>, variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockCookiesAction> });
 }
 
 TEST_F(ContentExtensionTest, TopURL)
@@ -942,23 +942,23 @@ TEST_F(ContentExtensionTest, StringParameters)
     ASSERT_TRUE(actionsEqual(allActionsForResourceLoad(backend2, mainDocumentRequest("http://G"_s)), Vector<Action>::from(Action { ContentExtensions::NotifyAction { { "GGG"_s } } })));
     ASSERT_TRUE(actionsEqual(allActionsForResourceLoad(backend2, mainDocumentRequest("http://GIK"_s)), Vector<Action>::from(Action { ContentExtensions::NotifyAction { { "GGG"_s } } })));
     ASSERT_TRUE(actionsEqual(allActionsForResourceLoad(backend2, mainDocumentRequest("http://AJ"_s)), Vector<Action>::from(
-    Action { ContentExtensions::NotifyAction { { "AAA"_s } } },
-    Action { ContentExtensions::NotifyAction { { "AAA"_s } } } // ignore-previous-rules makes the AAA actions need to be unique.
+        Action { ContentExtensions::NotifyAction { { "AAA"_s } } },
+        Action { ContentExtensions::NotifyAction { { "AAA"_s } } } // ignore-previous-rules makes the AAA actions need to be unique.
     )));
     // FIXME: Add a test that matches actions with AAA with ignore-previous-rules between them and makes sure we only get one notification.
     ASSERT_TRUE(actionsEqual(allActionsForResourceLoad(backend2, mainDocumentRequest("http://AE"_s)), { }, true));
     ASSERT_TRUE(actionsEqual(allActionsForResourceLoad(backend2, mainDocumentRequest("http://ABCDE"_s)), { }, true));
     ASSERT_TRUE(actionsEqual(allActionsForResourceLoad(backend2, mainDocumentRequest("http://ABCDEFG"_s)), Vector<Action>::from(
-        Action { ContentExtensions::NotifyAction { { "GGG"_s } } },
-        Action { ContentExtensions::BlockLoadAction() }
+        Action { ContentExtensions::BlockLoadAction() },
+        Action { ContentExtensions::NotifyAction { { "GGG"_s } } }
     ), true));
     ASSERT_TRUE(actionsEqual(allActionsForResourceLoad(backend2, mainDocumentRequest("http://FG"_s)), Vector<Action>::from(
-        Action { ContentExtensions::NotifyAction { { "GGG"_s } } },
-        Action { ContentExtensions::BlockLoadAction() }
+        Action { ContentExtensions::BlockLoadAction() },
+        Action { ContentExtensions::NotifyAction { { "GGG"_s } } }
     )));
     ASSERT_TRUE(actionsEqual(allActionsForResourceLoad(backend2, mainDocumentRequest("http://EFG"_s)), Vector<Action>::from(
-        Action { ContentExtensions::NotifyAction { { "GGG"_s } } },
-        Action { ContentExtensions::BlockLoadAction() }
+        Action { ContentExtensions::BlockLoadAction() },
+        Action { ContentExtensions::NotifyAction { { "GGG"_s } } }
     ), true));
 }
 
@@ -1203,7 +1203,7 @@ TEST_F(ContentExtensionTest, ResourceOrLoadTypeMatchingEverything)
     
     testRequest(backend, mainDocumentRequest("http://webkit.org"_s), { }, 0);
     testRequest(backend, { URL { "http://webkit.org"_str }, URL { "http://not_webkit.org"_str }, URL { "http://not_webkit.org"_str }, ResourceType::TopDocument }, { variantIndex<ContentExtensions::BlockCookiesAction> });
-    testRequest(backend, { URL { "http://webkit.org"_str }, URL { "http://not_webkit.org"_str }, URL { "http://not_webkit.org"_str }, ResourceType::Image }, { variantIndex<ContentExtensions::BlockCookiesAction>, variantIndex<ContentExtensions::BlockLoadAction> });
+    testRequest(backend, { URL { "http://webkit.org"_str }, URL { "http://not_webkit.org"_str }, URL { "http://not_webkit.org"_str }, ResourceType::Image }, { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::BlockCookiesAction> });
 }
     
 TEST_F(ContentExtensionTest, WideNFA)
@@ -1461,7 +1461,7 @@ TEST_F(ContentExtensionTest, MatchesEverything)
     testRequest(backend6, subResourceRequest("http://example.com/image.png"_s, "http://w3c.org/"_s, ResourceType::Image), { variantIndex<ContentExtensions::BlockCookiesAction> });
     testRequest(backend6, subResourceRequest("http://example.com/doc.html"_s, "http://webkit.org/"_s), { variantIndex<ContentExtensions::BlockLoadAction> });
     testRequest(backend6, subResourceRequest("http://example.com/script.js"_s, "http://webkit.org/"_s, ResourceType::Script), { variantIndex<ContentExtensions::BlockLoadAction> });
-    testRequest(backend6, subResourceRequest("http://example.com/script.js"_s, "http://w3c.org/"_s, ResourceType::Script), { variantIndex<ContentExtensions::BlockCookiesAction>, variantIndex<ContentExtensions::BlockLoadAction> });
+    testRequest(backend6, subResourceRequest("http://example.com/script.js"_s, "http://w3c.org/"_s, ResourceType::Script), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::BlockCookiesAction> });
     testRequest(backend6, subResourceRequest("http://example.com/script.js"_s, "http://example.com/"_s, ResourceType::Script), { });
     testRequest(backend6, subResourceRequest("http://example.com/ignore/image.png"_s, "http://webkit.org/"_s, ResourceType::Image), { }, 0);
     testRequest(backend6, subResourceRequest("http://example.com/ignore/image.png"_s, "http://example.com/"_s, ResourceType::Image), { });
@@ -1705,7 +1705,7 @@ TEST_F(ContentExtensionTest, StrictPrefixSeparatedMachines3)
     testRequest(backend, mainDocumentRequest("http://webkit.org/ABC"_s), { variantIndex<ContentExtensions::MakeHTTPSAction> });
     testRequest(backend, mainDocumentRequest("http://webkit.org/ABABC"_s), { variantIndex<ContentExtensions::MakeHTTPSAction> }, 0);
     testRequest(backend, mainDocumentRequest("http://webkit.org/ABABCAD"_s), { variantIndex<ContentExtensions::MakeHTTPSAction> }, 0);
-    testRequest(backend, mainDocumentRequest("http://webkit.org/ABCAD"_s), { variantIndex<ContentExtensions::MakeHTTPSAction>, variantIndex<ContentExtensions::BlockLoadAction> });
+    testRequest(backend, mainDocumentRequest("http://webkit.org/ABCAD"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::MakeHTTPSAction> });
 }
     
 TEST_F(ContentExtensionTest, StrictPrefixSeparatedMachines3Partitioning)
@@ -1927,7 +1927,7 @@ TEST_F(ContentExtensionTest, StatesWithDifferentActionsAreNotUnified2)
         "{\"action\":{\"type\":\"css-display-none\", \"selector\":\"#foo\"},\"trigger\":{\"url-filter\":\"^https://www.webkit.org/\"}}]"_s);
 
     testRequest(backend, mainDocumentRequest("http://www.webkit.org/"_s), { variantIndex<ContentExtensions::BlockLoadAction> });
-    testRequest(backend, mainDocumentRequest("https://www.webkit.org/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockCookiesAction> });
+    testRequest(backend, mainDocumentRequest("https://www.webkit.org/"_s), { variantIndex<ContentExtensions::BlockCookiesAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(backend, mainDocumentRequest("https://www.whatwg.org/"_s), { });
     testRequest(backend, mainDocumentRequest("attps://www.whatwg.org/"_s), { });
 }
@@ -2175,8 +2175,8 @@ TEST_F(ContentExtensionTest, RangeOverlapCase3)
         "{\"action\":{\"type\":\"css-display-none\",\"selector\":\".hidden\"},\"trigger\":{\"url-filter\":\"^[a-m]\"}}]"_s);
 
     testRequest(matchBackend, mainDocumentRequest("a://www.webkit.org/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
-    testRequest(matchBackend, mainDocumentRequest("b://www.webkit.org/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction> });
-    testRequest(matchBackend, mainDocumentRequest("d://www.webkit.org/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction> });
+    testRequest(matchBackend, mainDocumentRequest("b://www.webkit.org/"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
+    testRequest(matchBackend, mainDocumentRequest("d://www.webkit.org/"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(matchBackend, mainDocumentRequest("e://www.webkit.org/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(matchBackend, mainDocumentRequest("m://www.webkit.org/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(matchBackend, mainDocumentRequest("n://www.webkit.org/"_s), { });
@@ -2184,8 +2184,8 @@ TEST_F(ContentExtensionTest, RangeOverlapCase3)
     auto searchBackend = makeBackend("[{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"[b-d]\"}},"
         "{\"action\":{\"type\":\"css-display-none\",\"selector\":\".hidden\"},\"trigger\":{\"url-filter\":\"[a-m]\"}}]"_s);
     testRequest(searchBackend, mainDocumentRequest("zzz://www.a.xxx/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
-    testRequest(searchBackend, mainDocumentRequest("zzz://www.b.xxx/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction> });
-    testRequest(searchBackend, mainDocumentRequest("zzz://www.d.xxx/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction> });
+    testRequest(searchBackend, mainDocumentRequest("zzz://www.b.xxx/"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
+    testRequest(searchBackend, mainDocumentRequest("zzz://www.d.xxx/"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(searchBackend, mainDocumentRequest("zzz://www.e.xxx/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(searchBackend, mainDocumentRequest("zzz://www.m.xxx/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(searchBackend, mainDocumentRequest("zzz://www.n.xxx/"_s), { });
@@ -2198,7 +2198,7 @@ TEST_F(ContentExtensionTest, RangeOverlapCase4)
 
     testRequest(matchBackend, mainDocumentRequest("a://www.webkit.org/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(matchBackend, mainDocumentRequest("k://www.webkit.org/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
-    testRequest(matchBackend, mainDocumentRequest("l://www.webkit.org/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction> });
+    testRequest(matchBackend, mainDocumentRequest("l://www.webkit.org/"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(matchBackend, mainDocumentRequest("m://www.webkit.org/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(matchBackend, mainDocumentRequest("n://www.webkit.org/"_s), { });
 
@@ -2206,7 +2206,7 @@ TEST_F(ContentExtensionTest, RangeOverlapCase4)
         "{\"action\":{\"type\":\"css-display-none\",\"selector\":\".hidden\"},\"trigger\":{\"url-filter\":\"[a-m]\"}}]"_s);
     testRequest(searchBackend, mainDocumentRequest("zzz://www.a.xxx/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(searchBackend, mainDocumentRequest("zzz://www.k.xxx/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
-    testRequest(searchBackend, mainDocumentRequest("zzz://www.l.xxx/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction> });
+    testRequest(searchBackend, mainDocumentRequest("zzz://www.l.xxx/"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(searchBackend, mainDocumentRequest("zzz://www.m.xxx/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(searchBackend, mainDocumentRequest("zzz://www.n.xxx/"_s), { });
 }
@@ -2218,7 +2218,7 @@ TEST_F(ContentExtensionTest, RangeOverlapCase5)
 
     testRequest(matchBackend, mainDocumentRequest("a://www.webkit.org/"_s), { variantIndex<ContentExtensions::BlockLoadAction> });
     testRequest(matchBackend, mainDocumentRequest("d://www.webkit.org/"_s), { variantIndex<ContentExtensions::BlockLoadAction> });
-    testRequest(matchBackend, mainDocumentRequest("e://www.webkit.org/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction> });
+    testRequest(matchBackend, mainDocumentRequest("e://www.webkit.org/"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(matchBackend, mainDocumentRequest("f://www.webkit.org/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(matchBackend, mainDocumentRequest("h://www.webkit.org/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(matchBackend, mainDocumentRequest("i://www.webkit.org/"_s), { });
@@ -2227,7 +2227,7 @@ TEST_F(ContentExtensionTest, RangeOverlapCase5)
         "{\"action\":{\"type\":\"css-display-none\",\"selector\":\".hidden\"},\"trigger\":{\"url-filter\":\"[e-h]\"}}]"_s);
     testRequest(searchBackend, mainDocumentRequest("zzz://www.a.xxx/"_s), { variantIndex<ContentExtensions::BlockLoadAction> });
     testRequest(searchBackend, mainDocumentRequest("zzz://www.d.xxx/"_s), { variantIndex<ContentExtensions::BlockLoadAction> });
-    testRequest(searchBackend, mainDocumentRequest("zzz://www.e.xxx/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction> });
+    testRequest(searchBackend, mainDocumentRequest("zzz://www.e.xxx/"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(searchBackend, mainDocumentRequest("zzz://www.f.xxx/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(searchBackend, mainDocumentRequest("zzz://www.h.xxx/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(searchBackend, mainDocumentRequest("zzz://www.i.xxx/"_s), { });
@@ -2240,7 +2240,7 @@ TEST_F(ContentExtensionTest, RangeOverlapCase6)
 
     testRequest(matchBackend, mainDocumentRequest("a://www.webkit.org/"_s), { });
     testRequest(matchBackend, mainDocumentRequest("d://www.webkit.org/"_s), { });
-    testRequest(matchBackend, mainDocumentRequest("e://www.webkit.org/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction> });
+    testRequest(matchBackend, mainDocumentRequest("e://www.webkit.org/"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(matchBackend, mainDocumentRequest("f://www.webkit.org/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(matchBackend, mainDocumentRequest("h://www.webkit.org/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(matchBackend, mainDocumentRequest("i://www.webkit.org/"_s), { });
@@ -2249,7 +2249,7 @@ TEST_F(ContentExtensionTest, RangeOverlapCase6)
         "{\"action\":{\"type\":\"css-display-none\",\"selector\":\".hidden\"},\"trigger\":{\"url-filter\":\"[e-h]\"}}]"_s);
     testRequest(searchBackend, mainDocumentRequest("zzz://www.a.xxx/"_s), { });
     testRequest(searchBackend, mainDocumentRequest("zzz://www.d.xxx/"_s), { });
-    testRequest(searchBackend, mainDocumentRequest("zzz://www.e.xxx/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction> });
+    testRequest(searchBackend, mainDocumentRequest("zzz://www.e.xxx/"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(searchBackend, mainDocumentRequest("zzz://www.f.xxx/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(searchBackend, mainDocumentRequest("zzz://www.h.xxx/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(searchBackend, mainDocumentRequest("zzz://www.i.xxx/"_s), { });
@@ -2262,14 +2262,14 @@ TEST_F(ContentExtensionTest, RangeOverlapCase7)
 
     testRequest(matchBackend, mainDocumentRequest("a://www.webkit.org/"_s), { variantIndex<ContentExtensions::BlockLoadAction> });
     testRequest(matchBackend, mainDocumentRequest("d://www.webkit.org/"_s), { variantIndex<ContentExtensions::BlockLoadAction> });
-    testRequest(matchBackend, mainDocumentRequest("e://www.webkit.org/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction> });
+    testRequest(matchBackend, mainDocumentRequest("e://www.webkit.org/"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(matchBackend, mainDocumentRequest("f://www.webkit.org/"_s), { });
 
     auto searchBackend = makeBackend("[{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"[a-e]\"}},"
         "{\"action\":{\"type\":\"css-display-none\",\"selector\":\".hidden\"},\"trigger\":{\"url-filter\":\"e\"}}]"_s);
     testRequest(searchBackend, mainDocumentRequest("zzz://www.a.xxx/"_s), { variantIndex<ContentExtensions::BlockLoadAction> });
     testRequest(searchBackend, mainDocumentRequest("zzz://www.d.xxx/"_s), { variantIndex<ContentExtensions::BlockLoadAction> });
-    testRequest(searchBackend, mainDocumentRequest("zzz://www.e.xxx/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction> });
+    testRequest(searchBackend, mainDocumentRequest("zzz://www.e.xxx/"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(searchBackend, mainDocumentRequest("zzz://www.f.xxx/"_s), { });
 }
 
@@ -2280,7 +2280,7 @@ TEST_F(ContentExtensionTest, RangeOverlapCase8)
 
     testRequest(matchBackend, mainDocumentRequest("a://www.webkit.org/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(matchBackend, mainDocumentRequest("d://www.webkit.org/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
-    testRequest(matchBackend, mainDocumentRequest("e://www.webkit.org/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction> });
+    testRequest(matchBackend, mainDocumentRequest("e://www.webkit.org/"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(matchBackend, mainDocumentRequest("f://www.webkit.org/"_s), { variantIndex<ContentExtensions::BlockLoadAction> });
     testRequest(matchBackend, mainDocumentRequest("h://www.webkit.org/"_s), { variantIndex<ContentExtensions::BlockLoadAction> });
     testRequest(matchBackend, mainDocumentRequest("i://www.webkit.org/"_s), { });
@@ -2289,7 +2289,7 @@ TEST_F(ContentExtensionTest, RangeOverlapCase8)
         "{\"action\":{\"type\":\"css-display-none\",\"selector\":\".hidden\"},\"trigger\":{\"url-filter\":\"[a-e]\"}}]"_s);
     testRequest(searchBackend, mainDocumentRequest("zzz://www.a.xxx/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(searchBackend, mainDocumentRequest("zzz://www.d.xxx/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
-    testRequest(searchBackend, mainDocumentRequest("zzz://www.e.xxx/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction> });
+    testRequest(searchBackend, mainDocumentRequest("zzz://www.e.xxx/"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(searchBackend, mainDocumentRequest("zzz://www.f.xxx/"_s), { variantIndex<ContentExtensions::BlockLoadAction> });
     testRequest(searchBackend, mainDocumentRequest("zzz://www.h.xxx/"_s), { variantIndex<ContentExtensions::BlockLoadAction> });
     testRequest(searchBackend, mainDocumentRequest("zzz://www.i.xxx/"_s), { });
@@ -2302,14 +2302,14 @@ TEST_F(ContentExtensionTest, RangeOverlapCase9)
 
     testRequest(matchBackend, mainDocumentRequest("a://www.webkit.org/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(matchBackend, mainDocumentRequest("d://www.webkit.org/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
-    testRequest(matchBackend, mainDocumentRequest("e://www.webkit.org/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction> });
+    testRequest(matchBackend, mainDocumentRequest("e://www.webkit.org/"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(matchBackend, mainDocumentRequest("f://www.webkit.org/"_s), { });
 
     auto searchBackend = makeBackend("[{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"e\"}},"
         "{\"action\":{\"type\":\"css-display-none\",\"selector\":\".hidden\"},\"trigger\":{\"url-filter\":\"[a-e]\"}}]"_s);
     testRequest(searchBackend, mainDocumentRequest("zzz://www.a.xxx/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(searchBackend, mainDocumentRequest("zzz://www.d.xxx/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
-    testRequest(searchBackend, mainDocumentRequest("zzz://www.e.xxx/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction> });
+    testRequest(searchBackend, mainDocumentRequest("zzz://www.e.xxx/"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(searchBackend, mainDocumentRequest("zzz://www.f.xxx/"_s), { });
 }
 
@@ -2320,7 +2320,7 @@ TEST_F(ContentExtensionTest, RangeOverlapCase10)
 
     testRequest(matchBackend, mainDocumentRequest("a://www.webkit.org/"_s), { });
     testRequest(matchBackend, mainDocumentRequest("d://www.webkit.org/"_s), { });
-    testRequest(matchBackend, mainDocumentRequest("e://www.webkit.org/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction> });
+    testRequest(matchBackend, mainDocumentRequest("e://www.webkit.org/"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(matchBackend, mainDocumentRequest("f://www.webkit.org/"_s), { variantIndex<ContentExtensions::BlockLoadAction> });
     testRequest(matchBackend, mainDocumentRequest("h://www.webkit.org/"_s), { variantIndex<ContentExtensions::BlockLoadAction> });
     testRequest(matchBackend, mainDocumentRequest("i://www.webkit.org/"_s), { });
@@ -2329,7 +2329,7 @@ TEST_F(ContentExtensionTest, RangeOverlapCase10)
         "{\"action\":{\"type\":\"css-display-none\",\"selector\":\".hidden\"},\"trigger\":{\"url-filter\":\"e\"}}]"_s);
     testRequest(searchBackend, mainDocumentRequest("zzz://www.a.xxx/"_s), { });
     testRequest(searchBackend, mainDocumentRequest("zzz://www.d.xxx/"_s), { });
-    testRequest(searchBackend, mainDocumentRequest("zzz://www.e.xxx/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction> });
+    testRequest(searchBackend, mainDocumentRequest("zzz://www.e.xxx/"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(searchBackend, mainDocumentRequest("zzz://www.f.xxx/"_s), { variantIndex<ContentExtensions::BlockLoadAction> });
     testRequest(searchBackend, mainDocumentRequest("zzz://www.h.xxx/"_s), { variantIndex<ContentExtensions::BlockLoadAction> });
     testRequest(searchBackend, mainDocumentRequest("zzz://www.i.xxx/"_s), { });
@@ -2342,8 +2342,8 @@ TEST_F(ContentExtensionTest, RangeOverlapCase11)
 
     testRequest(matchBackend, mainDocumentRequest("c://www.webkit.org/"_s), { });
     testRequest(matchBackend, mainDocumentRequest("d://www.webkit.org/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
-    testRequest(matchBackend, mainDocumentRequest("e://www.webkit.org/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction> });
-    testRequest(matchBackend, mainDocumentRequest("f://www.webkit.org/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction> });
+    testRequest(matchBackend, mainDocumentRequest("e://www.webkit.org/"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
+    testRequest(matchBackend, mainDocumentRequest("f://www.webkit.org/"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(matchBackend, mainDocumentRequest("g://www.webkit.org/"_s), { variantIndex<ContentExtensions::BlockLoadAction> });
     testRequest(matchBackend, mainDocumentRequest("h://www.webkit.org/"_s), { });
 
@@ -2351,8 +2351,8 @@ TEST_F(ContentExtensionTest, RangeOverlapCase11)
         "{\"action\":{\"type\":\"css-display-none\",\"selector\":\".hidden\"},\"trigger\":{\"url-filter\":\"[d-f]\"}}]"_s);
     testRequest(searchBackend, mainDocumentRequest("zzz://www.c.xxx/"_s), { });
     testRequest(searchBackend, mainDocumentRequest("zzz://www.d.xxx/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
-    testRequest(searchBackend, mainDocumentRequest("zzz://www.e.xxx/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction> });
-    testRequest(searchBackend, mainDocumentRequest("zzz://www.f.xxx/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction> });
+    testRequest(searchBackend, mainDocumentRequest("zzz://www.e.xxx/"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
+    testRequest(searchBackend, mainDocumentRequest("zzz://www.f.xxx/"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(searchBackend, mainDocumentRequest("zzz://www.g.xxx/"_s), { variantIndex<ContentExtensions::BlockLoadAction> });
     testRequest(searchBackend, mainDocumentRequest("zzz://www.h.xxx/"_s), { });
 }
@@ -2365,18 +2365,18 @@ TEST_F(ContentExtensionTest, RangeOverlapCase12)
 
     testRequest(matchBackend, mainDocumentRequest("c://www.webkit.org/"_s), { });
     testRequest(matchBackend, mainDocumentRequest("d://www.webkit.org/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
-    testRequest(matchBackend, mainDocumentRequest("e://www.webkit.org/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction> });
-    testRequest(matchBackend, mainDocumentRequest("f://www.webkit.org/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction> });
-    testRequest(matchBackend, mainDocumentRequest("g://www.webkit.org/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction> });
+    testRequest(matchBackend, mainDocumentRequest("e://www.webkit.org/"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
+    testRequest(matchBackend, mainDocumentRequest("f://www.webkit.org/"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
+    testRequest(matchBackend, mainDocumentRequest("g://www.webkit.org/"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(matchBackend, mainDocumentRequest("h://www.webkit.org/"_s), { });
 
     auto searchBackend = makeBackend("[{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"[e-g]\"}},"
         "{\"action\":{\"type\":\"css-display-none\",\"selector\":\".hidden\"},\"trigger\":{\"url-filter\":\"[d-g]\"}}]"_s);
     testRequest(searchBackend, mainDocumentRequest("zzz://www.c.xxx/"_s), { });
     testRequest(searchBackend, mainDocumentRequest("zzz://www.d.xxx/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
-    testRequest(searchBackend, mainDocumentRequest("zzz://www.e.xxx/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction> });
-    testRequest(searchBackend, mainDocumentRequest("zzz://www.f.xxx/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction> });
-    testRequest(searchBackend, mainDocumentRequest("zzz://www.g.xxx/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction> });
+    testRequest(searchBackend, mainDocumentRequest("zzz://www.e.xxx/"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
+    testRequest(searchBackend, mainDocumentRequest("zzz://www.f.xxx/"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
+    testRequest(searchBackend, mainDocumentRequest("zzz://www.g.xxx/"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(searchBackend, mainDocumentRequest("zzz://www.h.xxx/"_s), { });
 }
 
@@ -2387,8 +2387,8 @@ TEST_F(ContentExtensionTest, RangeOverlapCase13)
 
     testRequest(matchBackend, mainDocumentRequest("a://www.webkit.org/"_s), { });
     testRequest(matchBackend, mainDocumentRequest("b://www.webkit.org/"_s), { variantIndex<ContentExtensions::BlockLoadAction> });
-    testRequest(matchBackend, mainDocumentRequest("c://www.webkit.org/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction> });
-    testRequest(matchBackend, mainDocumentRequest("d://www.webkit.org/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction> });
+    testRequest(matchBackend, mainDocumentRequest("c://www.webkit.org/"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
+    testRequest(matchBackend, mainDocumentRequest("d://www.webkit.org/"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(matchBackend, mainDocumentRequest("e://www.webkit.org/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(matchBackend, mainDocumentRequest("h://www.webkit.org/"_s), { });
 
@@ -2396,8 +2396,8 @@ TEST_F(ContentExtensionTest, RangeOverlapCase13)
         "{\"action\":{\"type\":\"css-display-none\",\"selector\":\".hidden\"},\"trigger\":{\"url-filter\":\"[c-e]\"}}]"_s);
     testRequest(searchBackend, mainDocumentRequest("zzz://www.a.xxx/"_s), { });
     testRequest(searchBackend, mainDocumentRequest("zzz://www.b.xxx/"_s), { variantIndex<ContentExtensions::BlockLoadAction> });
-    testRequest(searchBackend, mainDocumentRequest("zzz://www.c.xxx/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction> });
-    testRequest(searchBackend, mainDocumentRequest("zzz://www.d.xxx/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction> });
+    testRequest(searchBackend, mainDocumentRequest("zzz://www.c.xxx/"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
+    testRequest(searchBackend, mainDocumentRequest("zzz://www.d.xxx/"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(searchBackend, mainDocumentRequest("zzz://www.e.xxx/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(searchBackend, mainDocumentRequest("zzz://www.h.xxx/"_s), { });
 }
@@ -2409,18 +2409,18 @@ TEST_F(ContentExtensionTest, RangeOverlapCase14)
 
     testRequest(matchBackend, mainDocumentRequest("a://www.webkit.org/"_s), { });
     testRequest(matchBackend, mainDocumentRequest("b://www.webkit.org/"_s), { variantIndex<ContentExtensions::BlockLoadAction> });
-    testRequest(matchBackend, mainDocumentRequest("c://www.webkit.org/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction> });
-    testRequest(matchBackend, mainDocumentRequest("d://www.webkit.org/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction> });
-    testRequest(matchBackend, mainDocumentRequest("e://www.webkit.org/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction> });
+    testRequest(matchBackend, mainDocumentRequest("c://www.webkit.org/"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
+    testRequest(matchBackend, mainDocumentRequest("d://www.webkit.org/"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
+    testRequest(matchBackend, mainDocumentRequest("e://www.webkit.org/"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(matchBackend, mainDocumentRequest("h://www.webkit.org/"_s), { });
 
     auto searchBackend = makeBackend("[{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"[b-e]\"}},"
         "{\"action\":{\"type\":\"css-display-none\",\"selector\":\".hidden\"},\"trigger\":{\"url-filter\":\"[c-e]\"}}]"_s);
     testRequest(searchBackend, mainDocumentRequest("zzz://www.a.xxx/"_s), { });
     testRequest(searchBackend, mainDocumentRequest("zzz://www.b.xxx/"_s), { variantIndex<ContentExtensions::BlockLoadAction> });
-    testRequest(searchBackend, mainDocumentRequest("zzz://www.c.xxx/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction> });
-    testRequest(searchBackend, mainDocumentRequest("zzz://www.d.xxx/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction> });
-    testRequest(searchBackend, mainDocumentRequest("zzz://www.e.xxx/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction> });
+    testRequest(searchBackend, mainDocumentRequest("zzz://www.c.xxx/"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
+    testRequest(searchBackend, mainDocumentRequest("zzz://www.d.xxx/"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
+    testRequest(searchBackend, mainDocumentRequest("zzz://www.e.xxx/"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(searchBackend, mainDocumentRequest("zzz://www.h.xxx/"_s), { });
 }
 
@@ -2431,20 +2431,20 @@ TEST_F(ContentExtensionTest, RangeOverlapCase15)
 
     testRequest(matchBackend, mainDocumentRequest("a://www.webkit.org/"_s), { });
     testRequest(matchBackend, mainDocumentRequest("b://www.webkit.org/"_s), { });
-    testRequest(matchBackend, mainDocumentRequest("c://www.webkit.org/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction> });
-    testRequest(matchBackend, mainDocumentRequest("d://www.webkit.org/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction> });
-    testRequest(matchBackend, mainDocumentRequest("e://www.webkit.org/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction> });
-    testRequest(matchBackend, mainDocumentRequest("f://www.webkit.org/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction> });
+    testRequest(matchBackend, mainDocumentRequest("c://www.webkit.org/"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
+    testRequest(matchBackend, mainDocumentRequest("d://www.webkit.org/"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
+    testRequest(matchBackend, mainDocumentRequest("e://www.webkit.org/"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
+    testRequest(matchBackend, mainDocumentRequest("f://www.webkit.org/"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(matchBackend, mainDocumentRequest("g://www.webkit.org/"_s), { });
 
     auto searchBackend = makeBackend("[{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"[c-f]\"}},"
         "{\"action\":{\"type\":\"css-display-none\",\"selector\":\".hidden\"},\"trigger\":{\"url-filter\":\"[c-f]\"}}]"_s);
     testRequest(searchBackend, mainDocumentRequest("zzz://www.a.xxx/"_s), { });
     testRequest(searchBackend, mainDocumentRequest("zzz://www.b.xxx/"_s), { });
-    testRequest(searchBackend, mainDocumentRequest("zzz://www.c.xxx/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction> });
-    testRequest(searchBackend, mainDocumentRequest("zzz://www.d.xxx/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction> });
-    testRequest(searchBackend, mainDocumentRequest("zzz://www.e.xxx/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction> });
-    testRequest(searchBackend, mainDocumentRequest("zzz://www.f.xxx/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction> });
+    testRequest(searchBackend, mainDocumentRequest("zzz://www.c.xxx/"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
+    testRequest(searchBackend, mainDocumentRequest("zzz://www.d.xxx/"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
+    testRequest(searchBackend, mainDocumentRequest("zzz://www.e.xxx/"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
+    testRequest(searchBackend, mainDocumentRequest("zzz://www.f.xxx/"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(searchBackend, mainDocumentRequest("zzz://www.g.xxx/"_s), { });
 }
 
@@ -2455,7 +2455,7 @@ TEST_F(ContentExtensionTest, RangeOverlapCase16)
 
     testRequest(matchBackend, mainDocumentRequest("a://www.webkit.org/"_s), { });
     testRequest(matchBackend, mainDocumentRequest("b://www.webkit.org/"_s), { });
-    testRequest(matchBackend, mainDocumentRequest("c://www.webkit.org/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction> });
+    testRequest(matchBackend, mainDocumentRequest("c://www.webkit.org/"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(matchBackend, mainDocumentRequest("d://www.webkit.org/"_s), { });
     testRequest(matchBackend, mainDocumentRequest("e://www.webkit.org/"_s), { });
 
@@ -2463,7 +2463,7 @@ TEST_F(ContentExtensionTest, RangeOverlapCase16)
         "{\"action\":{\"type\":\"css-display-none\",\"selector\":\".hidden\"},\"trigger\":{\"url-filter\":\"c\"}}]"_s);
     testRequest(searchBackend, mainDocumentRequest("zzz://www.a.xxx/"_s), { });
     testRequest(searchBackend, mainDocumentRequest("zzz://www.b.xxx/"_s), { });
-    testRequest(searchBackend, mainDocumentRequest("zzz://www.c.xxx/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction> });
+    testRequest(searchBackend, mainDocumentRequest("zzz://www.c.xxx/"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(searchBackend, mainDocumentRequest("zzz://www.d.xxx/"_s), { });
     testRequest(searchBackend, mainDocumentRequest("zzz://www.e.xxx/"_s), { });
 }
@@ -2509,16 +2509,16 @@ TEST_F(ContentExtensionTest, QuantifiedOneOrMoreRangesCase11And13)
     testRequest(searchBackend, mainDocumentRequest("zzz://www.ceyyy.xxx/"_s), { });
     testRequest(searchBackend, mainDocumentRequest("zzz://www.cfyyy.xxx/"_s), { });
     testRequest(searchBackend, mainDocumentRequest("zzz://www.cgyyy.xxx/"_s), { variantIndex<ContentExtensions::BlockLoadAction> });
-    testRequest(searchBackend, mainDocumentRequest("zzz://www.chyyy.xxx/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction> });
-    testRequest(searchBackend, mainDocumentRequest("zzz://www.ciyyy.xxx/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction> });
+    testRequest(searchBackend, mainDocumentRequest("zzz://www.chyyy.xxx/"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
+    testRequest(searchBackend, mainDocumentRequest("zzz://www.ciyyy.xxx/"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(searchBackend, mainDocumentRequest("zzz://www.cjyyy.xxx/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(searchBackend, mainDocumentRequest("zzz://www.ckyyy.xxx/"_s), { });
 
     // 'd' is in the first range of both rule. This series cover overlaps between the two rules.
     testRequest(searchBackend, mainDocumentRequest("zzz://www.dgyyy.xxx/"_s), { variantIndex<ContentExtensions::BlockLoadAction> });
     testRequest(searchBackend, mainDocumentRequest("zzz://www.ddgyyy.xxx/"_s), { variantIndex<ContentExtensions::BlockLoadAction> });
-    testRequest(searchBackend, mainDocumentRequest("zzz://www.ddhyyy.xxx/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction> });
-    testRequest(searchBackend, mainDocumentRequest("zzz://www.ddhhyyy.xxx/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction> });
+    testRequest(searchBackend, mainDocumentRequest("zzz://www.ddhyyy.xxx/"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
+    testRequest(searchBackend, mainDocumentRequest("zzz://www.ddhhyyy.xxx/"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(searchBackend, mainDocumentRequest("zzz://www.degyyy.xxx/"_s), { variantIndex<ContentExtensions::BlockLoadAction> });
     testRequest(searchBackend, mainDocumentRequest("zzz://www.dehyyy.xxx/"_s), { variantIndex<ContentExtensions::BlockLoadAction> });
     testRequest(searchBackend, mainDocumentRequest("zzz://www.dfgyyy.xxx/"_s), { });
@@ -2569,16 +2569,16 @@ TEST_F(ContentExtensionTest, QuantifiedOneOrMoreRangesCase11And13InGroups)
     testRequest(searchBackend, mainDocumentRequest("zzz://www.ceyyy.xxx/"_s), { });
     testRequest(searchBackend, mainDocumentRequest("zzz://www.cfyyy.xxx/"_s), { });
     testRequest(searchBackend, mainDocumentRequest("zzz://www.cgyyy.xxx/"_s), { variantIndex<ContentExtensions::BlockLoadAction> });
-    testRequest(searchBackend, mainDocumentRequest("zzz://www.chyyy.xxx/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction> });
-    testRequest(searchBackend, mainDocumentRequest("zzz://www.ciyyy.xxx/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction> });
+    testRequest(searchBackend, mainDocumentRequest("zzz://www.chyyy.xxx/"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
+    testRequest(searchBackend, mainDocumentRequest("zzz://www.ciyyy.xxx/"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(searchBackend, mainDocumentRequest("zzz://www.cjyyy.xxx/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(searchBackend, mainDocumentRequest("zzz://www.ckyyy.xxx/"_s), { });
 
     // 'd' is in the first range of both rule. This series cover overlaps between the two rules.
     testRequest(searchBackend, mainDocumentRequest("zzz://www.dgyyy.xxx/"_s), { variantIndex<ContentExtensions::BlockLoadAction> });
     testRequest(searchBackend, mainDocumentRequest("zzz://www.ddgyyy.xxx/"_s), { variantIndex<ContentExtensions::BlockLoadAction> });
-    testRequest(searchBackend, mainDocumentRequest("zzz://www.ddhyyy.xxx/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction> });
-    testRequest(searchBackend, mainDocumentRequest("zzz://www.ddhhyyy.xxx/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction> });
+    testRequest(searchBackend, mainDocumentRequest("zzz://www.ddhyyy.xxx/"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
+    testRequest(searchBackend, mainDocumentRequest("zzz://www.ddhhyyy.xxx/"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(searchBackend, mainDocumentRequest("zzz://www.degyyy.xxx/"_s), { variantIndex<ContentExtensions::BlockLoadAction> });
     testRequest(searchBackend, mainDocumentRequest("zzz://www.dehyyy.xxx/"_s), { variantIndex<ContentExtensions::BlockLoadAction> });
     testRequest(searchBackend, mainDocumentRequest("zzz://www.dfgyyy.xxx/"_s), { });
@@ -2641,8 +2641,8 @@ TEST_F(ContentExtensionTest, CombinedRangeOverlapCase3)
         "{\"action\":{\"type\":\"css-display-none\",\"selector\":\".hidden\"},\"trigger\":{\"url-filter\":\"^(bar)*[a-m]\"}}]"_s);
 
     testRequest(matchBackend, mainDocumentRequest("a://www.webkit.org/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
-    testRequest(matchBackend, mainDocumentRequest("b://www.webkit.org/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction> });
-    testRequest(matchBackend, mainDocumentRequest("d://www.webkit.org/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction> });
+    testRequest(matchBackend, mainDocumentRequest("b://www.webkit.org/"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
+    testRequest(matchBackend, mainDocumentRequest("d://www.webkit.org/"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(matchBackend, mainDocumentRequest("e://www.webkit.org/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(matchBackend, mainDocumentRequest("m://www.webkit.org/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(matchBackend, mainDocumentRequest("n://www.webkit.org/"_s), { });
@@ -2650,8 +2650,8 @@ TEST_F(ContentExtensionTest, CombinedRangeOverlapCase3)
     auto searchBackend = makeBackend("[{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"(foo)*[b-d]\"}},"
         "{\"action\":{\"type\":\"css-display-none\",\"selector\":\".hidden\"},\"trigger\":{\"url-filter\":\"(bar)*[a-m]\"}}]"_s);
     testRequest(searchBackend, mainDocumentRequest("zzz://www.a.xxx/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
-    testRequest(searchBackend, mainDocumentRequest("zzz://www.b.xxx/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction> });
-    testRequest(searchBackend, mainDocumentRequest("zzz://www.d.xxx/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction> });
+    testRequest(searchBackend, mainDocumentRequest("zzz://www.b.xxx/"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
+    testRequest(searchBackend, mainDocumentRequest("zzz://www.d.xxx/"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(searchBackend, mainDocumentRequest("zzz://www.e.xxx/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(searchBackend, mainDocumentRequest("zzz://www.m.xxx/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(searchBackend, mainDocumentRequest("zzz://www.n.xxx/"_s), { });
@@ -2664,7 +2664,7 @@ TEST_F(ContentExtensionTest, CombinedRangeOverlapCase4)
 
     testRequest(matchBackend, mainDocumentRequest("a://www.webkit.org/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(matchBackend, mainDocumentRequest("k://www.webkit.org/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
-    testRequest(matchBackend, mainDocumentRequest("l://www.webkit.org/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction> });
+    testRequest(matchBackend, mainDocumentRequest("l://www.webkit.org/"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(matchBackend, mainDocumentRequest("m://www.webkit.org/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(matchBackend, mainDocumentRequest("n://www.webkit.org/"_s), { });
 
@@ -2672,7 +2672,7 @@ TEST_F(ContentExtensionTest, CombinedRangeOverlapCase4)
         "{\"action\":{\"type\":\"css-display-none\",\"selector\":\".hidden\"},\"trigger\":{\"url-filter\":\"(bar)*[a-m]\"}}]"_s);
     testRequest(searchBackend, mainDocumentRequest("zzz://www.a.xxx/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(searchBackend, mainDocumentRequest("zzz://www.k.xxx/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
-    testRequest(searchBackend, mainDocumentRequest("zzz://www.l.xxx/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction> });
+    testRequest(searchBackend, mainDocumentRequest("zzz://www.l.xxx/"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(searchBackend, mainDocumentRequest("zzz://www.m.xxx/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(searchBackend, mainDocumentRequest("zzz://www.n.xxx/"_s), { });
 }
@@ -2684,7 +2684,7 @@ TEST_F(ContentExtensionTest, CombinedRangeOverlapCase5)
 
     testRequest(matchBackend, mainDocumentRequest("a://www.webkit.org/"_s), { variantIndex<ContentExtensions::BlockLoadAction> });
     testRequest(matchBackend, mainDocumentRequest("d://www.webkit.org/"_s), { variantIndex<ContentExtensions::BlockLoadAction> });
-    testRequest(matchBackend, mainDocumentRequest("e://www.webkit.org/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction> });
+    testRequest(matchBackend, mainDocumentRequest("e://www.webkit.org/"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(matchBackend, mainDocumentRequest("f://www.webkit.org/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(matchBackend, mainDocumentRequest("h://www.webkit.org/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(matchBackend, mainDocumentRequest("i://www.webkit.org/"_s), { });
@@ -2693,7 +2693,7 @@ TEST_F(ContentExtensionTest, CombinedRangeOverlapCase5)
         "{\"action\":{\"type\":\"css-display-none\",\"selector\":\".hidden\"},\"trigger\":{\"url-filter\":\"(bar)*[e-h]\"}}]"_s);
     testRequest(searchBackend, mainDocumentRequest("zzz://www.a.xxx/"_s), { variantIndex<ContentExtensions::BlockLoadAction> });
     testRequest(searchBackend, mainDocumentRequest("zzz://www.d.xxx/"_s), { variantIndex<ContentExtensions::BlockLoadAction> });
-    testRequest(searchBackend, mainDocumentRequest("zzz://www.e.xxx/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction> });
+    testRequest(searchBackend, mainDocumentRequest("zzz://www.e.xxx/"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(searchBackend, mainDocumentRequest("zzz://www.f.xxx/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(searchBackend, mainDocumentRequest("zzz://www.h.xxx/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(searchBackend, mainDocumentRequest("zzz://www.i.xxx/"_s), { });
@@ -2706,7 +2706,7 @@ TEST_F(ContentExtensionTest, CombinedRangeOverlapCase6)
 
     testRequest(matchBackend, mainDocumentRequest("a://www.webkit.org/"_s), { });
     testRequest(matchBackend, mainDocumentRequest("d://www.webkit.org/"_s), { });
-    testRequest(matchBackend, mainDocumentRequest("e://www.webkit.org/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction> });
+    testRequest(matchBackend, mainDocumentRequest("e://www.webkit.org/"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(matchBackend, mainDocumentRequest("f://www.webkit.org/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(matchBackend, mainDocumentRequest("h://www.webkit.org/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(matchBackend, mainDocumentRequest("i://www.webkit.org/"_s), { });
@@ -2715,7 +2715,7 @@ TEST_F(ContentExtensionTest, CombinedRangeOverlapCase6)
         "{\"action\":{\"type\":\"css-display-none\",\"selector\":\".hidden\"},\"trigger\":{\"url-filter\":\"(bar)*[e-h]\"}}]"_s);
     testRequest(searchBackend, mainDocumentRequest("zzz://www.a.xxx/"_s), { });
     testRequest(searchBackend, mainDocumentRequest("zzz://www.d.xxx/"_s), { });
-    testRequest(searchBackend, mainDocumentRequest("zzz://www.e.xxx/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction> });
+    testRequest(searchBackend, mainDocumentRequest("zzz://www.e.xxx/"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(searchBackend, mainDocumentRequest("zzz://www.f.xxx/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(searchBackend, mainDocumentRequest("zzz://www.h.xxx/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(searchBackend, mainDocumentRequest("zzz://www.i.xxx/"_s), { });
@@ -2728,14 +2728,14 @@ TEST_F(ContentExtensionTest, CombinedRangeOverlapCase7)
 
     testRequest(matchBackend, mainDocumentRequest("a://www.webkit.org/"_s), { variantIndex<ContentExtensions::BlockLoadAction> });
     testRequest(matchBackend, mainDocumentRequest("d://www.webkit.org/"_s), { variantIndex<ContentExtensions::BlockLoadAction> });
-    testRequest(matchBackend, mainDocumentRequest("e://www.webkit.org/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction> });
+    testRequest(matchBackend, mainDocumentRequest("e://www.webkit.org/"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(matchBackend, mainDocumentRequest("f://www.webkit.org/"_s), { });
 
     auto searchBackend = makeBackend("[{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"(foo)*[a-e]\"}},"
         "{\"action\":{\"type\":\"css-display-none\",\"selector\":\".hidden\"},\"trigger\":{\"url-filter\":\"(bar)*e\"}}]"_s);
     testRequest(searchBackend, mainDocumentRequest("zzz://www.a.xxx/"_s), { variantIndex<ContentExtensions::BlockLoadAction> });
     testRequest(searchBackend, mainDocumentRequest("zzz://www.d.xxx/"_s), { variantIndex<ContentExtensions::BlockLoadAction> });
-    testRequest(searchBackend, mainDocumentRequest("zzz://www.e.xxx/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction> });
+    testRequest(searchBackend, mainDocumentRequest("zzz://www.e.xxx/"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(searchBackend, mainDocumentRequest("zzz://www.f.xxx/"_s), { });
 }
 
@@ -2746,7 +2746,7 @@ TEST_F(ContentExtensionTest, CombinedRangeOverlapCase8)
 
     testRequest(matchBackend, mainDocumentRequest("a://www.webkit.org/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(matchBackend, mainDocumentRequest("d://www.webkit.org/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
-    testRequest(matchBackend, mainDocumentRequest("e://www.webkit.org/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction> });
+    testRequest(matchBackend, mainDocumentRequest("e://www.webkit.org/"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(matchBackend, mainDocumentRequest("f://www.webkit.org/"_s), { variantIndex<ContentExtensions::BlockLoadAction> });
     testRequest(matchBackend, mainDocumentRequest("h://www.webkit.org/"_s), { variantIndex<ContentExtensions::BlockLoadAction> });
     testRequest(matchBackend, mainDocumentRequest("i://www.webkit.org/"_s), { });
@@ -2755,7 +2755,7 @@ TEST_F(ContentExtensionTest, CombinedRangeOverlapCase8)
         "{\"action\":{\"type\":\"css-display-none\",\"selector\":\".hidden\"},\"trigger\":{\"url-filter\":\"(bar)*[a-e]\"}}]"_s);
     testRequest(searchBackend, mainDocumentRequest("zzz://www.a.xxx/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(searchBackend, mainDocumentRequest("zzz://www.d.xxx/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
-    testRequest(searchBackend, mainDocumentRequest("zzz://www.e.xxx/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction> });
+    testRequest(searchBackend, mainDocumentRequest("zzz://www.e.xxx/"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(searchBackend, mainDocumentRequest("zzz://www.f.xxx/"_s), { variantIndex<ContentExtensions::BlockLoadAction> });
     testRequest(searchBackend, mainDocumentRequest("zzz://www.h.xxx/"_s), { variantIndex<ContentExtensions::BlockLoadAction> });
     testRequest(searchBackend, mainDocumentRequest("zzz://www.i.xxx/"_s), { });
@@ -2768,14 +2768,14 @@ TEST_F(ContentExtensionTest, CombinedRangeOverlapCase9)
 
     testRequest(matchBackend, mainDocumentRequest("a://www.webkit.org/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(matchBackend, mainDocumentRequest("d://www.webkit.org/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
-    testRequest(matchBackend, mainDocumentRequest("e://www.webkit.org/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction> });
+    testRequest(matchBackend, mainDocumentRequest("e://www.webkit.org/"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(matchBackend, mainDocumentRequest("f://www.webkit.org/"_s), { });
 
     auto searchBackend = makeBackend("[{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"(foo)*e\"}},"
         "{\"action\":{\"type\":\"css-display-none\",\"selector\":\".hidden\"},\"trigger\":{\"url-filter\":\"(bar)*[a-e]\"}}]"_s);
     testRequest(searchBackend, mainDocumentRequest("zzz://www.a.xxx/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(searchBackend, mainDocumentRequest("zzz://www.d.xxx/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
-    testRequest(searchBackend, mainDocumentRequest("zzz://www.e.xxx/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction> });
+    testRequest(searchBackend, mainDocumentRequest("zzz://www.e.xxx/"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(searchBackend, mainDocumentRequest("zzz://www.f.xxx/"_s), { });
 }
 
@@ -2786,7 +2786,7 @@ TEST_F(ContentExtensionTest, CombinedRangeOverlapCase10)
 
     testRequest(matchBackend, mainDocumentRequest("a://www.webkit.org/"_s), { });
     testRequest(matchBackend, mainDocumentRequest("d://www.webkit.org/"_s), { });
-    testRequest(matchBackend, mainDocumentRequest("e://www.webkit.org/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction> });
+    testRequest(matchBackend, mainDocumentRequest("e://www.webkit.org/"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(matchBackend, mainDocumentRequest("f://www.webkit.org/"_s), { variantIndex<ContentExtensions::BlockLoadAction> });
     testRequest(matchBackend, mainDocumentRequest("h://www.webkit.org/"_s), { variantIndex<ContentExtensions::BlockLoadAction> });
     testRequest(matchBackend, mainDocumentRequest("i://www.webkit.org/"_s), { });
@@ -2795,7 +2795,7 @@ TEST_F(ContentExtensionTest, CombinedRangeOverlapCase10)
         "{\"action\":{\"type\":\"css-display-none\",\"selector\":\".hidden\"},\"trigger\":{\"url-filter\":\"(bar)*e\"}}]"_s);
     testRequest(searchBackend, mainDocumentRequest("zzz://www.a.xxx/"_s), { });
     testRequest(searchBackend, mainDocumentRequest("zzz://www.d.xxx/"_s), { });
-    testRequest(searchBackend, mainDocumentRequest("zzz://www.e.xxx/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction> });
+    testRequest(searchBackend, mainDocumentRequest("zzz://www.e.xxx/"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(searchBackend, mainDocumentRequest("zzz://www.f.xxx/"_s), { variantIndex<ContentExtensions::BlockLoadAction> });
     testRequest(searchBackend, mainDocumentRequest("zzz://www.h.xxx/"_s), { variantIndex<ContentExtensions::BlockLoadAction> });
     testRequest(searchBackend, mainDocumentRequest("zzz://www.i.xxx/"_s), { });
@@ -2808,8 +2808,8 @@ TEST_F(ContentExtensionTest, CombinedRangeOverlapCase11)
 
     testRequest(matchBackend, mainDocumentRequest("c://www.webkit.org/"_s), { });
     testRequest(matchBackend, mainDocumentRequest("d://www.webkit.org/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
-    testRequest(matchBackend, mainDocumentRequest("e://www.webkit.org/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction> });
-    testRequest(matchBackend, mainDocumentRequest("f://www.webkit.org/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction> });
+    testRequest(matchBackend, mainDocumentRequest("e://www.webkit.org/"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
+    testRequest(matchBackend, mainDocumentRequest("f://www.webkit.org/"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(matchBackend, mainDocumentRequest("g://www.webkit.org/"_s), { variantIndex<ContentExtensions::BlockLoadAction> });
     testRequest(matchBackend, mainDocumentRequest("h://www.webkit.org/"_s), { });
 
@@ -2817,8 +2817,8 @@ TEST_F(ContentExtensionTest, CombinedRangeOverlapCase11)
         "{\"action\":{\"type\":\"css-display-none\",\"selector\":\".hidden\"},\"trigger\":{\"url-filter\":\"(bar)*[d-f]\"}}]"_s);
     testRequest(searchBackend, mainDocumentRequest("zzz://www.c.xxx/"_s), { });
     testRequest(searchBackend, mainDocumentRequest("zzz://www.d.xxx/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
-    testRequest(searchBackend, mainDocumentRequest("zzz://www.e.xxx/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction> });
-    testRequest(searchBackend, mainDocumentRequest("zzz://www.f.xxx/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction> });
+    testRequest(searchBackend, mainDocumentRequest("zzz://www.e.xxx/"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
+    testRequest(searchBackend, mainDocumentRequest("zzz://www.f.xxx/"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(searchBackend, mainDocumentRequest("zzz://www.g.xxx/"_s), { variantIndex<ContentExtensions::BlockLoadAction> });
     testRequest(searchBackend, mainDocumentRequest("zzz://www.h.xxx/"_s), { });
 }
@@ -2831,18 +2831,18 @@ TEST_F(ContentExtensionTest, CombinedRangeOverlapCase12)
 
     testRequest(matchBackend, mainDocumentRequest("c://www.webkit.org/"_s), { });
     testRequest(matchBackend, mainDocumentRequest("d://www.webkit.org/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
-    testRequest(matchBackend, mainDocumentRequest("e://www.webkit.org/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction> });
-    testRequest(matchBackend, mainDocumentRequest("f://www.webkit.org/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction> });
-    testRequest(matchBackend, mainDocumentRequest("g://www.webkit.org/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction> });
+    testRequest(matchBackend, mainDocumentRequest("e://www.webkit.org/"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
+    testRequest(matchBackend, mainDocumentRequest("f://www.webkit.org/"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
+    testRequest(matchBackend, mainDocumentRequest("g://www.webkit.org/"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(matchBackend, mainDocumentRequest("h://www.webkit.org/"_s), { });
 
     auto searchBackend = makeBackend("[{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"(foo)*[e-g]\"}},"
         "{\"action\":{\"type\":\"css-display-none\",\"selector\":\".hidden\"},\"trigger\":{\"url-filter\":\"(bar)*[d-g]\"}}]"_s);
     testRequest(searchBackend, mainDocumentRequest("zzz://www.c.xxx/"_s), { });
     testRequest(searchBackend, mainDocumentRequest("zzz://www.d.xxx/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
-    testRequest(searchBackend, mainDocumentRequest("zzz://www.e.xxx/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction> });
-    testRequest(searchBackend, mainDocumentRequest("zzz://www.f.xxx/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction> });
-    testRequest(searchBackend, mainDocumentRequest("zzz://www.g.xxx/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction> });
+    testRequest(searchBackend, mainDocumentRequest("zzz://www.e.xxx/"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
+    testRequest(searchBackend, mainDocumentRequest("zzz://www.f.xxx/"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
+    testRequest(searchBackend, mainDocumentRequest("zzz://www.g.xxx/"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(searchBackend, mainDocumentRequest("zzz://www.h.xxx/"_s), { });
 }
 
@@ -2853,8 +2853,8 @@ TEST_F(ContentExtensionTest, CombinedRangeOverlapCase13)
 
     testRequest(matchBackend, mainDocumentRequest("a://www.webkit.org/"_s), { });
     testRequest(matchBackend, mainDocumentRequest("b://www.webkit.org/"_s), { variantIndex<ContentExtensions::BlockLoadAction> });
-    testRequest(matchBackend, mainDocumentRequest("c://www.webkit.org/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction> });
-    testRequest(matchBackend, mainDocumentRequest("d://www.webkit.org/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction> });
+    testRequest(matchBackend, mainDocumentRequest("c://www.webkit.org/"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
+    testRequest(matchBackend, mainDocumentRequest("d://www.webkit.org/"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(matchBackend, mainDocumentRequest("e://www.webkit.org/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(matchBackend, mainDocumentRequest("h://www.webkit.org/"_s), { });
 
@@ -2862,8 +2862,8 @@ TEST_F(ContentExtensionTest, CombinedRangeOverlapCase13)
         "{\"action\":{\"type\":\"css-display-none\",\"selector\":\".hidden\"},\"trigger\":{\"url-filter\":\"(bar)*[c-e]\"}}]"_s);
     testRequest(searchBackend, mainDocumentRequest("zzz://www.a.xxx/"_s), { });
     testRequest(searchBackend, mainDocumentRequest("zzz://www.b.xxx/"_s), { variantIndex<ContentExtensions::BlockLoadAction> });
-    testRequest(searchBackend, mainDocumentRequest("zzz://www.c.xxx/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction> });
-    testRequest(searchBackend, mainDocumentRequest("zzz://www.d.xxx/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction> });
+    testRequest(searchBackend, mainDocumentRequest("zzz://www.c.xxx/"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
+    testRequest(searchBackend, mainDocumentRequest("zzz://www.d.xxx/"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(searchBackend, mainDocumentRequest("zzz://www.e.xxx/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(searchBackend, mainDocumentRequest("zzz://www.h.xxx/"_s), { });
 }
@@ -2875,18 +2875,18 @@ TEST_F(ContentExtensionTest, CombinedRangeOverlapCase14)
 
     testRequest(matchBackend, mainDocumentRequest("a://www.webkit.org/"_s), { });
     testRequest(matchBackend, mainDocumentRequest("b://www.webkit.org/"_s), { variantIndex<ContentExtensions::BlockLoadAction> });
-    testRequest(matchBackend, mainDocumentRequest("c://www.webkit.org/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction> });
-    testRequest(matchBackend, mainDocumentRequest("d://www.webkit.org/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction> });
-    testRequest(matchBackend, mainDocumentRequest("e://www.webkit.org/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction> });
+    testRequest(matchBackend, mainDocumentRequest("c://www.webkit.org/"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
+    testRequest(matchBackend, mainDocumentRequest("d://www.webkit.org/"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
+    testRequest(matchBackend, mainDocumentRequest("e://www.webkit.org/"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(matchBackend, mainDocumentRequest("h://www.webkit.org/"_s), { });
 
     auto searchBackend = makeBackend("[{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"(foo)*[b-e]\"}},"
         "{\"action\":{\"type\":\"css-display-none\",\"selector\":\".hidden\"},\"trigger\":{\"url-filter\":\"(bar)*[c-e]\"}}]"_s);
     testRequest(searchBackend, mainDocumentRequest("zzz://www.a.xxx/"_s), { });
     testRequest(searchBackend, mainDocumentRequest("zzz://www.b.xxx/"_s), { variantIndex<ContentExtensions::BlockLoadAction> });
-    testRequest(searchBackend, mainDocumentRequest("zzz://www.c.xxx/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction> });
-    testRequest(searchBackend, mainDocumentRequest("zzz://www.d.xxx/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction> });
-    testRequest(searchBackend, mainDocumentRequest("zzz://www.e.xxx/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction> });
+    testRequest(searchBackend, mainDocumentRequest("zzz://www.c.xxx/"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
+    testRequest(searchBackend, mainDocumentRequest("zzz://www.d.xxx/"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
+    testRequest(searchBackend, mainDocumentRequest("zzz://www.e.xxx/"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(searchBackend, mainDocumentRequest("zzz://www.h.xxx/"_s), { });
 }
 
@@ -2897,20 +2897,20 @@ TEST_F(ContentExtensionTest, CombinedRangeOverlapCase15)
 
     testRequest(matchBackend, mainDocumentRequest("a://www.webkit.org/"_s), { });
     testRequest(matchBackend, mainDocumentRequest("b://www.webkit.org/"_s), { });
-    testRequest(matchBackend, mainDocumentRequest("c://www.webkit.org/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction> });
-    testRequest(matchBackend, mainDocumentRequest("d://www.webkit.org/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction> });
-    testRequest(matchBackend, mainDocumentRequest("e://www.webkit.org/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction> });
-    testRequest(matchBackend, mainDocumentRequest("f://www.webkit.org/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction> });
+    testRequest(matchBackend, mainDocumentRequest("c://www.webkit.org/"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
+    testRequest(matchBackend, mainDocumentRequest("d://www.webkit.org/"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
+    testRequest(matchBackend, mainDocumentRequest("e://www.webkit.org/"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
+    testRequest(matchBackend, mainDocumentRequest("f://www.webkit.org/"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(matchBackend, mainDocumentRequest("g://www.webkit.org/"_s), { });
 
     auto searchBackend = makeBackend("[{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"(foo)*[c-f]\"}},"
         "{\"action\":{\"type\":\"css-display-none\",\"selector\":\".hidden\"},\"trigger\":{\"url-filter\":\"(bar)*[c-f]\"}}]"_s);
     testRequest(searchBackend, mainDocumentRequest("zzz://www.a.xxx/"_s), { });
     testRequest(searchBackend, mainDocumentRequest("zzz://www.b.xxx/"_s), { });
-    testRequest(searchBackend, mainDocumentRequest("zzz://www.c.xxx/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction> });
-    testRequest(searchBackend, mainDocumentRequest("zzz://www.d.xxx/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction> });
-    testRequest(searchBackend, mainDocumentRequest("zzz://www.e.xxx/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction> });
-    testRequest(searchBackend, mainDocumentRequest("zzz://www.f.xxx/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction> });
+    testRequest(searchBackend, mainDocumentRequest("zzz://www.c.xxx/"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
+    testRequest(searchBackend, mainDocumentRequest("zzz://www.d.xxx/"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
+    testRequest(searchBackend, mainDocumentRequest("zzz://www.e.xxx/"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
+    testRequest(searchBackend, mainDocumentRequest("zzz://www.f.xxx/"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(searchBackend, mainDocumentRequest("zzz://www.g.xxx/"_s), { });
 }
 
@@ -2921,7 +2921,7 @@ TEST_F(ContentExtensionTest, CombinedRangeOverlapCase16)
 
     testRequest(matchBackend, mainDocumentRequest("a://www.webkit.org/"_s), { });
     testRequest(matchBackend, mainDocumentRequest("b://www.webkit.org/"_s), { });
-    testRequest(matchBackend, mainDocumentRequest("c://www.webkit.org/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction> });
+    testRequest(matchBackend, mainDocumentRequest("c://www.webkit.org/"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(matchBackend, mainDocumentRequest("d://www.webkit.org/"_s), { });
     testRequest(matchBackend, mainDocumentRequest("e://www.webkit.org/"_s), { });
 
@@ -2929,7 +2929,7 @@ TEST_F(ContentExtensionTest, CombinedRangeOverlapCase16)
         "{\"action\":{\"type\":\"css-display-none\",\"selector\":\".hidden\"},\"trigger\":{\"url-filter\":\"(bar)*c\"}}]"_s);
     testRequest(searchBackend, mainDocumentRequest("zzz://www.a.xxx/"_s), { });
     testRequest(searchBackend, mainDocumentRequest("zzz://www.b.xxx/"_s), { });
-    testRequest(searchBackend, mainDocumentRequest("zzz://www.c.xxx/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction> });
+    testRequest(searchBackend, mainDocumentRequest("zzz://www.c.xxx/"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(searchBackend, mainDocumentRequest("zzz://www.d.xxx/"_s), { });
     testRequest(searchBackend, mainDocumentRequest("zzz://www.e.xxx/"_s), { });
 }
@@ -2975,16 +2975,16 @@ TEST_F(ContentExtensionTest, CombinedQuantifiedOneOrMoreRangesCase11And13)
     testRequest(searchBackend, mainDocumentRequest("zzz://www.ceyyy.xxx/"_s), { });
     testRequest(searchBackend, mainDocumentRequest("zzz://www.cfyyy.xxx/"_s), { });
     testRequest(searchBackend, mainDocumentRequest("zzz://www.cgyyy.xxx/"_s), { variantIndex<ContentExtensions::BlockLoadAction> });
-    testRequest(searchBackend, mainDocumentRequest("zzz://www.chyyy.xxx/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction> });
-    testRequest(searchBackend, mainDocumentRequest("zzz://www.ciyyy.xxx/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction> });
+    testRequest(searchBackend, mainDocumentRequest("zzz://www.chyyy.xxx/"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
+    testRequest(searchBackend, mainDocumentRequest("zzz://www.ciyyy.xxx/"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(searchBackend, mainDocumentRequest("zzz://www.cjyyy.xxx/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(searchBackend, mainDocumentRequest("zzz://www.ckyyy.xxx/"_s), { });
 
     // 'd' is in the first range of both rule. This series cover overlaps between the two rules.
     testRequest(searchBackend, mainDocumentRequest("zzz://www.dgyyy.xxx/"_s), { variantIndex<ContentExtensions::BlockLoadAction> });
     testRequest(searchBackend, mainDocumentRequest("zzz://www.ddgyyy.xxx/"_s), { variantIndex<ContentExtensions::BlockLoadAction> });
-    testRequest(searchBackend, mainDocumentRequest("zzz://www.ddhyyy.xxx/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction> });
-    testRequest(searchBackend, mainDocumentRequest("zzz://www.ddhhyyy.xxx/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction> });
+    testRequest(searchBackend, mainDocumentRequest("zzz://www.ddhyyy.xxx/"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
+    testRequest(searchBackend, mainDocumentRequest("zzz://www.ddhhyyy.xxx/"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(searchBackend, mainDocumentRequest("zzz://www.degyyy.xxx/"_s), { variantIndex<ContentExtensions::BlockLoadAction> });
     testRequest(searchBackend, mainDocumentRequest("zzz://www.dehyyy.xxx/"_s), { variantIndex<ContentExtensions::BlockLoadAction> });
     testRequest(searchBackend, mainDocumentRequest("zzz://www.dfgyyy.xxx/"_s), { });
@@ -3035,16 +3035,16 @@ TEST_F(ContentExtensionTest, CombinedQuantifiedOneOrMoreRangesCase11And13InGroup
     testRequest(searchBackend, mainDocumentRequest("zzz://www.ceyyy.xxx/"_s), { });
     testRequest(searchBackend, mainDocumentRequest("zzz://www.cfyyy.xxx/"_s), { });
     testRequest(searchBackend, mainDocumentRequest("zzz://www.cgyyy.xxx/"_s), { variantIndex<ContentExtensions::BlockLoadAction> });
-    testRequest(searchBackend, mainDocumentRequest("zzz://www.chyyy.xxx/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction> });
-    testRequest(searchBackend, mainDocumentRequest("zzz://www.ciyyy.xxx/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction> });
+    testRequest(searchBackend, mainDocumentRequest("zzz://www.chyyy.xxx/"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
+    testRequest(searchBackend, mainDocumentRequest("zzz://www.ciyyy.xxx/"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(searchBackend, mainDocumentRequest("zzz://www.cjyyy.xxx/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(searchBackend, mainDocumentRequest("zzz://www.ckyyy.xxx/"_s), { });
 
     // 'd' is in the first range of both rule. This series cover overlaps between the two rules.
     testRequest(searchBackend, mainDocumentRequest("zzz://www.dgyyy.xxx/"_s), { variantIndex<ContentExtensions::BlockLoadAction> });
     testRequest(searchBackend, mainDocumentRequest("zzz://www.ddgyyy.xxx/"_s), { variantIndex<ContentExtensions::BlockLoadAction> });
-    testRequest(searchBackend, mainDocumentRequest("zzz://www.ddhyyy.xxx/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction> });
-    testRequest(searchBackend, mainDocumentRequest("zzz://www.ddhhyyy.xxx/"_s), { variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction>, variantIndex<ContentExtensions::BlockLoadAction> });
+    testRequest(searchBackend, mainDocumentRequest("zzz://www.ddhyyy.xxx/"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
+    testRequest(searchBackend, mainDocumentRequest("zzz://www.ddhhyyy.xxx/"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::CSSDisplayNoneSelectorAction> });
     testRequest(searchBackend, mainDocumentRequest("zzz://www.degyyy.xxx/"_s), { variantIndex<ContentExtensions::BlockLoadAction> });
     testRequest(searchBackend, mainDocumentRequest("zzz://www.dehyyy.xxx/"_s), { variantIndex<ContentExtensions::BlockLoadAction> });
     testRequest(searchBackend, mainDocumentRequest("zzz://www.dfgyyy.xxx/"_s), { });
@@ -3132,7 +3132,7 @@ TEST_F(ContentExtensionTest, IfFrameURL)
     "]"_s);
     testRequest(otherRulesWithConditions, requestInTopAndFrameURLs("https://example.com/"_s, "https://webkit.org/"_s, "https://whatwg.org/"_s), { variantIndex<BlockLoadAction> });
     testRequest(otherRulesWithConditions, requestInTopAndFrameURLs("https://example.com/"_s, "https://example.com/"_s, "https://webkit.org/"_s), { variantIndex<BlockCookiesAction> });
-    testRequest(otherRulesWithConditions, requestInTopAndFrameURLs("https://example.com/"_s, "https://example.com/"_s, "https://whatwg.org/"_s), { variantIndex<BlockCookiesAction>, variantIndex<BlockLoadAction> });
+    testRequest(otherRulesWithConditions, requestInTopAndFrameURLs("https://example.com/"_s, "https://example.com/"_s, "https://whatwg.org/"_s), { variantIndex<BlockLoadAction>, variantIndex<BlockCookiesAction> });
     
     auto matchingEverything = makeBackend("[{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"https\", \"if-frame-url\":[\".*\"]}}]"_s);
     testRequest(matchingEverything, requestInTopAndFrameURLs("https://example.com/"_s, "https://webkit.org/"_s, "https://whatwg.org/"_s), { variantIndex<BlockLoadAction> });
@@ -3162,7 +3162,7 @@ TEST_F(ContentExtensionTest, UnlessFrameURL)
     "]"_s);
     testRequest(otherRulesWithConditions, requestInTopAndFrameURLs("https://example.com/"_s, "https://webkit.org/"_s, "https://whatwg.org/"_s), { });
     testRequest(otherRulesWithConditions, requestInTopAndFrameURLs("https://example.com/"_s, "https://webkit.org/"_s, "https://www.w3.org/"_s), { variantIndex<BlockLoadAction> });
-    testRequest(otherRulesWithConditions, requestInTopAndFrameURLs("https://example.com/"_s, "https://example.com/"_s, "https://webkit.org/"_s), { variantIndex<BlockCookiesAction>, variantIndex<BlockLoadAction> });
+    testRequest(otherRulesWithConditions, requestInTopAndFrameURLs("https://example.com/"_s, "https://example.com/"_s, "https://webkit.org/"_s), { variantIndex<BlockLoadAction>, variantIndex<BlockCookiesAction> });
     testRequest(otherRulesWithConditions, requestInTopAndFrameURLs("https://example.com/"_s, "https://example.com/"_s, "https://whatwg.org/"_s), { variantIndex<BlockCookiesAction> });
 
     auto matchingNothing = makeBackend("[{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"https\", \"unless-frame-url\":[\".*\"]}}]"_s);
@@ -3184,6 +3184,28 @@ TEST_F(ContentExtensionTest, RegexSubstitution)
     transformURL("https://example.com/\\0\\1"_s, "^https://www\\.(abc?)\\.xyz\\.com/"_s, "https://www.ab.xyz.com"_s, "https://example.com/https://www.ab.xyz.com/ab"_s);
     transformURL("https://example.com/\\1\\2\\3\\4\\5\\6\\7\\8\\9\\10\\11\\12\\13\\14"_s, "^https://(e)(x)(a)(m)(p)(l)(e)(w)(e)(b)(s)(i)(t)(e)/"_s, "https://examplewebsite/"_s, "https://example.com/examplewee0e1e2e3e4"_s);
     transformURL("https://!@#$%^&*invalidURL\\1/"_s, "^https://www\\.(abc?)\\.xyz\\.com/"_s, "https://www.abc.xyz.com"_s, "https://www.abc.xyz.com/"_s);
+}
+
+TEST_F(ContentExtensionTest, IgnoreFollowingRules)
+{
+    auto backend = makeBackend("["_s
+        "{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"https://www.webkit.org/\"}},"_s
+        "{\"action\":{\"type\":\"ignore-following-rules\"},\"trigger\":{\"url-filter\":\"https://www.apple.com/\"}},"_s
+        "{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"https://www.apple.com/\"}},"_s
+        "{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\".*\"}}"_s
+    "]"_s);
+
+    testRequest(backend, mainDocumentRequest("https://www.webkit.org/"_s), { variantIndex<ContentExtensions::BlockLoadAction>, variantIndex<ContentExtensions::BlockLoadAction> });
+    testRequest(backend, mainDocumentRequest("https://www.apple.com/"_s), { });
+    testRequest(backend, mainDocumentRequest("https://www.w3.org/"_s), { variantIndex<ContentExtensions::BlockLoadAction> });
+
+    backend = makeBackend("["_s
+        "{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"https://www.webkit.org/\"}},"_s
+        "{\"action\":{\"type\":\"ignore-following-rules\"},\"trigger\":{\"url-filter\":\".*\"}},"_s
+        "{\"action\":{\"type\":\"ignore-previous-rules\"},\"trigger\":{\"url-filter\":\".*\"}}"_s
+    "]"_s);
+
+    testRequest(backend, mainDocumentRequest("https://www.webkit.org/"_s), { variantIndex<ContentExtensions::BlockLoadAction> });
 }
 
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### 1d7b6a797ab4170ebc01a323bb7861ad97e4ba3a
<pre>
Introduce ignore-following-rules action type in WebKit Content Blockers
<a href="https://bugs.webkit.org/show_bug.cgi?id=294037">https://bugs.webkit.org/show_bug.cgi?id=294037</a>
<a href="https://rdar.apple.com/152588124">rdar://152588124</a>

Reviewed by Timothy Hatcher.

This patch introduces a new content blocker action type, ignore-following-rules,
which does the same thing as ignore-previous-rules but inverted.

We need this action type to be able to correctly fix this dNR bug:
<a href="https://bugs.webkit.org/show_bug.cgi?id=293809">https://bugs.webkit.org/show_bug.cgi?id=293809</a>

To implement this, we just have to follow in the footsteps of how the
ignore-previous-rules action type is implemented. There are two major steps:

1) When compiling the rules, we need to make sure to maintain the position of
   the ignore-future-rules actions so that we know their position when we
   process the actions later.
2) When processing the actions for a load, we need to iterate both directions,
   right-to-left first so that ignore-future-rules actions take priority over
   ignore-previous-rules actions.

It&apos;s also worth noting that 2) causes the order in which the actions are added
to the actions struct to be reversed, but order isn&apos;t important here.

* Source/WebCore/contentextensions/ContentExtensionActions.h:
Introduce the IgnoreFollowingRulesAction type.

* Source/WebCore/contentextensions/ContentExtensionCompiler.cpp:
(WebCore::ContentExtensions::serializeActions):
When serializing actions, we maintain maps of rules to batch them into groups
until we hit an ignore-previous-rules action, and we need to extend this to also
happen for ignore-following-rules actions. When we hit an ignore-following-rules
action, we need to clear the maps and unconditionally add the action without
trying to combine it with duplicate actions so that we maintain its position in
the vector. This is crucial to do; otherwise, we wouldn&apos;t know the action&apos;s
position when processing the matched actions for a load later.

* Source/WebCore/contentextensions/ContentExtensionParser.cpp:
(WebCore::ContentExtensions::loadAction):
Match the &quot;ignore-following-rules&quot; string to the newly added type.

* Source/WebCore/contentextensions/ContentExtensionsBackend.cpp:
(WebCore::ContentExtensions::ContentExtensionsBackend::actionsFromContentRuleList const):
(WebCore::ContentExtensions::ContentExtensionsBackend::processContentRuleListsForLoad):
(WebCore::ContentExtensions::ContentExtensionsBackend::processContentRuleListsForPingLoad):
(WebCore::ContentExtensions::ContentExtensionsBackend::processContentRuleListsForResourceMonitoring):
When processing rules, we first look for ignore-following-rules actions and then
reverse iterate to handle ignore-previous-rules actions.

Again, this does have the affect of reversing the order of the actions in the
actions struct, but it doesn&apos;t matter.

* Tools/TestWebKitAPI/Tests/WebCore/ContentExtensions.cpp:
(TestWebKitAPI::TEST_F(ContentExtensionTest, DistinguishableActionInsidePrefixTree)):
(TestWebKitAPI::TEST_F(ContentExtensionTest, DomainTriggers)):
(TestWebKitAPI::TEST_F(ContentExtensionTest, DomainTriggersAlongMergedActions)):
(TestWebKitAPI::TEST_F(ContentExtensionTest, StringParameters)):
(TestWebKitAPI::TEST_F(ContentExtensionTest, ResourceOrLoadTypeMatchingEverything)):
(TestWebKitAPI::TEST_F(ContentExtensionTest, MatchesEverything)):
(TestWebKitAPI::TEST_F(ContentExtensionTest, StrictPrefixSeparatedMachines3)):
(TestWebKitAPI::TEST_F(ContentExtensionTest, StatesWithDifferentActionsAreNotUnified2)):
(TestWebKitAPI::TEST_F(ContentExtensionTest, RangeOverlapCase3)):
(TestWebKitAPI::TEST_F(ContentExtensionTest, RangeOverlapCase4)):
(TestWebKitAPI::TEST_F(ContentExtensionTest, RangeOverlapCase5)):
(TestWebKitAPI::TEST_F(ContentExtensionTest, RangeOverlapCase6)):
(TestWebKitAPI::TEST_F(ContentExtensionTest, RangeOverlapCase7)):
(TestWebKitAPI::TEST_F(ContentExtensionTest, RangeOverlapCase8)):
(TestWebKitAPI::TEST_F(ContentExtensionTest, RangeOverlapCase9)):
(TestWebKitAPI::TEST_F(ContentExtensionTest, RangeOverlapCase10)):
(TestWebKitAPI::TEST_F(ContentExtensionTest, RangeOverlapCase11)):
(TestWebKitAPI::TEST_F(ContentExtensionTest, RangeOverlapCase12)):
(TestWebKitAPI::TEST_F(ContentExtensionTest, RangeOverlapCase13)):
(TestWebKitAPI::TEST_F(ContentExtensionTest, RangeOverlapCase14)):
(TestWebKitAPI::TEST_F(ContentExtensionTest, RangeOverlapCase15)):
(TestWebKitAPI::TEST_F(ContentExtensionTest, RangeOverlapCase16)):
(TestWebKitAPI::TEST_F(ContentExtensionTest, QuantifiedOneOrMoreRangesCase11And13)):
(TestWebKitAPI::TEST_F(ContentExtensionTest, QuantifiedOneOrMoreRangesCase11And13InGroups)):
(TestWebKitAPI::TEST_F(ContentExtensionTest, CombinedRangeOverlapCase3)):
(TestWebKitAPI::TEST_F(ContentExtensionTest, CombinedRangeOverlapCase4)):
(TestWebKitAPI::TEST_F(ContentExtensionTest, CombinedRangeOverlapCase5)):
(TestWebKitAPI::TEST_F(ContentExtensionTest, CombinedRangeOverlapCase6)):
(TestWebKitAPI::TEST_F(ContentExtensionTest, CombinedRangeOverlapCase7)):
(TestWebKitAPI::TEST_F(ContentExtensionTest, CombinedRangeOverlapCase8)):
(TestWebKitAPI::TEST_F(ContentExtensionTest, CombinedRangeOverlapCase9)):
(TestWebKitAPI::TEST_F(ContentExtensionTest, CombinedRangeOverlapCase10)):
(TestWebKitAPI::TEST_F(ContentExtensionTest, CombinedRangeOverlapCase11)):
(TestWebKitAPI::TEST_F(ContentExtensionTest, CombinedRangeOverlapCase12)):
(TestWebKitAPI::TEST_F(ContentExtensionTest, CombinedRangeOverlapCase13)):
(TestWebKitAPI::TEST_F(ContentExtensionTest, CombinedRangeOverlapCase14)):
(TestWebKitAPI::TEST_F(ContentExtensionTest, CombinedRangeOverlapCase15)):
(TestWebKitAPI::TEST_F(ContentExtensionTest, CombinedRangeOverlapCase16)):
(TestWebKitAPI::TEST_F(ContentExtensionTest, CombinedQuantifiedOneOrMoreRangesCase11And13)):
(TestWebKitAPI::TEST_F(ContentExtensionTest, CombinedQuantifiedOneOrMoreRangesCase11And13InGroups)):
(TestWebKitAPI::TEST_F(ContentExtensionTest, IfFrameURL)):
(TestWebKitAPI::TEST_F(ContentExtensionTest, UnlessFrameURL)):
Update existing tests to take the new order of the actions into account.

(TestWebKitAPI::TEST_F(ContentExtensionTest, IgnoreFollowingRules)):
Write a new test to validate the new action type.

Canonical link: <a href="https://commits.webkit.org/295875@main">https://commits.webkit.org/295875@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/51886c7a262e9e718ea792d021b2ffb99e06c20d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/106279 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/26028 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/16424 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/111477 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/56875 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/108318 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/26691 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34531 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80732 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/109283 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/21122 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95907 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/61059 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/20642 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/14006 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/56315 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/90472 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/14041 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/114337 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33417 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24643 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89802 "Found 1 new test failure: compositing/patterns/direct-pattern-compositing-size.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33781 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/92136 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89503 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34379 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/12191 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/29001 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17240 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/33342 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/38754 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/33088 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/36441 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34686 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->