### PR TITLE
Split function and method structure IDs

### DIFF
--- a/JSTests/stress/dont-make-assumptions-about-function-prototype-property.js
+++ b/JSTests/stress/dont-make-assumptions-about-function-prototype-property.js
@@ -1,0 +1,78 @@
+
+equals = function (a, e) {
+   if (a !== e)
+    throw new Error(`Expected = ${e} but got: ${a}`);
+}
+exists = function (a) {
+   if (a === undefined)
+    throw new Error(`Expected = not undefined but got undefined`);
+}
+notexists = function (a) {
+   if (a !== undefined)
+    throw new Error(`Expected = undefined but got ${a}`);
+}
+
+function get_proto(x) {
+    return x.prototype;
+}
+
+function delete_proto(x) {
+    return delete x.prototype;
+}
+
+function round0() {
+    function func() {
+        return 1;
+    }
+    const obj = {
+        method() {
+            return 2;
+        },
+    }
+    exists(get_proto(func));
+    exists(get_proto(func));
+    notexists(get_proto(obj.method));
+    notexists(get_proto(obj.method));
+}
+
+function testGet() {
+    function func() {
+        return 1;
+    }
+    const obj = {
+        method() {
+            return 2;
+        },
+    }
+    exists(get_proto(func));
+    exists(get_proto(func));
+    notexists(get_proto(obj.method));
+    notexists(get_proto(obj.method));
+}
+
+function testDelete() {
+    function func() {
+        return 1;
+    }
+    const obj = {
+        method() {
+            return 2;
+        },
+    }
+    equals(delete_proto(func), false);
+    equals(delete_proto(func), false);
+    equals(delete_proto(obj), true);
+    equals(delete_proto(obj.method), true);
+    equals(delete_proto(obj.method), true);
+}
+
+round0();
+
+for (let i = 0; i < 10000; i++) {
+    testGet();
+}
+for (let i = 0; i < 10000; i++) {
+    testDelete();
+}
+
+

--- a/Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp
+++ b/Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp
@@ -6754,7 +6754,11 @@ AccessGenerationResult InlineCacheCompiler::compileHandler(const GCSafeConcurren
         }
     }
     poly.append(&accessCase);
-    dataLogLnIf(InlineCacheCompilerInternal::verbose, "Generate with m_list: ", listDump(poly));
+    dataLogLnIf(InlineCacheCompilerInternal::verbose, "Generate with m_list: ", poly.size(), " elements");
+    if constexpr (InlineCacheCompilerInternal::verbose) {
+        for (unsigned i = 0; i < poly.size(); ++i)
+            dataLogLn("  m_list[", i , "] = ", *poly[i]);
+    }
 
     Vector<WatchpointSet*, 8> additionalWatchpointSets;
     if (auto megamorphicCase = tryFoldToMegamorphic(codeBlock, poly.span()))

