### PR TITLE
[JSC] Add ConcatKeyAtomStringCache

### DIFF
--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -2060,6 +2060,8 @@
 		E3A32BC71FC83147007D7E76 /* WeakMapImpl.h in Headers */ = {isa = PBXBuildFile; fileRef = E3A32BC61FC8312E007D7E76 /* WeakMapImpl.h */; };
 		E3A421431D6F58930007C617 /* PreciseJumpTargetsInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = E3A421421D6F588F0007C617 /* PreciseJumpTargetsInlines.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E3AC277721FDB4940024452C /* RegExpCachedResult.h in Headers */ = {isa = PBXBuildFile; fileRef = 86F75EFC151C062F007C9BA3 /* RegExpCachedResult.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		E3B2329D2DF7A0CC00ECC447 /* ConcatKeyAtomStringCache.h in Headers */ = {isa = PBXBuildFile; fileRef = E3B2329A2DF7A0BE00ECC447 /* ConcatKeyAtomStringCache.h */; };
+		E3B2329E2DF7A0D300ECC447 /* ConcatKeyAtomStringCacheInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = E3B2329C2DF7A0BE00ECC447 /* ConcatKeyAtomStringCacheInlines.h */; };
 		E3B24859291224540029C08A /* BufferMemoryHandle.h in Headers */ = {isa = PBXBuildFile; fileRef = E3B24857291224530029C08A /* BufferMemoryHandle.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E3B876292C40CC170004DF71 /* JSFloat16Array.h in Headers */ = {isa = PBXBuildFile; fileRef = E3B876282C40CC0C0004DF71 /* JSFloat16Array.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E3B8762A2C40CC1F0004DF71 /* Float16Array.h in Headers */ = {isa = PBXBuildFile; fileRef = E3B876272C40CC0C0004DF71 /* Float16Array.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -5799,6 +5801,9 @@
 		E3A32BC51FC8312D007D7E76 /* WeakMapImpl.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WeakMapImpl.cpp; sourceTree = "<group>"; };
 		E3A32BC61FC8312E007D7E76 /* WeakMapImpl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WeakMapImpl.h; sourceTree = "<group>"; };
 		E3A421421D6F588F0007C617 /* PreciseJumpTargetsInlines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PreciseJumpTargetsInlines.h; sourceTree = "<group>"; };
+		E3B2329A2DF7A0BE00ECC447 /* ConcatKeyAtomStringCache.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ConcatKeyAtomStringCache.h; sourceTree = "<group>"; };
+		E3B2329B2DF7A0BE00ECC447 /* ConcatKeyAtomStringCache.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ConcatKeyAtomStringCache.cpp; sourceTree = "<group>"; };
+		E3B2329C2DF7A0BE00ECC447 /* ConcatKeyAtomStringCacheInlines.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ConcatKeyAtomStringCacheInlines.h; sourceTree = "<group>"; };
 		E3B24857291224530029C08A /* BufferMemoryHandle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BufferMemoryHandle.h; sourceTree = "<group>"; };
 		E3B24858291224530029C08A /* BufferMemoryHandle.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = BufferMemoryHandle.cpp; sourceTree = "<group>"; };
 		E3B4683D2DD25DFC00F7DBBF /* Zydis.c.inc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.pascal; name = Zydis.c.inc; path = disassembler/zydis/Zydis.c.inc; sourceTree = SOURCE_ROOT; };
@@ -8112,6 +8117,9 @@
 				A7E5A3A61797432D00E893C0 /* CompilationResult.h */,
 				969A09220ED1E09C00F1F681 /* Completion.cpp */,
 				F5BB2BC5030F772101FCFE1D /* Completion.h */,
+				E3B2329B2DF7A0BE00ECC447 /* ConcatKeyAtomStringCache.cpp */,
+				E3B2329A2DF7A0BE00ECC447 /* ConcatKeyAtomStringCache.h */,
+				E3B2329C2DF7A0BE00ECC447 /* ConcatKeyAtomStringCacheInlines.h */,
 				E36EDCE424F0975700E60DA2 /* Concurrency.h */,
 				0FDB2CE9174896C7007B3C1B /* ConcurrentJSLock.h */,
 				658824B01E5CFDF400FB7359 /* ConfigFile.cpp */,
@@ -10625,6 +10633,8 @@
 				0FD2FD9420B52BDE00F09441 /* CompleteSubspaceInlines.h in Headers */,
 				BC18C3F40E16F5CD00B34460 /* Completion.h in Headers */,
 				0F6FC751196110A800E1D02D /* ComplexGetStatus.h in Headers */,
+				E3B2329D2DF7A0CC00ECC447 /* ConcatKeyAtomStringCache.h in Headers */,
+				E3B2329E2DF7A0D300ECC447 /* ConcatKeyAtomStringCacheInlines.h in Headers */,
 				E36EDCE524F0975700E60DA2 /* Concurrency.h in Headers */,
 				0FDB2CEA174896C7007B3C1B /* ConcurrentJSLock.h in Headers */,
 				BC18C3F50E16F5CD00B34460 /* config.h in Headers */,

--- a/Source/JavaScriptCore/Sources.txt
+++ b/Source/JavaScriptCore/Sources.txt
@@ -774,6 +774,7 @@ runtime/CommonIdentifiers.cpp
 runtime/CommonSlowPaths.cpp
 runtime/CompilationResult.cpp
 runtime/Completion.cpp
+runtime/ConcatKeyAtomStringCache.cpp
 runtime/ConfigFile.cpp
 runtime/ConsoleClient.cpp
 runtime/ConsoleObject.cpp

--- a/Source/JavaScriptCore/bytecode/CodeBlock.cpp
+++ b/Source/JavaScriptCore/bytecode/CodeBlock.cpp
@@ -1946,6 +1946,8 @@ void CodeBlock::stronglyVisitStrongReferences(const ConcurrentJSLocker& locker, 
         DFG::CommonData* dfgCommon = m_jitCode->dfgCommon();
         if (auto* statuses = dfgCommon->recordedStatuses.get())
             statuses->visitAggregate(visitor);
+        for (auto& cache : dfgCommon->m_concatKeyAtomStringCaches)
+            cache->visitAggregate(visitor);
         visitOSRExitTargets(locker, visitor);
 #endif
     }

--- a/Source/JavaScriptCore/dfg/DFGCommonData.h
+++ b/Source/JavaScriptCore/dfg/DFGCommonData.h
@@ -30,6 +30,7 @@
 #include "BaselineJITCode.h"
 #include "CallLinkInfo.h"
 #include "CodeBlockJettisoningWatchpoint.h"
+#include "ConcatKeyAtomStringCache.h"
 #include "DFGAdaptiveInferredPropertyValueWatchpoint.h"
 #include "DFGAdaptiveStructureWatchpoint.h"
 #include "DFGCodeOriginPool.h"
@@ -130,6 +131,7 @@ public:
     std::unique_ptr<RecordedStatuses> recordedStatuses;
     FixedVector<JumpReplacement> m_jumpReplacements;
     FixedVector<std::unique_ptr<BoyerMooreHorspoolTable<uint8_t>>> m_stringSearchTable8;
+    FixedVector<std::unique_ptr<ConcatKeyAtomStringCache>> m_concatKeyAtomStringCaches;
     Bag<StructureStubInfo> m_stubInfos;
     Bag<OptimizingCallLinkInfo> m_callLinkInfos;
     Bag<DirectCallLinkInfo> m_directCallLinkInfos;

--- a/Source/JavaScriptCore/dfg/DFGGraph.cpp
+++ b/Source/JavaScriptCore/dfg/DFGGraph.cpp
@@ -2024,6 +2024,14 @@ const BoyerMooreHorspoolTable<uint8_t>* Graph::tryAddStringSearchTable8(const St
     }).iterator->value.get();
 }
 
+const ConcatKeyAtomStringCache* Graph::tryAddConcatKeyAtomStringCache(const String& s0, const String& s1, ConcatKeyAtomStringCache::Mode mode)
+{
+    if ((s0.length() + s1.length()) > ConcatKeyAtomStringCache::maxStringLengthForCache)
+        return nullptr;
+    m_concatKeyAtomStringCaches.append(makeUnique<ConcatKeyAtomStringCache>(m_codeBlock, mode));
+    return m_concatKeyAtomStringCaches.last().get();
+}
+
 void Prefix::dump(PrintStream& out) const
 {
     if (!m_enabled)

--- a/Source/JavaScriptCore/dfg/DFGGraph.h
+++ b/Source/JavaScriptCore/dfg/DFGGraph.h
@@ -30,6 +30,7 @@
 #include "AssemblyHelpers.h"
 #include "BytecodeLivenessAnalysisInlines.h"
 #include "CodeBlock.h"
+#include "ConcatKeyAtomStringCache.h"
 #include "DFGArgumentPosition.h"
 #include "DFGBasicBlock.h"
 #include "DFGFrozenValue.h"
@@ -1225,6 +1226,7 @@ public:
     bool isNeverResizableOrGrowableSharedTypedArrayIncludingDataView(const AbstractValue&);
 
     const BoyerMooreHorspoolTable<uint8_t>* tryAddStringSearchTable8(const String&);
+    const ConcatKeyAtomStringCache* tryAddConcatKeyAtomStringCache(const String&, const String&, ConcatKeyAtomStringCache::Mode);
 
     bool afterFixup() { return m_planStage >= PlanStage::AfterFixup; }
 
@@ -1252,6 +1254,7 @@ public:
     Vector<const UnlinkedStringJumpTable*> m_unlinkedStringSwitchJumpTables;
     Vector<StringJumpTable> m_stringSwitchJumpTables;
     UncheckedKeyHashMap<String, std::unique_ptr<BoyerMooreHorspoolTable<uint8_t>>> m_stringSearchTable8;
+    Vector<std::unique_ptr<ConcatKeyAtomStringCache>> m_concatKeyAtomStringCaches;
 
     UncheckedKeyHashMap<EncodedJSValue, FrozenValue*, EncodedJSValueHash, EncodedJSValueHashTraits> m_frozenValueMap;
     SegmentedVector<FrozenValue, 16> m_frozenValues;

--- a/Source/JavaScriptCore/dfg/DFGJITCompiler.cpp
+++ b/Source/JavaScriptCore/dfg/DFGJITCompiler.cpp
@@ -192,6 +192,7 @@ void JITCompiler::link(LinkBuffer& linkBuffer)
             tables[index++] = WTFMove(entry.value);
         m_jitCode->common.m_stringSearchTable8 = WTFMove(tables);
     }
+    m_jitCode->common.m_concatKeyAtomStringCaches = WTFMove(m_graph.m_concatKeyAtomStringCaches);
 
 #if USE(JSVALUE32_64)
     m_jitCode->common.doubleConstants = WTFMove(m_graph.m_doubleConstants);

--- a/Source/JavaScriptCore/dfg/DFGOperations.h
+++ b/Source/JavaScriptCore/dfg/DFGOperations.h
@@ -37,6 +37,7 @@
 
 namespace JSC {
 
+class ConcatKeyAtomStringCache;
 class DateInstance;
 class DirectCallLinkInfo;
 class JSBigInt;
@@ -360,6 +361,8 @@ JSC_DECLARE_JIT_OPERATION(operationStrCat3, JSString*, (JSGlobalObject*, Encoded
 JSC_DECLARE_JIT_OPERATION(operationMakeAtomString1, JSString*, (JSGlobalObject*, JSString*));
 JSC_DECLARE_JIT_OPERATION(operationMakeAtomString2, JSString*, (JSGlobalObject*, JSString*, JSString*));
 JSC_DECLARE_JIT_OPERATION(operationMakeAtomString3, JSString*, (JSGlobalObject*, JSString*, JSString*, JSString*));
+JSC_DECLARE_JIT_OPERATION(operationMakeAtomString2WithCache, JSString*, (JSGlobalObject*, JSString*, JSString*, ConcatKeyAtomStringCache*));
+JSC_DECLARE_JIT_OPERATION(operationMakeAtomString3WithCache, JSString*, (JSGlobalObject*, JSString*, JSString*, JSString*, ConcatKeyAtomStringCache*));
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationFindSwitchImmTargetForDouble, char*, (VM*, EncodedJSValue, size_t tableIndex, int32_t));
 JSC_DECLARE_JIT_OPERATION(operationSwitchString, char*, (JSGlobalObject*, size_t tableIndex, const UnlinkedStringJumpTable*, JSString*));
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationCompareStringImplLess, uintptr_t, (StringImpl*, StringImpl*));

--- a/Source/JavaScriptCore/ftl/FTLLink.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLink.cpp
@@ -56,6 +56,7 @@ void link(State& state)
             tables[index++] = WTFMove(entry.value);
         state.jitCode->common.m_stringSearchTable8 = WTFMove(tables);
     }
+    state.jitCode->common.m_concatKeyAtomStringCaches = WTFMove(graph.m_concatKeyAtomStringCaches);
 
     graph.registerFrozenValues();
 

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -10976,12 +10976,37 @@ IGNORE_CLANG_WARNINGS_END
         case 1:
             setJSValue(vmCall(pointerType(), operationMakeAtomString1, weakPointer(globalObject), strings[0]));
             break;
-        case 2:
-            setJSValue(vmCall(pointerType(), operationMakeAtomString2, weakPointer(globalObject), strings[0], strings[1]));
+        case 2: {
+            const ConcatKeyAtomStringCache* cache = nullptr;
+            if (auto string = m_node->child1()->tryGetString(m_graph); !string.isNull())
+                cache = m_graph.tryAddConcatKeyAtomStringCache(string, emptyString(), ConcatKeyAtomStringCache::Mode::Variable1);
+            else if (auto string = m_node->child2()->tryGetString(m_graph); !string.isNull())
+                cache = m_graph.tryAddConcatKeyAtomStringCache(string, emptyString(), ConcatKeyAtomStringCache::Mode::Variable0);
+
+            if (cache)
+                setJSValue(vmCall(pointerType(), operationMakeAtomString2WithCache, weakPointer(globalObject), strings[0], strings[1], m_out.constIntPtr(cache)));
+            else
+                setJSValue(vmCall(pointerType(), operationMakeAtomString2, weakPointer(globalObject), strings[0], strings[1]));
             break;
-        case 3:
-            setJSValue(vmCall(pointerType(), operationMakeAtomString3, weakPointer(globalObject), strings[0], strings[1], strings[2]));
+        }
+        case 3: {
+            const ConcatKeyAtomStringCache* cache = nullptr;
+            if (auto s0 = m_node->child1()->tryGetString(m_graph); !s0.isNull()) {
+                if (auto s1 = m_node->child2()->tryGetString(m_graph); !s1.isNull())
+                    cache = m_graph.tryAddConcatKeyAtomStringCache(s0, s1, ConcatKeyAtomStringCache::Mode::Variable2);
+                else if (auto s2 = m_node->child3()->tryGetString(m_graph); !s2.isNull())
+                    cache = m_graph.tryAddConcatKeyAtomStringCache(s0, s2, ConcatKeyAtomStringCache::Mode::Variable1);
+            } else if (auto s1 = m_node->child2()->tryGetString(m_graph); !s1.isNull()) {
+                if (auto s2 = m_node->child3()->tryGetString(m_graph); !s2.isNull())
+                    cache = m_graph.tryAddConcatKeyAtomStringCache(s1, s2, ConcatKeyAtomStringCache::Mode::Variable0);
+            }
+
+            if (cache)
+                setJSValue(vmCall(pointerType(), operationMakeAtomString3WithCache, weakPointer(globalObject), strings[0], strings[1], strings[2], m_out.constIntPtr(cache)));
+            else
+                setJSValue(vmCall(pointerType(), operationMakeAtomString3, weakPointer(globalObject), strings[0], strings[1], strings[2]));
             break;
+        }
         default:
             RELEASE_ASSERT_NOT_REACHED();
             break;

--- a/Source/JavaScriptCore/runtime/ConcatKeyAtomStringCache.cpp
+++ b/Source/JavaScriptCore/runtime/ConcatKeyAtomStringCache.cpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "ConcatKeyAtomStringCache.h"
+
+#include "AbstractSlotVisitor.h"
+#include <wtf/TZoneMallocInlines.h>
+
+namespace JSC {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ConcatKeyAtomStringCache);
+
+template<typename Visitor>
+void ConcatKeyAtomStringCache::visitAggregateImpl(Visitor& visitor)
+{
+    Locker locker { m_lock };
+    for (auto& entry : m_cache)
+        visitor.appendUnbarriered(entry.value);
+}
+
+DEFINE_VISIT_AGGREGATE(ConcatKeyAtomStringCache);
+
+}

