### PR TITLE
Sync `css/css-device-adapt` from WPT upstream

### DIFF
--- a/LayoutTests/imported/w3c/resources/import-expectations.json
+++ b/LayoutTests/imported/w3c/resources/import-expectations.json
@@ -73,7 +73,7 @@
     "web-platform-tests/css/css-contain": "import",
     "web-platform-tests/css/css-content": "import",
     "web-platform-tests/css/css-counter-styles": "import",
-    "web-platform-tests/css/css-device-adapt": "skip",
+    "web-platform-tests/css/css-device-adapt": "import",
     "web-platform-tests/css/css-display": "import",
     "web-platform-tests/css/css-easing": "import",
     "web-platform-tests/css/css-env": "skip",

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-device-adapt/META.yml
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-device-adapt/META.yml
@@ -1,0 +1,3 @@
+spec: https://drafts.csswg.org/css-device-adapt/
+suggested_reviewers:
+  - ChumpChief

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-device-adapt/documentElement-clientWidth-on-minimum-scale-size.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-device-adapt/documentElement-clientWidth-on-minimum-scale-size.tentative-expected.txt
@@ -1,0 +1,3 @@
+
+PASS documentElement clientWidth should be equal to device-width even if overflow:hidden region is visible
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-device-adapt/documentElement-clientWidth-on-minimum-scale-size.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-device-adapt/documentElement-clientWidth-on-minimum-scale-size.tentative.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<meta charset=utf-8>
+<meta name="viewport" content="width=device-width minimum-scale=0.5">
+<link rel="help" href="https://drafts.csswg.org/css-device-adapt/">
+<style>
+html {
+  overflow: hidden;
+}
+body {
+  margin: 0;
+}
+div {
+  height: 200%;
+  position: absolute;
+}
+</style>
+<title></title>
+<div style="width: 200%;"></div>
+<div id="reference" style="width: 100%;"></div>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script>
+'use strict';
+test(() => {
+  assert_equals(document.documentElement.clientWidth, reference.clientWidth,
+    'documentElement clientWidth should be 100%');
+}, 'documentElement clientWidth should be equal to device-width even if ' +
+   'overflow:hidden region is visible');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-device-adapt/viewport-user-scalable-no-clamp-to-max.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-device-adapt/viewport-user-scalable-no-clamp-to-max.tentative-expected.txt
@@ -1,0 +1,4 @@
+Content
+
+PASS Page with meta viewport "width=device-width, user-scalable=no, initial-scale=device-width, maximum-scale=1.0" should scale to 1.0.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-device-adapt/viewport-user-scalable-no-clamp-to-max.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-device-adapt/viewport-user-scalable-no-clamp-to-max.tentative.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<meta charset=utf-8>
+<meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=device-width, maximum-scale=1.0">
+<link rel="help" href="https://drafts.csswg.org/css-device-adapt/">
+<link rel="help" href="https://webcompat.com/issues/52856">
+<style>
+body {
+  margin: 0;
+}
+#content {
+  width: 100px;
+  height: 100px;
+  background: green;
+}
+</style>
+
+<div id="content">Content</div>
+
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script>
+'use strict';
+test(() => {
+  assert_equals(window.visualViewport.scale, 1.0,
+    'visual viewport scale should be 1.0');
+}, 'Page with meta viewport "width=device-width, user-scalable=no, ' +
+   'initial-scale=device-width, maximum-scale=1.0" ' +
+   'should scale to 1.0.');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-device-adapt/viewport-user-scalable-no-clamp-to-min.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-device-adapt/viewport-user-scalable-no-clamp-to-min.tentative-expected.txt
@@ -1,0 +1,4 @@
+Content
+
+PASS Page with meta viewport "width=device-width, user-scalable=no, initial-scale=0.25, minimum-scale=1.0" should scale to 1.0.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-device-adapt/viewport-user-scalable-no-clamp-to-min.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-device-adapt/viewport-user-scalable-no-clamp-to-min.tentative.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<meta charset=utf-8>
+<meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=0.25, minimum-scale=1.0">
+<link rel="help" href="https://drafts.csswg.org/css-device-adapt/">
+<link rel="help" href="https://webcompat.com/issues/52856">
+<style>
+body {
+  margin: 0;
+}
+#content {
+  width: 100px;
+  height: 100px;
+  background: green;
+}
+</style>
+
+<div id="content">Content</div>
+
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script>
+'use strict';
+test(() => {
+  assert_equals(window.visualViewport.scale, 1.0,
+    'visual viewport scale should be 1.0');
+}, 'Page with meta viewport "width=device-width, user-scalable=no, ' +
+   'initial-scale=0.25, minimum-scale=1.0" ' +
+   'should scale to 1.0.');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-device-adapt/viewport-user-scalable-no-wide-content.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-device-adapt/viewport-user-scalable-no-wide-content.tentative-expected.txt
@@ -1,0 +1,4 @@
+Content
+
+PASS Page with meta viewport "width=device-width, user-scalable=no" should scale document with very wide content to 1.0.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-device-adapt/viewport-user-scalable-no-wide-content.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-device-adapt/viewport-user-scalable-no-wide-content.tentative.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<meta charset=utf-8>
+<meta name="viewport" content="width=device-width, user-scalable=no">
+<link rel="help" href="https://drafts.csswg.org/css-device-adapt/">
+<link rel="help" href="https://github.com/w3c/csswg-drafts/issues/5016">
+<style>
+body {
+  margin: 0;
+}
+#content {
+  width: 10000px;
+  height: 10000px;
+  background: green;
+}
+</style>
+
+<div id="content">Content</div>
+
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script>
+'use strict';
+test(() => {
+  assert_equals(window.visualViewport.scale, 1.0,
+    'visual viewport scale should be 1.0');
+}, 'Page with meta viewport "width=device-width, user-scalable=no" ' +
+   'should scale document with very wide content to 1.0.');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-device-adapt/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-device-adapt/w3c-import.log
@@ -1,0 +1,21 @@
+The tests in this directory were imported from the W3C repository.
+Do NOT modify these tests directly in WebKit.
+Instead, create a pull request on the WPT github:
+	https://github.com/web-platform-tests/wpt
+
+Then run the Tools/Scripts/import-w3c-tests in WebKit to reimport
+
+Do NOT modify or remove this file.
+
+------------------------------------------------------------------------
+Properties requiring vendor prefixes:
+None
+Property values requiring vendor prefixes:
+None
+------------------------------------------------------------------------
+List of files:
+/LayoutTests/imported/w3c/web-platform-tests/css/css-device-adapt/META.yml
+/LayoutTests/imported/w3c/web-platform-tests/css/css-device-adapt/documentElement-clientWidth-on-minimum-scale-size.tentative.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-device-adapt/viewport-user-scalable-no-clamp-to-max.tentative.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-device-adapt/viewport-user-scalable-no-clamp-to-min.tentative.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-device-adapt/viewport-user-scalable-no-wide-content.tentative.html


