### PR TITLE
[build-webkit] Remove --no-use-workspace, fix --only-webkit, and support custom schemes

### DIFF
--- a/Tools/Scripts/build-webkit
+++ b/Tools/Scripts/build-webkit
@@ -74,11 +74,11 @@ my $prefixPath;
 my $makeArgs = "";
 my @cmakeArgs;
 my $onlyWebKitProject = 0;
+my $xcodeScheme;
 my $coverageSupport = 0;
 my $shouldRunStaticAnalyzer = 0;
 my $noExperimentalFeatures = 0;
 my $ltoMode = "default";
-my $useWorkspace = 1;
 my $startTime = time();
 my $archs32bit = 0;
 my $useCCache = -1;
@@ -128,7 +128,6 @@ Usage: $programName [options] [options to pass to build system]
   --coverage                        Enable code coverage support (Mac only)
   --analyze                         Enable static anaylsis (Apple platforms only)
   --lto-mode=<mode>                 Set Link Time Optimization mode (full, thin, or none) (LLVM only)
-  --no-use-workspace                Build projects one at a time instead of using WebKit.xcworkspace (Apple platforms only)
   --cross-target=<target_machine>   Use the cross-toolchain-helper to build WebKit for the specified machine (Linux platforms only)
 
   --gtk                             Build the GTK+ port
@@ -147,6 +146,7 @@ Usage: $programName [options] [options to pass to build system]
   --no-experimental-features        No experimental features, unless explicitly enabled (CMake only)
 
   --only-webkit                     Build only the WebKit project
+  --only=<scheme>                   Build only the given scheme, instead of the entire project (Xcode builds only)
 
   --skip-library-update             Skip the check to see if windows libraries are up to date
 
@@ -167,11 +167,11 @@ my %options = (
     'cmakeargs=s' => \@cmakeArgs,
     'minimal' => \$minimal,
     'only-webkit' => \$onlyWebKitProject,
+    'only=s' => \$xcodeScheme,
     'coverage' => \$coverageSupport,
     'analyze' => \$shouldRunStaticAnalyzer,
     'no-experimental-features' => \$noExperimentalFeatures,
     'lto-mode=s' => \$ltoMode,
-    'use-workspace!' => \$useWorkspace,
     'use-ccache!' => \$useCCache,
     'export-compile-commands' => \$exportCompileCommands
 );
@@ -202,29 +202,6 @@ $ENV{'EXPORT_COMPILE_COMMANDS'} = "YES" if $exportCompileCommands;
 
 my $productDir = productDir();
 
-# Check that all the project directories are there.
-my @projects = ("Source/JavaScriptCore");
-if (isAppleCocoaWebKit()) {
-    push @projects, ("Source/WebGPU");
-}
-push @projects, ("Source/WebCore");
-push @projects, ("Source/WebKitLegacy");
-
-
-# Build WTF as a separate static library on ports which support it.
-splice @projects, 0, 0, "Source/WTF" if isWin();
-
-splice @projects, 0, 0, "Source/bmalloc" if isAppleCocoaWebKit();
-
-# Ports using CMake will check if directories exist in the CMake configuration.
-if (!isCMakeBuild()) {
-    for my $dir (@projects) {
-        if (! -d $dir) {
-            die "Error: No $dir directory found. Please do a fresh checkout.\n";
-        }
-    }
-}
-
 if ((isAppleWebKit() || isPlayStation()) && !-d "WebKitLibraries") {
     die "Error: No WebKitLibraries directory found. Please do a fresh checkout.\n";
 }
