### PR TITLE
[JSC] JITLess WasmToJS needs to construct CallFrame appropriately

### DIFF
--- a/JSTests/wasm/stress/jitless-wasm-to-js-should-follow-to-wasm-call-frame-convention-2.js
+++ b/JSTests/wasm/stress/jitless-wasm-to-js-should-follow-to-wasm-call-frame-convention-2.js
@@ -1,0 +1,217 @@
+//@ runDefault("--jitPolicyScale=0.1", "--useJIT=0", "--watchdog-exception-ok", "--watchdog=500")
+function instantiate(moduleBase64, importObject) {
+    let bytes = Uint8Array.fromBase64(moduleBase64);
+    return WebAssembly.instantiate(bytes, importObject);
+  }
+  const report = $.agent.report;
+  const isJIT = callerIsBBQOrOMGCompiled;
+const extra = {isJIT};
+(async function () {
+let memory0 = new WebAssembly.Memory({initial: 3320, shared: true, maximum: 5066});
+/**
+@param {ExternRef} a0
+@param {I64} a1
+@param {FuncRef} a2
+@returns {[ExternRef, I64, FuncRef]}
+ */
+let fn0 = function (a0, a1, a2) {
+a0?.toString(); a1?.toString(); a2?.toString();
+return [a0, 1661n, a2];
+};
+/**
+@param {ExternRef} a0
+@param {ExternRef} a1
+@param {I64} a2
+@returns {[FuncRef, I64]}
+ */
+let fn1 = function (a0, a1, a2) {
+a0?.toString(); a1?.toString(); a2?.toString();
+return [null, 1462n];
+};
+/**
+@param {I64} a0
+@returns {void}
+ */
+let fn2 = function (a0) {
+a0?.toString();
+};
+/**
+@param {ExternRef} a0
+@param {I64} a1
+@param {FuncRef} a2
+@returns {[ExternRef, I64, FuncRef]}
+ */
+let fn3 = function (a0, a1, a2) {
+a0?.toString(); a1?.toString(); a2?.toString();
+return [a0, 77n, a2];
+};
+/**
+@param {I64} a0
+@returns {void}
+ */
+let fn4 = function (a0) {
+a0?.toString();
+};
+/**
+@param {I64} a0
+@returns {void}
+ */
+let fn5 = function (a0) {
+a0?.toString();
+};
+/**
+@param {ExternRef} a0
+@param {ExternRef} a1
+@param {I64} a2
+@returns {[ExternRef, ExternRef, I64]}
+ */
+let fn6 = function (a0, a1, a2) {
+a0?.toString(); a1?.toString(); a2?.toString();
+return [a0, a0, 759n];
+};
+/**
+@param {I64} a0
+@returns {void}
+ */
+let fn7 = function (a0) {
+a0?.toString();
+};
+/**
+@param {ExternRef} a0
+@param {I64} a1
+@param {FuncRef} a2
+@returns {void}
+ */
+let fn8 = function (a0, a1, a2) {
+a0?.toString(); a1?.toString(); a2?.toString();
+};
+let tag6 = new WebAssembly.Tag({parameters: ['externref', 'externref', 'i64']});
+let tag7 = new WebAssembly.Tag({parameters: ['i64']});
+let tag9 = new WebAssembly.Tag({parameters: ['externref', 'i64', 'anyfunc']});
+let global0 = new WebAssembly.Global({value: 'i64', mutable: true}, 2341610737n);
+let global1 = new WebAssembly.Global({value: 'f32', mutable: true}, 379045.1329523022);
+let table0 = new WebAssembly.Table({initial: 68, element: 'externref'});
+let table1 = new WebAssembly.Table({initial: 65, element: 'externref', maximum: 375});
+let table3 = new WebAssembly.Table({initial: 5, element: 'anyfunc', maximum: 495});
+let table4 = new WebAssembly.Table({initial: 72, element: 'anyfunc', maximum: 72});
+let table6 = new WebAssembly.Table({initial: 88, element: 'externref'});
+let m0 = {fn0, fn4, fn5, fn6, memory0, table5: table4, tag10: tag9, tag11: tag9};
+let m2 = {fn1, fn2, fn3, global0, global1, global3: global1, global4: global0, table2: table0, table6, tag6, tag7};
+let m1 = {fn7, fn8, global2: 499464717n, table0, table1, table3, table4, tag8: tag6, tag9};
+let importObject0 = /** @type {Imports2} */ ({extra, m0, m1, m2});
+let i0 = await instantiate('AGFzbQEAAAABPwpgAAF/YAF+AGABfgF+YAF+AGADb35wAX5gA29+cANvfnBgA29+cABgA29vfgJwfmADb29+A29vfmADb29+AALkAh0CbTAHbWVtb3J5MAID+BnKJwJtMANmbjAABQJtMgNmbjEABwJtMgNmbjIAAQJtMgNmbjMABQJtMANmbjQAAQJtMANmbjUAAwJtMANmbjYACAJtMQNmbjcAAwJtMQNmbjgABgVleHRyYQVpc0pJVAAAAm0yBHRhZzYEAAkCbTIEdGFnNwQAAwJtMQR0YWc4BAAJAm0xBHRhZzkEAAYCbTAFdGFnMTAEAAYCbTAFdGFnMTEEAAYCbTIHZ2xvYmFsMAN+AQJtMgdnbG9iYWwxA30BAm0xB2dsb2JhbDIDfgACbTIHZ2xvYmFsMwN9AQJtMgdnbG9iYWw0A34BAm0xBnRhYmxlMAFvAEQCbTEGdGFibGUxAW8BQfcCAm0yBnRhYmxlMgFvABwCbTEGdGFibGUzAXABBe8DAm0xBnRhYmxlNAFwAUhIAm0wBnRhYmxlNQFwAUGZAgJtMgZ0YWJsZTYBbwBYAwIBCAQaBnAADHABKu8CbwFelAFwAExwAQiFAXABPDwNHQ4ABgAJAAYABgABAAEACQADAAYAAwABAAYAAQAJBmAOcADSAwt/AEH676wNC3wBRJKXiMRm87eJC34BQvUBC3AA0gULbwHQbwt9AUNS7Ll3C38BQfXIzgILbwHQbwt8AUTplIBFOiqDowt+AULIAQtwAdIFC38BQQ0LcAHSBgsH+gEbCGdsb2JhbDE2AxIIZ2xvYmFsMTUDEQd0YWJsZTEwAQoIZ2xvYmFsMTIDDAZ0YWJsZTcBBwd0YWJsZTEyAQwHZ2xvYmFsNgMGCGdsb2JhbDEwAwoHZ2xvYmFsOQMJBnRhYmxlOQEJBHRhZzUEDQR0YWcxBAUHbWVtb3J5MQIACGdsb2JhbDEzAw0IZ2xvYmFsMTQDDwNmbjkABQhnbG9iYWwxMQMLBHRhZzQEDARmbjEwAAoHZ2xvYmFsNQMFB3RhYmxlMTEBCwdnbG9iYWw3AwcEdGFnMAQABnRhYmxlOAEIBHRhZzIEBgR0YWczBAkHZ2xvYmFsOAMICdEBCgIIQSkLAAEGAQBMBgoBBggDCAcCAAkKCAMBCgAABgIHBQgGCQEAAwEDAQcIBwcIAwkHAgEABQIJCQIIAgAIBwkIAgoHCQYHBQkIBAAFCgYICQkIAgQIBQMAAAIKQRcLAC0FAQMDCAYBBgQKAwUGCAgACQAABwYJBgQKCgkGBQQJCgEKAQUIBQQHBwoBBQUCCkHEAAsAAgADAgVBKwsAAQEGBEELC3AE0gIL0gQL0gUL0gcLBgtBBAtwAtIGC9IKCwIMQTILAAEIAgdBAAsAAQkMAQIKlDsBkTsLAHwAfQF+An0BcAB/AnADfwF+AX0BfCMEIwk/APwQAHAlAES5guD/W3Z7dJwkBwN+RO1eI8q9JiG8IwkjEELzwOHPFhAFAn8CfSAKQQFqIgpBJkkNAkLSAAZ+IA5EAAAAAAAA8D+gIg5EAAAAAACAQUBjDQP8EAsMAgtXDAEACwZ90gHSCkEAQQxBL/wMAQX8EAZEliYEdAc52KtB8QFBoJ/nAA0BDAEL/BAFAm8QCUUEQAwDC0MY2CMTAn4QCSAADAEACwAL0UEBcA4HAAAAAAAAAAALHAFwAn4jDULmAQJ+PwACcCAMQgF8IgxCDlQEQAwECwYABgAgCUEBaiIJQQpJBEAMBgsGACAJQQFqIglBI0kNBkPUFLBa/AQMBQsMAAsMAAv8EAFBAnAEAAYARM1gt0USB1hXQtTRub2v68QAxAwDCwwAAAUgCAwBAAtBAnAEfvwQCUEYQQBBBPwMAQUGbyMI0gUCfiALQQFqIgtBK0kNBtIIIAgjCMMMBAALBgIYAAZA/BAAQQJwBG8gAEQmt6XAUrKZS55BgAFChNjil4eLRiQPDgEBAQUDAAYAQ//U6/8kAQYAIA1DAACAP5IiDUMAACBBXQRADAMLBgAMBQsMAQABCxgDJBEgAEEoDgIDAQEBAAtBDUEhQSH8DAEMJAwMAQABC9IA0gVCigH8EAZBA3AOAwUCBAULDAQL0UlBAnAEfEG7jMUJIwD8EABBA3AOAwEEAwEBBRAJ/BAHJBEkERAJQQJwBAACACALQQFqIgtBLUkEQAwIC0HGrgpBAnAEAEK8nnvDBgICAgwAAAsMBwtBDhEBBAYAQdaWs6sEDAALDAIABRAJDAIACwwAAAskDD8ADAAFIwY/ACQMDAAAC60MAQALJAcCAESxaUcBViwHBpogAgwBAAtFQ8lKxRQGQCAMQgF8IgxCHFQEQAwGCyAMQgF8IgxCAVQNBQZvDAEL0UECcARABgBBiZLOnnpBAnAOBwIBAQECAQEBAQtBAnAOAgEAAAtBpM7yOg4AAAsjDEPY/n7aJAFBAnAEfgIABkAZQqXRkM7oGwwDCwMAIA5EAAAAAAAA8D+gIg5EAAAAAAAAFEBjDQcCAAZAIwcjAhAEQsMBDAcL0gQgBLwMAAALDAEACwALQuwABgIMBQsMAAAFAgAgACEBIwokDQYAAgAgDkQAAAAAAADwP6AiDkQAAAAAAAAIQGMEQAwJC9IJAnADfBAJDAIACwALAAtE+97kLrTRgaUkDgwACwwAAAtBAnAEbxAJQQJwBH8CANIKIAcMBQALAAUCAAMAAgAGf0Or7fldQwYDOTReQQJwBH3SBwZ9BgAgBSAIDAsLIAZB5AAMAwsjAQwAAAUDACAJQQFqIglBIUkNBAIAAn0QCUUNDyMADAsACwALAAsACyAHPwANCEEgQ1mMvz0kCw0IDAgHEgwKC/wQDEEDcA4DAgMAAwsCfgYAA33SAiMHRE/jIShdvCDGIw4kB0H588gBQdyC054DDAQACwNwIApBAWoiCkEYSQRADAEL/BACDAEACwwIC/wQB3AlBwwHAAsACwwBAAs/AAwAAQsjDQwAAAVBLcAkDBAJQQJwBH0gDUMAAIA/kiINQwAAwEFdBEAMCAsjDPwQAXAlASQK/BAAAnwgBPwEDAMACwAFBn4GAAYAAgAGACMQBn8QCUUNDQYABgADAAJ/0gRBlgNB6tIAQeEs/AoAAEI9IgL8EAMCbwMAIAlBAWoiCUEcSQRADBQLAgACAET2i+r6JqM8N9IEQeYBDAwACwALAAsACwALAAsMBQsGfiMEIw7SCCMEDAcLJAQMBAsjCdIJIwwEfBAJBEAgCkEBaiIKQS5JBEAMEAsgDkQAAAAAAADwP6AiDkQAAAAAAAAUQGMNDwIAIA1DAACAP5IiDUMAAOhBXQ0QDAEACwAF0grSCUEDDQAgAwwOCwMARGo27zMN4fKtDAEACwAFEAkMAQAL/BAFBEAFBgACACMHJAcgBiQSQeX42wAMBQALDgEBAQsMAQtEfxfQgOP4Ye0jEkIABgMgASIADAgZDAALDAoHEwwLCwwCAAsMAAsMAQsYCSMPAgFC7gEiAj8AswwCAAskERAJQQJwBH0GACAMQgF8IgxCIlQNCgJvIwsMAgALDAQBCwJvQrsBxEEMEQEEAwAgCkEBaiIKQQVJBEAMAQtEZo37ilurO6EjED8A/BABcCUBQ+dA2/8MAgALAAsMAwVEDQsD7HEElME/AAJ8IwUhCEP0iinx/BAEDQEMAwALPwAjDvwQB0ECcAR8An0jCwwEAAsABSMAxAwJAAskByQOQ4ZOFS4kA0Keq/AADAELJANC2wAMBgsMBQsjAwJ/AgAjEAwFAAsACwNwBgAgDUMAAIA/kiINQwAAoEFdDQEjAfwBDAALQQJwBG8QCUUNCAYAEAlBmy8NAEECcARwIwkMBwAFIwsjD3sMBQALIAEGfSAKQQFqIgpBL0kNAwIA0gVDd1rb3yMOtgwBAAsjCAwJC9IIQQpBJUEB/AwBBz8ADAAHEgYDDAkLBgACfgZ/AgAgAgMCDAwACwALQQJwBH8GfQYAEAkgBgwMCz8ADQEgAgYDBgMJBwsgCkEBaiIKQQJJBEAMCQsCAAYABgAgBQwEC0EBcA4BAgILGkEADgEBAQsMBQsGcCABJA0QCcEMBQELQRVBL0EI/AwBBdIBQZDuA0HWiAJByq4C/AoAAENHO04WIQXSCfwQA0H//wNxNAK5AnkgCCAIJBD8EAT8EANwJQP8CQFBCEHGAEEF/AwBCEL9fQwJCwJwEAkMBAALDAoABSAKQQFqIgpBDUkEQAwOCyMQDAoACyMPDAgLDAIAC0EDQR9BAPwMAQsGAyQEIAtBAWoiC0EWSQ0EBwskDwwACwYABgAGACAHIgcMCgELQQJwBHAQCUUEQAwOC9IHIAYMAAAFAwBEzJTb/utdYu0jA0EADAUACwALDAkLQQJwBHwQCQwBAAVBn+zKACABAm8GAD8AGAMCcAIABn1E6TiIzjK0+H8jC0KK7f7pr7niSwwMC47SByAAJAo/AEECcAR+BgAgDEIBfCIMQjFUBEAMCwvSAPwQAtIIA0AgDEIBfCIMQidUBEAMEwsgDEIBfCIMQg5UBEAMAQsjCAwRAAtCwJd+DA8ZAwBDkgDufyABJAr8EAhB//8DcS4A+AQkEQkJC0ECcAR+EAlFBEAMDAsjCSQSIAxCAXwiDEIEVA0SIAxCAXwiDEIDVARADBMLIApBAWoiCkEUSQ0LBgDSBkH1ACMDBnD8EAMMAQvSACACQwAAAIDSAfwQCUHH+OK8AwwCCwwIAAUDAEGuj90+0ghBkNIAIAghB/wQAwwJAAsAC0MAAAAAIAEMCwsjAgYDDA8LQYyQC078EAxwJQwMAgAFIwnSAz8A/BAHQQRwDgQBBgUHBgunDAQLDAMLIQYkESMN0G8MBwALAAsCfCAKQQFqIgpBFUkEQAwGCyANQwAAgD+SIg1DAABwQV0NBQJwBgAgAQwGCwwDAAsACyQO/BALJAwgByQSIwIMBwsMAAsMAAtCqqTVmfCF4H0MAwVDCJeCrdICIwIMAwALIgEMAQALDAMLIwACfwZ8EAlFDQcGACAI0gZEQmJs92AFPA4MAQELDAEAAQtCvZDTEAwEC/wQA3AlA0HJtuTQAkEBcA4BAgILBgIMAAsGAwwEC9IBIAACf/wQCUECcAR8QR9BG0EH/AwBBQYAIA5EAAAAAAAA8D+gIg5EAAAAAAAAFEBjDQcCAAN+/BADJBEDAAJw/BAFQQJwBH4GAAYAQ11OGKJClZrp+fLfvH0MAgsMCAsjCQwBBQIAIAxCAXwiDEIIVA0NIA5EAAAAAAAA8D+gIg5EAAAAAAAAM0BjBEAMDgsCfyAKQQFqIgpBDEkEQAwGC9IEQ0Kez9JBASQR0gQjDSQKIAZEfWWi4nliT+JBr+UBQQBBAPwIAQAkBwwLAAsACwALBgMhAhgE0gBCxAAMBwtDeaIiAUGo5LPYAEH+/wNx/hMBACQMkfwFDAgACwALAAsGf9IFIAMgAgZ/0gNC3AAMCAtBA3AOAwQGBwYAAAtBAnAOAgACAAsjCiEB/BAAcCABJgBExx1p1KU48H8MAAAF0gkgBSIEIwMjCiQKuwwAAAvSAyMFDAIL0gZCmQEMAwUGACAFRA5Ac+hlkPF/QvMB0gNEI9cZQ50PUn1BCvwQCwwAAAtB0AAGf0OVNT/TJAsgCkEBaiIKQQhJDQVCDwMBQ8OYOSrSBtIJAnDSAEH99IkLDAIACwALQi8MAwALJAwgBNIBQa8BQf//A3EqAOkHIAMkCCQB0gRC8gEjCiQKIgMMAwALEAVCFQwCCyEH/BADcCAHJgMQCUH//wNxNAG7BQwBCwMBtCQDBgDSCQZ/IAtBAWoiC0EHSQRADAULEAlFDQQCAAJwAkAMAAALIA1DAACAP5IiDUMAAAhCXQRADAcLAn/SBNIAPwAMAAALIAMQCUUEAgwFCwYBDAYLJBH8EAQCbxAJRQ0H0gJEHk7JO+AF1avSCdIGPwAMAwALAAsAC0EoQSdBEfwMAQwMAQtC36yOawwCCyMHPwAgAAJwIAAGQET0hmuZ/Gzz/yQOGAT8EAj8EAlC4QAQByQM0gJDnfEL4SQB/BAFJBEDcELZAQJAIAHSB0RrhHV2bOr4/yQO0gf8EAM/AA0ADgEAAAELAn/SANIBIwQgCkEBaiIKQSRJDQMCbyAMQgF8IgxCKFQNAhAJQQJwBG8jDvwC0gL8EAMkDCMS0gjSANIF/BAEDAIABSADIA5EAAAAAAAA8D+gIg5EAAAAAAAAREBjBAIMBgv8EAIMAgALIAAkCgwAAAsjAgwEC0EBcA4BAwML/BAIBn4gASMRQQJwBHBDk6nSf0OqxiSgIQT8EAxEXuje0khzFTWcQ9HiU0tEhoIt4qBn9B5EFKXj4jnkAO78EAI/AAR//BADIxAMAQAFAgAGAEL9AQIBIgMMBQALBgACAAYABgBCfwIBUAwBAAsCANIBQ4macw+QIw8MDAALPwBBAnAEcCMLJAsCACADEAlFDQxQQQJwBH3SBNIG/BALDAkABRAJRQRADBALQTTSAiACBkBCygECcPwQBgwHAAskEAwPCwwOAAskAwYAEAlFBEAMEAsQCUUEQAwQCyAJQQFqIglBJEkND9IGBm8jDCQMIANCFkEOEQEEIgIGAwwQCwZ+AkAGAAIABgAMAwsMDgALDQEMAQtDaFcp0SIEvEEJcA4JDAkLAwcIBgQKAwsgBEE1QRFBAvwMAQRB3abkoAQMAhkgCkEBaiIKQRVJBEAMEgtB6YEhQQJwBHAQCQwHAAUjEtIIQSJBB0EG/AwBDAN/Q55ZtGMkAyAAQRgMBAALAAtEZfBGateD5aggAfwQAawMEAsgDkQAAAAAAADwP6AiDkQAAAAAAIBDQGMNDgwPC0QAAAAAAAAAgEM1/KFYJAEkDiQNIwefJAcCbwYA0gMgAhAFIwYMBQsMBwALIAACb0KolNDk8/kA/BAADAUAC/wQDAwBC9IKAnwgCUEBaiIJQTBJDQ8DAETOOW+Zs4wDzAwBAAsACyQO/BADQQJwBG8jCgwAAAVBJCUJIgAMAAALJApBxM+SCgwFAQv8EAsMBAAFAkALEAlFDQ38EAUCb0HZPQwIAAsACyMQIwgQCUUEAgwLCwIDBnwQCUUNDtIE0gEa/BADQQFwDggBAQEBAQEBAQELJAcCAUEOEQMEIApBAWoiCkEMSQ0OBgAgCUEBaiIJQSpJDQ8MARkQCQsMBQsGb0HuoAMMBQALIAUGfQwBAAsiBdIIQ4XauppEPoZ/pCx4GJxEABr2Uyvs+38GfSMFDAkLQayMGAwECwwJCwsMBAsMAAsCfPwQCAwBAAskByADDAQLrAwGC0ECcAQAQ7y5F3IgBUS329hJE85/VwJ/IAlBAWoiCUEHSQ0IIAtBAWoiC0EoSQRADAkLRMDLKkMWgF7vIw5BxgBBAnAEfxAJDAMABQIAEAlBsQENAdIIIAIMCQALQ5Z4RbYGfSAEDAALQb4B0gNB64btsAQMAwtB//8DcS4AsAZBAnAEAEH9AQwDAAUQCfwQDEECcARA0gRDTQcnZCQBQrTzAAZ/AkAGcAZ9IA1DAACAP5IiDUMAANBBXQ0ODAIL0gogBPwQBw0BIQUgBI5CyN73k6m7xKZ+AgILEAlFDQsMCQsMCQsgAdIERIoT07FUxvn/0gBBkQEMBQvSARoMAQAFBgAMAQsMBAsMAQsGcAYAIAtBAWoiC0EOSQRADAsLEAkLBEBBopjZAyAAAkBBzABBAnAOAgEAAQskDQ0AAgAgCUEBaiIJQQFJBEAMDAsgCUEBaiIJQQ5JDQsgCkEBaiIKQR9JDQsCfyAMQgF8IgxCLFQNDNIDGgwCAAsACwRvAnwMAgALAAUgAAwAAAtEfA98Djx742NEtl4EEmIFw2ojBAwGCyAHJBAgDEIBfCIMQidUBEAMCgtDjv4u3CQDRD+L0W3/4ngLJA5BASUDBn1B9AAMBAAL/BAF0gcaPwAMAgsDcAYABgAGQAsjAUL9xuyZhrjBknwMBwsMBAsCfwYAIAMMChkQCQJ9IwEMAAALIQQMBQsMAgALAAsMAwsMAQUQCUECcAR/QZkBDAEABQIAIA5EAAAAAAAA8D+gIg5EAAAAAAAACEBjDQkjEiQQIAlBAWoiCUEeSQRADAoLIAxCAXwiDEIwVA0JBgAgDEIBfCIMQg9UDQoCAAIAQd3v4ARBAnAEAAYAIA5EAAAAAAAA8D+gIg5EAAAAAACAREBjDQ4jCSQQIAQjEQJ+IApBAWoiCkEPSQ0PAgBDZCkd1yADDAwACwALuUSAsd2OQ7x3GGUMBAsjByQHRHZdInMckn1B/AIMAAAFBnwCQAsGABAJDAALDAULIAYMCAALQQJwBH4jAESFNaPSBssAytICIwOOiyAI0gX8EAoMAgAF0ghDLbBTXpEgAgwAAAsgDUMAAIA/kiINQwAAQEJdDQohAkHTAAwEAAsLQQJwBG8gAAZ/IAUgByAGDAcACw0ADAAFBgAGAAIAPwAgBD8ADAgAC/wQAHAlAAwCCyQRIAtBAWoiC0EuSQ0MIwkhCD8ACwwDCyEAQQRBNEEA/AwBA0EnGAUMAAsLRMRYXy1NxjHPJAcMAAALDAALQ506XpkkC3ckEWFBAnAEbz8ABkAMAAsGQCAE0ggjEAwEC0ECcAR/BgAGANIBIwMkC0Hkxc2IfwQAQQEMAQAFEAkMAgALDAALCwwAAAUQCQN+IxAMAwALAAvSABokEUEfQQJwBHA/ACQMIAtBAWoiC0EpSQ0HIwkkEkEYJQgjAQNACyQDJBICACAEAnADAES4bxn7XWf4/yQOQurH/eq3fkGmvecAQQJwDgIGCQkBCwwBAAsAC/wQBSQMJAxBAiUDDAQABQYA/BAKC/wQC3AlCwsMAQAFIApBAWoiCkEESQ0GEAkaQuIAEAlFDQQMAgALIgAkCiQLJAcakCMHIAgMAgUCACMGDAAACxoCAEHh3O7BBAtDWSRgfCEEQf//A3EgBDgCwgUGACAJQQFqIglBC0kEQAwHC0Hg8hYMAAskEdIEAkALIAMgDEIBfCIMQgZUBAIMBAsMAQALDAELDAIACyEIJAr8EAlwIwomCQJ/An9Bt98OAn9DR49a1yQLAwAGACMGDAQACyQMBnAgDkQAAAAAAADwP6AiDkQAAAAAAABHQGMEQAwCCwYAQd0BCwwDC0EKQRBBHPwMAQVCJyICIAxCAXwiDEIEVA0EDAUACwALJBEjAAYCQQwRAQQgCkEBaiIKQRNJBEAMBgsCcCMSCyEIQuHyz4P9w4PqAwsGAULTARAEDAQLQQJwBH9Bpf4EDAEABRAJQQJwBH5C/gEFIApBAWoiCkEjSQ0GQpLUlYXQt9QAIAxCAXwiDEIVVA0ECyAJQQFqIglBHEkNAwYDEAlFBAIMBQsgCUEBaiIJQRFJBAIMBQsgACIAJA0MBQsgBiQQIAtBAWoiC0EtSQ0FBnAjABAJRQQCDAULIAxCAXwiDEIZVA0EDAULBn8QCQtBAnAEQBAJDAEABQsiB0GgAgwBCwtBAnAEfkKB0I/wu30GbyAAGAUhACAMQgF8IgxCGFQEAgwDCwwAAAUgAgsMAgusPwBBAXAOAQEBCwwACyECQZH1ka1//BAHJBEaJBAkDgYAAwAGbyABDAALJA1B0+CZxgRBAnAEcCMSJBIgAiIDAwMkBAJAC0Q2fr0o8JzTQ70kAAYAAgBB07zjCyMEIQNB+P8DcSAD/i0DACQEEAkEfiANQwAAgD+SIg1DAAAgQl0NBxAJDAIABSACCyEDIwwMAQALCwwDAAsABSMNIgBD3GpkcSQLIwMiBfwQCwwCAAtBGUECQQv8DAEEQR9BGkEK/AwBDCQSQfYADAEACwsaBgBBCAsaPwAaIAlBAWoiCUEgSQRADAELEAlFDQAGAAIAAgBC7gACASQEAwAMAQALAAsgDkQAAAAAAADwP6AiDkQAAAAAAAA5QGMNAyMMCyABIQEMAQALGAEDbwYAIAxCAXwiDEIrVARADAILQx1x+YBEyZVkQaCO8REkB/wAGSAGIQhBloPp+QBBtxBBAXAOAAALQQJwBHBCmoWCvtH7qr5/BgPDBgIgBgwCC9IAAkALGgZ+/BAAQQFwDgEBAQshAgYDIQMLEAlBAXAOCgAAAAAAAAAAAAAAC9IDIwgCAwYCBgMGfSAFuxogDUMAAIA/kiINQwAAPEJdBEAMBwsjEUECcA4CAwEBC4wjDT8AQzliTDskC0ECcA4CAAIACyALQQFqIgtBIUkEQAwFCxAJQQFwDgEBAQELQZOFjf8BQQJwBHwgDEIBfCIMQgBUBEAMBAsMAQAFAwAjB0Ogp05SJAEMAQALAAsgASQNJA4jDNIDBnAGbyAKQQFqIgpBA0kNBAwCC9IFQxE/3GICbwwCAAvRQQFwDgEBAQALAnwMAQALJAcMAQEL0gEgBwwAAAUgC0EBaiILQQhJDQJBASUDDAAAC/wQCSMLIQQCQAsgBdIKGkLSnNGrDMQgBSQBJAD8EAlBAnAEcCAJQQFqIglBFkkEQAwCCyAFJANC+77vi72QRwIBJAQLIxIiBiIIDAAABSAICyQQBkAYArskByQRJBIjEUECcARvBgBBjAcLJBEjDSIBDAAABRAJRQRADAIL0gdDNFukfyMIpyQM/BAMJAwkAdBvDAAACwsgAtIHGiQEIQD8EAlwIAAmCRAJRQ0AQpfF/I4dEAcQCUUNAEKIAQsCAUKa+sic4N3nAAIDeyQIDAEACwALJA0kEHrSCRr8EARBAnAEbwMAIwZBAnAEfSAFJAsDACMQJBAGABAJRQRADAILAn3SAxoQCQRACxAJRQRADAULIAlBAWoiCUEOSQ0CIwsGfNIAAnxEyDu6EKlm98YjDEECcA4CAQABCwwACyQHCwZ9IAtBAWoiC0EoSQ0CIAULDAIL0gVCzwEaGgskDCANQwAAgD+SIg1DAAA0Ql0NAUKctNCbwntBCxEBBERdAmku8QtK9JsGfCANQwAAgD+SIg1DAADwQV0NAiABA3/8EAQLDQMgBtICGiQSDAMLIAQMAAEFEAkGQAtB//8DcTIApwckACALQQFqIgtBIUkNASMLCyAHJBAjECQQIAMkCCQLBgACAAYAIAlBAWoiCUEjSQRADAQLIApBAWoiCkEeSQRADAQLIApBAWoiCkEhSQ0DIwYEfSAFRAAAAAAAAPD/nSQH/AAEb0EHJQLSCSAGJBIaJA0gDUMAAIA/kiINQwAAyEFdDQVBGiUJDAYABSMNCyEAIAxCAXwiDEIKVA0EIAUMAAAFQe45DAIACyMMDAAACwZwIAtBAWoiC0ExSQRADAQLIAxCAXwiDEIIVA0DQQAlBwwAC/wQC0ECcARABQskEPwQDHAjECYMAnDSABoGAEHWFwwCCyAGDAAACyQQ0gYgAAwDCwZvIwoLIgAMAgsLPwAkDCQRQRYlAtIEGgwABSMJQ0Vn02MkC/wQAyQRJBAjCgskCnpBDBEBBEEcJQBBCCUCQvuni5PLiv/SeQwAAQsLFwIAQZ+ZAgsAAgBBlrADCwfUTK5IY+j6', importObject0);
+let {fn9, fn10, global5, global6, global7, global8, global9, global10, global11, global12, global13, global14, global15, global16, memory1, table7, table8, table9, table10, table11, table12, tag0, tag1, tag2, tag3, tag4, tag5} = /**
+  @type {{
+fn9: (a0: I64) => void,
+fn10: (a0: ExternRef, a1: ExternRef, a2: I64) => [ExternRef, ExternRef, I64],
+global5: WebAssembly.Global,
+global6: WebAssembly.Global,
+global7: WebAssembly.Global,
+global8: WebAssembly.Global,
+global9: WebAssembly.Global,
+global10: WebAssembly.Global,
+global11: WebAssembly.Global,
+global12: WebAssembly.Global,
+global13: WebAssembly.Global,
+global14: WebAssembly.Global,
+global15: WebAssembly.Global,
+global16: WebAssembly.Global,
+memory1: WebAssembly.Memory,
+table7: WebAssembly.Table,
+table8: WebAssembly.Table,
+table9: WebAssembly.Table,
+table10: WebAssembly.Table,
+table11: WebAssembly.Table,
+table12: WebAssembly.Table,
+tag0: WebAssembly.Tag,
+tag1: WebAssembly.Tag,
+tag2: WebAssembly.Tag,
+tag3: WebAssembly.Tag,
+tag4: WebAssembly.Tag,
+tag5: WebAssembly.Tag
+  }} */ (i0.instance.exports);
+table9.set(6, table9);
+table9.set(17, table1);
+table9.set(6, table6);
+table0.set(61, table6);
+table1.set(16, table0);
+table6.set(33, table0);
+table9.set(58, table0);
+table9.set(47, table9);
+table9.set(63, table6);
+table9.set(56, table6);
+table6.set(65, table1);
+table6.set(39, table6);
+table6.set(50, table9);
+table9.set(14, table1);
+table6.set(18, table1);
+table0.set(59, table1);
+table0.set(27, table6);
+table6.set(58, table1);
+table6.set(64, table0);
+table9.set(88, table6);
+global14.value = 0n;
+global16.value = null;
+report('progress');
+try {
+  for (let k=0; k<11; k++) {
+  let zzz = fn10(global10.value, global10.value, global8.value);
+  if (!(zzz instanceof Array)) { throw new Error('expected array but return value is '+zzz); }
+if (zzz.length != 3) { throw new Error('expected array of length 3 but return value is '+zzz); }
+let [r0, r1, r2] = zzz;
+r0?.toString(); r1?.toString(); r2?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') {} else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) {} else { throw e; }
+}
+report('progress');
+try {
+  for (let k=0; k<23; k++) {
+  let zzz = fn9(global8.value);
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') {} else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) {} else { throw e; }
+}
+report('progress');
+try {
+  for (let k=0; k<13; k++) {
+  let zzz = fn9(global14.value);
+  if (zzz !== undefined) { throw new Error('expected undefined but return value is '+zzz); }
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') {} else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) {} else { throw e; }
+}
+report('progress');
+try {
+  for (let k=0; k<8; k++) {
+  let zzz = fn10(global10.value, global13.value, global8.value);
+  if (!(zzz instanceof Array)) { throw new Error('expected array but return value is '+zzz); }
+if (zzz.length != 3) { throw new Error('expected array of length 3 but return value is '+zzz); }
+let [r0, r1, r2] = zzz;
+r0?.toString(); r1?.toString(); r2?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') {} else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) {} else { throw e; }
+}
+let tables = [table0, table1, table6, table9, table4, table3, table10, table7, table12, table11, table8];
+for (let table of tables) {
+for (let k=0; k < table.length; k++) { table.get(k)?.toString(); }
+}
+})().then(() => {
+  report('after');
+}).catch(e => {
+  report('error');
+})

--- a/JSTests/wasm/stress/jitless-wasm-to-js-should-follow-to-wasm-call-frame-convention.js
+++ b/JSTests/wasm/stress/jitless-wasm-to-js-should-follow-to-wasm-call-frame-convention.js
@@ -1,0 +1,166 @@
+//@ runDefault("--jitPolicyScale=0.1", "--useJIT=0", "--watchdog-exception-ok", "--watchdog=500")
+
+function instantiate(moduleBase64, importObject) {
+    let bytes = Uint8Array.fromBase64(moduleBase64);
+    return WebAssembly.instantiate(bytes, importObject);
+  }
+  const report = $.agent.report;
+  const isJIT = callerIsBBQOrOMGCompiled;
+const extra = {isJIT};
+(async function () {
+/**
+@param {I64} a0
+@returns {I64}
+ */
+let fn0 = function (a0) {
+a0?.toString();
+return 1325n;
+};
+/**
+@param {I64} a0
+@returns {I64}
+ */
+let fn1 = function (a0) {
+a0?.toString();
+return 1602n;
+};
+/**
+@param {I64} a0
+@returns {void}
+ */
+let fn2 = function (a0) {
+a0?.toString();
+};
+/**
+@param {I64} a0
+@returns {[FuncRef, I32]}
+ */
+let fn3 = function (a0) {
+a0?.toString();
+return [null, 47];
+};
+/**
+@param {I64} a0
+@returns {void}
+ */
+let fn4 = function (a0) {
+a0?.toString();
+};
+/**
+@param {I64} a0
+@returns {I64}
+ */
+let fn5 = function (a0) {
+a0?.toString();
+return 119n;
+};
+/**
+@param {I64} a0
+@returns {void}
+ */
+let fn6 = function (a0) {
+a0?.toString();
+};
+/**
+@param {I64} a0
+@returns {void}
+ */
+let fn7 = function (a0) {
+a0?.toString();
+};
+let tag1 = new WebAssembly.Tag({parameters: ['i64']});
+let global0 = new WebAssembly.Global({value: 'i32', mutable: true}, 2663374967);
+let table0 = new WebAssembly.Table({initial: 12, element: 'anyfunc'});
+let table1 = new WebAssembly.Table({initial: 71, element: 'anyfunc'});
+let table3 = new WebAssembly.Table({initial: 22, element: 'externref'});
+let table4 = new WebAssembly.Table({initial: 49, element: 'externref'});
+let table5 = new WebAssembly.Table({initial: 86, element: 'externref'});
+let table7 = new WebAssembly.Table({initial: 92, element: 'anyfunc'});
+let m0 = {fn0, fn6, global0, table0};
+let m1 = {fn1, fn3, fn4, fn5, fn7, table5};
+let m2 = {fn2, table1, table2: table1, table3, table4, table6: table5, table7, tag1};
+let importObject0 = /** @type {Imports2} */ ({extra, m0, m1, m2});
+let i0 = await instantiate('AGFzbQEAAAABFARgAAF/YAF+AnB/YAF+AX5gAX4AAuABEwJtMANmbjAAAgJtMQNmbjEAAgJtMgNmbjIAAwJtMQNmbjMAAQJtMQNmbjQAAwJtMQNmbjUAAgJtMANmbjYAAwJtMQNmbjcAAwVleHRyYQVpc0pJVAAAAm0yBHRhZzEEAAMCbTAHZ2xvYmFsMAN/AQJtMAZ0YWJsZTABcAAMAm0yBnRhYmxlMQFwAEcCbTIGdGFibGUyAXAAGQJtMgZ0YWJsZTMBbwAWAm0yBnRhYmxlNAFvADECbTEGdGFibGU1AW8AVgJtMgZ0YWJsZTYBbwAnAm0yBnRhYmxlNwFwAFwDAwIBAgUGAQORBvYJDQMBAAMGJAV8AURNaJzXsl44xwt/AUErC3AB0gYLcAHSBwt+AELwrv4FCwdZCgNmbjkACgZ0YWJsZTgBAQdnbG9iYWwxAwEHbWVtb3J5MAIABHRhZzAEAAdnbG9iYWw0AwQDZm44AAkHZ2xvYmFsNQMFB2dsb2JhbDMDAwdnbG9iYWwyAwIJyAEHAwBjCAIBAQMHAwEJCAIJAwMDCAAECggDCgEAAAUDCAAGAwYEAQYCAQkHBwADAQUBCAEACgUGAgYCBAUBBAcAAAgDAQQBBAkJBAEFCgoICQMFCQYDAQkIAgEECgQHAAQKAwcDBAQCAwAcBwkJAgEECAMHBggHAgkJBAQICgUABQAEAgYFBAIBQRYLAA4KAQQBAgEJBwcECAoEAQICQQsLAAQAAQUKAgBBAQsABAIEBgcGB0ELC3AC0gML0gkLBgBBCQtwAdIICwwBBwrPKQKnHQgCcAB8AX4BfgN/AX4BfQF8BgADABAIQhpD70TBTyMAQa2Hjet4QQJwBH78EAIEf0EBQQJwBH9C6JwMAwECAQYBIQAQCCQC/BAF0ghErxubNqCwBzUjBCQD/BABQQJwBEADACABBm8gAxAGBnDSAkQOTr/hjKN7XCABAnAGAAYAEAhFBEAMDgsQCEEBcA4BBgYLDQXSBESeEpoO0NeA1URe51SzXcH7xaSfIAIhASQBIwFEAeSeEgjsffX8BiEEIAQMCwALQQFwDgEEBAsMAAtDAAAAgD8ADAoLQbAdQQFwDgEBAQsMCAsgAxAKIAdBAWoiB0EmSQQCDAMLAgIQBEElQQBBAPwMBAdEatZBIJvxxPcCfiMFBgMQCEUEAgwGCwID0gD8EAQMCAALEAhFBEAMCgsgCEIBfCIIQh5UBEAMCgsCAAIAIAlDAACAP5IiCUMAAEBBXQ0LBnAMAwskBAwCAAsACw0ABgAjBQwCC0ECcARAAn0MAgALAAUGANIBQ/7H0H/8EAFBAnAOAgECAgsMCwELDAABCwYAEAhB+P8Dcf4RAwAMAQskAiACRGy6ItVVwhP4/BAHDAUBCwwAAAsGAwIDIgAhAAwAAAsDcCAEIAhCAXwiCEIXVA0E/BAEDQEiBCMDJARDhZlKpj8ADAYACyQEIAlDAACAP5IiCUMAAPhBXQ0HEAgMBQuZvfwQBA0FAgIQBiAIQgF8IghCIVQNByAEIQACANIDPwAEcBAIIwRCmnMMCAAFQTUGfCAEAm8CABAIIAEjBCAAIAVBAWoiBUEcSQ0IAgIMBgALAAsAC0KjyHkMAwsGfSAIQgF8IghCG1QEQAwLCyAKRAAAAAAAAPA/oCIKRAAAAAAAADNAYwRADAsLQYe3DCMBBn8CfQZAEAhBAXAOAQAACyMCDAQACyAADAoLDAcLIAQMAgALJARBMkEAQQD8DAIBIwREi5P9A8b01T0kASMD0SQCJAM/APwQAA0JQ5W4WSzSA9IHA0AgCEIBfCIIQhRUBEAMAQsgCkQAAAAAAADwP6AiCkQAAAAAAAAQQGMEQAwKCwIAAn8QCEUNAiAFQQFqIgVBBkkNCwYAREkMthP7krhq0gdEwAjgAzuUsptEAAAAAAAA8P8gAAwFCwwBAAsAC0S+6CCdDTRANQJ+AgD8EAUMCQALAAsACyADIwTRDAAAC0ECcAR8AwAgCEIBfCIIQh5UDQkgAtIC0gogAwYCBnAgBUEBaiIFQQhJBEAMDAsCAAIAQrgBBgECA0G85RINDnq6DAcACwYA0gcgAQwEAQEBC0EHQQBBAPwMAAAEfhAIJALSBUH9ACQCIAEMBAAFQQJBAEEA/AwBAgIAIAEkAwJ+IAVBAWoiBUEhSQ0RIAdBAWoiB0EoSQ0RIAZBAWoiBkETSQ0REAhFBEAMCQsGACMC/BADcCUDRPKn2v8FstVH/BACDAALAkDSAiADREVWHwnPyEfpDAoACwALAAsACyAB/BAG/A8CDgMHBA0HC0EBcA4AAgsMAAALDAwLJAMCfQYA0gbSCEIABnAQCEUEQAwOC0LdASAAQx86aoYjBAZ/BgAGfyADDAYBAAsMAwtDfI1fqkP0wwEXDAMLDAcLIAMMCwsMCQv8BSAA0gj8EAJBAnAEb/wQBgJAEAhEzyuvc64ZM54kAQwKAAsABQIA0gMjAQwEAAsAC0PYb4z/0gkGQNIB0gkGfgwBAAsCAQYCAgLSBNIEQYuXxboCDQNEaCJ2as9W5TMkAdICBnxBBkEAQQD8DAACDAQHAQZ8QsfAYAIBDAoAC0KgAQwJC/wQAkEBcA4BBAQLQ/a3qTdBAUEBcA4BAwMLDAMLQf7WAgZvDAIBCyMD/BADDwALDQD8EAHSBkHYAEEAQQD8DAUH0gYgAUT7JOXtnA7eOkPZ1XkL/BACQAACQCAGQQFqIgZBJkkNDEKhAQICIAZBAWoiBkEvSQQCDAoLBgH8EAANAyEDIAQgAgJ+BgACcAIAAgBCxPSSqprFAgwEAAsACwAL0gUCcNIE0gdDAAAAAELpAAZ+IwUCAQwGAAtBAXAOAQEBAQcBEAcgCEIBfCIIQhRUBEAMEwsCABAIRQRADBQLIwUGbyMDIQEjAkLgWwZ+BgAQCEUEQAwOCyAGQQFqIgZBLEkEQAwOCwIAIAdBAWoiB0EYSQRADBgLBgAjAbb8CQGRi0H3uu+afgwZCwwBAAu4PwAMFwAACw0KDAoLAm8gCkQAAAAAAADwP6AiCkQAAAAAAABIQGMNFQwJAAsMAAsjBAwCAAsgAgwBAQsMCgtBwOn9uQIMCgsNAwwDC0S33IE9IFxszAwGCyQCJAQGACAIQgF8IghCJlQEQAwGCyMBIwAEfEPD4Bs9Am9EeK6WVdn/iCQMCAALAAUgCEIBfCIIQidUBEAMEAsMBAALYgwLC0ECcA4CAQIBCyEEIAlDAACAP5IiCUMAAAhCXQRADA0LDAELDAwAC0QAAAAAAAAAAEG036Ys0gYgAAIDBgJDK+9ntNIH/BAGDA0LIQTSAyMFQeDh2QDBQQNwDgMKBAEBCwZvBn8CAAZvIAICfyAGQQFqIgZBBUkNBtIBIwQkAyAEQ38DtKMjAgwQAAtBAnAEcCAGQQFqIgZBBkkEQAwQC9IHRFm6ObCC8DKpDAcABdIA/BAD/BAHQfj/A3H+EQMAAgMMBgALAAtB9AAMAQsMAgALDAkLDAgLIAB7DAkLvwwBAAsMBgAF0gdBrMSytwEkACMEPwDSAUTntcS1WJ8jLgwAAAsGffwQBiAADAcLQi25IALSBNIKAkADfSAJQwAAgD+SIglDAAAcQl0EQAwBCyAHQQFqIgdBIEkNCSAIQgF8IghCGVQEQAwKCyAIQgF8IghCA1QNCSAIQgF8IghCLVQNACAGQQFqIgZBGEkNCSAHQQFqIgdBAEkEQAwBCwYABgBDVrjPq0EAswJ/IAVBAWoiBUElSQ0DPwANBAYAQbTnusF6DAELQQJwBH4QCAwDAAVCFAwAAAtCDhAAIApEAAAAAAAA8D+gIgpEAAAAAAAANkBjDQgMBQsMAAELDAgBCwwHAAuMGgsgASIC0gIGfSAJQwAAgD+SIglDAACAQV0EQAwJC0SsqPyHSb1HwvwCDAUL0gpEpUCvBQS5HlfSBSAAIgMMAAEBC0MAAACAIwJBAnAEb0J/Am9BIyUGCwwAAAXSAyAADAYACyABIAAQCEUEAgwDCyAGQQFqIgZBFUkEAgwDCwwFCyQCBm8GAAYAIAZBAWoiBkEfSQRADAkLBn7SAkQ/C1iR49qcdCMBtiMDAn7SBkEjs0T9E4kMKIn5fxr8EAT8EAJBBXAOBQIDBwgLBwsCAiAKRAAAAAAAAPA/oCIKRAAAAAAAACRAYw0Ge0QlZQgNASv0mptEu24nEEa2wYP8B7VDCGvR/wZ/AgBBAfwQAXAlASEBEAgLDAgLDAsACyAIQgF8IghCHFQNBSAHQQFqIgdBBkkNBUTRUmNLEcKVOyMC0gIaDAYL0gFBBkEAQQD8DAYCQfQAIAIkA/wQAHAjAyYA0gkgBAZ9AgBB1rQoDAMACyQAEAgMAgsaDAcAAQtCOwwGAAsMAwtEn4QDR92iUwckAUQ16CEUBSxSJSQBAn1DBs69qwNwIAIgACMBmUK5AUOrsgWkDAEACwAL/BACQQJwBH5EAAAAAAAAAAAkAQIAIwALDAcABSMFIAdBAWoiB0ESSQQCDAMLBgMhBEKuyITfARAIRQ0DQfEBDQEMAQsDAAYAEAhFBEAMAgsGb9IBIwUgCEIBfCIIQiBUBAIMBgsMAws/AAwGC0TyD27MDmI73CQBCwwHCyAIQgF8IghCH1QNAfwQBA0EDAQACwALDAQFQeDvhDQkAkHBlPYACwwDBSMFDAEAC0ECcAR8REWkpcNPB0aiDAAABRAIDAMACyQBIAIjAAwDAAXSB0H77ZrfASQCPwAMAgALQe4AJAAhACMCDAEACwwACwJwRGT74dId/Pj//BACBAAGAEEAGSMAQsYBBgHDAgMhBCAEtCAEBkALIQACfwwBAAsACwN/EAhFDQACb0EsJQQLQSEMAgALDAILDAALQSdBAXAOCQAAAAAAAAAAAAAFBnAGAD8ADAABCwwBCwwBC0ECcARwAwAQCEUNAAJ9IApEAAAAAAAA8D+gIgpEAAAAAAAAQkBjBEAMAgtDmjWR5I4Li/wQBhoa/BAGCyQAIwREwbjM0fIGVS22IAO5IAMQAvwQAEH4/wNx/hEDACEA0gT8EAdB//8DcTQAxwIGAUHSDEP77fFe/BAGQf//A3EtALkH/BAAcCUADAILDAIABUEEJQALDAALIQL8EAdwIAImBwYAQQMMAAsEfD8ARcFBAnAEfUMnbv//DAAABQIABgAgAiEBQfykCgsLBG8/AEECcAR/IwK4QwcFApEjAQwDAAVBse/U+wULJAIgAvwQAQ8ABQJ/QQr8EAJwJQIkA0GkAQsgAdIFGiQD/BACcCMDJgJBCyUECyAAIAQGAhkGf0GQAQskAkLePfwQAEL4iYekiqSw9wQMAAALIQMaQdA8QQJwBH4gASQDIwUjBCQDDAAABSMFCwZwIwQkAyABCyQDAn8GABAICwZ8IwEkAUQMlrOl1S0ySSQBRNEYfX3mmQJZCwwCAAsAC/wAPwAkAkH//wNxKwOCBQUjAdICBn1Dub4roQtBDEEAQQD8DAQCGvwQBARvIwL8EAMkAvwQBCMFAgIMAAALQQlBAEEA/AwEBwYBBgIjAkEBcA4BAAAACyEDIAJBiowH0gQaDxkjBCMAtwwCCwwCAAVBJCUEC/wQBUECcAR8RLcPHOo+rCMGDAEABSMC/BAGcCUG0gkaGiMAJALSB9IDQY7Irq4BQQJwBH9CACEDIwL8EAdwJQckBEEkRLEfw4L0XIqIDAIABSMAROYdI+Ds4wDsnUQA1gTb8Jb/fyQB/BAADAAACwJ/A0BEdNkGJNdI8H8MAwALAAsACwwACyQBQRklAUGAOAujDAcAfwB/AHADfwF+AX0BfCMCIwXSAwN+IwJDMaIMiiAADAEACwZ+EAgEcCAAA28gAkEBaiICQSpJDQAgAEEOEQICDAMACwAFQQEDfgIAQdQB0gdDAAAAAEHoAQwAAAu4IwHSAgJvIARCAXwiBEIsVARADAILBgAgBUMAAIA/kiIFQwAAAEBdBEAMAwsQCLgDQAMA0gUgACEABm8gBEIBfCIEQilUDQIjBQYBQYqPBgwEAQtBAXAOAQYGCwwDAAsAC0G9AQwAAAtCEg8LQYz8AEHLn/SeBEHn6wP8CwADfgMAIANBAWoiA0EMSQ0CEAhBAnAEfgYAIAVDAACAP5IiBUMAACxCXQRADAML0gLSByMEQsqsu4j+APwQAEECcAR/0gL8EAQMAAAFIADSB0Moat//QdGJtcZ7DAEAC0EDcA4CAQYHC0HGANIEQrf6nKoGAn0CACACQQFqIgJBAkkNA9IEIAAGAwwDC0S80mEptgUkXUHsAEECcAQAIANBAWoiA0EaSQRADAcLBgACAERMH6cCAsUthyAABn3SBNIC/BAEDAIACwwEAAsMAgsMAAAFBgACcAIAIAACAwZ8IAFBAWoiAUEtSQ0JBm/SByMDJATSBEHIjgJBjARBzYAB/AsAQQdBAEEA/AwAAEKeAQwJCyAA/BAEQQJwBAMPAAUMDgAL/BABDQECbwZAGA4QCEGntOTvBwwFAAsCfgwCAAsMDQAL0gUGfhAIRQ0JPwBBAXAOAQEBC/wQB9IE/BACDAMLQcXUFCQAEAgMAAALDAEACwwIAAALJAIgA0EBaiIDQQ1JBEAMBQtCPhAD/BAFDQH8EAJwJQIjAkEBcA4BBwcLIwIMAAv8EAdwJQcjBNIAQpv8yIiOipCWIAIDBgECAQYBIgAMBQsMAAALDQH8EAEZIwBB//8DcS0A5gEOAQEBCyMF/BAGIwQMBgsjBQYDIwBBA3AOAwcCCAIL0gEgAAwHC0QxavadbakyfkRGm67D7JV27yAAIQAGfkQqOFw+nM2G/SQBIAVDAACAP5IiBUMAALhBXQRADAQLRE3YAbqeoonEnAJvBnAjAPwQByQC/BAGIwAgACEAQf7/A3EgAP4xAQAiAEECQQJwBEAgAkEBaiICQS5JBEAMBgsGACAABgECAgYCAm8QCCMDPwANDSQDDQUQCEUNC0GslAJBAXAOAQUFCyMAQQFwDgEEBAsgAAwNAAsMDAtBAXAOAQEBAAv8EARqRGPMXX7+hv5/Qe6FCAJvEAhBAnAEfwYA0gEjBQwNCw0CQQNBAEEA/AwBAAIAQ5fEq9KOQ+PFlX+TIAAGAb9DGk1QofwQBAwCCw0D0gIgAAYDDA4BC9ICBm8GACABQQFqIgFBG0kNDEHPAQusAgPSBES58fRQkkvolNIB/BAEQrTRhAEhAEH8/wNxIAD+MgIADA8ACyABQQFqIgFBEkkNCtII/BABDAILDAUACw4BAgIFIARCAXwiBEIEVARADAoLBgAMAwsjASQBQQFwDgECAgELQQFwDgQBAQEBAQALQe/DkghBAXAOAQAAAAsMAwv8EARBAXAOAQYGC9IGQvQB0gkaQurf2p7p+2r8EAVBBHAOBAEGBwAACwwGBRAIRQ0B0gXSCBoaIwT8EAQjAwwEAAv8EAdBAnAOAQUEAAsjAgJ8EAhFBEAMAwsGAEGnvRUL/BADcCUDRJvkUZh8pfT/JAEgAANwIAA/ACMABG9CAAwGAAUgBEIBfCIEQgFUDQQgBUMAAIA/kiIFQwAAPEJdDQECAEGqASAADwALAAsaDgIFBgUL/BAFDgEDAwALA33SCBoCcELQAAYC0gka0gUaBgIYBhACEAhBAnAEfiMFBUKY2saek9VvCwsPAAsACwALAAsMAQskBCAAIwPSCiAADwsGAQwBC0O+ksfdGiQAQ/m1S2H8EAQkAAZw0gQaQpLo19+3swcPC9ID/BAAQwi4Z1cjAEECcARADAAABQv8EAEjAyMEJAMkA/wQB3AjAyYHGkLMARAEJAAGfgYA0goaQ6kBq0SOIAAPAAvSA9IHRFsF5O0/HfP/Am8gAAwBAAsamUHaAAJ/QczrEwusDAALDAALC0AHAQiKqo+8ZuUq8QBBw78CCwYAroPL494BCJeSacTh4iy/AQTtzYQcAEG+9QILARABB3Cx4K6JfpYAQZOBAQsA', importObject0);
+let {fn8, fn9, global1, global2, global3, global4, global5, memory0, table8, tag0} = /**
+  @type {{
+fn8: (a0: I64) => [FuncRef, I32],
+fn9: (a0: I64) => I64,
+global1: WebAssembly.Global,
+global2: WebAssembly.Global,
+global3: WebAssembly.Global,
+global4: WebAssembly.Global,
+global5: WebAssembly.Global,
+memory0: WebAssembly.Memory,
+table8: WebAssembly.Table,
+tag0: WebAssembly.Tag
+  }} */ (i0.instance.exports);
+table3.set(4, table5);
+table5.set(58, table5);
+table5.set(18, table3);
+table5.set(37, table4);
+global2.value = 0;
+global1.value = 0;
+global3.value = null;
+report('progress');
+try {
+  for (let k=0; k<26; k++) {
+  let zzz = fn9(1329794613271303928n);
+  zzz?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') {} else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) {} else { throw e; }
+}
+report('progress');
+try {
+  for (let k=0; k<16; k++) {
+  let zzz = fn8(-2254323512825350491n);
+  if (!(zzz instanceof Array)) { throw new Error('expected array but return value is '+zzz); }
+if (zzz.length != 2) { throw new Error('expected array of length 2 but return value is '+zzz); }
+let [r0, r1] = zzz;
+r0?.toString(); r1?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') {} else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) {} else { throw e; }
+}
+report('progress');
+try {
+  for (let k=0; k<23; k++) {
+  let zzz = fn9(3633256515183120413n);
+  zzz?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') {} else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) {} else { throw e; }
+}
+report('progress');
+try {
+  for (let k=0; k<24; k++) {
+  let zzz = fn8(6267585709684061258n);
+  if (!(zzz instanceof Array)) { throw new Error('expected array but return value is '+zzz); }
+if (zzz.length != 2) { throw new Error('expected array of length 2 but return value is '+zzz); }
+let [r0, r1] = zzz;
+r0?.toString(); r1?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') {} else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) {} else { throw e; }
+}
+let tables = [table3, table5, table4, table1, table0, table7, table8];
+for (let table of tables) {
+for (let k=0; k < table.length; k++) { table.get(k)?.toString(); }
+}
+})().then(() => {
+  report('after');
+}).catch(e => {
+  report('error');
+})

--- a/Source/JavaScriptCore/llint/WebAssembly.asm
+++ b/Source/JavaScriptCore/llint/WebAssembly.asm
@@ -26,6 +26,8 @@ const CalleeSaveSpaceAsVirtualRegisters = constexpr Wasm::numberOfLLIntCalleeSav
 const CalleeSaveSpaceStackAligned = (CalleeSaveSpaceAsVirtualRegisters * SlotSize + StackAlignment - 1) & ~StackAlignmentMask
 const WasmEntryPtrTag = constexpr WasmEntryPtrTag
 const UnboxedWasmCalleeStackSlot = CallerFrame - constexpr Wasm::numberOfLLIntCalleeSaveRegisters * SlotSize - MachineRegisterSize
+const WasmToJSScratchSpaceSize = constexpr Wasm::WasmToJSScratchSpaceSize
+const WasmToJSCallableFunctionSlot = constexpr Wasm::WasmToJSCallableFunctionSlot
 
 if HAVE_FAST_TLS
     const WTF_WASM_CONTEXT_KEY = constexpr WTF_WASM_CONTEXT_KEY
@@ -983,31 +985,11 @@ op(wasm_to_js_wrapper_entry, macro()
     tagReturnAddress sp
     preserveCallerPCAndCFR()
 
-    loadp (CodeBlock)[sp], ws0
-    loadp (Callee)[sp], ws1
-
-    const ScratchSpaceSize = 0x8 * 3 + 0x8 # alignment
-    const CalleeScratch = -0x10
-    const WasmInstanceScratch = -0x8
-    const WasmCallableFunctionScratch = -0x18
-
-    subp ScratchSpaceSize, sp
-
-if ARM64 or ARM64E
-    storepairq ws1, wasmInstance, CalleeScratch[cfr]
-elsif JSVALUE64
-    storeq ws1, CalleeScratch[cfr]
-    storeq wasmInstance, WasmInstanceScratch[cfr]
-else
-    storep ws1, CalleeScratch+PayloadOffset[cfr]
-    move constexpr JSValue::NativeCalleeTag, ws1
-    storep ws1, CalleeScratch+TagOffset[cfr]
-    storep wasmInstance, WasmInstanceScratch[cfr]
-end
-    storep ws0, WasmCallableFunctionScratch[cfr]
-
     const RegisterSpaceScratchSize = 0x80
-    subp RegisterSpaceScratchSize, sp
+    subp (WasmToJSScratchSpaceSize + RegisterSpaceScratchSize), sp
+
+    loadp CodeBlock[cfr], ws0
+    storep ws0, WasmToJSCallableFunctionSlot[cfr]
 
     # Store all the registers here
 
@@ -1059,7 +1041,7 @@ end
     break
 
 .safe:
-    loadp WasmCallableFunctionScratch[cfr], t2
+    loadp WasmToJSCallableFunctionSlot[cfr], t2
     loadp JSC::Wasm::WasmOrJSImportableFunctionCallLinkInfo::importFunction[t2], t0
 if not JSVALUE64
     move (constexpr JSValue::CellTag), t1
@@ -1093,13 +1075,12 @@ end
     call t5, JSEntryPtrTag
 
 .postcall:
-    subp RegisterSpaceScratchSize, sp
     storep r0, [sp]
 if not JSVALUE64
     storep r1, TagOffset[sp]
 end
 
-    loadp WasmCallableFunctionScratch[cfr], a0
+    loadp WasmToJSCallableFunctionSlot[cfr], a0
     call _operationWasmToJSExitNeedToUnpack
     btpnz r0, .unpack
 
@@ -1170,9 +1151,7 @@ else
     end)
 end
 
-    loadp WasmInstanceScratch[cfr], wasmInstance
-    addp (ScratchSpaceSize + RegisterSpaceScratchSize), sp
-
+    loadp CodeBlock[cfr], wasmInstance
     restoreCallerPCAndCFR()
     ret
 

--- a/Source/JavaScriptCore/wasm/WasmCallingConvention.h
+++ b/Source/JavaScriptCore/wasm/WasmCallingConvention.h
@@ -48,6 +48,8 @@ constexpr unsigned numberOfIPIntCalleeSaveRegisters = 3;
 #endif
 constexpr unsigned numberOfLLIntInternalRegisters = 2;
 constexpr unsigned numberOfIPIntInternalRegisters = 2;
+constexpr ptrdiff_t WasmToJSScratchSpaceSize = 0x8 * 1 + 0x8; // Needs to be aligned to 0x10.
+constexpr ptrdiff_t WasmToJSCallableFunctionSlot = -0x8;
 
 struct ArgumentLocation {
 #if USE(JSVALUE32_64)

--- a/Source/JavaScriptCore/wasm/WasmOperations.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOperations.cpp
@@ -296,15 +296,22 @@ JSC_DEFINE_JIT_OPERATION(operationWasmToJSExitMarshalArguments, bool, (void* sp,
         return &reinterpret_cast<V*>(arr)[i / sizeof(V)];
     };
 
+    // We need to set up them immediately before potentially throwing anything.
+    auto singletonCallee = CalleeBits::boxNativeCallee(&WasmToJSCallee::singleton());
+    *access.operator()<uintptr_t>(cfr, CallFrameSlot::codeBlock * sizeof(Register)) = std::bit_cast<uintptr_t>(instance);
+    *access.operator()<uintptr_t>(cfr, CallFrameSlot::callee * sizeof(Register)) = std::bit_cast<uintptr_t>(singletonCallee);
+#if USE(JSVALUE32_64)
+    *access.operator()<uintptr_t>(cfr, CallFrameSlot::callee * sizeof(Register) + TagOffset) = JSValue::NativeCalleeTag;
+#endif
+
     CallFrame* calleeFrame = std::bit_cast<CallFrame*>(reinterpret_cast<uintptr_t>(sp) - sizeof(CallerFrameAndPC));
     ASSERT(instance);
     ASSERT(instance->globalObject());
     VM& vm = instance->vm();
+
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    constexpr int codeBlockOffset = -0x18;
-
-    auto* importableFunction = *access.operator()<WasmOrJSImportableFunctionCallLinkInfo*>(cfr, codeBlockOffset);
+    auto* importableFunction = *access.operator()<WasmOrJSImportableFunctionCallLinkInfo*>(cfr, WasmToJSCallableFunctionSlot);
     auto typeIndex = importableFunction->typeIndex;
     const TypeDefinition& typeDefinition = TypeInformation::get(typeIndex).expand();
     const auto& signature = *typeDefinition.as<FunctionSignature>();
@@ -427,14 +434,6 @@ JSC_DEFINE_JIT_OPERATION(operationWasmToJSExitMarshalArguments, bool, (void* sp,
     *access.operator()<uint64_t>(calleeFrame, CallFrameSlot::callee * sizeof(Register)) = JSValue::encode(importableFunction->importFunction.get());
     *access.operator()<uint32_t>(calleeFrame, CallFrameSlot::argumentCountIncludingThis * static_cast<int>(sizeof(Register)) + PayloadOffset) = argCount + 1; // including this = +1
 
-    // set up codeblock
-    auto singletonCallee = CalleeBits::boxNativeCallee(&WasmToJSCallee::singleton());
-    *access.operator()<uintptr_t>(cfr, CallFrameSlot::codeBlock * sizeof(Register)) = std::bit_cast<uintptr_t>(instance);
-    *access.operator()<uintptr_t>(cfr, CallFrameSlot::callee * sizeof(Register)) = std::bit_cast<uintptr_t>(singletonCallee);
-#if USE(JSVALUE32_64)
-    *access.operator()<uintptr_t>(cfr, CallFrameSlot::callee * sizeof(Register) + TagOffset) = JSValue::NativeCalleeTag;
-#endif
-
     OPERATION_RETURN(scope, true);
 }
 
@@ -457,8 +456,7 @@ JSC_DEFINE_JIT_OPERATION(operationWasmToJSExitMarshalReturnValues, void, (void* 
     NativeCallFrameTracer tracer(instance->vm(), cfr);
     auto scope = DECLARE_THROW_SCOPE(instance->vm());
 
-    constexpr int codeBlockOffset = -0x18;
-    auto* importableFunction = *access.operator()<WasmOrJSImportableFunctionCallLinkInfo*>(cfr, codeBlockOffset);
+    auto* importableFunction = *access.operator()<WasmOrJSImportableFunctionCallLinkInfo*>(cfr, WasmToJSCallableFunctionSlot);
     auto typeIndex = importableFunction->typeIndex;
     const TypeDefinition& typeDefinition = TypeInformation::get(typeIndex).expand();
     const auto& signature = *typeDefinition.as<FunctionSignature>();


### PR DESCRIPTION
#### d55c91ba94f57f368297ae8891b12300dc4f2c03
<pre>
[JSC] JITLess WasmToJS needs to construct CallFrame appropriately
<a href="https://bugs.webkit.org/show_bug.cgi?id=290033">https://bugs.webkit.org/show_bug.cgi?id=290033</a>
&lt;<a href="https://rdar.apple.com/146100752">rdar://146100752</a>&gt;

Reviewed by Mark Lam.

CallFrame with WasmCallee needs to store

1. JSWebAssemblyInstance* in CodeBlock[cfr]
2. Boxed WasmCallee* in Callee[cfr]

we already have a code storing them in operationWasmToJSExitMarshalArguments.
But the code is executed at the end of function, so when an error is
thrown before that place, we may throw an error with inappropriately
constructed CallFrame, thus unwinding will fail.
This patch moves these setup in the prologue of operationWasmToJSExitMarshalArguments
so that we ensure that they are already stored when unwinding happens.
We also clean up stack size calculation code by avoiding directly used constants
in the different places. And we remove unnecessary code in
WebAssembly.asm.

* JSTests/wasm/stress/jitless-wasm-to-js-should-follow-to-wasm-call-frame-convention-2.js: Added.
(instantiate):
(async let):
* JSTests/wasm/stress/jitless-wasm-to-js-should-follow-to-wasm-call-frame-convention.js: Added.
(instantiate):
(async let.fn0):
(let.fn1):
(let.fn2):
(let.fn3):
(let.fn4):
(let.fn5):
(let.fn6):
(let.fn7):
(async let):
* Source/JavaScriptCore/llint/WebAssembly.asm:
* Source/JavaScriptCore/wasm/WasmCallingConvention.h:
* Source/JavaScriptCore/wasm/WasmOperations.cpp:
(JSC::Wasm::JSC_DEFINE_JIT_OPERATION):

Originally-landed-as: 289651.297@safari-7621-branch (88afd93c3a5e). <a href="https://rdar.apple.com/151710096">rdar://151710096</a>
Canonical link: <a href="https://commits.webkit.org/295864@main">https://commits.webkit.org/295864@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/645bd6ba15ec2df00ff50e996d30ab8ba1a5c7ad

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/106325 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/26074 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/16470 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/111525 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/56921 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/26739 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34577 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80762 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/109329 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/21167 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95947 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/61090 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/20675 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/14045 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/56361 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/98964 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/90514 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/14080 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/114385 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/104942 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33463 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24671 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89832 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33827 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/92175 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89535 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34415 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/12227 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/29048 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17234 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/33388 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/38800 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/129254 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/33134 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/35213 "Found 2 new JSC stress test failures: wasm.yaml/wasm/stress/jitless-wasm-to-js-should-follow-to-wasm-call-frame-convention-2.js.default, wasm.yaml/wasm/stress/jitless-wasm-to-js-should-follow-to-wasm-call-frame-convention.js.default (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/36487 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34732 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->