### PR TITLE
Reduce unsafeness by making WebCore/platform/graphics class member variables const

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -570,7 +570,6 @@ platform/graphics/ca/GraphicsLayerCA.cpp
 platform/graphics/ca/PlatformCALayer.mm
 platform/graphics/ca/TileController.cpp
 platform/graphics/ca/TileCoverageMap.cpp
-platform/graphics/ca/TileGrid.cpp
 platform/graphics/ca/cocoa/WebTiledBackingLayer.mm
 platform/graphics/cg/CGSubimageCacheWithTimer.cpp
 platform/ios/PlaybackSessionInterfaceIOS.mm

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -831,7 +831,6 @@ platform/graphics/ComplexTextController.cpp
 platform/graphics/DisplayRefreshMonitorManager.h
 platform/graphics/FontCache.cpp
 platform/graphics/FontRanges.cpp
-platform/graphics/GradientImage.cpp
 platform/graphics/GraphicsLayer.cpp
 platform/graphics/GraphicsLayer.h
 platform/graphics/ImageAdapter.cpp
@@ -859,11 +858,9 @@ platform/graphics/ca/TileGrid.cpp
 platform/graphics/ca/cocoa/GraphicsLayerAsyncContentsDisplayDelegateCocoa.mm
 platform/graphics/ca/cocoa/PlatformCAAnimationCocoa.mm
 platform/graphics/ca/cocoa/PlatformCALayerCocoa.mm
-platform/graphics/cg/GraphicsContextGLCG.cpp
 platform/graphics/cocoa/ImageAdapterCocoa.mm
 platform/graphics/cocoa/MediaPlayerCocoa.mm
 platform/graphics/cocoa/SourceBufferParser.cpp
-platform/graphics/cocoa/WebProcessGraphicsContextGLCocoa.mm
 platform/graphics/controls/ApplePayButtonPart.cpp
 platform/graphics/controls/ButtonPart.h
 platform/graphics/controls/ColorWellPart.h

--- a/Source/WebCore/platform/FileMonitor.h
+++ b/Source/WebCore/platform/FileMonitor.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -58,7 +58,7 @@ private:
     static void fileChangedCallback(GFileMonitor*, GFile*, GFile*, GFileMonitorEvent, FileMonitor*);
     void didChange(FileChangeType);
     void cancel();
-    Ref<WorkQueue> m_handlerQueue;
+    const Ref<WorkQueue> m_handlerQueue;
     Function<void(FileChangeType)> m_modificationHandler;
     GRefPtr<GFileMonitor> m_platformMonitor;
 #endif

--- a/Source/WebCore/platform/audio/cocoa/AudioEncoderCocoa.h
+++ b/Source/WebCore/platform/audio/cocoa/AudioEncoderCocoa.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2024-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -51,7 +51,7 @@ private:
     void reset() final;
     void close() final;
 
-    Ref<InternalAudioEncoderCocoa> m_internalEncoder;
+    const Ref<InternalAudioEncoderCocoa> m_internalEncoder;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/audio/cocoa/AudioFileReaderCocoa.h
+++ b/Source/WebCore/platform/audio/cocoa/AudioFileReaderCocoa.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2010 Google Inc. All rights reserved.
- * Copyright (C) 2011-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2011-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -89,7 +89,7 @@ private:
     std::unique_ptr<AudioFileReaderWebMData> m_webmData;
 
 #if !RELEASE_LOG_DISABLED
-    const Ref<Logger> m_logger;
+    const Ref<const Logger> m_logger;
     const uint64_t m_logIdentifier;
 #endif
 

--- a/Source/WebCore/platform/cocoa/VideoPresentationModelVideoElement.h
+++ b/Source/WebCore/platform/cocoa/VideoPresentationModelVideoElement.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2014-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -138,7 +138,7 @@ private:
     // HTMLMediaElementClient
     void audioSessionCategoryChanged(AudioSessionCategory, AudioSessionMode, RouteSharingPolicy) final;
 
