### PR TITLE
WebKit Content Blockers: CSS display none that matches everything still applied even after a ignore-following-rules action was matched

### DIFF
--- a/Source/WebCore/contentextensions/ContentExtension.cpp
+++ b/Source/WebCore/contentextensions/ContentExtension.cpp
@@ -55,12 +55,12 @@ ContentExtension::ContentExtension(const String& identifier, Ref<CompiledContent
     m_universalActions.shrinkToFit();
 }
 
-uint32_t ContentExtension::findFirstIgnorePreviousRules() const
+uint32_t ContentExtension::findFirstIgnoreRule() const
 {
     auto serializedActions = m_compiledExtension->serializedActions();
     uint32_t currentActionIndex = 0;
     while (currentActionIndex < serializedActions.size()) {
-        if (serializedActions[currentActionIndex] == WTF::alternativeIndexV<IgnorePreviousRulesAction, ActionData>)
+        if (serializedActions[currentActionIndex] == WTF::alternativeIndexV<IgnorePreviousRulesAction, ActionData> || serializedActions[currentActionIndex] == WTF::alternativeIndexV<IgnoreFollowingRulesAction, ActionData>)
             return currentActionIndex;
         currentActionIndex += DeserializedAction::serializedLength(serializedActions, currentActionIndex);
     }
@@ -74,16 +74,16 @@ StyleSheetContents* ContentExtension::globalDisplayNoneStyleSheet()
 
 void ContentExtension::compileGlobalDisplayNoneStyleSheet()
 {
-    uint32_t firstIgnorePreviousRules = findFirstIgnorePreviousRules();
-    
+    uint32_t firstIgnoreRule = findFirstIgnoreRule();
+
     auto serializedActions = m_compiledExtension->serializedActions();
 
     auto inGlobalDisplayNoneStyleSheet = [&](const uint32_t location) {
         auto serializedActionSize = serializedActions.size();
         RELEASE_ASSERT(location < serializedActionSize, location, serializedActionSize);
-        return location < firstIgnorePreviousRules && serializedActions[location] == WTF::alternativeIndexV<CSSDisplayNoneSelectorAction, ActionData>;
+        return location < firstIgnoreRule && serializedActions[location] == WTF::alternativeIndexV<CSSDisplayNoneSelectorAction, ActionData>;
     };
-    
+
     StringBuilder css;
     for (uint64_t universalActionLocation : m_universalActions) {
         if (inGlobalDisplayNoneStyleSheet(universalActionLocation)) {

--- a/Source/WebCore/contentextensions/ContentExtension.h
+++ b/Source/WebCore/contentextensions/ContentExtension.h
@@ -54,7 +54,7 @@ public:
 
 private:
     ContentExtension(const String& identifier, Ref<CompiledContentExtension>&&, URL&&, ShouldCompileCSS);
-    uint32_t findFirstIgnorePreviousRules() const;
+    uint32_t findFirstIgnoreRule() const;
     
     String m_identifier;
     const Ref<CompiledContentExtension> m_compiledExtension;


### PR DESCRIPTION
#### d6b06ef9d0a8df37b5bd1ae0b755a37dba8061d9
<pre>
WebKit Content Blockers: CSS display none that matches everything still applied even after a ignore-following-rules action was matched
<a href="https://bugs.webkit.org/show_bug.cgi?id=294281">https://bugs.webkit.org/show_bug.cgi?id=294281</a>
<a href="https://rdar.apple.com/152996225">rdar://152996225</a>

Reviewed by Alex Christensen.

This patch fixes a bug where a global css-display-none rule would still be
applied after an ignore-following-rules rule. The fix is to only include the
global css-display-none rules in the global stylesheet until *either* an ignore-
previous-rules or ignore-following-rules rule is encountered.

Additionally, wrote a lot more tests for ignore-following-rules.

* Source/WebCore/contentextensions/ContentExtension.cpp:
(WebCore::ContentExtensions::ContentExtension::findFirstIgnoreRule const):
(WebCore::ContentExtensions::ContentExtension::compileGlobalDisplayNoneStyleSheet):
(WebCore::ContentExtensions::ContentExtension::findFirstIgnorePreviousRules const): Deleted.
* Source/WebCore/contentextensions/ContentExtension.h:
* Tools/TestWebKitAPI/Tests/WebCore/ContentExtensions.cpp:
(TestWebKitAPI::TEST_F(ContentExtensionTest, IgnoreFollowingRules)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ContentRuleListNotification.mm:
(TEST(ContentRuleList, DisplayNoneAfterIgnoreFollowingRules)):

Canonical link: <a href="https://commits.webkit.org/296149@main">https://commits.webkit.org/296149@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/575772ee8eb7d8f95a8ef4a46f9730a101d8f185

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/107415 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27097 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/17502 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/112629 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/57951 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/109379 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/27780 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/35597 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/81541 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/110344 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22007 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/96817 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/61916 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/21448 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/14948 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/57395 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/91377 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/14982 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/115730 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/34482 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/25417 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/90584 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/34857 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93066 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/90321 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35232 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13021 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/30225 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17388 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/34403 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/39944 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34149 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/37504 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/35810 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->