### PR TITLE
[Safe CPP] Address Warnings in LegacyRenderSVGResource

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -789,16 +789,10 @@ rendering/svg/legacy/LegacyRenderSVGModelObject.cpp
 rendering/svg/legacy/LegacyRenderSVGPath.cpp
 rendering/svg/legacy/LegacyRenderSVGResource.cpp
 rendering/svg/legacy/LegacyRenderSVGResourceClipper.cpp
-rendering/svg/legacy/LegacyRenderSVGResourceClipperInlines.h
 rendering/svg/legacy/LegacyRenderSVGResourceContainer.cpp
 rendering/svg/legacy/LegacyRenderSVGResourceFilter.cpp
-rendering/svg/legacy/LegacyRenderSVGResourceFilterInlines.h
 rendering/svg/legacy/LegacyRenderSVGResourceFilterPrimitive.cpp
 rendering/svg/legacy/LegacyRenderSVGResourceGradient.cpp
-rendering/svg/legacy/LegacyRenderSVGResourceMarker.cpp
-rendering/svg/legacy/LegacyRenderSVGResourceMarkerInlines.h
-rendering/svg/legacy/LegacyRenderSVGResourceMasker.cpp
-rendering/svg/legacy/LegacyRenderSVGResourceMaskerInlines.h
 rendering/svg/legacy/LegacyRenderSVGResourcePattern.cpp
 rendering/svg/legacy/LegacyRenderSVGResourceSolidColor.cpp
 rendering/svg/legacy/LegacyRenderSVGRoot.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
@@ -547,7 +547,6 @@ rendering/svg/legacy/LegacyRenderSVGResourceClipper.cpp
 rendering/svg/legacy/LegacyRenderSVGResourceContainer.cpp
 rendering/svg/legacy/LegacyRenderSVGResourceContainer.h
 rendering/svg/legacy/LegacyRenderSVGResourceGradient.cpp
-rendering/svg/legacy/LegacyRenderSVGResourceMasker.cpp
 rendering/svg/legacy/LegacyRenderSVGResourcePattern.cpp
 rendering/svg/legacy/LegacyRenderSVGRoot.cpp
 rendering/svg/legacy/LegacyRenderSVGTransformableContainer.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -1068,16 +1068,10 @@ rendering/svg/legacy/LegacyRenderSVGModelObject.cpp
 rendering/svg/legacy/LegacyRenderSVGPath.cpp
 rendering/svg/legacy/LegacyRenderSVGResource.cpp
 rendering/svg/legacy/LegacyRenderSVGResourceClipper.cpp
-rendering/svg/legacy/LegacyRenderSVGResourceClipperInlines.h
 rendering/svg/legacy/LegacyRenderSVGResourceContainer.cpp
 rendering/svg/legacy/LegacyRenderSVGResourceFilter.cpp
-rendering/svg/legacy/LegacyRenderSVGResourceFilterInlines.h
 rendering/svg/legacy/LegacyRenderSVGResourceFilterPrimitive.cpp
 rendering/svg/legacy/LegacyRenderSVGResourceGradient.cpp
-rendering/svg/legacy/LegacyRenderSVGResourceMarker.cpp
-rendering/svg/legacy/LegacyRenderSVGResourceMarkerInlines.h
-rendering/svg/legacy/LegacyRenderSVGResourceMasker.cpp
-rendering/svg/legacy/LegacyRenderSVGResourceMaskerInlines.h
 rendering/svg/legacy/LegacyRenderSVGResourcePattern.cpp
 rendering/svg/legacy/LegacyRenderSVGResourceSolidColor.cpp
 rendering/svg/legacy/LegacyRenderSVGRoot.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -605,7 +605,6 @@ rendering/svg/legacy/LegacyRenderSVGResource.cpp
 rendering/svg/legacy/LegacyRenderSVGResourceClipper.cpp
 rendering/svg/legacy/LegacyRenderSVGResourceContainer.cpp
 rendering/svg/legacy/LegacyRenderSVGResourceGradient.cpp
