### PR TITLE
REGRESSION (251714@main): video element's webkitPresentationMode remains 'picture-in-picture' when returning from PiP to fullscreen on iOS

### DIFF
--- a/LayoutTests/media/video-presentation-mode-expected.txt
+++ b/LayoutTests/media/video-presentation-mode-expected.txt
@@ -22,6 +22,14 @@ EVENT(webkitpresentationmodechanged)
 EXPECTED (internals.isChangingPresentationMode(video) == 'false') OK
 EXPECTED (video.webkitPresentationMode == 'picture-in-picture') OK
 
+** Try to return to fullscreen
+RUN(video.webkitSetPresentationMode('fullscreen'))
+EVENT(webkitpresentationmodechanged)
+
+** Received webkitpresentationmodechanged event
+EXPECTED (internals.isChangingPresentationMode(video) == 'false') OK
+EXPECTED (video.webkitPresentationMode == 'fullscreen') OK
+
 ** Try to return to inline
 RUN(video.webkitSetPresentationMode('inline'))
 EVENT(webkitpresentationmodechanged)

--- a/LayoutTests/media/video-presentation-mode.html
+++ b/LayoutTests/media/video-presentation-mode.html
@@ -43,6 +43,16 @@
                 consoleWrite("<br>** Received webkitpresentationmodechanged event");
                 await testExpectedEventually("internals.isChangingPresentationMode(video)", false);
                 testExpected("video.webkitPresentationMode", "picture-in-picture");
