### PR TITLE
[Safe CPP] Address Warnings in RenderMarquee, RenderText, RenderVideo, and TextPaintStyle

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/NoUncheckedPtrMemberCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/NoUncheckedPtrMemberCheckerExpectations
@@ -83,7 +83,6 @@ rendering/RenderLayerCompositor.cpp
 rendering/RenderLayerCompositor.h
 rendering/RenderLayerScrollableArea.h
 rendering/RenderLayoutState.h
-rendering/RenderMarquee.h
 rendering/RenderSelection.h
 rendering/RenderSelectionGeometry.h
 rendering/RenderTableSection.h

--- a/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -665,7 +665,6 @@ rendering/RenderLineBreak.cpp
 rendering/RenderListBox.cpp
 rendering/RenderListItem.cpp
 rendering/RenderListMarker.cpp
-rendering/RenderMarquee.cpp
 rendering/RenderMenuList.cpp
 rendering/RenderMultiColumnFlow.cpp
 rendering/RenderMultiColumnSet.cpp
@@ -697,7 +696,6 @@ rendering/RenderTextLineBoxes.cpp
 rendering/RenderTheme.cpp
 rendering/RenderTreeAsText.cpp
 rendering/RenderVTTCue.cpp
-rendering/RenderVideo.cpp
 rendering/RenderView.cpp
 rendering/RenderViewTransitionCapture.cpp
 rendering/RenderWidget.cpp
@@ -707,7 +705,6 @@ rendering/TextAutoSizing.h
 rendering/TextBoxPainter.cpp
 rendering/TextBoxTrimmer.cpp
 rendering/TextDecorationPainter.cpp
-rendering/TextPaintStyle.cpp
 rendering/TextPainter.cpp
 rendering/TextPainter.h
 rendering/cocoa/RenderThemeCocoa.mm

--- a/Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
@@ -448,7 +448,6 @@ rendering/RenderLineBreak.cpp
 rendering/RenderListBox.cpp
 rendering/RenderListItem.cpp
 rendering/RenderListMarker.cpp
-rendering/RenderMarquee.cpp
 rendering/RenderMenuList.cpp
 rendering/RenderMultiColumnFlow.cpp
 rendering/RenderMultiColumnSet.cpp
@@ -476,7 +475,6 @@ rendering/RenderTextFragment.cpp
 rendering/RenderTheme.cpp
 rendering/RenderTreeAsText.cpp
 rendering/RenderVTTCue.cpp
-rendering/RenderVideo.cpp
 rendering/RenderView.cpp
 rendering/RenderWidget.cpp
 rendering/StyledMarkedText.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -971,11 +971,9 @@ rendering/RenderTextControlSingleLine.h
 rendering/RenderTextFragment.cpp
 rendering/RenderTheme.cpp
 rendering/RenderTreeAsText.cpp
-rendering/RenderVideo.cpp
 rendering/RenderView.cpp
 rendering/RenderWidget.cpp
 rendering/TextBoxPainter.cpp
-rendering/TextPaintStyle.cpp
 rendering/cocoa/RenderThemeCocoa.mm
 rendering/mac/RenderThemeMac.mm
 rendering/mathml/MathMLStyle.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -555,7 +555,6 @@ rendering/RenderLayerFilters.cpp
 rendering/RenderLayerModelObject.cpp
 rendering/RenderListBox.cpp
 rendering/RenderListItem.cpp
-rendering/RenderMarquee.cpp
 rendering/RenderMenuList.cpp
 rendering/RenderObject.cpp
 rendering/RenderProgress.cpp
@@ -570,7 +569,6 @@ rendering/RenderTheme.cpp
 rendering/RenderTreeAsText.cpp
 rendering/RenderWidget.cpp
 rendering/TextBoxPainter.cpp
-rendering/TextPaintStyle.cpp
 rendering/mac/RenderThemeMac.mm
 rendering/mathml/MathMLStyle.cpp
 rendering/shapes/ShapeOutsideInfo.cpp

--- a/Source/WebCore/rendering/RenderMarquee.h
+++ b/Source/WebCore/rendering/RenderMarquee.h
@@ -84,7 +84,7 @@ private:
 
     void timerFired();
 
-    RenderLayer* m_layer;
+    const CheckedPtr<RenderLayer> m_layer;
     Timer m_timer;
     int m_currentLoop { 0 };
     int m_totalLoops { 0 };

--- a/Source/WebCore/rendering/RenderText.h
+++ b/Source/WebCore/rendering/RenderText.h
@@ -63,6 +63,8 @@ public:
     RefPtr<Text> protectedTextNode() const { return textNode(); }
 
     const RenderStyle& style() const;
