### PR TITLE
[css-size-shorthand] Prevent size shorthand from being parsed in @page context

### DIFF
--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -7734,6 +7734,34 @@
                 "url": "https://www.w3.org/TR/css-speech-1/#propdef-speak-as"
             }
         },
+        "size": {
+            "animation-type": "not animatable",
+            "inherited": false,
+            "initial": "auto",
+            "values": [
+                "auto",
+                "min-content",
+                "max-content",
+                {
+                    "value": "<length-percentage>",
+                    "comment": "Accepts any <length> or <percentage> (e.g. 100px, 50%)"
+                }
+            ],
+            "codegen-properties": {
+                "longhands": [
+                    "width",
+                    "height"
+                ],
+                "shorthand-pattern": "CoalescingPair",
+                "parser-function": "consumeSizeShorthand",
+                "parser-grammar-unused": "<width-or-height> || <width-or-height>",
+                "parser-grammar-unused-reason": "Needs support for shorthand grammars."
+            },
+            "specification": {
+                "category": "css-22",
+                "url": "https://drafts.csswg.org/css-sizing-4/#the-size-shorthand"
+            }
+        },
         "table-layout": {
             "animation-type": "discrete",
             "initial": "auto",

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -7753,9 +7753,6 @@
                     "height"
                 ],
                 "shorthand-pattern": "CoalescingPair",
-                "parser-function": "consumeSizeShorthand",
-                "parser-grammar-unused": "<width-or-height> || <width-or-height>",
-                "parser-grammar-unused-reason": "Needs support for shorthand grammars."
             },
             "specification": {
                 "category": "css-22",

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -7752,7 +7752,7 @@
                     "width",
                     "height"
                 ],
-                "shorthand-pattern": "CoalescingPair",
+                "shorthand-pattern": "CoalescingPair"
             },
             "specification": {
                 "category": "css-22",

--- a/Source/WebCore/css/parser/CSSPropertyParserCustom.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserCustom.h
@@ -181,6 +181,7 @@ public:
     static bool consumeWhiteSpaceShorthand(CSSParserTokenRange&, PropertyParserState&, const StylePropertyShorthand&, PropertyParserResult&);
     static bool consumePositionTryShorthand(CSSParserTokenRange&, PropertyParserState&, const StylePropertyShorthand&, PropertyParserResult&);
     static bool consumeMarkerShorthand(CSSParserTokenRange&, PropertyParserState&, const StylePropertyShorthand&, PropertyParserResult&);
+    static bool consumeSizeShorthand(CSSParserTokenRange&, PropertyParserState&, const StylePropertyShorthand&, PropertyParserResult&);
 };
 
 struct BorderShorthandComponents {
@@ -2172,6 +2173,28 @@ inline bool PropertyParserCustom::consumeMarkerShorthand(CSSParserTokenRange& ra
     return true;
 }
 
+inline bool PropertyParserCustom::consumeSizeShorthand(CSSParserTokenRange& range, PropertyParserState& state, const StylePropertyShorthand& shorthand, PropertyParserResult& result)
+{
+    ASSERT(state.currentProperty == shorthand.id());
+    ASSERT(shorthand.length() == 2);
+    auto longhands = shorthand.properties();
+    
+    // Parse the first value (width)
+    RefPtr width = CSSPropertyParsing::parseStylePropertyLonghand(range, longhands[0], state);
+    if (!width)
+        return false;
+
+    // Parse the second value (height) if present
+    RefPtr height = CSSPropertyParsing::parseStylePropertyLonghand(range, longhands[1], state);
+    auto heightImplicit = !height ? IsImplicit::Yes : IsImplicit::No;
+    if (heightImplicit == IsImplicit::Yes)
+        height = width;
+
+    // Add both properties to the result
+    result.addPropertyForCurrentShorthand(state, longhands[0], width.releaseNonNull());
+    result.addPropertyForCurrentShorthand(state, longhands[1], height.releaseNonNull(), heightImplicit);
+    return range.atEnd();
+}
 
 } // namespace CSS
 } // namespace WebCore

--- a/Source/WebCore/css/parser/CSSPropertyParserCustom.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserCustom.h
@@ -2172,5 +2172,6 @@ inline bool PropertyParserCustom::consumeMarkerShorthand(CSSParserTokenRange& ra
     return true;
 }
 
+
 } // namespace CSS
 } // namespace WebCore

