### PR TITLE
[JSC] Harden IPInt dispatch

### DIFF
--- a/Source/JavaScriptCore/llint/InPlaceInterpreter.asm
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter.asm
@@ -49,17 +49,11 @@
 # - PC: (Program Counter) IPInt's program counter. This records the interpreter's position in Wasm bytecode.
 # - MC: (Metadata Counter) IPInt's metadata pointer. This records the corresponding position in generated metadata.
 # - WI: (Wasm Instance) pointer to the current JSWebAssemblyInstance object. This is used for accessing
-#       function-specific data.
+#       function-specific data (callee-save).
 # - PL: (Pointer to Locals) pointer to the address of local 0 in the current function. This is used for accessing
 #       locals quickly.
-# - MB: (Memory Base) pointer to the current Wasm memory base address.
-# - BC: (Bounds Check) the size of the current Wasm memory region, for bounds checking.
-#
-# Additionally, there are a few registers that are optionally supported for optimization:
-# - IB: (Instruction Base) pointer to the address of the `unreachable` (0x00) label, removing the need to reload
-#       this address at every dispatch.
-# - HR: (Hoist Register) used for hoisting the load of the next opcode in Wasm instructions with low register
-#       pressure, helping reduce the impact of load misses.
+# - MB: (Memory Base) pointer to the current Wasm memory base address (callee-save).
+# - BC: (Bounds Check) the size of the current Wasm memory region, for bounds checking (callee-save).
 #
 # Finally, we provide four "sc" (safe for call) registers which are guaranteed to not overlap with argument
 # registers (sc0, sc1, sc2, sc3)
@@ -71,9 +65,6 @@ if ARM64 or ARM64E
     const PL = t6
     const MB = csr3
     const BC = csr4
-
-    const IB = t7
-    const HR = t3
 
     const sc0 = ws0
     const sc1 = ws1
@@ -87,9 +78,6 @@ elsif X86_64
     const MB = csr3
     const BC = csr4
 
-    const IB = t7
-    const HR = t3
-
     const sc0 = ws0
     const sc1 = ws1
     const sc2 = csr3
@@ -101,9 +89,6 @@ elsif RISCV64
     const PL = csr10
     const MB = csr3
     const BC = csr4
-
-    const IB = invalidGPR
-    const HR = invalidGPR
 
     const sc0 = ws0
     const sc1 = ws1
@@ -117,9 +102,6 @@ elsif ARMv7
     const MB = invalidGPR
     const BC = invalidGPR
 
-    const IB = invalidGPR
-    const HR = invalidGPR
-
     const sc0 = t4
     const sc1 = t5
     const sc2 = csr0
@@ -131,9 +113,6 @@ else
     const PL = invalidGPR
     const MB = invalidGPR
     const BC = invalidGPR
-
-    const IB = invalidGPR
-    const HR = invalidGPR
 
     const sc0 = invalidGPR
     const sc1 = invalidGPR
@@ -172,30 +151,6 @@ const UnboxedWasmCalleeStackSlot = CallerFrame - constexpr Wasm::numberOfIPIntCa
 const IPIntCalleeSaveSpaceAsVirtualRegisters = constexpr Wasm::numberOfIPIntCalleeSaveRegisters + constexpr Wasm::numberOfIPIntInternalRegisters
 const IPIntCalleeSaveSpaceStackAligned = (IPIntCalleeSaveSpaceAsVirtualRegisters * SlotSize + StackAlignment - 1) & ~StackAlignmentMask
 const IPIntCalleeSaveSpaceStackAligned = 2*IPIntCalleeSaveSpaceStackAligned
-
-# ---------------------------
-# 1.2: Optional optimizations
-# ---------------------------
-
-macro IfIPIntUsesIB(m)
-    if ARM64 or ARM64E or X86_64
-        m()
-    end
-end
-
-macro IfIPIntUsesHR(m, m2)
-    if ARM64 or ARM64E
-        m()
-    else
-        m2()
-    end
-end
-
-macro HoistNextOpcode(offset)
-    IfIPIntUsesHR(macro()
-        loadb offset[PC], HR
-    end, macro() end)
-end
 
 ##############################
 # 2. Core interpreter macros #
