### PR TITLE
Sync `html/rendering/non-replaced-elements/sections-and-headings` from WPT upstream

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/sections-and-headings/headings-styles-no-h1-in-section.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/sections-and-headings/headings-styles-no-h1-in-section.tentative-expected.txt
@@ -1,0 +1,563 @@
+
+PASS <h1> - display
+PASS <h1> - margin-top
+PASS <h1> - margin-right
+PASS <h1> - margin-bottom
+PASS <h1> - margin-left
+PASS <h1> - padding-top
+PASS <h1> - padding-right
+PASS <h1> - padding-bottom
+PASS <h1> - padding-left
+PASS <h1> - font-size
+PASS <h1> - font-weight
+PASS <h2> - display
+PASS <h2> - margin-top
+PASS <h2> - margin-right
+PASS <h2> - margin-bottom
+PASS <h2> - margin-left
+PASS <h2> - padding-top
+PASS <h2> - padding-right
+PASS <h2> - padding-bottom
+PASS <h2> - padding-left
+PASS <h2> - font-size
+PASS <h2> - font-weight
+PASS <h3> - display
+PASS <h3> - margin-top
+PASS <h3> - margin-right
+PASS <h3> - margin-bottom
+PASS <h3> - margin-left
+PASS <h3> - padding-top
+PASS <h3> - padding-right
+PASS <h3> - padding-bottom
+PASS <h3> - padding-left
+PASS <h3> - font-size
+PASS <h3> - font-weight
+PASS <h4> - display
+PASS <h4> - margin-top
+PASS <h4> - margin-right
+PASS <h4> - margin-bottom
+PASS <h4> - margin-left
+PASS <h4> - padding-top
+PASS <h4> - padding-right
+PASS <h4> - padding-bottom
+PASS <h4> - padding-left
+PASS <h4> - font-size
+PASS <h4> - font-weight
+PASS <h5> - display
+PASS <h5> - margin-top
+PASS <h5> - margin-right
+PASS <h5> - margin-bottom
+PASS <h5> - margin-left
+PASS <h5> - padding-top
+PASS <h5> - padding-right
+PASS <h5> - padding-bottom
+PASS <h5> - padding-left
+PASS <h5> - font-size
+PASS <h5> - font-weight
+PASS <h6> - display
+PASS <h6> - margin-top
+PASS <h6> - margin-right
+PASS <h6> - margin-bottom
+PASS <h6> - margin-left
+PASS <h6> - padding-top
+PASS <h6> - padding-right
+PASS <h6> - padding-bottom
+PASS <h6> - padding-left
+PASS <h6> - font-size
+PASS <h6> - font-weight
+PASS <hgroup> - display
+PASS <hgroup> - margin-top
+PASS <hgroup> - margin-right
+PASS <hgroup> - margin-bottom
+PASS <hgroup> - margin-left
+PASS <hgroup> - padding-top
+PASS <hgroup> - padding-right
+PASS <hgroup> - padding-bottom
+PASS <hgroup> - padding-left
+PASS <hgroup> - font-size
+PASS <hgroup> - font-weight
+PASS <article> - display
+PASS <article> - margin-top
+PASS <article> - margin-right
+PASS <article> - margin-bottom
+PASS <article> - margin-left
+PASS <article> - padding-top
+PASS <article> - padding-right
+PASS <article> - padding-bottom
+PASS <article> - padding-left
+PASS <article> - font-size
+PASS <article> - font-weight
+PASS <aside> - display
+PASS <aside> - margin-top
+PASS <aside> - margin-right
+PASS <aside> - margin-bottom
+PASS <aside> - margin-left
+PASS <aside> - padding-top
+PASS <aside> - padding-right
+PASS <aside> - padding-bottom
+PASS <aside> - padding-left
+PASS <aside> - font-size
+PASS <aside> - font-weight
+PASS <nav> - display
+PASS <nav> - margin-top
+PASS <nav> - margin-right
+PASS <nav> - margin-bottom
+PASS <nav> - margin-left
+PASS <nav> - padding-top
+PASS <nav> - padding-right
+PASS <nav> - padding-bottom
+PASS <nav> - padding-left
+PASS <nav> - font-size
+PASS <nav> - font-weight
+PASS <section> - display
+PASS <section> - margin-top
+PASS <section> - margin-right
+PASS <section> - margin-bottom
+PASS <section> - margin-left
+PASS <section> - padding-top
+PASS <section> - padding-right
+PASS <section> - padding-bottom
+PASS <section> - padding-left
+PASS <section> - font-size
+PASS <section> - font-weight
+PASS <h1> (in <article>) - display
+FAIL <h1> (in <article>) - margin-top assert_equals: expected "21.4375px" but got "19.90625px"
+PASS <h1> (in <article>) - margin-right
+FAIL <h1> (in <article>) - margin-bottom assert_equals: expected "21.4375px" but got "19.90625px"
+PASS <h1> (in <article>) - margin-left
+PASS <h1> (in <article>) - padding-top
+PASS <h1> (in <article>) - padding-right
+PASS <h1> (in <article>) - padding-bottom
+PASS <h1> (in <article>) - padding-left
+FAIL <h1> (in <article>) - font-size assert_equals: expected "32px" but got "24px"
+PASS <h1> (in <article>) - font-weight
+PASS <h1> (in <article><article>) - display
+FAIL <h1> (in <article><article>) - margin-top assert_equals: expected "21.4375px" but got "18.71875px"
+PASS <h1> (in <article><article>) - margin-right
+FAIL <h1> (in <article><article>) - margin-bottom assert_equals: expected "21.4375px" but got "18.71875px"
+PASS <h1> (in <article><article>) - margin-left
+PASS <h1> (in <article><article>) - padding-top
+PASS <h1> (in <article><article>) - padding-right
+PASS <h1> (in <article><article>) - padding-bottom
+PASS <h1> (in <article><article>) - padding-left
+FAIL <h1> (in <article><article>) - font-size assert_equals: expected "32px" but got "18.719999px"
+PASS <h1> (in <article><article>) - font-weight
+PASS <h1> (in <article><article><article>) - display
+FAIL <h1> (in <article><article><article>) - margin-top assert_equals: expected "21.4375px" but got "21.265625px"
+PASS <h1> (in <article><article><article>) - margin-right
+FAIL <h1> (in <article><article><article>) - margin-bottom assert_equals: expected "21.4375px" but got "21.265625px"
+PASS <h1> (in <article><article><article>) - margin-left
+PASS <h1> (in <article><article><article>) - padding-top
+PASS <h1> (in <article><article><article>) - padding-right
+PASS <h1> (in <article><article><article>) - padding-bottom
+PASS <h1> (in <article><article><article>) - padding-left
+FAIL <h1> (in <article><article><article>) - font-size assert_equals: expected "32px" but got "16px"
+PASS <h1> (in <article><article><article>) - font-weight
+PASS <h1> (in <article><article><article><article>) - display
+FAIL <h1> (in <article><article><article><article>) - margin-top assert_equals: expected "21.4375px" but got "22.171875px"
+PASS <h1> (in <article><article><article><article>) - margin-right
+FAIL <h1> (in <article><article><article><article>) - margin-bottom assert_equals: expected "21.4375px" but got "22.171875px"
+PASS <h1> (in <article><article><article><article>) - margin-left
+PASS <h1> (in <article><article><article><article>) - padding-top
+PASS <h1> (in <article><article><article><article>) - padding-right
+PASS <h1> (in <article><article><article><article>) - padding-bottom
+PASS <h1> (in <article><article><article><article>) - padding-left
+FAIL <h1> (in <article><article><article><article>) - font-size assert_equals: expected "32px" but got "13.28px"
+PASS <h1> (in <article><article><article><article>) - font-weight
+PASS <h1> (in <article><article><article><article><article>) - display
+FAIL <h1> (in <article><article><article><article><article>) - margin-top assert_equals: expected "21.4375px" but got "24.96875px"
+PASS <h1> (in <article><article><article><article><article>) - margin-right
+FAIL <h1> (in <article><article><article><article><article>) - margin-bottom assert_equals: expected "21.4375px" but got "24.96875px"
+PASS <h1> (in <article><article><article><article><article>) - margin-left
+PASS <h1> (in <article><article><article><article><article>) - padding-top
+PASS <h1> (in <article><article><article><article><article>) - padding-right
+PASS <h1> (in <article><article><article><article><article>) - padding-bottom
+PASS <h1> (in <article><article><article><article><article>) - padding-left
+FAIL <h1> (in <article><article><article><article><article>) - font-size assert_equals: expected "32px" but got "10.72px"
+PASS <h1> (in <article><article><article><article><article>) - font-weight
+PASS <h1> (in <article><article><article><article><article><hgroup>) - display
+FAIL <h1> (in <article><article><article><article><article><hgroup>) - margin-top assert_equals: expected "21.4375px" but got "24.96875px"
+PASS <h1> (in <article><article><article><article><article><hgroup>) - margin-right
+FAIL <h1> (in <article><article><article><article><article><hgroup>) - margin-bottom assert_equals: expected "21.4375px" but got "24.96875px"
+PASS <h1> (in <article><article><article><article><article><hgroup>) - margin-left
+PASS <h1> (in <article><article><article><article><article><hgroup>) - padding-top
+PASS <h1> (in <article><article><article><article><article><hgroup>) - padding-right
+PASS <h1> (in <article><article><article><article><article><hgroup>) - padding-bottom
+PASS <h1> (in <article><article><article><article><article><hgroup>) - padding-left
+FAIL <h1> (in <article><article><article><article><article><hgroup>) - font-size assert_equals: expected "32px" but got "10.72px"
+PASS <h1> (in <article><article><article><article><article><hgroup>) - font-weight
+PASS <h2> (in <article><article><article><article><article><hgroup>) - display
+PASS <h2> (in <article><article><article><article><article><hgroup>) - margin-top
+PASS <h2> (in <article><article><article><article><article><hgroup>) - margin-right
+PASS <h2> (in <article><article><article><article><article><hgroup>) - margin-bottom
+PASS <h2> (in <article><article><article><article><article><hgroup>) - margin-left
+PASS <h2> (in <article><article><article><article><article><hgroup>) - padding-top
+PASS <h2> (in <article><article><article><article><article><hgroup>) - padding-right
+PASS <h2> (in <article><article><article><article><article><hgroup>) - padding-bottom
+PASS <h2> (in <article><article><article><article><article><hgroup>) - padding-left
+PASS <h2> (in <article><article><article><article><article><hgroup>) - font-size
+PASS <h2> (in <article><article><article><article><article><hgroup>) - font-weight
+PASS <h3> (in <article><article><article><article><article><hgroup>) - display
+PASS <h3> (in <article><article><article><article><article><hgroup>) - margin-top
+PASS <h3> (in <article><article><article><article><article><hgroup>) - margin-right
+PASS <h3> (in <article><article><article><article><article><hgroup>) - margin-bottom
+PASS <h3> (in <article><article><article><article><article><hgroup>) - margin-left
+PASS <h3> (in <article><article><article><article><article><hgroup>) - padding-top
+PASS <h3> (in <article><article><article><article><article><hgroup>) - padding-right
+PASS <h3> (in <article><article><article><article><article><hgroup>) - padding-bottom
+PASS <h3> (in <article><article><article><article><article><hgroup>) - padding-left
+PASS <h3> (in <article><article><article><article><article><hgroup>) - font-size
+PASS <h3> (in <article><article><article><article><article><hgroup>) - font-weight
+PASS <h4> (in <article><article><article><article><article><hgroup>) - display
+PASS <h4> (in <article><article><article><article><article><hgroup>) - margin-top
+PASS <h4> (in <article><article><article><article><article><hgroup>) - margin-right
+PASS <h4> (in <article><article><article><article><article><hgroup>) - margin-bottom
+PASS <h4> (in <article><article><article><article><article><hgroup>) - margin-left
+PASS <h4> (in <article><article><article><article><article><hgroup>) - padding-top
+PASS <h4> (in <article><article><article><article><article><hgroup>) - padding-right
+PASS <h4> (in <article><article><article><article><article><hgroup>) - padding-bottom
+PASS <h4> (in <article><article><article><article><article><hgroup>) - padding-left
+PASS <h4> (in <article><article><article><article><article><hgroup>) - font-size
+PASS <h4> (in <article><article><article><article><article><hgroup>) - font-weight
+PASS <h5> (in <article><article><article><article><article><hgroup>) - display
+PASS <h5> (in <article><article><article><article><article><hgroup>) - margin-top
+PASS <h5> (in <article><article><article><article><article><hgroup>) - margin-right
+PASS <h5> (in <article><article><article><article><article><hgroup>) - margin-bottom
+PASS <h5> (in <article><article><article><article><article><hgroup>) - margin-left
+PASS <h5> (in <article><article><article><article><article><hgroup>) - padding-top
+PASS <h5> (in <article><article><article><article><article><hgroup>) - padding-right
+PASS <h5> (in <article><article><article><article><article><hgroup>) - padding-bottom
+PASS <h5> (in <article><article><article><article><article><hgroup>) - padding-left
+PASS <h5> (in <article><article><article><article><article><hgroup>) - font-size
+PASS <h5> (in <article><article><article><article><article><hgroup>) - font-weight
+PASS <h1> (in <aside>) - display
+FAIL <h1> (in <aside>) - margin-top assert_equals: expected "21.4375px" but got "19.90625px"
+PASS <h1> (in <aside>) - margin-right
+FAIL <h1> (in <aside>) - margin-bottom assert_equals: expected "21.4375px" but got "19.90625px"
+PASS <h1> (in <aside>) - margin-left
+PASS <h1> (in <aside>) - padding-top
+PASS <h1> (in <aside>) - padding-right
+PASS <h1> (in <aside>) - padding-bottom
+PASS <h1> (in <aside>) - padding-left
+FAIL <h1> (in <aside>) - font-size assert_equals: expected "32px" but got "24px"
+PASS <h1> (in <aside>) - font-weight
+PASS <h1> (in <aside><aside>) - display
+FAIL <h1> (in <aside><aside>) - margin-top assert_equals: expected "21.4375px" but got "18.71875px"
+PASS <h1> (in <aside><aside>) - margin-right
+FAIL <h1> (in <aside><aside>) - margin-bottom assert_equals: expected "21.4375px" but got "18.71875px"
+PASS <h1> (in <aside><aside>) - margin-left
+PASS <h1> (in <aside><aside>) - padding-top
+PASS <h1> (in <aside><aside>) - padding-right
+PASS <h1> (in <aside><aside>) - padding-bottom
+PASS <h1> (in <aside><aside>) - padding-left
+FAIL <h1> (in <aside><aside>) - font-size assert_equals: expected "32px" but got "18.719999px"
+PASS <h1> (in <aside><aside>) - font-weight
+PASS <h1> (in <aside><aside><aside>) - display
+FAIL <h1> (in <aside><aside><aside>) - margin-top assert_equals: expected "21.4375px" but got "21.265625px"
+PASS <h1> (in <aside><aside><aside>) - margin-right
+FAIL <h1> (in <aside><aside><aside>) - margin-bottom assert_equals: expected "21.4375px" but got "21.265625px"
+PASS <h1> (in <aside><aside><aside>) - margin-left
+PASS <h1> (in <aside><aside><aside>) - padding-top
+PASS <h1> (in <aside><aside><aside>) - padding-right
+PASS <h1> (in <aside><aside><aside>) - padding-bottom
+PASS <h1> (in <aside><aside><aside>) - padding-left
+FAIL <h1> (in <aside><aside><aside>) - font-size assert_equals: expected "32px" but got "16px"
+PASS <h1> (in <aside><aside><aside>) - font-weight
+PASS <h1> (in <aside><aside><aside><aside>) - display
+FAIL <h1> (in <aside><aside><aside><aside>) - margin-top assert_equals: expected "21.4375px" but got "22.171875px"
+PASS <h1> (in <aside><aside><aside><aside>) - margin-right
+FAIL <h1> (in <aside><aside><aside><aside>) - margin-bottom assert_equals: expected "21.4375px" but got "22.171875px"
+PASS <h1> (in <aside><aside><aside><aside>) - margin-left
+PASS <h1> (in <aside><aside><aside><aside>) - padding-top
+PASS <h1> (in <aside><aside><aside><aside>) - padding-right
+PASS <h1> (in <aside><aside><aside><aside>) - padding-bottom
+PASS <h1> (in <aside><aside><aside><aside>) - padding-left
+FAIL <h1> (in <aside><aside><aside><aside>) - font-size assert_equals: expected "32px" but got "13.28px"
+PASS <h1> (in <aside><aside><aside><aside>) - font-weight
+PASS <h1> (in <aside><aside><aside><aside><aside>) - display
+FAIL <h1> (in <aside><aside><aside><aside><aside>) - margin-top assert_equals: expected "21.4375px" but got "24.96875px"
+PASS <h1> (in <aside><aside><aside><aside><aside>) - margin-right
+FAIL <h1> (in <aside><aside><aside><aside><aside>) - margin-bottom assert_equals: expected "21.4375px" but got "24.96875px"
+PASS <h1> (in <aside><aside><aside><aside><aside>) - margin-left
+PASS <h1> (in <aside><aside><aside><aside><aside>) - padding-top
+PASS <h1> (in <aside><aside><aside><aside><aside>) - padding-right
+PASS <h1> (in <aside><aside><aside><aside><aside>) - padding-bottom
+PASS <h1> (in <aside><aside><aside><aside><aside>) - padding-left
+FAIL <h1> (in <aside><aside><aside><aside><aside>) - font-size assert_equals: expected "32px" but got "10.72px"
+PASS <h1> (in <aside><aside><aside><aside><aside>) - font-weight
+PASS <h1> (in <aside><aside><aside><aside><aside><hgroup>) - display
+FAIL <h1> (in <aside><aside><aside><aside><aside><hgroup>) - margin-top assert_equals: expected "21.4375px" but got "24.96875px"
+PASS <h1> (in <aside><aside><aside><aside><aside><hgroup>) - margin-right
+FAIL <h1> (in <aside><aside><aside><aside><aside><hgroup>) - margin-bottom assert_equals: expected "21.4375px" but got "24.96875px"
+PASS <h1> (in <aside><aside><aside><aside><aside><hgroup>) - margin-left
+PASS <h1> (in <aside><aside><aside><aside><aside><hgroup>) - padding-top
+PASS <h1> (in <aside><aside><aside><aside><aside><hgroup>) - padding-right
+PASS <h1> (in <aside><aside><aside><aside><aside><hgroup>) - padding-bottom
+PASS <h1> (in <aside><aside><aside><aside><aside><hgroup>) - padding-left
+FAIL <h1> (in <aside><aside><aside><aside><aside><hgroup>) - font-size assert_equals: expected "32px" but got "10.72px"
+PASS <h1> (in <aside><aside><aside><aside><aside><hgroup>) - font-weight
+PASS <h2> (in <aside><aside><aside><aside><aside><hgroup>) - display
+PASS <h2> (in <aside><aside><aside><aside><aside><hgroup>) - margin-top
+PASS <h2> (in <aside><aside><aside><aside><aside><hgroup>) - margin-right
+PASS <h2> (in <aside><aside><aside><aside><aside><hgroup>) - margin-bottom
+PASS <h2> (in <aside><aside><aside><aside><aside><hgroup>) - margin-left
+PASS <h2> (in <aside><aside><aside><aside><aside><hgroup>) - padding-top
+PASS <h2> (in <aside><aside><aside><aside><aside><hgroup>) - padding-right
+PASS <h2> (in <aside><aside><aside><aside><aside><hgroup>) - padding-bottom
+PASS <h2> (in <aside><aside><aside><aside><aside><hgroup>) - padding-left
+PASS <h2> (in <aside><aside><aside><aside><aside><hgroup>) - font-size
+PASS <h2> (in <aside><aside><aside><aside><aside><hgroup>) - font-weight
+PASS <h3> (in <aside><aside><aside><aside><aside><hgroup>) - display
+PASS <h3> (in <aside><aside><aside><aside><aside><hgroup>) - margin-top
+PASS <h3> (in <aside><aside><aside><aside><aside><hgroup>) - margin-right
+PASS <h3> (in <aside><aside><aside><aside><aside><hgroup>) - margin-bottom
+PASS <h3> (in <aside><aside><aside><aside><aside><hgroup>) - margin-left
+PASS <h3> (in <aside><aside><aside><aside><aside><hgroup>) - padding-top
+PASS <h3> (in <aside><aside><aside><aside><aside><hgroup>) - padding-right
+PASS <h3> (in <aside><aside><aside><aside><aside><hgroup>) - padding-bottom
+PASS <h3> (in <aside><aside><aside><aside><aside><hgroup>) - padding-left
+PASS <h3> (in <aside><aside><aside><aside><aside><hgroup>) - font-size
+PASS <h3> (in <aside><aside><aside><aside><aside><hgroup>) - font-weight
+PASS <h4> (in <aside><aside><aside><aside><aside><hgroup>) - display
+PASS <h4> (in <aside><aside><aside><aside><aside><hgroup>) - margin-top
+PASS <h4> (in <aside><aside><aside><aside><aside><hgroup>) - margin-right
+PASS <h4> (in <aside><aside><aside><aside><aside><hgroup>) - margin-bottom
+PASS <h4> (in <aside><aside><aside><aside><aside><hgroup>) - margin-left
+PASS <h4> (in <aside><aside><aside><aside><aside><hgroup>) - padding-top
+PASS <h4> (in <aside><aside><aside><aside><aside><hgroup>) - padding-right
+PASS <h4> (in <aside><aside><aside><aside><aside><hgroup>) - padding-bottom
+PASS <h4> (in <aside><aside><aside><aside><aside><hgroup>) - padding-left
+PASS <h4> (in <aside><aside><aside><aside><aside><hgroup>) - font-size
+PASS <h4> (in <aside><aside><aside><aside><aside><hgroup>) - font-weight
+PASS <h5> (in <aside><aside><aside><aside><aside><hgroup>) - display
+PASS <h5> (in <aside><aside><aside><aside><aside><hgroup>) - margin-top
+PASS <h5> (in <aside><aside><aside><aside><aside><hgroup>) - margin-right
+PASS <h5> (in <aside><aside><aside><aside><aside><hgroup>) - margin-bottom
+PASS <h5> (in <aside><aside><aside><aside><aside><hgroup>) - margin-left
+PASS <h5> (in <aside><aside><aside><aside><aside><hgroup>) - padding-top
+PASS <h5> (in <aside><aside><aside><aside><aside><hgroup>) - padding-right
+PASS <h5> (in <aside><aside><aside><aside><aside><hgroup>) - padding-bottom
+PASS <h5> (in <aside><aside><aside><aside><aside><hgroup>) - padding-left
+PASS <h5> (in <aside><aside><aside><aside><aside><hgroup>) - font-size
+PASS <h5> (in <aside><aside><aside><aside><aside><hgroup>) - font-weight
+PASS <h1> (in <nav>) - display
+FAIL <h1> (in <nav>) - margin-top assert_equals: expected "21.4375px" but got "19.90625px"
+PASS <h1> (in <nav>) - margin-right
+FAIL <h1> (in <nav>) - margin-bottom assert_equals: expected "21.4375px" but got "19.90625px"
+PASS <h1> (in <nav>) - margin-left
+PASS <h1> (in <nav>) - padding-top
+PASS <h1> (in <nav>) - padding-right
+PASS <h1> (in <nav>) - padding-bottom
+PASS <h1> (in <nav>) - padding-left
+FAIL <h1> (in <nav>) - font-size assert_equals: expected "32px" but got "24px"
+PASS <h1> (in <nav>) - font-weight
+PASS <h1> (in <nav><nav>) - display
+FAIL <h1> (in <nav><nav>) - margin-top assert_equals: expected "21.4375px" but got "18.71875px"
+PASS <h1> (in <nav><nav>) - margin-right
+FAIL <h1> (in <nav><nav>) - margin-bottom assert_equals: expected "21.4375px" but got "18.71875px"
+PASS <h1> (in <nav><nav>) - margin-left
+PASS <h1> (in <nav><nav>) - padding-top
+PASS <h1> (in <nav><nav>) - padding-right
+PASS <h1> (in <nav><nav>) - padding-bottom
+PASS <h1> (in <nav><nav>) - padding-left
+FAIL <h1> (in <nav><nav>) - font-size assert_equals: expected "32px" but got "18.719999px"
+PASS <h1> (in <nav><nav>) - font-weight
+PASS <h1> (in <nav><nav><nav>) - display
+FAIL <h1> (in <nav><nav><nav>) - margin-top assert_equals: expected "21.4375px" but got "21.265625px"
+PASS <h1> (in <nav><nav><nav>) - margin-right
+FAIL <h1> (in <nav><nav><nav>) - margin-bottom assert_equals: expected "21.4375px" but got "21.265625px"
+PASS <h1> (in <nav><nav><nav>) - margin-left
+PASS <h1> (in <nav><nav><nav>) - padding-top
+PASS <h1> (in <nav><nav><nav>) - padding-right
+PASS <h1> (in <nav><nav><nav>) - padding-bottom
+PASS <h1> (in <nav><nav><nav>) - padding-left
+FAIL <h1> (in <nav><nav><nav>) - font-size assert_equals: expected "32px" but got "16px"
+PASS <h1> (in <nav><nav><nav>) - font-weight
+PASS <h1> (in <nav><nav><nav><nav>) - display
+FAIL <h1> (in <nav><nav><nav><nav>) - margin-top assert_equals: expected "21.4375px" but got "22.171875px"
+PASS <h1> (in <nav><nav><nav><nav>) - margin-right
+FAIL <h1> (in <nav><nav><nav><nav>) - margin-bottom assert_equals: expected "21.4375px" but got "22.171875px"
+PASS <h1> (in <nav><nav><nav><nav>) - margin-left
+PASS <h1> (in <nav><nav><nav><nav>) - padding-top
+PASS <h1> (in <nav><nav><nav><nav>) - padding-right
+PASS <h1> (in <nav><nav><nav><nav>) - padding-bottom
+PASS <h1> (in <nav><nav><nav><nav>) - padding-left
+FAIL <h1> (in <nav><nav><nav><nav>) - font-size assert_equals: expected "32px" but got "13.28px"
+PASS <h1> (in <nav><nav><nav><nav>) - font-weight
+PASS <h1> (in <nav><nav><nav><nav><nav>) - display
+FAIL <h1> (in <nav><nav><nav><nav><nav>) - margin-top assert_equals: expected "21.4375px" but got "24.96875px"
+PASS <h1> (in <nav><nav><nav><nav><nav>) - margin-right
+FAIL <h1> (in <nav><nav><nav><nav><nav>) - margin-bottom assert_equals: expected "21.4375px" but got "24.96875px"
+PASS <h1> (in <nav><nav><nav><nav><nav>) - margin-left
+PASS <h1> (in <nav><nav><nav><nav><nav>) - padding-top
+PASS <h1> (in <nav><nav><nav><nav><nav>) - padding-right
+PASS <h1> (in <nav><nav><nav><nav><nav>) - padding-bottom
+PASS <h1> (in <nav><nav><nav><nav><nav>) - padding-left
+FAIL <h1> (in <nav><nav><nav><nav><nav>) - font-size assert_equals: expected "32px" but got "10.72px"
+PASS <h1> (in <nav><nav><nav><nav><nav>) - font-weight
+PASS <h1> (in <nav><nav><nav><nav><nav><hgroup>) - display
+FAIL <h1> (in <nav><nav><nav><nav><nav><hgroup>) - margin-top assert_equals: expected "21.4375px" but got "24.96875px"
+PASS <h1> (in <nav><nav><nav><nav><nav><hgroup>) - margin-right
+FAIL <h1> (in <nav><nav><nav><nav><nav><hgroup>) - margin-bottom assert_equals: expected "21.4375px" but got "24.96875px"
+PASS <h1> (in <nav><nav><nav><nav><nav><hgroup>) - margin-left
+PASS <h1> (in <nav><nav><nav><nav><nav><hgroup>) - padding-top
+PASS <h1> (in <nav><nav><nav><nav><nav><hgroup>) - padding-right
+PASS <h1> (in <nav><nav><nav><nav><nav><hgroup>) - padding-bottom
+PASS <h1> (in <nav><nav><nav><nav><nav><hgroup>) - padding-left
+FAIL <h1> (in <nav><nav><nav><nav><nav><hgroup>) - font-size assert_equals: expected "32px" but got "10.72px"
+PASS <h1> (in <nav><nav><nav><nav><nav><hgroup>) - font-weight
+PASS <h2> (in <nav><nav><nav><nav><nav><hgroup>) - display
+PASS <h2> (in <nav><nav><nav><nav><nav><hgroup>) - margin-top
+PASS <h2> (in <nav><nav><nav><nav><nav><hgroup>) - margin-right
+PASS <h2> (in <nav><nav><nav><nav><nav><hgroup>) - margin-bottom
+PASS <h2> (in <nav><nav><nav><nav><nav><hgroup>) - margin-left
+PASS <h2> (in <nav><nav><nav><nav><nav><hgroup>) - padding-top
+PASS <h2> (in <nav><nav><nav><nav><nav><hgroup>) - padding-right
+PASS <h2> (in <nav><nav><nav><nav><nav><hgroup>) - padding-bottom
+PASS <h2> (in <nav><nav><nav><nav><nav><hgroup>) - padding-left
+PASS <h2> (in <nav><nav><nav><nav><nav><hgroup>) - font-size
+PASS <h2> (in <nav><nav><nav><nav><nav><hgroup>) - font-weight
+PASS <h3> (in <nav><nav><nav><nav><nav><hgroup>) - display
+PASS <h3> (in <nav><nav><nav><nav><nav><hgroup>) - margin-top
+PASS <h3> (in <nav><nav><nav><nav><nav><hgroup>) - margin-right
+PASS <h3> (in <nav><nav><nav><nav><nav><hgroup>) - margin-bottom
+PASS <h3> (in <nav><nav><nav><nav><nav><hgroup>) - margin-left
+PASS <h3> (in <nav><nav><nav><nav><nav><hgroup>) - padding-top
+PASS <h3> (in <nav><nav><nav><nav><nav><hgroup>) - padding-right
+PASS <h3> (in <nav><nav><nav><nav><nav><hgroup>) - padding-bottom
+PASS <h3> (in <nav><nav><nav><nav><nav><hgroup>) - padding-left
+PASS <h3> (in <nav><nav><nav><nav><nav><hgroup>) - font-size
+PASS <h3> (in <nav><nav><nav><nav><nav><hgroup>) - font-weight
+PASS <h4> (in <nav><nav><nav><nav><nav><hgroup>) - display
+PASS <h4> (in <nav><nav><nav><nav><nav><hgroup>) - margin-top
+PASS <h4> (in <nav><nav><nav><nav><nav><hgroup>) - margin-right
+PASS <h4> (in <nav><nav><nav><nav><nav><hgroup>) - margin-bottom
+PASS <h4> (in <nav><nav><nav><nav><nav><hgroup>) - margin-left
+PASS <h4> (in <nav><nav><nav><nav><nav><hgroup>) - padding-top
+PASS <h4> (in <nav><nav><nav><nav><nav><hgroup>) - padding-right
+PASS <h4> (in <nav><nav><nav><nav><nav><hgroup>) - padding-bottom
+PASS <h4> (in <nav><nav><nav><nav><nav><hgroup>) - padding-left
+PASS <h4> (in <nav><nav><nav><nav><nav><hgroup>) - font-size
+PASS <h4> (in <nav><nav><nav><nav><nav><hgroup>) - font-weight
+PASS <h5> (in <nav><nav><nav><nav><nav><hgroup>) - display
+PASS <h5> (in <nav><nav><nav><nav><nav><hgroup>) - margin-top
+PASS <h5> (in <nav><nav><nav><nav><nav><hgroup>) - margin-right
+PASS <h5> (in <nav><nav><nav><nav><nav><hgroup>) - margin-bottom
+PASS <h5> (in <nav><nav><nav><nav><nav><hgroup>) - margin-left
+PASS <h5> (in <nav><nav><nav><nav><nav><hgroup>) - padding-top
+PASS <h5> (in <nav><nav><nav><nav><nav><hgroup>) - padding-right
+PASS <h5> (in <nav><nav><nav><nav><nav><hgroup>) - padding-bottom
+PASS <h5> (in <nav><nav><nav><nav><nav><hgroup>) - padding-left
+PASS <h5> (in <nav><nav><nav><nav><nav><hgroup>) - font-size
+PASS <h5> (in <nav><nav><nav><nav><nav><hgroup>) - font-weight
+PASS <h1> (in <section>) - display
+FAIL <h1> (in <section>) - margin-top assert_equals: expected "21.4375px" but got "19.90625px"
+PASS <h1> (in <section>) - margin-right
+FAIL <h1> (in <section>) - margin-bottom assert_equals: expected "21.4375px" but got "19.90625px"
+PASS <h1> (in <section>) - margin-left
+PASS <h1> (in <section>) - padding-top
+PASS <h1> (in <section>) - padding-right
+PASS <h1> (in <section>) - padding-bottom
+PASS <h1> (in <section>) - padding-left
+FAIL <h1> (in <section>) - font-size assert_equals: expected "32px" but got "24px"
+PASS <h1> (in <section>) - font-weight
+PASS <h1> (in <section><section>) - display
+FAIL <h1> (in <section><section>) - margin-top assert_equals: expected "21.4375px" but got "18.71875px"
+PASS <h1> (in <section><section>) - margin-right
+FAIL <h1> (in <section><section>) - margin-bottom assert_equals: expected "21.4375px" but got "18.71875px"
+PASS <h1> (in <section><section>) - margin-left
+PASS <h1> (in <section><section>) - padding-top
+PASS <h1> (in <section><section>) - padding-right
+PASS <h1> (in <section><section>) - padding-bottom
+PASS <h1> (in <section><section>) - padding-left
+FAIL <h1> (in <section><section>) - font-size assert_equals: expected "32px" but got "18.719999px"
+PASS <h1> (in <section><section>) - font-weight
+PASS <h1> (in <section><section><section>) - display
+FAIL <h1> (in <section><section><section>) - margin-top assert_equals: expected "21.4375px" but got "21.265625px"
+PASS <h1> (in <section><section><section>) - margin-right
+FAIL <h1> (in <section><section><section>) - margin-bottom assert_equals: expected "21.4375px" but got "21.265625px"
+PASS <h1> (in <section><section><section>) - margin-left
+PASS <h1> (in <section><section><section>) - padding-top
+PASS <h1> (in <section><section><section>) - padding-right
+PASS <h1> (in <section><section><section>) - padding-bottom
+PASS <h1> (in <section><section><section>) - padding-left
+FAIL <h1> (in <section><section><section>) - font-size assert_equals: expected "32px" but got "16px"
+PASS <h1> (in <section><section><section>) - font-weight
+PASS <h1> (in <section><section><section><section>) - display
+FAIL <h1> (in <section><section><section><section>) - margin-top assert_equals: expected "21.4375px" but got "22.171875px"
+PASS <h1> (in <section><section><section><section>) - margin-right
+FAIL <h1> (in <section><section><section><section>) - margin-bottom assert_equals: expected "21.4375px" but got "22.171875px"
+PASS <h1> (in <section><section><section><section>) - margin-left
+PASS <h1> (in <section><section><section><section>) - padding-top
+PASS <h1> (in <section><section><section><section>) - padding-right
+PASS <h1> (in <section><section><section><section>) - padding-bottom
+PASS <h1> (in <section><section><section><section>) - padding-left
+FAIL <h1> (in <section><section><section><section>) - font-size assert_equals: expected "32px" but got "13.28px"
+PASS <h1> (in <section><section><section><section>) - font-weight
+PASS <h1> (in <section><section><section><section><section>) - display
+FAIL <h1> (in <section><section><section><section><section>) - margin-top assert_equals: expected "21.4375px" but got "24.96875px"
+PASS <h1> (in <section><section><section><section><section>) - margin-right
+FAIL <h1> (in <section><section><section><section><section>) - margin-bottom assert_equals: expected "21.4375px" but got "24.96875px"
+PASS <h1> (in <section><section><section><section><section>) - margin-left
+PASS <h1> (in <section><section><section><section><section>) - padding-top
+PASS <h1> (in <section><section><section><section><section>) - padding-right
+PASS <h1> (in <section><section><section><section><section>) - padding-bottom
+PASS <h1> (in <section><section><section><section><section>) - padding-left
+FAIL <h1> (in <section><section><section><section><section>) - font-size assert_equals: expected "32px" but got "10.72px"
+PASS <h1> (in <section><section><section><section><section>) - font-weight
+PASS <h1> (in <section><section><section><section><section><hgroup>) - display
+FAIL <h1> (in <section><section><section><section><section><hgroup>) - margin-top assert_equals: expected "21.4375px" but got "24.96875px"
+PASS <h1> (in <section><section><section><section><section><hgroup>) - margin-right
+FAIL <h1> (in <section><section><section><section><section><hgroup>) - margin-bottom assert_equals: expected "21.4375px" but got "24.96875px"
+PASS <h1> (in <section><section><section><section><section><hgroup>) - margin-left
+PASS <h1> (in <section><section><section><section><section><hgroup>) - padding-top
+PASS <h1> (in <section><section><section><section><section><hgroup>) - padding-right
+PASS <h1> (in <section><section><section><section><section><hgroup>) - padding-bottom
+PASS <h1> (in <section><section><section><section><section><hgroup>) - padding-left
+FAIL <h1> (in <section><section><section><section><section><hgroup>) - font-size assert_equals: expected "32px" but got "10.72px"
+PASS <h1> (in <section><section><section><section><section><hgroup>) - font-weight
+PASS <h2> (in <section><section><section><section><section><hgroup>) - display
+PASS <h2> (in <section><section><section><section><section><hgroup>) - margin-top
+PASS <h2> (in <section><section><section><section><section><hgroup>) - margin-right
+PASS <h2> (in <section><section><section><section><section><hgroup>) - margin-bottom
+PASS <h2> (in <section><section><section><section><section><hgroup>) - margin-left
+PASS <h2> (in <section><section><section><section><section><hgroup>) - padding-top
+PASS <h2> (in <section><section><section><section><section><hgroup>) - padding-right
+PASS <h2> (in <section><section><section><section><section><hgroup>) - padding-bottom
+PASS <h2> (in <section><section><section><section><section><hgroup>) - padding-left
+PASS <h2> (in <section><section><section><section><section><hgroup>) - font-size
+PASS <h2> (in <section><section><section><section><section><hgroup>) - font-weight
+PASS <h3> (in <section><section><section><section><section><hgroup>) - display
+PASS <h3> (in <section><section><section><section><section><hgroup>) - margin-top
+PASS <h3> (in <section><section><section><section><section><hgroup>) - margin-right
+PASS <h3> (in <section><section><section><section><section><hgroup>) - margin-bottom
+PASS <h3> (in <section><section><section><section><section><hgroup>) - margin-left
+PASS <h3> (in <section><section><section><section><section><hgroup>) - padding-top
+PASS <h3> (in <section><section><section><section><section><hgroup>) - padding-right
+PASS <h3> (in <section><section><section><section><section><hgroup>) - padding-bottom
+PASS <h3> (in <section><section><section><section><section><hgroup>) - padding-left
+PASS <h3> (in <section><section><section><section><section><hgroup>) - font-size
+PASS <h3> (in <section><section><section><section><section><hgroup>) - font-weight
+PASS <h4> (in <section><section><section><section><section><hgroup>) - display
+PASS <h4> (in <section><section><section><section><section><hgroup>) - margin-top
+PASS <h4> (in <section><section><section><section><section><hgroup>) - margin-right
+PASS <h4> (in <section><section><section><section><section><hgroup>) - margin-bottom
+PASS <h4> (in <section><section><section><section><section><hgroup>) - margin-left
+PASS <h4> (in <section><section><section><section><section><hgroup>) - padding-top
+PASS <h4> (in <section><section><section><section><section><hgroup>) - padding-right
+PASS <h4> (in <section><section><section><section><section><hgroup>) - padding-bottom
+PASS <h4> (in <section><section><section><section><section><hgroup>) - padding-left
+PASS <h4> (in <section><section><section><section><section><hgroup>) - font-size
+PASS <h4> (in <section><section><section><section><section><hgroup>) - font-weight
+PASS <h5> (in <section><section><section><section><section><hgroup>) - display
+PASS <h5> (in <section><section><section><section><section><hgroup>) - margin-top
+PASS <h5> (in <section><section><section><section><section><hgroup>) - margin-right
+PASS <h5> (in <section><section><section><section><section><hgroup>) - margin-bottom
+PASS <h5> (in <section><section><section><section><section><hgroup>) - margin-left
+PASS <h5> (in <section><section><section><section><section><hgroup>) - padding-top
+PASS <h5> (in <section><section><section><section><section><hgroup>) - padding-right
+PASS <h5> (in <section><section><section><section><section><hgroup>) - padding-bottom
+PASS <h5> (in <section><section><section><section><section><hgroup>) - padding-left
+PASS <h5> (in <section><section><section><section><section><hgroup>) - font-size
+PASS <h5> (in <section><section><section><section><section><hgroup>) - font-weight
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/sections-and-headings/headings-styles-no-h1-in-section.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/sections-and-headings/headings-styles-no-h1-in-section.tentative.html
@@ -1,9 +1,10 @@
 <!doctype html>
