### PR TITLE
[WPEPlatform] Introduce support for Android's AHardwareBuffer

### DIFF
--- a/Source/WebKit/Shared/glib/RendererBufferFormat.h
+++ b/Source/WebKit/Shared/glib/RendererBufferFormat.h
@@ -25,7 +25,10 @@
 
 #pragma once
 
+#if USE(GBM)
 #include <WebCore/DRMDevice.h>
+#endif
+
 #include <wtf/Vector.h>
 #include <wtf/text/CString.h>
 

--- a/Source/WebKit/WPEPlatform/CMakeLists.txt
+++ b/Source/WebKit/WPEPlatform/CMakeLists.txt
@@ -12,6 +12,7 @@ configure_file(wpe/WPEVersion.h.in ${WPEPlatform_DERIVED_SOURCES_DIR}/wpe/WPEVer
 
 set(WPEPlatform_SOURCES
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEBuffer.cpp
+    ${WEBKIT_DIR}/WPEPlatform/wpe/WPEBufferAndroid.cpp
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEBufferDMABuf.cpp
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEBufferDMABufFormats.cpp
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEBufferSHM.cpp
@@ -46,6 +47,7 @@ set(WPEPlatform_SOURCES
 
 set(WPEPlatform_INSTALLED_HEADERS
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEBuffer.h
+    ${WEBKIT_DIR}/WPEPlatform/wpe/WPEBufferAndroid.h
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEBufferDMABuf.h
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEBufferDMABufFormats.h
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEBufferSHM.h
@@ -127,6 +129,10 @@ if (USE_LIBDRM)
     list(APPEND WPEPlatform_SOURCES
         ${WEBKIT_DIR}/WPEPlatform/wpe/WPEScreenSyncObserverDRM.cpp
     )
+endif ()
+
+if (ANDROID)
+    list(APPEND WPEPlatform_LIBRARIES Android::Android)
 endif ()
 
 if (USE_ATK)

--- a/Source/WebKit/WPEPlatform/wpe/WPEBufferAndroid.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEBufferAndroid.cpp
@@ -1,0 +1,231 @@
+/*
+ * Copyright (C) 2025 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WPEBufferAndroid.h"
+
+#if OS(ANDROID)
+#include <android/hardware_buffer.h>
+#include <drm/drm_fourcc.h>
+#include <epoxy/egl.h>
+#include <wtf/glib/GUniquePtr.h>
+#include <wtf/glib/WTFGType.h>
+#include <wtf/unix/UnixFileDescriptor.h>
+
+/**
+ * WPEBufferAndroid:
+ *
+ */
+struct _WPEBufferAndroidPrivate {
+    AHardwareBuffer* ahb;
+    EGLImage eglImage { EGL_NO_IMAGE };
+};
+WEBKIT_DEFINE_FINAL_TYPE(WPEBufferAndroid, wpe_buffer_android, WPE_TYPE_BUFFER, WPEBuffer)
+
+static std::function<EGLImage(EGLDisplay, AHardwareBuffer*)> s_createImage = nullptr;
+static PFNEGLDESTROYIMAGEKHRPROC s_eglDestroyImage = nullptr;
+static PFNEGLCREATEIMAGEKHRPROC s_eglCreateImageKHR = nullptr;
+static PFNEGLCREATEIMAGEPROC s_eglCreateImage = nullptr;
+
+static EGLImage createImageEGL15(EGLDisplay display, AHardwareBuffer * ahb)
+{
+    static constexpr std::array<EGLAttrib, 3> attributes = { EGL_IMAGE_PRESERVED, EGL_TRUE, EGL_NONE };
+    return s_eglCreateImage(display, EGL_NO_CONTEXT, EGL_NATIVE_BUFFER_ANDROID, ahb, attributes.data());
+}
+
+static EGLImage createImageKHRImageBase(EGLDisplay display, AHardwareBuffer* ahb)
+{
+    static constexpr std::array<EGLint, 3> attributes = { EGL_IMAGE_PRESERVED, EGL_TRUE, EGL_NONE };
+    return s_eglCreateImageKHR(display, EGL_NO_CONTEXT, EGL_NATIVE_BUFFER_ANDROID, ahb, attributes.data());
+}
+
+static void wpeBufferAndroidDisposeEGLImageIfNeeded(WPEBufferAndroid* androidBuffer)
+{
+    RELEASE_ASSERT(s_eglDestroyImage);
+
+    auto* priv = androidBuffer->priv;
+    if (priv->eglImage == EGL_NO_IMAGE)
+        return;
+
+    auto* eglImage = std::exchange(priv->eglImage, EGL_NO_IMAGE);
+    auto* display = wpe_buffer_get_display(WPE_BUFFER(androidBuffer));
+    if (!display)
+        return;
+
+    if (auto* eglDisplay = wpe_display_get_egl_display(display, nullptr))
+        s_eglDestroyImage(eglDisplay, eglImage);
+}
+
+static void wpeBufferAndroidDispose(GObject* object)
+{
+    auto* androidBuffer = WPE_BUFFER_ANDROID(object);
+
+    wpeBufferAndroidDisposeEGLImageIfNeeded(androidBuffer);
+    g_clear_pointer(&androidBuffer->priv->ahb, AHardwareBuffer_release);
+
+    G_OBJECT_CLASS(wpe_buffer_android_parent_class)->dispose(object);
+}
+
+static gpointer wpeBufferAndroidImportToEGLImage(WPEBuffer* buffer, GError** error)
+{
+    auto* priv = WPE_BUFFER_ANDROID(buffer)->priv;
+    auto* display = wpe_buffer_get_display(buffer);
+    if (!display) {
+        priv->eglImage = EGL_NO_IMAGE;
+        g_set_error_literal(error, WPE_BUFFER_ERROR, WPE_BUFFER_ERROR_IMPORT_FAILED, "The WPE display of the buffer has already been closed");
+        return nullptr;
+    }
+
+    if (priv->eglImage)
+        return priv->eglImage;
+
+    GUniqueOutPtr<GError> eglError;
+    auto* eglDisplay = wpe_display_get_egl_display(display, &eglError.outPtr());
+    if (eglDisplay == EGL_NO_DISPLAY) {
+        g_set_error(error, WPE_BUFFER_ERROR, WPE_BUFFER_ERROR_IMPORT_FAILED, "Failed to get EGLDisplay when importing buffer to EGL image: %s", eglError->message);
+        return nullptr;
+    }
+
+    if (!s_createImage) {
+        if (epoxy_egl_version(eglDisplay) >= 15) {
+            s_eglCreateImage = reinterpret_cast<PFNEGLCREATEIMAGEPROC>(epoxy_eglGetProcAddress("eglCreateImage"));
+            s_eglDestroyImage = reinterpret_cast<PFNEGLDESTROYIMAGEPROC>(epoxy_eglGetProcAddress("eglDestroyImage"));
+            if (s_eglCreateImage && s_eglDestroyImage)
+                s_createImage = createImageEGL15;
+        }
+        if (!s_createImage && epoxy_has_egl_extension(eglDisplay, "EGL_KHR_image_base")) {
+            s_eglCreateImageKHR = reinterpret_cast<PFNEGLCREATEIMAGEKHRPROC>(epoxy_eglGetProcAddress("eglCreateImageKHR"));
+            s_eglDestroyImage = reinterpret_cast<PFNEGLDESTROYIMAGEKHRPROC>(epoxy_eglGetProcAddress("eglDestroyImageKHR"));
+            if (s_eglCreateImageKHR && s_eglDestroyImage)
+                s_createImage = createImageKHRImageBase;
+        }
+        if (!s_eglCreateImage) {
+            g_set_error_literal(error, WPE_BUFFER_ERROR, WPE_BUFFER_ERROR_IMPORT_FAILED, "No EGLImage support, EGL 1.5 or EGL_KHR_image needed");
+            return nullptr;
+        }
+    }
+    RELEASE_ASSERT(s_createImage);
+    RELEASE_ASSERT(s_eglDestroyImage);
+
+    priv->eglImage = s_createImage(eglDisplay, priv->ahb);
+    if (!priv->eglImage)
+        g_set_error(error, WPE_BUFFER_ERROR, WPE_BUFFER_ERROR_IMPORT_FAILED, "Failed to import buffer to EGL image: eglCreateImageKHR failed with error %#04x", eglGetError());
+    return priv->eglImage;
+}
+
+static void wpe_buffer_android_class_init(WPEBufferAndroidClass* bufferAndroidClass)
+{
+    GObjectClass* objectClass = G_OBJECT_CLASS(bufferAndroidClass);
+    objectClass->dispose = wpeBufferAndroidDispose;
+
+    // FIXME(297316): Implement import_to_pixels vfunc.
+    WPEBufferClass* bufferClass = WPE_BUFFER_CLASS(bufferAndroidClass);
+    bufferClass->import_to_egl_image = wpeBufferAndroidImportToEGLImage;
+}
+
+/**
+ * wpe_buffer_android_new: (constructor):
+ * @display: a #WPEDisplay
+ * @ahb: an #AHardwareBuffer
+ *
+ * Create a new #WPEBufferAndroid for the given buffer.
+ *
+ * The reference count of the @ahb will be incremented using
+ * %AHardwareBuffer_acquire().
+ *
+ * Returns: (transfer full): a #WPEBufferAndroid
+ */
+WPEBufferAndroid* wpe_buffer_android_new(WPEDisplay* display, AHardwareBuffer* ahb)
+{
+    g_return_val_if_fail(WPE_IS_DISPLAY(display), nullptr);
+    g_return_val_if_fail(ahb != nullptr, nullptr);
+
+    AHardwareBuffer_acquire(ahb);
+
+    AHardwareBuffer_Desc description;
+    AHardwareBuffer_describe(ahb, &description);
+
+    auto* buffer = WPE_BUFFER_ANDROID(g_object_new(WPE_TYPE_BUFFER_ANDROID,
+        "display", display,
+        "width", description.width,
+        "height", description.height,
+        nullptr));
+
+    buffer->priv->ahb = ahb;
+
+    return buffer;
+}
+
+/**
+ * wpe_buffer_android_get_hardware_buffer:
+ * @buffer: a #WPEBufferAndroid
+ *
+ * Get the underlying #AHardwareBuffer for @buffer.
+ * Note that the returned #AHardwareBuffer might be destroyed along with
+ * the @buffer; and `AHardwareBuffer_acquire()` may be called on the
+ * returned value to ensure that the underlying #AHardwareBuffer stays
+ * valid.
+ *
+ * Returns: (transfer none): a valid #AHardwareBuffer pointer.
+ */
+AHardwareBuffer* wpe_buffer_android_get_hardware_buffer(WPEBufferAndroid* buffer)
+{
+    g_return_val_if_fail(WPE_IS_BUFFER_ANDROID(buffer), nullptr);
+
+    return buffer->priv->ahb;
+}
+
+/**
+ * wpe_buffer_android_get_format:
+ * @buffer: a #WPEBufferAndroid
+ *
+ * Get the pixel format of the @buffer as a DRM FourCC code.
+ *
+ * Returns: a DRM FourCC code.
+ */
+guint32 wpe_buffer_android_get_format(WPEBufferAndroid* buffer)
+{
+    g_return_val_if_fail(WPE_IS_BUFFER_ANDROID(buffer), 0);
+
+    AHardwareBuffer_Desc description;
+    AHardwareBuffer_describe(buffer->priv->ahb, &description);
+
+    switch (description.format) {
+    case AHARDWAREBUFFER_FORMAT_R8G8B8A8_UNORM:
+        return DRM_FORMAT_RGBA8888;
+    case AHARDWAREBUFFER_FORMAT_R8G8B8X8_UNORM:
+        return DRM_FORMAT_RGBX8888;
+    case AHARDWAREBUFFER_FORMAT_R8G8B8_UNORM:
+        return DRM_FORMAT_RGB888;
+    case AHARDWAREBUFFER_FORMAT_R5G6B5_UNORM:
+        return DRM_FORMAT_RGB565;
+    case AHARDWAREBUFFER_FORMAT_R10G10B10A2_UNORM:
+        return DRM_FORMAT_RGBA1010102;
+    default:
+        RELEASE_ASSERT_NOT_REACHED();
+        return 0;
+    }
+}
+#endif // OS(ANDROID)

--- a/Source/WebKit/WPEPlatform/wpe/WPEBufferAndroid.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPEBufferAndroid.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Igalia S.L.
+ * Copyright (C) 2025 Igalia S.L.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -22,45 +22,36 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-#ifndef __WPE_PLATFORM_H__
-#define __WPE_PLATFORM_H__
 
-#define __WPE_PLATFORM_H_INSIDE__
+#ifndef WPEBufferAndroid_h
+#define WPEBufferAndroid_h
 
-#include <wpe/WPEBuffer.h>
-#include <wpe/WPEBufferDMABuf.h>
-#include <wpe/WPEBufferDMABufFormats.h>
-#include <wpe/WPEBufferSHM.h>
-#include <wpe/WPEClipboard.h>
-#include <wpe/WPEColor.h>
-#include <wpe/WPEConfig.h>
-#include <wpe/WPEDRMDevice.h>
-#include <wpe/WPEDefines.h>
-#include <wpe/WPEDisplay.h>
-#include <wpe/WPEEGLError.h>
-#include <wpe/WPEEnumTypes.h>
-#include <wpe/WPEEvent.h>
-#include <wpe/WPEGamepad.h>
-#include <wpe/WPEGamepadManager.h>
-#include <wpe/WPEGestureController.h>
-#include <wpe/WPEInputMethodContext.h>
-#include <wpe/WPEKeymap.h>
-#include <wpe/WPEKeyUnicode.h>
-#include <wpe/WPEKeymapXKB.h>
-#include <wpe/WPEKeysyms.h>
-#include <wpe/WPEKeysyms.h>
-#include <wpe/WPERectangle.h>
-#include <wpe/WPEScreen.h>
-#include <wpe/WPEScreenSyncObserver.h>
-#include <wpe/WPEToplevel.h>
-#include <wpe/WPEVersion.h>
-#include <wpe/WPEView.h>
-#include <wpe/WPEViewAccessible.h>
-
-#ifdef WPE_PLATFORM_BUFFER_ANDROID
-#include <wpe/WPEBufferAndroid.h>
+#if !defined(__WPE_PLATFORM_H_INSIDE__) && !defined(BUILDING_WEBKIT)
+#error "Only <wpe/wpe-platform.h> can be included directly."
 #endif
 
-#undef __WPE_PLATFORM_H_INSIDE__
+#ifndef __GI_SCANNER__
 
-#endif /* __WPE_PLATFORM_H__ */
+#include <glib-object.h>
+#include <wpe/WPEDefines.h>
+#include <wpe/WPEBuffer.h>
+
+G_BEGIN_DECLS
+
+typedef struct AHardwareBuffer AHardwareBuffer;
+
+#define WPE_TYPE_BUFFER_ANDROID (wpe_buffer_android_get_type())
+WPE_API G_DECLARE_FINAL_TYPE (WPEBufferAndroid, wpe_buffer_android, WPE, BUFFER_ANDROID, WPEBuffer)
+
+WPE_API WPEBufferAndroid *wpe_buffer_android_new                  (WPEDisplay       *display,
+                                                                   AHardwareBuffer  *ahb);
+
+WPE_API AHardwareBuffer  *wpe_buffer_android_get_hardware_buffer  (WPEBufferAndroid *buffer);
+
+WPE_API guint32           wpe_buffer_android_get_format           (WPEBufferAndroid *buffer);
+
+G_END_DECLS
+
+#endif /* !__GI_SCANNER__ */
+
+#endif /* !WPEBufferAndroid_h */

--- a/Source/WebKit/WPEPlatform/wpe/WPEConfig.h.in
+++ b/Source/WebKit/WPEPlatform/wpe/WPEConfig.h.in
@@ -30,6 +30,8 @@
 #error "Only <wpe/wpe-platform.h> can be included directly."
 #endif
 
+#cmakedefine WPE_PLATFORM_BUFFER_ANDROID
+
 #cmakedefine WPE_PLATFORM_DRM
 #cmakedefine WPE_PLATFORM_HEADLESS
 #cmakedefine WPE_PLATFORM_WAYLAND

--- a/Source/cmake/OptionsWPE.cmake
+++ b/Source/cmake/OptionsWPE.cmake
@@ -24,7 +24,7 @@ find_package(WPE REQUIRED)
 find_package(ZLIB REQUIRED)
 
 if (ANDROID)
-    find_package(Android REQUIRED COMPONENTS Log)
+    find_package(Android REQUIRED COMPONENTS Android Log)
 endif ()
 
 WEBKIT_OPTION_BEGIN()
@@ -273,6 +273,10 @@ if (ENABLE_XSLT)
 endif ()
 
 if (ENABLE_WPE_PLATFORM)
+    if (ANDROID)
+        set(WPE_PLATFORM_BUFFER_ANDROID ON)
+    endif ()
+
     if (ENABLE_WPE_PLATFORM_DRM)
         find_package(LibInput 1.19.0 REQUIRED)
         find_package(Udev REQUIRED)


### PR DESCRIPTION
#### fd72faeef06a1b166d79872ae8d5c96182996c69
<pre>
[WPEPlatform] Introduce support for Android&apos;s AHardwareBuffer
<a href="https://bugs.webkit.org/show_bug.cgi?id=294317">https://bugs.webkit.org/show_bug.cgi?id=294317</a>

Reviewed by Carlos Garcia Campos.

Introduce a new WPEBufferAndroid subclass of WPEBuffer that wraps an
AHardwareBuffer instance. Similarly to WPEBufferDMABuf, it supports
setting rendering and release fences (as file descriptors). The
WPEBuffer.import_to_pixels virtual method is left unimplemented for
now, but it should be possible to provide the operation for buffers
created with AHARDWAREBUFFER_USAGE_CPU_READ_{RARELY,OFTEN} in the
future.

* Source/WebKit/Shared/glib/RendererBufferFormat.h:
* Source/WebKit/WPEPlatform/CMakeLists.txt:
* Source/WebKit/WPEPlatform/wpe/WPEBufferAndroid.cpp: Added.
(createImageEGL15):
(createImageKHRImageBase):
(wpeBufferAndroidDisposeEGLImageIfNeeded):
(wpeBufferAndroidDispose):
(wpeBufferAndroidImportToEGLImage):
(wpe_buffer_android_class_init):
(wpe_buffer_android_new):
(wpe_buffer_android_get_hardware_buffer):
(wpe_buffer_android_get_format):
* Source/WebKit/WPEPlatform/wpe/WPEBufferAndroid.h: Copied from Source/WebKit/WPEPlatform/wpe/WPEConfig.h.in.
* Source/WebKit/WPEPlatform/wpe/WPEConfig.h.in:
* Source/WebKit/WPEPlatform/wpe/wpe-platform.h:
* Source/cmake/OptionsWPE.cmake:

Canonical link: <a href="https://commits.webkit.org/298619@main">https://commits.webkit.org/298619@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8351b30d51bfa2a487ffe7d6fc28cd62546b0516

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116075 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35736 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/26278 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/122131 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/66625 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/36430 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/44324 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/88184 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/66625 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/119023 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29059 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104157 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68595 "Found 1 new API test failure: /WPE/TestSSL:/webkit/WebKitWebView/ephemeral-tls-errors (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28174 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65813 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/108184 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98447 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/22402 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/125281 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/114603 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/42969 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32257 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/96917 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/43334 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100347 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/96701 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24606 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41973 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/19861 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/38915 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42856 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/48448 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/143300 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/42323 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/36943 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/45658 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/44027 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->