### PR TITLE
Further use C++ concepts in rest of WebCore

### DIFF
--- a/Source/WebCore/bindings/js/JSDOMConvertInterface.h
+++ b/Source/WebCore/bindings/js/JSDOMConvertInterface.h
@@ -46,7 +46,8 @@ struct JSToWrappedOverloader {
 };
 
 template<typename T>
-struct JSToWrappedOverloader<T, typename std::enable_if<JSDOMWrapperConverterTraits<T>::needsState>::type> {
+    requires JSDOMWrapperConverterTraits<T>::needsState
+struct JSToWrappedOverloader<T> {
     using ReturnType = typename JSDOMWrapperConverterTraits<T>::ToWrappedReturnType;
     using WrapperType = typename JSDOMWrapperConverterTraits<T>::WrapperClass;
 

--- a/Source/WebCore/bindings/js/JSDOMIterator.h
+++ b/Source/WebCore/bindings/js/JSDOMIterator.h
@@ -43,8 +43,8 @@ enum class JSDOMIteratorType { Set, Map };
 //     using ValueType = [IDLType];
 // };
 
-template<typename T, typename U = void> using EnableIfMap = typename std::enable_if<T::type == JSDOMIteratorType::Map, U>::type;
-template<typename T, typename U = void> using EnableIfSet = typename std::enable_if<T::type == JSDOMIteratorType::Set, U>::type;
+template<typename T, typename U = void> using EnableIfMap = typename std::enable_if_t<T::type == JSDOMIteratorType::Map, U>;
+template<typename T, typename U = void> using EnableIfSet = typename std::enable_if_t<T::type == JSDOMIteratorType::Set, U>;
 
 template<typename JSWrapper, typename IteratorTraits> class JSDOMIteratorPrototype final : public JSC::JSNonFinalObject {
 public:

--- a/Source/WebCore/bindings/js/WebCoreOpaqueRoot.h
+++ b/Source/WebCore/bindings/js/WebCoreOpaqueRoot.h
@@ -32,7 +32,8 @@ namespace WebCore {
 
 class WebCoreOpaqueRoot {
 public:
-    template<typename T, typename = typename std::enable_if_t<!std::is_same_v<T, void>>>
+    template<typename T>
+        requires (!std::same_as<T, void>)
     explicit WebCoreOpaqueRoot(T* pointer)
         : m_pointer(static_cast<void*>(pointer))
     {

--- a/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
+++ b/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
@@ -5438,7 +5438,9 @@ extern "C" { extern void (*const ${vtableRefWin}[])(); }
 #else
 extern "C" { extern void* ${vtableNameGnu}[]; }
 #endif
-template<typename T, typename = std::enable_if_t<std::is_same_v<T, ${implType}>, void>> static inline void verifyVTable(${implType}* ptr) {
+template<std::same_as<${implType}> T>
+static inline void verifyVTable(${implType}* ptr) 
+{
     if constexpr (std::is_polymorphic_v<T>) {
         const void* actualVTablePointer = getVTablePointer<T>(ptr);
 #if PLATFORM(WIN)

--- a/Source/WebCore/bindings/scripts/test/JS/JSExposedStar.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSExposedStar.cpp
@@ -258,7 +258,9 @@ extern "C" { extern void (*const __identifier("??_7ExposedStar@WebCore@@6B@")[])
 #else
 extern "C" { extern void* _ZTVN7WebCore11ExposedStarE[]; }
 #endif
-template<typename T, typename = std::enable_if_t<std::is_same_v<T, ExposedStar>, void>> static inline void verifyVTable(ExposedStar* ptr) {
+template<std::same_as<ExposedStar> T>
+static inline void verifyVTable(ExposedStar* ptr) 
+{
     if constexpr (std::is_polymorphic_v<T>) {
         const void* actualVTablePointer = getVTablePointer<T>(ptr);
 #if PLATFORM(WIN)

--- a/Source/WebCore/bindings/scripts/test/JS/JSExposedToWorkerAndWindow.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSExposedToWorkerAndWindow.cpp
@@ -286,7 +286,9 @@ extern "C" { extern void (*const __identifier("??_7ExposedToWorkerAndWindow@WebC
 #else
 extern "C" { extern void* _ZTVN7WebCore24ExposedToWorkerAndWindowE[]; }
 #endif
-template<typename T, typename = std::enable_if_t<std::is_same_v<T, ExposedToWorkerAndWindow>, void>> static inline void verifyVTable(ExposedToWorkerAndWindow* ptr) {
+template<std::same_as<ExposedToWorkerAndWindow> T>
+static inline void verifyVTable(ExposedToWorkerAndWindow* ptr) 
+{
     if constexpr (std::is_polymorphic_v<T>) {
         const void* actualVTablePointer = getVTablePointer<T>(ptr);
 #if PLATFORM(WIN)

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestAsyncIterable.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestAsyncIterable.cpp
@@ -304,7 +304,9 @@ extern "C" { extern void (*const __identifier("??_7TestAsyncIterable@WebCore@@6B
 #else
 extern "C" { extern void* _ZTVN7WebCore17TestAsyncIterableE[]; }
 #endif
-template<typename T, typename = std::enable_if_t<std::is_same_v<T, TestAsyncIterable>, void>> static inline void verifyVTable(TestAsyncIterable* ptr) {
+template<std::same_as<TestAsyncIterable> T>
+static inline void verifyVTable(TestAsyncIterable* ptr) 
+{
     if constexpr (std::is_polymorphic_v<T>) {
         const void* actualVTablePointer = getVTablePointer<T>(ptr);
 #if PLATFORM(WIN)

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestAsyncKeyValueIterable.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestAsyncKeyValueIterable.cpp
@@ -305,7 +305,9 @@ extern "C" { extern void (*const __identifier("??_7TestAsyncKeyValueIterable@Web
 #else
 extern "C" { extern void* _ZTVN7WebCore25TestAsyncKeyValueIterableE[]; }
 #endif
-template<typename T, typename = std::enable_if_t<std::is_same_v<T, TestAsyncKeyValueIterable>, void>> static inline void verifyVTable(TestAsyncKeyValueIterable* ptr) {
+template<std::same_as<TestAsyncKeyValueIterable> T>
+static inline void verifyVTable(TestAsyncKeyValueIterable* ptr) 
+{
     if constexpr (std::is_polymorphic_v<T>) {
         const void* actualVTablePointer = getVTablePointer<T>(ptr);
 #if PLATFORM(WIN)

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCEReactions.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCEReactions.cpp
@@ -478,7 +478,9 @@ extern "C" { extern void (*const __identifier("??_7TestCEReactions@WebCore@@6B@"
 #else
 extern "C" { extern void* _ZTVN7WebCore15TestCEReactionsE[]; }
 #endif
-template<typename T, typename = std::enable_if_t<std::is_same_v<T, TestCEReactions>, void>> static inline void verifyVTable(TestCEReactions* ptr) {
+template<std::same_as<TestCEReactions> T>
+static inline void verifyVTable(TestCEReactions* ptr) 
+{
     if constexpr (std::is_polymorphic_v<T>) {
         const void* actualVTablePointer = getVTablePointer<T>(ptr);
 #if PLATFORM(WIN)

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCEReactionsStringifier.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCEReactionsStringifier.cpp
@@ -298,7 +298,9 @@ extern "C" { extern void (*const __identifier("??_7TestCEReactionsStringifier@We
 #else
 extern "C" { extern void* _ZTVN7WebCore26TestCEReactionsStringifierE[]; }
 #endif
-template<typename T, typename = std::enable_if_t<std::is_same_v<T, TestCEReactionsStringifier>, void>> static inline void verifyVTable(TestCEReactionsStringifier* ptr) {
+template<std::same_as<TestCEReactionsStringifier> T>
+static inline void verifyVTable(TestCEReactionsStringifier* ptr) 
+{
     if constexpr (std::is_polymorphic_v<T>) {
         const void* actualVTablePointer = getVTablePointer<T>(ptr);
 #if PLATFORM(WIN)

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallTracer.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallTracer.cpp
@@ -557,7 +557,9 @@ extern "C" { extern void (*const __identifier("??_7TestCallTracer@WebCore@@6B@")
 #else
 extern "C" { extern void* _ZTVN7WebCore14TestCallTracerE[]; }
 #endif
-template<typename T, typename = std::enable_if_t<std::is_same_v<T, TestCallTracer>, void>> static inline void verifyVTable(TestCallTracer* ptr) {
+template<std::same_as<TestCallTracer> T>
+static inline void verifyVTable(TestCallTracer* ptr) 
+{
     if constexpr (std::is_polymorphic_v<T>) {
         const void* actualVTablePointer = getVTablePointer<T>(ptr);
 #if PLATFORM(WIN)

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestClassWithJSBuiltinConstructor.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestClassWithJSBuiltinConstructor.cpp
@@ -206,7 +206,9 @@ extern "C" { extern void (*const __identifier("??_7TestClassWithJSBuiltinConstru
 #else
 extern "C" { extern void* _ZTVN7WebCore33TestClassWithJSBuiltinConstructorE[]; }
 #endif
-template<typename T, typename = std::enable_if_t<std::is_same_v<T, TestClassWithJSBuiltinConstructor>, void>> static inline void verifyVTable(TestClassWithJSBuiltinConstructor* ptr) {
+template<std::same_as<TestClassWithJSBuiltinConstructor> T>
+static inline void verifyVTable(TestClassWithJSBuiltinConstructor* ptr) 
+{
     if constexpr (std::is_polymorphic_v<T>) {
         const void* actualVTablePointer = getVTablePointer<T>(ptr);
 #if PLATFORM(WIN)

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestConditionalIncludes.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestConditionalIncludes.cpp
@@ -827,7 +827,9 @@ extern "C" { extern void (*const __identifier("??_7TestConditionalIncludes@WebCo
 #else
 extern "C" { extern void* _ZTVN7WebCore23TestConditionalIncludesE[]; }
 #endif
-template<typename T, typename = std::enable_if_t<std::is_same_v<T, TestConditionalIncludes>, void>> static inline void verifyVTable(TestConditionalIncludes* ptr) {
+template<std::same_as<TestConditionalIncludes> T>
+static inline void verifyVTable(TestConditionalIncludes* ptr) 
+{
     if constexpr (std::is_polymorphic_v<T>) {
         const void* actualVTablePointer = getVTablePointer<T>(ptr);
 #if PLATFORM(WIN)

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestConditionallyReadWrite.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestConditionallyReadWrite.cpp
@@ -498,7 +498,9 @@ extern "C" { extern void (*const __identifier("??_7TestConditionallyReadWrite@We
 #else
 extern "C" { extern void* _ZTVN7WebCore26TestConditionallyReadWriteE[]; }
 #endif
-template<typename T, typename = std::enable_if_t<std::is_same_v<T, TestConditionallyReadWrite>, void>> static inline void verifyVTable(TestConditionallyReadWrite* ptr) {
+template<std::same_as<TestConditionallyReadWrite> T>
+static inline void verifyVTable(TestConditionallyReadWrite* ptr) 
+{
     if constexpr (std::is_polymorphic_v<T>) {
         const void* actualVTablePointer = getVTablePointer<T>(ptr);
 #if PLATFORM(WIN)

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestDefaultToJSON.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestDefaultToJSON.cpp
@@ -867,7 +867,9 @@ extern "C" { extern void (*const __identifier("??_7TestDefaultToJSON@WebCore@@6B
 #else
 extern "C" { extern void* _ZTVN7WebCore17TestDefaultToJSONE[]; }
 #endif
-template<typename T, typename = std::enable_if_t<std::is_same_v<T, TestDefaultToJSON>, void>> static inline void verifyVTable(TestDefaultToJSON* ptr) {
+template<std::same_as<TestDefaultToJSON> T>
+static inline void verifyVTable(TestDefaultToJSON* ptr) 
+{
     if constexpr (std::is_polymorphic_v<T>) {
         const void* actualVTablePointer = getVTablePointer<T>(ptr);
 #if PLATFORM(WIN)

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestDefaultToJSONFilteredByExposed.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestDefaultToJSONFilteredByExposed.cpp
@@ -302,7 +302,9 @@ extern "C" { extern void (*const __identifier("??_7TestDefaultToJSONFilteredByEx
 #else
 extern "C" { extern void* _ZTVN7WebCore34TestDefaultToJSONFilteredByExposedE[]; }
 #endif
-template<typename T, typename = std::enable_if_t<std::is_same_v<T, TestDefaultToJSONFilteredByExposed>, void>> static inline void verifyVTable(TestDefaultToJSONFilteredByExposed* ptr) {
+template<std::same_as<TestDefaultToJSONFilteredByExposed> T>
+static inline void verifyVTable(TestDefaultToJSONFilteredByExposed* ptr) 
+{
     if constexpr (std::is_polymorphic_v<T>) {
         const void* actualVTablePointer = getVTablePointer<T>(ptr);
 #if PLATFORM(WIN)

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestDelegateToSharedSyntheticAttribute.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestDelegateToSharedSyntheticAttribute.cpp
@@ -280,7 +280,9 @@ extern "C" { extern void (*const __identifier("??_7TestDelegateToSharedSynthetic
 #else
 extern "C" { extern void* _ZTVN7WebCore38TestDelegateToSharedSyntheticAttributeE[]; }
 #endif
-template<typename T, typename = std::enable_if_t<std::is_same_v<T, TestDelegateToSharedSyntheticAttribute>, void>> static inline void verifyVTable(TestDelegateToSharedSyntheticAttribute* ptr) {
+template<std::same_as<TestDelegateToSharedSyntheticAttribute> T>
+static inline void verifyVTable(TestDelegateToSharedSyntheticAttribute* ptr) 
+{
     if constexpr (std::is_polymorphic_v<T>) {
         const void* actualVTablePointer = getVTablePointer<T>(ptr);
 #if PLATFORM(WIN)

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestDomainSecurity.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestDomainSecurity.cpp
@@ -354,7 +354,9 @@ extern "C" { extern void (*const __identifier("??_7TestDomainSecurity@WebCore@@6
 #else
 extern "C" { extern void* _ZTVN7WebCore18TestDomainSecurityE[]; }
 #endif
-template<typename T, typename = std::enable_if_t<std::is_same_v<T, TestDomainSecurity>, void>> static inline void verifyVTable(TestDomainSecurity* ptr) {
+template<std::same_as<TestDomainSecurity> T>
+static inline void verifyVTable(TestDomainSecurity* ptr) 
+{
     if constexpr (std::is_polymorphic_v<T>) {
         const void* actualVTablePointer = getVTablePointer<T>(ptr);
 #if PLATFORM(WIN)

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestEnabledBySetting.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestEnabledBySetting.cpp
@@ -503,7 +503,9 @@ extern "C" { extern void (*const __identifier("??_7TestEnabledBySetting@WebCore@
 #else
 extern "C" { extern void* _ZTVN7WebCore20TestEnabledBySettingE[]; }
 #endif
-template<typename T, typename = std::enable_if_t<std::is_same_v<T, TestEnabledBySetting>, void>> static inline void verifyVTable(TestEnabledBySetting* ptr) {
+template<std::same_as<TestEnabledBySetting> T>
+static inline void verifyVTable(TestEnabledBySetting* ptr) 
+{
     if constexpr (std::is_polymorphic_v<T>) {
         const void* actualVTablePointer = getVTablePointer<T>(ptr);
 #if PLATFORM(WIN)

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestEnabledForContext.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestEnabledForContext.cpp
@@ -225,7 +225,9 @@ extern "C" { extern void (*const __identifier("??_7TestEnabledForContext@WebCore
 #else
 extern "C" { extern void* _ZTVN7WebCore21TestEnabledForContextE[]; }
 #endif
-template<typename T, typename = std::enable_if_t<std::is_same_v<T, TestEnabledForContext>, void>> static inline void verifyVTable(TestEnabledForContext* ptr) {
+template<std::same_as<TestEnabledForContext> T>
+static inline void verifyVTable(TestEnabledForContext* ptr) 
+{
     if constexpr (std::is_polymorphic_v<T>) {
         const void* actualVTablePointer = getVTablePointer<T>(ptr);
 #if PLATFORM(WIN)

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestEventConstructor.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestEventConstructor.cpp
@@ -341,7 +341,9 @@ extern "C" { extern void (*const __identifier("??_7TestEventConstructor@WebCore@
 #else
 extern "C" { extern void* _ZTVN7WebCore20TestEventConstructorE[]; }
 #endif
-template<typename T, typename = std::enable_if_t<std::is_same_v<T, TestEventConstructor>, void>> static inline void verifyVTable(TestEventConstructor* ptr) {
+template<std::same_as<TestEventConstructor> T>
+static inline void verifyVTable(TestEventConstructor* ptr) 
+{
     if constexpr (std::is_polymorphic_v<T>) {
         const void* actualVTablePointer = getVTablePointer<T>(ptr);
 #if PLATFORM(WIN)

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestEventTarget.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestEventTarget.cpp
@@ -406,7 +406,9 @@ extern "C" { extern void (*const __identifier("??_7TestEventTarget@WebCore@@6B@"
 #else
 extern "C" { extern void* _ZTVN7WebCore15TestEventTargetE[]; }
 #endif
-template<typename T, typename = std::enable_if_t<std::is_same_v<T, TestEventTarget>, void>> static inline void verifyVTable(TestEventTarget* ptr) {
+template<std::same_as<TestEventTarget> T>
+static inline void verifyVTable(TestEventTarget* ptr) 
+{
     if constexpr (std::is_polymorphic_v<T>) {
         const void* actualVTablePointer = getVTablePointer<T>(ptr);
 #if PLATFORM(WIN)

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestException.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestException.cpp
@@ -217,7 +217,9 @@ extern "C" { extern void (*const __identifier("??_7TestException@WebCore@@6B@")[
 #else
 extern "C" { extern void* _ZTVN7WebCore13TestExceptionE[]; }
 #endif
-template<typename T, typename = std::enable_if_t<std::is_same_v<T, TestException>, void>> static inline void verifyVTable(TestException* ptr) {
+template<std::same_as<TestException> T>
+static inline void verifyVTable(TestException* ptr) 
+{
     if constexpr (std::is_polymorphic_v<T>) {
         const void* actualVTablePointer = getVTablePointer<T>(ptr);
 #if PLATFORM(WIN)

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestGenerateAddOpaqueRoot.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestGenerateAddOpaqueRoot.cpp
@@ -229,7 +229,9 @@ extern "C" { extern void (*const __identifier("??_7TestGenerateAddOpaqueRoot@Web
 #else
 extern "C" { extern void* _ZTVN7WebCore25TestGenerateAddOpaqueRootE[]; }
 #endif
-template<typename T, typename = std::enable_if_t<std::is_same_v<T, TestGenerateAddOpaqueRoot>, void>> static inline void verifyVTable(TestGenerateAddOpaqueRoot* ptr) {
+template<std::same_as<TestGenerateAddOpaqueRoot> T>
+static inline void verifyVTable(TestGenerateAddOpaqueRoot* ptr) 
+{
     if constexpr (std::is_polymorphic_v<T>) {
         const void* actualVTablePointer = getVTablePointer<T>(ptr);
 #if PLATFORM(WIN)

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestGenerateIsReachable.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestGenerateIsReachable.cpp
@@ -229,7 +229,9 @@ extern "C" { extern void (*const __identifier("??_7TestGenerateIsReachable@WebCo
 #else
 extern "C" { extern void* _ZTVN7WebCore23TestGenerateIsReachableE[]; }
 #endif
-template<typename T, typename = std::enable_if_t<std::is_same_v<T, TestGenerateIsReachable>, void>> static inline void verifyVTable(TestGenerateIsReachable* ptr) {
+template<std::same_as<TestGenerateIsReachable> T>
+static inline void verifyVTable(TestGenerateIsReachable* ptr) 
+{
     if constexpr (std::is_polymorphic_v<T>) {
         const void* actualVTablePointer = getVTablePointer<T>(ptr);
 #if PLATFORM(WIN)

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestIndexedSetterNoIdentifier.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestIndexedSetterNoIdentifier.cpp
@@ -351,7 +351,9 @@ extern "C" { extern void (*const __identifier("??_7TestIndexedSetterNoIdentifier
 #else
 extern "C" { extern void* _ZTVN7WebCore29TestIndexedSetterNoIdentifierE[]; }
 #endif
-template<typename T, typename = std::enable_if_t<std::is_same_v<T, TestIndexedSetterNoIdentifier>, void>> static inline void verifyVTable(TestIndexedSetterNoIdentifier* ptr) {
+template<std::same_as<TestIndexedSetterNoIdentifier> T>
+static inline void verifyVTable(TestIndexedSetterNoIdentifier* ptr) 
+{
     if constexpr (std::is_polymorphic_v<T>) {
         const void* actualVTablePointer = getVTablePointer<T>(ptr);
 #if PLATFORM(WIN)

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestIndexedSetterThrowingException.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestIndexedSetterThrowingException.cpp
@@ -351,7 +351,9 @@ extern "C" { extern void (*const __identifier("??_7TestIndexedSetterThrowingExce
 #else
 extern "C" { extern void* _ZTVN7WebCore34TestIndexedSetterThrowingExceptionE[]; }
 #endif
-template<typename T, typename = std::enable_if_t<std::is_same_v<T, TestIndexedSetterThrowingException>, void>> static inline void verifyVTable(TestIndexedSetterThrowingException* ptr) {
+template<std::same_as<TestIndexedSetterThrowingException> T>
+static inline void verifyVTable(TestIndexedSetterThrowingException* ptr) 
+{
     if constexpr (std::is_polymorphic_v<T>) {
         const void* actualVTablePointer = getVTablePointer<T>(ptr);
 #if PLATFORM(WIN)

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestIndexedSetterWithIdentifier.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestIndexedSetterWithIdentifier.cpp
@@ -385,7 +385,9 @@ extern "C" { extern void (*const __identifier("??_7TestIndexedSetterWithIdentifi
 #else
 extern "C" { extern void* _ZTVN7WebCore31TestIndexedSetterWithIdentifierE[]; }
 #endif
-template<typename T, typename = std::enable_if_t<std::is_same_v<T, TestIndexedSetterWithIdentifier>, void>> static inline void verifyVTable(TestIndexedSetterWithIdentifier* ptr) {
+template<std::same_as<TestIndexedSetterWithIdentifier> T>
+static inline void verifyVTable(TestIndexedSetterWithIdentifier* ptr) 
+{
     if constexpr (std::is_polymorphic_v<T>) {
         const void* actualVTablePointer = getVTablePointer<T>(ptr);
 #if PLATFORM(WIN)

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestInterface.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestInterface.cpp
@@ -1242,7 +1242,9 @@ extern "C" { extern void (*const __identifier("??_7TestInterface@WebCore@@6B@")[
 #else
 extern "C" { extern void* _ZTVN7WebCore13TestInterfaceE[]; }
 #endif
-template<typename T, typename = std::enable_if_t<std::is_same_v<T, TestInterface>, void>> static inline void verifyVTable(TestInterface* ptr) {
+template<std::same_as<TestInterface> T>
+static inline void verifyVTable(TestInterface* ptr) 
+{
     if constexpr (std::is_polymorphic_v<T>) {
         const void* actualVTablePointer = getVTablePointer<T>(ptr);
 #if PLATFORM(WIN)

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestInterfaceLeadingUnderscore.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestInterfaceLeadingUnderscore.cpp
@@ -217,7 +217,9 @@ extern "C" { extern void (*const __identifier("??_7TestInterfaceLeadingUnderscor
 #else
 extern "C" { extern void* _ZTVN7WebCore30TestInterfaceLeadingUnderscoreE[]; }
 #endif
-template<typename T, typename = std::enable_if_t<std::is_same_v<T, TestInterfaceLeadingUnderscore>, void>> static inline void verifyVTable(TestInterfaceLeadingUnderscore* ptr) {
+template<std::same_as<TestInterfaceLeadingUnderscore> T>
+static inline void verifyVTable(TestInterfaceLeadingUnderscore* ptr) 
+{
     if constexpr (std::is_polymorphic_v<T>) {
         const void* actualVTablePointer = getVTablePointer<T>(ptr);
 #if PLATFORM(WIN)

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestIterable.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestIterable.cpp
@@ -309,7 +309,9 @@ extern "C" { extern void (*const __identifier("??_7TestIterable@WebCore@@6B@")[]
 #else
 extern "C" { extern void* _ZTVN7WebCore12TestIterableE[]; }
 #endif
-template<typename T, typename = std::enable_if_t<std::is_same_v<T, TestIterable>, void>> static inline void verifyVTable(TestIterable* ptr) {
+template<std::same_as<TestIterable> T>
+static inline void verifyVTable(TestIterable* ptr) 
+{
     if constexpr (std::is_polymorphic_v<T>) {
         const void* actualVTablePointer = getVTablePointer<T>(ptr);
 #if PLATFORM(WIN)

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestLegacyFactoryFunction.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestLegacyFactoryFunction.cpp
@@ -271,7 +271,9 @@ extern "C" { extern void (*const __identifier("??_7TestLegacyFactoryFunction@Web
 #else
 extern "C" { extern void* _ZTVN7WebCore25TestLegacyFactoryFunctionE[]; }
 #endif
-template<typename T, typename = std::enable_if_t<std::is_same_v<T, TestLegacyFactoryFunction>, void>> static inline void verifyVTable(TestLegacyFactoryFunction* ptr) {
+template<std::same_as<TestLegacyFactoryFunction> T>
+static inline void verifyVTable(TestLegacyFactoryFunction* ptr) 
+{
     if constexpr (std::is_polymorphic_v<T>) {
         const void* actualVTablePointer = getVTablePointer<T>(ptr);
 #if PLATFORM(WIN)

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestLegacyNoInterfaceObject.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestLegacyNoInterfaceObject.cpp
@@ -372,7 +372,9 @@ extern "C" { extern void (*const __identifier("??_7TestLegacyNoInterfaceObject@W
 #else
 extern "C" { extern void* _ZTVN7WebCore27TestLegacyNoInterfaceObjectE[]; }
 #endif
-template<typename T, typename = std::enable_if_t<std::is_same_v<T, TestLegacyNoInterfaceObject>, void>> static inline void verifyVTable(TestLegacyNoInterfaceObject* ptr) {
+template<std::same_as<TestLegacyNoInterfaceObject> T>
+static inline void verifyVTable(TestLegacyNoInterfaceObject* ptr) 
+{
     if constexpr (std::is_polymorphic_v<T>) {
         const void* actualVTablePointer = getVTablePointer<T>(ptr);
 #if PLATFORM(WIN)

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestLegacyOverrideBuiltIns.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestLegacyOverrideBuiltIns.cpp
@@ -399,7 +399,9 @@ extern "C" { extern void (*const __identifier("??_7TestLegacyOverrideBuiltIns@We
 #else
 extern "C" { extern void* _ZTVN7WebCore26TestLegacyOverrideBuiltInsE[]; }
 #endif
-template<typename T, typename = std::enable_if_t<std::is_same_v<T, TestLegacyOverrideBuiltIns>, void>> static inline void verifyVTable(TestLegacyOverrideBuiltIns* ptr) {
+template<std::same_as<TestLegacyOverrideBuiltIns> T>
+static inline void verifyVTable(TestLegacyOverrideBuiltIns* ptr) 
+{
     if constexpr (std::is_polymorphic_v<T>) {
         const void* actualVTablePointer = getVTablePointer<T>(ptr);
 #if PLATFORM(WIN)

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestMapLike.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestMapLike.cpp
@@ -402,7 +402,9 @@ extern "C" { extern void (*const __identifier("??_7TestMapLike@WebCore@@6B@")[])
 #else
 extern "C" { extern void* _ZTVN7WebCore11TestMapLikeE[]; }
 #endif
-template<typename T, typename = std::enable_if_t<std::is_same_v<T, TestMapLike>, void>> static inline void verifyVTable(TestMapLike* ptr) {
+template<std::same_as<TestMapLike> T>
+static inline void verifyVTable(TestMapLike* ptr) 
+{
     if constexpr (std::is_polymorphic_v<T>) {
         const void* actualVTablePointer = getVTablePointer<T>(ptr);
 #if PLATFORM(WIN)

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestMapLikeWithOverriddenOperations.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestMapLikeWithOverriddenOperations.cpp
@@ -416,7 +416,9 @@ extern "C" { extern void (*const __identifier("??_7TestMapLikeWithOverriddenOper
 #else
 extern "C" { extern void* _ZTVN7WebCore35TestMapLikeWithOverriddenOperationsE[]; }
 #endif
-template<typename T, typename = std::enable_if_t<std::is_same_v<T, TestMapLikeWithOverriddenOperations>, void>> static inline void verifyVTable(TestMapLikeWithOverriddenOperations* ptr) {
+template<std::same_as<TestMapLikeWithOverriddenOperations> T>
+static inline void verifyVTable(TestMapLikeWithOverriddenOperations* ptr) 
+{
     if constexpr (std::is_polymorphic_v<T>) {
         const void* actualVTablePointer = getVTablePointer<T>(ptr);
 #if PLATFORM(WIN)

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedAndIndexedSetterNoIdentifier.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedAndIndexedSetterNoIdentifier.cpp
@@ -436,7 +436,9 @@ extern "C" { extern void (*const __identifier("??_7TestNamedAndIndexedSetterNoId
 #else
 extern "C" { extern void* _ZTVN7WebCore37TestNamedAndIndexedSetterNoIdentifierE[]; }
 #endif
-template<typename T, typename = std::enable_if_t<std::is_same_v<T, TestNamedAndIndexedSetterNoIdentifier>, void>> static inline void verifyVTable(TestNamedAndIndexedSetterNoIdentifier* ptr) {
+template<std::same_as<TestNamedAndIndexedSetterNoIdentifier> T>
+static inline void verifyVTable(TestNamedAndIndexedSetterNoIdentifier* ptr) 
+{
     if constexpr (std::is_polymorphic_v<T>) {
         const void* actualVTablePointer = getVTablePointer<T>(ptr);
 #if PLATFORM(WIN)

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedAndIndexedSetterThrowingException.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedAndIndexedSetterThrowingException.cpp
@@ -436,7 +436,9 @@ extern "C" { extern void (*const __identifier("??_7TestNamedAndIndexedSetterThro
 #else
 extern "C" { extern void* _ZTVN7WebCore42TestNamedAndIndexedSetterThrowingExceptionE[]; }
 #endif
-template<typename T, typename = std::enable_if_t<std::is_same_v<T, TestNamedAndIndexedSetterThrowingException>, void>> static inline void verifyVTable(TestNamedAndIndexedSetterThrowingException* ptr) {
+template<std::same_as<TestNamedAndIndexedSetterThrowingException> T>
+static inline void verifyVTable(TestNamedAndIndexedSetterThrowingException* ptr) 
+{
     if constexpr (std::is_polymorphic_v<T>) {
         const void* actualVTablePointer = getVTablePointer<T>(ptr);
 #if PLATFORM(WIN)

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedAndIndexedSetterWithIdentifier.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedAndIndexedSetterWithIdentifier.cpp
@@ -497,7 +497,9 @@ extern "C" { extern void (*const __identifier("??_7TestNamedAndIndexedSetterWith
 #else
 extern "C" { extern void* _ZTVN7WebCore39TestNamedAndIndexedSetterWithIdentifierE[]; }
 #endif
-template<typename T, typename = std::enable_if_t<std::is_same_v<T, TestNamedAndIndexedSetterWithIdentifier>, void>> static inline void verifyVTable(TestNamedAndIndexedSetterWithIdentifier* ptr) {
+template<std::same_as<TestNamedAndIndexedSetterWithIdentifier> T>
+static inline void verifyVTable(TestNamedAndIndexedSetterWithIdentifier* ptr) 
+{
     if constexpr (std::is_polymorphic_v<T>) {
         const void* actualVTablePointer = getVTablePointer<T>(ptr);
 #if PLATFORM(WIN)

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedDeleterNoIdentifier.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedDeleterNoIdentifier.cpp
@@ -365,7 +365,9 @@ extern "C" { extern void (*const __identifier("??_7TestNamedDeleterNoIdentifier@
 #else
 extern "C" { extern void* _ZTVN7WebCore28TestNamedDeleterNoIdentifierE[]; }
 #endif
-template<typename T, typename = std::enable_if_t<std::is_same_v<T, TestNamedDeleterNoIdentifier>, void>> static inline void verifyVTable(TestNamedDeleterNoIdentifier* ptr) {
+template<std::same_as<TestNamedDeleterNoIdentifier> T>
+static inline void verifyVTable(TestNamedDeleterNoIdentifier* ptr) 
+{
     if constexpr (std::is_polymorphic_v<T>) {
         const void* actualVTablePointer = getVTablePointer<T>(ptr);
 #if PLATFORM(WIN)

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedDeleterThrowingException.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedDeleterThrowingException.cpp
@@ -365,7 +365,9 @@ extern "C" { extern void (*const __identifier("??_7TestNamedDeleterThrowingExcep
 #else
 extern "C" { extern void* _ZTVN7WebCore33TestNamedDeleterThrowingExceptionE[]; }
 #endif
-template<typename T, typename = std::enable_if_t<std::is_same_v<T, TestNamedDeleterThrowingException>, void>> static inline void verifyVTable(TestNamedDeleterThrowingException* ptr) {
+template<std::same_as<TestNamedDeleterThrowingException> T>
+static inline void verifyVTable(TestNamedDeleterThrowingException* ptr) 
+{
     if constexpr (std::is_polymorphic_v<T>) {
         const void* actualVTablePointer = getVTablePointer<T>(ptr);
 #if PLATFORM(WIN)

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedDeleterWithIdentifier.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedDeleterWithIdentifier.cpp
@@ -390,7 +390,9 @@ extern "C" { extern void (*const __identifier("??_7TestNamedDeleterWithIdentifie
 #else
 extern "C" { extern void* _ZTVN7WebCore30TestNamedDeleterWithIdentifierE[]; }
 #endif
-template<typename T, typename = std::enable_if_t<std::is_same_v<T, TestNamedDeleterWithIdentifier>, void>> static inline void verifyVTable(TestNamedDeleterWithIdentifier* ptr) {
+template<std::same_as<TestNamedDeleterWithIdentifier> T>
+static inline void verifyVTable(TestNamedDeleterWithIdentifier* ptr) 
+{
     if constexpr (std::is_polymorphic_v<T>) {
         const void* actualVTablePointer = getVTablePointer<T>(ptr);
 #if PLATFORM(WIN)

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedDeleterWithIndexedGetter.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedDeleterWithIndexedGetter.cpp
@@ -382,7 +382,9 @@ extern "C" { extern void (*const __identifier("??_7TestNamedDeleterWithIndexedGe
 #else
 extern "C" { extern void* _ZTVN7WebCore33TestNamedDeleterWithIndexedGetterE[]; }
 #endif
-template<typename T, typename = std::enable_if_t<std::is_same_v<T, TestNamedDeleterWithIndexedGetter>, void>> static inline void verifyVTable(TestNamedDeleterWithIndexedGetter* ptr) {
+template<std::same_as<TestNamedDeleterWithIndexedGetter> T>
+static inline void verifyVTable(TestNamedDeleterWithIndexedGetter* ptr) 
+{
     if constexpr (std::is_polymorphic_v<T>) {
         const void* actualVTablePointer = getVTablePointer<T>(ptr);
 #if PLATFORM(WIN)

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedGetterCallWith.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedGetterCallWith.cpp
@@ -375,7 +375,9 @@ extern "C" { extern void (*const __identifier("??_7TestNamedGetterCallWith@WebCo
 #else
 extern "C" { extern void* _ZTVN7WebCore23TestNamedGetterCallWithE[]; }
 #endif
-template<typename T, typename = std::enable_if_t<std::is_same_v<T, TestNamedGetterCallWith>, void>> static inline void verifyVTable(TestNamedGetterCallWith* ptr) {
+template<std::same_as<TestNamedGetterCallWith> T>
+static inline void verifyVTable(TestNamedGetterCallWith* ptr) 
+{
     if constexpr (std::is_polymorphic_v<T>) {
         const void* actualVTablePointer = getVTablePointer<T>(ptr);
 #if PLATFORM(WIN)

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedGetterNoIdentifier.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedGetterNoIdentifier.cpp
@@ -375,7 +375,9 @@ extern "C" { extern void (*const __identifier("??_7TestNamedGetterNoIdentifier@W
 #else
 extern "C" { extern void* _ZTVN7WebCore27TestNamedGetterNoIdentifierE[]; }
 #endif
-template<typename T, typename = std::enable_if_t<std::is_same_v<T, TestNamedGetterNoIdentifier>, void>> static inline void verifyVTable(TestNamedGetterNoIdentifier* ptr) {
+template<std::same_as<TestNamedGetterNoIdentifier> T>
+static inline void verifyVTable(TestNamedGetterNoIdentifier* ptr) 
+{
     if constexpr (std::is_polymorphic_v<T>) {
         const void* actualVTablePointer = getVTablePointer<T>(ptr);
 #if PLATFORM(WIN)

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedGetterWithIdentifier.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedGetterWithIdentifier.cpp
@@ -402,7 +402,9 @@ extern "C" { extern void (*const __identifier("??_7TestNamedGetterWithIdentifier
 #else
 extern "C" { extern void* _ZTVN7WebCore29TestNamedGetterWithIdentifierE[]; }
 #endif
-template<typename T, typename = std::enable_if_t<std::is_same_v<T, TestNamedGetterWithIdentifier>, void>> static inline void verifyVTable(TestNamedGetterWithIdentifier* ptr) {
+template<std::same_as<TestNamedGetterWithIdentifier> T>
+static inline void verifyVTable(TestNamedGetterWithIdentifier* ptr) 
+{
     if constexpr (std::is_polymorphic_v<T>) {
         const void* actualVTablePointer = getVTablePointer<T>(ptr);
 #if PLATFORM(WIN)

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterNoIdentifier.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterNoIdentifier.cpp
@@ -394,7 +394,9 @@ extern "C" { extern void (*const __identifier("??_7TestNamedSetterNoIdentifier@W
 #else
 extern "C" { extern void* _ZTVN7WebCore27TestNamedSetterNoIdentifierE[]; }
 #endif
-template<typename T, typename = std::enable_if_t<std::is_same_v<T, TestNamedSetterNoIdentifier>, void>> static inline void verifyVTable(TestNamedSetterNoIdentifier* ptr) {
+template<std::same_as<TestNamedSetterNoIdentifier> T>
+static inline void verifyVTable(TestNamedSetterNoIdentifier* ptr) 
+{
     if constexpr (std::is_polymorphic_v<T>) {
         const void* actualVTablePointer = getVTablePointer<T>(ptr);
 #if PLATFORM(WIN)

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterThrowingException.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterThrowingException.cpp
@@ -394,7 +394,9 @@ extern "C" { extern void (*const __identifier("??_7TestNamedSetterThrowingExcept
 #else
 extern "C" { extern void* _ZTVN7WebCore32TestNamedSetterThrowingExceptionE[]; }
 #endif
-template<typename T, typename = std::enable_if_t<std::is_same_v<T, TestNamedSetterThrowingException>, void>> static inline void verifyVTable(TestNamedSetterThrowingException* ptr) {
+template<std::same_as<TestNamedSetterThrowingException> T>
+static inline void verifyVTable(TestNamedSetterThrowingException* ptr) 
+{
     if constexpr (std::is_polymorphic_v<T>) {
         const void* actualVTablePointer = getVTablePointer<T>(ptr);
 #if PLATFORM(WIN)

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterWithIdentifier.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterWithIdentifier.cpp
@@ -427,7 +427,9 @@ extern "C" { extern void (*const __identifier("??_7TestNamedSetterWithIdentifier
 #else
 extern "C" { extern void* _ZTVN7WebCore29TestNamedSetterWithIdentifierE[]; }
 #endif
-template<typename T, typename = std::enable_if_t<std::is_same_v<T, TestNamedSetterWithIdentifier>, void>> static inline void verifyVTable(TestNamedSetterWithIdentifier* ptr) {
+template<std::same_as<TestNamedSetterWithIdentifier> T>
+static inline void verifyVTable(TestNamedSetterWithIdentifier* ptr) 
+{
     if constexpr (std::is_polymorphic_v<T>) {
         const void* actualVTablePointer = getVTablePointer<T>(ptr);
 #if PLATFORM(WIN)

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterWithIndexedGetter.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterWithIndexedGetter.cpp
@@ -470,7 +470,9 @@ extern "C" { extern void (*const __identifier("??_7TestNamedSetterWithIndexedGet
 #else
 extern "C" { extern void* _ZTVN7WebCore32TestNamedSetterWithIndexedGetterE[]; }
 #endif
-template<typename T, typename = std::enable_if_t<std::is_same_v<T, TestNamedSetterWithIndexedGetter>, void>> static inline void verifyVTable(TestNamedSetterWithIndexedGetter* ptr) {
+template<std::same_as<TestNamedSetterWithIndexedGetter> T>
+static inline void verifyVTable(TestNamedSetterWithIndexedGetter* ptr) 
+{
     if constexpr (std::is_polymorphic_v<T>) {
         const void* actualVTablePointer = getVTablePointer<T>(ptr);
 #if PLATFORM(WIN)

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterWithIndexedGetterAndSetter.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterWithIndexedGetterAndSetter.cpp
@@ -525,7 +525,9 @@ extern "C" { extern void (*const __identifier("??_7TestNamedSetterWithIndexedGet
 #else
 extern "C" { extern void* _ZTVN7WebCore41TestNamedSetterWithIndexedGetterAndSetterE[]; }
 #endif
-template<typename T, typename = std::enable_if_t<std::is_same_v<T, TestNamedSetterWithIndexedGetterAndSetter>, void>> static inline void verifyVTable(TestNamedSetterWithIndexedGetterAndSetter* ptr) {
+template<std::same_as<TestNamedSetterWithIndexedGetterAndSetter> T>
+static inline void verifyVTable(TestNamedSetterWithIndexedGetterAndSetter* ptr) 
+{
     if constexpr (std::is_polymorphic_v<T>) {
         const void* actualVTablePointer = getVTablePointer<T>(ptr);
 #if PLATFORM(WIN)

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterWithLegacyOverrideBuiltIns.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterWithLegacyOverrideBuiltIns.cpp
@@ -370,7 +370,9 @@ extern "C" { extern void (*const __identifier("??_7TestNamedSetterWithLegacyOver
 #else
 extern "C" { extern void* _ZTVN7WebCore41TestNamedSetterWithLegacyOverrideBuiltInsE[]; }
 #endif
-template<typename T, typename = std::enable_if_t<std::is_same_v<T, TestNamedSetterWithLegacyOverrideBuiltIns>, void>> static inline void verifyVTable(TestNamedSetterWithLegacyOverrideBuiltIns* ptr) {
+template<std::same_as<TestNamedSetterWithLegacyOverrideBuiltIns> T>
+static inline void verifyVTable(TestNamedSetterWithLegacyOverrideBuiltIns* ptr) 
+{
     if constexpr (std::is_polymorphic_v<T>) {
         const void* actualVTablePointer = getVTablePointer<T>(ptr);
 #if PLATFORM(WIN)

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterWithLegacyUnforgeableProperties.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterWithLegacyUnforgeableProperties.cpp
@@ -454,7 +454,9 @@ extern "C" { extern void (*const __identifier("??_7TestNamedSetterWithLegacyUnfo
 #else
 extern "C" { extern void* _ZTVN7WebCore46TestNamedSetterWithLegacyUnforgeablePropertiesE[]; }
 #endif
-template<typename T, typename = std::enable_if_t<std::is_same_v<T, TestNamedSetterWithLegacyUnforgeableProperties>, void>> static inline void verifyVTable(TestNamedSetterWithLegacyUnforgeableProperties* ptr) {
+template<std::same_as<TestNamedSetterWithLegacyUnforgeableProperties> T>
+static inline void verifyVTable(TestNamedSetterWithLegacyUnforgeableProperties* ptr) 
+{
     if constexpr (std::is_polymorphic_v<T>) {
         const void* actualVTablePointer = getVTablePointer<T>(ptr);
 #if PLATFORM(WIN)

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterWithLegacyUnforgeablePropertiesAndLegacyOverrideBuiltIns.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterWithLegacyUnforgeablePropertiesAndLegacyOverrideBuiltIns.cpp
@@ -430,7 +430,9 @@ extern "C" { extern void (*const __identifier("??_7TestNamedSetterWithLegacyUnfo
 #else
 extern "C" { extern void* _ZTVN7WebCore71TestNamedSetterWithLegacyUnforgeablePropertiesAndLegacyOverrideBuiltInsE[]; }
 #endif
-template<typename T, typename = std::enable_if_t<std::is_same_v<T, TestNamedSetterWithLegacyUnforgeablePropertiesAndLegacyOverrideBuiltIns>, void>> static inline void verifyVTable(TestNamedSetterWithLegacyUnforgeablePropertiesAndLegacyOverrideBuiltIns* ptr) {
+template<std::same_as<TestNamedSetterWithLegacyUnforgeablePropertiesAndLegacyOverrideBuiltIns> T>
+static inline void verifyVTable(TestNamedSetterWithLegacyUnforgeablePropertiesAndLegacyOverrideBuiltIns* ptr) 
+{
     if constexpr (std::is_polymorphic_v<T>) {
         const void* actualVTablePointer = getVTablePointer<T>(ptr);
 #if PLATFORM(WIN)

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNode.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNode.cpp
@@ -507,7 +507,9 @@ extern "C" { extern void (*const __identifier("??_7TestNode@WebCore@@6B@")[])();
 #else
 extern "C" { extern void* _ZTVN7WebCore8TestNodeE[]; }
 #endif
-template<typename T, typename = std::enable_if_t<std::is_same_v<T, TestNode>, void>> static inline void verifyVTable(TestNode* ptr) {
+template<std::same_as<TestNode> T>
+static inline void verifyVTable(TestNode* ptr) 
+{
     if constexpr (std::is_polymorphic_v<T>) {
         const void* actualVTablePointer = getVTablePointer<T>(ptr);
 #if PLATFORM(WIN)

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestObj.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestObj.cpp
@@ -10054,7 +10054,9 @@ extern "C" { extern void (*const __identifier("??_7TestObj@WebCore@@6B@")[])(); 
 #else
 extern "C" { extern void* _ZTVN7WebCore7TestObjE[]; }
 #endif
-template<typename T, typename = std::enable_if_t<std::is_same_v<T, TestObj>, void>> static inline void verifyVTable(TestObj* ptr) {
+template<std::same_as<TestObj> T>
+static inline void verifyVTable(TestObj* ptr) 
+{
     if constexpr (std::is_polymorphic_v<T>) {
         const void* actualVTablePointer = getVTablePointer<T>(ptr);
 #if PLATFORM(WIN)

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestOperationConditional.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestOperationConditional.cpp
@@ -264,7 +264,9 @@ extern "C" { extern void (*const __identifier("??_7TestOperationConditional@WebC
 #else
 extern "C" { extern void* _ZTVN7WebCore24TestOperationConditionalE[]; }
 #endif
-template<typename T, typename = std::enable_if_t<std::is_same_v<T, TestOperationConditional>, void>> static inline void verifyVTable(TestOperationConditional* ptr) {
+template<std::same_as<TestOperationConditional> T>
+static inline void verifyVTable(TestOperationConditional* ptr) 
+{
     if constexpr (std::is_polymorphic_v<T>) {
         const void* actualVTablePointer = getVTablePointer<T>(ptr);
 #if PLATFORM(WIN)

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestOverloadedConstructors.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestOverloadedConstructors.cpp
@@ -340,7 +340,9 @@ extern "C" { extern void (*const __identifier("??_7TestOverloadedConstructors@We
 #else
 extern "C" { extern void* _ZTVN7WebCore26TestOverloadedConstructorsE[]; }
 #endif
-template<typename T, typename = std::enable_if_t<std::is_same_v<T, TestOverloadedConstructors>, void>> static inline void verifyVTable(TestOverloadedConstructors* ptr) {
+template<std::same_as<TestOverloadedConstructors> T>
+static inline void verifyVTable(TestOverloadedConstructors* ptr) 
+{
     if constexpr (std::is_polymorphic_v<T>) {
         const void* actualVTablePointer = getVTablePointer<T>(ptr);
 #if PLATFORM(WIN)

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestOverloadedConstructorsWithSequence.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestOverloadedConstructorsWithSequence.cpp
@@ -275,7 +275,9 @@ extern "C" { extern void (*const __identifier("??_7TestOverloadedConstructorsWit
 #else
 extern "C" { extern void* _ZTVN7WebCore38TestOverloadedConstructorsWithSequenceE[]; }
 #endif
-template<typename T, typename = std::enable_if_t<std::is_same_v<T, TestOverloadedConstructorsWithSequence>, void>> static inline void verifyVTable(TestOverloadedConstructorsWithSequence* ptr) {
+template<std::same_as<TestOverloadedConstructorsWithSequence> T>
+static inline void verifyVTable(TestOverloadedConstructorsWithSequence* ptr) 
+{
     if constexpr (std::is_polymorphic_v<T>) {
         const void* actualVTablePointer = getVTablePointer<T>(ptr);
 #if PLATFORM(WIN)

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestPluginInterface.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestPluginInterface.cpp
@@ -308,7 +308,9 @@ extern "C" { extern void (*const __identifier("??_7TestPluginInterface@WebCore@@
 #else
 extern "C" { extern void* _ZTVN7WebCore19TestPluginInterfaceE[]; }
 #endif
-template<typename T, typename = std::enable_if_t<std::is_same_v<T, TestPluginInterface>, void>> static inline void verifyVTable(TestPluginInterface* ptr) {
+template<std::same_as<TestPluginInterface> T>
+static inline void verifyVTable(TestPluginInterface* ptr) 
+{
     if constexpr (std::is_polymorphic_v<T>) {
         const void* actualVTablePointer = getVTablePointer<T>(ptr);
 #if PLATFORM(WIN)

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestPromiseRejectionEvent.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestPromiseRejectionEvent.cpp
@@ -323,7 +323,9 @@ extern "C" { extern void (*const __identifier("??_7TestPromiseRejectionEvent@Web
 #else
 extern "C" { extern void* _ZTVN7WebCore25TestPromiseRejectionEventE[]; }
 #endif
-template<typename T, typename = std::enable_if_t<std::is_same_v<T, TestPromiseRejectionEvent>, void>> static inline void verifyVTable(TestPromiseRejectionEvent* ptr) {
+template<std::same_as<TestPromiseRejectionEvent> T>
+static inline void verifyVTable(TestPromiseRejectionEvent* ptr) 
+{
     if constexpr (std::is_polymorphic_v<T>) {
         const void* actualVTablePointer = getVTablePointer<T>(ptr);
 #if PLATFORM(WIN)

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestReadOnlyMapLike.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestReadOnlyMapLike.cpp
@@ -338,7 +338,9 @@ extern "C" { extern void (*const __identifier("??_7TestReadOnlyMapLike@WebCore@@
 #else
 extern "C" { extern void* _ZTVN7WebCore19TestReadOnlyMapLikeE[]; }
 #endif
-template<typename T, typename = std::enable_if_t<std::is_same_v<T, TestReadOnlyMapLike>, void>> static inline void verifyVTable(TestReadOnlyMapLike* ptr) {
+template<std::same_as<TestReadOnlyMapLike> T>
+static inline void verifyVTable(TestReadOnlyMapLike* ptr) 
+{
     if constexpr (std::is_polymorphic_v<T>) {
         const void* actualVTablePointer = getVTablePointer<T>(ptr);
 #if PLATFORM(WIN)

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestReadOnlySetLike.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestReadOnlySetLike.cpp
@@ -316,7 +316,9 @@ extern "C" { extern void (*const __identifier("??_7TestReadOnlySetLike@WebCore@@
 #else
 extern "C" { extern void* _ZTVN7WebCore19TestReadOnlySetLikeE[]; }
 #endif
-template<typename T, typename = std::enable_if_t<std::is_same_v<T, TestReadOnlySetLike>, void>> static inline void verifyVTable(TestReadOnlySetLike* ptr) {
+template<std::same_as<TestReadOnlySetLike> T>
+static inline void verifyVTable(TestReadOnlySetLike* ptr) 
+{
     if constexpr (std::is_polymorphic_v<T>) {
         const void* actualVTablePointer = getVTablePointer<T>(ptr);
 #if PLATFORM(WIN)

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestReportExtraMemoryCost.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestReportExtraMemoryCost.cpp
@@ -225,7 +225,9 @@ extern "C" { extern void (*const __identifier("??_7TestReportExtraMemoryCost@Web
 #else
 extern "C" { extern void* _ZTVN7WebCore25TestReportExtraMemoryCostE[]; }
 #endif
-template<typename T, typename = std::enable_if_t<std::is_same_v<T, TestReportExtraMemoryCost>, void>> static inline void verifyVTable(TestReportExtraMemoryCost* ptr) {
+template<std::same_as<TestReportExtraMemoryCost> T>
+static inline void verifyVTable(TestReportExtraMemoryCost* ptr) 
+{
     if constexpr (std::is_polymorphic_v<T>) {
         const void* actualVTablePointer = getVTablePointer<T>(ptr);
 #if PLATFORM(WIN)

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestScheduledAction.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestScheduledAction.cpp
@@ -231,7 +231,9 @@ extern "C" { extern void (*const __identifier("??_7TestScheduledAction@WebCore@@
 #else
 extern "C" { extern void* _ZTVN7WebCore19TestScheduledActionE[]; }
 #endif
-template<typename T, typename = std::enable_if_t<std::is_same_v<T, TestScheduledAction>, void>> static inline void verifyVTable(TestScheduledAction* ptr) {
+template<std::same_as<TestScheduledAction> T>
+static inline void verifyVTable(TestScheduledAction* ptr) 
+{
     if constexpr (std::is_polymorphic_v<T>) {
         const void* actualVTablePointer = getVTablePointer<T>(ptr);
 #if PLATFORM(WIN)

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestSerializedScriptValueInterface.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestSerializedScriptValueInterface.cpp
@@ -396,7 +396,9 @@ extern "C" { extern void (*const __identifier("??_7TestSerializedScriptValueInte
 #else
 extern "C" { extern void* _ZTVN7WebCore34TestSerializedScriptValueInterfaceE[]; }
 #endif
-template<typename T, typename = std::enable_if_t<std::is_same_v<T, TestSerializedScriptValueInterface>, void>> static inline void verifyVTable(TestSerializedScriptValueInterface* ptr) {
+template<std::same_as<TestSerializedScriptValueInterface> T>
+static inline void verifyVTable(TestSerializedScriptValueInterface* ptr) 
+{
     if constexpr (std::is_polymorphic_v<T>) {
         const void* actualVTablePointer = getVTablePointer<T>(ptr);
 #if PLATFORM(WIN)

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestSetLike.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestSetLike.cpp
@@ -376,7 +376,9 @@ extern "C" { extern void (*const __identifier("??_7TestSetLike@WebCore@@6B@")[])
 #else
 extern "C" { extern void* _ZTVN7WebCore11TestSetLikeE[]; }
 #endif
-template<typename T, typename = std::enable_if_t<std::is_same_v<T, TestSetLike>, void>> static inline void verifyVTable(TestSetLike* ptr) {
+template<std::same_as<TestSetLike> T>
+static inline void verifyVTable(TestSetLike* ptr) 
+{
     if constexpr (std::is_polymorphic_v<T>) {
         const void* actualVTablePointer = getVTablePointer<T>(ptr);
 #if PLATFORM(WIN)

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestSetLikeWithOverriddenOperations.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestSetLikeWithOverriddenOperations.cpp
@@ -388,7 +388,9 @@ extern "C" { extern void (*const __identifier("??_7TestSetLikeWithOverriddenOper
 #else
 extern "C" { extern void* _ZTVN7WebCore35TestSetLikeWithOverriddenOperationsE[]; }
 #endif
-template<typename T, typename = std::enable_if_t<std::is_same_v<T, TestSetLikeWithOverriddenOperations>, void>> static inline void verifyVTable(TestSetLikeWithOverriddenOperations* ptr) {
+template<std::same_as<TestSetLikeWithOverriddenOperations> T>
+static inline void verifyVTable(TestSetLikeWithOverriddenOperations* ptr) 
+{
     if constexpr (std::is_polymorphic_v<T>) {
         const void* actualVTablePointer = getVTablePointer<T>(ptr);
 #if PLATFORM(WIN)

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestStringifier.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestStringifier.cpp
@@ -222,7 +222,9 @@ extern "C" { extern void (*const __identifier("??_7TestStringifier@WebCore@@6B@"
 #else
 extern "C" { extern void* _ZTVN7WebCore15TestStringifierE[]; }
 #endif
-template<typename T, typename = std::enable_if_t<std::is_same_v<T, TestStringifier>, void>> static inline void verifyVTable(TestStringifier* ptr) {
+template<std::same_as<TestStringifier> T>
+static inline void verifyVTable(TestStringifier* ptr) 
+{
     if constexpr (std::is_polymorphic_v<T>) {
         const void* actualVTablePointer = getVTablePointer<T>(ptr);
 #if PLATFORM(WIN)

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestStringifierAnonymousOperation.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestStringifierAnonymousOperation.cpp
@@ -222,7 +222,9 @@ extern "C" { extern void (*const __identifier("??_7TestStringifierAnonymousOpera
 #else
 extern "C" { extern void* _ZTVN7WebCore33TestStringifierAnonymousOperationE[]; }
 #endif
-template<typename T, typename = std::enable_if_t<std::is_same_v<T, TestStringifierAnonymousOperation>, void>> static inline void verifyVTable(TestStringifierAnonymousOperation* ptr) {
+template<std::same_as<TestStringifierAnonymousOperation> T>
+static inline void verifyVTable(TestStringifierAnonymousOperation* ptr) 
+{
     if constexpr (std::is_polymorphic_v<T>) {
         const void* actualVTablePointer = getVTablePointer<T>(ptr);
 #if PLATFORM(WIN)

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestStringifierNamedOperation.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestStringifierNamedOperation.cpp
@@ -239,7 +239,9 @@ extern "C" { extern void (*const __identifier("??_7TestStringifierNamedOperation
 #else
 extern "C" { extern void* _ZTVN7WebCore29TestStringifierNamedOperationE[]; }
 #endif
-template<typename T, typename = std::enable_if_t<std::is_same_v<T, TestStringifierNamedOperation>, void>> static inline void verifyVTable(TestStringifierNamedOperation* ptr) {
+template<std::same_as<TestStringifierNamedOperation> T>
+static inline void verifyVTable(TestStringifierNamedOperation* ptr) 
+{
     if constexpr (std::is_polymorphic_v<T>) {
         const void* actualVTablePointer = getVTablePointer<T>(ptr);
 #if PLATFORM(WIN)

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestStringifierOperationImplementedAs.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestStringifierOperationImplementedAs.cpp
@@ -239,7 +239,9 @@ extern "C" { extern void (*const __identifier("??_7TestStringifierOperationImple
 #else
 extern "C" { extern void* _ZTVN7WebCore37TestStringifierOperationImplementedAsE[]; }
 #endif
-template<typename T, typename = std::enable_if_t<std::is_same_v<T, TestStringifierOperationImplementedAs>, void>> static inline void verifyVTable(TestStringifierOperationImplementedAs* ptr) {
+template<std::same_as<TestStringifierOperationImplementedAs> T>
+static inline void verifyVTable(TestStringifierOperationImplementedAs* ptr) 
+{
     if constexpr (std::is_polymorphic_v<T>) {
         const void* actualVTablePointer = getVTablePointer<T>(ptr);
 #if PLATFORM(WIN)

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestStringifierOperationNamedToString.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestStringifierOperationNamedToString.cpp
@@ -222,7 +222,9 @@ extern "C" { extern void (*const __identifier("??_7TestStringifierOperationNamed
 #else
 extern "C" { extern void* _ZTVN7WebCore37TestStringifierOperationNamedToStringE[]; }
 #endif
-template<typename T, typename = std::enable_if_t<std::is_same_v<T, TestStringifierOperationNamedToString>, void>> static inline void verifyVTable(TestStringifierOperationNamedToString* ptr) {
+template<std::same_as<TestStringifierOperationNamedToString> T>
+static inline void verifyVTable(TestStringifierOperationNamedToString* ptr) 
+{
     if constexpr (std::is_polymorphic_v<T>) {
         const void* actualVTablePointer = getVTablePointer<T>(ptr);
 #if PLATFORM(WIN)

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestStringifierReadOnlyAttribute.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestStringifierReadOnlyAttribute.cpp
@@ -238,7 +238,9 @@ extern "C" { extern void (*const __identifier("??_7TestStringifierReadOnlyAttrib
 #else
 extern "C" { extern void* _ZTVN7WebCore32TestStringifierReadOnlyAttributeE[]; }
 #endif
-template<typename T, typename = std::enable_if_t<std::is_same_v<T, TestStringifierReadOnlyAttribute>, void>> static inline void verifyVTable(TestStringifierReadOnlyAttribute* ptr) {
+template<std::same_as<TestStringifierReadOnlyAttribute> T>
+static inline void verifyVTable(TestStringifierReadOnlyAttribute* ptr) 
+{
     if constexpr (std::is_polymorphic_v<T>) {
         const void* actualVTablePointer = getVTablePointer<T>(ptr);
 #if PLATFORM(WIN)

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestStringifierReadWriteAttribute.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestStringifierReadWriteAttribute.cpp
@@ -259,7 +259,9 @@ extern "C" { extern void (*const __identifier("??_7TestStringifierReadWriteAttri
 #else
 extern "C" { extern void* _ZTVN7WebCore33TestStringifierReadWriteAttributeE[]; }
 #endif
-template<typename T, typename = std::enable_if_t<std::is_same_v<T, TestStringifierReadWriteAttribute>, void>> static inline void verifyVTable(TestStringifierReadWriteAttribute* ptr) {
+template<std::same_as<TestStringifierReadWriteAttribute> T>
+static inline void verifyVTable(TestStringifierReadWriteAttribute* ptr) 
+{
     if constexpr (std::is_polymorphic_v<T>) {
         const void* actualVTablePointer = getVTablePointer<T>(ptr);
 #if PLATFORM(WIN)

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestTaggedWrapper.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestTaggedWrapper.cpp
@@ -200,7 +200,9 @@ extern "C" { extern void (*const __identifier("??_7TestTaggedWrapper@WebCore@@6B
 #else
 extern "C" { extern void* _ZTVN7WebCore17TestTaggedWrapperE[]; }
 #endif
-template<typename T, typename = std::enable_if_t<std::is_same_v<T, TestTaggedWrapper>, void>> static inline void verifyVTable(TestTaggedWrapper* ptr) {
+template<std::same_as<TestTaggedWrapper> T>
+static inline void verifyVTable(TestTaggedWrapper* ptr) 
+{
     if constexpr (std::is_polymorphic_v<T>) {
         const void* actualVTablePointer = getVTablePointer<T>(ptr);
 #if PLATFORM(WIN)

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestTypedefs.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestTypedefs.cpp
@@ -842,7 +842,9 @@ extern "C" { extern void (*const __identifier("??_7TestTypedefs@WebCore@@6B@")[]
 #else
 extern "C" { extern void* _ZTVN7WebCore12TestTypedefsE[]; }
 #endif
-template<typename T, typename = std::enable_if_t<std::is_same_v<T, TestTypedefs>, void>> static inline void verifyVTable(TestTypedefs* ptr) {
+template<std::same_as<TestTypedefs> T>
+static inline void verifyVTable(TestTypedefs* ptr) 
+{
     if constexpr (std::is_polymorphic_v<T>) {
         const void* actualVTablePointer = getVTablePointer<T>(ptr);
 #if PLATFORM(WIN)

--- a/Source/WebCore/dom/ExceptionOr.h
+++ b/Source/WebCore/dom/ExceptionOr.h
@@ -39,7 +39,10 @@ public:
 
     ExceptionOr(Exception&&);
     ExceptionOr(ReturnType&&);
-    template<typename OtherType> ExceptionOr(const OtherType&, typename std::enable_if<std::is_scalar<OtherType>::value && std::is_convertible<OtherType, ReturnType>::value>::type* = nullptr);
+    template<typename OtherType>
+        requires std::is_scalar_v<OtherType> && std::convertible_to<OtherType, ReturnType>
+    ExceptionOr(const OtherType&);
+
 
     bool hasException() const;
     const Exception& exception() const;
@@ -100,7 +103,10 @@ template<typename ReturnType> inline ExceptionOr<ReturnType>::ExceptionOr(Return
 {
 }
 
-template<typename ReturnType> template<typename OtherType> inline ExceptionOr<ReturnType>::ExceptionOr(const OtherType& returnValue, typename std::enable_if<std::is_scalar<OtherType>::value && std::is_convertible<OtherType, ReturnType>::value>::type*)
+template<typename ReturnType>
+template<typename OtherType>
+    requires std::is_scalar_v<OtherType> && std::convertible_to<OtherType, ReturnType>
+inline ExceptionOr<ReturnType>::ExceptionOr(const OtherType& returnValue)
     : m_value(static_cast<ReturnType>(returnValue))
 {
 }

--- a/Source/WebCore/dom/GCReachableRef.h
+++ b/Source/WebCore/dom/GCReachableRef.h
@@ -52,7 +52,8 @@ private:
     WEBCORE_EXPORT static HashCountedSet<EventTarget*>& map();
 };
 
-template <typename T, typename = std::enable_if_t<std::is_same<T, typename std::remove_const<T>::type>::value>>
+template <typename T>
+    requires std::same_as<T, std::remove_const_t<T>>
 class GCReachableRef {
     WTF_MAKE_NONCOPYABLE(GCReachableRef);
 public:
@@ -136,15 +137,15 @@ template<typename P> struct HashTraits<WebCore::GCReachableRef<P>> : SimpleClass
     static TakeType take(Ref<P>&& value) { return isEmptyValue(value) ? std::nullopt : std::optional<Ref<P>>(WTFMove(value)); }
 };
 
-template <typename T, typename U>
-struct GetPtrHelper<WebCore::GCReachableRef<T, U>> {
+template <typename T>
+struct GetPtrHelper<WebCore::GCReachableRef<T>> {
     using PtrType = T*;
     using UnderlyingType = T;
-    static T* getPtr(const WebCore::GCReachableRef<T, U>& reference) { return const_cast<T*>(reference.ptr()); }
+    static T* getPtr(const WebCore::GCReachableRef<T>& reference) { return const_cast<T*>(reference.ptr()); }
 };
 
-template <typename T, typename U>
-struct IsSmartPtr<WebCore::GCReachableRef<T, U>> {
+template <typename T>
+struct IsSmartPtr<WebCore::GCReachableRef<T>> {
     static const bool value = true;
     static constexpr bool isNullable = true;
 };


### PR DESCRIPTION
#### 4fc477a8449a25e3549d211782c955c35bd86d1a
<pre>
Further use C++ concepts in rest of WebCore
<a href="https://bugs.webkit.org/show_bug.cgi?id=294128">https://bugs.webkit.org/show_bug.cgi?id=294128</a>
<a href="https://rdar.apple.com/problem/152726842">rdar://problem/152726842</a>

Reviewed by Sam Weinig.

Replace std::enable_if with C++20 concepts and require clauses for template constraints.

* Source/WebCore/bindings/js/JSDOMConvertInterface.h:
(): Deleted.
* Source/WebCore/bindings/js/JSDOMIterator.h:
* Source/WebCore/bindings/js/WebCoreOpaqueRoot.h:
* Source/WebCore/bindings/scripts/CodeGeneratorJS.pm:
(GenerateImplementation):
* Source/WebCore/dom/ExceptionOr.h:
(WebCore::ExceptionOr&lt;ReturnType&gt;::ExceptionOr):
* Source/WebCore/dom/GCReachableRef.h:
(WTF::GetPtrHelper&lt;WebCore::GCReachableRef&lt;T&gt;&gt;::getPtr):

Canonical link: <a href="https://commits.webkit.org/296043@main">https://commits.webkit.org/296043@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8a5071bb15d5ce31e6f3d66b7e04bda18a49b634

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/106745 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/26496 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/16893 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/111956 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/57343 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/108784 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/27166 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34998 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/81046 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/109749 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/21555 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/96323 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/61387 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/20994 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/14430 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/56797 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/90895 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/14459 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/114883 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33883 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24978 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/90111 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/34248 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/92554 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89821 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22980 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34758 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/12569 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/29530 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/33808 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/39221 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/33554 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/36907 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/35153 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->