### PR TITLE
[JSC] Vector shift should use imm-based instructions on ARM64

### DIFF
--- a/Source/JavaScriptCore/assembler/ARM64Assembler.h
+++ b/Source/JavaScriptCore/assembler/ARM64Assembler.h
@@ -2028,16 +2028,43 @@ public:
         insn(0b01001110001000000100010000000000 | (sizeForIntegralSIMDOp(lane) << 22) | (vm << 16) | (vn << 5) | vd);
     }
 
+    ALWAYS_INLINE void shl_vi(FPRegisterID vd, FPRegisterID vn, uint8_t shift, SIMDLane lane)
+    {
+        uint8_t maxShift = elementByteSize(lane) * 8;
+        ASSERT(shift < maxShift && shift < 64 && shift);
+        shift = shift & (maxShift - 1);
+        shift = shift + maxShift;
+        unsigned immh = elementByteSize(lane) | ((shift & 0b0111000) >> 3);
+        unsigned immb = shift & 0b0111;
+        ASSERT(immh);
+        ASSERT(!(immh&(~0b1111)));
+        insn(0b010'011110'0000'000'010101'00000'00000 | (immh << 19) | (immb << 16) | (vn << 5) | vd);
+    }
+
     ALWAYS_INLINE void sshr_vi(FPRegisterID vd, FPRegisterID vn, uint8_t shift, SIMDLane lane)
     {
         uint8_t maxShift = elementByteSize(lane) * 8;
         ASSERT(shift < maxShift && shift < 64 && shift);
+        shift = shift & (maxShift - 1);
         shift = maxShift - shift;
         unsigned immh = elementByteSize(lane) | ((shift & 0b0111000) >> 3);
         unsigned immb = shift & 0b0111;
         ASSERT(immh);
         ASSERT(!(immh&(~0b1111)));
         insn(0b010'011110'0000'000'000001'00000'00000 | (immh << 19) | (immb << 16) | (vn << 5) | vd);
+    }
+
+    ALWAYS_INLINE void ushr_vi(FPRegisterID vd, FPRegisterID vn, uint8_t shift, SIMDLane lane)
+    {
+        uint8_t maxShift = elementByteSize(lane) * 8;
+        ASSERT(shift < maxShift && shift < 64 && shift);
+        shift = shift & (maxShift - 1);
+        shift = maxShift - shift;
+        unsigned immh = elementByteSize(lane) | ((shift & 0b0111000) >> 3);
+        unsigned immb = shift & 0b0111;
+        ASSERT(immh);
+        ASSERT(!(immh&(~0b1111)));
+        insn(0b011'011110'0000'000'000001'00000'00000 | (immh << 19) | (immb << 16) | (vn << 5) | vd);
     }
 
     ALWAYS_INLINE void sqadd(FPRegisterID vd, FPRegisterID vn, FPRegisterID vm, SIMDLane lane)

--- a/Source/JavaScriptCore/assembler/MacroAssemblerARM64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerARM64.h
@@ -6211,10 +6211,22 @@ public:
         m_assembler.sshl(dest, input, shift, simdInfo.lane);
     }
 
+    void vectorShl8(SIMDInfo simdInfo, FPRegisterID input, TrustedImm32 shift, FPRegisterID dest)
+    {
+        ASSERT(scalarTypeIsIntegral(simdInfo.lane));
+        m_assembler.shl_vi(dest, input, shift.m_value, simdInfo.lane);
+    }
+
     void vectorSshr8(SIMDInfo simdInfo, FPRegisterID input, TrustedImm32 shift, FPRegisterID dest)
     {
         ASSERT(scalarTypeIsIntegral(simdInfo.lane));
         m_assembler.sshr_vi(dest, input, shift.m_value, simdInfo.lane);
+    }
+
+    void vectorUshr8(SIMDInfo simdInfo, FPRegisterID input, TrustedImm32 shift, FPRegisterID dest)
+    {
+        ASSERT(scalarTypeIsIntegral(simdInfo.lane));
+        m_assembler.ushr_vi(dest, input, shift.m_value, simdInfo.lane);
     }
 
     void vectorHorizontalAdd(SIMDInfo simdInfo, FPRegisterID input, FPRegisterID dest)

