### PR TITLE
Change current Apple OS versions to 26.

### DIFF
--- a/Tools/CISupport/build-webkit-org/steps.py
+++ b/Tools/CISupport/build-webkit-org/steps.py
@@ -2047,9 +2047,9 @@ class PrintConfiguration(steps.ShellSequence, ShellMixin):
             return 'Unknown'
 
         build_to_name_mapping = {
+            '26': 'Tahoe',
             '15': 'Sequoia',
-            '14': 'Sonoma',
-            '13': 'Ventura',
+            '14': 'Sonoma'
         }
 
         for key, value in build_to_name_mapping.items():

--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -5990,9 +5990,9 @@ class PrintConfiguration(steps.ShellSequence):
             return 'Unknown'
 
         build_to_name_mapping = {
+            '26': 'Tahoe',
             '15': 'Sequoia',
-            '14': 'Sonoma',
-            '13': 'Ventura'
+            '14': 'Sonoma'
         }
 
         for key, value in build_to_name_mapping.items():

--- a/Tools/Scripts/webkitpy/common/version_name_map.py
+++ b/Tools/Scripts/webkitpy/common/version_name_map.py
@@ -67,11 +67,12 @@ class VersionNameMap(object):
                 'Ventura': Version(13, 0),
                 'Sonoma': Version(14, 0),
                 'Sequoia': Version(15, 0),
+                'Tahoe': Version(26, 0)
             },