### PR DESCRIPTION
#### 4e59b6909a05e91662c2684bcba66f925c94dafb
<pre>
Sync `css/css-device-adapt` from WPT upstream

<a href="https://bugs.webkit.org/show_bug.cgi?id=294192">https://bugs.webkit.org/show_bug.cgi?id=294192</a>
<a href="https://rdar.apple.com/152822309">rdar://152822309</a>

Reviewed by Tim Nguyen.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/0b74b3f4686dd456429e72988e7f7e5d4b82e4ec">https://github.com/web-platform-tests/wpt/commit/0b74b3f4686dd456429e72988e7f7e5d4b82e4ec</a>

* LayoutTests/imported/w3c/resources/import-expectations.json:
* LayoutTests/imported/w3c/web-platform-tests/css/css-device-adapt/documentElement-clientWidth-on-minimum-scale-size.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-device-adapt/documentElement-clientWidth-on-minimum-scale-size.tentative.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-device-adapt/META.yml:
* LayoutTests/imported/w3c/web-platform-tests/css/css-device-adapt/viewport-user-scalable-no-clamp-to-max.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-device-adapt/viewport-user-scalable-no-clamp-to-max.tentative.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-device-adapt/viewport-user-scalable-no-clamp-to-min.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-device-adapt/viewport-user-scalable-no-clamp-to-min.tentative.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-device-adapt/viewport-user-scalable-no-wide-content.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-device-adapt/viewport-user-scalable-no-wide-content.tentative.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-device-adapt/w3c-import.log:

Canonical link: <a href="https://commits.webkit.org/295985@main">https://commits.webkit.org/295985@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0dea1d7c5f7b6233a89b77d9f853ead0cf6d8b16

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/106847 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/26589 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/16986 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/112054 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/57433 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/27257 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/35090 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/81135 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/109840 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/21640 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/96410 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/61476 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/21080 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/14519 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/56888 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/90981 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/14546 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/115031 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33975 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/25067 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/90199 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/34340 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/92641 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89909 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22939 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34840 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/12656 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/29663 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/33899 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/33646 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/36999 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/35250 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->