### PR TITLE
AX: Make various accessibility smart pointer member variables const to help prove memory safety to the safer-CPP static analysis tool

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -240,15 +240,12 @@ accessibility/AccessibilityObject.h
 accessibility/AccessibilityRenderObject.cpp
 accessibility/AccessibilitySVGObject.cpp
 accessibility/AccessibilityScrollView.cpp
-accessibility/AccessibilityScrollbar.cpp
 accessibility/AccessibilitySlider.cpp
 accessibility/AccessibilitySpinButton.cpp
 accessibility/AccessibilityTable.cpp
 accessibility/AccessibilityTableCell.cpp
 accessibility/AccessibilityTableColumn.cpp
 accessibility/AccessibilityTableHeaderContainer.cpp
-accessibility/isolatedtree/AXIsolatedObject.cpp
-accessibility/isolatedtree/AXIsolatedObject.h
 accessibility/isolatedtree/AXIsolatedTree.cpp
 accessibility/mac/AXObjectCacheMac.mm
 accessibility/mac/AccessibilityObjectMac.mm

--- a/Source/WebCore/accessibility/AXGeometryManager.h
+++ b/Source/WebCore/accessibility/AXGeometryManager.h
@@ -67,7 +67,7 @@ private:
     void scheduleRenderingUpdate();
 
     // The cache that owns this instance.
-    WeakPtr<AXObjectCache> m_cache;
+    const WeakPtr<AXObjectCache> m_cache;
     HashMap<AXID, IntRect> m_cachedRects;
     Timer m_updateObjectRegionsTimer;
 

--- a/Source/WebCore/accessibility/AXObjectCache.h
+++ b/Source/WebCore/accessibility/AXObjectCache.h
@@ -832,7 +832,7 @@ private:
     Ref<AccessibilityRenderObject> createObjectFromRenderer(RenderObject&);
     Ref<AccessibilityNodeObject> createFromNode(Node&);
 
-    WeakPtr<Document, WeakPtrImplWithEventTargetData> m_document;
+    const WeakPtr<Document, WeakPtrImplWithEventTargetData> m_document;
     const std::optional<PageIdentifier> m_pageID; // constant for object's lifetime.
     OptionSet<ActivityState> m_pageActivityState;
     HashMap<AXID, Ref<AccessibilityObject>> m_objects;
@@ -920,7 +920,7 @@ private:
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
     Timer m_buildIsolatedTreeTimer;
     bool m_deferredRegenerateIsolatedTree { false };
-    Ref<AXGeometryManager> m_geometryManager;
+    const Ref<AXGeometryManager> m_geometryManager;
     DeferrableOneShotTimer m_selectedTextRangeTimer;
     Markable<AXID> m_lastDebouncedTextRangeObject;
 

--- a/Source/WebCore/accessibility/AccessibilityMenuList.h
+++ b/Source/WebCore/accessibility/AccessibilityMenuList.h
@@ -55,7 +55,7 @@ private:
     void setNeedsToUpdateChildren() final { };
 
     // FIXME: Nothing calls AXObjectCache::remove for m_popup.
-    Ref<AccessibilityMenuListPopup> m_popup;
+    const Ref<AccessibilityMenuListPopup> m_popup;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/accessibility/AccessibilityObject.h
+++ b/Source/WebCore/accessibility/AccessibilityObject.h
@@ -873,7 +873,7 @@ public:
 
         RefPtr<const AccessibilityObject> m_current;
         // If the original object had a display:contents parent, it is stored here. This is nullptr otherwise.
-        RefPtr<const AccessibilityObject> m_displayContentsParent { nullptr };
+        const RefPtr<const AccessibilityObject> m_displayContentsParent { nullptr };
     }; // class iterator
 
 protected:
@@ -1017,7 +1017,7 @@ public:
         return AccessibilityObject::iterator { };
     }
 private:
-    Ref<const AccessibilityObject> m_parent;
+    const Ref<const AccessibilityObject> m_parent;
 }; // class AXChildIterator
 
 #if PLATFORM(COCOA)

