### PR TITLE
[JSC] Constant fold JSImmutableButterfly's length and do integer range optimization with constants

### DIFF
--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -2002,6 +2002,7 @@
 		E3555B8A1DAE03A500F36921 /* DOMJITCallDOMGetterSnippet.h in Headers */ = {isa = PBXBuildFile; fileRef = E3555B891DAE03A200F36921 /* DOMJITCallDOMGetterSnippet.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E355D38F22446877008F1AD6 /* GlobalExecutable.h in Headers */ = {isa = PBXBuildFile; fileRef = E355D38D2244686B008F1AD6 /* GlobalExecutable.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E356987222841187008CDCCB /* PackedCellPtr.h in Headers */ = {isa = PBXBuildFile; fileRef = E356987122841183008CDCCB /* PackedCellPtr.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		E359BBD92DF8CA6F0019830F /* DFGDesiredConstantProperties.h in Headers */ = {isa = PBXBuildFile; fileRef = E359BBD62DF8CA6F0019830F /* DFGDesiredConstantProperties.h */; };
 		E35A0B9D220AD87A00AC4474 /* ExecutableBaseInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = E35A0B9C220AD87A00AC4474 /* ExecutableBaseInlines.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E35B36072A2E981E004EC264 /* StringReplaceCacheInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = E35B36052A2E981E004EC264 /* StringReplaceCacheInlines.h */; };
 		E35B36082A2E981E004EC264 /* StringReplaceCache.h in Headers */ = {isa = PBXBuildFile; fileRef = E35B36062A2E981E004EC264 /* StringReplaceCache.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -5710,6 +5711,8 @@
 		E355D38D2244686B008F1AD6 /* GlobalExecutable.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GlobalExecutable.h; sourceTree = "<group>"; };
 		E355D38E2244686C008F1AD6 /* GlobalExecutable.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = GlobalExecutable.cpp; sourceTree = "<group>"; };
 		E356987122841183008CDCCB /* PackedCellPtr.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PackedCellPtr.h; sourceTree = "<group>"; };
+		E359BBD62DF8CA6F0019830F /* DFGDesiredConstantProperties.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = DFGDesiredConstantProperties.h; path = dfg/DFGDesiredConstantProperties.h; sourceTree = "<group>"; };
+		E359BBD72DF8CA6F0019830F /* DFGDesiredConstantProperties.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = DFGDesiredConstantProperties.cpp; path = dfg/DFGDesiredConstantProperties.cpp; sourceTree = "<group>"; };
 		E35A0B9C220AD87A00AC4474 /* ExecutableBaseInlines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ExecutableBaseInlines.h; sourceTree = "<group>"; };
 		E35B36052A2E981E004EC264 /* StringReplaceCacheInlines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StringReplaceCacheInlines.h; sourceTree = "<group>"; };
 		E35B36062A2E981E004EC264 /* StringReplaceCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StringReplaceCache.h; sourceTree = "<group>"; };
@@ -9201,6 +9204,8 @@
 				0FFFC94E14EF909500C72532 /* DFGCSEPhase.h */,
 				0F2FC77016E12F6F0038D976 /* DFGDCEPhase.cpp */,
 				0F2FC77116E12F6F0038D976 /* DFGDCEPhase.h */,
+				E359BBD72DF8CA6F0019830F /* DFGDesiredConstantProperties.cpp */,
+				E359BBD62DF8CA6F0019830F /* DFGDesiredConstantProperties.h */,
 				E3BFA5CB21E853A0009C0EBA /* DFGDesiredGlobalProperties.cpp */,
 				E3BFA5CC21E853A0009C0EBA /* DFGDesiredGlobalProperties.h */,
 				E3BFA5CD21E853A1009C0EBA /* DFGDesiredGlobalProperty.h */,
@@ -10747,6 +10752,7 @@
 				A7D89CF617A0B8CC00773AD8 /* DFGCriticalEdgeBreakingPhase.h in Headers */,
 				0FFFC95A14EF90A900C72532 /* DFGCSEPhase.h in Headers */,
 				0F2FC77316E12F740038D976 /* DFGDCEPhase.h in Headers */,
+				E359BBD92DF8CA6F0019830F /* DFGDesiredConstantProperties.h in Headers */,
 				E3BFA5D021E853A1009C0EBA /* DFGDesiredGlobalProperty.h in Headers */,
 				0F8F2B9A172F0501007DBDA5 /* DFGDesiredIdentifiers.h in Headers */,
 				C2C0F7CE17BBFC5B00464FE4 /* DFGDesiredTransitions.h in Headers */,

--- a/Source/JavaScriptCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/JavaScriptCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -33,6 +33,7 @@ dfg/DFGClobberize.h
 dfg/DFGCommonData.cpp
 dfg/DFGConstantFoldingPhase.cpp
 dfg/DFGDesiredGlobalProperties.cpp
+dfg/DFGDesiredConstantProperties.cpp
 dfg/DFGDesiredIdentifiers.cpp
 dfg/DFGDesiredWatchpoints.cpp
 dfg/DFGFixupPhase.cpp

--- a/Source/JavaScriptCore/Sources.txt
+++ b/Source/JavaScriptCore/Sources.txt
@@ -354,6 +354,7 @@ dfg/DFGConstantFoldingPhase.cpp
 dfg/DFGConstantHoistingPhase.cpp
 dfg/DFGCriticalEdgeBreakingPhase.cpp
 dfg/DFGDCEPhase.cpp
+dfg/DFGDesiredConstantProperties.cpp
 dfg/DFGDesiredGlobalProperties.cpp
 dfg/DFGDesiredIdentifiers.cpp
 dfg/DFGDesiredTransitions.cpp

--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
@@ -34,6 +34,7 @@
 #include "CheckPrivateBrandStatus.h"
 #include "DFGAbstractInterpreter.h"
 #include "DFGAbstractInterpreterClobberState.h"
+#include "DFGDesiredConstantProperties.h"
 #include "DOMJITGetterSetter.h"
 #include "DOMJITSignature.h"
 #include "FunctionPrototype.h"
@@ -4374,6 +4375,71 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
 
             if (constant.isString() && node->arrayMode().type() == Array::String) {
                 setConstant(node, jsNumber(asString(constant)->length()));
+                break;
+            }
+
+            if (auto result =
+                ([&]() -> std::optional<JSValue> {
+                    // Check the structure set is finite. This means that this constant's structure is watched and guaranteed the one of this set.
+                    // When the structure is changed, this code should be invalidated. This is important since the following code relies on the
+                    // constant object's is not changed.
+                    if (!abstractValue.m_structure.isFinite())
+                        return std::nullopt;
+
+                    JSValue arrayConstant = abstractValue.value();
+                    if (!arrayConstant)
+                        return std::nullopt;
+
+                    JSArray* array = jsDynamicCast<JSArray*>(arrayConstant);
+                    if (!array)
+                        return std::nullopt;
+
+                    // Check that the early StructureID is not nuked, get the butterfly, and check the late StructureID again.
+                    // And we check the indexing mode of the structure. If the indexing mode is CoW, the butterfly is
+                    // definitely JSImmutableButterfly.
+                    StructureID structureIDEarly = array->structureID();
+                    if (structureIDEarly.isNuked())
+                        return std::nullopt;
+
+                    if (arrayMode.arrayClass() != Array::OriginalCopyOnWriteArray)
+                        return std::nullopt;
+
+                    WTF::loadLoadFence();
+                    Butterfly* butterfly = array->butterfly();
+
+                    WTF::loadLoadFence();
+                    StructureID structureIDLate = array->structureID();
+
+                    if (structureIDEarly != structureIDLate)
+                        return std::nullopt;
+
+                    if (!butterfly)
+                        return std::nullopt;
+
+                    Structure* structure = structureIDLate.decode();
+                    switch (arrayMode.type()) {
+                    case Array::Int32:
+                    case Array::Contiguous:
+                    case Array::Double:
+                        if (structure->indexingMode() != (toIndexingShape(arrayMode.type()) | CopyOnWrite | IsArray))
+                            return std::nullopt;
+                        break;
+                    default:
+                        return std::nullopt;
+                    }
+                    ASSERT(isCopyOnWrite(structure->indexingMode()));
+                    if (abstractValue.m_structure.onlyStructure() != m_graph.registerStructure(structure))
+                        return std::nullopt;
+
+                    JSImmutableButterfly* immutableButterfly = JSImmutableButterfly::fromButterfly(butterfly);
+                    unsigned length = immutableButterfly->length();
+                    if (length > INT32_MAX)
+                        return std::nullopt;
+                    JSValue lengthValue = jsNumber(length);
+                    m_graph.m_plan.constantProperties().add(DesiredConstantProperties::Type::ImmutableButterflyLength, m_graph.freeze(immutableButterfly), m_graph.freeze(lengthValue));
+                    return lengthValue;
+                }())) {
+                setConstant(node, result.value());
                 break;
             }
         }

--- a/Source/JavaScriptCore/dfg/DFGDesiredConstantProperties.cpp
+++ b/Source/JavaScriptCore/dfg/DFGDesiredConstantProperties.cpp
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "DFGDesiredConstantProperties.h"
+
+#if ENABLE(DFG_JIT)
+
+#include "CodeBlock.h"
+#include "JSImmutableButterfly.h"
+
+namespace JSC { namespace DFG {
+
+DesiredConstantProperties::DesiredConstantProperties() = default;
+
+DesiredConstantProperties::~DesiredConstantProperties() = default;
+
+void DesiredConstantProperties::add(Type type, FrozenValue* base, FrozenValue* value)
+{
+    m_constantProperties.add({ base->cell(), JSValue::encode(value->value()), static_cast<std::underlying_type_t<Type>>(type) });
+}
+
+bool DesiredConstantProperties::reallyAdd(VM&, CommonData*)
+{
+    for (auto [base, encodedJSValue, type] : m_constantProperties) {
+        switch (static_cast<Type>(type)) {
+        case Type::ImmutableButterflyLength: {
+            auto* immutableButterfly = jsCast<JSImmutableButterfly*>(base);
+            JSValue value = JSValue::decode(encodedJSValue);
+            if (immutableButterfly->length() != static_cast<uint32_t>(value.asInt32()))
+                return false;
+            break;
+        }
+        case Type::None:
+            RELEASE_ASSERT_NOT_REACHED();
+            break;
+        }
+    }
+    return true;
+}
+
+} } // namespace JSC::DFG
+
+#endif // ENABLE(DFG_JIT)

--- a/Source/JavaScriptCore/dfg/DFGDesiredConstantProperties.h
+++ b/Source/JavaScriptCore/dfg/DFGDesiredConstantProperties.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(DFG_JIT)
+
+#include "DFGFrozenValue.h"
+#include <wtf/HashMap.h>
+
+namespace JSC {
+
+class CodeBlock;
+class VM;
+
+namespace DFG {
+
+class CommonData;
+
+class DesiredConstantProperties {
+public:
+    enum class Type : uint8_t {
+        None,
+        ImmutableButterflyLength,
+    };
+    using Entry = std::tuple<JSCell*, EncodedJSValue, uint8_t>;
+
+    DesiredConstantProperties();
+    ~DesiredConstantProperties();
+
+    void add(Type, FrozenValue* base, FrozenValue* value);
+    bool reallyAdd(VM&, CommonData*);
+
+private:
+    HashSet<Entry> m_constantProperties;
+};
+
+} } // namespace JSC::DFG
+
+#endif // ENABLE(DFG_JIT)

--- a/Source/JavaScriptCore/dfg/DFGIntegerRangeOptimizationPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGIntegerRangeOptimizationPhase.cpp
@@ -1420,22 +1420,49 @@ public:
                     auto iter = m_relationships.find(node->child1().node());
                     if (iter == m_relationships.end())
                         break;
-                    
+
                     bool nonNegative = false;
                     bool lessThanLength = false;
                     for (Relationship relationship : iter->value) {
                         if (relationship.minValueOfLeft() >= 0)
                             nonNegative = true;
-                        
+
                         if (relationship.right() == node->child2().node()) {
-                            if (relationship.kind() == Relationship::Equal
-                                && relationship.offset() < 0)
-                                lessThanLength = true;
-                            
-                            if (relationship.kind() == Relationship::LessThan
-                                && relationship.offset() <= 0)
-                                lessThanLength = true;
+                            if (relationship.kind() == Relationship::Equal) {
+                                if (relationship.offset() < 0)
+                                    lessThanLength = true;
+                            }
+
+                            if (relationship.kind() == Relationship::LessThan) {
+                                if (relationship.offset() <= 0)
+                                    lessThanLength = true;
+                            }
                         }
+
+                        if (relationship.right()->isInt32Constant() && node->child2()->isInt32Constant()) {
+                            int32_t right = relationship.right()->asInt32();
+                            int32_t bound = node->child2()->asInt32();
+                            // CheckInBounds: n < $bound
+                            //     where n == $right + $offset
+                            // Then, we can remove CheckInBounds if $right + $offset < $bound
+                            if (relationship.kind() == Relationship::Equal) {
+                                auto sum = checkedSum<int32_t>(right, relationship.offset());
+                                if (!sum.hasOverflowed() && sum.value() >= 0 && sum.value() < bound)
+                                    lessThanLength = true;
+                            }
+
+                            // CheckInBounds: n < $bound
+                            //     where n < $right + $offset
+                            // Then, we can remove CheckInBounds if $right + $offset <= $bound
+                            if (relationship.kind() == Relationship::LessThan) {
+                                auto sum = checkedSum<int32_t>(right, relationship.offset());
+                                if (!sum.hasOverflowed() && sum.value() >= 0 && sum.value() <= bound)
+                                    lessThanLength = true;
+                            }
+                        }
+
+                        if (nonNegative && lessThanLength)
+                            break;
                     }
 
                     dataLogLnIf(DFGIntegerRangeOptimizationPhaseInternal::verbose, "CheckInBounds ", node, " has: ", nonNegative, " ", lessThanLength);
@@ -1622,6 +1649,26 @@ private:
                             std::numeric_limits<int>::max() - offset + 1),
                         0);
                 }