--- a/Source/JavaScriptCore/b3/B3LowerMacros.cpp
+++ b/Source/JavaScriptCore/b3/B3LowerMacros.cpp
@@ -544,10 +544,17 @@ private:
             case VectorShl: {
                 if constexpr (!isARM64())
                     break;
+
                 SIMDValue* value = m_value->as<SIMDValue>();
                 SIMDLane lane = value->simdLane();
 
                 int32_t mask = (elementByteSize(lane) * CHAR_BIT) - 1;
+                if (value->child(1)->hasInt32()) {
+                    int32_t shift = value->child(1)->asInt32();
+                    if ((shift & mask) == shift)
+                        break;
+                }
+
                 Value* shiftAmount = m_insertionSet.insert<Value>(m_index, BitAnd, m_origin, value->child(1), m_insertionSet.insertIntConstant(m_index, m_origin, Int32, mask));
                 if (value->opcode() == VectorShr) {
                     // ARM64 doesn't have a version of this instruction for right shift. Instead, if the input to

--- a/Source/JavaScriptCore/b3/B3LowerToAir.cpp
+++ b/Source/JavaScriptCore/b3/B3LowerToAir.cpp
@@ -4306,10 +4306,25 @@ private:
 
         case B3::VectorShr:
         case B3::VectorShl: {
-            ASSERT(!isARM64()); // In ARM64, they are macro.
             SIMDValue* value = m_value->as<SIMDValue>();
-            SIMDLane lane = value->simdLane();
+            if (isARM64()) {
+                if (value->opcode() == VectorShl) {
+                    ASSERT(isValidForm(VectorShl8, Arg::SIMDInfo, Arg::Tmp, Arg::Imm, Arg::Tmp));
+                    append(VectorShl8, Arg::simdInfo(value->simdInfo()), tmp(value->child(0)), imm(value->child(1)), tmp(value));
+                    return;
+                }
+                ASSERT(value->opcode() == VectorShr);
+                if (value->signMode() == SIMDSignMode::Signed) {
+                    ASSERT(isValidForm(VectorSshr8, Arg::SIMDInfo, Arg::Tmp, Arg::Imm, Arg::Tmp));
+                    append(VectorSshr8, Arg::simdInfo(value->simdInfo()), tmp(value->child(0)), imm(value->child(1)), tmp(value));
+                    return;
+                }
+                ASSERT(isValidForm(VectorUshr8, Arg::SIMDInfo, Arg::Tmp, Arg::Imm, Arg::Tmp));
+                append(VectorUshr8, Arg::simdInfo(value->simdInfo()), tmp(value->child(0)), imm(value->child(1)), tmp(value));
+                return;
+            }
 
+            SIMDLane lane = value->simdLane();
             int32_t mask = (elementByteSize(lane) * CHAR_BIT) - 1;
 
             auto v = tmp(value->child(0));

--- a/Source/JavaScriptCore/b3/B3ReduceStrength.cpp
+++ b/Source/JavaScriptCore/b3/B3ReduceStrength.cpp
@@ -3211,6 +3211,75 @@ private:
             break;
         }
 
+        case VectorShiftByVector: {
+            auto extractShiftAmount = [&](v128_t constant, SIMDLane lane) -> std::optional<int64_t> {
+                switch (lane) {
+                case SIMDLane::i8x16: {
+                    auto v = constant.u8x16[0];
+                    for (unsigned i = 1; i < elementCount(lane); ++i) {
+                        auto next = constant.u8x16[i];
+                        if (next != v)
+                            return std::nullopt;
+                    }
+                    return static_cast<int8_t>(v);
+                }
+                case SIMDLane::i16x8: {
+                    auto v = constant.u16x8[0];
+                    for (unsigned i = 1; i < elementCount(lane); ++i) {
+                        auto next = constant.u16x8[i];
+                        if (next != v)
+                            return std::nullopt;
+                    }
+                    return static_cast<int16_t>(v);
+                }
+                case SIMDLane::i32x4: {
+                    auto v = constant.u32x4[0];
+                    for (unsigned i = 1; i < elementCount(lane); ++i) {
+                        auto next = constant.u32x4[i];
+                        if (next != v)
+                            return std::nullopt;
+                    }
+                    return static_cast<int32_t>(v);
+                }
+                case SIMDLane::i64x2: {
+                    auto v = constant.u64x2[0];
+                    for (unsigned i = 1; i < elementCount(lane); ++i) {
+                        auto next = constant.u64x2[i];
+                        if (next != v)
+                            return std::nullopt;
+                    }
+                    return static_cast<int64_t>(v);
+                }
+                case SIMDLane::v128:
+                case SIMDLane::f32x4:
+                case SIMDLane::f64x2:
+                    return std::nullopt;
+                }
+                return std::nullopt;
+            };
+
+            SIMDValue* value = m_value->as<SIMDValue>();
+            if (value->child(1)->hasV128()) {
+                if (auto shiftAmount = extractShiftAmount(value->child(1)->asV128(), value->simdLane())) {
+                    int32_t maxShift = elementByteSize(value->simdLane()) * CHAR_BIT;
+                    if (shiftAmount.value() >= 0) {
+                        if (shiftAmount.value() < maxShift) {
+                            auto* shift = m_insertionSet.insertIntConstant(m_index, m_value->origin(), Int32, shiftAmount.value());
+                            replaceWithNew<SIMDValue>(m_value->origin(), VectorShl, B3::V128, value->simdInfo(), value->child(0), shift);
+                            break;
+                        }
+                    } else {
+                        if (shiftAmount.value() > - maxShift) {
+                            auto* shift = m_insertionSet.insertIntConstant(m_index, m_value->origin(), Int32, -shiftAmount.value());
+                            replaceWithNew<SIMDValue>(m_value->origin(), VectorShr, B3::V128, value->simdInfo(), value->child(0), shift);
+                            break;
+                        }
+                    }
+                }
+            }
+            break;
+        }
+
         default:
             break;
         }

--- a/Source/JavaScriptCore/b3/air/AirOpcode.opcodes
+++ b/Source/JavaScriptCore/b3/air/AirOpcode.opcodes
@@ -1953,6 +1953,9 @@ x86_64: VectorUshr U:G:Ptr, U:F:128, U:F:128, D:F:128
 arm64: VectorSshl U:G:Ptr, U:F:128, U:F:128, D:F:128
     SIMDInfo, Tmp, Tmp, Tmp
 
+arm64: VectorShl8 U:G:Ptr, U:F:128, U:G:8, D:F:128
+    SIMDInfo, Tmp, Imm, Tmp
+
 x86_64: VectorUshl8 U:F:128, U:F:128, D:F:128, S:F:128, S:F:128
     Tmp, Tmp, Tmp, Tmp, Tmp
 
@@ -1962,7 +1965,7 @@ x86_64: VectorUshr8 U:F:128, U:F:128, D:F:128, S:F:128, S:F:128
 x86_64: VectorSshr8 U:F:128, U:F:128, D:F:128, S:F:128, S:F:128
     Tmp, Tmp, Tmp, Tmp, Tmp
 
-x86_64: VectorUshr8 U:G:Ptr, U:F:128, U:G:8, D:F:128
+64: VectorUshr8 U:G:Ptr, U:F:128, U:G:8, D:F:128
     SIMDInfo, Tmp, Imm, Tmp
 
 64: VectorSshr8 U:G:Ptr, U:F:128, U:G:8, D:F:128


### PR DESCRIPTION
#### 25a99882090c5e8299bb3bca1e1f92fff9d598ef
<pre>
[JSC] Vector shift should use imm-based instructions on ARM64
<a href="https://bugs.webkit.org/show_bug.cgi?id=294240">https://bugs.webkit.org/show_bug.cgi?id=294240</a>
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

WIP

* Source/JavaScriptCore/assembler/ARM64Assembler.h:
* Source/JavaScriptCore/assembler/MacroAssemblerARM64.h:
(JSC::MacroAssemblerARM64::vectorShl8):
(JSC::MacroAssemblerARM64::vectorUshr8):
* Source/JavaScriptCore/b3/B3LowerMacros.cpp:
* Source/JavaScriptCore/b3/B3LowerToAir.cpp:
* Source/JavaScriptCore/b3/B3ReduceStrength.cpp:
* Source/JavaScriptCore/b3/air/AirOpcode.opcodes:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/25a99882090c5e8299bb3bca1e1f92fff9d598ef

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/107089 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/26793 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/17192 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/112298 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/57640 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/27465 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/35296 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/81297 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/110042 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/21798 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/96567 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/61658 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/21221 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/14694 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/57091 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/99688 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/91149 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/14716 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/115385 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/105658 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/34177 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/25189 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/90341 "Passed tests") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/34549 "Failed to checkout and rebase branch from PR 46530") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/92819 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/90074 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35009 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/12785 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/29894 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/34102 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/39559 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/129972 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/33849 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/35369 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/37201 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/35485 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->