### PR TITLE
Inline elements don't relayout out-of-flow descendants when they become containing blocks for position:fixed descendants.

### DIFF
--- a/LayoutTests/fast/block/missing-absolute-positioned-content-expected.html
+++ b/LayoutTests/fast/block/missing-absolute-positioned-content-expected.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+div {
+  width: 100%;
+  height: 200px;
+}
+
+.inner {
+  width: 100px;
+  height: 100px;
+  background-color: green;
+  right: 0px;
+}
+
+.fixedCB {
+  filter: blur(0px);
+}
+
+.absCB {
+  position: absolute;
+}
+
+.fixed {
+  position: fixed;
+}
+
+.abs {
+  position: absolute;
+  top: 100px;
+}
+
+</style>
+</head>
+<body>
+<div class="fixedCB">
+  <div class="absCB" style="width:500px">
+    <div style="width: 100px;" class="fixedCB">
+      <div class="inner fixed"></div>
+      <div class="inner abs"></div>
+    </div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/LayoutTests/fast/block/missing-absolute-positioned-content-inline-expected.html
+++ b/LayoutTests/fast/block/missing-absolute-positioned-content-inline-expected.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+div {
+  width: 100%;
+  height: 200px;
+}
+
+.inner {
+  width: 100px;
+  height: 100px;
+  background-color: green;
+  right: 0px;
+}
+
+.fixedCB {
+  filter: blur(0px);
+}
+
+.absCB {
+  position: absolute;
+}
+
+.fixed {
+  position: fixed;
+}
+
+.abs {
+  position: absolute;
+  top: 100px;
+}
+
+</style>
+</head>
+<body>
+<div class="fixedCB">
+  <div class="absCB" style="width:500px">
+    <span class="fixedCB">
+      Text content to give some width
+      <div class="inner fixed"></div>
+      <div class="inner abs"></div>
+    </span>
+  </div>
+</div>
+
+</body>
+</html>

--- a/LayoutTests/fast/block/missing-absolute-positioned-content-inline.html
+++ b/LayoutTests/fast/block/missing-absolute-positioned-content-inline.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+div {
+  width: 100%;
+  height: 200px;
+}
+
+.inner {
+  width: 100px;
+  height: 100px;
+  background-color: green;
+  right: 0px;
+}
+
+.fixedCB {
+  filter: blur(0px);
+}
+
+.absCB {
+  position: absolute;
+}
+
+.fixed {
+  position: fixed;
+}
+
+.abs {
+  position: absolute;
+  top: 100px;
+}
+
+</style>
+</head>
+<body>
+<div class="fixedCB">
+  <div class="absCB" style="width:500px">
+    <span id="mutate">
+      Text content to give some width
+      <div class="inner fixed"></div>
+      <div class="inner abs"></div>
+    </span>
+  </div>
+</div>
+
+</body>
+<script>
+document.body.offsetHeight;
+mutate.classList.add("fixedCB");
+document.body.offsetHeight;
+</script>
+</html>

--- a/LayoutTests/fast/block/missing-absolute-positioned-content.html
+++ b/LayoutTests/fast/block/missing-absolute-positioned-content.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+div {
+  width: 100%;
+  height: 200px;
+}
+
+.inner {
+  width: 100px;
+  height: 100px;
+  background-color: green;
+  right: 0px;
+}
+
+.fixedCB {
+  filter: blur(0px);
+}
+
+.absCB {
+  position: absolute;
+}
+
+.fixed {
+  position: fixed;
+}
+
+.abs {
+  position: absolute;
+  top: 100px;
+}
+
+</style>
+</head>
+<body>
+<div class="fixedCB">
+  <div class="absCB" style="width:500px">
+    <div style="width: 100px;" id="mutate">
+      <div class="inner fixed"></div>
+      <div class="inner abs"></div>
+    </div>
+  </div>
+</div>
+
+</body>
+<script>
+document.body.offsetHeight;
+mutate.classList.add("fixedCB");
+document.body.offsetHeight;
+</script>
+</html>

--- a/Source/WebCore/rendering/RenderBlock.h
+++ b/Source/WebCore/rendering/RenderBlock.h
@@ -407,8 +407,6 @@ private:
 
     RenderFragmentedFlow* updateCachedEnclosingFragmentedFlow(RenderFragmentedFlow*) const;
 
-    void removeOutOfFlowBoxesIfNeededOnStyleChange(const RenderStyle& oldStyle, const RenderStyle& newStyle);
-
     void absoluteQuadsIgnoringContinuation(const FloatRect&, Vector<FloatQuad>&, bool* wasFixed) const override;
 
     void paintDebugBoxShadowIfApplicable(GraphicsContext&, const LayoutRect&) const;

--- a/Source/WebCore/rendering/RenderBoxModelObject.h
+++ b/Source/WebCore/rendering/RenderBoxModelObject.h
@@ -249,6 +249,8 @@ public:
 
     RenderBlock* containingBlockForAutoHeightDetection(Length logicalHeight) const;
 
