### PR TITLE
Some backdrop-filter WPTs are fuzzy failures.

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6095,9 +6095,7 @@ imported/w3c/web-platform-tests/css/filter-effects/svg-external-filter-resource.
 imported/w3c/web-platform-tests/css/filter-effects/svg-mutation-filter-used-by-mask.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/filter-effects/will-change-blur-filter-under-clip.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/filter-effects/svg-feimage-002.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/filter-effects/backdrop-filter-backdrop-root-filter.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/filter-effects/backdrop-filter-backdrop-root-opacity.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/filter-effects/backdrop-filter-edge-pixels-2.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/filter-effects/backdrop-filter-reference-filter-mutated.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/filter-effects/backdrop-filter-svg-blur.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/filter-effects/empty-element-with-filter-002.html [ ImageOnlyFailure ]
@@ -6105,7 +6103,6 @@ imported/w3c/web-platform-tests/css/filter-effects/empty-element-with-filter-003
 imported/w3c/web-platform-tests/css/filter-effects/empty-element-with-filter-004.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/filter-effects/filter-region-html-content-viewport.tentative.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/filter-effects/svg-feimage-003.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/filter-effects/backdrop-filter-transform.html [ ImageOnlyFailure ]
 
 imported/w3c/web-platform-tests/content-security-policy/script-src/ [ DumpJSConsoleLogInStdErr ]
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/backdrop-filter-backdrop-root-filter.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/backdrop-filter-backdrop-root-filter.html
@@ -5,7 +5,7 @@
 <link rel="help" href="https://drafts.fxtf.org/filter-effects-2/#BackdropRoot">
 <link rel=stylesheet  href="resources/backdrop-filter-backdrop-root.css">
 <link rel="match"  href="backdrop-filter-backdrop-root-filter-ref.html">
-<meta name="fuzzy" content="maxDifference=0-5;totalPixels=0-500">
+<meta name="fuzzy" content="maxDifference=0-5;totalPixels=0-2696">
 
 <!-- A Backdrop Root is formed, anywhere in the document, by:
      - An element with a filter property other than "none".

--- a/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/backdrop-filter-boundary.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/backdrop-filter-boundary.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
-<meta name=fuzzy content="maxDifference=0-20;totalPixels=0-100000">
+<meta name=fuzzy content="maxDifference=0-67;totalPixels=0-100000">
 <title>backdrop-filter: Correctly apply backdrop-filter with an SVG filter</title>
 <link rel="help" href="https://drafts.fxtf.org/filter-effects-2/#BackdropFilterProperty">
 <link rel="match" href="reference/backdrop-filter-boundary-ref.html">

--- a/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/backdrop-filter-edge-behavior-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/backdrop-filter-edge-behavior-expected.html
@@ -7,26 +7,31 @@
 
 
 <div>
-  <p>Expected: The black box inside the red box should not contain any red.</p>
+  <p>Expected: The black box inside the red box should contain some red, despite being outside of the scroller's clip</p>
 </div>
 
-<div id=backdrop></div>
-<div id=scroller></div>
+<div id=scroller>
+  <div id=backdrop></div>
+</div>
+<div id=scroller class=second></div>
 
 <style>
   #scroller {
-    position: relative;
-    top:-202px;
     width: 250px;
     height: 250px;
     border: 6px solid red;
   }
   #backdrop {
     position: relative;
+    top: -3px;
     height: 200px;
     width: 200px;
-    left: 6px;
-    top: 3px;
+    backdrop-filter: blur(10px);
     border: 1px solid black;
   }
+  .second {
+    position: relative;
+    top: -262px;
+  }
 </style>
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/backdrop-filter-edge-behavior-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/backdrop-filter-edge-behavior-ref.html
@@ -7,26 +7,31 @@
 
 
 <div>
-  <p>Expected: The black box inside the red box should not contain any red.</p>
+  <p>Expected: The black box inside the red box should contain some red, despite being outside of the scroller's clip</p>
 </div>
 
