### PR TITLE
Apple Safari Scrollbar Animation Use-After-Free Remote Code Execution Vulnerability

### DIFF
--- a/LayoutTests/fast/scrolling/mac/scrollbars/scrollbar-crash-expected.txt
+++ b/LayoutTests/fast/scrolling/mac/scrollbars/scrollbar-crash-expected.txt
@@ -1,0 +1,2 @@
+This test passes if it doesn't crash
+

--- a/LayoutTests/fast/scrolling/mac/scrollbars/scrollbar-crash.html
+++ b/LayoutTests/fast/scrolling/mac/scrollbars/scrollbar-crash.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+
+<style>
+    *:root {margin-right: 100%;}
+    *:last-child {direction: rtl;}
+</style>
+
+<script>
+    function main() {
+        ele1.scrollIntoViewIfNeeded();
+        document.onpointerlockerror = func;
+        ele1.requestPointerLock();
+        ele2.submit();
+        if (window.testRunner)
+            testRunner.dumpAsText();
+    }
+
+    function func() {
+        document.styleSheets[0].media.appendMedium("Sample");
+    }
+
+</script>
+<body onload="main()">
+This test passes if it doesn't crash
+<time id="ele1" onfocusin="main()">
+</time>
+<form id="ele2">
+</form>
+</body>
+
+</html>