--- a/Source/WebCore/css/parser/CSSPropertyParserCustom.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserCustom.h
@@ -2171,5 +2171,6 @@ inline bool PropertyParserCustom::consumeMarkerShorthand(CSSParserTokenRange& ra
     result.addPropertyForCurrentShorthand(state, CSSPropertyMarkerEnd, WTFMove(markerRef));
     return true;
 }
+
 } // namespace CSS
 } // namespace WebCore

--- a/Source/WebCore/css/parser/CSSPropertyParserCustom.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserCustom.h
@@ -181,7 +181,6 @@ public:
     static bool consumeWhiteSpaceShorthand(CSSParserTokenRange&, PropertyParserState&, const StylePropertyShorthand&, PropertyParserResult&);
     static bool consumePositionTryShorthand(CSSParserTokenRange&, PropertyParserState&, const StylePropertyShorthand&, PropertyParserResult&);
     static bool consumeMarkerShorthand(CSSParserTokenRange&, PropertyParserState&, const StylePropertyShorthand&, PropertyParserResult&);
-    static bool consumeSizeShorthand(CSSParserTokenRange&, PropertyParserState&, const StylePropertyShorthand&, PropertyParserResult&);
 };
 
 struct BorderShorthandComponents {
@@ -2172,33 +2171,5 @@ inline bool PropertyParserCustom::consumeMarkerShorthand(CSSParserTokenRange& ra
     result.addPropertyForCurrentShorthand(state, CSSPropertyMarkerEnd, WTFMove(markerRef));
     return true;
 }
-
-inline bool PropertyParserCustom::consumeSizeShorthand(CSSParserTokenRange& range, PropertyParserState& state, const StylePropertyShorthand& shorthand, PropertyParserResult& result)
-{
-    if (state.currentRule == StyleRuleType::Page) {
-        // Do not parse size shorthand in @page context; let it be handled as a page-size descriptor.
-        return false;
-    }
-    ASSERT(state.currentProperty == shorthand.id());
-    ASSERT(shorthand.length() == 2);
-    auto longhands = shorthand.properties();
-
-    // Parse the first value (width)
-    RefPtr width = CSSPropertyParsing::parseStylePropertyLonghand(range, longhands[0], state);
-    if (!width)
-        return false;
-
-    // Parse the second value (height) if present
-    RefPtr height = CSSPropertyParsing::parseStylePropertyLonghand(range, longhands[1], state);
-    auto heightImplicit = !height ? IsImplicit::Yes : IsImplicit::No;
-    if (heightImplicit == IsImplicit::Yes)
-        height = width;
-
-    // Add both properties to the result
-    result.addPropertyForCurrentShorthand(state, longhands[0], width.releaseNonNull());
-    result.addPropertyForCurrentShorthand(state, longhands[1], height.releaseNonNull(), heightImplicit);
-    return range.atEnd();
-}
-
 } // namespace CSS
 } // namespace WebCore

