### PR TITLE
[Single Tab mode] Safari UI flickers when scrolling with color-extension on the bottom edge

### DIFF
--- a/LayoutTests/fast/page-color-sampling/color-sampling-includes-sides-that-had-insets-expected.txt
+++ b/LayoutTests/fast/page-color-sampling/color-sampling-includes-sides-that-had-insets-expected.txt
@@ -1,0 +1,10 @@
+PASS initialEdgeColors.top is "rgb(0, 122, 255)"
+PASS initialEdgeColors.bottom is "rgb(255, 59, 48)"
+PASS afterRemovingInset.top is "rgb(0, 122, 255)"
+PASS initialEdgeColors.bottom is "rgb(255, 59, 48)"
+PASS afterRemovingBottomContainer.top is "rgb(0, 122, 255)"
+PASS afterRemovingBottomContainer.bottom is null
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/page-color-sampling/color-sampling-includes-sides-that-had-insets.html
+++ b/LayoutTests/fast/page-color-sampling/color-sampling-includes-sides-that-had-insets.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true pageTopColorSamplingEnabled=true useFlexibleViewport=true ] -->
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <style>
+        body, html {
+            width: 100%;
+            height: 100%;
+            margin: 0;
+            padding: 0;
+            font-family: system-ui;
+        }
+
+        .content {
+            width: 100%;
+            height: 2000px;
+            padding: 120px 20px;
+            box-sizing: border-box;
+        }
+
+        .top {
+            position: fixed;
+            top: 0;
+            left: 0;
+            right: 0;
+            height: 80px;
+            background-color: rgb(0, 122, 255);
+            z-index: 100;
+        }
+
+        .bottom {
+            position: fixed;
+            bottom: 0;
+            left: 0;
+            right: 0;
+            height: 80px;
+            background-color: rgb(255, 59, 48);
+            z-index: 100;
+        }
+    </style>
+    <script src="../../resources/js-test.js"></script>
+    <script src="../../resources/ui-helper.js"></script>
+    <script>
+    jsTestIsAsync = true;
+
+    addEventListener("load", async () => {
+        await UIHelper.setObscuredInsets(40, 0, 40, 0);
+        await UIHelper.ensurePresentationUpdate();
+
+        initialEdgeColors = await UIHelper.fixedContainerEdgeColors();
+        shouldBeEqualToString("initialEdgeColors.top", "rgb(0, 122, 255)");
+        shouldBeEqualToString("initialEdgeColors.bottom", "rgb(255, 59, 48)");
+
+        await UIHelper.setObscuredInsets(40, 0, 0, 0);
+        await UIHelper.ensurePresentationUpdate();
+        afterRemovingInset = await UIHelper.fixedContainerEdgeColors();
+        shouldBeEqualToString("afterRemovingInset.top", "rgb(0, 122, 255)");
+        shouldBeEqualToString("initialEdgeColors.bottom", "rgb(255, 59, 48)");
+
+        document.querySelector(".bottom").remove();
+        await UIHelper.ensurePresentationUpdate();
+        afterRemovingBottomContainer = await UIHelper.fixedContainerEdgeColors();
+        shouldBeEqualToString("afterRemovingBottomContainer.top", "rgb(0, 122, 255)");
+        shouldBeNull("afterRemovingBottomContainer.bottom");
+
+        finishJSTest();
+    });
+    </script>
+</head>
+<body>
+    <div class="top"></div>
+    <div class="bottom"></div>
+    <div class="content"></div>
+</body>
+</html>

--- a/Source/WebCore/platform/FixedContainerEdges.cpp
+++ b/Source/WebCore/platform/FixedContainerEdges.cpp
@@ -43,6 +43,20 @@ bool FixedContainerEdges::hasFixedEdge(BoxSide side) const
     }), colors.at(side));
 }
 
