### PR TITLE
[WPE] Crash when running the mdn-bcd-collector test suite after 292932@main

### DIFF
--- a/Source/WebCore/platform/mediastream/gstreamer/DesktopPortal.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/DesktopPortal.h
@@ -57,12 +57,12 @@ public:
     static RefPtr<DesktopPortalCamera> create();
 
     bool isCameraPresent();
-    bool accessCamera();
-    std::optional<int> openCameraPipewireRemote();
+    void accessCamera(Function<void(std::optional<int>)>&&);
 
 private:
+    std::optional<int> openCameraPipewireRemote();
+
     DesktopPortalCamera(ASCIILiteral, GRefPtr<GDBusProxy>&&);
-    HashMap<String, std::optional<bool>> m_cameraAccessResults;
 };
 
 class DesktopPortalScreenCast : public DesktopPortal {

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCaptureSource.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCaptureSource.cpp
@@ -69,9 +69,7 @@ GStreamerVideoCaptureDeviceManager::GStreamerVideoCaptureDeviceManager()
 void GStreamerVideoCaptureDeviceManager::computeCaptureDevices(CompletionHandler<void()>&& callback)
 {
     m_devices.clear();
-    m_pipewireCaptureDeviceManager->computeCaptureDevices();
-
-    callback();
+    m_pipewireCaptureDeviceManager->computeCaptureDevices(WTFMove(callback));
 }
 
 CaptureSourceOrError GStreamerVideoCaptureDeviceManager::createVideoCaptureSource(const CaptureDevice& device, MediaDeviceHashSalts&& hashSalts, const MediaConstraints* constraints)

--- a/Source/WebCore/platform/mediastream/gstreamer/PipeWireCaptureDeviceManager.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/PipeWireCaptureDeviceManager.h
@@ -39,13 +39,12 @@ public:
     static RefPtr<PipeWireCaptureDeviceManager> create(OptionSet<CaptureDevice::DeviceType>);
     PipeWireCaptureDeviceManager(OptionSet<CaptureDevice::DeviceType>);
 
-    void computeCaptureDevices();
+    void computeCaptureDevices(CompletionHandler<void()>&&);
     const Vector<CaptureDevice>& captureDevices() const { return m_devices; }
     CaptureSourceOrError createCaptureSource(const CaptureDevice&, MediaDeviceHashSalts&&, const MediaConstraints*);
 
 private:
     OptionSet<CaptureDevice::DeviceType> m_deviceTypes;
-    RefPtr<DesktopPortalCamera> m_portal;
     GRefPtr<GstDeviceProvider> m_pipewireDeviceProvider;
     Vector<CaptureDevice> m_devices;
 };


### PR DESCRIPTION
#### fc82cafe4cd6e2c87babd4a9aba25dbf7916be2a
<pre>
[WPE] Crash when running the mdn-bcd-collector test suite after 292932@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=293786">https://bugs.webkit.org/show_bug.cgi?id=293786</a>

Reviewed by Xabier Rodriguez-Calvar.

A new DesktopPortal client is now created for each enumerateDevices() call, in order to prevent
recursion if the call site is not properly awaiting the result. The computeCaptureDevices completion
handler is also now chained from the PipeWireCaptureDeviceManager to the DesktopPortal, allowing us
to keep the openCameraPipewireRemote() method private to DesktopPortal.

Canonical link: <a href="https://commits.webkit.org/296261@main">https://commits.webkit.org/296261@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e7d0d2a6cffcc7378379159eb6f0030bfcf1fbe9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/106896 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/26615 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/17012 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/112105 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/57465 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/108901 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/27283 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/35117 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/81178 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/109866 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/21665 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/96432 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/61519 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/21108 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/14541 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/56914 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/91007 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/14568 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/115087 "Build is being retried. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Failed to compile WebKit; Failed to compile WebKit; Unable to build WebKit without PR, retrying build (failure)") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/34001 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/25091 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/90232 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/34368 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/92663 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89943 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23135 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34866 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/12678 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/29707 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/33925 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/39370 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/33672 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/37025 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/35296 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->