-<div id=backdrop></div>
-<div id=scroller></div>
+<div id=scroller>
+  <div id=backdrop></div>
+</div>
+<div id=scroller class=second></div>
 
 <style>
   #scroller {
-    position: relative;
-    top:-202px;
     width: 250px;
     height: 250px;
     border: 6px solid red;
   }
   #backdrop {
     position: relative;
+    top: -3px;
     height: 200px;
     width: 200px;
-    left: 6px;
-    top: 3px;
+    backdrop-filter: blur(10px);
     border: 1px solid black;
   }
+  .second {
+    position: relative;
+    top: -262px;
+  }
 </style>
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/backdrop-filter-edge-behavior.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/backdrop-filter-edge-behavior.html
@@ -7,7 +7,7 @@
 <link rel="match"  href="backdrop-filter-edge-behavior-ref.html">
 
 <div>
-  <p>Expected: The black box inside the red box should not contain any red.</p>
+  <p>Expected: The black box inside the red box should contain some red, despite being outside of the scroller's clip</p>
 </div>
 
 <div id=scroller>
@@ -21,6 +21,7 @@
     width: 250px;
     height: 250px;
     overflow: scroll;
+    scrollbar-width: none;
     border: 6px solid red;
   }
   #scroller::-webkit-scrollbar {

--- a/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/backdrop-filter-edge-mirror.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/backdrop-filter-edge-mirror.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
-<meta name=fuzzy content="maxDifference=0-10;totalPixels=0-10000">
+<meta name=fuzzy content="maxDifference=0-11;totalPixels=0-10000">
 <title>backdrop-filter: Sampled pixels beyond edge should mirror back into the content.</title>
 <link rel="author" href="mailto:flackr@chromium.org">
 <link rel="help" href="https://drafts.fxtf.org/filter-effects-2/#backdrop-filter-operation">

--- a/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/backdrop-filter-edge-pixels-2.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/backdrop-filter-edge-pixels-2.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<meta name=fuzzy content="maxDifference=0-20;totalPixels=0-30000">
+<meta name=fuzzy content="maxDifference=0-25;totalPixels=0-30000">
 <link rel="author" href="mailto:masonf@chromium.org">
 <link rel="author" href="mailto:flackr@chromium.org">
 <link rel="help" href="https://drafts.fxtf.org/filter-effects-2/#BackdropFilterProperty">

--- a/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/backdrop-filter-transform.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/backdrop-filter-transform.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
-<meta name=fuzzy content="maxDifference=0-100; totalPixels=0-1000">
+<meta name=fuzzy content="maxDifference=0-127; totalPixels=0-1000">
 <title>backdrop-filter: backdrop-filter plus transform should be applied correctly</title>
 <link rel="author" href="mailto:masonf@chromium.org">
 <link rel="help" href="https://drafts.fxtf.org/filter-effects-2/#BackdropFilterProperty">

--- a/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/backdrop-filters-brightness.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/backdrop-filters-brightness.html
@@ -3,7 +3,7 @@
 <link rel="author" href="mailto:masonf@chromium.org">
 <link rel="help" href="https://drafts.fxtf.org/filter-effects-2/#BackdropFilterProperty">
 <link rel="match" href="backdrop-filters-brightness-ref.html">
