### PR TITLE
Need Safari setting to allow autoplaying audio for web-platform-tests

### DIFF
--- a/Source/JavaScriptCore/inspector/remote/RemoteInspector.h
+++ b/Source/JavaScriptCore/inspector/remote/RemoteInspector.h
@@ -105,6 +105,7 @@ public:
 #if PLATFORM(COCOA)
             std::optional<bool> allowInsecureMediaCapture;
             std::optional<bool> suppressICECandidateFiltering;
+            std::optional<bool> alwaysAllowAutoplay;
 #endif
         };
 

--- a/Source/JavaScriptCore/inspector/remote/RemoteInspectorConstants.h
+++ b/Source/JavaScriptCore/inspector/remote/RemoteInspectorConstants.h
@@ -119,6 +119,7 @@
 // The value for WIRSessionCapabilitiesKey is a dictionary that holds these capability key-value pairs.
 
 #define WIRAcceptInsecureCertificatesKey               @"org.webkit.webdriver.accept-insecure-certificates"
+#define WIRAlwaysAllowAutoplay                         @"org.webkit.webdriver.always-allow-autoplay"
 #define WIRAllowInsecureMediaCaptureCapabilityKey      @"org.webkit.webdriver.webrtc.allow-insecure-media-capture"
 #define WIRSuppressICECandidateFilteringCapabilityKey  @"org.webkit.webdriver.webrtc.suppress-ice-candidate-filtering"
 

--- a/Source/JavaScriptCore/inspector/remote/cocoa/RemoteInspectorCocoa.mm
+++ b/Source/JavaScriptCore/inspector/remote/cocoa/RemoteInspectorCocoa.mm
@@ -849,6 +849,11 @@ void RemoteInspector::receivedAutomationSessionRequestMessage(NSDictionary *user
             sessionCapabilities.suppressICECandidateFiltering = value.boolValue;
     }
 
+    if (NSNumber *value = forwardedCapabilities[WIRAlwaysAllowAutoplay]) {
+        if ([value isKindOfClass:NSNumber.class])
+            sessionCapabilities.alwaysAllowAutoplay = value.boolValue;
+    }
+
     if (!m_client)
         return;
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKAutomationSessionConfiguration.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKAutomationSessionConfiguration.h
@@ -35,6 +35,7 @@ WK_CLASS_AVAILABLE(macos(10.13.4), ios(12.2))
 @property (nonatomic) BOOL acceptInsecureCertificates;
 @property (nonatomic) BOOL allowsInsecureMediaCapture;
 @property (nonatomic) BOOL suppressesICECandidateFiltering;
+@property (nonatomic) BOOL alwaysAllowAutoplay;
 
 @end
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKAutomationSessionConfiguration.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKAutomationSessionConfiguration.mm
@@ -36,6 +36,7 @@
     _acceptInsecureCertificates = NO;
     _allowsInsecureMediaCapture = YES;
     _suppressesICECandidateFiltering = NO;
+    _alwaysAllowAutoplay = NO;
 
     return self;
 }
@@ -47,6 +48,7 @@
     configuration.acceptInsecureCertificates = self.acceptInsecureCertificates;
     configuration.allowsInsecureMediaCapture = self.allowsInsecureMediaCapture;
     configuration.suppressesICECandidateFiltering = self.suppressesICECandidateFiltering;
+    configuration.alwaysAllowAutoplay = self.alwaysAllowAutoplay;
 
     return configuration;
 }

--- a/Source/WebKit/UIProcess/Cocoa/AutomationClient.mm
+++ b/Source/WebKit/UIProcess/Cocoa/AutomationClient.mm
@@ -83,6 +83,8 @@ void AutomationClient::requestAutomationSession(const String& sessionIdentifier,
         [configuration setAllowsInsecureMediaCapture:sessionCapabilities.allowInsecureMediaCapture.value()];
     if (sessionCapabilities.suppressICECandidateFiltering)
         [configuration setSuppressesICECandidateFiltering:sessionCapabilities.suppressICECandidateFiltering.value()];
+    if (sessionCapabilities.alwaysAllowAutoplay)
+        [configuration setAlwaysAllowAutoplay:sessionCapabilities.alwaysAllowAutoplay.value()];
 
     // Force clients to create and register a session asynchronously. Otherwise,
     // RemoteInspector will try to acquire its lock to register the new session and


### PR DESCRIPTION
#### 6e333ad75559a9f898558d43f4b64ef87b99d87c
<pre>
Need Safari setting to allow autoplaying audio for web-platform-tests
<a href="https://rdar.apple.com/75495649">rdar://75495649</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=190775">https://bugs.webkit.org/show_bug.cgi?id=190775</a>

Reviewed by BJ Burg.

Introduce support of a new WebDriver capability, webkit:alwaysAllowAutoplay,
to allow autoplaying media without needing the user gesture.

* Source/JavaScriptCore/inspector/remote/RemoteInspector.h:
* Source/JavaScriptCore/inspector/remote/RemoteInspectorConstants.h:
* Source/JavaScriptCore/inspector/remote/cocoa/RemoteInspectorCocoa.mm:
(Inspector::RemoteInspector::receivedAutomationSessionRequestMessage):
* Source/WebKit/UIProcess/API/Cocoa/_WKAutomationSessionConfiguration.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKAutomationSessionConfiguration.mm:
(-[_WKAutomationSessionConfiguration init]):
(-[_WKAutomationSessionConfiguration copyWithZone:]):
* Source/WebKit/UIProcess/Cocoa/AutomationClient.mm:
(WebKit::AutomationClient::requestAutomationSession):

Canonical link: <a href="https://commits.webkit.org/296109@main">https://commits.webkit.org/296109@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/445423b7d08d409a73a1dbc4008c73ef5eb49542

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/107399 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27081 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/17486 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/112613 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/57935 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/27763 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/35581 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/81530 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/57935 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/110328 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/21996 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/96800 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/61905 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/21437 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/14930 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/57379 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/99988 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/91365 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/14964 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/115714 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/105946 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/34466 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/25406 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/90572 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/34841 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93048 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/90309 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23025 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35221 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13006 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/30209 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/34387 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/39928 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/130262 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34133 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/35430 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/37488 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/35794 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->