### PR TITLE
Optimize registration of user installed fonts

### DIFF
--- a/Source/WTF/wtf/cf/TypeCastsCF.h
+++ b/Source/WTF/wtf/cf/TypeCastsCF.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <CoreFoundation/CoreFoundation.h>
+#include <CoreText/CTFontDescriptor.h>
 #include <wtf/Assertions.h>
 
 #ifndef CF_BRIDGED_TYPE
@@ -88,6 +89,7 @@ WTF_DECLARE_CF_TYPE_TRAIT(CFDictionary);
 WTF_DECLARE_CF_TYPE_TRAIT(CFNumber);
 WTF_DECLARE_CF_TYPE_TRAIT(CFString);
 WTF_DECLARE_CF_TYPE_TRAIT(CFURL);
+WTF_DECLARE_CF_TYPE_TRAIT(CTFontDescriptor);
 
 #define WTF_DECLARE_CF_MUTABLE_TYPE_TRAIT(ClassName, MutableClassName) \
 template <> \

--- a/Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.h
+++ b/Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.h
@@ -100,4 +100,7 @@ WEBCORE_EXPORT CFStringRef contentSizeCategory();
 
 VariationDefaultsMap defaultVariationValues(CTFontRef, ShouldLocalizeAxisNames);
 
+WEBCORE_EXPORT Lock& userInstalledFontMapLock();
+WEBCORE_EXPORT HashMap<String, URL>& userInstalledFontMap() WTF_REQUIRES_LOCK(userInstalledFontMapLock());
+
 } // namespace WebCore

--- a/Source/WebKit/UIProcess/WebProcessPool.h
+++ b/Source/WebKit/UIProcess/WebProcessPool.h
@@ -1006,7 +1006,8 @@ private:
 
 #if PLATFORM(COCOA)
     std::optional<Vector<URL>> m_assetFontURLs;
-    std::optional<Vector<URL>> m_userInstalledFontURLs;
+    std::optional<HashMap<String, URL>> m_userInstalledFontURLs;
+    std::optional<Vector<URL>> m_sandboxExtensionURLs;
 #endif
 
 #if ENABLE(IPC_TESTING_API)

--- a/Source/WebKit/WebProcess/WebProcess.h
+++ b/Source/WebKit/WebProcess/WebProcess.h
@@ -501,6 +501,7 @@ public:
 
 #if PLATFORM(COCOA)
     void registerAdditionalFonts(AdditionalFonts&&);
+    void registerFontMap(HashMap<String, URL>&&, Vector<SandboxExtension::Handle>&& sandboxExtensions);
 #endif
 
 private:

--- a/Source/WebKit/WebProcess/WebProcess.messages.in
+++ b/Source/WebKit/WebProcess/WebProcess.messages.in
@@ -242,5 +242,6 @@ messages -> WebProcess : AuxiliaryProcess WantsAsyncDispatchMessage {
 
 #if PLATFORM(COCOA)
     RegisterAdditionalFonts(struct WebKit::AdditionalFonts fonts)
+    RegisterFontMap(HashMap<String, URL> fonts, Vector<WebKit::SandboxExtensionHandle> sandboxExtensions)
 #endif
 }

--- a/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
+++ b/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
@@ -1640,6 +1640,14 @@ void WebProcess::registerAdditionalFonts(AdditionalFonts&& fonts)
     CTFontManagerRegisterFontURLs((__bridge CFArrayRef)fontURLs.get(), kCTFontManagerScopeProcess, true, blockPtr.get());
 }
 
+void WebProcess::registerFontMap(HashMap<String, URL>&& fontMap, Vector<SandboxExtension::Handle>&& sandboxExtensions)
+{
+    RELEASE_LOG(Process, "WebProcess::registerFontMap");
+    SandboxExtension::consumePermanently(sandboxExtensions);
+    Locker locker(userInstalledFontMapLock());
+    userInstalledFontMap() = WTFMove(fontMap);
+}
+
 } // namespace WebKit
 
 #undef RELEASE_LOG_SESSION_ID


### PR DESCRIPTION
#### b788bbfd09071496ddd5bda1675fe1a41ff80291
<pre>
Optimize registration of user installed fonts
<a href="https://bugs.webkit.org/show_bug.cgi?id=294168">https://bugs.webkit.org/show_bug.cgi?id=294168</a>
<a href="https://rdar.apple.com/150061783">rdar://150061783</a>

Reviewed by Sihui Liu and Chris Dumez.

Improve performance by only registering user installed fonts with font manager when they are actually being used on the page.

* Source/WTF/wtf/cf/TypeCastsCF.h:
* Source/WebCore/platform/graphics/FontCache.cpp:
(WebCore::FontCache::cachedFontPlatformData):
* Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp:
(WebCore::platformFontLookupWithFamily):
(WebCore::FontCache::createFontPlatformData):
(WebCore::userInstalledFontMap):
* Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.h:
* Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm:
(WebKit::sandboxExtensionsForUserInstalledFonts):
(WebKit::addUserInstalledFontURLs):
(WebKit::WebProcessPool::registerUserInstalledFonts):
(WebKit::WebProcessPool::registerAdditionalFonts):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::creationParameters):
* Source/WebKit/UIProcess/WebProcessPool.h:
* Source/WebKit/WebProcess/WebProcess.h:
* Source/WebKit/WebProcess/WebProcess.messages.in:
* Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm:
(WebKit::WebProcess::registerFontMap):

Canonical link: <a href="https://commits.webkit.org/296142@main">https://commits.webkit.org/296142@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c14581930717aa403172b71bcd3974570c804cff

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/107409 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27091 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/17496 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/112623 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/57945 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/109373 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/27774 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/35591 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/81537 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/110338 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22002 "Found 2 new test failures: fast/events/ios/select-all-with-existing-selection.html http/tests/geolocation/geolocation-get-current-position-does-not-leak.https.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/96807 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/61912 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/21443 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/14938 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/57389 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/99998 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/91372 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/14972 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/115724 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/105956 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/34476 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/25412 "Found 3 new test failures: inspector/model/remote-object-get-properties.html inspector/runtime/getDisplayableProperties.html inspector/runtime/getProperties.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/90577 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/34851 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93056 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/90314 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35227 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13013 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/30219 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17385 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/34397 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/39938 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/130272 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34143 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/35433 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/37498 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/35804 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->