@@ -349,18 +304,18 @@ macro operationCall(fn)
     if ARM64 or ARM64E
         push PL, ws0
     elsif X86_64
-        push PL, IB
+        push PL
+        # preserve 16 byte alignment.
+        subq MachineRegisterSize, sp
     end
     fn()
     if ARM64 or ARM64E
         pop ws0, PL
     elsif X86_64
-        pop IB, PL
+        addq MachineRegisterSize, sp
+        pop PL
     end
     pop MC, PC
-    if ARM64 or ARM64E
-        pcrtoaddr _ipint_unreachable, IB
-    end
 end
 
 macro operationCallMayThrow(fn)
@@ -371,7 +326,9 @@ macro operationCallMayThrow(fn)
     if ARM64 or ARM64E
         push PL, ws0
     elsif X86_64
-        push PL, IB
+        push PL
+        # preserve 16 byte alignment.
+        subq MachineRegisterSize, sp
     end
     fn()
     bpneq r1, (constexpr JSC::IPInt::SlowPathExceptionTag), .continuation
@@ -381,12 +338,10 @@ macro operationCallMayThrow(fn)
     if ARM64 or ARM64E
         pop ws0, PL
     elsif X86_64
-        pop IB, PL
+        addq MachineRegisterSize, sp
+        pop PL
     end
     pop MC, PC
-    if ARM64 or ARM64E
-        pcrtoaddr _ipint_unreachable, IB
-    end
 end
 
 # Exception handling
@@ -573,13 +528,6 @@ if WEBASSEMBLY and (ARM64 or ARM64E or X86_64 or ARMv7)
     # OSR Check
     ipintPrologueOSR(5)
 
-    IfIPIntUsesIB(macro ()
-if ARM64 or ARM64E
-        pcrtoaddr _ipint_unreachable, IB
-elsif X86_64
-        leap (_ipint_unreachable - _ipint_entry_relativePCBase)[PL], IB
-end
-    end)
     move sp, PL
 
     loadp Wasm::IPIntCallee::m_bytecode[ws0], PC
@@ -621,9 +569,6 @@ if ARMv7
 end
 
     loadp CodeBlock[cfr], wasmInstance
-    if ARM64 or ARM64E
-        pcrtoaddr _ipint_unreachable, IB
-    end
     loadp Wasm::IPIntCallee::m_bytecode[ws0], t1
     addp t1, PC
     loadp Wasm::IPIntCallee::m_metadata[ws0], t1
@@ -661,10 +606,6 @@ global _ipint_catch_entry
 _ipint_catch_entry:
 if WEBASSEMBLY and (ARM64 or ARM64E or X86_64)
     ipintCatchCommon()
-if X86_64
-    initPCRelative(ipint_catch_entry, IB)
-    leap (_ipint_unreachable - _ipint_catch_entry_relativePCBase)[IB], IB
-end
 
     move cfr, a1
     move sp, a2
@@ -682,10 +623,6 @@ global _ipint_catch_all_entry
 _ipint_catch_all_entry:
 if WEBASSEMBLY and (ARM64 or ARM64E or X86_64)
     ipintCatchCommon()
-if X86_64
-    initPCRelative(ipint_catch_all_entry, IB)
-    leap (_ipint_unreachable - _ipint_catch_all_entry_relativePCBase)[IB], IB
-end
 
     move cfr, a1
     move 0, a2
@@ -703,10 +640,6 @@ global _ipint_table_catch_entry
 _ipint_table_catch_entry:
 if WEBASSEMBLY and (ARM64 or ARM64E or X86_64 or ARMv7)
     ipintCatchCommon()
-if X86_64
-    initPCRelative(ipint_table_catch_entry, IB)
-    leap (_ipint_unreachable - _ipint_table_catch_entry_relativePCBase)[IB], IB
-end
 
     # push arguments but no ref: sp in a2, call normal operation
 
