### PR TITLE
Leverage the `RefPtr<T>(T&)` constructor in more places

### DIFF
--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUCompositorIntegrationImpl.h
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUCompositorIntegrationImpl.h
@@ -65,7 +65,7 @@ public:
     void setPresentationContext(PresentationContextImpl& presentationContext)
     {
         ASSERT(!m_presentationContext);
-        m_presentationContext = &presentationContext;
+        m_presentationContext = presentationContext;
     }
 
     void registerCallbacks(WTF::Function<void(CFArrayRef)>&& renderBuffersWereRecreatedCallback, WTF::Function<void(CompletionHandler<void()>&&)>&& onSubmittedWorkScheduledCallback)

--- a/Source/WebCore/Modules/applepay/PaymentCoordinator.cpp
+++ b/Source/WebCore/Modules/applepay/PaymentCoordinator.cpp
@@ -126,7 +126,7 @@ bool PaymentCoordinator::beginPaymentSession(Document& document, PaymentSession&
         document.addConsoleMessage(MessageSource::PaymentRequest, MessageLevel::Warning, "`enabled` is a deprecated value for `shippingContactEditingMode`. Please use `available` instead."_s);
 #endif
 
-    m_activeSession = &paymentSession;
+    m_activeSession = paymentSession;
     return true;
 }
 

