### PR TITLE
Revert "Assign to self before returning in init methods"

### DIFF
--- a/Source/WebCore/PAL/pal/system/mac/WebPanel.mm
+++ b/Source/WebCore/PAL/pal/system/mac/WebPanel.mm
@@ -38,8 +38,7 @@ ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     static NSUInteger styleMask = NSWindowStyleMaskMiniaturizable | NSWindowStyleMaskClosable | NSWindowStyleMaskResizable | NSWindowStyleMaskTitled | NSSmallWindowMask | NSSideUtilityWindowMask | NSWindowStyleMaskUtilityWindow;
 ALLOW_DEPRECATED_DECLARATIONS_END
 
-    self = [super initWithContentRect:NSZeroRect styleMask:styleMask backing:NSBackingStoreBuffered defer:YES];
-    return self;
+    return [super initWithContentRect:NSZeroRect styleMask:styleMask backing:NSBackingStoreBuffered defer:YES];
 }
 
 @end

--- a/Source/WebKit/Shared/Cocoa/WKNSDictionary.mm
+++ b/Source/WebKit/Shared/Cocoa/WKNSDictionary.mm
@@ -56,8 +56,7 @@ using namespace WebKit;
 - (instancetype)initWithObjects:(const id [])objects forKeys:(const id <NSCopying> [])keys count:(NSUInteger)count
 {
     ASSERT_NOT_REACHED();
-    self = [super initWithObjects:objects forKeys:keys count:count];
-    return self;
+    return [super initWithObjects:objects forKeys:keys count:count];
 }
 
 - (NSUInteger)count

--- a/Source/WebKit/UIProcess/Cocoa/WKReloadFrameErrorRecoveryAttempter.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WKReloadFrameErrorRecoveryAttempter.mm
@@ -77,8 +77,7 @@
 
 - (instancetype)initWithCoder:(NSCoder *)coder
 {
-    self = [super init];
-    return self;
+    return [super init];
 }
 
 + (BOOL)supportsSecureCoding

