### PR TITLE
[macOS] Fullscreen animation looks incorrect on ign.com

### DIFF
--- a/LayoutTests/fullscreen/fullscreen-zero-height-element-with-non-zero-children-expected.txt
+++ b/LayoutTests/fullscreen/fullscreen-zero-height-element-with-non-zero-children-expected.txt
@@ -1,0 +1,12 @@
+supportsFullScreen() == true
+enterFullScreenForElement()
+beganEnterFullScreen() - initialRect.size: {100, 100}, finalRect.size: {800, 600}
+exitFullScreenForElement()
+beganExitFullScreen() - initialRect.size: {800, 600}, finalRect.size: {100, 100}
+RUN(testRunner.dumpFullScreenCallbacks())
+RUN(target.webkitRequestFullScreen())
+EVENT(webkitfullscreenchange)
+RUN(document.webkitExitFullscreen())
+EVENT(webkitfullscreenchange)
+END OF TEST
+

--- a/LayoutTests/fullscreen/fullscreen-zero-height-element-with-non-zero-children.html
+++ b/LayoutTests/fullscreen/fullscreen-zero-height-element-with-non-zero-children.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>fullscreen-zero-height-element-with-non-zero-children</title>
+    <style>
+        #target { 
+            width: 100px;
+            height: 0;
+        }
+        #child { 
+            width: 100px;
+            height: 100px;
+            position: absolute;
+        }
+    </style>
+    <script src="full-screen-test.js"></script>
+    <script>
+
+    window.addEventListener('load', async event => {
+        run("testRunner.dumpFullScreenCallbacks()");
+
+        internals.withUserGesture(() => { run('target.webkitRequestFullScreen()'); });
+        await waitFor(target, 'webkitfullscreenchange');
+        await sleepFor(10);
+        if (window.testRunner) { await testRunner.updatePresentation() }
+
+        run('document.webkitExitFullscreen()');
+
+        await waitFor(target, 'webkitfullscreenchange');
+
+        await sleepFor(10);
+
+        endTest();
+    });
+</script>
+</head>
+<body>
+<div id="target">
+    <div id="child"></div>
+</div>
+</body>
+</html>

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -1063,6 +1063,7 @@ http/tests/local/blob/navigate-blob.html [ Skip ]
 media/no-fullscreen-when-hidden.html [ Skip ]
 fullscreen/full-screen-enter-while-exiting-fully-mid-completion-handler.html [ Skip ]
 fullscreen/full-screen-enter-while-exiting-mid-completion-handler.html [ Skip ]
+fullscreen/fullscreen-zero-height-element-with-non-zero-children.html [ Skip ]
 
 # Multi-process test
 fullscreen/iframe-fullscreen-system-exit.html [ Skip ]


### PR DESCRIPTION
#### 71cbb1ee223bcca3a73efccd837600ae58b913c6
<pre>
[macOS] Fullscreen animation looks incorrect on ign.com
<a href="https://rdar.apple.com/152181188">rdar://152181188</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=294209">https://bugs.webkit.org/show_bug.cgi?id=294209</a>

Reviewed by Eric Carlson.

IGN.com requests fullscreen on an element whose height is explicitly zero, and with an absolute
positioned child. screenRectOfContents() would return a zero-height rect, and this would cause
the fullscreen animation to start and end at the wrong visual position.

Update screenRectOfContents() to use paintingRootRect() rather than screenRect().

* LayoutTests/fullscreen/fullscreen-zero-height-element-with-non-zero-children-expected.txt: Added.
* LayoutTests/fullscreen/fullscreen-zero-height-element-with-non-zero-children.html: Added.
* Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp:
(WebKit::screenRectOfContents):
(WebKit::WebFullScreenManager::enterFullScreenForElement):
(WebKit::WebFullScreenManager::willEnterFullScreen):
(WebKit::WebFullScreenManager::willExitFullScreen):

Canonical link: <a href="https://commits.webkit.org/296331@main">https://commits.webkit.org/296331@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5755bcd49771fd8dabe8c38593cacd54f1dab285

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/107459 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27141 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/17548 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/112673 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/57995 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/27825 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/35641 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/81571 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/110388 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22035 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/96847 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/61956 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/21475 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/14987 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/57439 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/91404 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15019 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/115774 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/34526 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/25440 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/90608 "Found 1 new test failure: fullscreen/fullscreen-zero-height-element-with-non-zero-children.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/34901 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93103 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/90353 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23185 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35262 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13043 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/30269 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/34447 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/39988 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34193 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/37548 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/35854 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->