### PR TITLE
Unable to make the video play in full screen in Facebook.com on macOS

### DIFF
--- a/LayoutTests/fullscreen/full-screen-enter-while-exiting-multiple-elements-expected.txt
+++ b/LayoutTests/fullscreen/full-screen-enter-while-exiting-multiple-elements-expected.txt
@@ -1,4 +1,4 @@
-CONSOLE MESSAGE: Unhandled Promise Rejection: TypeError: Fullscreen request aborted by a request to exit fullscreen.
+CONSOLE MESSAGE: Unhandled Promise Rejection: TypeError: Fullscreen request aborted by a fullscreen request for another element.
 Enter fullscreen with target1
 RUN(target1.requestFullscreen())
 EVENT(fullscreenchange)

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -889,6 +889,9 @@ void Document::removedLastRef()
         m_focusNavigationStartingNode = nullptr;
         m_userActionElements.clear();
         m_asyncNodeDeletionQueue.deleteNodesNow();
+#if ENABLE(FULLSCREEN_API)
+        fullscreen().clear();
+#endif
         m_associatedFormControls.clear();
         m_pendingRenderTreeUpdate = { };
 

--- a/Source/WebCore/dom/DocumentFullscreen.cpp
+++ b/Source/WebCore/dom/DocumentFullscreen.cpp
@@ -195,11 +195,18 @@ void DocumentFullscreen::requestFullscreen(Ref<Element>&& element, FullscreenChe
 
     INFO_LOG(identifier);
 
+    m_pendingFullscreenElement = element.ptr();
+
     protectedDocument()->eventLoop().queueTask(TaskSource::MediaElement, [weakThis = WeakPtr { *this }, element = WTFMove(element), scope = CompletionHandlerScope(WTFMove(completionHandler)), hasKeyboardAccess, checkType, handleError, identifier, mode]() mutable {
         auto completionHandler = scope.release();
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis)
             return completionHandler(Exception { ExceptionCode::TypeError });
+
+        // Don't allow fullscreen if it has been cancelled or a different fullscreen elementAdd commentMore actions
+        // has requested fullscreen.
+        if (protectedThis->m_pendingFullscreenElement != element.ptr())
+            return handleError("Fullscreen request aborted by a fullscreen request for another element."_s, EmitErrorEvent::Yes, WTFMove(completionHandler));
 
         // Don't allow fullscreen if we're inside an exitFullscreen operation.
         if (protectedThis->m_pendingExitFullscreen)
@@ -207,7 +214,7 @@ void DocumentFullscreen::requestFullscreen(Ref<Element>&& element, FullscreenChe
 
         // Don't allow fullscreen if document is hidden.
         Ref document = protectedThis->document();
-        if (document->hidden() && mode != HTMLMediaElementEnums::VideoFullscreenModeInWindow)
+        if ((document->hidden() && mode != HTMLMediaElementEnums::VideoFullscreenModeInWindow) || protectedThis->m_pendingFullscreenElement != element.ptr())
             return handleError("Cannot request fullscreen in a hidden document."_s, EmitErrorEvent::Yes, WTFMove(completionHandler));
 
         // Fullscreen element ready check.
@@ -276,6 +283,19 @@ ExceptionOr<void> DocumentFullscreen::willEnterFullscreen(Element& element, HTML
         return Exception { ExceptionCode::TypeError, error };
     }
 
+    // If pending fullscreen element is unset or another element's was requested,
+    // issue a cancel fullscreen request to the client
+    if (m_pendingFullscreenElement != &element) {
+        INFO_LOG(LOGIDENTIFIER, "Pending element mismatch; issuing exit fullscreen request");
+        page->chrome().client().exitFullScreenForElement(&element, [weakThis = WeakPtr { *this }] {
+            RefPtr protectedThis = weakThis.get();
+            if (!protectedThis)
+                return;
+            protectedThis->didExitFullscreen([] (auto) { });
+        });
+        return Exception { ExceptionCode::TypeError, "Element requested for fullscreen has changed."_s };
+    }
+
     INFO_LOG(LOGIDENTIFIER);
     ASSERT(page->isDocumentFullscreenEnabled());
 
@@ -285,6 +305,11 @@ ExceptionOr<void> DocumentFullscreen::willEnterFullscreen(Element& element, HTML
     else
 #endif
         element.willBecomeFullscreenElement();
+
+    ASSERT(&element == m_pendingFullscreenElement);
+    m_pendingFullscreenElement = nullptr;
+
+    m_fullscreenElement = &element;
 
     Vector<Ref<Element>> ancestors { { element } };
     for (RefPtr<Frame> frame = element.document().frame(); frame; frame = frame->tree().parent()) {
@@ -330,7 +355,7 @@ void DocumentFullscreen::elementEnterFullscreen(Element& element)
 
 bool DocumentFullscreen::didEnterFullscreen()
 {
-    RefPtr fullscreenElement = this->fullscreenElement();
+    RefPtr fullscreenElement = m_fullscreenElement;
     if (!fullscreenElement) {
         ERROR_LOG(LOGIDENTIFIER, "No fullscreenElement; bailing");
         return false;
@@ -472,10 +497,13 @@ void DocumentFullscreen::exitFullscreen(CompletionHandler<void(ExceptionOr<void>
             return completionHandler({ });
         }
 
-        // If there is no fullscreen element, bail out early.
+        // If there is a pending fullscreen element but no fullscreen element
+        // there is a pending task in requestFullscreenForElement(). Cause it to cancel and fire an error
+        // by clearing the pending fullscreen element.
         RefPtr exitedFullscreenElement = protectedThis->fullscreenElement();
-        if (!exitedFullscreenElement) {
-            INFO_LOG_WITH_THIS(protectedThis, identifier, "task - No fullscreen element.");
+        if (!exitedFullscreenElement && protectedThis->m_pendingFullscreenElement) {
+            INFO_LOG_WITH_THIS(protectedThis, identifier, "task - Cancelling pending fullscreen request.");
+            protectedThis->m_pendingFullscreenElement = nullptr;
             return completionHandler({ });
         }
 
@@ -492,8 +520,9 @@ void DocumentFullscreen::exitFullscreen(CompletionHandler<void(ExceptionOr<void>
                 protectedThis->finishExitFullscreen(*frame, ExitMode::NoResize);
 
             // We just popped off one fullscreen element out of the top layer, query the new one.
-            if (RefPtr newFullscreenElement = protectedThis->fullscreenElement()) {
-                page->chrome().client().enterFullScreenForElement(*newFullscreenElement, HTMLMediaElementEnums::VideoFullscreenModeStandard, WTFMove(completionHandler), [weakThis = WTFMove(weakThis), resetPendingExitFullscreenScope = WTFMove(resetPendingExitFullscreenScope)](bool success) mutable {
+            protectedThis->m_pendingFullscreenElement = protectedThis->fullscreenElement();
+            if (protectedThis->m_pendingFullscreenElement) {
+                page->chrome().client().enterFullScreenForElement(Ref { *protectedThis->m_pendingFullscreenElement }, HTMLMediaElementEnums::VideoFullscreenModeStandard, WTFMove(completionHandler), [weakThis = WTFMove(weakThis), resetPendingExitFullscreenScope = WTFMove(resetPendingExitFullscreenScope)](bool success) mutable {
                     RefPtr protectedThis = weakThis.get();
                     if (!protectedThis || !success)
                         return true;
@@ -553,9 +582,9 @@ void DocumentFullscreen::finishExitFullscreen(Frame& currentFrame, ExitMode mode
 
 bool DocumentFullscreen::willExitFullscreen()
 {
-    RefPtr fullscreenElement = this->fullscreenElement();
+    RefPtr fullscreenElement = fullscreenOrPendingElement();
     if (!fullscreenElement) {
-        ERROR_LOG(LOGIDENTIFIER, "No fullscreenElement; bailing");
+        ERROR_LOG(LOGIDENTIFIER, "No fullscreenOrPendingElement(); bailing");
         return false;
     }
 
@@ -577,15 +606,15 @@ void DocumentFullscreen::didExitFullscreen(CompletionHandler<void(ExceptionOr<vo
     }
     INFO_LOG(LOGIDENTIFIER);
 
-    // Get `fullscreenElement()` before `finishExitFullscreen` clears it.
-    RefPtr exitedFullscreenElement = fullscreenElement();
     if (RefPtr frame = document().frame())
         finishExitFullscreen(frame->protectedMainFrame(), ExitMode::Resize);
 
-    if (exitedFullscreenElement)
+    if (RefPtr exitedFullscreenElement = fullscreenOrPendingElement())
         exitedFullscreenElement->didStopBeingFullscreenElement();
 
     m_areKeysEnabledInFullscreen = false;
+    m_fullscreenElement = nullptr;
+    m_pendingFullscreenElement = nullptr;
 
     completionHandler({ });
 }
@@ -615,7 +644,11 @@ void DocumentFullscreen::fullyExitFullscreen()
         LOG_ONCE(SiteIsolation, "Unable to fully perform DocumentFullscreen::fullyExitFullscreen() without access to the main frame document ");
 
     if (!mainFrameDocument || !mainFrameDocument->protectedFullscreen()->fullscreenElement()) {
-        INFO_LOG(LOGIDENTIFIER, "No element to unfullscreen.");
+        // If there is a pending fullscreen element but no top document fullscreen element,Add commentMore actions
+        // there is a pending task in enterFullscreen(). Cause it to cancel and fire an error
+        // by clearing the pending fullscreen element.
+        m_pendingFullscreenElement = nullptr;
+        INFO_LOG(LOGIDENTIFIER, "Cancelling pending fullscreen request.");
         return;
     }
 
@@ -736,6 +769,12 @@ void DocumentFullscreen::setAnimatingFullscreen(bool flag)
     if (RefPtr fullscreenElement = this->fullscreenElement())
         emplace(styleInvalidation, *fullscreenElement, { { CSSSelector::PseudoClass::InternalAnimatingFullscreenTransition, flag } });
     m_isAnimatingFullscreen = flag;
+}
+
+void DocumentFullscreen::clear()
+{
+    m_pendingFullscreenElement = nullptr;
+    m_fullscreenElement = nullptr;
 }
 
 // MARK: - Log channel.

--- a/Source/WebCore/dom/DocumentFullscreen.h
+++ b/Source/WebCore/dom/DocumentFullscreen.h
@@ -102,6 +102,8 @@ public:
     WEBCORE_EXPORT bool isAnimatingFullscreen() const;
     WEBCORE_EXPORT void setAnimatingFullscreen(bool);
 
+    void clear();
+
 protected:
     friend class Document;
 
@@ -117,6 +119,8 @@ private:
 
     Document* mainFrameDocument() { return protectedDocument()->mainFrameDocument(); }
 
+    RefPtr<Element> fullscreenOrPendingElement() const { return m_fullscreenElement ? m_fullscreenElement : m_pendingFullscreenElement; }
+
     bool didEnterFullscreen();
 
     enum class EventType : bool { Change, Error };
@@ -124,6 +128,9 @@ private:
     void queueFullscreenChangeEventForElement(Element& target) { m_pendingEvents.append({ EventType::Change, GCReachableRef(target) }); }
 
     WeakRef<Document, WeakPtrImplWithEventTargetData> m_document;
+
+    RefPtr<Element> m_fullscreenElement;
+    RefPtr<Element> m_pendingFullscreenElement;
 
     Deque<std::pair<EventType, GCReachableRef<Element>>> m_pendingEvents;
 


### PR DESCRIPTION
#### 8a207fb6bfa4fe076030b579bd5bf90b5ccc0d54
<pre>
Unable to make the video play in full screen in Facebook.com on macOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=294080">https://bugs.webkit.org/show_bug.cgi?id=294080</a>
<a href="https://rdar.apple.com/152175833">rdar://152175833</a>

Reviewed by Pascoe.

This reverts both 290855@main and 290863@main, which caused this regression.

* LayoutTests/fullscreen/full-screen-enter-while-exiting-multiple-elements-expected.txt:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::removedLastRef):
* Source/WebCore/dom/DocumentFullscreen.cpp:
(WebCore::DocumentFullscreen::requestFullscreen):
(WebCore::DocumentFullscreen::willEnterFullscreen):
(WebCore::DocumentFullscreen::didEnterFullscreen):
(WebCore::DocumentFullscreen::exitFullscreen):
(WebCore::DocumentFullscreen::willExitFullscreen):
(WebCore::DocumentFullscreen::didExitFullscreen):
(WebCore::DocumentFullscreen::fullyExitFullscreen):
(WebCore::DocumentFullscreen::clear):
* Source/WebCore/dom/DocumentFullscreen.h:

Canonical link: <a href="https://commits.webkit.org/295901@main">https://commits.webkit.org/295901@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ea60531527ee8bf251ba5a2d0858ea9e19f8c7ac

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/106468 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/26217 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/16615 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/111670 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/57064 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/108507 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/26884 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34720 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80862 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/109472 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/21318 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/96075 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/61191 "Found 1 new API test failure: /WPE/TestSSL:/webkit/WebKitWebView/ephemeral-tls-errors (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/20786 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/14174 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/56505 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/90650 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/14209 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/114530 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33606 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24775 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89932 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33970 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/92304 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89638 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34529 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/12350 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/29215 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17256 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/33531 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/38943 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/33277 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/36630 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34875 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->