--- a/Source/JavaScriptCore/runtime/ConcatKeyAtomStringCache.h
+++ b/Source/JavaScriptCore/runtime/ConcatKeyAtomStringCache.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "JSString.h"
+#include <wtf/TZoneMalloc.h>
+#include <wtf/text/AtomStringImpl.h>
+
+namespace JSC {
+
+class VM;
+
+class ConcatKeyAtomStringCache {
+    WTF_MAKE_TZONE_ALLOCATED(ConcatKeyAtomStringCache);
+    WTF_MAKE_NONCOPYABLE(ConcatKeyAtomStringCache);
+public:
+    enum class Mode : uint8_t {
+        Variable0,
+        Variable1,
+        Variable2,
+        Megamorphic,
+    };
+
+    static constexpr auto maxCapacity = 64;
+    static constexpr auto maxStringLengthForCache = 64;
+
+    ConcatKeyAtomStringCache(CodeBlock* owner, Mode mode)
+        : m_owner(owner)
+        , m_mode(mode)
+    { }
+
+    template<typename Func>
+    JSString* getOrInsert(VM&, JSString*, JSString*, JSString*, const Func&);
+
+    DECLARE_VISIT_AGGREGATE;
+
+private:
+    CodeBlock* m_owner { nullptr };
+    UncheckedKeyHashMap<Ref<AtomStringImpl>, JSString*> m_cache;
+    Mode m_mode { Mode::Megamorphic };
+    Lock m_lock;
+};
+
+} // namespace JSC

