### PR TITLE
[WebDriver][GLIB] Notify automation session on abnormal disconnections from the browser

### DIFF
--- a/Source/JavaScriptCore/inspector/remote/RemoteInspector.h
+++ b/Source/JavaScriptCore/inspector/remote/RemoteInspector.h
@@ -115,7 +115,7 @@ public:
         virtual String browserVersion() const { return { }; }
         virtual void requestAutomationSession(const String& sessionIdentifier, const SessionCapabilities&) = 0;
         virtual void requestedDebuggablesToWakeUp() { };
-#if USE(INSPECTOR_SOCKET_SERVER)
+#if USE(INSPECTOR_SOCKET_SERVER) || USE(GLIB)
         virtual void closeAutomationSession() = 0;
 #endif
     };
@@ -170,6 +170,7 @@ public:
 
 #if USE(GLIB)
     void requestAutomationSession(const char* sessionID, const Client::SessionCapabilities&);
+    void automationConnectionDidClose();
 #endif
 #if USE(GLIB) || USE(INSPECTOR_SOCKET_SERVER)
     void setup(TargetID);

--- a/Source/JavaScriptCore/inspector/remote/glib/RemoteInspectorGlib.cpp
+++ b/Source/JavaScriptCore/inspector/remote/glib/RemoteInspectorGlib.cpp
@@ -320,6 +320,13 @@ void RemoteInspector::requestAutomationSession(const char* sessionID, const Clie
     updateClientCapabilities();
 }
 
+void RemoteInspector::automationConnectionDidClose()
+{
+    if (!m_client)
+        return;
+    m_client->closeAutomationSession();
+}
+
 void RemoteInspector::setInspectorServerAddress(CString&& address)
 {
     s_inspectorServerAddress = WTFMove(address);

--- a/Source/JavaScriptCore/inspector/remote/glib/RemoteInspectorServer.cpp
+++ b/Source/JavaScriptCore/inspector/remote/glib/RemoteInspectorServer.cpp
@@ -288,6 +288,12 @@ void RemoteInspectorServer::connectionDidClose(SocketConnection& clientConnectio
         for (auto connectionTargetPair : copyToVector(m_automationTargets))
             close(clientConnection, connectionTargetPair.first, connectionTargetPair.second);
         m_automationConnection = nullptr;
+#if USE(GLIB)
+        // As we support single sessions, there's no need to send a sessionID like we do when setting up the automation connection
+        // in startAutomationSession(). If we ever support multiple sessions, we should eventually map the sessionID to the connectionID and
+        // send it here.
+        RemoteInspector::singleton().automationConnectionDidClose();
+#endif
     } else if (&clientConnection == m_clientConnection) {
         for (auto connectionTargetPair : copyToVector(m_inspectionTargets))
             close(clientConnection, connectionTargetPair.first, connectionTargetPair.second);


### PR DESCRIPTION
#### 20fa2504d9b7c8f3779941ef1953192850c67705
<pre>
[WebDriver][GLIB] Notify automation session on abnormal disconnections from the browser
<a href="https://bugs.webkit.org/show_bug.cgi?id=294044">https://bugs.webkit.org/show_bug.cgi?id=294044</a>

Reviewed by Carlos Garcia Campos.

Currently, an automation session is just cleared up on normal
disconnections through `WebAutomationSession::terminate()`. This method
notifies the WebKitWebContext to make its WebKitAutomationSession emit
the &quot;will-close&quot; signal, allowing the browser to clean up resources,
alongside releasing the automation session reference. This signal was
added in 282489@main.

In unclean terminations, like a driver crash or failure to setup
capabilities, the session currently is left open, as this code path is
not hit.

This brings problems when we&apos;re connecting to a running browser (common
scenario when working with less powerful boards). In this case,
WebKitAutomationSession/WebKitWebContext are not notified of the
connection closure and we might get an inconsistent automation state
despite a successful initial connection. For example, if assertions are
disabled, we end up with no error messages until trying to create the
first browsing context reference, where we get the generic &quot;Failed to
create a browsing context&quot; message.

This commits addresses this issue by making the RemoteInspectorServer
notify the RemoteInspector of the connection closure, which in turn
notifies the WebKitWebContext client, ensuring &quot;will-close&quot; gets called.

With this, the browser is able to recover and make new incoming sessions
work normally.

* Source/JavaScriptCore/inspector/remote/RemoteInspector.h: Expose
  `closeAutomationSession` to GLIB client and add new
  automationConnectionDidClose Inspector method.
* Source/JavaScriptCore/inspector/remote/glib/RemoteInspectorGlib.cpp:
(Inspector::RemoteInspector::automationConnectionDidClose): call new
client method.
* Source/JavaScriptCore/inspector/remote/glib/RemoteInspectorServer.cpp:
(Inspector::RemoteInspectorServer::connectionDidClose): Notify
inspector that the automation connection was closed.
* Source/WebKit/UIProcess/API/glib/WebKitWebContext.cpp:
(WebKitAutomationClient::requestAutomationSession): Replace assert with
a g_critical, so release builds can notify a double attempt to connect.
(webkitWebContextWillCloseAutomationSession): Check for session presence
before trying to emit the signal.

Canonical link: <a href="https://commits.webkit.org/296096@main">https://commits.webkit.org/296096@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3c513c60dbf638e1608e595983ec51737b28af18

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/107306 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/26988 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/17392 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/112520 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/57840 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/27669 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/35488 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/81453 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/110235 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/21925 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/96716 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/61827 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/21357 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/14846 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/57285 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/99895 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/91287 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/14880 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/115621 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/105852 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/34372 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/25328 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/90499 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/34748 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/92966 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/90235 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23019 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35143 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/12925 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/30102 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/34294 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/39820 "Failed to build and analyze WebKit") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/130169 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34040 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/35404 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/37395 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/35701 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->