+            }
+            break;
+        }
+
+        case ArithBitAnd: {
+            // We're only interested in int32 additions and we currently only know how to
+            // handle the non-wrapping ones.
+            if (!node->isBinaryInt32UseKind())
+                break;
+
+            // Handle bitAnd: @value & constant.
+            if (!node->child2()->isInt32Constant())
+                break;
+
+            int32_t mask = node->child2()->asInt32();
+            if (mask >= 0) {
+                setRelationship(Relationship(node, m_zero, Relationship::GreaterThan, -1));
+                if (mask != INT32_MAX)
+                    setRelationship(Relationship(node, m_zero, Relationship::LessThan, mask + 1));
+                break;
             }
             break;
         }

--- a/Source/JavaScriptCore/dfg/DFGPlan.cpp
+++ b/Source/JavaScriptCore/dfg/DFGPlan.cpp
@@ -180,6 +180,7 @@ void Plan::cancel()
     m_identifiers = DesiredIdentifiers();
     m_weakReferences = DesiredWeakReferences();
     m_transitions = DesiredTransitions();
+    m_constantProperties = DesiredConstantProperties();
     m_callback = nullptr;
 }
 
@@ -556,6 +557,8 @@ bool Plan::reallyAdd(CommonData* commonData)
     m_weakReferences.reallyAdd(*m_vm, commonData);
     m_transitions.reallyAdd(*m_vm, commonData);
     if (!m_watchpoints.reallyAdd(m_codeBlock, m_identifiers, commonData))
