### PR TITLE
[Model Element] Update entity transform if the model size changes with stagemode=orbit

### DIFF
--- a/LayoutTests/model-element/model-element-update-transform-after-resize-expected.txt
+++ b/LayoutTests/model-element/model-element-update-transform-after-resize-expected.txt
@@ -1,0 +1,4 @@
+
+PASS <model> should not update entity transform after resize if stagemode=none
+PASS <model> should update entity transform after resize if stagemode=orbit
+

--- a/LayoutTests/model-element/model-element-update-transform-after-resize.html
+++ b/LayoutTests/model-element/model-element-update-transform-after-resize.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ ModelElementEnabled=true ModelProcessEnabled=true ] -->
+<meta charset="utf-8">
+<title>&lt;model> update transform after resize</title>
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src="resources/model-element-test-utils.js"></script>
+<script src="resources/model-utils.js"></script>
+<script src="../resources/js-test-pre.js"></script>
+<body>
+<script>
+'use strict';
+
+promise_test(async t => {
+    const model1 = document.createElement("model");
+    model1.setAttribute("stagemode", "none");
+    model1.setAttribute("width", "300px");
+    model1.setAttribute("height", "1px");
+    document.body.appendChild(model1);
+    model1.appendChild(makeSource("resources/flat-rectangle.usdz"));
+    
+    const model2 = document.createElement("model");
+    model2.setAttribute("stagemode", "none");
+    model2.setAttribute("width", "300px");
+    model2.setAttribute("height", "300px");
+    document.body.appendChild(model2);
+    model2.appendChild(makeSource("resources/flat-rectangle.usdz"));
+
+    await model1.ready;
+    await model2.ready;
+
+    assert_3d_matrix_not_equals(model1.entityTransform, model2.entityTransform);
+    let originalTransformForModel1 = model1.entityTransform;
+
+    model1.setAttribute("height", "300px");
+    await sleepForSeconds(0.1);
+    assert_3d_matrix_not_equals(model1.entityTransform, model2.entityTransform);
+    assert_3d_matrix_approx_equals(model1.entityTransform, originalTransformForModel1);
+}, `<model> should not update entity transform after resize if stagemode=none`);
+
+promise_test(async t => {
+    const model1 = document.createElement("model");
+    model1.setAttribute("stagemode", "orbit");
+    model1.setAttribute("width", "300px");
+    model1.setAttribute("height", "1px");
+    document.body.appendChild(model1);
+    model1.appendChild(makeSource("resources/flat-rectangle.usdz"));
+    
+    const model2 = document.createElement("model");
+    model2.setAttribute("stagemode", "orbit");
+    model2.setAttribute("width", "300px");
+    model2.setAttribute("height", "300px");
+    document.body.appendChild(model2);
+    model2.appendChild(makeSource("resources/flat-rectangle.usdz"));
+
+    await model1.ready;
+    await model2.ready;
+
+    assert_3d_matrix_not_equals(model1.entityTransform, model2.entityTransform);
+    let originalTransformForModel1 = model1.entityTransform;
+
+    model1.setAttribute("height", "300px");
+    await sleepForSeconds(0.1);
+    assert_3d_matrix_approx_equals(model1.entityTransform, model2.entityTransform);
+    assert_3d_matrix_not_equals(model1.entityTransform, originalTransformForModel1);
+}, `<model> should update entity transform after resize if stagemode=orbit`);
+
+</script>
+</body>

--- a/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.h
+++ b/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.h
@@ -82,7 +82,7 @@ public:
     template<typename T> void send(T&& message);
 
     void unloadModelTimerFired();
-    void updateTransform();
+    void updateTransformAfterLayout();
     void updateOpacity();
     void startAnimating();
     void animationPlaybackStateDidUpdate();
