### PR TITLE
[JSC] Prevent SEGV triggered by exceptions from `Wasm::Global::get`

### DIFF
--- a/JSTests/wasm/stress/exnref-global-get-segv.js
+++ b/JSTests/wasm/stress/exnref-global-get-segv.js
@@ -1,0 +1,17 @@
+// (module
+//   (global (export "g") (ref null exn) (ref.null exn))
+// )
+const wasm1 = new Uint8Array([0, 97, 115, 109, 1, 0, 0, 0, 6, 6, 1, 105, 0, 208, 105, 11, 7, 5, 1, 1, 103, 3, 0]);
+const module1 = new WebAssembly.Module(wasm1);
+const instance1 = new WebAssembly.Instance(module1);
+
+// (module
+//   (import "M" "g" (global (ref null exn)))
+// )
+const wasm2 = new Uint8Array([0, 97, 115, 109, 1, 0, 0, 0, 2, 8, 1, 1, 77, 1, 103, 3, 105, 0]);
+const module2 = new WebAssembly.Module(wasm2);
+try {
+    const instance2 = new WebAssembly.Instance(module2, { M: { g: instance1.exports.g } });
+} catch {
+    // no segv
+}

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp
@@ -291,7 +291,9 @@ void WebAssemblyModuleRecord::initializeImports(JSGlobalObject* globalObject, JS
 
                             m_instance->setGlobal(import.kindIndex, value);
                         } else {
-                            value = Wasm::internalizeExternref(globalValue->global()->get(globalObject));
+                            auto global = globalValue->global()->get(globalObject);
+                            RETURN_IF_EXCEPTION(scope, void());
+                            value = Wasm::internalizeExternref(global);
                             if (!Wasm::TypeInformation::castReference(value, declaredGlobalType.isNullable(), declaredGlobalType.index))
                                 return exception(createJSWebAssemblyLinkError(globalObject, vm, importFailMessage(import, "imported global"_s, "Argument value did not match the reference type"_s)));
                             m_instance->setGlobal(import.kindIndex, value);


### PR DESCRIPTION
#### bb7181ea246c063f033380b4efad3ffe5cf00125
<pre>
[JSC] Prevent SEGV triggered by exceptions from `Wasm::Global::get`
<a href="https://bugs.webkit.org/show_bug.cgi?id=294119">https://bugs.webkit.org/show_bug.cgi?id=294119</a>

Reviewed by Justin Michaud.

Running the test case attached to 293340 on current JSC ends in a
segmentation fault.

That crash is itself a bug, so this patch adds proper handling for
the exception raised by global get and ensures JSC no longer SEGVs.

NOTE: This patch does not fix the functional bug reported in 293340;
it only removes the SEGV.

Canonical link: <a href="https://commits.webkit.org/295943@main">https://commits.webkit.org/295943@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8bdf29155dca831d8c6dd8e430b7d15c3bf4219d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/106580 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/26331 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/16728 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/111785 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/57176 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/27001 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34833 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80933 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/109584 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/21415 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/96168 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/61268 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/20867 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/14273 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/56619 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/99220 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/90754 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/14305 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/114646 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/105198 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33718 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24856 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/90005 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/34082 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/92399 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89714 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22910 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34622 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/12432 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/29339 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/33643 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/39056 "Found 2 new failures in rendering/svg/RenderSVGResourceContainer.cpp, style/values/color/StyleLightDarkColor.cpp") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/129509 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/33389 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/35261 "Found 1 new JSC stress test failure: wasm.yaml/wasm/gc/ref-i31-eq.js.wasm-slow-memory (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/36742 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34988 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->