### PR TITLE
Clean up IntSizeHash

### DIFF
--- a/Source/WebCore/loader/cache/CachedImage.h
+++ b/Source/WebCore/loader/cache/CachedImage.h
@@ -26,7 +26,6 @@
 #include "Image.h"
 #include "ImageObserver.h"
 #include "IntRect.h"
-#include "IntSizeHash.h"
 #include "LayoutSize.h"
 #include "SVGImageCache.h"
 #include <wtf/HashMap.h>

--- a/Source/WebCore/platform/graphics/IntSizeHash.h
+++ b/Source/WebCore/platform/graphics/IntSizeHash.h
@@ -17,26 +17,25 @@
  * Boston, MA 02110-1301, USA.
  *
  */
-#ifndef IntSizeHash_h
-#define IntSizeHash_h
+
+#pragma once
 
 #include "IntSize.h"
 #include <wtf/HashTraits.h>
 
 namespace WTF {
 
-    template<> struct IntHash<WebCore::IntSize> {
-        static unsigned hash(const WebCore::IntSize& key) { return pairIntHash(key.width(), key.height()); }
-        static bool equal(const WebCore::IntSize& a, const WebCore::IntSize& b) { return a == b; }
-        static const bool safeToCompareToEmptyOrDeleted = true;
-    };
-    template<> struct DefaultHash<WebCore::IntSize> : IntHash<WebCore::IntSize> { };
-    
-    template<> struct HashTraits<WebCore::IntSize> : GenericHashTraits<WebCore::IntSize> {
-        static const bool emptyValueIsZero = true;
-        static void constructDeletedValue(WebCore::IntSize& slot) { new (NotNull, &slot) WebCore::IntSize(-1, -1); }
-        static bool isDeletedValue(const WebCore::IntSize& value) { return value.width() == -1 && value.height() == -1; }
-    };
-} // namespace WTF
+template<> struct IntHash<WebCore::IntSize> {
+    static unsigned hash(const WebCore::IntSize& key) { return pairIntHash(key.width(), key.height()); }
+    static bool equal(const WebCore::IntSize& a, const WebCore::IntSize& b) { return a == b; }
+    static const bool safeToCompareToEmptyOrDeleted = true;
+};
+template<> struct DefaultHash<WebCore::IntSize> : IntHash<WebCore::IntSize> { };
 
-#endif
+template<> struct HashTraits<WebCore::IntSize> : GenericHashTraits<WebCore::IntSize> {
+    static const bool emptyValueIsZero = true;
+    static void constructDeletedValue(WebCore::IntSize& slot) { new (NotNull, &slot) WebCore::IntSize(-1, -1); }
+    static bool isDeletedValue(const WebCore::IntSize& value) { return value.width() == -1 && value.height() == -1; }
+};
+
+} // namespace WTF

--- a/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.h
+++ b/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.h
@@ -27,7 +27,7 @@
 
 #if ENABLE(MEDIA_STREAM) && HAVE(AVCAPTUREDEVICE)
 
-#include "IntSizeHash.h"
+#include "IntSize.h"
 #include "OrientationNotifier.h"
 #include "RealtimeVideoCaptureSource.h"
 #include "Timer.h"

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -2573,7 +2573,7 @@ void WebPage::didScalePage(double scale, const IntPoint& origin)
 #if PLATFORM(IOS_FAMILY)
     if (willChangeScaleFactor) {
         if (!m_inDynamicSizeUpdate)
-            m_dynamicSizeUpdateHistory.clear();
+            m_internals->dynamicSizeUpdateHistory.clear();
         m_scaleWasSetByUIProcess = false;
     }
 #endif