+BoxSideSet FixedContainerEdges::fixedEdges() const
+{
+    BoxSideSet edges;
+    if (hasFixedEdge(BoxSide::Top))
+        edges.add(BoxSideFlag::Top);
+    if (hasFixedEdge(BoxSide::Left))
+        edges.add(BoxSideFlag::Left);
+    if (hasFixedEdge(BoxSide::Bottom))
+        edges.add(BoxSideFlag::Bottom);
+    if (hasFixedEdge(BoxSide::Right))
+        edges.add(BoxSideFlag::Right);
+    return edges;
+}
+
 Color FixedContainerEdges::predominantColor(BoxSide side) const
 {
     return WTF::visit(WTF::makeVisitor([&](PredominantColorType) -> Color {

--- a/Source/WebCore/platform/FixedContainerEdges.h
+++ b/Source/WebCore/platform/FixedContainerEdges.h
@@ -58,6 +58,7 @@ public:
 
     WEBCORE_EXPORT bool hasFixedEdge(BoxSide) const;
     WEBCORE_EXPORT Color predominantColor(BoxSide) const;
+    WEBCORE_EXPORT BoxSideSet fixedEdges() const;
 
     bool operator==(const FixedContainerEdges&) const = default;
 };

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -3199,7 +3199,7 @@ static WebCore::CocoaColor *sampledFixedPositionContentColor(const WebCore::Fixe
         }
 
         RetainPtr predominantColor = cocoaColorOrNil(_fixedContainerEdges.predominantColor(side));
-        [extensionView fadeToColor:predominantColor.get() ?: self.underPageBackgroundColor];
+        [extensionView updateColor:predominantColor.get() ?: self.underPageBackgroundColor];
         return;
     };
 
@@ -3231,7 +3231,7 @@ static WebCore::CocoaColor *sampledFixedPositionContentColor(const WebCore::Fixe
         [view setFrame:[parentView convertRect:CGRectMake(insets.left(), bounds.height() - insets.bottom(), bounds.width() - insets.left() - insets.right(), insets.bottom()) fromView:self]];
 }
 
-- (void)_updateFixedColorExtensionEdges
+- (void)_updateHiddenContentInsetFillEdges
 {
 #if PLATFORM(IOS_FAMILY)
     [_scrollView _setHiddenContentInsetFillEdges:[&] {
@@ -3296,17 +3296,17 @@ static WebCore::CocoaColor *sampledFixedPositionContentColor(const WebCore::Fixe
 
 #pragma mark - WKColorExtensionViewDelegate
 
-- (void)colorExtensionViewWillFadeOut:(WKColorExtensionView *)view
+- (void)colorExtensionViewWillDisappear:(WKColorExtensionView *)view
 {
 #if PLATFORM(IOS_FAMILY)
-    [self _updateFixedColorExtensionEdges];
+    [self _updateHiddenContentInsetFillEdges];
 #endif
 }
 
-- (void)colorExtensionViewDidFadeIn:(WKColorExtensionView *)view
+- (void)colorExtensionViewDidAppear:(WKColorExtensionView *)view
 {
 #if PLATFORM(IOS_FAMILY)
-    [self _updateFixedColorExtensionEdges];
+    [self _updateHiddenContentInsetFillEdges];
 #endif
 }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -533,6 +533,7 @@ struct PerWebProcessState {
 #endif
 
 #if ENABLE(CONTENT_INSET_BACKGROUND_FILL)
+- (void)_updateFixedColorExtensionViews;
 - (void)_updateFixedColorExtensionViewFrames;
 - (BOOL)_hasVisibleColorExtensionView:(WebCore::BoxSide)side;
 - (void)_addReasonToHideTopContentInsetFill:(WebKit::HideContentInsetFillReason)reason;

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -4184,11 +4184,30 @@ static bool isLockdownModeWarningNeeded()
     if (UIEdgeInsetsEqualToEdgeInsets(_obscuredInsets, obscuredInsets))
         return;
 
+#if ENABLE(CONTENT_INSET_BACKGROUND_FILL)
+    auto sidesWithInsets = [](UIEdgeInsets insets) {
+        WebCore::BoxSideSet sides;
+        if (insets.top > 0)
+            sides.add(WebCore::BoxSideFlag::Top);
+        if (insets.left > 0)
+            sides.add(WebCore::BoxSideFlag::Left);
+        if (insets.bottom > 0)
+            sides.add(WebCore::BoxSideFlag::Bottom);
+        if (insets.right > 0)
+            sides.add(WebCore::BoxSideFlag::Right);
+        return sides;
+    };
+    BOOL updateFixedColorExtensionViews = sidesWithInsets(_obscuredInsets) != sidesWithInsets(obscuredInsets);
+#endif // ENABLE(CONTENT_INSET_BACKGROUND_FILL)
+
     _obscuredInsets = obscuredInsets;
 
     [self _scheduleVisibleContentRectUpdate];
 #if ENABLE(CONTENT_INSET_BACKGROUND_FILL)
-    [self _updateFixedColorExtensionViewFrames];
+    if (updateFixedColorExtensionViews)
+        [self _updateFixedColorExtensionViews];
+    else
+        [self _updateFixedColorExtensionViewFrames];
 #endif
     [_warningView setContentInset:[self _computedObscuredInsetForWarningView]];
 }

--- a/Source/WebKit/UIProcess/Cocoa/WKColorExtensionView.h
+++ b/Source/WebKit/UIProcess/Cocoa/WKColorExtensionView.h
@@ -35,14 +35,14 @@
 #endif
 
 @protocol WKColorExtensionViewDelegate <NSObject>
-- (void)colorExtensionViewWillFadeOut:(WKColorExtensionView *)view;
-- (void)colorExtensionViewDidFadeIn:(WKColorExtensionView *)view;
+- (void)colorExtensionViewWillDisappear:(WKColorExtensionView *)view;
+- (void)colorExtensionViewDidAppear:(WKColorExtensionView *)view;
 @end
 
 @interface WKColorExtensionView : CocoaView
 
 - (instancetype)initWithFrame:(CGRect)frame delegate:(id<WKColorExtensionViewDelegate>)delegate;
-- (void)fadeToColor:(WebCore::CocoaColor *)color;
+- (void)updateColor:(WebCore::CocoaColor *)color;
 - (void)fadeOut;
 - (void)cancelFadeAnimation;
 

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -56,6 +56,7 @@
 #import <WebCore/Editor.h>
 #import <WebCore/EventHandler.h>
 #import <WebCore/EventNames.h>
+#import <WebCore/FixedContainerEdges.h>
 #import <WebCore/FocusController.h>
 #import <WebCore/FrameLoader.h>
 #import <WebCore/FrameView.h>
@@ -1363,7 +1364,7 @@ BoxSideSet WebPage::sidesRequiringFixedContainerEdges() const
     auto obscuredInsets = m_page->obscuredContentInsets();
 #endif
 
-    BoxSideSet sides;
+    auto sides = m_page->fixedContainerEdges().fixedEdges();
 
     if (obscuredInsets.top() > 0)
         sides.add(BoxSideFlag::Top);


### PR DESCRIPTION
#### 19d2b6dde1295a71f57021992e7b8d0c8431d5ce
<pre>
[Single Tab mode] Safari UI flickers when scrolling with color-extension on the bottom edge
<a href="https://bugs.webkit.org/show_bug.cgi?id=294083">https://bugs.webkit.org/show_bug.cgi?id=294083</a>
<a href="https://rdar.apple.com/151639773">rdar://151639773</a>

Reviewed by Abrar Rahman Protyasha.

When fixed color extension views are shown, there&apos;s currently a slight flicker when scrolling down
in Safari in single tab mode, due to the fact that the color extension view fades in over the course
of 100 ms.

To fix this, we make several adjustments to stabilize the bottom sampled color even when the bottom
obscured inset is zero (i.e. no color extension view is actually required), such that we don&apos;t end
up with a visible flash when the bottom inset becomes nonzero again.

See below for more details.

* LayoutTests/fast/page-color-sampling/color-sampling-includes-sides-that-had-insets-expected.txt: Added.
* LayoutTests/fast/page-color-sampling/color-sampling-includes-sides-that-had-insets.html: Added.

Add a layout test to exercise this new behavior, by verifying that the bottom sampled color is
visible even if the bottom obscured inset becomes 0.

* Source/WebCore/platform/FixedContainerEdges.cpp:
(WebCore::FixedContainerEdges::fixedEdges const):
* Source/WebCore/platform/FixedContainerEdges.h:

Add a helper method to return all edges that contain fixed edges.

* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _updateFixedColorExtensionViews]):
(-[WKWebView _updateHiddenContentInsetFillEdges]):

Drive-by rename: `_updateFixedColorExtensionEdges` -&gt; `_updateHiddenContentInsetFillEdges`, to
better reflect the purpose of this method.

(-[WKWebView colorExtensionViewWillDisappear:]):
(-[WKWebView colorExtensionViewDidAppear:]):

Also adjust `WKColorExtensionView` so that it instantly changes background colors when updated with
a background color while hidden (instead of fading over the course of 100 ms). Note that we&apos;ll still
animate when transitioning between different background colors, or when the color fades out. This
ensures that the Safari UI doesn&apos;t change colors while it&apos;s animating in.

(-[WKWebView _updateFixedColorExtensionEdges]): Deleted.
(-[WKWebView colorExtensionViewWillFadeOut:]): Deleted.
(-[WKWebView colorExtensionViewDidFadeIn:]): Deleted.

Rename these delegate methods from `WillFadeOut`/`DidFadeIn` -&gt; `WillDisappear`/`DidAppear`, to
reflect the fact that they don&apos;t always fade between the target colors.

* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _setObscuredInsets:]):

Fix one flaky issue I discovered while debugging this, where — in single tab mode — the bottom fixed
color view sometimes fails to appear at all. This is because we currently only update the frames of
fixed color views when changing obscured insets (in an attempt to avoid doing more work per frame),
but the full call to `-_updateFixedColorExtensionViews` is necessary in the case where an obscured
inset either becomes zero (from nonzero) or vice versa.

* Source/WebKit/UIProcess/Cocoa/WKColorExtensionView.h:
* Source/WebKit/UIProcess/Cocoa/WKColorExtensionView.mm:
(-[WKColorExtensionView updateColor:]):
(-[WKColorExtensionView fadeOut]):
(-[WKColorExtensionView _updateColor:visible:]):
(-[WKColorExtensionView animationDidStop:finished:]):
(-[WKColorExtensionView fadeToColor:]): Deleted.
(-[WKColorExtensionView _fadeToColor:visible:]): Deleted.

Rename `fadeToColor` to `updateColor` to reflect the fact that it may no longer perform animated
transitions, and make it instantly set the color in the case where the view was hidden beforehand.

* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::sidesRequiringFixedContainerEdges const):

Even on rect sides that don&apos;t contain obscured insets, continue sampling those edges until there&apos;s
no longer any fixed container on that edge. This ensures that in the case where the obscured inset
reaches 0 temporarily but comes back later (after scrolling), the sampled color will remain up-to-
date and we don&apos;t end up with a flicker.

Canonical link: <a href="https://commits.webkit.org/295900@main">https://commits.webkit.org/295900@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c4759b9e12364954520786434e001c1c6aaaff47

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/106460 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/26209 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/16607 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/111662 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/57056 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/108499 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/26876 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34712 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80857 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/109464 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/21313 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/96067 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/61186 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/20782 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/14166 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/56497 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/90645 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/14201 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/114522 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33598 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24771 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89927 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33962 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/92296 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89631 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22878 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34525 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/12343 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/29207 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/33523 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/38935 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/33269 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/36622 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34867 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->