### PR TITLE
Fix recent Safer CPP bot regressions

### DIFF
--- a/Source/JavaScriptCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
+++ b/Source/JavaScriptCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
@@ -7,6 +7,7 @@ API/tests/testapi.cpp
 BytecodeStructs.h
 bytecode/InlineCacheCompiler.h
 bytecode/SharedJITStubSet.h
+bytecode/StructureStubClearingWatchpoint.h
 bytecompiler/BytecodeGenerator.h
 bytecompiler/Label.h
 debugger/Debugger.cpp

--- a/Source/JavaScriptCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/JavaScriptCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -27,6 +27,7 @@ bytecode/DirectEvalCodeCache.h
 bytecode/GetByStatus.cpp
 bytecode/InByStatus.cpp
 bytecode/InlineCacheCompiler.cpp
+bytecode/ObjectPropertyConditionSet.cpp
 bytecode/PolyProtoAccessChain.cpp
 bytecode/PropertyCondition.cpp
 bytecode/PutByStatus.cpp

--- a/Source/JavaScriptCore/parser/ModuleAnalyzer.h
+++ b/Source/JavaScriptCore/parser/ModuleAnalyzer.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "ErrorType.h"
+#include "JSModuleRecord.h"
 #include "Nodes.h"
 
 namespace JSC {

--- a/Source/WebCore/Modules/mediastream/CanvasCaptureMediaStreamTrack.cpp
+++ b/Source/WebCore/Modules/mediastream/CanvasCaptureMediaStreamTrack.cpp
@@ -225,7 +225,7 @@ void CanvasCaptureMediaStreamTrack::Source::captureCanvas()
 
     RefPtr videoFrame = [&]() -> RefPtr<VideoFrame> {
 #if ENABLE(WEBGL)
-        if (auto* gl = dynamicDowncast<WebGLRenderingContextBase>(canvas->renderingContext()))
+        if (RefPtr gl = dynamicDowncast<WebGLRenderingContextBase>(canvas->renderingContext()))
             return gl->surfaceBufferToVideoFrame(CanvasRenderingContext::SurfaceBuffer::DisplayBuffer);
 #endif
         return canvas->toVideoFrame();

--- a/Source/WebCore/dom/ViewTransition.cpp
+++ b/Source/WebCore/dom/ViewTransition.cpp
@@ -366,7 +366,7 @@ static AtomString effectiveViewTransitionName(RenderLayerModelObject& renderer, 
 
     Ref element = *renderer.element();
     if (transitionName.isAuto() && scope == &Style::Scope::forNode(element) && element->hasID())
-        return makeAtomString("-ua-id-"_s, renderer.element()->getIdAttribute());
+        return makeAtomString("-ua-id-"_s, renderer.protectedElement()->getIdAttribute());
 
     if (isCrossDocument)
         return nullAtom();

--- a/Source/WebCore/html/FormAssociatedElement.h
+++ b/Source/WebCore/html/FormAssociatedElement.h
@@ -33,6 +33,7 @@ public:
     virtual ~FormAssociatedElement() { RELEASE_ASSERT(!m_form); }
     virtual HTMLElement& asHTMLElement() = 0;
     virtual const HTMLElement& asHTMLElement() const = 0;
+    Ref<const HTMLElement> asProtectedHTMLElement() const { return asHTMLElement(); }
     virtual bool isFormListedElement() const = 0;
 
     virtual void formWillBeDestroyed() { m_form = nullptr; }

--- a/Source/WebCore/html/FormController.cpp
+++ b/Source/WebCore/html/FormController.cpp
@@ -43,7 +43,7 @@ HTMLFormElement* FormController::ownerForm(const FormListedElement& control)
     // Assume controls with form attribute have no owners because we restore
     // state during parsing and form owners of such controls might be
     // indeterminate.
-    return control.asHTMLElement().hasAttributeWithoutSynchronization(HTMLNames::formAttr) ? nullptr : control.form();
+    return control.asProtectedHTMLElement()->hasAttributeWithoutSynchronization(HTMLNames::formAttr) ? nullptr : control.form();
 }
 
 struct AtomStringVectorReader {

--- a/Source/WebCore/html/FormListedElement.cpp
+++ b/Source/WebCore/html/FormListedElement.cpp
@@ -281,7 +281,7 @@ void FormListedElement::setCustomValidity(const String& error)
 void FormListedElement::resetFormAttributeTargetObserver()
 {
     ASSERT_WITH_SECURITY_IMPLICATION(asHTMLElement().isConnected());
-    m_formAttributeTargetObserver = makeUnique<FormAttributeTargetObserver>(asHTMLElement().attributeWithoutSynchronization(formAttr), *this);
+    m_formAttributeTargetObserver = makeUnique<FormAttributeTargetObserver>(asProtectedHTMLElement()->attributeWithoutSynchronization(formAttr), *this);
 }
 
 void FormListedElement::formAttributeTargetChanged()
@@ -291,7 +291,7 @@ void FormListedElement::formAttributeTargetChanged()
 
 const AtomString& FormListedElement::name() const
 {
-    const AtomString& name = asHTMLElement().getNameAttribute();
+    const AtomString& name = asProtectedHTMLElement()->getNameAttribute();
     return name.isNull() ? emptyAtom() : name;
 }
 

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -2531,7 +2531,7 @@ bool Page::shouldUpdateAccessibilityRegions() const
         if (RefPtr localMainFrame = this->localMainFrame())
             protectedMainDocument = localMainFrame ? localMainFrame->document() : nullptr;
         else if (RefPtr remoteFrame = dynamicDowncast<RemoteFrame>(mainFrame())) {
-            if (auto* owner = remoteFrame->ownerElement())
+            if (RefPtr owner = remoteFrame->ownerElement())
                 protectedMainDocument = owner->document();
         }
 

--- a/Source/WebCore/page/scrolling/mac/ScrollerMac.mm
+++ b/Source/WebCore/page/scrolling/mac/ScrollerMac.mm
@@ -184,7 +184,7 @@ enum class FeatureToAnimate {
 
     ASSERT_UNUSED(scrollerImp, scrollerImp == _scroller->scrollerImp());
 
-    return _scroller->lastKnownMousePositionInScrollbar();
+    return CheckedPtr { _scroller }->lastKnownMousePositionInScrollbar();
 }
 
 - (NSRect)convertRectToLayer:(NSRect)rect
@@ -237,7 +237,7 @@ enum class FeatureToAnimate {
         return;
 
     ASSERT_UNUSED(scrollerImp, scrollerImp == _scroller->scrollerImp());
-    _scroller->visibilityChanged(newKnobAlpha > 0);
+    CheckedPtr { _scroller }->visibilityChanged(newKnobAlpha > 0);
     [self setUpAlphaAnimation:_knobAlphaAnimation featureToAnimate:FeatureToAnimate::KnobAlpha animateAlphaTo:newKnobAlpha duration:duration];
 }
 

--- a/Source/WebCore/page/scrolling/mac/ScrollerPairMac.h
+++ b/Source/WebCore/page/scrolling/mac/ScrollerPairMac.h
@@ -92,7 +92,11 @@ public:
 
     // Only for use by WebScrollerImpPairDelegateMac. Do not use elsewhere!
     ScrollerMac& verticalScroller() { return m_verticalScroller; }
+    CheckedRef<ScrollerMac> checkedVerticalScroller()  { return m_verticalScroller; }
+    CheckedRef<const ScrollerMac> checkedVerticalScroller() const { return m_verticalScroller; }
     ScrollerMac& horizontalScroller() { return m_horizontalScroller; }
+    CheckedRef<ScrollerMac> checkedHorizontalScroller() { return m_horizontalScroller; }
+    CheckedRef<const ScrollerMac> checkedHorizontalScroller() const { return m_horizontalScroller; }
 
     String scrollbarStateForOrientation(ScrollbarOrientation) const;
 

--- a/Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.mm
+++ b/Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.mm
@@ -60,28 +60,31 @@ void ScrollingTreeScrollingNodeDelegateMac::nodeWillBeDestroyed()
 
 void ScrollingTreeScrollingNodeDelegateMac::updateFromStateNode(const ScrollingStateScrollingNode& scrollingStateNode)
 {
+    CheckedRef horizontalScroller = m_scrollerPair->horizontalScroller();
+    CheckedRef verticalScroller = m_scrollerPair->verticalScroller();
+
     if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::PainterForScrollbar)) {
         auto horizontalScrollbar = scrollingStateNode.horizontalScrollerImp();
         auto verticalScrollbar = scrollingStateNode.verticalScrollerImp();
         if (horizontalScrollbar || verticalScrollbar) {
             m_scrollerPair->releaseReferencesToScrollerImpsOnTheMainThread();
-            m_scrollerPair->horizontalScroller().setScrollerImp(horizontalScrollbar);
-            m_scrollerPair->verticalScroller().setScrollerImp(verticalScrollbar);
+            horizontalScroller->setScrollerImp(horizontalScrollbar);
+            verticalScroller->setScrollerImp(verticalScrollbar);
         }
     }
-    
+
     if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::ScrollbarHoverState))
         m_scrollerPair->mouseIsInScrollbar(scrollingStateNode.scrollbarHoverState());
