### PR TITLE
[css-anchor-position-1] Support implicit anchor element for pseudo-elements with position-area

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-pseudo-element-implicit-anchor-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-pseudo-element-implicit-anchor-expected.txt
@@ -1,0 +1,4 @@
+
+PASS The implicit anchor element of a pseudo-element is its originating element
+PASS Anchored position after moving
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-pseudo-element-implicit-anchor.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-pseudo-element-implicit-anchor.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<title>Implicit anchor element for pseudo-elements using anchor functions</title>
+<link rel="help" href="https://drafts.csswg.org/css-anchor-position-1/#implicit">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+body { margin: 0 }
+#target  {
+    margin-top: 100px;
+    margin-left: 50px;
+    width: 100px;
+    height: 100px;
+    background: blue;
+}
+#target::before, #target::after {
+    width: 100px;
+    height: 100px;
+    position: absolute;
+}
+#target.moved {
+    margin-top: 200px;
+    margin-left: 200px;
+}
+#target::before {
+    position-area: center right;
+    background: green;
+    content:'';
+}
+#target::after {
+    position-area: bottom center;
+    background: green;
+    content:'';
+}
+</style>
+<div id=target></div>
+<script>
+test(() => {
+    assert_equals(getComputedStyle(target, '::before').top, '100px');
+    assert_equals(getComputedStyle(target, '::before').left, '150px');
+    assert_equals(getComputedStyle(target, '::after').top, '200px');
+    assert_equals(getComputedStyle(target, '::after').left, '50px');
+}, "The implicit anchor element of a pseudo-element is its originating element");
+
+test(() => {
+    target.classList.add("moved");
+    assert_equals(getComputedStyle(target, '::before').top, '200px');
+    assert_equals(getComputedStyle(target, '::before').left, '300px');
+    assert_equals(getComputedStyle(target, '::after').top, '300px');
+    assert_equals(getComputedStyle(target, '::after').left, '200px');
+}, "Anchored position after moving");
+</script>

--- a/Source/WebCore/rendering/PositionedLayoutConstraints.cpp
+++ b/Source/WebCore/rendering/PositionedLayoutConstraints.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "PositionedLayoutConstraints.h"
 
+#include "AnchorPositionEvaluator.h"
 #include "ContainerNodeInlines.h"
 #include "InlineIteratorBoxInlines.h"
 #include "InlineIteratorInlineBox.h"
@@ -65,7 +66,7 @@ PositionedLayoutConstraints::PositionedLayoutConstraints(const RenderBox& render
     , m_containingAxis(!isOrthogonal() ? selfAxis : oppositeAxis(selfAxis))
     , m_style(style)
     , m_alignment(m_containingAxis == LogicalBoxAxis::Inline ? style.justifySelf() : style.alignSelf())
-    , m_defaultAnchorBox(needsAnchor() ? renderer.defaultAnchorRenderer() : nullptr)
+    , m_defaultAnchorBox(needsAnchor() ? Style::AnchorPositionEvaluator::defaultAnchorForBox(renderer) : nullptr)
     , m_marginBefore { 0_css_px }
     , m_marginAfter { 0_css_px }
     , m_insetBefore { 0_css_px }

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -1664,37 +1664,6 @@ bool RenderElement::isVisibleInViewport() const
     return isVisibleInDocumentRect(visibleRect);
 }
 
