### PR TITLE
[JSC] Track String Resolution in SpeculatedTypes

### DIFF
--- a/Source/JavaScriptCore/bytecode/SpeculatedType.cpp
+++ b/Source/JavaScriptCore/bytecode/SpeculatedType.cpp
@@ -251,16 +251,27 @@ void dumpSpeculation(PrintStream& outStream, SpeculatedType value)
 
         if ((value & SpecString) == SpecString)
             strOut.print("String");
+        else if ((value & SpecStringResolved) == SpecStringResolved)
+            strOut.print("StringResolved");
         else {
             if (value & SpecStringIdent)
                 strOut.print("StringIdent");
             else
                 isTop = false;
             
-            if (value & SpecStringVar)
+            if ((value & SpecStringVar) == SpecStringVar)
                 strOut.print("StringVar");
-            else
-                isTop = false;
+            else {
+                if (value & SpecStringResolvedVar)
+                    strOut.print("StringResolvedVar");
+                else
+                    isTop = false;
+
+                if (value & SpecStringUnresolvedVar)
+                    strOut.print("StringUnresolvedVar");
+                else
+                    isTop = false;
+            }
         }
 
         if (value & SpecSymbol)
@@ -597,6 +608,7 @@ SpeculatedType speculationFromCell(JSCell* cell)
             }
             if (impl->isAtom())
                 return SpecStringIdent;
+            return SpecStringResolved;
         }
         return SpecString;
     }

--- a/Source/JavaScriptCore/bytecode/SpeculatedType.h
+++ b/Source/JavaScriptCore/bytecode/SpeculatedType.h
@@ -70,23 +70,26 @@ static constexpr SpeculatedType SpecGlobalProxy                       = 1ull << 
 static constexpr SpeculatedType SpecDerivedArray                      = 1ull << 28; // It's definitely a DerivedArray object.
 static constexpr SpeculatedType SpecObjectOther                       = 1ull << 29; // It's definitely an object but not JSFinalObject, JSArray, or JSFunction.
 static constexpr SpeculatedType SpecStringIdent                       = 1ull << 30; // It's definitely a JSString, and it's an identifier.
-static constexpr SpeculatedType SpecStringVar                         = 1ull << 31; // It's definitely a JSString, and it's not an identifier.
+static constexpr SpeculatedType SpecStringResolvedVar                 = 1ull << 31; // It's definitely a JSString, and it's not an identifier. And string is resolved.
+static constexpr SpeculatedType SpecStringUnresolvedVar               = 1ull << 32; // It's definitely a JSString, and it's not an identifier. And string is unresolved.
+static constexpr SpeculatedType SpecStringVar                         = SpecStringUnresolvedVar | SpecStringResolvedVar; // It's definitely a JSString, and it's not an identifier.
+static constexpr SpeculatedType SpecStringResolved                    = SpecStringIdent | SpecStringResolvedVar; // It's definitely a JSString, and it's resolved. May be an identifier or not.
 static constexpr SpeculatedType SpecString                            = SpecStringIdent | SpecStringVar; // It's definitely a JSString.
-static constexpr SpeculatedType SpecSymbol                            = 1ull << 32; // It's definitely a Symbol.
-static constexpr SpeculatedType SpecCellOther                         = 1ull << 33; // It's definitely a JSCell but not a subclass of JSObject and definitely not a JSString, BigInt, or Symbol.
-static constexpr SpeculatedType SpecBoolInt32                         = 1ull << 34; // It's definitely an Int32 with value 0 or 1.
-static constexpr SpeculatedType SpecNonBoolInt32                      = 1ull << 35; // It's definitely an Int32 with value other than 0 or 1.
+static constexpr SpeculatedType SpecSymbol                            = 1ull << 33; // It's definitely a Symbol.
+static constexpr SpeculatedType SpecCellOther                         = 1ull << 34; // It's definitely a JSCell but not a subclass of JSObject and definitely not a JSString, BigInt, or Symbol.
+static constexpr SpeculatedType SpecBoolInt32                         = 1ull << 35; // It's definitely an Int32 with value 0 or 1.
+static constexpr SpeculatedType SpecNonBoolInt32                      = 1ull << 36; // It's definitely an Int32 with value other than 0 or 1.
 static constexpr SpeculatedType SpecInt32Only                         = SpecBoolInt32 | SpecNonBoolInt32; // It's definitely an Int32.
 
-static constexpr SpeculatedType SpecInt32AsInt52                      = 1ull << 36; // It's an Int52 and it can fit in an int32.
-static constexpr SpeculatedType SpecNonInt32AsInt52                   = 1ull << 37; // It's an Int52 and it can't fit in an int32.
+static constexpr SpeculatedType SpecInt32AsInt52                      = 1ull << 37; // It's an Int52 and it can fit in an int32.
+static constexpr SpeculatedType SpecNonInt32AsInt52                   = 1ull << 38; // It's an Int52 and it can't fit in an int32.
 static constexpr SpeculatedType SpecInt52Any                          = SpecInt32AsInt52 | SpecNonInt32AsInt52; // It's any kind of Int52.
 