-rendering/svg/legacy/LegacyRenderSVGResourceMasker.cpp
 rendering/svg/legacy/LegacyRenderSVGResourcePattern.cpp
 rendering/svg/legacy/LegacyRenderSVGResourceSolidColor.cpp
 rendering/svg/legacy/LegacyRenderSVGShape.cpp

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceClipperInlines.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceClipperInlines.h
@@ -42,7 +42,7 @@ inline Ref<SVGClipPathElement> LegacyRenderSVGResourceClipper::protectedClipPath
 
 inline SVGUnitTypes::SVGUnitType LegacyRenderSVGResourceClipper::clipPathUnits() const
 {
-    return clipPathElement().clipPathUnits();
+    return protectedClipPathElement()->clipPathUnits();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceFilterInlines.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceFilterInlines.h
@@ -42,12 +42,12 @@ inline Ref<SVGFilterElement> LegacyRenderSVGResourceFilter::protectedFilterEleme
 
 inline SVGUnitTypes::SVGUnitType LegacyRenderSVGResourceFilter::filterUnits() const
 {
-    return filterElement().filterUnits();
+    return protectedFilterElement()->filterUnits();
 }
 
 inline SVGUnitTypes::SVGUnitType LegacyRenderSVGResourceFilter::primitiveUnits() const
 {
-    return filterElement().primitiveUnits();
+    return protectedFilterElement()->primitiveUnits();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceMarker.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceMarker.cpp
@@ -87,14 +87,15 @@ FloatPoint LegacyRenderSVGResourceMarker::referencePoint() const
 
 std::optional<float> LegacyRenderSVGResourceMarker::angle() const
 {
-    if (markerElement().orientType() == SVGMarkerOrientAngle)
-        return markerElement().orientAngle().value();
+    Ref markerElement = this->markerElement();
+    if (markerElement->orientType() == SVGMarkerOrientAngle)
+        return markerElement->orientAngle().value();
     return std::nullopt;
 }
 
 AffineTransform LegacyRenderSVGResourceMarker::markerTransformation(const FloatPoint& origin, float autoAngle, float strokeWidth) const
 {
-    bool useStrokeWidth = markerElement().markerUnits() == SVGMarkerUnitsType::StrokeWidth;
+    bool useStrokeWidth = protectedMarkerElement()->markerUnits() == SVGMarkerUnitsType::StrokeWidth;
 
     AffineTransform transform;
     transform.translate(origin);
@@ -105,8 +106,9 @@ AffineTransform LegacyRenderSVGResourceMarker::markerTransformation(const FloatP
 
 void LegacyRenderSVGResourceMarker::draw(PaintInfo& paintInfo, const AffineTransform& transform)
 {
+    Ref markerElement = this->markerElement();
     // An empty viewBox disables rendering.
-    if (markerElement().hasAttribute(SVGNames::viewBoxAttr) && markerElement().hasEmptyViewBox())
+    if (markerElement->hasAttribute(SVGNames::viewBoxAttr) && markerElement->hasEmptyViewBox())
         return;
 
     PaintInfo info(paintInfo);
@@ -130,7 +132,7 @@ AffineTransform LegacyRenderSVGResourceMarker::markerContentTransformation(const
 
 AffineTransform LegacyRenderSVGResourceMarker::viewportTransform() const
 {
-    return markerElement().viewBoxToViewTransform(m_viewport.width(), m_viewport.height());
+    return protectedMarkerElement()->viewBoxToViewTransform(m_viewport.width(), m_viewport.height());
 }
 
 void LegacyRenderSVGResourceMarker::calcViewport()

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceMarker.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceMarker.h
@@ -37,6 +37,7 @@ public:
     virtual ~LegacyRenderSVGResourceMarker();
 
     inline SVGMarkerElement& markerElement() const;
+    inline Ref<SVGMarkerElement> protectedMarkerElement() const;
 
     void removeAllClientsFromCache() override { }
     void removeClientFromCache(RenderElement&) override { }

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceMarkerInlines.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceMarkerInlines.h
@@ -36,9 +36,14 @@ inline SVGMarkerElement& LegacyRenderSVGResourceMarker::markerElement() const
     return downcast<SVGMarkerElement>(LegacyRenderSVGResourceContainer::element());
 }
 
+inline Ref<SVGMarkerElement> LegacyRenderSVGResourceMarker::protectedMarkerElement() const
+{
+    return markerElement();
+}
+
 inline SVGMarkerUnitsType LegacyRenderSVGResourceMarker::markerUnits() const
 {
-    return markerElement().markerUnits();
+    return protectedMarkerElement()->markerUnits();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceMasker.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceMasker.cpp
@@ -103,21 +103,22 @@ auto LegacyRenderSVGResourceMasker::applyResource(RenderElement& renderer, const
 
 bool LegacyRenderSVGResourceMasker::drawContentIntoMaskImage(MaskerData* maskerData, const DestinationColorSpace& colorSpace, RenderObject* object)
 {
-    auto& maskImageContext = maskerData->maskImage->context();
+    RefPtr maskImage = maskerData->maskImage;
+    auto& maskImageContext = maskImage->context();
     auto objectBoundingBox = object->objectBoundingBox();
 
     if (!drawContentIntoContext(maskImageContext, objectBoundingBox))
         return false;
 
 #if !USE(CG) && !USE(SKIA)
-    maskerData->maskImage->transformToColorSpace(colorSpace);
+    maskImage->transformToColorSpace(colorSpace);
 #else
     UNUSED_PARAM(colorSpace);
 #endif
 
     // Create the luminance mask.
     if (style().svgStyle().maskType() == MaskType::Luminance)
-        maskerData->maskImage->convertToLuminanceMask();
+        maskImage->convertToLuminanceMask();
 
     return true;
 }
@@ -127,21 +128,22 @@ bool LegacyRenderSVGResourceMasker::drawContentIntoContext(GraphicsContext& cont
     // Eventually adjust the mask image context according to the target objectBoundingBox.
     AffineTransform maskContentTransformation;
 
-    if (maskElement().maskContentUnits() == SVGUnitTypes::SVG_UNIT_TYPE_OBJECTBOUNDINGBOX) {
+    Ref maskElement = this->maskElement();
+    if (maskElement->maskContentUnits() == SVGUnitTypes::SVG_UNIT_TYPE_OBJECTBOUNDINGBOX) {
         maskContentTransformation.translate(objectBoundingBox.location());
         maskContentTransformation.scale(objectBoundingBox.size());
         context.concatCTM(maskContentTransformation);
     }
 
     // Draw the content into the ImageBuffer.
-    for (auto& child : childrenOfType<SVGElement>(protectedMaskElement())) {
-        auto renderer = child.renderer();
+    for (Ref child : childrenOfType<SVGElement>(maskElement)) {
+        CheckedPtr renderer = child->renderer();
         if (!renderer)
             continue;
         if (renderer->needsLayout())
             return false;
-        const RenderStyle& style = renderer->style();
-        if (style.display() == DisplayType::None || style.usedVisibility() != Visibility::Visible)
+        const CheckedRef style = renderer->style();
+        if (style->display() == DisplayType::None || style->usedVisibility() != Visibility::Visible)
             continue;
         SVGRenderingContext::renderSubtreeToContext(context, *renderer, maskContentTransformation);
     }
@@ -167,12 +169,12 @@ bool LegacyRenderSVGResourceMasker::drawContentIntoContext(GraphicsContext& cont
 
 void LegacyRenderSVGResourceMasker::calculateMaskContentRepaintRect(RepaintRectCalculation repaintRectCalculation)
 {
-    for (Node* childNode = maskElement().firstChild(); childNode; childNode = childNode->nextSibling()) {
+    for (RefPtr childNode = maskElement().firstChild(); childNode; childNode = childNode->nextSibling()) {
         CheckedPtr renderer = dynamicDowncast<RenderElement>(childNode->renderer());
         if (!renderer || !childNode->isSVGElement())
             continue;
-        const RenderStyle& style = renderer->style();
-        if (style.display() == DisplayType::None || style.usedVisibility() != Visibility::Visible)
+        const CheckedRef style = renderer->style();
+        if (style->display() == DisplayType::None || style->usedVisibility() != Visibility::Visible)
              continue;
         m_maskContentBoundaries[repaintRectCalculation].unite(renderer->localToParentTransform().mapRect(renderer->repaintRectInLocalCoordinates(repaintRectCalculation)));
     }

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceMaskerInlines.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceMaskerInlines.h
@@ -43,12 +43,12 @@ inline Ref<SVGMaskElement> LegacyRenderSVGResourceMasker::protectedMaskElement()
 
 SVGUnitTypes::SVGUnitType LegacyRenderSVGResourceMasker::maskUnits() const
 {
-    return maskElement().maskUnits();
+    return protectedMaskElement()->maskUnits();
 }
 
 SVGUnitTypes::SVGUnitType LegacyRenderSVGResourceMasker::maskContentUnits() const
 {
-    return maskElement().maskContentUnits();
+    return protectedMaskElement()->maskContentUnits();
 }
 
 }


### PR DESCRIPTION
#### 0e40efaed0bee5249a6b0f21f2e0ad332f107e01
<pre>
[Safe CPP] Address Warnings in LegacyRenderSVGResource
<a href="https://bugs.webkit.org/show_bug.cgi?id=294178">https://bugs.webkit.org/show_bug.cgi?id=294178</a>
<a href="https://rdar.apple.com/problem/152800490">rdar://problem/152800490</a>

Reviewed by Chris Dumez.

Address safer cpp warnings in LegacyRenderSVGResource.

 * Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
 * Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceClipperInlines.h:
 (WebCore::LegacyRenderSVGResourceClipper::clipPathUnits const):
 * Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceFilterInlines.h:
 (WebCore::LegacyRenderSVGResourceFilter::filterUnits const):
 (WebCore::LegacyRenderSVGResourceFilter::primitiveUnits const):
 * Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceMarker.cpp:
 (WebCore::LegacyRenderSVGResourceMarker::angle const):
 (WebCore::LegacyRenderSVGResourceMarker::markerTransformation const):
 (WebCore::LegacyRenderSVGResourceMarker::draw):
 (WebCore::LegacyRenderSVGResourceMarker::viewportTransform const):
 * Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceMarker.h:
 * Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceMarkerInlines.h:
 (WebCore::LegacyRenderSVGResourceMarker::protectedMarkerElement const):
 (WebCore::LegacyRenderSVGResourceMarker::markerUnits const):
 * Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceMasker.cpp:
 (WebCore::LegacyRenderSVGResourceMasker::drawContentIntoMaskImage):
 (WebCore::LegacyRenderSVGResourceMasker::drawContentIntoContext):
 (WebCore::LegacyRenderSVGResourceMasker::calculateMaskContentRepaintRect):
 * Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceMaskerInlines.h:
 (WebCore::LegacyRenderSVGResourceMasker::maskUnits const):
 (WebCore::LegacyRenderSVGResourceMasker::maskContentUnits const):

Canonical link: <a href="https://commits.webkit.org/295976@main">https://commits.webkit.org/295976@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/97c16e31299284d68f620fbec23b5a20f379a1ee

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/106825 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/26575 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/16973 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/112037 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/57422 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/108863 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/27245 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/35077 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/81119 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/109828 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/21629 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/96397 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/61460 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/21069 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/14505 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/56876 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/90970 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/14533 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/114996 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33964 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/25055 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/90181 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/34327 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/92628 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89891 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22933 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34828 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/12643 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/29648 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/33887 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/39302 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/33634 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/36987 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/35233 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->