### PR TITLE
AX: Implement support for AXAttributedStringForRange off the main-thread

### DIFF
--- a/Source/WebCore/accessibility/AXCoreObject.h
+++ b/Source/WebCore/accessibility/AXCoreObject.h
@@ -798,7 +798,7 @@ public:
     String dbg(bool verbose = false) const { return dbgInternal(verbose, { }); }
     String dbg(OptionSet<AXDebugStringOption> options) const { return dbgInternal(false, options); }
 
-    AXID objectID() const { return m_id; }
+    inline AXID objectID() const { return m_id; }
     virtual std::optional<AXID> treeID() const = 0;
     virtual ProcessID processID() const = 0;
 
@@ -1329,6 +1329,11 @@ public:
     AXCoreObject* nextSiblingIncludingIgnored(bool updateChildrenIfNeeded) const;
     AXCoreObject* nextUnignoredSibling(bool updateChildrenIfNeeded, AXCoreObject* unignoredParent = nullptr) const;
     AXCoreObject* nextSiblingIncludingIgnoredOrParent() const;
+    std::optional<AXID> idOfNextSiblingIncludingIgnoredOrParent() const
+    {
+        auto* object = nextSiblingIncludingIgnoredOrParent();
+        return object ? std::optional(object->objectID()) : std::nullopt;
+    }
 
     AXCoreObject* previousInPreOrder(bool updateChildrenIfNeeded = true, AXCoreObject* stayWithin = nullptr);
     AXCoreObject* previousSiblingIncludingIgnored(bool updateChildrenIfNeeded);
@@ -1938,6 +1943,9 @@ using PlatformRoleMap = HashMap<AccessibilityRole, String, DefaultHash<unsigned>
 void initializeRoleMap();
 PlatformRoleMap createPlatformRoleMap();
 String roleToPlatformString(AccessibilityRole);
+#if ENABLE(AX_THREAD_TEXT_APIS)
+std::optional<AXTextMarkerRange> markerRangeFrom(NSRange, const AXCoreObject&);
+#endif
 
 } // namespace Accessibility
 

--- a/Source/WebCore/accessibility/AXTextMarker.h
+++ b/Source/WebCore/accessibility/AXTextMarker.h
@@ -339,7 +339,7 @@ public:
     // Returns a range pointing to the start and end positions that have the same text styles as `this`.
     AXTextMarkerRange rangeWithSameStyle() const;
     // Starting from this marker, return a text marker that is `offset` characters away.
-    AXTextMarker nextMarkerFromOffset(unsigned, ForceSingleOffsetMovement = ForceSingleOffsetMovement::No) const;
+    AXTextMarker nextMarkerFromOffset(unsigned, ForceSingleOffsetMovement = ForceSingleOffsetMovement::No, std::optional<AXID> stopAtID = std::nullopt) const;
     // Returns the number of intermediate text markers between this and the root.
     unsigned offsetFromRoot() const;
     // Starting from this marker, navigate to the last marker before the given AXID. Assumes `this`

--- a/Source/WebCore/accessibility/cocoa/AXCoreObjectCocoa.mm
+++ b/Source/WebCore/accessibility/cocoa/AXCoreObjectCocoa.mm
@@ -618,8 +618,22 @@ PlatformRoleMap createPlatformRoleMap()
     return roleMap;
 }
 
-} // namespace Accessibility
+#if ENABLE(AX_THREAD_TEXT_APIS)
+std::optional<AXTextMarkerRange> markerRangeFrom(NSRange range, const AXCoreObject& object)
+{
+    std::optional stopAtID = object.idOfNextSiblingIncludingIgnoredOrParent();
+    auto markerToLocation = AXTextMarker { object, 0 }.nextMarkerFromOffset(range.location, ForceSingleOffsetMovement::Yes, stopAtID);
+    if (!markerToLocation.isValid())
+        return std::nullopt;
 
+    auto markerToRangeEnd = markerToLocation.nextMarkerFromOffset(range.length, ForceSingleOffsetMovement::Yes, stopAtID);
+    if (!markerToRangeEnd.isValid())
+        return std::nullopt;
+    return std::optional(AXTextMarkerRange { WTFMove(markerToLocation), WTFMove(markerToRangeEnd) });
+}
+#endif // ENABLE(AX_THREAD_TEXT_APIS)
+
+} // namespace Accessibility
 
 #endif // PLATFORM(MAC)
 

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
@@ -2866,26 +2866,11 @@ static bool isMatchingPlugin(AXCoreObject& axObject, const AccessibilitySearchCr
         && (!criteria.visibleOnly || axObject.isVisible());
 }
 