-static constexpr SpeculatedType SpecAnyIntAsDouble                    = 1ull << 38; // It's definitely an Int52 and it's inside a double.
-static constexpr SpeculatedType SpecNonIntAsDouble                    = 1ull << 39; // It's definitely not an Int52 but it's a real number and it's a double.
+static constexpr SpeculatedType SpecAnyIntAsDouble                    = 1ull << 39; // It's definitely an Int52 and it's inside a double.
+static constexpr SpeculatedType SpecNonIntAsDouble                    = 1ull << 40; // It's definitely not an Int52 but it's a real number and it's a double.
 static constexpr SpeculatedType SpecDoubleReal                        = SpecNonIntAsDouble | SpecAnyIntAsDouble; // It's definitely a non-NaN double.
-static constexpr SpeculatedType SpecDoublePureNaN                     = 1ull << 40; // It's definitely a NaN that is safe to tag (i.e. pure).
-static constexpr SpeculatedType SpecDoubleImpureNaN                   = 1ull << 41; // It's definitely a NaN that is unsafe to tag (i.e. impure).
+static constexpr SpeculatedType SpecDoublePureNaN                     = 1ull << 41; // It's definitely a NaN that is safe to tag (i.e. pure).
+static constexpr SpeculatedType SpecDoubleImpureNaN                   = 1ull << 42; // It's definitely a NaN that is unsafe to tag (i.e. impure).
 static constexpr SpeculatedType SpecDoubleNaN                         = SpecDoublePureNaN | SpecDoubleImpureNaN; // It's definitely some kind of NaN.
 static constexpr SpeculatedType SpecBytecodeDouble                    = SpecDoubleReal | SpecDoublePureNaN; // It's either a non-NaN or a NaN double, but it's definitely not impure NaN.
 static constexpr SpeculatedType SpecFullDouble                        = SpecDoubleReal | SpecDoubleNaN; // It's either a non-NaN or a NaN double.
@@ -96,19 +99,19 @@ static constexpr SpeculatedType SpecBytecodeNumber                    = SpecInt3
 static constexpr SpeculatedType SpecIntAnyFormat                      = SpecInt52Any | SpecInt32Only | SpecAnyIntAsDouble;
 
 static constexpr SpeculatedType SpecFullNumber                        = SpecIntAnyFormat | SpecFullDouble; // It's either an Int32, Int52, or a Double, and the Double can be impure NaN.
-static constexpr SpeculatedType SpecBoolean                           = 1ull << 42; // It's definitely a Boolean.
-static constexpr SpeculatedType SpecOther                             = 1ull << 43; // It's definitely either Null or Undefined.
+static constexpr SpeculatedType SpecBoolean                           = 1ull << 43; // It's definitely a Boolean.
+static constexpr SpeculatedType SpecOther                             = 1ull << 44; // It's definitely either Null or Undefined.
 static constexpr SpeculatedType SpecMisc                              = SpecBoolean | SpecOther; // It's definitely either a boolean, Null, or Undefined.
-static constexpr SpeculatedType SpecEmpty                             = 1ull << 44; // It's definitely an empty value marker.
-static constexpr SpeculatedType SpecHeapBigInt                        = 1ull << 45; // It's definitely a BigInt that is allocated on the heap
-static constexpr SpeculatedType SpecBigInt32                          = 1ull << 46; // It's definitely a small BigInt that is inline the JSValue
+static constexpr SpeculatedType SpecEmpty                             = 1ull << 45; // It's definitely an empty value marker.
+static constexpr SpeculatedType SpecHeapBigInt                        = 1ull << 46; // It's definitely a BigInt that is allocated on the heap
+static constexpr SpeculatedType SpecBigInt32                          = 1ull << 47; // It's definitely a small BigInt that is inline the JSValue
 #if USE(BIGINT32)
 static constexpr SpeculatedType SpecBigInt                            = SpecBigInt32 | SpecHeapBigInt;
 #else
 // We should not include SpecBigInt32. We are using SpecBigInt in various places like prediction. If this includes SpecBigInt32, fixup phase is confused if !USE(BIGINT32) since it is not using AnyBigIntUse.
 static constexpr SpeculatedType SpecBigInt                            = SpecHeapBigInt;
 #endif
-static constexpr SpeculatedType SpecDataViewObject                    = 1ull << 47; // It's definitely a JSDataView.
+static constexpr SpeculatedType SpecDataViewObject                    = 1ull << 48; // It's definitely a JSDataView.
 static constexpr SpeculatedType SpecPrimitive                         = SpecString | SpecSymbol | SpecBytecodeNumber | SpecMisc | SpecBigInt; // It's any non-Object JSValue.
 static constexpr SpeculatedType SpecObject                            = SpecFinalObject | SpecArray | SpecFunction | SpecTypedArrayView | SpecDirectArguments | SpecScopedArguments | SpecStringObject | SpecRegExpObject | SpecDateObject | SpecPromiseObject | SpecMapObject | SpecSetObject | SpecWeakMapObject | SpecWeakSetObject | SpecProxyObject | SpecGlobalProxy | SpecDerivedArray | SpecObjectOther | SpecDataViewObject; // Bitmask used for testing for any kind of object prediction.
 static constexpr SpeculatedType SpecCell                              = SpecObject | SpecString | SpecSymbol | SpecCellOther | SpecHeapBigInt; // It's definitely a JSCell.

