### PR TITLE
AX: Build the placeholder empty-content isolated tree before starting the AX thread to guarantee it's in place for the first accessibility request

### DIFF
--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -1097,7 +1097,7 @@ AXCoreObject* AXObjectCache::rootObjectForFrame(LocalFrame& frame)
 }
 
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
-void AXObjectCache::buildAccessibilityTreeIfNeeded()
+void AXObjectCache::buildIsolatedTreeIfNeeded()
 {
     if (!gAccessibilityEnabled)
         return;

--- a/Source/WebCore/accessibility/AXObjectCache.h
+++ b/Source/WebCore/accessibility/AXObjectCache.h
@@ -304,7 +304,7 @@ public:
     // Returns the root object for a specific frame.
     WEBCORE_EXPORT AXCoreObject* rootObjectForFrame(LocalFrame&);
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
-    WEBCORE_EXPORT void buildAccessibilityTreeIfNeeded();
+    WEBCORE_EXPORT void buildIsolatedTreeIfNeeded();
 #endif
 
     // Creation/retrieval of AX objects associated with a DOM or RenderTree object.

--- a/Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectBase.h
+++ b/Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectBase.h
@@ -68,6 +68,7 @@ class AXIsolatedTree;
 - (void)setSize:(const WebCore::IntSize&)size;
 - (void)setIsolatedTree:(Ref<WebCore::AXIsolatedTree>&&)tree;
 - (void)setWindow:(id)window;
+- (void)_buildIsolatedTreeIfNeeded;
 #endif
 - (void)setRemoteParent:(id)parent;
 - (void)setRemoteFrameOffset:(WebCore::IntPoint)offset;

--- a/Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectBase.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectBase.mm
@@ -118,7 +118,7 @@ namespace ax = WebCore::Accessibility;
             // isolated objects are able to be attached to those text annotation object wrappers.
             // If they aren't, we never have a backing object to serve any requests from.
             if (auto cache = protectedSelf.get().axObjectCache)
-                cache->buildAccessibilityTreeIfNeeded();
+                cache->buildIsolatedTreeIfNeeded();
 #endif // ENABLE(ACCESSIBILITY_ISOLATED_TREE)
             return protectedSelf.get().accessibilityPluginObject;
         }
@@ -187,12 +187,18 @@ namespace ax = WebCore::Accessibility;
 - (void)setWindow:(id)window
 {
     ASSERT(isMainRunLoop());
-#if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
     Locker lock { m_windowLock };
-#endif // ENABLE(ACCESSIBILITY_ISOLATED_TREE)
     m_window = window;
 }
-#endif
+
+- (void)_buildIsolatedTreeIfNeeded
+{
+    ensureOnMainThread([protectedSelf = RetainPtr { self }] {
+        if (auto cache = protectedSelf.get().axObjectCache)
+            cache->buildIsolatedTreeIfNeeded();
+    });
+}
+#endif // ENABLE(ACCESSIBILITY_ISOLATED_TREE)
 
 - (void)setHasMainFramePlugin:(bool)hasPlugin
 {

--- a/Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectMac.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectMac.mm
@@ -170,7 +170,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
             if (WebCore::AXObjectCache::isIsolatedTreeEnabled())
-                WebCore::AXObjectCache::initializeAXThreadIfNeeded();
+                [protectedSelf _buildIsolatedTreeIfNeeded];
 #endif // ENABLE(ACCESSIBILITY_ISOLATED_TREE)
 
             float roundedHeight = std::round(WebCore::screenRectForPrimaryScreen().size().height());


### PR DESCRIPTION
#### 1c8dc7444b9c08b3346d1b9011ec61fb4f436f40
<pre>
AX: Build the placeholder empty-content isolated tree before starting the AX thread to guarantee it&apos;s in place for the first accessibility request
<a href="https://bugs.webkit.org/show_bug.cgi?id=294054">https://bugs.webkit.org/show_bug.cgi?id=294054</a>
<a href="https://rdar.apple.com/152617287">rdar://152617287</a>

Reviewed by Joshua Hoffman.

Prior to this commit, we would start the accessibility thread during the initial main-thread initialization that happens
in the first -[WKAccessibilityWebPageObjectMac accessibilityAttributeValue:] request, but the trigger to create the
placeholder tree wouldn&apos;t happen until later, meaning any subsequent accessibilityRootObjectWrapper or accessibilityFocusedUIElement
would be guaranteed to hit the main-thread. This manifested 100% of the time on <a href="http://html.spec.whatwg.org">http://html.spec.whatwg.org</a>, a large
page that takes a long time to load, and resulted in a complete Safari-not-responding until the page fully loaded, which
entirely defeats the purpose of having the empty-content placeholder tree.

With this commit, we create the empty placeholder tree first, then initialize the secondary thread, guaranteeing we have
a tree ready to go for the first off-main-thread request.

* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::buildIsolatedTreeIfNeeded):
(WebCore::AXObjectCache::buildAccessibilityTreeIfNeeded): Deleted.
* Source/WebCore/accessibility/AXObjectCache.h:
* Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectBase.h:
* Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectBase.mm:
(-[WKAccessibilityWebPageObjectBase accessibilityRootObjectWrapper:]):
(-[WKAccessibilityWebPageObjectBase setWindow:]):
(-[WKAccessibilityWebPageObjectBase _buildIsolatedTreeIfNeeded]):
* Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectMac.mm:
(-[WKAccessibilityWebPageObject accessibilityAttributeValue:]):

Canonical link: <a href="https://commits.webkit.org/295863@main">https://commits.webkit.org/295863@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f294bf509487f6693d6747b98237632252cc56fd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/106350 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/26099 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/16497 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/111550 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/56946 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/108389 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/26765 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34602 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80778 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/109354 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/21196 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95976 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/61106 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/20703 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/14075 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/56386 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/90539 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/14110 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/114410 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33488 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24687 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89852 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33852 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/92205 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89556 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22854 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34439 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/12256 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/29074 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/33413 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/38825 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/33159 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/36512 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34757 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->