### PR TITLE
2D context state flag for inverse transform is not maintained correctly

### DIFF
--- a/LayoutTests/fast/canvas/canvas-state-non-invertible-ctm-expected.txt
+++ b/LayoutTests/fast/canvas/canvas-state-non-invertible-ctm-expected.txt
@@ -1,0 +1,21 @@
+Tests 2d context non-invertible ctm
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS ctx.getTransform().toString() is "matrix(1, 0, 0, 1, 0, 0)"
+PASS ctx.getTransform().toString() is "matrix(0, 0, 0, 0, 0, 0)"
+PASS ctx.getTransform().toString() is "matrix(0, 0, 0, 0, 0, 0)"
+PASS ctx.getTransform().toString() is "matrix(0, 0, 0, 0, 0, 0)"
+PASS ctx.getTransform().toString() is "matrix(1, 0, 0, 1, 0, 0)"
+PASS ctx.getTransform().toString() is "matrix(1, 0, 0, 1, 1, 1)"
+PASS ctx.getTransform().toString() is "matrix(2147483647, 2147483648, 4294967296, -1, 65535, 536870911)"
+PASS ctx.getTransform().toString() is "matrix(2305843008139952000, 2305843009213694000, 21474836480, -5, 65535, 536870911)"
+PASS ctx.getTransform().toString() is "matrix(-2305843008139952000, -2305843009213694000, 6.1897001935445976e+26, 6.189700196426902e+26, 9.903520399599234e+27, 9.903520311977199e+27)"
+PASS ctx.getTransform().toString() is "matrix(-2305843008139952000, -2305843009213694000, 6.1897001935445976e+26, 6.189700196426902e+26, 9.903520399599234e+27, 9.903520311977199e+27)"
+PASS ctx.getTransform().toString() is "matrix(-2305843008139952000, -2305843009213694000, 6.1897001935445976e+26, 6.189700196426902e+26, 9.903520399599234e+27, 9.903520311977199e+27)"
+PASS ctx.getTransform().toString() is "matrix(2305843008139952000, 2305843009213694000, 21474836480, -5, 65535, 536870911)"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/canvas/canvas-state-non-invertible-ctm.html
+++ b/LayoutTests/fast/canvas/canvas-state-non-invertible-ctm.html
@@ -1,0 +1,56 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+<script>
+description("Tests 2d context non-invertible ctm");
+var ctx = document.createElement("canvas").getContext('2d');
+shouldBeEqualToString("ctx.getTransform().toString()", "matrix(1, 0, 0, 1, 0, 0)");
+
+// Non-invertible transforms get disabled.
+ctx.save();
+ctx.scale(0, 0);
+shouldBeEqualToString("ctx.getTransform().toString()", "matrix(0, 0, 0, 0, 0, 0)");
+ctx.translate(1, 1);
+ctx.scale(1, 1);
+ctx.transform(1, 0, 0, 1, 0, 0);
+shouldBeEqualToString("ctx.getTransform().toString()", "matrix(0, 0, 0, 0, 0, 0)");
+ctx.restore();
+
+// .resetTransform works for non-invertible transforms.
+ctx.save();
+ctx.scale(0, 0);
+shouldBeEqualToString("ctx.getTransform().toString()", "matrix(0, 0, 0, 0, 0, 0)");
+ctx.resetTransform();
+shouldBeEqualToString("ctx.getTransform().toString()", "matrix(1, 0, 0, 1, 0, 0)");
+ctx.translate(1, 1);
+shouldBeEqualToString("ctx.getTransform().toString()", "matrix(1, 0, 0, 1, 1, 1)");
+ctx.restore();
+
+// Cumulative values might make the transform non-invertible and disable it.
+// save()/restore() still works with those.
+ctx.save();
+ctx.setTransform(2147483647, 2147483648, 4294967296, -1, 65535, 536870911);
+shouldBeEqualToString("ctx.getTransform().toString()", "matrix(2147483647, 2147483648, 4294967296, -1, 65535, 536870911)");
+ctx.scale(1073741824, 5);
+// The expected signifies that transform is still functional.
+var expectedFunctional = "matrix(2305843008139952000, 2305843009213694000, 21474836480, -5, 65535, 536870911)";
+shouldBeEqualToString("ctx.getTransform().toString()", expectedFunctional);
+ctx.save();
+ctx.transform(-1, 0, 268435456, 1, 4294967295, 4294967295);
+// The above transform makes it non-invertible. The expected2 will signify that transform is disabled.
+var expectedDisabled = "matrix(-2305843008139952000, -2305843009213694000, 6.1897001935445976e+26, 6.189700196426902e+26, 9.903520399599234e+27, 9.903520311977199e+27)"
+shouldBeEqualToString("ctx.getTransform().toString()", expectedDisabled);
+ctx.save();
+ctx.rotate(-2);
+shouldBeEqualToString("ctx.getTransform().toString()", expectedDisabled);
+ctx.restore();
+shouldBeEqualToString("ctx.getTransform().toString()", expectedDisabled);
+ctx.restore();
+shouldBeEqualToString("ctx.getTransform().toString()", expectedFunctional); // After restore, transform is functional.
+ctx.restore();
+</script>
+</body>
+ </html>

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2D.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2D.cpp
@@ -158,7 +158,7 @@ void CanvasRenderingContext2D::drawFocusIfNeededInternal(const Path& path, Eleme
 {
     auto* context = effectiveDrawingContext();
     Ref canvas = this->canvas();
-    if (!element.focused() || !state().hasInvertibleTransform || path.isEmpty() || !element.isDescendantOf(canvas.get()) || !context)
+    if (!element.focused() || !hasInvertibleTransform() || path.isEmpty() || !element.isDescendantOf(canvas.get()) || !context)
         return;
     context->drawFocusRing(path, 1, RenderTheme::singleton().focusRingColor(element.protectedDocument()->styleColorOptions(canvas->computedStyle())));
     didDrawEntireCanvas();

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h
@@ -303,7 +303,7 @@ public:
         CompositeOperator globalComposite;
         BlendMode globalBlend;
         AffineTransform transform;
-        bool hasInvertibleTransform;
+        std::optional<AffineTransform> transformInverse;
         Vector<double> lineDash;
         double lineDashOffset;
         bool imageSmoothingEnabled;
@@ -394,6 +394,7 @@ protected:
 
     bool usesCSSCompatibilityParseMode() const { return m_usesCSSCompatibilityParseMode; }
 
+    void updateStateTransform(const AffineTransform&);
 private:
     struct CachedContentsTransparent {
     };
@@ -406,7 +407,6 @@ private:
         DeferrableOneShotTimer evictionTimer;
     };
 
-    void setHasInvertibleTransform(bool);
     void applyLineDash() const;
     void setShadow(const FloatSize& offset, float blur, const Color&);
     void applyShadow();


### PR DESCRIPTION
#### e0c0c143f85c8f2bfd2b4e00d0c9aa944ab30902
<pre>
2D context state flag for inverse transform is not maintained correctly
<a href="https://bugs.webkit.org/show_bug.cgi?id=294117">https://bugs.webkit.org/show_bug.cgi?id=294117</a>
<a href="https://rdar.apple.com/149686936">rdar://149686936</a>

Reviewed by Said Abou-Hallawa.

293589@main would make CanvasRenderingContext2DBase::restore() use
    if (hasInvertibleTransform())
instead of:
    if (auto inverse = transform.inverse())

This would cause dereference of unengaged optional for the `inverse`,
because the operations could make the transform non-invertible
even though the operation parameters would not indicate so.
E.g. consider:
  canvas.transform(..., number1, ...);
  canvas.scale(1, bignumber2);

Some pairs of number1, bignumber2 could make the transform
non-invertible.

Fix by modifying the CanvasPath::m_hasInvertibleTransform and
modifiableState().transform only in one function, the added
CanvasRenderingContext2DBase::updateState. Use the actual
inversible state as the source of the m_hasInvertibleTransform.

* LayoutTests/fast/canvas/canvas-state-non-invertible-ctm-expected.txt: Added.
* LayoutTests/fast/canvas/canvas-state-non-invertible-ctm.html: Added.
* Source/WebCore/html/canvas/CanvasRenderingContext2D.cpp:
(WebCore::CanvasRenderingContext2D::drawFocusIfNeededInternal):
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
(WebCore::CanvasRenderingContext2DBase::restore):
(WebCore::CanvasRenderingContext2DBase::scale):
(WebCore::CanvasRenderingContext2DBase::rotate):
(WebCore::CanvasRenderingContext2DBase::translate):
(WebCore::CanvasRenderingContext2DBase::transform):
(WebCore::CanvasRenderingContext2DBase::resetTransform):
(WebCore::CanvasRenderingContext2DBase::updateStateTransform):
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h:

Canonical link: <a href="https://commits.webkit.org/296373@main">https://commits.webkit.org/296373@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fba9ca116c58e154c22a2771f5ade379e8e643ed

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108148 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27811 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18231 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/113359 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/58634 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/110111 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/28509 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/36361 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82113 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111096 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22588 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97424 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62544 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22002 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/15560 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58099 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/91952 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15616 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/116485 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35214 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/25930 "Found 1 new test failure: fast/webgpu/nocrash/fuzz-291180.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91140 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/35588 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93701 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/90935 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23209 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35826 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13587 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/31012 "Build was cancelled. Recent messages:Printed configuration") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35113 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/40669 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34847 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38205 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/36514 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->