### PR TITLE
ASAN_TRAP | WTF::HashTable::lookup; WebCore::LegacyRenderSVGResource::markForLayoutAndParentResourceInvalidation; WebCore::SVGResourcesCache::clientStyleChanged

### DIFF
--- a/LayoutTests/css3/masking/shared-clip-path-reference-crash-expected.txt
+++ b/LayoutTests/css3/masking/shared-clip-path-reference-crash-expected.txt
@@ -1,0 +1,1 @@
+ Test passes if it does not crash.

--- a/LayoutTests/css3/masking/shared-clip-path-reference-crash.html
+++ b/LayoutTests/css3/masking/shared-clip-path-reference-crash.html
@@ -1,0 +1,12 @@
+<style>
+  div, svg, clipPath { clip-path: url(#clipPath); }
+</style>
+<div></div>
+<svg>
+  <clipPath id="clipPath">
+</svg>
+<script>
+  if (window.testRunner)
+    testRunner.dumpAsText();
+  document.write("Test passes if it does not crash.");
+</script>

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -405,6 +405,8 @@ RenderLayer::~RenderLayer()
 
     clearBacking({ }, true);
 
+    removeClipperClientIfNeeded();
+
     // Layer and all its children should be removed from the tree before destruction.
     RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(renderer().renderTreeBeingDestroyed() || !parent());
     RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(renderer().renderTreeBeingDestroyed() || !firstChild());
@@ -418,6 +420,15 @@ RenderLayer::PaintedContentRequest::PaintedContentRequest(const RenderLayer& own
 #else
     UNUSED_PARAM(owningLayer);
 #endif
+}
+
+void RenderLayer::removeClipperClientIfNeeded() const
+{
+    auto& style = renderer().style();
+    if (RefPtr referenceClipPathOperation = dynamicDowncast<ReferencePathOperation>(style.clipPath())) {
+        if (auto* clipperRenderer = ReferencedSVGResources::referencedClipperRenderer(renderer().treeScopeForSVGReferences(), *referenceClipPathOperation))
+            clipperRenderer->removeClientFromCache(renderer());
+    }
 }
 
 void RenderLayer::addChild(RenderLayer& child, RenderLayer* beforeChild)

--- a/Source/WebCore/rendering/RenderLayer.h
+++ b/Source/WebCore/rendering/RenderLayer.h
@@ -1299,6 +1299,8 @@ private:
     void setIndirectCompositingReason(IndirectCompositingReason reason) { m_indirectCompositingReason = static_cast<unsigned>(reason); }
     bool mustCompositeForIndirectReasons() const { return m_indirectCompositingReason; }
 
+    void removeClipperClientIfNeeded() const;
+
     struct OverflowControlRects {
         IntRect horizontalScrollbar;
         IntRect verticalScrollbar;

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceContainer.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceContainer.cpp
@@ -168,7 +168,7 @@ void LegacyRenderSVGResourceContainer::markAllClientLayersForInvalidation()
 
 void LegacyRenderSVGResourceContainer::markClientForInvalidation(RenderObject& client, InvalidationMode mode)
 {
-    ASSERT(!m_clients.isEmptyIgnoringNullReferences());
+    ASSERT(!m_clients.isEmptyIgnoringNullReferences() || client.style().clipPath());
 
     switch (mode) {
     case LayoutAndBoundariesInvalidation:


### PR DESCRIPTION
#### 869aebafb6b4c4d590bba4ab6a2913ff203624ed
<pre>
ASAN_TRAP | WTF::HashTable::lookup; WebCore::LegacyRenderSVGResource::markForLayoutAndParentResourceInvalidation; WebCore::SVGResourcesCache::clientStyleChanged
<a href="https://bugs.webkit.org/show_bug.cgi?id=288442">https://bugs.webkit.org/show_bug.cgi?id=288442</a>
<a href="https://rdar.apple.com/144407636">rdar://144407636</a>

Reviewed by Simon Fraser.

LegacyRenderSVGResourceClipper.m_clipperMap is used to keep track of clipper data per client, the client
can be a HTML element referencing the clipper by using the clip-path property. The registering for that is done
in RenderLayer::setupClipPath but there is no code to deregister on HTML element removal, so the m_clipperMap
keys will become a WeakRef with empty internal pointer for HTML elements, causing a RELEASE_ASSERT.

To fix this, include deregistering code on RenderLayer destruction.

* LayoutTests/css3/masking/shared-clip-path-reference-crash-expected.txt: Added.
* LayoutTests/css3/masking/shared-clip-path-reference-crash.html: Added.
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::~RenderLayer):
(WebCore::RenderLayer::removeClipperClientIfNeeded const):
* Source/WebCore/rendering/RenderLayer.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceContainer.cpp:
(WebCore::LegacyRenderSVGResourceContainer::markClientForInvalidation):

Originally-landed-as: 289651.9@webkit-2025.2-embargoed (ff0112ba3d52). <a href="https://rdar.apple.com/151715112">rdar://151715112</a>
Canonical link: <a href="https://commits.webkit.org/295938@main">https://commits.webkit.org/295938@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fb41c0d91b392950a2ef9a8c304569b94c496a0a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/106497 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/26247 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/16644 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/111700 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/57093 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/108536 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/26917 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34749 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80877 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/109501 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/21342 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/96094 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/61210 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/20803 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/14195 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/56534 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/90675 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/14230 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/114559 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33635 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24794 "Found 1 new test failure: svg/zoom/page/text-with-non-scaling-stroke.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89948 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33999 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/92325 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89656 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34551 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/12367 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/29244 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17275 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/33560 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/38972 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/33306 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/36659 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34904 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->