### PR TITLE
dNR: allow and allowAllRequests rules aren't respecting priority

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIDeclarativeNetRequest.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIDeclarativeNetRequest.mm
@@ -1423,7 +1423,7 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, SubFrameResourceRuleConversion)
 
     NSDictionary *correctRuleConversion = @{
         @"action": @{
-            @"type": @"ignore-previous-rules",
+            @"type": @"ignore-following-rules",
         },
         @"trigger": @{
             @"url-filter": @"crouton\\.net",
@@ -1453,7 +1453,7 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, RepeatedMainFrameResourceRuleConver
 
     NSDictionary *correctRuleConversion = @{
         @"action": @{
-            @"type": @"ignore-previous-rules",
+            @"type": @"ignore-following-rules",
         },
         @"trigger": @{
             @"url-filter": @"crouton\\.net",
@@ -1604,16 +1604,6 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, UpgradeSchemeRuleConversion)
     NSArray<NSDictionary *> *convertedRules = validatedRule.ruleInWebKitFormat;
     EXPECT_EQ(convertedRules.count, 2ul);
 
-    NSDictionary *sortingRule = @{
-        @"action": @{
-            @"type": @"ignore-previous-rules",
-        },
-        @"trigger": @{
-            @"url-filter": @"crouton\\.net",
-            @"resource-type": @[ @"image" ],
-        },
-    };
-
     NSDictionary *makeHTTPSRule = @{
         @"action": @{
             @"type": @"make-https",
@@ -1624,8 +1614,19 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, UpgradeSchemeRuleConversion)
         },
     };
 
-    EXPECT_NS_EQUAL(convertedRules[0], sortingRule);
-    EXPECT_NS_EQUAL(convertedRules[1], makeHTTPSRule);
+
+    NSDictionary *sortingRule = @{
+        @"action": @{
+            @"type": @"ignore-following-rules",
+        },
+        @"trigger": @{
+            @"url-filter": @"crouton\\.net",
+            @"resource-type": @[ @"image" ],
+        },
+    };
+
+    EXPECT_NS_EQUAL(convertedRules[0], makeHTTPSRule);
+    EXPECT_NS_EQUAL(convertedRules[1], sortingRule);
 }
 
 TEST(WKWebExtensionAPIDeclarativeNetRequest, UpgradeSchemeForMainFrameRuleConversion)
@@ -1644,17 +1645,6 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, UpgradeSchemeForMainFrameRuleConver
     NSArray<NSDictionary *> *convertedRules = validatedRule.ruleInWebKitFormat;
     EXPECT_EQ(convertedRules.count, 2ul);
 
-    NSDictionary *sortingRule = @{
-        @"action": @{
-            @"type": @"ignore-previous-rules",
-        },
-        @"trigger": @{
-            @"url-filter": @"crouton\\.net",
-            @"resource-type": @[ @"top-document" ],
-        },
-    };
-    EXPECT_NS_EQUAL(convertedRules[0], sortingRule);
-
     NSDictionary *makeHTTPSRule = @{
         @"action": @{
             @"type": @"make-https",
@@ -1664,7 +1654,18 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, UpgradeSchemeForMainFrameRuleConver
             @"resource-type": @[ @"top-document" ],
         },
     };
-    EXPECT_NS_EQUAL(convertedRules[1], makeHTTPSRule);
+    EXPECT_NS_EQUAL(convertedRules[0], makeHTTPSRule);
+
+    NSDictionary *sortingRule = @{
+        @"action": @{
+            @"type": @"ignore-following-rules",
+        },
+        @"trigger": @{
+            @"url-filter": @"crouton\\.net",
+            @"resource-type": @[ @"top-document" ],
+        },
+    };
+    EXPECT_NS_EQUAL(convertedRules[1], sortingRule);
 }
 
 TEST(WKWebExtensionAPIDeclarativeNetRequest, RuleWithoutAPriority)
