### PR TITLE
Google Spreadsheet is glitchy in Safari

### DIFF
--- a/LayoutTests/fast/events/page-visibility-resize-event-order-expected.txt
+++ b/LayoutTests/fast/events/page-visibility-resize-event-order-expected.txt
@@ -1,0 +1,17 @@
+This test checks that resize event fires after visibilitychange event when a frame is resized while the page is hidden.
+To manually test, minimize this window and restore the window. You should see a series of "PASS" below:
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS document.visibilityState is "visible"
+PASS document.hidden is false
+PASS document.visibilityState is "hidden"
+PASS document.hidden is true
+PASS document.visibilityState is "visible"
+PASS document.hidden is false
+PASS didReceiveResizeEvent is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/events/page-visibility-resize-event-order.html
+++ b/LayoutTests/fast/events/page-visibility-resize-event-order.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="../../resources/js-test.js"></script>
+<script>
+description(`This test checks that resize event fires after visibilitychange event when a frame is resized while the page is hidden.<br>
+To manually test, minimize this window and restore the window. You should see a series of "PASS" below:`);
+
+const iframe = document.createElement('iframe');
+iframe.style = 'width: 100px; height: 100px;';
+iframe.onload = () => {
+    iframe.contentWindow.requestAnimationFrame(() => {
+        setTimeout(startTest, 0);
+    });
+}
+document.body.appendChild(iframe);
+
+var jsTestIsAsync = true;
+
+function setPageVisibility(state) {
+    if (window.testRunner)
+        testRunner.setPageVisibility(state);
+}
+
+function checkIsPageVisible() {
+    shouldBeEqualToString("document.visibilityState", "visible");
+    shouldBeFalse("document.hidden");
+}
+
+function checkIsPageHidden() {
+    shouldBeEqualToString("document.visibilityState", "hidden");
+    shouldBeTrue("document.hidden");
+}
+
+function startTest() {
+    iframe.contentDocument.onvisibilitychange = function () {
+        checkIsPageHidden();
+        iframe.style = 'width: 200px; height: 200px;';
+        iframe.contentDocument.onvisibilitychange = function () {
+            window.didReceiveResizeEvent = false;
+            iframe.contentWindow.addEventListener('resize', () => {
+                window.didReceiveResizeEvent = true;
+            });
+
+            checkIsPageVisible();
+            requestAnimationFrame(() => {
+                setTimeout(() => {
+                    shouldBeTrue('didReceiveResizeEvent');
+                    if (window.testRunner)
+                        testRunner.resetPageVisibility();
+                    finishJSTest();
+                }, 0);
+            });
+        }
+        setTimeout(() => setPageVisibility("visible"), 20);
+    };
+    checkIsPageVisible();
+    setPageVisibility("hidden");
+}
+
+
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/wpe/TestExpectations
+++ b/LayoutTests/platform/wpe/TestExpectations
@@ -934,6 +934,7 @@ webkit.org/b/173419 fast/events/page-visibility-iframe-delete-test.html [ Timeou
 webkit.org/b/173419 fast/events/page-visibility-iframe-move-test.html [ Timeout ]
 webkit.org/b/173419 fast/events/page-visibility-iframe-propagation-test.html [ Timeout ]
 webkit.org/b/173419 fast/events/page-visibility-onvisibilitychange.html [ Timeout ]
+webkit.org/b/173419 fast/events/page-visibility-resize-event-order.html [ Timeout ]
 webkit.org/b/173419 fast/events/page-visibility-transition-test.html [ Timeout ]
 webkit.org/b/173419 fast/events/scroll-in-scaled-page-with-overflow-hidden.html [ Failure Timeout ]
 webkit.org/b/173419 fast/events/shadow-event-path-2.html [ Failure ]

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -2332,6 +2332,7 @@ private:
     UncheckedKeyHashSet<WeakRef<Element, WeakPtrImplWithEventTargetData>> m_articleElements;
 
     WeakHashSet<VisibilityChangeClient> m_visibilityStateCallbackClients;
+    bool m_deferResizeEventForVisibilityChange { false };
 
     std::unique_ptr<UncheckedKeyHashMap<String, WeakPtr<Element, WeakPtrImplWithEventTargetData>, ASCIICaseInsensitiveHash>> m_accessKeyCache;
 


### PR DESCRIPTION
#### 8dbebaa6d56be48eca38f560fb23754b279ff69d
<pre>
Google Spreadsheet is glitchy in Safari
<a href="https://bugs.webkit.org/show_bug.cgi?id=294310">https://bugs.webkit.org/show_bug.cgi?id=294310</a>

Reviewed by Simon Fraser.

The bug was caused by WebKit firing resize event before visibilitychange event.
Defer the dispatching of resize event while the page is not visible to emulate the behavior of Chrome.

This fixes the glitch on Google spreadsheet.

* LayoutTests/fast/events/page-visibility-resize-event-order-expected.txt: Added.
* LayoutTests/fast/events/page-visibility-resize-event-order.html: Added.
* LayoutTests/platform/wpe/TestExpectations:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::visibilityStateChanged):
(WebCore::Document::runResizeSteps):
* Source/WebCore/dom/Document.h:

Canonical link: <a href="https://commits.webkit.org/296124@main">https://commits.webkit.org/296124@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b87bcfa1766b71d6d7d5d108bd48ef35a3c30bc2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/107423 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27105 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/17511 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/112637 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/57959 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/109387 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/27788 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/35605 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/81551 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/110352 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22012 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/96819 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/61927 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/21453 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/14950 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/57403 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/91383 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/14984 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/115738 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/34490 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/25422 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/90590 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/34865 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93068 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/90327 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35241 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13022 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/30233 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17375 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/34411 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/39952 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34157 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/37512 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/35818 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->