### PR TITLE
[GLib] Add a GRefPtr::ref() method

### DIFF
--- a/Source/WTF/wtf/glib/GRefPtr.h
+++ b/Source/WTF/wtf/glib/GRefPtr.h
@@ -130,6 +130,12 @@ public:
         return ptr;
     }
 
+    // Increments the reference count.
+    T* /* (transfer full) */ ref() WARN_UNUSED_RETURN {
+        refGPtr(m_ptr);
+        return m_ptr;
+    }
+
     T*& outPtr()
     {
         clear();

--- a/Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.cpp
@@ -845,7 +845,7 @@ static gboolean webKitMediaSrcSendEvent(GstElement* element, GstEvent* eventTran
         if (forwardToAllPads) {
             wasEventHandledByAllStreams = !source->priv->streams.isEmpty();
             for (const RefPtr<Stream>& stream : source->priv->streams.values()) {
-                bool wasHandled = gst_pad_push_event(stream->pad.get(), gst_event_ref(event.get()));
+                bool wasHandled = gst_pad_push_event(stream->pad.get(), event.ref());
                 wasEventHandledByAllStreams &= wasHandled;
                 wasEventHandledByAnyStream |= wasHandled;
             }

--- a/Source/WebCore/platform/gstreamer/VideoEncoderPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/gstreamer/VideoEncoderPrivateGStreamer.cpp
@@ -538,11 +538,11 @@ static GRefPtr<GstCaps> createSrcPadTemplateCaps()
 {
     auto* caps = gst_caps_new_empty();
 
-    for (const auto& [id, encoder] : Encoders::singleton()) {
+    for (auto& [id, encoder] : Encoders::singleton()) {
         if (encoder.encodedFormat)
-            caps = gst_caps_merge(caps, gst_caps_ref(encoder.encodedFormat.get()));
+            caps = gst_caps_merge(caps, encoder.encodedFormat.ref());
         else
-            caps = gst_caps_merge(caps, gst_caps_ref(encoder.caps.get()));
+            caps = gst_caps_merge(caps, encoder.caps.ref());
     }
 
     GST_DEBUG("Source pad template caps: %" GST_PTR_FORMAT, caps);

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerDTMFSenderBackend.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerDTMFSenderBackend.cpp
@@ -125,7 +125,7 @@ void GStreamerDTMFSenderPrivate::playTone(const RefPtr<RealtimeOutgoingAudioSour
 void GStreamerDTMFSenderPrivate::sendEvent(const GRefPtr<GstPad>& pad, int number, int volume, bool start)
 {
     auto event = adoptGRef(gst_event_new_custom(GST_EVENT_CUSTOM_UPSTREAM, gst_structure_new("dtmf-event", "type", G_TYPE_INT, 1, "number", G_TYPE_INT, number, "volume", G_TYPE_INT, volume, "start", G_TYPE_BOOLEAN, start, nullptr)));
-    gst_pad_send_event(pad.get(), gst_event_ref(event.get()));
+    gst_pad_send_event(pad.get(), event.ref());
     gst_element_send_event(m_dtmfSrc.get(), event.leakRef());
 }
 

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp
@@ -1187,7 +1187,7 @@ static GstPadProbeReturn webkitMediaStreamSrcPadProbeCb(GstPad* pad, GstPadProbe
             data->streamStartEvent = adoptGRef(gst_event_make_writable(data->streamStartEvent.leakRef()));
             IGNORE_WARNINGS_END
             gst_event_set_seqnum(data->streamStartEvent.get(), sequenceNumber);
-            info->data = gst_event_ref(data->streamStartEvent.get());
+            info->data = data->streamStartEvent.ref();
         }
         return GST_PAD_PROBE_OK;
     }


### PR DESCRIPTION
#### 3741afc7d1c29a13a224637d99dc597884aaf983
<pre>
[GLib] Add a GRefPtr::ref() method
<a href="https://bugs.webkit.org/show_bug.cgi?id=294113">https://bugs.webkit.org/show_bug.cgi?id=294113</a>

Reviewed by Xabier Rodriguez-Calvar.

This allows for simplification of function calls expecting a GObject reference.

* Source/WTF/wtf/glib/GRefPtr.h:
* Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.cpp:
(webKitMediaSrcSendEvent):
* Source/WebCore/platform/gstreamer/VideoEncoderPrivateGStreamer.cpp:
(createSrcPadTemplateCaps):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerDTMFSenderBackend.cpp:
(WebCore::GStreamerDTMFSenderPrivate::sendEvent):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp:
(webkitMediaStreamSrcPadProbeCb):

Canonical link: <a href="https://commits.webkit.org/295914@main">https://commits.webkit.org/295914@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7ea8dc938a2d9dffd08336abefda9b0f7832c0d6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/106566 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/26317 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/16714 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/111771 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/57162 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/108605 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/26987 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34818 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80922 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/109570 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/21401 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/96157 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/61257 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/20851 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/14262 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/56605 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/99206 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/90740 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/14294 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/114632 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/105184 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33704 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24840 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89995 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/34068 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/92388 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89704 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22888 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34610 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/12421 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/29323 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/33629 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/39042 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/129495 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/33375 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/35257 "Found 6 new JSC stress test failures: wasm.yaml/wasm/gc/ref-i31-eq.js.default-wasm, wasm.yaml/wasm/gc/ref-i31-eq.js.wasm-collect-continuously, wasm.yaml/wasm/gc/ref-i31-eq.js.wasm-eager, wasm.yaml/wasm/gc/ref-i31-eq.js.wasm-slow-memory, wasm.yaml/wasm/stress/jitless-wasm-to-js-should-follow-to-wasm-call-frame-convention-2.js.default, wasm.yaml/wasm/stress/jitless-wasm-to-js-should-follow-to-wasm-call-frame-convention.js.default (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/36728 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34974 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->