### PR TITLE
Allow WKNavigationAction.request.URL to be valid NSURL that isn't valid WTF::URL

### DIFF
--- a/Source/WTF/wtf/URL.h
+++ b/Source/WTF/wtf/URL.h
@@ -230,6 +230,7 @@ public:
 #if USE(CF)
     WTF_EXPORT_PRIVATE URL(CFURLRef);
     WTF_EXPORT_PRIVATE RetainPtr<CFURLRef> createCFURL() const;
+    WTF_EXPORT_PRIVATE static RetainPtr<CFURLRef> createCFURL(const String&);
 #endif
 
 #if USE(FOUNDATION)

--- a/Source/WTF/wtf/cf/URLCF.cpp
+++ b/Source/WTF/wtf/cf/URLCF.cpp
@@ -43,6 +43,17 @@ URL::URL(CFURLRef url)
         *this = URLParser(bytesAsString(url)).result();
 }
 
+RetainPtr<CFURLRef> URL::createCFURL(const String& string)
+{
+    if (string.is8Bit() && string.containsOnlyASCII()) [[likely]] {
+        auto characters = string.span8();
+        return adoptCF(CFURLCreateAbsoluteURLWithBytes(nullptr, characters.data(), characters.size(), kCFStringEncodingUTF8, nullptr, true));
+    }
+    CString utf8 = string.utf8();
+    auto utf8Span = utf8.span();
+    return adoptCF(CFURLCreateAbsoluteURLWithBytes(nullptr, byteCast<UInt8>(utf8Span.data()), utf8Span.size(), kCFStringEncodingUTF8, nullptr, true));
+}
+
 RetainPtr<CFURLRef> URL::createCFURL() const
 {
     if (isNull())
@@ -54,15 +65,7 @@ RetainPtr<CFURLRef> URL::createCFURL() const
     if (!isValid() && linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::ConvertsInvalidURLsToNull))
         return nullptr;
 
-    RetainPtr<CFURLRef> result;
-    if (m_string.is8Bit() && m_string.containsOnlyASCII()) [[likely]] {
-        auto characters = m_string.span8();
-        result = adoptCF(CFURLCreateAbsoluteURLWithBytes(nullptr, characters.data(), characters.size(), kCFStringEncodingUTF8, nullptr, true));
-    } else {
-        CString utf8 = m_string.utf8();
-        auto utf8Span = utf8.span();
-        result = adoptCF(CFURLCreateAbsoluteURLWithBytes(nullptr, byteCast<UInt8>(utf8Span.data()), utf8Span.size(), kCFStringEncodingUTF8, nullptr, true));
-    }
+    RetainPtr result = createCFURL(m_string);
 
     // This additional check is only needed for invalid URLs, for which we've already returned null with new SDKs.
     if (!linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::ConvertsInvalidURLsToNull)

--- a/Source/WebKit/Shared/NavigationActionData.h
+++ b/Source/WebKit/Shared/NavigationActionData.h
@@ -88,6 +88,7 @@ struct NavigationActionData {
     std::optional<WebCore::NavigationIdentifier> navigationID;
     WebCore::ResourceRequest originalRequest;
     WebCore::ResourceRequest request;
+    String invalidURLString;
 };
 
 }

--- a/Source/WebKit/Shared/NavigationActionData.serialization.in
+++ b/Source/WebKit/Shared/NavigationActionData.serialization.in
@@ -62,4 +62,5 @@ struct WebKit::NavigationActionData {
     std::optional<WebCore::NavigationIdentifier> navigationID;
     WebCore::ResourceRequest originalRequest;
     [EncodeRequestBody] WebCore::ResourceRequest request;
+    String invalidURLString;
 };