-    Ref<VideoListener> m_videoListener;
+    const Ref<VideoListener> m_videoListener;
     RefPtr<HTMLVideoElement> m_videoElement;
     RetainPtr<PlatformLayer> m_videoFullscreenLayer;
     bool m_isListening { false };

--- a/Source/WebCore/platform/graphics/CrossfadeGeneratedImage.h
+++ b/Source/WebCore/platform/graphics/CrossfadeGeneratedImage.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011 Apple Inc. All rights reserved.
+ * Copyright (C) 2011-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -57,8 +57,8 @@ private:
     
     void drawCrossfade(GraphicsContext&);
 
-    Ref<Image> m_fromImage;
-    Ref<Image> m_toImage;
+    const Ref<Image> m_fromImage;
+    const Ref<Image> m_toImage;
 
     float m_percentage;
     FloatSize m_crossfadeSize;

--- a/Source/WebCore/platform/graphics/GradientImage.h
+++ b/Source/WebCore/platform/graphics/GradientImage.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2008-2016 Apple Inc. All rights reserved.
+ * Copyright (C) 2008-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -51,7 +51,7 @@ private:
     bool isGradientImage() const final { return true; }
     void dump(WTF::TextStream&) const final;
     
-    Ref<Gradient> m_gradient;
+    const Ref<Gradient> m_gradient;
     RefPtr<ImageBuffer> m_cachedImage;
     FloatSize m_cachedAdjustedSize;
     unsigned m_cachedGeneratorHash { 0 };

--- a/Source/WebCore/platform/graphics/GraphicsContextGLImageExtractor.h
+++ b/Source/WebCore/platform/graphics/GraphicsContextGLImageExtractor.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2020-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -67,7 +67,7 @@ private:
     sk_sp<SkData> m_pixelData;
     sk_sp<SkImage> m_skImage;
 #endif
-    Ref<Image> m_image;
+    const Ref<Image> m_image;
     DOMSource m_imageHtmlDomSource;
     bool m_extractSucceeded;
     std::span<const uint8_t> m_imagePixelData;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.h
@@ -94,7 +94,7 @@ protected:
 
     RetainPtr<AVContentKeySession> m_contentKeySession;
     RetainPtr<WebCDMSessionAVContentKeySessionDelegate> m_contentKeySessionDelegate;
-    Ref<WTF::WorkQueue> m_delegateQueue;
+    const Ref<WTF::WorkQueue> m_delegateQueue;
     Semaphore m_hasKeyRequestSemaphore;
     mutable Lock m_keyRequestLock;
     RetainPtr<AVContentKeyRequest> m_keyRequest;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/WebCoreAVFResourceLoader.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/WebCoreAVFResourceLoader.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 Apple Inc. All rights reserved.
+ * Copyright (C) 2012-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -83,7 +83,7 @@ private:
     int64_t m_requestedOffset { 0 };
     int64_t m_currentOffset { 0 };
 
-    Ref<GuaranteedSerialFunctionDispatcher> m_targetDispatcher;
+    const Ref<GuaranteedSerialFunctionDispatcher> m_targetDispatcher;
 };
 
 }

--- a/Source/WebCore/platform/graphics/avfoundation/objc/WebCoreAVFResourceLoader.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/WebCoreAVFResourceLoader.mm
@@ -169,7 +169,7 @@ private:
     void loadFinished(PlatformMediaResource&, const NetworkLoadMetrics&) final { loadFinished(); }
 
     WebCoreAVFResourceLoader& m_parent;
-    Ref<GuaranteedSerialFunctionDispatcher> m_targetDispatcher;
+    const Ref<GuaranteedSerialFunctionDispatcher> m_targetDispatcher;
     RefPtr<PlatformMediaResource> m_resource WTF_GUARDED_BY_CAPABILITY(m_targetDispatcher.get());
     SharedBufferBuilder m_buffer WTF_GUARDED_BY_CAPABILITY(m_targetDispatcher.get());
 };