@@ -726,10 +659,6 @@ global _ipint_table_catch_ref_entry
 _ipint_table_catch_ref_entry:
 if WEBASSEMBLY and (ARM64 or ARM64E or X86_64 or ARMv7)
     ipintCatchCommon()
-if X86_64
-    initPCRelative(ipint_table_catch_ref_entry, IB)
-    leap (_ipint_unreachable - _ipint_table_catch_ref_entry_relativePCBase)[IB], IB
-end
 
     # push both arguments and ref
 
@@ -749,10 +678,6 @@ global _ipint_table_catch_all_entry
 _ipint_table_catch_all_entry:
 if WEBASSEMBLY and (ARM64 or ARM64E or X86_64 or ARMv7)
     ipintCatchCommon()
-if X86_64
-    initPCRelative(ipint_table_catch_all_entry, IB)
-    leap (_ipint_unreachable - _ipint_table_catch_all_entry_relativePCBase)[IB], IB
-end
 
     # do nothing: 0 in sp for no arguments, call normal operation
 
@@ -772,10 +697,6 @@ global _ipint_table_catch_allref_entry
 _ipint_table_catch_allref_entry:
 if WEBASSEMBLY and (ARM64 or ARM64E or X86_64 or ARMv7)
     ipintCatchCommon()
-if X86_64
-    initPCRelative(ipint_table_catch_allref_entry, IB)
-    leap (_ipint_unreachable - _ipint_table_catch_allref_entry_relativePCBase)[IB], IB
-end
 
     # push only the ref
 

