### PR TITLE
Leverage the `RefPtr<T>(T&)` constructor in more places

### DIFF
--- a/Source/WebCore/platform/audio/mac/SharedRoutingArbitrator.mm
+++ b/Source/WebCore/platform/audio/mac/SharedRoutingArbitrator.mm
@@ -160,7 +160,7 @@ void SharedRoutingArbitrator::endRoutingArbitrationForToken(const SharedRoutingA
 void SharedRoutingArbitrator::setLogger(const Logger& logger)
 {
     if (!m_logger)
-        m_logger = &logger;
+        m_logger = logger;
 }
 
 const Logger& SharedRoutingArbitrator::logger()

--- a/Source/WebCore/platform/cocoa/SharedBufferCocoa.mm
+++ b/Source/WebCore/platform/cocoa/SharedBufferCocoa.mm
@@ -71,7 +71,7 @@
 
     RELEASE_ASSERT(position <= dataSegment.size());
     RELEASE_ASSERT(size <= dataSegment.size() - position);
-    _dataSegment = &dataSegment;
+    _dataSegment = dataSegment;
     _position = position;
     _size = size;
     return self;

--- a/Source/WebCore/platform/cocoa/ThermalMitigationNotifier.mm
+++ b/Source/WebCore/platform/cocoa/ThermalMitigationNotifier.mm
@@ -53,7 +53,7 @@ static bool isThermalMitigationEnabled()
     if (!self)
         return nil;
 
-    _notifier = &notifier;
+    _notifier = notifier;
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(thermalStateDidChange) name:NSProcessInfoThermalStateDidChangeNotification object:nil];
     return self;
 }

