### PR TITLE
Reduce unsafeness by adopting more smart pointers in WebCore

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -498,7 +498,6 @@ page/DebugPageOverlays.cpp
 page/DragController.cpp
 page/ElementTargetingController.cpp
 page/EventHandler.cpp
-page/EventSource.cpp
 page/FocusController.cpp
 page/Frame.cpp
 page/FrameSnapshotting.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
@@ -107,7 +107,6 @@ css/typedom/ComputedStylePropertyMapReadOnly.cpp
 css/typedom/HashMapStylePropertyMapReadOnly.cpp
 css/typedom/MainThreadStylePropertyMapReadOnly.cpp
 dom/ActiveDOMObject.cpp
-dom/BroadcastChannel.cpp
 dom/CollectionIndexCacheInlines.h
 dom/ComposedTreeAncestorIterator.h
 dom/ComposedTreeIterator.cpp
@@ -125,8 +124,6 @@ dom/ElementTextDirection.cpp
 dom/ElementTraversal.h
 dom/EventLoop.cpp
 dom/EventPath.cpp
-dom/FragmentDirectiveGenerator.cpp
-dom/FragmentDirectiveRangeFinder.cpp
 dom/InlineStyleSheetOwner.cpp
 dom/Microtasks.cpp
 dom/MouseRelatedEvent.cpp
@@ -188,7 +185,6 @@ html/Autofill.cpp
 html/CachedHTMLCollectionInlines.h
 html/CanvasBase.cpp
 html/CollectionTraversalInlines.h
-html/CustomPaintImage.cpp
 html/FormAssociatedCustomElement.cpp
 html/FormListedElement.cpp
 html/HTMLAttachmentElement.cpp
@@ -197,7 +193,6 @@ html/HTMLDocument.cpp
 html/HTMLEmbedElement.cpp
 html/HTMLFormControlElement.cpp
 html/HTMLFormElement.cpp
-html/HTMLFrameElementBase.cpp
 html/HTMLImageElement.cpp
 html/HTMLInputElement.cpp
 html/HTMLLabelElement.cpp
@@ -222,7 +217,6 @@ html/ValidatedFormListedElement.cpp
 html/ValidationMessage.cpp
 html/canvas/CanvasRenderingContext2D.cpp
 html/canvas/CanvasRenderingContext2DBase.cpp
-html/canvas/GPUCanvasContextCocoa.mm
 html/parser/HTMLConstructionSite.cpp
 html/shadow/DateTimeEditElement.cpp
 html/shadow/DateTimeNumericFieldElement.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -265,8 +265,6 @@ dom/ElementIteratorInlines.h
 dom/ElementTextDirection.cpp
 dom/ElementTraversal.h
 dom/EventPath.cpp
-dom/FragmentDirectiveGenerator.cpp
-dom/FragmentDirectiveRangeFinder.cpp
 dom/InlineStyleSheetOwner.cpp
 dom/KeyboardEvent.cpp
 dom/MessagePort.cpp
@@ -328,16 +326,13 @@ html/Autofill.cpp
 html/CachedHTMLCollectionInlines.h
 html/CanvasBase.cpp
 html/CollectionTraversalInlines.h
-html/CustomPaintImage.cpp
 html/FormAssociatedCustomElement.cpp
 html/FormListedElement.cpp
-html/HTMLAnchorElement.cpp
 html/HTMLAttachmentElement.cpp
 html/HTMLDocument.cpp
 html/HTMLEmbedElement.cpp
 html/HTMLFieldSetElement.cpp
 html/HTMLFormElement.cpp
-html/HTMLFrameElementBase.cpp
 html/HTMLImageElement.cpp
 html/HTMLInputElement.cpp
 html/HTMLLabelElement.cpp
@@ -360,7 +355,6 @@ html/ValidatedFormListedElement.cpp
 html/ValidationMessage.cpp
 html/canvas/CanvasRenderingContext2D.cpp
 html/canvas/CanvasRenderingContext2DBase.cpp
-html/canvas/GPUCanvasContextCocoa.mm
 html/canvas/OffscreenCanvasRenderingContext2D.cpp
 html/parser/HTMLConstructionSite.cpp
 html/shadow/DateTimeEditElement.cpp
@@ -429,13 +423,11 @@ page/BarProp.cpp
 page/CaptionUserPreferences.cpp
 page/CaptionUserPreferencesMediaAF.cpp
 page/ContextMenuController.cpp
