### PR TITLE
FELighting.lightSource shouldn't return a Ref

### DIFF
--- a/Source/WebCore/platform/graphics/filters/FELighting.h
+++ b/Source/WebCore/platform/graphics/filters/FELighting.h
@@ -59,7 +59,7 @@ public:
     float kernelUnitLengthY() const { return m_kernelUnitLengthY; }
     bool setKernelUnitLengthY(float);
 
-    Ref<LightSource> lightSource() const { return m_lightSource; }
+    LightSource& lightSource() const { return m_lightSource; }
 
 protected:
     FELighting(Type, const Color& lightingColor, float surfaceScale, float diffuseConstant, float specularConstant, float specularExponent, float kernelUnitLengthX, float kernelUnitLengthY, Ref<LightSource>&&, DestinationColorSpace);

--- a/Source/WebCore/platform/graphics/filters/software/FELightingSoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FELightingSoftwareApplier.cpp
@@ -204,7 +204,7 @@ bool FELightingSoftwareApplier::apply(const Filter& filter, std::span<const Ref<
     data.diffuseConstant = m_effect->diffuseConstant();
     data.specularConstant = m_effect->specularConstant();
     data.specularExponent = m_effect->specularExponent();
-    data.lightSource = m_effect->lightSource().ptr();
+    data.lightSource = m_effect->lightSource();
     data.operatingColorSpace = &m_effect->operatingColorSpace();
 
     data.pixels = destinationPixelBuffer.releaseNonNull();

--- a/Source/WebCore/svg/SVGFEDiffuseLightingElement.cpp
+++ b/Source/WebCore/svg/SVGFEDiffuseLightingElement.cpp
@@ -98,25 +98,25 @@ bool SVGFEDiffuseLightingElement::setFilterEffectAttribute(FilterEffect& filterE
     case AttributeNames::diffuseConstantAttr:
         return effect.setDiffuseConstant(diffuseConstant());
     case AttributeNames::azimuthAttr:
-        return effect.lightSource()->setAzimuth(lightElement()->azimuth());
+        return effect.lightSource().setAzimuth(lightElement()->azimuth());
     case AttributeNames::elevationAttr:
-        return effect.lightSource()->setElevation(lightElement()->elevation());
+        return effect.lightSource().setElevation(lightElement()->elevation());
     case AttributeNames::xAttr:
-        return effect.lightSource()->setX(lightElement()->x());
+        return effect.lightSource().setX(lightElement()->x());
     case AttributeNames::yAttr:
-        return effect.lightSource()->setY(lightElement()->y());
+        return effect.lightSource().setY(lightElement()->y());
     case AttributeNames::zAttr:
-        return effect.lightSource()->setZ(lightElement()->z());
+        return effect.lightSource().setZ(lightElement()->z());
     case AttributeNames::pointsAtXAttr:
-        return effect.lightSource()->setPointsAtX(lightElement()->pointsAtX());
+        return effect.lightSource().setPointsAtX(lightElement()->pointsAtX());
     case AttributeNames::pointsAtYAttr:
-        return effect.lightSource()->setPointsAtY(lightElement()->pointsAtY());
+        return effect.lightSource().setPointsAtY(lightElement()->pointsAtY());
     case AttributeNames::pointsAtZAttr:
-        return effect.lightSource()->setPointsAtZ(lightElement()->pointsAtZ());
+        return effect.lightSource().setPointsAtZ(lightElement()->pointsAtZ());
     case AttributeNames::specularExponentAttr:
-        return effect.lightSource()->setSpecularExponent(lightElement()->specularExponent());
+        return effect.lightSource().setSpecularExponent(lightElement()->specularExponent());
     case AttributeNames::limitingConeAngleAttr:
-        return effect.lightSource()->setLimitingConeAngle(lightElement()->limitingConeAngle());
+        return effect.lightSource().setLimitingConeAngle(lightElement()->limitingConeAngle());
     default:
         break;
     }

--- a/Source/WebCore/svg/SVGFESpecularLightingElement.cpp
+++ b/Source/WebCore/svg/SVGFESpecularLightingElement.cpp
@@ -106,23 +106,23 @@ bool SVGFESpecularLightingElement::setFilterEffectAttribute(FilterEffect& filter
     case AttributeNames::specularExponentAttr:
         return effect.setSpecularExponent(specularExponent());
     case AttributeNames::azimuthAttr:
-        return effect.lightSource()->setAzimuth(lightElement()->azimuth());
+        return effect.lightSource().setAzimuth(lightElement()->azimuth());
     case AttributeNames::elevationAttr:
-        return effect.lightSource()->setElevation(lightElement()->elevation());
+        return effect.lightSource().setElevation(lightElement()->elevation());
     case AttributeNames::xAttr:
-        return effect.lightSource()->setX(lightElement()->x());
+        return effect.lightSource().setX(lightElement()->x());
     case AttributeNames::yAttr:
-        return effect.lightSource()->setY(lightElement()->y());
+        return effect.lightSource().setY(lightElement()->y());
     case AttributeNames::zAttr:
-        return effect.lightSource()->setZ(lightElement()->z());
+        return effect.lightSource().setZ(lightElement()->z());
     case AttributeNames::pointsAtXAttr:
-        return effect.lightSource()->setPointsAtX(lightElement()->pointsAtX());
+        return effect.lightSource().setPointsAtX(lightElement()->pointsAtX());
     case AttributeNames::pointsAtYAttr:
-        return effect.lightSource()->setPointsAtY(lightElement()->pointsAtY());
+        return effect.lightSource().setPointsAtY(lightElement()->pointsAtY());
     case AttributeNames::pointsAtZAttr:
-        return effect.lightSource()->setPointsAtZ(lightElement()->pointsAtZ());
+        return effect.lightSource().setPointsAtZ(lightElement()->pointsAtZ());
     case AttributeNames::limitingConeAngleAttr:
-        return effect.lightSource()->setLimitingConeAngle(lightElement()->limitingConeAngle());
+        return effect.lightSource().setLimitingConeAngle(lightElement()->limitingConeAngle());
     default:
         break;
     }

--- a/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp
@@ -740,25 +740,31 @@ std::optional<Namespace::ConditionalCommonClass> ArgumentCoder<Namespace::Condit
 void ArgumentCoder<Namespace::CommonClass>::encode(Encoder& encoder, const Namespace::CommonClass& instance)
 {
     static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.value)>, int>);
