### PR TITLE
Decrease maximum medium bitfit size to 32kB in libpas

### DIFF
--- a/Source/bmalloc/libpas/src/libpas/pas_bitfit_max_free.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_bitfit_max_free.h
@@ -36,6 +36,8 @@ typedef uint8_t pas_bitfit_max_free;
 #define PAS_BITFIT_MAX_FREE_UNPROCESSED ((pas_bitfit_max_free)254)
 #define PAS_BITFIT_MAX_FREE_EMPTY       ((pas_bitfit_max_free)255)
 
+#define PAS_BITFIT_MAX_FREE_MAX_VALID_MEDIUM   ((pas_bitfit_max_free)64)
+
 PAS_END_EXTERN_C;
 
 #endif /* PAS_BITFIT_MAX_FREE_H */

--- a/Source/bmalloc/libpas/src/libpas/pas_bitfit_page_config.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_bitfit_page_config.h
@@ -65,9 +65,12 @@ typedef size_t (*pas_bitfit_page_config_specialized_page_get_allocation_size_wit
 typedef void (*pas_bitfit_page_config_specialized_page_shrink_with_page)(
     pas_bitfit_page* page, uintptr_t begin, size_t new_size);
 
-#define PAS_MAX_BITFIT_OBJECT_SIZE(payload_size, min_align_shift) \
+#define PAS_MAX_BITFIT_OBJECT_SIZE_WITH_MAX_BITS(payload_size, min_align_shift, max_bits) \
     PAS_MIN_CONST(PAS_MAX_OBJECT_SIZE((payload_size)), \
-                  PAS_BITFIT_MAX_FREE_MAX_VALID * (1u << (min_align_shift)))
+                  max_bits * (1u << (min_align_shift)))
+
+#define PAS_MAX_BITFIT_OBJECT_SIZE(payload_size, min_align_shift) \
+    PAS_MAX_BITFIT_OBJECT_SIZE_WITH_MAX_BITS(payload_size, min_align_shift, PAS_BITFIT_MAX_FREE_MAX_VALID)
 
 struct pas_bitfit_page_config {
     pas_page_base_config base;

--- a/Source/bmalloc/libpas/src/libpas/pas_heap_config_utils.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_heap_config_utils.h
@@ -279,9 +279,10 @@ typedef struct {
                 ((pas_basic_heap_config_arguments){__VA_ARGS__}).medium_page_size, \
             .granule_size = \
                 ((pas_basic_heap_config_arguments){__VA_ARGS__}).granule_size, \
-            .max_object_size = PAS_MAX_BITFIT_OBJECT_SIZE( \
+            .max_object_size = PAS_MAX_BITFIT_OBJECT_SIZE_WITH_MAX_BITS( \
                 ((pas_basic_heap_config_arguments){__VA_ARGS__}).medium_page_size, \
-                ((pas_basic_heap_config_arguments){__VA_ARGS__}).medium_bitfit_min_align_shift), \
+                ((pas_basic_heap_config_arguments){__VA_ARGS__}).medium_bitfit_min_align_shift, \
+                PAS_BITFIT_MAX_FREE_MAX_VALID_MEDIUM), \
             .page_header_for_boundary = name ## _medium_bitfit_page_header_for_boundary, \
             .boundary_for_page_header = name ## _medium_bitfit_boundary_for_page_header, \
             .page_header_for_boundary_remote = name ## _medium_bitfit_page_header_for_boundary_remote, \


### PR DESCRIPTION
#### 2fad6d3c34f936933f649105cef570caddbac41c
<pre>
Decrease maximum medium bitfit size to 32kB in libpas
<a href="https://bugs.webkit.org/show_bug.cgi?id=294341">https://bugs.webkit.org/show_bug.cgi?id=294341</a>
<a href="https://rdar.apple.com/153118277">rdar://153118277</a>

Reviewed by Keith Miller.

This seems to be a potential modest memory win and slight MotionMark
progression, possibly because we&apos;re encountering less fragmentation
by allocating huge objects in medium bitfit pages.

* Source/bmalloc/libpas/src/libpas/pas_bitfit_max_free.h:
* Source/bmalloc/libpas/src/libpas/pas_bitfit_page_config.h:
* Source/bmalloc/libpas/src/libpas/pas_heap_config_utils.h:

Canonical link: <a href="https://commits.webkit.org/296158@main">https://commits.webkit.org/296158@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ba76bb1beb102458f49afefb1d409c57fe14f10d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/107412 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27094 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/17499 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/112626 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/57948 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/27777 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/35594 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/81540 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/110341 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22005 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/96809 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/61915 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/21446 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/14940 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/57392 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/100001 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/91375 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/14974 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/115727 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/105959 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/34479 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/25415 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/90581 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/34854 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93058 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/90318 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23060 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35231 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13014 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/30222 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/34400 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/130275 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34146 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/35434 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/37501 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/35807 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->