### PR TITLE
Generated methods in WebKitLogClientDeclarations.h/WebCoreLogClientDeclarations.h should not be marked virtual

### DIFF
--- a/Source/WebKit/Scripts/generate-derived-log-sources.py
+++ b/Source/WebKit/Scripts/generate-derived-log-sources.py
@@ -39,7 +39,7 @@ def generate_log_client_declarations_file(log_messages, log_client_declarations_
             function_name = log_message[0]
             parameters = log_message[2]
             arguments_string = log_declarations_module.get_arguments_string(parameters, log_declarations_module.PARAMETER_LIST_INCLUDE_TYPE | log_declarations_module.PARAMETER_LIST_INCLUDE_NAME | log_declarations_module.PARAMETER_LIST_MODIFY_CSTRING)
-            file.write("    virtual void " + function_name + "(" + arguments_string + ")\n")
+            file.write("    void " + function_name + "(" + arguments_string + ")\n")
             file.write("    {\n")
             file.write("#if ENABLE(STREAMING_IPC_IN_LOG_FORWARDING)\n")
             file.write("        Locker locker { m_logStreamLock };\n")

--- a/Source/WebKit/Shared/LogStream.h
+++ b/Source/WebKit/Shared/LogStream.h
@@ -38,7 +38,7 @@ struct StreamServerConnectionHandle;
 
 namespace WebKit {
 
-class LogStream
+class LogStream final
 #if ENABLE(STREAMING_IPC_IN_LOG_FORWARDING)
 : public IPC::StreamMessageReceiver {
 #else


### PR DESCRIPTION
#### 983414c7fa8ea53821fd3f69d84fff9270e3c0c4
<pre>
Generated methods in WebKitLogClientDeclarations.h/WebCoreLogClientDeclarations.h should not be marked virtual
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=294042">https://bugs.webkit.org/show_bug.cgi?id=294042</a>&gt;
&lt;<a href="https://rdar.apple.com/152594431">rdar://152594431</a>&gt;

Reviewed by Per Arne Vollan.

* Source/WebKit/Scripts/generate-derived-log-sources.py:
(generate_log_client_declarations_file):
- Don&apos;t mark generated methods as `virtual` since they&apos;re in a class
  marked `final` and can&apos;t be overridden.
* Source/WebKit/Shared/LogStream.h:
(WebKit::LogStream):
- Mark class as `final` to match WebKit::LogClient.

Canonical link: <a href="https://commits.webkit.org/295851@main">https://commits.webkit.org/295851@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7857c432fc8637cdbaa378ed767a10a7d1c62d9e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/106288 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/26037 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/16433 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/111486 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/56884 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/26700 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34540 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80737 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/109292 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/21129 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95916 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/61064 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/105765 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/20648 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/56324 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/90478 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/14049 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/114346 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33426 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24650 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89809 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33790 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/92144 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89510 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34385 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/12199 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/29010 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17231 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/33351 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/38763 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/33097 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/36450 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34695 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->