### PR TITLE
[HDR] The gain-map image should be decoded as HDR only if it is displayed on HDR display

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -814,7 +814,7 @@ platform/graphics/GraphicsLayer.h
 platform/graphics/ImageAdapter.cpp
 platform/graphics/ImageBackingStore.h
 platform/graphics/ImageBufferContextSwitcher.cpp
-platform/graphics/ImageFrame.cpp
+platform/graphics/ImageFrame.h
 platform/graphics/ImageFrameWorkQueue.cpp
 platform/graphics/MediaPlayer.cpp
 platform/graphics/Path.cpp

--- a/Source/WebCore/loader/cache/CachedImage.cpp
+++ b/Source/WebCore/loader/cache/CachedImage.cpp
@@ -369,13 +369,6 @@ bool CachedImage::hasHDRContent() const
     return m_image && m_image->hasHDRContent();
 }
 
-Headroom CachedImage::currentFrameHeadroom() const
-{
-    if (!m_image)
-        return Headroom::None;
-    return m_image->currentFrameHeadroom();
-}
-
 void CachedImage::notifyObservers(const IntRect* changeRect)
 {
     CachedResourceClientWalker<CachedImageClient> walker(*this);

--- a/Source/WebCore/loader/cache/CachedImage.h
+++ b/Source/WebCore/loader/cache/CachedImage.h
@@ -97,7 +97,6 @@ public:
     void computeIntrinsicDimensions(Length& intrinsicWidth, Length& intrinsicHeight, FloatSize& intrinsicRatio);
 
     bool hasHDRContent() const;
-    Headroom currentFrameHeadroom() const;
 
     bool isManuallyCached() const { return m_isManuallyCached; }
     RevalidationDecision makeRevalidationDecision(CachePolicy) const override;

--- a/Source/WebCore/platform/graphics/BitmapImage.cpp
+++ b/Source/WebCore/platform/graphics/BitmapImage.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2006 Samuel Weinig (sam.weinig@gmail.com)
- * Copyright (C) 2004-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2004-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -96,8 +96,9 @@ ImageDrawResult BitmapImage::draw(GraphicsContext& context, const FloatRect& des
     auto scaleFactorForDrawing = context.scaleFactorForDrawing(destinationRect, adjustedSourceRect);
     auto sizeForDrawing = expandedIntSize(sourceSize * scaleFactorForDrawing);
     auto subsamplingLevel =  m_source->subsamplingLevelForScaleFactor(context, scaleFactorForDrawing, options.allowImageSubsampling());
+    auto shouldDecodeToHDR = m_source->hasHDRGainMap() && options.drawsHDRContent() == DrawsHDRContent::Yes && options.dynamicRangeLimit() != PlatformDynamicRangeLimit::standard() ? ShouldDecodeToHDR::Yes : ShouldDecodeToHDR::No;
 
-    auto nativeImage = m_source->currentNativeImageForDrawing(subsamplingLevel, { options.decodingMode(), m_source->shouldDecodeToHDR(), sizeForDrawing });
+    auto nativeImage = m_source->currentNativeImageForDrawing(subsamplingLevel, { options.decodingMode(), shouldDecodeToHDR, sizeForDrawing });
 
     if (!nativeImage) {
         if (nativeImage.error() != DecodingStatus::Decoding)
@@ -126,7 +127,7 @@ ImageDrawResult BitmapImage::draw(GraphicsContext& context, const FloatRect& des
             fillWithSolidColor(context, destinationRect, Color::gold, options.compositeOperator());
         else {
             if (headroom == Headroom::FromImage)
-                headroom = currentFrameHeadroom();
+                headroom = currentFrameHeadroom(shouldDecodeToHDR);
 
             context.drawNativeImage(*nativeImage, destinationRect, adjustedSourceRect, { options, orientation, headroom });
         }

--- a/Source/WebCore/platform/graphics/BitmapImage.h
+++ b/Source/WebCore/platform/graphics/BitmapImage.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2006 Samuel Weinig (sam.weinig@gmail.com)
- * Copyright (C) 2004-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2004-2025 Apple Inc. All rights reserved.
  * Copyright (C) 2008-2009 Torch Mobile, Inc.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -60,8 +60,8 @@ public:
     unsigned currentFrameIndex() const { return m_source->currentFrameIndex(); }
     bool currentFrameHasAlpha() const { return m_source->currentImageFrame().hasAlpha(); }
     ImageOrientation currentFrameOrientation() const { return m_source->currentImageFrame().orientation(); }
-    Headroom currentFrameHeadroom() const final { return m_source->currentImageFrame().headroom(); }
-    DecodingOptions currentFrameDecodingOptions() const { return m_source->currentImageFrame().decodingOptions(); }
+    Headroom currentFrameHeadroom(ShouldDecodeToHDR shouldDecodeToHDR) const { return m_source->currentImageFrame().headroom(shouldDecodeToHDR); }
+    DecodingOptions currentFrameDecodingOptions() const { return m_source->currentImageFrame().decodingOptions(std::nullopt); }
 
     // Primary & current NativeImage
     RefPtr<NativeImage> primaryNativeImage() { return m_source->primaryNativeImage(); }

--- a/Source/WebCore/platform/graphics/BitmapImageSource.cpp
+++ b/Source/WebCore/platform/graphics/BitmapImageSource.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2024-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -196,12 +196,12 @@ void BitmapImageSource::decodedSizeReset(unsigned decodedSize)
     decodedSizeChanged(-static_cast<long long>(decodedSize));
 }
 
-void BitmapImageSource::destroyNativeImageAtIndex(unsigned index)
+void BitmapImageSource::destroyNativeImageAtIndex(unsigned index, std::optional<ShouldDecodeToHDR> shouldDecodeToHDR)
 {
     if (index >= m_frames.size())
         return;
 
-    decodedSizeDecreased(m_frames[index].clearImage());
+    decodedSizeDecreased(m_frames[index].clearImage(shouldDecodeToHDR));
 }
 
 bool BitmapImageSource::canDestroyDecodedData() const
@@ -349,7 +349,7 @@ bool BitmapImageSource::isPendingDecodingAtIndex(unsigned index, SubsamplingLeve
 
 bool BitmapImageSource::isCompatibleWithOptionsAtIndex(unsigned index, SubsamplingLevel subsamplingLevel, const DecodingOptions& options) const
 {
-    return frameAtIndex(index).hasDecodedNativeImageCompatibleWithOptions(subsamplingLevel, options);
+    return frameAtIndex(index).hasDecodedNativeImageCompatibleWithOptions(options, subsamplingLevel);
 }
 
 void BitmapImageSource::decode(Function<void(DecodingStatus)>&& decodeCallback)
@@ -362,9 +362,11 @@ void BitmapImageSource::decode(Function<void(DecodingStatus)>&& decodeCallback)
         return;
     }
 
-    bool isCompatibleNativeImage = isCompatibleWithOptionsAtIndex(index, SubsamplingLevel::Default, { DecodingMode::Asynchronous, shouldDecodeToHDR() });
-    RefPtr frameAnimator = this->frameAnimator();
+    // FIXME: HTMLImageElement.decode() needs a parameter to control whether it should decode SDR or HDR image.
+    auto shouldDecodeToHDR = hasHDRGainMap() ? ShouldDecodeToHDR::Yes : ShouldDecodeToHDR::No;
+    bool isCompatibleNativeImage = isCompatibleWithOptionsAtIndex(index, SubsamplingLevel::Default, { DecodingMode::Asynchronous, shouldDecodeToHDR });
 
+    RefPtr frameAnimator = this->frameAnimator();
     if (frameAnimator && (frameAnimator->hasEverAnimated() || isCompatibleNativeImage)) {
         // startAnimation() always decodes the nextFrame which is currentFrameIndex + 1.
         // If primaryFrameIndex = 0, then the sequence of decoding is { 1, 2, .., n, 0, 1, ...}.
@@ -376,7 +378,7 @@ void BitmapImageSource::decode(Function<void(DecodingStatus)>&& decodeCallback)
 
     if (!isCompatibleNativeImage) {
         LOG(Images, "BitmapImageSource::%s - %p - url: %s. Decoding for frame at index = %d will be requested.", __FUNCTION__, this, sourceUTF8().data(), index);
-        requestNativeImageAtIndex(index, SubsamplingLevel::Default, ImageAnimatingState::No, { DecodingMode::Asynchronous, shouldDecodeToHDR() });
+        requestNativeImageAtIndex(index, SubsamplingLevel::Default, ImageAnimatingState::No, { DecodingMode::Asynchronous, shouldDecodeToHDR });
         return;
     }
 
@@ -424,7 +426,7 @@ void BitmapImageSource::imageFrameDecodeAtIndexHasFinished(unsigned index, Subsa
     if (!nativeImage || !m_decoder) {
         LOG(Images, "BitmapImageSource::%s - %p - url: %s. Frame at index = %d has failed.", __FUNCTION__, this, sourceUTF8().data(), index);
 
-        destroyNativeImageAtIndex(index);
+        destroyNativeImageAtIndex(index, options.shouldDecodeToHDR());
         imageFrameDecodeAtIndexHasFinished(index, animatingState, DecodingStatus::Invalid);
     } else {
         LOG(Images, "BitmapImageSource::%s - %p - url: %s. Frame at index = %d has been decoded.", __FUNCTION__, this, sourceUTF8().data(), index);
@@ -469,18 +471,21 @@ void BitmapImageSource::cacheNativeImageAtIndex(unsigned index, SubsamplingLevel
     if (index >= m_frames.size())
         return;
 
-    destroyNativeImageAtIndex(index);
+    destroyNativeImageAtIndex(index, options.shouldDecodeToHDR());
 
-    // Do not cache NativeImage if adding its frameByes to MemoryCache will cause numerical overflow.
-    auto frameBytes = nativeImage->size().unclampedArea() * sizeof(uint32_t);
-    if (!isInBounds<unsigned>(frameBytes + m_decodedSize))
+    // Do not cache NativeImage if adding its sizeInBytes to MemoryCache will cause numerical overflow.
+    auto sizeInBytes = nativeImage->size().unclampedArea() * sizeof(uint32_t);
+    if (!isInBounds<unsigned>(sizeInBytes + m_decodedSize))
         return;
 
     auto& frame = m_frames[index];
-    frame.m_nativeImage = WTFMove(nativeImage);
+    auto& source = frame.source(options.shouldDecodeToHDR());
+    source.nativeImage = WTFMove(nativeImage);
+    source.decodingOptions = options;
+    source.headroom = source.nativeImage->headroom();
 
     cacheMetadataAtIndex(index, subsamplingLevel, options);
-    decodedSizeIncreased(frame.frameBytes());
+    decodedSizeIncreased(frame.sizeInBytes());
 }
 
 const ImageFrame& BitmapImageSource::frameAtIndex(unsigned index) const
@@ -563,16 +568,17 @@ Expected<Ref<NativeImage>, DecodingStatus> BitmapImageSource::nativeImageAtIndex
     }
 
     if (!isCompatibleWithOptionsAtIndex(index, subsamplingLevel, options)) {
-        PlatformImagePtr platformImage = m_decoder->createFrameImageAtIndex(index, subsamplingLevel, { DecodingMode::Synchronous, shouldDecodeToHDR() });
+        DecodingOptions decodingOptions = { DecodingMode::Synchronous, options.shouldDecodeToHDR() };
+        PlatformImagePtr platformImage = m_decoder->createFrameImageAtIndex(index, subsamplingLevel, decodingOptions);
 
         RefPtr nativeImage = NativeImage::create(WTFMove(platformImage));
         if (!nativeImage)
             return makeUnexpected(DecodingStatus::Invalid);
 
-        cacheNativeImageAtIndex(index, subsamplingLevel, DecodingMode::Synchronous, nativeImage.releaseNonNull());
+        cacheNativeImageAtIndex(index, subsamplingLevel, decodingOptions, nativeImage.releaseNonNull());
     }
 
-    if (RefPtr nativeImage = frameAtIndex(index).nativeImage())
+    if (RefPtr nativeImage = frameAtIndex(index).nativeImage(options.shouldDecodeToHDR()))
         return nativeImage.releaseNonNull();
 
     return makeUnexpected(DecodingStatus::Invalid);
@@ -589,7 +595,7 @@ Expected<Ref<NativeImage>, DecodingStatus> BitmapImageSource::nativeImageAtIndex
     if (status == DecodingStatus::Invalid || status == DecodingStatus::Decoding)
         return makeUnexpected(status);
 
-    if (RefPtr nativeImage = frameAtIndex(index).nativeImage())
+    if (RefPtr nativeImage = frameAtIndex(index).nativeImage(options.shouldDecodeToHDR()))
         return nativeImage.releaseNonNull();
 
     return makeUnexpected(DecodingStatus::Invalid);
@@ -613,7 +619,7 @@ Expected<Ref<NativeImage>, DecodingStatus> BitmapImageSource::currentNativeImage
     // If frame0 is displayed for the first time, startAnimation() has to request decoding frame1
     // asynchronously. A flicker will occur if we request decoding frame0 also asynchronously.
     if (options.decodingMode() == DecodingMode::Asynchronous && isAnimated() && !hasEverAnimated())
-        effectiveOptions = { DecodingMode::Synchronous, shouldDecodeToHDR(), options.sizeForDrawing() };
+        effectiveOptions = { DecodingMode::Synchronous, options.shouldDecodeToHDR(), options.sizeForDrawing() };
 
     return nativeImageAtIndexForDrawing(currentFrameIndex(), subsamplingLevel, effectiveOptions);
 }

--- a/Source/WebCore/platform/graphics/BitmapImageSource.h
+++ b/Source/WebCore/platform/graphics/BitmapImageSource.h
@@ -62,7 +62,7 @@ public:
 
     // Decoding & animation
     bool isPendingDecodingAtIndex(unsigned index, SubsamplingLevel, const DecodingOptions&) const;
-    void destroyNativeImageAtIndex(unsigned index);
+    void destroyNativeImageAtIndex(unsigned index, std::optional<ShouldDecodeToHDR> = std::nullopt);
     void imageFrameAtIndexAvailable(unsigned index, ImageAnimatingState, DecodingStatus);
     void imageFrameDecodeAtIndexHasFinished(unsigned index, SubsamplingLevel, ImageAnimatingState, const DecodingOptions&, RefPtr<NativeImage>&&);
 
@@ -75,7 +75,7 @@ public:
     // NativeImage
     DecodingStatus requestNativeImageAtIndexIfNeeded(unsigned index, SubsamplingLevel, ImageAnimatingState, const DecodingOptions&);
 
-    RefPtr<NativeImage> primaryNativeImageIfExists() { return frameAtIndex(primaryFrameIndex()).nativeImage(); }
+    RefPtr<NativeImage> primaryNativeImageIfExists() { return frameAtIndex(primaryFrameIndex()).nativeImage(std::nullopt); }
     RefPtr<NativeImage> primaryNativeImage() final { return nativeImageAtIndex(primaryFrameIndex()); }
 
     // Image Metadata

--- a/Source/WebCore/platform/graphics/Image.h
+++ b/Source/WebCore/platform/graphics/Image.h
@@ -125,7 +125,6 @@ public:
 
     virtual DestinationColorSpace colorSpace();
     virtual bool hasHDRContent() const { return false; }
-    virtual Headroom currentFrameHeadroom() const { return Headroom::None; }
 
     // Animation begins whenever someone draws the image, so startAnimation() is not normally called.
     // It will automatically pause once all observers no longer want to render the image anywhere.

--- a/Source/WebCore/platform/graphics/ImageDecoder.cpp
+++ b/Source/WebCore/platform/graphics/ImageDecoder.cpp
@@ -158,17 +158,15 @@ bool ImageDecoder::supportsMediaType(MediaType type)
 bool ImageDecoder::fetchFrameMetaDataAtIndex(size_t index, SubsamplingLevel subsamplingLevel, const DecodingOptions& options, ImageFrame& frame) const
 {
     if (options.hasSizeForDrawing()) {
-        ASSERT(frame.hasNativeImage());
-        frame.m_size = frame.nativeImage()->size();
+        ASSERT(frame.hasNativeImage(options.shouldDecodeToHDR()));
+        frame.m_size = frame.nativeImage(options.shouldDecodeToHDR())->size();
     } else
         frame.m_size = frameSizeAtIndex(index, subsamplingLevel);
 
     frame.m_densityCorrectedSize = frameDensityCorrectedSizeAtIndex(index);
     frame.m_subsamplingLevel = subsamplingLevel;
-    frame.m_decodingOptions = options;
     frame.m_hasAlpha = frameHasAlphaAtIndex(index);
     frame.m_orientation = frameOrientationAtIndex(index);
-    frame.m_headroom = frameHeadroomAtIndex(index);
     frame.m_decodingStatus = frameIsCompleteAtIndex(index) ? DecodingStatus::Complete : DecodingStatus::Partial;
     return true;
 }

--- a/Source/WebCore/platform/graphics/ImageDecoder.h
+++ b/Source/WebCore/platform/graphics/ImageDecoder.h
@@ -103,7 +103,6 @@ public:
     virtual IntSize frameSizeAtIndex(size_t, SubsamplingLevel = SubsamplingLevel::Default) const = 0;
     virtual bool frameIsCompleteAtIndex(size_t) const = 0;
     virtual ImageOrientation frameOrientationAtIndex(size_t) const { return ImageOrientation::Orientation::None; }
-    virtual Headroom frameHeadroomAtIndex(size_t) const { return Headroom::None; }
     virtual std::optional<IntSize> frameDensityCorrectedSizeAtIndex(size_t) const { return std::nullopt; }
 
     virtual Seconds frameDurationAtIndex(size_t) const = 0;

--- a/Source/WebCore/platform/graphics/ImageFrame.cpp
+++ b/Source/WebCore/platform/graphics/ImageFrame.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -35,10 +35,12 @@ ImageFrame::ImageFrame()
 }
 
 ImageFrame::ImageFrame(Ref<NativeImage>&& nativeImage)
-    : m_nativeImage(WTFMove(nativeImage))
 {
-    m_size = m_nativeImage->size();
-    m_hasAlpha = m_nativeImage->hasAlpha();
+    m_size = nativeImage->size();
+    m_hasAlpha = nativeImage->hasAlpha();
+
+    m_source.headroom = nativeImage->headroom();
+    m_source.nativeImage = WTFMove(nativeImage);
 }
 
 ImageFrame::~ImageFrame()
@@ -58,15 +60,17 @@ ImageFrame& ImageFrame::operator=(const ImageFrame& other)
         return *this;
 
     m_decodingStatus = other.m_decodingStatus;
-    m_size = other.m_size;
 
-    m_nativeImage = other.m_nativeImage;
+    m_size = other.m_size;
+    m_densityCorrectedSize = other.m_densityCorrectedSize;
     m_subsamplingLevel = other.m_subsamplingLevel;
-    m_decodingOptions = other.m_decodingOptions;
 
     m_orientation = other.m_orientation;
     m_duration = other.m_duration;
     m_hasAlpha = other.m_hasAlpha;
+
+    m_source = other.m_source;
+    m_hdrSource = other.m_hdrSource;
     return *this;
 }
 
@@ -82,16 +86,25 @@ DecodingStatus ImageFrame::decodingStatus() const
     return m_decodingStatus;
 }
 
-unsigned ImageFrame::clearImage()
+unsigned ImageFrame::clearSourceImage(ShouldDecodeToHDR shouldDecodeToHDR)
 {
-    if (!hasNativeImage())
+    auto& source = this->source(shouldDecodeToHDR);
+    if (!source.hasNativeImage())
         return 0;
 
-    unsigned frameBytes = this->frameBytes();
+    source.clear();
+    return sizeInBytes();
+}
 
-    m_nativeImage->clearSubimages();
-    m_nativeImage = nullptr;
-    m_decodingOptions = DecodingOptions();
+unsigned ImageFrame::clearImage(std::optional<ShouldDecodeToHDR> shouldDecodeToHDR)
+{
+
+    unsigned frameBytes = 0;
+    if (!shouldDecodeToHDR || *shouldDecodeToHDR == ShouldDecodeToHDR::No)
+        frameBytes += clearSourceImage(ShouldDecodeToHDR::No);
+
+    if (!shouldDecodeToHDR || *shouldDecodeToHDR == ShouldDecodeToHDR::Yes)
+        frameBytes += clearSourceImage(ShouldDecodeToHDR::Yes);
 
     return frameBytes;
 }
@@ -103,19 +116,19 @@ unsigned ImageFrame::clear()
     return frameBytes;
 }
 
