### PR TITLE
[Grid] Fix css-grid/layout-algorithm/grid-content-distribution-must-account-for-track-sizing-002 WPT.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/layout-algorithm/grid-content-distribution-must-account-for-track-sizing-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/layout-algorithm/grid-content-distribution-must-account-for-track-sizing-002-expected.txt
@@ -1,8 +1,4 @@
 XXX XX X XX X XXX
 
-FAIL .grid 1 assert_equals:
-<div class="grid justifyContentStart alignContentSpaceBetween" data-expected-width="40" data-expected-height="200">
-        <div class="item" data-expected-width="40" data-expected-height="200">XXX XX X XX X XXX</div>
-    </div>
-width expected 40 but got 80
+PASS .grid 1
 

--- a/Source/WebCore/rendering/GridTrackSizingAlgorithm.h
+++ b/Source/WebCore/rendering/GridTrackSizingAlgorithm.h
@@ -159,6 +159,7 @@ public:
 
     LayoutUnit computeTrackBasedSize() const;
 
+    bool hasAllLengthRowSizes() const;
     bool hasAnyPercentSizedRowsIndefiniteHeight() const { return m_hasPercentSizedRowsIndefiniteHeight; }
     bool hasAnyFlexibleMaxTrackBreadth() const { return m_hasFlexibleMaxTrackBreadth; }
     bool hasAnyBaselineAlignmentItem() const { return !m_baselineAlignmentItemsForRows.isEmpty() || !m_baselineAlignmentItemsForColumns.isEmpty(); }

--- a/Source/WebCore/rendering/RenderGrid.h
+++ b/Source/WebCore/rendering/RenderGrid.h
@@ -78,6 +78,9 @@ public:
 
     bool canDropAnonymousBlockChild() const override { return false; }
 
+    bool hasDefiniteLogicalHeight() const;
+    const std::optional<LayoutUnit> availableLogicalHeightForContentBox() const;
+
     void setNeedsItemPlacement(SubgridDidChange descendantSubgridsNeedItemPlacement = SubgridDidChange::No);
     Vector<LayoutUnit> trackSizesForComputedStyle(GridTrackSizingDirection) const;
 


### PR DESCRIPTION
#### c3dbdf3e5964008fab9b6618989dd9f3ccae056c
<pre>
[Grid] Fix css-grid/layout-algorithm/grid-content-distribution-must-account-for-track-sizing-002 WPT.
<a href="https://bugs.webkit.org/show_bug.cgi?id=232667">https://bugs.webkit.org/show_bug.cgi?id=232667</a>
<a href="https://rdar.apple.com/problem/85252183">rdar://problem/85252183</a>

Reviewed by Alan Baradlay.

From the grid spec regarding the first pass of column sizing:

&quot;If calculating the layout of a grid item in this step depends on the
available space in the block axis, assume the available space that
it would have if any row with a definite max track sizing function
had that size and all other rows were infinite. If both the grid
container and all tracks have definite sizes, also apply
align-content to find the final effective size of any gaps spanned
by such items; otherwise ignore the effects of track alignment in
this estimation.&quot;

<a href="https://drafts.csswg.org/css-grid-2/#algo-grid-sizing">https://drafts.csswg.org/css-grid-2/#algo-grid-sizing</a>

The WPT mentioned in the title has content of the following lines:

&lt;grid style=&quot;display: inline-grid; grid-template-rows: 50px 50px; height: 200px;&quot;&gt;
  &lt;item style=&quot;grid-row: span 2; writing-mode: vertical-lr;&quot;&gt;
    some text content inside of the grid item
  &lt;/item&gt;
&lt;/grid&gt;

We end up computing an incorrect width for the grid because of the following:
1.) We call into RenderGrid::computeIntrinsicLogicalWidths to compute
its intrinsic sizes.
2.) The min/max-content sizes of the grid container are the sum of the
track sizes which requires running the track sizing algorithm.
3.) When sizing the columns we detect this case that the spec mentions
above, but we fail to apply the space from the align-content
space-between distribution.

In the test case, since the block size is definite (200px) and the row
sizes are all definite (50px each), we should be able to figure out how
the spacing from the content alignment should be calculated and
distributed.

* Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp:
(WebCore::GridTrackSizingAlgorithm::gridAreaBreadthForGridItem const):
We properly check for this case by seeing if the grid container has a
definite size via availableLogicalHeightForContentBox, which should
return std::nullopt if the available space is indefinite, and a helper
method to check that all of the row sizes are definite.

(WebCore::GridTrackSizingAlgorithm::hasAllLengthTrackSizingRows const):
Aforementioned helper method to check if the row track sizes are
definite. This is done by checking The GridTrackSizeType for each row to
make sure it is LengthTrackSizing to refer to the &lt;track-breadth&gt;
portion of the &lt;track-size&gt; syntax. We also need to check that
&lt;track-breadth&gt; is a length of percentage as opposed to something like
a flex value.

* Source/WebCore/rendering/GridTrackSizingAlgorithm.h:
* Source/WebCore/rendering/RenderGrid.cpp:
(WebCore::RenderGrid::hasDefiniteLogicalHeight const):
(WebCore::RenderGrid::availableLogicalHeightForContentBox const):
(WebCore::RenderGrid::layoutGrid):
This should just be a small code reshuffling so that
availableLogicalHeightForContextBox is available to use from the track
sizing algorithm. Instead of using a bool to keep track of whether we
are going to size the rows using a definite height and then compute that
height. We can attempt to compute this earlier and store the result in a
std::optional&lt;LayoutUnit&gt; that represents where or not the available
logical height is definite. We need to do this after the call to
updateLogicalWidth since aspect-ratio may use the grid&apos;s logical width
to compute the logical height.

Canonical link: <a href="https://commits.webkit.org/296300@main">https://commits.webkit.org/296300@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1fc3025226e6bf6a92ee77042bb850fa40235661

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108047 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27712 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18131 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/113257 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/58562 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/110010 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/28407 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/36262 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82026 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/110995 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22515 "Found 1 new test failure: fast/filter-image/clipped-filter.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97344 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62458 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/21927 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/15479 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58003 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/91867 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15543 "Found 1 new test failure: imported/w3c/web-platform-tests/feature-policy/feature-policy-frame-policy-timing.https.sub.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/116384 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35118 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/25860 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91056 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/35494 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93622 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/90850 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23161 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35752 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13509 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/30963 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35017 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/40572 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34758 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38116 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/36420 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->