-page/DOMWindow.cpp
 page/DebugPageOverlays.cpp
 page/DeviceController.cpp
 page/DragController.cpp
 page/ElementTargetingController.cpp
 page/EventHandler.cpp
-page/EventSource.cpp
 page/FocusController.cpp
 page/Frame.cpp
 page/FrameSnapshotting.cpp
@@ -540,7 +532,6 @@ platform/mock/MockRealtimeMediaSourceCenter.cpp
 platform/mock/MockRealtimeVideoSource.cpp
 platform/text/BidiContext.cpp
 platform/text/BidiResolver.h
-plugins/DOMPluginArray.cpp
 plugins/PluginData.cpp
 plugins/PluginInfoProvider.cpp
 rendering/AccessibilityRegionContext.cpp

--- a/Source/WebCore/dom/BroadcastChannel.cpp
+++ b/Source/WebCore/dom/BroadcastChannel.cpp
@@ -115,7 +115,7 @@ void BroadcastChannel::MainThreadBridge::ensureOnMainThread(Function<void(Page*)
         return;
     }
 
-    auto* workerLoaderProxy = downcast<WorkerGlobalScope>(*context).protectedThread()->workerLoaderProxy();
+    CheckedPtr workerLoaderProxy = downcast<WorkerGlobalScope>(*context).protectedThread()->workerLoaderProxy();
     if (!workerLoaderProxy)
         return;
 

--- a/Source/WebCore/dom/FragmentDirectiveGenerator.cpp
+++ b/Source/WebCore/dom/FragmentDirectiveGenerator.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2024-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -109,11 +109,11 @@ static String previousWordsFromPositionInSameBlock(unsigned numberOfWords, Visib
         previousPosition = potentialPreviousPosition;
     }
 
-    auto document = startPosition.deepEquivalent().document();
+    RefPtr document = startPosition.deepEquivalent().document();
     if (!document)
         return { };
 
-    auto range = Range::create(*document);
+    Ref range = Range::create(*document);
     RefPtr startNode = previousPosition.deepEquivalent().containerNode();
     range->setStart(startNode.releaseNonNull(), previousPosition.deepEquivalent().computeOffsetInContainerNode());
     RefPtr endNode = startPosition.deepEquivalent().containerNode();
@@ -132,11 +132,11 @@ static String nextWordsFromPositionInSameBlock(unsigned numberOfWords, VisiblePo
         nextPosition = potentialNextPosition;
     }
 
-    auto document = nextPosition.deepEquivalent().document();
+    RefPtr document = nextPosition.deepEquivalent().document();
     if (!document)
         return { };
 
-    auto range = Range::create(*document);
+    Ref range = Range::create(*document);
     RefPtr startNode = startPosition.deepEquivalent().containerNode();
     range->setStart(startNode.releaseNonNull(), startPosition.deepEquivalent().computeOffsetInContainerNode());
     RefPtr endNode = nextPosition.deepEquivalent().containerNode();

