### PR TITLE
[css-anchor-position-1] Support implicit anchor element for pseudo-elements with anchor functions

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-function-pseudo-element-implicit-anchor-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-function-pseudo-element-implicit-anchor-expected.txt
@@ -1,0 +1,4 @@
+
+PASS The implicit anchor element of a pseudo-element is its originating element
+PASS Anchored position after moving
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-function-pseudo-element-implicit-anchor.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-function-pseudo-element-implicit-anchor.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<title>Implicit anchor element for pseudo-elements using anchor functions</title>
+<link rel="help" href="https://drafts.csswg.org/css-anchor-position-1/#implicit">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+body { margin: 0 }
+#target  {
+    margin-top: 100px;
+    margin-left: 50px;
+    width: 100px;
+    height: 100px;
+    background: blue;
+}
+#target::before, #target::after {
+    width: 100px;
+    height: 100px;
+    position: absolute;
+}
+#target.moved {
+    margin-top: 200px;
+    margin-left: 200px;
+}
+#target::before {
+    left: anchor(right);
+    top: anchor(top);
+    background: green;
+    content:'';
+}
+#target::after {
+    left: anchor(left);
+    top: anchor(bottom);
+    background: green;
+    content:'';
+}
+</style>
+<div id=target></div>
+<script>
+test(() => {
+    assert_equals(getComputedStyle(target, '::before').top, '100px');
+    assert_equals(getComputedStyle(target, '::before').left, '150px');
+    assert_equals(getComputedStyle(target, '::after').top, '200px');
+    assert_equals(getComputedStyle(target, '::after').left, '50px');
+}, "The implicit anchor element of a pseudo-element is its originating element");
+
+test(() => {
+    target.classList.add("moved");
+    assert_equals(getComputedStyle(target, '::before').top, '200px');
+    assert_equals(getComputedStyle(target, '::before').left, '300px');
+    assert_equals(getComputedStyle(target, '::after').top, '300px');
+    assert_equals(getComputedStyle(target, '::after').left, '200px');
+}, "Anchored position after moving");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/global-attributes/the-anchor-attribute-003.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/global-attributes/the-anchor-attribute-003.tentative-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL ::before uses originating element's implicit anchor assert_equals: expected "50px" but got "0px"
-FAIL ::after uses originating element's implicit anchor assert_equals: expected "250px" but got "0px"
+FAIL ::before uses originating element's implicit anchor assert_equals: expected "50px" but got "-100px"
+FAIL ::after uses originating element's implicit anchor assert_equals: expected "250px" but got "800px"
 FAIL ::backdrop uses originating element's implicit anchor assert_equals: expected "140px" but got "-10px"
 


### PR DESCRIPTION
#### 59f39608a5553557ca6bfd729433b0bc4027eb51
<pre>
[css-anchor-position-1] Support implicit anchor element for pseudo-elements with anchor functions
<a href="https://bugs.webkit.org/show_bug.cgi?id=294066">https://bugs.webkit.org/show_bug.cgi?id=294066</a>
<a href="https://rdar.apple.com/152635393">rdar://152635393</a>

Reviewed by Alan Baradlay.

&quot;The implicit anchor element of a pseudo-element is its originating element, unless otherwise specified.&quot;
<a href="https://drafts.csswg.org/css-anchor-position-1/#implicit">https://drafts.csswg.org/css-anchor-position-1/#implicit</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-function-pseudo-element-implicit-anchor-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-function-pseudo-element-implicit-anchor.html: Added.

Add a test.

* LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/global-attributes/the-anchor-attribute-003.tentative-expected.txt:

This tests a proposed &apos;anchor&apos; attribute which we (nor anyone else) supports.

* Source/WebCore/style/AnchorPositionEvaluator.cpp:
(WebCore::Style::implicitAnchorElementName):
(WebCore::Style::AnchorPositionEvaluator::findAnchorForAnchorFunctionAndAttemptResolution):

If no anchor name is specified then use the special implicit element name.

(WebCore::Style::findLastAcceptableAnchorWithName):

When resolving the implicit element name look for the pseudo-element host.

(WebCore::Style::AnchorPositionEvaluator::isLayoutTimeAnchorPositioned):
(WebCore::Style::AnchorPositionEvaluator::isAnchor):

Host element of an anchored pseudo element is an anchor.

Canonical link: <a href="https://commits.webkit.org/295871@main">https://commits.webkit.org/295871@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/377eb6779e275c1f1be0032a078777dfbafe540c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/106385 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/26134 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/16532 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/111586 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/56981 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/108424 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/26801 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34637 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80806 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/109389 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/21240 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/96009 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/61134 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/20729 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/14108 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/56421 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/90577 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/14143 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/114445 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33523 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24714 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89878 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33887 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/92238 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89581 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22857 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34467 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/12288 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/29121 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/33448 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/38860 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/33194 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/36547 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34792 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->