### PR TITLE
Web Inspector: Broken Sources and Network tabs after creating Local Override with invalid Regular Expression

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Controllers/NetworkManager.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/NetworkManager.js
@@ -73,6 +73,18 @@ WI.NetworkManager = class NetworkManager extends WI.Object
                 for (let serializedLocalResourceOverride of serializedLocalResourceOverrides) {
                     let localResourceOverride = WI.LocalResourceOverride.fromJSON(serializedLocalResourceOverride);
 
+                    if (localResourceOverride.isRegex) {
+                        // FIXME <https://webkit.org/b/294126> Remove fix for stored local overrides created before URL regex checking was added
+                        try {
+                            localResourceOverride._urlRegex;
+                        } catch {
+                            const key = null;
+                            WI.objectStores.localResourceOverrides.associateObject(localResourceOverride, key, serializedLocalResourceOverride);
+                            WI.objectStores.localResourceOverrides.deleteObject(localResourceOverride);
+                            continue;
+                        }
+                    }
+
                     let supported = false;
                     switch (localResourceOverride.type) {
                     case WI.LocalResourceOverride.InterceptType.Block:

--- a/Source/WebInspectorUI/UserInterface/Views/LocalResourceOverridePopover.js
+++ b/Source/WebInspectorUI/UserInterface/Views/LocalResourceOverridePopover.js
@@ -73,7 +73,13 @@ WI.LocalResourceOverridePopover = class LocalResourceOverridePopover extends WI.
         if (!data.url)
             return null;
 
-        if (!data.isRegex) {
+        if (data.isRegex) {
+            try {
+                new RegExp(data.url);
+            } catch {
+                return null;
+            }
+        } else {
             const schemes = ["http:", "https:", "file:"];
             if (!schemes.some((scheme) => data.url.toLowerCase().startsWith(scheme)))
                 return null;


### PR DESCRIPTION
#### 1d01240dc0835e67852aa75ffae66327316e9395
<pre>
Web Inspector: Broken Sources and Network tabs after creating Local Override with invalid Regular Expression
<a href="https://bugs.webkit.org/show_bug.cgi?id=294072">https://bugs.webkit.org/show_bug.cgi?id=294072</a>
<a href="https://rdar.apple.com/152651800">rdar://152651800</a>

Reviewed by Devin Rousso.

Prevent creating a Local Override with an invalid URL regular expression
to avoid triggering an exception when it is applied.

Since Local Overrides are stored and re-applied on every Web Inspector
session, this unhandled exception triggered on every URL request
makes the Sources and Network tabs unusable for every inspected page.

With the Sources tab in a broken state, a user cannot even remove
the faulty Local Override.

For users who end up in this state, we include a mitigation to automatically
delete Local Overrides with broken regular expressions as URLs.

* Source/WebInspectorUI/UserInterface/Models/LocalResourceOverride.js:
(WI.LocalResourceOverride.prototype.matches):
(WI.LocalResourceOverride.prototype.get _urlRegex):
(WI.LocalResourceOverride):

Canonical link: <a href="https://commits.webkit.org/295928@main">https://commits.webkit.org/295928@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1ae28dcaed09fd9e79922009d8c3efaa21df12ce

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/106597 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/26348 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/16745 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/111805 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/57193 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/27018 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34850 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/80952 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/57193 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/109601 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/21432 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/96190 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/61288 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/20884 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/14296 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/56638 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/90771 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/14326 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/114666 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33735 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24873 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/90021 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/34099 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/92420 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89730 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22897 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34640 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/12453 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/29362 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/33660 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/39073 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/33406 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/36759 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/35005 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->