### PR TITLE
Calling scripting.registerContentScripts() sometimes returns the error: "Error: Invalid call to scripting.registerContentScripts(). Failed to add content script."

### DIFF
--- a/Source/WebKit/Shared/Extensions/_WKWebExtensionRegisteredScriptsSQLiteStore.mm
+++ b/Source/WebKit/Shared/Extensions/_WKWebExtensionRegisteredScriptsSQLiteStore.mm
@@ -202,7 +202,7 @@ static NSString *rowFilterStringFromRowKeys(NSArray *keys)
 
 - (NSArray *)_getKeysAndValuesFromRowEnumerator:(_WKWebExtensionSQLiteRowEnumerator *)rows
 {
-    static NSSet *allowedClasses = [NSSet setWithObjects:NSString.class, NSArray.class, NSMutableDictionary.class, nil];
+    static NSSet *allowedClasses = [NSSet setWithObjects:NSString.class, NSNumber.class, NSArray.class, NSMutableDictionary.class, nil];
 
     NSMutableArray<NSDictionary<NSString *, id> *> *scripts = [NSMutableArray array];
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIScripting.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIScripting.mm
@@ -1235,6 +1235,71 @@ TEST(WKWebExtensionAPIScripting, RegisteredScriptIsInjectedAfterContextReloads)
     [manager run];
 }
 
+TEST(WKWebExtensionAPIScripting, PersistentRegisteredScriptIsInjectedAfterContextReloads)
+{
+    TestWebKitAPI::HTTPServer server({
+        { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } }
+    }, TestWebKitAPI::HTTPServer::Protocol::Http);
+
+    auto *backgroundScript = Util::constructScript(@[
+        @"browser.webNavigation.onCompleted.addListener(async (details) => {",
+        @"  const pinkValue = 'rgb(255, 192, 203)'",
+        @"  function getBackgroundColor() { return window.getComputedStyle(document.body).getPropertyValue('background-color') }",
+
+        @"  let results = await browser.scripting.executeScript({ target: { tabId: details.tabId, allFrames: false }, func: getBackgroundColor })",
+        @"  browser.test.assertEq(results?.[0]?.result, pinkValue)",
+
+        @"  browser.test.notifyPass()",
+        @"})",
+
+        @"let registeredScripts = await browser.scripting.getRegisteredContentScripts()",
+        @"if (!registeredScripts.length) {",
+        @"  await browser.scripting.registerContentScripts([{ id: '1', matches: [ '*://localhost/*' ], js: [ 'changeBackgroundColorScript.js' ], 'allFrames': true, 'persistAcrossSessions': true }])",
+
+        @"  registeredScripts = await browser.scripting.getRegisteredContentScripts()",
+        @"  browser.test.assertEq(registeredScripts.length, 1)",
+
+        @"  browser.test.sendMessage('Unload extension')",
+        @"} else {",
+        @"  browser.test.assertEq(registeredScripts.length, 1)",
+
+        @"  browser.test.sendMessage('Load Tab')",
+        @"}"
+    ]);
+
+    static auto *resources = @{
+        @"background.js": backgroundScript,
+        @"changeBackgroundColorScript.js": changeBackgroundColorScript,
+    };
+
+    auto manager = Util::parseExtension(scriptingManifest, resources, WKWebExtensionControllerConfiguration._temporaryConfiguration);
+
+    // Give the extension a unique identifier so it opts into saving data in the temporary configuration.
+    manager.get().context.uniqueIdentifier = @"org.webkit.test.extension (76C788B8)";
+
+    EXPECT_FALSE(manager.get().context.hasInjectedContent);
+
+    [manager load];
+    [manager runUntilTestMessage:@"Unload extension"];
+
+    EXPECT_TRUE(manager.get().context.hasInjectedContent);
+
+    [manager unload];
+
+    EXPECT_FALSE(manager.get().context.hasInjectedContent);
+
+    [manager load];
+    [manager runUntilTestMessage:@"Load Tab"];
+
+    EXPECT_TRUE(manager.get().context.hasInjectedContent);
+
+    auto *urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+    [manager.get().defaultTab.webView loadRequest:urlRequest];
+
+    [manager run];
+}
+
 TEST(WKWebExtensionAPIScripting, RegisteredScriptExcludeMatches)
 {
     TestWebKitAPI::HTTPServer server({


### PR DESCRIPTION
#### c8d987888268e34c950756d816d0fdcb96c98119
<pre>
Calling scripting.registerContentScripts() sometimes returns the error: &quot;Error: Invalid call to scripting.registerContentScripts(). Failed to add content script.&quot;
<a href="https://bugs.webkit.org/show_bug.cgi?id=294298">https://bugs.webkit.org/show_bug.cgi?id=294298</a>
<a href="https://rdar.apple.com/153001967">rdar://153001967</a>

Reviewed by Brian Weinstein.

This patch fixes a bug where quitting and relaunching Safari would cause
registered content scripts to fail to load. This was happening because we were
missing NSNumber as an allowed class to be passed into +[NSKeyedUnarchiver
unarchivedObjectOfClasses:fromData:error:].

Wrote a new test to validate this fix.

* Source/WebKit/Shared/Extensions/_WKWebExtensionRegisteredScriptsSQLiteStore.mm:
(-[_WKWebExtensionRegisteredScriptsSQLiteStore _getKeysAndValuesFromRowEnumerator:]):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIScripting.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPIScripting, RegisteredScriptIsInjectedAfterContextReloads)):
(TestWebKitAPI::TEST(WKWebExtensionAPIScripting, PersistentRegisteredScriptIsInjectedAfterContextReloads)):

Canonical link: <a href="https://commits.webkit.org/296093@main">https://commits.webkit.org/296093@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9297b23b7b6aa1fd365c6806dec42a93fb12286e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/107277 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/26959 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/17363 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/112491 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/57811 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/109241 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/27640 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/35459 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/81432 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/110206 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/21908 "Found 3 new test failures: fast/events/ios/select-all-with-existing-selection.html webgl/1.0.x/conformance/textures/misc/gl-teximage.html webgl/2.0.y/conformance/textures/misc/gl-teximage.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/96689 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/61802 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/21336 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/14823 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/57256 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/91265 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/14853 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/115592 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/34343 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/25305 "Found 10 new test failures: http/tests/media/hls/hls-audio-tracks-language.html http/tests/media/hls/hls-webvtt-default.html http/tests/media/hls/hls-webvtt-style.html http/tests/media/hls/range-request-cross-origin.html http/tests/media/hls/track-in-band-multiple-cues.html http/tests/media/hls/track-webvtt-multitracks.html inspector/model/remote-object-get-properties.html inspector/runtime/getDisplayableProperties.html inspector/runtime/getProperties.html platform/mac/media/encrypted-media/fps-generateRequest.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/90475 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/34719 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/92938 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/90209 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35113 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/12902 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/30073 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17360 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/34265 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/39797 "Failed to build and analyze WebKit") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34011 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/37366 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/35672 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->