-<title>default styles for h1..h6, hgroup, article, aside, nav, section</title>
+<title>default styles for h1..h6, hgroup, article, aside, nav, section (no h1 in section UA styles)</title>
 <meta name="viewport" content="width=device-width">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/html/rendering/support/test-ua-stylesheet.js"></script>
+<link rel="help" href="https://github.com/whatwg/html/issues/7867">
 <style>
 /* Specify this bogus namespace, so the rules in this stylesheet only apply to the `fakeClone`d elements in #refs, not the HTML elements in #tests. */
 @namespace url(urn:not-html);
@@ -18,12 +19,6 @@ h3 { margin-block: 1.00em; font-size: 1.17em; font-weight: bold; }
 h4 { margin-block: 1.33em; font-size: 1.00em; font-weight: bold; }
 h5 { margin-block: 1.67em; font-size: 0.83em; font-weight: bold; }
 h6 { margin-block: 2.33em; font-size: 0.67em; font-weight: bold; }
-
-:is(article, aside, nav, section) h1 { margin-block: 0.83em; font-size: 1.50em; }
-:is(article, aside, nav, section) :is(article, aside, nav, section) h1 { margin-block: 1.00em; font-size: 1.17em; }
-:is(article, aside, nav, section) :is(article, aside, nav, section) :is(article, aside, nav, section) h1 { margin-block: 1.33em; font-size: 1.00em; }
-:is(article, aside, nav, section) :is(article, aside, nav, section) :is(article, aside, nav, section) :is(article, aside, nav, section) h1 { margin-block: 1.67em; font-size: 0.83em; }
-:is(article, aside, nav, section) :is(article, aside, nav, section) :is(article, aside, nav, section) :is(article, aside, nav, section) :is(article, aside, nav, section) h1 { margin-block: 2.33em; font-size: 0.67em; }
 
 </style>
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/sections-and-headings/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/sections-and-headings/w3c-import.log
@@ -14,4 +14,5 @@ Property values requiring vendor prefixes:
 None
 ------------------------------------------------------------------------
 List of files:
