### PR TITLE
Drag snapshot paints unrelated content

### DIFF
--- a/LayoutTests/fast/snapshot/nested-stacking-context-expected.html
+++ b/LayoutTests/fast/snapshot/nested-stacking-context-expected.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+#box {
+    width: 100px;
+    height: 100px;
+    background-color: blue;
+    color: black;
+}
+</style>
+</head>
+<body>
+    <div id="box" style="opacity: 0.95;">
+        <div style="opacity: 0.95;">
+            Is this included?
+        </div>
+    </div>
+</body>
+</html>

--- a/LayoutTests/fast/snapshot/nested-stacking-context.html
+++ b/LayoutTests/fast/snapshot/nested-stacking-context.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-10000" />
+<style>
+#box {
+    width: 100px;
+    height: 100px;
+    background-color: blue;
+    color: black;
+}
+</style>
+</head>
+<body>
+    <div id="box" style="opacity: 0.95;">
+        <div style="opacity: 0.95;">
+            Is this included?
+        </div>
+    </div>
+    <canvas id="canvas"></canvas>
+<script>
+if (window.testRunner) {
+    testRunner.waitUntilDone();
+}
+
+async function main() {
+    const box = document.getElementById('box');
+    const canvas = document.getElementById('canvas');
+
+    if (!window.internals) {
+        console.log('FAIL: window.internals is not available');
+        return;
+    }
+
+    const imageData = internals.snapshotNode(box);
+    
+    if (!imageData) {
+        console.log('FAIL: snapshotNode returned null');
+        return;
+    }
+
+    canvas.width = imageData.width;
+    canvas.height = imageData.height;
+    
+    const ctx = canvas.getContext('2d');
+    ctx.putImageData(imageData, 0, 0);
+
+    box.remove();
+
+    if (window.testRunner) {
+        testRunner.notifyDone();
+    }
+}
+
+window.addEventListener('load', () => {
+    setTimeout(main, 200);
+}, false)
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/snapshot/positioned-abs-relative-body-expected.html
+++ b/LayoutTests/fast/snapshot/positioned-abs-relative-body-expected.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+#box {
+    width: 100px;
+    height: 100px;
+    background-color: blue;
+    color: black;
+}
+</style>
+</head>
+<body>
+    <div id="box" style="opacity: 0.9;"></div>
+</body>
+</html>

--- a/LayoutTests/fast/snapshot/positioned-abs-relative-body.html
+++ b/LayoutTests/fast/snapshot/positioned-abs-relative-body.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+#box {
+    width: 100px;
+    height: 100px;
+    background-color: blue;
+    color: black;
+}
+</style>
+</head>
+<body>
+    <div id="box" style="opacity: 0.9;">
+        <div style="position: absolute;">
+            Is this included?
+        </div>
+    </div>
+    <canvas id="canvas"></canvas>
+<script>
+if (window.testRunner) {
+    testRunner.waitUntilDone();
+}
+
+async function main() {
+    const box = document.getElementById('box');
+    const canvas = document.getElementById('canvas');
+
+    if (!window.internals) {
+        console.log('FAIL: window.internals is not available');
+        return;
+    }
+
+    const imageData = internals.snapshotNode(box);
+
+    if (!imageData) {
+        console.log('FAIL: snapshotNode returned null');
+        return;
+    }
+
+    canvas.width = imageData.width;
+    canvas.height = imageData.height;
+    
+    const ctx = canvas.getContext('2d');
+    ctx.putImageData(imageData, 0, 0);
+
+    box.remove();
+
+    if (window.testRunner) {
+        testRunner.notifyDone();
+    }
+}
+
+window.addEventListener('load', () => {
+    setTimeout(main, 200);
+}, false)
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -7932,3 +7932,6 @@ webkit.org/b/294274 [ Debug ] platform/ios/mediastream/audio-muted-in-background
  webgl/2.0.y/conformance/textures/misc/gl-teximage.html [ Failure ]
 
 webkit.org/b/294346 fast/events/ios/select-all-with-existing-selection.html [ Pass Crash ]
+
+fast/snapshot/nested-stacking-context.html [ Skip ]
+fast/snapshot/positioned-abs-relative-body.html [ Skip ]

