### PR TITLE
REGRESSION (293295@main): Missing UI in Logic Pro UAD plugins

### DIFF
--- a/LayoutTests/fast/css/relative-url-in-style-in-template-expected.txt
+++ b/LayoutTests/fast/css/relative-url-in-style-in-template-expected.txt
@@ -1,0 +1,4 @@
+
+PASS Cloning a template via document fragment
+PASS Cloning a template via element
+

--- a/LayoutTests/fast/css/relative-url-in-style-in-template.html
+++ b/LayoutTests/fast/css/relative-url-in-style-in-template.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+</head>
+<body>
+<template>
+    <div class="container" style="background-image: url('resources/green-128x128.png');"></div>
+</template>
+<div id="container">
+  <div id="target"></div>
+</div>
+<script>
+
+test(() => {
+  const template = document.querySelector("template");
+
+  document.body.appendChild(template.content.cloneNode(true));
+  const viaFragment = document.body.lastElementChild;
+
+  const resolved = new URL("resources/green-128x128.png", document.URL).href;
+
+  assert_equals(viaFragment.style.backgroundImage, `url("resources/green-128x128.png")`)
+  assert_equals(window.getComputedStyle(viaFragment).backgroundImage, `url("${resolved}")`)
+}, "Cloning a template via document fragment");
+
+test(() => {
+  const template = document.querySelector("template");
+
+  document.body.appendChild(template.content.children[0]);
+  const viaElement = document.body.lastElementChild;
+
+  const resolved = new URL("resources/green-128x128.png", document.URL).href;
+
+  assert_equals(viaElement.style.backgroundImage, `url("resources/green-128x128.png")`)
+  assert_equals(window.getComputedStyle(viaElement).backgroundImage, `url("${resolved}")`)
+}, "Cloning a template via element");
+
+</script>
+</body>
+</html>

--- a/Source/WebCore/css/values/primitives/CSSURL.cpp
+++ b/Source/WebCore/css/values/primitives/CSSURL.cpp
@@ -73,7 +73,7 @@ static URL completeURL(const String& string, const WTF::URL& baseURL)
 {
     if (string.isEmpty() || string.startsWith('#'))
         return URL { .specified = string, .resolved = WTF::URL { string }, .modifiers = { } };
-    if (baseURL.isNull())
+    if (baseURL.isNull() || baseURL.isAboutBlank())
         return URL { .specified = string, .resolved = WTF::URL { }, .modifiers = { } };
     return URL { .specified = string, .resolved = WTF::URL { baseURL, string }, .modifiers = { } };
 }


### PR DESCRIPTION
#### ac7bad8bf1526493adbca75380667018b8cd7983
<pre>
REGRESSION (293295@main): Missing UI in Logic Pro UAD plugins
<a href="https://bugs.webkit.org/show_bug.cgi?id=294219">https://bugs.webkit.org/show_bug.cgi?id=294219</a>

Reviewed by Wenson Hsieh.

When parsing CSS URL values, treat a base URL of about:blank, implicitly used
for templates, the same as a null base URL. This allows late re-resolving of
the URL value at style building time, which will happen after the template is
cloned and instantiated.

* LayoutTests/fast/css/relative-url-in-style-in-template-expected.txt: Added.
* LayoutTests/fast/css/relative-url-in-style-in-template.html: Added.
* Source/WebCore/css/values/primitives/CSSURL.cpp:
(WebCore::CSS::completeURL):

Canonical link: <a href="https://commits.webkit.org/296076@main">https://commits.webkit.org/296076@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ffdbdcca26664c680810e487ed2315d1853fe48f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/107245 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/26927 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/17331 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/112459 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/57778 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/109209 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/27608 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/35427 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/81408 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/110174 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/21887 "Found 3 new test failures: fast/events/ios/select-all-with-existing-selection.html webgl/1.0.x/conformance/textures/misc/gl-teximage.html webgl/2.0.y/conformance/textures/misc/gl-teximage.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/96664 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/61776 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/21313 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/14798 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/57224 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/91242 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/14827 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/115559 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/34311 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/25281 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/90453 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/34687 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/92912 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/90184 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23004 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35097 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/12876 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/30041 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/34233 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/39725 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/33979 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/37334 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/35635 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->