### PR TITLE
Sync `css/css-easing` from WPT upstream

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-easing/linear-timing-functions-chrome-406926307-crash.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-easing/linear-timing-functions-chrome-406926307-crash.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<title>Chrome crash bug 406926307</title>
+<link rel="help" href="https://crbug.com/406926307">
+<style>
+  div {
+    transition-timing-function: linear(0, 0.25, sibling-index());
+    transition-timing-function: linear(0, 0.25, sign(2em - 20px));
+  }
+</style>
+<p>Passes if test does not fail any CHECKs or DCHECKs.</p>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-easing/linear-timing-functions-syntax-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-easing/linear-timing-functions-syntax-expected.txt
@@ -12,6 +12,7 @@ PASS e.style['animation-timing-function'] = "linear(0, 0.5 25% 75%, 1 100% 100%)
 PASS e.style['animation-timing-function'] = "linear(0, 1.3, 1, 0.92, 1, 0.99, 1, 0.998, 1 100% 100%)" should set the property value
 PASS e.style['animation-timing-function'] = "linear(0, 0 40%, 1, 0.5, 1)" should set the property value
 PASS e.style['animation-timing-function'] = "linear(0, 1.3, 1, 0.92, 1, 0.99, 1, 1.004, 0.998, 1 100% 100%)" should set the property value