+    // FIXME: Remove checkedStyle once https://github.com/llvm/llvm-project/pull/142485 lands. This is a false positive.
+    const CheckedRef<const RenderStyle> checkedStyle() const { return style(); }
     const RenderStyle& firstLineStyle() const;
     const RenderStyle* getCachedPseudoStyle(const Style::PseudoElementIdentifier&, const RenderStyle* parentStyle = nullptr) const;
 

--- a/Source/WebCore/rendering/RenderVideo.cpp
+++ b/Source/WebCore/rendering/RenderVideo.cpp
@@ -213,7 +213,7 @@ bool RenderVideo::shouldDisplayVideo() const
 
 bool RenderVideo::failedToLoadPosterImage() const
 {
-    return imageResource().errorOccurred();
+    return checkedImageResource()->errorOccurred();
 }
 
 void RenderVideo::paintReplaced(PaintInfo& paintInfo, const LayoutPoint& paintOffset)
@@ -221,25 +221,26 @@ void RenderVideo::paintReplaced(PaintInfo& paintInfo, const LayoutPoint& paintOf
     ASSERT(!isSkippedContentRoot(*this));
 
     Ref videoElement = this->videoElement();
+    Ref page = this->page();
     RefPtr mediaPlayer = videoElement->player();
     bool displayingPoster = videoElement->shouldDisplayPosterImage();
 
     if (!displayingPoster && !mediaPlayer) {
         if (paintInfo.phase == PaintPhase::Foreground)
-            page().addRelevantUnpaintedObject(*this, visualOverflowRect());
+            page->addRelevantUnpaintedObject(*this, visualOverflowRect());
         return;
     }
 
     LayoutRect rect = videoBox();
     if (rect.isEmpty()) {
         if (paintInfo.phase == PaintPhase::Foreground)
-            page().addRelevantUnpaintedObject(*this, visualOverflowRect());
+            page->addRelevantUnpaintedObject(*this, visualOverflowRect());
         return;
     }
     rect.moveBy(paintOffset);
 
     if (paintInfo.phase == PaintPhase::Foreground)
-        page().addRelevantRepaintedObject(*this, rect);
+        page->addRelevantRepaintedObject(*this, rect);
 
     LayoutRect contentRect = contentBoxRect();
     contentRect.moveBy(paintOffset);
@@ -387,7 +388,7 @@ bool RenderVideo::hasPosterFrameSize() const
     // so that contain: inline-size could affect the intrinsic size, which should be 0 x block-size.
     if (shouldApplyInlineSizeContainment())
         isEmpty = isHorizontalWritingMode() ? !m_cachedImageSize.height() : !m_cachedImageSize.width();
-    return protectedVideoElement()->shouldDisplayPosterImage() && !isEmpty && !imageResource().errorOccurred();
+    return protectedVideoElement()->shouldDisplayPosterImage() && !isEmpty && !checkedImageResource()->errorOccurred();
 }
 
 bool RenderVideo::hasDefaultObjectSize() const
@@ -397,7 +398,7 @@ bool RenderVideo::hasDefaultObjectSize() const
 
 void RenderVideo::invalidateLineLayout()
 {
-    if (auto* inlineLayout = LayoutIntegration::LineLayout::containing(*this))
+    if (CheckedPtr inlineLayout = LayoutIntegration::LineLayout::containing(*this))
         inlineLayout->boxContentWillChange(*this);
 }
 