+        return false;
+    if (!m_constantProperties.reallyAdd(*m_vm, commonData))
         return false;
 
     commonData->recordedStatuses = WTFMove(m_recordedStatuses);

--- a/Source/JavaScriptCore/dfg/DFGPlan.h
+++ b/Source/JavaScriptCore/dfg/DFGPlan.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "CompilationResult.h"
+#include "DFGDesiredConstantProperties.h"
 #include "DFGDesiredGlobalProperties.h"
 #include "DFGDesiredIdentifiers.h"
 #include "DFGDesiredTransitions.h"
@@ -92,6 +93,7 @@ public:
     DesiredIdentifiers& identifiers() { return m_identifiers; }
     DesiredWeakReferences& weakReferences() { return m_weakReferences; }
     DesiredTransitions& transitions() { return m_transitions; }
+    DesiredConstantProperties& constantProperties() { return m_constantProperties; }
     RecordedStatuses& recordedStatuses() { return *m_recordedStatuses.get(); }
 
     bool willTryToTierUp() const { return m_willTryToTierUp; }
@@ -132,6 +134,7 @@ private:
     DesiredIdentifiers m_identifiers;
     DesiredWeakReferences m_weakReferences;
     DesiredTransitions m_transitions;
+    DesiredConstantProperties m_constantProperties;
     std::unique_ptr<RecordedStatuses> m_recordedStatuses;
 
     UncheckedKeyHashMap<BytecodeIndex, FixedVector<BytecodeIndex>> m_tierUpInLoopHierarchy;


