### PR TITLE
[popover] Integrate with anchor positioning

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/popover-implicit-anchor-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/popover-implicit-anchor-expected.txt
@@ -1,4 +1,4 @@
 Button Popover
 
-FAIL Popover invokers form an implicit anchor reference assert_equals: expected 100 but got 55
+PASS Popover invokers form an implicit anchor reference
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/popover-implicit-anchor.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/popover-implicit-anchor.html
@@ -34,7 +34,7 @@ promise_test(async (t) => {
   await clickOn(button);
   assert_true(popover.matches(':popover-open'));
   // Popover should be anchored to the button.
-  assert_equals(popover.offsetLeft + popover.offsetWidth, 100);
-  assert_equals(popover.offsetTop + popover.offsetHeight, 100);
+  assert_equals(popover.offsetLeft + popover.offsetWidth, button.offsetLeft);
+  assert_equals(popover.offsetTop + popover.offsetHeight, button.offsetTop);
 }, 'Popover invokers form an implicit anchor reference');
 </script>

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -3204,6 +3204,9 @@ void Element::setInvokedPopover(RefPtr<Element>&& element)
 {
     auto& data = ensureElementRareData();
     data.setInvokedPopover(WTFMove(element));
+
+    // Invalidate so isPopoverInvoker style bit gets updated.
+    invalidateStyleInternal();
 }
 
 void Element::addShadowRoot(Ref<ShadowRoot>&& newShadowRoot)

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -412,6 +412,9 @@ public:
     void setUsesAnchorFunctions();
     bool usesAnchorFunctions() const;
 
+    void setIsPopoverInvoker();
+    bool isPopoverInvoker() const;
+
     void setColumnStylesFromPaginationMode(PaginationMode);
     
     inline bool isFloating() const;