@@ -1745,7 +1746,7 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, RuleConversionWithNoSpecifiedResour
 
     NSMutableDictionary *correctRuleConversion = [@{
         @"action": @{
-            @"type": @"ignore-previous-rules",
+            @"type": @"ignore-following-rules",
         },
         @"trigger": [@{
             @"url-filter": @".*",
@@ -2141,20 +2142,20 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, RuleConversionWithExcludedInitiator
     NSArray *correctRuleConversion = @[
         @{
             @"action": @{
-                @"type": @"block",
+                @"type": @"ignore-following-rules",
             },
             @"trigger": @{
-                @"if-frame-url": @[ @"^[^:]+://+([^:/]+\\.)?example\\.com/.*" ],
+                @"if-frame-url": @[ @"^[^:]+://+([^:/]+\\.)?blog\\.example\\.com/.*" ],
                 @"resource-type": @[ @"font" ],
                 @"url-filter": @".*",
             }
         },
         @{
             @"action": @{
-                @"type": @"ignore-previous-rules",
+                @"type": @"block",
             },
             @"trigger": @{
-                @"if-frame-url": @[ @"^[^:]+://+([^:/]+\\.)?blog\\.example\\.com/.*" ],
+                @"if-frame-url": @[ @"^[^:]+://+([^:/]+\\.)?example\\.com/.*" ],
                 @"resource-type": @[ @"font" ],
                 @"url-filter": @".*",
             }
@@ -2253,6 +2254,17 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, RuleConversionWithExcludedRequestDo
     NSArray<NSDictionary *> *convertedRules = validatedRule.ruleInWebKitFormat;
     EXPECT_EQ(convertedRules.count, 2ul);
 
+    NSDictionary *passRuleConversion = @{
+        @"action": @{
+            @"type": @"ignore-following-rules",
+        },
+        @"trigger": @{
+            @"resource-type": @[ @"media" ],
+            @"url-filter": @"apple\\.com",
+        },
+    };
+    EXPECT_NS_EQUAL(convertedRules[0], passRuleConversion);
+
     NSDictionary *blockRuleConversion = @{
         @"action": @{
             @"type": @"block",
@@ -2262,18 +2274,7 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, RuleConversionWithExcludedRequestDo
             @"url-filter": @".*",
         },
     };
-    EXPECT_NS_EQUAL(convertedRules[0], blockRuleConversion);
-
-    NSDictionary *passRuleConversion = @{
-        @"action": @{
-            @"type": @"ignore-previous-rules",
-        },
-        @"trigger": @{
-            @"resource-type": @[ @"media" ],
-            @"url-filter": @"apple\\.com",
-        },
-    };
-    EXPECT_NS_EQUAL(convertedRules[1], passRuleConversion);
+    EXPECT_NS_EQUAL(convertedRules[1], blockRuleConversion);
 }
 
 TEST(WKWebExtensionAPIDeclarativeNetRequest, RuleConversionWithInvalidRequestMethods)
@@ -2365,16 +2366,7 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, RuleConversionWithExcludedRequestMe
     NSArray *correctRuleConversion = @[
         @{
             @"action": @{
-                @"type": @"block",
-            },
-            @"trigger": @{
-                @"url-filter": @".*",
-                @"resource-type": @[ @"top-document" ],
-            },
-        },
-        @{
-            @"action": @{
-                @"type": @"ignore-previous-rules",
+                @"type": @"ignore-following-rules",
             },
             @"trigger": @{
                 @"url-filter": @".*",
@@ -2384,12 +2376,21 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, RuleConversionWithExcludedRequestMe
         },
         @{
             @"action": @{
-                @"type": @"ignore-previous-rules",
+                @"type": @"ignore-following-rules",
             },
             @"trigger": @{
                 @"url-filter": @".*",
                 @"resource-type": @[ @"top-document" ],
                 @"request-method": @"post",
+            },
+        },
+        @{
+            @"action": @{
+                @"type": @"block",
+            },
+            @"trigger": @{
+                @"url-filter": @".*",
+                @"resource-type": @[ @"top-document" ],
             },
         }
     ];
@@ -2418,17 +2419,7 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, RuleConversionWithRequestMethodsAnd
     NSArray *correctRuleConversion = @[
         @{
             @"action": @{
-                @"type": @"block",
-            },
-            @"trigger": @{
-                @"url-filter": @"^[^:]+://+([^:/]+\\.)?apple\\.com",
-                @"resource-type": @[ @"top-document" ],
-                @"request-method": @"get",
-            },
-        },
-        @{
-            @"action": @{
-                @"type": @"ignore-previous-rules",
+                @"type": @"ignore-following-rules",
             },
             @"trigger": @{
                 @"url-filter": @"google\\.com",
@@ -2436,6 +2427,16 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, RuleConversionWithRequestMethodsAnd
                 @"request-method": @"post",
             },
         },
+        @{
+            @"action": @{
+                @"type": @"block",
+            },
+            @"trigger": @{
+                @"url-filter": @"^[^:]+://+([^:/]+\\.)?apple\\.com",
+                @"resource-type": @[ @"top-document" ],
+                @"request-method": @"get",
+            },
+        }
     ];
 
     EXPECT_NS_EQUAL(convertedRules, correctRuleConversion);
@@ -2578,7 +2579,7 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, RuleConversionWithAllowAllRequests)
 
         NSMutableDictionary *correctRuleConversion = [@{
             @"action": @{
-                @"type": @"ignore-previous-rules",
+                @"type": @"ignore-following-rules",
             },
             @"trigger": [@{
                 @"url-filter": @".*",
@@ -2832,7 +2833,7 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, RulesSortByPriorityFromDifferentRul
     NSArray *sortedTranslatedRules = [_WKWebExtensionDeclarativeNetRequestTranslator translateRules:rules errorStrings:nil];
     EXPECT_NOT_NULL(sortedTranslatedRules);
 
-    EXPECT_NS_EQUAL(sortedTranslatedRules[0][@"action"][@"type"], @"ignore-previous-rules");
+    EXPECT_NS_EQUAL(sortedTranslatedRules[0][@"action"][@"type"], @"ignore-following-rules");
     EXPECT_NS_EQUAL(sortedTranslatedRules[1][@"action"][@"type"], @"block");
 }
 
@@ -2864,8 +2865,8 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, RulesSortWithoutExplicitPriority)
     EXPECT_NOT_NULL(sortedTranslatedRules);
 
     EXPECT_NS_EQUAL(sortedTranslatedRules[0][@"action"][@"type"], @"block");
-    EXPECT_NS_EQUAL(sortedTranslatedRules[1][@"action"][@"type"], @"ignore-previous-rules");
-    EXPECT_NS_EQUAL(sortedTranslatedRules[2][@"action"][@"type"], @"make-https");
+    EXPECT_NS_EQUAL(sortedTranslatedRules[1][@"action"][@"type"], @"make-https");
+    EXPECT_NS_EQUAL(sortedTranslatedRules[2][@"action"][@"type"], @"ignore-following-rules");
 }
 
 TEST(WKWebExtensionAPIDeclarativeNetRequest, RulesSortByActionType)
@@ -2923,12 +2924,12 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, RulesSortByActionType)
     NSArray *sortedTranslatedRules = [_WKWebExtensionDeclarativeNetRequestTranslator translateRules:rules errorStrings:nil];
     EXPECT_NOT_NULL(sortedTranslatedRules);
 
-    EXPECT_NS_EQUAL(sortedTranslatedRules[0][@"action"][@"type"], @"modify-headers");
-    EXPECT_NS_EQUAL(sortedTranslatedRules[1][@"action"][@"type"], @"ignore-previous-rules");
-    EXPECT_NS_EQUAL(sortedTranslatedRules[2][@"action"][@"type"], @"make-https");
-    EXPECT_NS_EQUAL(sortedTranslatedRules[3][@"action"][@"type"], @"block");
-    EXPECT_NS_EQUAL(sortedTranslatedRules[4][@"action"][@"type"], @"ignore-previous-rules");
-    EXPECT_NS_EQUAL(sortedTranslatedRules[5][@"action"][@"type"], @"ignore-previous-rules");
+    EXPECT_NS_EQUAL(sortedTranslatedRules[0][@"action"][@"type"], @"ignore-following-rules");
+    EXPECT_NS_EQUAL(sortedTranslatedRules[1][@"action"][@"type"], @"ignore-following-rules");
+    EXPECT_NS_EQUAL(sortedTranslatedRules[2][@"action"][@"type"], @"block");
+    EXPECT_NS_EQUAL(sortedTranslatedRules[3][@"action"][@"type"], @"make-https");
+    EXPECT_NS_EQUAL(sortedTranslatedRules[4][@"action"][@"type"], @"ignore-following-rules");
+    EXPECT_NS_EQUAL(sortedTranslatedRules[5][@"action"][@"type"], @"modify-headers");
 }
 
 TEST(WKWebExtensionAPIDeclarativeNetRequest, RemoveAllContentRuleListsDoesNotRemoveWebExtensionRuleLists)


### PR DESCRIPTION
#### 64d63ae859b8dcdaf7a0e9be6e939527258caff4
<pre>
dNR: allow and allowAllRequests rules aren&apos;t respecting priority
<a href="https://bugs.webkit.org/show_bug.cgi?id=293809">https://bugs.webkit.org/show_bug.cgi?id=293809</a>
<a href="https://rdar.apple.com/152193087">rdar://152193087</a>

Reviewed by Timothy Hatcher.

This patch adopts the use of ignore-following-rules for correcting the sorting
of dNR rules. As it stands, higher priority allow and allowAllRequests rules
do not take precedence over lower priority block rules because the dNR rules
are converted into ignore-previous-rules in WebKit Content Blocking.

Now, dNR rules are sorted first by priority and then by rule type, so we have
rules correctly sorted like:

Priority | Type
---------------------------------
     100 | ignore-following-rules
     100 | block
     100 | modify-headers
     100 | redirect
     100 | make-https
---------------------------------
      10 | ignore-following-rules
      10 | block
      10 | modify-headers
      10 | redirect
      10 | make-https

Everywhere ignore-previous-rules was used was inverted, so for example, excluded
request methods/domains are added before requst methods/domains, make-https,
excluded initiator domains, etc. Also, the compare: method was update to invert
the order of the inherent rule type priorities.

* Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionDeclarativeNetRequestRule.mm:
(-[_WKWebExtensionDeclarativeNetRequestRule ruleInWebKitFormat]):
(-[_WKWebExtensionDeclarativeNetRequestRule _convertRulesWithModifiedCondition:webKitActionType:chromeActionType:]):
(-[_WKWebExtensionDeclarativeNetRequestRule compare:]):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIDeclarativeNetRequest.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPIDeclarativeNetRequest, SubFrameResourceRuleConversion)):
(TestWebKitAPI::TEST(WKWebExtensionAPIDeclarativeNetRequest, RepeatedMainFrameResourceRuleConversion)):
(TestWebKitAPI::TEST(WKWebExtensionAPIDeclarativeNetRequest, UpgradeSchemeRuleConversion)):
(TestWebKitAPI::TEST(WKWebExtensionAPIDeclarativeNetRequest, UpgradeSchemeForMainFrameRuleConversion)):
(TestWebKitAPI::TEST(WKWebExtensionAPIDeclarativeNetRequest, RuleConversionWithNoSpecifiedResourceTypes)):
(TestWebKitAPI::TEST(WKWebExtensionAPIDeclarativeNetRequest, RuleConversionWithExcludedInitiatorDomainsAndInitiatorDomains)):
(TestWebKitAPI::TEST(WKWebExtensionAPIDeclarativeNetRequest, RuleConversionWithExcludedRequestDomains)):
(TestWebKitAPI::TEST(WKWebExtensionAPIDeclarativeNetRequest, RuleConversionWithExcludedRequestMethods)):
(TestWebKitAPI::TEST(WKWebExtensionAPIDeclarativeNetRequest, RuleConversionWithRequestMethodsAndExcludedRequestMethodsAndRequestDomainsAndExcludedRequestDomains)):
(TestWebKitAPI::TEST(WKWebExtensionAPIDeclarativeNetRequest, RuleConversionWithAllowAllRequests)):
(TestWebKitAPI::TEST(WKWebExtensionAPIDeclarativeNetRequest, RulesSortByPriorityFromDifferentRulesets)):
(TestWebKitAPI::TEST(WKWebExtensionAPIDeclarativeNetRequest, RulesSortWithoutExplicitPriority)):
(TestWebKitAPI::TEST(WKWebExtensionAPIDeclarativeNetRequest, RulesSortByActionType)):

Canonical link: <a href="https://commits.webkit.org/295927@main">https://commits.webkit.org/295927@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/01f61ddc6e8fc3af51771297e3c52d18fadebc84

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/106456 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/26205 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/16603 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/111658 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/57052 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/108495 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/26872 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34708 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80852 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/109460 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/21311 "Found 1 new test failure: http/tests/site-isolation/history/add-iframes-and-navigate-mainframe.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/96066 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/61181 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/20779 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/14164 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/56493 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/90642 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/14199 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/114518 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33594 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24769 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89926 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33958 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/92294 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89630 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34528 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/12342 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/29203 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17270 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/33519 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/38931 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/33265 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/36618 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34863 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->