--- a/Source/WebCore/dom/FragmentDirectiveRangeFinder.cpp
+++ b/Source/WebCore/dom/FragmentDirectiveRangeFinder.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2022-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -214,10 +214,10 @@ static std::optional<SimpleRange> findRangeFromNodeList(const String& query, con
 static std::optional<SimpleRange> rangeOfStringInRange(const String& query, SimpleRange& searchRange, WordBounded wordStartBounded, WordBounded wordEndBounded)
 {
     while (!searchRange.collapsed()) {
-        RefPtr<Node> currentNode = &searchRange.startContainer();
+        RefPtr currentNode = &searchRange.startContainer();
         
         if (isNonSearchableSubtree(*currentNode)) {
-            if (auto newStart = NodeTraversal::nextSkippingChildren(*currentNode))
+            if (RefPtr newStart = NodeTraversal::nextSkippingChildren(*currentNode))
                 searchRange.start = { *newStart, 0 };
             else
                 return std::nullopt;
@@ -226,7 +226,7 @@ static std::optional<SimpleRange> rangeOfStringInRange(const String& query, Simp
         
         if (!isVisibleTextNode(*currentNode)) {
             do {
-                if (auto newStart = NodeTraversal::next(*currentNode)) {
+                if (RefPtr newStart = NodeTraversal::next(*currentNode)) {
                     searchRange.start = { *newStart, 0 };
                     currentNode = newStart;
                 } else
@@ -246,7 +246,7 @@ static std::optional<SimpleRange> rangeOfStringInRange(const String& query, Simp
                 currentNode = NodeTraversal::nextSkippingChildren(*currentNode);
                 continue;
             }
-            auto* textNode = dynamicDowncast<Text>(*currentNode);
+            RefPtr textNode = dynamicDowncast<Text>(*currentNode);
             if (textNode && isVisibleTextNode(*textNode))
                 textNodeList.append(*textNode);
             currentNode = NodeTraversal::next(*currentNode);
@@ -280,7 +280,7 @@ static std::optional<SimpleRange> advanceRangeStartToNextNonWhitespace(SimpleRan
         // I believe there is an error in the spec which I have filed an issue for
         // https://github.com/WICG/scroll-to-text-fragment/issues/189
         if (offset == node->length()) {
-            if (auto newStart = NodeTraversal::next(node)) {
+            if (RefPtr newStart = NodeTraversal::next(node)) {
                 newRange.start = { *newStart, 0 };
                 continue;
             }
@@ -288,7 +288,7 @@ static std::optional<SimpleRange> advanceRangeStartToNextNonWhitespace(SimpleRan
         }
         
         if (isNonSearchableSubtree(node)) {
-            if (auto newStart = NodeTraversal::next(node))
+            if (RefPtr newStart = NodeTraversal::next(node))
                 newRange.start = { *newStart, 0 };
             else
                 return newRange;
@@ -296,7 +296,7 @@ static std::optional<SimpleRange> advanceRangeStartToNextNonWhitespace(SimpleRan
         }
 
         if (!isVisibleTextNode(node)) {
-            if (auto newStart = NodeTraversal::next(node))
+            if (RefPtr newStart = NodeTraversal::next(node))
                 newRange.start = { *newStart, 0 };
             else
                 return newRange;
@@ -316,7 +316,7 @@ static std::optional<SimpleRange> advanceRangeStartToNextNonWhitespace(SimpleRan
         offset++;
 
         if (offset >= node->length()) {
-            if (auto newStart = NodeTraversal::next(node))
+            if (RefPtr newStart = NodeTraversal::next(node))
                 newRange.start = { *newStart, 0 };
             else
                 return newRange;

--- a/Source/WebCore/html/CustomPaintImage.cpp
+++ b/Source/WebCore/html/CustomPaintImage.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2018-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -98,7 +98,7 @@ ImageDrawResult CustomPaintImage::doCustomPaint(GraphicsContext& destContext, co
 
     UncheckedKeyHashMap<AtomString, RefPtr<CSSValue>> propertyValues;
 
-    if (auto* element = renderElement->element()) {
+    if (RefPtr element = renderElement->element()) {
         for (auto& name : m_inputProperties)
             propertyValues.add(name, extractComputedProperty(name, *element));
     }

--- a/Source/WebCore/html/HTMLAnchorElement.cpp
+++ b/Source/WebCore/html/HTMLAnchorElement.cpp
@@ -383,12 +383,13 @@ std::optional<URL> HTMLAnchorElement::attributionDestinationURLForPCM() const
 
 std::optional<RegistrableDomain> HTMLAnchorElement::mainDocumentRegistrableDomainForPCM() const
 {
-    if (auto* page = document().page()) {
+    Ref document = this->document();
+    if (RefPtr page = document->page()) {
         if (auto mainFrameURL = page->mainFrameURL(); !mainFrameURL.isEmpty())
             return RegistrableDomain(mainFrameURL);
     }
 
-    protectedDocument()->addConsoleMessage(MessageSource::Other, MessageLevel::Warning, "Could not find a main document to use as source site for Private Click Measurement."_s);
+    document->addConsoleMessage(MessageSource::Other, MessageLevel::Warning, "Could not find a main document to use as source site for Private Click Measurement."_s);
     return std::nullopt;
 }
 

--- a/Source/WebCore/html/HTMLFrameElementBase.cpp
+++ b/Source/WebCore/html/HTMLFrameElementBase.cpp
@@ -3,7 +3,7 @@
  *           (C) 1999 Antti Koivisto (koivisto@kde.org)
  *           (C) 2000 Simon Hausmann (hausmann@kde.org)
  *           (C) 2001 Dirk Mueller (mueller@kde.org)
- * Copyright (C) 2004-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2004-2025 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -174,7 +174,7 @@ void HTMLFrameElementBase::didFinishInsertingNode()
 
 void HTMLFrameElementBase::didAttachRenderers()
 {
-    if (RenderWidget* part = renderWidget()) {
+    if (CheckedPtr part = renderWidget()) {
         if (RefPtr frame = contentFrame())
             part->setWidget(frame->virtualView());
     }

--- a/Source/WebCore/page/DOMWindow.cpp
+++ b/Source/WebCore/page/DOMWindow.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2018-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -130,7 +130,7 @@ void DOMWindow::close()
 
 PageConsoleClient* DOMWindow::console() const
 {
-    auto* frame = this->frame();
+    RefPtr frame = this->frame();
     return frame && frame->page() ? &frame->page()->console() : nullptr;
 }
 

--- a/Source/WebCore/page/EventSource.cpp
+++ b/Source/WebCore/page/EventSource.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2009, 2012 Ericsson AB. All rights reserved.
  * Copyright (C) 2010-2025 Apple Inc. All rights reserved.
- * Copyright (C) 2011, Code Aurora Forum. All rights reserved.
+ * Copyright (C) 2011 Code Aurora Forum. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -43,6 +43,7 @@
 #include "ResourceRequest.h"
 #include "ResourceResponse.h"
 #include "ScriptExecutionContext.h"
+#include "ScriptExecutionContextInlines.h"
 #include "SecurityOrigin.h"
 #include "SharedBuffer.h"
 #include "TextResourceDecoder.h"
@@ -136,8 +137,7 @@ void EventSource::scheduleInitialConnect()
     ASSERT(m_state == CONNECTING);
     ASSERT(!m_requestInFlight);
 
-    auto* context = scriptExecutionContext();
-    m_connectTimer = context->eventLoop().scheduleTask(0_s, TaskSource::DOMManipulation, [weakThis = WeakPtr { *this }] {
+    m_connectTimer = protectedScriptExecutionContext()->checkedEventLoop()->scheduleTask(0_s, TaskSource::DOMManipulation, [weakThis = WeakPtr { *this }] {
         if (RefPtr protectedThis = weakThis.get())
             protectedThis->connect();
     });
@@ -147,8 +147,7 @@ void EventSource::scheduleReconnect()
 {
     RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(!m_isSuspendedForBackForwardCache);
     m_state = CONNECTING;
-    auto* context = scriptExecutionContext();
-    m_connectTimer = context->eventLoop().scheduleTask(1_ms * m_reconnectDelay, TaskSource::DOMManipulation, [weakThis = WeakPtr { *this }] {
+    m_connectTimer = protectedScriptExecutionContext()->checkedEventLoop()->scheduleTask(1_ms * m_reconnectDelay, TaskSource::DOMManipulation, [weakThis = WeakPtr { *this }] {
         if (RefPtr protectedThis = weakThis.get())
             protectedThis->connect();
     });

--- a/Source/WebCore/plugins/DOMPluginArray.cpp
+++ b/Source/WebCore/plugins/DOMPluginArray.cpp
@@ -1,6 +1,6 @@
 /*
  *  Copyright (C) 2008 Nokia Corporation and/or its subsidiary(-ies)
- *  Copyright (C) 2008, 2015 Apple Inc. All rights reserved.
+ *  Copyright (C) 2008-2025 Apple Inc. All rights reserved.
  *
  *  This library is free software; you can redistribute it and/or
  *  modify it under the terms of the GNU Lesser General Public
@@ -90,7 +90,7 @@ void DOMPluginArray::refresh(bool reloadPages)
     if (!m_navigator)
         return;
 
-    auto* frame = m_navigator->frame();
+    RefPtr frame = m_navigator->frame();
     if (!frame)
         return;
 


### PR DESCRIPTION
#### ddc51f3156e57162f04f03972b0cc39a602ec3ba
<pre>
Reduce unsafeness by adopting more smart pointers in WebCore
<a href="https://bugs.webkit.org/show_bug.cgi?id=294115">https://bugs.webkit.org/show_bug.cgi?id=294115</a>
<a href="https://rdar.apple.com/152711984">rdar://152711984</a>

Reviewed by Chris Dumez.

Apply <a href="https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines">https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines</a>

Canonical link: <a href="https://commits.webkit.org/295936@main">https://commits.webkit.org/295936@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/903e8e70a18cc18c576f3bc8faf4f54e730409fa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/106588 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/26339 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/16736 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/111793 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/57184 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/108627 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/27009 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34841 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80941 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/109592 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/21419 "Found 2 new test failures: http/tests/misc/timer-vs-loading.html media/video-unmuted-after-play-holds-sleep-assertion.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/96180 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/61277 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/20872 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/14285 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/56627 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/90758 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/14317 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/114654 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33726 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24865 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/90013 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/34090 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/92411 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89722 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34627 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/12444 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/29351 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17274 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/33651 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/39064 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/33397 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/36750 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34996 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->