### PR TITLE
Another unreviewed Safer CPP build fix after 296071@main

### DIFF
--- a/Source/WebCore/crypto/cocoa/CryptoAlgorithmX25519Cocoa.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoAlgorithmX25519Cocoa.cpp
@@ -47,10 +47,10 @@ static std::optional<Vector<uint8_t>> deriveBitsCoreCrypto(const Vector<uint8_t>
     ccec25519pubkey derivedKey;
     static_assert(sizeof(derivedKey) == ed25519KeySize);
 #if HAVE(CORE_CRYPTO_SIGNATURES_INT_RETURN_VALUE)
-    if (cccurve25519(derivedKey, baseKey.data(), publicKey.data()))
+    if (cccurve25519(derivedKey, baseKey.span().data(), publicKey.span().data()))
         return std::nullopt;
 #else
-    cccurve25519(derivedKey, baseKey.data(), publicKey.data());
+    cccurve25519(derivedKey, baseKey.span().data(), publicKey.span().data());
 #endif
     return Vector<uint8_t>(std::span { derivedKey });
 }

--- a/Source/WebCore/crypto/cocoa/CryptoKeyOKPCocoa.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoKeyOKPCocoa.cpp
@@ -143,16 +143,16 @@ bool CryptoKeyOKP::platformCheckPairedKeys(CryptoAlgorithmIdentifier identifier,
     switch (identifier) {
     case CryptoAlgorithmIdentifier::Ed25519: {
         auto* di = ccsha512_di();
-        if (cced25519_make_pub(di, ccPublicKey, privateKey.data()))
+        if (cced25519_make_pub(di, ccPublicKey, privateKey.span().data()))
             return false;
         break;
     }
     case CryptoAlgorithmIdentifier::X25519: {
 #if HAVE(CORE_CRYPTO_SIGNATURES_INT_RETURN_VALUE)
-        if (cccurve25519_make_pub(ccPublicKey, privateKey.data()))
+        if (cccurve25519_make_pub(ccPublicKey, privateKey.span().data()))
             return false;
 #else
-        cccurve25519_make_pub(ccPublicKey, privateKey.data());
+        cccurve25519_make_pub(ccPublicKey, privateKey.span().data());
 #endif
         break;
     }
@@ -434,14 +434,14 @@ String CryptoKeyOKP::generateJwkX() const
     switch (namedCurve()) {
     case NamedCurve::Ed25519: {
         auto* di = ccsha512_di();
-        RELEASE_ASSERT_WITH_MESSAGE(!cced25519_make_pub(di, publicKey, m_data.data()), "cced25519_make_pub failed");
+        RELEASE_ASSERT_WITH_MESSAGE(!cced25519_make_pub(di, publicKey, m_data.span().data()), "cced25519_make_pub failed");
         break;
     }
     case NamedCurve::X25519: {
 #if HAVE(CORE_CRYPTO_SIGNATURES_INT_RETURN_VALUE)
-        RELEASE_ASSERT_WITH_MESSAGE(!cccurve25519_make_pub(publicKey, m_data.data()), "cccurve25519_make_pub failed.");
+        RELEASE_ASSERT_WITH_MESSAGE(!cccurve25519_make_pub(publicKey, m_data.span().data()), "cccurve25519_make_pub failed.");
 #else
-        cccurve25519_make_pub(publicKey, m_data.data());
+        cccurve25519_make_pub(publicKey, m_data.span().data());
 #endif
         break;
     }


### PR DESCRIPTION
#### 196b8e2c88347a6dabd3579969bcbb8de472569b
<pre>
Another unreviewed Safer CPP build fix after 296071@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=294326">https://bugs.webkit.org/show_bug.cgi?id=294326</a>
<a href="https://rdar.apple.com/153085879">rdar://153085879</a>

Unreviewed build fix.

* Source/WebCore/crypto/cocoa/CryptoAlgorithmX25519Cocoa.cpp:
(WebCore::deriveBitsCoreCrypto):
* Source/WebCore/crypto/cocoa/CryptoKeyECMac.cpp:
(WebCore::CryptoKeyEC::platformImportRaw):
(WebCore::CryptoKeyEC::platformExportRaw const):
(WebCore::CryptoKeyEC::platformImportJWKPrivate):
(WebCore::CryptoKeyEC::platformAddFieldElements const):
(WebCore::CryptoKeyEC::platformExportSpki const):
(WebCore::CryptoKeyEC::platformImportPkcs8):
(WebCore::CryptoKeyEC::platformExportPkcs8 const):
* Source/WebCore/crypto/cocoa/CryptoKeyOKPCocoa.cpp:
(WebCore::CryptoKeyOKP::platformCheckPairedKeys):
(WebCore::CryptoKeyOKP::generateJwkX const):

Canonical link: <a href="https://commits.webkit.org/296088@main">https://commits.webkit.org/296088@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cdf11882d8e0a92af7f7852597316a6ef8c562a4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/107349 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27031 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/17435 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/112563 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/57885 "Build is in progress. Recent messages:") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/109313 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/27713 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/35531 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/81490 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/57885 "Build is in progress. Recent messages:") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/110278 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/21955 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/96749 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/61864 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/21394 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/14880 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/57328 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/91324 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/14913 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/115664 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/34415 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/25363 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/115664 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/34791 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/92999 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/115664 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35174 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/12958 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/30159 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17356 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/34337 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/39874 "Failed to build and analyze WebKit") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34083 "Build is in progress. Recent messages:") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/37438 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/35744 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->