### PR TITLE
document should not be null after navigation with site isolation enabled

### DIFF
--- a/LayoutTests/http/tests/site-isolation/document-access-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/document-access-expected.txt
@@ -1,0 +1,2 @@
+ALERT: document is null? false
+

--- a/LayoutTests/http/tests/site-isolation/document-access.html
+++ b/LayoutTests/http/tests/site-isolation/document-access.html
@@ -1,0 +1,8 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<body>
+<script>
+    if (window.testRunner) { testRunner.dumpAsText(); testRunner.waitUntilDone() }
+    onload = ()=>{ window.location = 'http://localhost:8000/site-isolation/resources/access-document.html' }
+</script>
+<iframe src="http://localhost:8000/site-isolation/resources/access-parent.html" frameborder=0></iframe>
+</body>

--- a/LayoutTests/http/tests/site-isolation/resources/access-document.html
+++ b/LayoutTests/http/tests/site-isolation/resources/access-document.html
@@ -1,0 +1,4 @@
+<script>
+    alert('document is null? ' + (document == null))
+    if (window.testRunner) { testRunner.notifyDone() }
+</script>

--- a/LayoutTests/http/tests/site-isolation/resources/access-parent.html
+++ b/LayoutTests/http/tests/site-isolation/resources/access-parent.html
@@ -1,0 +1,3 @@
+<script>
+    window.parent.frames
+</script>

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -754,7 +754,7 @@ public:
     inline CachedResourceLoader& cachedResourceLoader();
     inline Ref<CachedResourceLoader> protectedCachedResourceLoader() const;
 
-    void didBecomeCurrentDocumentInFrame();
+    WEBCORE_EXPORT void didBecomeCurrentDocumentInFrame();
     void destroyRenderTree();
     WEBCORE_EXPORT void willBeRemovedFromFrame();
 

--- a/Source/WebCore/page/Frame.cpp
+++ b/Source/WebCore/page/Frame.cpp
@@ -173,6 +173,7 @@ void Frame::disconnectOwnerElement()
 
 void Frame::takeWindowProxyAndOpenerFrom(Frame& frame)
 {
+    ASSERT(is<LocalDOMWindow>(window()) != is<LocalDOMWindow>(frame.window()) || page() != frame.page());
     ASSERT(m_windowProxy->frame() == this);
     m_windowProxy->detachFromFrame();
     m_windowProxy = frame.windowProxy();

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -518,6 +518,8 @@ void WebFrame::commitProvisionalFrame()
     if (remoteFrame->isMainFrame())
         corePage->setMainFrame(*localFrame);
     localFrame->takeWindowProxyAndOpenerFrom(*remoteFrame);
+    if (RefPtr document = localFrame->document())
+        document->didBecomeCurrentDocumentInFrame();
 
     if (corePage->focusController().focusedFrame() == remoteFrame.get())
         corePage->focusController().setFocusedFrame(localFrame.get(), FocusController::BroadcastFocusedFrame::No);


### PR DESCRIPTION
#### 3c907c552d9c986d0149653bb629cfcdaec5ac3f
<pre>
document should not be null after navigation with site isolation enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=294228">https://bugs.webkit.org/show_bug.cgi?id=294228</a>
<a href="https://rdar.apple.com/152872994">rdar://152872994</a>

Reviewed by Charlie Wolfe.

<a href="https://commits.webkit.org/292437@main">https://commits.webkit.org/292437@main</a> introduced a case where we take the WindowProxy
from one page to another when navigating the main frame from one domain to another.
If the WindowProxy that we are taking had its JSWindowProxy initialized by an iframe
on the previous page accessing its parent&apos;s properties, then JSDOMWindowBase::initStaticGlobals
has already been called to initialize document to null, but ScriptController::initScriptForWindowProxy
won&apos;t call JSDOMWindowBase::updateDocument to set document to the document instead of null
because WindowProxy::jsWindowProxy will find an already existing JSWindowProxy initialized
where WindowProxy::createJSWindowProxyWithInitializedScript has skipped the call to
initScriptForWindowProxy because the Frame was a RemoteFrame when it was initialized.

To fix this issue, we add another call to didBecomeCurrentDocumentInFrame after swapping
from a RemoteFrame to a LocalFrame.  That will call updateDocument as well as do
possibly other initialization needed.

I also restore an assertion that was removed in 292437@main, but I added a condition to
make it pass when taking a WindowProxy from one page to another.

This fixes one of the issues I found in <a href="https://rdar.apple.com/152460976">rdar://152460976</a> but not the initial one, so
that still needs more investigation.

* LayoutTests/http/tests/site-isolation/document-access-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/document-access.html: Added.
* LayoutTests/http/tests/site-isolation/resources/access-document.html: Added.
* LayoutTests/http/tests/site-isolation/resources/access-parent.html: Added.
* Source/WebCore/dom/Document.h:
* Source/WebCore/page/Frame.cpp:
(WebCore::Frame::takeWindowProxyAndOpenerFrom):
* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
(WebKit::WebFrame::commitProvisionalFrame):

Canonical link: <a href="https://commits.webkit.org/296022@main">https://commits.webkit.org/296022@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/48cd3635890fab67d11839e1487836753391f749

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/107023 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/26731 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/17129 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/112232 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/57581 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/109016 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/27404 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/35233 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/81258 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/57581 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/109981 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/21751 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/96521 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/61616 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/21177 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/14639 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/57030 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/91093 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/14663 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/115284 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/34116 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/25152 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/90297 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/34484 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/92764 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/90025 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34957 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/12752 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/29828 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17314 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/34041 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/39493 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/33788 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/37140 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/35420 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->