+                consoleWrite("<br>** Try to return to fullscreen");
+                waitForEventOnce('webkitpresentationmodechanged', presentationModeChanged3);
+                runWithKeyDown("video.webkitSetPresentationMode('fullscreen')");
+            }
+
+            async function presentationModeChanged3()
+            {
+                consoleWrite("<br>** Received webkitpresentationmodechanged event");
+                await testExpectedEventually("internals.isChangingPresentationMode(video)", false);
+                testExpected("video.webkitPresentationMode", "fullscreen");
                 consoleWrite("<br>** Try to return to inline");
                 waitForEventOnce('webkitpresentationmodechanged', testCompleted);
                 runWithKeyDown("video.webkitSetPresentationMode('inline')");

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -7466,7 +7466,7 @@ void HTMLMediaElement::enterFullscreen(VideoFullscreenMode mode)
         if (RefPtr asVideo = dynamicDowncast<HTMLVideoElement>(element)) {
             auto& client = element.document().page()->chrome().client();
             auto supportsFullscreen = client.supportsVideoFullscreen(mode);
-            auto canEnterFullscreen = client.canEnterVideoFullscreen(mode);
+            auto canEnterFullscreen = client.canEnterVideoFullscreen(*asVideo, mode);
             if (supportsFullscreen && canEnterFullscreen) {
                 ALWAYS_LOG_WITH_THIS(&element, logIdentifier, "Entering fullscreen mode ", mode, ", element.m_videoFullscreenStandby = ", element.m_videoFullscreenStandby);
 

--- a/Source/WebCore/page/ChromeClient.h
+++ b/Source/WebCore/page/ChromeClient.h
@@ -489,7 +489,7 @@ public:
     WEBCORE_EXPORT virtual RefPtr<ScrollingCoordinator> createScrollingCoordinator(Page&) const;
     WEBCORE_EXPORT virtual void ensureScrollbarsController(Page&, ScrollableArea&, bool update = false) const;
 
-    virtual bool canEnterVideoFullscreen(HTMLMediaElementEnums::VideoFullscreenMode) const { return false; }
+    virtual bool canEnterVideoFullscreen(HTMLVideoElement&, HTMLMediaElementEnums::VideoFullscreenMode) const { return false; }
     virtual bool supportsVideoFullscreen(HTMLMediaElementEnums::VideoFullscreenMode) { return false; }
     virtual bool supportsVideoFullscreenStandby() { return false; }
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -1425,10 +1425,10 @@ void WebChromeClient::prepareForVideoFullscreen()
         page->videoPresentationManager();
 }
 
-bool WebChromeClient::canEnterVideoFullscreen(HTMLMediaElementEnums::VideoFullscreenMode mode) const
+bool WebChromeClient::canEnterVideoFullscreen(HTMLVideoElement& videoElement, HTMLMediaElementEnums::VideoFullscreenMode mode) const
 {
     RefPtr page = m_page.get();
-    return page && page->videoPresentationManager().canEnterVideoFullscreen(mode);
+    return page && page->videoPresentationManager().canEnterVideoFullscreen(videoElement, mode);
 }
 
 bool WebChromeClient::supportsVideoFullscreen(HTMLMediaElementEnums::VideoFullscreenMode mode)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
@@ -310,7 +310,7 @@ private:
 
 #if ENABLE(VIDEO_PRESENTATION_MODE)
     void prepareForVideoFullscreen() final;
-    bool canEnterVideoFullscreen(WebCore::HTMLMediaElementEnums::VideoFullscreenMode) const final;
+    bool canEnterVideoFullscreen(WebCore::HTMLVideoElement&, WebCore::HTMLMediaElementEnums::VideoFullscreenMode) const final;
     bool supportsVideoFullscreen(WebCore::HTMLMediaElementEnums::VideoFullscreenMode) final;
     bool supportsVideoFullscreenStandby() final;
     void setMockVideoPresentationModeEnabled(bool) final;

--- a/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.h
+++ b/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.h
@@ -156,7 +156,7 @@ public:
     void swapFullscreenModes(WebCore::HTMLVideoElement&, WebCore::HTMLVideoElement&);
 
     // Interface to WebChromeClient
-    bool canEnterVideoFullscreen(WebCore::HTMLMediaElementEnums::VideoFullscreenMode) const;
+    bool canEnterVideoFullscreen(WebCore::HTMLVideoElement&, WebCore::HTMLMediaElementEnums::VideoFullscreenMode) const;
     bool supportsVideoFullscreen(WebCore::HTMLMediaElementEnums::VideoFullscreenMode) const;
     bool supportsVideoFullscreenStandby() const;
     void enterVideoFullscreenForVideoElement(WebCore::HTMLVideoElement&, WebCore::HTMLMediaElementEnums::VideoFullscreenMode, bool standby);
@@ -219,7 +219,7 @@ protected:
     void requestRouteSharingPolicyAndContextUID(PlaybackSessionContextIdentifier, CompletionHandler<void(WebCore::RouteSharingPolicy, String)>&&);
     void ensureUpdatedVideoDimensions(PlaybackSessionContextIdentifier, WebCore::FloatSize existingVideoDimensions);
 
-    void setCurrentlyInFullscreen(VideoPresentationInterfaceContext&, bool);
+    void setCurrentVideoFullscreenMode(VideoPresentationInterfaceContext&, WebCore::HTMLMediaElementEnums::VideoFullscreenMode);
     void setRequiresTextTrackRepresentation(PlaybackSessionContextIdentifier, bool);
     void setTextTrackRepresentationBounds(PlaybackSessionContextIdentifier, const WebCore::IntRect&);
 
@@ -236,7 +236,7 @@ protected:
     HashMap<PlaybackSessionContextIdentifier, ModelInterfaceTuple> m_contextMap;
     HashMap<PlaybackSessionContextIdentifier, int> m_clientCounts;
     WeakPtr<WebCore::HTMLVideoElement> m_videoElementInPictureInPicture;
-    bool m_currentlyInFullscreen { false };
+    WebCore::HTMLMediaElementEnums::VideoFullscreenMode m_currentVideoFullscreenMode { WebCore::HTMLMediaElementEnums::VideoFullscreenModeNone };
 };
 
 } // namespace WebKit

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.h
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.h
@@ -199,7 +199,7 @@ private:
 #endif
 
 #if ENABLE(VIDEO)
-    bool canEnterVideoFullscreen(WebCore::HTMLMediaElementEnums::VideoFullscreenMode) const final;
+    bool canEnterVideoFullscreen(WebCore::HTMLVideoElement&, WebCore::HTMLMediaElementEnums::VideoFullscreenMode) const final;
     bool supportsVideoFullscreen(WebCore::HTMLMediaElementEnums::VideoFullscreenMode) final;
 #if ENABLE(VIDEO_PRESENTATION_MODE)
     void setMockVideoPresentationModeEnabled(bool) final;

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.mm
@@ -956,7 +956,7 @@ void WebChromeClient::triggerRenderingUpdate()
 
 #if ENABLE(VIDEO)
 