-<meta name="fuzzy" content="maxDifference=0-1; totalPixels=37500" />
+<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-37500">
 <style>
     .square {
         position: absolute;

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1991,6 +1991,10 @@ imported/w3c/web-platform-tests/css/filter-effects/drop-shadow-currentcolor-dyna
 imported/w3c/web-platform-tests/css/filter-effects/backdrop-filter-boundary.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/filter-effects/backdrop-filter-edge-clipping-2.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/filter-effects/backdrop-filter-edge-mirror.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/css/filter-effects/backdrop-filter-backdrop-root-filter.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/css/filter-effects/backdrop-filter-edge-behavior.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/css/filter-effects/backdrop-filter-edge-pixels-2.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/css/filter-effects/backdrop-filter-transform.html [ ImageOnlyFailure ]
 
 
 # The following tests need LBSE enabled builds, which is off by default for this port.

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -4648,8 +4648,6 @@ imported/w3c/web-platform-tests/css/filter-effects/filter-function/filter-functi
 imported/w3c/web-platform-tests/css/filter-effects/filter-function/filter-function-repeating-linear-gradient.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/filter-effects/filter-function/filter-function-repeating-radial-gradient.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/filter-effects/backdrop-filter-plus-mask-large.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/filter-effects/backdrop-filter-edge-mirror.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/filter-effects/backdrop-filter-boundary.html [ ImageOnlyFailure ]
 
 http/tests/site-isolation/mouse-events/ [ Skip ]
 webkit.org/b/257904 http/tests/site-isolation/draw-after-navigation.html [ Skip ]
@@ -4783,8 +4781,6 @@ imported/w3c/web-platform-tests/svg/painting/reftests/marker-path-023.svg [ Imag
 imported/w3c/web-platform-tests/svg/embedded/image-embedding-nested-data-url-from-canvas-post-window-load.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/svg/embedded/image-embedding-nested-data-url-from-canvas-window-load.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/svg/embedded/image-embedding-nested-data-url-from-canvas.html [ ImageOnlyFailure ]
-
-webkit.org/b/269852 imported/w3c/web-platform-tests/css/filter-effects/backdrop-filter-edge-behavior.html [ ImageOnlyFailure ]
 
 webkit.org/b/269873 imported/w3c/web-platform-tests/webrtc-extensions/transfer-datachannel-service-worker.https.html [ Pass Failure ]
 

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -2198,8 +2198,6 @@ imported/w3c/web-platform-tests/svg/painting/reftests/marker-path-023.svg [ Imag
 imported/w3c/web-platform-tests/svg/path/distance/pathlength-circle-mutating.svg [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/svg/painting/svg-percent-stroke-width-viewbox-update.html [ ImageOnlyFailure ]
 
-webkit.org/b/269852 imported/w3c/web-platform-tests/css/filter-effects/backdrop-filter-edge-behavior.html [ ImageOnlyFailure ]
-
 webkit.org/b/269873 imported/w3c/web-platform-tests/webrtc-extensions/transfer-datachannel-service-worker.https.html [ Pass Failure ]
 
 # webkit.org/b/267869 Multiple queues experiencing sporadic 0.01% ImageOnlyFailures.


### PR DESCRIPTION
#### 7e5e631bcee839e3c76329a0d56af6547dfc9216
<pre>
Some backdrop-filter WPTs are fuzzy failures.
<a href="https://bugs.webkit.org/show_bug.cgi?id=294053">https://bugs.webkit.org/show_bug.cgi?id=294053</a>

Reviewed by Tim Nguyen.

These are all very close, and mostly have existing fuzz values that don&apos;t quite match.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/backdrop-filter-backdrop-root-filter.html:
* LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/backdrop-filter-backdrop-root-opacity.html:
* LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/backdrop-filter-edge-pixels-2.html:
* LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/backdrop-filter-transform.html:
* LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/backdrop-filters-brightness.html:

Canonical link: <a href="https://commits.webkit.org/296927@main">https://commits.webkit.org/296927@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/71355adb2f7a4a28d5b09304a0f4b60f89bb69d6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/109941 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/29599 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/20030 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/115963 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/60189 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/30277 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/38187 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/83578 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/112889 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/24139 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/99002 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/64020 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/23511 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/17151 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/59757 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/93510 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/17192 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/118754 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/36980 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/27407 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/92555 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/37353 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/95268 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/92379 "Found 1 new API test failure: /WebKitGTK/TestWebProcessExtensions:/webkit/WebKitWebView/web-process-crashed (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23552 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/37352 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/15094 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/32850 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/36875 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/36535 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/39877 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/38244 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->