### PR TITLE
[libpas] Enumerator should not assume remote mappings persist across calls to memory_reader_t

### DIFF
--- a/Source/bmalloc/libpas/src/libpas/jit_heap_config.c
+++ b/Source/bmalloc/libpas/src/libpas/jit_heap_config.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022 Apple Inc. All rights reserved.
+ * Copyright (c) 2021-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -276,42 +276,47 @@ pas_aligned_allocation_result jit_aligned_allocator(
 void* jit_prepare_to_enumerate(pas_enumerator* enumerator)
 {
     pas_basic_heap_config_enumerator_data* result;
-    const pas_heap_config** configs;
-    const pas_heap_config* config;
-    jit_heap_config_root_data* root_data;
 
-    configs = (const pas_heap_config**)pas_enumerator_read(
-        enumerator, enumerator->root->heap_configs,
-        sizeof(const pas_heap_config*) * pas_heap_config_kind_num_kinds);
-    if (!configs)
-        return NULL;
-    
-    config = (const pas_heap_config*)pas_enumerator_read(
-        enumerator, (void*)(uintptr_t)configs[pas_heap_config_kind_jit], sizeof(pas_heap_config));
-    if (!config)
+    pas_heap_config* config_ptr;
+    jit_heap_config_root_data* root_data_ptr;
+    jit_heap_config_root_data root_data;
+    pas_page_header_table small_page_header_table;
+    pas_page_header_table medium_page_header_table;
+
+    if (!pas_enumerator_copy_remote(
+            enumerator, &config_ptr, enumerator->root->heap_configs + pas_heap_config_kind_jit, sizeof(pas_heap_config*)))
         return NULL;
 
-    root_data = (jit_heap_config_root_data*)pas_enumerator_read(
-        enumerator, config->root_data, sizeof(jit_heap_config_root_data));
-    if (!root_data)
+    if (!pas_enumerator_copy_remote(
+            enumerator, &root_data_ptr, &config_ptr->root_data, sizeof(jit_heap_config_root_data*)))
         return NULL;
 
-    result = (pas_basic_heap_config_enumerator_data*)pas_enumerator_allocate(enumerator, sizeof(pas_basic_heap_config_enumerator_data));
+    if (!pas_enumerator_copy_remote(
+            enumerator, &root_data, root_data_ptr, sizeof(jit_heap_config_root_data)))
+        return NULL;
+
+    result = pas_enumerator_allocate(enumerator, sizeof(pas_basic_heap_config_enumerator_data));
     
     pas_ptr_hash_map_construct(&result->page_header_table);
 
+    if (!pas_enumerator_copy_remote(
+            enumerator, &small_page_header_table, root_data.small_page_header_table, sizeof(pas_page_header_table)))
+        return NULL;
+
     if (!pas_basic_heap_config_enumerator_data_add_page_header_table(
             result,
             enumerator,
-            (pas_page_header_table*)pas_enumerator_read(
-                enumerator, root_data->small_page_header_table, sizeof(pas_page_header_table))))
+            &small_page_header_table))
         return NULL;
     
+    if (!pas_enumerator_copy_remote(
+            enumerator, &medium_page_header_table, root_data.medium_page_header_table, sizeof(pas_page_header_table)))
+        return NULL;
+
     if (!pas_basic_heap_config_enumerator_data_add_page_header_table(
             result,
             enumerator,
-            (pas_page_header_table*)pas_enumerator_read(
-                enumerator, root_data->medium_page_header_table, sizeof(pas_page_header_table))))
+            &medium_page_header_table))
         return NULL;
     
     return result;