--- a/Source/WebCore/rendering/TextPaintStyle.cpp
+++ b/Source/WebCore/rendering/TextPaintStyle.cpp
@@ -72,10 +72,11 @@ static Color adjustColorForVisibilityOnBackground(const Color& textColor, const 
 
 TextPaintStyle computeTextPaintStyle(const RenderText& renderer, const RenderStyle& lineStyle, const PaintInfo& paintInfo)
 {
-    auto& frame = renderer.frame();
+    Ref frame = renderer.frame();
+    RefPtr frameView = frame->view();
     TextPaintStyle paintStyle;
 
-    auto viewportSize = frame.view() ? frame.view()->size() : IntSize();
+    auto viewportSize = frameView ? frameView->size() : IntSize();
     paintStyle.strokeWidth = lineStyle.computedStrokeWidth(viewportSize);
     paintStyle.paintOrder = lineStyle.paintOrder();
     paintStyle.lineJoin = lineStyle.joinStyle();
@@ -90,7 +91,7 @@ TextPaintStyle computeTextPaintStyle(const RenderText& renderer, const RenderSty
     }
 
     if (lineStyle.insideDefaultButton()) {
-        Page* page = renderer.frame().page();
+        RefPtr page = renderer.frame().page();
         if (page && page->focusController().isActive()) {
             OptionSet<StyleColorOptions> options;
             if (page->settings().useSystemAppearance())
@@ -103,15 +104,15 @@ TextPaintStyle computeTextPaintStyle(const RenderText& renderer, const RenderSty
     paintStyle.fillColor = lineStyle.visitedDependentColorWithColorFilter(CSSPropertyWebkitTextFillColor, paintInfo.paintBehavior);
 
     bool forceBackgroundToWhite = false;
-    if (frame.document() && frame.document()->printing()) {
+    if (frame->document() && frame->document()->printing()) {
         if (lineStyle.printColorAdjust() == PrintColorAdjust::Economy)
             forceBackgroundToWhite = true;
 
-        if (frame.settings().shouldPrintBackgrounds())
+        if (frame->settings().shouldPrintBackgrounds())
             forceBackgroundToWhite = false;
 
         if (forceBackgroundToWhite) {
-            if (renderer.style().hasAnyBackgroundClipText())
+            if (renderer.checkedStyle()->hasAnyBackgroundClipText())
                 paintStyle.fillColor = Color::black;
         }
     }
@@ -148,10 +149,11 @@ TextPaintStyle computeTextSelectionPaintStyle(const TextPaintStyle& textPaintSty
     if (emphasisMarkForeground.isValid() && emphasisMarkForeground != selectionPaintStyle.emphasisMarkColor)
         selectionPaintStyle.emphasisMarkColor = emphasisMarkForeground;
 
+    RefPtr view = renderer.frame().view();
     if (auto pseudoStyle = renderer.selectionPseudoStyle()) {
         selectionPaintStyle.hasExplicitlySetFillColor = pseudoStyle->hasExplicitlySetColor();
         selectionShadow = paintInfo.forceTextColor() ? FixedVector<Style::TextShadow> { } : pseudoStyle->textShadow();
-        auto viewportSize = renderer.frame().view() ? renderer.frame().view()->size() : IntSize();
+        auto viewportSize = view ? view->size() : IntSize();
         float strokeWidth = pseudoStyle->computedStrokeWidth(viewportSize);
         if (strokeWidth != selectionPaintStyle.strokeWidth)
             selectionPaintStyle.strokeWidth = strokeWidth;


### PR DESCRIPTION
#### eb6a94b1305d8a393c933da906e672757003ecb2
<pre>
[Safe CPP] Address Warnings in RenderMarquee, RenderText, RenderVideo, and TextPaintStyle
<a href="https://bugs.webkit.org/show_bug.cgi?id=294203">https://bugs.webkit.org/show_bug.cgi?id=294203</a>
<a href="https://rdar.apple.com/problem/152837623">rdar://problem/152837623</a>

Reviewed by Chris Dumez.

Address safe cpp warnings in RenderMarquee, RenderText, RenderVideo, and TextPaintStyle.

* Source/WebCore/SaferCPPExpectations/NoUncheckedPtrMemberCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
* Source/WebCore/rendering/RenderMarquee.cpp:
(WebCore::RenderMarquee::marqueeSpeed const):
(WebCore::RenderMarquee::computePosition):
(WebCore::RenderMarquee::start):
(WebCore::RenderMarquee::updateMarqueeStyle):
(WebCore::RenderMarquee::timerFired):
* Source/WebCore/rendering/RenderMarquee.h:
* Source/WebCore/rendering/RenderText.h:
(WebCore::RenderText::checkedStyle const):
* Source/WebCore/rendering/RenderVideo.cpp:
(WebCore::RenderVideo::failedToLoadPosterImage const):
(WebCore::RenderVideo::paintReplaced):
(WebCore::RenderVideo::hasPosterFrameSize const):
(WebCore::RenderVideo::invalidateLineLayout):
* Source/WebCore/rendering/TextPaintStyle.cpp:
(WebCore::computeTextPaintStyle):
(WebCore::computeTextSelectionPaintStyle):

Canonical link: <a href="https://commits.webkit.org/296010@main">https://commits.webkit.org/296010@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/92bf631813f27d3552ba0d51c7b16b87d7de836b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/106940 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/26647 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/17044 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/112148 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/57500 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/108933 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/27320 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/35149 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/81204 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/109898 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/21691 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/96459 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/61548 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/21131 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/14569 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/56946 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/91035 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/14596 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/115148 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/34033 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/25112 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/90257 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/34401 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/92690 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/89971 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22956 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34889 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/12703 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/29747 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/33957 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/39412 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/33705 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/37057 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/35337 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->