### PR TITLE
WebKit to adopt API in AVSampleBufferVideoRenderer to get a recommendation of PixelBufferAttribute for optimal playback

### DIFF
--- a/Source/WebCore/platform/cocoa/CoreVideoSoftLink.cpp
+++ b/Source/WebCore/platform/cocoa/CoreVideoSoftLink.cpp
@@ -102,6 +102,8 @@ SOFT_LINK_CONSTANT_FOR_SOURCE(WebCore, CoreVideo, kCVPixelBufferExtendedPixelsBo
 SOFT_LINK_CONSTANT_FOR_SOURCE(WebCore, CoreVideo, kCVPixelBufferOpenGLCompatibilityKey, CFStringRef)
 #endif
 
+SOFT_LINK_CONSTANT_FOR_SOURCE(WebCore, CoreVideo, kCVPixelBufferPreferRealTimeCacheModeIfEveryoneDoesKey, CFStringRef)
+
 SOFT_LINK_FUNCTION_FOR_SOURCE(WebCore, CoreVideo, CVPixelBufferCreate, CVReturn, (CFAllocatorRef allocator, size_t width, size_t height, OSType pixelFormatType, CFDictionaryRef pixelBufferAttributes, CVPixelBufferRef *pixelBufferOut), (allocator, width, height, pixelFormatType, pixelBufferAttributes, pixelBufferOut))
 SOFT_LINK_FUNCTION_FOR_SOURCE(WebCore, CoreVideo, CVPixelBufferCreateWithBytes, CVReturn, (CFAllocatorRef allocator, size_t width, size_t height, OSType pixelFormatType, void* data, size_t bytesPerRow, void (*releaseCallback)(void*, const void*), void* releasePointer, CFDictionaryRef pixelBufferAttributes, CVPixelBufferRef *pixelBufferOut), (allocator, width, height, pixelFormatType, data, bytesPerRow, releaseCallback, releasePointer, pixelBufferAttributes, pixelBufferOut))
 SOFT_LINK_FUNCTION_FOR_SOURCE_WITH_EXPORT(WebCore, CoreVideo, CVPixelBufferCreateWithIOSurface, CVReturn, (CFAllocatorRef allocator, IOSurfaceRef surface, CFDictionaryRef pixelBufferAttributes, CVPixelBufferRef * pixelBufferOut), (allocator, surface, pixelBufferAttributes, pixelBufferOut), WEBCORE_EXPORT)

--- a/Source/WebCore/platform/cocoa/CoreVideoSoftLink.h
+++ b/Source/WebCore/platform/cocoa/CoreVideoSoftLink.h
@@ -163,6 +163,9 @@ SOFT_LINK_CONSTANT_FOR_HEADER(WebCore, CoreVideo, kCVPixelBufferOpenGLCompatibil
 #define kCVPixelBufferOpenGLCompatibilityKey get_CoreVideo_kCVPixelBufferOpenGLCompatibilityKey()
 #endif
 
+SOFT_LINK_CONSTANT_FOR_HEADER(WebCore, CoreVideo, kCVPixelBufferPreferRealTimeCacheModeIfEveryoneDoesKey, CFStringRef)
+#define kCVPixelBufferPreferRealTimeCacheModeIfEveryoneDoesKey get_CoreVideo_kCVPixelBufferPreferRealTimeCacheModeIfEveryoneDoesKey()
+
 SOFT_LINK_FUNCTION_FOR_HEADER(WebCore, CoreVideo, CVPixelBufferCreate, CVReturn, (CFAllocatorRef allocator, size_t width, size_t height, OSType pixelFormatType, CFDictionaryRef pixelBufferAttributes, CF_RETURNS_RETAINED CVPixelBufferRef *pixelBufferOut), (allocator, width, height, pixelFormatType, pixelBufferAttributes, pixelBufferOut))
 #define CVPixelBufferCreate softLink_CoreVideo_CVPixelBufferCreate
 

--- a/Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.mm
+++ b/Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.mm
@@ -61,6 +61,12 @@
 @end
 #endif
 
+#if HAVE(RECOMMENDED_PIXEL_ATTRIBUTES_API)
+@interface AVSampleBufferVideoRenderer (Staging_152246223)
+@property (readonly, nonnull) NSDictionary<NSString*, NS_SWIFT_SENDABLE id> *recommendedPixelBufferAttributes;
+@end
+#endif
+
 // Equivalent to WTF_DECLARE_CF_TYPE_TRAIT(CMSampleBuffer);
 // Needed due to requirement of specifying the PAL namespace.
 template <>
@@ -645,7 +651,14 @@ void VideoMediaSampleRenderer::initializeDecompressionSession()
         if (m_decompressionSession)
             return;
 
-        m_decompressionSession = WebCoreDecompressionSession::createOpenGL();
+#if HAVE(RECOMMENDED_PIXEL_ATTRIBUTES_API)
+        if (m_renderer) {
+            if ([m_renderer.get() respondsToSelector:@selector(recommendedPixelBufferAttributes)])
+                m_decompressionSession = WebCoreDecompressionSession::create([m_renderer recommendedPixelBufferAttributes]);
+        }
+#endif
+        if (!m_decompressionSession)
+            m_decompressionSession = WebCoreDecompressionSession::createOpenGL();
         m_isUsingDecompressionSession = true;
     }
     if (!m_decodedSampleQueue) {


### PR DESCRIPTION
#### 73c1a27f8ffdc49b2e19034ba599aa65fbbf7e6b
<pre>
WebKit to adopt API in AVSampleBufferVideoRenderer to get a recommendation of PixelBufferAttribute for optimal playback
<a href="https://bugs.webkit.org/show_bug.cgi?id=294101">https://bugs.webkit.org/show_bug.cgi?id=294101</a>
<a href="https://rdar.apple.com/152269285">rdar://152269285</a>

Reviewed by Youenn Fablet.

Use the recommended PixelBuffer attributes if available, otherwise continue
using the existing defaults. We also set the key kCVPixelBufferPreferRealTimeCacheModeIfEveryoneDoesKey
so that CoreAnimation doesn&apos;t have to composite the IOSurface when rendering
in fullscreen.

* Source/WebCore/platform/cocoa/CoreVideoSoftLink.h:  Add required key soflink
* Source/WebCore/platform/graphics/cocoa/WebCoreDecompressionSession.mm:
(WebCore::canCopyFormatDescriptionExtension): Fly-by change, tidying method and remove use of static global variable.

Canonical link: <a href="https://commits.webkit.org/296136@main">https://commits.webkit.org/296136@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/74fcdeb194610f15f066aea78ffebdf9f6bf8fc9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/107325 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27007 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/17411 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/112539 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/57860 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/109289 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/27688 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/35507 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/81472 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/110254 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/21936 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/96730 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/61846 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/21374 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/14860 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/57304 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/91304 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/14894 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/115640 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/34391 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/25342 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/90514 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/34767 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/92980 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/90250 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23043 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35156 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/12939 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/30123 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/34313 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/39847 "Failed to build and analyze WebKit") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34059 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/37414 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/35720 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->