@@ -236,11 +213,10 @@ if (shouldUseVcpkg() && ! defined $ENV{"VCPKG_ROOT"}) {
 my @options = ();
 
 if (isAppleCocoaWebKit()) {
-    if (!$useWorkspace) {
-        # Ignore any workspace set by set-webkit-configuration
-        overrideConfiguredXcodeWorkspace("");
+    if ($onlyWebKitProject) {
+        die "--only-webkit cannot be combined with --only\n" if defined $xcodeScheme;
+        $xcodeScheme = "WebKit";
     }
-
     if (xcodeVersion() ge "14.0" && xcodeVersion() lt "15.0" && !defined($ENV{UseSRCROOTSupportForTAPI})) {
         # The call to XcodeOptions below checks this environment variable and
         # sets TAPI_USE_SRCROOT for xcconfigs.
@@ -260,51 +236,9 @@ if (isAppleCocoaWebKit()) {
         my $option = option($_->{define}, ${$_->{value}});
         push @options, $option unless $option eq "";
     }
-
-    # In workspaces, build order is determined by XCBuild.
-    if (!$useWorkspace) {
-        print STDERR "warning: Building with --no-use-workspace is " .
-        "deprecated.\nIf you have a workflow requirement that depends " .
-        "on building targets in manual order, please document it in " .
-        "https://bugs.webkit.org/show_bug.cgi?id=241295.\n";
-        
-        # ANGLE and libwebrtc must come before WebCore
-        splice @projects, 0, 0, ("Source/ThirdParty/ANGLE");
-        # if (not $archs32bit and (portName() eq Mac or portName() eq iOS or portName() eq watchOS)) {
-        if (portName() eq Mac or portName() eq iOS) {
-            splice @projects, 0, 0, ("Source/ThirdParty/libwebrtc");
-        }
-
-        push @projects, ("Source/WebKit");
-
-        if (!isEmbeddedWebKit()) {
-            push @projects, ("Tools/MiniBrowser");
-
-            # WebInspectorUI must come after JavaScriptCore and WebCore but before WebKit and WebKit2
-            my $webKitIndex = first { $projects[$_] eq "Source/WebKitLegacy" } 0..$#projects;
-            splice(@projects, $webKitIndex, 0, "Source/WebInspectorUI");
-        }
-
-        if (isAppleMacWebKit()) {
-            push @projects, ("Tools/lldb/lldbWebKitTester");
-        }
-
-        # Build Tools needed for Apple ports (except for tvOS)
-        push @projects, ("Tools/DumpRenderTree", "Tools/WebKitTestRunner", "Source/ThirdParty/gtest", "Tools/TestWebKitAPI");
-    }
 }
-
-# If asked to build just the WebKit project, overwrite the projects
-# list after all of the port specific tweaks have been made to
-# build options, etc.
-@projects = ("Source/WebKitLegacy") if $onlyWebKitProject;
 
 my $result = 0;
-
-if (isInspectorFrontend()) {
-    die "The --inspector-frontend option is not supported for CMake-based builds." if isCMakeBuild();
-    @projects = ("Source/WebInspectorUI");
-}
 
 if (isCMakeBuild() && !isAnyWindows()) {
     if (!canUseNinja() || defined($ENV{NUMBER_OF_PROCESSORS})) {
@@ -364,33 +298,15 @@ if (isWin() || isPlayStation() || (isJSCOnly() && isWindows())) {
     ## on dependency validation errors. Other conditions (e.g. whether we're in
     ## a script phase or not) influence the actual VALIDATE_DEPENDENCIES setting
     ## recognized by the build system.
-    #push @local_options, "WK_VALIDATE_DEPENDENCIES=YES_ERROR" if $useWorkspace;
+    #push @local_options, "WK_VALIDATE_DEPENDENCIES=YES_ERROR";
  
     markBaseProductDirectoryAsCreatedByXcodeBuildSystem();
 
     # Build, and abort if the build fails.
-    if ($useWorkspace) {
-        my $scheme = $onlyWebKitProject ? "WebKitLegacy" : "Everything up to WebKit + Tools";
-        $result = buildXcodeScheme($scheme, $clean, @local_options, @ARGV);
-        if (exitStatus($result)) {
-            exit exitStatus($result);
-        }
-    } else {
-        for my $dir (@projects) {
-            chdir $dir or die;
-            $result = 0;
-
-            my $project = basename($dir);
-            my $projectPath = $project =~ /gtest/ ? "xcode/gtest" : $project;
-            $result = buildXCodeProject($projectPath, $clean, @local_options, @ARGV);
-
-            # Various build* calls above may change the CWD.
-            chdirWebKit();
-
-            if (exitStatus($result)) {
-                exit exitStatus($result);
-            }
-        }
+    my $scheme = $xcodeScheme // "Everything up to WebKit + Tools";
+    $result = buildXcodeScheme($scheme, $clean, @local_options, @ARGV);
+    if (exitStatus($result)) {
+        exit exitStatus($result);
     }
 
     if (isInspectorFrontend()) {
@@ -439,10 +355,11 @@ sub writeCongrats()
     my $launcherName = launcherName();
     my $endTime = time();
     my $buildTime = formatBuildTime($endTime - $startTime);
+    my $projectName = $xcodeScheme // "WebKit";
 
     print "\n";
     print "====================================================================\n";
-    print " WebKit is now built ($buildTime). \n";
+    print " $projectName is now built ($buildTime). \n";
     if ($launcherCommand && $launcherName) {
         print " To run $launcherName with this newly-built code, use\n";
         print " the command \"$launcherCommand\".\n";


### PR DESCRIPTION
#### 77e2f7223a5fa7be068bfbc5c18b9578ccbdb676
<pre>
[build-webkit] Remove --no-use-workspace, fix --only-webkit, and support custom schemes
<a href="https://bugs.webkit.org/show_bug.cgi?id=241295">https://bugs.webkit.org/show_bug.cgi?id=241295</a>
<a href="https://rdar.apple.com/94852818">rdar://94852818</a>

Reviewed by Alexey Proskuryakov and Mike Wyrzykowski.

This Xcode-specific option has been deprecated with a warning for years,
and infrastructure stopped building non-workspace style long ago.
Removing it allows us to remove lots of additional logic keeping track
of which projects are being built.

Also introduce a &quot;--only=&lt;project&gt;&quot; argument which builds a specific
scheme, complementing the longstanding --only-webkit flag. For example,
&quot;--only WebGPU&quot; builds the WebGPU scheme (which itself builds all of
WebGPU&apos;s dependencies).

--only-webkit built the &quot;WebKitLegacy&quot; project, which seems misleading,
at least on Apple platforms. Change its scheme to &quot;WebKit&quot; to build the
WK2 layer.

* Tools/Scripts/build-webkit:
(writeCongrats):

Canonical link: <a href="https://commits.webkit.org/296046@main">https://commits.webkit.org/296046@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/75d0363630caef68478382eaf3e6184083b80571

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/106964 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/26671 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/17068 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/112172 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/57524 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/108957 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/27344 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/35173 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/81216 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/109922 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/21707 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/96473 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/61566 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/21142 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/14586 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/56970 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/99569 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/91050 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/14612 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/115212 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/105536 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/34057 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/25123 "Found 1 new test failure: fast/scrolling/mac/scrollbars/overflow-in-iframe-overlay-scrollbar-reveal.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/90268 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/34425 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/92707 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89991 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22984 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34910 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/12715 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/29771 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/33981 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/129849 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/33729 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/35351 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/37081 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/35361 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->