--- a/Source/WebKit/UIProcess/ios/forms/WKDatePickerViewController.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKDatePickerViewController.mm
@@ -223,8 +223,7 @@ struct EraAndYear {
 
 - (instancetype)initWithDelegate:(id <WKQuickboardViewControllerDelegate>)delegate
 {
-    self = [super initWithDelegate:delegate];
-    return self;
+    return [super initWithDelegate:delegate];
 }
 
 - (void)viewDidLoad

--- a/Source/WebKit/UIProcess/ios/forms/WKDateTimeInputControl.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKDateTimeInputControl.mm
@@ -409,8 +409,7 @@ static constexpr auto yearAndMonthDatePickerMode = static_cast<UIDatePickerMode>
 #if HAVE(UI_CALENDAR_SELECTION_WEEK_OF_YEAR)
     case WebKit::InputType::Week:
 #endif
-        self = [super initWithView:view control:adoptNS([[WKDateTimePicker alloc] initWithView:view inputType:controlType])];
-        return self;
+        return [super initWithView:view control:adoptNS([[WKDateTimePicker alloc] initWithView:view inputType:controlType])];
     default:
         [self release];
         return nil;

--- a/Source/WebKit/UIProcess/ios/forms/WKFormColorControl.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKFormColorControl.mm
@@ -161,8 +161,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 - (instancetype)initWithView:(WKContentView *)view
 {
     RetainPtr<NSObject <WKFormControl>> control = adoptNS([[WKColorPicker alloc] initWithView:view]);
-    self = [super initWithView:view control:WTFMove(control)];
-    return self;
+    return [super initWithView:view control:WTFMove(control)];
 }
 
 @end

--- a/Source/WebKit/UIProcess/ios/forms/WKFormSelectControl.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKFormSelectControl.mm
@@ -80,9 +80,7 @@ CGFloat adjustedFontSize(CGFloat textWidth, UIFont *font, CGFloat initialFontSiz
             control = adoptNS([[WKSelectMultiplePicker alloc] initWithView:view]);
         else
             control = adoptNS([[WKSelectPicker alloc] initWithView:view]);
-
-        self = [super initWithView:view control:WTFMove(control)];
-        return self;
+        return [super initWithView:view control:WTFMove(control)];
     }
 
     if (!PAL::currentUserInterfaceIdiomIsSmallScreen())
@@ -92,8 +90,7 @@ CGFloat adjustedFontSize(CGFloat textWidth, UIFont *font, CGFloat initialFontSiz
     else
         control = adoptNS([[WKSelectSinglePicker alloc] initWithView:view]);
 
-    self = [super initWithView:view control:WTFMove(control)];
-    return self;
+    return [super initWithView:view control:WTFMove(control)];
 }
 
 @end

--- a/Source/WebKit/UIProcess/ios/forms/WKSelectMenuListViewController.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKSelectMenuListViewController.mm
@@ -138,8 +138,7 @@ static constexpr CGFloat itemCellBaselineToBottom = 8;
 
 - (instancetype)initWithDelegate:(id <WKSelectMenuListViewControllerDelegate>)delegate
 {
-    self = [super initWithDelegate:delegate dictationMode:PUICDictationModeText];
-    return self;
+    return [super initWithDelegate:delegate dictationMode:PUICDictationModeText];
 }
 
 - (void)viewDidLoad

--- a/Source/WebKit/UIProcess/ios/forms/WKTimePickerViewController.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKTimePickerViewController.mm
@@ -53,8 +53,7 @@ static NSString *timePickerDateFormat = @"HH:mm";
 
 - (instancetype)initWithDelegate:(id <WKQuickboardViewControllerDelegate>)delegate
 {
-    self = [super initWithDelegate:delegate];
-    return self;
+    return [super initWithDelegate:delegate];
 }
 
 - (NSDateFormatter *)dateFormatter

--- a/Source/WebKitLegacy/mac/Misc/WebDownload.mm
+++ b/Source/WebKitLegacy/mac/Misc/WebDownload.mm
@@ -223,7 +223,6 @@ using namespace WebCore;
 
 - (id)init
 {
-    self = [super init];
     if (self == nil)
         return nil;
 

--- a/Source/WebKitLegacy/mac/Misc/WebIconDatabase.mm
+++ b/Source/WebKitLegacy/mac/Misc/WebIconDatabase.mm
@@ -120,8 +120,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 {
     WebCoreThreadViolationCheckRoundOne();
 
-    self = [super init];
-    return self;
+    return [super init];
 }
 
 - (NSImage *)iconForURL:(NSString *)URL withSize:(NSSize)size cache:(BOOL)cache

--- a/Source/WebKitLegacy/mac/WebView/WebResource.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebResource.mm
@@ -76,8 +76,7 @@ static NSString * const WebResourceResponseKey =          @"WebResourceResponse"
 
 - (instancetype)init
 {
-    self = [super init];
-    return self;
+    return [super init];
 }
 
 - (instancetype)initWithCoreResource:(Ref<ArchiveResource>&&)passedResource

--- a/Tools/DumpRenderTree/mac/DumpRenderTreeDraggingInfo.mm
+++ b/Tools/DumpRenderTree/mac/DumpRenderTreeDraggingInfo.mm
@@ -141,16 +141,12 @@ static std::pair<NSURL *, NSError *> copyFile(NSURL *sourceURL, NSURL *destinati
 
 - (id)initWithImage:(NSImage *)anImage offset:(NSSize)o pasteboard:(NSPasteboard *)pboard source:(id)source
 {
-    self = [super init];
-    if (!self)
-        return nil;
-
     draggedImage = [anImage retain];
     draggingPasteboard = [pboard retain];
     draggingSource = [source retain];
     offset = o;
 
-    return self;
+    return [super init];
 }
 
 - (void)dealloc

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ContentFiltering.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ContentFiltering.mm
@@ -79,8 +79,7 @@ using DecisionPoint = WebCore::MockContentFilterSettings::DecisionPoint;
 
 - (instancetype)initWithCoder:(NSCoder *)decoder
 {
-    self = [super init];
-    return self;
+    return [super init];
 }
 
 - (instancetype)initWithDecision:(Decision)decision decisionPoint:(DecisionPoint)decisionPoint

--- a/Tools/TestWebKitAPI/ios/DragAndDropSimulatorIOS.mm
+++ b/Tools/TestWebKitAPI/ios/DragAndDropSimulatorIOS.mm
@@ -197,8 +197,7 @@ InteractionType *findInteractionOfType(UIView *view)
     for (NSItemProvider *itemProvider in providers)
         [items addObject:adoptNS([[UIDragItem alloc] initWithItemProvider:itemProvider]).get()];
 
-    self = [super initWithItems:items.get() location:locationInWindow window:window allowMove:allowMove];
-    return self;
+    return [super initWithItems:items.get() location:locationInWindow window:window allowMove:allowMove];
 }
 
 - (BOOL)isLocal
@@ -256,8 +255,7 @@ InteractionType *findInteractionOfType(UIView *view)
 
 - (instancetype)initWithWindow:(UIWindow *)window allowMove:(BOOL)allowMove
 {
-    self = [super initWithItems:@[] location:CGPointZero window:window allowMove:allowMove];
-    return self;
+    return [super initWithItems:@[] location:CGPointZero window:window allowMove:allowMove];
 }
 
 - (NSUInteger)localOperationMask


### PR DESCRIPTION
<pre>Revert "Assign to self before returning in init methods"
https://bugs.webkit.org/show_bug.cgi?id=255341

Reviewed by NOBODY (OOPS!).

Turns out this is fine even under ARC.

Reverts 4c8ed9ea14550faa4067caf7e5985a71ee569760
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/173f9a0df34b82a926542875ca5c36457e52df3d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/106814 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/26565 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/16963 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/112025 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/57412 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/108853 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/27235 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/35067 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/81107 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/109818 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/21618 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/96387 "1 api test failed or timed out") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/61448 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/21058 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/14495 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/56866 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/90959 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/14523 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/114978 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33952 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/25045 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/90169 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/34317 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/92618 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89879 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34819 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/12633 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/29630 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/33877 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/39290 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/33624 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/36977 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/35222 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->