### PR TITLE
Resync Cookie Store API WPT tests

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/META.yml
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/META.yml
@@ -1,4 +1,3 @@
 spec: https://wicg.github.io/cookie-store/
 suggested_reviewers:
-  - inexorabletash
-  - ayuishii
+  - dcthetall

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/change_eventhandler_for_already_expired.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/change_eventhandler_for_already_expired.https.window-expected.txt
@@ -1,0 +1,4 @@
+
+PASS CookieStore setting already-expired cookie should not be observed
+PASS CookieStore setting already-expired partitioned cookie should not be observed
+

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/change_eventhandler_for_already_expired.https.window.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/change_eventhandler_for_already_expired.https.window.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/change_eventhandler_for_already_expired.https.window.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/change_eventhandler_for_already_expired.https.window.js
@@ -1,0 +1,41 @@
+// META: title=Cookie Store API: Test that setting an already-expired cookie does not trigger an event.
+// META: script=resources/cookie-test-helpers.js
+
+'use strict';
+
+cookie_test(async t => {
+  const eventPromise = observeNextCookieChangeEvent();
+  await cookieStore.set({
+    name: 'cookie',
+    value: 'ALREADY-EXPIRED',
+    expires: new Date(new Date() - 10_000),
+  });
+  await cookieStore.set('alt-cookie', 'IGNORE');
+  assert_equals(
+    await getCookieString(),
+    'alt-cookie=IGNORE',
+    'Already-expired cookie not included in CookieStore');
+  await verifyCookieChangeEvent(
+    eventPromise,
+    {deleted: [], changed: [{name: 'alt-cookie', value: 'IGNORE'}]},
+    'Deletion not observed after document.cookie sets already-expired cookie');
+}, 'CookieStore setting already-expired cookie should not be observed');
+
+cookie_test(async t => {
+  const eventPromise = observeNextCookieChangeEvent();
+  await cookieStore.set({
+    name: 'cookie',
+    value: 'ALREADY-EXPIRED',
+    expires: new Date(new Date() - 10_000),
+    partitioned: true,
+  });
+  await cookieStore.set('alt-cookie', 'IGNORE');
+  assert_equals(
+    await getCookieString(),
+    'alt-cookie=IGNORE',
+    'Already-expired cookie not included in CookieStore');
+  await verifyCookieChangeEvent(
+    eventPromise,
+    {deleted: [], changed: [{name: 'alt-cookie', value: 'IGNORE'}]},
+    'Deletion not observed after document.cookie sets already-expired cookie');
+}, 'CookieStore setting already-expired partitioned cookie should not be observed');

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/change_eventhandler_for_document_cookie.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/change_eventhandler_for_document_cookie.https.window-expected.txt
@@ -1,5 +1,7 @@
 
 PASS document.cookie set/overwrite/delete observed by CookieStore
+PASS document.cookie set already-expired cookie should not be observed by CookieStore
+PASS document.cookie duplicate cookie should not be observed by CookieStore
 PASS CookieStore set/overwrite/delete observed by document.cookie
 FAIL CookieStore agrees with document.cookie on encoding non-ASCII cookies assert_equals: Cookie we wrote using document.cookie in cookie jar expected (string) "DOCUMENT-🍪=🔵" but got (undefined) undefined
 PASS document.cookie agrees with CookieStore on encoding non-ASCII cookies

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/change_eventhandler_for_http_cookie_and_set_cookie_headers.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/change_eventhandler_for_http_cookie_and_set_cookie_headers.https.window-expected.txt
@@ -1,7 +1,9 @@
 
 PASS HTTP set/overwrite/delete observed in CookieStore
+PASS HTTP set already-expired cookie should not be observed by CookieStore
+PASS HTTP duplicate cookie should not be observed by CookieStore
 FAIL CookieStore agreed with HTTP headers agree on encoding non-ASCII cookies assert_equals: Cookie we wrote using HTTP in cookie jar expected "HTTP-🍪=🔵" but got "HTTP-ðª=ðµ"
 PASS CookieStore set/overwrite/delete observed in HTTP headers
-FAIL HTTP headers agreed with CookieStore on encoding non-ASCII cookies assert_equals: HTTP cookie jar contains only cookie we set expected "🍪=🔵" but got ""
+PASS HTTP headers agreed with CookieStore on encoding non-ASCII cookies
 FAIL Binary HTTP set/overwrite/delete observed in CookieStore assert_equals: Binary cookie we wrote using HTTP in cookie jar expected "HTTP-cookie=value\ufffd" but got "HTTP-cookie=valueï¿½"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/change_eventhandler_for_no_change.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/change_eventhandler_for_no_change.https.window-expected.txt
@@ -1,0 +1,4 @@
+
+PASS CookieStore duplicate cookie should not be observed
+PASS CookieStore duplicate partitioned cookie should not be observed
+

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/change_eventhandler_for_no_change.https.window.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/change_eventhandler_for_no_change.https.window.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/change_eventhandler_for_no_change.https.window.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/change_eventhandler_for_no_change.https.window.js
@@ -1,0 +1,43 @@
+// META: title=Cookie Store API: Test that setting a duplicate cookie does not fire a second event.
+// META: script=resources/cookie-test-helpers.js
+
+'use strict';
+
+cookie_test(async t => {
+  let eventPromise = observeNextCookieChangeEvent();
+  await cookieStore.set('cookie', 'VALUE');
+  await verifyCookieChangeEvent(
+    eventPromise, {changed: [{name: 'cookie', value: 'VALUE'}]},
+    'Original cookie is observed.');
+
+  eventPromise = observeNextCookieChangeEvent();
+  await cookieStore.set('cookie', 'VALUE');
+  await cookieStore.set('alt-cookie', 'IGNORE');
+  await verifyCookieChangeEvent(
+    eventPromise, {changed: [{name: 'alt-cookie', value: 'IGNORE'}]},
+    'Duplicate cookie is not observed.');
+}, 'CookieStore duplicate cookie should not be observed');
+
+cookie_test(async t => {
+  let eventPromise = observeNextCookieChangeEvent();
+  await cookieStore.set({
+    name: 'cookie',
+    value: 'VALUE',
+    partitioned: true,
+  });
+  await verifyCookieChangeEvent(
+    eventPromise,
+    {changed: [{name: 'cookie', value: 'VALUE', partitioned: true}]},
+    'Original cookie is observed.');
+
+  eventPromise = observeNextCookieChangeEvent();
+  await cookieStore.set({
+    name: 'cookie',
+    value: 'VALUE',
+    partitioned: true,
+  });
+  await cookieStore.set('alt-cookie', 'IGNORE');
+  await verifyCookieChangeEvent(
+    eventPromise, {changed: [{name: 'alt-cookie', value: 'IGNORE'}]},
+    'Duplicate cookie is not observed.');
+}, 'CookieStore duplicate partitioned cookie should not be observed');

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieListItem_attributes.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieListItem_attributes.https.any-expected.txt
@@ -5,9 +5,10 @@ FAIL CookieListItem - cookieStore.set with expires set to a timestamp 10 years i
 FAIL CookieListItem - cookieStore.set with expires set to a Date 10 years in the future assert_equals: expected (object) null but got (string) "localhost"
 FAIL CookieListItem - cookieStore.set with domain set to the current hostname assert_equals: expected (object) null but got (undefined) undefined
 FAIL CookieListItem - cookieStore.set with path set to the current directory assert_equals: expected (object) null but got (string) "localhost"
-FAIL CookieListItem - cookieStore.set adds / to path if it does not end with / assert_equals: expected (object) null but got (string) "localhost"
+FAIL CookieListItem - cookieStore.set does not add / to path if it does not end with / assert_equals: expected (object) null but got (string) "localhost"
 FAIL CookieListItem - cookieStore.set with sameSite set to strict assert_equals: expected (object) null but got (string) "localhost"
 FAIL CookieListItem - cookieStore.set with sameSite set to lax assert_equals: expected (object) null but got (string) "localhost"
 FAIL CookieListItem - cookieStore.set with sameSite set to none assert_equals: expected (object) null but got (string) "localhost"
 PASS CookieListItem - secure defaults to true