-            'ios': self._automap_to_major_version('iOS', minimum=Version(10), maximum=Version(18)),
-            'tvos': self._automap_to_major_version('tvOS', minimum=Version(10), maximum=Version(18)),
-            'watchos': self._automap_to_major_version('watchOS', minimum=Version(1), maximum=Version(11)),
-            'visionos': self._automap_to_major_version('visionOS', minimum=Version(1), maximum=Version(2)),
+            'ios': self._automap_to_major_version('iOS', minimum=Version(10), maximum=Version(26)),
+            'tvos': self._automap_to_major_version('tvOS', minimum=Version(10), maximum=Version(26)),
+            'watchos': self._automap_to_major_version('watchOS', minimum=Version(1), maximum=Version(26)),
+            'visionos': self._automap_to_major_version('visionOS', minimum=Version(1), maximum=Version(26)),
             'win': {
                 'Win10': Version(10),
                 '8.1': Version(6, 3),

--- a/Tools/Scripts/webkitpy/port/ios.py
+++ b/Tools/Scripts/webkitpy/port/ios.py
@@ -36,7 +36,7 @@ _log = logging.getLogger(__name__)
 class IOSPort(DevicePort):
     port_name = "ios"
 
-    CURRENT_VERSION = Version(18)
+    CURRENT_VERSION = Version(26)
     DEVICE_TYPE = DeviceType(software_variant='iOS')
 
     def __init__(self, host, port_name, **kwargs):

--- a/Tools/Scripts/webkitpy/port/ios_device_unittest.py
+++ b/Tools/Scripts/webkitpy/port/ios_device_unittest.py
@@ -115,18 +115,18 @@ class IOSDeviceTest(ios_testcase.IOSTest):
             search_path = self.make_port().default_baseline_search_path()
 
         self.assertEqual(search_path, [
-            '/additional_testing_path/ios-device-add-ios18-wk1',
-            '/mock-checkout/LayoutTests/platform/ios-device-18-wk1',
-            '/additional_testing_path/ios-device-add-ios18',
-            '/mock-checkout/LayoutTests/platform/ios-device-18',
+            '/additional_testing_path/ios-device-add-ios26-wk1',
+            '/mock-checkout/LayoutTests/platform/ios-device-26-wk1',
+            '/additional_testing_path/ios-device-add-ios26',
+            '/mock-checkout/LayoutTests/platform/ios-device-26',
             '/additional_testing_path/ios-device-wk1',
             '/mock-checkout/LayoutTests/platform/ios-device-wk1',
             '/additional_testing_path/ios-device',
             '/mock-checkout/LayoutTests/platform/ios-device',
-            '/additional_testing_path/ios-add-ios18-wk1',
-            '/mock-checkout/LayoutTests/platform/ios-18-wk1',
-            '/additional_testing_path/ios-add-ios18',
-            '/mock-checkout/LayoutTests/platform/ios-18',
+            '/additional_testing_path/ios-add-ios26-wk1',
+            '/mock-checkout/LayoutTests/platform/ios-26-wk1',
+            '/additional_testing_path/ios-add-ios26',
+            '/mock-checkout/LayoutTests/platform/ios-26',
             '/additional_testing_path/ios-wk1',
             '/mock-checkout/LayoutTests/platform/ios-wk1',
             '/additional_testing_path/ios',
@@ -134,46 +134,46 @@ class IOSDeviceTest(ios_testcase.IOSTest):
         ])
 
     def test_layout_test_searchpath_without_apple_additions(self):
-        search_path = self.make_port(port_name='ios-device-wk2', os_version=Version(18)).default_baseline_search_path()
+        search_path = self.make_port(port_name='ios-device-wk2', os_version=Version(26)).default_baseline_search_path()
 
         self.assertEqual(search_path, [
-            '/mock-checkout/LayoutTests/platform/ios-device-18-wk2',
-            '/mock-checkout/LayoutTests/platform/ios-device-18',
+            '/mock-checkout/LayoutTests/platform/ios-device-26-wk2',
+            '/mock-checkout/LayoutTests/platform/ios-device-26',
             '/mock-checkout/LayoutTests/platform/ios-device-wk2',
             '/mock-checkout/LayoutTests/platform/ios-device',
-            '/mock-checkout/LayoutTests/platform/ios-18-wk2',
-            '/mock-checkout/LayoutTests/platform/ios-18',
+            '/mock-checkout/LayoutTests/platform/ios-26-wk2',
+            '/mock-checkout/LayoutTests/platform/ios-26',
             '/mock-checkout/LayoutTests/platform/ios-wk2',
             '/mock-checkout/LayoutTests/platform/ios',
             '/mock-checkout/LayoutTests/platform/wk2',
         ])
 
     def test_layout_searchpath_wih_device_type(self):
-        search_path = self.make_port(port_name='ios-device-wk2', os_version=Version(18)).default_baseline_search_path(DeviceType.from_string('iPhone SE'))
+        search_path = self.make_port(port_name='ios-device-wk2', os_version=Version(26)).default_baseline_search_path(DeviceType.from_string('iPhone SE'))
 
         self.assertEqual(search_path, [
-            '/mock-checkout/LayoutTests/platform/iphone-se-device-18-wk2',
-            '/mock-checkout/LayoutTests/platform/iphone-se-device-18',
+            '/mock-checkout/LayoutTests/platform/iphone-se-device-26-wk2',
+            '/mock-checkout/LayoutTests/platform/iphone-se-device-26',
             '/mock-checkout/LayoutTests/platform/iphone-se-device-wk2',
             '/mock-checkout/LayoutTests/platform/iphone-se-device',
-            '/mock-checkout/LayoutTests/platform/iphone-device-18-wk2',
-            '/mock-checkout/LayoutTests/platform/iphone-device-18',
+            '/mock-checkout/LayoutTests/platform/iphone-device-26-wk2',
+            '/mock-checkout/LayoutTests/platform/iphone-device-26',
             '/mock-checkout/LayoutTests/platform/iphone-device-wk2',
             '/mock-checkout/LayoutTests/platform/iphone-device',
-            '/mock-checkout/LayoutTests/platform/ios-device-18-wk2',
-            '/mock-checkout/LayoutTests/platform/ios-device-18',
+            '/mock-checkout/LayoutTests/platform/ios-device-26-wk2',
+            '/mock-checkout/LayoutTests/platform/ios-device-26',
             '/mock-checkout/LayoutTests/platform/ios-device-wk2',
             '/mock-checkout/LayoutTests/platform/ios-device',
-            '/mock-checkout/LayoutTests/platform/iphone-se-18-wk2',
-            '/mock-checkout/LayoutTests/platform/iphone-se-18',
+            '/mock-checkout/LayoutTests/platform/iphone-se-26-wk2',
+            '/mock-checkout/LayoutTests/platform/iphone-se-26',
             '/mock-checkout/LayoutTests/platform/iphone-se-wk2',
             '/mock-checkout/LayoutTests/platform/iphone-se',
-            '/mock-checkout/LayoutTests/platform/iphone-18-wk2',
-            '/mock-checkout/LayoutTests/platform/iphone-18',
+            '/mock-checkout/LayoutTests/platform/iphone-26-wk2',
+            '/mock-checkout/LayoutTests/platform/iphone-26',
             '/mock-checkout/LayoutTests/platform/iphone-wk2',
             '/mock-checkout/LayoutTests/platform/iphone',
-            '/mock-checkout/LayoutTests/platform/ios-18-wk2',
-            '/mock-checkout/LayoutTests/platform/ios-18',
+            '/mock-checkout/LayoutTests/platform/ios-26-wk2',
+            '/mock-checkout/LayoutTests/platform/ios-26',
             '/mock-checkout/LayoutTests/platform/ios-wk2',
             '/mock-checkout/LayoutTests/platform/ios',
             '/mock-checkout/LayoutTests/platform/wk2',

--- a/Tools/Scripts/webkitpy/port/ios_simulator_unittest.py
+++ b/Tools/Scripts/webkitpy/port/ios_simulator_unittest.py
@@ -39,7 +39,7 @@ class IOSSimulatorTest(ios_testcase.IOSTest):
     port_name = 'ios-simulator'
     port_maker = IOSSimulatorPort
 
-    def make_port(self, host=None, port_name=None, options=None, os_name=None, os_version=Version(18), **kwargs):
+    def make_port(self, host=None, port_name=None, options=None, os_name=None, os_version=Version(26), **kwargs):
         port = super(IOSSimulatorTest, self).make_port(host=host, port_name=port_name, options=options, os_name=os_name, os_version=os_version, kwargs=kwargs)
         port.set_option('child_processes', 1)
         return port
@@ -86,18 +86,18 @@ class IOSSimulatorTest(ios_testcase.IOSTest):
             search_path = self.make_port().default_baseline_search_path()
 
         self.assertEqual(search_path, [
-            '/additional_testing_path/ios-simulator-add-ios18-wk1',
-            '/mock-checkout/LayoutTests/platform/ios-simulator-18-wk1',
-            '/additional_testing_path/ios-simulator-add-ios18',
-            '/mock-checkout/LayoutTests/platform/ios-simulator-18',
+            '/additional_testing_path/ios-simulator-add-ios26-wk1',
+            '/mock-checkout/LayoutTests/platform/ios-simulator-26-wk1',
+            '/additional_testing_path/ios-simulator-add-ios26',
+            '/mock-checkout/LayoutTests/platform/ios-simulator-26',
             '/additional_testing_path/ios-simulator-wk1',
             '/mock-checkout/LayoutTests/platform/ios-simulator-wk1',
             '/additional_testing_path/ios-simulator',
             '/mock-checkout/LayoutTests/platform/ios-simulator',
-            '/additional_testing_path/ios-add-ios18-wk1',
-            '/mock-checkout/LayoutTests/platform/ios-18-wk1',
-            '/additional_testing_path/ios-add-ios18',
-            '/mock-checkout/LayoutTests/platform/ios-18',
+            '/additional_testing_path/ios-add-ios26-wk1',
+            '/mock-checkout/LayoutTests/platform/ios-26-wk1',
+            '/additional_testing_path/ios-add-ios26',
+            '/mock-checkout/LayoutTests/platform/ios-26',
             '/additional_testing_path/ios-wk1',
             '/mock-checkout/LayoutTests/platform/ios-wk1',
             '/additional_testing_path/ios',
@@ -105,46 +105,46 @@ class IOSSimulatorTest(ios_testcase.IOSTest):
         ])
 
     def test_layout_test_searchpath_without_apple_additions(self):
-        search_path = self.make_port(port_name='ios-simulator-wk2', os_version=Version(18)).default_baseline_search_path()
+        search_path = self.make_port(port_name='ios-simulator-wk2', os_version=Version(26)).default_baseline_search_path()
 
         self.assertEqual(search_path, [
-            '/mock-checkout/LayoutTests/platform/ios-simulator-18-wk2',
-            '/mock-checkout/LayoutTests/platform/ios-simulator-18',
+            '/mock-checkout/LayoutTests/platform/ios-simulator-26-wk2',
+            '/mock-checkout/LayoutTests/platform/ios-simulator-26',
             '/mock-checkout/LayoutTests/platform/ios-simulator-wk2',
             '/mock-checkout/LayoutTests/platform/ios-simulator',
-            '/mock-checkout/LayoutTests/platform/ios-18-wk2',
-            '/mock-checkout/LayoutTests/platform/ios-18',
+            '/mock-checkout/LayoutTests/platform/ios-26-wk2',
+            '/mock-checkout/LayoutTests/platform/ios-26',
             '/mock-checkout/LayoutTests/platform/ios-wk2',
             '/mock-checkout/LayoutTests/platform/ios',
             '/mock-checkout/LayoutTests/platform/wk2',
         ])
 
     def test_layout_searchpath_wih_device_type(self):
-        search_path = self.make_port(port_name='ios-simulator-wk2', os_version=Version(18)).default_baseline_search_path(DeviceType.from_string('iPhone SE'))
+        search_path = self.make_port(port_name='ios-simulator-wk2', os_version=Version(26)).default_baseline_search_path(DeviceType.from_string('iPhone SE'))
 
         self.assertEqual(search_path, [
-            '/mock-checkout/LayoutTests/platform/iphone-se-simulator-18-wk2',
-            '/mock-checkout/LayoutTests/platform/iphone-se-simulator-18',
+            '/mock-checkout/LayoutTests/platform/iphone-se-simulator-26-wk2',
+            '/mock-checkout/LayoutTests/platform/iphone-se-simulator-26',
             '/mock-checkout/LayoutTests/platform/iphone-se-simulator-wk2',
             '/mock-checkout/LayoutTests/platform/iphone-se-simulator',
-            '/mock-checkout/LayoutTests/platform/iphone-simulator-18-wk2',
-            '/mock-checkout/LayoutTests/platform/iphone-simulator-18',
+            '/mock-checkout/LayoutTests/platform/iphone-simulator-26-wk2',
+            '/mock-checkout/LayoutTests/platform/iphone-simulator-26',
             '/mock-checkout/LayoutTests/platform/iphone-simulator-wk2',
             '/mock-checkout/LayoutTests/platform/iphone-simulator',
-            '/mock-checkout/LayoutTests/platform/ios-simulator-18-wk2',
-            '/mock-checkout/LayoutTests/platform/ios-simulator-18',
+            '/mock-checkout/LayoutTests/platform/ios-simulator-26-wk2',
+            '/mock-checkout/LayoutTests/platform/ios-simulator-26',
             '/mock-checkout/LayoutTests/platform/ios-simulator-wk2',
             '/mock-checkout/LayoutTests/platform/ios-simulator',
-            '/mock-checkout/LayoutTests/platform/iphone-se-18-wk2',
-            '/mock-checkout/LayoutTests/platform/iphone-se-18',
+            '/mock-checkout/LayoutTests/platform/iphone-se-26-wk2',
+            '/mock-checkout/LayoutTests/platform/iphone-se-26',
             '/mock-checkout/LayoutTests/platform/iphone-se-wk2',
             '/mock-checkout/LayoutTests/platform/iphone-se',
-            '/mock-checkout/LayoutTests/platform/iphone-18-wk2',
-            '/mock-checkout/LayoutTests/platform/iphone-18',
+            '/mock-checkout/LayoutTests/platform/iphone-26-wk2',
+            '/mock-checkout/LayoutTests/platform/iphone-26',
             '/mock-checkout/LayoutTests/platform/iphone-wk2',
             '/mock-checkout/LayoutTests/platform/iphone',
-            '/mock-checkout/LayoutTests/platform/ios-18-wk2',
-            '/mock-checkout/LayoutTests/platform/ios-18',
+            '/mock-checkout/LayoutTests/platform/ios-26-wk2',
+            '/mock-checkout/LayoutTests/platform/ios-26',
             '/mock-checkout/LayoutTests/platform/ios-wk2',
             '/mock-checkout/LayoutTests/platform/ios',
             '/mock-checkout/LayoutTests/platform/wk2',

--- a/Tools/Scripts/webkitpy/port/ios_testcase.py
+++ b/Tools/Scripts/webkitpy/port/ios_testcase.py
@@ -28,7 +28,7 @@ from webkitpy.port import darwin_testcase
 class IOSTest(darwin_testcase.DarwinTest):
     disable_setup = True
 
-    def make_port(self, host=None, port_name=None, options=None, os_name=None, os_version=Version(18), **kwargs):
+    def make_port(self, host=None, port_name=None, options=None, os_name=None, os_version=Version(26), **kwargs):
         port = super(IOSTest, self).make_port(host=host, port_name=port_name, options=options, os_name=os_name, os_version=None, kwargs=kwargs)
         port.set_option('version', str(os_version))
         return port

--- a/Tools/Scripts/webkitpy/port/mac.py
+++ b/Tools/Scripts/webkitpy/port/mac.py
@@ -48,7 +48,7 @@ _log = logging.getLogger(__name__)
 class MacPort(DarwinPort):
     port_name = "mac"
 
-    CURRENT_VERSION = Version(15, 0)
+    CURRENT_VERSION = Version(26, 0)
     LAST_MACOSX = Version(10, 15)
 
     SDK = 'macosx'

--- a/Tools/Scripts/webkitpy/port/mac_unittest.py
+++ b/Tools/Scripts/webkitpy/port/mac_unittest.py
@@ -187,10 +187,17 @@ class MacTest(darwin_testcase.DarwinTest):
         self.assertEqual(search_path[4], '/additional_testing_path/mac-add-mountainlion-wk1')
         self.assertEqual(search_path[5], '/mock-checkout/LayoutTests/platform/mac-mountainlion-wk1')
 
-    def test_sequoia_baseline_search_path(self):
-        search_path = self.make_port(port_name='macos-sequoia').default_baseline_search_path()
+    def test_latest_baseline_search_path(self):
+        search_path = self.make_port(port_name='macos-tahoe').default_baseline_search_path()
         self.assertEqual(search_path[0], '/mock-checkout/LayoutTests/platform/mac-wk1')
         self.assertEqual(search_path[1], '/mock-checkout/LayoutTests/platform/mac')
+
+    def test_downlevel_baseline_search_path(self):
+        search_path = self.make_port(port_name='macos-sequoia').default_baseline_search_path()
+        self.assertEqual(search_path[0], '/mock-checkout/LayoutTests/platform/mac-sequoia-wk1')
+        self.assertEqual(search_path[1], '/mock-checkout/LayoutTests/platform/mac-sequoia')
+        self.assertEqual(search_path[2], '/mock-checkout/LayoutTests/platform/mac-wk1')
+        self.assertEqual(search_path[3], '/mock-checkout/LayoutTests/platform/mac')
 
     def test_factory_with_future_version(self):
         port = self.make_port(options=MockOptions(webkit_test_runner=True), os_version=MacTest.FUTURE_VERSION, os_name='mac', port_name='mac')

--- a/Tools/Scripts/webkitpy/port/visionos.py
+++ b/Tools/Scripts/webkitpy/port/visionos.py
@@ -36,7 +36,7 @@ _log = logging.getLogger(__name__)
 class VisionOSPort(DevicePort):
     port_name = 'visionos'
 
-    CURRENT_VERSION = Version(2)
+    CURRENT_VERSION = Version(26)
     DEVICE_TYPE = DeviceType(software_variant='visionOS')
 
     def __init__(self, *args, **kwargs):

--- a/Tools/Scripts/webkitpy/port/visionos_testcase.py
+++ b/Tools/Scripts/webkitpy/port/visionos_testcase.py
@@ -29,7 +29,7 @@ from webkitpy.tool.mocktool import MockOptions
 class VisionOSTest(darwin_testcase.DarwinTest):
     disable_setup = True
 
-    def make_port(self, host=None, port_name=None, options=None, os_name=None, os_version=Version(5), **kwargs):
+    def make_port(self, host=None, port_name=None, options=None, os_name=None, os_version=Version(26), **kwargs):
         if options:
             options.architecture = 'arm64'
             options.webkit_test_runner = True

--- a/Tools/Scripts/webkitpy/port/watch.py
+++ b/Tools/Scripts/webkitpy/port/watch.py
@@ -36,7 +36,7 @@ _log = logging.getLogger(__name__)
 class WatchPort(DevicePort):
     port_name = 'watchos'
 
-    CURRENT_VERSION = Version(5)
+    CURRENT_VERSION = Version(26)
     DEVICE_TYPE = DeviceType(software_variant='watchOS')
 
     def __init__(self, *args, **kwargs):

--- a/Tools/Scripts/webkitpy/port/watch_simulator_unittest.py
+++ b/Tools/Scripts/webkitpy/port/watch_simulator_unittest.py
@@ -38,7 +38,7 @@ class WatchSimulatorTest(watch_testcase.WatchTest):
     port_name = 'watch-simulator'
     port_maker = WatchSimulatorPort
 
-    def make_port(self, host=None, port_name=None, options=None, os_name=None, os_version=Version(5), **kwargs):
+    def make_port(self, host=None, port_name=None, options=None, os_name=None, os_version=Version(26), **kwargs):
         port = super(WatchSimulatorTest, self).make_port(host=host, port_name=port_name, options=options, os_name=os_name, os_version=os_version, kwargs=kwargs)
         port.set_option('child_processes', 1)
         return port

--- a/Tools/Scripts/webkitpy/port/watch_testcase.py
+++ b/Tools/Scripts/webkitpy/port/watch_testcase.py
@@ -29,7 +29,7 @@ from webkitpy.tool.mocktool import MockOptions
 class WatchTest(darwin_testcase.DarwinTest):
     disable_setup = True
 
-    def make_port(self, host=None, port_name=None, options=None, os_name=None, os_version=Version(5), **kwargs):
+    def make_port(self, host=None, port_name=None, options=None, os_name=None, os_version=Version(26), **kwargs):
         if options:
             options.architecture = 'x86'
             options.webkit_test_runner = True


### PR DESCRIPTION
#### a1229133acc9c7252f2ba1b72c76ff542638392f
<pre>
Change current Apple OS versions to 26.
<a href="https://bugs.webkit.org/show_bug.cgi?id=294267">https://bugs.webkit.org/show_bug.cgi?id=294267</a>
<a href="https://rdar.apple.com/152964437">rdar://152964437</a>

Reviewed by Ryan Haddad.

This bumps the current version of all Apple OSes to 26 in webkitpy and the
PrintConfiguration build step on ews-build and build-webkit-org to reflect the
new OS versions Apple announced at WWDC yesterday.

* Tools/CISupport/build-webkit-org/steps.py: Add Tahoe to PrintConfiguration OS name mapping.
* Tools/CISupport/ews-build/steps.py: Ditto.
* Tools/Scripts/webkitpy/common/version_name_map.py: Add Tahoe and bump all current OS versions to 26.
* Tools/Scripts/webkitpy/port/ios.py: Bump current version to 26.
* Tools/Scripts/webkitpy/port/ios_device_unittest.py: Ditto.
* Tools/Scripts/webkitpy/port/ios_simulator_unittest.py: Ditto.
* Tools/Scripts/webkitpy/port/ios_testcase.py: Ditto.
* Tools/Scripts/webkitpy/port/visionos.py: Ditto.
* Tools/Scripts/webkitpy/port/visionos_testcase.py: Ditto.
* Tools/Scripts/webkitpy/port/watch.py: Ditto.
* Tools/Scripts/webkitpy/port/watch_simulator_unittest.py: Ditto.
* Tools/Scripts/webkitpy/port/watch_testcase.py: Ditto.
* Tools/Scripts/webkitpy/port/mac.py: Ditto.
* Tools/Scripts/webkitpy/port/mac_unittest.py:
    (MacTest):
        -&gt; (test_sequoia_baseline_search_path): Renamed to test_latest_baseline_search_path.
        -&gt; (test_downlevel_baseline_search_path): Added new unit test for downlevel baseline search path validation.

Canonical link: <a href="https://commits.webkit.org/296105@main">https://commits.webkit.org/296105@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5d54082071451813e10abc136eb7de3c40ecbb6a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/107397 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27079 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/17484 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/112611 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/57933 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/109361 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/27761 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/35579 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/112611 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/57933 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/110326 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/21995 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/96795 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/112611 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/106802 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/21435 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/14925 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/57377 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/91364 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/14959 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/115712 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/34464 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/25404 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/90569 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/106905 "Passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/34839 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/93043 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/90306 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/35219 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/13001 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/30207 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17369 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/34385 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/34131 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/37486 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/35792 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->