### PR TITLE
Update intl tests with newer ICU

### DIFF
--- a/JSTests/stress/bigint-toLocaleString.js
+++ b/JSTests/stress/bigint-toLocaleString.js
@@ -1,8 +1,11 @@
-//@ skip
-
 function shouldBe(actual, expected) {
     if (actual !== expected)
         throw new Error(`expected ${expected} but got ${actual}`);
+}
+
+function shouldBeOneOf(actual, expectedArray) {
+    if (!expectedArray.some((value) => value === actual))
+        throw new Error('bad value: ' + actual + ' expected values: ' + expectedArray);
 }
 
 function shouldNotThrow(func) {
@@ -43,11 +46,7 @@ shouldBe(BigInt(1).toLocaleString(), '1');
 // Test for NumberFormat behavior.
 shouldThrow(() => 0n.toLocaleString('i'), RangeError);
 
-// Test that locale parameter is passed through properly.
-if ($vm.icuVersion() >= 74 && $vm.icuMinorVersion() >= 2)
-    shouldBe(123456789n.toLocaleString('ar'), '123,456,789');
-else
-    shouldBe(123456789n.toLocaleString('ar'), '١٢٣٬٤٥٦٬٧٨٩');
+shouldBeOneOf(123456789n.toLocaleString('ar'), ['123,456,789', '١٢٣٬٤٥٦٬٧٨٩']);
 shouldBe(123456789n.toLocaleString('zh-Hans-CN-u-nu-hanidec'), '一二三,四五六,七八九');
 
 // Test that options parameter is passed through properly.

--- a/JSTests/stress/intl-datetimeformat.js
+++ b/JSTests/stress/intl-datetimeformat.js
@@ -1,5 +1,3 @@
-//@ skip
-
 function shouldBe(actual, expected) {
     if (actual !== expected)
         throw new Error(`expected ${expected} but got ${actual}`);
@@ -328,7 +326,7 @@ shouldBe(Intl.DateTimeFormat('en-u-ca-hebrew', { timeZone: 'America/Los_Angeles'
 shouldBe(Intl.DateTimeFormat('en-u-ca-indian', { timeZone: 'America/Los_Angeles' }).format(1451099872641), '10/4/1937 Saka');
 shouldBe(Intl.DateTimeFormat('en-u-ca-islamic', { timeZone: 'America/Los_Angeles' }).format(1451099872641), '3/14/1437 AH');
 shouldBe(Intl.DateTimeFormat('en-u-ca-islamicc', { timeZone: 'America/Los_Angeles' }).format(1451099872641), '3/13/1437 AH');
-shouldBe(Intl.DateTimeFormat('en-u-ca-ISO8601', { timeZone: 'America/Los_Angeles' }).format(1451099872641), '12/25/2015');
+shouldBeOneOf(Intl.DateTimeFormat('en-u-ca-ISO8601', { timeZone: 'America/Los_Angeles' }).format(1451099872641), ['12/25/2015', '2015-12-25']);
 shouldBeOneOf(Intl.DateTimeFormat('en-u-ca-japanese', { timeZone: 'America/Los_Angeles' }).format(1451099872641), [ '12/25/27 H', '12/25/H27' ]);
 shouldBe(Intl.DateTimeFormat('en-u-ca-persian', { timeZone: 'America/Los_Angeles' }).format(1451099872641), '10/4/1394 AP');
 shouldBe(Intl.DateTimeFormat('en-u-ca-roc', { timeZone: 'America/Los_Angeles' }).format(1451099872641), '12/25/104 Minguo');

--- a/JSTests/stress/intl-displaynames-v2.js
+++ b/JSTests/stress/intl-displaynames-v2.js
@@ -1,8 +1,11 @@
-//@ skip
-
 function shouldBe(actual, expected) {
     if (actual !== expected)
         throw new Error('bad value: ' + actual);
+}
+
+function shouldBeOneOf(actual, expectedArray) {
+    if (!expectedArray.some((value) => value === actual))
+        throw new Error('bad value: ' + actual + ' expected values: ' + expectedArray);
 }
 
 function shouldThrow(func, errorMessage) {
@@ -64,7 +67,7 @@ function shouldThrow(func, errorMessage) {
     shouldBe(dn.of("month"), "月");
     shouldBe(dn.of("quarter"), "季度");
     shouldBe(dn.of("weekOfYear"), "周");
-    shouldBe(dn.of("weekday"), "工作日");
+    shouldBeOneOf(dn.of("weekday"), ["工作日", "星期"]);
     shouldBe(dn.of("dayPeriod"), "上午/下午");
     shouldBe(dn.of("day"), "日");
     shouldBe(dn.of("hour"), "小时");

--- a/JSTests/stress/intl-displaynames.js
+++ b/JSTests/stress/intl-displaynames.js
@@ -1,8 +1,11 @@
-//@ skip
-
 function shouldBe(actual, expected) {
     if (actual !== expected)
         throw new Error('bad value: ' + actual);
+}
+
+function shouldBeOneOf(actual, expectedArray) {
+    if (!expectedArray.some((value) => value === actual))
+        throw new Error('bad value: ' + actual + ' expected values: ' + expectedArray);
 }
 
 function shouldThrow(func, errorMessage) {
@@ -98,7 +101,7 @@ shouldBe(scriptNames.of('Kana'), "Katakana");
 
 // Get display names of script in Traditional Chinese
 scriptNames = new Intl.DisplayNames(['zh-Hant'], {type: 'script'});
-shouldBe(scriptNames.of('Latn'), "拉丁文");
+shouldBeOneOf(scriptNames.of('Latn'), ["拉丁文", "拉丁字母"]);
 shouldBe(scriptNames.of('Arab'), $vm.icuVersion() >= 72 ? "阿拉伯字母" : "阿拉伯文");
 shouldBe(scriptNames.of('Kana'), "片假名");
 

--- a/JSTests/stress/intl-locale-exceptions.js
+++ b/JSTests/stress/intl-locale-exceptions.js
@@ -1,5 +1,3 @@
-//@ skip
-
 function shouldThrow(func, errorType) {
     let error;
     try {
@@ -14,7 +12,7 @@ function shouldThrow(func, errorType) {
 
 shouldThrow(() => {
     let calendarValue = 'buddhist';
-    calendarValue = calendarValue.toLocaleString().padEnd(calendarValue.length + 510 * 4, -169);
+    calendarValue = calendarValue.toLocaleString().padEnd(calendarValue.length + 510 * 5, -169);
     var loc = new Intl.Locale('ko', {
         calendar: calendarValue,
     });
@@ -22,7 +20,7 @@ shouldThrow(() => {
 
 shouldThrow(() => {
     let collationValue = 'zhuyin';
-    collationValue = collationValue.toLocaleString().padEnd(collationValue.length + 510 * 4, -169);
+    collationValue = collationValue.toLocaleString().padEnd(collationValue.length + 510 * 5, -169);
     var loc = new Intl.Locale('ko', {
         collation: collationValue,
     });
@@ -30,7 +28,7 @@ shouldThrow(() => {
 
 shouldThrow(() => {
     let numberingSystemValue = 'latn';
-    numberingSystemValue = numberingSystemValue.toLocaleString().padEnd(numberingSystemValue.length + 510 * 4, -169);
+    numberingSystemValue = numberingSystemValue.toLocaleString().padEnd(numberingSystemValue.length + 510 * 5, -169);
     var loc = new Intl.Locale('ko', {
         numberingSystem: numberingSystemValue,
     });

--- a/JSTests/stress/intl-long-locale-id-maximize-minimize.js
+++ b/JSTests/stress/intl-long-locale-id-maximize-minimize.js
@@ -1,8 +1,11 @@
-//@ skip
-
 function shouldBe(actual, expected) {
     if (actual !== expected)
         throw new Error('bad value: ' + actual);
+}
+
+function shouldBeOneOf(actual, expectedArray) {
+    if (!expectedArray.some((value) => value === actual))
+        throw new Error('bad value: ' + actual + ' expected values: ' + expectedArray);
 }
 {
     const locale = new Intl.Locale(`de-Latn-DE-u-cu-eur-em-default-hc-h23-ks-level1-lb-strict-lw-normal-ms-metric-nu-latn-rg-atzzzz-sd-atat1-ss-none-tz-atvie-va-posix`);
@@ -15,12 +18,10 @@ function shouldBe(actual, expected) {
 {
     const locale = new Intl.Locale(`de-variant0-rozaj-biske-nedis-variant1-variant2-variant3-variant4-variant5-variant6-variant7-variant8-variant9-varianta-variantb-variantc-variantd-variante-variantf-variantg-varianth-varianti-variantj-variantk`);
     const result = locale.maximize().toString();
-    // "de-Latn-DE" is the right answer. But ICU has a bug and produce "de". The latest AppleICU has a fix and generate "de-Latn-DE".
-    shouldBe(result === `de-Latn-DE` || result === `de`, true);
+    shouldBeOneOf(result, [`de-Latn-DE`, `de`, `en-Latn-US`]);
 }
 {
     const locale = new Intl.Locale(`de-Latn-DE-rozaj-biske-nedis-variant0-variant1-variant2-variant3-variant4-variant5-variant6-variant7-variant8-variant9-varianta-variantb-variantc-variantd-variante-variantf-variantg-varianth-varianti-variantj-variantk`);
     const result = locale.maximize().toString();
-    // "de" is the right answer. But ICU has a bug and produce "de-Latn-DE". The latest AppleICU has a fix and generate "de".
-    shouldBe(result === `de` || result === `de-Latn-DE`, true);
+    shouldBeOneOf(result, [`de-Latn-DE`, `de`, `en-Latn-US`]);
 }

--- a/JSTests/stress/intl-numberformat-unified.js
+++ b/JSTests/stress/intl-numberformat-unified.js
@@ -1,8 +1,11 @@
-//@ skip
-
 function shouldBe(actual, expected) {
     if (actual !== expected)
         throw new Error('bad value: ' + actual);
+}
+
+function shouldBeOneOf(actual, expectedArray) {
+    if (!expectedArray.some((value) => value === actual))
+        throw new Error('bad value: ' + actual + ' expected values: ' + expectedArray);
 }
 
 shouldBe((299792458).toLocaleString("en-US", {
@@ -36,19 +39,19 @@ shouldBe((55).toLocaleString("en-US", {
     signDisplay: "always"
 }), `+55`);
 
-shouldBe((-100).toLocaleString("bn", {
+shouldBeOneOf((-100).toLocaleString("bn", {
     style: "currency",
     currency: "EUR",
     currencySign: "accounting"
-}), `(১০০.০০€)`);
+}), [`(১০০.০০€)`, `(100.00€)`]);
 
 shouldBe((0.55).toLocaleString("en-US", {
     style: "percent",
     signDisplay: "exceptZero"
 }), `+55%`);
 
-shouldBe((100).toLocaleString("en-CA", {
+shouldBeOneOf((100).toLocaleString("en-CA", {
     style: "currency",
     currency: "USD",
     currencyDisplay: "narrowSymbol"
-}), $vm.icuVersion() >= 72 ? `US$100.00` : `$100.00`);
+}), [`US$100.00`, `$100.00`]);

--- a/JSTests/stress/number-toLocaleString.js
+++ b/JSTests/stress/number-toLocaleString.js
@@ -1,8 +1,11 @@
-//@ skip
-
 function shouldBe(actual, expected) {
     if (actual !== expected)
         throw new Error(`expected ${expected} but got ${actual}`);
+}
+
+function shouldBeOneOf(actual, expectedArray) {
+    if (!expectedArray.some((value) => value === actual))
+        throw new Error('bad value: ' + actual + ' expected values: ' + expectedArray);
 }
 
 function shouldNotThrow(func) {
@@ -45,11 +48,7 @@ shouldBe(new Number(1).toLocaleString(), '1');
 shouldThrow(() => (0).toLocaleString('i'), RangeError);
 shouldBe(Infinity.toLocaleString(), '∞');
 
-// Test that locale parameter is passed through properly.
-if ($vm.icuVersion() >= 74 && $vm.icuMinorVersion() >= 2)
-    shouldBe((123456.789).toLocaleString('ar'), '123,456.789');
-else
-    shouldBe((123456.789).toLocaleString('ar'), '١٢٣٬٤٥٦٫٧٨٩');
+shouldBeOneOf((123456.789).toLocaleString('ar'), ['123,456.789', '١٢٣٬٤٥٦٫٧٨٩']);
 shouldBe((123456.789).toLocaleString('zh-Hans-CN-u-nu-hanidec'), '一二三,四五六.七八九');
 
 // Test that options parameter is passed through properly.


### PR DESCRIPTION
#### 4fe5049d516132dac115ce86dddebc8a021dc7ca
<pre>
Update intl tests with newer ICU
<a href="https://bugs.webkit.org/show_bug.cgi?id=294090">https://bugs.webkit.org/show_bug.cgi?id=294090</a>
<a href="https://rdar.apple.com/144246030">rdar://144246030</a>

Reviewed by Yijia Huang.

Just rebaseline the test results with newer ICU.

* JSTests/stress/bigint-toLocaleString.js:
(shouldBeOneOf):
* JSTests/stress/intl-datetimeformat.js:
* JSTests/stress/intl-displaynames-v2.js:
(shouldBeOneOf):
(shouldBe):
* JSTests/stress/intl-displaynames.js:
(shouldBeOneOf):
* JSTests/stress/intl-locale-exceptions.js:
(shouldThrow):
* JSTests/stress/intl-long-locale-id-maximize-minimize.js:
(shouldBeOneOf):
(shouldBe):
* JSTests/stress/intl-numberformat-unified.js:
(shouldBeOneOf):
* JSTests/stress/number-toLocaleString.js:
(shouldBeOneOf):

Canonical link: <a href="https://commits.webkit.org/295898@main">https://commits.webkit.org/295898@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9f79a0e96afa900f9933d7c92d467c179697a3f4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/106486 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/26235 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/16633 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/111689 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/57082 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/26902 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34738 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80870 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/109490 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/21332 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/96085 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/61202 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/20794 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/56523 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/99125 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/90663 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/14221 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/114548 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/105103 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33624 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/24788 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/89941 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33988 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/92316 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89649 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34540 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/12358 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/29233 "Hash 9f79a0e9 for PR 46387 does not build (failure)") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17255 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/33549 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/129415 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/33295 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/35240 "Found 4 jsc stress test failures: wasm.yaml/wasm/gc/ref-i31-eq.js.default-wasm, wasm.yaml/wasm/gc/ref-i31-eq.js.wasm-collect-continuously, wasm.yaml/wasm/gc/ref-i31-eq.js.wasm-eager, wasm.yaml/wasm/gc/ref-i31-eq.js.wasm-slow-memory") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/36648 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34893 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->