### PR TITLE
Object.getOwnPropertyDescriptors should return a consistent order for JSFunctions

### DIFF
--- a/JSTests/stress/object-property-descriptors-order-should-be-consistent.js
+++ b/JSTests/stress/object-property-descriptors-order-should-be-consistent.js
@@ -1,0 +1,35 @@
+function abc() {}
+let s = JSON.stringify(Object.keys(Object.getOwnPropertyDescriptors(abc)));
+if (s !== `["length","name","prototype"]`) {
+    throw Error("wrong");
+}
+
+function test(f) {
+    let result = null;
+    let testConsistent = (x) => {
+        if (result == null) {
+            result = x;
+        } else {
+            if (result !== x) {
+                throw Error("inconsistent");
+            }
+        }
+    };
+
+    function a() {}
+    f(a);
+    testConsistent(JSON.stringify(Object.keys(Object.getOwnPropertyDescriptors(a))));
+    testConsistent(JSON.stringify(Object.keys(Object.getOwnPropertyDescriptors(a))));
+    testConsistent(JSON.stringify(Object.keys(Object.getOwnPropertyDescriptors(a))));
+}
+
+test((_) => {});
+
+test((a) => {return a.prototype});
+test((a) => {return a.length});
+test((a) => {return a.name});
+
+test((a) => {delete a.prototype});
+test((a) => {delete a.length});
+test((a) => {delete a.name});
+

--- a/JSTests/test262/expectations.yaml
+++ b/JSTests/test262/expectations.yaml
@@ -34,9 +34,6 @@ test/built-ins/Iterator/concat/fresh-iterator-result.js:
 test/built-ins/Iterator/concat/next-method-returns-throwing-value.js:
   default: 'Test262Error: '
   strict mode: 'Test262Error: '
-test/built-ins/Object/entries/order-after-define-property-with-function.js:
-  default: 'Test262Error: Actual [a, name] and expected [name, a] should have the same contents. '
-  strict mode: 'Test262Error: Actual [a, name] and expected [name, a] should have the same contents. '
 test/built-ins/Object/keys/order-after-define-property-with-function.js:
   default: 'Test262Error: Actual [a, length] and expected [length, a] should have the same contents. '
   strict mode: 'Test262Error: Actual [a, length] and expected [length, a] should have the same contents. '
@@ -1310,12 +1307,6 @@ test/language/statements/async-generator/yield-star-promise-not-unwrapped.js:
 test/language/statements/async-generator/yield-star-return-then-getter-ticks.js:
   default: 'Test262:AsyncTestFailure:Test262Error: Test262Error: Actual [start, tick 1, tick 2, get then, tick 3, get return, get then] and expected [start, tick 1, get then, tick 2, get return, get then, tick 3] should have the same contents. Ticks for return with thenable getter'
   strict mode: 'Test262:AsyncTestFailure:Test262Error: Test262Error: Actual [start, tick 1, tick 2, get then, tick 3, get return, get then] and expected [start, tick 1, get then, tick 2, get return, get then, tick 3] should have the same contents. Ticks for return with thenable getter'
-test/language/statements/class/definition/fn-length-static-precedence-order.js:
-  default: 'Test262Error: Actual [name, prototype, method, length] and expected [length, name, prototype, method] should have the same contents. '
-  strict mode: 'Test262Error: Actual [name, prototype, method, length] and expected [length, name, prototype, method] should have the same contents. '
-test/language/statements/class/definition/fn-name-static-precedence-order.js:
-  default: 'Test262Error: Actual [length, prototype, method, name] and expected [length, name, prototype, method] should have the same contents. '
-  strict mode: 'Test262Error: Actual [length, prototype, method, name] and expected [length, name, prototype, method] should have the same contents. '
 test/language/statements/class/elements/arrow-body-direct-eval-err-contains-arguments.js:
   default: 'Test262Error: Expected a SyntaxError but got a ReferenceError'
   strict mode: 'Test262Error: Expected a SyntaxError but got a ReferenceError'