+PASS Test max-age attribute over the 400 days
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieListItem_attributes.https.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieListItem_attributes.https.any.serviceworker-expected.txt
@@ -5,7 +5,7 @@ FAIL CookieListItem - cookieStore.set with expires set to a timestamp 10 years i
 FAIL CookieListItem - cookieStore.set with expires set to a Date 10 years in the future assert_equals: expected (object) null but got (string) "localhost"
 FAIL CookieListItem - cookieStore.set with domain set to the current hostname assert_equals: expected (object) null but got (undefined) undefined
 FAIL CookieListItem - cookieStore.set with path set to the current directory assert_equals: expected (object) null but got (string) "localhost"
-FAIL CookieListItem - cookieStore.set adds / to path if it does not end with / assert_equals: expected (object) null but got (string) "localhost"
+FAIL CookieListItem - cookieStore.set does not add / to path if it does not end with / assert_equals: expected (object) null but got (string) "localhost"
 FAIL CookieListItem - cookieStore.set with sameSite set to strict assert_equals: expected (object) null but got (string) "localhost"
 FAIL CookieListItem - cookieStore.set with sameSite set to lax assert_equals: expected (object) null but got (string) "localhost"
 FAIL CookieListItem - cookieStore.set with sameSite set to none assert_equals: expected (object) null but got (string) "localhost"

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_delete.sub.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_delete.sub.https-expected.txt
@@ -1,0 +1,8 @@
+Blocked access to external URL https://www1.localhost:9443/cookie-store/resources/helper_iframe.sub.html
+CONSOLE MESSAGE: Unable to post message to https://www1.localhost:9443. Recipient has origin https://localhost:9443.
+
+
+Harness Error (TIMEOUT), message = null
+
+TIMEOUT Async Cookies: cookieStore basic API across origins Test timed out
+

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_delete.sub.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_delete.sub.https.html
@@ -1,0 +1,65 @@
+<!doctype html>
+<meta charset='utf-8'>
+<title>Async Cookies: cookieStore basic API across origins</title>
+<link rel='help' href='https://github.com/WICG/cookie-store'>
+<link rel='author' href='jarrydg@chromium.org' title='Jarryd Goodman'>
+<script src='/resources/testharness.js'></script>
+<script src='/resources/testharnessreport.js'></script>
+<script src='resources/helpers.js'></script>
+<style>iframe { display: none; }</style>
+
+<script>
+'use strict';
+
+const kPath = '/cookie-store/resources/helper_iframe.sub.html';
+const kCorsBase = `https://{{domains[www1]}}:{{ports[https][0]}}`;
+const kCorsUrl = `${kCorsBase}${kPath}`;
+
+promise_test(async t => {
+  const iframe = await createIframe(kCorsUrl, t);
+  assert_true(iframe != null);
+
+  iframe.contentWindow.postMessage({
+    opname: 'set-cookie-without-domain-attr',
+    name: 'cookie-name',
+    value: 'cookie-value',
+  }, kCorsBase);
+  t.add_cleanup(async () => {
+    await cookieStore.delete({ name: 'cookie-name', domain: '{{host}}' });
+  });
+  await waitForMessage();
+
+  iframe.contentWindow.postMessage({
+    opname: 'get-cookie',
+    name: 'cookie-name',
+    options: {}
+  }, '*');
+
+  {
+    const message = await waitForMessage();
+    const { frameCookie } = message;
+    assert_not_equals(frameCookie, null);
+    assert_equals(frameCookie.name, 'cookie-name');
+    assert_equals(frameCookie.value, 'cookie-value');
+  }
+
+  iframe.contentWindow.postMessage({
+    opname: 'delete-cookie-without-domain-attr',
+    name: 'cookie-name',
+  }, kCorsBase);
+
+  await waitForMessage();
+
+  iframe.contentWindow.postMessage({
+    opname: 'get-cookie',
+    name: 'cookie-name',
+    options: {}
+  }, '*');
+
+  {
+    const message = await waitForMessage();
+    const { frameCookie } = message;
+    assert_equals(frameCookie, null);
+  }
+});
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_delete_arguments.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_delete_arguments.https.any-expected.txt
@@ -8,9 +8,11 @@ PASS cookieStore.delete with domain set to a subdomain of the current hostname
 PASS cookieStore.delete with domain set to a non-domain-matching suffix of the current hostname
 PASS cookieStore.delete with path set to the current directory
 PASS cookieStore.delete with path set to subdirectory of the current directory
-PASS cookieStore.delete with missing / at the end of path
+FAIL cookieStore.delete does not append / at the end of path assert_equals: expected null but got object "[object Object]"
+FAIL cookieStore.delete can delete a cookie set by document.cookie if document is defined assert_equals: expected null but got object "[object Object]"
 PASS cookieStore.delete with path that does not start with /
 PASS cookieStore.delete with get result
 FAIL cookieStore.delete with positional empty name promise_test: Unhandled rejection with value: object "TypeError: Type error"
 FAIL cookieStore.delete with empty name in options promise_test: Unhandled rejection with value: object "TypeError: Type error"
+PASS cookieStore.delete with a __Host- prefix should not have a domain
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_delete_arguments.https.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_delete_arguments.https.any.serviceworker-expected.txt
@@ -8,9 +8,11 @@ PASS cookieStore.delete with domain set to a subdomain of the current hostname
 PASS cookieStore.delete with domain set to a non-domain-matching suffix of the current hostname
 PASS cookieStore.delete with path set to the current directory
 PASS cookieStore.delete with path set to subdirectory of the current directory
-PASS cookieStore.delete with missing / at the end of path
+FAIL cookieStore.delete does not append / at the end of path assert_equals: expected null but got object "[object Object]"
+PASS cookieStore.delete can delete a cookie set by document.cookie if document is defined
 PASS cookieStore.delete with path that does not start with /
 PASS cookieStore.delete with get result
 FAIL cookieStore.delete with positional empty name promise_test: Unhandled rejection with value: object "TypeError: Type error"
 FAIL cookieStore.delete with empty name in options promise_test: Unhandled rejection with value: object "TypeError: Type error"
+PASS cookieStore.delete with a __Host- prefix should not have a domain
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_event_delete.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_event_delete.https.window-expected.txt
@@ -1,4 +1,4 @@
 
 PASS cookieStore fires change event for cookie deleted by cookieStore.delete()
-FAIL cookieStore does not fire change events for non-existing expired cookies assert_equals: expected 2 but got 4
+PASS cookieStore does not fire change events for non-existing expired cookies
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_get_set_across_origins.sub.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_get_set_across_origins.sub.https-expected.txt
@@ -6,4 +6,6 @@ Harness Error (TIMEOUT), message = null
 
 TIMEOUT cookieStore.get() sees cookieStore.set() in cross-origin frame Test timed out
 NOTRUN cookieStore.get() in cross-origin frame sees cookieStore.set()
+NOTRUN cookieStore.set() in cross-origin does not overwrite the __Host- cookie
+NOTRUN __Host- cookies set via cookieStore.set() in same-site domains don't overwrite each other
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_get_set_across_origins.sub.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_get_set_across_origins.sub.https.html
@@ -63,4 +63,87 @@ promise_test(async t => {
   assert_equals(frameCookie.name, 'cookie-name');
   assert_equals(frameCookie.value, 'cookie-value');
 }, 'cookieStore.get() in cross-origin frame sees cookieStore.set()');
