### PR TITLE
AX: DidSpellCheck attribute not applied for editable pages/documents

### DIFF
--- a/LayoutTests/accessibility/mac/designmode-lazy-spellchecking-expected.txt
+++ b/LayoutTests/accessibility/mac/designmode-lazy-spellchecking-expected.txt
@@ -1,0 +1,17 @@
+This test ensures that the proper attributes are present when "lazy" spellchecking happens in a document with design mode turned on.
+
+Attributed string with range: Attributes in range {0, 45}:
+AXDidSpellCheck: 0
+AXFont: {
+    AXFontFamily = Times;
+    AXFontName = "Times-Roman";
+    AXFontSize = 16;
+}
+AXForegroundColor: (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; sRGB IEC61966-2.1) ( 0 0 0 1 )
+AXBackgroundColor: (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; sRGB IEC61966-2.1) ( 0 0 0 0 )
+wrods is misspelled aab lotsi nowadays. euep.
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+wrods is misspelled aab lotsi nowadays. euep.

--- a/LayoutTests/accessibility/mac/designmode-lazy-spellchecking.html
+++ b/LayoutTests/accessibility/mac/designmode-lazy-spellchecking.html
@@ -1,0 +1,27 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+
+<div id="contenteditable">
+wrods is misspelled aab lotsi nowadays. euep.
+</div>
+
+<script>
+var output = "This test ensures that the proper attributes are present when \"lazy\" spellchecking happens in a document with design mode turned on.\n\n";
+
+if (window.accessibilityController && window.textInputController) {
+    accessibilityController.setForceDeferredSpellChecking(true);
+    document.designMode = "on";
+
+    var contenteditable = accessibilityController.accessibleElementById("contenteditable");
+    var range = contenteditable.textMarkerRangeForElement(contenteditable);
+    output += `Attributed string with range: ${contenteditable.attributedStringForTextMarkerRangeWithDidSpellCheck(range)}\n`;
+    debug(output);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/mac/editable-page-lazy-spellchecking-expected.txt
+++ b/LayoutTests/accessibility/mac/editable-page-lazy-spellchecking-expected.txt
@@ -1,0 +1,17 @@
+This test ensures that the proper attributes are present when "lazy" spellchecking happens in a page marked as editable.
+
+Attributed string with range: Attributes in range {0, 45}:
+AXDidSpellCheck: 0
+AXFont: {
+    AXFontFamily = Times;
+    AXFontName = "Times-Roman";
+    AXFontSize = 16;
+}
+AXForegroundColor: (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; sRGB IEC61966-2.1) ( 0 0 0 1 )
+AXBackgroundColor: (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; sRGB IEC61966-2.1) ( 0 0 0 0 )
+wrods is misspelled aab lotsi nowadays. euep.
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+wrods is misspelled aab lotsi nowadays. euep.

--- a/LayoutTests/accessibility/mac/editable-page-lazy-spellchecking.html
+++ b/LayoutTests/accessibility/mac/editable-page-lazy-spellchecking.html
@@ -1,0 +1,27 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+
+<div id="contenteditable">
+wrods is misspelled aab lotsi nowadays. euep.
+</div>
+
+<script>
+var output = "This test ensures that the proper attributes are present when \"lazy\" spellchecking happens in a page marked as editable.\n\n";
+
+if (window.accessibilityController && window.textInputController) {
+    accessibilityController.setForceDeferredSpellChecking(true);
+    textInputController.setPageEditable(true);
+
+    var contenteditable = accessibilityController.accessibleElementById("contenteditable");
+    var range = contenteditable.textMarkerRangeForElement(contenteditable);
+    output += `Attributed string with range: ${contenteditable.attributedStringForTextMarkerRangeWithDidSpellCheck(range)}\n`;
+    debug(output);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -955,6 +955,8 @@ accessibility/display-contents/aria-owns.html [ Skip ]
 accessibility/mac/text-field-number-of-characters.html [ Skip ]
 accessibility/mac/content-editable-attributed-string.html [ Skip ]
 accessibility/mac/lazy-spellchecking.html [ Skip ]
+accessibility/mac/editable-page-lazy-spellchecking.html [ Skip ]
+accessibility/mac/designmode-lazy-spellchecking.html [ Skip ]
 accessibility/mac/spellcheck-with-voiceover.html [ Skip ]
 accessibility/text-marker/text-marker-range-with-unordered-markers.html
 accessibility/mac/line-boundary-at-br.html [ Skip ]

--- a/Source/WebCore/accessibility/AXCoreObject.h
+++ b/Source/WebCore/accessibility/AXCoreObject.h
@@ -925,6 +925,7 @@ public:
     bool isSwitch() const { return role() == AccessibilityRole::Switch; }
     bool isToggleButton() const { return role() == AccessibilityRole::ToggleButton; }
     bool isTextControl() const;
+    virtual bool isEditableWebArea() const = 0;
     virtual bool isNonNativeTextControl() const = 0;
     bool isTabList() const { return role() == AccessibilityRole::TabList; }
     bool isTabItem() const { return role() == AccessibilityRole::Tab; }
@@ -1784,7 +1785,7 @@ template<typename T>
 T* editableAncestor(const T& startObject)
 {
     return findAncestor<T>(startObject, false, [] (const auto& ancestor) {
-        return ancestor.isTextControl();
+        return ancestor.isTextControl() || ancestor.isEditableWebArea();
     });
 }
 

--- a/Source/WebCore/accessibility/AXLogger.cpp
+++ b/Source/WebCore/accessibility/AXLogger.cpp
@@ -807,6 +807,9 @@ TextStream& operator<<(WTF::TextStream& stream, AXProperty property)
     case AXProperty::HasRemoteFrameChild:
         stream << "HasRemoteFrameChild";
         break;
+    case AXProperty::IsEditableWebArea:
+        stream << "IsEditableWebArea";
+        break;
     case AXProperty::IsSubscript:
         stream << "IsSubscript";
         break;

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -2903,6 +2903,15 @@ void AXObjectCache::handleReferenceTargetChanged()
     relationsNeedUpdate(true);
 }
 
+void AXObjectCache::handlePageEditibilityChanged(Document& document)
+{
+#if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
+    postNotification(&document, AXNotification::IsEditableWebAreaChanged);
+#else
+    UNUSED_PARAM(document);
+#endif
+}
+
 bool AXObjectCache::shouldProcessAttributeChange(Element* element, const QualifiedName& attrName)
 {
     if (!element)
@@ -4972,6 +4981,9 @@ void AXObjectCache::updateIsolatedTree(const Vector<std::pair<Ref<AccessibilityO
             break;
         case AXNotification::InputTypeChanged:
             tree->queueNodeUpdate(notification.first->objectID(), { AXProperty::InputType });
+            break;
+        case AXNotification::IsEditableWebAreaChanged:
+            tree->queueNodeUpdate(notification.first->objectID(), { AXProperty::IsEditableWebArea });
             break;
         case AXNotification::LevelChanged:
             tree->queueNodeUpdate(notification.first->objectID(), { AXProperty::ARIALevel });

--- a/Source/WebCore/accessibility/AXObjectCache.h
+++ b/Source/WebCore/accessibility/AXObjectCache.h
@@ -199,6 +199,7 @@ protected:
     macro(InertOrVisibilityChanged) \
     macro(InputTypeChanged) \
     macro(IsAtomicChanged) \
+    macro(IsEditableWebAreaChanged) \
     macro(KeyShortcutsChanged) \
     macro(LabelChanged) \
     macro(LanguageChanged) \
@@ -417,6 +418,7 @@ public:
     void autofillTypeChanged(HTMLInputElement&);
     void handleRoleChanged(AccessibilityObject&, AccessibilityRole previousRole);
     void handleReferenceTargetChanged();
+    void handlePageEditibilityChanged(Document&);
 
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
     void columnIndexChanged(AccessibilityObject&);

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -383,6 +383,19 @@ bool AccessibilityObject::isARIATextControl() const
     return ariaRoleAttribute() == AccessibilityRole::TextArea || ariaRoleAttribute() == AccessibilityRole::TextField || ariaRoleAttribute() == AccessibilityRole::SearchField;
 }
 
+bool AccessibilityObject::isEditableWebArea() const
+{
+    if (!isWebArea())
+        return false;
+
+    auto* page = this->page();
+    if (page && page->isEditable())
+        return true;
+
+    auto* document = this->document();
+    return document && document->inDesignMode();
+}
+
 bool AccessibilityObject::isNonNativeTextControl() const
 {
     return (isARIATextControl() || hasContentEditableAttributeSet()) && !isNativeTextControl();

--- a/Source/WebCore/accessibility/AccessibilityObject.h
+++ b/Source/WebCore/accessibility/AccessibilityObject.h
@@ -185,6 +185,7 @@ public:
     bool isMockObject() const override { return false; }
     virtual bool isMediaObject() const { return false; }
     bool isARIATextControl() const;
+    bool isEditableWebArea() const final;
     bool isNonNativeTextControl() const final;
     bool isRangeControl() const;
     bool isStyleFormatGroup() const;

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
@@ -81,6 +81,7 @@ public:
 #endif // ENABLE(INCLUDE_IGNORED_IN_CORE_AX_TREE)
     AXIsolatedObject* clickableSelfOrAncestor(ClickHandlerFilter filter = ClickHandlerFilter::ExcludeBody) const final { return Accessibility::clickableSelfOrAncestor(*this, filter); };
     AXIsolatedObject* editableAncestor() const final { return Accessibility::editableAncestor(*this); };
+    bool isEditableWebArea() const final { return boolAttributeValue(AXProperty::IsEditableWebArea); }
     bool canSetFocusAttribute() const final { return boolAttributeValue(AXProperty::CanSetFocusAttribute); }
     AttributedStringStyle stylesForAttributedString() const final;
     Color textColor() const final { return colorAttributeValue(AXProperty::TextColor); }

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
@@ -692,6 +692,9 @@ void AXIsolatedTree::updateNodeProperties(AccessibilityObject& axObject, const A
         case AXProperty::IsColumnHeader:
             properties.append({ AXProperty::IsColumnHeader, axObject.isColumnHeader() });
             break;
+        case AXProperty::IsEditableWebArea:
+            properties.append({ AXProperty::IsEditableWebArea, axObject.isEditableWebArea() });
+            break;
         case AXProperty::IsEnabled:
             properties.append({ AXProperty::IsEnabled, axObject.isEnabled() });
             break;
@@ -1842,6 +1845,9 @@ IsolatedObjectData createIsolatedObjectData(const Ref<AccessibilityObject>& axOb
             setProperty(AXProperty::RelativeFrame, IntRect());
         } else
             setProperty(AXProperty::InitialFrameRect, object.frameRect());
+
+        if (isWebArea)
+            setProperty(AXProperty::IsEditableWebArea, object.isEditableWebArea());
 
         if (object.supportsPath()) {
             setProperty(AXProperty::SupportsPath, true);

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
@@ -149,6 +149,7 @@ enum class AXProperty : uint16_t {
     HasPlainText,
     HasRemoteFrameChild,
     InputType,
+    IsEditableWebArea,
     IsSubscript,
     IsSuperscript,
     HasTextShadow,

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -7721,6 +7721,8 @@ void Document::setDesignMode(const String& value)
     DesignMode mode = equalLettersIgnoringASCIICase(value, "on"_s) ? DesignMode::On : DesignMode::Off;
     m_designMode = mode;
     scheduleFullStyleRebuild();
+    if (CheckedPtr cache = existingAXObjectCache())
+        cache->handlePageEditibilityChanged(*this);
 }
 
 Document* Document::parentDocument() const

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -2830,6 +2830,17 @@ void Page::setMemoryCacheClientCallsEnabled(bool enabled)
     m_hasPendingMemoryCacheLoadNotifications = false;
 }
 
+void Page::setEditable(bool isEditable)
+{
+    m_isEditable = isEditable;
+
+    if (CheckedPtr cache = axObjectCache()) {
+        forEachDocument([&] (Document& document) {
+            cache->handlePageEditibilityChanged(document);
+        });
+    }
+}
+
 void Page::hiddenPageDOMTimerThrottlingStateChanged()
 {
     // Disable & reengage to ensure state is updated.

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -889,7 +889,7 @@ public:
     // Don't allow more than a certain frame depth to avoid stack exhaustion.
     static constexpr int maxFrameDepth = 32;
 
-    void setEditable(bool isEditable) { m_isEditable = isEditable; }
+    WEBCORE_EXPORT void setEditable(bool);
     bool isEditable() const { return m_isEditable; }
 
     WEBCORE_EXPORT VisibilityState visibilityState() const;

--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePage.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePage.cpp
@@ -278,6 +278,13 @@ void WKAccessibilitySetForceInitialFrameCaching(bool shouldForce)
     WebCore::AXObjectCache::setForceInitialFrameCaching(shouldForce);
 }
 
+void WKBundlePageSetEditable(WKBundlePageRef pageRef, bool isEditable)
+{
+    WebKit::WebPage* webPage = WebKit::toImpl(pageRef);
+    if (WebCore::Page* page = webPage ? webPage->corePage() : nullptr)
+        page->setEditable(isEditable);
+}
+
 void WKBundlePageSetDefersLoading(WKBundlePageRef, bool)
 {
 }

--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePagePrivate.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePagePrivate.h
@@ -90,6 +90,8 @@ WK_EXPORT void WKAccessibilityEnableEnhancedAccessibility(bool);
 WK_EXPORT bool WKAccessibilityEnhancedAccessibilityEnabled();
 WK_EXPORT void WKAccessibilitySetForceInitialFrameCaching(bool);
 
+WK_EXPORT void WKBundlePageSetEditable(WKBundlePageRef page, bool isEditable);
+
 WK_EXPORT void WKBundlePageClickMenuItem(WKBundlePageRef, WKContextMenuItemRef);
 WK_EXPORT WKArrayRef WKBundlePageCopyContextMenuItems(WKBundlePageRef);
 WK_EXPORT WKArrayRef WKBundlePageCopyContextMenuAtPointInWindow(WKBundlePageRef, WKPoint);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -1840,8 +1840,8 @@ void WebPage::executeEditingCommand(const String& commandName, const String& arg
 
 void WebPage::setEditable(bool editable)
 {
-    m_page->setEditable(editable);
-    m_page->setTabKeyCyclesThroughElements(!editable);
+    protectedCorePage()->setEditable(editable);
+    protectedCorePage()->setTabKeyCyclesThroughElements(!editable);
     RefPtr frame = protectedCorePage()->checkedFocusController()->focusedOrMainFrame();
     if (!frame)
         return;

--- a/Tools/WebKitTestRunner/InjectedBundle/AccessibilityUIElement.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/AccessibilityUIElement.h
@@ -367,6 +367,7 @@ public:
     JSRetainPtr<JSStringRef> stringForTextMarkerRange(AccessibilityTextMarkerRange*);
     JSRetainPtr<JSStringRef> rectsForTextMarkerRange(AccessibilityTextMarkerRange*, JSStringRef);
     JSRetainPtr<JSStringRef> attributedStringForTextMarkerRange(AccessibilityTextMarkerRange*);
+    JSRetainPtr<JSStringRef> attributedStringForTextMarkerRangeWithDidSpellCheck(AccessibilityTextMarkerRange*);
     JSRetainPtr<JSStringRef> attributedStringForTextMarkerRangeWithOptions(AccessibilityTextMarkerRange*, bool);
     int textMarkerRangeLength(AccessibilityTextMarkerRange*);
     bool attributedStringForTextMarkerRangeContainsAttribute(JSStringRef, AccessibilityTextMarkerRange*);

--- a/Tools/WebKitTestRunner/InjectedBundle/Bindings/AccessibilityUIElement.idl
+++ b/Tools/WebKitTestRunner/InjectedBundle/Bindings/AccessibilityUIElement.idl
@@ -274,6 +274,7 @@ interface AccessibilityUIElement {
     DOMString stringForTextMarkerRange(AccessibilityTextMarkerRange range);
     DOMString rectsForTextMarkerRange(AccessibilityTextMarkerRange range, DOMString searchText);
     DOMString attributedStringForTextMarkerRange(AccessibilityTextMarkerRange range);
+    DOMString attributedStringForTextMarkerRangeWithDidSpellCheck(AccessibilityTextMarkerRange range);
     DOMString attributedStringForTextMarkerRangeWithOptions(AccessibilityTextMarkerRange range, boolean includeSpellCheck);
     long textMarkerRangeLength(AccessibilityTextMarkerRange range);
     boolean attributedStringForTextMarkerRangeContainsAttribute(DOMString attr, AccessibilityTextMarkerRange range);

--- a/Tools/WebKitTestRunner/InjectedBundle/Bindings/TextInputController.idl
+++ b/Tools/WebKitTestRunner/InjectedBundle/Bindings/TextInputController.idl
@@ -28,5 +28,6 @@ interface TextInputController {
     boolean hasMarkedText();
     undefined unmarkText();
     undefined insertText(DOMString string);
+    undefined setPageEditable(boolean isEditable);
 };
 

--- a/Tools/WebKitTestRunner/InjectedBundle/TextInputController.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/TextInputController.cpp
@@ -124,4 +124,9 @@ void TextInputController::insertText(JSStringRef text)
     WKBundlePageConfirmCompositionWithText(InjectedBundle::singleton().page()->page(), toWK(text).get());
 }
 
+void TextInputController::setPageEditable(bool isEditable)
+{
+    WKBundlePageSetEditable(InjectedBundle::singleton().page()->page(), isEditable);
+}
+
 } // namespace WTR

--- a/Tools/WebKitTestRunner/InjectedBundle/TextInputController.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/TextInputController.h
@@ -45,6 +45,8 @@ public:
     void unmarkText();
     void insertText(JSStringRef text);
 
+    void setPageEditable(bool);
+
 private:
     TextInputController() = default;
 

--- a/Tools/WebKitTestRunner/InjectedBundle/atspi/AccessibilityUIElementAtspi.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/atspi/AccessibilityUIElementAtspi.cpp
@@ -1728,6 +1728,11 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::attributedStringForTextMarkerRa
     return nullptr;
 }
 
+JSRetainPtr<JSStringRef> AccessibilityUIElement::attributedStringForTextMarkerRangeWithDidSpellCheck(AccessibilityTextMarkerRange*)
+{
+    return nullptr;
+}
+
 JSRetainPtr<JSStringRef> AccessibilityUIElement::attributedStringForTextMarkerRangeWithOptions(AccessibilityTextMarkerRange*, bool)
 {
     return nullptr;

--- a/Tools/WebKitTestRunner/InjectedBundle/ios/AccessibilityUIElementIOS.mm
+++ b/Tools/WebKitTestRunner/InjectedBundle/ios/AccessibilityUIElementIOS.mm
@@ -1391,6 +1391,11 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::attributedStringForTextMarkerRa
     return nullptr;
 }
 
+JSRetainPtr<JSStringRef> AccessibilityUIElement::attributedStringForTextMarkerRangeWithDidSpellCheck(AccessibilityTextMarkerRange* markerRange)
+{
+    return nullptr;
+}
+
 JSRetainPtr<JSStringRef> AccessibilityUIElement::attributedStringForTextMarkerRangeWithOptions(AccessibilityTextMarkerRange* markerRange, bool)
 {
     return nullptr;

--- a/Tools/WebKitTestRunner/InjectedBundle/playstation/AccessibilityUIElementPlayStation.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/playstation/AccessibilityUIElementPlayStation.cpp
@@ -928,6 +928,12 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::attributedStringForTextMarkerRa
     return nullptr;
 }
 
+JSRetainPtr<JSStringRef> AccessibilityUIElement::attributedStringForTextMarkerRangeWithDidSpellCheck(AccessibilityTextMarkerRange*)
+{
+    notImplemented();
+    return nullptr;
+}
+
 JSRetainPtr<JSStringRef> AccessibilityUIElement::attributedStringForTextMarkerRangeWithOptions(AccessibilityTextMarkerRange*, bool)
 {
     notImplemented();

--- a/Tools/WebKitTestRunner/InjectedBundle/win/AccessibilityUIElementWin.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/win/AccessibilityUIElementWin.cpp
@@ -928,6 +928,12 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::attributedStringForTextMarkerRa
     return nullptr;
 }
 
+JSRetainPtr<JSStringRef> AccessibilityUIElement::attributedStringForTextMarkerRangeWithDidSpellCheck(AccessibilityTextMarkerRange*)
+{
+    notImplemented();
+    return nullptr;
+}
+
 JSRetainPtr<JSStringRef> AccessibilityUIElement::attributedStringForTextMarkerRangeWithOptions(AccessibilityTextMarkerRange*, bool)
 {
     notImplemented();


### PR DESCRIPTION
#### 08cc264f5e2337bed167ab1d39c54057540c5bc2
<pre>
AX: DidSpellCheck attribute not applied for editable pages/documents
<a href="https://bugs.webkit.org/show_bug.cgi?id=294103">https://bugs.webkit.org/show_bug.cgi?id=294103</a>
<a href="https://rdar.apple.com/149710398">rdar://149710398</a>

Reviewed by Tyler Wilcock.

We did not previously consider an editable web area (page) to be an editible
ancestor, so the AXDidSpellCheck attribute would not be applied. This caused
certain ATs to not read out misspellings, if they handle the spellchecking.

This PR adds a new check to editableAncestor to return true if we hit a
web area that is also editable. New testing infrastructure was also added to
allow this attribute to be visible to tests that use the
attributedStringForTextMarkerRangeWithDidSpellCheck method.

* LayoutTests/accessibility/mac/designmode-lazy-spellchecking-expected.txt: Added.
* LayoutTests/accessibility/mac/designmode-lazy-spellchecking.html: Added.
* LayoutTests/accessibility/mac/editable-page-lazy-spellchecking-expected.txt: Added.
* LayoutTests/accessibility/mac/editable-page-lazy-spellchecking.html: Added.
* LayoutTests/platform/mac-wk1/TestExpectations:
* Source/WebCore/accessibility/AXCoreObject.h:
(WebCore::Accessibility::editableAncestor):
* Source/WebCore/accessibility/AXLogger.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::handlePageEditibilityChanged):
(WebCore::AXObjectCache::updateIsolatedTree):
* Source/WebCore/accessibility/AXObjectCache.h:
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::isEditableWebArea const):
* Source/WebCore/accessibility/AccessibilityObject.h:
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h:
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp:
(WebCore::AXIsolatedTree::updateNodeProperties):
(WebCore::createIsolatedObjectData):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::setDesignMode):
* Source/WebCore/page/Page.cpp:
(WebCore::Page::setEditable):
* Source/WebCore/page/Page.h:
(WebCore::Page::setEditable): Deleted.
* Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePage.cpp:
(WKBundlePageSetEditable):
* Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePagePrivate.h:
* Tools/WebKitTestRunner/InjectedBundle/AccessibilityUIElement.h:
* Tools/WebKitTestRunner/InjectedBundle/Bindings/AccessibilityUIElement.idl:
* Tools/WebKitTestRunner/InjectedBundle/Bindings/TextInputController.idl:
* Tools/WebKitTestRunner/InjectedBundle/TextInputController.cpp:
(WTR::TextInputController::setPageEditable):
* Tools/WebKitTestRunner/InjectedBundle/TextInputController.h:
* Tools/WebKitTestRunner/InjectedBundle/atspi/AccessibilityUIElementAtspi.cpp:
(WTR::AccessibilityUIElement::attributedStringForTextMarkerRangeWithDidSpellCheck):
* Tools/WebKitTestRunner/InjectedBundle/ios/AccessibilityUIElementIOS.mm:
(WTR::AccessibilityUIElement::attributedStringForTextMarkerRangeWithDidSpellCheck):
* Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.mm:
(WTR::createJSStringRef):
(WTR::AccessibilityUIElement::attributedStringForTextMarkerRange):
(WTR::AccessibilityUIElement::attributedStringForTextMarkerRangeWithDidSpellCheck):
(WTR::AccessibilityUIElement::attributedStringForTextMarkerRangeWithOptions):
* Tools/WebKitTestRunner/InjectedBundle/playstation/AccessibilityUIElementPlayStation.cpp:
(WTR::AccessibilityUIElement::attributedStringForTextMarkerRangeWithDidSpellCheck):
* Tools/WebKitTestRunner/InjectedBundle/win/AccessibilityUIElementWin.cpp:
(WTR::AccessibilityUIElement::attributedStringForTextMarkerRangeWithDidSpellCheck):

Canonical link: <a href="https://commits.webkit.org/295998@main">https://commits.webkit.org/295998@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b60dee6c7d9b27f71bfb57fa8e8a3552745dcf87

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/106684 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/26435 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/16832 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/111894 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/57282 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/108723 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/27105 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34937 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/81013 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/109688 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/21505 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/96270 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/61352 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/20951 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/14377 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/56736 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/90845 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/14406 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/114792 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33822 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24936 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/90075 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/34186 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/92501 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89784 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/22947 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34711 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/12521 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/29449 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/33747 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/39160 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/33493 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/36846 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/35092 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->