### PR TITLE
SVG translate(X) not equal to translate(X,0)

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/coordinate-systems/transform-translate-single-parameter-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/coordinate-systems/transform-translate-single-parameter-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Dynamic update of transform; setAttribute()
+

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/coordinate-systems/transform-translate-single-parameter.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/coordinate-systems/transform-translate-single-parameter.html
@@ -1,0 +1,26 @@
+<!DOCTYPE HTML>
+<link rel="help" href="https://svgwg.org/svg2-draft/coords.html#InterfaceSVGTransform">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body>
+
+<svg width="200" height="100" xmlns="http://www.w3.org/2000/svg">
+  <rect x="10" y="10" width="180" height="80" fill="red" />
+</svg>
+
+<script>
+test(() => {
+const rectElement = document.querySelector("rect");
+
+// Apply single parameter translate - should behave as translate(100, 0)
+rectElement.setAttribute("transform", "translate(100)");
+
+assert_equals(rectElement.getAttribute('transform'), "translate(100)");
+
+assert_equals(rectElement.transform.baseVal.getItem(0).matrix.e, 100);
+assert_equals(rectElement.transform.baseVal.getItem(0).matrix.f, 0);
+
+}, 'Dynamic update of transform; setAttribute()');
+</script>
+</body>
+</html>

--- a/Source/WebCore/svg/SVGTransformable.cpp
+++ b/Source/WebCore/svg/SVGTransformable.cpp
@@ -134,7 +134,7 @@ bool SVGTransformable::parseAndReplaceTransform(SVGTransformValue::SVGTransformT
 
     case SVGTransformValue::SVG_TRANSFORM_TRANSLATE:
         if (valueCount == 1)
-            transform.value().setTranslate(values[0], values[0]);
+            transform.value().setTranslate(values[0], 0);
         else
             transform.value().setTranslate(values[0], values[1]);
         return true;


### PR DESCRIPTION
#### ae28047548e765c9a42d190954e952b6751537ac
<pre>
SVG translate(X) not equal to translate(X,0)
<a href="https://bugs.webkit.org/show_bug.cgi?id=293244">https://bugs.webkit.org/show_bug.cgi?id=293244</a>
<a href="https://rdar.apple.com/151643419">rdar://151643419</a>

Reviewed by Simon Fraser and Alan Baradlay.

When updating SVG transform attributes via setAttribute,
translate(x) was incorrectly interpreted as translate(x,x)
instead of translate(x,0).

This fix defaults the second parameter of translate to 0.

* Source/WebCore/svg/SVGTransformable.cpp:
(WebCore::SVGTransformable::parseAndReplaceTransform):
(WebCore::SVGTransformable::parseTransform):

Canonical link: <a href="https://commits.webkit.org/296008@main">https://commits.webkit.org/296008@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/326789487e8914ada930d0fe74a0a9e4796bc9e0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/106936 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/26643 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/17040 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/112144 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/57496 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/108929 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/27316 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/35145 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/81202 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/109894 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/21692 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/96453 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/61546 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/21132 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/14562 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/56942 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/91036 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/14589 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/115166 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/34029 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/25111 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/90260 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/34397 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/92683 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89975 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22954 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34891 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/12698 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/29743 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/33953 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/39408 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/33701 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/37053 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/35333 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->