### PR TITLE
ASAN_ILL crash in WebCore::LegacyRenderSVGShape::layout

### DIFF
--- a/LayoutTests/fast/svg/path-NaN-bounding-box-crash-expected.txt
+++ b/LayoutTests/fast/svg/path-NaN-bounding-box-crash-expected.txt
@@ -1,0 +1,2 @@
+This test passes if it does not crash
+

--- a/LayoutTests/fast/svg/path-NaN-bounding-box-crash.html
+++ b/LayoutTests/fast/svg/path-NaN-bounding-box-crash.html
@@ -1,0 +1,25 @@
+<style>
+    *:only-of-type { 
+        transform: skewX(90deg);
+    }
+    .class4,* {
+        padding: 1em 8% 10em 26%;
+        rotate: z 90deg;
+    }
+</style>
+<script>
+    if (window.testRunner)
+        testRunner.dumpAsText();
+</script>
+</head>
+<body>
+    <svg>
+        <text x="10" y="10">This test passes if it does not crash</text>
+        <clipPath id="x29">
+            <ellipse cy="0em" clip-path="url(#x29)" cx="14%">
+            </ellipse>
+            <ellipse ry="10em" vector-effect="non-scaling-stroke" stroke="rgb(41,106,102)">
+            </ellipse>
+        </clipPath>
+    </svg>
+</body>

--- a/Source/WebCore/rendering/svg/SVGRenderSupport.cpp
+++ b/Source/WebCore/rendering/svg/SVGRenderSupport.cpp
@@ -606,7 +606,8 @@ FloatRect SVGRenderSupport::calculateApproximateStrokeBoundingBox(const RenderEl
             auto* usePath = renderer.nonScalingStrokePath(&renderer.path(), nonScalingTransform);
             auto strokeBoundingRect = calculateApproximateScalingStrokeBoundingBox(renderer, usePath->fastBoundingRect());
             strokeBoundingRect = inverse.value().mapRect(strokeBoundingRect);
-            strokeBoundingBox.unite(strokeBoundingRect);
+            if (!strokeBoundingRect.isNaN())
+                strokeBoundingBox.unite(strokeBoundingRect);
         }
         return strokeBoundingBox;
     };

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.cpp
@@ -398,7 +398,8 @@ FloatRect LegacyRenderSVGShape::calculateStrokeBoundingBox() const
                     SVGRenderSupport::applyStrokeStyleToContext(context, style(), *this);
                 } });
                 strokeBoundingRect = inverse.value().mapRect(strokeBoundingRect);
-                strokeBoundingBox.unite(strokeBoundingRect);
+                if (!strokeBoundingRect.isNaN())
+                    strokeBoundingBox.unite(strokeBoundingRect);
             }
         } else {
             strokeBoundingBox.unite(path().strokeBoundingRect(Function<void(GraphicsContext&)> { [this] (GraphicsContext& context) {


### PR DESCRIPTION
#### d1bf7f2a3884e3acb1ae14a1df6b291a5a4795b8
<pre>
ASAN_ILL crash in WebCore::LegacyRenderSVGShape::layout
<a href="https://bugs.webkit.org/show_bug.cgi?id=294273">https://bugs.webkit.org/show_bug.cgi?id=294273</a>
<a href="https://rdar.apple.com/152182457">rdar://152182457</a>

Reviewed by Said Abou-Hallawa.

Added checks for any invalid geometry Leading to NaN.

* LayoutTests/fast/svg/path-NaN-bounding-box-crash-expected.txt: Added.
* LayoutTests/fast/svg/path-NaN-bounding-box-crash.html: Added.
* Source/WebCore/rendering/svg/SVGRenderSupport.cpp:
(WebCore::SVGRenderSupport::calculateApproximateStrokeBoundingBox):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.cpp:
(WebCore::LegacyRenderSVGShape::calculateStrokeBoundingBox const):

Canonical link: <a href="https://commits.webkit.org/296099@main">https://commits.webkit.org/296099@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c72f6e2427d7a6c57f83e18d75606953fb918dbc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/107196 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/26877 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/17278 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/112408 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/57733 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/109160 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/27555 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/35381 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/81374 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/110125 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/21857 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/96634 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/61742 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/21280 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/14765 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/57174 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | 
| | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/91208 "Build is in progress. Recent messages:OS: Sequoia (15.5), Xcode: 16.4; Running apply-patch; Checked out pull request; run-api-tests (cancelled)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/14787 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/115506 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/34261 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/25243 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/90437 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/34637 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/92889 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/90163 "Build is in progress. Recent messages:Printed configuration") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23021 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35068 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/12847 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/29991 "The change is no longer eligible for processing.") | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17362 "") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/34185 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/39689 "Built successfully") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/33931 "Build was cancelled. Recent messages:OS: Sequoia (15.5), Xcode: 16.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | | | 
| | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/37284 "Build is in progress. Recent messages:OS: Sequoia (15.5), Xcode: 16.4; Running apply-patch; Checked out pull request; Compiled WebKit (cancelled)") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/35588 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->