### PR TITLE
[JSC] Optimize `Array#toReversed` for an array contains hole

### DIFF
--- a/JSTests/microbenchmarks/array-prototype-toReversed-hole-int32.js
+++ b/JSTests/microbenchmarks/array-prototype-toReversed-hole-int32.js
@@ -1,0 +1,14 @@
+const arr = [];
+for (let i = 0; i < 1024; i++) {
+    arr.push(i);
+}
+delete arr[512];
+
+function test() {
+    arr.toReversed();
+}
+noInline(test);
+
+for (let i = 0; i < 1e4; i++) {
+    test();
+}

--- a/JSTests/microbenchmarks/array-prototype-toReversed-hole-object.js
+++ b/JSTests/microbenchmarks/array-prototype-toReversed-hole-object.js
@@ -1,0 +1,14 @@
+const arr = [];
+for (let i = 0; i < 1024; i++) {
+    arr.push({ i });
+}
+delete arr[512];
+
+function test() {
+    arr.toReversed();
+}
+noInline(test);
+
+for (let i = 0; i < 1e4; i++) {
+    test();
+}

--- a/JSTests/microbenchmarks/array-prototype-toReversed-hole-string.js
+++ b/JSTests/microbenchmarks/array-prototype-toReversed-hole-string.js
@@ -1,0 +1,15 @@
+const characters = "abcdefghijklmnopqrstuvwxyz";
+const arr = [];
+for (let i = 0; i < 1024; i++) {
+    arr.push(characters[i % 26]);
+}
+delete arr[512];
+
+function test() {
+    arr.toReversed();
+}
+noInline(test);
+
+for (let i = 0; i < 1e4; i++) {
+    test();
+}

--- a/JSTests/stress/array-prototype-toReversed-hole-contiguous.js
+++ b/JSTests/stress/array-prototype-toReversed-hole-contiguous.js
@@ -1,0 +1,16 @@
+function sameArray(a, b) {
+    if (a.length !== b.length)
+        throw new Error(`Expected array length ${b.length} but got ${a.length}`);
+    for (let i = 0; i < a.length; i++) {
+        if (a[i] !== b[i])
+            throw new Error(`Expected ${b[i]} but got ${a[i]} (${i})`);
+    }
+}
+const arr = [];
+for (let i = 0; i < 10; i++) {
+    arr.push({ i });
+}
+delete arr[5];
+
+const result = arr.toReversed();
+sameArray(result, [arr[9], arr[8], arr[7], arr[6], undefined, arr[4], arr[3], arr[2], arr[1], arr[0]]);

--- a/JSTests/stress/array-prototype-toReversed-hole-double.js
+++ b/JSTests/stress/array-prototype-toReversed-hole-double.js
@@ -1,0 +1,17 @@
+function sameArray(a, b) {
+    if (a.length !== b.length)
+        throw new Error(`Expected array length ${b.length} but got ${a.length}`);
+    for (let i = 0; i < a.length; i++) {
+        if (a[i] !== b[i])
+            throw new Error(`Expected ${b[i]} but got ${a[i]} (${i})`);
+    }
+}
+
+
+const arr = [];
+for (let i = 0; i < 10; i++) {
+    arr.push(i + 0.1);
+}
+delete arr[5];
+const result = arr.toReversed();
+sameArray(result, [9.1, 8.1, 7.1, 6.1, undefined, 4.1, 3.1, 2.1, 1.1, 0.1]);

--- a/JSTests/stress/array-prototype-toReversed-hole-int32.js
+++ b/JSTests/stress/array-prototype-toReversed-hole-int32.js
@@ -1,0 +1,17 @@
+function sameArray(a, b) {
+    if (a.length !== b.length)
+        throw new Error(`Expected array length ${b.length} but got ${a.length}`);
+    for (let i = 0; i < a.length; i++) {
+        if (a[i] !== b[i])
+            throw new Error(`Expected ${b[i]} but got ${a[i]} (${i})`);
+    }
+}
+
+
+const arr = [];
+for (let i = 0; i < 10; i++) {
+    arr.push(i);
+}
+delete arr[5];
+const result = arr.toReversed();
+sameArray(result, [9, 8, 7, 6, undefined, 4, 3, 2, 1, 0]);


### PR DESCRIPTION
#### efffcbcdef8631f9526d6dfcf08b1bd7c99dd0ea
<pre>
[JSC] Optimize `Array#toReversed` for an array contains hole
<a href="https://bugs.webkit.org/show_bug.cgi?id=294097">https://bugs.webkit.org/show_bug.cgi?id=294097</a>

Reviewed by Yusuke Suzuki.

Previously, the fast path for `toReversed` would fall
back to the slow path whenever `this` was a holey array.

This patch adopts the same strategy as `tryCloneArrayFromFast`,
allowing the fast path to be retained whenever possible even
when `this` contains holes.

                                                TipOfTree                  Patched

array-prototype-toReversed-hole-string       30.8089+-0.6040     ^      7.3049+-0.2939        ^ definitely 4.2175x faster
array-prototype-toReversed-hole-int32        32.4921+-0.6975     ^      7.6792+-0.3627        ^ definitely 4.2312x faster
array-prototype-toReversed-hole-object       30.7505+-0.4679     ^      7.3179+-0.3822        ^ definitely 4.2021x faster

Canonical link: <a href="https://commits.webkit.org/296030@main">https://commits.webkit.org/296030@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cd35717109a9881c87f6dacf3e1a9873975b9aa0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/106880 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/26606 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/17003 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/112087 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/57458 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/27274 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/35107 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/81163 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/109857 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/21654 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/96425 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/61504 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/21096 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/14534 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/56905 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/99502 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/90995 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/14561 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/115069 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/105471 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33992 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/25084 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/90222 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/34358 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/92656 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89932 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22973 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34856 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/12671 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/29695 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/33916 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/39356 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/129783 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/33663 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/35346 "Found 1 new JSC stress test failure: wasm.yaml/wasm/gc/ref-i31-eq.js.wasm-collect-continuously (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/37016 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/35281 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->