### PR TITLE
Reduce unsafeness by making more WebCore/bindings class member variables const

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -342,7 +342,6 @@ bindings/js/ScheduledAction.cpp
 bindings/js/ScriptBufferSourceProvider.h
 bindings/js/ScriptCachedFrameData.cpp
 bindings/js/ScriptModuleLoader.cpp
-bindings/js/ScriptSourceCode.h
 bindings/js/SerializedScriptValue.cpp
 bindings/js/WebAssemblyScriptBufferSourceProvider.h
 bindings/js/WebCoreJSClientData.cpp

--- a/Source/WebCore/bindings/js/JSWindowProxy.cpp
+++ b/Source/WebCore/bindings/js/JSWindowProxy.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2008-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2008-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -81,11 +81,6 @@ JSWindowProxy& JSWindowProxy::create(VM& vm, DOMWindow& window, DOMWrapperWorld&
 void JSWindowProxy::destroy(JSCell* cell)
 {
     static_cast<JSWindowProxy*>(cell)->JSWindowProxy::~JSWindowProxy();
-}
-
-DOMWrapperWorld& JSWindowProxy::world()
-{
-    return m_world;
 }
 
 void JSWindowProxy::setWindow(VM& vm, JSDOMGlobalObject& window)
@@ -188,11 +183,6 @@ WindowProxy* JSWindowProxy::toWrapped(VM&, JSValue value)
 JSC::GCClient::IsoSubspace* JSWindowProxy::subspaceForImpl(JSC::VM& vm)
 {
     return &downcast<JSVMClientData>(vm.clientData)->windowProxySpace();
-}
-
-Ref<DOMWrapperWorld> JSWindowProxy::protectedWorld()
-{
-    return m_world;
 }
 
 #if ENABLE(WINDOW_PROXY_PROPERTY_ACCESS_NOTIFICATION)

--- a/Source/WebCore/bindings/js/JSWindowProxy.h
+++ b/Source/WebCore/bindings/js/JSWindowProxy.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2008-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2008-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -64,8 +64,7 @@ public:
     Ref<DOMWindow> protectedWrapped() const;
     static WindowProxy* toWrapped(JSC::VM&, JSC::JSValue);
 
-    DOMWrapperWorld& world();
-    Ref<DOMWrapperWorld> protectedWorld();
+    DOMWrapperWorld& world() { return m_world; }
 
     void attachDebugger(JSC::Debugger*);
 
@@ -88,7 +87,7 @@ private:
     static bool defineOwnProperty(JSC::JSObject*, JSC::JSGlobalObject*, JSC::PropertyName, const JSC::PropertyDescriptor&, bool shouldThrow);
 #endif
 
-    Ref<DOMWrapperWorld> m_world;
+    const Ref<DOMWrapperWorld> m_world;
 };
 
 // JSWindowProxy is a little odd in that it's not a traditional wrapper and has no back pointer.

--- a/Source/WebCore/bindings/js/ModuleScriptLoader.h
+++ b/Source/WebCore/bindings/js/ModuleScriptLoader.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -58,7 +58,7 @@ protected:
 
     ModuleScriptLoaderClient* m_client;
     RefPtr<DeferredPromise> m_promise;
-    Ref<JSC::ScriptFetcher> m_scriptFetcher;
+    const Ref<JSC::ScriptFetcher> m_scriptFetcher;
     RefPtr<JSC::ScriptFetchParameters> m_parameters;
 };
 

--- a/Source/WebCore/bindings/js/ScriptSourceCode.h
+++ b/Source/WebCore/bindings/js/ScriptSourceCode.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2008 Google Inc. All rights reserved.
- * Copyright (c) 2023 Apple Inc. All rights reserved.
+ * Copyright (c) 2023-2025 Apple Inc. All rights reserved.
  * 
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -92,7 +92,7 @@ public:
     const URL& url() const { return m_provider->sourceOrigin().url(); }
     
 private:
-    Ref<JSC::SourceProvider> m_provider;
+    const Ref<JSC::SourceProvider> m_provider;
     JSC::SourceCode m_code;
     CachedResourceHandle<CachedScript> m_cachedScript;
 };

--- a/Source/WebCore/bindings/js/WebAssemblyScriptSourceCode.h
+++ b/Source/WebCore/bindings/js/WebAssemblyScriptSourceCode.h
@@ -58,7 +58,7 @@ public:
     const JSC::SourceCode& jsSourceCode() const { return m_code; }
 
 private:
-    Ref<JSC::SourceProvider> m_provider;
+    const Ref<JSC::SourceProvider> m_provider;
     JSC::SourceCode m_code;
     CachedResourceHandle<CachedScript> m_cachedScript;
 };

--- a/Source/WebCore/inspector/agents/page/PageRuntimeAgent.cpp
+++ b/Source/WebCore/inspector/agents/page/PageRuntimeAgent.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2011 Google Inc. All rights reserved.
- * Copyright (C) 2015 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -157,7 +157,7 @@ void PageRuntimeAgent::reportExecutionContextCreation()
                 continue;
 
             Ref securityOrigin = downcast<LocalDOMWindow>(jsWindowProxy->wrapped()).document()->securityOrigin();
-            notifyContextCreated(frameId, globalObject, jsWindowProxy->protectedWorld(), securityOrigin.ptr());
+            notifyContextCreated(frameId, globalObject, jsWindowProxy->world(), securityOrigin.ptr());
         }
     });
 }


### PR DESCRIPTION
#### 3bd00083bede3394a9c212c25383ad196fe2fed9
<pre>
Reduce unsafeness by making more WebCore/bindings class member variables const
<a href="https://bugs.webkit.org/show_bug.cgi?id=294140">https://bugs.webkit.org/show_bug.cgi?id=294140</a>

Reviewed by Chris Dumez.

Apply <a href="https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines">https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines</a>

Canonical link: <a href="https://commits.webkit.org/295966@main">https://commits.webkit.org/295966@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7bc946b6955991f5241d76a506ac758d9d51330e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/106714 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/26465 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/16862 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/111925 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/57312 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/108753 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/27135 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34967 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/81023 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/109718 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/21528 "Found 1 new test failure: media/video-unmuted-after-play-holds-sleep-assertion.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/96292 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/61363 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/20966 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/14399 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/56766 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/90868 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/14428 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/114837 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33852 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24948 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/90088 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/34217 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/92523 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89798 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34731 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/12538 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/29479 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17289 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/33777 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/39190 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/33523 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/36876 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/35122 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->