### PR TITLE
[JSC] Optimize `Array#with` for an array contains hole

### DIFF
--- a/JSTests/microbenchmarks/array-prototype-with-hole-contiguous.js
+++ b/JSTests/microbenchmarks/array-prototype-with-hole-contiguous.js
@@ -1,0 +1,14 @@
+const arr = [];
+for (let i = 0; i < 1024; i++) {
+    arr.push({ i });
+}
+delete arr[512];
+
+function test(index) {
+    arr.with(index, { i: 55 });
+}
+noInline(test);
+
+for (let i = 0; i < 1e4; i++) {
+    test(i % 1024);
+}

--- a/JSTests/microbenchmarks/array-prototype-with-hole-double.js
+++ b/JSTests/microbenchmarks/array-prototype-with-hole-double.js
@@ -1,0 +1,14 @@
+const arr = [];
+for (let i = 0; i < 1024; i++) {
+    arr.push(i + 0.1);
+}
+delete arr[512];
+
+function test(index) {
+    arr.with(index, 5.5);
+}
+noInline(test);
+
+for (let i = 0; i < 1e4; i++) {
+    test(i % 1024);
+}

--- a/JSTests/microbenchmarks/array-prototype-with-hole-int32.js
+++ b/JSTests/microbenchmarks/array-prototype-with-hole-int32.js
@@ -1,0 +1,14 @@
+const arr = [];
+for (let i = 0; i < 1024; i++) {
+    arr.push(i);
+}
+delete arr[512];
+
+function test(index) {
+    arr.with(index, 55);
+}
+noInline(test);
+
+for (let i = 0; i < 1e4; i++) {
+    test(i % 1024);
+}

--- a/JSTests/stress/array-prototype-with-hole-contiguous.js
+++ b/JSTests/stress/array-prototype-with-hole-contiguous.js
@@ -1,0 +1,19 @@
+function sameArray(a, b) {
+    if (a.length !== b.length)
+        throw new Error(`Expected array length ${b.length} but got ${a.length}`);
+    for (let i = 0; i < a.length; i++) {
+        if (a[i] !== b[i])
+            throw new Error(`Expected ${b[i]} but got ${a[i]} (${i})`);
+    }
+}
+
+
+const arr = [];
+for (let i = 0; i < 10; i++) {
+    arr.push({ i });
+}
+delete arr[5];
+
+const value = { i: 555 };
+const result = arr.with(2, value);
+sameArray(result, [arr[0], arr[1], value, arr[3], arr[4], undefined, arr[6], arr[7], arr[8], arr[9]]);

--- a/JSTests/stress/array-prototype-with-hole-double.js
+++ b/JSTests/stress/array-prototype-with-hole-double.js
@@ -1,0 +1,17 @@
+function sameArray(a, b) {
+    if (a.length !== b.length)
+        throw new Error(`Expected array length ${b.length} but got ${a.length}`);
+    for (let i = 0; i < a.length; i++) {
+        if (a[i] !== b[i])
+            throw new Error(`Expected ${b[i]} but got ${a[i]} (${i})`);
+    }
+}
+
+
+const arr = [];
+for (let i = 0; i < 10; i++) {
+    arr.push(i + 0.1);
+}
+delete arr[5];
+const result = arr.with(2, 555.5);
+sameArray(result, [0.1, 1.1, 555.5, 3.1, 4.1, undefined, 6.1, 7.1, 8.1, 9.1]);

--- a/JSTests/stress/array-prototype-with-hole-int32.js
+++ b/JSTests/stress/array-prototype-with-hole-int32.js
@@ -1,0 +1,17 @@
+function sameArray(a, b) {
+    if (a.length !== b.length)
+        throw new Error(`Expected array length ${b.length} but got ${a.length}`);
+    for (let i = 0; i < a.length; i++) {
+        if (a[i] !== b[i])
+            throw new Error(`Expected ${b[i]} but got ${a[i]} (${i})`);
+    }
+}
+
+
+const arr = [];
+for (let i = 0; i < 10; i++) {
+    arr.push(i);
+}
+delete arr[5];
+const result = arr.with(2, 555);
+sameArray(result, [0, 1, 555, 3, 4, undefined, 6, 7, 8, 9]);


### PR DESCRIPTION
#### b7531471ce2191cf7c7b92cb149e9f0c7afaca69
<pre>
[JSC] Optimize `Array#with` for an array contains hole
<a href="https://bugs.webkit.org/show_bug.cgi?id=294321">https://bugs.webkit.org/show_bug.cgi?id=294321</a>

Reviewed by Yusuke Suzuki.

This patch changes to optimize `Array#with` in the same way as
<a href="https://commits.webkit.org/296030@main">https://commits.webkit.org/296030@main</a>

                                              TipOfTree                  Patched

array-prototype-with-hole-contiguous       31.9492+-1.3400     ^      8.5727+-1.4653        ^ definitely 3.7269x faster
array-prototype-with-hole-double           39.5734+-0.6956     ^      8.3763+-1.2650        ^ definitely 4.7244x faster
array-prototype-with-hole-int32            31.1004+-1.1727     ^      8.3870+-0.4299        ^ definitely 3.7082x faster

* JSTests/microbenchmarks/array-prototype-with-hole-contiguous.js: Added.
(test):
* JSTests/microbenchmarks/array-prototype-with-hole-double.js: Added.
(test):
* JSTests/microbenchmarks/array-prototype-with-hole-int32.js: Added.
(test):
* JSTests/stress/array-prototype-with-hole-contiguous.js: Added.
(sameArray):
* JSTests/stress/array-prototype-with-hole-double.js: Added.
(sameArray):
* JSTests/stress/array-prototype-with-hole-int32.js: Added.
(sameArray):
* Source/JavaScriptCore/runtime/JSArray.cpp:
(JSC::JSArray::fastWith):

Canonical link: <a href="https://commits.webkit.org/296436@main">https://commits.webkit.org/296436@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/577a5c02b535b902c51e0ba749d72e64d4ef55d4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/107599 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27282 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/17693 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/112816 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/58141 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/27974 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/35784 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/81695 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/110528 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22172 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/96980 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62075 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/21608 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/15119 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/57580 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/100191 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/91543 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15153 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/115917 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/106148 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/34667 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/25567 "Build is in progress. Recent messages:OS: Sequoia (15.5), Xcode: 16.4; Running apply-patch; Checked out pull request; Skipped layout-tests; Running layout-tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/90727 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/35043 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93230 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/90468 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23249 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35392 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13169 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/30430 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/34588 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/40144 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/130462 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34334 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/35467 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/37694 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/35997 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->