+
+promise_test(async t => {
+  const iframe = await createIframe(kCorsUrl, t);
+  assert_true(iframe != null);
+
+  document.cookie = "__Host-test=a; Path=/; Secure";
+  iframe.contentWindow.postMessage({
+    opname: 'set-host-cookie',
+    name: '__Host-test',
+    value: 'b',
+  }, kCorsBase);
+
+  const message = await waitForMessage();
+  t.add_cleanup(async () => {
+    await cookieStore.delete({ name: '__Host-test'});
+  });
+
+  assert_equals(document.cookie, '__Host-test=a');
+
+  // Cleanup iframe cookie
+  iframe.contentWindow.postMessage({
+    opname: 'delete-host-cookie',
+    name: '__Host-test',
+  }, kCorsBase);
+  await waitForMessage();
+}, 'cookieStore.set() in cross-origin does not overwrite the __Host- cookie');
+
+promise_test(async t => {
+  const iframe = await createIframe(kCorsUrl, t);
+  assert_true(iframe != null);
+
+  document.cookie = "__Host-test=a; Path=/; Secure";
+  await cookieStore.set({name: "__Host-test", value: "a", path: "/"});
+  t.add_cleanup(async () => {
+    await cookieStore.delete({ name: '__Host-test'});
+  });
+
+  iframe.contentWindow.postMessage({
+    opname: 'set-host-cookie',
+    name: '__Host-test',
+    value: 'b',
+  }, kCorsBase);
+
+  let message = await waitForMessage();
+
+  let cookies = await cookieStore.getAll();
+  assert_equals(cookies.length, 1);
+  assert_equals(cookies[0].name, '__Host-test');
+  assert_equals(cookies[0].value, 'a');
+
+  iframe.contentWindow.postMessage({
+    opname: 'get-cookie',
+    name: '__Host-test',
+  }, kCorsBase);
+  message = await waitForMessage();
+  let { frameCookie } = message;
+  assert_not_equals(frameCookie, null);
+  assert_equals(frameCookie.name, '__Host-test');
+  assert_equals(frameCookie.value, 'b');
+
+  // Make sure deleting the cookie doesn't affect the other domain's cookie
+  await cookieStore.delete({ name: '__Host-test'});
+  cookies = await cookieStore.getAll();
+  assert_equals(cookies.length, 0);
+
+  iframe.contentWindow.postMessage({
+    opname: 'get-cookie',
+    name: '__Host-test',
+  }, kCorsBase);
+  message = await waitForMessage();
+  ({ frameCookie } = message);
+  assert_not_equals(frameCookie, null);
+  assert_equals(frameCookie.name, '__Host-test');
+  assert_equals(frameCookie.value, 'b');
+
+  // Cleanup iframe cookie
+  iframe.contentWindow.postMessage({
+    opname: 'delete-host-cookie',
+    name: '__Host-test',
+  }, kCorsBase);
+  await waitForMessage();
+}, "__Host- cookies set via cookieStore.set() in same-site domains don't overwrite each other");
+
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_set_arguments.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_set_arguments.https.any-expected.txt
@@ -44,9 +44,13 @@ PASS cookieStore.set default domain is null and differs from current hostname
 PASS cookieStore.set with path set to the current directory
 PASS cookieStore.set with path set to a subdirectory of the current directory
 PASS cookieStore.set default path is /
-PASS cookieStore.set adds / to path that does not end with /
+FAIL cookieStore.set does not add / to path that does not end with / assert_equals: expected null but got object "[object Object]"
+FAIL cookieStore.set can modify a cookie set by document.cookie if document is defined assert_equals: expected 1 but got 2
 PASS cookieStore.set with path that does not start with /
 PASS cookieStore.set with get result
 PASS cookieStore.set checks if the path is too long
 PASS cookieStore.set checks if the domain is too long
+PASS cookieStore.set with a __Host- prefix should not have a domain
+FAIL cookieStore.set with whitespace only name and value assert_unreached: Should have rejected: undefined Reached unreachable code
+FAIL cookieStore.set with whitespace at begining or end assert_unreached: Should have rejected: undefined Reached unreachable code
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_set_arguments.https.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_set_arguments.https.any.js
@@ -1,4 +1,5 @@
 // META: title=Cookie Store API: cookieStore.set() arguments
+// META: script=resources/cookie-test-helpers.js
 // META: global=window,serviceworker
 
 'use strict';