--- a/Source/JavaScriptCore/runtime/ConcatKeyAtomStringCacheInlines.h
+++ b/Source/JavaScriptCore/runtime/ConcatKeyAtomStringCacheInlines.h
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "ConcatKeyAtomStringCache.h"
+#include "Identifier.h"
+#include "SmallStrings.h"
+#include "VM.h"
+
+namespace JSC {
+
+template<typename Func>
+inline JSString* ConcatKeyAtomStringCache::getOrInsert(VM& vm, JSString* s0, JSString* s1, JSString* s2, const Func& func)
+{
+    JSString* variable = nullptr;
+    switch (m_mode) {
+    case Mode::Variable0: {
+        variable = s0;
+        break;
+    }
+    case Mode::Variable1: {
+        variable = s1;
+        break;
+    }
+    case Mode::Variable2: {
+        variable = s2;
+        break;
+    }
+    case Mode::Megamorphic: {
+        return nullptr;
+    }
+    }
+
+    auto value = variable->tryGetValue();
+    SUPPRESS_UNCOUNTED_LOCAL auto* impl = value->impl();
+
+    if (!impl)
+        return nullptr;
+
+    if (!impl->isAtom())
+        return nullptr;
+
+    SUPPRESS_UNCOUNTED_LOCAL auto& atomStringImpl = *static_cast<AtomStringImpl*>(impl);
+    if (atomStringImpl.length() > maxStringLengthForCache)
+        return nullptr;
+
+
+    if (auto* result = m_cache.get(atomStringImpl))
+        return result;
+
+    if (auto* result = func(vm)) [[likely]] {
+        if (m_cache.size() == maxCapacity) [[unlikely]] {
+            {
+                Locker locker { m_lock };
+                m_cache.clear();
+            }
+            m_mode = Mode::Megamorphic;
+        } else {
+            {
+                Locker locker { m_lock };
+                m_cache.add(atomStringImpl, result);
+            }
+            vm.writeBarrier(m_owner, result);
+        }
+        return result;
+    }
+
+    return nullptr;
+}
+
+} // namespace JSC