+/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/sections-and-headings/headings-styles-no-h1-in-section.tentative.html
 /LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/sections-and-headings/headings-styles.html


### PR DESCRIPTION
#### 1c0e4dec20e50f9a8da5d7525dd8b77db3897206
<pre>
Sync `html/rendering/non-replaced-elements/sections-and-headings` from WPT upstream

<a href="https://bugs.webkit.org/show_bug.cgi?id=294174">https://bugs.webkit.org/show_bug.cgi?id=294174</a>

Reviewed by Tim Nguyen.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/3c2b49a7d66f5f144ea6705fe4b2c297953ea22b">https://github.com/web-platform-tests/wpt/commit/3c2b49a7d66f5f144ea6705fe4b2c297953ea22b</a>

* LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/sections-and-headings/headings-styles.html:
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/sections-and-headings/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/sections-and-headings/headings-styles-no-h1-in-section.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/sections-and-headings/headings-styles-no-h1-in-section.tentative.html:

Canonical link: <a href="https://commits.webkit.org/295973@main">https://commits.webkit.org/295973@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ff4f0d12728ccbf4013dde7e1848c27d8fc15d9e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/106791 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/26542 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/16940 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/112002 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/57389 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/27212 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/35044 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/81088 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/109795 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/21599 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/96366 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/61429 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/21039 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/14474 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/56843 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/90940 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/14502 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/114947 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33929 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/25022 "Found 1 new test failure: fast/scrolling/mac/scrollbars/overflow-overlay-scrollbar-reveal.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/90150 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/34294 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/92597 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89860 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22929 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34799 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/12612 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/29584 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/33854 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/33601 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/36954 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/35199 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->