### PR TITLE
Web Inspector: Uncaught Exception: TypeError: undefined is not an object (evaluating 'node.endPosition.isBefore')

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Models/ScriptSyntaxTree.js
+++ b/Source/WebInspectorUI/UserInterface/Models/ScriptSyntaxTree.js
@@ -88,9 +88,9 @@ WI.ScriptSyntaxTree = class ScriptSyntaxTree
         let allNodes = [];
 
         this.forEachNode((node, state) => {
-            if (node.endPosition.isBefore(position))
+            if (node.endPosition?.isBefore(position))
                 state.skipChildNodes = true;
-            else if (node.startPosition.isAfter(position))
+            else if (node.startPosition?.isAfter(position))
                 state.shouldStopEarly = true;
             else
                 allNodes.push(node);
@@ -114,13 +114,13 @@ WI.ScriptSyntaxTree = class ScriptSyntaxTree
 
             // If a node's range ends before the range we're interested in starts, we don't need to search any of its
             // enclosing ranges, because, by definition, those enclosing ranges are contained within this node's range.
-            if (node.endPosition.isBefore(startPosition)) {
+            if (node.endPosition?.isBefore(startPosition)) {
                 state.skipChildNodes = true;
                 return;
             }
 
             // We are only interested in nodes whose start position is within our range.
-            if (node.startPosition.isWithin(startPosition, endPosition)) {
+            if (node.startPosition?.isWithin(startPosition, endPosition)) {
                 allNodes.push(node);
                 return;
             }
@@ -128,7 +128,7 @@ WI.ScriptSyntaxTree = class ScriptSyntaxTree
             // Once we see nodes that start beyond our range, we can quit traversing the AST. We can do this safely
             // because we know the AST is traversed using depth first search, so it will traverse into enclosing ranges
             // before it traverses into adjacent ranges.
-            if (node.startPosition.isAfter(endPosition))
+            if (node.startPosition?.isAfter(endPosition))
                 state.shouldStopEarly = true;
         }
 


### PR DESCRIPTION
#### c8f955b60752e247cca45fc17ebf4d2416cd6b19
<pre>
Web Inspector: Uncaught Exception: TypeError: undefined is not an object (evaluating &apos;node.endPosition.isBefore&apos;)
<a href="https://bugs.webkit.org/show_bug.cgi?id=294183">https://bugs.webkit.org/show_bug.cgi?id=294183</a>

Reviewed by BJ Burg.

* Source/WebInspectorUI/UserInterface/Models/ScriptSyntaxTree.js:
(WI.ScriptSyntaxTree.prototype.containersOfPosition):
(WI.ScriptSyntaxTree.prototype.filterByRange):
If it&apos;s possible for `node.endPosition` to not exist then don&apos;t assume it does.

Canonical link: <a href="https://commits.webkit.org/296072@main">https://commits.webkit.org/296072@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/971617c50a908a20edfd7a9dc94d25cfdbf40a2d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/107271 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/26953 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/17357 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/112485 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/57805 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/27634 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/35453 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/81429 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/57805 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/110200 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/21902 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/96686 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/61799 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/21329 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/14820 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/57250 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/91258 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/14850 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/115586 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/34337 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/25301 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/90472 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/34713 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/92935 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/90206 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22997 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35109 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/12898 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/30067 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/34259 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/39792 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34005 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/37360 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/35666 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->