--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
@@ -4654,18 +4654,22 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
         break;
     }
     case ResolveRope: {
-        JSValue childConst = forNode(node->child1()).value();
+        AbstractValue& value = forNode(node->child1());
+        JSValue childConst = value.value();
         if (childConst && childConst.isString() && !asString(childConst)->isRope()) {
             setConstant(node, *m_graph.freeze(childConst));
             break;
         }
 
-        if (!(forNode(node->child1()).m_type & ~SpecStringIdent)) {
-            setForNode(node, forNode(node->child1()));
+        if (value.isType(SpecStringResolved)) {
+            setForNode(node, value);
             break;
         }
 
-        setTypeForNode(node, SpecString);
+        auto resolved = value;
+        resolved.setType(m_graph, SpecStringResolved);
+        forNode(node->child1()) = resolved;
+        setForNode(node, resolved);
         break;
     }
     case ConstantStoragePointer: {

--- a/Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp
@@ -1114,7 +1114,7 @@ private:
             }
 
             case ResolveRope: {
-                if (m_state.forNode(node->child1()).m_type & ~SpecStringIdent)
+                if (!m_state.forNode(node->child1()).isType(SpecStringResolved))
                     break;
 
                 node->convertToIdentity();

--- a/Source/JavaScriptCore/dfg/DFGIntegerRangeOptimizationPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGIntegerRangeOptimizationPhase.cpp
@@ -1653,6 +1653,12 @@ private:
             break;
         }
 
+        case StringCharCodeAt: {
+            setRelationship(Relationship::safeCreate(node->child2().node(), m_zero, Relationship::GreaterThan, -1));
+            setRelationship(Relationship::safeCreate(node->child2().node(), m_zero, Relationship::LessThan, StringImpl::MaxLength));
+            break;
+        }
+
         case Upsilon: {
             auto shadowNode = NodeFlowProjection(node->phi(), NodeFlowProjection::Shadow);
             // We must first remove all relationships involving the shadow node, because setEquivalence does not overwrite them.

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -8048,7 +8048,7 @@ void SpeculativeJIT::compileUnwrapGlobalProxy(Node* node)
 
 bool SpeculativeJIT::canBeRope(Edge& edge)
 {
-    if (m_state.forNode(edge).isType(SpecStringIdent))
+    if (m_state.forNode(edge).isType(SpecStringResolved))
         return false;
     // If this value is LazyValue, it will be converted to JSString, and the result must be non-rope string.
     String string = edge->tryGetString(m_graph);


### PR DESCRIPTION
#### d5d653f36164e67aac33691010c9f858ef1e0d4a
<pre>
[JSC] Track String Resolution in SpeculatedTypes
<a href="https://bugs.webkit.org/show_bug.cgi?id=294164">https://bugs.webkit.org/show_bug.cgi?id=294164</a>
<a href="https://rdar.apple.com/152778287">rdar://152778287</a>

Reviewed by Yijia Huang.

This patch adds String resolution information to SpeculatedTypes. We add
SpecStringResolvedVar and SpecStringUnresolvedVar. And we add SpecStringResolved
combined SpeculatedType. So we can see whether the string is definitely
resolved or not from AbstractValue&apos;s type. We also add bound information
from StringCharCodeAt in integer range optimization to avoid some
checked addition after this.

* Source/JavaScriptCore/bytecode/SpeculatedType.cpp:
(JSC::dumpSpeculation):
(JSC::speculationFromCell):
* Source/JavaScriptCore/bytecode/SpeculatedType.h:
* Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h:
(JSC::DFG::AbstractInterpreter&lt;AbstractStateType&gt;::executeEffects):
* Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp:
(JSC::DFG::ConstantFoldingPhase::foldConstants):
* Source/JavaScriptCore/dfg/DFGIntegerRangeOptimizationPhase.cpp:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileStringCharCodeAt):
(JSC::FTL::DFG::LowerDFGToB3::compileCompareStrictEq):

Canonical link: <a href="https://commits.webkit.org/295993@main">https://commits.webkit.org/295993@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fa153d0885aadf6c6efb01d9a1d35c15e05cf014

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/106763 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/26514 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/16912 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/111974 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/57361 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/27184 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/35016 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/81060 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/109767 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/21572 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/96339 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/61401 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/21011 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/14447 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/56815 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/99403 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/90912 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/14475 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/114912 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/105381 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33901 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24995 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/90124 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/34266 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/92570 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89834 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34774 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/12585 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/29551 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17296 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/33826 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/39239 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/129692 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/33573 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/35317 "Found 4 new JSC stress test failures: wasm.yaml/wasm/gc/ref-i31-eq.js.default-wasm, wasm.yaml/wasm/gc/ref-i31-eq.js.wasm-collect-continuously, wasm.yaml/wasm/gc/ref-i31-eq.js.wasm-eager, wasm.yaml/wasm/gc/ref-i31-eq.js.wasm-eager-jettison (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/36926 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/35171 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->