--- a/ManualTests/compositing/drag-image.html
+++ b/ManualTests/compositing/drag-image.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <style>
+        .text-at-origin {
+            font-size: 24px;
+            font-weight: bold;
+            color: #ff0000;
+        }
+
+        .draggable-box {
+            width: 100px;
+            height: 100px;
+            background-color: #4CAF50;
+            color: white;
+            cursor: move;
+            user-select: none;
+        }
+
+        .drag-preview {
+            width: 100px;
+            height: 100px;
+            border: 2px dashed #333;
+        }
+
+        .child {
+            position: absolute;
+            top: -50px;
+        }
+    </style>
+</head>
+
+<body>
+    <div class="text-at-origin">UNDERLYING TEXT AT (0,0)</div>
+    <div class="container">
+        <div>
+            <h3>Transparent Drag Preview (Shows Bug)</h3>
+            <div class="draggable-box" draggable="true">
+                Drag Me
+            </div>
+        </div>
+    </div>
+    <script>
+        function setupCustomDragPreview() {
+            const draggables = document.querySelectorAll('[draggable="true"]');
+
+            draggables.forEach(draggable => {
+                draggable.addEventListener('dragstart', (e) => {
+                    const type = e.target.dataset.type;
+
+                    const dragPreview = document.createElement('div');
+                    dragPreview.className = 'drag-preview';
+                    dragPreview.textContent = 'Custom drag preview\n';
+
+                    const div = document.createElement('div');
+                    div.textContent = 'Im a child!';
+                    div.classList.add('child');
+                    dragPreview.append(div);
+
+                    dragPreview.style.position = 'fixed';
+                    dragPreview.style.top = '0';
+                    dragPreview.style.left = '0';
+
+                    document.body.appendChild(dragPreview);
+
+                    e.dataTransfer.setDragImage(dragPreview, 0, 0);
+
+                    setTimeout(() => {
+                        document.body.removeChild(dragPreview);
+                    });
+                });
+            });
+        }
+
+        async function main() {
+            setupCustomDragPreview();
+        }
+
+        window.addEventListener('load', main, false);
+    </script>
+</body>
+</html>

--- a/Source/WebCore/page/FrameSnapshotting.h
+++ b/Source/WebCore/page/FrameSnapshotting.h
@@ -68,7 +68,7 @@ struct SnapshotOptions {
 
 WEBCORE_EXPORT RefPtr<ImageBuffer> snapshotFrameRect(LocalFrame&, const IntRect&, SnapshotOptions&&);
 RefPtr<ImageBuffer> snapshotFrameRectWithClip(LocalFrame&, const IntRect&, const Vector<FloatRect>& clipRects, SnapshotOptions&&);
-RefPtr<ImageBuffer> snapshotNode(LocalFrame&, Node&, SnapshotOptions&&);
+WEBCORE_EXPORT RefPtr<ImageBuffer> snapshotNode(LocalFrame&, Node&, SnapshotOptions&&);
 WEBCORE_EXPORT RefPtr<ImageBuffer> snapshotSelection(LocalFrame&, SnapshotOptions&&);
 
 Color estimatedBackgroundColorForRange(const SimpleRange&, const LocalFrame&);

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -364,6 +364,7 @@ public:
     ExceptionOr<String> markerDescriptionForNode(Node&, const String& markerType, unsigned index);
     ExceptionOr<String> dumpMarkerRects(const String& markerType);
     ExceptionOr<void> setMarkedTextMatchesAreHighlighted(bool);
+    ExceptionOr<RefPtr<ImageData>> snapshotNode(Node&);
 
     void invalidateFontCache();
 

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -586,6 +586,7 @@ enum ContentsFormat {
     DOMString markerDescriptionForNode(Node node, DOMString markerType, unsigned long index);
     DOMString dumpMarkerRects(DOMString markerType);
     undefined setMarkedTextMatchesAreHighlighted(boolean flag);
+    ImageData snapshotNode(Node node);
 
     undefined invalidateFontCache();
 


### PR DESCRIPTION
#### a3e5281daec2d26daf7fdf385a0fd213437e814c
<pre>
Drag snapshot paints unrelated content
<a href="https://bugs.webkit.org/show_bug.cgi?id=237446">https://bugs.webkit.org/show_bug.cgi?id=237446</a>
<a href="https://rdar.apple.com/90120656">rdar://90120656</a>

Reviewed by Simon Fraser.

When using setDragImage with a fixed-position element,
the drag preview bitmap incorrectly included content
from other stacking contexts.

During painting, we did not properly filter
layers based on subtreePaintRoot, causing unrelated
stacking context layers to be composited
into the dragged element&apos;s snapshot.

This fix ensures that only content layers within
the same stacking context are painted.

* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::paintLayer):
(WebCore::RenderLayer::paintLayerContents):

Canonical link: <a href="https://commits.webkit.org/296117@main">https://commits.webkit.org/296117@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9afa2b9e444fee6d63b026d5c0178a47fdf106b1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/107439 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27121 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/17528 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/112653 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/57975 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/109403 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/27804 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/35621 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/81559 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/57975 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/110368 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22021 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/96829 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/61935 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/21461 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/14960 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/57419 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/91391 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/14995 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/115754 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/34506 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/25430 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/90597 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/34881 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93079 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/90336 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23032 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35249 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13030 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/30249 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/34427 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/39968 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34173 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/37528 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/35834 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->