### PR TITLE
Crash in WebGeolocationClient::geolocationDestroyed

### DIFF
--- a/Source/WebKit/WebProcess/WebCoreSupport/WebGeolocationClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebGeolocationClient.cpp
@@ -40,29 +40,36 @@ using namespace WebCore;
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(WebGeolocationClient);
 
-WebGeolocationClient::~WebGeolocationClient()
+WebGeolocationClient::WebGeolocationClient(WebPage& page)
+    : m_page(page)
 {
 }
 
+WebGeolocationClient::~WebGeolocationClient() = default;
+
 void WebGeolocationClient::geolocationDestroyed()
 {
-    WebProcess::singleton().supplement<WebGeolocationManager>()->unregisterWebPage(m_page.get());
+    if (m_page)
+        WebProcess::singleton().supplement<WebGeolocationManager>()->unregisterWebPage(*m_page);
     delete this;
 }
 
 void WebGeolocationClient::startUpdating(const String& authorizationToken, bool needsHighAccuracy)
 {
-    WebProcess::singleton().supplement<WebGeolocationManager>()->registerWebPage(m_page.get(), authorizationToken, needsHighAccuracy);
+    if (m_page)
+        WebProcess::singleton().supplement<WebGeolocationManager>()->registerWebPage(*m_page, authorizationToken, needsHighAccuracy);
 }
 
 void WebGeolocationClient::stopUpdating()
 {
-    WebProcess::singleton().supplement<WebGeolocationManager>()->unregisterWebPage(m_page.get());
+    if (m_page)
+        WebProcess::singleton().supplement<WebGeolocationManager>()->unregisterWebPage(*m_page);
 }
 
 void WebGeolocationClient::setEnableHighAccuracy(bool enabled)
 {
-    WebProcess::singleton().supplement<WebGeolocationManager>()->setEnableHighAccuracyForPage(m_page.get(), enabled);
+    if (m_page)
+        WebProcess::singleton().supplement<WebGeolocationManager>()->setEnableHighAccuracyForPage(*m_page, enabled);
 }
 
 std::optional<GeolocationPositionData> WebGeolocationClient::lastPosition()
@@ -72,17 +79,20 @@ std::optional<GeolocationPositionData> WebGeolocationClient::lastPosition()
 
 void WebGeolocationClient::requestPermission(Geolocation& geolocation)
 {
-    m_page.get().geolocationPermissionRequestManager().startRequestForGeolocation(geolocation);
+    if (m_page)
+        m_page->geolocationPermissionRequestManager().startRequestForGeolocation(geolocation);
 }
 
 void WebGeolocationClient::revokeAuthorizationToken(const String& authorizationToken)
 {
-    m_page.get().geolocationPermissionRequestManager().revokeAuthorizationToken(authorizationToken);
+    if (m_page)
+        m_page->geolocationPermissionRequestManager().revokeAuthorizationToken(authorizationToken);
 }
 
 void WebGeolocationClient::cancelPermissionRequest(Geolocation& geolocation)
 {
-    m_page.get().geolocationPermissionRequestManager().cancelRequestForGeolocation(geolocation);
+    if (m_page)
+        m_page->geolocationPermissionRequestManager().cancelRequestForGeolocation(geolocation);
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebGeolocationClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebGeolocationClient.h
@@ -36,11 +36,7 @@ class WebGeolocationClient final : public WebCore::GeolocationClient {
     WTF_MAKE_TZONE_ALLOCATED(WebGeolocationClient);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WebGeolocationClient);
 public:
-    WebGeolocationClient(WebPage& page)
-        : m_page(page)
-    {
-    }
-
+    explicit WebGeolocationClient(WebPage&);
     virtual ~WebGeolocationClient();
 
 private:
@@ -56,7 +52,7 @@ private:
     void requestPermission(WebCore::Geolocation&) final;
     void cancelPermissionRequest(WebCore::Geolocation&) final;
 
-    WeakRef<WebPage> m_page;
+    WeakPtr<WebPage> m_page;
 };
 
 } // namespace WebKit


### PR DESCRIPTION
#### 8ea398a5e6b3706609203186eb96c55a5480e806
<pre>
Crash in WebGeolocationClient::geolocationDestroyed
<a href="https://bugs.webkit.org/show_bug.cgi?id=289999">https://bugs.webkit.org/show_bug.cgi?id=289999</a>
<a href="https://rdar.apple.com/147875308">rdar://147875308</a>

Reviewed by Per Arne Vollan.

Make m_page a WeakPtr since it can become null. WebGeolocationClient is owned by
WebCore::Page, not WebKit::WebPage and m_page is a WebPage. The Page can outlive
the WebPage since it is refcounted.

* Source/WebKit/WebProcess/WebCoreSupport/WebGeolocationClient.cpp:
(WebKit::WebGeolocationClient::WebGeolocationClient):
(WebKit::WebGeolocationClient::geolocationDestroyed):
(WebKit::WebGeolocationClient::startUpdating):
(WebKit::WebGeolocationClient::stopUpdating):
(WebKit::WebGeolocationClient::setEnableHighAccuracy):
(WebKit::WebGeolocationClient::requestPermission):
(WebKit::WebGeolocationClient::revokeAuthorizationToken):
(WebKit::WebGeolocationClient::cancelPermissionRequest):
(WebKit::WebGeolocationClient::~WebGeolocationClient): Deleted.
* Source/WebKit/WebProcess/WebCoreSupport/WebGeolocationClient.h:

Canonical link: <a href="https://commits.webkit.org/296054@main">https://commits.webkit.org/296054@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/32af68760ced035df5da5993ec4c1fb1dbcb9280

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/107187 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/131/builds/26868 "Build was cancelled. Recent messages:OS: Sequoia (15.5), Xcode: 16.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/138/builds/17268 "Build was cancelled. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/112399 "Build was cancelled. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/57724 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/27543 "Build was cancelled. Recent messages:OS: Sequoia (15.5), Xcode: 16.4; Running apply-patch; Checked out pull request; Compiled WebKit (cancelled)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/35372 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/81367 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/57724 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/110116 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/21849 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/96627 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/61735 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/21272 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/57165 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/91200 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/14781 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/115497 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/34251 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/25261 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/90415 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/34627 "Build was cancelled. Recent messages:OS: Sequoia (15.5), Xcode: 16.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/92883 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/90149 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22988 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35063 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/12841 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/29982 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/34176 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/39651 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/33922 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/37275 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/35579 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->