--- a/Source/WebCore/accessibility/AccessibilitySVGObject.h
+++ b/Source/WebCore/accessibility/AccessibilitySVGObject.h
@@ -56,7 +56,7 @@ private:
     template <typename ChildrenType>
     Element* childElementWithMatchingLanguage(ChildrenType&) const;
 
-    WeakPtr<AXObjectCache> m_axObjectCache;
+    const WeakPtr<AXObjectCache> m_axObjectCache;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/accessibility/AccessibilityScrollbar.h
+++ b/Source/WebCore/accessibility/AccessibilityScrollbar.h
@@ -55,7 +55,7 @@ private:
     bool setValue(float) final;
     float valueForRange() const final;
 
-    Ref<Scrollbar> m_scrollbar;
+    const Ref<Scrollbar> m_scrollbar;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/accessibility/AccessibilitySpinButton.h
+++ b/Source/WebCore/accessibility/AccessibilitySpinButton.h
@@ -55,8 +55,8 @@ private:
 
     WeakPtr<SpinButtonElement, WeakPtrImplWithEventTargetData> m_spinButtonElement;
     // FIXME: Nothing calls AXObjectCache::remove for m_incrementor and m_decrementor.
-    Ref<AccessibilitySpinButtonPart> m_incrementor;
-    Ref<AccessibilitySpinButtonPart> m_decrementor;
+    const Ref<AccessibilitySpinButtonPart> m_incrementor;
+    const Ref<AccessibilitySpinButtonPart> m_decrementor;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
@@ -592,7 +592,7 @@ private:
     AXPropertyVector m_properties;
 
     // FIXME: Make this a ThreadSafeWeakPtr<AXIsolatedTree>.
-    Ref<AXIsolatedTree> m_tree;
+    const Ref<AXIsolatedTree> m_tree;
     Markable<AXID> m_parentID;
 
     OptionSet<AXPropertyFlag> m_propertyFlags;

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
@@ -577,7 +577,7 @@ private:
     void objectChangedIgnoredState(const AccessibilityObject&);
 
     const ProcessID m_processID { legacyPresentingApplicationPID() };
-    WeakPtr<AXObjectCache> m_axObjectCache;
+    const WeakPtr<AXObjectCache> m_axObjectCache;
     OptionSet<ActivityState> m_pageActivityState;
     RefPtr<AXGeometryManager> m_geometryManager;
     bool m_isEmptyContentTree { false };


### PR DESCRIPTION
#### a358164ca51ea7a25b72361b1a0ccac2278757db
<pre>
AX: Make various accessibility smart pointer member variables const to help prove memory safety to the safer-CPP static analysis tool
<a href="https://bugs.webkit.org/show_bug.cgi?id=294057">https://bugs.webkit.org/show_bug.cgi?id=294057</a>
<a href="https://rdar.apple.com/152619003">rdar://152619003</a>

Reviewed by Joshua Hoffman.

This is part of the Safer CPP Guidelines:

<a href="https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines#mark-data-members-that-are-smart-pointers-as-const-if-they-never-get-reassigned">https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines#mark-data-members-that-are-smart-pointers-as-const-if-they-never-get-reassigned</a>

* Source/WebCore/accessibility/AXGeometryManager.h:
* Source/WebCore/accessibility/AXObjectCache.h:
* Source/WebCore/accessibility/AccessibilityMenuList.h:
* Source/WebCore/accessibility/AccessibilityObject.h:
* Source/WebCore/accessibility/AccessibilitySVGObject.h:
* Source/WebCore/accessibility/AccessibilityScrollbar.h:
* Source/WebCore/accessibility/AccessibilitySpinButton.h:
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h:
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h:
* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
Mark AccessibilityScrollbar.cpp, AXIsolatedObject.cpp, and AXIsolatedObject.h as fixed.

Canonical link: <a href="https://commits.webkit.org/295877@main">https://commits.webkit.org/295877@main</a>
</pre>
