### PR TITLE
Unreviewed Windows build fix after 296071@main

### DIFF
--- a/Source/WTF/wtf/win/LoggingWin.cpp
+++ b/Source/WTF/wtf/win/LoggingWin.cpp
@@ -45,10 +45,10 @@ String logLevelString()
 
     Vector<char> buffer(length);
 
-    if (!GetEnvironmentVariableA(loggingEnvironmentVariable, buffer.data(), length))
+    if (!GetEnvironmentVariableA(loggingEnvironmentVariable, buffer.mutableSpan().data(), length))
         return emptyString();
 
-    return String::fromLatin1(buffer.data());
+    return String::fromLatin1(buffer.span().data());
 #else
     return String();
 #endif

--- a/Source/WebCore/PAL/pal/win/LoggingWin.cpp
+++ b/Source/WebCore/PAL/pal/win/LoggingWin.cpp
@@ -44,10 +44,10 @@ String logLevelString()
 
     Vector<char> buffer(length);
 
-    if (!GetEnvironmentVariableA(loggingEnvironmentVariable, buffer.data(), length))
+    if (!GetEnvironmentVariableA(loggingEnvironmentVariable, buffer.mutableSpan().data(), length))
         return emptyString();
 
-    return String::fromLatin1(buffer.data());
+    return String::fromLatin1(buffer.span().data());
 #else
     return String();
 #endif

--- a/Source/WebCore/platform/win/LoggingWin.cpp
+++ b/Source/WebCore/platform/win/LoggingWin.cpp
@@ -45,10 +45,10 @@ String logLevelString()
 
     Vector<char> buffer(length);
 
-    if (!GetEnvironmentVariableA(loggingEnvironmentVariable, buffer.data(), length))
+    if (!GetEnvironmentVariableA(loggingEnvironmentVariable, buffer.mutableSpan().data(), length))
         return emptyString();
 
-    return String::fromLatin1(buffer.data());
+    return String::fromLatin1(buffer.span().data());
 #else
     return String();
 #endif

--- a/Source/WebDriver/win/LoggingWin.cpp
+++ b/Source/WebDriver/win/LoggingWin.cpp
@@ -45,10 +45,10 @@ String logLevelString()
 
     Vector<char> buffer(length);
 
-    if (!GetEnvironmentVariableA(loggingEnvironmentVariable, buffer.data(), length))
+    if (!GetEnvironmentVariableA(loggingEnvironmentVariable, buffer.mutableSpan().data(), length))
         return emptyString();
 
-    return String::fromLatin1(buffer.data());
+    return String::fromLatin1(buffer.span().data());
 #else
     return String();
 #endif

--- a/Source/WebKit/Platform/win/LoggingWin.cpp
+++ b/Source/WebKit/Platform/win/LoggingWin.cpp
@@ -45,10 +45,10 @@ String logLevelString()
 
     Vector<char> buffer(length);
 
-    if (!GetEnvironmentVariableA(loggingEnvironmentVariable, buffer.data(), length))
+    if (!GetEnvironmentVariableA(loggingEnvironmentVariable, buffer.mutableSpan().data(), length))
         return emptyString();
 
-    return String::fromLatin1(buffer.data());
+    return String::fromLatin1(buffer.span().data());
 #else
     return String();
 #endif


### PR DESCRIPTION
#### d59b6db0358f2f2ed9bd6680a627d98622599a1f
<pre>
Unreviewed Windows build fix after 296071@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=294304">https://bugs.webkit.org/show_bug.cgi?id=294304</a>
<a href="https://rdar.apple.com/153027288">rdar://153027288</a>

* Source/WTF/wtf/win/LoggingWin.cpp:
(WTF::logLevelString):
* Source/WebCore/PAL/pal/win/LoggingWin.cpp:
(PAL::logLevelString):
* Source/WebCore/platform/win/LoggingWin.cpp:
(WebCore::logLevelString):
* Source/WebDriver/win/LoggingWin.cpp:
(WebDriver::logLevelString):
* Source/WebKit/Platform/win/LoggingWin.cpp:
(WebKit::logLevelString):

Canonical link: <a href="https://commits.webkit.org/296075@main">https://commits.webkit.org/296075@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d408e8462442931b16df3ee4ca0d2178a87ea5b0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/107293 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/26975 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/17379 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/112507 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/57827 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/109257 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/27656 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/35475 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/81445 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/57827 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/110222 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/21916 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/96704 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/61818 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/21346 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/14834 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/57272 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/99882 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/91276 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/14868 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/115608 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/105839 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/34359 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/25316 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/90488 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/34735 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/92954 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/90224 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/35127 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/12913 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/30089 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17350 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/34281 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/39807 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/130156 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34027 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/35400 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/37382 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/35688 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->