### PR TITLE
[Site Isolation] DrawingArea of RemotePageProxy can be out-of-sync

### DIFF
--- a/Source/WebKit/UIProcess/BrowsingContextGroup.h
+++ b/Source/WebKit/UIProcess/BrowsingContextGroup.h
@@ -36,6 +36,7 @@ class Connection;
 
 namespace WebKit {
 
+class DrawingAreaProxy;
 class FrameProcess;
 class ProvisionalPageProxy;
 class RemotePageProxy;
@@ -60,6 +61,9 @@ public:
     void addPage(WebPageProxy&);
     void addRemotePage(WebPageProxy&, Ref<RemotePageProxy>&&);
     void removePage(WebPageProxy&);
+    void addProvisionalPage(ProvisionalPageProxy&);
+    void removeProvisionalPage(ProvisionalPageProxy&);
+    void commitProvisionalPage(ProvisionalPageProxy&);
     void forEachRemotePage(const WebPageProxy&, Function<void(RemotePageProxy&)>&&);
 
     RemotePageProxy* remotePageInProcess(const WebPageProxy&, const WebProcessProxy&);
@@ -76,6 +80,7 @@ private:
     HashMap<WebCore::Site, WeakPtr<FrameProcess>> m_processMap;
     WeakListHashSet<WebPageProxy> m_pages;
     WeakHashMap<WebPageProxy, HashSet<Ref<RemotePageProxy>>> m_remotePages;
+    WeakHashMap<WebPageProxy, HashSet<Ref<RemotePageProxy>>> m_provisionalRemotePages;
 };
 
 }

--- a/Source/WebKit/UIProcess/ProvisionalPageProxy.h
+++ b/Source/WebKit/UIProcess/ProvisionalPageProxy.h
@@ -157,6 +157,8 @@ public:
 
     bool needsMainFrameObserver() const { return m_needsMainFrameObserver; }
 
+    URL requestURL() const { return m_request.url(); }
+
 private:
     ProvisionalPageProxy(WebPageProxy&, Ref<FrameProcess>&&, BrowsingContextGroup&, RefPtr<SuspendedPageProxy>&&, API::Navigation&, bool isServerRedirect, const WebCore::ResourceRequest&, ProcessSwapRequestedByClient, bool isProcessSwappingOnNavigationResponse, API::WebsitePolicies*, WebsiteDataStore* replacedDataStoreForWebArchiveLoad = nullptr);
 

--- a/Source/WebKit/UIProcess/RemotePageDrawingAreaProxy.h
+++ b/Source/WebKit/UIProcess/RemotePageDrawingAreaProxy.h
@@ -47,6 +47,7 @@ public:
 
     WebProcessProxy& process() { return m_process; }
     Ref<WebProcessProxy> protectedProcess();
+    DrawingAreaIdentifier identifier() const { return m_identifier; }
 
 private:
     RemotePageDrawingAreaProxy(DrawingAreaProxy&, WebProcessProxy&);