+    static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.nonRefMemberWithSubclasses)>, WebCore::TimingFunction>);
     struct ShouldBeSameSizeAsCommonClass : public VirtualTableAndRefCountOverhead<std::is_polymorphic_v<Namespace::CommonClass>, false> {
         int value;
+        WebCore::TimingFunction nonRefMemberWithSubclasses;
     };
     static_assert(sizeof(ShouldBeSameSizeAsCommonClass) == sizeof(Namespace::CommonClass));
     static_assert(MembersInCorrectOrder < 0
         , offsetof(Namespace::CommonClass, value)
+        , offsetof(Namespace::CommonClass, nonRefMemberWithSubclasses)
     >::value);
 
     encoder << instance.value;
+    encoder << instance.nonRefMemberWithSubclasses;
 }
 
 std::optional<Namespace::CommonClass> ArgumentCoder<Namespace::CommonClass>::decode(Decoder& decoder)
 {
     auto value = decoder.decode<int>();
+    auto nonRefMemberWithSubclasses = decoder.decode<Ref<WebCore::TimingFunction>>();
     if (!decoder.isValid()) [[unlikely]]
         return std::nullopt;
     return {
         Namespace::CommonClass {
-            WTFMove(*value)
+            WTFMove(*value),
+            WTFMove(*nonRefMemberWithSubclasses)
         }
     };
 }

--- a/Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp
@@ -71,18 +71,14 @@
 #include <WebCore/ScrollingStateFrameHostingNode.h>
 #include <WebCore/ScrollingStateFrameHostingNodeWithStuffAfterTuple.h>
 #include <WebCore/TimingFunction.h>
-#include <wtf/CreateUsingClass.h>
-#include <wtf/EnumTraits.h>
-#include <wtf/Seconds.h>
-#include <wtf/StdLibExtras.h>
-
 #if USE(AVFOUNDATION)
 #include <pal/cocoa/AVFoundationSoftLink.h>
 #endif
-
 #if ENABLE(DATA_DETECTION)
 #include <pal/cocoa/DataDetectorsCoreSoftLink.h>
 #endif
