### PR TITLE
[Text-Wrap][Balance][Pretty] Ignore out-of-flow elements when computing line constraints.

### DIFF
--- a/LayoutTests/fast/css3-text/css3-text-wrap/text-wrap-balance-with-absolute-positioned-element-expected.html
+++ b/LayoutTests/fast/css3-text/css3-text-wrap/text-wrap-balance-with-absolute-positioned-element-expected.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+  <title>Text-Wrap Test</title>
+  <head>
+    <style>
+    body {
+    font-family: "Ahem";
+    font-size: 12px;
+    }
+    .absolute-block {
+        display: block;
+        position: absolute;
+    }
+    </style>
+  </head>
+  <body>
+      <span>This test passes if it has the correct<br> breaking points to balance the text.</span>
+      <div class = "absolute-block"></div>
+  </body>
+</html>

--- a/LayoutTests/fast/css3-text/css3-text-wrap/text-wrap-balance-with-absolute-positioned-element.html
+++ b/LayoutTests/fast/css3-text/css3-text-wrap/text-wrap-balance-with-absolute-positioned-element.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+  <title>Text-Wrap Test</title>
+  <head>
+    <style>
+    body {
+    font-family: "Ahem";
+    font-size: 12px;
+    text-wrap: balance;
+    width: 500px;
+    }
+    .absolute-block {
+        display: block;
+        position: absolute;
+    }
+    </style>
+  </head>
+  <body>
+      <span>This test passes if it has the correct breaking points to balance the text.</span>
+      <div class = "absolute-block"></div>
+  </body>
+</html>


### PR DESCRIPTION
#### b9dc5b0c1bb4f40ed59d4e87d1c2e02a24491f58
<pre>
[Text-Wrap][Balance][Pretty] Ignore out-of-flow elements when computing line constraints.
<a href="https://bugs.webkit.org/show_bug.cgi?id=294085">https://bugs.webkit.org/show_bug.cgi?id=294085</a>
&lt;<a href="https://rdar.apple.com/152549818">rdar://152549818</a>&gt;

Reviewed by Alan Baradlay.

This PR updates the InlineContentConstrainer to ignore opaque inline items when performing width computations.

Combined changes:
* LayoutTests/fast/css3-text/css3-text-wrap/text-wrap-balance-with-absolute-positioned-element-expected.html: Added.
* LayoutTests/fast/css3-text/css3-text-wrap/text-wrap-balance-with-absolute-positioned-element.html: Added.
* Source/WebCore/layout/formattingContexts/inline/InlineContentConstrainer.cpp:
(WebCore::Layout::InlineContentConstrainer::updateCachedWidths):
(WebCore::Layout::InlineContentConstrainer::checkCanConstrainInlineItems):
(WebCore::Layout::InlineContentConstrainer::inlineItemWidth const):

Canonical link: <a href="https://commits.webkit.org/295924@main">https://commits.webkit.org/295924@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a079c8d7341422751a0328108baa61f26ab24ed0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/106478 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/26227 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/16625 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/111680 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/57074 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/108517 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/26894 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34730 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80866 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/109482 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/21326 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/96081 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/61198 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/20790 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/14182 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/56515 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/90657 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/14217 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/114540 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33616 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24781 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89936 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33980 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/92312 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89643 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22892 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34541 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/12354 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/29225 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/33541 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/38953 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/33287 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/36640 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34885 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->