### PR TITLE
Allow focusing into cross-origin iframes that have never had user interaction if currently processing a user interaction

### DIFF
--- a/LayoutTests/http/tests/dom/focus-in-cross-origin-iframe-expected.txt
+++ b/LayoutTests/http/tests/dom/focus-in-cross-origin-iframe-expected.txt
@@ -1,0 +1,4 @@
+DIV with tabindex 1
+
+
+PASSED

--- a/LayoutTests/http/tests/dom/focus-in-cross-origin-iframe.html
+++ b/LayoutTests/http/tests/dom/focus-in-cross-origin-iframe.html
@@ -1,0 +1,35 @@
+<script src="/js-test-resources/ui-helper.js"></script>
+
+<script>
+
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+window.addEventListener("message", (event) => {
+	document.getElementById("result").innerText = event.data;
+	if (window.testRunner)
+		testRunner.notifyDone()
+})
+
+function startTest()
+{
+	if (!eventSender)
+		return
+		
+	UIHelper.keyDown("\t")
+	UIHelper.keyDown("\t")
+
+	window.frames[0].postMessage("RunTest", "http://localhost:8000")	
+}
+
+// With the bug, tabbing twice will choose the DIV from inside the cross origin iframe, but fail to *actually focus it*
+// because the iframe had never seen interaction.
+// After the fix, the fact that the focus is happening via `tab` key presses counts as user interaction, and the div
+// inside the frame *is* focused.
+
+</script>
+<div tabindex="1">DIV with tabindex 1</div><br>
+<iframe onload="startTest()" src="http://localhost:8000/dom/resources/focus-in-cross-origin-iframe-iframe.html"></iframe><br>
+<div id="result">FAILED</div>

--- a/LayoutTests/http/tests/dom/resources/focus-in-cross-origin-iframe-iframe.html
+++ b/LayoutTests/http/tests/dom/resources/focus-in-cross-origin-iframe-iframe.html
@@ -1,0 +1,18 @@
+<script>
+
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+window.addEventListener("message", (event) => {
+	if (document.activeElement == document.getElementById("targetElement"))
+		event.source.postMessage("PASSED", "http://127.0.0.1:8000");
+	else
+		event.source.postMessage("FAILED", "http://127.0.0.1:8000");
+
+});
+
+</script>
+<div id="targetElement" tabindex="1">iframe DIV with tabindex 1</div><br>
+	

--- a/LayoutTests/platform/ios/http/tests/dom/focus-in-cross-origin-iframe-expected.txt
+++ b/LayoutTests/platform/ios/http/tests/dom/focus-in-cross-origin-iframe-expected.txt
@@ -1,0 +1,4 @@
+DIV with tabindex 1
+
+
+FAILED

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -4073,7 +4073,7 @@ void Element::focus(const FocusOptions& options)
 
     if (RefPtr page = document->page()) {
         Ref frame = *document->frame();
-        if (!frame->hasHadUserInteraction() && !frame->isMainFrame() && !document->topOrigin().isSameOriginDomain(document->securityOrigin()))
+        if (!frame->hasHadUserInteraction() && !UserGestureIndicator::processingUserGesture() && !frame->isMainFrame() && !document->topOrigin().isSameOriginDomain(document->securityOrigin()))
             return;
 
         FocusOptions optionsWithVisibility = options;


### PR DESCRIPTION
#### a513eb610e7a089a5c5b2d1904ac661a1f68ede9
<pre>
Allow focusing into cross-origin iframes that have never had user interaction if currently processing a user interaction
<a href="https://rdar.apple.com/153007151">rdar://153007151</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=294296">https://bugs.webkit.org/show_bug.cgi?id=294296</a>

Reviewed by Ryosuke Niwa and Alex Christensen.

When tabbing through a document, you might reach the end of the current frame&apos;s focusable elements
and dig into an iframe to find the first focusable one there.

When we do this today, if the iframe is cross-origin and has never been interacted with, we find
the element but refuse to actually focus it.

This makes sense to prevent programatic JS focus into a cross-origin iframe, but does not make sense
when the user is driving the focusing themselves (e.g. pressing tab)

Making this change matches other browsers.

* LayoutTests/http/tests/dom/focus-in-cross-origin-iframe-expected.txt: Added.
* LayoutTests/http/tests/dom/focus-in-cross-origin-iframe.html: Added.
* LayoutTests/http/tests/dom/resources/focus-in-cross-origin-iframe-iframe.html: Added.

* Source/WebCore/dom/Element.cpp:
(WebCore::Element::focus): Add an &quot;is NOT processing user gesture&quot; qualification to the early return for
  focus into a cross-origin iframe.

Canonical link: <a href="https://commits.webkit.org/296110@main">https://commits.webkit.org/296110@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c23df231c40ded80641dec02c4f4a1693d0ee533

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/107391 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27073 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/17477 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/112605 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/57927 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/109355 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/27755 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/35573 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/81522 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/57927 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/110320 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/21987 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/96792 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/61897 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/21427 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/14923 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/57371 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/91356 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/14957 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/115706 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/34457 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/25396 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/90563 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/34833 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93041 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/90300 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23027 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35210 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/12999 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/30201 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/34379 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/39920 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34125 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/37480 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/35786 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->