-bool ImageFrame::hasNativeImage(const std::optional<SubsamplingLevel>& subsamplingLevel) const
+bool ImageFrame::hasNativeImage(ShouldDecodeToHDR shouldDecodeToHDR, SubsamplingLevel subsamplingLevel) const
 {
-    return m_nativeImage && (!subsamplingLevel || *subsamplingLevel >= m_subsamplingLevel);
+    return source(shouldDecodeToHDR).hasNativeImage() && subsamplingLevel >= m_subsamplingLevel;
 }
 
-bool ImageFrame::hasFullSizeNativeImage(const std::optional<SubsamplingLevel>& subsamplingLevel) const
+bool ImageFrame::hasFullSizeNativeImage(ShouldDecodeToHDR shouldDecodeToHDR, SubsamplingLevel subsamplingLevel) const
 {
-    return hasNativeImage(subsamplingLevel) && m_decodingOptions.hasFullSize();
+    return source(shouldDecodeToHDR).hasFullSizeNativeImage() && subsamplingLevel >= m_subsamplingLevel;
 }
 
-bool ImageFrame::hasDecodedNativeImageCompatibleWithOptions(const std::optional<SubsamplingLevel>& subsamplingLevel, const DecodingOptions& decodingOptions) const
+bool ImageFrame::hasDecodedNativeImageCompatibleWithOptions(const DecodingOptions& decodingOptions, SubsamplingLevel subsamplingLevel) const
 {
-    return isComplete() && hasNativeImage(subsamplingLevel) && m_decodingOptions.isCompatibleWith(decodingOptions);
+    return isComplete() && source(decodingOptions.shouldDecodeToHDR()).hasDecodedNativeImageCompatibleWithOptions(decodingOptions) && subsamplingLevel >= m_subsamplingLevel;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/ImageFrame.h
+++ b/Source/WebCore/platform/graphics/ImageFrame.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -33,12 +33,6 @@
 #include "NativeImage.h"
 #include <wtf/Seconds.h>
 
-// X11 headers define a bunch of macros with common terms, interfering with WebCore and WTF enum values.
-// As a workaround, we explicitly undef them here.
-#if defined(None)
-#undef None
-#endif
-
 namespace WebCore {
 
 class ImageFrame {
@@ -58,7 +52,8 @@ public:
 
     ImageFrame& operator=(const ImageFrame& other);
 
-    unsigned clearImage();
+    unsigned clearSourceImage(ShouldDecodeToHDR);
+    unsigned clearImage(std::optional<ShouldDecodeToHDR> = std::nullopt);
     unsigned clear();
 
     void setDecodingStatus(DecodingStatus);
@@ -71,20 +66,19 @@ public:
     void setSize(const IntSize& size) { m_size = size; }
     IntSize size() const { return m_size; }
 
-    unsigned frameBytes() const { return hasNativeImage() ? (size().area() * sizeof(uint32_t)).value() : 0; }
-    SubsamplingLevel subsamplingLevel() const { return m_subsamplingLevel; }
-    DecodingOptions decodingOptions() const { return m_decodingOptions; }
-
-    RefPtr<NativeImage> nativeImage() const { return m_nativeImage; }
-
-    void setOrientation(ImageOrientation orientation) { m_orientation = orientation; };
-    ImageOrientation orientation() const { return m_orientation; }
-
-    void setHeadroom(Headroom headroom) { m_headroom = headroom; };
-    Headroom headroom() const { return m_headroom; }
+    unsigned sizeInBytes() const { return (size().area() * sizeof(uint32_t)).value(); }
 
     void setDensityCorrectedSize(const IntSize& size) { m_densityCorrectedSize = size; }
     std::optional<IntSize> densityCorrectedSize() const { return m_densityCorrectedSize; }
+
+    SubsamplingLevel subsamplingLevel() const { return m_subsamplingLevel; }
+
+    RefPtr<NativeImage> nativeImage(std::optional<ShouldDecodeToHDR> shouldDecodeToHDR) const { return source(shouldDecodeToHDR).nativeImage; }
+    DecodingOptions decodingOptions(std::optional<ShouldDecodeToHDR> shouldDecodeToHDR) const { return source(shouldDecodeToHDR).decodingOptions; }
+    Headroom headroom(std::optional<ShouldDecodeToHDR> shouldDecodeToHDR) const { return source(shouldDecodeToHDR).headroom; }
+
+    void setOrientation(ImageOrientation orientation) { m_orientation = orientation; };
+    ImageOrientation orientation() const { return m_orientation; }
 
     void setDuration(const Seconds& duration) { m_duration = duration; }
     Seconds duration() const { return m_duration; }
@@ -92,24 +86,76 @@ public:
     void setHasAlpha(bool hasAlpha) { m_hasAlpha = hasAlpha; }
     bool hasAlpha() const { return !hasMetadata() || m_hasAlpha; }
 
-    bool hasNativeImage(const std::optional<SubsamplingLevel>& = { }) const;
-    bool hasFullSizeNativeImage(const std::optional<SubsamplingLevel>& = { }) const;
-    bool hasDecodedNativeImageCompatibleWithOptions(const std::optional<SubsamplingLevel>&, const DecodingOptions&) const;
+    bool hasNativeImage(ShouldDecodeToHDR shouldDecodeToHDR) const { return source(shouldDecodeToHDR).hasNativeImage(); }
+    bool hasNativeImage(ShouldDecodeToHDR, SubsamplingLevel) const;
+    bool hasFullSizeNativeImage(ShouldDecodeToHDR, SubsamplingLevel) const;
+    bool hasDecodedNativeImageCompatibleWithOptions(const DecodingOptions&, SubsamplingLevel) const;
     bool hasMetadata() const { return !size().isEmpty(); }
 
 private:
-    DecodingStatus m_decodingStatus { DecodingStatus::Invalid };
-    IntSize m_size;
+    struct Source {
+        RefPtr<NativeImage> nativeImage;
+        DecodingOptions decodingOptions { DecodingMode::Auto };
+        Headroom headroom { Headroom::None };
 
-    RefPtr<NativeImage> m_nativeImage;
+        bool hasNativeImage() const { return nativeImage; }
+
+        bool hasFullSizeNativeImage() const
+        {
+            return hasNativeImage() && decodingOptions.hasFullSize();
+        }
+
+        bool hasDecodedNativeImageCompatibleWithOptions(const DecodingOptions& decodingOptions) const
+        {
+            return hasNativeImage() && this->decodingOptions.isCompatibleWith(decodingOptions);
+        }
+
+        void clear()
+        {
+            if (!nativeImage)
+                return;
+
+            nativeImage->clearSubimages();
+            nativeImage = nullptr;
+            decodingOptions = DecodingOptions();
+            headroom = Headroom::None;
+        }
+    };
+
+    ShouldDecodeToHDR shouldDecodeToHDRIfExists() const
+    {
+        return hasNativeImage(ShouldDecodeToHDR::Yes) ? ShouldDecodeToHDR::Yes : ShouldDecodeToHDR::No;
+    }
+
+    Source& source(std::optional<ShouldDecodeToHDR> shouldDecodeToHDR)
+    {
+        if (shouldDecodeToHDR)
+            return *shouldDecodeToHDR == ShouldDecodeToHDR::No ? m_source : m_hdrSource;
+
+        return shouldDecodeToHDRIfExists() == ShouldDecodeToHDR::No ? m_source : m_hdrSource;
+    }
+
+    const Source& source(std::optional<ShouldDecodeToHDR> shouldDecodeToHDR) const
+    {
+        if (shouldDecodeToHDR)
+            return *shouldDecodeToHDR == ShouldDecodeToHDR::No ? m_source : m_hdrSource;
+
+        return shouldDecodeToHDRIfExists() == ShouldDecodeToHDR::No ? m_source : m_hdrSource;
+    }
+
+    DecodingStatus m_decodingStatus { DecodingStatus::Invalid };
+
+    IntSize m_size;
+    std::optional<IntSize> m_densityCorrectedSize;
+
     SubsamplingLevel m_subsamplingLevel { SubsamplingLevel::Default };
-    DecodingOptions m_decodingOptions { DecodingMode::Auto };
 
     ImageOrientation m_orientation { ImageOrientation::Orientation::None };
-    Headroom m_headroom { Headroom::None };
-    std::optional<IntSize> m_densityCorrectedSize;
     Seconds m_duration;
     bool m_hasAlpha { true };
+
+    Source m_source;
+    Source m_hdrSource;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/ImagePaintingOptions.h
+++ b/Source/WebCore/platform/graphics/ImagePaintingOptions.h
@@ -48,6 +48,7 @@ struct ImagePaintingOptions {
         || std::is_same_v<Type, StrictImageClamping>
 #endif
         || std::is_same_v<Type, ShowDebugBackground>
+        || std::is_same_v<Type, DrawsHDRContent>
         || std::is_same_v<Type, Headroom>
         || std::is_same_v<Type, PlatformDynamicRangeLimit>;
 
@@ -101,6 +102,7 @@ struct ImagePaintingOptions {
     StrictImageClamping strictImageClamping() const { return m_strictImageClamping; }
 #endif
     ShowDebugBackground showDebugBackground() const { return m_showDebugBackground; }
+    DrawsHDRContent drawsHDRContent() const { return m_drawsHDRContent; }
     Headroom headroom() const { return m_headroom; }
     PlatformDynamicRangeLimit dynamicRangeLimit() const { return m_dynamicRangeLimit; }
 
@@ -116,6 +118,7 @@ private:
     void setOption(StrictImageClamping strictImageClamping) { m_strictImageClamping = strictImageClamping; }
 #endif
     void setOption(ShowDebugBackground showDebugBackground) { m_showDebugBackground = showDebugBackground; }
+    void setOption(DrawsHDRContent drawsHDRContent) { m_drawsHDRContent = drawsHDRContent; }
     void setOption(Headroom headroom) { m_headroom = headroom; }
     void setOption(PlatformDynamicRangeLimit dynamicRangeLimit) { m_dynamicRangeLimit = dynamicRangeLimit; }
 
@@ -129,6 +132,7 @@ private:
     StrictImageClamping m_strictImageClamping: 1 { StrictImageClamping::Yes };
 #endif
     ShowDebugBackground m_showDebugBackground : 1 { ShowDebugBackground::No };
+    DrawsHDRContent m_drawsHDRContent : 1 { DrawsHDRContent::No };
     Headroom m_headroom { Headroom::FromImage };
     PlatformDynamicRangeLimit m_dynamicRangeLimit { PlatformDynamicRangeLimit::initialValue() };
 };

--- a/Source/WebCore/platform/graphics/ImageSource.h
+++ b/Source/WebCore/platform/graphics/ImageSource.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -83,7 +83,6 @@ public:
     virtual bool hasHDRGainMap() const { return false; }
     virtual bool hasHDRContent() const = 0;
 
-    ShouldDecodeToHDR shouldDecodeToHDR() const { return hasHDRGainMap() ? ShouldDecodeToHDR::Yes : ShouldDecodeToHDR::No; }
     bool hasSolidColor() const;
 
     virtual String uti() const { return String(); }

--- a/Source/WebCore/platform/graphics/ImageTypes.h
+++ b/Source/WebCore/platform/graphics/ImageTypes.h
@@ -102,6 +102,11 @@ enum class AllowImageSubsampling : bool {
     Yes
 };
 
+enum class DrawsHDRContent : uint8_t {
+    No,
+    Yes
+};
+
 struct Headroom {
     constexpr Headroom(float headroom)
     {

--- a/Source/WebCore/platform/graphics/NativeImage.cpp
+++ b/Source/WebCore/platform/graphics/NativeImage.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2020-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/Source/WebCore/platform/graphics/NativeImage.h
+++ b/Source/WebCore/platform/graphics/NativeImage.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2004-2025 Apple Inc. All rights reserved.
  * Copyright (C) 2007-2008 Torch Mobile, Inc.
  * Copyright (C) 2012 Company 100 Inc.
  *

--- a/Source/WebCore/platform/graphics/NativeImageSource.h
+++ b/Source/WebCore/platform/graphics/NativeImageSource.h
@@ -37,13 +37,13 @@ private:
     NativeImageSource(Ref<NativeImage>&&);
 
     IntSize size(ImageOrientation = ImageOrientation::Orientation::FromImage) const final { return m_frame.size(); }
-    DestinationColorSpace colorSpace() const final { return m_frame.nativeImage()->colorSpace(); }
-    std::optional<Color> singlePixelSolidColor() const final { return m_frame.nativeImage()->singlePixelSolidColor(); }
-    bool hasHDRContent() const final { return m_frame.nativeImage()->hasHDRContent(); }
+    DestinationColorSpace colorSpace() const final { return m_frame.nativeImage(ShouldDecodeToHDR::No)->colorSpace(); }
+    std::optional<Color> singlePixelSolidColor() const final { return m_frame.nativeImage(ShouldDecodeToHDR::No)->singlePixelSolidColor(); }
+    bool hasHDRContent() const final { return m_frame.nativeImage(ShouldDecodeToHDR::No)->hasHDRContent(); }
 
     const ImageFrame& primaryImageFrame(const std::optional<SubsamplingLevel>& = std::nullopt) final { return m_frame; }
 
-    RefPtr<NativeImage> primaryNativeImage() final { return m_frame.nativeImage(); }
+    RefPtr<NativeImage> primaryNativeImage() final { return m_frame.nativeImage(ShouldDecodeToHDR::No); }
 
     void dump(TextStream&) const final;
 

--- a/Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp
@@ -404,7 +404,7 @@ void GraphicsContextCG::drawNativeImageInternal(NativeImage& nativeImage, const 
         CGContextSetEDRTargetHeadroom(context, headroom);
     }
 
-    if (options.dynamicRangeLimit() == PlatformDynamicRangeLimit::standard())
+    if (options.dynamicRangeLimit() == PlatformDynamicRangeLimit::standard() && options.drawsHDRContent() == DrawsHDRContent::Yes)
         setCGDynamicRangeLimitForImage(context, subImage.get(), options.dynamicRangeLimit().value());
 #endif
 

--- a/Source/WebCore/platform/graphics/cg/NativeImageCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/NativeImageCG.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/Source/WebCore/rendering/PaintPhase.h
+++ b/Source/WebCore/rendering/PaintPhase.h
@@ -78,6 +78,7 @@ enum class PaintBehavior : uint32_t {
     ExcludeReplacedContentExceptForIFrames      = 1 << 19,
     ExcludeText                                 = 1 << 20,
     FixedAndStickyLayersOnly                    = 1 << 21,
+    DrawsHDRContent                             = 1 << 22,
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderImage.cpp
+++ b/Source/WebCore/rendering/RenderImage.cpp
@@ -743,6 +743,7 @@ ImageDrawResult RenderImage::paintIntoRect(PaintInfo& paintInfo, const FloatRect
 #if USE(SKIA)
         StrictImageClamping::No,
 #endif
+        paintInfo.paintBehavior.contains(PaintBehavior::DrawsHDRContent) ? DrawsHDRContent::Yes : DrawsHDRContent::No,
         style().dynamicRangeLimit().toPlatformDynamicRangeLimit()
     };
 

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -417,6 +417,8 @@ RenderLayer::PaintedContentRequest::PaintedContentRequest(const RenderLayer& own
 #if HAVE(SUPPORT_HDR_DISPLAY)
     if (owningLayer.renderer().document().drawsHDRContent())
         makeHDRContentUnknown();
+    else
+        makeHDRContentFalse();
 #else
     UNUSED_PARAM(owningLayer);
 #endif
@@ -3817,6 +3819,7 @@ void RenderLayer::paintLayerContents(GraphicsContext& context, const LayerPainti
             PaintBehavior::ExcludeReplacedContentExceptForIFrames,
             PaintBehavior::ExcludeText,
             PaintBehavior::FixedAndStickyLayersOnly,
+            PaintBehavior::DrawsHDRContent,
         };
         OptionSet<PaintBehavior> paintBehavior = paintingInfo.paintBehavior & flagsToCopy;
 
@@ -4311,11 +4314,10 @@ void RenderLayer::paintForegroundForFragments(const LayerFragments& layerFragmen
         PaintBehavior::ExcludeReplacedContentExceptForIFrames,
         PaintBehavior::ExcludeText,
         PaintBehavior::FixedAndStickyLayersOnly,
+        PaintBehavior::DontShowVisitedLinks,
+        PaintBehavior::DrawsHDRContent,
     };
     localPaintBehavior.add(localPaintingInfo.paintBehavior & flagsToCopy);
-
-    if (localPaintingInfo.paintBehavior & PaintBehavior::DontShowVisitedLinks)
-        localPaintBehavior.add(PaintBehavior::DontShowVisitedLinks);
 
     GraphicsContextStateSaver stateSaver(context, false);
     RegionContextStateSaver regionContextStateSaver(localPaintingInfo.regionContext);
@@ -6091,7 +6093,7 @@ void RenderLayer::determineNonLayerDescendantsPaintedContent(PaintedContentReque
 bool RenderLayer::rendererHasHDRContent() const
 {
     if (auto* imageDocument = dynamicDowncast<ImageDocument>(renderer().document()))
-        return imageDocument->hasHDRContent();
+        return imageDocument->drawsHDRContent();
     return WebCore::rendererHasHDRContent(renderer());
 }
 #endif
@@ -6663,6 +6665,7 @@ TextStream& operator<<(TextStream& ts, PaintBehavior behavior)
     case PaintBehavior::ExcludeReplacedContentExceptForIFrames: ts << "ExcludeReplacedContentExceptForIFrames"_s; break;
     case PaintBehavior::ExcludeText: ts << "ExcludeText"_s; break;
     case PaintBehavior::FixedAndStickyLayersOnly: ts << "FixedAndStickyLayersOnly"_s; break;
+    case PaintBehavior::DrawsHDRContent: ts << "DrawsHDRContent"_s; break;
     }
 
     return ts;

--- a/Source/WebCore/rendering/RenderLayer.h
+++ b/Source/WebCore/rendering/RenderLayer.h
@@ -577,6 +577,7 @@ public:
 
 #if HAVE(SUPPORT_HDR_DISPLAY)
         void setHasHDRContent() { hasHDRContent = RequestState::True; }
+        void makeHDRContentFalse() { hasHDRContent = RequestState::False; }
         void makeHDRContentUnknown() { hasHDRContent = RequestState::Unknown; }
         bool isHDRContentSatisfied() const { return hasHDRContent != RequestState::Unknown; }
 #endif

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -2055,8 +2055,8 @@ void RenderLayerBacking::updateDrawsContent(PaintedContentsInfo& contentsInfo)
         m_backgroundLayer->setDrawsContent(m_backgroundLayerPaintsFixedRootBackground ? hasPaintedContent : contentsInfo.paintsBoxDecorations());
 
 #if HAVE(SUPPORT_HDR_DISPLAY)
+    m_graphicsLayer->setDrawsHDRContent(contentsInfo.paintsHDRContent() || contentsInfo.rendererHasHDRContent());
     if (contentsInfo.paintsHDRContent() || contentsInfo.rendererHasHDRContent()) {
-        m_graphicsLayer->setDrawsHDRContent(true);
         LOG_WITH_STREAM(HDR, stream << "RenderLayerBacking " << *this << " updateDrawContent headroom " << m_owningLayer.page().displayEDRHeadroom());
         m_graphicsLayer->setNeedsDisplayIfEDRHeadroomExceeds(m_owningLayer.page().displayEDRHeadroom());
     }
@@ -4133,6 +4133,11 @@ void RenderLayerBacking::paintContents(const GraphicsLayer* graphicsLayer, Graph
             behavior.add(PaintBehavior::ForceSynchronousImageDecode);
         else if (layerPaintBehavior.contains(GraphicsLayerPaintBehavior::DefaultAsynchronousImageDecode))
             behavior.add(PaintBehavior::DefaultAsynchronousImageDecode);
+
+#if HAVE(SUPPORT_HDR_DISPLAY)
+        if (graphicsLayer->drawsHDRContent())
+            behavior.add(PaintBehavior::DrawsHDRContent);
+#endif
 
         paintIntoLayer(graphicsLayer, context, dirtyRect, behavior);
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -5331,6 +5331,11 @@ header: <WebCore/DisplayListItems.h>
     WebCore::ImageOrientation::Orientation orientation()
 };
 
+[AdditionalEncoder=StreamConnectionEncoder] enum class WebCore::DrawsHDRContent : uint8_t {
+    No,
+    Yes
+};
+
 header: <WebCore/ImageTypes.h>
 [CustomHeader, AdditionalEncoder=StreamConnectionEncoder] struct WebCore::Headroom {
     float headroom;
@@ -5342,6 +5347,7 @@ header: <WebCore/ImageTypes.h>
     WebCore::DecodingMode decodingMode();
     WebCore::ImageOrientation::Orientation orientation().orientation();
     WebCore::InterpolationQuality interpolationQuality();
+    WebCore::DrawsHDRContent drawsHDRContent();
     WebCore::Headroom headroom();
     WebCore::PlatformDynamicRangeLimit dynamicRangeLimit();
 };


### PR DESCRIPTION
#### 3343818fbd1f972e0adeebdd92da2328f0469e38
<pre>
[HDR] The gain-map image should be decoded as HDR only if it is displayed on HDR display
<a href="https://bugs.webkit.org/show_bug.cgi?id=294150">https://bugs.webkit.org/show_bug.cgi?id=294150</a>
<a href="https://rdar.apple.com/152744271">rdar://152744271</a>

Reviewed by Simon Fraser.

The gain map image decodes an SDR image and gain-map. The gain-map can only be
used on HDR display. Decoding the SDR image should be requested for SDR display
and for the CSS style &quot;dynamic-range-limit: standard;&quot; case.

RenderLayerBacking has to propagate its GraphicsLayer::drawsHDRContent() to the
painting code through the PaintBehavior. RenderImage will pass it to
BitmapImage::draw() through ImagePaintingOptions. It will be eventually passed
to ImageDecoder as ShouldDecodeToHDR though the DecodingOptions.

RenderLayerBacking should consider turning off the GraphicsLayer::drawsHDRContent()
which may happen when moving the WebView from an HDR display to an SDR display.

ImageFrame should hold two sources of images: one for SDR and the second for HDR.
ImageFrame::Source should hold: NativeImage, DecodingOptions and Headroom.
Managing the sources is controlled by an argument of type ShouldDecodeToHDR which
is now passed to most of ImageFrame methods.

* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/loader/cache/CachedImage.cpp:
(WebCore::CachedImage::currentFrameHeadroom const): Deleted.
* Source/WebCore/loader/cache/CachedImage.h:
* Source/WebCore/platform/graphics/BitmapImage.cpp:
(WebCore::BitmapImage::draw):
* Source/WebCore/platform/graphics/BitmapImage.h:
* Source/WebCore/platform/graphics/BitmapImageSource.cpp:
(WebCore::BitmapImageSource::destroyNativeImageAtIndex):
(WebCore::BitmapImageSource::isCompatibleWithOptionsAtIndex const):
(WebCore::BitmapImageSource::decode):
(WebCore::BitmapImageSource::imageFrameDecodeAtIndexHasFinished):
(WebCore::BitmapImageSource::cacheNativeImageAtIndex):
(WebCore::BitmapImageSource::nativeImageAtIndexCacheIfNeeded):
(WebCore::BitmapImageSource::nativeImageAtIndexRequestIfNeeded):
(WebCore::BitmapImageSource::currentNativeImageForDrawing):
* Source/WebCore/platform/graphics/BitmapImageSource.h:
* Source/WebCore/platform/graphics/Image.h:
(WebCore::Image::hasHDRContent const):
(WebCore::Image::currentFrameHeadroom const): Deleted.
* Source/WebCore/platform/graphics/ImageDecoder.cpp:
(WebCore::ImageDecoder::fetchFrameMetaDataAtIndex const):
* Source/WebCore/platform/graphics/ImageDecoder.h:
(WebCore::ImageDecoder::frameOrientationAtIndex const):
(WebCore::ImageDecoder::frameHeadroomAtIndex const): Deleted.
* Source/WebCore/platform/graphics/ImageFrame.cpp:
(WebCore::ImageFrame::ImageFrame):
(WebCore::ImageFrame::operator=):
(WebCore::ImageFrame::clearSourceImage):
(WebCore::ImageFrame::clearImage):
(WebCore::ImageFrame::hasNativeImage const):
(WebCore::ImageFrame::hasFullSizeNativeImage const):
(WebCore::ImageFrame::hasDecodedNativeImageCompatibleWithOptions const):
* Source/WebCore/platform/graphics/ImageFrame.h:
(WebCore::ImageFrame::sizeInBytes const):
(WebCore::ImageFrame::setDensityCorrectedSize):
(WebCore::ImageFrame::densityCorrectedSize const):
(WebCore::ImageFrame::subsamplingLevel const):
(WebCore::ImageFrame::nativeImage const):
(WebCore::ImageFrame::decodingOptions const):
(WebCore::ImageFrame::headroom const):
(WebCore::ImageFrame::hasNativeImage const):
(WebCore::ImageFrame::Source::hasNativeImage const):
(WebCore::ImageFrame::Source::hasFullSizeNativeImage const):
(WebCore::ImageFrame::Source::hasDecodedNativeImageCompatibleWithOptions const):
(WebCore::ImageFrame::Source::clear):
(WebCore::ImageFrame::shouldDecodeToHDRIfExists const):
(WebCore::ImageFrame::source):
(WebCore::ImageFrame::source const):
(WebCore::ImageFrame::frameBytes const): Deleted.
(WebCore::ImageFrame::setHeadroom): Deleted.
(WebCore::ImageFrame::hasNativeImage): Deleted.
(WebCore::ImageFrame::hasFullSizeNativeImage): Deleted.
* Source/WebCore/platform/graphics/ImagePaintingOptions.h:
(WebCore::ImagePaintingOptions::drawsHDRContent const):
(WebCore::ImagePaintingOptions::setOption):
* Source/WebCore/platform/graphics/ImageSource.h:
(WebCore::ImageSource::shouldDecodeToHDR const): Deleted.
* Source/WebCore/platform/graphics/ImageTypes.h:
* Source/WebCore/platform/graphics/NativeImage.cpp:
* Source/WebCore/platform/graphics/NativeImage.h:
* Source/WebCore/platform/graphics/NativeImageSource.h:
* Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp:
(WebCore::GraphicsContextCG::drawNativeImageInternal):
* Source/WebCore/platform/graphics/cg/ImageDecoderCG.cpp:
(WebCore::ImageDecoderCG::fetchFrameMetaDataAtIndex const):
(WebCore::headroomFromProperties): Deleted.
* Source/WebCore/platform/graphics/cg/NativeImageCG.cpp:
* Source/WebCore/rendering/PaintPhase.h:
* Source/WebCore/rendering/RenderImage.cpp:
(WebCore::RenderImage::paintIntoRect):
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::PaintedContentRequest::PaintedContentRequest):
(WebCore::RenderLayer::paintLayerContents):
(WebCore::RenderLayer::paintForegroundForFragments):
(WebCore::RenderLayer::calculateClipRects const):
* Source/WebCore/rendering/RenderLayer.h:
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::updateDrawsContent):
(WebCore::RenderLayerBacking::paintContents):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/296430@main">https://commits.webkit.org/296430@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b9caaef66c66509278e8d99540bc305f087a2339

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108520 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28181 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18605 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/113729 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/58918 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/110483 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/28870 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/36733 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82418 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111468 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22907 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97747 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62854 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22324 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/15887 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58444 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92277 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15938 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/116850 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35574 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26219 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91442 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/35947 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94019 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91243 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23245 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36138 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13902 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/31323 "Hash b9caaef6 for PR 46450 does not build (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35476 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/41011 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35186 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38537 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/36866 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->