--- a/Source/WebCore/page/scrolling/mac/ScrollerMac.h
+++ b/Source/WebCore/page/scrolling/mac/ScrollerMac.h
@@ -40,7 +40,9 @@ namespace WebCore {
 class FloatPoint;
 class ScrollerPairMac;
 
-class ScrollerMac {
+class ScrollerMac final : public CanMakeCheckedPtr<ScrollerMac> {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(ScrollerMac);
     friend class ScrollerPairMac;
 public:
     ScrollerMac(ScrollerPairMac&, ScrollbarOrientation);

--- a/Source/WebCore/page/scrolling/mac/ScrollerMac.mm
+++ b/Source/WebCore/page/scrolling/mac/ScrollerMac.mm
@@ -47,7 +47,7 @@ enum class FeatureToAnimate {
 };
 
 @interface WebScrollbarPartAnimationMac : NSAnimation {
-    WebCore::ScrollerMac* _scroller;
+    CheckedPtr<WebCore::ScrollerMac> _scroller;
     FeatureToAnimate _featureToAnimate;
     CGFloat _startValue;
     CGFloat _endValue;
@@ -129,7 +129,7 @@ enum class FeatureToAnimate {
 @end
 
 @interface WebScrollerImpDelegateMac : NSObject<NSAnimationDelegate, NSScrollerImpDelegate> {
-    WebCore::ScrollerMac* _scroller;
+    CheckedPtr<WebCore::ScrollerMac> _scroller;
 
     RetainPtr<WebScrollbarPartAnimationMac> _knobAlphaAnimation;
     RetainPtr<WebScrollbarPartAnimationMac> _trackAlphaAnimation;
@@ -223,7 +223,7 @@ enum class FeatureToAnimate {
     RetainPtr scrollerImp = _scroller->scrollerImp();
     CGFloat currentAlpha = featureToAnimate == FeatureToAnimate::KnobAlpha ? [scrollerImp.get() knobAlpha] : [scrollerImp.get() trackAlpha];
 
-    scrollbarPartAnimation = adoptNS([[WebScrollbarPartAnimationMac alloc] initWithScroller:_scroller
+    scrollbarPartAnimation = adoptNS([[WebScrollbarPartAnimationMac alloc] initWithScroller:_scroller.get()
         featureToAnimate:featureToAnimate
         animateFrom:currentAlpha
         animateTo:newAlpha
@@ -261,7 +261,7 @@ enum class FeatureToAnimate {
     [scrollerImp setUiStateTransitionProgress:1 - [scrollerImp uiStateTransitionProgress]];
 
     if (!_uiStateTransitionAnimation) {
-        _uiStateTransitionAnimation = adoptNS([[WebScrollbarPartAnimationMac alloc] initWithScroller:_scroller
+        _uiStateTransitionAnimation = adoptNS([[WebScrollbarPartAnimationMac alloc] initWithScroller:_scroller.get()
             featureToAnimate:FeatureToAnimate::UIStateTransition
             animateFrom:[scrollerImp uiStateTransitionProgress]
             animateTo:1.0
@@ -286,7 +286,7 @@ enum class FeatureToAnimate {
     [scrollerImp setExpansionTransitionProgress:1 - [scrollerImp expansionTransitionProgress]];
 
     if (!_expansionTransitionAnimation) {
-        _expansionTransitionAnimation = adoptNS([[WebScrollbarPartAnimationMac alloc] initWithScroller:_scroller
+        _expansionTransitionAnimation = adoptNS([[WebScrollbarPartAnimationMac alloc] initWithScroller:_scroller.get()
             featureToAnimate:FeatureToAnimate::ExpansionTransition
             animateFrom:[scrollerImp expansionTransitionProgress]
             animateTo:1.0
@@ -334,6 +334,7 @@ ScrollerMac::~ScrollerMac()
 void ScrollerMac::attach()
 {
     RefPtr pair = m_pair.get();
+    [m_scrollerImpDelegate invalidate];
     m_scrollerImpDelegate = adoptNS([[WebScrollerImpDelegateMac alloc] initWithScroller:this]);
     setScrollerImp([NSScrollerImp scrollerImpWithStyle:nsScrollerStyle(pair->scrollbarStyle()) controlSize:nsControlSizeFromScrollbarWidth(pair->scrollbarWidthStyle()) horizontal:m_orientation == ScrollbarOrientation::Horizontal replacingScrollerImp:nil]);
     [m_scrollerImp setDelegate:m_scrollerImpDelegate.get()];


### PR DESCRIPTION
#### a23df0dfbec0c9df6dfee9ac5646d7f3665d85b4
<pre>
Apple Safari Scrollbar Animation Use-After-Free Remote Code Execution Vulnerability
<a href="https://bugs.webkit.org/show_bug.cgi?id=289653">https://bugs.webkit.org/show_bug.cgi?id=289653</a>
<a href="https://rdar.apple.com/146505163">rdar://146505163</a>

Reviewed by Simon Fraser and Chris Dumez.

Animations started by a WebScrollerImpDelegateMac have a chance of using a stale ScrollerMac
value if that delegate is replaced without invalidating the delegate&apos;s animations. Fix this by
calling invalidate on the WebScrollerImpDelegateMac before replacing it. Ensure this type of issue
doesn&apos;t occur by refactoring WebScrollerImpDelegateMac and WebScrollbarPartAnimationMac to use
smart pointers.

* Source/WebCore/page/scrolling/mac/ScrollerMac.h:
* Source/WebCore/page/scrolling/mac/ScrollerMac.mm:
(-[WebScrollerImpDelegateMac setUpAlphaAnimation:featureToAnimate:animateAlphaTo:duration:]):
(-[WebScrollerImpDelegateMac scrollerImp:animateUIStateTransitionWithDuration:]):
(-[WebScrollerImpDelegateMac scrollerImp:animateExpansionTransitionWithDuration:]):
(WebCore::ScrollerMac::ref):
(WebCore::ScrollerMac::deref):
(WebCore::ScrollerMac::attach):

Originally-landed-as: 289651.311@safari-7621-branch (656bcbf0bc42). <a href="https://rdar.apple.com/151714223">rdar://151714223</a>
Canonical link: <a href="https://commits.webkit.org/295925@main">https://commits.webkit.org/295925@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5667e25ab28af5d9d5e21ceac7aac9986ec66ef9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/106466 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/26215 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/16613 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/111668 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/57062 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/108505 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/26882 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34718 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80860 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/109470 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/21323 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/96073 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/61189 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/20788 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/14172 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/56503 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/90654 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/14207 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/114528 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33604 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24777 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89931 "Found 1 new test failure: fast/repaint/no-animation-outside-viewport-subframe.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33968 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/92302 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89637 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34527 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/12348 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/29213 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17267 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/33529 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/38941 "Found 31 new failures in page/scrolling/mac/ScrollerPairMac.mm, page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.mm, page/scrolling/mac/ScrollerMac.mm") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/33275 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/36628 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34873 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->