### PR TITLE
Address Safer CPP warnings in WebCookieManager classes

### DIFF
--- a/Source/WebKit/NetworkProcess/Cookies/WebCookieManager.cpp
+++ b/Source/WebKit/NetworkProcess/Cookies/WebCookieManager.cpp
@@ -78,14 +78,14 @@ Ref<NetworkProcess> WebCookieManager::protectedProcess()
 void WebCookieManager::getHostnamesWithCookies(PAL::SessionID sessionID, CompletionHandler<void(Vector<String>&&)>&& completionHandler)
 {
     HashSet<String> hostnames;
-    if (auto* storageSession = protectedProcess()->storageSession(sessionID))
+    if (CheckedPtr storageSession = protectedProcess()->storageSession(sessionID))
         storageSession->getHostnamesWithCookies(hostnames);
     completionHandler(copyToVector(hostnames));
 }
 
 void WebCookieManager::deleteCookiesForHostnames(PAL::SessionID sessionID, const Vector<String>& hostnames, CompletionHandler<void()>&& completionHandler)
 {
-    if (auto* storageSession = protectedProcess()->storageSession(sessionID))
+    if (CheckedPtr storageSession = protectedProcess()->storageSession(sessionID))
         storageSession->deleteCookiesForHostnames(hostnames, WTFMove(completionHandler));
     else
         completionHandler();
@@ -93,7 +93,7 @@ void WebCookieManager::deleteCookiesForHostnames(PAL::SessionID sessionID, const
 
 void WebCookieManager::deleteAllCookies(PAL::SessionID sessionID, CompletionHandler<void()>&& completionHandler)
 {
-    if (auto* storageSession = protectedProcess()->storageSession(sessionID))
+    if (CheckedPtr storageSession = protectedProcess()->storageSession(sessionID))
         storageSession->deleteAllCookies(WTFMove(completionHandler));
     else
         completionHandler();
@@ -101,7 +101,7 @@ void WebCookieManager::deleteAllCookies(PAL::SessionID sessionID, CompletionHand
 
 void WebCookieManager::deleteCookie(PAL::SessionID sessionID, const Cookie& cookie, CompletionHandler<void()>&& completionHandler)
 {
-    if (auto* storageSession = protectedProcess()->storageSession(sessionID))
+    if (CheckedPtr storageSession = protectedProcess()->storageSession(sessionID))
         storageSession->deleteCookie(cookie, WTFMove(completionHandler));
     else
         completionHandler();
@@ -109,7 +109,7 @@ void WebCookieManager::deleteCookie(PAL::SessionID sessionID, const Cookie& cook
 
 void WebCookieManager::deleteAllCookiesModifiedSince(PAL::SessionID sessionID, WallTime time, CompletionHandler<void()>&& completionHandler)
 {
-    if (auto* storageSession = protectedProcess()->storageSession(sessionID))
+    if (CheckedPtr storageSession = protectedProcess()->storageSession(sessionID))
         storageSession->deleteAllCookiesModifiedSince(time, WTFMove(completionHandler));
     else
         completionHandler();
@@ -118,7 +118,7 @@ void WebCookieManager::deleteAllCookiesModifiedSince(PAL::SessionID sessionID, W
 void WebCookieManager::getAllCookies(PAL::SessionID sessionID, CompletionHandler<void(Vector<WebCore::Cookie>&&)>&& completionHandler)
 {
     Vector<Cookie> cookies;
-    if (auto* storageSession = protectedProcess()->storageSession(sessionID))
+    if (CheckedPtr storageSession = protectedProcess()->storageSession(sessionID))
         cookies = storageSession->getAllCookies();
     completionHandler(WTFMove(cookies));
 }
@@ -126,14 +126,14 @@ void WebCookieManager::getAllCookies(PAL::SessionID sessionID, CompletionHandler
 void WebCookieManager::getCookies(PAL::SessionID sessionID, const URL& url, CompletionHandler<void(Vector<WebCore::Cookie>&&)>&& completionHandler)
 {
     Vector<Cookie> cookies;
-    if (auto* storageSession = protectedProcess()->storageSession(sessionID))
+    if (CheckedPtr storageSession = protectedProcess()->storageSession(sessionID))
         cookies = storageSession->getCookies(url);
     completionHandler(WTFMove(cookies));
 }
 
 void WebCookieManager::setCookie(PAL::SessionID sessionID, const Vector<Cookie>& cookies, uint64_t cookiesVersion, CompletionHandler<void()>&& completionHandler)
 {
-    if (auto* storageSession = protectedProcess()->storageSession(sessionID)) {
+    if (CheckedPtr storageSession = protectedProcess()->storageSession(sessionID)) {
         for (auto& cookie : cookies)
             storageSession->setCookie(cookie);
         storageSession->setCookiesVersion(cookiesVersion);
@@ -144,7 +144,7 @@ void WebCookieManager::setCookie(PAL::SessionID sessionID, const Vector<Cookie>&
 
 void WebCookieManager::setCookies(PAL::SessionID sessionID, const Vector<Cookie>& cookies, const URL& url, const URL& mainDocumentURL, CompletionHandler<void()>&& completionHandler)
 {
-    if (auto* storageSession = protectedProcess()->storageSession(sessionID))
+    if (CheckedPtr storageSession = protectedProcess()->storageSession(sessionID))
         storageSession->setCookies(cookies, url, mainDocumentURL);
     completionHandler();
 }
@@ -157,7 +157,7 @@ void WebCookieManager::notifyCookiesDidChange(PAL::SessionID sessionID)
 
 void WebCookieManager::startObservingCookieChanges(PAL::SessionID sessionID)
 {
-    if (auto* storageSession = protectedProcess()->storageSession(sessionID)) {
+    if (CheckedPtr storageSession = protectedProcess()->storageSession(sessionID)) {
         WebCore::startObservingCookieChanges(*storageSession, [weakThis = WeakPtr { *this }, sessionID] {
             if (RefPtr protectedThis = weakThis.get())
                 protectedThis->notifyCookiesDidChange(sessionID);
@@ -167,7 +167,7 @@ void WebCookieManager::startObservingCookieChanges(PAL::SessionID sessionID)
 
 void WebCookieManager::stopObservingCookieChanges(PAL::SessionID sessionID)
 {
-    if (auto* storageSession = protectedProcess()->storageSession(sessionID))
+    if (CheckedPtr storageSession = protectedProcess()->storageSession(sessionID))
         WebCore::stopObservingCookieChanges(*storageSession);
 }
 
@@ -182,7 +182,7 @@ void WebCookieManager::setHTTPCookieAcceptPolicy(PAL::SessionID sessionID, HTTPC
 
 void WebCookieManager::getHTTPCookieAcceptPolicy(PAL::SessionID sessionID, CompletionHandler<void(HTTPCookieAcceptPolicy)>&& completionHandler)
 {
-    if (auto* storageSession = protectedProcess()->storageSession(sessionID))
+    if (CheckedPtr storageSession = protectedProcess()->storageSession(sessionID))
         completionHandler(storageSession->cookieAcceptPolicy());
     else
         completionHandler(HTTPCookieAcceptPolicy::Never);

--- a/Source/WebKit/NetworkProcess/Cookies/curl/WebCookieManagerCurl.cpp
+++ b/Source/WebKit/NetworkProcess/Cookies/curl/WebCookieManagerCurl.cpp
@@ -52,7 +52,7 @@ void WebCookieManager::platformSetHTTPCookieAcceptPolicy(PAL::SessionID sessionI
         break;
     }
 
-    if (auto* storageSession = protectedProcess()->storageSession(sessionID))
+    if (CheckedPtr storageSession = protectedProcess()->storageSession(sessionID))
         storageSession->setCookieAcceptPolicy(curlPolicy);
 
     completionHandler();

--- a/Source/WebKit/NetworkProcess/Cookies/mac/WebCookieManagerMac.mm
+++ b/Source/WebKit/NetworkProcess/Cookies/mac/WebCookieManagerMac.mm
@@ -58,7 +58,7 @@ void WebCookieManager::platformSetHTTPCookieAcceptPolicy(PAL::SessionID sessionI
 {
     ASSERT(hasProcessPrivilege(ProcessPrivilege::CanAccessRawCookies));
 
-    auto* storageSession = protectedProcess()->storageSession(sessionID);
+    CheckedPtr storageSession = protectedProcess()->storageSession(sessionID);
     if (!storageSession)
         return completionHandler();
 

--- a/Source/WebKit/NetworkProcess/Cookies/soup/WebCookieManagerSoup.cpp
+++ b/Source/WebKit/NetworkProcess/Cookies/soup/WebCookieManagerSoup.cpp
@@ -39,7 +39,7 @@ using namespace WebCore;
 
 void WebCookieManager::platformSetHTTPCookieAcceptPolicy(PAL::SessionID sessionID, HTTPCookieAcceptPolicy policy, CompletionHandler<void()>&& completionHandler)
 {
-    if (auto* storageSession = protectedProcess()->storageSession(sessionID))
+    if (CheckedPtr storageSession = protectedProcess()->storageSession(sessionID))
         storageSession->setCookieAcceptPolicy(policy);
 
     completionHandler();
@@ -47,13 +47,13 @@ void WebCookieManager::platformSetHTTPCookieAcceptPolicy(PAL::SessionID sessionI
 
 void WebCookieManager::setCookiePersistentStorage(PAL::SessionID sessionID, const String& storagePath, SoupCookiePersistentStorageType storageType)
 {
-    if (auto* networkSession = protectedProcess()->networkSession(sessionID))
+    if (CheckedPtr networkSession = protectedProcess()->networkSession(sessionID))
         static_cast<NetworkSessionSoup&>(*networkSession).setCookiePersistentStorage(storagePath, storageType);
 }
 
 void WebCookieManager::replaceCookies(PAL::SessionID sessionID, const Vector<WebCore::Cookie>& cookies, CompletionHandler<void()>&& completionHandler)
 {
-    if (auto* storageSession = protectedProcess()->storageSession(sessionID))
+    if (CheckedPtr storageSession = protectedProcess()->storageSession(sessionID))
         storageSession->replaceCookies(cookies);
     completionHandler();
 }

--- a/Source/WebKit/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
@@ -1,6 +1,4 @@
 NetworkProcess/Classifier/ResourceLoadStatisticsStore.cpp
-NetworkProcess/Cookies/WebCookieManager.cpp
-NetworkProcess/Cookies/mac/WebCookieManagerMac.mm
 NetworkProcess/Downloads/cocoa/DownloadCocoa.mm
 NetworkProcess/NetworkConnectionToWebProcess.cpp
 NetworkProcess/NetworkDataTask.cpp


### PR DESCRIPTION
#### 884ccf24c1c19deae2a96c4fdaaa798b232ee74b
<pre>
Address Safer CPP warnings in WebCookieManager classes
<a href="https://bugs.webkit.org/show_bug.cgi?id=294107">https://bugs.webkit.org/show_bug.cgi?id=294107</a>

Reviewed by Chris Dumez and Carlos Garcia Campos.

* Source/WebKit/NetworkProcess/Cookies/WebCookieManager.cpp:
(WebKit::WebCookieManager::getHostnamesWithCookies):
(WebKit::WebCookieManager::deleteCookiesForHostnames):
(WebKit::WebCookieManager::deleteAllCookies):
(WebKit::WebCookieManager::deleteCookie):
(WebKit::WebCookieManager::deleteAllCookiesModifiedSince):
(WebKit::WebCookieManager::getAllCookies):
(WebKit::WebCookieManager::getCookies):
(WebKit::WebCookieManager::setCookie):
(WebKit::WebCookieManager::setCookies):
(WebKit::WebCookieManager::startObservingCookieChanges):
(WebKit::WebCookieManager::stopObservingCookieChanges):
(WebKit::WebCookieManager::getHTTPCookieAcceptPolicy):
* Source/WebKit/NetworkProcess/Cookies/curl/WebCookieManagerCurl.cpp:
(WebKit::WebCookieManager::platformSetHTTPCookieAcceptPolicy):
* Source/WebKit/NetworkProcess/Cookies/mac/WebCookieManagerMac.mm:
(WebKit::WebCookieManager::platformSetHTTPCookieAcceptPolicy):
* Source/WebKit/NetworkProcess/Cookies/soup/WebCookieManagerSoup.cpp:
(WebKit::WebCookieManager::platformSetHTTPCookieAcceptPolicy):
(WebKit::WebCookieManager::setCookiePersistentStorage):
(WebKit::WebCookieManager::replaceCookies):
* Source/WebKit/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations:

Canonical link: <a href="https://commits.webkit.org/295920@main">https://commits.webkit.org/295920@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/13c7a9c3873341e78229acabe2846951fbb7e5a0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/106555 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/26306 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/16703 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/111759 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/57151 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/26976 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34807 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80913 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/109559 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/21390 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/96145 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/61248 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/20841 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/56594 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/90729 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/14282 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/114621 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33693 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24830 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89983 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/34057 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/92376 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89692 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22890 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34599 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/12409 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/29309 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/33618 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/39031 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/33364 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/36717 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34963 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->