+FAIL e.style['animation-timing-function'] = "linear(calc(0/0), 1)" should set the property value assert_equals: serialization should be canonical expected "linear(0 0%, 1 100%)" but got "linear(calc(NaN), 1)"
 PASS e.style['animation-timing-function'] = "linear()" should not set the property value
 PASS e.style['animation-timing-function'] = "linear(0)" should not set the property value
 PASS e.style['animation-timing-function'] = "linear(100%)" should not set the property value

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-easing/linear-timing-functions-syntax.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-easing/linear-timing-functions-syntax.html
@@ -26,6 +26,7 @@ test_valid_value("animation-timing-function", "linear(0, 0.5 25% 75%, 1 100% 100
 test_valid_value("animation-timing-function", "linear(0, 1.3, 1, 0.92, 1, 0.99, 1, 0.998, 1 100% 100%)");
 test_valid_value("animation-timing-function", "linear(0, 0 40%, 1, 0.5, 1)");
 test_valid_value("animation-timing-function", "linear(0, 1.3, 1, 0.92, 1, 0.99, 1, 1.004, 0.998, 1 100% 100%)");
+test_valid_value("animation-timing-function", "linear(calc(0/0), 1)", "linear(0 0%, 1 100%)");
 
 test_invalid_value("animation-timing-function", "linear()");
 test_invalid_value("animation-timing-function", "linear(0)");

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-easing/step-timing-functions-syntax-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-easing/step-timing-functions-syntax-expected.txt
@@ -13,4 +13,5 @@ PASS e.style['animation-timing-function'] = "steps(0, jump-start)" should not se
 PASS e.style['animation-timing-function'] = "steps(0, jump-end)" should not set the property value
 PASS e.style['animation-timing-function'] = "steps(0, jump-both)" should not set the property value
 PASS e.style['animation-timing-function'] = "steps(1, jump-none)" should not set the property value
+FAIL e.style['animation-timing-function'] = "steps(calc(0/0), jump-none)" should not set the property value assert_equals: expected "" but got "steps(calc(NaN), jump-none)"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-easing/step-timing-functions-syntax.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-easing/step-timing-functions-syntax.html
@@ -29,6 +29,7 @@ test_invalid_value("animation-timing-function", "steps(0, jump-start)");
 test_invalid_value("animation-timing-function", "steps(0, jump-end)");
 test_invalid_value("animation-timing-function", "steps(0, jump-both)");
 test_invalid_value("animation-timing-function", "steps(1, jump-none)");
+test_invalid_value("animation-timing-function", "steps(calc(0/0), jump-none)");
 
 </script>
 </body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-easing/timing-functions-syntax-computed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-easing/timing-functions-syntax-computed-expected.txt
@@ -19,4 +19,5 @@ PASS Property animation-timing-function value 'steps(calc(-10), start)'
 PASS Property animation-timing-function value 'steps(calc(5 / 2), start)'
 PASS Property animation-timing-function value 'steps(calc(1), jump-none)'
 PASS Property animation-timing-function value 'linear, ease, linear'
+PASS Property animation-timing-function value 'steps(calc(2 + sign(100em - 1px)), end)'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-easing/timing-functions-syntax-computed.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-easing/timing-functions-syntax-computed.html
@@ -35,6 +35,8 @@ test_computed_value("animation-timing-function", "steps(calc(5 / 2), start)", "s
 test_computed_value("animation-timing-function", "steps(calc(1), jump-none)", "steps(2, jump-none)");
 
 test_computed_value("animation-timing-function", "linear, ease, linear");
+
+test_computed_value("animation-timing-function", "steps(calc(2 + sign(100em - 1px)), end)", "steps(3)");
 </script>
 </body>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-easing/timing-functions-syntax-valid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-easing/timing-functions-syntax-valid-expected.txt
@@ -8,6 +8,7 @@ PASS e.style['animation-timing-function'] = "cubic-bezier(0.1, 0.2, 0.8, 0.9)" s
 PASS e.style['animation-timing-function'] = "cubic-bezier(0, -2, 1, 3)" should set the property value
 PASS e.style['animation-timing-function'] = "cubic-bezier(0, 0.7, 1, 1.3)" should set the property value
 PASS e.style['animation-timing-function'] = "cubic-bezier(calc(-2), calc(0.7 / 2), calc(1.5), calc(0))" should set the property value
+PASS e.style['animation-timing-function'] = "cubic-bezier(0, sibling-index(), 1, sign(2em - 20px))" should set the property value
 PASS e.style['animation-timing-function'] = "steps(4, start)" should set the property value
 PASS e.style['animation-timing-function'] = "steps(2, end)" should set the property value
 PASS e.style['animation-timing-function'] = "steps( 2, end )" should set the property value
@@ -19,4 +20,5 @@ PASS e.style['animation-timing-function'] = "steps(calc(-10), start)" should set
 PASS e.style['animation-timing-function'] = "steps(calc(5 / 2), start)" should set the property value
 PASS e.style['animation-timing-function'] = "steps(calc(1), jump-none)" should set the property value
 PASS e.style['animation-timing-function'] = "linear, ease, linear" should set the property value
+PASS e.style['animation-timing-function'] = "steps(calc(2 + sign(100em - 1px)))" should set the property value
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-easing/timing-functions-syntax-valid.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-easing/timing-functions-syntax-valid.html
@@ -21,6 +21,7 @@ test_valid_value("animation-timing-function", "cubic-bezier(0.1, 0.2, 0.8, 0.9)"
 test_valid_value("animation-timing-function", "cubic-bezier(0, -2, 1, 3)");
 test_valid_value("animation-timing-function", "cubic-bezier(0, 0.7, 1, 1.3)");
 test_valid_value("animation-timing-function", "cubic-bezier(calc(-2), calc(0.7 / 2), calc(1.5), calc(0))", "cubic-bezier(calc(-2), calc(0.35), calc(1.5), calc(0))");
+test_valid_value("animation-timing-function", "cubic-bezier(0, sibling-index(), 1, sign(2em - 20px))");
 
 test_valid_value("animation-timing-function", "steps(4, start)");
 test_valid_value("animation-timing-function", "steps(2, end)", "steps(2)");
@@ -34,6 +35,8 @@ test_valid_value("animation-timing-function", "steps(calc(5 / 2), start)", "step
 test_valid_value("animation-timing-function", "steps(calc(1), jump-none)");
 
 test_valid_value("animation-timing-function", "linear, ease, linear");
+
+test_valid_value("animation-timing-function", "steps(calc(2 + sign(100em - 1px)))");
 </script>
 </body>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-easing/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-easing/w3c-import.log
@@ -17,6 +17,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/css/css-easing/META.yml
 /LayoutTests/imported/w3c/web-platform-tests/css/css-easing/WEB_FEATURES.yml
 /LayoutTests/imported/w3c/web-platform-tests/css/css-easing/cubic-bezier-timing-functions-output.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-easing/linear-timing-functions-chrome-406926307-crash.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-easing/linear-timing-functions-output.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-easing/linear-timing-functions-syntax.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-easing/step-timing-functions-output.html


### PR DESCRIPTION
#### 00e62406fca1059e9879654d2cf9e4c6b039c315
<pre>
Sync `css/css-easing` from WPT upstream

<a href="https://bugs.webkit.org/show_bug.cgi?id=294194">https://bugs.webkit.org/show_bug.cgi?id=294194</a>
<a href="https://rdar.apple.com/152823833">rdar://152823833</a>

Reviewed by Tim Nguyen.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/0b74b3f4686dd456429e72988e7f7e5d4b82e4ec">https://github.com/web-platform-tests/wpt/commit/0b74b3f4686dd456429e72988e7f7e5d4b82e4ec</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-easing/linear-timing-functions-syntax-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-easing/linear-timing-functions-syntax.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-easing/step-timing-functions-syntax-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-easing/step-timing-functions-syntax.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-easing/timing-functions-syntax-computed-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-easing/timing-functions-syntax-computed.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-easing/timing-functions-syntax-valid-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-easing/timing-functions-syntax-valid.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-easing/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/css/css-easing/linear-timing-functions-chrome-406926307-crash.html:

Canonical link: <a href="https://commits.webkit.org/295986@main">https://commits.webkit.org/295986@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3947c7d4e10e70d6b8cbe133fb2cb2b75237a354

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/106851 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/26591 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/16988 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/112058 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/57437 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/27259 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/35092 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/81139 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/109842 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/21643 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/96412 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/61480 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/21083 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/14521 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/56890 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/90984 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/14548 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/115036 "Build is being retried. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Failed to compile WebKit; Failed to compile WebKit; Unable to build WebKit without PR, retrying build (failure)") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/33977 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/25069 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/90202 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/34342 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/92643 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89912 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22940 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34843 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/12658 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/29668 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/33901 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/33648 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/37001 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/35254 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->