### PR TITLE
IntersectionObserver: Notify observers asynchronously

### DIFF
--- a/LayoutTests/intersection-observer/observations-queue-a-task-to-notify-expected.txt
+++ b/LayoutTests/intersection-observer/observations-queue-a-task-to-notify-expected.txt
@@ -1,0 +1,7 @@
+Intersection observations should queue a task to notify observers.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS The IntersectionObserver callback did not run synchronously
+

--- a/LayoutTests/intersection-observer/observations-queue-a-task-to-notify.html
+++ b/LayoutTests/intersection-observer/observations-queue-a-task-to-notify.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<script src="../resources/ui-helper.js"></script>
+<script src="../resources/js-test.js"></script>
+<style>
+#target {
+    width: 200px;
+    height: 200px;
+    margin: 200px;
+    background-color: green;
+}
+
+#target.intersecting {
+    background-color: red;
+}
+</style>
+<script>
+jsTestIsAsync = true;
+description('Intersection observations should queue a task to notify observers.');
+if (!window.internals)
+    testFailed('Test requires internals.');
+
+var observer;
+function ioCallback(entries)
+{
+    const target = document.getElementById('target');
+    for (const entry of entries) {
+        if (entry.intersectionRatio === 1)
+            target.classList.add('intersecting');
+        else
+            target.classList.remove('intersecting');
+    }
+}
+
+function testIOCallbackDidNotRun()
+{
+    if (target.classList.contains('intersecting'))
+        testFailed("The IntersectionObserver callback ran synchronously.");
+    else
+        testPassed("The IntersectionObserver callback did not run synchronously");
+    window.testRunner.notifyDone();
+}
+
+
+window.addEventListener('load', () => {
+    const target = document.getElementById('target');
+    observer = new IntersectionObserver(ioCallback, { threshold: [ 0, 1 ] });
+    observer.observe(target);
+    /*
+     * This dance deserves some comment.
+     * What we are trying to do is test that an intersection observation queued a task
+     * to run the callback instead of running it during the "update the rendering" step where
+     * the interesection was computed. In order to do that, we need the "update the rendering"
+     * algorithm to have run once and any observation tasks queued during that step to have not run.
+     * The way to accomplish this is earlier in the update the rendering steps we queue a task
+     * that will perform the final check. Since rAF callbacks are run before updating intersection
+     * observations we can queue a task from there which checks that the div has not yet been mutated.
+     * Unfortunately a zero delay timer does not run before the Event Loop's task queue so we can't use
+     * UIHelper.renderingUpdate which does approximately this sequence of steps but with Web APIs.
+     */
+    requestAnimationFrame(() => {
+        window.internals.queueTask('DOMManipulation', testIOCallbackDidNotRun);
+    });
+});
+
+</script>
+<body>
+<div id="target"></div>
+</body>

