### PR TITLE
Add a makeUniqueWithTrailingBytes

### DIFF
--- a/Source/WTF/wtf/FastMalloc.h
+++ b/Source/WTF/wtf/FastMalloc.h
@@ -474,6 +474,7 @@ using WTF::fastCompactAlignedMalloc;
     { \
         ::WTF::fastFree(p); \
     } \
+    using MallocImpl UNUSED_TYPE_ALIAS = FastMalloc; \
     using WTFIsFastMallocAllocated = int; \
 
 #define WTF_MAKE_FAST_COMPACT_ALLOCATED_IMPL \
@@ -509,6 +510,7 @@ using WTF::fastCompactAlignedMalloc;
     { \
         ::WTF::fastFree(p); \
     } \
+    using MallocImpl UNUSED_TYPE_ALIAS = FastMalloc; \
     using WTFIsFastMallocAllocated = int; \
 
 // FIXME: WTF_MAKE_FAST_ALLOCATED should take class name so that we can create malloc_zone per this macro.
@@ -532,6 +534,13 @@ using __thisIsHereToForceASemicolonAfterThisMacro UNUSED_TYPE_ALIAS = int
 #define WTF_MAKE_STRUCT_FAST_COMPACT_ALLOCATED \
     WTF_MAKE_FAST_COMPACT_ALLOCATED_IMPL \
 using __thisIsHereToForceASemicolonAfterThisMacro UNUSED_TYPE_ALIAS = int
+
+// ClassName is here so/when we address https://bugs.webkit.org/show_bug.cgi?id=205702 we can have heap breakdowns
+#define WTF_MAKE_FAST_ALLOCATED_WITH_TRAILING_BYTES(className) \
+public: \
+    using WTFIsFastMallocAllocatedWithTrailingBytes = int; \
+    WTF_MAKE_FAST_ALLOCATED
+
 
 #if ENABLE(MALLOC_HEAP_BREAKDOWN)
 
@@ -567,6 +576,7 @@ using __thisIsHereToForceASemicolonAfterThisMacro UNUSED_TYPE_ALIAS = int
     { \
         classname##Malloc::free(p); \
     } \
+    using MallocImpl UNUSED_TYPE_ALIAS = classname##Malloc; \
     using WTFIsFastMallocAllocated = int; \
 
 #define WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(classname) \


### PR DESCRIPTION
#### e88183a663d4f12c43ad69d055b5786334aa123b
<pre>
Add a makeUniqueWithTrailingBytes
<a href="https://bugs.webkit.org/show_bug.cgi?id=294093">https://bugs.webkit.org/show_bug.cgi?id=294093</a>
<a href="https://rdar.apple.com/152682334">rdar://152682334</a>

Reviewed by NOBODY (OOPS!).

Per offline discussion it seems like it would be a better idiom to have a specialized
makeUnique-esq function to create std::unique_ptr owned objects with trailing bytes.
This patch adds such a creation function `makeUniqueWithTrailingBytes` and applies
it to `JSC::ExpressionInfo`.

* Source/WTF/wtf/StdLibExtras.h:
(WTF::makeUniqueWithTrailingBytes):
    This function is like makeUnique except that it allocates trailing bytes as
    determined by the retained type&apos;s `allocationSize` member function for those
    arguments.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e88183a663d4f12c43ad69d055b5786334aa123b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/107384 "3 style errors") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27066 "Hash e88183a6 for PR 46392 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/17470 "Hash e88183a6 for PR 46392 does not build (failure)") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/112598 "Hash e88183a6 for PR 46392 does not build (failure)") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/57920 "Hash e88183a6 for PR 46392 does not build (failure)") 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/27748 "Hash e88183a6 for PR 46392 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/35566 "Hash e88183a6 for PR 46392 does not build (failure)") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/112598 "Hash e88183a6 for PR 46392 does not build (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/57920 "Hash e88183a6 for PR 46392 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/110313 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/130/builds/27748 "Hash e88183a6 for PR 46392 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/138/builds/17470 "Hash e88183a6 for PR 46392 does not build (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/112598 "Hash e88183a6 for PR 46392 does not build (failure)") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/130/builds/27748 "Hash e88183a6 for PR 46392 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/138/builds/17470 "Hash e88183a6 for PR 46392 does not build (failure)") | [❌ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/57364 "Hash e88183a6 for PR 46392 does not build (failure)") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/99973 "Hash e88183a6 for PR 46392 does not build (failure)") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/130/builds/27748 "Hash e88183a6 for PR 46392 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/138/builds/17470 "Hash e88183a6 for PR 46392 does not build (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/115699 "Hash e88183a6 for PR 46392 does not build (failure)") | 
| [❌ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/105930 "Hash e88183a6 for PR 46392 does not build (failure)") | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/34450 "Hash e88183a6 for PR 46392 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/123/builds/35566 "Hash e88183a6 for PR 46392 does not build (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/115699 "Hash e88183a6 for PR 46392 does not build (failure)") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/34826 "Hash e88183a6 for PR 46392 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/138/builds/17470 "Hash e88183a6 for PR 46392 does not build (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/115699 "Hash e88183a6 for PR 46392 does not build (failure)") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/138/builds/17470 "Hash e88183a6 for PR 46392 does not build (failure)") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/30194 "Hash e88183a6 for PR 46392 does not build (failure)") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/34372 "Hash e88183a6 for PR 46392 does not build (failure)") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/39913 "Failed to build and analyze WebKit") | [❌ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/130247 "Hash e88183a6 for PR 46392 does not build (failure)") | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34118 "Hash e88183a6 for PR 46392 does not build (failure)") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/35/builds/130247 "Hash e88183a6 for PR 46392 does not build (failure)") | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/37473 "Hash e88183a6 for PR 46392 does not build (failure)") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/35779 "Hash e88183a6 for PR 46392 does not build (failure)") | | | 
<!--EWS-Status-Bubble-End-->