--- a/Source/bmalloc/libpas/src/libpas/pas_basic_heap_config_enumerator_data.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_basic_heap_config_enumerator_data.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Apple Inc. All rights reserved.
+ * Copyright (c) 2021-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -38,7 +38,7 @@ bool pas_basic_heap_config_enumerator_data_add_page_header_table(
 {
     static const bool verbose = false;
     
-    pas_lock_free_read_ptr_ptr_hashtable_table* table;
+    unsigned table_size;
     size_t index;
 
     if (!page_header_table)
@@ -50,33 +50,26 @@ bool pas_basic_heap_config_enumerator_data_add_page_header_table(
     if (verbose)
         pas_log("Have a page header hashtable at %p.\n", page_header_table->hashtable.table);
     
-    table = pas_enumerator_read(
-        enumerator, page_header_table->hashtable.table,
-        PAS_OFFSETOF(pas_lock_free_read_ptr_ptr_hashtable_table, array));
-    if (!table)
+    if (!pas_enumerator_copy_remote(
+            enumerator, &table_size, &page_header_table->hashtable.table->table_size, sizeof(unsigned)))
         return false;
     
     if (verbose)
-        pas_log("The table has size %u.\n", table->table_size);
+        pas_log("The table has size %u.\n", table_size);
     
-    table = pas_enumerator_read(
-        enumerator, page_header_table->hashtable.table,
-        PAS_OFFSETOF(pas_lock_free_read_ptr_ptr_hashtable_table, array)
-        + sizeof(pas_pair) * table->table_size);
-    if (!table)
-        return false;
-    
-    for (index = table->table_size; index--;) {
-        pas_pair* pair;
+    for (index = table_size; index--;) {
+        pas_pair pair;
         pas_ptr_hash_map_entry entry;
         
-        pair = table->array + index;
+        if (!pas_enumerator_copy_remote(
+                enumerator, &pair, page_header_table->hashtable.table->array + index, sizeof(pas_pair)))
+            return false;
         
-        if (pas_pair_low(*pair) == UINTPTR_MAX)
+        if (pas_pair_low(pair) == UINTPTR_MAX)
             continue;
         
-        entry.key = (void*)pas_pair_low(*pair);
-        entry.value = (void*)pas_pair_high(*pair);
+        entry.key = (void*)pas_pair_low(pair);
+        entry.value = (void*)pas_pair_high(pair);
         
         pas_ptr_hash_map_add_new(
             &data->page_header_table, entry, NULL, &enumerator->allocation_config);

--- a/Source/bmalloc/libpas/src/libpas/pas_enumerable_range_list.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_enumerable_range_list.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Apple Inc. All rights reserved.
+ * Copyright (c) 2021-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -99,15 +99,14 @@ bool pas_enumerable_range_list_iterate_remote(
     pas_enumerable_range_list_iterate_remote_callback callback,
     void* arg)
 {
-    pas_enumerable_range_list* list;
+    pas_compact_atomic_enumerable_range_list_chunk_ptr list_head;
     pas_enumerable_range_list_chunk* chunk;
 
-    list = pas_enumerator_read(enumerator, remote_list, sizeof(pas_enumerable_range_list));
-    if (!list)
+    if (!pas_enumerator_copy_remote(enumerator, &list_head, &remote_list->head, sizeof(pas_compact_atomic_enumerable_range_list_chunk_ptr)))
         return false;
 
     for (chunk = pas_compact_atomic_enumerable_range_list_chunk_ptr_load_remote(enumerator,
-                                                                                &list->head);
+                                                                                &list_head);
          chunk;
          chunk = pas_compact_atomic_enumerable_range_list_chunk_ptr_load_remote(enumerator,
                                                                                 &chunk->next)) {

--- a/Source/bmalloc/libpas/src/libpas/pas_enumerate_bitfit_heaps.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_enumerate_bitfit_heaps.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021 Apple Inc. All rights reserved.
+ * Copyright (c) 2020-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -80,7 +80,7 @@ static bool view_callback(pas_enumerator* enumerator,
         enumerator, (void*)page_boundary);
     PAS_ASSERT_WITH_DETAIL(page);
 
-    page = pas_enumerator_read(enumerator, page, pas_bitfit_page_header_size(*page_config));
+    page = pas_enumerator_pin_remote(enumerator, page, pas_bitfit_page_header_size(*page_config));
     if (!page)
         return false;
 
@@ -141,7 +141,9 @@ static bool view_callback(pas_enumerator* enumerator,
             offset = second_offset;
         }
     }
-    
+
+    pas_enumerator_unpin_remote(enumerator, page);
+
     return true;
 }
 

--- a/Source/bmalloc/libpas/src/libpas/pas_enumerate_segregated_heaps.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_enumerate_segregated_heaps.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 Apple Inc. All rights reserved.
+ * Copyright (c) 2020-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -344,7 +344,7 @@ static bool enumerate_exclusive_view(pas_enumerator* enumerator,
         enumerator, (void*)page_boundary);
     PAS_ASSERT_WITH_DETAIL(page);
 
-    page = pas_enumerator_read(
+    page = pas_enumerator_pin_remote(
         enumerator, page, pas_segregated_page_header_size(*page_config, pas_segregated_page_exclusive_role));
     if (!page)
         return false;
@@ -375,7 +375,9 @@ static bool enumerate_exclusive_view(pas_enumerator* enumerator,
     alloc_bits.word_index_end = (unsigned)pas_segregated_page_config_num_alloc_words(*page_config);
     record_page_objects(
         enumerator, context, directory, page_config, page_boundary, page, allocator, &alloc_bits);
-    
+
+    pas_enumerator_unpin_remote(enumerator, page);
+
     return true;
 }
 
@@ -404,8 +406,8 @@ static bool enumerate_shared_view(pas_enumerator* enumerator,
             page = (pas_segregated_page*)page_config->base.page_header_for_boundary_remote(
                 enumerator, (void*)page_boundary);
             PAS_ASSERT_WITH_DETAIL(page);
-            
-            page = pas_enumerator_read(
+
+            page = pas_enumerator_pin_remote(
                 enumerator, page,
                 pas_segregated_page_header_size(*page_config, pas_segregated_page_shared_role));
             if (!page)
@@ -444,6 +446,8 @@ static bool enumerate_shared_view(pas_enumerator* enumerator,
                                      page,
                                      payload_begin,
                                      payload_end);
+
+        pas_enumerator_unpin_remote(enumerator, page);
     }
 
     return true;
@@ -475,20 +479,10 @@ static bool enumerate_partial_view(pas_enumerator* enumerator,
     if (!shared_view->is_owned)
         return true;
 
-    page = NULL;
     shared_handle_or_page_boundary = shared_view->shared_handle_or_page_boundary;
     shared_handle = pas_unwrap_shared_handle_no_liveness_checks(shared_handle_or_page_boundary);
     shared_handle = pas_enumerator_read_compact(enumerator, shared_handle);
     page_boundary = (uintptr_t)shared_handle->page_boundary;
-
-    page = (pas_segregated_page*)page_config->base.page_header_for_boundary_remote(
-        enumerator, (void*)page_boundary);
-    PAS_ASSERT_WITH_DETAIL(page);
-    
-    page = pas_enumerator_read(
-        enumerator, page, pas_segregated_page_header_size(*page_config, pas_segregated_page_shared_role));
-    if (!page)
-        return false;
 
     if (verbose)
         pas_log("Enumerating partial view of shared page %p\n", (void*)page_boundary);
@@ -522,9 +516,21 @@ static bool enumerate_partial_view(pas_enumerator* enumerator,
         enumerator, &view->alloc_bits, pas_segregated_page_config_num_alloc_bytes(*page_config));
     full_alloc_bits.word_index_begin = view->alloc_bits_offset;
     full_alloc_bits.word_index_end = view->alloc_bits_offset + view->alloc_bits_size;
+
+    page = (pas_segregated_page*)page_config->base.page_header_for_boundary_remote(
+        enumerator, (void*)page_boundary);
+    PAS_ASSERT_WITH_DETAIL(page);
+
+    page = pas_enumerator_pin_remote(
+        enumerator, page, pas_segregated_page_header_size(*page_config, pas_segregated_page_shared_role));
+    if (!page)
+        return false;
+
     record_page_objects(
         enumerator, context, directory, page_config, page_boundary, page, allocator, &full_alloc_bits);
-    
+
+    pas_enumerator_unpin_remote(enumerator, page);
+
     return true;
 }
 
@@ -625,51 +631,51 @@ static PAS_NEVER_INLINE void consider_allocator(pas_enumerator* enumerator, enum
 
 bool pas_enumerate_segregated_heaps(pas_enumerator* enumerator)
 {
-    pas_thread_local_cache_node** tlc_node_first_ptr;
-    pas_thread_local_cache_node* tlc_node;
-    pas_thread_local_cache_layout_segment** tlc_layout_first_segment_ptr;
+    pas_thread_local_cache_node* tlc_node_next;
+    pas_thread_local_cache_layout_segment* tlc_layout_first_segment;
     enumeration_context context;
-    pas_baseline_allocator** baseline_allocator_table_ptr;
+    pas_baseline_allocator* baseline_allocator_table_ptr;
     size_t index;
 
     local_allocator_map_construct(&context.allocators);
     pas_ptr_hash_set_construct(&context.shared_page_directories);
     pas_ptr_hash_set_construct(&context.objects_in_deallocation_log);
 
-    tlc_node_first_ptr = pas_enumerator_read(enumerator,
-                                             enumerator->root->thread_local_cache_node_first,
-                                             sizeof(pas_thread_local_cache_node*));
-    if (!tlc_node_first_ptr)
+    if (!pas_enumerator_copy_remote(
+            enumerator,
+            &tlc_node_next,
+            enumerator->root->thread_local_cache_node_first,
+            sizeof(pas_thread_local_cache_node*)))
         return false;
 
-    tlc_layout_first_segment_ptr = pas_enumerator_read(enumerator, enumerator->root->thread_local_cache_layout_first_segment, sizeof(pas_thread_local_cache_layout_segment*));
-    if (!tlc_layout_first_segment_ptr)
+    if (!pas_enumerator_copy_remote(
+            enumerator,
+            &tlc_layout_first_segment,
+            enumerator->root->thread_local_cache_layout_first_segment,
+            sizeof(pas_thread_local_cache_layout_segment*)))
         return false;
 
-    for (tlc_node = *tlc_node_first_ptr; tlc_node; tlc_node = tlc_node->next) {
+    while (tlc_node_next) {
+        pas_thread_local_cache_node tlc_node;
+        unsigned allocator_index_capacity;
         pas_thread_local_cache* tlc;
+        size_t tlc_size;
         unsigned index;
-        
-        tlc_node = pas_enumerator_read(enumerator,
-                                       tlc_node,
-                                       sizeof(pas_thread_local_cache_node));
-        if (!tlc_node)
-            return false;
 
-        if (!tlc_node->cache)
+        if (!pas_enumerator_copy_remote(enumerator, &tlc_node, tlc_node_next, sizeof(pas_thread_local_cache_node)))
+            return false;
+        tlc_node_next = tlc_node.next;
+
+        if (!tlc_node.cache)
             continue;
 
-        tlc = pas_enumerator_read(enumerator,
-                                  tlc_node->cache,
-                                  pas_thread_local_cache_size_for_allocator_index_capacity(0));
-        if (!tlc)
+        if (!pas_enumerator_copy_remote(enumerator, &allocator_index_capacity, &tlc_node.cache->allocator_index_capacity, sizeof(unsigned)))
             return false;
 
-        tlc = pas_enumerator_read(enumerator,
-                                  tlc_node->cache,
-                                  pas_thread_local_cache_size_for_allocator_index_capacity(
-                                      tlc->allocator_index_capacity));
-        if (!tlc)
+        /* Copy the remote tlc since consider_allocator will stash away pointers to the individual local allocators. */
+        tlc_size = pas_thread_local_cache_size_for_allocator_index_capacity(allocator_index_capacity);
+        tlc = pas_enumerator_allocate(enumerator, tlc_size);
+        if (!pas_enumerator_copy_remote(enumerator, tlc, tlc_node.cache, tlc_size))
             return false;
 
         for (index = PAS_DEALLOCATION_LOG_SIZE; index--;) {
@@ -682,37 +688,48 @@ bool pas_enumerate_segregated_heaps(pas_enumerator* enumerator)
             }
         }
 
-        if (*tlc_layout_first_segment_ptr) {
-            pas_thread_local_cache_layout_segment** tlc_layout_segment_ptr;
-            uintptr_t node_index = 0;
+        if (tlc_layout_first_segment) {
+            pas_thread_local_cache_layout_segment* tlc_layout_segment;
             pas_thread_local_cache_layout_node layout_node;
-            pas_compact_atomic_thread_local_cache_layout_node* layout_node_ptr;
+            pas_compact_atomic_thread_local_cache_layout_node layout_node_compact_ptr;
+            uintptr_t node_index = 0;
 
-            tlc_layout_segment_ptr = tlc_layout_first_segment_ptr;
+            tlc_layout_segment = tlc_layout_first_segment;
 
-            layout_node_ptr = pas_enumerator_read(enumerator, &((*tlc_layout_segment_ptr)->nodes[node_index]), sizeof(pas_compact_atomic_thread_local_cache_layout_node));
-            if (!layout_node_ptr)
-                return false;
-            layout_node = pas_compact_atomic_thread_local_cache_layout_node_load_remote(enumerator, layout_node_ptr);
             while (1) {
                 bool has_allocator;
                 unsigned allocator_index;
 
+                if (!pas_enumerator_copy_remote(
+                        enumerator,
+                        &layout_node_compact_ptr,
+                        &tlc_layout_segment->nodes[node_index], sizeof(pas_compact_atomic_thread_local_cache_layout_node)))
+                    return false;
+                layout_node = pas_compact_atomic_thread_local_cache_layout_node_load_remote(enumerator, &layout_node_compact_ptr);
+
                 if (!layout_node) {
-                    tlc_layout_segment_ptr = pas_enumerator_read(enumerator, &((*tlc_layout_segment_ptr)->next), sizeof(pas_thread_local_cache_layout_segment*));
-                    if (!tlc_layout_segment_ptr)
+                    /* Reached end of the segment; start the next segment. */
+                    if (!pas_enumerator_copy_remote(
+                            enumerator,
+                            &tlc_layout_segment,
+                            &tlc_layout_segment->next,
+                            sizeof(pas_thread_local_cache_layout_segment*)))
                         return false;
-                    if (!*tlc_layout_segment_ptr)
+
+                    if (!tlc_layout_segment)
                         break;
                     node_index = 0;
-                    layout_node_ptr = pas_enumerator_read(enumerator, &((*tlc_layout_segment_ptr)->nodes[node_index]), sizeof(pas_compact_atomic_thread_local_cache_layout_node));
-                    if (!layout_node_ptr)
+                    if (!pas_enumerator_copy_remote(
+                            enumerator,
+                            &layout_node_compact_ptr,
+                            &tlc_layout_segment->nodes[node_index], sizeof(pas_compact_atomic_thread_local_cache_layout_node)))
                         return false;
-                    layout_node = pas_compact_atomic_thread_local_cache_layout_node_load_remote(enumerator, layout_node_ptr);
+
+                    layout_node = pas_compact_atomic_thread_local_cache_layout_node_load_remote(enumerator, &layout_node_compact_ptr);
                     if (!layout_node)
                         break;
                 }
-                
+
                 if (pas_is_wrapped_segregated_size_directory(layout_node)) {
                     pas_segregated_size_directory* directory;
 
@@ -735,39 +752,36 @@ bool pas_enumerate_segregated_heaps(pas_enumerator* enumerator)
 
                 if (has_allocator) {
                     pas_local_allocator* allocator;
-                    
+
                     if (!allocator_index || allocator_index >= tlc->allocator_index_upper_bound)
                         break;
 
                     allocator = pas_thread_local_cache_get_local_allocator_direct(tlc, allocator_index);
-                    
+
                     consider_allocator(enumerator, &context, allocator);
                 }
 
                 ++node_index;
-                layout_node_ptr = pas_enumerator_read(enumerator, &((*tlc_layout_segment_ptr)->nodes[node_index]), sizeof(pas_compact_atomic_thread_local_cache_layout_node));
-                if (!layout_node_ptr)
-                    return false;
-                layout_node = pas_compact_atomic_thread_local_cache_layout_node_load_remote(enumerator, layout_node_ptr);
             }
         }
     }
 
-    baseline_allocator_table_ptr = pas_enumerator_read(enumerator,
-                                                       enumerator->root->baseline_allocator_table,
-                                                       sizeof(pas_baseline_allocator*));
-    if (!baseline_allocator_table_ptr)
+    if (!pas_enumerator_copy_remote(
+            enumerator,
+            &baseline_allocator_table_ptr,
+            enumerator->root->baseline_allocator_table,
+            sizeof(pas_baseline_allocator*)))
         return false;
 
-    if (*baseline_allocator_table_ptr) {
+    if (baseline_allocator_table_ptr) {
         pas_baseline_allocator* baseline_allocator_table;
+        size_t table_size;
         size_t index;
-        
-        baseline_allocator_table = pas_enumerator_read(
-            enumerator,
-            *baseline_allocator_table_ptr,
-            sizeof(pas_baseline_allocator) * enumerator->root->num_baseline_allocators);
-        if (!baseline_allocator_table)
+
+        /* Copy the remote baseline allocator table since consider_allocator will stash away pointers to the local allocators. */
+        table_size = sizeof(pas_baseline_allocator) * enumerator->root->num_baseline_allocators;
+        baseline_allocator_table = pas_enumerator_allocate(enumerator, table_size);
+        if (!pas_enumerator_copy_remote(enumerator, baseline_allocator_table, baseline_allocator_table_ptr, table_size))
             return false;
         
         for (index = enumerator->root->num_baseline_allocators; index--;)

--- a/Source/bmalloc/libpas/src/libpas/pas_enumerator.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_enumerator.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021 Apple Inc. All rights reserved.
+ * Copyright (c) 2020-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -72,17 +72,16 @@ pas_enumerator* pas_enumerator_create(pas_root* remote_root_address,
                                       pas_enumerator_object_recording_mode record_object)
 {
     pas_enumerator* result;
+    pas_enumerator_region* region;
+
     uintptr_t compact_heap_base;
-    pas_root* remote_root;
-    uintptr_t* compact_heap_base_ptr;
-    size_t* compact_heap_size_ptr;
-    size_t* compact_heap_guard_size_ptr;
     size_t compact_heap_size;
     size_t compact_heap_guard_size;
-    pas_enumerator_region* region;
+    size_t compact_heap_reservation_bump;
+    void* compact_heap_copy_base;
+
     const pas_heap_config* configs[pas_heap_config_kind_num_kinds];
     pas_heap_config_kind config_kind;
-    const pas_heap_config** remote_configs;
 
     region = NULL;
 
@@ -96,78 +95,88 @@ pas_enumerator* pas_enumerator_create(pas_root* remote_root_address,
     result->allocation_config.deallocate = deallocate;
     result->allocation_config.arg = result;
 
-    result->heap_config_datas = pas_enumerator_allocate(
-        result, sizeof(void*) * pas_heap_config_kind_num_kinds);
-    pas_zero_memory(result->heap_config_datas, sizeof(void*) * pas_heap_config_kind_num_kinds);
-
-    /*
-     * Some non-obvious behavior: even if we expect the remote address of a value (like the
-     * remote pas_root) to be persistent, our local mapping of the remote memory is allowed to
-     * change, and can in fact change any time we call the reader. So, it's unsafe to store
-     * a pointer to the remote memory across a call to reader, and we need to instead allocate
-     * local storage for these values and copy the remote values in.
-     */
-
-    remote_root = reader(result, remote_root_address, sizeof(pas_root), reader_arg);
-    if (!remote_root)
-        goto fail;
-    result->root = pas_enumerator_region_allocate(&region, sizeof(pas_root));
-    memcpy(result->root, remote_root, sizeof(pas_root));
-
-    PAS_ASSERT_WITH_DETAIL(result->root->magic == PAS_ROOT_MAGIC);
-    PAS_ASSERT_WITH_DETAIL(result->root->num_heap_configs == pas_heap_config_kind_num_kinds);
-
-    compact_heap_base_ptr = reader(
-        result, result->root->compact_heap_reservation_base, sizeof(uintptr_t), reader_arg);
-    if (!compact_heap_base_ptr)
-        goto fail;
-    compact_heap_base = *compact_heap_base_ptr;
-
-    compact_heap_size_ptr = reader(
-        result, result->root->compact_heap_reservation_size, sizeof(size_t), reader_arg);
-    if (!compact_heap_size_ptr)
-        goto fail;
-    compact_heap_size = *compact_heap_size_ptr;
-
-    compact_heap_guard_size_ptr = reader(
-        result, result->root->compact_heap_reservation_guard_size, sizeof(size_t), reader_arg);
-    if (!compact_heap_guard_size_ptr)
-        goto fail;
-    compact_heap_guard_size = *compact_heap_guard_size_ptr;
-
-    result->compact_heap_remote_base = (void*)compact_heap_base;
-    result->compact_heap_copy_base = (void*)(
-        (uintptr_t)reader(
-            result, (void*)(compact_heap_base + compact_heap_guard_size), compact_heap_size,
-            reader_arg)
-        - compact_heap_guard_size);
-    if (!result->compact_heap_copy_base)
-        goto fail;
-    
-    result->compact_heap_size = compact_heap_size;
-    result->compact_heap_guard_size = compact_heap_guard_size;
-
-    result->unaccounted_pages = pas_enumerator_allocate(result, sizeof(pas_ptr_hash_set));
-    pas_ptr_hash_set_construct(result->unaccounted_pages);
-
     result->reader = reader;
     result->reader_arg = reader_arg;
+    result->pinned_address = NULL;
     result->recorder = recorder;
     result->recorder_arg = recorder_arg;
     result->record_meta = record_meta;
     result->record_payload = record_payload;
     result->record_object = record_object;
+    result->lenient_compact_ptr_buffer = NULL;
+    result->lenient_compact_ptr_buffer_capacity = 0;
 
-    remote_configs = reader(
-        result,
-        result->root->heap_configs,
-        sizeof(const pas_heap_config*) * pas_heap_config_kind_num_kinds,
-        reader_arg);
-    if (!remote_configs)
+    result->heap_config_datas = pas_enumerator_allocate(
+        result, sizeof(void*) * pas_heap_config_kind_num_kinds);
+    pas_zero_memory(result->heap_config_datas, sizeof(void*) * pas_heap_config_kind_num_kinds);
+
+    result->root = pas_enumerator_allocate(result, sizeof(pas_root));
+    if (!pas_enumerator_copy_remote(
+            result,
+            result->root,
+            remote_root_address,
+            sizeof(pas_root)))
         goto fail;
-    for (PAS_EACH_HEAP_CONFIG_KIND(config_kind))
-        configs[config_kind] = remote_configs[config_kind];
-    
+
+    PAS_ASSERT_WITH_DETAIL(result->root->magic == PAS_ROOT_MAGIC);
+    PAS_ASSERT_WITH_DETAIL(result->root->num_heap_configs == pas_heap_config_kind_num_kinds);
+
+    if (!pas_enumerator_copy_remote(
+            result,
+            &compact_heap_base,
+            result->root->compact_heap_reservation_base,
+            sizeof(uintptr_t)))
+        goto fail;
+
+    if (!pas_enumerator_copy_remote(
+            result,
+            &compact_heap_size,
+            result->root->compact_heap_reservation_size,
+            sizeof(size_t)))
+        goto fail;
+
+    if (!pas_enumerator_copy_remote(
+            result,
+            &compact_heap_guard_size,
+            result->root->compact_heap_reservation_guard_size,
+            sizeof(size_t)))
+        goto fail;
+
+    if (!pas_enumerator_copy_remote(
+            result,
+            &compact_heap_reservation_bump,
+            result->root->compact_heap_reservation_bump,
+            sizeof(size_t)))
+        goto fail;
+
+    if (!compact_heap_base)
+        goto fail;
+
+    PAS_ASSERT(compact_heap_reservation_bump >= compact_heap_guard_size);
+
+    compact_heap_copy_base = pas_enumerator_allocate(result, compact_heap_size);
+    if (!pas_enumerator_copy_remote(
+            result,
+            (void*)((uintptr_t)compact_heap_copy_base + compact_heap_guard_size),
+            (void*)(compact_heap_base + compact_heap_guard_size),
+            compact_heap_reservation_bump - compact_heap_guard_size))
+        goto fail;
+
+    result->compact_heap_size = compact_heap_size;
+    result->compact_heap_guard_size = compact_heap_guard_size;
+    result->compact_heap_remote_base = (void*)compact_heap_base;
+    result->compact_heap_copy_base = compact_heap_copy_base;
+
+    result->unaccounted_pages = pas_enumerator_allocate(result, sizeof(pas_ptr_hash_set));
+    pas_ptr_hash_set_construct(result->unaccounted_pages);
+
+    if (!pas_enumerator_copy_remote(
+            result,
+            configs,
+            result->root->heap_configs,
+            sizeof(const pas_heap_config*) * pas_heap_config_kind_num_kinds))
+        goto fail;
+
     for (PAS_EACH_HEAP_CONFIG_KIND(config_kind)) {
         const pas_heap_config* config;
         const pas_heap_config* remote_config;
@@ -211,6 +220,20 @@ void* pas_enumerator_allocate(pas_enumerator* enumerator,
     return pas_enumerator_region_allocate(&enumerator->region, size);
 }
 
+void* pas_enumerator_lenient_compact_ptr_buffer(pas_enumerator* enumerator,
+                                                size_t size)
+{
+    PAS_ASSERT(size);
+    if (size > enumerator->lenient_compact_ptr_buffer_capacity) {
+        size_t new_capacity;
+
+        new_capacity = PAS_MAX(2 * enumerator->lenient_compact_ptr_buffer_capacity, size);
+        enumerator->lenient_compact_ptr_buffer = pas_enumerator_allocate(enumerator, new_capacity);
+        enumerator->lenient_compact_ptr_buffer_capacity = new_capacity;
+    }
+    return enumerator->lenient_compact_ptr_buffer;
+}
+
 void* pas_enumerator_read_compact(pas_enumerator* enumerator,
                                   void* remote_address)
 {
@@ -226,12 +249,16 @@ void* pas_enumerator_read_compact(pas_enumerator* enumerator,
         + (uintptr_t)remote_address - (uintptr_t)enumerator->compact_heap_remote_base);
 }
 
-void* pas_enumerator_read(pas_enumerator* enumerator,
-                          void* remote_address,
-                          size_t size)
+/* Call the "reader" to map remote_address into this process' address space.
+   The reader may invalidate previous mappings.
+ */
+static void* pas_enumerator_map_remote(pas_enumerator* enumerator,
+                                       void* remote_address,
+                                       size_t size)
 {
     void* compact_heap_end;
 
+    PAS_ASSERT(!enumerator->pinned_address);
     PAS_ASSERT_WITH_DETAIL(remote_address);
 
     compact_heap_end = (void*)(
@@ -247,6 +274,39 @@ void* pas_enumerator_read(pas_enumerator* enumerator,
         return &enumerator->dummy_byte;
     
     return enumerator->reader(enumerator, remote_address, size, enumerator->reader_arg);
+}
+
+void* pas_enumerator_pin_remote(pas_enumerator* enumerator,
+                                void* remote_address,
+                                size_t size)
+{
+    void* mapped_address;
+
+    PAS_ASSERT(!enumerator->pinned_address);
+    mapped_address = pas_enumerator_map_remote(enumerator, remote_address, size);
+    enumerator->pinned_address = mapped_address;
+    return mapped_address;
+}
+
+void pas_enumerator_unpin_remote(pas_enumerator* enumerator,
+                                 void* pinned_address)
+{
+    PAS_ASSERT(enumerator->pinned_address == pinned_address);
+    enumerator->pinned_address = NULL;
+}
+
+bool pas_enumerator_copy_remote(pas_enumerator* enumerator,
+                                void* local_buffer,
+                                void* remote_address,
+                                size_t size)
+{
+    void* mapped_address;
+
+    mapped_address = pas_enumerator_map_remote(enumerator, remote_address, size);
+    if (!mapped_address)
+        return false;
+    memcpy(local_buffer, mapped_address, size);
+    return true;
 }
 
 void pas_enumerator_add_unaccounted_pages(pas_enumerator* enumerator,
@@ -410,16 +470,16 @@ bool pas_enumerator_for_each_heap(pas_enumerator* enumerator,
 {
     size_t index;
     pas_heap* heap;
-    pas_heap** first_heap;
+    pas_heap* first_heap;
     pas_heap** static_heaps;
 
-    first_heap = pas_enumerator_read(enumerator,
-                                     enumerator->root->all_heaps_first_heap,
-                                     sizeof(pas_heap*));
-    if (!first_heap)
+    if (!pas_enumerator_copy_remote(enumerator,
+                                    &first_heap,
+                                    enumerator->root->all_heaps_first_heap,
+                                    sizeof(pas_heap*)))
         return false;
 
-    for (heap = pas_enumerator_read_compact(enumerator, *first_heap);
+    for (heap = pas_enumerator_read_compact(enumerator, first_heap);
          heap;
          heap = pas_compact_heap_ptr_load_remote(enumerator,
                                                  &heap->next_heap)) {
@@ -427,20 +487,18 @@ bool pas_enumerator_for_each_heap(pas_enumerator* enumerator,
             return false;
     }
 
-    static_heaps = pas_enumerator_read(enumerator,
-                                       enumerator->root->static_heaps,
-                                       sizeof(pas_heap*) * enumerator->root->num_static_heaps);
+    static_heaps = pas_enumerator_read_compact(enumerator,
+                                               enumerator->root->static_heaps);
     if (!static_heaps)
         return false;
 
     for (index = enumerator->root->num_static_heaps; index--;) {
-        pas_heap* heap;
+        pas_heap heap;
 
-        heap = pas_enumerator_read(enumerator, static_heaps[index], sizeof(pas_heap));
-        if (!heap)
+        if (!pas_enumerator_copy_remote(enumerator, &heap, static_heaps[index], sizeof(pas_heap)))
             return false;
-        
-        if (!callback(enumerator, heap, arg))
+
+        if (!callback(enumerator, &heap, arg))
             return false;
     }
 

--- a/Source/bmalloc/libpas/src/libpas/pas_enumerator.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_enumerator.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021 Apple Inc. All rights reserved.
+ * Copyright (c) 2020-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -124,6 +124,10 @@ struct pas_enumerator {
        as payload if it is still in this set, and then removes it from this set. */
     pas_ptr_hash_set* unaccounted_pages;
 
+    void* lenient_compact_ptr_buffer;
+    size_t lenient_compact_ptr_buffer_capacity;
+
+    void* pinned_address;
     pas_enumerator_reader reader;
     void* reader_arg;
 
@@ -158,12 +162,43 @@ PAS_API void pas_enumerator_destroy(pas_enumerator* enumerator);
 PAS_API void* pas_enumerator_allocate(pas_enumerator* enumerator,
                                       size_t size);
 
+void* pas_enumerator_lenient_compact_ptr_buffer(pas_enumerator* enumerator,
+                                                size_t size);
+
 PAS_API void* pas_enumerator_read_compact(pas_enumerator* enumerator,
                                           void* remote_address);
 
-PAS_API void* pas_enumerator_read(pas_enumerator* enumerator,
-                                  void* remote_address,
-                                  size_t size);
+/* Returns a virtual address in the local process that maps the range given by
+   remote_address and size from the target process, and pins the mapping.
+   Returns null if the remote range was invalid.
+
+   Only one such mapping can be pinned at a time, see the specification of
+   memory_reader_t in malloc.h:
+   
+   "validity of local_memory is assumed to be limited (until next call)"
+
+   pas_enumerator_copy_remote cannot be called while this mapping is pinned
+   since that also needs to call into the memory reader. The returned pointer
+   must not be stashed away since the mapping can be invalidated.
+
+   Prefer pas_enumerator_copy_remote instead. This interface is provided for 
+   convenience in cases where the structure is variable size and it's known 
+   that no other mappings will be needed while this one is live. */
+PAS_API void* pas_enumerator_pin_remote(pas_enumerator* enumerator,
+                                        void* remote_address,
+                                        size_t size);
+
+/* Unpin the mapping previously established by pas_enumerator_pin_remote. */
+PAS_API void pas_enumerator_unpin_remote(pas_enumerator* enumerator,
+                                         void* pinned_address);
+
+/* Copy size bytes from remote_address in the target process to the local_buffer.
+   Returns false if the remote_address is invalid. Cannot be called if a
+   remote address is currently pinned. */
+PAS_API bool pas_enumerator_copy_remote(pas_enumerator* enumerator,
+                                        void* local_buffer,
+                                        void* remote_address,
+                                        size_t size);
 
 PAS_API void pas_enumerator_add_unaccounted_pages(pas_enumerator* enumerator,
                                                   void* remote_address,

--- a/Source/bmalloc/libpas/src/libpas/pas_heap_config_utils.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_heap_config_utils.c
@@ -70,23 +70,27 @@ bool pas_heap_config_utils_for_each_shared_page_directory_remote(
                      void* arg),
     void* arg)
 {
-    pas_basic_heap_runtime_config* runtime_config;
-    pas_basic_heap_page_caches* page_caches;
+    pas_basic_heap_runtime_config runtime_config;
+    pas_basic_heap_page_caches page_caches;
     pas_segregated_page_config_variant variant;
 
-    runtime_config = pas_enumerator_read(
-        enumerator, heap->runtime_config, sizeof(pas_basic_heap_runtime_config));
-    if (!runtime_config)
+    if (!pas_enumerator_copy_remote(
+            enumerator,
+            &runtime_config,
+            heap->runtime_config,
+            sizeof(pas_basic_heap_runtime_config)))
         return false;
 
-    page_caches = pas_enumerator_read(
-        enumerator, runtime_config->page_caches, sizeof(pas_basic_heap_page_caches));
-    if (!page_caches)
+    if (!pas_enumerator_copy_remote(
+            enumerator,
+            &page_caches,
+            runtime_config.page_caches,
+            sizeof(pas_basic_heap_page_caches)))
         return false;
 
     for (PAS_EACH_SEGREGATED_PAGE_CONFIG_VARIANT_ASCENDING(variant)) {
         if (!pas_shared_page_directory_by_size_for_each_remote(
-                pas_basic_heap_page_caches_get_shared_page_directories(page_caches, variant),
+                pas_basic_heap_page_caches_get_shared_page_directories(&page_caches, variant),
                 enumerator, callback, arg))
             return false;
     }
@@ -156,41 +160,42 @@ void* pas_heap_config_utils_prepare_to_enumerate(pas_enumerator* enumerator,
                                                  const pas_heap_config* my_config)
 {
     pas_basic_heap_config_enumerator_data* result;
-    const pas_heap_config** configs;
-    const pas_heap_config* config;
-    pas_basic_heap_config_root_data* root_data;
 
-    configs = pas_enumerator_read(
-        enumerator, enumerator->root->heap_configs,
-        sizeof(const pas_heap_config*) * pas_heap_config_kind_num_kinds);
-    if (!configs)
-        return NULL;
-    
-    config = pas_enumerator_read(enumerator, (void*)(uintptr_t)configs[my_config->kind], sizeof(pas_heap_config));
-    if (!config)
+    pas_heap_config* config_ptr;
+    pas_basic_heap_config_root_data* root_data_ptr;
+    pas_basic_heap_config_root_data root_data;
+    pas_page_header_table medium_page_header_table;
+    pas_page_header_table marge_page_header_table;
+
+    if (!pas_enumerator_copy_remote(enumerator, &config_ptr, enumerator->root->heap_configs + my_config->kind, sizeof(pas_heap_config*)))
         return NULL;
 
-    root_data = pas_enumerator_read(
-        enumerator, config->root_data, sizeof(pas_basic_heap_config_root_data));
-    if (!root_data)
+    if (!pas_enumerator_copy_remote(enumerator, &root_data_ptr, &config_ptr->root_data, sizeof(pas_basic_heap_config_root_data*)))
+        return NULL;
+
+    if (!pas_enumerator_copy_remote(enumerator, &root_data, root_data_ptr, sizeof(pas_basic_heap_config_root_data)))
         return NULL;
 
     result = pas_enumerator_allocate(enumerator, sizeof(pas_basic_heap_config_enumerator_data));
     
     pas_ptr_hash_map_construct(&result->page_header_table);
 
+    if (!pas_enumerator_copy_remote(enumerator, &medium_page_header_table, root_data.medium_page_header_table, sizeof(pas_page_header_table)))
+        return NULL;
+
     if (!pas_basic_heap_config_enumerator_data_add_page_header_table(
             result,
             enumerator,
-            pas_enumerator_read(
-                enumerator, root_data->medium_page_header_table, sizeof(pas_page_header_table))))
+            &medium_page_header_table))
         return NULL;
     
+    if (!pas_enumerator_copy_remote(enumerator, &marge_page_header_table, root_data.marge_page_header_table, sizeof(pas_page_header_table)))
+        return NULL;
+
     if (!pas_basic_heap_config_enumerator_data_add_page_header_table(
             result,
             enumerator,
-            pas_enumerator_read(
-                enumerator, root_data->marge_page_header_table, sizeof(pas_page_header_table))))
+            &marge_page_header_table))
         return NULL;
     
     return result;

--- a/Source/bmalloc/libpas/src/test/EnumerationTests.cpp
+++ b/Source/bmalloc/libpas/src/test/EnumerationTests.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Apple Inc. All rights reserved.
+ * Copyright (c) 2023-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -106,30 +106,28 @@ struct ReaderRange {
         PAS_ASSERT(size);
     }
 
-    bool operator<(ReaderRange other) const
-    {
-        if (base != other.base)
-            return base < other.base;
-        return size < other.size;
-    }
-
     void* base { nullptr };
     size_t size { 0 };
 };
 
 map<pas_enumerator_record_kind, set<RecordedRange>> recordedRanges;
-map<ReaderRange, void*> readerCache;
+ReaderRange readerPreviousBuffer;
 
 void* enumeratorReader(pas_enumerator* enumerator, void* address, size_t size, void* arg)
 {
     CHECK(!arg);
     CHECK(size);
 
-    ReaderRange range = ReaderRange(address, size);
-
-    auto readerCacheIter = readerCache.find(range);
-    if (readerCacheIter != readerCache.end())
-        return readerCacheIter->second;
+    // Scribble the previously returned buffer to simulate the previously mapped region
+    // being invalidated as per the specification of memory_reader_t in malloc.h:
+    //
+    // typedef kern_return_t memory_reader_t(task_t remote_task, vm_address_t remote_address, vm_size_t size, void * __sized_by(size) *local_memory);
+    //
+    // given a task, "reads" the memory at the given address and size
+    // local_memory: set to a contiguous chunk of memory; validity of local_memory is assumed to be limited (until next call)
+    //
+    if (readerPreviousBuffer.base && readerPreviousBuffer.size)
+        memset(readerPreviousBuffer.base, 0xda, readerPreviousBuffer.size);
 
     void* result = pas_enumerator_allocate(enumerator, size);
 
@@ -175,7 +173,7 @@ void* enumeratorReader(pas_enumerator* enumerator, void* address, size_t size, v
         PAS_ASSERT(!systemResult);
     }
 
-    readerCache[range] = result;
+    readerPreviousBuffer = ReaderRange(result, size);
     return result;
 }
 


### PR DESCRIPTION
#### d6a6f29475b0e9a8ff0d85b0b73b1c18b6c922ff
<pre>
[libpas] Enumerator should not assume remote mappings persist across calls to memory_reader_t
<a href="https://bugs.webkit.org/show_bug.cgi?id=294130">https://bugs.webkit.org/show_bug.cgi?id=294130</a>
<a href="https://rdar.apple.com/143300973">rdar://143300973</a>

Reviewed by Yusuke Suzuki.

A tool that calls into the enumerator provides a memory_reader_t
callback to allow the enumerator to map the remote memory of the
target process. The address returned by the memory_reader_t callback is
guaranteed to persist only to the next call to the memory_reader_t
callback. This is documented in malloc.h.

The libpas enumerator was violating this by keeping addresses alive
across calls to the reader callback.

A few techniques are used to fix this:

1. The libpas compact heap (which is limited in size and stores
   libpas metadata) is copied into the local process, and pointers
   into the remote compact heap are translated to local pointers using
   pointer arithmetic. The only change here is to copy the compact
   heap during pas_enumerator_create(). The accessors generated by
   the compact pointer macros do not change.

2. The libpas enumerator creates a hashtable containing references to
   the local allocators. The local allocators live within the TLCs and
   the baseline allocator table, so these regions are also copied into
   the local process. Then the local allocators are accessed directly
   via hashtable lookups, as before.

3. Some other important &quot;root&quot; structures are copied during
   pas_enumerator_create and referenced directly by the pas_enumerator
   structure (this was mostly already done in 277271@main).

4. The final piece of metadata needed before recording objects is the
   page header, which are variable sized. Rather than deal with copying
   these variable sized structures, a pinning interface is used to
   ensure no other mapping (i.e. calls to the reader callback) is
   established while using this pointer.

5. The lenient compact pointer case is a weird case where the pointer
   may reference either the compact heap or bounce through the compact heap
   to another heap. This is used to store the fully alloc bits, which
   sometimes come from the local allocator and sometimes from the
   compact heap and are variable sized data structure.
   These are copied out into a special purpose resizable buffer when
   necessary. This code can be deleted if the partial view code is deleted.

6. All other remote address accesses (the common case) are handled by
   copying the remote scalar or structure into an automatic stack variable.
   i.e. the enumerator doesn&apos;t get direct access to the mapped address
   and thus no pointer lifetime issues can exist. This requires reworking
   e.g. list and hashtable traversals a bit so that pointer dereferencing
   occurs up front rather than between iterations (because the
   current iteration will make another call into the reader callback,
   potentially invalidating the mapping holding the &quot;next&quot; pointer).

Testing:
- The IsoHeapChaosTests provides good coverage of the enumerator code,
  but the reader implementation was caching all previous mappings.
  Changed the test reader to clobber all previously returned buffers
  to emulate the behavior that pointers returned by the reader can be
  invalidated by the next reader call.
- Run leaks and heap tools on WebContent with these changes and see that
  they work.

Canonical link: <a href="https://commits.webkit.org/296003@main">https://commits.webkit.org/296003@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a8cddf092692379fbaaddd33dca38126f6c4d060

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/106697 "41 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/26448 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/16845 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/111907 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/57295 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/27118 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34950 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/81018 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/109701 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/21511 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/96272 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/61358 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/14379 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/56749 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/99337 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/90851 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/14408 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/114812 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/105315 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33835 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24940 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/90082 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/34199 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/92503 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89792 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22948 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34718 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/29462 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/33760 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/129626 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/33506 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/35289 "Found 2 new JSC stress test failures: wasm.yaml/wasm/gc/ref-i31-eq.js.wasm-collect-continuously, wasm.yaml/wasm/gc/ref-i31-eq.js.wasm-eager (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/36859 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/35105 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->