--- a/Source/WebCore/rendering/style/RenderStyleInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleInlines.h
@@ -861,6 +861,8 @@ inline bool RenderStyle::isForceHidden() const { return m_rareInheritedData->isF
 inline Isolation RenderStyle::isolation() const { return static_cast<Isolation>(m_nonInheritedData->rareData->isolation); }
 inline bool RenderStyle::usesAnchorFunctions() const { return m_nonInheritedData->rareData->usesAnchorFunctions; }
 
+inline bool RenderStyle::isPopoverInvoker() const { return m_nonInheritedData->rareData->isPopoverInvoker; }
+
 inline Visibility RenderStyle::usedVisibility() const
 {
     if (isForceHidden()) [[unlikely]]

--- a/Source/WebCore/rendering/style/RenderStyleSetters.h
+++ b/Source/WebCore/rendering/style/RenderStyleSetters.h
@@ -348,6 +348,7 @@ inline void RenderStyle::setTransformOriginZ(float value) { SET_DOUBLY_NESTED(m_
 inline void RenderStyle::setTransformStyle3D(TransformStyle3D b) { SET_NESTED(m_nonInheritedData, rareData, transformStyle3D, static_cast<unsigned>(b)); }
 inline void RenderStyle::setTransformStyleForcedToFlat(bool b) { SET_NESTED(m_nonInheritedData, rareData, transformStyleForcedToFlat, static_cast<unsigned>(b)); }
 inline void RenderStyle::setUsesAnchorFunctions() { SET_NESTED(m_nonInheritedData, rareData, usesAnchorFunctions, true); }
+inline void RenderStyle::setIsPopoverInvoker() { SET_NESTED(m_nonInheritedData, rareData, isPopoverInvoker, true); }
 inline void RenderStyle::setUseSmoothScrolling(bool value) { SET_NESTED(m_nonInheritedData, rareData, useSmoothScrolling, value); }
 inline void RenderStyle::setUsedZIndex(int index) { SET_NESTED_PAIR(m_nonInheritedData, boxData, m_usedZIndex, index, m_hasAutoUsedZIndex, false); }
 inline void RenderStyle::setUserDrag(UserDrag value) { SET_NESTED(m_nonInheritedData, miscData, userDrag, static_cast<unsigned>(value)); }

--- a/Source/WebCore/rendering/style/StyleRareNonInheritedData.cpp
+++ b/Source/WebCore/rendering/style/StyleRareNonInheritedData.cpp
@@ -143,6 +143,7 @@ StyleRareNonInheritedData::StyleRareNonInheritedData()
 #endif
     , scrollbarWidth(static_cast<unsigned>(RenderStyle::initialScrollbarWidth()))
     , usesAnchorFunctions(false)
+    , isPopoverInvoker(false)
 {
 }
 
@@ -251,6 +252,7 @@ inline StyleRareNonInheritedData::StyleRareNonInheritedData(const StyleRareNonIn
 #endif
     , scrollbarWidth(o.scrollbarWidth)
     , usesAnchorFunctions(o.usesAnchorFunctions)
+    , isPopoverInvoker(o.isPopoverInvoker)
 {
 }
 
@@ -365,7 +367,8 @@ bool StyleRareNonInheritedData::operator==(const StyleRareNonInheritedData& o) c
         && appleVisualEffect == o.appleVisualEffect
 #endif
         && scrollbarWidth == o.scrollbarWidth
-        && usesAnchorFunctions == o.usesAnchorFunctions;
+        && usesAnchorFunctions == o.usesAnchorFunctions
+        && isPopoverInvoker == o.isPopoverInvoker;
 }
 
 OptionSet<Containment> StyleRareNonInheritedData::usedContain() const
@@ -543,6 +546,7 @@ void StyleRareNonInheritedData::dumpDifferences(TextStream& ts, const StyleRareN
     LOG_IF_DIFFERENT(scrollbarWidth);
 
     LOG_IF_DIFFERENT_WITH_CAST(bool, usesAnchorFunctions);
+    LOG_IF_DIFFERENT_WITH_CAST(bool, isPopoverInvoker);
 }
 #endif // !LOG_DISABLED
 

--- a/Source/WebCore/rendering/style/StyleRareNonInheritedData.h
+++ b/Source/WebCore/rendering/style/StyleRareNonInheritedData.h
@@ -293,6 +293,8 @@ public:
     unsigned usesAnchorFunctions : 1;
     unsigned usesTreeCountingFunctions : 1;
 
+    unsigned isPopoverInvoker : 1;
+
 private:
     StyleRareNonInheritedData();
     StyleRareNonInheritedData(const StyleRareNonInheritedData&);

--- a/Source/WebCore/style/AnchorPositionEvaluator.h
+++ b/Source/WebCore/style/AnchorPositionEvaluator.h
@@ -125,6 +125,7 @@ public:
 
     static ScopedName defaultAnchorName(const RenderStyle&);
     static bool isAnchor(const RenderStyle&);
+    static bool isImplicitAnchor(const RenderStyle&);
 
     static CheckedPtr<RenderBoxModelObject> defaultAnchorForBox(const RenderBox&);
 

--- a/Source/WebCore/style/StyleAdjuster.cpp
+++ b/Source/WebCore/style/StyleAdjuster.cpp
@@ -645,6 +645,9 @@ void Adjuster::adjust(RenderStyle& style) const
 
         if (m_element->visibilityAdjustment().contains(VisibilityAdjustment::Subtree)) [[unlikely]]
             style.setIsForceHidden();
+
+        if (m_element->invokedPopover())
+            style.setIsPopoverInvoker();
     }
 
     if (shouldInheritTextDecorationsInEffect(style, m_element.get()))


### PR DESCRIPTION
#### 6bea8210e2b59ee2e34de9cc7d860677cb6086ee
<pre>
[popover] Integrate with anchor positioning
<a href="https://bugs.webkit.org/show_bug.cgi?id=284226">https://bugs.webkit.org/show_bug.cgi?id=284226</a>
<a href="https://rdar.apple.com/141094328">rdar://141094328</a>

Reviewed by Alan Baradlay and Tim Nguyen.

See <a href="https://github.com/whatwg/html/pull/10728.">https://github.com/whatwg/html/pull/10728.</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/popover-implicit-anchor-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/popover-implicit-anchor.html:

Test against the actual button position so button margins from appearance don&apos;t affect the results.

* Source/WebCore/dom/Element.cpp:
(WebCore::Element::setInvokedPopover):

Invalidate the element style so the we update the isPopoverInvoker style bit.

* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/style/RenderStyleInlines.h:
(WebCore::RenderStyle::isPopoverInvoker const):
* Source/WebCore/rendering/style/RenderStyleSetters.h:
(WebCore::RenderStyle::setIsPopoverInvoker):

Add a bit. We use it to determine of a box is an implicit anchor.
Making this a style bit allows anchor registration and updates work correctly
without any new mechanisms.

* Source/WebCore/rendering/style/StyleRareNonInheritedData.cpp:
(WebCore::StyleRareNonInheritedData::StyleRareNonInheritedData):
(WebCore::StyleRareNonInheritedData::operator== const):
(WebCore::StyleRareNonInheritedData::dumpDifferences const):
* Source/WebCore/rendering/style/StyleRareNonInheritedData.h:
* Source/WebCore/style/AnchorPositionEvaluator.cpp:
(WebCore::Style::findImplicitAnchor):

The implicit anchor for a popover is its invoker.
Factor into a function.

(WebCore::Style::findLastAcceptableAnchorWithName):
(WebCore::Style::AnchorPositionEvaluator::findAnchorsForAnchorPositionedElement):
(WebCore::Style::AnchorPositionEvaluator::isAnchor):
(WebCore::Style::AnchorPositionEvaluator::isImplicitAnchor):

A popover invoker is an implicit anchor.
Factor into a function.

* Source/WebCore/style/AnchorPositionEvaluator.h:
* Source/WebCore/style/StyleAdjuster.cpp:
(WebCore::Style::Adjuster::adjust const):

Set isPopoverInvoker bit for invokers.

Canonical link: <a href="https://commits.webkit.org/295995@main">https://commits.webkit.org/295995@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/12d4116b6432f1155332dab15de11a3a6af4f8c4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/106898 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/26616 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/17013 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/112107 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/57466 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/108902 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/27284 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/35118 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/81179 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/109867 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/21664 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/96435 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/61520 "Found 1 new API test failure: /WPE/TestSSL:/webkit/WebKitWebView/ephemeral-tls-errors (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/21107 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/14544 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/56915 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/91006 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/14571 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/115089 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/34002 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/25092 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/90234 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/34369 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/92666 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89945 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22944 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34867 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/12681 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/29708 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/33926 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/39372 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/33673 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/37026 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/35298 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->