--- a/Source/JavaScriptCore/llint/InPlaceInterpreter.cpp
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2023-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -39,102 +39,38 @@
 
 namespace JSC { namespace IPInt {
 
-#define VALIDATE_IPINT_OPCODE(opcode, name) \
+#define VALIDATE_IPINT_OPCODE_FROM_BASE(dispatchBase, width, opcode, name) \
 do { \
-    void* base = reinterpret_cast<void*>(ipint_unreachable_validate); \
+    void* base = reinterpret_cast<void*>(dispatchBase); \
     void* ptr = reinterpret_cast<void*>(ipint_ ## name ## _validate); \
     void* untaggedBase = CodePtr<CFunctionPtrTag>::fromTaggedPtr(base).template untaggedPtr<>(); \
     void* untaggedPtr = CodePtr<CFunctionPtrTag>::fromTaggedPtr(ptr).template untaggedPtr<>(); \
-    RELEASE_ASSERT_WITH_MESSAGE((char*)(untaggedPtr) - (char*)(untaggedBase) == opcode * 256, #name); \
+    RELEASE_ASSERT_WITH_MESSAGE((char*)(untaggedPtr) - (char*)(untaggedBase) == opcode * width, #name); \
 } while (false);
 
-#define VALIDATE_IPINT_0xFB_OPCODE(opcode, name) \
-do { \
-    void* base = reinterpret_cast<void*>(ipint_struct_new_validate); \
-    void* ptr = reinterpret_cast<void*>(ipint_ ## name ## _validate); \
-    void* untaggedBase = CodePtr<CFunctionPtrTag>::fromTaggedPtr(base).template untaggedPtr<>(); \
-    void* untaggedPtr = CodePtr<CFunctionPtrTag>::fromTaggedPtr(ptr).template untaggedPtr<>(); \
-    RELEASE_ASSERT_WITH_MESSAGE((char*)(untaggedPtr) - (char*)(untaggedBase) == opcode * 256, #name); \
-} while (false);
-
-#define VALIDATE_IPINT_0xFC_OPCODE(opcode, name) \
-do { \
-    void* base = reinterpret_cast<void*>(ipint_i32_trunc_sat_f32_s_validate); \
-    void* ptr = reinterpret_cast<void*>(ipint_ ## name ## _validate); \
-    void* untaggedBase = CodePtr<CFunctionPtrTag>::fromTaggedPtr(base).template untaggedPtr<>(); \
-    void* untaggedPtr = CodePtr<CFunctionPtrTag>::fromTaggedPtr(ptr).template untaggedPtr<>(); \
-    RELEASE_ASSERT_WITH_MESSAGE((char*)(untaggedPtr) - (char*)(untaggedBase) == opcode * 256, #name); \
-} while (false);
-
-#define VALIDATE_IPINT_SIMD_OPCODE(opcode, name) \
-do { \
-    void* base = reinterpret_cast<void*>(ipint_simd_v128_load_mem_validate); \
-    void* ptr = reinterpret_cast<void*>(ipint_ ## name ## _validate); \
-    void* untaggedBase = CodePtr<CFunctionPtrTag>::fromTaggedPtr(base).template untaggedPtr<>(); \
-    void* untaggedPtr = CodePtr<CFunctionPtrTag>::fromTaggedPtr(ptr).template untaggedPtr<>(); \
-    RELEASE_ASSERT_WITH_MESSAGE((char*)(untaggedPtr) - (char*)(untaggedBase) == opcode * 256, #name); \
-} while (false);
-
-#define VALIDATE_IPINT_ATOMIC_OPCODE(opcode, name) \
-do { \
-    void* base = reinterpret_cast<void*>(ipint_memory_atomic_notify_validate); \
-    void* ptr = reinterpret_cast<void*>(ipint_ ## name ## _validate); \
-    void* untaggedBase = CodePtr<CFunctionPtrTag>::fromTaggedPtr(base).template untaggedPtr<>(); \
-    void* untaggedPtr = CodePtr<CFunctionPtrTag>::fromTaggedPtr(ptr).template untaggedPtr<>(); \
-    RELEASE_ASSERT_WITH_MESSAGE((char*)(untaggedPtr) - (char*)(untaggedBase) == opcode * 256, #name); \
-} while (false);
-
-#define VALIDATE_IPINT_ARGUMINT_OPCODE(opcode, name) \
-do { \
-    void* base = reinterpret_cast<void*>(ipint_argumINT_a0_validate); \
-    void* ptr = reinterpret_cast<void*>(ipint_ ## name ## _validate); \
-    void* untaggedBase = CodePtr<CFunctionPtrTag>::fromTaggedPtr(base).template untaggedPtr<>(); \
-    void* untaggedPtr = CodePtr<CFunctionPtrTag>::fromTaggedPtr(ptr).template untaggedPtr<>(); \
-    RELEASE_ASSERT_WITH_MESSAGE((char*)(untaggedPtr) - (char*)(untaggedBase) == opcode * 64, #name); \
-} while (false);
-
-#define VALIDATE_IPINT_SLOW_PATH(opcode, name) \
-do { \
-    void* base = reinterpret_cast<void*>(ipint_local_get_slow_path_validate); \
-    void* ptr = reinterpret_cast<void*>(ipint_ ## name ## _validate); \
-    void* untaggedBase = CodePtr<CFunctionPtrTag>::fromTaggedPtr(base).template untaggedPtr<>(); \
-    void* untaggedPtr = CodePtr<CFunctionPtrTag>::fromTaggedPtr(ptr).template untaggedPtr<>(); \
-    RELEASE_ASSERT_WITH_MESSAGE((char*)(untaggedPtr) - (char*)(untaggedBase) == opcode * 256, #name); \
-} while (false);
-
-#define VALIDATE_IPINT_MINT_CALL_OPCODE(opcode, name) \
-do { \
-    void* base = reinterpret_cast<void*>(ipint_mint_a0_validate); \
-    void* ptr = reinterpret_cast<void*>(ipint_ ## name ## _validate); \
-    void* untaggedBase = CodePtr<CFunctionPtrTag>::fromTaggedPtr(base).template untaggedPtr<>(); \
-    void* untaggedPtr = CodePtr<CFunctionPtrTag>::fromTaggedPtr(ptr).template untaggedPtr<>(); \
-    RELEASE_ASSERT_WITH_MESSAGE((char*)(untaggedPtr) - (char*)(untaggedBase) == opcode * 64, #name); \
-} while (false);
-
-#define VALIDATE_IPINT_MINT_RETURN_OPCODE(opcode, name) \
-do { \
-    void* base = reinterpret_cast<void*>(ipint_mint_r0_validate); \
-    void* ptr = reinterpret_cast<void*>(ipint_ ## name ## _validate); \
-    void* untaggedBase = CodePtr<CFunctionPtrTag>::fromTaggedPtr(base).template untaggedPtr<>(); \
-    void* untaggedPtr = CodePtr<CFunctionPtrTag>::fromTaggedPtr(ptr).template untaggedPtr<>(); \
-    RELEASE_ASSERT_WITH_MESSAGE((char*)(untaggedPtr) - (char*)(untaggedBase) == opcode * 64, #name); \
-} while (false);
-
-#define VALIDATE_IPINT_UINT_OPCODE(opcode, name) \
-do { \
-    void* base = reinterpret_cast<void*>(ipint_uint_r0_validate); \
-    void* ptr = reinterpret_cast<void*>(ipint_ ## name ## _validate); \
-    void* untaggedBase = CodePtr<CFunctionPtrTag>::fromTaggedPtr(base).template untaggedPtr<>(); \
-    void* untaggedPtr = CodePtr<CFunctionPtrTag>::fromTaggedPtr(ptr).template untaggedPtr<>(); \
-    RELEASE_ASSERT_WITH_MESSAGE((char*)(untaggedPtr) - (char*)(untaggedBase) == opcode * 64, #name); \
-} while (false);
+#define VALIDATE_IPINT_OPCODE(opcode, name) VALIDATE_IPINT_OPCODE_FROM_BASE(ipint_unreachable_validate, 256, opcode, name)
+#define VALIDATE_IPINT_GC_OPCODE(opcode, name) VALIDATE_IPINT_OPCODE_FROM_BASE(ipint_struct_new_validate, 256, opcode, name)
+#define VALIDATE_IPINT_CONVERSION_OPCODE(opcode, name) VALIDATE_IPINT_OPCODE_FROM_BASE(ipint_i32_trunc_sat_f32_s_validate, 256, opcode, name)
+#define VALIDATE_IPINT_SIMD_OPCODE(opcode, name) VALIDATE_IPINT_OPCODE_FROM_BASE(ipint_simd_v128_load_mem_validate, 256, opcode, name)
+#define VALIDATE_IPINT_ATOMIC_OPCODE(opcode, name) VALIDATE_IPINT_OPCODE_FROM_BASE(ipint_memory_atomic_notify_validate, 256, opcode, name)
+#define VALIDATE_IPINT_ARGUMINT_OPCODE(opcode, name) VALIDATE_IPINT_OPCODE_FROM_BASE(ipint_argumINT_a0_validate, 64, opcode, name)
+#define VALIDATE_IPINT_SLOW_PATH(opcode, name) VALIDATE_IPINT_OPCODE_FROM_BASE(ipint_local_get_slow_path_validate, 256, opcode, name)
+#define VALIDATE_IPINT_MINT_CALL_OPCODE(opcode, name) VALIDATE_IPINT_OPCODE_FROM_BASE(ipint_mint_a0_validate, 64, opcode, name)
+#define VALIDATE_IPINT_MINT_RETURN_OPCODE(opcode, name) VALIDATE_IPINT_OPCODE_FROM_BASE(ipint_mint_r0_validate, 64, opcode, name)
+#define VALIDATE_IPINT_UINT_OPCODE(opcode, name) VALIDATE_IPINT_OPCODE_FROM_BASE(ipint_uint_r0_validate, 64, opcode, name)
 
 void initialize()
 {
 #if !ENABLE(C_LOOP) && ((CPU(ADDRESS64) && (CPU(ARM64) || CPU(X86_64))) || (CPU(ADDRESS32) && CPU(ARM_THUMB2)))
+    g_jscConfig.ipint_dispatch_base = CodePtr<CFunctionPtrTag>::fromTaggedPtr(reinterpret_cast<void*>(ipint_unreachable_validate)).template untaggedPtr<>();
+    g_jscConfig.ipint_gc_dispatch_base = CodePtr<CFunctionPtrTag>::fromTaggedPtr(reinterpret_cast<void*>(ipint_struct_new_validate)).template untaggedPtr<>();
+    g_jscConfig.ipint_conversion_dispatch_base = CodePtr<CFunctionPtrTag>::fromTaggedPtr(reinterpret_cast<void*>(ipint_i32_trunc_sat_f32_s_validate)).template untaggedPtr<>();
+    g_jscConfig.ipint_simd_dispatch_base = CodePtr<CFunctionPtrTag>::fromTaggedPtr(reinterpret_cast<void*>(ipint_simd_v128_load_mem_validate)).template untaggedPtr<>();
+    g_jscConfig.ipint_atomic_dispatch_base = CodePtr<CFunctionPtrTag>::fromTaggedPtr(reinterpret_cast<void*>(ipint_memory_atomic_notify_validate)).template untaggedPtr<>();
+
     FOR_EACH_IPINT_OPCODE(VALIDATE_IPINT_OPCODE);
-    FOR_EACH_IPINT_0xFB_OPCODE(VALIDATE_IPINT_0xFB_OPCODE);
-    FOR_EACH_IPINT_0xFC_TRUNC_OPCODE(VALIDATE_IPINT_0xFC_OPCODE);
+    FOR_EACH_IPINT_GC_OPCODE(VALIDATE_IPINT_GC_OPCODE);
+    FOR_EACH_IPINT_CONVERSION_OPCODE(VALIDATE_IPINT_CONVERSION_OPCODE);
     FOR_EACH_IPINT_SIMD_OPCODE(VALIDATE_IPINT_SIMD_OPCODE);
     FOR_EACH_IPINT_ATOMIC_OPCODE(VALIDATE_IPINT_ATOMIC_OPCODE);
 

--- a/Source/JavaScriptCore/llint/InPlaceInterpreter.h
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2023-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -294,13 +294,13 @@ extern "C" void SYSV_ABI ipint_table_catch_allref_entry();
     m(0xf8, reserved_0xf8) \
     m(0xf9, reserved_0xf9) \
     m(0xfa, reserved_0xfa) \
-    m(0xfb, fb_block) \
-    m(0xfc, fc_block) \
-    m(0xfd, simd) \
-    m(0xfe, atomic) \
+    m(0xfb, gc_prefix) \
+    m(0xfc, conversion_prefix) \
+    m(0xfd, simd_prefix) \
+    m(0xfe, atomic_prefix) \
     m(0xff, reserved_0xff)
 
-#define FOR_EACH_IPINT_0xFB_OPCODE(m) \
+#define FOR_EACH_IPINT_GC_OPCODE(m) \
     m(0x00, struct_new) \
     m(0x01, struct_new_default) \
     m(0x02, struct_get) \
@@ -333,7 +333,7 @@ extern "C" void SYSV_ABI ipint_table_catch_allref_entry();
     m(0x1d, i31_get_s) \
     m(0x1e, i31_get_u)
 
-#define FOR_EACH_IPINT_0xFC_TRUNC_OPCODE(m) \
+#define FOR_EACH_IPINT_CONVERSION_OPCODE(m) \
     m(0x00, i32_trunc_sat_f32_s) \
     m(0x01, i32_trunc_sat_f32_u) \
     m(0x02, i32_trunc_sat_f64_s) \
@@ -786,8 +786,8 @@ extern "C" void SYSV_ABI ipint_table_catch_allref_entry();
 
 #if !ENABLE(C_LOOP) && (CPU(ADDRESS64) && (CPU(ARM64) || CPU(X86_64)) || (CPU(ADDRESS32) && CPU(ARM_THUMB2)))
 FOR_EACH_IPINT_OPCODE(IPINT_VALIDATE_DEFINE_FUNCTION);
-FOR_EACH_IPINT_0xFB_OPCODE(IPINT_VALIDATE_DEFINE_FUNCTION);
-FOR_EACH_IPINT_0xFC_TRUNC_OPCODE(IPINT_VALIDATE_DEFINE_FUNCTION);
+FOR_EACH_IPINT_GC_OPCODE(IPINT_VALIDATE_DEFINE_FUNCTION);
+FOR_EACH_IPINT_CONVERSION_OPCODE(IPINT_VALIDATE_DEFINE_FUNCTION);
 FOR_EACH_IPINT_SIMD_OPCODE(IPINT_VALIDATE_DEFINE_FUNCTION);
 FOR_EACH_IPINT_ATOMIC_OPCODE(IPINT_VALIDATE_DEFINE_FUNCTION);
 FOR_EACH_IPINT_ARGUMINT_OPCODE(IPINT_VALIDATE_DEFINE_FUNCTION);

--- a/Source/JavaScriptCore/llint/InPlaceInterpreter32_64.asm
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter32_64.asm
@@ -44,6 +44,14 @@ macro restoreIPIntRegisters()
     addp IPIntCalleeSaveSpaceStackAligned, sp
 end
 
+# Dispatch target bases
+
+const ipint_dispatch_base = _ipint_unreachable
+const ipint_gc_dispatch_base = _ipint_struct_new
+const ipint_conversion_dispatch_base = _ipint_i32_trunc_sat_f32_s
+const ipint_simd_dispatch_base = _ipint_simd_v128_load_mem
+const ipint_atomic_dispatch_base = _ipint_memory_atomic_notify
+
 # Tail-call dispatch
 
 macro nextIPIntInstruction()
@@ -3189,23 +3197,23 @@ reservedOpcode(0xf7)
 reservedOpcode(0xf8)
 reservedOpcode(0xf9)
 reservedOpcode(0xfa)
-unimplementedInstruction(_fb_block)
+unimplementedInstruction(_gc_prefix)
 
-ipintOp(_fc_block, macro()
+ipintOp(_conversion_prefix, macro()
     decodeLEBVarUInt32(1, t0, t1, t2, t3, t4)
     # Security guarantee: always less than 18 (0x00 -> 0x11)
-    biaeq t0, 0x12, .ipint_fc_nonexistent
+    biaeq t0, 0x12, .ipint_conversion_nonexistent
     lshiftp 8, t0
-    leap (_ipint_i32_trunc_sat_f32_s + 1), t1
+    leap (ipint_conversion_dispatch_base + 1), t1
     addp t1, t0
     emit "bx r0"
 
-.ipint_fc_nonexistent:
+.ipint_conversion_nonexistent:
     break
 end)
 
-unimplementedInstruction(_simd)
-unimplementedInstruction(_atomic)
+unimplementedInstruction(_simd_prefix)
+unimplementedInstruction(_atomic_prefix)
 reservedOpcode(0xff)
 
     #######################
@@ -3633,6 +3641,7 @@ end)
     #######################
 
 # 0xFD 0x00 - 0xFD 0x0B: memory
+
 unimplementedInstruction(_simd_v128_load_mem)
 unimplementedInstruction(_simd_v128_load_8x8s_mem)
 unimplementedInstruction(_simd_v128_load_8x8u_mem)
@@ -4526,10 +4535,6 @@ mintAlign(_end)
     getIPIntCallee()
     pop MC
 
-    # Restore IB
-    IfIPIntUsesIB(macro()
-        pcrtoaddr _ipint_unreachable, IB
-    end)
     nextIPIntInstruction()
 
 .ipint_perform_tail_call:

--- a/Source/JavaScriptCore/llint/LowLevelInterpreter.asm
+++ b/Source/JavaScriptCore/llint/LowLevelInterpreter.asm
@@ -1,4 +1,4 @@
-# Copyright (C) 2011-2024 Apple Inc. All rights reserved.
+# Copyright (C) 2011-2025 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/Source/JavaScriptCore/runtime/JSCConfig.h
+++ b/Source/JavaScriptCore/runtime/JSCConfig.h
@@ -93,6 +93,12 @@ struct Config {
     void* defaultCallThunk;
     void* arityFixupThunk;
 
+    void* ipint_dispatch_base;
+    void* ipint_gc_dispatch_base;
+    void* ipint_conversion_dispatch_base;
+    void* ipint_simd_dispatch_base;
+    void* ipint_atomic_dispatch_base;
+
 #if ENABLE(SEPARATED_WX_HEAP)
     JITWriteSeparateHeapsFunction jitWriteSeparateHeaps;
 #endif


### PR DESCRIPTION
#### 0220229336674e16179554f590e10644e4e021fd
<pre>
[JSC] Harden IPInt dispatch
<a href="https://bugs.webkit.org/show_bug.cgi?id=294344">https://bugs.webkit.org/show_bug.cgi?id=294344</a>
<a href="https://rdar.apple.com/153095450">rdar://153095450</a>

Reviewed by Keith Miller.

Relanding Keith&apos;s change with some fixes for x64. In x64, we cannot
directly get label address, so instead of doing it, we store them into
JSCConfig and load it.

This patch hardens how IPInt dispatches opcodes for better CFI protection. Since IPInt does an offset based
dispatch the previous dispatch was something like:

```
macro dispatchToNextIPIntInstruction()
    // x7 is set to _ipInt_instruction_base on entry to IPInt entry/call return.
    loadb [PC], x0
    emit &quot;add x0, x7, x0, lsl #8&quot;
    emit &quot;br x0&quot;
end

align 256
_ipint_dispatch_base:
.first_wasm_bytecode:
// stuff
dispatchToNextIPIntInstruction()

align 256
.second_wasm_bytecode:
// stuff
dispatchToNextIPIntInstruction()
...
align 256
.255_wasm_bytecode:
// stuff
dispatchToNextIPIntInstruction()
```
In the old system no matter what value [PC] points to there are 256 offsets reachable, all of which are
either a valid opcode or a slab of `brk`s.

However, this still means if an attacker is able to return to the IPInt interpreter on some path that
doesn&apos;t reset x7 then they&apos;ll be able to implement a JOP attack. One example would be to build a fake
object with a vtable pointing to one of the &quot;C function&quot; labels (e.g. _first_wasm_bytecode_validate,
which is used for offset validation).

After this change dispatch is now:

```
macro dispatchToNextIPIntInstruction()
    loadb something, x0
    pcrtoaddr _ipint_dispatch_base, x7
    emit &quot;add x0, x7, x0, lsl #8&quot;
    emit &quot;br x0&quot;
end
```

which makes it clearly impossible to get a PAC bypass in IPInt dispatch. Since there&apos;s no longer
a semi-pinned register with the base pointer this patch removes all that associated code.

Additionally, this change adds a names for all the dispatch starts to make the
code a bit easier to read.

Lastly, the SIMD prefix opcode was missing a security guard so this patch adds that too.

* Source/JavaScriptCore/llint/InPlaceInterpreter.asm:
* Source/JavaScriptCore/llint/InPlaceInterpreter.cpp:
(JSC::IPInt::initialize):
* Source/JavaScriptCore/llint/InPlaceInterpreter.h:
* Source/JavaScriptCore/llint/InPlaceInterpreter32_64.asm:
* Source/JavaScriptCore/llint/InPlaceInterpreter64.asm:
* Source/JavaScriptCore/llint/LowLevelInterpreter.asm:
* Source/JavaScriptCore/runtime/JSCConfig.h:

Canonical link: <a href="https://commits.webkit.org/296121@main">https://commits.webkit.org/296121@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c2851a89dfe1a0e85351340ebdffefc7bce2de5a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/107456 "5 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27138 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/17545 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/112670 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/57992 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/27822 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/35638 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/81570 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/110385 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/96845 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/61954 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/14985 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/57436 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/100045 "Built successfully and passed tests") | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15017 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/115771 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/106003 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/34523 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/25441 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/90605 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/34898 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93101 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/90351 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35264 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13042 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/30266 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17374 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/34444 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/39985 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/130319 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34190 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/35443 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/37545 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/35851 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->