-    
+
     if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::HorizontalScrollbarLayer))
-        m_scrollerPair->horizontalScroller().setHostLayer(static_cast<CALayer*>(scrollingStateNode.horizontalScrollbarLayer()));
-    
+        horizontalScroller->setHostLayer(static_cast<CALayer*>(scrollingStateNode.horizontalScrollbarLayer()));
+
     if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::VerticalScrollbarLayer))
-        m_scrollerPair->verticalScroller().setHostLayer(static_cast<CALayer*>(scrollingStateNode.verticalScrollbarLayer()));
+        verticalScroller->setHostLayer(static_cast<CALayer*>(scrollingStateNode.verticalScrollbarLayer()));
 
     if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::ScrollableAreaParams)) {
-        m_scrollerPair->horizontalScroller().setHiddenByStyle(scrollingStateNode.scrollableAreaParameters().horizontalNativeScrollbarVisibility);
-        m_scrollerPair->verticalScroller().setHiddenByStyle(scrollingStateNode.scrollableAreaParameters().verticalNativeScrollbarVisibility);
+        horizontalScroller->setHiddenByStyle(scrollingStateNode.scrollableAreaParameters().horizontalNativeScrollbarVisibility);
+        verticalScroller->setHiddenByStyle(scrollingStateNode.scrollableAreaParameters().verticalNativeScrollbarVisibility);
     }
 
     if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::ScrollbarEnabledState)) {
@@ -92,8 +95,8 @@ void ScrollingTreeScrollingNodeDelegateMac::updateFromStateNode(const ScrollingS
 
     if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::ScrollbarLayoutDirection)) {
         auto scrollbarLayoutDirection = scrollingStateNode.scrollbarLayoutDirection();
-        m_scrollerPair->horizontalScroller().setScrollbarLayoutDirection(scrollbarLayoutDirection);
-        m_scrollerPair->verticalScroller().setScrollbarLayoutDirection(scrollbarLayoutDirection);
+        horizontalScroller->setScrollbarLayoutDirection(scrollbarLayoutDirection);
+        verticalScroller->setScrollbarLayoutDirection(scrollbarLayoutDirection);
     }
 
     if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::ScrollbarWidth)) {

--- a/Source/WebCore/rendering/svg/RenderSVGResourceContainer.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceContainer.cpp
@@ -64,7 +64,7 @@ void RenderSVGResourceContainer::styleDidChange(StyleDifference diff, const Rend
 void RenderSVGResourceContainer::idChanged()
 {
     // Remove old id, that is guaranteed to be present in cache.
-    m_id = element().getIdAttribute();
+    m_id = protectedElement()->getIdAttribute();
 
     registerResource();
 }

--- a/Source/WebCore/style/values/color/StyleLightDarkColor.cpp
+++ b/Source/WebCore/style/values/color/StyleLightDarkColor.cpp
@@ -40,7 +40,7 @@ Color toStyleColor(const CSS::LightDarkColor& unresolved, ColorResolutionState& 
     ColorResolutionStateNester nester { state };
 
     Ref<const Document> document = state.document;
-    if (document->useDarkAppearance(&state.style))
+    if (document->useDarkAppearance(CheckedRef { state.style }.ptr()))
         return toStyleColor(unresolved.darkColor, state);
     return toStyleColor(unresolved.lightColor, state);
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/WKNavigationResponse.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKNavigationResponse.mm
@@ -39,7 +39,7 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
     if (WebCoreObjCScheduleDeallocateOnMainRunLoop(WKNavigationResponse.class, self))
         return;
 
-    _navigationResponse->~NavigationResponse();
+    RefPtr { _navigationResponse.get() }->~NavigationResponse();
 
     [super dealloc];
 }
@@ -83,7 +83,7 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
 
 - (WKFrameInfo *)_navigationInitiatingFrame
 {
-    return wrapper(_navigationResponse->navigationInitiatingFrame());
+    return wrapper(RefPtr { _navigationResponse.get() }->navigationInitiatingFrame());
 }
 
 - (WKNavigation *)_navigation

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKThumbnailView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKThumbnailView.mm
@@ -220,7 +220,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     [self _requestSnapshotIfNeeded];
 
     if (!_exclusivelyUsesSnapshot) {
-        auto obscuredContentInsets = _webPageProxy->obscuredContentInsets();
+        auto obscuredContentInsets = RefPtr { _webPageProxy.get() }->obscuredContentInsets();
         self._sublayerTranslation = CGPointMake(-obscuredContentInsets.left(), -obscuredContentInsets.top());
         if (_wkView) {
             [_wkView _setThumbnailView:self];

--- a/Source/WebKit/UIProcess/mac/WKTextAnimationManager.mm
+++ b/Source/WebKit/UIProcess/mac/WKTextAnimationManager.mm
@@ -234,7 +234,7 @@
             return;
         }
 
-        auto snapshot = textIndicator->contentImage();
+        RefPtr snapshot = textIndicator->contentImage();
         if (!snapshot) {
             completionHandler(nil);
             return;

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebCryptoClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebCryptoClient.cpp
@@ -29,6 +29,7 @@
 #include "WebPageProxyMessages.h"
 #include "WebProcess.h"
 #include "WebProcessProxyMessages.h"
+#include <WebCore/CryptoKeyData.h>
 #include <WebCore/SerializedCryptoKeyWrap.h>
 #include <WebCore/WrappedCryptoKey.h>
 #include <wtf/TZoneMallocInlines.h>

--- a/Source/WebKitLegacy/mac/WebCoreSupport/TextIndicatorWindow.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/TextIndicatorWindow.mm
@@ -127,7 +127,7 @@ void TextIndicatorWindow::setTextIndicator(Ref<WebCore::TextIndicator> textIndic
     [m_textIndicatorView setWantsLayer:YES];
     [m_textIndicatorWindow setContentView:m_textIndicatorView.get()];
 
-    [[m_targetView window] addChildWindow:m_textIndicatorWindow.get() ordered:NSWindowAbove];
+    [[m_targetView.get() window] addChildWindow:m_textIndicatorWindow.get() ordered:NSWindowAbove];
     [m_textIndicatorWindow setReleasedWhenClosed:NO];
 
     if (m_textIndicator->presentationTransition() != WebCore::TextIndicatorPresentationTransition::None)


### PR DESCRIPTION
#### 278f3a4e1280352da1b79cdad794c8409aa2ea34
<pre>
Fix recent Safer CPP bot regressions
<a href="https://bugs.webkit.org/show_bug.cgi?id=294238">https://bugs.webkit.org/show_bug.cgi?id=294238</a>

Reviewed by Chris Dumez.

* Source/JavaScriptCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations:
* Source/JavaScriptCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/JavaScriptCore/parser/ModuleAnalyzer.h:
* Source/WebCore/Modules/mediastream/CanvasCaptureMediaStreamTrack.cpp:
(WebCore::CanvasCaptureMediaStreamTrack::Source::captureCanvas):
* Source/WebCore/dom/ViewTransition.cpp:
(WebCore::effectiveViewTransitionName):
* Source/WebCore/html/FormAssociatedElement.h:
(WebCore::FormAssociatedElement::asProtectedHTMLElement const):
* Source/WebCore/html/FormController.cpp:
(WebCore::FormController::ownerForm):
* Source/WebCore/html/FormListedElement.cpp:
(WebCore::FormListedElement::resetFormAttributeTargetObserver):
(WebCore::FormListedElement::name const):
* Source/WebCore/page/Page.cpp:
(WebCore::Page::shouldUpdateAccessibilityRegions const):
* Source/WebCore/page/scrolling/mac/ScrollerMac.mm:
(-[WebScrollerImpDelegateMac mouseLocationInScrollerForScrollerImp:]):
(-[WebScrollerImpDelegateMac scrollerImp:animateKnobAlphaTo:duration:]):
* Source/WebCore/page/scrolling/mac/ScrollerPairMac.h:
(WebCore::ScrollerPairMac::checkedVerticalScroller):
(WebCore::ScrollerPairMac::checkedVerticalScroller const):
(WebCore::ScrollerPairMac::checkedHorizontalScroller):
(WebCore::ScrollerPairMac::checkedHorizontalScroller const):
* Source/WebCore/page/scrolling/mac/ScrollerPairMac.mm:
(-[WebScrollerImpPairDelegateMac scrollerImpPair:convertContentPoint:toScrollerImp:]):
(WebCore::ScrollerPairMac::init):
(WebCore::ScrollerPairMac::~ScrollerPairMac):
(WebCore::ScrollerPairMac::updateValues):
(WebCore::ScrollerPairMac::releaseReferencesToScrollerImpsOnTheMainThread):
(WebCore::ScrollerPairMac::scrollbarStateForOrientation const):
(WebCore::ScrollerPairMac::mouseIsInScrollbar):
(WebCore::ScrollerPairMac::setUseDarkAppearance):
(WebCore::ScrollerPairMac::setScrollbarWidth):
* Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.mm:
(WebCore::ScrollingTreeScrollingNodeDelegateMac::updateFromStateNode):
* Source/WebCore/rendering/svg/RenderSVGResourceContainer.cpp:
(WebCore::RenderSVGResourceContainer::idChanged):
* Source/WebCore/style/values/color/StyleLightDarkColor.cpp:
(WebCore::Style::toStyleColor):
* Source/WebKit/UIProcess/API/Cocoa/WKNavigationResponse.mm:
(-[WKNavigationResponse dealloc]):
(-[WKNavigationResponse _navigationInitiatingFrame]):
* Source/WebKit/UIProcess/API/Cocoa/_WKThumbnailView.mm:
(-[_WKThumbnailView _viewWasParented]):
* Source/WebKit/UIProcess/mac/WKTextAnimationManager.mm:
(-[WKTextAnimationManager textPreviewsForChunk:completion:]):
* Source/WebKit/WebProcess/WebCoreSupport/WebCryptoClient.cpp:
* Source/WebKitLegacy/mac/WebCoreSupport/TextIndicatorWindow.mm:
(TextIndicatorWindow::setTextIndicator):

Canonical link: <a href="https://commits.webkit.org/296189@main">https://commits.webkit.org/296189@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9160b2137996dc5975b5aa0b38d8b86569eea205

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/107640 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27318 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/17731 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/112853 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/58181 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/109599 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/28010 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/35831 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/81731 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/110572 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22206 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97021 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62111 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/21640 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/15160 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/57616 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/100227 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/91578 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15194 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/115966 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/106184 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/34714 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/25593 "Found 60 new test failures: accessibility/mac/element-focus.html compositing/repaint/sticky-repaint-on-scroll.html compositing/scrolling/async-overflow-scrolling/mac/overflow-in-flex-empty-tiles.html css3/scroll-snap/resnap-after-layout.html css3/scroll-snap/scroll-snap-discrete-wheel-event-in-mainframe.html fast/events/pointer-events-2.html fast/events/scroll-in-scaled-page-with-overflow-hidden.html fast/events/wheel/wheel-event-destroys-frame.html fast/events/wheel/wheel-event-in-passive-region-non-cancelable.html fast/events/wheel/wheel-event-listeners-on-document-made-passive.html ... (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/90769 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/35091 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93271 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/90515 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23080 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35433 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13208 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/30470 "Build is being retried. Recent messages:") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/34624 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/40180 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/130499 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34370 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/35476 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/37731 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/36033 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->