--- a/Source/JavaScriptCore/jit/JITOperations.cpp
+++ b/Source/JavaScriptCore/jit/JITOperations.cpp
@@ -2731,7 +2731,9 @@ JSC_DEFINE_JIT_OPERATION(operationNewSloppyFunction, EncodedJSValue, (JSGlobalOb
     auto scope = DECLARE_THROW_SCOPE(vm);
     constexpr bool isInvalidated = false;
     constexpr bool isBuiltin = false;
-    OPERATION_RETURN(scope, newFunctionCommon<JSFunction, isInvalidated>(vm, globalObject, environment, functionExecutable, globalObject->sloppyFunctionStructure(isBuiltin)));
+    if (jsCast<FunctionExecutable*>(functionExecutable)->hasPrototypeProperty())
+        OPERATION_RETURN(scope, newFunctionCommon<JSFunction, isInvalidated>(vm, globalObject, environment, functionExecutable, globalObject->sloppyFunctionStructure(isBuiltin)));
+    OPERATION_RETURN(scope, newFunctionCommon<JSFunction, isInvalidated>(vm, globalObject, environment, functionExecutable, globalObject->sloppyMethodStructure(isBuiltin)));
 }
 
 JSC_DEFINE_JIT_OPERATION(operationNewSloppyFunctionWithInvalidatedReallocationWatchpoint, EncodedJSValue, (JSGlobalObject* globalObject, JSScope* environment, JSCell* functionExecutable))
@@ -2753,7 +2755,9 @@ JSC_DEFINE_JIT_OPERATION(operationNewStrictFunction, EncodedJSValue, (JSGlobalOb
     auto scope = DECLARE_THROW_SCOPE(vm);
     constexpr bool isInvalidated = false;
     constexpr bool isBuiltin = false;
-    OPERATION_RETURN(scope, newFunctionCommon<JSFunction, isInvalidated>(vm, globalObject, environment, functionExecutable, globalObject->strictFunctionStructure(isBuiltin)));
+    if (jsCast<FunctionExecutable*>(functionExecutable)->hasPrototypeProperty())
+        OPERATION_RETURN(scope, newFunctionCommon<JSFunction, isInvalidated>(vm, globalObject, environment, functionExecutable, globalObject->strictFunctionStructure(isBuiltin)));
+    OPERATION_RETURN(scope, newFunctionCommon<JSFunction, isInvalidated>(vm, globalObject, environment, functionExecutable, globalObject->strictMethodStructure(isBuiltin)));
 }
 
 JSC_DEFINE_JIT_OPERATION(operationNewStrictFunctionWithInvalidatedReallocationWatchpoint, EncodedJSValue, (JSGlobalObject* globalObject, JSScope* environment, JSCell* functionExecutable))

--- a/Source/JavaScriptCore/jit/OperationResult.h
+++ b/Source/JavaScriptCore/jit/OperationResult.h
@@ -258,7 +258,7 @@ ALWAYS_INLINE T makeOperationResult(Scope& scope, T result)
 
 #endif // USE(JSVALUE64)
 
-#define OPERATION_RETURN(scope__, ...) return makeOperationResult(scope__, ## __VA_ARGS__);
+#define OPERATION_RETURN(scope__, ...) return makeOperationResult(scope__, ## __VA_ARGS__)
 #define OPERATION_RETURN_IF_EXCEPTION(scope__, ...) RETURN_IF_EXCEPTION(scope__, makeOperationResult(scope__, ## __VA_ARGS__))
 
 #if COMPILER(CLANG)

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -891,7 +891,9 @@ void JSGlobalObject::init(VM& vm)
 
     auto initFunctionStructures = [&] (FunctionStructures& structures) {
         structures.strictFunctionStructure.set(vm, this, JSStrictFunction::createStructure(vm, this, m_functionPrototype.get()));
+        structures.strictMethodStructure.set(vm, this, JSStrictFunction::createStructure(vm, this, m_functionPrototype.get()));
         structures.sloppyFunctionStructure.set(vm, this, JSSloppyFunction::createStructure(vm, this, m_functionPrototype.get()));
+        structures.sloppyMethodStructure.set(vm, this, JSSloppyFunction::createStructure(vm, this, m_functionPrototype.get()));
         structures.arrowFunctionStructure.set(vm, this, JSArrowFunction::createStructure(vm, this, m_functionPrototype.get()));
     };
     initFunctionStructures(m_builtinFunctions);
@@ -2685,7 +2687,9 @@ void JSGlobalObject::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     auto visitFunctionStructures = [&] (FunctionStructures& structures) {
         visitor.append(structures.arrowFunctionStructure);
         visitor.append(structures.sloppyFunctionStructure);
+        visitor.append(structures.sloppyMethodStructure);
         visitor.append(structures.strictFunctionStructure);
+        visitor.append(structures.strictMethodStructure);
     };
     visitFunctionStructures(thisObject->m_builtinFunctions);
     visitFunctionStructures(thisObject->m_ordinaryFunctions);

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.h
@@ -357,7 +357,9 @@ public:
     struct FunctionStructures {
         WriteBarrierStructureID arrowFunctionStructure;
         WriteBarrierStructureID sloppyFunctionStructure;
+        WriteBarrierStructureID sloppyMethodStructure;
         WriteBarrierStructureID strictFunctionStructure;
+        WriteBarrierStructureID strictMethodStructure;
     };
     FunctionStructures m_builtinFunctions;
     FunctionStructures m_ordinaryFunctions;
@@ -866,6 +868,18 @@ public:
         if (isBuiltin)
             return m_builtinFunctions.strictFunctionStructure.get();
         return m_ordinaryFunctions.strictFunctionStructure.get();
+    }
+    Structure* sloppyMethodStructure(bool isBuiltin) const
+    {
+        if (isBuiltin)
+            return m_builtinFunctions.sloppyMethodStructure.get();
+        return m_ordinaryFunctions.sloppyMethodStructure.get();
+    }
+    Structure* strictMethodStructure(bool isBuiltin) const
+    {
+        if (isBuiltin)
+            return m_builtinFunctions.strictMethodStructure.get();
+        return m_ordinaryFunctions.strictMethodStructure.get();
     }
 
     Structure* boundFunctionStructure() const { return m_boundFunctionStructure.get(); }


### PR DESCRIPTION
#### 89a54431217549a2cadfc4bc102e3951abdf8b5c
<pre>
Split function and method structure IDs
<a href="https://bugs.webkit.org/show_bug.cgi?id=294329">https://bugs.webkit.org/show_bug.cgi?id=294329</a>
<a href="https://rdar.apple.com/152034999">rdar://152034999</a>

Reviewed by Yusuke Suzuki.

Our inline caches can confuse between functions with a prototype and
functions without a prototype property. To remedy this, we introduce
different structure IDs for functions with a prototype property, and
methods without a prototype property. This ensures that ICs will not
incorrectly resolve one as the other, but allows us to still use the
IC for prototype accesses.

* JSTests/stress/dont-make-assumptions-about-function-prototype-property.js: Added.
(equals):
(exists):
(notexists):
(delete_proto):
(round0.func):
(round0):
(testGet.func):
(testGet):
(testDelete.func):
(testDelete):
* Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp:
(JSC::InlineCacheCompiler::compileHandler):
* Source/JavaScriptCore/bytecode/Repatch.cpp:
(JSC::tryCacheGetBy):
* Source/JavaScriptCore/jit/JITOperations.cpp:
(JSC::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/jit/JITOperations.h:
(JSC::selectNewFunctionOperation):
* Source/JavaScriptCore/runtime/JSFunction.cpp:
(JSC::JSFunction::selectStructureForNewFuncExp):
(JSC::JSFunction::getOwnPropertySlot):
(JSC::JSFunction::deleteProperty):
* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
(JSC::JSGlobalObject::init):
(JSC::JSGlobalObject::visitChildrenImpl):
* Source/JavaScriptCore/runtime/JSGlobalObject.h:
(JSC::JSGlobalObject::sloppyMethodStructure const):
(JSC::JSGlobalObject::strictMethodStructure const):

Canonical link: <a href="https://commits.webkit.org/296674@main">https://commits.webkit.org/296674@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e308f0070eb9885f9fb5fc1fa04bd846dc6b0472

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108847 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28507 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18932 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/114055 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59203 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29191 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/37073 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82704 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111795 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23197 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/98040 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/63143 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22618 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16177 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58758 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/101387 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92569 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16225 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/117176 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/107406 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35897 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26517 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91720 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36270 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94306 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91528 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23392 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36430 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14186 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/31766 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35796 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/41326 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/131682 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35497 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/35714 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38841 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/37183 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->