--- a/Source/JavaScriptCore/runtime/CustomGetterSetter.h
+++ b/Source/JavaScriptCore/runtime/CustomGetterSetter.h
@@ -29,6 +29,7 @@
 #include "PropertySlot.h"
 #include "PutPropertySlot.h"
 #include "Structure.h"
+#include "VM.h"
 
 namespace JSC {
 

--- a/Source/JavaScriptCore/runtime/DOMAttributeGetterSetter.h
+++ b/Source/JavaScriptCore/runtime/DOMAttributeGetterSetter.h
@@ -28,6 +28,7 @@
 
 #include "CustomGetterSetter.h"
 #include "DOMAnnotation.h"
+#include "VM.h"
 
 namespace JSC {
 namespace DOMJIT {

--- a/Source/JavaScriptCore/runtime/JSTypedArrayViewConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/JSTypedArrayViewConstructor.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "JSTypedArrayViewConstructor.h"
 
+#include "GetterSetter.h"
 #include "JSCBuiltins.h"
 #include "JSCInlines.h"
 #include "JSTypedArrayViewPrototype.h"

--- a/Source/JavaScriptCore/runtime/PropertyTable.h
+++ b/Source/JavaScriptCore/runtime/PropertyTable.h
@@ -23,6 +23,7 @@
 #include "JSExportMacros.h"
 #include "PropertyOffset.h"
 #include "Structure.h"
+#include "VM.h"
 #include "WriteBarrier.h"
 #include <wtf/HashTable.h>
 #include <wtf/MathExtras.h>


### PR DESCRIPTION
#### 133b2294fb903137aed15461980041ccfec0207c
<pre>
[JSC] Add ConcatKeyAtomStringCache
<a href="https://bugs.webkit.org/show_bug.cgi?id=294234">https://bugs.webkit.org/show_bug.cgi?id=294234</a>
<a href="https://rdar.apple.com/152888459">rdar://152888459</a>

Reviewed by Yijia Huang.

We can see a pattern like this,

    this[&quot;visit&quot; + name](arg)

In the above case, we already detect `&quot;visit&quot; + name` is used for
AtomString so we emit MakeAtomString DFG node. Also we are having
KeyAtomStringCache for these concatenation. However we can do better for
the above pattern: since &quot;visit&quot; is constant, the cache should be just
keyed with `name` side. Then we no longer need to flatten the concatenated
string.
This patch adds ConcatKeyAtomStringCache. This is emitted for each
MakeAtomString site in DFG / FTL, and we manage HashMap for `name` and
resulted atom string.

* Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj:
* Source/JavaScriptCore/Sources.txt:
* Source/JavaScriptCore/bytecode/CodeBlock.cpp:
(JSC::CodeBlock::stronglyVisitStrongReferences):
* Source/JavaScriptCore/dfg/DFGCommonData.h:
* Source/JavaScriptCore/dfg/DFGGraph.cpp:
(JSC::DFG::Graph::tryAddConcatKeyAtomStringCache):
* Source/JavaScriptCore/dfg/DFGGraph.h:
* Source/JavaScriptCore/dfg/DFGJITCompiler.cpp:
(JSC::DFG::JITCompiler::link):
* Source/JavaScriptCore/dfg/DFGOperations.cpp:
(JSC::DFG::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/dfg/DFGOperations.h:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
* Source/JavaScriptCore/ftl/FTLLink.cpp:
(JSC::FTL::link):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileMakeAtomString):
* Source/JavaScriptCore/runtime/ConcatKeyAtomStringCache.cpp: Added.
(JSC::ConcatKeyAtomStringCache::visitAggregateImpl):
* Source/JavaScriptCore/runtime/ConcatKeyAtomStringCache.h: Copied from Source/JavaScriptCore/runtime/DOMAttributeGetterSetter.h.
(JSC::ConcatKeyAtomStringCache::ConcatKeyAtomStringCache):
* Source/JavaScriptCore/runtime/ConcatKeyAtomStringCacheInlines.h: Copied from Source/JavaScriptCore/runtime/DOMAttributeGetterSetter.h.
(JSC::ConcatKeyAtomStringCache::getOrInsert):
* Source/JavaScriptCore/runtime/CustomGetterSetter.h:
* Source/JavaScriptCore/runtime/DOMAttributeGetterSetter.h:
* Source/JavaScriptCore/runtime/JSTypedArrayViewConstructor.cpp:
* Source/JavaScriptCore/runtime/PropertyTable.h:

Canonical link: <a href="https://commits.webkit.org/296047@main">https://commits.webkit.org/296047@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/46ea1a428094fcde0eb913949303a6ab5e2b6b5e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/107185 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/26866 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/17266 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/112397 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/57722 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/27541 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/35370 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/81371 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/57722 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/110114 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/21847 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/96626 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/61739 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/21270 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/14758 "Passed tests") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/57163 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/99771 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/91198 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/14780 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/115495 "Build was cancelled. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Compiled WebKit (cancelled)") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/105731 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/34249 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/25239 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/90416 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/34625 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/92882 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/90150 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35062 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/12840 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/29981 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17329 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/34174 "Build was cancelled. Recent messages:OS: Sequoia (15.5), Xcode: 16.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/39649 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/130048 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/33920 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/35383 "Found 2 new JSC stress test failures: wasm.yaml/wasm/gc/ref-i31-eq.js.wasm-eager, wasm.yaml/wasm/gc/ref-i31-eq.js.wasm-slow-memory (failure)") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/37273 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/35577 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->