### PR TITLE
Deprecate several WebKit APIs that are no longer needed or relevant (Part 2)

### DIFF
--- a/Source/WebKit/Shared/Cocoa/APIObject.mm
+++ b/Source/WebKit/Shared/Cocoa/APIObject.mm
@@ -215,11 +215,15 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         break;
 
     case Type::ProcessPool:
+        ALLOW_DEPRECATED_DECLARATIONS_BEGIN
         wrapper = [WKProcessPool alloc];
+        ALLOW_DEPRECATED_DECLARATIONS_END
         break;
 
     case Type::ProcessPoolConfiguration:
+        ALLOW_DEPRECATED_DECLARATIONS_BEGIN
         wrapper = [_WKProcessPoolConfiguration alloc];
+        ALLOW_DEPRECATED_DECLARATIONS_END
         break;
 
     case Type::PageConfiguration:

--- a/Source/WebKit/UIProcess/API/Cocoa/NSAttributedString.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/NSAttributedString.mm
@@ -168,6 +168,7 @@ static NSMutableArray<NSURL *> *readOnlyAccessPaths()
     if (!configuration) {
         configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
 
+        ALLOW_DEPRECATED_DECLARATIONS_BEGIN
         RetainPtr<WKProcessPool> processPool;
         if (readOnlyAccessPaths().count) {
             RELEASE_ASSERT(readOnlyAccessPaths().count <= 2);
@@ -176,6 +177,7 @@ static NSMutableArray<NSURL *> *readOnlyAccessPaths()
             processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
         } else
             processPool = adoptNS([[WKProcessPool alloc] init]).get();
+        ALLOW_DEPRECATED_DECLARATIONS_END
 
         auto dataStore = [] {
             auto identifier = sourceApplicationBundleIdentifier();
@@ -187,7 +189,9 @@ static NSMutableArray<NSURL *> *readOnlyAccessPaths()
             return adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:configuration.get()]);
         }();
 
+        ALLOW_DEPRECATED_DECLARATIONS_BEGIN
         [configuration setProcessPool:processPool.get()];
+        ALLOW_DEPRECATED_DECLARATIONS_END
         [configuration setWebsiteDataStore:dataStore.get()];
         [configuration setMediaTypesRequiringUserActionForPlayback:WKAudiovisualMediaTypeAll];
         [configuration _setAllowsJavaScriptMarkup:NO];

--- a/Source/WebKit/UIProcess/API/Cocoa/WKProcessPool.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKProcessPool.mm
@@ -77,12 +77,15 @@
 - (instancetype)initWithTaskInfo:(const WebKit::AuxiliaryProcessProxy::TaskInfo&)info process:(const WebKit::WebProcessProxy&)process;
 @end
 
+ALLOW_DEPRECATED_DECLARATIONS_BEGIN
 static RetainPtr<WKProcessPool>& sharedProcessPool()
 {
     static NeverDestroyed<RetainPtr<WKProcessPool>> sharedProcessPool;
     return sharedProcessPool;
 }
+ALLOW_DEPRECATED_DECLARATIONS_END
 
+ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
 @implementation WKProcessPool {
     WeakObjCPtr<id <_WKAutomationDelegate>> _automationDelegate;
     WeakObjCPtr<id <_WKDownloadDelegate>> _downloadDelegate;
@@ -93,6 +96,7 @@ static RetainPtr<WKProcessPool>& sharedProcessPool()
     RetainPtr<id <_WKGeolocationCoreLocationProvider>> _coreLocationProvider;
 #endif // PLATFORM(IOS_FAMILY)
 }
+ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 
 WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
 
@@ -174,7 +178,9 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
 
 @end
 
+ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
 @implementation WKProcessPool (WKPrivate)
+ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 
 + (WKProcessPool *)_sharedProcessPool
 {

--- a/Source/WebKit/UIProcess/API/Cocoa/WKProcessPoolInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKProcessPoolInternal.h
@@ -36,7 +36,9 @@
 namespace WebKit {
 
 template<> struct WrapperTraits<WebProcessPool> {
+    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     using WrapperClass = WKProcessPool;
+    ALLOW_DEPRECATED_DECLARATIONS_END
 };
 
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -594,7 +594,9 @@ static void addBrowsingContextControllerMethodStubsIfNeeded()
     }
     ALLOW_DEPRECATED_DECLARATIONS_END
 
+    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     Ref processPool = *[_configuration processPool]->_processPool;
+    ALLOW_DEPRECATED_DECLARATIONS_END
 
     // FIXME: This copy is probably not necessary.
     Ref pageConfiguration = Ref { *_configuration->_pageConfiguration }->copy();

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm
@@ -213,7 +213,9 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
 
 - (NSString *)description
 {
+    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     return [NSString stringWithFormat:@"<%@: %p; processPool = %@; preferences = %@>", NSStringFromClass(self.class), self, self.processPool, self.preferences];
+    ALLOW_DEPRECATED_DECLARATIONS_END
 }
 
 + (BOOL)supportsSecureCoding
@@ -223,7 +225,9 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
 
 - (void)encodeWithCoder:(NSCoder *)coder
 {
+    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     [coder encodeObject:self.processPool forKey:@"processPool"];
+    ALLOW_DEPRECATED_DECLARATIONS_END
     [coder encodeObject:self.preferences forKey:@"preferences"];
     [coder encodeObject:self.userContentController forKey:@"userContentController"];
     [coder encodeObject:self.websiteDataStore forKey:@"websiteDataStore"];
@@ -269,7 +273,9 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     if (!(self = [self init]))
         return nil;
 
+    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     self.processPool = [coder decodeObjectOfClass:[WKProcessPool class] forKey:@"processPool"];
+    ALLOW_DEPRECATED_DECLARATIONS_END
     self.preferences = [coder decodeObjectOfClass:[WKPreferences class] forKey:@"preferences"];
     self.userContentController = [coder decodeObjectOfClass:[WKUserContentController class] forKey:@"userContentController"];
     self.websiteDataStore = [coder decodeObjectOfClass:[WKWebsiteDataStore class] forKey:@"websiteDataStore"];

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKAutomationDelegate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKAutomationDelegate.h
@@ -30,6 +30,8 @@
 
 @protocol _WKAutomationDelegate <NSObject>
 @optional
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (BOOL)_processPoolAllowsRemoteAutomation:(WKProcessPool *)processPool WK_API_AVAILABLE(macos(10.13), ios(11.0));
 - (void)_processPool:(WKProcessPool *)processPool didRequestAutomationSessionWithIdentifier:(NSString *)identifier configuration:(_WKAutomationSessionConfiguration *)configuration WK_API_AVAILABLE(macos(10.13.4), ios(11.3));
 
@@ -37,4 +39,5 @@
 - (NSString *)_processPoolBrowserVersionForAutomation:(WKProcessPool *)processPool WK_API_AVAILABLE(macos(10.14), ios(12.0));
 
 - (void)_processPoolDidRequestInspectorDebuggablesToWakeUp:(WKProcessPool *)processPool WK_API_AVAILABLE(macos(12.0), ios(15.0));
+#pragma clang diagnostic pop
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKInspectorConfiguration.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKInspectorConfiguration.h
@@ -49,7 +49,10 @@ WK_CLASS_AVAILABLE(macos(12.0))
  This process pool is also used to obtain web content processes for tabs created via _WKInspectorExtension.
  If unspecified, all Web Inspector instances will use a private process pool that is separate from web content.
 */
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 @property (nonatomic, strong, nullable) WKProcessPool *processPool;
+#pragma clang diagnostic pop
 
 /*! @abstract An identifier that is set for all pages associated with this inspector configuration.
  @discussion This can be used to uniquely identify Web Inspector-related pages from within the injected bundle.

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKInspectorConfiguration.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKInspectorConfiguration.mm
@@ -61,6 +61,7 @@
     _configuration->addURLSchemeHandler(WebKit::WebURLSchemeHandlerCocoa::create(urlSchemeHandler), urlScheme);
 }
 
+ALLOW_DEPRECATED_DECLARATIONS_BEGIN
 - (void)setProcessPool:(WKProcessPool *)processPool
 {
     _configuration->setProcessPool(processPool ? processPool->_processPool.get() : nullptr);
@@ -70,6 +71,7 @@
 {
     return wrapper(_configuration->processPool());
 }
+ALLOW_DEPRECATED_DECLARATIONS_END
 
 - (void)applyToWebViewConfiguration:(WKWebViewConfiguration *)configuration
 {
@@ -78,8 +80,10 @@
         [configuration setURLSchemeHandler:handler.apiHandler() forURLScheme:pair.second.createNSString().get()];
     }
 
+    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     if (auto* processPool = self.processPool)
         [configuration setProcessPool:processPool];
+    ALLOW_DEPRECATED_DECLARATIONS_END
 
     if (auto* groupIdentifier = self.groupIdentifier)
         [configuration _setGroupIdentifier:groupIdentifier];

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKProcessPoolConfiguration.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKProcessPoolConfiguration.mm
@@ -32,7 +32,9 @@
 #import <wtf/RetainPtr.h>
 #import <wtf/cocoa/VectorCocoa.h>
 
+ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
 @implementation _WKProcessPoolConfiguration
+ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 
 - (instancetype)init
 {

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKProcessPoolConfigurationInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKProcessPoolConfigurationInternal.h
@@ -32,7 +32,9 @@
 namespace WebKit {
 
 template<> struct WrapperTraits<API::ProcessPoolConfiguration> {
+    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     using WrapperClass = _WKProcessPoolConfiguration;
+    ALLOW_DEPRECATED_DECLARATIONS_END
 };
 
 }

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -3801,8 +3801,10 @@ static bool isLockdownModeWarningNeeded()
     if (WTF::IOSApplication::isMobileSafari())
         return false;
 
+    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     if (![WKProcessPool _lockdownModeEnabledGloballyForTesting] || [[NSUserDefaults standardUserDefaults] boolForKey:WebKitLockdownModeAlertShownKey])
         return false;
+    ALLOW_DEPRECATED_DECLARATIONS_END
 
     return true;
 }

--- a/Source/WebKit/UIProcess/Cocoa/AutomationClient.h
+++ b/Source/WebKit/UIProcess/Cocoa/AutomationClient.h
@@ -41,7 +41,9 @@ namespace WebKit {
 class AutomationClient final : public API::AutomationClient, Inspector::RemoteInspector::Client {
     WTF_MAKE_TZONE_ALLOCATED(AutomationClient);
 public:
+    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     explicit AutomationClient(WKProcessPool *, id <_WKAutomationDelegate>);
+    ALLOW_DEPRECATED_DECLARATIONS_END
     virtual ~AutomationClient();
 
 private:
@@ -52,7 +54,9 @@ private:
     String browserName() const final;
     String browserVersion() const final;
 
+    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     WeakObjCPtr<WKProcessPool> m_processPool;
+    ALLOW_DEPRECATED_DECLARATIONS_END
     WeakObjCPtr<id <_WKAutomationDelegate>> m_delegate;
 
     struct {

--- a/Source/WebKit/UIProcess/Cocoa/AutomationClient.mm
+++ b/Source/WebKit/UIProcess/Cocoa/AutomationClient.mm
@@ -44,6 +44,7 @@ namespace WebKit {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(AutomationClient);
 
+ALLOW_DEPRECATED_DECLARATIONS_BEGIN
 AutomationClient::AutomationClient(WKProcessPool *processPool, id <_WKAutomationDelegate> delegate)
     : m_processPool(processPool)
     , m_delegate(delegate)
@@ -56,6 +57,7 @@ AutomationClient::AutomationClient(WKProcessPool *processPool, id <_WKAutomation
 
     RemoteInspector::singleton().setClient(this);
 }
+ALLOW_DEPRECATED_DECLARATIONS_END
 
 AutomationClient::~AutomationClient()
 {

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
@@ -4265,7 +4265,9 @@ void WebExtensionContext::loadInspectorBackgroundPage(WebInspectorUIProxy& inspe
             ALLOW_DEPRECATED_DECLARATIONS_END
 
             auto *inspectorWebViewConfiguration = inspectorWebView.configuration;
+            ALLOW_DEPRECATED_DECLARATIONS_BEGIN
             configuration.processPool = inspectorWebViewConfiguration.processPool;
+            ALLOW_DEPRECATED_DECLARATIONS_END
             configuration.websiteDataStore = inspectorWebViewConfiguration.websiteDataStore;
             configuration._processDisplayName = inspectorWebViewConfiguration._processDisplayName;
         }

--- a/Source/WebKit/UIProcess/Inspector/mac/WKInspectorViewController.mm
+++ b/Source/WebKit/UIProcess/Inspector/mac/WKInspectorViewController.mm
@@ -181,14 +181,18 @@ static void* const safeAreaInsetsKVOContext = (void*)&safeAreaInsetsKVOContext;
     // WKInspectorConfiguration allows the client to specify a process pool to use.
     // If not specified or the inspection level is >1, use the default strategy.
     // This ensures that Inspector^2 cannot be affected by client (mis)configuration.
+    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     auto* customProcessPool = configuration.get().processPool;
+    ALLOW_DEPRECATED_DECLARATIONS_END
     auto inspectorLevel = WebKit::inspectorLevelForPage(inspectedPage.get());
     auto useDefaultProcessPool = inspectorLevel > 1 || !customProcessPool;
     if (customProcessPool && !useDefaultProcessPool)
         WebKit::prepareProcessPoolForInspector(Ref { *customProcessPool->_processPool.get() });
 
+    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     if (useDefaultProcessPool)
         [configuration setProcessPool:wrapper(Ref { WebKit::defaultInspectorProcessPool(inspectorLevel) }.get())];
+    ALLOW_DEPRECATED_DECLARATIONS_END
 
     // Ensure that a page group identifier is set. This is for computing inspection levels.
     if (!configuration.get()._groupIdentifier)

--- a/Tools/MiniBrowser/mac/AppDelegate.m
+++ b/Tools/MiniBrowser/mac/AppDelegate.m
@@ -227,8 +227,11 @@ static NSNumber *_currentBadge;
 {
     _settingsController = [[SettingsController alloc] initWithMenu:_settingsMenu];
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     if ([_settingsController usesGameControllerFramework])
         [WKProcessPool _forceGameControllerFramework];
+#pragma clang diagnostic pop
 
     if ([NSApp respondsToSelector:@selector(setAutomaticCustomizeTouchBarMenuItemEnabled:)])
         [NSApp setAutomaticCustomizeTouchBarMenuItemEnabled:YES];
@@ -251,11 +254,14 @@ static NSNumber *_currentBadge;
         configuration = [[WKWebViewConfiguration alloc] init];
         configuration.websiteDataStore = [self persistentDataStore];
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         _WKProcessPoolConfiguration *processConfiguration = [[_WKProcessPoolConfiguration alloc] init];
         if (_settingsController.perWindowWebProcessesDisabled)
             processConfiguration.usesSingleWebProcess = YES;
-        
+
         configuration.processPool = [[WKProcessPool alloc] _initWithConfiguration:processConfiguration];
+#pragma clang diagnostic pop
 
         NSArray<_WKFeature *> *features = [WKPreferences _features];
         for (_WKFeature *feature in features) {

--- a/Tools/MiniBrowser/mac/main.m
+++ b/Tools/MiniBrowser/mac/main.m
@@ -28,7 +28,10 @@
 
 int main(int argc, char *argv[])
 {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     [WKProcessPool _setLinkedOnOrAfterEverythingForTesting];
+#pragma clang diagnostic pop
 
     return NSApplicationMain(argc,  (const char **) argv);
 }

--- a/Tools/MobileMiniBrowser/MobileMiniBrowser/main.m
+++ b/Tools/MobileMiniBrowser/MobileMiniBrowser/main.m
@@ -28,7 +28,10 @@
 
 int main(int argc, char * argv[])
 {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     [WKProcessPool _setLinkedOnOrAfterEverythingForTesting];
+#pragma clang diagnostic pop
 
     @autoreleasepool {
         return UIApplicationMain(argc, argv, nil, NSStringFromClass([AppDelegate class]));


### PR DESCRIPTION
#### 08370b3525786478277733be9e17c1d889a3ba7a
<pre>
Deprecate several WebKit APIs that are no longer needed or relevant (Part 2)
<a href="https://bugs.webkit.org/show_bug.cgi?id=294159">https://bugs.webkit.org/show_bug.cgi?id=294159</a>
<a href="https://rdar.apple.com/152772694">rdar://152772694</a>

Reviewed by Wenson Hsieh.

Prepare to deprecate WKProcessPool by suppressing would-be deprecation errors.

* Source/WebKit/Shared/Cocoa/APIObject.mm:
(API::Object::newObject):
* Source/WebKit/UIProcess/API/Cocoa/NSAttributedString.mm:
(+[_WKAttributedStringWebViewCache configuration]):
* Source/WebKit/UIProcess/API/Cocoa/WKProcessPool.mm:
* Source/WebKit/UIProcess/API/Cocoa/WKProcessPoolInternal.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _initializeWithConfiguration:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm:
(-[WKWebViewConfiguration description]):
(-[WKWebViewConfiguration encodeWithCoder:]):
(-[WKWebViewConfiguration initWithCoder:]):
* Source/WebKit/UIProcess/API/Cocoa/_WKAutomationDelegate.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKInspectorConfiguration.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKInspectorConfiguration.mm:
(-[_WKInspectorConfiguration applyToWebViewConfiguration:]):
* Source/WebKit/UIProcess/API/Cocoa/_WKProcessPoolConfiguration.mm:
* Source/WebKit/UIProcess/API/Cocoa/_WKProcessPoolConfigurationInternal.h:
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(isLockdownModeWarningNeeded):
* Source/WebKit/UIProcess/Cocoa/AutomationClient.h:
* Source/WebKit/UIProcess/Cocoa/AutomationClient.mm:
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::loadInspectorBackgroundPage):
* Source/WebKit/UIProcess/Inspector/mac/WKInspectorViewController.mm:
(-[WKInspectorViewController webViewConfiguration]):
* Tools/MiniBrowser/mac/AppDelegate.m:
(-[BrowserAppDelegate awakeFromNib]):
(-[BrowserAppDelegate defaultConfiguration]):
* Tools/MiniBrowser/mac/main.m:
(main):
* Tools/MobileMiniBrowser/MobileMiniBrowser/main.m:
(main):

Canonical link: <a href="https://commits.webkit.org/296062@main">https://commits.webkit.org/296062@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3281d848f78bc6088f426a335d514fbf6fcb5018

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/106756 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/26507 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/16905 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/111967 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/57354 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/108795 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/27177 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/35009 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/81054 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/109760 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/21565 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/96333 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/61395 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/21004 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/14441 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/56808 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/90905 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/14469 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/114900 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33894 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24989 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/90118 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/34259 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/92564 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89828 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22991 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34768 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/12579 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/29542 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/33819 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/39232 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/33565 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/36918 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/35164 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->