### PR TITLE
[Swift in WebKit] The Swift implementation of WKStageMode is incorrect

### DIFF
--- a/Source/WebKit/WebKitSwift/StageMode/WKStageMode.h
+++ b/Source/WebKit/WebKitSwift/StageMode/WKStageMode.h
@@ -31,30 +31,32 @@
 #import "WKRKEntity.h"
 #import <simd/simd.h>
 
-NS_ASSUME_NONNULL_BEGIN
+NS_HEADER_AUDIT_BEGIN(nullability, sendability)
 
 typedef NS_ENUM(NSInteger, WKStageModeOperation) {
     WKStageModeOperationNone = 0,
     WKStageModeOperationOrbit,
 };
 
+NS_SWIFT_UI_ACTOR
 @protocol WKStageModeInteractionAware <NSObject>
 - (void)stageModeInteractionDidUpdateModel;
 @end
 
+NS_SWIFT_UI_ACTOR
 @interface WKStageModeInteractionDriver : NSObject
 @property (nonatomic, readonly) REEntityRef interactionContainerRef;
 @property (nonatomic, readonly) bool stageModeInteractionInProgress;
 
-- (instancetype)initWithModel:(WKRKEntity *)model container:(REEntityRef)container delegate:(id<WKStageModeInteractionAware> _Nullable)delegate NS_SWIFT_NAME(init(with:container:delegate:));
-- (void)setContainerTransformInPortal NS_SWIFT_NAME(setContainerTransformInPortal());
-- (void)interactionDidBegin:(simd_float4x4)transform NS_SWIFT_NAME(interactionDidBegin(_:));
-- (void)interactionDidUpdate:(simd_float4x4)transform NS_SWIFT_NAME(interactionDidUpdate(_:));
-- (void)interactionDidEnd NS_SWIFT_NAME(interactionDidEnd());
-- (void)operationDidUpdate:(WKStageModeOperation)operation NS_SWIFT_NAME(operationDidUpdate(_:));
+- (instancetype)initWithModel:(WKRKEntity *)model container:(REEntityRef)container delegate:(id<WKStageModeInteractionAware> _Nullable)delegate;
+- (void)setContainerTransformInPortal;
+- (void)interactionDidBegin:(simd_float4x4)transform;
+- (void)interactionDidUpdate:(simd_float4x4)transform;
+- (void)interactionDidEnd;
+- (void)operationDidUpdate:(WKStageModeOperation)operation;
 - (void)removeInteractionContainerFromSceneOrParent;
 @end
 
-NS_ASSUME_NONNULL_END
+NS_HEADER_AUDIT_END(nullability, sendability)
 
-#endif
+#endif // ENABLE(MODEL_PROCESS)


### PR DESCRIPTION
#### 181a6a8ac480ce0e8545a883952e7321fc12e707
<pre>
[Swift in WebKit] The Swift implementation of WKStageMode is incorrect
<a href="https://bugs.webkit.org/show_bug.cgi?id=294349">https://bugs.webkit.org/show_bug.cgi?id=294349</a>
<a href="https://rdar.apple.com/153125940">rdar://153125940</a>

Reviewed by Ada Chan.

Use `@objc @implementation`, and fix some style issues.

* Source/WebKit/WebKitSwift/StageMode/WKStageMode.h:
* Source/WebKit/WebKitSwift/StageMode/WKStageMode.swift:
(WKStageModeInteractionDriver.delegate):
(WKStageModeInteractionDriver.initialManipulationPose):
(WKStageModeInteractionDriver.previousManipulationPose):
(WKStageModeInteractionDriver.initialTargetPose):
(WKStageModeInteractionDriver.initialTurntablePose):
(WKStageModeInteractionDriver.pitchSettleAnimationController):
(WKStageModeInteractionDriver.yawDecelerationAnimationController):
(WKStageModeInteractionDriver.pitchAnimationCompletionSubscription):
(WKStageModeInteractionDriver.yawAnimationCompletionSubscription):
(WKStageModeInteractionDriver.interactionContainerRef):
(WKStageModeInteractionDriver.stageModeInteractionInProgress):
(WKStageModeInteractionDriver.setContainerTransformInPortal):
(WKStageModeInteractionDriver.removeInteractionContainerFromSceneOrParent):
(WKStageModeInteractionDriver.interactionDidBegin(_:)):
(WKStageModeInteractionDriver.interactionDidUpdate(_:)):
(WKStageModeInteractionDriver.interactionDidEnd):
(WKStageModeInteractionDriver.operationDidUpdate(_:)):
(WKStageModeInteractionDriver.subscribeToPitchChanges):
(WKStageModeInteractionDriver.subscribeToYawChanges):
(simd_float3.xy):
(simd_float3.double3):
(simd_quatd.quatf):

Canonical link: <a href="https://commits.webkit.org/296148@main">https://commits.webkit.org/296148@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dd909845f7e14d0c95c137cfa4412a7bb620134d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/107413 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27095 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/17500 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/112627 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/57949 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/27778 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/35595 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/81539 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/110342 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22006 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/96810 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/61914 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/21447 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/57393 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/91376 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/14975 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/115728 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/34480 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/25414 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/90579 "Found 1 new test failure: imported/w3c/web-platform-tests/html/semantics/forms/constraints/infinite_backtracking.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/34855 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93059 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/90316 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23050 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35230 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13015 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/30223 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/34401 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/39942 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34147 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/37502 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/35808 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->