### PR TITLE
[ews] Improve readability of logs in find-modified-layout-tests

### DIFF
--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -1468,7 +1468,7 @@ class FindModifiedLayoutTests(shell.ShellCommandNewStyle, AnalyzeChange):
         modified_tests = set()
         log_text = self.log_observer.getStdout()
         match = re.findall(r'\+(.*\.html)', log_text) + re.findall(r'\+(.*\.svg)', log_text) + re.findall(r'\+(.*\.xml)', log_text)
-        yield self._addToLog('stdio', '\nLooking for test expectation changes...\n')
+        yield self._addToLog('stdio', 'Looking for test expectation changes...\n')
         for test in match:
             yield self._addToLog('stdio', f'    LayoutTests/{test}\n')
             modified_tests.add(f'LayoutTests/{test}')
@@ -1485,7 +1485,7 @@ class FindModifiedLayoutTests(shell.ShellCommandNewStyle, AnalyzeChange):
                 )], WARNINGS)
             return defer.returnValue(self.results)
 
-        yield self._addToLog('stdio', '\nLooking for layout test changes...\n')
+        yield self._addToLog('stdio', 'Looking for layout test changes...\n')
         tests_from_patch = self.find_test_names_from_patch(patch)
         modified_tests += tests_from_patch
 


### PR DESCRIPTION
#### 6e301cb57401be97c7d186ba7fc69de8e8c12129
<pre>
[ews] Improve readability of logs in find-modified-layout-tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=294332">https://bugs.webkit.org/show_bug.cgi?id=294332</a>

Reviewed by NOBODY (OOPS!).

Remove extra newlines.

* Tools/CISupport/ews-build/steps.py:
(FindModifiedLayoutTests.run):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6e301cb57401be97c7d186ba7fc69de8e8c12129

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/107380 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/131/builds/27062 "Build was cancelled. Recent messages:OS: Sequoia (15.5), Xcode: 16.4") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/138/builds/17466 "Build was cancelled. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/112594 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/57916 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/109344 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/27744 "Build was cancelled. Recent messages:OS: Sequoia (15.5), Xcode: 16.4") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/123/builds/35562 "Build was cancelled. Recent messages:OS: Sequoia (15.5), Xcode: 16.4") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/112594 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/110309 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/130/builds/27744 "Build was cancelled. Recent messages:OS: Sequoia (15.5), Xcode: 16.4") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/138/builds/17466 "Build was cancelled. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/112594 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/130/builds/27744 "Build was cancelled. Recent messages:OS: Sequoia (15.5), Xcode: 16.4") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/138/builds/17466 "Build was cancelled. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/57360 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/130/builds/27744 "Build was cancelled. Recent messages:OS: Sequoia (15.5), Xcode: 16.4") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/138/builds/17466 "Build was cancelled. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/115695 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/34446 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/123/builds/35562 "Build was cancelled. Recent messages:OS: Sequoia (15.5), Xcode: 16.4") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/90556 "Passed tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/120972 "Passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/34822 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/138/builds/17466 "Build was cancelled. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/90293 "Build was cancelled. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; run-api-tests (cancelled)") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35203 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/138/builds/17466 "Build was cancelled. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/30190 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/34368 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34114 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/37469 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/35775 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->