--- a/Source/WebCore/css/parser/CSSPropertyParserCustom.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserCustom.h
@@ -2175,10 +2175,6 @@ inline bool PropertyParserCustom::consumeMarkerShorthand(CSSParserTokenRange& ra
 
 inline bool PropertyParserCustom::consumeSizeShorthand(CSSParserTokenRange& range, PropertyParserState& state, const StylePropertyShorthand& shorthand, PropertyParserResult& result)
 {
-    if (state.currentRule == StyleRuleType::Page) {
-        // Do not parse size shorthand in @page context; let it be handled as a page-size descriptor.
-        return false;
-    }
     ASSERT(state.currentProperty == shorthand.id());
     ASSERT(shorthand.length() == 2);
     auto longhands = shorthand.properties();

--- a/Source/WebCore/css/parser/CSSPropertyParserCustom.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserCustom.h
@@ -2175,6 +2175,10 @@ inline bool PropertyParserCustom::consumeMarkerShorthand(CSSParserTokenRange& ra
 
 inline bool PropertyParserCustom::consumeSizeShorthand(CSSParserTokenRange& range, PropertyParserState& state, const StylePropertyShorthand& shorthand, PropertyParserResult& result)
 {
+    if (state.currentRule == StyleRuleType::Page) {
+        // Do not parse size shorthand in @page context; let it be handled as a page-size descriptor.
+        return false;
+    }
     ASSERT(state.currentProperty == shorthand.id());
     ASSERT(shorthand.length() == 2);
     auto longhands = shorthand.properties();

--- a/Source/WebCore/css/parser/CSSPropertyParserCustom.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserCustom.h
@@ -2178,7 +2178,7 @@ inline bool PropertyParserCustom::consumeSizeShorthand(CSSParserTokenRange& rang
     ASSERT(state.currentProperty == shorthand.id());
     ASSERT(shorthand.length() == 2);
     auto longhands = shorthand.properties();
-    
+
     // Parse the first value (width)
     RefPtr width = CSSPropertyParsing::parseStylePropertyLonghand(range, longhands[0], state);
     if (!width)

--- a/metadata/contributors.json
+++ b/metadata/contributors.json
@@ -8809,5 +8809,16 @@
          "zdobersek"
       ],
       "status" : "reviewer"
+   },
+   {
+      "emails": [
+         "ycao47@apple.com",
+         "1623295825@qq.com"
+      ],
+      "github": "Yuncong-Cao",
+      "name": "Edison Cao",
+      "nicks": [
+         "Edison"
+      ]
    }
 ]


### PR DESCRIPTION
#### 74423a462f2b030f1095658b381c09a7f542269f
<pre>
[css-size-shorthand] Prevent size shorthand from being parsed in @page context
</pre>
----------------------------------------------------------------------
#### d21725dcf6a42ff371504b55c94cee96011e07ee
<pre>
Revert &quot;[css-size-shorthand] Prevent size shorthand from being parsed in @page context&quot;
</pre>
----------------------------------------------------------------------
#### a439df150e604003a2b1f9bc0a392938d2375869
<pre>
[css-size-shorthand] Prevent size shorthand from being parsed in @page context
</pre>
----------------------------------------------------------------------
#### c725f497f35d95e4281a2d222c629e973858b73b
<pre>
chore: fix style error (remove trailing whitespace)
</pre>
----------------------------------------------------------------------
#### 18e2edfe88a5173a163c6f43b7a80d3c18a13b1a
<pre>
Implement CSS size shorthand property
</pre>
----------------------------------------------------------------------
#### 03cddc66a6d056b808c7c5c05baed1065a77e354
<pre>
test: add a blank line to trigger PR CI
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2a754a2532adf17889badd30b9bb04b3becf5247

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/106511 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/26261 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/16658 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/111714 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/57107 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/108550 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/26931 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34763 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80884 "Failure limit exceed. At least found 499 new test failures: accessibility/ARIA-reflection.html accessibility/accessibility-crash-focused-element-change.html accessibility/accessibility-crash-setattribute.html accessibility/accessibility-crash-with-dynamic-inline-content.html accessibility/accessibility-node-memory-management.html accessibility/accessibility-node-reparent.html accessibility/accessibility-object-detached.html accessibility/accessibility-object-update-during-style-resolution-crash.html accessibility/activation-of-input-field-inside-other-element.html accessibility/active-descendant-changes-result-in-focus-changes.html ... (failure)") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/109515 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/21350 "Found 8 new test failures: editing/execCommand/print.html fast/canvas/canvas-print-crash.html fast/media/print-restores-previous-mediatype.html fast/media/print-video-crash.html http/tests/misc/timer-vs-loading.html http/tests/security/sandboxed-iframe-ALLOWED-modals.html http/tests/site-isolation/history/add-iframes-and-navigate-mainframe.html imported/blink/fast/css/first-letter-crash-document-disposal.html (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/96108 "Found 2 new API test failures: TestWebKitAPI.WebKit.PrintFrame, TestWebKitAPI.Printing.PrintPageBorders (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/61219 "Found 225 new API test failures: /WPE/TestUIClient:/webkit/WebKitWebView/query-permission-requests, /TestWebKit:WebKit.PageLoadDidChangeLocationWithinPage, /WPE/TestWebsiteData:/webkit/WebKitWebsiteData/deviceidhashsalt, /TestWebKit:WebKit.AboutBlankLoad, /WPE/TestLoaderClient:/webkit/WebKitWebView/load-twice-and-reload, /WPE/TestCookieManager:/webkit/WebKitCookieManager/ephemeral, /TestWebKit:WebKit.PreventEmptyUserAgent, /WPE/TestWebKitWebView:/webkit/WebKitWebView/is-playing-audio, /WPE/TestConsoleMessage:/webkit/WebKitConsoleMessage/network-error, /TestWebKit:WebKit.PrivateBrowsingPushStateNoHistoryCallback ... (failure)") | 
| [❌ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/105988 "Found 1 webkitpy test failure: webkit.messages_unittest.GeneratedFileContentsTest.test_receiver") | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/20809 "Found 4 new test failures: imported/w3c/web-platform-tests/css/css-conditional/js/CSS-supports-CSSStyleDeclaration.html imported/w3c/web-platform-tests/css/css-page/parsing/size-invalid.html imported/w3c/web-platform-tests/css/cssom/cssom-getPropertyValue-common-checks.html imported/w3c/web-platform-tests/css/cssom/page-descriptors.html (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/14209 "Found 6 new test failures: imported/w3c/web-platform-tests/css/css-conditional/js/CSS-supports-CSSStyleDeclaration.html imported/w3c/web-platform-tests/css/css-page/parsing/size-invalid.html imported/w3c/web-platform-tests/css/cssom/cssom-getPropertyValue-common-checks.html imported/w3c/web-platform-tests/css/cssom/page-descriptors.html printing/page-format-data.html printing/page-rule-selection.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/56548 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/90686 "Found 2 new API test failures: TestWebKitAPI.WKWebView.PrintFormatterHangsIfWebProcessCrashesBeforeWaiting, TestWebKitAPI.WKWebView.PrintToPDFShouldPrintBackgrounds (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/14244 "Found 14 new test failures: editing/execCommand/print.html fast/canvas/canvas-print-crash.html fast/media/print-video-crash.html http/tests/security/sandboxed-iframe-ALLOWED-modals.html imported/blink/fast/css/first-letter-crash-document-disposal.html imported/w3c/web-platform-tests/css/css-conditional/container-queries/canvas-as-container-002.html imported/w3c/web-platform-tests/css/css-conditional/js/CSS-supports-CSSStyleDeclaration.html imported/w3c/web-platform-tests/css/css-page/parsing/size-invalid.html imported/w3c/web-platform-tests/css/cssom/cssom-getPropertyValue-common-checks.html imported/w3c/web-platform-tests/css/cssom/page-descriptors.html ... (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/114573 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33649 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24803 "Found 60 new test failures: accessibility/ARIA-reflection.html accessibility/accessibility-crash-focused-element-change.html accessibility/accessibility-crash-setattribute.html accessibility/combobox/aria-combobox-control-owns-elements.html accessibility/combobox/aria-combobox-hierarchy.html accessibility/combobox/aria-combobox-no-owns.html accessibility/combobox/mac/aria-combobox-activedescendant.html accessibility/combobox/mac/combobox-activedescendant-notifications.html accessibility/combobox/mac/combobox-inherited-role.html accessibility/custom-elements/autocomplete.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89958 "Failure limit exceed. At least found 490 new test failures: accessibility/ARIA-reflection.html accessibility/accessibility-crash-focused-element-change.html accessibility/accessibility-crash-setattribute.html accessibility/accessibility-crash-with-dynamic-inline-content.html accessibility/accessibility-node-memory-management.html accessibility/accessibility-node-reparent.html accessibility/accessibility-object-detached.html accessibility/accessibility-object-update-during-style-resolution-crash.html accessibility/activation-of-input-field-inside-other-element.html accessibility/active-descendant-changes-result-in-focus-changes.html ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/34013 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/92339 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89668 "Found 252 new API test failures: /WebKitGTK/TestWebsiteData:/webkit/WebKitWebsiteData/handle-corrupted-local-storage, /WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/snapshot, /TestWebKit:WebKit.PageLoadDidChangeLocationWithinPage, /TestWebKit:WebKit.AboutBlankLoad, /TestWebKit:WebKit.PreventEmptyUserAgent, /TestWebKit:WebKit.PrivateBrowsingPushStateNoHistoryCallback, /WebKitGTK/TestResources:/webkit/WebKitWebResource/get-data, /WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/content-type, /TestWebKit:WebKit.HitTestResultNodeHandle, /TestWebKit:WebKit.Find ... (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34564 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/12378 "Found 13 new test failures: editing/execCommand/print.html fast/canvas/canvas-print-crash.html fast/media/print-video-crash.html http/tests/security/sandboxed-iframe-ALLOWED-modals.html imported/blink/fast/css/first-letter-crash-document-disposal.html imported/w3c/web-platform-tests/css/css-conditional/js/CSS-supports-CSSStyleDeclaration.html imported/w3c/web-platform-tests/css/css-page/parsing/size-invalid.html imported/w3c/web-platform-tests/css/cssom/cssom-getPropertyValue-common-checks.html imported/w3c/web-platform-tests/css/cssom/page-descriptors.html printing/crash-while-formatting-subframe-for-printing.html ... (failure)") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/29258 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/33574 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/38987 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/33320 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/36673 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34919 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->