--- a/Source/WebCore/platform/graphics/ca/TileCoverageMap.h
+++ b/Source/WebCore/platform/graphics/ca/TileCoverageMap.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2014 Apple Inc. All rights reserved.
+ * Copyright (C) 2011-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -75,10 +75,10 @@ private:
     
     Timer m_updateTimer;
 
-    Ref<PlatformCALayer> m_layer;
-    Ref<PlatformCALayer> m_visibleViewportIndicatorLayer;
-    Ref<PlatformCALayer> m_layoutViewportIndicatorLayer;
-    Ref<PlatformCALayer> m_coverageRectIndicatorLayer;
+    const Ref<PlatformCALayer> m_layer;
+    const Ref<PlatformCALayer> m_visibleViewportIndicatorLayer;
+    const Ref<PlatformCALayer> m_layoutViewportIndicatorLayer;
+    const Ref<PlatformCALayer> m_coverageRectIndicatorLayer;
 
     FloatPoint m_position;
 };

--- a/Source/WebCore/platform/graphics/ca/TileGrid.h
+++ b/Source/WebCore/platform/graphics/ca/TileGrid.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2014 Apple Inc. All rights reserved.
+ * Copyright (C) 2011-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -165,9 +165,9 @@ private:
 #endif
 
     TileGridIdentifier m_identifier;
-    CheckedRef<TileController> m_controller;
+    const CheckedRef<TileController> m_controller;
 #if USE(CA)
-    Ref<PlatformCALayer> m_containerLayer;
+    const Ref<PlatformCALayer> m_containerLayer;
 #endif
 
     UncheckedKeyHashMap<TileIndex, TileInfo> m_tiles;

--- a/Source/WebCore/platform/graphics/cocoa/DynamicContentScalingDisplayList.h
+++ b/Source/WebCore/platform/graphics/cocoa/DynamicContentScalingDisplayList.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2022-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -50,7 +50,7 @@ public:
     Vector<MachSendRight> takeSurfaces() { return std::exchange(m_surfaces, { }); }
 
 private:
-    Ref<WebCore::SharedBuffer> m_displayList;
+    const Ref<WebCore::SharedBuffer> m_displayList;
     Vector<MachSendRight> m_surfaces;
 };
 

--- a/Source/WebCore/platform/graphics/cocoa/NullVideoPresentationInterface.h
+++ b/Source/WebCore/platform/graphics/cocoa/NullVideoPresentationInterface.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2023-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -103,7 +103,7 @@ private:
     void incrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
     void decrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
 
-    Ref<NullPlaybackSessionInterface> m_playbackSessionInterface;
+    const Ref<NullPlaybackSessionInterface> m_playbackSessionInterface;
     ThreadSafeWeakPtr<VideoPresentationModel> m_videoPresentationModel;
 };
 