@@ -8,7 +9,7 @@ promise_test(async testCase => {
 
   await cookieStore.set('cookie-name', 'cookie-value');
   testCase.add_cleanup(async () => {
-    await cookieStore.delete('cookie-name');
+    await setCookieStringHttp(`cookie-name=deleted; Max-Age=0`);
   });
 
   const cookie = await cookieStore.get('cookie-name');
@@ -21,7 +22,7 @@ promise_test(async testCase => {
 
   await cookieStore.set({ name: 'cookie-name', value: 'cookie-value' });
   testCase.add_cleanup(async () => {
-    await cookieStore.delete('cookie-name');
+    await setCookieStringHttp(`cookie-name=deleted; Max-Age=0`);
   });
   const cookie = await cookieStore.get('cookie-name');
   assert_equals(cookie.name, 'cookie-name');
@@ -42,7 +43,7 @@ promise_test(async testCase => {
   await cookieStore.delete('cookie-name');
   cookieStore.set('cookie-name', 'suspicious-value=resembles-name-and-value');
   testCase.add_cleanup(async () => {
-    await cookieStore.delete('cookie-name');
+    await setCookieStringHttp(`cookie-name=deleted; Max-Age=0`);
   });
   const cookie = await cookieStore.get('cookie-name');
   assert_equals(cookie.name, 'cookie-name');
@@ -81,7 +82,7 @@ promise_test(async testCase => {
         value: 'cookie-value',
         expires: new Date(tenYearsFromNow) });
   testCase.add_cleanup(async () => {
-    await cookieStore.delete('cookie-name');
+    await setCookieStringHttp(`cookie-name=deleted; Max-Age=0`);
   });
   const cookie = await cookieStore.get('cookie-name');
   assert_equals(cookie.name, 'cookie-name');
@@ -98,7 +99,7 @@ promise_test(async testCase => {
         value: 'cookie-value',
         expires: new Date(tenYearsAgo) });
   testCase.add_cleanup(async () => {
-    await cookieStore.delete('cookie-name');
+    await setCookieStringHttp(`cookie-name=deleted; Max-Age=0`);
   });
   const cookie = await cookieStore.get('cookie-name');
   assert_equals(cookie, null);
@@ -112,7 +113,7 @@ promise_test(async testCase => {
   await cookieStore.set(
       { name: 'cookie-name', value: 'cookie-value', expires: tenYearsFromNow });
   testCase.add_cleanup(async () => {
-    await cookieStore.delete('cookie-name');
+    await setCookieStringHttp(`cookie-name=deleted; Max-Age=0`);
   });
   const cookie = await cookieStore.get('cookie-name');
   assert_equals(cookie.name, 'cookie-name');
@@ -127,7 +128,7 @@ promise_test(async testCase => {
   await cookieStore.set(
       { name: 'cookie-name', value: 'cookie-value', expires: tenYearsAgo });
   testCase.add_cleanup(async () => {
-    await cookieStore.delete('cookie-name');
+    await setCookieStringHttp(`cookie-name=deleted; Max-Age=0`);
   });
   const cookie = await cookieStore.get('cookie-name');
   assert_equals(cookie, null);
@@ -156,7 +157,7 @@ promise_test(async testCase => {
   await cookieStore.set(
       { name: 'cookie-name', value: 'cookie-value', domain: currentDomain });
   testCase.add_cleanup(async () => {
-    await cookieStore.delete({ name: 'cookie-name', domain: currentDomain });
+    await setCookieStringHttp(`cookie-name=deleted; Domain=${currentDomain}; Path=/; Max-Age=0`);
   });
   const cookie = await cookieStore.get('cookie-name');
   assert_equals(cookie.name, 'cookie-name');
@@ -195,12 +196,12 @@ promise_test(async testCase => {
 
   await cookieStore.set('cookie-name', 'cookie-value1');
   testCase.add_cleanup(async () => {
-    await cookieStore.delete('cookie-name');
+    await setCookieStringHttp(`cookie-name=deleted; Path=/; Max-Age=0`);
   });
   await cookieStore.set(
       { name: 'cookie-name', value: 'cookie-value2', domain: currentDomain });
   testCase.add_cleanup(async () => {
-    await cookieStore.delete({ name: 'cookie-name', domain: currentDomain });
+    await setCookieStringHttp(`cookie-name=deleted; Domain=${currentDomain}; Path=/; Max-Age=0`);
   });
 
   const cookies = await cookieStore.getAll('cookie-name');
@@ -224,7 +225,7 @@ promise_test(async testCase => {
   await cookieStore.set(
       { name: 'cookie-name', value: 'cookie-value', path: currentDirectory });
   testCase.add_cleanup(async () => {
-    await cookieStore.delete({ name: 'cookie-name', path: currentDirectory });
+    await setCookieStringHttp(`cookie-name=deleted; Path=${currentDirectory}; Max-Age=0`);
   });
   const cookie = await cookieStore.get('cookie-name');
   assert_equals(cookie.name, 'cookie-name');
@@ -243,7 +244,7 @@ promise_test(async testCase => {
   await cookieStore.set(
       { name: 'cookie-name', value: 'cookie-value', path: subDirectory });
   testCase.add_cleanup(async () => {
-    await cookieStore.delete({ name: 'cookie-name', path: subDirectory });
+    await setCookieStringHttp(`cookie-name=deleted; Path=${subDirectory}; Max-Age=0`);
   });
   const cookie = await cookieStore.get('cookie-name');
   assert_equals(cookie, null);
@@ -254,12 +255,13 @@ promise_test(async testCase => {
 
   await cookieStore.set('cookie-name', 'cookie-old-value');
   testCase.add_cleanup(async () => {
-    await cookieStore.delete('cookie-name');
+    await setCookieStringHttp(`cookie-name=deleted; Max-Age=0`);
   });
+
   await cookieStore.set(
       { name: 'cookie-name', value: 'cookie-new-value', path: '/' });
   testCase.add_cleanup(async () => {
-    await cookieStore.delete({ name: 'cookie-name',  path: '/' });
+    await setCookieStringHttp(`cookie-name=deleted; Path=/; Max-Age=0`);
   });
 
   const cookies = await cookieStore.getAll('cookie-name');
@@ -277,13 +279,34 @@ promise_test(async testCase => {
   await cookieStore.set(
       { name: 'cookie-name', value: 'cookie-value', path: currentDirectory });
   testCase.add_cleanup(async () => {
-    await cookieStore.delete({ name: 'cookie-name', path: currentDirectory });
+    await setCookieStringHttp(`cookie-name=deleted; Path=${currentDirectory}/; Max-Age=0`);
   });
+  await setCookieStringHttp(`cookie-name=deleted; Path=${currentDirectory}; Max-Age=0`);
   const cookie = await cookieStore.get('cookie-name');
-  assert_equals(cookie.name, 'cookie-name');
-  assert_equals(cookie.value, 'cookie-value');
-  assert_equals(cookie.path, currentDirectory + '/');
-}, 'cookieStore.set adds / to path that does not end with /');
+  assert_equals(cookie, null);
+}, 'cookieStore.set does not add / to path that does not end with /');
+
+promise_test(async testCase => {
+  if (typeof self.document === 'undefined') {
+    // The test is being run from a service worker context where document is undefined
+    testCase.done();
+    return;
+  }
+  const currentUrl = new URL(self.location.href);
+  const currentPath = currentUrl.pathname;
+  const currentDirectory = currentPath.substr(0, currentPath.lastIndexOf('/'));
+  await setCookieStringDocument('cookie-name=cookie-value; path=' + currentDirectory);
+  await cookieStore.set(
+    { name: 'cookie-name', value: 'new-cookie-value', path: currentDirectory });
+  testCase.add_cleanup(async () => {
+    await setCookieStringHttp(`cookie-name=deleted; Path=${currentDirectory}; Max-Age=0`);
+    await setCookieStringHttp(`cookie-name=deleted; Path=${currentDirectory}/; Max-Age=0`);
+  });
+  const cookies = await cookieStore.getAll('cookie-name');
+  assert_equals(cookies.length, 1);
+  assert_equals(cookies[0].name, 'cookie-name');
+  assert_equals(cookies[0].value, 'cookie-new-value');
+}, 'cookieStore.set can modify a cookie set by document.cookie if document is defined');
 
 promise_test(async testCase => {
   const currentUrl = new URL(self.location.href);
@@ -299,7 +322,7 @@ promise_test(async testCase => {
 promise_test(async testCase => {
   await cookieStore.set('cookie-name', 'old-cookie-value');
   testCase.add_cleanup(async () => {
-    await cookieStore.delete('cookie-name');
+    await setCookieStringHttp(`cookie-name=deleted; Max-Age=0`);
   });
 
   const cookie_attributes = await cookieStore.get('cookie-name');
@@ -336,3 +359,57 @@ promise_test(async testCase => {
   const cookie = await cookieStore.get('cookie-name');
   assert_equals(cookie, null);
 }, 'cookieStore.set checks if the domain is too long');
+
+promise_test(async testCase => {
+  // Cookies having a __Host- prefix are not allowed to specify a domain
+  await cookieStore.delete('cookie-name');
+
+  const currentUrl = new URL(self.location.href);
+  const currentDomain = currentUrl.hostname;
+
+  await promise_rejects_js(testCase, TypeError, cookieStore.set(
+      { name: '__Host-cookie-name',
+        value: 'cookie-value',
+        domain: currentDomain }));
+  const cookie = await cookieStore.get('cookie-name');
+  assert_equals(cookie, null);
+}, 'cookieStore.set with a __Host- prefix should not have a domain');
+
+promise_test(async testCase => {
+  await promise_rejects_js(testCase, TypeError, cookieStore.set(
+      { name: '',
+        value: ' ' }));
+
+  await promise_rejects_js(testCase, TypeError, cookieStore.set(
+      { name: ' ',
+        value: '' }));
+
+  await promise_rejects_js(testCase, TypeError, cookieStore.set(
+      { name: '  ',
+        value: '  ' }));
+}, 'cookieStore.set with whitespace only name and value');
+
+promise_test(async testCase => {
+  testCase.add_cleanup(async () => {
+    await cookieStore.delete('a b');
+  });
+  await cookieStore.set('a b', 'x y');
+  const cookie = await cookieStore.get('a b');
+  assert_equals(cookie.value, "x y");
+
+  await promise_rejects_js(testCase, TypeError, cookieStore.set(
+      { name: 'a  ',
+        value: 'x' }));
+
+  await promise_rejects_js(testCase, TypeError, cookieStore.set(
+      { name: '  a',
+        value: 'x' }));
+
+  await promise_rejects_js(testCase, TypeError, cookieStore.set(
+      { name: 'a',
+        value: 'x ' }));
+
+  await promise_rejects_js(testCase, TypeError, cookieStore.set(
+      { name: 'a',
+        value: 'x ' }));
+}, 'cookieStore.set with whitespace at begining or end');

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_set_arguments.https.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_set_arguments.https.any.serviceworker-expected.txt
@@ -44,9 +44,13 @@ PASS cookieStore.set default domain is null and differs from current hostname
 PASS cookieStore.set with path set to the current directory
 PASS cookieStore.set with path set to a subdirectory of the current directory
 PASS cookieStore.set default path is /
-PASS cookieStore.set adds / to path that does not end with /
+FAIL cookieStore.set does not add / to path that does not end with / assert_equals: expected null but got object "[object Object]"
+PASS cookieStore.set can modify a cookie set by document.cookie if document is defined
 PASS cookieStore.set with path that does not start with /
 PASS cookieStore.set with get result
 PASS cookieStore.set checks if the path is too long
 PASS cookieStore.set checks if the domain is too long
+PASS cookieStore.set with a __Host- prefix should not have a domain
+FAIL cookieStore.set with whitespace only name and value assert_unreached: Should have rejected: undefined Reached unreachable code
+FAIL cookieStore.set with whitespace at begining or end assert_unreached: Should have rejected: undefined Reached unreachable code
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_set_limit.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_set_limit.https.any-expected.txt
@@ -1,0 +1,12 @@
+
+PASS Set max-size cookie with largest possible name and value (4096 bytes)
+PASS Ignore cookie with name larger than 4096 and 1 byte value
+PASS Set max-size value-less cookie
+PASS Ignore value-less cookie with name larger than 4096 bytes
+PASS Set max-size cookie with largest possible value (4095 bytes)
+PASS Ignore named cookie (with non-zero length) and value larger than 4095 bytes
+PASS Ignore named cookie with length larger than 4095 bytes, and a non-zero value
+FAIL Set max-size name-less cookie assert_equals: expected (undefined) undefined but got (object) object "[object Object]"
+PASS Ignore name-less cookie with value larger than 4096 bytes
+PASS Ignore name-less cookie (without leading =) with value larger than 4096 bytes
+

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_set_limit.https.any.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_set_limit.https.any.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_set_limit.https.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_set_limit.https.any.js
@@ -1,0 +1,68 @@
+// META: title=Cookie Store API: cookieStore.delete() return type
+// META: global=window,serviceworker
+
+'use strict';
+
+function cookieParamsWithNameAndValueLengths(nameLength, valueLength) {
+  return { name: "t".repeat(nameLength), value: "1".repeat(valueLength) }
+}
+
+const scenarios = [
+  {
+    cookie: cookieParamsWithNameAndValueLengths(2048, 2048),
+    expected: cookieParamsWithNameAndValueLengths(2048, 2048),
+    name: "Set max-size cookie with largest possible name and value (4096 bytes)",
+  },
+  {
+    cookie: cookieParamsWithNameAndValueLengths(4097, 1),
+    name: "Ignore cookie with name larger than 4096 and 1 byte value",
+  },
+  {
+    cookie: cookieParamsWithNameAndValueLengths(4096, 0),
+    expected: cookieParamsWithNameAndValueLengths(4096, 0),
+    name: "Set max-size value-less cookie",
+  },
+  {
+    cookie: cookieParamsWithNameAndValueLengths(4097, 0),
+    name: "Ignore value-less cookie with name larger than 4096 bytes",
+  },
+  {
+    cookie: cookieParamsWithNameAndValueLengths(1, 4095),
+    expected: cookieParamsWithNameAndValueLengths(1, 4095),
+    name: "Set max-size cookie with largest possible value (4095 bytes)",
+  },
+  {
+    cookie: cookieParamsWithNameAndValueLengths(1, 4096),
+    name: "Ignore named cookie (with non-zero length) and value larger than 4095 bytes",
+  },
+  {
+    cookie: cookieParamsWithNameAndValueLengths(4096, 1),
+    name: "Ignore named cookie with length larger than 4095 bytes, and a non-zero value",
+  },
+  {
+    cookie: cookieParamsWithNameAndValueLengths(0, 4096),
+    expected: cookieParamsWithNameAndValueLengths(0, 4096),
+    name: "Set max-size name-less cookie",
+  },
+  {
+    cookie: cookieParamsWithNameAndValueLengths(0, 4097),
+    name: "Ignore name-less cookie with value larger than 4096 bytes",
+  },
+  {
+    cookie: cookieParamsWithNameAndValueLengths(0, 4097),
+    name: "Ignore name-less cookie (without leading =) with value larger than 4096 bytes",
+  },
+];
+
+for (const scenario of scenarios) {
+  promise_test(async testCase => {
+    let value = "";
+    try {
+      await cookieStore.set(scenario.cookie.name, scenario.cookie.value);
+      value = (await cookieStore.get(scenario.cookie.name))?.value;
+      assert_equals(value, scenario.expected.value);
+    } catch(e) {
+      assert_equals(scenario.expected, undefined);
+    }
+  }, scenario.name);
+}

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_set_limit.https.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_set_limit.https.any.serviceworker-expected.txt
@@ -1,0 +1,12 @@
+
+PASS Set max-size cookie with largest possible name and value (4096 bytes)
+PASS Ignore cookie with name larger than 4096 and 1 byte value
+PASS Set max-size value-less cookie
+PASS Ignore value-less cookie with name larger than 4096 bytes
+PASS Set max-size cookie with largest possible value (4095 bytes)
+PASS Ignore named cookie (with non-zero length) and value larger than 4095 bytes
+PASS Ignore named cookie with length larger than 4095 bytes, and a non-zero value
+FAIL Set max-size name-less cookie assert_equals: expected (undefined) undefined but got (object) object "[object Object]"
+PASS Ignore name-less cookie with value larger than 4096 bytes
+PASS Ignore name-less cookie (without leading =) with value larger than 4096 bytes
+

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_set_limit.https.any.serviceworker.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_set_limit.https.any.serviceworker.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_special_names.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_special_names.https.any-expected.txt
@@ -16,4 +16,6 @@ PASS cookieStore.set with __Host- prefix a path option
 PASS cookieStore.set with __host- prefix and a domain option
 PASS cookieStore.set with __host- prefix a path option
 PASS cookieStore.set with malformed name.
+FAIL cookieStore.set a nameless cookie cannot have __Host- prefix promise_test: Unhandled rejection with value: object "TypeError: The cookie name and value must not both be empty."
+FAIL cookieStore.set a nameless cookie cannot have __Secure- prefix promise_test: Unhandled rejection with value: object "TypeError: The cookie name and value must not both be empty."
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_special_names.https.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_special_names.https.any.js
@@ -64,3 +64,33 @@ promise_test(async testCase => {
     }
     assert_true(exceptionThrown, "No exception thrown.");
 }, 'cookieStore.set with malformed name.');
+
+promise_test(async testCase => {
+  // Nameless cookies cannot have a __Host- prefix
+  await cookieStore.delete('');
+
+  const currentUrl = new URL(self.location.href);
+  const currentDomain = currentUrl.hostname;
+
+  await promise_rejects_js(testCase, TypeError, cookieStore.set(
+      { name: '',
+        value: '__Host-nameless-cookie',
+        domain: `.${currentDomain}` }));
+  const cookie = await cookieStore.get('');
+  assert_equals(cookie, null);
+}, 'cookieStore.set a nameless cookie cannot have __Host- prefix');
+
+promise_test(async testCase => {
+  // Nameless cookies cannot have a __Secure- prefix
+  await cookieStore.delete('');
+
+  const currentUrl = new URL(self.location.href);
+  const currentDomain = currentUrl.hostname;
+
+  await promise_rejects_js(testCase, TypeError, cookieStore.set(
+      { name: '',
+        value: '__Secure-nameless-cookie',
+        domain: `.${currentDomain}` }));
+  const cookie = await cookieStore.get('');
+  assert_equals(cookie, null);
+}, 'cookieStore.set a nameless cookie cannot have __Secure- prefix');

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_special_names.https.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_special_names.https.any.serviceworker-expected.txt
@@ -16,4 +16,6 @@ PASS cookieStore.set with __Host- prefix a path option
 PASS cookieStore.set with __host- prefix and a domain option
 PASS cookieStore.set with __host- prefix a path option
 PASS cookieStore.set with malformed name.
+FAIL cookieStore.set a nameless cookie cannot have __Host- prefix promise_test: Unhandled rejection with value: object "TypeError: The cookie name and value must not both be empty."
+FAIL cookieStore.set a nameless cookie cannot have __Secure- prefix promise_test: Unhandled rejection with value: object "TypeError: The cookie name and value must not both be empty."
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/encoding.https.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/encoding.https.any.js
@@ -4,15 +4,21 @@
 
 'use strict';
 
-cookie_test(async t => {
+promise_test(async t => {
   await setCookieStringHttp('\uFEFFcookie=value; path=/');
+  t.add_cleanup(async () => {
+    await setCookieStringHttp('\uFEFFcookie=value; path=/; Max-Age=0');
+  });
   const cookie = await cookieStore.get('\uFEFFcookie');
   assert_equals(cookie.name, '\uFEFFcookie');
   assert_equals(cookie.value, 'value');
 }, 'BOM not stripped from name');
 
-cookie_test(async t => {
+promise_test(async t => {
   await setCookieStringHttp('cookie=\uFEFFvalue; path=/');
+  t.add_cleanup(async () => {
+    await setCookieStringHttp('cookie=\uFEFFvalue; path=/; Max-Age=0');
+  });
   const cookie = await cookieStore.get('cookie');
   assert_equals(cookie.name, 'cookie');
   assert_equals(cookie.value, '\uFEFFvalue');

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/httponly_cookies.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/httponly_cookies.https.window-expected.txt
@@ -2,4 +2,5 @@
 PASS HttpOnly cookies are not observed
 PASS HttpOnly cookies can not be set by document.cookie
 PASS HttpOnly cookies can not be set by CookieStore
+FAIL HttpOnly cookies are not deleted/overwritten assert_equals: HttpOnly cookie is not overwritten expected (undefined) undefined but got (string) "HTTPONLY-cookie=dummy"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/resources/cookie-test-helpers.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/resources/cookie-test-helpers.js
@@ -210,9 +210,12 @@ async function cookie_test(func, description) {
 
   // Wipe cookies used by tests before and after the test.
   async function deleteAllCookies() {
-    (await cookieStore.getAll()).forEach(({name, value}) => {
-      cookieStore.delete(name);
-    });
+    const cookies = await cookieStore.getAll();
+    await Promise.all(cookies.flatMap(
+        ({name}) =>
+            [cookieStore.delete(name),
+             cookieStore.delete({name, partitioned: true}),
+    ]));
   }
 
   return promise_test(async t => {

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/resources/helper_iframe.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/resources/helper_iframe.sub.html
@@ -22,13 +22,35 @@
         domain: '{{host}}',
       });
       event.source.postMessage('Cookie has been set', event.origin);
+    } else if (opname === 'set-cookie-without-domain-attr') {
+      const { name, value } = event.data
+      await cookieStore.set({
+        name,
+        value,
+      });
+      event.source.postMessage('Cookie has been set', event.origin);
     } else if (opname === 'get-cookie') {
       const { name, options } = event.data
       const frameCookie = await cookieStore.get(name, options);
       event.source.postMessage({frameCookie}, event.origin);
+    } else if (opname === 'delete-cookie-without-domain-attr') {
+      const { name } = event.data
+      await cookieStore.delete({name});
+      event.source.postMessage('Cookie has been deleted', event.origin);
     } else if (opname === 'push-state') {
       history.pushState("foo", null, "some/path");
       event.source.postMessage('pushState called');
+    } else if (opname === "set-host-cookie") {
+      const { name, value } = event.data
+      await cookieStore.set({
+        name,
+        value,
+      });
+      event.source.postMessage('Cookie has been set', event.origin);
+    } else if (opname === "delete-host-cookie") {
+      const { name} = event.data
+      await cookieStore.delete({ name: name});
+      event.source.postMessage('Cookie has been deleted', event.origin);
     }
   });
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/serviceworker_cookiechange_eventhandler_already_expired.https.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/serviceworker_cookiechange_eventhandler_already_expired.https.any.js
@@ -1,0 +1,86 @@
+// META: title=Cookie Store API: cookiechange event in ServiceWorker with already-expired cookie.
+// META: global=serviceworker
+
+'use strict';
+
+const kScope = '/cookie-store/does/not/exist';
+
+function WorkerActivationPromise() {
+  return new Promise((resolve) => {
+    if (registration.active) {
+      resolve();
+      return;
+    }
+    self.addEventListener('activate', () => { resolve(); });
+  });
+}
+
+function RunOnceCookieChangeReceivedPromise() {
+  return new Promise(resolve => {
+    const listener = ev => {
+      resolve(ev);
+      self.removeEventListener('cookiechange', listener);
+    };
+    self.addEventListener('cookiechange', listener);
+  });
+}
+
+promise_test(async t => {
+  await WorkerActivationPromise();
+
+  const subscriptions = [{url: `${kScope}/path`}];
+  await registration.cookies.subscribe(subscriptions);
+  t.add_cleanup(() => registration.cookies.unsubscribe(subscriptions));
+
+  const eventPromise = RunOnceCookieChangeReceivedPromise();
+
+  await cookieStore.set({
+    name: 'cookie-name',
+    value: 'already-expired',
+    expires: new Date(new Date() - 10_000),
+  });
+
+  await cookieStore.set('another-cookie-name', 'ignore');
+  t.add_cleanup(() => cookieStore.delete('another-cookie-name'));
+
+  const event = await eventPromise;
+  assert_equals(event.type, 'cookiechange');
+  assert_equals(event.changed.length, 1);
+  assert_equals(event.changed[0].name, 'another-cookie-name');
+  assert_equals(event.changed[0].value, 'ignore');
+  assert_equals(event.deleted.length, 0);
+});
+
+promise_test(async t => {
+  await WorkerActivationPromise();
+
+  const subscriptions = [{url: `${kScope}/path`}];
+  await registration.cookies.subscribe(subscriptions);
+  t.add_cleanup(() => registration.cookies.unsubscribe(subscriptions));
+
+  const eventPromise = RunOnceCookieChangeReceivedPromise();
+
+  await cookieStore.set({
+    name: 'cookie-name',
+    value: 'already-expired',
+    expires: new Date(new Date() - 10_000),
+    partitioned: true,
+  });
+
+  await cookieStore.set({
+    name: 'another-cookie-name',
+    value: 'ignore',
+    partitioned: true,
+  });
+  t.add_cleanup(() => cookieStore.delete({
+    name: 'another-cookie-name',
+    partitioned: true,
+  }));
+
+  const event = await eventPromise;
+  assert_equals(event.type, 'cookiechange');
+  assert_equals(event.changed.length, 1);
+  assert_equals(event.changed[0].name, 'another-cookie-name');
+  assert_equals(event.changed[0].value, 'ignore');
+  assert_equals(event.deleted.length, 0);
+});

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/serviceworker_cookiechange_eventhandler_already_expired.https.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/serviceworker_cookiechange_eventhandler_already_expired.https.any.serviceworker-expected.txt
@@ -1,0 +1,6 @@
+
+Harness Error (TIMEOUT), message = null
+
+TIMEOUT Cookie Store API: cookiechange event in ServiceWorker with already-expired cookie. Test timed out
+NOTRUN Cookie Store API: cookiechange event in ServiceWorker with already-expired cookie. 1
+

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/serviceworker_cookiechange_eventhandler_already_expired.https.any.serviceworker.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/serviceworker_cookiechange_eventhandler_already_expired.https.any.serviceworker.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/serviceworker_cookiechange_eventhandler_no_change.https.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/serviceworker_cookiechange_eventhandler_no_change.https.any.js
@@ -1,0 +1,128 @@
+// META: title=Cookie Store API: cookiechange event in ServiceWorker with already-expired cookie.
+// META: global=serviceworker
+
+'use strict';
+
+const kScope = '/cookie-store/does/not/exist';
+
+// Resolves when the service worker receives the 'activate' event.
+function WorkerActivationPromise() {
+  return new Promise((resolve) => {
+    if (registration.active) {
+      resolve();
+      return;
+    }
+    self.addEventListener('activate', () => { resolve(); });
+  });
+}
+
+// Resolves when a cookiechange event is received.
+function RunOnceCookieChangeReceivedPromise() {
+  return new Promise(resolve => {
+    const listener = ev => {
+      resolve(ev);
+      self.removeEventListener('cookiechange', listener);
+    };
+    self.addEventListener('cookiechange', listener);
+  });
+}
+
+promise_test(async t => {
+  await WorkerActivationPromise();
+
+  const subscriptions = [{url: `${kScope}/path`}];
+  await registration.cookies.subscribe(subscriptions);
+  t.add_cleanup(() => registration.cookies.unsubscribe(subscriptions));
+
+  let cookie_change_promise = RunOnceCookieChangeReceivedPromise();
+
+  await cookieStore.set('cookie-name', 'value');
+  t.add_cleanup(async () => {
+    await cookieStore.delete('cookie-name');
+  });
+
+  // Observes original cookie.
+  let event = await cookie_change_promise;
+  assert_equals(event.type, 'cookiechange');
+  assert_equals(event.changed.length, 1);
+  assert_equals(event.changed[0].name, 'cookie-name');
+  assert_equals(event.changed[0].value, 'value');
+  assert_equals(event.deleted.length, 0);
+
+  cookie_change_promise = RunOnceCookieChangeReceivedPromise();
+
+  // Duplicate overwrite should not be observed.
+  await cookieStore.set('cookie-name', 'value');
+
+  // This cookie should be observed instead.
+  await cookieStore.set('alternate-cookie-name', 'ignore');
+  t.add_cleanup(async () => {
+    await cookieStore.delete('alternate-cookie-name');
+  });
+
+  event = await cookie_change_promise;
+  assert_equals(event.type, 'cookiechange');
+  assert_equals(event.changed.length, 1);
+  assert_equals(event.changed[0].name, 'alternate-cookie-name');
+  assert_equals(event.changed[0].value, 'ignore');
+  assert_equals(event.deleted.length, 0);
+});
+
+promise_test(async t => {
+  await WorkerActivationPromise();
+
+  const subscriptions = [{url: `${kScope}/path`}];
+  await registration.cookies.subscribe(subscriptions);
+  t.add_cleanup(() => registration.cookies.unsubscribe(subscriptions));
+
+  let cookie_change_promise = RunOnceCookieChangeReceivedPromise();
+
+  await cookieStore.set({
+    name: 'cookie-name',
+    value: 'value',
+    partitioned: true,
+  });
+  t.add_cleanup(async () => {
+    await cookieStore.delete({
+      name: 'cookie-name',
+      partitioned: true,
+    });
+  });
+
+  // Observes original cookie.
+  let event = await cookie_change_promise;
+  assert_equals(event.type, 'cookiechange');
+  assert_equals(event.changed.length, 1);
+  assert_equals(event.changed[0].name, 'cookie-name');
+  assert_equals(event.changed[0].value, 'value');
+  assert_equals(event.deleted.length, 0);
+
+  cookie_change_promise = RunOnceCookieChangeReceivedPromise();
+
+  // Duplicate overwrite should not be observed.
+  await cookieStore.set({
+    name: 'cookie-name',
+    value: 'value',
+    partitioned: true,
+  });
+
+  // This cookie should instead.
+  await cookieStore.set({
+    name: 'alternate-cookie-name',
+    value: 'ignore',
+    partitioned: true,
+  });
+  t.add_cleanup(async () => {
+    await cookieStore.delete({
+      name: 'alternate-cookie-name',
+      partitioned: true,
+    });
+  });
+
+  event = await cookie_change_promise;
+  assert_equals(event.type, 'cookiechange');
+  assert_equals(event.changed.length, 1);
+  assert_equals(event.changed[0].name, 'alternate-cookie-name');
+  assert_equals(event.changed[0].value, 'ignore');
+  assert_equals(event.deleted.length, 0);
+});

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/serviceworker_cookiechange_eventhandler_no_change.https.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/serviceworker_cookiechange_eventhandler_no_change.https.any.serviceworker-expected.txt
@@ -1,0 +1,6 @@
+
+Harness Error (TIMEOUT), message = null
+
+TIMEOUT Cookie Store API: cookiechange event in ServiceWorker with already-expired cookie. Test timed out
+NOTRUN Cookie Store API: cookiechange event in ServiceWorker with already-expired cookie. 1
+

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/serviceworker_cookiechange_eventhandler_no_change.https.any.serviceworker.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/serviceworker_cookiechange_eventhandler_no_change.https.any.serviceworker.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/serviceworker_cookiechange_eventhandler_overlapping_subscriptions.https.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/serviceworker_cookiechange_eventhandler_overlapping_subscriptions.https.any.js
@@ -15,21 +15,18 @@ let g_cookie_changes = [];
 
 // Resolved when a cookiechange event is received. Rearmed by
 // RearmCookieChangeReceivedPromise().
-let g_cookie_change_received_promise = null;
 let g_cookie_change_received_promise_resolver = null;
 self.addEventListener('cookiechange', (event) => {
   g_cookie_changes.push(event);
   if (g_cookie_change_received_promise_resolver) {
     g_cookie_change_received_promise_resolver();
-    RearmCookieChangeReceivedPromise();
   }
 });
 function RearmCookieChangeReceivedPromise() {
-  g_cookie_change_received_promise = new Promise((resolve) => {
+  return new Promise((resolve) => {
     g_cookie_change_received_promise_resolver = resolve;
   });
 }
-RearmCookieChangeReceivedPromise();
 
 promise_test(async testCase => {
   await kServiceWorkerActivatedPromise;
@@ -41,14 +38,16 @@ promise_test(async testCase => {
   await registration.cookies.subscribe(subscriptions);
   testCase.add_cleanup(() => registration.cookies.unsubscribe(subscriptions));
 
+  let cookie_change_received_promise = RearmCookieChangeReceivedPromise();
+
   await cookieStore.set('cookie-name', 'cookie-value');
   testCase.add_cleanup(async () => {
     await cookieStore.delete('cookie-name');
   });
   testCase.add_cleanup(() => { g_cookie_changes = []; });
 
-  await g_cookie_change_received_promise;
-  testCase.add_cleanup(() => RearmCookieChangeReceivedPromise());
+  await cookie_change_received_promise;
+  cookie_change_received_promise = RearmCookieChangeReceivedPromise();
 
   // To ensure that we are accounting for all events dispatched by the first
   // cookie change, we initiate and listen for a final cookie change that we
@@ -59,8 +58,7 @@ promise_test(async testCase => {
   });
   testCase.add_cleanup(() => { g_cookie_changes = []; });
 
-  await g_cookie_change_received_promise;
-  testCase.add_cleanup(() => RearmCookieChangeReceivedPromise());
+  await cookie_change_received_promise;
 
   assert_equals(g_cookie_changes.length, 2);
   {

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/w3c-import.log
@@ -16,8 +16,10 @@ None
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/cookie-store/META.yml
 /LayoutTests/imported/w3c/web-platform-tests/cookie-store/README.md
+/LayoutTests/imported/w3c/web-platform-tests/cookie-store/change_eventhandler_for_already_expired.https.window.js
 /LayoutTests/imported/w3c/web-platform-tests/cookie-store/change_eventhandler_for_document_cookie.https.window.js
 /LayoutTests/imported/w3c/web-platform-tests/cookie-store/change_eventhandler_for_http_cookie_and_set_cookie_headers.https.window.js
+/LayoutTests/imported/w3c/web-platform-tests/cookie-store/change_eventhandler_for_no_change.https.window.js
 /LayoutTests/imported/w3c/web-platform-tests/cookie-store/change_eventhandler_for_no_name_and_no_value.https.window.js
 /LayoutTests/imported/w3c/web-platform-tests/cookie-store/change_eventhandler_for_no_name_equals_in_value.https.window.js
 /LayoutTests/imported/w3c/web-platform-tests/cookie-store/change_eventhandler_for_no_name_multiple_values.https.window.js
@@ -25,6 +27,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStoreManager_getSubscriptions_empty.https.any.js
 /LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStoreManager_getSubscriptions_multiple.https.any.js
 /LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStoreManager_getSubscriptions_single.https.any.js
+/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_delete.sub.https.html
 /LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_delete_arguments.https.any.js
 /LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_delete_basic.https.any.js
 /LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_event_arguments.https.window.js
@@ -46,6 +49,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_in_detached_frame.https.html
 /LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_opaque_origin.https.html
 /LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_set_arguments.https.any.js
+/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_set_limit.https.any.js
 /LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_special_names.https.any.js
 /LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_subscribe_arguments.https.any.js
 /LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_subscriptions_empty.https.window.js
@@ -55,8 +59,10 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/cookie-store/serviceworker_cookieStore_cross_origin.https.sub.html
 /LayoutTests/imported/w3c/web-platform-tests/cookie-store/serviceworker_cookieStore_cross_origin.js
 /LayoutTests/imported/w3c/web-platform-tests/cookie-store/serviceworker_cookieStore_subscriptions_reset.https.html
+/LayoutTests/imported/w3c/web-platform-tests/cookie-store/serviceworker_cookiechange_eventhandler_already_expired.https.any.js
 /LayoutTests/imported/w3c/web-platform-tests/cookie-store/serviceworker_cookiechange_eventhandler_mismatched_subscription.https.any.js
 /LayoutTests/imported/w3c/web-platform-tests/cookie-store/serviceworker_cookiechange_eventhandler_multiple_subscriptions.https.any.js
+/LayoutTests/imported/w3c/web-platform-tests/cookie-store/serviceworker_cookiechange_eventhandler_no_change.https.any.js
 /LayoutTests/imported/w3c/web-platform-tests/cookie-store/serviceworker_cookiechange_eventhandler_overlapping_subscriptions.https.any.js
 /LayoutTests/imported/w3c/web-platform-tests/cookie-store/serviceworker_cookiechange_eventhandler_single_subscription.https.any.js
 /LayoutTests/imported/w3c/web-platform-tests/cookie-store/serviceworker_oncookiechange_eventhandler_single_subscription.https.any.js


### PR DESCRIPTION
#### 668454240d41e89be4a0d66c7137c03a2c864fe4
<pre>
Resync Cookie Store API WPT tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=293541">https://bugs.webkit.org/show_bug.cgi?id=293541</a>
<a href="https://rdar.apple.com/151985334">rdar://151985334</a>

Reviewed by NOBODY (OOPS!).

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/29e8152e6a03b0b884e1619e063df34c6320fafa">https://github.com/web-platform-tests/wpt/commit/29e8152e6a03b0b884e1619e063df34c6320fafa</a>

* LayoutTests/imported/w3c/web-platform-tests/cookie-store/META.yml:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/change_eventhandler_for_already_expired.https.window-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/change_eventhandler_for_already_expired.https.window.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/change_eventhandler_for_already_expired.https.window.js: Added.
(cookie_test.async t):
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/change_eventhandler_for_document_cookie.https.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/change_eventhandler_for_document_cookie.https.window.js:
(cookie_test.async t):
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/change_eventhandler_for_http_cookie_and_set_cookie_headers.https.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/change_eventhandler_for_http_cookie_and_set_cookie_headers.https.window.js:
(cookie_test.async t):
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/change_eventhandler_for_no_change.https.window-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/change_eventhandler_for_no_change.https.window.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/change_eventhandler_for_no_change.https.window.js: Added.
(cookie_test.async t):
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieListItem_attributes.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieListItem_attributes.https.any.js:
(promise_test.async testCase.async const):
(promise_test.async testCase):
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieListItem_attributes.https.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_delete.sub.https-expected.txt: Copied from LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_get_set_across_origins.sub.https-expected.txt.
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_delete.sub.https.html: Copied from LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_get_set_across_origins.sub.https.html.
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_delete_arguments.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_delete_arguments.https.any.js:
(promise_test.async testCase):
(promise_test.async testCase.async await):
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_delete_arguments.https.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_event_delete.https.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_get_set_across_origins.sub.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_get_set_across_origins.sub.https.html:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_set_arguments.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_set_arguments.https.any.js:
(promise_test.async testCase.async await):
(promise_test.async testCase):
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_set_arguments.https.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_set_limit.https.any-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_set_limit.https.any.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_set_limit.https.any.js: Added.
(cookieParamsWithNameAndValueLengths):
(const.scenario.of.scenarios.promise_test.async testCase):
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_set_limit.https.any.serviceworker-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_set_limit.https.any.serviceworker.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_special_names.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_special_names.https.any.js:
(promise_test.async testCase):
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_special_names.https.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/encoding.https.any.js:
(cookie_test.async t): Deleted.
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/httponly_cookies.https.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/httponly_cookies.https.window.js:
(promise_test.async t.async assert_equals):
(promise_test.async t):
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/resources/cookie-test-helpers.js:
(async deleteAllCookies):
(async cookie_test):
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/resources/helper_iframe.sub.html:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/serviceworker_cookiechange_eventhandler_already_expired.https.any.js: Added.
(WorkerActivationPromise):
(promise_test.async t):
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/serviceworker_cookiechange_eventhandler_already_expired.https.any.serviceworker-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/serviceworker_cookiechange_eventhandler_already_expired.https.any.serviceworker.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/serviceworker_cookiechange_eventhandler_multiple_subscriptions.https.any.js:
(RearmCookieChangeReceivedPromise):
(promise_test.async testCase):
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/serviceworker_cookiechange_eventhandler_no_change.https.any.js: Added.
(WorkerActivationPromise):
(promise_test.async t.async let):
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/serviceworker_cookiechange_eventhandler_no_change.https.any.serviceworker-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/serviceworker_cookiechange_eventhandler_no_change.https.any.serviceworker.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/serviceworker_cookiechange_eventhandler_overlapping_subscriptions.https.any.js:
(RearmCookieChangeReceivedPromise):
(promise_test.async testCase):
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/w3c-import.log:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/668454240d41e89be4a0d66c7137c03a2c864fe4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/106698 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/26449 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/16846 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/111908 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/57296 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/27119 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/34951 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/81015 "Found 15 new test failures: imported/w3c/web-platform-tests/cookie-store/change_eventhandler_for_document_cookie.https.window.html imported/w3c/web-platform-tests/cookie-store/change_eventhandler_for_http_cookie_and_set_cookie_headers.https.window.html imported/w3c/web-platform-tests/cookie-store/change_eventhandler_for_no_change.https.window.html imported/w3c/web-platform-tests/cookie-store/change_eventhandler_for_no_name_and_no_value.https.window.html imported/w3c/web-platform-tests/cookie-store/change_eventhandler_for_no_name_equals_in_value.https.window.html imported/w3c/web-platform-tests/cookie-store/change_eventhandler_for_no_name_multiple_values.https.window.html imported/w3c/web-platform-tests/cookie-store/cookieListItem_attributes.https.any.html imported/w3c/web-platform-tests/cookie-store/cookieListItem_attributes.https.any.serviceworker.html imported/w3c/web-platform-tests/cookie-store/cookieStore_delete.sub.https.html imported/w3c/web-platform-tests/cookie-store/cookieStore_delete_arguments.https.any.html ... (failure)") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/109702 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/21510 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/96279 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/61355 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/20954 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/14386 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/56750 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/90850 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/14415 "Found 4 new test failures: imported/w3c/web-platform-tests/cookie-store/change_eventhandler_for_already_expired.https.window.html imported/w3c/web-platform-tests/cookie-store/change_eventhandler_for_document_cookie.https.window.html imported/w3c/web-platform-tests/cookie-store/change_eventhandler_for_http_cookie_and_set_cookie_headers.https.window.html imported/w3c/web-platform-tests/cookie-store/change_eventhandler_for_no_change.https.window.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/114819 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33836 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24941 "Found 1 new test failure: imported/w3c/web-platform-tests/cookie-store/change_eventhandler_for_http_cookie_and_set_cookie_headers.https.window.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/90081 "Found 15 new test failures: imported/w3c/web-platform-tests/cookie-store/change_eventhandler_for_document_cookie.https.window.html imported/w3c/web-platform-tests/cookie-store/change_eventhandler_for_http_cookie_and_set_cookie_headers.https.window.html imported/w3c/web-platform-tests/cookie-store/change_eventhandler_for_no_change.https.window.html imported/w3c/web-platform-tests/cookie-store/change_eventhandler_for_no_name_and_no_value.https.window.html imported/w3c/web-platform-tests/cookie-store/change_eventhandler_for_no_name_equals_in_value.https.window.html imported/w3c/web-platform-tests/cookie-store/change_eventhandler_for_no_name_multiple_values.https.window.html imported/w3c/web-platform-tests/cookie-store/cookieListItem_attributes.https.any.html imported/w3c/web-platform-tests/cookie-store/cookieListItem_attributes.https.any.serviceworker.html imported/w3c/web-platform-tests/cookie-store/cookieStore_delete.sub.https.html imported/w3c/web-platform-tests/cookie-store/cookieStore_delete_arguments.https.any.html ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/34200 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/92510 "Exiting early after 10 failures. 32 tests run. 2 failures") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89791 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34715 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/12526 "Found 4 new test failures: imported/w3c/web-platform-tests/cookie-store/change_eventhandler_for_already_expired.https.window.html imported/w3c/web-platform-tests/cookie-store/change_eventhandler_for_document_cookie.https.window.html imported/w3c/web-platform-tests/cookie-store/change_eventhandler_for_http_cookie_and_set_cookie_headers.https.window.html imported/w3c/web-platform-tests/cookie-store/change_eventhandler_for_no_change.https.window.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/29463 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/33761 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/33507 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/36860 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/35106 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->