--- a/Source/WebCore/dom/ContentVisibilityDocumentState.cpp
+++ b/Source/WebCore/dom/ContentVisibilityDocumentState.cpp
@@ -105,7 +105,7 @@ IntersectionObserver* ContentVisibilityDocumentState::intersectionObserver(Docum
         auto callback = ContentVisibilityIntersectionObserverCallback::create(document);
         IntersectionObserver::Init options { &document, { }, { }, { } };
         auto includeObscuredInsets = document.settings().contentInsetBackgroundFillEnabled() ? IncludeObscuredInsets::Yes : IncludeObscuredInsets::No;
-        auto observer = IntersectionObserver::create(document, WTFMove(callback), WTFMove(options), includeObscuredInsets);
+        auto observer = IntersectionObserver::create(document, WTFMove(callback), WTFMove(options), includeObscuredInsets, IntersectionObserver::NotificationDelivery::Synchronous);
         if (observer.hasException())
             return nullptr;
         m_observer = observer.releaseReturnValue();

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -2716,6 +2716,8 @@ private:
 
     bool m_requiresTrustedTypes { false };
 
+    bool m_intersectionObserverUpdateTaskQueued { false };
+
     static bool hasEverCreatedAnAXObjectCache;
 
     const RefPtr<ResizeObserver> m_resizeObserverForContainIntrinsicSize;

--- a/Source/WebCore/dom/TaskSource.h
+++ b/Source/WebCore/dom/TaskSource.h
@@ -37,6 +37,7 @@ enum class TaskSource : uint8_t {
     IdleTask,
     ImageCapture,
     IndexedDB,
+    IntersectionObserver,
     MediaElement,
     Microtask,
     ModelElement,

--- a/Source/WebCore/html/LazyLoadImageObserver.cpp
+++ b/Source/WebCore/html/LazyLoadImageObserver.cpp
@@ -95,7 +95,7 @@ IntersectionObserver* LazyLoadImageObserver::intersectionObserver(Document& docu
         auto callback = LazyImageLoadIntersectionObserverCallback::create(document);
         static NeverDestroyed<const String> lazyLoadingScrollMarginFallback(MAKE_STATIC_STRING_IMPL("100%"));
         IntersectionObserver::Init options { std::nullopt, { }, lazyLoadingScrollMarginFallback, { } };
-        auto observer = IntersectionObserver::create(document, WTFMove(callback), WTFMove(options));
+        auto observer = IntersectionObserver::create(document, WTFMove(callback), WTFMove(options), IncludeObscuredInsets::No, IntersectionObserver::NotificationDelivery::Synchronous);
         if (observer.hasException())
             return nullptr;
         m_observer = observer.returnValue().ptr();


### PR DESCRIPTION
#### 620312427fc063962d3fb0757e91174e2dd32256
<pre>
IntersectionObserver: Notify observers asynchronously
<a href="https://bugs.webkit.org/show_bug.cgi?id=294096">https://bugs.webkit.org/show_bug.cgi?id=294096</a>
<a href="https://rdar.apple.com/152684301">rdar://152684301</a>

Reviewed by Simon Fraser.

IntersectionObservers are being notified synchronously once
we determine which observations are relevant. However, the
spec says we should queue a task to notify them.

Since lazy loading images and CSS Contain&apos;s content-visibility
both rely on IntersectionObserver internally, we differentiate between
an observer from JavaScript and internal users by allowing one to specify
a notification delivery preference as being either async (for JS) or
synchronous for other internal users.

This is a spec compliance change, but it also results in
~0.2% overall improvement on Speedometer3.

* LayoutTests/intersection-observer/observations-queue-a-task-to-notify-expected.txt: Added.
* LayoutTests/intersection-observer/observations-queue-a-task-to-notify.html: Added.
        Test that an observation queues a task to notify callbacks by injecting a task
        to check that a state change caused by the callback has not yet occured.

* Source/WebCore/dom/ContentVisibilityDocumentState.cpp:
(WebCore::ContentVisibilityDocumentState::intersectionObserver):
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::updateIntersectionObservations):
* Source/WebCore/dom/Document.h:
* Source/WebCore/dom/TaskSource.h:
* Source/WebCore/html/LazyLoadImageObserver.cpp:
(WebCore::LazyLoadImageObserver::intersectionObserver):
* Source/WebCore/page/IntersectionObserver.cpp:
(WebCore::IntersectionObserver::create):
(WebCore::IntersectionObserver::IntersectionObserver):
(WebCore::IntersectionObserver::updateObservations):
* Source/WebCore/page/IntersectionObserver.h:
(WebCore::IntersectionObserver::notificationDelivery const):

Canonical link: <a href="https://commits.webkit.org/296279@main">https://commits.webkit.org/296279@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d7217514d673ec5c5f66d5342def3b2f42885250

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/107739 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27413 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/17828 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/112949 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/58275 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/109694 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/28107 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/35950 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/81799 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/110673 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22280 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97093 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62188 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/21701 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/15238 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/57711 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/91650 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15272 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/116070 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/34815 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/25652 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/90836 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/35192 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93347 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/90597 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23146 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35509 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13276 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/30570 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/34720 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/40276 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34465 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/37827 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/36128 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->