--- a/Source/WebCore/platform/graphics/ComplexTextController.cpp
+++ b/Source/WebCore/platform/graphics/ComplexTextController.cpp
@@ -383,7 +383,7 @@ void ComplexTextController::collectComplexTextRuns()
 
     auto capitalizedBase = capitalized(baseCharacter);
     if (shouldSynthesizeSmallCaps(dontSynthesizeSmallCaps, nextFont.get(), baseCharacter, capitalizedBase, fontVariantCaps, engageAllSmallCapsProcessing)) {
-        synthesizedFont = &nextFont->noSynthesizableFeaturesFont();
+        synthesizedFont = nextFont->noSynthesizableFeaturesFont();
         smallSynthesizedFont = synthesizedFont->smallCapsFont(m_fontCascade->fontDescription());
         char32_t characterToWrite = capitalizedBase ? capitalizedBase.value() : baseOfString[0];
         unsigned characterIndex = 0;
@@ -428,7 +428,7 @@ void ComplexTextController::collectComplexTextRuns()
         capitalizedBase = capitalized(baseCharacter);
         if (!synthesizedFont && shouldSynthesizeSmallCaps(dontSynthesizeSmallCaps, nextFont.get(), baseCharacter, capitalizedBase, fontVariantCaps, engageAllSmallCapsProcessing)) {
             // Rather than synthesize each character individually, we should synthesize the entire "run" if any character requires synthesis.
-            synthesizedFont = &nextFont->noSynthesizableFeaturesFont();
+            synthesizedFont = nextFont->noSynthesizableFeaturesFont();
             smallSynthesizedFont = synthesizedFont->smallCapsFont(m_fontCascade->fontDescription());
             nextIsSmallCaps = true;
             currentIndex = indexOfFontTransition;

--- a/Source/WebCore/platform/graphics/FontCascade.cpp
+++ b/Source/WebCore/platform/graphics/FontCascade.cpp
@@ -1521,14 +1521,14 @@ inline bool shouldDrawIfLoading(const Font& font, FontCascade::CustomFontNotRead
 void FontCascade::drawGlyphBuffer(GraphicsContext& context, const GlyphBuffer& glyphBuffer, FloatPoint& point, CustomFontNotReadyAction customFontNotReadyAction) const
 {
     ASSERT(glyphBuffer.isFlattened());
-    RefPtr fontData = &glyphBuffer.fontAt(0);
+    RefPtr fontData = glyphBuffer.fontAt(0);
     FloatPoint startPoint = point;
     float nextX = startPoint.x() + WebCore::width(glyphBuffer.advanceAt(0));
     float nextY = startPoint.y() + height(glyphBuffer.advanceAt(0));
     unsigned lastFrom = 0;
     unsigned nextGlyph = 1;
     while (nextGlyph < glyphBuffer.size()) {
-        RefPtr nextFontData = &glyphBuffer.fontAt(nextGlyph);
+        RefPtr nextFontData = glyphBuffer.fontAt(nextGlyph);
 
         if (nextFontData != fontData) {
             if (shouldDrawIfLoading(*fontData, customFontNotReadyAction)) {

--- a/Source/WebCore/platform/graphics/FontCascadeFonts.cpp
+++ b/Source/WebCore/platform/graphics/FontCascadeFonts.cpp
@@ -353,7 +353,7 @@ static RefPtr<const Font> findBestFallbackFont(FontCascadeFonts& fontCascadeFont
             break;
         RefPtr currentFont = fontRanges.glyphDataForCharacter(character, ExternalResourceDownloadPolicy::Forbid).font.get();
         if (!currentFont)
-            currentFont = &fontRanges.fontForFirstRange();
+            currentFont = fontRanges.fontForFirstRange();
 
         if (!currentFont->isInterstitial())
             return currentFont;
@@ -367,7 +367,7 @@ GlyphData FontCascadeFonts::glyphDataForSystemFallback(char32_t character, const
     RefPtr font = findBestFallbackFont(*this, description, fontSelector, character);
 
     if (!font)
-        font = &realizeFallbackRangesAt(description, fontSelector, 0).fontForFirstRange();
+        font = realizeFallbackRangesAt(description, fontSelector, 0).fontForFirstRange();
 
     StringBuilder stringBuilder;
     stringBuilder.append(character);
@@ -453,7 +453,7 @@ GlyphData FontCascadeFonts::glyphDataForVariant(char32_t character, const FontCa
         }
 
         if (fallbackVisibility == FallbackVisibility::Invisible && data.font->visibility() == Font::Visibility::Visible)
-            data.font = &Ref { *data.font }->invisibleFont();
+            data.font = Ref { *data.font }->invisibleFont();
 
         if (variant == NormalVariant) {
             if (data.font->platformData().orientation() == FontOrientation::Vertical && !data.font->isTextOrientationFallback()) {

--- a/Source/WebCore/platform/graphics/MediaPlayer.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlayer.cpp
@@ -553,7 +553,7 @@ bool MediaPlayer::load(MediaStreamPrivate& mediaStream)
 {
     ASSERT(!m_reloadTimer.isActive());
 
-    m_mediaStream = &mediaStream;
+    m_mediaStream = mediaStream;
     m_loadOptions = { };
     loadWithNextMediaEngine(nullptr);
     return m_currentMediaEngine;

--- a/Source/WebCore/platform/graphics/TrackBuffer.cpp
+++ b/Source/WebCore/platform/graphics/TrackBuffer.cpp
@@ -533,7 +533,7 @@ void TrackBuffer::setRoundedTimestampOffset(const MediaTime& time, uint32_t time
 #if !RELEASE_LOG_DISABLED
 void TrackBuffer::setLogger(const Logger& newLogger, uint64_t newLogIdentifier)
 {
-    m_logger = &newLogger;
+    m_logger = newLogger;
     m_logIdentifier = childLogIdentifier(newLogIdentifier, cryptographicallyRandomNumber<uint32_t>());
     ALWAYS_LOG(LOGIDENTIFIER);
 }

--- a/Source/WebCore/platform/graphics/TrackPrivateBase.cpp
+++ b/Source/WebCore/platform/graphics/TrackPrivateBase.cpp
@@ -133,7 +133,7 @@ static uint64_t s_uniqueId = 0;
 
 void TrackPrivateBase::setLogger(const Logger& logger, uint64_t logIdentifier)
 {
-    m_logger = &logger;
+    m_logger = logger;
     m_logIdentifier = childLogIdentifier(logIdentifier, ++s_uniqueId);
 }
 

--- a/Source/WebCore/platform/graphics/WidthIterator.cpp
+++ b/Source/WebCore/platform/graphics/WidthIterator.cpp
@@ -235,7 +235,7 @@ struct SmallCapsState {
     {
         ASSERT(font);
         this->font = font;
-        synthesizedFont = &font->noSynthesizableFeaturesFont();
+        synthesizedFont = font->noSynthesizableFeaturesFont();
         smallSynthesizedFont = Ref { *synthesizedFont }->smallCapsFont(fontDescription);
         isLastSmallCaps = isSmallCaps;
         isSmallCaps = true;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.mm
@@ -285,7 +285,7 @@ void MediaPlayerPrivateMediaStreamAVFObjC::processNewVideoFrame(VideoFrame& vide
     if (!isMainThread()) {
         {
             Locker locker { m_currentVideoFrameLock };
-            m_currentVideoFrame = &videoFrame;
+            m_currentVideoFrame = videoFrame;
         }
         scheduleDeferredTask([weakThis = WeakPtr { *this }, metadata, presentationTime]() mutable {
             RefPtr protectedThis = weakThis.get();
@@ -307,7 +307,7 @@ void MediaPlayerPrivateMediaStreamAVFObjC::processNewVideoFrame(VideoFrame& vide
         return;
 
     if (!m_imagePainter.videoFrame || m_displayMode != PausedImage) {
-        m_imagePainter.videoFrame = &videoFrame;
+        m_imagePainter.videoFrame = videoFrame;
         m_imagePainter.cgImage = nullptr;
         if (m_readyState < MediaPlayer::ReadyState::HaveEnoughData)
             updateReadyState();
@@ -502,7 +502,7 @@ void MediaPlayerPrivateMediaStreamAVFObjC::load(MediaStreamPrivate& stream)
 
     m_intrinsicSize = { };
 
-    m_mediaStreamPrivate = &stream;
+    m_mediaStreamPrivate = stream;
     stream.addObserver(*this);
     m_ended = !stream.active();
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.mm
@@ -256,7 +256,7 @@ void MediaSourcePrivateAVFObjC::cdmInstanceAttached(CDMInstance& instance)
         return;
 
     ASSERT(!m_cdmInstance);
-    m_cdmInstance = &instance;
+    m_cdmInstance = instance;
     for (auto& sourceBuffer : m_sourceBuffers)
         sourceBuffer->setCDMInstance(&instance);
 }

--- a/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferParserAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferParserAVFObjC.mm
@@ -280,7 +280,7 @@ void SourceBufferParserAVFObjC::invalidate()
 #if !RELEASE_LOG_DISABLED
 void SourceBufferParserAVFObjC::setLogger(const Logger& newLogger, uint64_t newLogIdentifier)
 {
-    m_logger = &newLogger;
+    m_logger = newLogger;
     m_logIdentifier = newLogIdentifier;
     ALWAYS_LOG(LOGIDENTIFIER);
 }

--- a/Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.cpp
@@ -577,7 +577,7 @@ ExceptionOr<int> WebMParser::parse(SourceBufferParser::Segment&& segment)
 
 void WebMParser::setLogger(const Logger& newLogger, uint64_t newLogIdentifier)
 {
-    m_logger = &newLogger;
+    m_logger = newLogger;
     m_logIdentifier = newLogIdentifier;
     ALWAYS_LOG(LOGIDENTIFIER);
 }
@@ -1669,7 +1669,7 @@ void SourceBufferParserWebM::invalidate()
 
 void SourceBufferParserWebM::setLogger(const Logger& newLogger, uint64_t newLogIdentifier)
 {
-    m_logger = &newLogger;
+    m_logger = newLogger;
     m_logIdentifier = newLogIdentifier;
     ALWAYS_LOG(LOGIDENTIFIER);
 

--- a/Source/WebCore/platform/graphics/coretext/FontCascadeCoreText.cpp
+++ b/Source/WebCore/platform/graphics/coretext/FontCascadeCoreText.cpp
@@ -438,7 +438,7 @@ RefPtr<const Font> FontCascade::fontForCombiningCharacterSequence(StringView str
         if (font->platformData().orientation() == FontOrientation::Vertical) {
             if (isCJKIdeographOrSymbol(baseCharacter)) {
                 if (!font->hasVerticalGlyphs())
-                    font = &font->brokenIdeographFont();
+                    font = font->brokenIdeographFont();
             } else if (m_fontDescription.nonCJKGlyphOrientation() == NonCJKGlyphOrientation::Mixed) {
                 Ref verticalRightFont = font->verticalRightOrientationFont();
                 Glyph verticalRightGlyph = verticalRightFont->glyphForCharacter(baseCharacter);

--- a/Source/WebCore/platform/graphics/filters/software/FEGaussianBlurSoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FEGaussianBlurSoftwareApplier.cpp
@@ -386,8 +386,8 @@ inline void FEGaussianBlurSoftwareApplier::applyPlatform(PixelBuffer& ioBuffer, 
                 IntSize blockSize = { paintSize.width(), endY - startY };
 
                 if (!job) {
-                    params.ioBuffer = &ioBuffer;
-                    params.tempBuffer = &tempBuffer;
+                    params.ioBuffer = ioBuffer;
+                    params.tempBuffer = tempBuffer;
                 } else {
                     params.ioBuffer = ioBuffer.createScratchPixelBuffer(blockSize);
                     params.tempBuffer = tempBuffer.createScratchPixelBuffer(blockSize);

--- a/Source/WebCore/platform/graphics/filters/software/FELightingSoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FELightingSoftwareApplier.cpp
@@ -196,8 +196,8 @@ bool FELightingSoftwareApplier::apply(const Filter& filter, std::span<const Ref<
         return true;
 
     LightingData data;
-    data.filter = &filter;
-    data.result = &result;
+    data.filter = filter;
+    data.result = result;
     data.filterType = m_effect->filterType();
     data.lightingColor = m_effect->lightingColor();
     data.surfaceScale = m_effect->surfaceScale() / 255.0f;

--- a/Source/WebCore/platform/graphics/filters/software/FETurbulenceSoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FETurbulenceSoftwareApplier.cpp
@@ -323,7 +323,7 @@ void FETurbulenceSoftwareApplier::applyPlatform(const IntRect& filterRegion, con
                 ApplyParameters& params = parallelJobs.parameter(i);
                 params.filterRegion = filterRegion;
                 params.filterScale = filterScale;
-                params.pixelBuffer = &pixelBuffer;
+                params.pixelBuffer = pixelBuffer;
                 params.paintingData = &paintingData;
                 params.stitchData = stitchData;
                 params.startY = startY;

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp
@@ -1552,7 +1552,7 @@ bool RealtimeMediaSource::setShouldApplyRotation()
 #if !RELEASE_LOG_DISABLED
 void RealtimeMediaSource::setLogger(const Logger& newLogger, uint64_t newLogIdentifier)
 {
-    m_logger = &newLogger;
+    m_logger = newLogger;
     m_logIdentifier = newLogIdentifier;
     ALWAYS_LOG(LOGIDENTIFIER, m_type, ", ", name(), ", ", m_hashedID, ", ", m_ephemeralHashedID);
 }

--- a/Source/WebCore/platform/mediastream/cocoa/DisplayCaptureSourceCocoa.cpp
+++ b/Source/WebCore/platform/mediastream/cocoa/DisplayCaptureSourceCocoa.cpp
@@ -359,7 +359,7 @@ void DisplayCaptureSourceCocoa::setLogger(const Logger& logger, uint64_t identif
 
 void DisplayCaptureSourceCocoa::Capturer::setLogger(const Logger& newLogger, uint64_t newLogIdentifier)
 {
-    m_logger = &newLogger;
+    m_logger = newLogger;
     m_logIdentifier = newLogIdentifier;
 }
 

--- a/Source/WebCore/platform/mediastream/cocoa/IncomingAudioMediaStreamTrackRendererUnit.cpp
+++ b/Source/WebCore/platform/mediastream/cocoa/IncomingAudioMediaStreamTrackRendererUnit.cpp
@@ -89,7 +89,7 @@ void IncomingAudioMediaStreamTrackRendererUnit::addSource(const String& identifi
     ASSERT(isMainThread());
 #if !RELEASE_LOG_DISABLED
         if (!m_logger)
-            m_logger = &source->logger();
+            m_logger = source->logger();
 #endif
 
     ASSERT(source->outputDescription());

--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingMediaSourceGStreamer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingMediaSourceGStreamer.cpp
@@ -48,7 +48,7 @@ RealtimeOutgoingMediaSourceGStreamer::RealtimeOutgoingMediaSourceGStreamer(Type 
 {
     initialize();
 
-    m_track = &track.privateTrack();
+    m_track = track.privateTrack();
     m_outgoingSource = webkitMediaStreamSrcNew();
     GST_DEBUG_OBJECT(m_bin.get(), "Created outgoing source %" GST_PTR_FORMAT, m_outgoingSource.get());
     gst_bin_add(GST_BIN_CAST(m_bin.get()), m_outgoingSource.get());
@@ -388,7 +388,7 @@ void RealtimeOutgoingMediaSourceGStreamer::replaceTrack(RefPtr<MediaStreamTrack>
     m_track->removeObserver(*this);
     RefPtr<MediaStreamTrackPrivate> trackPrivate;
     if (newTrack)
-        trackPrivate = &(newTrack->privateTrack());
+        trackPrivate = newTrack->privateTrack();
 
     webkitMediaStreamSrcReplaceTrack(WEBKIT_MEDIA_STREAM_SRC_CAST(m_outgoingSource.get()), RefPtr(trackPrivate));
     if (!newTrack)

--- a/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm
+++ b/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm
@@ -1261,7 +1261,7 @@ void AVVideoCaptureSource::captureOutputDidOutputSampleBufferFromConnection(AVCa
         return;
 
     auto videoFrame = VideoFrameCV::create(sampleBuffer, [captureConnection isVideoMirrored], m_videoFrameRotation);
-    m_buffer = &videoFrame.get();
+    m_buffer = videoFrame.get();
     setIntrinsicSize(expandedIntSize(videoFrame->presentationSize()));
     VideoFrameTimeMetadata metadata;
     metadata.captureTime = MonotonicTime::now().secondsSinceEpoch();

--- a/Source/WebCore/platform/network/cocoa/WebCoreNSURLSession.mm
+++ b/Source/WebCore/platform/network/cocoa/WebCoreNSURLSession.mm
@@ -301,7 +301,7 @@ NS_ASSUME_NONNULL_END
     ASSERT(_corsResults == WebCoreNSURLSessionCORSAccessCheckResults::Unknown);
     ASSERT(!_invalidated);
 
-    _loader = &loader;
+    _loader = loader;
     _targetDispatcher = RefPtr { _loader }->targetDispatcher();
     self.delegate = inDelegate;
     _queue = inQueue ? inQueue : [NSOperationQueue mainQueue];

--- a/Source/WebCore/platform/sql/SQLiteDatabase.cpp
+++ b/Source/WebCore/platform/sql/SQLiteDatabase.cpp
@@ -177,7 +177,7 @@ bool SQLiteDatabase::open(const String& filename, OpenMode openMode, OptionSet<O
 
     overrideUnauthorizedFunctions();
 
-    m_openingThread = &Thread::currentSingleton();
+    m_openingThread = Thread::currentSingleton();
     if (sqlite3_extended_result_codes(m_db, 1) != SQLITE_OK)
         return false;
 
@@ -670,7 +670,7 @@ void SQLiteDatabase::setAuthorizer(DatabaseAuthorizer& authorizer)
 
     Locker locker { m_authorizerLock };
 
-    m_authorizer = &authorizer;
+    m_authorizer = authorizer;
     
     enableAuthorizer(true);
 }

--- a/Source/WebCore/rendering/RenderView.cpp
+++ b/Source/WebCore/rendering/RenderView.cpp
@@ -999,7 +999,7 @@ void RenderView::updatePlayStateForAllAnimations(const IntRect& visibleRect)
             }
         };
 
-        for (RefPtr layer = &renderElement.style().backgroundLayers(); layer; layer = layer->next())
+        for (RefPtr layer = renderElement.style().backgroundLayers(); layer; layer = layer->next())
             updateAnimation(layer->image() ? layer->image()->cachedImage() : nullptr);
 
         if (auto* renderImage = dynamicDowncast<RenderImage>(renderElement))

--- a/Source/WebCore/rendering/style/StyleCustomPropertyData.cpp
+++ b/Source/WebCore/rendering/style/StyleCustomPropertyData.cpp
@@ -50,7 +50,7 @@ StyleCustomPropertyData::StyleCustomPropertyData(const StyleCustomPropertyData& 
 
     // If there are mutations on multiple levels this constructs a linked list of property data objects.
     if (shouldReferenceAsParentValues)
-        m_parentValues = &other;
+        m_parentValues = other;
     else {
         m_parentValues = other.m_parentValues;
         m_ownValues = other.m_ownValues;

--- a/Source/WebCore/rendering/svg/RenderSVGResourcePattern.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourcePattern.cpp
@@ -52,7 +52,7 @@ void RenderSVGResourcePattern::collectPatternAttributesIfNeeded()
 
     auto attributes = PatternAttributes { };
 
-    RefPtr current = &patternElement();
+    RefPtr current = patternElement();
 
     current->synchronizeAllAttributes();
 

--- a/Source/WebCore/rendering/svg/SVGTextMetricsBuilder.cpp
+++ b/Source/WebCore/rendering/svg/SVGTextMetricsBuilder.cpp
@@ -112,7 +112,7 @@ void SVGTextMetricsBuilder::advanceComplexText()
 
 void SVGTextMetricsBuilder::initializeMeasurementWithTextRenderer(RenderSVGInlineText& text)
 {
-    m_text = &text;
+    m_text = text;
     m_textPosition = 0;
     m_currentMetrics = SVGTextMetrics();
     m_complexStartToCurrentMetrics = SVGTextMetrics();

--- a/Source/WebCore/storage/StorageNamespaceProvider.cpp
+++ b/Source/WebCore/storage/StorageNamespaceProvider.cpp
@@ -53,9 +53,9 @@ Ref<StorageArea> StorageNamespaceProvider::localStorageArea(Document& document)
 
     RefPtr<StorageNamespace> storageNamespace;
     if (document.canAccessResource(ScriptExecutionContext::ResourceType::LocalStorage) == ScriptExecutionContext::HasResourceAccess::DefaultForThirdParty)
-        storageNamespace = &transientLocalStorageNamespace(document.topOrigin(), document.page()->sessionID());
+        storageNamespace = transientLocalStorageNamespace(document.topOrigin(), document.page()->sessionID());
     else
-        storageNamespace = &localStorageNamespace(document.page()->sessionID());
+        storageNamespace = localStorageNamespace(document.page()->sessionID());
 
     return storageNamespace->storageArea(document.securityOrigin());
 }

--- a/Source/WebCore/style/RuleSet.cpp
+++ b/Source/WebCore/style/RuleSet.cpp
@@ -397,7 +397,7 @@ void RuleSet::addPageRule(StyleRulePage& rule)
 
 void RuleSet::setViewTransitionRule(StyleRuleViewTransition& rule)
 {
-    m_viewTransitionRule = &rule;
+    m_viewTransitionRule = rule;
 }
 
 RefPtr<StyleRuleViewTransition> RuleSet::viewTransitionRule() const

--- a/Source/WebCore/svg/SVGSVGElement.cpp
+++ b/Source/WebCore/svg/SVGSVGElement.cpp
@@ -727,7 +727,7 @@ bool SVGSVGElement::scrollToFragment(StringView fragmentIdentifier)
 
     if (fragmentIdentifier.startsWith("svgView("_s)) {
         if (!view)
-            view = &currentView(); // Create the SVGViewSpec.
+            view = currentView(); // Create the SVGViewSpec.
         if (view->parseViewSpec(fragmentIdentifier))
             m_useCurrentView = true;
         else

--- a/Source/WebCore/svg/animation/SVGSMILElement.cpp
+++ b/Source/WebCore/svg/animation/SVGSMILElement.cpp
@@ -285,7 +285,7 @@ Node::InsertedIntoAncestorResult SVGSMILElement::insertedIntoAncestor(InsertionT
     if (!owner)
         return InsertedIntoAncestorResult::Done;
 
-    m_timeContainer = &owner->timeContainer();
+    m_timeContainer = owner->timeContainer();
     protectedTimeContainer()->setDocumentOrderIndexesDirty();
 
     // "If no attribute is present, the default begin value (an offset-value of 0) must be evaluated."

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -6266,7 +6266,7 @@ void Internals::observeMediaStreamTrack(MediaStreamTrack& track)
     stopObservingRealtimeMediaSource();
 
     m_trackVideoRotation = -1;
-    m_trackSource = &track.source();
+    m_trackSource = track.source();
     m_trackSource->addObserver(*this);
     switch (m_trackSource->type()) {
     case RealtimeMediaSource::Type::Audio:

--- a/Source/WebCore/workers/WorkerInspectorProxy.cpp
+++ b/Source/WebCore/workers/WorkerInspectorProxy.cpp
@@ -148,7 +148,7 @@ auto WorkerInspectorProxy::pageOrWorkerGlobalScopeIdentifier(ScriptExecutionCont
 void WorkerInspectorProxy::workerStarted(ScriptExecutionContext& scriptExecutionContext, WorkerThread* thread, const URL& url, const String& name)
 {
     ASSERT(!m_workerThread);
-    m_scriptExecutionContext = &scriptExecutionContext;
+    m_scriptExecutionContext = scriptExecutionContext;
     m_contextIdentifier = pageOrWorkerGlobalScopeIdentifier(scriptExecutionContext);
 
     m_workerThread = thread;

--- a/Source/WebCore/workers/WorkerMessagingProxy.cpp
+++ b/Source/WebCore/workers/WorkerMessagingProxy.cpp
@@ -369,7 +369,7 @@ void WorkerMessagingProxy::setResourceCachingDisabledByWebInspector(bool disable
 void WorkerMessagingProxy::workerThreadCreated(DedicatedWorkerThread& workerThread)
 {
     ASSERT(!m_askedToTerminate);
-    m_workerThread = &workerThread;
+    m_workerThread = workerThread;
 
     if (m_askedToSuspend) {
         m_askedToSuspend = false;

--- a/Source/WebCore/workers/WorkerScriptLoader.cpp
+++ b/Source/WebCore/workers/WorkerScriptLoader.cpp
@@ -130,7 +130,7 @@ std::optional<Exception> WorkerScriptLoader::loadSynchronously(ScriptExecutionCo
 
 void WorkerScriptLoader::loadAsynchronously(ScriptExecutionContext& scriptExecutionContext, ResourceRequest&& scriptRequest, Source source, FetchOptions&& fetchOptions, ContentSecurityPolicyEnforcement contentSecurityPolicyEnforcement, ServiceWorkersMode serviceWorkerMode, WorkerScriptLoaderClient& client, String&& taskMode, std::optional<ScriptExecutionContextIdentifier> clientIdentifier)
 {
-    m_client = &client;
+    m_client = client;
     m_url = scriptRequest.url();
     m_source = source;
     m_destination = fetchOptions.destination;

--- a/Source/WebCore/workers/service/ServiceWorkerContainer.cpp
+++ b/Source/WebCore/workers/service/ServiceWorkerContainer.cpp
@@ -599,9 +599,9 @@ SWClientConnection& ServiceWorkerContainer::ensureSWClientConnection()
     if (!m_swConnection || m_swConnection->isClosed()) {
         // Using RefPtr here results in an m_adoptionIsRequired assert.
         if (auto* workerGlobal = dynamicDowncast<WorkerGlobalScope>(*scriptExecutionContext()))
-            m_swConnection = &workerGlobal->swClientConnection();
+            m_swConnection = workerGlobal->swClientConnection();
         else
-            m_swConnection = &mainThreadConnection();
+            m_swConnection = mainThreadConnection();
     }
     return *m_swConnection;
 }

--- a/Source/WebCore/workers/service/ServiceWorkerGlobalScope.cpp
+++ b/Source/WebCore/workers/service/ServiceWorkerGlobalScope.cpp
@@ -94,7 +94,7 @@ void ServiceWorkerGlobalScope::dispatchPushEvent(PushEvent& pushEvent)
     ASSERT(!m_pushEvent);
 #endif
 
-    m_pushEvent = &pushEvent;
+    m_pushEvent = pushEvent;
     m_lastPushEventTime = MonotonicTime::now();
     dispatchEvent(pushEvent);
     m_pushEvent = nullptr;
@@ -104,7 +104,7 @@ void ServiceWorkerGlobalScope::dispatchPushEvent(PushEvent& pushEvent)
 void ServiceWorkerGlobalScope::dispatchDeclarativePushEvent(PushEvent& event)
 {
     ASSERT(!m_declarativePushEvent && !m_pushEvent);
-    m_declarativePushEvent = &event;
+    m_declarativePushEvent = event;
     m_lastPushEventTime = MonotonicTime::now();
     dispatchEvent(event);
 }

--- a/Source/WebCore/xml/XPathExpression.cpp
+++ b/Source/WebCore/xml/XPathExpression.cpp
@@ -58,7 +58,7 @@ ExceptionOr<Ref<XPathResult>> XPathExpression::evaluate(Node& contextNode, unsig
         return Exception { ExceptionCode::NotSupportedError };
 
     auto& evaluationContext = XPath::Expression::evaluationContext();
-    evaluationContext.node = &contextNode;
+    evaluationContext.node = contextNode;
     evaluationContext.size = 1;
     evaluationContext.position = 1;
     evaluationContext.hadTypeConversionError = false;

--- a/Source/WebCore/xml/XPathResult.cpp
+++ b/Source/WebCore/xml/XPathResult.cpp
@@ -49,7 +49,7 @@ XPathResult::XPathResult(Document& document, const XPath::Value& value)
         m_resultType = UNORDERED_NODE_ITERATOR_TYPE;
         m_nodeSetPosition = 0;
         m_nodeSet = m_value.toNodeSet();
-        m_document = &document;
+        m_document = document;
         m_domTreeVersion = document.domTreeVersion();
         return;
     }

--- a/Source/WebGPU/WebGPU/ComputePassEncoder.mm
+++ b/Source/WebGPU/WebGPU/ComputePassEncoder.mm
@@ -514,7 +514,7 @@ void ComputePassEncoder::setPipeline(const ComputePipeline& pipeline)
         return;
     }
 
-    m_pipeline = &pipeline;
+    m_pipeline = pipeline;
     m_computeDynamicOffsets.resize(m_pipeline->protectedPipelineLayout()->sizeOfComputeDynamicOffsets());
     m_computeDynamicOffsets.fill(0);
     m_maxDynamicOffsetAtIndex.fill(0);

--- a/Source/WebGPU/WebGPU/PresentationContextIOSurface.mm
+++ b/Source/WebGPU/WebGPU/PresentationContextIOSurface.mm
@@ -160,7 +160,7 @@ void PresentationContextIOSurface::configure(Device& device, const WGPUSwapChain
         return;
 
     bool reportValidationErrors = descriptor.reportValidationErrors;
-    m_device = &device;
+    m_device = device;
     auto allowedFormat = ^(WGPUTextureFormat format) {
         return format == WGPUTextureFormat_BGRA8Unorm || format == WGPUTextureFormat_RGBA8Unorm || format == WGPUTextureFormat_RGBA16Float;
     };

--- a/Source/WebGPU/WebGPU/RenderBundleEncoder.mm
+++ b/Source/WebGPU/WebGPU/RenderBundleEncoder.mm
@@ -1051,7 +1051,7 @@ void RenderBundleEncoder::replayCommands(RenderPassEncoder& renderPassEncoder)
     if (!renderPassEncoder.renderCommandEncoder() || !isValid() || !m_device->isValid())
         return;
 
-    m_renderPassEncoder = &renderPassEncoder;
+    m_renderPassEncoder = renderPassEncoder;
     endCurrentICB();
     m_renderPassEncoder = nullptr;
     m_currentPipelineState = nil;
@@ -1196,7 +1196,7 @@ void RenderBundleEncoder::setBindGroup(uint32_t groupIndex, const BindGroup* gro
 void RenderBundleEncoder::setIndexBuffer(Buffer& buffer, WGPUIndexFormat format, uint64_t offset, uint64_t size)
 {
     RETURN_IF_FINISHED();
-    m_indexBuffer = &buffer;
+    m_indexBuffer = buffer;
     RELEASE_ASSERT(m_indexBuffer);
     m_indexType = format == WGPUIndexFormat_Uint32 ? MTLIndexTypeUInt32 : MTLIndexTypeUInt16;
     m_indexBufferOffset = offset;
@@ -1389,7 +1389,7 @@ void RenderBundleEncoder::setPipeline(const RenderPipeline& pipeline)
         });
     }
 
-    m_pipeline = &pipeline;
+    m_pipeline = pipeline;
 }
 
 void RenderBundleEncoder::setVertexBuffer(uint32_t slot, Buffer* optionalBuffer, uint64_t offset, uint64_t size)

--- a/Source/WebGPU/WebGPU/RenderPassEncoder.mm
+++ b/Source/WebGPU/WebGPU/RenderPassEncoder.mm
@@ -1502,7 +1502,7 @@ void RenderPassEncoder::setIndexBuffer(Buffer& buffer, WGPUIndexFormat format, u
         return;
     }
 
-    m_indexBuffer = &buffer;
+    m_indexBuffer = buffer;
     m_indexBufferSize = size == WGPU_WHOLE_SIZE ? buffer.initialSize() : size;
     m_indexType = format == WGPUIndexFormat_Uint32 ? MTLIndexTypeUInt32 : MTLIndexTypeUInt16;
     m_indexBufferOffset = offset;
@@ -1537,7 +1537,7 @@ void RenderPassEncoder::setPipeline(const RenderPipeline& pipeline)
 
     m_primitiveType = pipeline.primitiveType();
     if (m_pipeline.get() != &pipeline) {
-        m_pipeline = &pipeline;
+        m_pipeline = pipeline;
         m_bindGroupDynamicOffsetsChanged.fill(true);
         m_maxDynamicOffsetAtIndex.fill(0);
     }

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
@@ -194,7 +194,7 @@ void RemoteRenderingBackend::moveToSerializedBuffer(RenderingResourceIdentifier 
 static void adjustImageBufferCreationContext(RemoteSharedResourceCache& sharedResourceCache, ImageBufferCreationContext& creationContext)
 {
 #if HAVE(IOSURFACE)
-    creationContext.surfacePool = &sharedResourceCache.ioSurfacePool();
+    creationContext.surfacePool = sharedResourceCache.ioSurfacePool();
 #endif
     creationContext.resourceOwner = sharedResourceCache.resourceOwner();
 }

--- a/Source/WebKit/NetworkProcess/CustomProtocols/Cocoa/LegacyCustomProtocolManagerCocoa.mm
+++ b/Source/WebKit/NetworkProcess/CustomProtocols/Cocoa/LegacyCustomProtocolManagerCocoa.mm
@@ -61,7 +61,7 @@ void LegacyCustomProtocolManager::networkProcessCreated(NetworkProcess& networkP
     };
 
     RELEASE_ASSERT(!firstNetworkProcess() || !hasRegisteredSchemes(RefPtr { protectedFirstNetworkProcess()->supplement<LegacyCustomProtocolManager>() }.get()));
-    firstNetworkProcess() = &networkProcess;
+    firstNetworkProcess() = networkProcess;
 }
 
 @interface WKCustomProtocol : NSURLProtocol {

--- a/Source/WebKit/Platform/IPC/StreamServerConnection.cpp
+++ b/Source/WebKit/Platform/IPC/StreamServerConnection.cpp
@@ -62,7 +62,7 @@ StreamServerConnection::~StreamServerConnection()
 
 void StreamServerConnection::open(StreamConnectionWorkQueue& workQueue)
 {
-    m_workQueue = &workQueue;
+    m_workQueue = workQueue;
     // FIXME(http://webkit.org/b/238986): Workaround for not being able to deliver messages from the dedicated connection to the work queue the client uses.
     Ref connection = m_connection;
     connection->addMessageReceiveQueue(*this, { });

--- a/Source/WebKit/Shared/LogStream.cpp
+++ b/Source/WebKit/Shared/LogStream.cpp
@@ -118,7 +118,7 @@ void LogStream::setup(IPC::StreamServerConnectionHandle&& serverConnection, Comp
 #else
 void LogStream::setup(IPC::Connection& connection)
 {
-    m_logConnection = &connection;
+    m_logConnection = connection;
 }
 #endif
 

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithInProcessRenderingBackingStore.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithInProcessRenderingBackingStore.mm
@@ -206,7 +206,7 @@ static RefPtr<ImageBuffer> allocateBufferInternal(RemoteLayerBackingStore::Type 
 RefPtr<WebCore::ImageBuffer> RemoteLayerWithInProcessRenderingBackingStore::allocateBuffer()
 {
     ImageBufferCreationContext creationContext;
-    creationContext.surfacePool = &WebCore::IOSurfacePool::sharedPoolSingleton();
+    creationContext.surfacePool = WebCore::IOSurfacePool::sharedPoolSingleton();
 
 #if ENABLE(RE_DYNAMIC_CONTENT_SCALING)
     if (m_parameters.includeDisplayList == WebCore::IncludeDynamicContentScalingDisplayList::Yes) {

--- a/Source/WebKit/UIProcess/API/APIPageConfiguration.h
+++ b/Source/WebKit/UIProcess/API/APIPageConfiguration.h
@@ -476,7 +476,7 @@ private:
         template<typename T, Ref<T>(*initializer)()> class LazyInitializedRef {
         public:
             LazyInitializedRef() = default;
-            void operator=(const LazyInitializedRef& other) { m_value = &other.get(); }
+            void operator=(const LazyInitializedRef& other) { m_value = other.get(); }
             void operator=(RefPtr<T>&& t) { m_value = WTFMove(t); }
             T& get() const
             {

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKAttachment.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKAttachment.mm
@@ -57,7 +57,7 @@ static const NSInteger InvalidAttachmentErrorCode = 2;
     if (!(self = [super init]))
         return nil;
 
-    _attachment = &attachment;
+    _attachment = attachment;
     _filePath = attachment.filePath().createNSString();
     _mimeType = attachment.mimeType().createNSString();
     _utiType = attachment.utiType().createNSString();

--- a/Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.cpp
+++ b/Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.cpp
@@ -246,7 +246,7 @@ void WebInspectorUIProxy::updateForNewPageProcess(WebPageProxy& inspectedPage)
 {
     ASSERT(!m_inspectedPage);
 
-    m_inspectedPage = &inspectedPage;
+    m_inspectedPage = inspectedPage;
     m_inspectedPageIdentifier = inspectedPage.identifier();
 
     protectedInspectedPage()->protectedLegacyMainFrameProcess()->addMessageReceiver(Messages::WebInspectorUIProxy::messageReceiverName(), m_inspectedPage->webPageIDInMainFrameProcess(), *this);

--- a/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
+++ b/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
@@ -118,7 +118,7 @@ ProvisionalPageProxy::ProvisionalPageProxy(WebPageProxy& page, Ref<FrameProcess>
     if (suspendedPage) {
         ASSERT(&suspendedPage->process() == process.ptr());
         suspendedPage->unsuspend();
-        m_mainFrame = &suspendedPage->mainFrame();
+        m_mainFrame = suspendedPage->mainFrame();
         m_needsMainFrameObserver = true;
     } else if (m_isProcessSwappingForNewWindow)
         m_mainFrame = page.mainFrame();

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -558,11 +558,11 @@ void WebPageProxy::forMostVisibleWebPageIfAny(PAL::SessionID sessionID, const Se
         if (!page.mainFrame())
             return;
         if (page.isViewVisible() && (!selectedPage || !selectedPage->isViewVisible())) {
-            selectedPage = &page;
+            selectedPage = page;
             return;
         }
         if (page.isViewFocused() && (!selectedPage || !selectedPage->isViewFocused())) {
-            selectedPage = &page;
+            selectedPage = page;
             return;
         }
     });

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -694,7 +694,7 @@ void WebProcessPool::establishRemoteWorkerContextConnectionToNetworkProcess(Remo
     RefPtr<WebProcessProxy> remoteWorkerProcessProxy;
 
     auto useProcessForRemoteWorkers = [&](WebProcessProxy& process) {
-        remoteWorkerProcessProxy = &process;
+        remoteWorkerProcessProxy = process;
         process.enableRemoteWorkers(workerType, processPool->userContentControllerIdentifierForRemoteWorkers());
         if (process.isInProcessCache()) {
             processPool->checkedWebProcessCache()->removeProcess(process, WebProcessCache::ShouldShutDownProcess::No);
@@ -1279,7 +1279,7 @@ Ref<WebPageProxy> WebProcessPool::createWebPage(PageClient& pageClient, Ref<API:
         process = openerInfo->process.ptr();
     else if (relatedPage && !relatedPage->isClosed() && relatedPage->hasSameGPUAndNetworkProcessPreferencesAs(pageConfiguration)) {
         // Sharing processes, e.g. when creating the page via window.open().
-        process = &relatedPage->ensureRunningProcess();
+        process = relatedPage->ensureRunningProcess();
         // We do not support several WebsiteDataStores sharing a single process.
         ASSERT(process->isDummyProcessProxy() || &pageConfiguration->websiteDataStore() == process->websiteDataStore());
         ASSERT(&pageConfiguration->relatedPage()->websiteDataStore() == &pageConfiguration->websiteDataStore());
@@ -2007,7 +2007,7 @@ void WebProcessPool::addProcessToOriginCacheSet(WebProcessProxy& process, const 
     auto registrableDomain = WebCore::RegistrableDomain { url };
     auto result = m_swappedProcessesPerRegistrableDomain.add(registrableDomain, &process);
     if (!result.isNewEntry)
-        result.iterator->value = &process;
+        result.iterator->value = process;
 
     LOG(ProcessSwapping, "(ProcessSwapping) Registrable domain %s just saved a cached process with pid %i", registrableDomain.string().utf8().data(), process.processID());
     if (!result.isNewEntry)

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -465,7 +465,7 @@ void WebProcessProxy::setWebsiteDataStore(WebsiteDataStore& dataStore)
     if (!m_websiteDataStore)
         dataStore.protectedNetworkProcess()->sendXPCEndpointToProcess(*this);
 #endif
-    m_websiteDataStore = &dataStore;
+    m_websiteDataStore = dataStore;
     logger().setEnabled(this, isAlwaysOnLoggingAllowed());
     updateRegistrationWithDataStore();
     send(Messages::WebProcess::SetWebsiteDataStoreParameters(protectedProcessPool()->webProcessDataStoreParameters(*this, dataStore)), 0);

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
@@ -339,7 +339,7 @@ static Ref<NetworkProcessProxy> networkProcessForSession(PAL::SessionID sessionI
 void WebsiteDataStore::setNetworkProcess(NetworkProcessProxy& networkProcess)
 {
     ASSERT(!m_networkProcess);
-    m_networkProcess = &networkProcess;
+    m_networkProcess = networkProcess;
 }
 
 NetworkProcessProxy& WebsiteDataStore::networkProcess()
@@ -895,7 +895,7 @@ void WebsiteDataStore::removeDataInNetworkProcess(WebsiteDataStore::ProcessAcces
 {
     RefPtr<NetworkProcessProxy> networkProcess;
     if (networkProcessAccessType == ProcessAccessType::Launch)
-        networkProcess = &this->networkProcess();
+        networkProcess = this->networkProcess();
     else if (networkProcessAccessType == ProcessAccessType::OnlyIfLaunched)
         networkProcess = networkProcessIfExists();
 

--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
@@ -808,7 +808,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     self._webView = webView;
 #if !RELEASE_LOG_DISABLED
     if (auto webPage = RefPtr { [webView _page].get() }) {
-        _logger = &webPage->logger();
+        _logger = webPage->logger();
         _logIdentifier = webPage->logIdentifier();
     }
 #endif

--- a/Source/WebKit/UIProcess/mac/WKFullScreenWindowController.mm
+++ b/Source/WebKit/UIProcess/mac/WKFullScreenWindowController.mm
@@ -142,7 +142,7 @@ static void makeResponderFirstResponderIfDescendantOfView(NSWindow *window, NSRe
     _page = page.get();
 
 #if !RELEASE_LOG_DISABLED
-    _logger = &page.get().logger();
+    _logger = page.get().logger();
     _logIdentifier = page.get().logIdentifier();
 #endif
 

--- a/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm
@@ -205,7 +205,7 @@
     if (!(self = [super init]))
         return nil;
 
-    _menuProxy = &menuProxy;
+    _menuProxy = menuProxy;
 
     return self;
 }

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -4486,7 +4486,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     if (customDataBuffer)
         [pasteboard setData:customDataBuffer.get() forType:@(WebCore::PasteboardCustomData::cocoaType().characters())];
 
-    m_promisedImage = &image;
+    m_promisedImage = image;
 }
 
 void WebViewImpl::clearPromisedDragImage()

--- a/Source/WebKit/WebProcess/Cache/WebCacheStorageConnection.cpp
+++ b/Source/WebKit/WebProcess/Cache/WebCacheStorageConnection.cpp
@@ -55,7 +55,7 @@ Ref<IPC::Connection> WebCacheStorageConnection::connection()
 
     RefPtr<IPC::Connection> connection;
     callOnMainRunLoopAndWait([this, &connection]() mutable {
-        connection = &WebProcess::singleton().ensureNetworkProcessConnection().connection();
+        connection = WebProcess::singleton().ensureNetworkProcessConnection().connection();
         {
             Locker lock(m_connectionLock);
             m_connection = connection;

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIRuntimeCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIRuntimeCocoa.mm
@@ -85,7 +85,7 @@ using ReplyCallbackAggregator = EagerCallbackAggregator<void(id, IsDefaultReply)
     if (!(self = [super init]))
         return nil;
 
-    _aggregator = &aggregator;
+    _aggregator = aggregator;
 
     return self;
 }

--- a/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp
+++ b/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp
@@ -184,7 +184,7 @@ void WebFullScreenManager::setElement(WebCore::Element& element)
 
     clearElement();
 
-    m_element = &element;
+    m_element = element;
     m_elementToRestore = element;
 
     for (auto& eventName : eventsToObserve())

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp
@@ -117,7 +117,7 @@ void RemoteGraphicsContextGLProxy::initializeIPC(Ref<IPC::StreamClientConnection
         gpuProcessConnection->createGraphicsContextGL(m_identifier, contextAttributes(), renderingBackend, WTFMove(serverHandle));
         m_gpuProcessConnection = gpuProcessConnection.get();
 #if ENABLE(VIDEO)
-        m_videoFrameObjectHeapProxy = &gpuProcessConnection->videoFrameObjectHeapProxy();
+        m_videoFrameObjectHeapProxy = gpuProcessConnection->videoFrameObjectHeapProxy();
 #endif
     });
 

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCompositorIntegrationProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCompositorIntegrationProxy.h
@@ -61,7 +61,7 @@ public:
     void setPresentationContext(RemotePresentationContextProxy& presentationContext)
     {
         ASSERT(!m_presentationContext);
-        m_presentationContext = &presentationContext;
+        m_presentationContext = presentationContext;
     }
 
     void paintCompositedResultsToCanvas(WebCore::ImageBuffer&, uint32_t) final;

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQueueProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQueueProxy.cpp
@@ -48,7 +48,7 @@ RemoteQueueProxy::RemoteQueueProxy(RemoteAdapterProxy& parent, ConvertToBackingC
 #if ENABLE(VIDEO) && PLATFORM(COCOA) && ENABLE(WEB_CODECS)
     RefPtr<RemoteVideoFrameObjectHeapProxy> videoFrameObjectHeapProxy;
     callOnMainRunLoopAndWait([&videoFrameObjectHeapProxy] {
-        videoFrameObjectHeapProxy = &WebProcess::singleton().ensureProtectedGPUProcessConnection()->videoFrameObjectHeapProxy();
+        videoFrameObjectHeapProxy = WebProcess::singleton().ensureProtectedGPUProcessConnection()->videoFrameObjectHeapProxy();
     });
 
     m_videoFrameObjectHeapProxy = videoFrameObjectHeapProxy;

--- a/Source/WebKit/WebProcess/GPU/graphics/wc/RemoteWCLayerTreeHostProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/wc/RemoteWCLayerTreeHostProxy.cpp
@@ -58,9 +58,9 @@ IPC::Connection* RemoteWCLayerTreeHostProxy::messageSenderConnection() const
 
 GPUProcessConnection& RemoteWCLayerTreeHostProxy::ensureGPUProcessConnection()
 {
-    auto gpuProcessConnection = m_gpuProcessConnection.get();
+    RefPtr gpuProcessConnection = m_gpuProcessConnection.get();
     if (!gpuProcessConnection) {
-        gpuProcessConnection = &WebProcess::singleton().ensureGPUProcessConnection();
+        gpuProcessConnection = WebProcess::singleton().ensureGPUProcessConnection();
         m_gpuProcessConnection = gpuProcessConnection;
         gpuProcessConnection->addClient(*this);
         gpuProcessConnection->connection().send(

--- a/Source/WebKit/WebProcess/Model/ModelProcessModelPlayerManager.cpp
+++ b/Source/WebKit/WebProcess/Model/ModelProcessModelPlayerManager.cpp
@@ -53,11 +53,11 @@ ModelProcessModelPlayerManager::~ModelProcessModelPlayerManager() = default;
 
 ModelProcessConnection& ModelProcessModelPlayerManager::modelProcessConnection()
 {
-    auto modelProcessConnection = m_modelProcessConnection.get();
+    RefPtr modelProcessConnection = m_modelProcessConnection.get();
     if (!modelProcessConnection) {
-        modelProcessConnection = &WebProcess::singleton().ensureModelProcessConnection();
+        modelProcessConnection = WebProcess::singleton().ensureModelProcessConnection();
         m_modelProcessConnection = modelProcessConnection;
-        modelProcessConnection = &WebProcess::singleton().ensureModelProcessConnection();
+        modelProcessConnection = WebProcess::singleton().ensureModelProcessConnection();
         modelProcessConnection->addClient(*this);
     }
 


### PR DESCRIPTION
#### 26bc2c3f9a83474fa871274d0ca2ef2043cde33f
<pre>
Leverage the `RefPtr&lt;T&gt;(T&amp;)` constructor in more places
<a href="https://bugs.webkit.org/show_bug.cgi?id=294139">https://bugs.webkit.org/show_bug.cgi?id=294139</a>

Reviewed by Mike Wyrzykowski.

* Source/WebCore/platform/audio/mac/SharedRoutingArbitrator.mm:
(WebCore::SharedRoutingArbitrator::setLogger):
* Source/WebCore/platform/cocoa/SharedBufferCocoa.mm:
(-[WebCoreSharedBufferData initWithDataSegment:position:size:]):
* Source/WebCore/platform/cocoa/ThermalMitigationNotifier.mm:
(-[WebThermalMitigationObserver initWithNotifier:]):
* Source/WebCore/platform/graphics/ComplexTextController.cpp:
(WebCore::ComplexTextController::enclosingGlyphBoundsForTextRun):
* Source/WebCore/platform/graphics/FontCascade.cpp:
(WebCore::FontCascade::drawGlyphBuffer const):
* Source/WebCore/platform/graphics/FontCascadeFonts.cpp:
(WebCore::findBestFallbackFont):
(WebCore::FontCascadeFonts::glyphDataForSystemFallback):
(WebCore::FontCascadeFonts::glyphDataForVariant):
* Source/WebCore/platform/graphics/MediaPlayer.cpp:
(WebCore::MediaPlayer::load):
* Source/WebCore/platform/graphics/TrackBuffer.cpp:
(WebCore::TrackBuffer::setLogger):
* Source/WebCore/platform/graphics/TrackPrivateBase.cpp:
(WebCore::TrackPrivateBase::setLogger):
* Source/WebCore/platform/graphics/WidthIterator.cpp:
(WebCore::SmallCapsState::setSmallCapsData):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaStreamAVFObjC::processNewVideoFrame):
(WebCore::MediaPlayerPrivateMediaStreamAVFObjC::load):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.mm:
(WebCore::MediaSourcePrivateAVFObjC::cdmInstanceAttached):
* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferParserAVFObjC.mm:
(WebCore::SourceBufferParserAVFObjC::setLogger):
* Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.cpp:
(WebCore::WebMParser::setLogger):
(WebCore::SourceBufferParserWebM::setLogger):
* Source/WebCore/platform/graphics/coretext/FontCascadeCoreText.cpp:
(WebCore::FontCascade::fontForCombiningCharacterSequence const):
* Source/WebCore/platform/graphics/filters/software/FEGaussianBlurSoftwareApplier.cpp:
(WebCore::FEGaussianBlurSoftwareApplier::applyPlatform):
* Source/WebCore/platform/graphics/filters/software/FELightingSoftwareApplier.cpp:
(WebCore::FELightingSoftwareApplier::apply const):
* Source/WebCore/platform/graphics/filters/software/FETurbulenceSoftwareApplier.cpp:
(WebCore::FETurbulenceSoftwareApplier::applyPlatform):
* Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp:
(WebCore::RealtimeMediaSource::setLogger):
* Source/WebCore/platform/mediastream/cocoa/DisplayCaptureSourceCocoa.cpp:
(WebCore::DisplayCaptureSourceCocoa::Capturer::setLogger):
* Source/WebCore/platform/mediastream/cocoa/IncomingAudioMediaStreamTrackRendererUnit.cpp:
(WebCore::IncomingAudioMediaStreamTrackRendererUnit::addSource):
* Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingMediaSourceGStreamer.cpp:
(WebCore::RealtimeOutgoingMediaSourceGStreamer::RealtimeOutgoingMediaSourceGStreamer):
(WebCore::RealtimeOutgoingMediaSourceGStreamer::replaceTrack):
* Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm:
(WebCore::AVVideoCaptureSource::captureOutputDidOutputSampleBufferFromConnection):
* Source/WebCore/platform/network/cocoa/WebCoreNSURLSession.mm:
(-[WebCoreNSURLSession initWithResourceLoader:delegate:delegateQueue:]):
* Source/WebCore/platform/sql/SQLiteDatabase.cpp:
(WebCore::SQLiteDatabase::open):
(WebCore::SQLiteDatabase::setAuthorizer):
* Source/WebCore/rendering/RenderView.cpp:
(WebCore::RenderView::updatePlayStateForAllAnimations):
* Source/WebCore/rendering/style/StyleCustomPropertyData.cpp:
(WebCore::StyleCustomPropertyData::StyleCustomPropertyData):
* Source/WebCore/rendering/svg/RenderSVGResourcePattern.cpp:
(WebCore::RenderSVGResourcePattern::collectPatternAttributesIfNeeded):
* Source/WebCore/rendering/svg/SVGTextMetricsBuilder.cpp:
(WebCore::SVGTextMetricsBuilder::initializeMeasurementWithTextRenderer):
* Source/WebCore/storage/StorageNamespaceProvider.cpp:
(WebCore::StorageNamespaceProvider::localStorageArea):
* Source/WebCore/style/RuleSet.cpp:
(WebCore::Style::RuleSet::setViewTransitionRule):
* Source/WebCore/svg/SVGSVGElement.cpp:
(WebCore::SVGSVGElement::scrollToFragment):
* Source/WebCore/svg/animation/SVGSMILElement.cpp:
(WebCore::SVGSMILElement::insertedIntoAncestor):
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::observeMediaStreamTrack):
* Source/WebCore/workers/WorkerInspectorProxy.cpp:
(WebCore::WorkerInspectorProxy::workerStarted):
* Source/WebCore/workers/WorkerMessagingProxy.cpp:
(WebCore::WorkerMessagingProxy::workerThreadCreated):
* Source/WebCore/workers/WorkerScriptLoader.cpp:
(WebCore::WorkerScriptLoader::loadAsynchronously):
* Source/WebCore/workers/service/ServiceWorkerContainer.cpp:
(WebCore::ServiceWorkerContainer::ensureSWClientConnection):
* Source/WebCore/workers/service/ServiceWorkerGlobalScope.cpp:
(WebCore::ServiceWorkerGlobalScope::dispatchPushEvent):
(WebCore::ServiceWorkerGlobalScope::dispatchDeclarativePushEvent):
* Source/WebCore/xml/XPathExpression.cpp:
(WebCore::XPathExpression::evaluate):
* Source/WebCore/xml/XPathResult.cpp:
(WebCore::XPathResult::XPathResult):
* Source/WebGPU/WebGPU/ComputePassEncoder.mm:
(WebGPU::ComputePassEncoder::setPipeline):
* Source/WebGPU/WebGPU/PresentationContextIOSurface.mm:
(WebGPU::PresentationContextIOSurface::configure):
* Source/WebGPU/WebGPU/RenderBundleEncoder.mm:
(WebGPU::RenderBundleEncoder::replayCommands):
(WebGPU::RenderBundleEncoder::setIndexBuffer):
(WebGPU::RenderBundleEncoder::setPipeline):
* Source/WebGPU/WebGPU/RenderPassEncoder.mm:
(WebGPU::RenderPassEncoder::setIndexBuffer):
(WebGPU::RenderPassEncoder::setPipeline):
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp:
(WebKit::adjustImageBufferCreationContext):
* Source/WebKit/NetworkProcess/CustomProtocols/Cocoa/LegacyCustomProtocolManagerCocoa.mm:
(LegacyCustomProtocolManager::networkProcessCreated):
* Source/WebKit/Platform/IPC/StreamServerConnection.cpp:
(IPC::StreamServerConnection::open):
* Source/WebKit/Shared/LogStream.cpp:
(WebKit::LogStream::setup):
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithInProcessRenderingBackingStore.mm:
(WebKit::RemoteLayerWithInProcessRenderingBackingStore::allocateBuffer):
* Source/WebKit/UIProcess/API/APIPageConfiguration.h:
(API::PageConfiguration::Data::initializer):
* Source/WebKit/UIProcess/API/Cocoa/_WKAttachment.mm:
(-[_WKAttachmentInfo initWithAttachment:]):
* Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.cpp:
(WebKit::WebInspectorUIProxy::updateForNewPageProcess):
* Source/WebKit/UIProcess/ProvisionalPageProxy.cpp:
(WebKit::ProvisionalPageProxy::ProvisionalPageProxy):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::forMostVisibleWebPageIfAny):
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::establishRemoteWorkerContextConnectionToNetworkProcess):
(WebKit::WebProcessPool::createWebPage):
(WebKit::WebProcessPool::addProcessToOriginCacheSet):
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::setWebsiteDataStore):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp:
(WebKit::WebsiteDataStore::setNetworkProcess):
(WebKit::WebsiteDataStore::removeDataInNetworkProcess):
* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm:
(-[WKFullScreenWindowController initWithWebView:]):
* Source/WebKit/UIProcess/mac/WKFullScreenWindowController.mm:
(-[WKFullScreenWindowController initWithWindow:webView:page:]):
* Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm:
(-[WKMenuDelegate initWithMenuProxy:]):
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::setPromisedDataForImage):
* Source/WebKit/WebProcess/Cache/WebCacheStorageConnection.cpp:
(WebKit::WebCacheStorageConnection::connection):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIRuntimeCocoa.mm:
(-[_WKReplyCallbackAggregator initWithAggregator:]):
* Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp:
(WebKit::WebFullScreenManager::setElement):
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp:
(WebKit::RemoteGraphicsContextGLProxy::initializeIPC):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCompositorIntegrationProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQueueProxy.cpp:
(WebKit::WebGPU::RemoteQueueProxy::RemoteQueueProxy):
* Source/WebKit/WebProcess/GPU/graphics/wc/RemoteWCLayerTreeHostProxy.cpp:
(WebKit::RemoteWCLayerTreeHostProxy::ensureGPUProcessConnection):
* Source/WebKit/WebProcess/Model/ModelProcessModelPlayerManager.cpp:
(WebKit::ModelProcessModelPlayerManager::modelProcessConnection):

Canonical link: <a href="https://commits.webkit.org/295947@main">https://commits.webkit.org/295947@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/70b06507dff7f3758f5fc7ca244fcbccc330adb3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/106632 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/26383 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/16780 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/111840 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/57228 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/108671 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/27053 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34885 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80977 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/57228 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/109636 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/21458 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/96221 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/61312 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/20910 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/14328 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/56680 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/90797 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/14357 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/114708 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33770 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24900 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/90041 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/34134 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/92452 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89749 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22915 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34665 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/12483 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/29397 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/33695 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/39108 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/33441 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/36794 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/35040 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->