@@ -3255,7 +3255,7 @@ void WebPage::pageDidScroll()
 {
 #if PLATFORM(IOS_FAMILY)
     if (!m_inDynamicSizeUpdate)
-        m_dynamicSizeUpdateHistory.clear();
+        m_internals->dynamicSizeUpdateHistory.clear();
 #endif
     m_uiClient->pageDidScroll(this);
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -41,7 +41,6 @@
 #include <WebCore/FrameTreeSyncData.h>
 #include <WebCore/HighlightVisibility.h>
 #include <WebCore/IntDegrees.h>
-#include <WebCore/IntSizeHash.h>
 #include <WebCore/LayerHostingContextIdentifier.h>
 #include <WebCore/MediaControlsContextMenuItem.h>
 #include <WebCore/MediaKeySystemRequest.h>
@@ -95,7 +94,7 @@
 #include "DynamicViewportSizeUpdate.h"
 #include "GestureTypes.h"
 #include <WebCore/InspectorOverlay.h>
-#include <WebCore/IntPointHash.h>
+#include <WebCore/IntPoint.h>
 #include <WebCore/WKContentObservation.h>
 #endif
 
@@ -2901,7 +2900,6 @@ private:
     WebCore::IntDegrees m_deviceOrientation { 0 };
     bool m_keyboardIsAttached { false };
     bool m_inDynamicSizeUpdate { false };
-    HashMap<std::pair<WebCore::IntSize, double>, WebCore::IntPoint> m_dynamicSizeUpdateHistory;
     RefPtr<WebCore::Node> m_pendingSyntheticClickNode;
     WebCore::FloatPoint m_pendingSyntheticClickLocation;
     WebCore::FloatRect m_previousExposedContentRect;

--- a/Source/WebKit/WebProcess/WebPage/WebPageInternals.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPageInternals.h
@@ -27,6 +27,8 @@
 
 #include "IdentifierTypes.h"
 #include "WebPage.h"
+#include <WebCore/IntPointHash.h>
+#include <WebCore/IntSizeHash.h>
 #include <WebCore/ScrollTypes.h>
 #include <WebCore/TextManipulationControllerExclusionRule.h>
 #include <WebCore/UserActivity.h>
@@ -57,6 +59,7 @@ struct WebPage::Internals {
     HashSet<WebCore::RegistrableDomain> loadedSubresourceDomains;
     UserActivity userActivity { "App nap disabled for page due to user activity"_s };
     std::optional<Vector<WebCore::TextManipulationControllerExclusionRule>> textManipulationExclusionRules;
+    HashMap<std::pair<WebCore::IntSize, double>, WebCore::IntPoint> dynamicSizeUpdateHistory;
 #if ENABLE(ADVANCED_PRIVACY_PROTECTIONS)
     struct LinkDecorationFilteringConditionals {
         HashSet<WebCore::RegistrableDomain> domains;

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -4426,7 +4426,7 @@ void WebPage::dynamicViewportSizeUpdate(const DynamicViewportSizeUpdate& target)
     auto oldUnobscuredContentRect = frameView.unobscuredContentRect();
     bool wasAtInitialScale = scalesAreEssentiallyEqual(oldPageScaleFactor, m_viewportConfiguration.initialScale());
 
-    m_dynamicSizeUpdateHistory.add(std::make_pair(oldContentSize, oldPageScaleFactor), frameView.scrollPosition());
+    m_internals->dynamicSizeUpdateHistory.add(std::make_pair(oldContentSize, oldPageScaleFactor), frameView.scrollPosition());
 
     RefPtr<Node> oldNodeAtCenter;
     double visibleHorizontalFraction = 1;
@@ -4514,8 +4514,8 @@ void WebPage::dynamicViewportSizeUpdate(const DynamicViewportSizeUpdate& target)
         newUnobscuredContentRect.setHeight(std::min(static_cast<float>(newContentSize.height()), newUnobscuredContentRect.height()));
 
         bool positionWasRestoredFromSizeUpdateHistory = false;
-        const auto& previousPosition = m_dynamicSizeUpdateHistory.find(std::pair<IntSize, float>(newContentSize, scale));
-        if (previousPosition != m_dynamicSizeUpdateHistory.end()) {
+        const auto& previousPosition = m_internals->dynamicSizeUpdateHistory.find(std::pair<IntSize, float>(newContentSize, scale));
+        if (previousPosition != m_internals->dynamicSizeUpdateHistory.end()) {
             IntPoint restoredPosition = previousPosition->value;
             FloatPoint deltaPosition(restoredPosition.x() - newUnobscuredContentRect.x(), restoredPosition.y() - newUnobscuredContentRect.y());
             newUnobscuredContentRect.moveBy(deltaPosition);
@@ -5133,7 +5133,7 @@ void WebPage::updateVisibleContentRects(const VisibleContentRectUpdateInfo& visi
             m_scaleWasSetByUIProcess = true;
             m_hasStablePageScaleFactor = m_isInStableState;
 
-            m_dynamicSizeUpdateHistory.clear();
+            m_internals->dynamicSizeUpdateHistory.clear();
 
             if (shouldSetCorePageScale)
                 setCorePageScaleFactor(scaleFromUIProcess.value(), scrollPosition, m_isInStableState);
@@ -5147,7 +5147,7 @@ void WebPage::updateVisibleContentRects(const VisibleContentRectUpdateInfo& visi
     }
 
     if (scrollPosition != frameView.scrollPosition())
-        m_dynamicSizeUpdateHistory.clear();
+        m_internals->dynamicSizeUpdateHistory.clear();
 
     if (m_viewportConfiguration.setCanIgnoreScalingConstraints(visibleContentRectUpdateInfo.allowShrinkToFit()))
         viewportConfigurationChanged();


### PR DESCRIPTION
#### 14b2e515281bb49a9daac151cba827579f5debd4
<pre>
Clean up IntSizeHash
<a href="https://bugs.webkit.org/show_bug.cgi?id=294345">https://bugs.webkit.org/show_bug.cgi?id=294345</a>

Reviewed by Abrar Rahman Protyasha.

A small build time reduction.

* Source/WebCore/loader/cache/CachedImage.h:
* Source/WebCore/platform/graphics/IntSizeHash.h:
(WTF::IntHash&lt;WebCore::IntSize&gt;::hash):
(WTF::IntHash&lt;WebCore::IntSize&gt;::equal):
(WTF::HashTraits&lt;WebCore::IntSize&gt;::constructDeletedValue):
(WTF::HashTraits&lt;WebCore::IntSize&gt;::isDeletedValue):
* Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.h:
* Source/WebCore/testing/WebFakeXRDevice.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::didScalePage):
(WebKit::WebPage::pageDidScroll):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPageInternals.h:
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::dynamicViewportSizeUpdate):
(WebKit::WebPage::updateVisibleContentRects):

Canonical link: <a href="https://commits.webkit.org/296232@main">https://commits.webkit.org/296232@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aed50c47aca7bbbfa84a053744429f5ba2b84c49

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/107863 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27531 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/17949 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/113077 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/58387 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/109829 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/28226 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/36074 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/81867 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/110808 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22357 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97175 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62293 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/21774 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/15309 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/57830 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/91706 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15374 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/116198 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/34932 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/25698 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/90905 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/35308 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93453 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/90687 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35587 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13343 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/30682 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17433 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/34836 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/40388 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34578 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/37939 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/36240 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->