### PR TITLE
Reduce unsafeness of UIProcess's DrawingAreaProxy

### DIFF
--- a/Source/WebKit/UIProcess/DrawingAreaProxy.cpp
+++ b/Source/WebKit/UIProcess/DrawingAreaProxy.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2010-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -56,16 +56,6 @@ DrawingAreaProxy::DrawingAreaProxy(DrawingAreaType type, WebPageProxy& webPagePr
 
 DrawingAreaProxy::~DrawingAreaProxy() = default;
 
-RefPtr<WebPageProxy> DrawingAreaProxy::protectedWebPageProxy() const
-{
-    return m_webPageProxy.get();
-}
-
-Ref<WebProcessProxy> DrawingAreaProxy::protectedWebProcessProxy() const
-{
-    return m_webProcessProxy.get();
-}
-
 void DrawingAreaProxy::startReceivingMessages(WebProcessProxy& process)
 {
     for (auto& name : messageReceiverNames())
@@ -91,12 +81,12 @@ IPC::Connection* DrawingAreaProxy::messageSenderConnection() const
 
 bool DrawingAreaProxy::sendMessage(UniqueRef<IPC::Encoder>&& encoder, OptionSet<IPC::SendOption> sendOptions)
 {
-    return protectedWebProcessProxy()->sendMessage(WTFMove(encoder), sendOptions);
+    return m_webProcessProxy->sendMessage(WTFMove(encoder), sendOptions);
 }
 
 bool DrawingAreaProxy::sendMessageWithAsyncReply(UniqueRef<IPC::Encoder>&& encoder, AsyncReplyHandler handler, OptionSet<IPC::SendOption> sendOptions)
 {
-    return protectedWebProcessProxy()->sendMessage(WTFMove(encoder), sendOptions, WTFMove(handler));
+    return m_webProcessProxy->sendMessage(WTFMove(encoder), sendOptions, WTFMove(handler));
 }
 
 uint64_t DrawingAreaProxy::messageSenderDestinationID() const
@@ -125,6 +115,11 @@ WebPageProxy* DrawingAreaProxy::page() const
     return m_webPageProxy.get();
 }
 
+RefPtr<WebPageProxy> DrawingAreaProxy::protectedPage() const
+{
+    return page();
+}
+
 #if PLATFORM(COCOA)
 MachSendRight DrawingAreaProxy::createFence()
 {
@@ -135,7 +130,7 @@ MachSendRight DrawingAreaProxy::createFence()
 #if PLATFORM(MAC)
 void DrawingAreaProxy::didChangeViewExposedRect()
 {
-    if (!protectedWebPageProxy()->hasRunningProcess())
+    if (!protectedPage()->hasRunningProcess())
         return;
 
     if (!m_viewExposedRectChangedTimer.isActive())

--- a/Source/WebKit/UIProcess/DrawingAreaProxy.h
+++ b/Source/WebKit/UIProcess/DrawingAreaProxy.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2010-2025 Apple Inc. All rights reserved.
  * Portions Copyright (c) 2010 Motorola Mobility, Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -154,15 +154,8 @@ public:
 protected:
     DrawingAreaProxy(DrawingAreaType, WebPageProxy&, WebProcessProxy&);
 
-    RefPtr<WebPageProxy> protectedWebPageProxy() const;
-    Ref<WebProcessProxy> protectedWebProcessProxy() const;
-
-    DrawingAreaType m_type;
-    WeakPtr<WebPageProxy> m_webPageProxy;
-    Ref<WebProcessProxy> m_webProcessProxy;
-
-    WebCore::IntSize m_size;
-    WebCore::IntSize m_scrollOffset;
+    RefPtr<WebPageProxy> protectedPage() const;
+    WebProcessProxy& webProcessProxy() const { return m_webProcessProxy; }
 
 private:
     virtual void sizeDidChange() = 0;
@@ -172,15 +165,23 @@ private:
     virtual void enterAcceleratedCompositingMode(uint64_t /* backingStoreStateID */, const LayerTreeContext&) { }
     virtual void updateAcceleratedCompositingMode(uint64_t /* backingStoreStateID */, const LayerTreeContext&) { }
     virtual void didFirstLayerFlush(uint64_t /* backingStoreStateID */, const LayerTreeContext&) { }
-#if PLATFORM(MAC)
-    RunLoop::Timer m_viewExposedRectChangedTimer;
-    std::optional<WebCore::FloatRect> m_lastSentViewExposedRect;
-#endif // PLATFORM(MAC)
 
 #if USE(COORDINATED_GRAPHICS) || USE(TEXTURE_MAPPER)
     virtual void update(uint64_t /* backingStoreStateID */, UpdateInfo&&) { }
     virtual void exitAcceleratedCompositingMode(uint64_t /* backingStoreStateID */, UpdateInfo&&) { }
 #endif
+
+    DrawingAreaType m_type;
+    WeakPtr<WebPageProxy> m_webPageProxy;
+    const Ref<WebProcessProxy> m_webProcessProxy;
+
+    WebCore::IntSize m_size;
+    WebCore::IntSize m_scrollOffset;
+
+#if PLATFORM(MAC)
+    RunLoop::Timer m_viewExposedRectChangedTimer;
+    std::optional<WebCore::FloatRect> m_lastSentViewExposedRect;
+#endif // PLATFORM(MAC)
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2012-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -103,7 +103,7 @@ std::unique_ptr<RemoteLayerTreeHost> RemoteLayerTreeDrawingAreaProxy::detachRemo
 
 void RemoteLayerTreeDrawingAreaProxy::sizeDidChange()
 {
-    RefPtr page = m_webPageProxy.get();
+    RefPtr page = this->page();
     if (!page || !page->hasRunningProcess())
         return;
     if (auto scrollingCoordinator = page->scrollingCoordinatorProxy())
@@ -119,7 +119,7 @@ void RemoteLayerTreeDrawingAreaProxy::remotePageProcessDidTerminate(WebCore::Pro
     if (!m_remoteLayerTreeHost)
         return;
 
-    if (auto* scrollingCoordinator = m_webPageProxy ? m_webPageProxy->scrollingCoordinatorProxy() : nullptr) {
+    if (auto* scrollingCoordinator = page() ? page()->scrollingCoordinatorProxy() : nullptr) {
         scrollingCoordinator->willCommitLayerAndScrollingTrees();
         m_remoteLayerTreeHost->remotePageProcessDidTerminate(processIdentifier);
         scrollingCoordinator->didCommitLayerAndScrollingTrees();
@@ -128,13 +128,13 @@ void RemoteLayerTreeDrawingAreaProxy::remotePageProcessDidTerminate(WebCore::Pro
 
 void RemoteLayerTreeDrawingAreaProxy::viewWillStartLiveResize()
 {
-    if (auto scrollingCoordinator = m_webPageProxy ? m_webPageProxy->scrollingCoordinatorProxy() : nullptr)
+    if (auto scrollingCoordinator = page() ? page()->scrollingCoordinatorProxy() : nullptr)
         scrollingCoordinator->viewWillStartLiveResize();
 }
 
 void RemoteLayerTreeDrawingAreaProxy::viewWillEndLiveResize()
 {
-    if (auto scrollingCoordinator = m_webPageProxy ? m_webPageProxy->scrollingCoordinatorProxy() : nullptr)
+    if (auto scrollingCoordinator = page() ? page()->scrollingCoordinatorProxy() : nullptr)
         scrollingCoordinator->viewWillEndLiveResize();
 }
 
@@ -142,7 +142,7 @@ void RemoteLayerTreeDrawingAreaProxy::deviceScaleFactorDidChange(CompletionHandl
 {
     Ref aggregator = CallbackAggregator::create(WTFMove(completionHandler));
     forEachProcessState([&](ProcessState& state, WebProcessProxy& webProcess) {
-        if (RefPtr page = m_webPageProxy.get())
+        if (RefPtr page = this->page())
             webProcess.sendWithAsyncReply(Messages::DrawingArea::SetDeviceScaleFactor(page->deviceScaleFactor()), [aggregator] { }, identifier());
     });
 }
@@ -153,33 +153,33 @@ void RemoteLayerTreeDrawingAreaProxy::didUpdateGeometry()
 
     m_isWaitingForDidUpdateGeometry = false;
 
-    RefPtr webPageProxy = m_webPageProxy.get();
-    if (!webPageProxy)
+    RefPtr page = this->page();
+    if (!page)
         return;
 
-    IntSize minimumSizeForAutoLayout = webPageProxy->minimumSizeForAutoLayout();
-    IntSize sizeToContentAutoSizeMaximumSize = webPageProxy->sizeToContentAutoSizeMaximumSize();
+    IntSize minimumSizeForAutoLayout = page->minimumSizeForAutoLayout();
+    IntSize sizeToContentAutoSizeMaximumSize = page->sizeToContentAutoSizeMaximumSize();
 
     // If the WKView was resized while we were waiting for a DidUpdateGeometry reply from the web process,
     // we need to resend the new size here.
-    if (m_lastSentSize != m_size || m_lastSentMinimumSizeForAutoLayout != minimumSizeForAutoLayout || m_lastSentSizeToContentAutoSizeMaximumSize != sizeToContentAutoSizeMaximumSize)
+    if (m_lastSentSize != size() || m_lastSentMinimumSizeForAutoLayout != minimumSizeForAutoLayout || m_lastSentSizeToContentAutoSizeMaximumSize != sizeToContentAutoSizeMaximumSize)
         sendUpdateGeometry();
 }
 
 void RemoteLayerTreeDrawingAreaProxy::sendUpdateGeometry()
 {
-    RefPtr webPageProxy = m_webPageProxy.get();
-    if (!webPageProxy)
+    RefPtr page = this->page();
+    if (!page)
         return;
 
-    m_lastSentMinimumSizeForAutoLayout = webPageProxy->minimumSizeForAutoLayout();
-    m_lastSentSizeToContentAutoSizeMaximumSize = webPageProxy->sizeToContentAutoSizeMaximumSize();
-    m_lastSentSize = m_size;
+    m_lastSentMinimumSizeForAutoLayout = page->minimumSizeForAutoLayout();
+    m_lastSentSizeToContentAutoSizeMaximumSize = page->sizeToContentAutoSizeMaximumSize();
+    m_lastSentSize = size();
 
     dispatchSetObscuredContentInsets();
 
     m_isWaitingForDidUpdateGeometry = true;
-    sendWithAsyncReply(Messages::DrawingArea::UpdateGeometry(m_size, false /* flushSynchronously */, MachSendRight()), [weakThis = WeakPtr { this }] {
+    sendWithAsyncReply(Messages::DrawingArea::UpdateGeometry(size(), false /* flushSynchronously */, MachSendRight()), [weakThis = WeakPtr { this }] {
         if (!weakThis)
             return;
         weakThis->didUpdateGeometry();
@@ -194,13 +194,13 @@ RemoteLayerTreeDrawingAreaProxy::ProcessState& RemoteLayerTreeDrawingAreaProxy::
             return value;
     }
 
-    RELEASE_ASSERT(m_webProcessProxy->hasConnection(connection));
+    RELEASE_ASSERT(webProcessProxy().hasConnection(connection));
     return m_webPageProxyProcessState;
 }
 
 void RemoteLayerTreeDrawingAreaProxy::forEachProcessState(NOESCAPE Function<void(ProcessState&, WebProcessProxy&)>&& callback)
 {
-    callback(m_webPageProxyProcessState, m_webProcessProxy);
+    callback(m_webPageProxyProcessState, webProcessProxy());
     for (auto& [key, value] : m_remotePageProcessState) {
         RefPtr webProcess = WebProcessProxy::processForIdentifier(key);
         if (webProcess)
@@ -210,7 +210,7 @@ void RemoteLayerTreeDrawingAreaProxy::forEachProcessState(NOESCAPE Function<void
 
 const RemoteLayerTreeDrawingAreaProxy::ProcessState& RemoteLayerTreeDrawingAreaProxy::processStateForIdentifier(WebCore::ProcessIdentifier identifier) const
 {
-    if (m_webProcessProxy->coreProcessIdentifier() == identifier)
+    if (webProcessProxy().coreProcessIdentifier() == identifier)
         return m_webPageProxyProcessState;
 
     auto iter = m_remotePageProcessState.find(identifier);
@@ -239,7 +239,7 @@ void RemoteLayerTreeDrawingAreaProxy::commitLayerTreeNotTriggered(IPC::Connectio
     maybePauseDisplayRefreshCallbacks();
 
 #if ENABLE(ASYNC_SCROLLING)
-    if (RefPtr page = m_webPageProxy.get())
+    if (RefPtr page = this->page())
         page->scrollingCoordinatorProxy()->applyScrollingTreeLayerPositionsAfterCommit();
 #endif
 }
@@ -314,8 +314,8 @@ void RemoteLayerTreeDrawingAreaProxy::commitLayerTreeTransaction(IPC::Connection
     LOG_WITH_STREAM(RemoteLayerTree, stream << "RemoteLayerTreeDrawingAreaProxy::commitLayerTree transaction:" << layerTreeTransaction.description());
     LOG_WITH_STREAM(RemoteLayerTree, stream << "RemoteLayerTreeDrawingAreaProxy::commitLayerTree scrolling tree:" << scrollingTreeTransaction.description());
 
-    RefPtr webPageProxy = m_webPageProxy.get();
-    if (!webPageProxy)
+    RefPtr page = this->page();
+    if (!page)
         return;
 
     state.lastLayerTreeTransactionID = layerTreeTransaction.transactionID();
@@ -329,7 +329,7 @@ void RemoteLayerTreeDrawingAreaProxy::commitLayerTreeTransaction(IPC::Connection
         m_activityStateChangeID = layerTreeTransaction.activityStateChangeID();
 
         // FIXME(site-isolation): Editor state should be updated for subframes.
-        didUpdateEditorState = layerTreeTransaction.hasEditorState() && webPageProxy->updateEditorState(EditorState { layerTreeTransaction.editorState() }, WebPageProxy::ShouldMergeVisualEditorState::Yes);
+        didUpdateEditorState = layerTreeTransaction.hasEditorState() && page->updateEditorState(EditorState { layerTreeTransaction.editorState() }, WebPageProxy::ShouldMergeVisualEditorState::Yes);
     }
 
 #if ENABLE(ASYNC_SCROLLING)
@@ -353,13 +353,13 @@ void RemoteLayerTreeDrawingAreaProxy::commitLayerTreeTransaction(IPC::Connection
 
         if (m_remoteLayerTreeHost->updateLayerTree(connection, layerTreeTransaction)) {
             if (!m_replyForUnhidingContent)
-                webPageProxy->setRemoteLayerTreeRootNode(m_remoteLayerTreeHost->protectedRootNode().get());
+                page->setRemoteLayerTreeRootNode(m_remoteLayerTreeHost->protectedRootNode().get());
             else
                 m_remoteLayerTreeHost->detachRootLayer();
         }
 
 #if ENABLE(ASYNC_SCROLLING)
-    requestedScroll = webPageProxy->scrollingCoordinatorProxy()->commitScrollingTreeState(connection, scrollingTreeTransaction, layerTreeTransaction.remoteContextHostedIdentifier());
+    requestedScroll = page->scrollingCoordinatorProxy()->commitScrollingTreeState(connection, scrollingTreeTransaction, layerTreeTransaction.remoteContextHostedIdentifier());
 #endif
     };
 
@@ -368,38 +368,38 @@ void RemoteLayerTreeDrawingAreaProxy::commitLayerTreeTransaction(IPC::Connection
     state.animationCurrentTime = MonotonicTime::now();
 #endif
 
-    webPageProxy->scrollingCoordinatorProxy()->willCommitLayerAndScrollingTrees();
+    page->scrollingCoordinatorProxy()->willCommitLayerAndScrollingTrees();
     commitLayerAndScrollingTrees();
-    webPageProxy->scrollingCoordinatorProxy()->didCommitLayerAndScrollingTrees();
+    page->scrollingCoordinatorProxy()->didCommitLayerAndScrollingTrees();
 
-    webPageProxy->didCommitLayerTree(layerTreeTransaction);
+    page->didCommitLayerTree(layerTreeTransaction);
     didCommitLayerTree(connection, layerTreeTransaction, scrollingTreeTransaction);
 
 #if ENABLE(ASYNC_SCROLLING)
-    webPageProxy->scrollingCoordinatorProxy()->applyScrollingTreeLayerPositionsAfterCommit();
+    page->scrollingCoordinatorProxy()->applyScrollingTreeLayerPositionsAfterCommit();
 #if PLATFORM(IOS_FAMILY)
-    webPageProxy->adjustLayersForLayoutViewport(webPageProxy->unobscuredContentRect().location(), webPageProxy->unconstrainedLayoutViewportRect(), webPageProxy->displayedContentScale());
+    page->adjustLayersForLayoutViewport(page->unobscuredContentRect().location(), page->unconstrainedLayoutViewportRect(), page->displayedContentScale());
 #endif
 
     // Handle requested scroll position updates from the scrolling tree transaction after didCommitLayerTree()
     // has updated the view size based on the content size.
     if (requestedScroll) {
-        auto currentScrollPosition = webPageProxy->scrollingCoordinatorProxy()->currentMainFrameScrollPosition();
+        auto currentScrollPosition = page->scrollingCoordinatorProxy()->currentMainFrameScrollPosition();
         if (auto previousData = std::exchange(requestedScroll->requestedDataBeforeAnimatedScroll, std::nullopt)) {
             auto& [requestType, positionOrDeltaBeforeAnimatedScroll, scrollType, clamping] = *previousData;
             if (requestType != ScrollRequestType::CancelAnimatedScroll)
                 currentScrollPosition = RequestedScrollData::computeDestinationPosition(currentScrollPosition, requestType, positionOrDeltaBeforeAnimatedScroll);
         }
 
-        webPageProxy->requestScroll(requestedScroll->destinationPosition(currentScrollPosition), layerTreeTransaction.scrollOrigin(), requestedScroll->animated);
+        page->requestScroll(requestedScroll->destinationPosition(currentScrollPosition), layerTreeTransaction.scrollOrigin(), requestedScroll->animated);
     }
 #endif // ENABLE(ASYNC_SCROLLING)
 
     if (m_debugIndicatorLayerTreeHost && layerTreeTransaction.isMainFrameProcessTransaction()) {
         float scale = indicatorScale(layerTreeTransaction.contentsSize());
-        webPageProxy->scrollingCoordinatorProxy()->willCommitLayerAndScrollingTrees();
+        page->scrollingCoordinatorProxy()->willCommitLayerAndScrollingTrees();
         bool rootLayerChanged = m_debugIndicatorLayerTreeHost->updateLayerTree(connection, layerTreeTransaction, scale);
-        webPageProxy->scrollingCoordinatorProxy()->didCommitLayerAndScrollingTrees();
+        page->scrollingCoordinatorProxy()->didCommitLayerAndScrollingTrees();
         IntPoint scrollPosition;
 #if PLATFORM(MAC)
         scrollPosition = layerTreeTransaction.scrollPosition();
@@ -408,14 +408,14 @@ void RemoteLayerTreeDrawingAreaProxy::commitLayerTreeTransaction(IPC::Connection
         m_debugIndicatorLayerTreeHost->rootLayer().name = @"Indicator host root";
     }
 
-    webPageProxy->layerTreeCommitComplete();
+    page->layerTreeCommitComplete();
 
     if (didUpdateEditorState)
-        webPageProxy->dispatchDidUpdateEditorState();
+        page->dispatchDidUpdateEditorState();
 
     if (layerTreeTransaction.isMainFrameProcessTransaction()) {
         if (auto milestones = layerTreeTransaction.newlyReachedPaintingMilestones())
-            webPageProxy->didReachLayoutMilestone(milestones, WallTime::now());
+            page->didReachLayoutMilestone(milestones, WallTime::now());
     }
 
     for (auto& callbackID : layerTreeTransaction.callbackIDs()) {
@@ -446,22 +446,22 @@ static const float indicatorInset = 10;
 FloatPoint RemoteLayerTreeDrawingAreaProxy::indicatorLocation() const
 {
     FloatPoint tiledMapLocation;
-    RefPtr webPageProxy = m_webPageProxy.get();
-    if (!webPageProxy)
+    RefPtr page = this->page();
+    if (!page)
         return { };
 
 #if PLATFORM(IOS_FAMILY)
-    tiledMapLocation = webPageProxy->unobscuredContentRect().location().expandedTo(FloatPoint());
-    tiledMapLocation = tiledMapLocation.expandedTo(webPageProxy->exposedContentRect().location());
+    tiledMapLocation = page->unobscuredContentRect().location().expandedTo(FloatPoint());
+    tiledMapLocation = tiledMapLocation.expandedTo(page->exposedContentRect().location());
 
-    float absoluteInset = indicatorInset / webPageProxy->displayedContentScale();
+    float absoluteInset = indicatorInset / page->displayedContentScale();
     tiledMapLocation += FloatSize(absoluteInset, absoluteInset);
 #else
-    if (auto viewExposedRect = webPageProxy->viewExposedRect())
+    if (auto viewExposedRect = page->viewExposedRect())
         tiledMapLocation = viewExposedRect->location();
 
     tiledMapLocation += FloatSize(indicatorInset, indicatorInset);
-    float scale = 1 / webPageProxy->pageScaleFactor();
+    float scale = 1 / page->pageScaleFactor();
     tiledMapLocation.scale(scale);
 #endif
     return tiledMapLocation;
@@ -478,7 +478,7 @@ void RemoteLayerTreeDrawingAreaProxy::updateDebugIndicatorPosition()
 float RemoteLayerTreeDrawingAreaProxy::indicatorScale(IntSize contentsSize) const
 {
     // Pick a good scale.
-    RefPtr page = m_webPageProxy.get();
+    RefPtr page = this->page();
     if (!page)
         return 1;
 
@@ -522,16 +522,16 @@ void RemoteLayerTreeDrawingAreaProxy::updateDebugIndicator(IntSize contentsSize,
     [m_exposedRectIndicatorLayer setBorderWidth:counterScaledBorder];
 
     FloatRect scaledExposedRect;
-    RefPtr webPageProxy = m_webPageProxy.get();
-    if (!webPageProxy)
+    RefPtr page = this->page();
+    if (!page)
         return;
 
 #if PLATFORM(IOS_FAMILY)
-    scaledExposedRect = webPageProxy->exposedContentRect();
+    scaledExposedRect = page->exposedContentRect();
 #else
-    if (auto viewExposedRect = webPageProxy->viewExposedRect())
+    if (auto viewExposedRect = page->viewExposedRect())
         scaledExposedRect = *viewExposedRect;
-    float counterScale = 1 / webPageProxy->pageScaleFactor();
+    float counterScale = 1 / page->pageScaleFactor();
     scaledExposedRect.scale(counterScale);
 #endif
     [m_exposedRectIndicatorLayer setPosition:scaledExposedRect.location()];
@@ -602,8 +602,8 @@ void RemoteLayerTreeDrawingAreaProxy::didRefreshDisplay(ProcessState& state, IPC
 
     state.commitLayerTreeMessageState = CommitLayerTreePending;
 
-    if (&state == &m_webPageProxyProcessState && m_webPageProxy)
-        m_webPageProxy->scrollingCoordinatorProxy()->sendScrollingTreeNodeDidScroll();
+    if (&state == &m_webPageProxyProcessState && page())
+        page()->scrollingCoordinatorProxy()->sendScrollingTreeNodeDidScroll();
 
     // Waiting for CA to commit is insufficient, because the render server can still be
     // using our backing store. We can improve this by waiting for the render server to commit
@@ -618,7 +618,7 @@ void RemoteLayerTreeDrawingAreaProxy::didRefreshDisplay(ProcessState& state, IPC
 
 void RemoteLayerTreeDrawingAreaProxy::didRefreshDisplay(IPC::Connection* connection)
 {
-    RefPtr page = m_webPageProxy.get();
+    RefPtr page = this->page();
     if (!page || !page->hasRunningProcess())
         return;
 
@@ -635,7 +635,7 @@ void RemoteLayerTreeDrawingAreaProxy::didRefreshDisplay(IPC::Connection* connect
     if (maybePauseDisplayRefreshCallbacks())
         return;
 
-    if (RefPtr page = m_webPageProxy.get())
+    if (RefPtr page = this->page())
         page->didUpdateActivityState();
 }
 
@@ -643,10 +643,10 @@ void RemoteLayerTreeDrawingAreaProxy::waitForDidUpdateActivityState(ActivityStat
 {
     ASSERT(activityStateChangeID != ActivityStateChangeAsynchronous);
 
-    if (!m_webProcessProxy->hasConnection() || activityStateChangeID == ActivityStateChangeAsynchronous)
+    if (!webProcessProxy().hasConnection() || activityStateChangeID == ActivityStateChangeAsynchronous)
         return;
 
-    Ref connection = m_webProcessProxy->connection();
+    Ref connection = webProcessProxy().connection();
 
     // We must send the didUpdate message before blocking on the next commit, otherwise
     // we can be guaranteed that the next commit won't come until after the waitForAndDispatchImmediately times out.
@@ -672,7 +672,7 @@ void RemoteLayerTreeDrawingAreaProxy::waitForDidUpdateActivityState(ActivityStat
 
 void RemoteLayerTreeDrawingAreaProxy::hideContentUntilPendingUpdate()
 {
-    m_replyForUnhidingContent = protectedWebProcessProxy()->sendWithAsyncReply(Messages::DrawingArea::DispatchAfterEnsuringDrawing(), [] () { }, messageSenderDestinationID(), { }, WebProcessProxy::ShouldStartProcessThrottlerActivity::No);
+    m_replyForUnhidingContent = webProcessProxy().sendWithAsyncReply(Messages::DrawingArea::DispatchAfterEnsuringDrawing(), [] () { }, messageSenderDestinationID(), { }, WebProcessProxy::ShouldStartProcessThrottlerActivity::No);
     m_remoteLayerTreeHost->detachRootLayer();
 }
 
@@ -698,14 +698,14 @@ CALayer *RemoteLayerTreeDrawingAreaProxy::layerWithIDForTesting(WebCore::Platfor
 
 void RemoteLayerTreeDrawingAreaProxy::windowKindDidChange()
 {
-    RefPtr page = m_webPageProxy.get();
+    RefPtr page = this->page();
     if (page && page->windowKind() == WindowKind::InProcessSnapshotting)
         m_remoteLayerTreeHost->mapAllIOSurfaceBackingStore();
 }
 
 void RemoteLayerTreeDrawingAreaProxy::minimumSizeForAutoLayoutDidChange()
 {
-    RefPtr page = m_webPageProxy.get();
+    RefPtr page = this->page();
     if (!page || !page->hasRunningProcess())
         return;
 
@@ -717,7 +717,7 @@ void RemoteLayerTreeDrawingAreaProxy::minimumSizeForAutoLayoutDidChange()
 
 void RemoteLayerTreeDrawingAreaProxy::sizeToContentAutoSizeMaximumSizeDidChange()
 {
-    RefPtr page = m_webPageProxy.get();
+    RefPtr page = this->page();
     if (!page || !page->hasRunningProcess())
         return;
 
@@ -730,13 +730,13 @@ void RemoteLayerTreeDrawingAreaProxy::sizeToContentAutoSizeMaximumSizeDidChange(
 #if ENABLE(THREADED_ANIMATION_RESOLUTION)
 void RemoteLayerTreeDrawingAreaProxy::animationsWereAddedToNode(RemoteLayerTreeNode& node)
 {
-    if (RefPtr page = m_webPageProxy.get())
+    if (RefPtr page = this->page())
         page->scrollingCoordinatorProxy()->animationsWereAddedToNode(node);
 }
 
 void RemoteLayerTreeDrawingAreaProxy::animationsWereRemovedFromNode(RemoteLayerTreeNode& node)
 {
-    if (RefPtr page = m_webPageProxy.get())
+    if (RefPtr page = this->page())
         page->scrollingCoordinatorProxy()->animationsWereRemovedFromNode(node);
 }
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeDrawingAreaProxyIOS.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeDrawingAreaProxyIOS.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2022-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -204,7 +204,7 @@ RemoteLayerTreeDrawingAreaProxyIOS::~RemoteLayerTreeDrawingAreaProxyIOS()
 
 std::unique_ptr<RemoteScrollingCoordinatorProxy> RemoteLayerTreeDrawingAreaProxyIOS::createScrollingCoordinatorProxy() const
 {
-    return makeUnique<RemoteScrollingCoordinatorProxyIOS>(*m_webPageProxy);
+    return makeUnique<RemoteScrollingCoordinatorProxyIOS>(*page());
 }
 
 DelegatedScrollingMode RemoteLayerTreeDrawingAreaProxyIOS::delegatedScrollingMode() const
@@ -221,7 +221,7 @@ WKDisplayLinkHandler *RemoteLayerTreeDrawingAreaProxyIOS::displayLinkHandler()
 
 void RemoteLayerTreeDrawingAreaProxyIOS::setPreferredFramesPerSecond(IPC::Connection& connection, FramesPerSecond preferredFramesPerSecond)
 {
-    if (!m_webProcessProxy->hasConnection(connection))
+    if (!webProcessProxy().hasConnection(connection))
         return;
 
     [displayLinkHandler() setPreferredFramesPerSecond:preferredFramesPerSecond];
@@ -233,7 +233,7 @@ void RemoteLayerTreeDrawingAreaProxyIOS::didRefreshDisplay()
         RemoteLayerTreeDrawingAreaProxy::didRefreshDisplay();
 
     if (m_needsDisplayRefreshCallbacksForAnimation) {
-        RefPtr page = m_webPageProxy.get();
+        RefPtr page = this->page();
         if (!page)
             return;
         if (auto displayID = page->displayID())

--- a/Source/WebKit/UIProcess/wc/DrawingAreaProxyWC.cpp
+++ b/Source/WebKit/UIProcess/wc/DrawingAreaProxyWC.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011 Apple Inc. All rights reserved.
+ * Copyright (C) 2011-2025 Apple Inc. All rights reserved.
  * Copyright (C) 2013 Nokia Corporation and/or its subsidiary(-ies).
  * Copyright (C) 2016-2019 Igalia S.L.
  * Copyright (C) 2021 Sony Interactive Entertainment Inc.
@@ -71,8 +71,8 @@ void DrawingAreaProxyWC::sizeDidChange()
 {
     discardBackingStore();
     m_currentBackingStoreStateID++;
-    if (m_webPageProxy)
-        send(Messages::DrawingArea::UpdateGeometryWC(m_currentBackingStoreStateID, m_size, m_webPageProxy->deviceScaleFactor(), m_webPageProxy->intrinsicDeviceScaleFactor()));
+    if (page())
+        send(Messages::DrawingArea::UpdateGeometryWC(m_currentBackingStoreStateID, size(), page()->deviceScaleFactor(), page()->intrinsicDeviceScaleFactor()));
 }
 
 void DrawingAreaProxyWC::update(uint64_t backingStoreStateID, UpdateInfo&& updateInfo)
@@ -95,7 +95,7 @@ void DrawingAreaProxyWC::incorporateUpdate(UpdateInfo&& updateInfo)
     if (!m_backingStore)
         m_backingStore.emplace(updateInfo.viewSize, updateInfo.deviceScaleFactor);
 
-    RefPtr page = m_webPageProxy.get();
+    RefPtr page = this->page();
     if (!page)
         return;
 


### PR DESCRIPTION
#### 65af33026617991fd513d9c4377ef51d210c6b39
<pre>
Reduce unsafeness of UIProcess&apos;s DrawingAreaProxy
<a href="https://bugs.webkit.org/show_bug.cgi?id=294258">https://bugs.webkit.org/show_bug.cgi?id=294258</a>
<a href="https://rdar.apple.com/152951159">rdar://152951159</a>

Reviewed by Charlie Wolfe.

Apply <a href="https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines">https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines</a> by
making member variables private and const.

Also rename protectedWebPageProxy() to protectedPage() as the
non-protected variant is called page().

Canonical link: <a href="https://commits.webkit.org/296127@main">https://commits.webkit.org/296127@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a54cad274fa0f711d11e692c096b1f9df5487881

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/107313 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/26995 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/17399 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/112527 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/57848 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/27676 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/35495 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/81461 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/110242 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/21931 "Found 1 new test failure: fast/events/ios/select-all-with-existing-selection.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/96720 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/61835 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/21363 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/57292 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/91293 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/14884 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/115628 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/34379 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/25332 "Found 3 new test failures: inspector/model/remote-object-get-properties.html inspector/runtime/getDisplayableProperties.html inspector/runtime/getProperties.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/90503 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/34755 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/92970 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/90239 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35145 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/12929 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/30109 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17378 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/34301 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/40009 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34047 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/37402 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/35708 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->