@@ -151,12 +151,14 @@ private:
     ModelProcessModelPlayerProxy(ModelProcessModelPlayerManagerProxy&, WebCore::ModelPlayerIdentifier, Ref<IPC::Connection>&&, const std::optional<String>&);
 
     void computeTransform(bool);
+    void updateTransform();
     void applyEnvironmentMapDataAndRelease();
     void applyStageModeOperationToDriver();
     bool stageModeInteractionInProgress() const;
     void updateTransformSRT();
     void notifyModelPlayerOfEntityTransformChange();
     void applyDefaultIBL();
+    void updateForCurrentStageMode();
 
     WebCore::ModelPlayerIdentifier m_id;
     bool m_isVisible { true };
@@ -178,6 +180,7 @@ private:
     float m_yaw { 0 };
 
     RESRT m_transformSRT; // SRT=Scaling/Rotation/Translation. This is stricter than a WebCore::TransformationMatrix.
+    bool m_transformNeedsUpdateAfterNextLayout { false };
 
     bool m_autoplay { false };
     bool m_loop { false };

--- a/Source/WebKit/ModelProcess/cocoa/WKModelProcessModelLayer.mm
+++ b/Source/WebKit/ModelProcess/cocoa/WKModelProcessModelLayer.mm
@@ -38,7 +38,7 @@
     [super layoutSublayers];
 
     if (RefPtr strongPlayer = _player.get())
-        strongPlayer->updateTransform();
+        strongPlayer->updateTransformAfterLayout();
 }
 
 @end


### PR DESCRIPTION
#### 547dbe34daf3f291a9314089886704971b9e13d2
<pre>
[Model Element] Update entity transform if the model size changes with stagemode=orbit
<a href="https://bugs.webkit.org/show_bug.cgi?id=294162">https://bugs.webkit.org/show_bug.cgi?id=294162</a>
<a href="https://rdar.apple.com/151031284">rdar://151031284</a>

Reviewed by Mike Wyrzykowski.

When stagemode is set to orbit, we ensure that the model&apos;s transform is
updated such that it can be rotated within the portal (fit according to
its bounding sphere). If the model size changes afterwards, we need to
update its transform based on the new size following the stagemode=orbit
fitting rules.

To fix this, when ModelProcessModelPlayerProxy is notified of a size change
and stagemode is orbit, set a flag to remember to recompute the model
transform for orbit fit after frame layout.

* LayoutTests/model-element/model-element-update-transform-after-resize-expected.txt: Added.
* LayoutTests/model-element/model-element-update-transform-after-resize.html: Added.
* Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.h:
* Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm:
(WebKit::ModelProcessModelPlayerProxy::updateTransformAfterLayout):
If m_transformNeedsUpdateAfterNextLayout is set, call updateForCurrentStageMode()
to handle the transform update instead.
(WebKit::ModelProcessModelPlayerProxy::sizeDidChange):
Set m_transformNeedsUpdateAfterNextLayout to true if the model size changes
and stagemode is set to orbit.
(WebKit::ModelProcessModelPlayerProxy::updateForCurrentStageMode):
Logic moved from setStageMode().
(WebKit::ModelProcessModelPlayerProxy::setStageMode):
* Source/WebKit/ModelProcess/cocoa/WKModelProcessModelLayer.mm:
(-[WKModelProcessModelLayer layoutSublayers]):
Call ModelProcessModelPlayerProxy::updateTransformAfterLayout()
after frame layout.

Canonical link: <a href="https://commits.webkit.org/296026@main">https://commits.webkit.org/296026@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f3083ed9f6c7f73ce6ebd0865d23ecb85a514f5a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/106752 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/26503 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/16900 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/111963 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/57350 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/27173 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/35005 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/81050 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/109756 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/21559 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/96325 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/61391 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/20998 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/14432 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/56804 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/90899 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/14461 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/114896 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33890 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24982 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/90115 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/34255 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/92556 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89825 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22970 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34761 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/12571 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/29538 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/33815 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/39228 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/33561 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/36914 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/35160 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->