-bool WebChromeClient::canEnterVideoFullscreen(WebCore::HTMLMediaElementEnums::VideoFullscreenMode) const
+bool WebChromeClient::canEnterVideoFullscreen(HTMLVideoElement&, WebCore::HTMLMediaElementEnums::VideoFullscreenMode) const
 {
 #if !PLATFORM(IOS_FAMILY) || HAVE(AVKIT)
     return true;


### PR DESCRIPTION
#### f720edf270760b6bdd4bb5be65a43e557d53817b
<pre>
REGRESSION (251714@main): video element&apos;s webkitPresentationMode remains &apos;picture-in-picture&apos; when returning from PiP to fullscreen on iOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=294233">https://bugs.webkit.org/show_bug.cgi?id=294233</a>
<a href="https://rdar.apple.com/151050209">rdar://151050209</a>

Reviewed by Eric Carlson.

251714@main made it so that only one video element could be in fullscreen at a time by storing an
m_currentlyInFullscreen boolean on VideoPresentationManager that is set to true whenever a video
element is in a VideoFullscreenMode other than VideoFullscreenModeNone. In
HTMLMediaElement::enterFullscreen, if the new mode was VideoFullscreenModeStandard and
m_currentlyInFullscreen was set, then we would abort entering fullscreen in order to prevent a
second, overlapping fullscreen interface from being presented. However, this introduced a bug where
we would incorrectly abort when returning from PiP to fullscreen, since in that case the new mode
will be VideoFullscreenModeStandard and m_currentlyInFullscreen will be set.

Fixed this by changing m_currentlyInFullscreen from a boolean to a VideoFullscreenMode named
m_currentVideoFullscreenMode, and only aborting in HTMLMediaElement::enterFullscreen when the new
mode matches the current mode (and the allowLayeredFullscreenVideos quirk is not active). This
ensures that we can correctly transition between PiP, fullscreen, and in-window fullscreen modes.

Modified LayoutTests/media/video-presentation-mode.html to cover the transition from PiP to
fullscreen.

* LayoutTests/media/video-presentation-mode-expected.txt:
* LayoutTests/media/video-presentation-mode.html:
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::enterFullscreen):
* Source/WebCore/page/ChromeClient.h:
(WebCore::ChromeClient::canEnterVideoFullscreen const):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::canEnterVideoFullscreen const):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h:
* Source/WebKit/WebProcess/cocoa/VideoPresentationManager.h:
* Source/WebKit/WebProcess/cocoa/VideoPresentationManager.mm:
(WebKit::VideoPresentationManager::canEnterVideoFullscreen const):
(WebKit::VideoPresentationManager::enterVideoFullscreenForVideoElement):
(WebKit::VideoPresentationManager::exitVideoFullscreenForVideoElement):
(WebKit::VideoPresentationManager::exitVideoFullscreenToModeWithoutAnimation):
(WebKit::VideoPresentationManager::didCleanupFullscreen):
(WebKit::VideoPresentationManager::setCurrentVideoFullscreenMode):
(WebKit::VideoPresentationManager::setCurrentlyInFullscreen): Deleted.
* Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.h:
* Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.mm:
(WebChromeClient::canEnterVideoFullscreen const):

Canonical link: <a href="https://commits.webkit.org/296041@main">https://commits.webkit.org/296041@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e8f3515b2bf24811457e9e988b01551aeed1d3c5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/107073 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/26781 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/17181 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/112282 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/57631 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/109066 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/27454 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/35283 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/81283 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/110031 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/21788 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/96559 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/61644 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/21215 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/14688 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/57080 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/91139 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/14710 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/115366 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/34166 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/25179 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/90328 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/34534 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/92813 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/90061 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22981 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/34997 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/12779 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/29878 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/34091 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/39543 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/33838 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/37190 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/35470 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->