--- a/Source/WebKit/UIProcess/RemotePageProxy.h
+++ b/Source/WebKit/UIProcess/RemotePageProxy.h
@@ -60,6 +60,7 @@ using MediaProducerMediaStateFlags = OptionSet<MediaProducerMediaState>;
 namespace WebKit {
 
 class NativeWebMouseEvent;
+class ProvisionalPageProxy;
 class RemotePageDrawingAreaProxy;
 class RemotePageFullscreenManagerProxy;
 class RemotePageVisitedLinkStoreRegistration;
@@ -78,7 +79,7 @@ enum class ProcessTerminationReason : uint8_t;
 class RemotePageProxy : public IPC::MessageReceiver, public RefCounted<RemotePageProxy> {
     WTF_MAKE_TZONE_ALLOCATED(RemotePageProxy);
 public:
-    static Ref<RemotePageProxy> create(WebPageProxy&, WebProcessProxy&, const WebCore::Site&, WebPageProxyMessageReceiverRegistration* = nullptr, std::optional<WebCore::PageIdentifier> = std::nullopt);
+    static Ref<RemotePageProxy> create(WebPageProxy&, WebCore::PageIdentifier trackingWebPageID, WebProcessProxy&, const WebCore::Site&, WebPageProxyMessageReceiverRegistration* = nullptr, std::optional<WebCore::PageIdentifier> = std::nullopt);
     ~RemotePageProxy();
 
     void ref() const final { RefCounted::ref(); }
@@ -88,6 +89,7 @@ public:
     RefPtr<WebPageProxy> protectedPage() const;
 
     void injectPageIntoNewProcess();
+    void injectProvisionalPageIntoProcess(ProvisionalPageProxy&);
     void processDidTerminate(WebProcessProxy&, ProcessTerminationReason);
 
     WebPageProxyMessageReceiverRegistration& messageReceiverRegistration() { return m_messageReceiverRegistration; }
@@ -96,6 +98,7 @@ public:
     Ref<WebProcessProxy> protectedProcess() const;
     WebProcessProxy& siteIsolatedProcess() const { return m_process.get(); }
     WebCore::PageIdentifier pageID() const { return m_webPageID; } // FIXME: Remove this in favor of identifierInSiteIsolatedProcess.
+    WebCore::PageIdentifier trackingWebPageID() const { return m_trackingWebPageID; }
     WebCore::PageIdentifier identifierInSiteIsolatedProcess() const { return m_webPageID; }
     const WebCore::Site& site() const { return m_site; }
 
@@ -104,7 +107,7 @@ public:
     WebCore::MediaProducerMediaStateFlags mediaState() const { return m_mediaState; }
 
 private:
-    RemotePageProxy(WebPageProxy&, WebProcessProxy&, const WebCore::Site&, WebPageProxyMessageReceiverRegistration*, std::optional<WebCore::PageIdentifier>);
+    RemotePageProxy(WebPageProxy&, WebCore::PageIdentifier trackingWebPageID, WebProcessProxy&, const WebCore::Site&, WebPageProxyMessageReceiverRegistration*, std::optional<WebCore::PageIdentifier>);
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
     bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) final;
     void isPlayingMediaDidChange(WebCore::MediaProducerMediaStateFlags);
@@ -112,6 +115,7 @@ private:
     const WebCore::PageIdentifier m_webPageID;
     const Ref<WebProcessProxy> m_process;
     const WeakPtr<WebPageProxy> m_page;
+    const WebCore::PageIdentifier m_trackingWebPageID;
     const WebCore::Site m_site;
     const UniqueRef<WebProcessActivityState> m_processActivityState;
     RefPtr<RemotePageDrawingAreaProxy> m_drawingArea;

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -1515,6 +1515,7 @@ void WebPageProxy::swapToProvisionalPage(Ref<ProvisionalPageProxy>&& provisional
     // FIXME: Think about what to do if the provisional page didn't get its browsing context group from the SuspendedPageProxy.
     // We do need to clear it at some point for navigations that aren't from back/forward navigations. Probably in the same place as PSON?
     setBrowsingContextGroup(provisionalPage->protectedBrowsingContextGroup());
+    m_browsingContextGroup->commitProvisionalPage(provisionalPage.get());
 
     protectedLegacyMainFrameProcess()->addExistingWebPage(*this, WebProcessProxy::BeginsUsingDataStore::No);
     addAllMessageReceivers();

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm
@@ -4942,4 +4942,38 @@ TEST(SiteIsolation, FramesDuringProvisionalNavigation)
     });
 }
 
+TEST(SiteIsolation, DoAfterNextPresentationUpdate)
+{
+    HTTPServer server({
+        { "/main"_s, { "<iframe src='https://webkit2.org/text'></iframe></iframe><iframe src='https://webkit3.org/text'></iframe>"_s } },
+        { "/navigatefrom"_s, { "<script>window.location='https://webkit2.org/navigateto'</script>"_s } },
+        { "/navigateto"_s, { "<iframe src='https://webkit1.org/alert'></iframe>"_s } },
+        { "/alert"_s, { "<script>alert('loaded')</script>"_s } },
+        { "/text"_s, { "hi"_s } }
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto webViewAndDelegates = makeWebViewAndDelegates(server);
+    RetainPtr webView = webViewAndDelegates.webView;
+    RetainPtr navigationDelegate = webViewAndDelegates.navigationDelegate;
+    RetainPtr uiDelegate = webViewAndDelegates.uiDelegate;
+    RetainPtr<WKWebView> openedWebView;
+    uiDelegate.get().createWebViewWithConfiguration = [&](WKWebViewConfiguration *configuration, WKNavigationAction *action, WKWindowFeatures *windowFeatures) {
+        openedWebView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration]);
+        openedWebView.get().navigationDelegate = navigationDelegate.get();
+        openedWebView.get().UIDelegate = uiDelegate.get();
+        return openedWebView.get();
+    };
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://webkit1.org/main"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    [webView evaluateJavaScript:@"window.open('https://webkit1.org/navigatefrom')" completionHandler:nil];
+    EXPECT_WK_STREQ([uiDelegate waitForAlert], "loaded");
+
+    __block bool done = false;
+    [openedWebView _doAfterNextPresentationUpdate:^{
+        done = true;
+    }];
+    Util::run(&done);
+}
+
 }


### PR DESCRIPTION
#### 32aa700f588e4a2d202a9d7d20eaae6f420f390f
<pre>
[Site Isolation] DrawingArea of RemotePageProxy can be out-of-sync
<a href="https://bugs.webkit.org/show_bug.cgi?id=294282">https://bugs.webkit.org/show_bug.cgi?id=294282</a>

Reviewed by NOBODY (OOPS!).

WIP.