-#if ENABLE(AX_THREAD_TEXT_APIS)
-static std::optional<AXTextMarkerRange> markerRangeFrom(NSRange range, const AXCoreObject& object)
-{
-    auto markerToLocation = AXTextMarker { object, 0 }.nextMarkerFromOffset(range.location, ForceSingleOffsetMovement::Yes);
-    if (!markerToLocation.isValid())
-        return std::nullopt;
-
-    auto markerToRangeEnd = markerToLocation.nextMarkerFromOffset(range.length, ForceSingleOffsetMovement::Yes);
-    if (!markerToRangeEnd.isValid())
-        return std::nullopt;
-    return std::optional(AXTextMarkerRange { WTFMove(markerToLocation), WTFMove(markerToRangeEnd) });
-}
-
-#endif // ENABLE(AX_THREAD_TEXT_APIS)
-
 static NSRect computeTextBoundsForRange(NSRange range, const AXCoreObject& backingObject)
 {
 #if ENABLE(AX_THREAD_TEXT_APIS)
     if (AXObjectCache::useAXThreadTextApis()) {
-        std::optional markerRange = markerRangeFrom(range, backingObject);
+        std::optional markerRange = Accessibility::markerRangeFrom(range, backingObject);
         return markerRange ? static_cast<CGRect>(markerRange->viewportRelativeFrame()) : CGRectZero;
     }
 #endif // ENABLE(AX_THREAD_TEXT_APIS)
@@ -3281,7 +3266,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 
 #if ENABLE(AX_THREAD_TEXT_APIS)
         if (AXObjectCache::useAXThreadTextApis()) {
-            std::optional markerRange = markerRangeFrom(range, *backingObject);
+            std::optional markerRange = Accessibility::markerRangeFrom(range, *backingObject);
             return markerRange ? markerRange->toString().createNSString().autorelease() : @"";
         }
 #endif // ENABLE(AX_THREAD_TEXT_APIS)


### PR DESCRIPTION
#### d8c9786a163a0e54418f0619723e128a4b9e7d47
<pre>
AX: Implement support for AXAttributedStringForRange off the main-thread
<a href="https://bugs.webkit.org/show_bug.cgi?id=294211">https://bugs.webkit.org/show_bug.cgi?id=294211</a>
<a href="https://rdar.apple.com/152849965">rdar://152849965</a>

Reviewed by Joshua Hoffman.

Even prior to this commit, we&apos;ve already had the ability to turn AXTextMarkerRanges into attributed strings. The only
missing piece to move this API off the main-thread was making AXIsolatedObject::textMarkerRangeForNSRange use off-main
thread data to do the conversion.

Behavior tested by existing layout tests, e.g.:
  - accessibility/mac/attributed-string-includes-misspelled-with-selection.html
  - accessibility/content-editable-as-textarea.html
  - accessibility/native-text-control-attributed-string.html

These layout tests exposed an existing deficiency in our NSRange to AXTextMarkerRange conversion — we did not handle
out-of-bounds NSRanges, and did not limit traversal to stay within the &quot;root&quot; of the NSRange. Both are fixed with
this commit.

* Source/WebCore/accessibility/AXCoreObject.h:
* Source/WebCore/accessibility/AXTextMarker.cpp:
(WebCore::AXTextMarker::nextMarkerFromOffset const):
* Source/WebCore/accessibility/AXTextMarker.h:
* Source/WebCore/accessibility/cocoa/AXCoreObjectCocoa.mm:
(WebCore::Accessibility::markerRangeFrom):
* Source/WebCore/accessibility/isolatedtree/mac/AXIsolatedObjectMac.mm:
(WebCore::AXIsolatedObject::textMarkerRangeForNSRange const):
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm:
(computeTextBoundsForRange):
(-[WebAccessibilityObjectWrapper accessibilityAttributeValue:forParameter:]):
(markerRangeFrom): Deleted.

Canonical link: <a href="https://commits.webkit.org/296085@main">https://commits.webkit.org/296085@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/57c022bfa1cd0282aae7cce4abdbec09f5b4ef8e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/107257 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/26939 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/17343 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/112471 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/57790 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/109221 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/27620 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/35439 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/81426 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/110186 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/21893 "Found 1 new test failure: fast/events/ios/select-all-with-existing-selection.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/96670 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/61796 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/21319 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/14805 "Found 3 new test failures: inspector/model/remote-object-get-properties.html inspector/runtime/getDisplayableProperties.html inspector/runtime/getProperties.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/57236 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/91248 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/14834 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/115572 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/34323 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/25289 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/90465 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/34699 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/92919 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/90198 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23012 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35099 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/12882 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/30053 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/34245 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/39737 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/33991 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/37346 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/35652 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->