+    void removeOutOfFlowBoxesIfNeededOnStyleChange(RenderBlock& delegateBlock, const RenderStyle& oldStyle, const RenderStyle& newStyle);
+
     struct ContinuationChainNode {
         WTF_MAKE_STRUCT_FAST_ALLOCATED;
 

--- a/Source/WebCore/rendering/RenderInline.cpp
+++ b/Source/WebCore/rendering/RenderInline.cpp
@@ -166,19 +166,16 @@ static void updateStyleOfAnonymousBlockContinuations(const RenderBlock& block, c
 void RenderInline::styleWillChange(StyleDifference diff, const RenderStyle& newStyle)
 {
     RenderBoxModelObject::styleWillChange(diff, newStyle);
+
     // RenderInlines forward their absolute positioned descendants to their (non-anonymous) containing block.
     // Check if this non-anonymous containing block can hold the absolute positioned elements when the inline is no longer positioned.
-    if (canContainAbsolutelyPositionedObjects() && !canContainAbsolutelyPositionedObjects(&newStyle)) {
-        auto* container = containingBlock();
-        if (container && !container->canContainAbsolutelyPositionedObjects())
-            container->removeOutOfFlowBoxes({ }, RenderBlock::ContainingBlockState::NewContainingBlock);
-    }
+    CheckedPtr container = containingBlock();
+    if (!container)
+        return;
 
-    if (canContainFixedPositionObjects() && !canContainFixedPositionObjects(&newStyle)) {
-        auto* container = containingBlock();
-        if (container && !container->canContainFixedPositionObjects())
-            container->removeOutOfFlowBoxes({ }, RenderBlock::ContainingBlockState::NewContainingBlock);
-    }
+    const RenderStyle* oldStyle = hasInitializedStyle() ? &style() : nullptr;
+    if (oldStyle)
+        removeOutOfFlowBoxesIfNeededOnStyleChange(*container, *oldStyle, newStyle);
 }
 
 void RenderInline::styleDidChange(StyleDifference diff, const RenderStyle* oldStyle)


### PR DESCRIPTION
#### 286da457d7a6bc70021bd2f9e36774e1f7b2f381
<pre>
Inline elements don&apos;t relayout out-of-flow descendants when they become containing blocks for position:fixed descendants.
<a href="https://bugs.webkit.org/show_bug.cgi?id=294189">https://bugs.webkit.org/show_bug.cgi?id=294189</a>

Reviewed by Alan Baradlay.

RenderInline::styleWillChange currently only handles the case where the element
is no longer a containing block, but not where it newly is one.

It also incorrectly handles the case where the parent was previously holding
out-of-flows as a delegate for the inline, and now is the actual containing
block for those out-of-flows. The current code makes no change, and it needs to
at least request layout since the actual containing block (and thus sizing) has
changed.

There&apos;s also a third issue where RenderBlock early exits after removing
position:fixed out-of-flows from the old containing block, but may also need to
remove position:absolute out-of-flows from their containing block (which could
be different).

The fix moves the existing RenderBlock code into RenderBoxModelObject, so that
both renderer types can use it, and removes the early return.

It handles the parent changing from being a delegate to the actual containing
block by just removing the out-of-flows regardless. This is probably less
performant than detecting this situation and just requesting layout, but makes
the logic significantly simpler.

Two new tests added, that cover all three of these issues.

* LayoutTests/fast/block/missing-absolute-positioned-content-expected.html: Added.
* LayoutTests/fast/block/missing-absolute-positioned-content-inline-expected.html: Added.
* LayoutTests/fast/block/missing-absolute-positioned-content-inline.html: Added.
* LayoutTests/fast/block/missing-absolute-positioned-content.html: Added.
* Source/WebCore/rendering/RenderBlock.cpp:
(WebCore::RenderBlock::styleWillChange):
(WebCore::RenderBlock::removeOutOfFlowBoxesIfNeededOnStyleChange): Deleted.
* Source/WebCore/rendering/RenderBlock.h:
* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::removeOutOfFlowBoxesIfNeededOnStyleChange):
* Source/WebCore/rendering/RenderElement.h:
* Source/WebCore/rendering/RenderInline.cpp:
(WebCore::RenderInline::styleWillChange):

Canonical link: <a href="https://commits.webkit.org/295979@main">https://commits.webkit.org/295979@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5f797cd71fdf13a799376179faedf62c97ad1092

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/106839 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/26583 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/16981 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/112048 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/57429 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/108871 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/27253 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/35086 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/81131 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/109836 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/21636 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/96405 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/61472 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/21076 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/14514 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/56884 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/90977 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/14541 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/115016 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33971 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/25062 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/90195 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/34336 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/92636 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89905 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22936 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34838 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/12651 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/29658 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/33895 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/39316 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/33642 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/36995 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/35244 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->