--- a/Source/WebKit/UIProcess/API/Cocoa/WKNavigationAction.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKNavigationAction.mm
@@ -120,7 +120,9 @@ static WKSyntheticClickType toWKSyntheticClickType(WebKit::WebMouseEventSyntheti
 
 - (NSURLRequest *)request
 {
-    return _navigationAction->request().nsURLRequest(WebCore::HTTPBodyUpdatePolicy::UpdateHTTPBody);
+    if (RetainPtr request = _navigationAction->request().nsURLRequest(WebCore::HTTPBodyUpdatePolicy::UpdateHTTPBody))
+        return request.autorelease();
+    return [NSURLRequest requestWithURL:bridge_cast(URL::createCFURL(_navigationAction->data().invalidURLString).get())];
 }
 
 - (BOOL)shouldPerformDownload

--- a/Source/WebKit/UIProcess/win/AutomationSessionClientWin.cpp
+++ b/Source/WebKit/UIProcess/win/AutomationSessionClientWin.cpp
@@ -100,7 +100,8 @@ void AutomationSessionClient::requestNewPageWithOptions(WebKit::WebAutomationSes
                 legacyEmptyFrameInfo(WebCore::ResourceRequest()), /* frameInfo */
                 std::nullopt, /* navigationID */
                 { }, /* originalRequest */
-                { } /* request */
+                { }, /* request */
+                { } /* invalidURLString */
             };
 
             auto userInitiatedActivity = API::UserInitiatedAction::create();

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -351,6 +351,7 @@ RefPtr<Page> WebChromeClient::createWindow(LocalFrame& frame, const String& open
     if (!page)
         return nullptr;
 
+    auto& originalRequest = navigationAction.originalRequest();
     NavigationActionData navigationActionData {
         navigationAction.type(),
         modifiersForNavigationAction(navigationAction),
@@ -391,8 +392,9 @@ RefPtr<Page> WebChromeClient::createWindow(LocalFrame& frame, const String& open
         webFrame->page()->webPageProxyIdentifier(),
         webFrame->info(), /* frameInfo */
         std::nullopt, /* navigationID */
-        navigationAction.originalRequest(), /* originalRequest */
-        navigationAction.originalRequest() /* request */
+        originalRequest, /* originalRequest */
+        originalRequest, /* request */
+        originalRequest.url().isValid() ? String() : originalRequest.url().string(), /* invalidURLString */
     };
 
     auto sendResult = webProcess.parentProcessConnection()->sendSync(Messages::WebPageProxy::CreateNewPage(windowFeatures, navigationActionData), page->identifier(), IPC::Timeout::infinity(), { IPC::SendSyncOption::MaintainOrderingWithAsyncMessages });

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
@@ -174,7 +174,8 @@ std::optional<NavigationActionData> WebFrameLoaderClient::navigationActionData(c
         m_frame->info(),
         navigationID,
         navigationAction.originalRequest(),
-        request
+        request,
+        request.url().isValid() ? String() : request.url().string(),
     };
 }
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
@@ -523,7 +523,8 @@ void WebLocalFrameLoaderClient::didSameDocumentNavigationForFrameViaJS(SameDocum
         m_frame->info(),
         { }, /* navigationID */
         { }, /* originalRequest */
-        { } /* request */
+        { }, /* request */
+        { }, /* invalidURLString */
     };
 
     // Notify the UIProcess.
@@ -1029,7 +1030,8 @@ void WebLocalFrameLoaderClient::dispatchDecidePolicyForNewWindowAction(const Nav
         m_frame->info(),
         { }, /* navigationID */
         { }, /* originalRequest */
-        request
+        request,
+        request.url().isValid() ? String() : request.url().string(), /* invalidURLString */
     };
 
     webPage->sendWithAsyncReply(Messages::WebPageProxy::DecidePolicyForNewWindowAction(navigationActionData, frameName), [frame = m_frame, listenerID] (PolicyDecision&& policyDecision) {

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/NavigationAction.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/NavigationAction.mm
@@ -209,7 +209,7 @@ TEST(WKNavigationAction, BlobRequestBody)
         if ([action.request.URL.absoluteString isEqualToString:@"about:blank"])
             completionHandler(WKNavigationActionPolicyAllow);
         else {
-            EXPECT_WK_STREQ(action.request.URL.absoluteString, "");
+            EXPECT_WK_STREQ(action.request.URL.absoluteString, "/formAction");
             completionHandler(WKNavigationActionPolicyCancel);
             done = true;
         }


### PR DESCRIPTION
#### 7b37bf4eada1c881ba0453f9dc6b04b772a03e47
<pre>
Allow WKNavigationAction.request.URL to be valid NSURL that isn&apos;t valid WTF::URL
<a href="https://bugs.webkit.org/show_bug.cgi?id=294333">https://bugs.webkit.org/show_bug.cgi?id=294333</a>
<a href="https://rdar.apple.com/145790356">rdar://145790356</a>

Reviewed by Chris Dumez.

In 289946@main I made it so an invalid WTF::URL can&apos;t convert to a valid NSURL.
This fixed a large number of issues involving improper use of URLs.
However, this also prevented a legitimate use of invalid WTF::URLs:
An app can get a WKNavigationAction with the URL and decide to do something with
it that is not related to WebKit.  For compatibility, we need to explicitly allow
this.  Since the WebCore::ResourceRequest IPC encoder uses conversion to NSURL,
if we have an invalid WTF::URL we need to send the invalid URL string separately
then use it on the other side.  Since NSURL.URLWithString also doesn&apos;t successfully
parse such a URL, we need to use CFURLCreateAbsoluteURLWithBytes, which I made
into its own function to share between its existing and introduced uses.

An alternative I considered was to percent encode spaces in hosts of URLs with
non-special schemes, but that goes against behavior of Chrome, Firefox, Safari,
and NSURL.URLWithString so I decided not to.

* Source/WTF/wtf/URL.h:
* Source/WTF/wtf/cf/URLCF.cpp:
(WTF::URL::createCFURL):
(WTF::URL::createCFURL const):
* Source/WebKit/Shared/NavigationActionData.h:
* Source/WebKit/Shared/NavigationActionData.serialization.in:
* Source/WebKit/UIProcess/API/Cocoa/WKNavigationAction.mm:
(-[WKNavigationAction request]):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::createWindow):
* Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp:
(WebKit::WebFrameLoaderClient::navigationActionData const):
* Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp:
(WebKit::WebLocalFrameLoaderClient::didSameDocumentNavigationForFrameViaJS):
(WebKit::WebLocalFrameLoaderClient::dispatchDecidePolicyForNewWindowAction):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/LoadInvalidURLRequest.mm:
(TestWebKitAPI::TEST(WebKit, NavigateToInvalidURL)):

Canonical link: <a href="https://commits.webkit.org/296130@main">https://commits.webkit.org/296130@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/052587e1af40cc973ae180e965be5b136fb2f2ba

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/107473 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27155 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/17563 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/112687 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/58009 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/109437 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/27839 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/35655 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/81581 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/110402 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22049 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/96860 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/61966 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/21485 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/15001 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/57453 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/100062 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/91415 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15032 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/115788 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/106020 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/34540 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/25450 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/90619 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/34915 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93116 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/90365 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23039 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35277 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13053 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/30285 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/34461 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/40003 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/130336 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34207 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/35446 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/37562 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/35868 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->