### PR TITLE
[JSC] Stop regenerating conditions for loops

### DIFF
--- a/Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp
+++ b/Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp
@@ -4577,22 +4577,18 @@ void WhileNode::emitBytecode(BytecodeGenerator& generator, RegisterID* dst)
         generator.emitLoad(dst, jsUndefined());
 
     Ref<LabelScope> scope = generator.newLabelScope(LabelScope::Loop);
-    Ref<Label> topOfLoop = generator.newLabel();
-
-    generator.emitNodeInConditionContext(m_expr, topOfLoop.get(), scope->breakTarget(), FallThroughMeansTrue);
-
-    generator.emitLabel(topOfLoop.get());
-    generator.emitLoopHint();
-    
-    generator.emitProfileControlFlow(m_statement->startOffset());
-    generator.emitNodeInTailPosition(dst, m_statement);
+    Ref<Label> loopBody = generator.newLabel();
 
     generator.emitLabel(*scope->continueTarget());
+    generator.emitLoopHint();
+    generator.emitNodeInConditionContext(m_expr, loopBody.get(), scope->breakTarget(), FallThroughMeansTrue);
 
-    generator.emitNodeInConditionContext(m_expr, topOfLoop.get(), scope->breakTarget(), FallThroughMeansFalse);
+    generator.emitLabel(loopBody.get());
+    generator.emitProfileControlFlow(m_statement->startOffset());
+    generator.emitNodeInTailPosition(dst, m_statement);
+    generator.emitJump(*scope->continueTarget());
 
     generator.emitLabel(scope->breakTarget());
-
     generator.emitProfileControlFlow(m_statement->endOffset() + (m_statement->isBlock() ? 1 : 0));
 }
 
@@ -4615,11 +4611,13 @@ void ForNode::emitBytecode(BytecodeGenerator& generator, RegisterID* dst)
     }
 
     Ref<Label> topOfLoop = generator.newLabel();
-    if (m_expr2)
-        generator.emitNodeInConditionContext(m_expr2, topOfLoop.get(), scope->breakTarget(), FallThroughMeansTrue);
-
+    Ref<Label> loopBody = generator.newLabel();
     generator.emitLabel(topOfLoop.get());
     generator.emitLoopHint();
+    if (m_expr2)
+        generator.emitNodeInConditionContext(m_expr2, loopBody.get(), scope->breakTarget(), FallThroughMeansTrue);
+
+    generator.emitLabel(loopBody.get());
     generator.emitProfileControlFlow(m_statement->startOffset());
 
     generator.emitNodeInTailPosition(dst, m_statement);
@@ -4628,11 +4626,7 @@ void ForNode::emitBytecode(BytecodeGenerator& generator, RegisterID* dst)
     generator.prepareLexicalScopeForNextForLoopIteration(this, forLoopSymbolTable);
     if (m_expr3)
         generator.emitNodeInIgnoreResultPosition(m_expr3);
-
-    if (m_expr2)
-        generator.emitNodeInConditionContext(m_expr2, topOfLoop.get(), scope->breakTarget(), FallThroughMeansFalse);
-    else
-        generator.emitJump(topOfLoop.get());
+    generator.emitJump(topOfLoop.get());
 
     generator.emitLabel(scope->breakTarget());
     generator.popLexicalScope(this);


### PR DESCRIPTION
#### 11b651e5158f7bec26b6916ca7e61f7109be9a40
<pre>
[JSC] Stop regenerating conditions for loops
<a href="https://bugs.webkit.org/show_bug.cgi?id=294171">https://bugs.webkit.org/show_bug.cgi?id=294171</a>
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

WIP

* Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp:
(JSC::WhileNode::emitBytecode):
(JSC::ForNode::emitBytecode):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/316afbe6bcc698a528ed8543eb026e3594ad4b0c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/106776 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/26527 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/16925 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/111987 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/57374 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/27197 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/35029 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/81073 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/109780 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/21584 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/96351 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/61414 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/21024 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/14459 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/56828 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/99416 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/90925 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/14487 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/114929 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/105394 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33914 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/25007 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/90136 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/34279 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/92582 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89846 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34785 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/12597 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/29566 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/33839 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/39252 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/129705 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/33586 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/35322 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/36939 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/35184 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->