+#include <wtf/CreateUsingClass.h>
+#include <wtf/Seconds.h>
 
 static_assert(std::is_same_v<WebCore::SharedStringHash,
     uint32_t
@@ -119,7 +115,7 @@ namespace WebKit {
 
 template<typename E> uint64_t enumValueForIPCTestAPI(E e)
 {
-    return unsignedCast(e);
+    return static_cast<std::make_unsigned_t<std::underlying_type_t<E>>>(e);
 }
 
 Vector<SerializedTypeInfo> allSerializedTypes()
@@ -299,6 +295,10 @@ Vector<SerializedTypeInfo> allSerializedTypes()
             {
                 "int"_s,
                 "value"_s
+            },
+            {
+                "WebCore::TimingFunction"_s,
+                "nonRefMemberWithSubclasses"_s
             },
         } },
         { "Namespace::AnotherCommonClass"_s, {

--- a/Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in
+++ b/Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in
@@ -156,6 +156,7 @@ headers: "CommonHeader.h"
 headers: "CommonHeader.h"
 [CustomHeader] class Namespace::CommonClass {
     int value;
+    WebCore::TimingFunction nonRefMemberWithSubclasses;
 }
 
 headers: "CommonHeader.h"

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -4067,7 +4067,7 @@ header: <WebCore/FEComponentTransfer.h>
     float diffuseConstant();
     float kernelUnitLengthX();
     float kernelUnitLengthY();
-    Ref<WebCore::LightSource> lightSource();
+    WebCore::LightSource lightSource();
 
     WebCore::DestinationColorSpace operatingColorSpace();
 };
@@ -4144,7 +4144,7 @@ header: <WebCore/FEComponentTransfer.h>
     float specularExponent();
     float kernelUnitLengthX();
     float kernelUnitLengthY();
-    Ref<WebCore::LightSource> lightSource();
+    WebCore::LightSource lightSource();
 
     WebCore::DestinationColorSpace operatingColorSpace();
 };


### PR DESCRIPTION
#### 49361c471c5c6f924cf002cde4b99e93b35c6a5b
<pre>
FELighting.lightSource shouldn&apos;t return a Ref
<a href="https://bugs.webkit.org/show_bug.cgi?id=294261">https://bugs.webkit.org/show_bug.cgi?id=294261</a>
<a href="https://rdar.apple.com/152957868">rdar://152957868</a>

Reviewed by Ryosuke Niwa.

LightSource is a pure virtual class, so decoder.decode&lt;WebCore::LightSource&gt;()
can&apos;t return anything but decoder.decode&lt;Ref&lt;WebCore::LightSource&gt;&gt;() can.
I added a bit of logic to the decoder generator to detect if we are decoding a
class with subclasses and decode a Ref&lt;T&gt; instead of a T.

Many thanks to Anne van Kesteren for finding this issue.

* Source/WebCore/platform/graphics/filters/FELighting.h:
(WebCore::FELighting::lightSource const):
* Source/WebCore/platform/graphics/filters/software/FELightingSoftwareApplier.cpp:
(WebCore::FELightingSoftwareApplier::apply const):
* Source/WebCore/svg/SVGFEDiffuseLightingElement.cpp:
(WebCore::SVGFEDiffuseLightingElement::setFilterEffectAttribute):
* Source/WebCore/svg/SVGFESpecularLightingElement.cpp:
(WebCore::SVGFESpecularLightingElement::setFilterEffectAttribute):
* Source/WebKit/Scripts/generate-serializers.py:
(decode_cf_type):
(should_decode_ref):
(decode_type):
(decode_type.is):
(generate_one_impl):
(generate_impl):
* Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp:
(IPC::ArgumentCoder&lt;Namespace::CommonClass&gt;::encode):
(IPC::ArgumentCoder&lt;Namespace::CommonClass&gt;::decode):
* Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp:
(WebKit::enumValueForIPCTestAPI):
(WebKit::allSerializedTypes):
* Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/296040@main">https://commits.webkit.org/296040@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/055c2fd6ed0a2186fd47dbd318f1c75ac7839144

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/107175 "3 style errors") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/131/builds/26856 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/17256 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/112387 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/57709 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/109139 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/27531 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/123/builds/35360 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/112387 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/57709 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/110104 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/130/builds/27531 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/96622 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/112387 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/106580 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/130/builds/27531 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/14752 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/57153 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/130/builds/27531 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/14774 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/115485 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/34239 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/123/builds/35360 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/115485 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/34616 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/92877 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/115485 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/12836 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/29976 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17327 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/34164 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/39639 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [⏳ 🛠 tv-sim ](https://ews-build.webkit.org/#/builders/tvOS-18-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/37263 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/35567 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->