### PR TITLE
Repeated IPC calls to StorageArea may loop over freed cache after closing connection, leading to use after free

### DIFF
--- a/LayoutTests/ipc/storage-area-cache-use-after-free-expected.txt
+++ b/LayoutTests/ipc/storage-area-cache-use-after-free-expected.txt
@@ -1,0 +1,1 @@
+This test passes if WebKit does not crash

--- a/LayoutTests/ipc/storage-area-cache-use-after-free.html
+++ b/LayoutTests/ipc/storage-area-cache-use-after-free.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html><!-- webkit-test-runner [ IPCTestingAPIEnabled=true ] -->
+<script>
+  window.testRunner?.waitUntilDone();
+    window.testRunner?.dumpAsText();
+    function runTest() {
+        if (window.IPC) {
+            import('./coreipc.js').then(({
+                CoreIPC
+            }) => {
+                window.CoreIPC = CoreIPC;
+                const longStr = "A".repeat(16384);
+                CoreIPC.Networking.NetworkStorageManager.ConnectToStorageArea(0, {
+                    type: 1,
+                    sourceIdentifier: 262153,
+                    namespaceIdentifier: {
+                        optionalValue: 262156
+                    },
+                    origin: {
+                        topOrigin: {
+                            data: {
+                                variantType: 'WebCore::OpaqueOriginIdentifierProcessQualified',
+                                variant: {
+                                    object: 262144,
+                                    processIdentifier: 262154
+                                }
+                            }
+                        },
+                        clientOrigin: {
+                            data: {
+                                variantType: 'WebCore::OpaqueOriginIdentifierProcessQualified',
+                                variant: {
+                                    object: 262144,
+                                    processIdentifier: 262154
+                                }
+                            }
+                        }
+                    }
+                }, (parsedResult) => {
+                    o99 = parsedResult.identifier.optionalValue;
+                    CoreIPC.Networking.NetworkStorageManager.ConnectToStorageArea(0, {
+                        type: 1,
+                        sourceIdentifier: 262153,
+                        namespaceIdentifier: {
+                            optionalValue: 262156
+                        },
+                        origin: {
+                            topOrigin: {
+                                data: {
+                                    variantType: 'WebCore::OpaqueOriginIdentifierProcessQualified',
+                                    variant: {
+                                        object: 262144,
+                                        processIdentifier: 262154
+                                    }
+                                }
+                            },
+                            clientOrigin: {
+                                data: {
+                                    variantType: 'WebCore::OpaqueOriginIdentifierProcessQualified',
+                                    variant: {
+                                        object: 262144,
+                                        processIdentifier: 262157
+                                    }
+                                }
+                            }
+                        }
+                    }, (parsedResult2) => {
+                        o109 = parsedResult2.identifier.optionalValue;
+                        CoreIPC.Networking.NetworkStorageManager.DisconnectFromStorageArea(0, {
+                            identifier: o109
+                        });
+                    });
+                    CoreIPC.Networking.NetworkStorageManager.SetItem(0, {
+                        identifier: o99,
+                        implIdentifier: 262150,
+                        key: 'abc',
+                        value: longStr,
+                        urlString: location.href
+                    });
+                    let reloadCount = parseInt(sessionStorage.getItem('reloadCount') || '0', 10);
+
+                    if (reloadCount < 10) {
+                        sessionStorage.setItem('reloadCount', reloadCount + 1);
+                        window.location.reload();
+                    } else {
+                        window.testRunner?.notifyDone();
+                    }
+                });
+            });
+        } else {
+            window.testRunner?.notifyDone();
+        }
+    }
+</script>
+<body onload="runTest()">
+  <p>This test passes if WebKit does not crash</p>
+</body>


### PR DESCRIPTION
#### f9641bf127f539a4388e261e67ef912a24d9702c
<pre>
Repeated IPC calls to StorageArea may loop over freed cache after closing connection, leading to use after free
<a href="https://bugs.webkit.org/show_bug.cgi?id=289571">https://bugs.webkit.org/show_bug.cgi?id=289571</a>
<a href="https://rdar.apple.com/146475370">rdar://146475370</a>

Reviewed by Sihui Liu.

This fixes the bug by printing an error and returning empty data if an error happens with the database

* LayoutTests/ipc/coreipc.js:
(splitClassAndFunction):
(CoreIPCClass.prototype.initializeMessageByName):
(CoreIPCClass.prototype.initializeMessages):
(CoreIPCClass.prototype.generateSendingFunction):
(export.StreamConnectionInterface):
(export.StreamConnectionInterface.prototype.getIdentifier):
(export.StreamConnectionInterface.prototype.initializeMessages):
(export.StreamConnectionInterface.prototype.generateStreamSendingFunction):
(export.ArgumentSerializer.parseTemplate):
(export.ArgumentSerializer):
* LayoutTests/ipc/storage-area-cache-use-after-free-expected.txt: Added.
* LayoutTests/ipc/storage-area-cache-use-after-free.html: Added.
* Source/WebKit/NetworkProcess/storage/SQLiteStorageArea.cpp:
(WebKit::SQLiteStorageArea::allItems):

Originally-landed-as: 289651.283@safari-7621-branch (7719e167beea). <a href="https://rdar.apple.com/151707003">rdar://151707003</a>
Canonical link: <a href="https://commits.webkit.org/295838@main">https://commits.webkit.org/295838@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7f2e4850584635e539f9b4b931dd83b95b1edfc3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/106287 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/26036 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/16432 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/111485 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/56883 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/26699 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34539 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80736 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/109291 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/21127 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95918 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/61063 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/20646 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/14016 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/56323 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/90476 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/14051 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/114345 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33425 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/24649 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89808 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33789 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/92146 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89509 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22828 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34383 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/12201 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/29009 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/33350 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/38762 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/33096 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/36449 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34694 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->