--- a/Source/WebCore/platform/graphics/cocoa/WebProcessGraphicsContextGLCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/WebProcessGraphicsContextGLCocoa.mm
@@ -1,6 +1,6 @@
 
 /*
- * Copyright (C) 2009-2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2009-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -141,7 +141,7 @@ public:
     void prepareForDisplay() final;
 private:
     WebProcessGraphicsContextGLCocoa(GraphicsContextGLAttributes&&);
-    Ref<DisplayBufferDisplayDelegate> m_layerContentsDisplayDelegate;
+    const Ref<DisplayBufferDisplayDelegate> m_layerContentsDisplayDelegate;
 
     friend RefPtr<GraphicsContextGL> WebCore::createWebProcessGraphicsContextGL(const GraphicsContextGLAttributes&);
     friend class GraphicsContextGLOpenGL;

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListItems.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListItems.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -401,7 +401,7 @@ public:
     void dump(TextStream&, OptionSet<AsTextFlag>) const;
 
 private:
-    Ref<ImageBuffer> m_imageBuffer;
+    const Ref<ImageBuffer> m_imageBuffer;
     FloatRect m_destinationRect;
 };
 
@@ -486,9 +486,9 @@ public:
     void dump(TextStream&, OptionSet<AsTextFlag>) const;
 
 private:
-    RefPtr<ImageBuffer> m_sourceImage;
+    const RefPtr<ImageBuffer> m_sourceImage;
     FloatRect m_sourceImageRect;
-    Ref<Filter> m_filter;
+    const Ref<Filter> m_filter;
 };
 
 class DrawGlyphs {
@@ -580,7 +580,7 @@ public:
     void dump(TextStream&, OptionSet<AsTextFlag>) const;
 
 private:
-    Ref<ImageBuffer> m_imageBuffer;
+    const Ref<ImageBuffer> m_imageBuffer;
     FloatRect m_destinationRect;
     FloatRect m_srcRect;
     ImagePaintingOptions m_options;
@@ -607,7 +607,7 @@ public:
     void dump(TextStream&, OptionSet<AsTextFlag>) const;
 
 private:
-    Ref<NativeImage> m_image;
+    const Ref<NativeImage> m_image;
     FloatRect m_destinationRect;
     FloatRect m_srcRect;
     ImagePaintingOptions m_options;
@@ -630,7 +630,7 @@ public:
     void dump(TextStream&, OptionSet<AsTextFlag>) const;
 
 private:
-    Ref<SystemImage> m_systemImage;
+    const Ref<SystemImage> m_systemImage;
     FloatRect m_destinationRect;
 };
 
@@ -660,7 +660,7 @@ public:
     void dump(TextStream&, OptionSet<AsTextFlag>) const;
 
 private:
-    Ref<NativeImage> m_image;
+    const Ref<NativeImage> m_image;
     FloatRect m_destination;
     FloatRect m_tileRect;
     AffineTransform m_patternTransform;
@@ -695,7 +695,7 @@ public:
     void dump(TextStream&, OptionSet<AsTextFlag>) const;
 
 private:
-    Ref<ImageBuffer> m_imageBuffer;
+    const Ref<ImageBuffer> m_imageBuffer;
     FloatRect m_destination;
     FloatRect m_tileRect;
     AffineTransform m_patternTransform;
@@ -1000,7 +1000,7 @@ public:
 
 private:
     FloatRect m_rect;
-    Ref<Gradient> m_gradient;
+    const Ref<Gradient> m_gradient;
 };
 
 class FillRectWithGradientAndSpaceTransform {
@@ -1020,7 +1020,7 @@ public:
 
 private:
     FloatRect m_rect;
-    Ref<Gradient> m_gradient;
+    const Ref<Gradient> m_gradient;
     AffineTransform m_gradientSpaceTransform;
     GraphicsContext::RequiresClipToRect m_requiresClipToRect;
 };
@@ -1237,7 +1237,7 @@ public:
     void dump(TextStream&, OptionSet<AsTextFlag>) const;
 
 private:
-    Ref<ControlPart> m_part;
+    const Ref<ControlPart> m_part;
     FloatRoundedRect m_borderRect;
     float m_deviceScaleFactor;
     ControlStyle m_style;

--- a/Source/WebCore/platform/graphics/filters/FELighting.h
+++ b/Source/WebCore/platform/graphics/filters/FELighting.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2010 University of Szeged
  * Copyright (C) 2010 Zoltan Herczeg
- * Copyright (C) 2021-2023 Apple Inc.  All rights reserved.
+ * Copyright (C) 2021-2025 Apple Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -77,7 +77,7 @@ protected:
     float m_specularExponent;
     float m_kernelUnitLengthX;
     float m_kernelUnitLengthY;
-    Ref<LightSource> m_lightSource;
+    const Ref<LightSource> m_lightSource;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/texmap/BitmapTexturePool.h
+++ b/Source/WebCore/platform/graphics/texmap/BitmapTexturePool.h
@@ -67,7 +67,7 @@ private:
         void markIsInUse() { m_lastUsedTime = MonotonicTime::now(); }
         bool canBeReleased (MonotonicTime minUsedTime) const { return m_lastUsedTime < minUsedTime && m_texture->refCount() == 1; }
 
-        Ref<BitmapTexture> m_texture;
+        const Ref<BitmapTexture> m_texture;
         MonotonicTime m_lastUsedTime;
     };
 

--- a/Source/WebCore/platform/graphics/texmap/TextureMapper.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapper.cpp
@@ -125,7 +125,7 @@ private:
         int32_t m_maxTextureSize;
     };
 
-    Ref<SharedGLData> m_sharedGLData;
+    const Ref<SharedGLData> m_sharedGLData;
     UncheckedKeyHashMap<const void*, GLuint> m_vbos;
     UncheckedKeyHashMap<uint64_t, Vector<Ref<TextureMapperGPUBuffer>>> m_buffers;
 };

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferDMABuf.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferDMABuf.h
@@ -48,7 +48,7 @@ private:
     std::unique_ptr<CoordinatedPlatformLayerBuffer> importDMABuf(TextureMapper&) const;
     std::unique_ptr<CoordinatedPlatformLayerBuffer> importYUV(TextureMapper&) const;
 
-    Ref<DMABufBuffer> m_dmabuf;
+    const Ref<DMABufBuffer> m_dmabuf;
     WTF::UnixFileDescriptor m_fenceFD;
 };
 

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferNativeImage.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferNativeImage.h
@@ -45,7 +45,7 @@ private:
 
     bool tryEnsureBuffer(TextureMapper&);
 
-    Ref<NativeImage> m_image;
+    const Ref<NativeImage> m_image;
     std::unique_ptr<CoordinatedPlatformLayerBuffer> m_buffer;
 };
 

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedTileBuffer.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedTileBuffer.h
@@ -157,7 +157,7 @@ private:
     bool tryEnsureSurface() final;
     void completePainting() final;
 
-    Ref<BitmapTexture> m_texture;
+    const Ref<BitmapTexture> m_texture;
     std::unique_ptr<GLFence> m_fence;
 };
 #endif

--- a/Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerAsyncContentsDisplayDelegateCoordinated.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerAsyncContentsDisplayDelegateCoordinated.h
@@ -50,7 +50,7 @@ private:
 
     bool tryCopyToLayer(ImageBuffer&) override;
 
-    Ref<GraphicsLayerContentsDisplayDelegate> m_delegate;
+    const Ref<GraphicsLayerContentsDisplayDelegate> m_delegate;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerCoordinated.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerCoordinated.h
@@ -192,7 +192,7 @@ private:
     bool updateBackingStoresIfNeeded();
     bool updateBackingStoreIfNeeded();
 
-    Ref<CoordinatedPlatformLayer> m_platformLayer;
+    const Ref<CoordinatedPlatformLayer> m_platformLayer;
     OptionSet<Change> m_pendingChanges;
     bool m_hasDescendantsWithPendingChanges { false };
     bool m_hasDescendantsWithPendingTilesCreation { false };


### PR DESCRIPTION
#### 7bde58068252f6360db07c27e26733e2b1b5d467
<pre>
Reduce unsafeness by making WebCore/platform/graphics class member variables const
<a href="https://bugs.webkit.org/show_bug.cgi?id=294180">https://bugs.webkit.org/show_bug.cgi?id=294180</a>
<a href="https://rdar.apple.com/152804488">rdar://152804488</a>

Reviewed by Charlie Wolfe.

Apply <a href="https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines">https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines</a>

Canonical link: <a href="https://commits.webkit.org/295983@main">https://commits.webkit.org/295983@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ac9547d1514fa514710f12ac1b0b1f0efc1f1f71

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/106857 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/26594 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/16991 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/112063 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/57440 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/108880 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/27262 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/35095 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/81143 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/57440 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/109845 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/21646 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/96415 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/61484 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/21087 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/14524 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/56893 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/90987 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/14551 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/115041 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33980 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/25073 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/115041 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/34345 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/92646 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/115041 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/34846 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/12661 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/29672 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17292 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/33904 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/39332 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/33651 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/37004 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/35259 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->