### PR TITLE
OverconstrainedError in getUserMedia on iOS 18.1 Simulator

### DIFF
--- a/Source/WebCore/platform/mediastream/mac/AVCaptureDeviceManager.mm
+++ b/Source/WebCore/platform/mediastream/mac/AVCaptureDeviceManager.mm
@@ -185,7 +185,7 @@ Vector<CaptureDevice> AVCaptureDeviceManager::retrieveCaptureDevices()
 #if HAVE(AVCAPTUREDEVICE)
     auto currentDevices = currentCameras();
     AVCaptureDevice *defaultVideoDevice = nil;
-#if HAVE(CONTINUITY_CAMERA)
+#if HAVE(CONTINUITY_CAMERA) && !PLATFORM(IOS_FAMILY_SIMULATOR)
     auto haveSystemPreferredCamera = !![PAL::getAVCaptureDeviceClass() respondsToSelector:@selector(systemPreferredCamera)];
     if (haveSystemPreferredCamera)
         defaultVideoDevice = [PAL::getAVCaptureDeviceClass() systemPreferredCamera];
@@ -195,7 +195,7 @@ Vector<CaptureDevice> AVCaptureDeviceManager::retrieveCaptureDevices()
 
 #if PLATFORM(IOS) || PLATFORM(VISION)
     ([&] {
-#if HAVE(CONTINUITY_CAMERA)
+#if HAVE(CONTINUITY_CAMERA) && !PLATFORM(IOS_FAMILY_SIMULATOR)
         if (haveSystemPreferredCamera && defaultVideoDevice)
             return;
 #endif


### PR DESCRIPTION
#### 22a5e4f2aa67f7103a6d4ad05e72717cfca4261c
<pre>
OverconstrainedError in getUserMedia on iOS 18.1 Simulator
<a href="https://rdar.apple.com/152938326">rdar://152938326</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=293949">https://bugs.webkit.org/show_bug.cgi?id=293949</a>

Reviewed by Jean-Yves Avenard.

IOS Simulator does not have a camera but AVCaptureDevice systemPreferredCamera may not be null.
To prevent the case of exposing a camera that is not there, we do not use systemPreferredCamera in iOS simulator.

* Source/WebCore/platform/mediastream/mac/AVCaptureDeviceManager.mm:
(WebCore::AVCaptureDeviceManager::retrieveCaptureDevices):

Canonical link: <a href="https://commits.webkit.org/296083@main">https://commits.webkit.org/296083@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e5ae0a8045cb65e29eed4b77f442869230a679d8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/107322 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27004 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/17408 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/112536 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/57857 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/109286 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/27685 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/35504 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/81469 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/110251 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/21933 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/96726 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/61843 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/21371 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/14856 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/57301 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/91301 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/14890 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/115637 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/34388 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/25341 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/90511 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/34764 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/92976 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/90247 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23010 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35152 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/12935 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/30120 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/34310 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/39842 "Failed to build and analyze WebKit") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34056 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/37411 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/35717 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->