--- a/Source/JavaScriptCore/runtime/JSFunction.cpp
+++ b/Source/JavaScriptCore/runtime/JSFunction.cpp
@@ -378,11 +378,22 @@ void JSFunction::getOwnSpecialPropertyNames(JSObject* object, JSGlobalObject* gl
 {
     JSFunction* thisObject = jsCast<JSFunction*>(object);
     VM& vm = globalObject->vm();
+    auto scope = DECLARE_CATCH_SCOPE(vm);
 
     if (mode == DontEnumPropertiesMode::Include) {
-        if (!thisObject->hasReifiedLength())
+        bool hasLength = thisObject->hasOwnProperty(globalObject, vm.propertyNames->length);
+        if (scope.exception()) [[unlikely]] {
+            hasLength = false;
+            scope.clearException();
+        }
+        if (!thisObject->hasReifiedLength() || hasLength)
             propertyNames.add(vm.propertyNames->length);
-        if (!thisObject->hasReifiedName())
+        bool hasName = thisObject->hasOwnProperty(globalObject, vm.propertyNames->name);
+        if (scope.exception()) [[unlikely]] {
+            hasName = false;
+            scope.clearException();
+        }
+        if (!thisObject->hasReifiedName() || hasName)
             propertyNames.add(vm.propertyNames->name);
         if (!thisObject->isHostOrBuiltinFunction() && thisObject->jsExecutable()->hasPrototypeProperty())
             propertyNames.add(vm.propertyNames->prototype);


### PR DESCRIPTION
#### 651e28b4c2df42e778f601b1256ffffc2b424a08
<pre>
Object.getOwnPropertyDescriptors should return a consistent order for JSFunctions
<a href="https://bugs.webkit.org/show_bug.cgi?id=286996">https://bugs.webkit.org/show_bug.cgi?id=286996</a>
<a href="https://rdar.apple.com/144590087">rdar://144590087</a>

Reviewed by Yusuke Suzuki.

Section 10.1.11.1 of the spec[1] specifies that we should return keys of objects
in ascending chronological order of creation. When we get the keys of a function
object, we originally return these properties in the correct order. However, the
JSFunction class utilizes lazy reification as an optimization. During this first
access, we reify all three properties, as weaccessing their property descriptor.
This leads to a different ordering when we call getOwnPropertyDescriptors again.
This patch fixes this issue by checking if a lazily reified property has already
been reified and still exists as an own property. If so, we can directly list it
along with the other lazily reified properties. (`prototype` is non-configurable
and thus is exempt from this check, since it cannot be deleted)

The correct order of these properties should be [&apos;length&apos;, &apos;name&apos;, &apos;prototype&apos;].
This is specified by the semantics of `InstantiateOrdinaryFunctionObject`, under
section 15.2.4 of the spec [2]. We start by calling `OrdinaryFunctionCreate` (3)
and assigning the result to `F`. Within this call (specified in 10.2.3 [3]), the
function object is initialized. In step 22, we perform `SetFunctionLength`, thus
adding the `length` property first. Returning from `OrdinaryFunctionCreate` then
brings us to a call to `SetFunctionName` (15.2.4 step 4), which makes `name` the
second property to be initialized. Finally, we call `MakeConstructor` in step 5.
As specified in 10.2.5 [4], we perform `DefinePropertyOrThrow(F,&quot;prototype&quot;,...`
in step 6, thus making `prototype` the third and last property to be initialized
for a function object. Thus the proper order is [&apos;length&apos;, &apos;name&apos;, &apos;prototype&apos;].

[1] <a href="https://tc39.es/ecma262/multipage/ordinary-and-exotic-objects-behaviours.html#sec-ordinaryownpropertykeys">https://tc39.es/ecma262/multipage/ordinary-and-exotic-objects-behaviours.html#sec-ordinaryownpropertykeys</a>
[2] <a href="https://tc39.es/ecma262/#sec-runtime-semantics-instantiateordinaryfunctionobject">https://tc39.es/ecma262/#sec-runtime-semantics-instantiateordinaryfunctionobject</a>
[3] <a href="https://tc39.es/ecma262/#sec-ordinaryfunctioncreate">https://tc39.es/ecma262/#sec-ordinaryfunctioncreate</a>
[4] <a href="https://tc39.es/ecma262/#sec-makeconstructor">https://tc39.es/ecma262/#sec-makeconstructor</a>

* JSTests/stress/object-property-descriptors-order-should-be-consistent.js: Added.
(test.a):
(test):
* JSTests/test262/expectations.yaml:
* Source/JavaScriptCore/runtime/JSFunction.cpp:
(JSC::JSFunction::getOwnSpecialPropertyNames):

Canonical link: <a href="https://commits.webkit.org/296060@main">https://commits.webkit.org/296060@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bf5e4d4d031370aad976d37a8b3a7d260d7d2304

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/107000 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/26708 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/17105 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/112208 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/57558 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/27381 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/35210 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/81236 "Found 1 new test failure: imported/w3c/web-platform-tests/service-workers/service-worker/redirected-response.https.html (failure)") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/109958 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/21735 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/96504 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/61590 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/21161 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/14621 "Found 3 new test failures: inspector/model/remote-object-get-properties.html inspector/runtime/getDisplayableProperties.html inspector/runtime/getProperties.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/57006 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/99605 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/91077 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/14815 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/115254 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/105573 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/34093 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/25141 "6 flakes 3 failures") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/90282 "Found 3 new test failures: inspector/model/remote-object-get-properties.html inspector/runtime/getDisplayableProperties.html inspector/runtime/getProperties.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/34461 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/92743 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/90010 "Passed tests") | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22987 "Found 3 new test failures: inspector/model/remote-object-get-properties.html inspector/runtime/getDisplayableProperties.html inspector/runtime/getProperties.html (failure)") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34939 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/12743 "Found 3 new test failures: inspector/model/remote-object-get-properties.html inspector/runtime/getDisplayableProperties.html inspector/runtime/getProperties.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/29805 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17340 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/34017 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/39470 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/129885 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/33765 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/35357 "Found 1 new JSC stress test failure: wasm.yaml/wasm/gc/ref-i31-eq.js.default-wasm (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/37117 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/35397 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->