### PR DESCRIPTION
#### bbeb011cde1cf4e94906c4e2f6a2f9a08fbf04d9
<pre>
[JSC] Constant fold JSImmutableButterfly&apos;s length and do integer range optimization with constants
<a href="https://bugs.webkit.org/show_bug.cgi?id=294279">https://bugs.webkit.org/show_bug.cgi?id=294279</a>
<a href="https://rdar.apple.com/152990326">rdar://152990326</a>

Reviewed by NOBODY (OOPS!).

This patch adds JSImmutableButterfly::length constant folding. When we
detect CoW array, we get length and ensure this is right value in DFGDesiredConstantProperties
on the main thread when finalizing so that we ensure that constant is
correct. Based on this, we extend integer range optimization to handle
CheckInBounds(@value, @constant) case well too. Also adding ArithBitAnd
based integer range relationship to use it in some code like,
`array[code &amp; 0xf7]`.

* Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj:
* Source/JavaScriptCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
* Source/JavaScriptCore/Sources.txt:
* Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h:
(JSC::DFG::AbstractInterpreter&lt;AbstractStateType&gt;::executeEffects):
* Source/JavaScriptCore/dfg/DFGDesiredConstantProperties.cpp: Added.
(JSC::DFG::DesiredConstantProperties::add):
(JSC::DFG::DesiredConstantProperties::reallyAdd):
* Source/JavaScriptCore/dfg/DFGDesiredConstantProperties.h: Added.
* Source/JavaScriptCore/dfg/DFGIntegerRangeOptimizationPhase.cpp:
* Source/JavaScriptCore/dfg/DFGPlan.cpp:
(JSC::DFG::Plan::cancel):
(JSC::DFG::Plan::reallyAdd):
* Source/JavaScriptCore/dfg/DFGPlan.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bbeb011cde1cf4e94906c4e2f6a2f9a08fbf04d9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/107282 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/26964 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/17368 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/112496 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/57816 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/27645 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/35464 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/81439 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/110211 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/21912 "Found 3 new test failures: fast/events/ios/select-all-with-existing-selection.html webgl/1.0.x/conformance/textures/misc/gl-teximage.html webgl/2.0.y/conformance/textures/misc/gl-teximage.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/96695 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/61811 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/21341 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/14829 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/57261 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/99871 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/91271 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/14859 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/115597 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/105828 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/34348 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/25310 "Found 1 new test failure: imported/w3c/web-platform-tests/fetch/api/response/response-cancel-stream.any.worker.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/90480 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/34724 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/92945 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/90214 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35121 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/12908 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/30078 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/34270 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/39799 "Failed to build and analyze WebKit") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/130145 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34016 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/35398 "Found 1 new JSC stress test failure: wasm.yaml/wasm/gc/ref-i31-eq.js.wasm-collect-continuously (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/37371 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/35677 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->