### PR TITLE
[JSC] Extend JSOnlyStringsJoiner with Int32

### DIFF
--- a/JSTests/stress/array-join-string-and-int32.js
+++ b/JSTests/stress/array-join-string-and-int32.js
@@ -1,0 +1,14 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+var array = [42, "Hello", 32, "World", -333];
+shouldBe(array.join(""), `42Hello32World-333`);
+shouldBe(array.join(","), `42,Hello,32,World,-333`);
+array.pop();
+array.pop();
+array.pop();
+array.pop();
+shouldBe(array.join(""), `42`);
+shouldBe(array.join(","), `42`);

--- a/Source/JavaScriptCore/runtime/ArrayPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/ArrayPrototype.cpp
@@ -287,7 +287,7 @@ inline JSValue fastJoin(JSGlobalObject* globalObject, JSObject* thisObject, Stri
         auto data = butterfly.contiguous().data();
         bool holesKnownToBeOK = false;
 
-        JSOnlyStringsJoiner onlyStringsJoiner(separator);
+        JSOnlyStringsAndInt32sJoiner onlyStringsJoiner(separator);
         if (auto joined = onlyStringsJoiner.tryJoin(globalObject, data, length))
             RELEASE_AND_RETURN(scope, joined);
         RETURN_IF_EXCEPTION(scope, { });


### PR DESCRIPTION
#### 76f8911c68827db5f2887a90118aed4e320d75b1
<pre>
[JSC] Extend JSOnlyStringsJoiner with Int32
<a href="https://bugs.webkit.org/show_bug.cgi?id=294089">https://bugs.webkit.org/show_bug.cgi?id=294089</a>
<a href="https://rdar.apple.com/152675771">rdar://152675771</a>

Reviewed by Yijia Huang.

It turned out that this is common that Array includes Strings and Int32s,
and `join` will generate a concatenated string. This patch extends
JSOnlyStringsJoiner to support Int32s. Renaming JSOnlyStringsJoiner to
JSOnlyStringsAndInt32sJoiner, and handling Int32 too.

* JSTests/stress/array-join-string-and-int32.js: Added.
(shouldBe):
* Source/JavaScriptCore/runtime/ArrayPrototype.cpp:
(JSC::fastJoin):
* Source/JavaScriptCore/runtime/JSStringJoiner.cpp:
(JSC::appendStringToData):
(JSC::joinStrings):
(JSC::JSOnlyStringsAndInt32sJoiner::joinImpl):
(JSC::JSOnlyStringsJoiner::joinImpl): Deleted.
* Source/JavaScriptCore/runtime/JSStringJoiner.h:
(JSC::JSOnlyStringsAndInt32sJoiner::JSOnlyStringsAndInt32sJoiner):
(JSC::JSOnlyStringsAndInt32sJoiner::tryJoin):
(JSC::JSOnlyStringsJoiner::JSOnlyStringsJoiner): Deleted.
(JSC::JSOnlyStringsJoiner::tryJoin): Deleted.

Canonical link: <a href="https://commits.webkit.org/295918@main">https://commits.webkit.org/295918@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aa075b13c92b028b4930b6f9ba8c283a66b92d99

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/106517 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/26267 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/16665 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/111720 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/57113 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/26937 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34769 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80886 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/109521 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/21353 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/96110 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/61221 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/20813 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/14212 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/56554 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/99157 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/90691 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/14246 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/114579 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/105134 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33655 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24806 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89957 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/34019 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/92341 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89667 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34563 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/12380 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/29264 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17264 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/33580 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/38993 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/129446 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/33326 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/35248 "Found 1 new JSC stress test failure: wasm.yaml/wasm/gc/ref-i31-eq.js.wasm-eager (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/36679 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34925 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->