* Source/WebKit/UIProcess/BrowsingContextGroup.cpp:
(WebKit::BrowsingContextGroup::addFrameProcessAndInjectPageContextIf):
(WebKit::BrowsingContextGroup::addPage):
(WebKit::BrowsingContextGroup::addProvisionalPage):
(WebKit::BrowsingContextGroup::removeProvisionalPage):
(WebKit::BrowsingContextGroup::commitProvisionalPage):
(WebKit::BrowsingContextGroup::transitionPageToRemotePage):
(WebKit::BrowsingContextGroup::transitionProvisionalPageToRemotePage):
* Source/WebKit/UIProcess/BrowsingContextGroup.h:
* Source/WebKit/UIProcess/ProvisionalPageProxy.cpp:
(WebKit::ProvisionalPageProxy::ProvisionalPageProxy):
(WebKit::ProvisionalPageProxy::initializeWebPage):
(WebKit::ProvisionalPageProxy::didFailProvisionalLoadForFrame):
(WebKit::ProvisionalPageProxy::didCommitLoadForFrame):
* Source/WebKit/UIProcess/ProvisionalPageProxy.h:
* Source/WebKit/UIProcess/RemotePageDrawingAreaProxy.h:
(WebKit::RemotePageDrawingAreaProxy::identifier const):
* Source/WebKit/UIProcess/RemotePageProxy.cpp:
(WebKit::RemotePageProxy::create):
(WebKit::RemotePageProxy::RemotePageProxy):
(WebKit::RemotePageProxy::injectProvisionalPageIntoProcess):
* Source/WebKit/UIProcess/RemotePageProxy.h:
(WebKit::RemotePageProxy::trackingWebPageID const):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::swapToProvisionalPage):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm:
(TestWebKitAPI::(SiteIsolation, DoAfterNextPresentationUpdate)):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/32aa700f588e4a2d202a9d7d20eaae6f420f390f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/107242 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/26924 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/17328 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/112456 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/57775 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/109206 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/27605 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/35424 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/81405 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/110171 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/21883 "Found 5 new test failures: fast/events/ios/select-all-with-existing-selection.html http/tests/site-isolation/frame-access-after-window-open.html http/tests/site-isolation/iframe-and-window-open.html http/tests/site-isolation/window-open-with-name-cross-site.html http/tests/site-isolation/window-open-with-name.html (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/96657 "Found 14 new API test failures: TestWebKitAPI.SiteIsolation.PresentationUpdateAfterCrossSiteNavigation, TestWebKitAPI.SiteIsolation.LoadStringAfterOpen, TestWebKitAPI.SiteIsolation.ParentOpener, TestWebKitAPI.SiteIsolation.FocusOpenedWindow, TestWebKitAPI.SiteIsolation.WindowOpenRedirect, TestWebKitAPI.SiteIsolation.LoadHTMLString, TestWebKitAPI.SiteIsolation.ClosedStatePropagation, TestWebKitAPI.SiteIsolation.CloseAfterWindowOpen, TestWebKitAPI.SiteIsolation.OpenedWindowFocusDelegates, TestWebKitAPI.SiteIsolation.DrawAfterNavigateToDomainAgain ... (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/61773 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/21309 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/14791 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/57221 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/91238 "Found 13 new API test failures: TestWebKitAPI.SiteIsolation.PresentationUpdateAfterCrossSiteNavigation, TestWebKitAPI.SiteIsolation.LoadStringAfterOpen, TestWebKitAPI.SiteIsolation.ParentOpener, TestWebKitAPI.SiteIsolation.FocusOpenedWindow, TestWebKitAPI.SiteIsolation.WindowOpenRedirect, TestWebKitAPI.SiteIsolation.LoadHTMLString, TestWebKitAPI.SiteIsolation.ClosedStatePropagation, TestWebKitAPI.SiteIsolation.CloseAfterWindowOpen, TestWebKitAPI.SiteIsolation.DrawAfterNavigateToDomainAgain, TestWebKitAPI.SiteIsolation.NavigationAfterWindowOpen ... (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/14820 "Found 4 new test failures: http/tests/site-isolation/frame-access-after-window-open.html http/tests/site-isolation/iframe-and-window-open.html http/tests/site-isolation/window-open-with-name-cross-site.html http/tests/site-isolation/window-open-with-name.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/115556 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/34308 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/25276 "Found 5 new test failures: http/tests/site-isolation/document-access.html http/tests/site-isolation/frame-access-after-window-open.html http/tests/site-isolation/iframe-and-window-open.html http/tests/site-isolation/iframe-top-level-navigation.html http/tests/site-isolation/window-open-with-name.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/90450 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/34684 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/92905 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/90181 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35090 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/12870 "Found 4 new test failures: http/tests/site-isolation/frame-access-after-window-open.html http/tests/site-isolation/iframe-and-window-open.html http/tests/site-isolation/window-open-with-name-cross-site.html http/tests/site-isolation/window-open-with-name.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/30038 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/34230 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/39722 "Found 2 new failures in UIProcess/BrowsingContextGroup.cpp") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/33976 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/37331 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/35632 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->