-const Element* RenderElement::defaultAnchor() const
-{
-    if (!element())
-        return nullptr;
-
-    auto& anchorPositionedMap = document().styleScope().anchorPositionedToAnchorMap();
-    auto it = anchorPositionedMap.find(*element());
-    if (it == anchorPositionedMap.end())
-        return nullptr;
-    const auto& anchorName = style().positionAnchor();
-    if (!anchorName)
-        return nullptr;
-
-    for (auto& anchor : it->value) {
-        if (!anchor)
-            continue;
-        for (auto& name : anchor->style().anchorNames()) {
-            if (name.name == anchorName->name)
-                return anchor->element();
-        }
-    }
-    return nullptr;
-}
-
-const RenderBoxModelObject* RenderElement::defaultAnchorRenderer() const
-{
-    if (auto* defaultAnchor = this->defaultAnchor())
-        return dynamicDowncast<RenderBoxModelObject>(defaultAnchor->renderer());
-    return nullptr;
-}
-
 VisibleInViewportState RenderElement::imageFrameAvailable(CachedImage& image, ImageAnimatingState animatingState, const IntRect* changeRect)
 {
     bool isVisible = isVisibleInViewport();

--- a/Source/WebCore/rendering/RenderElement.h
+++ b/Source/WebCore/rendering/RenderElement.h
@@ -310,9 +310,6 @@ public:
     bool renderBoxHasShapeOutsideInfo() const { return m_renderBoxHasShapeOutsideInfo; }
     bool hasCachedSVGResource() const { return m_hasCachedSVGResource; }
 
-    const Element* defaultAnchor() const;
-    const RenderBoxModelObject* defaultAnchorRenderer() const;
-
     bool isAnonymousBlock() const;
     bool isAnonymousForPercentageResolution() const { return isAnonymous() && !isViewTransitionPseudo(); }
     inline bool isBlockBox() const;

--- a/Source/WebCore/style/AnchorPositionEvaluator.h
+++ b/Source/WebCore/style/AnchorPositionEvaluator.h
@@ -87,7 +87,12 @@ enum class AnchorSizeDimension : uint8_t {
     SelfInline
 };
 
-using AnchorPositionedToAnchorMap = WeakHashMap<Element, Vector<SingleThreadWeakPtr<RenderBoxModelObject>>, WeakPtrImplWithEventTargetData>;
+struct ResolvedAnchor {
+    SingleThreadWeakPtr<RenderBoxModelObject> renderer;
+    ResolvedScopedName name;
+};
+
+using AnchorPositionedToAnchorMap = WeakHashMap<Element, Vector<ResolvedAnchor>, WeakPtrImplWithEventTargetData>;
 using AnchorToAnchorPositionedMap = SingleThreadWeakHashMap<const RenderBoxModelObject, Vector<Ref<Element>>>;
 
 class AnchorPositionEvaluator {
@@ -118,7 +123,10 @@ public:
     static bool overflowsInsetModifiedContainingBlock(const RenderBox& anchoredBox);
     static bool isDefaultAnchorInvisibleOrClippedByInterveningBoxes(const RenderBox& anchoredBox);
 
+    static ScopedName defaultAnchorName(const RenderStyle&);
     static bool isAnchor(const RenderStyle&);
+
+    static CheckedPtr<RenderBoxModelObject> defaultAnchorForBox(const RenderBox&);
 
 private:
     static AnchorElements findAnchorsForAnchorPositionedElement(const Element&, const UncheckedKeyHashSet<ResolvedScopedName>& anchorNames, const AnchorsForAnchorName&);

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -1379,12 +1379,21 @@ auto TreeResolver::updateAnchorPositioningState(Element& element, const RenderSt
     if (!style)
         return LayoutInterleavingAction::None;
 
-    AnchorPositionEvaluator::updateAnchorPositionedStateForLayoutTimePositioned(element, *style, m_treeResolutionState.anchorPositionedStates);
+    auto update = [&](const RenderStyle* style) {
+        if (!style)
+            return;
 
-    if (changes && !style->anchorNames().isEmpty()) {
-        // Existing anchor positions may change due to a style change. We need a round of interleaving.
-        m_needsInterleavedLayout = true;
-    }
+        AnchorPositionEvaluator::updateAnchorPositionedStateForLayoutTimePositioned(element, *style, m_treeResolutionState.anchorPositionedStates);
+
+        if (changes && !style->anchorNames().isEmpty()) {
+            // Existing anchor positions may change due to a style change. We need a round of interleaving.
+            m_needsInterleavedLayout = true;
+        }
+    };
+
+    update(style);
+    update(style->getCachedPseudoStyle({ PseudoId::Before }));
+    update(style->getCachedPseudoStyle({ PseudoId::After }));
 
     auto needsInterleavedLayout = hasUnresolvedAnchorPosition({ element, { } });
     if (needsInterleavedLayout)


### PR DESCRIPTION
#### d464b0a192cf527fc0b9ce0d08349f6e81f4f744
<pre>
[css-anchor-position-1] Support implicit anchor element for pseudo-elements with position-area
<a href="https://bugs.webkit.org/show_bug.cgi?id=294112">https://bugs.webkit.org/show_bug.cgi?id=294112</a>
<a href="https://rdar.apple.com/problem/152707685">rdar://problem/152707685</a>

Reviewed by Alan Baradlay.

Support ::before/::after with implicit anchor and layout time positioning (position-area/anchor-center).

* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-pseudo-element-implicit-anchor-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-pseudo-element-implicit-anchor.html: Added.
* Source/WebCore/rendering/PositionedLayoutConstraints.cpp:
(WebCore::PositionedLayoutConstraints::PositionedLayoutConstraints):
* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::defaultAnchor const): Deleted.
(WebCore::RenderElement::defaultAnchorRenderer const): Deleted.

Move default anchor finding code to AnchorPositionEvaluator.

* Source/WebCore/rendering/RenderElement.h:
* Source/WebCore/style/AnchorPositionEvaluator.cpp:
(WebCore::Style::AnchorPositionEvaluator::findAnchorForAnchorFunctionAndAttemptResolution):

Save the resolved anchor names to anchorPositionedToAnchorMap along with the anchor box so we can find the implicit anchor easily.

(WebCore::Style::AnchorPositionEvaluator::updateAnchorPositioningStatesAfterInterleavedLayout):
(WebCore::Style::AnchorPositionEvaluator::updateAnchorPositionedStateForLayoutTimePositioned):

Implicit layout-time positioned don&apos;t specify position-anchor, so test for positioning properties also.

(WebCore::Style::AnchorPositionEvaluator::updateSnapshottedScrollOffsets):
(WebCore::Style::AnchorPositionEvaluator::makeAnchorPositionedForAnchorMap):
(WebCore::Style::AnchorPositionEvaluator::isDefaultAnchorInvisibleOrClippedByInterveningBoxes):
(WebCore::Style::AnchorPositionEvaluator::defaultAnchorName):

Helper to get the name of the default anchor.

(WebCore::Style::AnchorPositionEvaluator::defaultAnchorForBox):

Move the code from RenderElement::defaultAnchor and test the names saved in the anchorPositionedToAnchorMap.

* Source/WebCore/style/AnchorPositionEvaluator.h:
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::updateAnchorPositioningState):

Also upadate the state for pseudo elements.

Canonical link: <a href="https://commits.webkit.org/295913@main">https://commits.webkit.org/295913@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b8c7f0d8d00c0baac192aba6909b9a4501f5512d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/106570 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/26321 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/16718 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/111775 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/57166 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/108609 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/26991 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34823 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/80927 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/109574 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/21406 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/96161 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/61262 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/20857 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/14266 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/56609 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/90745 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/14298 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/114636 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33708 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24846 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/90000 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/34072 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/92392 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89709 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22887 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34614 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/12425 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/29327 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/33633 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/39046 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/33379 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/36732 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34978 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->