--- a/Source/WebCore/Modules/highlight/AppHighlightStorage.cpp
+++ b/Source/WebCore/Modules/highlight/AppHighlightStorage.cpp
@@ -70,7 +70,7 @@ static std::pair<RefPtr<Node>, size_t> findNodeStartingAtPathComponentIndex(cons
     if (initialIndexToFollow >= path.size())
         return { nullptr, initialIndexToFollow };
 
-    RefPtr currentNode = &initialNode;
+    RefPtr currentNode = initialNode;
     size_t currentPathIndex = initialIndexToFollow;
     for (; currentPathIndex < path.size(); ++currentPathIndex) {
         auto& component = path[currentPathIndex];

--- a/Source/WebCore/Modules/indexeddb/IDBDatabase.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBDatabase.cpp
@@ -332,7 +332,7 @@ Ref<IDBTransaction> IDBDatabase::startVersionChangeTransaction(const IDBTransact
     ASSERT(scriptExecutionContext());
 
     Ref<IDBTransaction> transaction = IDBTransaction::create(*this, info, request);
-    m_versionChangeTransaction = &transaction.get();
+    m_versionChangeTransaction = transaction.get();
 
     m_activeTransactions.set(transaction->info().identifier(), &transaction.get());
 

--- a/Source/WebCore/Modules/indexeddb/IDBRequest.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBRequest.cpp
@@ -193,7 +193,7 @@ void IDBRequest::setVersionChangeTransaction(IDBTransaction& transaction)
     ASSERT(transaction.isVersionChange());
     ASSERT(!transaction.isFinishedOrFinishing());
 
-    m_transaction = &transaction;
+    m_transaction = transaction;
 }
 
 RefPtr<WebCore::IDBTransaction> IDBRequest::transaction() const
@@ -296,7 +296,7 @@ void IDBRequest::dispatchEvent(Event& event)
         return;
     }
 
-    m_eventBeingDispatched = &event;
+    m_eventBeingDispatched = event;
 
     if (event.type() != eventNames().blockedEvent) {
         m_readyState = ReadyState::Done;
@@ -465,7 +465,7 @@ void IDBRequest::willIterateCursor(IDBCursor& cursor)
     ASSERT(!m_pendingCursor);
     ASSERT(&cursor == resultCursor());
 
-    m_pendingCursor = &cursor;
+    m_pendingCursor = cursor;
     m_result = NullResultType::Undefined;
 
     RefPtr context = scriptExecutionContext();

--- a/Source/WebCore/Modules/indexeddb/IDBTransaction.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBTransaction.cpp
@@ -191,7 +191,7 @@ void IDBTransaction::abortDueToFailedRequest(DOMException& error)
     if (isFinishedOrFinishing())
         return;
 
-    m_domError = &error;
+    m_domError = error;
     abortInternal();
 }
 
@@ -436,7 +436,7 @@ void IDBTransaction::completeNoncursorRequest(IDBRequest& request, const IDBResu
 
     request.completeRequestAndDispatchEvent(result);
 
-    m_currentlyCompletingRequest = &request;
+    m_currentlyCompletingRequest = request;
 }
 
 void IDBTransaction::completeCursorRequest(IDBRequest& request, const IDBResultData& result)
@@ -445,7 +445,7 @@ void IDBTransaction::completeCursorRequest(IDBRequest& request, const IDBResultD
 
     request.didOpenOrIterateCursor(result);
 
-    m_currentlyCompletingRequest = &request;
+    m_currentlyCompletingRequest = request;
 }
 
 void IDBTransaction::finishedDispatchEventForRequest(IDBRequest& request)

--- a/Source/WebCore/Modules/indexeddb/server/MemoryIndex.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/MemoryIndex.cpp
@@ -326,7 +326,7 @@ void MemoryIndex::writeTransactionStarted(MemoryBackingStoreTransaction& transac
 {
     ASSERT(!m_writeTransaction);
 
-    m_writeTransaction = &transaction;
+    m_writeTransaction = transaction;
 }
 
 void MemoryIndex::writeTransactionFinished(MemoryBackingStoreTransaction& transaction)

--- a/Source/WebCore/Modules/indexeddb/server/MemoryObjectStore.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/MemoryObjectStore.cpp
@@ -81,7 +81,7 @@ void MemoryObjectStore::writeTransactionStarted(MemoryBackingStoreTransaction& t
     LOG(IndexedDB, "MemoryObjectStore::writeTransactionStarted");
 
     ASSERT(!m_writeTransaction);
-    m_writeTransaction = &transaction;
+    m_writeTransaction = transaction;
     m_keyGeneratorValueBeforeTransaction = m_keyGeneratorValue;
 
     for (auto& index : m_indexesByIdentifier.values())

--- a/Source/WebCore/Modules/mediacontrols/MediaControlsHost.cpp
+++ b/Source/WebCore/Modules/mediacontrols/MediaControlsHost.cpp
@@ -866,12 +866,12 @@ void MediaControlsHost::savePreviouslySelectedTextTrackIfNecessary()
 
     switch (page->group().ensureCaptionPreferences().captionDisplayMode()) {
     case CaptionUserPreferences::CaptionDisplayMode::Automatic:
-        m_previouslySelectedTextTrack = &TextTrack::captionMenuAutomaticItem();
+        m_previouslySelectedTextTrack = TextTrack::captionMenuAutomaticItem();
         return;
     case CaptionUserPreferences::CaptionDisplayMode::ForcedOnly:
     case CaptionUserPreferences::CaptionDisplayMode::Manual:
     case CaptionUserPreferences::CaptionDisplayMode::AlwaysOn:
-        m_previouslySelectedTextTrack = &TextTrack::captionMenuOffItem();
+        m_previouslySelectedTextTrack = TextTrack::captionMenuOffItem();
         return;
     }
 }

--- a/Source/WebCore/Modules/mediasession/MediaSession.cpp
+++ b/Source/WebCore/Modules/mediasession/MediaSession.cpp
@@ -155,7 +155,7 @@ MediaSession::MediaSession(Navigator& navigator)
     , m_coordinator(MediaSessionCoordinator::create(navigator.scriptExecutionContext()))
 #endif
 {
-    m_logger = &Document::sharedLogger();
+    m_logger = Document::sharedLogger();
     m_logIdentifier = nextLogIdentifier();
 
 #if ENABLE(MEDIA_SESSION_COORDINATOR)

--- a/Source/WebCore/Modules/mediasession/MediaSessionCoordinatorPrivate.cpp
+++ b/Source/WebCore/Modules/mediasession/MediaSessionCoordinatorPrivate.cpp
@@ -35,7 +35,7 @@ namespace WebCore {
 
 void MediaSessionCoordinatorPrivate::setLogger(const Logger& logger, uint64_t logIdentifier)
 {
-    m_logger = &logger;
+    m_logger = logger;
     m_logIdentifier = logIdentifier;
 }
 

--- a/Source/WebCore/Modules/mediastream/ImageCapture.cpp
+++ b/Source/WebCore/Modules/mediastream/ImageCapture.cpp
@@ -225,7 +225,7 @@ private:
     {
         {
             Locker locker(m_frameLock);
-            m_frame = &frame;
+            m_frame = frame;
         }
         callOnMainThread([weakThis = ThreadSafeWeakPtr { *this }] {
             RefPtr protectedThis = weakThis.get();

--- a/Source/WebCore/Modules/mediastream/RTCEncodedFrame.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCEncodedFrame.cpp
@@ -47,7 +47,7 @@ RefPtr<JSC::ArrayBuffer> RTCEncodedFrame::data() const
 
 void RTCEncodedFrame::setData(JSC::ArrayBuffer& buffer)
 {
-    m_data = &buffer;
+    m_data = buffer;
 }
 
 uint64_t RTCEncodedFrame::timestamp() const

--- a/Source/WebCore/Modules/mediastream/RTCRtpScriptTransform.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCRtpScriptTransform.cpp
@@ -115,7 +115,7 @@ void RTCRtpScriptTransform::initializeTransformer(RTCRtpTransformBackend& backen
 {
     m_isAttached = true;
     if (!setupTransformer(backend))
-        m_backend = &backend;
+        m_backend = backend;
 }
 
 bool RTCRtpScriptTransform::setupTransformer(Ref<RTCRtpTransformBackend>&& backend)

--- a/Source/WebCore/Modules/speech/SpeechRecognition.cpp
+++ b/Source/WebCore/Modules/speech/SpeechRecognition.cpp
@@ -56,7 +56,7 @@ SpeechRecognition::SpeechRecognition(Document& document)
     : ActiveDOMObject(document)
 {
     if (auto* page = document.page()) {
-        m_connection = &page->speechRecognitionConnection();
+        m_connection = page->speechRecognitionConnection();
         m_connection->registerClient(*this);
     }
 }

--- a/Source/WebCore/Modules/system-preview/ARKitBadgeSystemImage.h
+++ b/Source/WebCore/Modules/system-preview/ARKitBadgeSystemImage.h
@@ -59,7 +59,7 @@ public:
     void draw(GraphicsContext&, const FloatRect&) const final;
 
     Image* image() const { return m_image.get(); }
-    void setImage(Image& image) { m_image = &image; }
+    void setImage(Image& image) { m_image = image; }
 
     RenderingResourceIdentifier imageIdentifier() const;
 
@@ -67,7 +67,7 @@ private:
     friend struct IPC::ArgumentCoder<ARKitBadgeSystemImage, void>;
     ARKitBadgeSystemImage(Image& image)
         : SystemImage(SystemImageType::ARKitBadge)
-        , m_image(&image)
+        , m_image(image)
         , m_imageSize(image.size())
     {
     }

--- a/Source/WebCore/Modules/webaudio/AudioWorkletNode.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioWorkletNode.cpp
@@ -186,7 +186,7 @@ void AudioWorkletNode::setProcessor(RefPtr<AudioWorkletProcessor>&& processor)
     if (processor) {
         Locker locker { m_processLock };
         m_processor = WTFMove(processor);
-        m_workletThread = &Thread::currentSingleton();
+        m_workletThread = Thread::currentSingleton();
     } else
         fireProcessorErrorOnMainThread(ProcessorError::ConstructorError);
 }

--- a/Source/WebCore/Modules/webaudio/AudioWorkletNode.h
+++ b/Source/WebCore/Modules/webaudio/AudioWorkletNode.h
@@ -91,7 +91,7 @@ private:
     Lock m_processLock;
     RefPtr<AudioWorkletProcessor> m_processor; // Should only be used on the rendering thread.
     MemoryCompactLookupOnlyRobinHoodHashMap<String, std::unique_ptr<AudioFloatArray>> m_paramValuesMap;
-    RefPtr<Thread> m_workletThread { nullptr };
+    RefPtr<Thread> m_workletThread;
 
     // Keeps the reference of AudioBus objects from AudioNodeInput and AudioNodeOutput in order
     // to pass them to AudioWorkletProcessor.

--- a/Source/WebCore/Modules/webaudio/OscillatorNode.cpp
+++ b/Source/WebCore/Modules/webaudio/OscillatorNode.cpp
@@ -434,7 +434,7 @@ void OscillatorNode::setPeriodicWave(PeriodicWave& periodicWave)
     
     // This synchronizes with process().
     Locker locker { m_processLock };
-    m_periodicWave = &periodicWave;
+    m_periodicWave = periodicWave;
     m_type = OscillatorType::Custom;
 }
 

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.cpp
@@ -526,7 +526,7 @@ ExceptionOr<Ref<WebCodecsVideoFrame>> WebCodecsVideoFrame::clone(ScriptExecution
 
     auto clone = adoptRef(*new WebCodecsVideoFrame(context, WebCodecsVideoFrameData { m_data }));
 
-    clone->m_colorSpace = &colorSpace();
+    clone->m_colorSpace = colorSpace();
     clone->m_codedRect = codedRect();
     clone->m_visibleRect = visibleRect();
     clone->m_isDetached = m_isDetached;

--- a/Source/WebCore/accessibility/AXCoreObject.cpp
+++ b/Source/WebCore/accessibility/AXCoreObject.cpp
@@ -1579,7 +1579,7 @@ std::partial_ordering AXCoreObject::partialOrder(const AXCoreObject& other)
         return std::partial_ordering::equivalent;
 
     RefPtr current = this;
-    RefPtr otherCurrent = &other;
+    RefPtr otherCurrent = other;
 
     auto orderingFromIndices = [&] (unsigned ourAncestorIndex, unsigned otherAncestorIndex) {
         if (ourAncestorIndex < otherAncestorIndex)

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -1465,7 +1465,7 @@ void AXObjectCache::handleChildrenChanged(AccessibilityObject& object)
     // Go up the existing ancestors chain and fire the appropriate notifications.
     bool shouldUpdateParent = true;
     bool foundTableCaption = false;
-    for (RefPtr parent = &object; parent; parent = parent->parentObject()) {
+    for (RefPtr parent = object; parent; parent = parent->parentObject()) {
         if (shouldUpdateParent)
             parent->setNeedsToUpdateChildren();
 

--- a/Source/WebCore/accessibility/AXTextMarker.cpp
+++ b/Source/WebCore/accessibility/AXTextMarker.cpp
@@ -1614,7 +1614,7 @@ AXIsolatedObject* findObjectWithRuns(AXIsolatedObject& start, AXDirection direct
                 }
             }
 
-            RefPtr current = &object;
+            RefPtr current = object;
             RefPtr next = object.nextSiblingIncludingIgnored(/* updateChildrenIfNeeded */ true);
             for (; !next; next = current->nextSiblingIncludingIgnored(/* updateChildrenIfNeeded */ true)) {
                 if (shouldStop(*current))

--- a/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
+++ b/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
@@ -1392,12 +1392,12 @@ static void appendStringToResult(NSMutableString *result, NSString *string)
     RefPtr<AXCoreObject> listItemAncestor;
     Accessibility::findAncestor<AXCoreObject>(*self.axBackingObject, true, [&] (auto& object) {
         if (object.isExposedTableCell()) {
-            tableCellAncestor = &object;
+            tableCellAncestor = object;
             return true;
         }
 
         if (object.isListItem()) {
-            listItemAncestor = &object;
+            listItemAncestor = object;
             return true;
         }
         return false;

--- a/Source/WebCore/accessibility/playstation/AXObjectCachePlayStation.cpp
+++ b/Source/WebCore/accessibility/playstation/AXObjectCachePlayStation.cpp
@@ -86,7 +86,7 @@ void AXObjectCache::postPlatformNotification(AccessibilityObject& object, AXNoti
         || object.document()->childNeedsStyleRecalc())
         return;
 
-    RefPtr protectedObject = &object;
+    RefPtr protectedObject = object;
     switch (notification) {
     case AXNotification::SelectedChildrenChanged:
         protectedObject = downcast<AccessibilityObject>(notifyChildrenSelectionChange(protectedObject.get()));

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -1587,7 +1587,7 @@ void KeyframeEffect::setTarget(RefPtr<Element>&& newTarget)
     auto& previousTargetStyleable = targetStyleable();
     RefPtr<Element> protector;
     if (previousTargetStyleable)
-        protector = &previousTargetStyleable->element;
+        protector = previousTargetStyleable->element;
     m_target = WTFMove(newTarget);
     didChangeTargetStyleable(previousTargetStyleable);
 }

--- a/Source/WebCore/animation/StyleOriginatedTimelinesController.cpp
+++ b/Source/WebCore/animation/StyleOriginatedTimelinesController.cpp
@@ -98,7 +98,7 @@ static bool containsElement(const Vector<WeakStyleable>& timelineScopeElements, 
 
 ScrollTimeline* StyleOriginatedTimelinesController::determineTreeOrder(const Vector<Ref<ScrollTimeline>>& ancestorTimelines, const Styleable& styleable, const Vector<WeakStyleable>& timelineScopeElements)
 {
-    RefPtr element = &styleable.element;
+    RefPtr element = styleable.element;
     while (element) {
         Vector<Ref<ScrollTimeline>> matchedTimelines;
         for (auto& timeline : ancestorTimelines) {
@@ -177,7 +177,7 @@ void StyleOriginatedTimelinesController::updateTimelineForTimelineScope(const Re
                 matchedTimelineScopeElements.appendIfNotContains(*entryElement);
         }
     }
-    RefPtr element = &timelineElement->element;
+    RefPtr element = timelineElement->element;
     while (element) {
         auto it = matchedTimelineScopeElements.findIf([element] (const Styleable& entry) {
             return &entry.element == element;

--- a/Source/WebCore/bindings/js/ScriptController.cpp
+++ b/Source/WebCore/bindings/js/ScriptController.cpp
@@ -538,7 +538,7 @@ void ScriptController::collectIsolatedContexts(Vector<std::pair<JSC::JSGlobalObj
 {
     for (auto& jsWindowProxy : protectedWindowProxy()->jsWindowProxiesAsVector()) {
         auto* lexicalGlobalObject = jsWindowProxy->window();
-        RefPtr origin = &downcast<LocalDOMWindow>(jsWindowProxy->protectedWrapped())->protectedDocument()->securityOrigin();
+        RefPtr origin = downcast<LocalDOMWindow>(jsWindowProxy->protectedWrapped())->protectedDocument()->securityOrigin();
         result.append(std::make_pair(lexicalGlobalObject, WTFMove(origin)));
     }
 }

--- a/Source/WebCore/bindings/js/ScriptModuleLoader.cpp
+++ b/Source/WebCore/bindings/js/ScriptModuleLoader.cpp
@@ -204,7 +204,7 @@ JSC::JSInternalPromise* ScriptModuleLoader::fetch(JSC::JSGlobalObject* jsGlobalO
 
     RefPtr<JSC::ScriptFetchParameters> parameters;
     if (auto* scriptFetchParameters = JSC::jsDynamicCast<JSC::JSScriptFetchParameters*>(parametersValue))
-        parameters = &scriptFetchParameters->parameters();
+        parameters = scriptFetchParameters->parameters();
 
     if (m_ownerType == OwnerType::Document) {
         auto loader = CachedModuleScriptLoader::create(*this, deferred.get(), *static_cast<CachedScriptFetcher*>(JSC::jsCast<JSC::JSScriptFetcher*>(scriptFetcher)->fetcher()), WTFMove(parameters));

--- a/Source/WebCore/bindings/js/WorkerScriptFetcher.h
+++ b/Source/WebCore/bindings/js/WorkerScriptFetcher.h
@@ -50,7 +50,7 @@ public:
 
     void notifyLoadCompleted(UniquedStringImpl& moduleKey)
     {
-        m_moduleKey = &moduleKey;
+        m_moduleKey = moduleKey;
         m_isLoaded = true;
     }
 

--- a/Source/WebCore/css/CSSFontFaceSrcValue.cpp
+++ b/Source/WebCore/css/CSSFontFaceSrcValue.cpp
@@ -61,7 +61,7 @@ SVGFontFaceElement* CSSFontFaceSrcLocalValue::svgFontFaceElement() const
 
 void CSSFontFaceSrcLocalValue::setSVGFontFaceElement(SVGFontFaceElement& element)
 {
-    m_element = &element;
+    m_element = element;
 }
 
 String CSSFontFaceSrcLocalValue::customCSSText(const CSS::SerializationContext&) const

--- a/Source/WebCore/css/ShorthandSerializer.cpp
+++ b/Source/WebCore/css/ShorthandSerializer.cpp
@@ -887,8 +887,8 @@ String ShorthandSerializer::serializeBorderRadius() const
     std::array<RefPtr<const CSSValue>, 4> verticalRadii;
     for (unsigned i = 0; i < 4; ++i) {
         auto& value = longhandValue(i);
-        horizontalRadii[i] = &value.first();
-        verticalRadii[i] = &value.second();
+        horizontalRadii[i] = value.first();
+        verticalRadii[i] = value.second();
     }
 
     bool serializeBoth = false;

--- a/Source/WebCore/css/calc/CSSCalcTree+ContainerProgressEvaluator.cpp
+++ b/Source/WebCore/css/calc/CSSCalcTree+ContainerProgressEvaluator.cpp
@@ -38,7 +38,7 @@ std::optional<double> evaluateContainerProgress(const ContainerProgress& root, c
 {
     // FIXME: This lookup loop is the same as the one used in CSSPrimitiveValue for resolving container units. Would be good to figure out a nice place to share this.
 
-    RefPtr element = &initialElement;
+    RefPtr element = initialElement;
 
     auto mode = conversionData.style()->pseudoElementType() == PseudoId::None
         ? Style::ContainerQueryEvaluator::SelectionMode::Element

--- a/Source/WebCore/dom/Attr.cpp
+++ b/Source/WebCore/dom/Attr.cpp
@@ -150,7 +150,7 @@ void Attr::detachFromElementWithValue(const AtomString& value)
 void Attr::attachToElement(Element& element)
 {
     ASSERT(!m_element);
-    m_element = &element;
+    m_element = element;
     m_standaloneValue = nullAtom();
     setTreeScopeRecursively(element.treeScope());
 }

--- a/Source/WebCore/dom/ChildListMutationScope.cpp
+++ b/Source/WebCore/dom/ChildListMutationScope.cpp
@@ -90,7 +90,7 @@ void ChildListMutationAccumulator::childAdded(Node& child)
         m_nextSibling = child.nextSibling();
     }
 
-    m_lastAdded = &child;
+    m_lastAdded = child;
     m_addedNodes.append(child);
 }
 

--- a/Source/WebCore/dom/ContainerNode.cpp
+++ b/Source/WebCore/dom/ContainerNode.cpp
@@ -437,7 +437,7 @@ static inline bool isChildTypeAllowed(ContainerNode& newParent, Node& child)
 
 static bool containsIncludingHostElements(const Node& possibleAncestor, const Node& node)
 {
-    RefPtr<const Node> currentNode = &node;
+    RefPtr<const Node> currentNode = node;
     do {
         if (currentNode == &possibleAncestor)
             return true;
@@ -1084,7 +1084,7 @@ static void dispatchChildInsertionEvents(Node& child)
 
     ASSERT_WITH_SECURITY_IMPLICATION(ScriptDisallowedScope::InMainThread::isEventDispatchAllowedInSubtree(child));
 
-    RefPtr c = &child;
+    RefPtr c = child;
     if (c->parentNode() && document->hasListenerType(Document::ListenerType::DOMNodeInserted))
         c->dispatchScopedEvent(MutationEvent::create(eventNames().DOMNodeInsertedEvent, Event::CanBubble::Yes, c->protectedParentNode().get()));
 

--- a/Source/WebCore/dom/ContainerNodeAlgorithms.cpp
+++ b/Source/WebCore/dom/ContainerNodeAlgorithms.cpp
@@ -50,7 +50,7 @@ static void notifyNodeInsertedIntoDocument(ContainerNode& parentOfInsertedTree, 
     ASSERT(parentOfInsertedTree.isConnected());
     ASSERT(!node.isConnected());
 
-    for (RefPtr currentNode = &node; currentNode; currentNode = NodeTraversal::next(*currentNode, &node)) {
+    for (RefPtr currentNode = node; currentNode; currentNode = NodeTraversal::next(*currentNode, &node)) {
         auto result = currentNode->insertedIntoAncestor(Node::InsertionType { /* connectedToDocument */ true, treeScopeChange == TreeScopeChange::Changed }, parentOfInsertedTree);
         if (result == Node::InsertedIntoAncestorResult::NeedsPostInsertionCallback)
             postInsertionNotificationTargets.append(*currentNode);
@@ -64,7 +64,7 @@ static void notifyNodeInsertedIntoTree(ContainerNode& parentOfInsertedTree, Node
     ASSERT(!parentOfInsertedTree.isConnected());
     ASSERT(!node.isConnected());
 
-    for (RefPtr currentNode = &node; currentNode; currentNode = NodeTraversal::next(*currentNode, &node)) {
+    for (RefPtr currentNode = node; currentNode; currentNode = NodeTraversal::next(*currentNode, &node)) {
         auto result = currentNode->insertedIntoAncestor(Node::InsertionType { /* connectedToDocument */ false, treeScopeChange == TreeScopeChange::Changed }, parentOfInsertedTree);
         UNUSED_PARAM(result);
         if (RefPtr root = currentNode->shadowRoot())
@@ -112,7 +112,7 @@ static RemovedSubtreeResult notifyNodeRemovedFromDocument(ContainerNode& oldPare
     RemovedSubtreeObservability observability = RemovedSubtreeObservability::NotObservable;
     auto canDelayNodeDeletion = ContainerNode::CanDelayNodeDeletion::Yes;
     unsigned subTreeSize = 0;
-    for (RefPtr currentNode = &node; currentNode; currentNode = NodeTraversal::next(*currentNode)) {
+    for (RefPtr currentNode = node; currentNode; currentNode = NodeTraversal::next(*currentNode)) {
         ++subTreeSize;
         currentNode->removedFromAncestor(Node::RemovalType { /* disconnectedFromDocument */ true, treeScopeChange == TreeScopeChange::Changed }, oldParentOfRemovedTree);
         updateCanDelayNodeDeletion(canDelayNodeDeletion, AsyncNodeDeletionQueue::canNodeBeDeletedAsync(node));
@@ -134,7 +134,7 @@ static RemovedSubtreeResult notifyNodeRemovedFromTree(ContainerNode& oldParentOf
     unsigned subTreeSize = 0;
     auto canDelayNodeDeletion = ContainerNode::CanDelayNodeDeletion::Yes;
     RemovedSubtreeObservability observability = RemovedSubtreeObservability::NotObservable;
-    for (RefPtr currentNode = &node; currentNode; currentNode = NodeTraversal::next(*currentNode)) {
+    for (RefPtr currentNode = node; currentNode; currentNode = NodeTraversal::next(*currentNode)) {
         ++subTreeSize;
         currentNode->removedFromAncestor(Node::RemovalType { /* disconnectedFromDocument */ false, treeScopeChange == TreeScopeChange::Changed }, oldParentOfRemovedTree);
         updateCanDelayNodeDeletion(canDelayNodeDeletion, AsyncNodeDeletionQueue::canNodeBeDeletedAsync(node));

--- a/Source/WebCore/dom/ContentVisibilityDocumentState.cpp
+++ b/Source/WebCore/dom/ContentVisibilityDocumentState.cpp
@@ -222,7 +222,7 @@ void ContentVisibilityDocumentState::updateContentRelevancyForScrollIfNeeded(con
     auto findSkippedContentRoot = [](const Element& element) -> RefPtr<const Element> {
         RefPtr<const Element> found;
         if (element.renderer() && element.renderer()->isSkippedContent()) {
-            for (RefPtr candidate = &element; candidate; candidate = candidate->parentElementInComposedTree()) {
+            for (RefPtr candidate = element; candidate; candidate = candidate->parentElementInComposedTree()) {
                 if (candidate->renderer() && candidate->renderStyle()->contentVisibility() == ContentVisibility::Auto)
                     found = candidate;
             }

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -1271,7 +1271,7 @@ void Document::invalidateQuerySelectorAllResults(Node& startingNode)
 {
     if (m_querySelectorAllResults.isEmptyIgnoringNullReferences())
         return;
-    for (RefPtr<Node> currentNode = &startingNode; currentNode; currentNode = currentNode->parentNode()) {
+    for (RefPtr currentNode = startingNode; currentNode; currentNode = currentNode->parentNode()) {
         if (!currentNode->hasValidQuerySelectorAllResults())
             continue;
         m_querySelectorAllResults.remove(*currentNode);
@@ -1283,7 +1283,7 @@ void Document::invalidateQuerySelectorAllResultsForClassAttributeChange(Node& st
 {
     if (m_querySelectorAllResults.isEmptyIgnoringNullReferences())
         return;
-    for (RefPtr<Node> currentNode = &startingNode; currentNode; currentNode = currentNode->parentNode()) {
+    for (RefPtr currentNode = startingNode; currentNode; currentNode = currentNode->parentNode()) {
         if (!currentNode->hasValidQuerySelectorAllResults())
             continue;
         auto it = m_querySelectorAllResults.find(*currentNode);
@@ -4630,7 +4630,7 @@ void Document::processBaseElement()
     auto baseDescendants = descendantsOfType<HTMLBaseElement>(*this);
     for (auto& base : baseDescendants) {
         if (!baseElement)
-            baseElement = &base;
+            baseElement = base;
 
         if (href.isNull()) {
             auto& value = base.attributeWithoutSynchronization(hrefAttr);
@@ -4711,7 +4711,7 @@ IDBClient::IDBConnectionProxy* Document::idbConnectionProxy()
         RefPtr currentPage = page();
         if (!currentPage)
             return nullptr;
-        m_idbConnectionProxy = &currentPage->idbConnection().proxy();
+        m_idbConnectionProxy = currentPage->idbConnection().proxy();
     }
     return m_idbConnectionProxy.get();
 }

--- a/Source/WebCore/dom/DocumentFullscreen.cpp
+++ b/Source/WebCore/dom/DocumentFullscreen.cpp
@@ -309,7 +309,7 @@ ExceptionOr<void> DocumentFullscreen::willEnterFullscreen(Element& element, HTML
     ASSERT(&element == m_pendingFullscreenElement);
     m_pendingFullscreenElement = nullptr;
 
-    m_fullscreenElement = &element;
+    m_fullscreenElement = element;
 
     Vector<Ref<Element>> ancestors { { element } };
     for (RefPtr<Frame> frame = element.document().frame(); frame; frame = frame->tree().parent()) {
@@ -399,7 +399,7 @@ LocalFrame* DocumentFullscreen::frame() const
 static Vector<Ref<Document>> documentsToUnfullscreen(Frame& firstFrame)
 {
     Vector<Ref<Document>> documents;
-    for (RefPtr frame = &firstFrame; frame; frame = frame->tree().parent()) {
+    for (RefPtr frame = firstFrame; frame; frame = frame->tree().parent()) {
         RefPtr localFrame = dynamicDowncast<LocalFrame>(frame);
         if (!localFrame)
             continue;

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -6270,7 +6270,7 @@ HTMLElement* Element::topmostPopoverAncestor(TopLayerElementType topLayerType)
 
         // https://html.spec.whatwg.org/#nearest-inclusive-open-popover
         auto nearestInclusiveOpenPopover = [](Element& candidate) -> HTMLElement* {
-            for (RefPtr element = &candidate; element; element = element->parentElementInComposedTree()) {
+            for (RefPtr element = candidate; element; element = element->parentElementInComposedTree()) {
                 if (auto* htmlElement = dynamicDowncast<HTMLElement>(element.get())) {
                     if (htmlElement->popoverState() == PopoverState::Auto && htmlElement->popoverData()->visibilityState() == PopoverVisibilityState::Showing)
                         return htmlElement;

--- a/Source/WebCore/dom/Event.cpp
+++ b/Source/WebCore/dom/Event.cpp
@@ -158,7 +158,7 @@ void Event::setCurrentTarget(RefPtr<EventTarget>&& currentTarget, std::optional<
 
 void Event::setEventPath(const EventPath& path)
 {
-    m_eventPath = &path;
+    m_eventPath = path;
 }
 
 Vector<Ref<EventTarget>> Event::composedPath(JSC::JSGlobalObject& lexicalGlobalObject) const
@@ -184,9 +184,9 @@ DOMHighResTimeStamp Event::timeStampForBindings(ScriptExecutionContext& context)
 {
     RefPtr<Performance> performance;
     if (auto* globalScope = dynamicDowncast<WorkerGlobalScope>(context))
-        performance = &globalScope->performance();
+        performance = globalScope->performance();
     else if (RefPtr window = downcast<Document>(context).domWindow())
-        performance = &window->performance();
+        performance = window->performance();
 
     if (!performance)
         return 0;

--- a/Source/WebCore/dom/EventPath.cpp
+++ b/Source/WebCore/dom/EventPath.cpp
@@ -319,7 +319,7 @@ RelatedNodeRetargeter::RelatedNodeRetargeter(Ref<Node>&& relatedNode, Node& targ
     , m_retargetedRelatedNode(m_relatedNode.copyRef())
 {
     auto& targetTreeScope = target.treeScope();
-    RefPtr currentTreeScope = &m_relatedNode->treeScope();
+    RefPtr currentTreeScope = m_relatedNode->treeScope();
     if (currentTreeScope == &targetTreeScope && target.isConnected() && m_relatedNode->isConnected()) [[likely]]
         return;
 

--- a/Source/WebCore/dom/FragmentDirectiveRangeFinder.cpp
+++ b/Source/WebCore/dom/FragmentDirectiveRangeFinder.cpp
@@ -214,7 +214,7 @@ static std::optional<SimpleRange> findRangeFromNodeList(const String& query, con
 static std::optional<SimpleRange> rangeOfStringInRange(const String& query, SimpleRange& searchRange, WordBounded wordStartBounded, WordBounded wordEndBounded)
 {
     while (!searchRange.collapsed()) {
-        RefPtr currentNode = &searchRange.startContainer();
+        RefPtr currentNode = searchRange.startContainer();
         
         if (isNonSearchableSubtree(*currentNode)) {
             if (RefPtr newStart = NodeTraversal::nextSkippingChildren(*currentNode))

--- a/Source/WebCore/dom/FragmentDirectiveUtilities.cpp
+++ b/Source/WebCore/dom/FragmentDirectiveUtilities.cpp
@@ -37,7 +37,7 @@ namespace FragmentDirectiveUtilities {
 // https://wicg.github.io/scroll-to-text-fragment/#nearest-block-ancestor
 ContainerNode& nearestBlockAncestor(Node& node)
 {
-    for (RefPtr currentNode = &node; currentNode; currentNode = currentNode->parentNode()) {
+    for (RefPtr currentNode = node; currentNode; currentNode = currentNode->parentNode()) {
         if (CheckedPtr renderElement = dynamicDowncast<RenderElement>(currentNode->renderer()); renderElement && renderElement->style().isDisplayBlockLevel())
             return downcast<ContainerNode>(*currentNode);
     }

--- a/Source/WebCore/dom/InternalObserverDrop.cpp
+++ b/Source/WebCore/dom/InternalObserverDrop.cpp
@@ -62,7 +62,7 @@ public:
             }
 
             SubscribeOptions options;
-            options.signal = &subscriber.signal();
+            options.signal = subscriber.signal();
             m_sourceObservable->subscribeInternal(*context, InternalObserverDrop::create(*context, subscriber, m_amount), options);
 
             return { };

--- a/Source/WebCore/dom/InternalObserverFilter.cpp
+++ b/Source/WebCore/dom/InternalObserverFilter.cpp
@@ -63,7 +63,7 @@ public:
             }
 
             SubscribeOptions options;
-            options.signal = &subscriber.signal();
+            options.signal = subscriber.signal();
             m_sourceObservable->subscribeInternal(*context, InternalObserverFilter::create(*context, subscriber, m_predicate), options);
 
             return { };

--- a/Source/WebCore/dom/InternalObserverMap.cpp
+++ b/Source/WebCore/dom/InternalObserverMap.cpp
@@ -63,7 +63,7 @@ public:
             }
 
             SubscribeOptions options;
-            options.signal = &subscriber.signal();
+            options.signal = subscriber.signal();
             m_sourceObservable->subscribeInternal(*context, InternalObserverMap::create(*context, subscriber, m_mapper), options);
 
             return { };

--- a/Source/WebCore/dom/InternalObserverTake.cpp
+++ b/Source/WebCore/dom/InternalObserverTake.cpp
@@ -62,7 +62,7 @@ public:
             }
 
             SubscribeOptions options;
-            options.signal = &subscriber.signal();
+            options.signal = subscriber.signal();
             m_sourceObservable->subscribeInternal(*context, InternalObserverTake::create(*context, subscriber, m_amount), options);
 
             return { };

--- a/Source/WebCore/dom/LoadableModuleScript.cpp
+++ b/Source/WebCore/dom/LoadableModuleScript.cpp
@@ -70,7 +70,7 @@ bool LoadableModuleScript::wasCanceled() const
 
 void LoadableModuleScript::notifyLoadCompleted(UniquedStringImpl& moduleKey)
 {
-    m_moduleKey = &moduleKey;
+    m_moduleKey = moduleKey;
     m_isLoaded = true;
     notifyClientFinished();
 }

--- a/Source/WebCore/dom/Range.cpp
+++ b/Source/WebCore/dom/Range.cpp
@@ -859,10 +859,10 @@ ExceptionOr<void> Range::surroundContents(Node& newParent)
     Ref protectedNewParent = newParent;
 
     // Step 1: If a non-Text node is partially contained in the context object, then throw an InvalidStateError.
-    RefPtr startNonTextContainer = &startContainer();
+    RefPtr startNonTextContainer = startContainer();
     if (is<Text>(startNonTextContainer))
         startNonTextContainer = startNonTextContainer->parentNode();
-    RefPtr endNonTextContainer = &endContainer();
+    RefPtr endNonTextContainer = endContainer();
     if (is<Text>(endNonTextContainer))
         endNonTextContainer = endNonTextContainer->parentNode();
     if (startNonTextContainer != endNonTextContainer)

--- a/Source/WebCore/dom/RejectedPromiseTracker.cpp
+++ b/Source/WebCore/dom/RejectedPromiseTracker.cpp
@@ -165,7 +165,7 @@ void RejectedPromiseTracker::reportUnhandledRejections(Vector<UnhandledPromise>&
 
         PromiseRejectionEvent::Init initializer;
         initializer.cancelable = true;
-        initializer.promise = &domPromise;
+        initializer.promise = domPromise;
         initializer.reason = promise.result(vm);
 
         Ref event = PromiseRejectionEvent::create(eventNames().unhandledrejectionEvent, initializer);

--- a/Source/WebCore/dom/UserGestureIndicator.cpp
+++ b/Source/WebCore/dom/UserGestureIndicator.cpp
@@ -75,7 +75,7 @@ UserGestureToken::UserGestureToken(IsProcessingUserGesture isProcessingUserGestu
     }
 
     Ref documentOrigin = document->securityOrigin();
-    for (RefPtr frame = &documentFrame->tree().top(); frame; frame = frame->tree().traverseNext()) {
+    for (RefPtr frame = documentFrame->tree().top(); frame; frame = frame->tree().traverseNext()) {
         RefPtr localFrame = dynamicDowncast<LocalFrame>(frame);
         if (!localFrame)
             continue;

--- a/Source/WebCore/editing/ApplyStyleCommand.cpp
+++ b/Source/WebCore/editing/ApplyStyleCommand.cpp
@@ -667,7 +667,7 @@ void ApplyStyleCommand::applyInlineStyle(EditingStyle& style)
     // to check a computed style
     document().updateLayoutIgnorePendingStylesheets();
 
-    RefPtr<EditingStyle> styleToApply = &style;
+    RefPtr styleToApply = style;
     if (textDirection) {
         // Avoid applying the unicode-bidi and direction properties beneath ancestors that already have them.
         RefPtr startNode = start.deprecatedNode();
@@ -775,7 +775,7 @@ void ApplyStyleCommand::applyInlineStyleToNodeRange(EditingStyle& style, Node& s
     document().updateLayoutIgnorePendingStylesheets();
 
     Vector<InlineRunToApplyStyle> runs;
-    RefPtr<Node> node = &startNode;
+    RefPtr node = startNode;
     for (RefPtr<Node> next; node && node != pastEndNode; node = next) {
         next = NodeTraversal::next(*node);
 
@@ -1339,17 +1339,17 @@ bool ApplyStyleCommand::mergeEndWithNextIfIdentical(const Position& start, const
 
 bool ApplyStyleCommand::surroundNodeRangeWithElement(Node& startNode, Node& endNode, Ref<Element>&& elementToInsert)
 {
-    Ref<Node> protectedStartNode = startNode;
-    Ref<Element> element = WTFMove(elementToInsert);
+    Ref protectedStartNode = startNode;
+    Ref element = WTFMove(elementToInsert);
 
     if (!insertNodeBefore(element.copyRef(), startNode) || !element->isContentRichlyEditable()) {
         removeNode(element);
         return false;
     }
 
-    RefPtr<Node> node = &startNode;
+    RefPtr node = startNode;
     while (node) {
-        RefPtr<Node> next = node->nextSibling();
+        RefPtr next = node->nextSibling();
         if (isEditableNode(*node)) {
             removeNode(*node);
             appendNode(*node, element.copyRef());
@@ -1359,8 +1359,8 @@ bool ApplyStyleCommand::surroundNodeRangeWithElement(Node& startNode, Node& endN
         node = next;
     }
 
-    RefPtr<Node> nextSibling = element->nextSibling();
-    RefPtr<Node> previousSibling = element->previousSibling();
+    RefPtr nextSibling = element->nextSibling();
+    RefPtr previousSibling = element->previousSibling();
 
     if (nextSibling && nextSibling->hasEditableStyle()) {
         if (RefPtr nextElement = elementIfEquivalent(element, *nextSibling))
@@ -1427,8 +1427,8 @@ Position ApplyStyleCommand::positionToComputeInlineStyleChange(Node& startNode, 
 
 void ApplyStyleCommand::applyInlineStyleChange(Node& passedStart, Node& passedEnd, StyleChange& styleChange, AddStyledElement addStyledElement)
 {
-    RefPtr<Node> startNode = &passedStart;
-    RefPtr<Node> endNode = &passedEnd;
+    RefPtr startNode = passedStart;
+    RefPtr endNode = passedEnd;
     ASSERT(startNode->isConnected());
     ASSERT(endNode->isConnected());
 

--- a/Source/WebCore/editing/CompositeEditCommand.cpp
+++ b/Source/WebCore/editing/CompositeEditCommand.cpp
@@ -1785,13 +1785,13 @@ RefPtr<Node> CompositeEditCommand::splitTreeToNode(Node& start, Node& end, bool 
 {
     ASSERT(&start != &end);
 
-    RefPtr adjustedEnd = &end;
+    RefPtr adjustedEnd = end;
     if (shouldSplitAncestor && adjustedEnd->parentNode())
         adjustedEnd = adjustedEnd->parentNode();
 
     ASSERT(adjustedEnd);
     RefPtr<Node> node;
-    for (node = &start; node && node->parentNode() != adjustedEnd;) {
+    for (node = start; node && node->parentNode() != adjustedEnd;) {
         RefPtr parentNode = node->parentNode();
         RefPtr parentElement = dynamicDowncast<Element>(parentNode);
         if (!parentElement || editingIgnoresContent(*parentNode))

--- a/Source/WebCore/editing/EditingStyle.cpp
+++ b/Source/WebCore/editing/EditingStyle.cpp
@@ -1331,7 +1331,7 @@ Ref<EditingStyle> EditingStyle::wrappingStyleForSerialization(Node& context, boo
     auto wrappingStyle = EditingStyle::create();
 
     // When not annotating for interchange, we only preserve inline style declarations.
-    for (RefPtr node = &context; node && !node->isDocumentNode(); node = node->parentNode()) {
+    for (RefPtr node = context; node && !node->isDocumentNode(); node = node->parentNode()) {
         if (auto* element = dynamicDowncast<StyledElement>(*node); element && !isMailBlockquote(*element))
             wrappingStyle->mergeInlineAndImplicitStyleOfElement(*element, DoNotOverrideValues, PropertiesToInclude::EditingPropertiesInEffect, standardFontFamilySerializationMode);
     }

--- a/Source/WebCore/editing/Editor.cpp
+++ b/Source/WebCore/editing/Editor.cpp
@@ -1285,7 +1285,7 @@ void Editor::appliedEditing(CompositeEditCommand& command)
         else {
             // Only register a new undo command if the command passed in is
             // different from the last command
-            m_lastEditCommand = &command;
+            m_lastEditCommand = command;
             if (client())
                 client()->registerUndoStep(m_lastEditCommand->ensureComposition());
         }

--- a/Source/WebCore/editing/FrameSelection.cpp
+++ b/Source/WebCore/editing/FrameSelection.cpp
@@ -273,7 +273,7 @@ void DragCaretController::setCaretPosition(const VisiblePosition& position)
     RefPtr<Document> document;
     if (RefPtr node = m_position.deepEquivalent().deprecatedNode()) {
         invalidateCaretRect(node.get());
-        document = &node->document();
+        document = node->document();
     }
     if (m_position.isNull() || m_position.isOrphan())
         clearCaretRect();
@@ -3079,7 +3079,7 @@ void FrameSelection::disassociateLiveRange()
 void FrameSelection::associateLiveRange(Range& liveRange)
 {
     disassociateLiveRange();
-    m_associatedLiveRange = &liveRange;
+    m_associatedLiveRange = liveRange;
     liveRange.didAssociateWithSelection();
     updateFromAssociatedLiveRange();
 }

--- a/Source/WebCore/editing/MarkupAccumulator.cpp
+++ b/Source/WebCore/editing/MarkupAccumulator.cpp
@@ -283,7 +283,7 @@ void MarkupAccumulator::serializeNodesWithNamespaces(Node& targetNode, Serialize
         return currentTemplate ? currentTemplate->content().firstChild() : current.firstChild();
     };
 
-    RefPtr<const Node> current = &targetNode;
+    RefPtr<const Node> current = targetNode;
     do {
         bool shouldSkipNode = false;
         if (RefPtr element = dynamicDowncast<const Element>(current); element && shouldExcludeElement(*element))

--- a/Source/WebCore/editing/TextIterator.cpp
+++ b/Source/WebCore/editing/TextIterator.cpp
@@ -199,7 +199,7 @@ static RefPtr<Node> nextInPreOrderCrossingShadowBoundaries(Node& rangeEndContain
         if (RefPtr next = rangeEndContainer.traverseToChildAt(rangeEndOffset))
             return next;
     }
-    for (RefPtr node = &rangeEndContainer; node; node = node->parentOrShadowHostNode()) {
+    for (RefPtr node = rangeEndContainer; node; node = node->parentOrShadowHostNode()) {
         if (RefPtr next = node->nextSibling())
             return next;
     }
@@ -962,7 +962,7 @@ static bool shouldEmitNewlineAfterNode(Node& node, bool emitsCharactersBetweenAl
     // Don't emit a new line at the end of the document unless we're matching the behavior of VisiblePosition.
     if (emitsCharactersBetweenAllVisiblePositions)
         return true;
-    RefPtr subsequentNode = &node;
+    RefPtr subsequentNode = node;
     while ((subsequentNode = NodeTraversal::nextSkippingChildren(*subsequentNode))) {
         if (subsequentNode->renderer())
             return true;
@@ -1206,7 +1206,7 @@ void TextIterator::emitText(Text& textNode, RenderText& renderer, int textStartO
 
     textEndOffset = std::min(string.length(), static_cast<unsigned>(textEndOffset));
 
-    m_positionNode = &textNode;
+    m_positionNode = textNode;
     m_positionOffsetBaseNode = nullptr;
     m_positionStartOffset = textStartOffset;
     m_positionEndOffset = textEndOffset;

--- a/Source/WebCore/editing/VisibleSelection.cpp
+++ b/Source/WebCore/editing/VisibleSelection.cpp
@@ -523,7 +523,7 @@ static bool isInUserAgentShadowRootOrHasEditableShadowAncestor(Node& node)
     if (shadowRoot->mode() == ShadowRootMode::UserAgent)
         return true;
 
-    for (RefPtr currentNode = &node; currentNode; currentNode = currentNode->parentOrShadowHostNode()) {
+    for (RefPtr currentNode = node; currentNode; currentNode = currentNode->parentOrShadowHostNode()) {
         if (currentNode->hasEditableStyle())
             return true;
     }

--- a/Source/WebCore/editing/markup.cpp
+++ b/Source/WebCore/editing/markup.cpp
@@ -281,7 +281,7 @@ auto UserSelectNoneStateCache::computeState(Node& targetNode) -> State
     if (!Position::nodeIsUserSelectNone(&targetNode))
         return State::NotUserSelectNone;
     auto state = State::OnlyUserSelectNone;
-    RefPtr currentNode = &targetNode;
+    RefPtr currentNode = targetNode;
     bool foundMixed = false;
     while (currentNode) {
         if (!Position::nodeIsUserSelectNone(currentNode.get())) {
@@ -850,12 +850,12 @@ RefPtr<Node> StyledMarkupAccumulator::traverseNodesForSerialization(Node& startN
             else
                 wrapWithNode(node);
         }
-        lastClosed = &node;
+        lastClosed = node;
     };
 
     RefPtr<Node> lastNode;
     RefPtr<Node> next;
-    for (RefPtr n = &startNode; n != pastEnd; lastNode = n, n = next) {
+    for (RefPtr n = startNode; n != pastEnd; lastNode = n, n = next) {
 
         Vector<RefPtr<Node>, 8> exitedAncestors;
         next = nullptr;
@@ -1046,7 +1046,7 @@ static RefPtr<Node> highestAncestorToWrapMarkup(const Position& start, const Pos
     if (!specialCommonAncestor && parentTabSpanNode(&commonAncestor))
         specialCommonAncestor = commonAncestor.parentNode();
     if (!specialCommonAncestor && tabSpanNode(&commonAncestor))
-        specialCommonAncestor = &commonAncestor;
+        specialCommonAncestor = commonAncestor;
 
     if (RefPtr enclosingAnchor = enclosingElementWithTag(firstPositionInNode(specialCommonAncestor ? specialCommonAncestor.get() : &commonAncestor), aTag))
         specialCommonAncestor = WTFMove(enclosingAnchor);

--- a/Source/WebCore/fileapi/FileReader.cpp
+++ b/Source/WebCore/fileapi/FileReader.cpp
@@ -120,7 +120,7 @@ ExceptionOr<void> FileReader::readInternal(Blob& blob, FileReaderLoader::ReadTyp
     if (m_state == LOADING)
         return Exception { ExceptionCode::InvalidStateError };
 
-    m_blob = &blob;
+    m_blob = blob;
     m_readType = type;
     m_state = LOADING;
     m_error = nullptr;

--- a/Source/WebCore/html/HTMLFrameOwnerElement.cpp
+++ b/Source/WebCore/html/HTMLFrameOwnerElement.cpp
@@ -159,7 +159,7 @@ bool HTMLFrameOwnerElement::isProhibitedSelfReference(const URL& completeURL) co
 
 bool SubframeLoadingDisabler::canLoadFrame(HTMLFrameOwnerElement& owner)
 {
-    for (RefPtr<ContainerNode> node = &owner; node; node = node->parentOrShadowHostNode()) {
+    for (RefPtr<ContainerNode> node = owner; node; node = node->parentOrShadowHostNode()) {
         if (disabledSubtreeRoots().contains(node.get()))
             return false;
     }

--- a/Source/WebCore/html/HTMLInputElement.cpp
+++ b/Source/WebCore/html/HTMLInputElement.cpp
@@ -2220,7 +2220,7 @@ RefPtr<HTMLInputElement> HTMLInputElement::checkedRadioButtonForGroup() const
     RefPtr<HTMLInputElement> checkedRadio;
     RadioInputType::forEachButtonInDetachedGroup(rootNode(), name, [&](auto& input) {
         if (input.checked()) {
-            checkedRadio = &input;
+            checkedRadio = input;
             return false;
         }
         return true;

--- a/Source/WebCore/html/HTMLMapElement.cpp
+++ b/Source/WebCore/html/HTMLMapElement.cpp
@@ -65,7 +65,7 @@ bool HTMLMapElement::mapMouseEvent(LayoutPoint location, const LayoutSize& size,
     for (auto& area : descendantsOfType<HTMLAreaElement>(*this)) {
         if (area.isDefault()) {
             if (!defaultArea)
-                defaultArea = &area;
+                defaultArea = area;
         } else if (area.mapMouseEvent(location, size, result))
             return true;
     }

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -2383,7 +2383,7 @@ void HTMLMediaElement::speakCueText(TextTrackCue& cue)
     if (m_speechState != SpeechSynthesisState::None)
         cancelSpeakingCueText();
 
-    m_cueBeingSpoken = &cue;
+    m_cueBeingSpoken = cue;
     RefPtr { m_cueBeingSpoken }->prepareToSpeak(protectedSpeechSynthesis(), m_reportedPlaybackRate ? m_reportedPlaybackRate : m_requestedPlaybackRate, volume(), [weakThis = WeakPtr { *this }](const TextTrackCue&) {
         ASSERT(isMainThread());
         RefPtr<HTMLMediaElement> protectedThis = weakThis.get();
@@ -5786,7 +5786,7 @@ void HTMLMediaElement::sourceWasAdded(HTMLSourceElement& source)
     // attribute and whose networkState has the value NETWORK_EMPTY, the user agent must invoke
     // the media element's resource selection algorithm.
     if (m_networkState == NETWORK_EMPTY) {
-        m_nextChildNodeToConsider = &source;
+        m_nextChildNodeToConsider = source;
 #if PLATFORM(IOS_FAMILY)
         if (mediaSession().dataLoadingPermitted())
 #endif
@@ -5796,7 +5796,7 @@ void HTMLMediaElement::sourceWasAdded(HTMLSourceElement& source)
 
     if (m_currentSourceNode && &source == Traversal<HTMLSourceElement>::nextSibling(*m_currentSourceNode.copyRef())) {
         INFO_LOG(LOGIDENTIFIER, "<source> inserted immediately after current source");
-        m_nextChildNodeToConsider = &source;
+        m_nextChildNodeToConsider = source;
         return;
     }
 
@@ -5814,7 +5814,7 @@ void HTMLMediaElement::sourceWasAdded(HTMLSourceElement& source)
     m_networkState = NETWORK_LOADING;
 
     // 25. Jump back to the find next candidate step above.
-    m_nextChildNodeToConsider = &source;
+    m_nextChildNodeToConsider = source;
     scheduleNextSourceChild();
 }
 

--- a/Source/WebCore/html/HTMLSelectElement.cpp
+++ b/Source/WebCore/html/HTMLSelectElement.cpp
@@ -829,13 +829,13 @@ void HTMLSelectElement::recalcListItems(bool updateSelectedStates, AllowStyleInv
         m_listItems.append(&option);
         if (updateSelectedStates && !m_multiple) {
             if (!firstOption)
-                firstOption = &option;
+                firstOption = option;
             if (option.selected()) {
                 if (foundSelected)
                     foundSelected->setSelectedState(false, allowStyleInvalidation);
-                foundSelected = &option;
+                foundSelected = option;
             } else if (m_size <= 1 && !foundSelected && !option.isDisabledFormControl()) {
-                foundSelected = &option;
+                foundSelected = option;
                 foundSelected->setSelectedState(true, allowStyleInvalidation);
             }
         }

--- a/Source/WebCore/html/HTMLTextFormControlElement.cpp
+++ b/Source/WebCore/html/HTMLTextFormControlElement.cpp
@@ -501,7 +501,7 @@ TextFieldSelectionDirection HTMLTextFormControlElement::computeSelectionDirectio
 static void setContainerAndOffsetForRange(Node& node, unsigned offset, RefPtr<Node>& containerNode, unsigned& offsetInContainer)
 {
     if (node.isTextNode()) {
-        containerNode = &node;
+        containerNode = node;
         offsetInContainer = offset;
     } else {
         containerNode = node.parentNode();

--- a/Source/WebCore/html/PluginDocument.cpp
+++ b/Source/WebCore/html/PluginDocument.cpp
@@ -186,7 +186,7 @@ PluginViewBase* PluginDocument::pluginWidget()
 
 void PluginDocument::setPluginElement(HTMLPlugInElement& element)
 {
-    m_pluginElement = &element;
+    m_pluginElement = element;
 }
 
 void PluginDocument::detachFromPluginElement()

--- a/Source/WebCore/html/ValidatedFormListedElement.cpp
+++ b/Source/WebCore/html/ValidatedFormListedElement.cpp
@@ -384,7 +384,7 @@ bool ValidatedFormListedElement::computeIsDisabledByFieldsetAncestor() const
             bool isInFirstLegend = is<HTMLLegendElement>(previousAncestor) && previousAncestor == fieldset->legend();
             return !isInFirstLegend;
         }
-        previousAncestor = &ancestor;
+        previousAncestor = ancestor;
     }
     return false;
 }

--- a/Source/WebCore/html/canvas/WebGL2RenderingContext.cpp
+++ b/Source/WebCore/html/canvas/WebGL2RenderingContext.cpp
@@ -1780,7 +1780,7 @@ void WebGL2RenderingContext::beginQuery(GCGLenum target, WebGLQuery& query)
         synthesizeGLError(GraphicsContextGL::INVALID_OPERATION, "beginQuery"_s, "query object of target is already active"_s);
         return;
     }
-    m_activeQueries[*activeQueryKey] = &query;
+    m_activeQueries[*activeQueryKey] = query;
     protectedGraphicsContextGL()->beginQuery(target, query.object());
     query.setTarget(target);
 }

--- a/Source/WebCore/html/canvas/WebGLTransformFeedback.cpp
+++ b/Source/WebCore/html/canvas/WebGLTransformFeedback.cpp
@@ -66,7 +66,7 @@ void WebGLTransformFeedback::deleteObjectImpl(const AbstractLocker&, GraphicsCon
 
 void WebGLTransformFeedback::setProgram(const AbstractLocker&, WebGLProgram& program)
 {
-    m_program = &program;
+    m_program = program;
     m_programLinkCount = program.getLinkCount();
 }
 

--- a/Source/WebCore/html/parser/HTMLConstructionSite.cpp
+++ b/Source/WebCore/html/parser/HTMLConstructionSite.cpp
@@ -133,7 +133,7 @@ static inline bool causesFosterParenting(const HTMLStackItem& item)
 static inline void insert(HTMLConstructionSiteTask& task)
 {
     if (auto templateElement = dynamicDowncast<HTMLTemplateElement>(task.parent)) {
-        task.parent = &templateElement->fragmentForInsertion();
+        task.parent = templateElement->fragmentForInsertion();
         task.nextChild = nullptr;
     }
 
@@ -692,7 +692,7 @@ static ALWAYS_INLINE unsigned findBreakIndex(const String& string, unsigned curr
 void HTMLConstructionSite::insertTextNode(const String& characters)
 {
     HTMLConstructionSiteTask task(HTMLConstructionSiteTask::Insert);
-    task.parent = &currentNode();
+    task.parent = currentNode();
 
     if (shouldFosterParent())
         findFosterSite(task);
@@ -744,8 +744,8 @@ void HTMLConstructionSite::insertTextNode(const String& characters)
 void HTMLConstructionSite::reparent(HTMLElementStack::ElementRecord& newParent, HTMLElementStack::ElementRecord& child)
 {
     HTMLConstructionSiteTask task(HTMLConstructionSiteTask::Reparent);
-    task.parent = &newParent.node();
-    task.child = &child.element();
+    task.parent = newParent.node();
+    task.child = child.element();
     m_taskQueue.append(WTFMove(task));
 }
 
@@ -756,16 +756,16 @@ void HTMLConstructionSite::insertAlreadyParsedChild(HTMLStackItem& newParent, HT
         findFosterSite(task);
         ASSERT(task.parent);
     } else
-        task.parent = &newParent.node();
-    task.child = &child.element();
+        task.parent = newParent.node();
+    task.child = child.element();
     m_taskQueue.append(WTFMove(task));
 }
 
 void HTMLConstructionSite::takeAllChildrenAndReparent(HTMLStackItem& newParent, HTMLElementStack::ElementRecord& oldParent)
 {
     HTMLConstructionSiteTask task(HTMLConstructionSiteTask::TakeAllChildrenAndReparent);
-    task.parent = &newParent.node();
-    task.child = &oldParent.node();
+    task.parent = newParent.node();
+    task.child = oldParent.node();
     m_taskQueue.append(WTFMove(task));
 }
 
@@ -946,23 +946,23 @@ void HTMLConstructionSite::findFosterSite(HTMLConstructionSiteTask& task)
     auto* lastTemplate = m_openElements.topmost(HTML::template_);
     auto* lastTable = m_openElements.topmost(HTML::table);
     if (lastTemplate && (!lastTable || lastTemplate->isAbove(*lastTable))) {
-        task.parent = &lastTemplate->element();
+        task.parent = lastTemplate->element();
         return;
     }
 
     if (!lastTable) {
         // Fragment case
-        task.parent = &m_openElements.rootNode();
+        task.parent = m_openElements.rootNode();
         return;
     }
 
     if (auto* parent = lastTable->element().parentNode()) {
         task.parent = parent;
-        task.nextChild = &lastTable->element();
+        task.nextChild = lastTable->element();
         return;
     }
 
-    task.parent = &lastTable->next()->element();
+    task.parent = lastTable->next()->element();
 }
 
 bool HTMLConstructionSite::shouldFosterParent() const

--- a/Source/WebCore/html/parser/HTMLTreeBuilder.cpp
+++ b/Source/WebCore/html/parser/HTMLTreeBuilder.cpp
@@ -2295,7 +2295,7 @@ void HTMLTreeBuilder::processEndTag(AtomHTMLToken&& token)
             // Pause ourselves so that parsing stops until the script can be processed by the caller.
             ASSERT(m_tree.currentStackItem().elementName() == HTML::script);
             if (scriptingContentIsAllowed(m_tree.parserContentPolicy()))
-                m_scriptToProcess = &downcast<HTMLScriptElement>(m_tree.currentElement());
+                m_scriptToProcess = downcast<HTMLScriptElement>(m_tree.currentElement());
             m_tree.openElements().pop();
             m_insertionMode = m_originalInsertionMode;
 
@@ -2470,7 +2470,7 @@ void HTMLTreeBuilder::linkifyPhoneNumbers(const String& string)
     // While there's a phone number in the rest of the string...
     while (!span.empty() && TelephoneNumberDetector::find(span, &relativeStartPosition, &relativeEndPosition)) {
         if (std::exchange(shouldCheckElementAncestors, false)) {
-            for (RefPtr ancestor = &m_tree.currentElement(); ancestor; ancestor = ancestor->parentElement()) {
+            for (RefPtr ancestor = m_tree.currentElement(); ancestor; ancestor = ancestor->parentElement()) {
                 if (auto value = ancestor->getAttribute("data-mime-type"_s); value == "text/latex"_s) {
                     m_tree.insertTextNode(string);
                     return;
@@ -3079,7 +3079,7 @@ void HTMLTreeBuilder::processTokenInForeignContent(AtomHTMLToken&& token)
 
         if (token.tagName() == TagName::script && m_tree.currentStackItem().elementName() == SVG::script) {
             if (scriptingContentIsAllowed(m_tree.parserContentPolicy()))
-                m_scriptToProcess = &downcast<SVGScriptElement>(m_tree.currentElement());
+                m_scriptToProcess = downcast<SVGScriptElement>(m_tree.currentElement());
             m_tree.openElements().pop();
             return;
         }

--- a/Source/WebCore/html/shadow/MediaControlTextTrackContainerElement.cpp
+++ b/Source/WebCore/html/shadow/MediaControlTextTrackContainerElement.cpp
@@ -492,7 +492,7 @@ bool MediaControlTextTrackContainerElement::isShowing() const
 const Logger& MediaControlTextTrackContainerElement::logger() const
 {
     if (!m_logger)
-        m_logger = &document().logger();
+        m_logger = document().logger();
 
     return *m_logger;
 }

--- a/Source/WebCore/html/track/TrackBase.cpp
+++ b/Source/WebCore/html/track/TrackBase.cpp
@@ -188,7 +188,7 @@ void TrackBase::setLanguage(const AtomString& language)
 #if !RELEASE_LOG_DISABLED
 void TrackBase::setLogger(const Logger& logger, uint64_t logIdentifier)
 {
-    m_logger = &logger;
+    m_logger = logger;
     m_logIdentifier = childLogIdentifier(logIdentifier, m_uniqueId);
 }
 

--- a/Source/WebCore/html/track/VTTCue.cpp
+++ b/Source/WebCore/html/track/VTTCue.cpp
@@ -1443,7 +1443,7 @@ void VTTCue::prepareToSpeak(SpeechSynthesis& speechSynthesis, double rate, doubl
     }
 
     Ref track = *this->track();
-    m_speechSynthesis = &speechSynthesis;
+    m_speechSynthesis = speechSynthesis;
     m_speechUtterance = SpeechSynthesisUtterance::create(Ref { *track->scriptExecutionContext() }, m_content, [protectedThis = Ref { *this }, completion = WTFMove(completion)](const SpeechSynthesisUtterance&) {
         protectedThis->m_speechUtterance = nullptr;
         protectedThis->m_speechSynthesis = nullptr;

--- a/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
@@ -2136,7 +2136,7 @@ Ref<Inspector::Protocol::DOM::EventListener> InspectorDOMAgent::buildObjectForEv
         if (auto* scriptExecutionContext = eventTarget.scriptExecutionContext())
             document = dynamicDowncast<Document>(*scriptExecutionContext);
         else if (RefPtr node = dynamicDowncast<Node>(eventTarget))
-            document = &node->document();
+            document = node->document();
 
         JSC::JSObject* handlerObject = nullptr;
         JSC::JSGlobalObject* globalObject = nullptr;

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -3160,7 +3160,7 @@ void FrameLoader::checkLoadComplete(LoadWillContinueInAnotherProcess loadWillCon
     // FIXME: Always traversing the entire frame tree is a bit inefficient, but 
     // is currently needed in order to null out the previous history item for all frames.
     Vector<Ref<LocalFrame>, 16> frames;
-    for (RefPtr frame = &m_frame->mainFrame(); frame; frame = frame->tree().traverseNext()) {
+    for (RefPtr frame = m_frame->mainFrame(); frame; frame = frame->tree().traverseNext()) {
         if (RefPtr localFrame = dynamicDowncast<LocalFrame>(frame))
             frames.append(localFrame.releaseNonNull());
     }
@@ -4499,7 +4499,7 @@ void FrameLoader::loadDifferentDocumentItem(HistoryItem& item, HistoryItem* from
 // Loads content into this frame, as specified by history item
 void FrameLoader::loadItem(HistoryItem& item, HistoryItem* fromItem, FrameLoadType loadType, ShouldTreatAsContinuingLoad shouldTreatAsContinuingLoad)
 {
-    m_requestedHistoryItem = &item;
+    m_requestedHistoryItem = item;
     RefPtr currentItem = history().currentItem();
 
     if (frame().document() && frame().document()->settings().navigationAPIEnabled() && fromItem && SecurityOrigin::create(item.url())->isSameOriginAs(SecurityOrigin::create(fromItem->url()))) {

--- a/Source/WebCore/loader/HistoryController.cpp
+++ b/Source/WebCore/loader/HistoryController.cpp
@@ -441,7 +441,7 @@ void HistoryController::goToItemForNavigationAPI(HistoryItem& targetItem, FrameL
 
 void HistoryController::goToItemShared(HistoryItem& targetItem, CompletionHandler<void(ShouldGoToHistoryItem)>&& completionHandler, ProcessSwapDisposition processSwapDisposition)
 {
-    m_policyItem = &targetItem;
+    m_policyItem = targetItem;
 
     // Same document navigations must continue synchronously from here,
     // therefore their policy checks must go down the synchronous path.
@@ -937,7 +937,7 @@ void HistoryController::recursiveSetProvisionalItem(HistoryItem& item, HistoryIt
             return;
     } else {
         // Set provisional item, which will be committed in recursiveUpdateForCommit.
-        m_provisionalItem = &item;
+        m_provisionalItem = item;
     }
 
     for (Ref childItem : item.children()) {

--- a/Source/WebCore/loader/ImageLoader.cpp
+++ b/Source/WebCore/loader/ImageLoader.cpp
@@ -572,7 +572,7 @@ void ImageLoader::updatedHasPendingEvent()
         if (m_derefElementTimer.isActive())
             m_derefElementTimer.stop();
         else
-            m_protectedElement = &element();
+            m_protectedElement = element();
     } else {
         ASSERT(!m_derefElementTimer.isActive());
         m_derefElementTimer.startOneShot(0_s);

--- a/Source/WebCore/loader/ProgressTracker.cpp
+++ b/Source/WebCore/loader/ProgressTracker.cpp
@@ -118,7 +118,7 @@ void ProgressTracker::progressStarted(LocalFrame& frame)
     if (!m_numProgressTrackedFrames || m_originatingProgressFrame == &frame) {
         reset();
         m_progressValue = initialProgressValue;
-        m_originatingProgressFrame = &frame;
+        m_originatingProgressFrame = frame;
 
         m_progressHeartbeatTimer.startRepeating(progressHeartbeatInterval);
         RefPtr originatingProgressFrame = m_originatingProgressFrame.get();

--- a/Source/WebCore/loader/ResourceTimingInformation.cpp
+++ b/Source/WebCore/loader/ResourceTimingInformation.cpp
@@ -59,7 +59,7 @@ void ResourceTimingInformation::addResourceTiming(CachedResource& resource, Docu
     if (info.added == Added)
         return;
 
-    RefPtr initiatorDocument = &document;
+    RefPtr initiatorDocument = document;
     if (resource.type() == CachedResource::Type::MainResource && document.frame() && document.frame()->loader().shouldReportResourceTimingToParentFrame()) {
         initiatorDocument = document.parentDocument();
         if (initiatorDocument)

--- a/Source/WebCore/loader/cache/CachedResource.cpp
+++ b/Source/WebCore/loader/cache/CachedResource.cpp
@@ -1047,7 +1047,7 @@ void CachedResource::tryReplaceEncodedData(SharedBuffer& newBuffer)
     if (*m_data != newBuffer)
         return;
 
-    m_data = &newBuffer;
+    m_data = newBuffer;
     didReplaceSharedBufferContents();
 }
 

--- a/Source/WebCore/loader/cache/CachedResourceLoader.cpp
+++ b/Source/WebCore/loader/cache/CachedResourceLoader.cpp
@@ -882,7 +882,7 @@ bool CachedResourceLoader::canRequestInContentDispositionAttachmentSandbox(Cache
     switch (type) {
     case CachedResource::Type::MainResource:
         if (RefPtr ownerElement = frame() ? frame()->ownerElement() : nullptr) {
-            document = &ownerElement->document();
+            document = ownerElement->document();
             break;
         }
         return true;

--- a/Source/WebCore/loader/cache/CachedResourceRequest.cpp
+++ b/Source/WebCore/loader/cache/CachedResourceRequest.cpp
@@ -73,7 +73,7 @@ void CachedResourceRequest::setInitiator(Element& element)
 {
     ASSERT(!m_initiatorElement);
     ASSERT(m_initiatorType.isEmpty());
-    m_initiatorElement = &element;
+    m_initiatorElement = element;
 }
 
 void CachedResourceRequest::setInitiatorType(const AtomString& type)
@@ -98,7 +98,7 @@ void CachedResourceRequest::updateForAccessControl(Document& document)
 {
     ASSERT(m_options.mode == FetchOptions::Mode::Cors);
 
-    m_origin = &document.securityOrigin();
+    m_origin = document.securityOrigin();
     updateRequestForAccessControl(m_resourceRequest, *m_origin, m_options.storedCredentialsPolicy);
 }
 

--- a/Source/WebCore/page/ContextMenuController.cpp
+++ b/Source/WebCore/page/ContextMenuController.cpp
@@ -150,7 +150,7 @@ static std::unique_ptr<ContextMenuItem> separatorItem()
 
 void ContextMenuController::showContextMenu(Event& event, ContextMenuProvider& provider)
 {
-    m_menuProvider = &provider;
+    m_menuProvider = provider;
 
     auto contextType = provider.contextMenuContextType();
 
@@ -192,7 +192,7 @@ static void prepareContextForQRCode(ContextMenuContext& context)
     RefPtr<Element> element;
     for (auto& lineage : lineageOfType<Element>(*nodeElement)) {
         if (is<HTMLTableElement>(lineage) || is<HTMLCanvasElement>(lineage) || is<HTMLImageElement>(lineage) || is<SVGSVGElement>(lineage)) {
-            element = &lineage;
+            element = lineage;
             break;
         }
     }

--- a/Source/WebCore/page/DOMWindow.cpp
+++ b/Source/WebCore/page/DOMWindow.cpp
@@ -65,7 +65,7 @@ ExceptionOr<RefPtr<SecurityOrigin>> DOMWindow::createTargetOriginForPostMessage(
 {
     RefPtr<SecurityOrigin> targetSecurityOrigin;
     if (targetOrigin == "/"_s)
-        targetSecurityOrigin = &sourceDocument.securityOrigin();
+        targetSecurityOrigin = sourceDocument.securityOrigin();
     else if (targetOrigin != "*"_s) {
         targetSecurityOrigin = SecurityOrigin::createFromString(targetOrigin);
         // It doesn't make sense target a postMessage at an opaque origin

--- a/Source/WebCore/page/ElementTargetingController.cpp
+++ b/Source/WebCore/page/ElementTargetingController.cpp
@@ -228,8 +228,8 @@ static inline ChildElementPosition findChild(const Element& element, const Eleme
 
         if (child.tagName() == elementTagName) {
             if (!firstOfType)
-                firstOfType = &child;
-            lastOfType = &child;
+                firstOfType = child;
+            lastOfType = child;
         }
         currentChildIndex++;
     }
@@ -726,7 +726,7 @@ static std::optional<TargetedElementInfo> targetedElementInfo(Element& element, 
     }
 
     bool isInVisibilityAdjustmentSubtree = [&] {
-        for (RefPtr ancestor = &element; ancestor; ancestor = ancestor->parentElementInComposedTree()) {
+        for (RefPtr ancestor = element; ancestor; ancestor = ancestor->parentElementInComposedTree()) {
             if (adjustedElements.contains(*ancestor))
                 return true;
         }
@@ -768,7 +768,7 @@ static const HTMLElement* findOnlyMainElement(const HTMLBodyElement& bodyElement
             break;
         }
 
-        onlyMainElement = &descendant;
+        onlyMainElement = descendant;
     }
     return onlyMainElement.get();
 }
@@ -1310,7 +1310,7 @@ Vector<TargetedElementInfo> ElementTargetingController::extractTargets(Vector<Re
             if (RefPtr pseudo = dynamicDowncast<PseudoElement>(candidate))
                 candidateOrHost = pseudo->hostElement();
             else
-                candidateOrHost = &candidate;
+                candidateOrHost = candidate;
             return candidateOrHost && target.isShadowIncludingInclusiveAncestorOf(candidateOrHost.get());
         };
 

--- a/Source/WebCore/page/FocusController.cpp
+++ b/Source/WebCore/page/FocusController.cpp
@@ -350,7 +350,7 @@ FocusNavigationScope FocusNavigationScope::scopeOf(Node& startingNode)
     ASSERT(startingNode.isInTreeScope());
     RefPtr<Node> root;
     RefPtr<Node> parentNode;
-    for (RefPtr<Node> currentNode = &startingNode; currentNode; currentNode = parentNode) {
+    for (RefPtr<Node> currentNode = startingNode; currentNode; currentNode = parentNode) {
         root = currentNode;
         if (HTMLSlotElement* slot = currentNode->assignedSlot()) {
             if (isFocusScopeOwner(*slot))
@@ -1155,7 +1155,7 @@ void FocusController::findFocusCandidateInContainer(const ContainerNode& contain
             continue;
 
         candidateCount++;
-        candidate.enclosingScrollableBox = &container;
+        candidate.enclosingScrollableBox = container;
         updateFocusCandidateIfNeeded(direction, current, candidate, closest);
     }
 

--- a/Source/WebCore/page/FrameTree.cpp
+++ b/Source/WebCore/page/FrameTree.cpp
@@ -71,9 +71,9 @@ void FrameTree::appendChild(Frame& child)
 
     if (oldLast) {
         child.tree().m_previousSibling = oldLast;
-        oldLast->tree().m_nextSibling = &child;
+        oldLast->tree().m_nextSibling = child;
     } else
-        m_firstChild = &child;
+        m_firstChild = child;
 
     m_scopedChildCount = invalidCount;
 
@@ -122,9 +122,9 @@ void FrameTree::replaceChild(Frame& oldChild, Frame& newChild)
     newTree.m_previousSibling = oldPreviousSibling.get();
 
     if (oldChildWasFirst)
-        m_firstChild = &newChild;
+        m_firstChild = newChild;
     if (oldChildWasLast)
-        m_lastChild = &newChild;
+        m_lastChild = newChild;
     if (oldNextSibling)
         oldNextSibling->tree().m_previousSibling = &newChild;
     if (oldPreviousSibling)

--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -2707,7 +2707,7 @@ ExceptionOr<RefPtr<WindowProxy>> LocalDOMWindow::open(LocalDOMWindow& activeWind
     // In those cases, we schedule a location change right now and return early.
     RefPtr<Frame> targetFrame;
     if (isTopTargetFrameName(frameName))
-        targetFrame = &frame->tree().top();
+        targetFrame = frame->tree().top();
     else if (isParentTargetFrameName(frameName)) {
         if (RefPtr parent = frame->tree().parent())
             targetFrame = parent.get();

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -1113,7 +1113,7 @@ bool Page::showAllPlugins() const
 
 inline std::optional<std::pair<WeakRef<MediaCanStartListener>, WeakRef<Document, WeakPtrImplWithEventTargetData>>>  Page::takeAnyMediaCanStartListener()
 {
-    for (RefPtr frame = &mainFrame(); frame; frame = frame->tree().traverseNext()) {
+    for (RefPtr frame = mainFrame(); frame; frame = frame->tree().traverseNext()) {
         RefPtr localFrame = dynamicDowncast<LocalFrame>(*frame);
         if (!localFrame)
             continue;
@@ -1297,7 +1297,7 @@ unsigned Page::findMatchesForText(const String& target, FindOptions options, uns
 
     unsigned matchCount = 0;
 
-    RefPtr frame = &mainFrame();
+    RefPtr frame = mainFrame();
     do {
         RefPtr localFrame = dynamicDowncast<LocalFrame>(frame.get());
         if (!localFrame) {
@@ -1559,7 +1559,7 @@ void Page::setDefersLoading(bool defers)
     }
 
     m_defersLoading = defers;
-    for (RefPtr frame = &mainFrame(); frame; frame = frame->tree().traverseNext()) {
+    for (RefPtr frame = mainFrame(); frame; frame = frame->tree().traverseNext()) {
         if (RefPtr localFrame = dynamicDowncast<LocalFrame>(*frame))
             localFrame->protectedLoader()->setDefersLoading(defers);
     }
@@ -1912,7 +1912,7 @@ void Page::lockAllOverlayScrollbarsToHidden(bool lockOverlayScrollbars)
 
     view->lockOverlayScrollbarStateToHidden(lockOverlayScrollbars);
     
-    for (RefPtr frame = &mainFrame(); frame; frame = frame->tree().traverseNext()) {
+    for (RefPtr frame = mainFrame(); frame; frame = frame->tree().traverseNext()) {
         RefPtr localFrame = dynamicDowncast<LocalFrame>(*frame);
         if (!localFrame)
             continue;
@@ -1998,7 +1998,7 @@ void Page::setIsInWindow(bool isInWindow)
 
 void Page::setIsInWindowInternal(bool isInWindow)
 {
-    for (RefPtr frame = &mainFrame(); frame; frame = frame->tree().traverseNext()) {
+    for (RefPtr frame = mainFrame(); frame; frame = frame->tree().traverseNext()) {
         RefPtr localFrame = dynamicDowncast<LocalFrame>(*frame);
         if (!localFrame)
             continue;
@@ -2532,7 +2532,7 @@ bool Page::shouldUpdateAccessibilityRegions() const
             protectedMainDocument = localMainFrame ? localMainFrame->document() : nullptr;
         else if (RefPtr remoteFrame = dynamicDowncast<RemoteFrame>(mainFrame())) {
             if (auto* owner = remoteFrame->ownerElement())
-                protectedMainDocument = &(owner->document());
+                protectedMainDocument = owner->document();
         }
 
         // If accessibility is enabled and we have a main document, that document should have an AX object cache.
@@ -2789,7 +2789,7 @@ void Page::setDebugger(JSC::Debugger* debugger)
 
     m_debugger = debugger;
 
-    for (RefPtr frame = &m_mainFrame.get(); frame; frame = frame->tree().traverseNext())
+    for (RefPtr frame = m_mainFrame.get(); frame; frame = frame->tree().traverseNext())
         frame->protectedWindowProxy()->attachDebugger(m_debugger);
 }
 
@@ -2823,7 +2823,7 @@ void Page::setMemoryCacheClientCallsEnabled(bool enabled)
     if (!enabled || !m_hasPendingMemoryCacheLoadNotifications)
         return;
 
-    for (RefPtr frame = &mainFrame(); frame; frame = frame->tree().traverseNext()) {
+    for (RefPtr frame = mainFrame(); frame; frame = frame->tree().traverseNext()) {
         if (RefPtr localFrame = dynamicDowncast<LocalFrame>(*frame))
             localFrame->protectedLoader()->tellClientAboutPastMemoryCacheLoads();
     }
@@ -3226,7 +3226,7 @@ void Page::setActivityState(OptionSet<ActivityState> activityState)
 
 void Page::stopKeyboardScrollAnimation()
 {
-    for (RefPtr frame = &mainFrame(); frame; frame = frame->tree().traverseNext()) {
+    for (RefPtr frame = mainFrame(); frame; frame = frame->tree().traverseNext()) {
         RefPtr localFrame = dynamicDowncast<LocalFrame>(*frame);
         if (!localFrame)
             continue;
@@ -3673,7 +3673,7 @@ void Page::addRelevantUnpaintedObject(const RenderObject& object, const LayoutRe
 
 void Page::suspendActiveDOMObjectsAndAnimations()
 {
-    for (RefPtr frame = &mainFrame(); frame; frame = frame->tree().traverseNext()) {
+    for (RefPtr frame = mainFrame(); frame; frame = frame->tree().traverseNext()) {
         if (RefPtr localFrame = dynamicDowncast<LocalFrame>(*frame))
             localFrame->suspendActiveDOMObjectsAndAnimations();
     }
@@ -3681,7 +3681,7 @@ void Page::suspendActiveDOMObjectsAndAnimations()
 
 void Page::resumeActiveDOMObjectsAndAnimations()
 {
-    for (RefPtr frame = &mainFrame(); frame; frame = frame->tree().traverseNext()) {
+    for (RefPtr frame = mainFrame(); frame; frame = frame->tree().traverseNext()) {
         if (RefPtr localFrame = dynamicDowncast<LocalFrame>(*frame))
             localFrame->resumeActiveDOMObjectsAndAnimations();
     }
@@ -3924,7 +3924,7 @@ void Page::setSessionID(PAL::SessionID sessionID)
 
     if (sessionID != m_sessionID) {
         constexpr auto doNotCreate = StorageNamespaceProvider::ShouldCreateNamespace::No;
-        RefPtr topOrigin = &mainFrameOrigin();
+        RefPtr topOrigin = mainFrameOrigin();
         if (RefPtr sessionStorage = topOrigin ? m_storageNamespaceProvider->sessionStorageNamespace(*topOrigin, *this, doNotCreate) : nullptr)
             sessionStorage->setSessionIDForTesting(sessionID);
     }
@@ -4083,7 +4083,7 @@ void Page::setAllowsMediaDocumentInlinePlayback(bool flag)
 IDBClient::IDBConnectionToServer& Page::idbConnection()
 {
     if (!m_idbConnectionToServer)
-        m_idbConnectionToServer = &m_databaseProvider->idbConnectionToServerForSession(m_sessionID);
+        m_idbConnectionToServer = m_databaseProvider->idbConnectionToServerForSession(m_sessionID);
     
     return *m_idbConnectionToServer;
 }
@@ -4382,7 +4382,7 @@ RenderingUpdateScheduler* Page::existingRenderingUpdateScheduler()
 void Page::forEachDocumentFromMainFrame(const Frame& mainFrame, NOESCAPE const Function<void(Document&)>& functor)
 {
     Vector<Ref<Document>, 8> documents;
-    for (RefPtr frame = &mainFrame; frame; frame = frame->tree().traverseNext()) {
+    for (RefPtr frame = mainFrame; frame; frame = frame->tree().traverseNext()) {
         RefPtr localFrame = dynamicDowncast<LocalFrame>(*frame);
         if (!localFrame)
             continue;
@@ -4401,7 +4401,7 @@ void Page::forEachDocument(NOESCAPE const Function<void(Document&)>& functor) co
 
 bool Page::findMatchingLocalDocument(NOESCAPE const Function<bool(Document&)>& functor) const
 {
-    for (RefPtr frame = &mainFrame(); frame; frame = frame->tree().traverseNext()) {
+    for (RefPtr frame = mainFrame(); frame; frame = frame->tree().traverseNext()) {
         RefPtr localFrame = dynamicDowncast<LocalFrame>(*frame);
         if (!localFrame)
             continue;
@@ -4417,7 +4417,7 @@ bool Page::findMatchingLocalDocument(NOESCAPE const Function<bool(Document&)>& f
 void Page::forEachRenderableDocument(NOESCAPE const Function<void(Document&)>& functor) const
 {
     Vector<Ref<Document>, 8> documents;
-    for (RefPtr frame = &mainFrame(); frame; frame = frame->tree().traverseNext()) {
+    for (RefPtr frame = mainFrame(); frame; frame = frame->tree().traverseNext()) {
         RefPtr localFrame = dynamicDowncast<LocalFrame>(*frame);
         if (!localFrame)
             continue;
@@ -4448,7 +4448,7 @@ void Page::forEachMediaElement(NOESCAPE const Function<void(HTMLMediaElement&)>&
 void Page::forEachLocalFrame(NOESCAPE const Function<void(LocalFrame&)>& functor)
 {
     Vector<Ref<LocalFrame>> frames;
-    for (RefPtr frame = &mainFrame(); frame; frame = frame->tree().traverseNext()) {
+    for (RefPtr frame = mainFrame(); frame; frame = frame->tree().traverseNext()) {
         if (RefPtr localFrame = dynamicDowncast<LocalFrame>(*frame))
             frames.append(localFrame.releaseNonNull());
     }
@@ -4461,7 +4461,7 @@ void Page::forEachWindowEventLoop(NOESCAPE const Function<void(WindowEventLoop&)
 {
     UncheckedKeyHashSet<Ref<WindowEventLoop>> windowEventLoops;
     RefPtr<WindowEventLoop> lastEventLoop;
-    for (RefPtr frame = &mainFrame(); frame; frame = frame->tree().traverseNext()) {
+    for (RefPtr frame = mainFrame(); frame; frame = frame->tree().traverseNext()) {
         RefPtr localFrame = dynamicDowncast<LocalFrame>(*frame);
         if (!localFrame)
             continue;
@@ -4555,7 +4555,7 @@ enum class DispatchedOnDocumentEventLoop : bool { No, Yes };
 static void dispatchPrintEvent(Frame& mainFrame, const AtomString& eventType, DispatchedOnDocumentEventLoop dispatchedOnDocumentEventLoop)
 {
     Vector<Ref<LocalFrame>> frames;
-    for (RefPtr frame = &mainFrame; frame; frame = frame->tree().traverseNext()) {
+    for (RefPtr frame = mainFrame; frame; frame = frame->tree().traverseNext()) {
         RefPtr localFrame = dynamicDowncast<LocalFrame>(frame);
         if (!localFrame)
             continue;
@@ -4599,7 +4599,7 @@ bool Page::startApplePayAMSUISession(const URL& originatingURL, ApplePayAMSUIPay
     if (hasActiveApplePayAMSUISession())
         return false;
 
-    m_activeApplePayAMSUIPaymentHandler = &paymentHandler;
+    m_activeApplePayAMSUIPaymentHandler = paymentHandler;
 
     chrome().client().startApplePayAMSUISession(originatingURL, request, [weakThis = WeakPtr { *this }, paymentHandler = Ref { paymentHandler }] (std::optional<bool>&& result) {
         RefPtr protectedThis = weakThis.get();
@@ -5044,7 +5044,7 @@ void Page::setupForRemoteWorker(const URL& scriptURL, const SecurityOriginData& 
 
 void Page::forceRepaintAllFrames()
 {
-    for (RefPtr frame = &mainFrame(); frame; frame = frame->tree().traverseNext()) {
+    for (RefPtr frame = mainFrame(); frame; frame = frame->tree().traverseNext()) {
         RefPtr localFrame = dynamicDowncast<LocalFrame>(*frame);
         if (!localFrame)
             continue;
@@ -5153,7 +5153,7 @@ void Page::reloadExecutionContextsForOrigin(const ClientOrigin& origin, std::opt
     if (!localMainFrame || localMainFrame->protectedDocument()->topOrigin().data() != origin.topOrigin)
         return;
 
-    for (RefPtr frame = &m_mainFrame.get(); frame;) {
+    for (RefPtr frame = m_mainFrame.get(); frame;) {
         RefPtr localFrame = dynamicDowncast<LocalFrame>(*frame);
         if (!localFrame || frame->frameID() == triggeringFrame) {
             frame = frame->tree().traverseNext();
@@ -5321,7 +5321,7 @@ bool Page::hasActiveImmersiveSession() const
 
 RefPtr<WebXRSession> Page::activeImmersiveXRSession() const
 {
-    for (RefPtr frame = &m_mainFrame.get(); frame; frame = frame->tree().traverseNext()) {
+    for (RefPtr frame = m_mainFrame.get(); frame; frame = frame->tree().traverseNext()) {
         RefPtr localFrame = dynamicDowncast<LocalFrame>(*frame);
         RefPtr window = localFrame ? localFrame->window() : nullptr;
         if (!window)

--- a/Source/WebCore/page/PerformanceObserver.cpp
+++ b/Source/WebCore/page/PerformanceObserver.cpp
@@ -40,9 +40,9 @@ PerformanceObserver::PerformanceObserver(ScriptExecutionContext& scriptExecution
 {
     if (RefPtr document = dynamicDowncast<Document>(scriptExecutionContext)) {
         if (auto* window = document->domWindow())
-            m_performance = &window->performance();
+            m_performance = window->performance();
     } else if (RefPtr workerGlobalScope = dynamicDowncast<WorkerGlobalScope>(scriptExecutionContext))
-        m_performance = &workerGlobalScope->performance();
+        m_performance = workerGlobalScope->performance();
     else
         ASSERT_NOT_REACHED();
 }

--- a/Source/WebCore/page/PointerCaptureController.cpp
+++ b/Source/WebCore/page/PointerCaptureController.cpp
@@ -225,7 +225,7 @@ void PointerCaptureController::dispatchOverOrOutEvent(const AtomString& type, Ev
 void PointerCaptureController::dispatchEnterOrLeaveEvent(const AtomString& type, Element& targetElement, const PlatformTouchEvent& event, unsigned index, bool isPrimary, WindowProxy& view, IntPoint touchDelta)
 {
     bool hasCapturingListenerInHierarchy = false;
-    for (RefPtr<ContainerNode> currentNode = &targetElement; currentNode; currentNode = currentNode->parentInComposedTree()) {
+    for (RefPtr<ContainerNode> currentNode = targetElement; currentNode; currentNode = currentNode->parentInComposedTree()) {
         if (currentNode->hasCapturingEventListeners(type)) {
             hasCapturingListenerInHierarchy = true;
             break;
@@ -233,7 +233,7 @@ void PointerCaptureController::dispatchEnterOrLeaveEvent(const AtomString& type,
     }
 
     Vector<Ref<Element>, 32> targetChain;
-    for (RefPtr element = &targetElement; element; element = element->parentElementInComposedTree()) {
+    for (RefPtr element = targetElement; element; element = element->parentElementInComposedTree()) {
         if (hasCapturingListenerInHierarchy || element->hasEventListeners(type))
             targetChain.append(*element);
     }
@@ -465,7 +465,7 @@ void PointerCaptureController::pointerEventWillBeDispatched(const PointerEvent& 
     // Let targetDocument be target's node document.
     // If the event is pointerdown, pointermove, or pointerup set active document for the event's pointerId to targetDocument.
     auto capturingData = ensureCapturingDataForPointerEvent(event);
-    capturingData->activeDocument = &element.document();
+    capturingData->activeDocument = element.document();
 
     if (isPointermove)
         return;

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -966,7 +966,7 @@ static bool isKinjaLoginAvatarElement(const Element& element)
 
     RefPtr<const Element> svgElement;
     if (is<SVGSVGElement>(element))
-        svgElement = &element;
+        svgElement = element;
     else if (is<SVGPathElement>(element) && is<SVGSVGElement>(element.parentElement()))
         svgElement = element.parentElement();
 

--- a/Source/WebCore/page/UserContentProvider.cpp
+++ b/Source/WebCore/page/UserContentProvider.cpp
@@ -115,9 +115,9 @@ static ContentExtensions::ContentExtensionsBackend::RuleListFilter ruleListFilte
         };
     }
 
-    auto policySourceLoader = mainLoader;
+    RefPtr policySourceLoader = mainLoader;
     if (!mainLoader->request().url().hasSpecialScheme() && documentLoader.request().url().protocolIsInHTTPFamily())
-        policySourceLoader = &documentLoader;
+        policySourceLoader = documentLoader;
 
     auto& exceptions = policySourceLoader->contentExtensionEnablement().second;
     switch (policySourceLoader->contentExtensionEnablement().first) {

--- a/Source/WebCore/page/cocoa/PageCocoa.mm
+++ b/Source/WebCore/page/cocoa/PageCocoa.mm
@@ -95,7 +95,7 @@ void Page::addSchedulePair(Ref<SchedulePair>&& pair)
         m_scheduledRunLoopPairs = makeUnique<SchedulePairHashSet>();
     m_scheduledRunLoopPairs->add(pair.ptr());
 
-    for (RefPtr frame = &m_mainFrame.get(); frame; frame = frame->tree().traverseNext()) {
+    for (RefPtr frame = m_mainFrame.get(); frame; frame = frame->tree().traverseNext()) {
         RefPtr localFrame = dynamicDowncast<LocalFrame>(frame);
         if (!localFrame)
             continue;
@@ -116,7 +116,7 @@ void Page::removeSchedulePair(Ref<SchedulePair>&& pair)
 
     m_scheduledRunLoopPairs->remove(pair.ptr());
 
-    for (RefPtr frame = &m_mainFrame.get(); frame; frame = frame->tree().traverseNext()) {
+    for (RefPtr frame = m_mainFrame.get(); frame; frame = frame->tree().traverseNext()) {
         RefPtr localFrame = dynamicDowncast<LocalFrame>(frame);
         if (!localFrame)
             continue;

--- a/Source/WebCore/page/ios/ContentChangeObserver.cpp
+++ b/Source/WebCore/page/ios/ContentChangeObserver.cpp
@@ -199,7 +199,7 @@ ContentChangeObserver::ContentChangeObserver(Document& document)
 
 static void willNotProceedWithClick(LocalFrame& mainFrame)
 {
-    for (RefPtr<Frame> frame = &mainFrame; frame; frame = frame->tree().traverseNext()) {
+    for (RefPtr<Frame> frame = mainFrame; frame; frame = frame->tree().traverseNext()) {
         RefPtr localFrame = dynamicDowncast<LocalFrame>(frame);
         if (!localFrame)
             continue;

--- a/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp
+++ b/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp
@@ -586,7 +586,7 @@ LocalFrameView* AsyncScrollingCoordinator::frameViewForScrollingNode(LocalFrame&
 
     // Walk the frame tree to find the matching LocalFrameView. This is not ideal, but avoids back pointers to LocalFrameViews
     // from ScrollingTreeStateNodes.
-    for (RefPtr<Frame> frame = &rootFrame; frame; frame = frame->tree().traverseNext()) {
+    for (RefPtr<Frame> frame = rootFrame; frame; frame = frame->tree().traverseNext()) {
         auto* localFrame = dynamicDowncast<LocalFrame>(frame.get());
         if (!localFrame)
             continue;

--- a/Source/WebCore/page/writing-tools/WritingToolsController.mm
+++ b/Source/WebCore/page/writing-tools/WritingToolsController.mm
@@ -1181,8 +1181,8 @@ std::optional<std::tuple<Node&, DocumentMarker&>> WritingToolsController::findTe
         if (data.suggestionID != textSuggestionID)
             return false;
 
-        targetNode = &node;
-        targetMarker = &marker;
+        targetNode = node;
+        targetMarker = marker;
 
         return true;
     });
@@ -1211,8 +1211,8 @@ std::optional<std::tuple<Node&, DocumentMarker&>> WritingToolsController::findTe
         if (!contains(TreeType::ComposedTree, markerRange, range))
             return false;
 
-        targetNode = &node;
-        targetMarker = &marker;
+        targetNode = node;
+        targetMarker = marker;
 
         return true;
     });

--- a/Source/WebCore/platform/audio/AudioBus.cpp
+++ b/Source/WebCore/platform/audio/AudioBus.cpp
@@ -529,7 +529,7 @@ RefPtr<AudioBus> AudioBus::createBySampleRateConverting(const AudioBus& sourceBu
         resamplerSourceBus = mixedMonoBus.get();
     } else {
         // Directly resample without down-mixing.
-        resamplerSourceBus = &sourceBus;
+        resamplerSourceBus = sourceBus;
     }
 
     // Calculate destination length based on the sample-rates.


### PR DESCRIPTION
#### 3c7fe87417430cf1feec93079e4c4576eee0264a
<pre>
Leverage the `RefPtr&lt;T&gt;(T&amp;)` constructor in more places
<a href="https://bugs.webkit.org/show_bug.cgi?id=294309">https://bugs.webkit.org/show_bug.cgi?id=294309</a>

Reviewed by Anne van Kesteren.

* Source/WebCore/Modules/WebGPU/Implementation/WebGPUCompositorIntegrationImpl.h:
* Source/WebCore/Modules/applepay/PaymentCoordinator.cpp:
(WebCore::PaymentCoordinator::beginPaymentSession):
* Source/WebCore/Modules/highlight/AppHighlightStorage.cpp:
(WebCore::findNodeStartingAtPathComponentIndex):
* Source/WebCore/Modules/indexeddb/IDBDatabase.cpp:
(WebCore::IDBDatabase::startVersionChangeTransaction):
* Source/WebCore/Modules/indexeddb/IDBRequest.cpp:
(WebCore::IDBRequest::setVersionChangeTransaction):
(WebCore::IDBRequest::dispatchEvent):
(WebCore::IDBRequest::willIterateCursor):
* Source/WebCore/Modules/indexeddb/IDBTransaction.cpp:
(WebCore::IDBTransaction::abortDueToFailedRequest):
(WebCore::IDBTransaction::completeNoncursorRequest):
(WebCore::IDBTransaction::completeCursorRequest):
* Source/WebCore/Modules/indexeddb/server/MemoryIndex.cpp:
(WebCore::IDBServer::MemoryIndex::writeTransactionStarted):
* Source/WebCore/Modules/indexeddb/server/MemoryObjectStore.cpp:
(WebCore::IDBServer::MemoryObjectStore::writeTransactionStarted):
* Source/WebCore/Modules/mediacontrols/MediaControlsHost.cpp:
(WebCore::MediaControlsHost::savePreviouslySelectedTextTrackIfNecessary):
* Source/WebCore/Modules/mediasession/MediaSession.cpp:
(WebCore::MediaSession::MediaSession):
* Source/WebCore/Modules/mediasession/MediaSessionCoordinatorPrivate.cpp:
(WebCore::MediaSessionCoordinatorPrivate::setLogger):
* Source/WebCore/Modules/mediastream/ImageCapture.cpp:
* Source/WebCore/Modules/mediastream/RTCEncodedFrame.cpp:
(WebCore::RTCEncodedFrame::setData):
* Source/WebCore/Modules/mediastream/RTCRtpScriptTransform.cpp:
(WebCore::RTCRtpScriptTransform::initializeTransformer):
* Source/WebCore/Modules/speech/SpeechRecognition.cpp:
(WebCore::SpeechRecognition::SpeechRecognition):
* Source/WebCore/Modules/system-preview/ARKitBadgeSystemImage.h:
* Source/WebCore/Modules/webaudio/AudioWorkletNode.cpp:
(WebCore::AudioWorkletNode::setProcessor):
* Source/WebCore/Modules/webaudio/AudioWorkletNode.h:
* Source/WebCore/Modules/webaudio/OscillatorNode.cpp:
(WebCore::OscillatorNode::setPeriodicWave):
* Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.cpp:
(WebCore::WebCodecsVideoFrame::clone):
* Source/WebCore/accessibility/AXCoreObject.cpp:
(WebCore::AXCoreObject::partialOrder):
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::handleChildrenChanged):
* Source/WebCore/accessibility/AXTextMarker.cpp:
(WebCore::Accessibility::findObjectWithRuns):
* Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm:
(-[WebAccessibilityObjectWrapper accessibilityRowRange]):
* Source/WebCore/accessibility/playstation/AXObjectCachePlayStation.cpp:
(WebCore::AXObjectCache::postPlatformNotification):
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::setTarget):
* Source/WebCore/animation/StyleOriginatedTimelinesController.cpp:
(WebCore::StyleOriginatedTimelinesController::determineTreeOrder):
(WebCore::StyleOriginatedTimelinesController::updateTimelineForTimelineScope):
* Source/WebCore/bindings/js/ScriptController.cpp:
(WebCore::ScriptController::collectIsolatedContexts):
* Source/WebCore/bindings/js/ScriptModuleLoader.cpp:
(WebCore::ScriptModuleLoader::fetch):
* Source/WebCore/bindings/js/WorkerScriptFetcher.h:
* Source/WebCore/css/CSSFontFaceSrcValue.cpp:
(WebCore::CSSFontFaceSrcLocalValue::setSVGFontFaceElement):
* Source/WebCore/css/ShorthandSerializer.cpp:
(WebCore::ShorthandSerializer::serializeBorderRadius const):
* Source/WebCore/css/calc/CSSCalcTree+ContainerProgressEvaluator.cpp:
(WebCore::CSSCalc::evaluateContainerProgress):
* Source/WebCore/dom/Attr.cpp:
(WebCore::Attr::attachToElement):
* Source/WebCore/dom/ChildListMutationScope.cpp:
(WebCore::ChildListMutationAccumulator::childAdded):
* Source/WebCore/dom/ContainerNode.cpp:
(WebCore::containsIncludingHostElements):
(WebCore::dispatchChildInsertionEvents):
* Source/WebCore/dom/ContainerNodeAlgorithms.cpp:
(WebCore::notifyNodeInsertedIntoDocument):
(WebCore::notifyNodeInsertedIntoTree):
(WebCore::notifyNodeRemovedFromDocument):
(WebCore::notifyNodeRemovedFromTree):
* Source/WebCore/dom/ContentVisibilityDocumentState.cpp:
(WebCore::ContentVisibilityDocumentState::updateContentRelevancyForScrollIfNeeded):
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::invalidateQuerySelectorAllResults):
(WebCore::Document::invalidateQuerySelectorAllResultsForClassAttributeChange):
(WebCore::Document::processBaseElement):
(WebCore::Document::idbConnectionProxy):
* Source/WebCore/dom/DocumentFullscreen.cpp:
(WebCore::DocumentFullscreen::willEnterFullscreen):
(WebCore::documentsToUnfullscreen):
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::topmostPopoverAncestor):
* Source/WebCore/dom/Event.cpp:
(WebCore::Event::setEventPath):
(WebCore::Event::timeStampForBindings const):
* Source/WebCore/dom/EventPath.cpp:
(WebCore::RelatedNodeRetargeter::RelatedNodeRetargeter):
* Source/WebCore/dom/FragmentDirectiveRangeFinder.cpp:
(WebCore::FragmentDirectiveRangeFinder::rangeOfStringInRange):
* Source/WebCore/dom/FragmentDirectiveUtilities.cpp:
(WebCore::FragmentDirectiveUtilities::nearestBlockAncestor):
* Source/WebCore/dom/InternalObserverDrop.cpp:
* Source/WebCore/dom/InternalObserverFilter.cpp:
* Source/WebCore/dom/InternalObserverMap.cpp:
* Source/WebCore/dom/InternalObserverTake.cpp:
* Source/WebCore/dom/LoadableModuleScript.cpp:
(WebCore::LoadableModuleScript::notifyLoadCompleted):
* Source/WebCore/dom/Range.cpp:
(WebCore::Range::surroundContents):
* Source/WebCore/dom/RejectedPromiseTracker.cpp:
(WebCore::RejectedPromiseTracker::reportUnhandledRejections):
* Source/WebCore/dom/UserGestureIndicator.cpp:
(WebCore::UserGestureToken::UserGestureToken):
* Source/WebCore/editing/ApplyStyleCommand.cpp:
(WebCore::ApplyStyleCommand::applyInlineStyle):
(WebCore::ApplyStyleCommand::applyInlineStyleToNodeRange):
(WebCore::ApplyStyleCommand::surroundNodeRangeWithElement):
(WebCore::ApplyStyleCommand::applyInlineStyleChange):
* Source/WebCore/editing/CompositeEditCommand.cpp:
(WebCore::CompositeEditCommand::moveParagraphs):
* Source/WebCore/editing/EditingStyle.cpp:
(WebCore::EditingStyle::wrappingStyleForSerialization):
* Source/WebCore/editing/Editor.cpp:
(WebCore::Editor::appliedEditing):
* Source/WebCore/editing/FrameSelection.cpp:
(WebCore::DragCaretController::setCaretPosition):
(WebCore::FrameSelection::associateLiveRange):
* Source/WebCore/editing/MarkupAccumulator.cpp:
(WebCore::MarkupAccumulator::serializeNodesWithNamespaces):
* Source/WebCore/editing/TextIterator.cpp:
(WebCore::nextInPreOrderCrossingShadowBoundaries):
(WebCore::shouldEmitNewlineAfterNode):
(WebCore::TextIterator::emitText):
* Source/WebCore/editing/VisibleSelection.cpp:
(WebCore::isInUserAgentShadowRootOrHasEditableShadowAncestor):
* Source/WebCore/editing/markup.cpp:
(WebCore::UserSelectNoneStateCache::computeState):
(WebCore::StyledMarkupAccumulator::traverseNodesForSerialization):
(WebCore::highestAncestorToWrapMarkup):
* Source/WebCore/fileapi/FileReader.cpp:
(WebCore::FileReader::readInternal):
* Source/WebCore/html/HTMLFrameOwnerElement.cpp:
(WebCore::SubframeLoadingDisabler::canLoadFrame):
* Source/WebCore/html/HTMLInputElement.cpp:
(WebCore::HTMLInputElement::checkedRadioButtonForGroup const):
* Source/WebCore/html/HTMLMapElement.cpp:
(WebCore::HTMLMapElement::mapMouseEvent):
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::speakCueText):
(WebCore::HTMLMediaElement::sourceWasAdded):
* Source/WebCore/html/HTMLSelectElement.cpp:
(WebCore::HTMLSelectElement::recalcListItems const):
* Source/WebCore/html/HTMLTextFormControlElement.cpp:
(WebCore::setContainerAndOffsetForRange):
* Source/WebCore/html/PluginDocument.cpp:
* Source/WebCore/html/ValidatedFormListedElement.cpp:
(WebCore::ValidatedFormListedElement::computeIsDisabledByFieldsetAncestor const):
* Source/WebCore/html/canvas/WebGL2RenderingContext.cpp:
(WebCore::WebGL2RenderingContext::beginQuery):
* Source/WebCore/html/canvas/WebGLTransformFeedback.cpp:
(WebCore::WebGLTransformFeedback::setProgram):
* Source/WebCore/html/parser/HTMLConstructionSite.cpp:
(WebCore::insert):
(WebCore::HTMLConstructionSite::insertTextNode):
(WebCore::HTMLConstructionSite::reparent):
(WebCore::HTMLConstructionSite::insertAlreadyParsedChild):
(WebCore::HTMLConstructionSite::takeAllChildrenAndReparent):
(WebCore::HTMLConstructionSite::findFosterSite):
* Source/WebCore/html/parser/HTMLTreeBuilder.cpp:
(WebCore::HTMLTreeBuilder::processEndTag):
(WebCore::HTMLTreeBuilder::linkifyPhoneNumbers):
(WebCore::HTMLTreeBuilder::processTokenInForeignContent):
* Source/WebCore/html/shadow/MediaControlTextTrackContainerElement.cpp:
(WebCore::MediaControlTextTrackContainerElement::logger const):
* Source/WebCore/html/track/TrackBase.cpp:
(WebCore::TrackBase::setLogger):
* Source/WebCore/html/track/VTTCue.cpp:
(WebCore::VTTCue::prepareToSpeak):
* Source/WebCore/inspector/agents/InspectorDOMAgent.cpp:
(WebCore::InspectorDOMAgent::buildObjectForEventListener):
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::checkLoadComplete):
(WebCore::FrameLoader::loadItem):
* Source/WebCore/loader/HistoryController.cpp:
(WebCore::HistoryController::goToItemShared):
(WebCore::HistoryController::recursiveSetProvisionalItem):
* Source/WebCore/loader/ImageLoader.cpp:
(WebCore::ImageLoader::updatedHasPendingEvent):
* Source/WebCore/loader/ProgressTracker.cpp:
(WebCore::ProgressTracker::progressStarted):
* Source/WebCore/loader/ResourceTimingInformation.cpp:
(WebCore::ResourceTimingInformation::addResourceTiming):
* Source/WebCore/loader/cache/CachedResource.cpp:
(WebCore::CachedResource::tryReplaceEncodedData):
* Source/WebCore/loader/cache/CachedResourceLoader.cpp:
(WebCore::CachedResourceLoader::canRequestInContentDispositionAttachmentSandbox const):
* Source/WebCore/loader/cache/CachedResourceRequest.cpp:
(WebCore::CachedResourceRequest::setInitiator):
(WebCore::CachedResourceRequest::updateForAccessControl):
* Source/WebCore/page/ContextMenuController.cpp:
(WebCore::ContextMenuController::showContextMenu):
(WebCore::prepareContextForQRCode):
* Source/WebCore/page/DOMWindow.cpp:
(WebCore::DOMWindow::createTargetOriginForPostMessage):
* Source/WebCore/page/ElementTargetingController.cpp:
(WebCore::findChild):
(WebCore::targetedElementInfo):
(WebCore::findOnlyMainElement):
(WebCore::ElementTargetingController::extractTargets):
* Source/WebCore/page/FocusController.cpp:
(WebCore::FocusNavigationScope::scopeOf):
(WebCore::FocusController::findFocusCandidateInContainer):
* Source/WebCore/page/FrameTree.cpp:
(WebCore::FrameTree::appendChild):
(WebCore::FrameTree::replaceChild):
* Source/WebCore/page/LocalDOMWindow.cpp:
(WebCore::LocalDOMWindow::open):
* Source/WebCore/page/Page.cpp:
(WebCore::Page::takeAnyMediaCanStartListener):
(WebCore::Page::findMatchesForText):
(WebCore::Page::setDefersLoading):
(WebCore::Page::lockAllOverlayScrollbarsToHidden):
(WebCore::Page::setIsInWindowInternal):
(WebCore::Page::shouldUpdateAccessibilityRegions const):
(WebCore::Page::setDebugger):
(WebCore::Page::setMemoryCacheClientCallsEnabled):
(WebCore::Page::stopKeyboardScrollAnimation):
(WebCore::Page::suspendActiveDOMObjectsAndAnimations):
(WebCore::Page::resumeActiveDOMObjectsAndAnimations):
(WebCore::Page::setSessionID):
(WebCore::Page::idbConnection):
(WebCore::Page::forEachDocumentFromMainFrame):
(WebCore::Page::findMatchingLocalDocument const):
(WebCore::Page::forEachRenderableDocument const):
(WebCore::Page::forEachLocalFrame):
(WebCore::Page::forEachWindowEventLoop):
(WebCore::dispatchPrintEvent):
(WebCore::Page::startApplePayAMSUISession):
(WebCore::Page::forceRepaintAllFrames):
(WebCore::Page::reloadExecutionContextsForOrigin const):
(WebCore::Page::activeImmersiveXRSession const):
* Source/WebCore/page/PerformanceObserver.cpp:
(WebCore::PerformanceObserver::PerformanceObserver):
* Source/WebCore/page/PointerCaptureController.cpp:
(WebCore::PointerCaptureController::dispatchEnterOrLeaveEvent):
(WebCore::PointerCaptureController::pointerEventWillBeDispatched):
* Source/WebCore/page/Quirks.cpp:
(WebCore::isKinjaLoginAvatarElement):
* Source/WebCore/page/UserContentProvider.cpp:
(WebCore::ruleListFilter):
* Source/WebCore/page/cocoa/PageCocoa.mm:
(WebCore::Page::addSchedulePair):
(WebCore::Page::removeSchedulePair):
* Source/WebCore/page/ios/ContentChangeObserver.cpp:
(WebCore::willNotProceedWithClick):
* Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp:
(WebCore::AsyncScrollingCoordinator::frameViewForScrollingNode const):
* Source/WebCore/page/writing-tools/WritingToolsController.mm:
(WebCore::WritingToolsController::findTextSuggestionMarkerByID const):
(WebCore::WritingToolsController::findTextSuggestionMarkerContainingRange const):
* Source/WebCore/platform/audio/AudioBus.cpp:
(WebCore::AudioBus::createBySampleRateConverting):

Canonical link: <a href="https://commits.webkit.org/296098@main">https://commits.webkit.org/296098@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/73762a20f8569017b4ab14aac119477b44ae2f80

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/107340 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27022 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/17426 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/112554 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/57876 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/109304 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/27704 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/35522 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/81483 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/110269 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/21950 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/96743 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/61857 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/21389 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/14874 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/57319 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/91319 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/14907 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/115655 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/34406 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/25357 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/90525 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/34782 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/92993 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/90261 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35169 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/12952 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/30150 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17364 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/34328 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/39865 "Failed to build and analyze WebKit") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34074 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/37429 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/35735 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->