### PR TITLE
REGRESSION (293308@main): TikTok app crashes under various use cases

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -556,14 +556,15 @@ static id browsingContextControllerMethodStub(id, SEL)
     return nil;
 }
 
-static void addBrowsingContextControllerMethodStubIfNeeded()
+static void addBrowsingContextControllerMethodStubsIfNeeded()
 {
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
         if (linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::BrowsingContextControllerMethodStubRemoved))
             return;
 
-        class_addMethod(WKWebView.class, NSSelectorFromString(@"browsingContextController"), reinterpret_cast<IMP>(browsingContextControllerMethodStub), "@@:");
+        for (auto wkClass : std::array { WKWebView.class, WKContentView.class })
+            class_addMethod(wkClass, NSSelectorFromString(@"browsingContextController"), reinterpret_cast<IMP>(browsingContextControllerMethodStub), "@@:");
     });
 }
 
@@ -577,7 +578,7 @@ static void addBrowsingContextControllerMethodStubIfNeeded()
     _configuration = adoptNS([configuration copy]);
 
 #if PLATFORM(IOS_FAMILY)
-    addBrowsingContextControllerMethodStubIfNeeded();
+    addBrowsingContextControllerMethodStubsIfNeeded();
 #endif
 
     ALLOW_DEPRECATED_DECLARATIONS_BEGIN


### PR DESCRIPTION
#### 9faf72782aa2bf2191dbba8223946fb41992fb12
<pre>
REGRESSION (293308@main): TikTok app crashes under various use cases
<a href="https://bugs.webkit.org/show_bug.cgi?id=294143">https://bugs.webkit.org/show_bug.cgi?id=294143</a>
<a href="https://rdar.apple.com/152206323">rdar://152206323</a>

Reviewed by Wenson Hsieh.

Reintroduce this SPI method implementation to work around the binary incompatibility, but guard it
behind a linked-on check to ensure that there are no new usages of it moving forward.

* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(browsingContextControllerMethodStub): Added.
(addBrowsingContextControllerMethodStubIfNeeded): Deleted.
(addBrowsingContextControllerMethodStubsIfNeeded): Added.
(-[WKWebView _initializeWithConfiguration:]): Call renamed method.

Canonical link: <a href="https://commits.webkit.org/295957@main">https://commits.webkit.org/295957@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b19505c63478c942c440fa03634eb038439027d8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/106663 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/26414 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/16811 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/111873 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/57261 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/27084 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34916 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80999 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/109667 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/21483 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/96247 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/61336 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/20935 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/56715 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/90823 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/14383 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/114751 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33801 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24923 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/90061 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/34165 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/92478 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89769 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22918 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34688 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/12504 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/29428 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/33726 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/39139 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/33472 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/36825 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/35071 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->