### PR TITLE
[HDR] Don't calculate the bitsPerComponent of an image

### DIFF
--- a/Source/WebCore/platform/graphics/ShareableBitmap.cpp
+++ b/Source/WebCore/platform/graphics/ShareableBitmap.cpp
@@ -41,6 +41,7 @@ ShareableBitmapConfiguration::ShareableBitmapConfiguration(const IntSize& size, 
     , m_colorSpace(validateColorSpace(colorSpace))
     , m_headroom(headroom)
     , m_isOpaque(isOpaque)
+    , m_bitsPerComponent(calculateBitsPerComponent(this->colorSpace()))
     , m_bytesPerPixel(calculateBytesPerPixel(this->colorSpace()))
     , m_bytesPerRow(calculateBytesPerRow(size, this->colorSpace()))
 #if USE(CG)
@@ -53,7 +54,7 @@ ShareableBitmapConfiguration::ShareableBitmapConfiguration(const IntSize& size, 
     ASSERT(!m_size.isEmpty());
 }
 
-ShareableBitmapConfiguration::ShareableBitmapConfiguration(const IntSize& size, std::optional<DestinationColorSpace> colorSpace, Headroom headroom, bool isOpaque, unsigned bytesPerPixel, unsigned bytesPerRow
+ShareableBitmapConfiguration::ShareableBitmapConfiguration(const IntSize& size, std::optional<DestinationColorSpace> colorSpace, Headroom headroom, bool isOpaque, unsigned bitsPerComponent, unsigned bytesPerPixel, unsigned bytesPerRow
 #if USE(CG)
     , CGBitmapInfo bitmapInfo
 #endif
@@ -62,6 +63,7 @@ ShareableBitmapConfiguration::ShareableBitmapConfiguration(const IntSize& size, 
     , m_colorSpace(colorSpace)
     , m_headroom(headroom)
     , m_isOpaque(isOpaque)
+    , m_bitsPerComponent(bitsPerComponent)
     , m_bytesPerPixel(bytesPerPixel)
     , m_bytesPerRow(bytesPerRow)
 #if USE(CG)

--- a/Source/WebCore/platform/graphics/ShareableBitmap.h
+++ b/Source/WebCore/platform/graphics/ShareableBitmap.h
@@ -52,7 +52,7 @@ public:
     ShareableBitmapConfiguration() = default;
 
     WEBCORE_EXPORT ShareableBitmapConfiguration(const IntSize&, std::optional<DestinationColorSpace> = std::nullopt, Headroom = Headroom::None, bool isOpaque = false);
-    WEBCORE_EXPORT ShareableBitmapConfiguration(const IntSize&, std::optional<DestinationColorSpace>, Headroom, bool isOpaque, unsigned bytesPerPixel, unsigned bytesPerRow
+    WEBCORE_EXPORT ShareableBitmapConfiguration(const IntSize&, std::optional<DestinationColorSpace>, Headroom, bool isOpaque, unsigned bitsPerComponent, unsigned bytesPerPixel, unsigned bytesPerRow
 #if USE(CG)
         , CGBitmapInfo
 #endif
@@ -67,6 +67,7 @@ public:
     Headroom headroom() const { return m_headroom; }
     bool isOpaque() const { return m_isOpaque; }
 
+    unsigned bitsPerComponent() const { ASSERT(!m_bitsPerComponent.hasOverflowed()); return m_bitsPerComponent; }
     unsigned bytesPerPixel() const { ASSERT(!m_bytesPerPixel.hasOverflowed()); return m_bytesPerPixel; }
     unsigned bytesPerRow() const { ASSERT(!m_bytesPerRow.hasOverflowed()); return m_bytesPerRow; }
 #if USE(CG)
@@ -85,6 +86,7 @@ private:
     friend struct IPC::ArgumentCoder<ShareableBitmapConfiguration, void>;
 
     static std::optional<DestinationColorSpace> validateColorSpace(std::optional<DestinationColorSpace>);
+    static CheckedUint32 calculateBitsPerComponent(const DestinationColorSpace&);
     static CheckedUint32 calculateBytesPerPixel(const DestinationColorSpace&);
 #if USE(CG)
     static CGBitmapInfo calculateBitmapInfo(const DestinationColorSpace&, bool isOpaque);
@@ -95,6 +97,7 @@ private:
     Headroom m_headroom { Headroom::None };
     bool m_isOpaque { false };
 
+    CheckedUint32 m_bitsPerComponent;
     CheckedUint32 m_bytesPerPixel;
     CheckedUint32 m_bytesPerRow;
 #if USE(CG)

--- a/Source/WebCore/platform/graphics/cairo/ShareableBitmapCairo.cpp
+++ b/Source/WebCore/platform/graphics/cairo/ShareableBitmapCairo.cpp
@@ -43,6 +43,11 @@ std::optional<DestinationColorSpace> ShareableBitmapConfiguration::validateColor
     return colorSpace;
 }
 
+CheckedUint32 ShareableBitmapConfiguration::calculateBitsPerComponent(const DestinationColorSpace& colorSpace)
+{
+    return (calculateBytesPerPixel(colorSpace) / 4) * 8;
+}
+
 CheckedUint32 ShareableBitmapConfiguration::calculateBytesPerPixel(const DestinationColorSpace&)
 {
     return 4;

--- a/Source/WebCore/platform/graphics/skia/ShareableBitmapSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/ShareableBitmapSkia.cpp
@@ -42,6 +42,11 @@ std::optional<DestinationColorSpace> ShareableBitmapConfiguration::validateColor
     return colorSpace;
 }
 
+CheckedUint32 ShareableBitmapConfiguration::calculateBitsPerComponent(const DestinationColorSpace& colorSpace)
+{
+    return (calculateBytesPerPixel(colorSpace) / 4) * 8;
+}
+
 CheckedUint32 ShareableBitmapConfiguration::calculateBytesPerPixel(const DestinationColorSpace& colorSpace)
 {
     return SkImageInfo::MakeN32Premul(1, 1, colorSpace.platformColorSpace()).bytesPerPixel();

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -8545,6 +8545,7 @@ header: <WebCore/ShareableBitmap.h>
     std::optional<WebCore::DestinationColorSpace> m_colorSpace;
     WebCore::Headroom m_headroom;
     bool m_isOpaque;
+    unsigned bitsPerComponent();
     unsigned bytesPerPixel();
     unsigned bytesPerRow();
 #if USE(CG)


### PR DESCRIPTION
#### 1f30718ac2689b24dc51500d9cf42d22eb75def3
<pre>
[HDR] Don&apos;t calculate the bitsPerComponent of an image
<a href="https://bugs.webkit.org/show_bug.cgi?id=294353">https://bugs.webkit.org/show_bug.cgi?id=294353</a>
<a href="https://rdar.apple.com/152609863">rdar://152609863</a>

Reviewed by Simon Fraser.

bitsPerComponent should not be calculated as bitsPerPixel / 4. This is an invalid
assumption. For example, the bitsPerComponent can be = 10 while bitsPerPixel = 32.
This means each color component takes 10 bits while the remaining 2 bits may be
unused (or used as a 4-level alpha channel).

For Cocoa platforms, CGImageGetBitsPerComponent() can be used for this purpose.

* Source/WebCore/platform/graphics/ShareableBitmap.cpp:
(WebCore::ShareableBitmapConfiguration::ShareableBitmapConfiguration):
* Source/WebCore/platform/graphics/ShareableBitmap.h:
(WebCore::ShareableBitmapConfiguration::bitsPerComponent const):
* Source/WebCore/platform/graphics/cairo/ShareableBitmapCairo.cpp:
(WebCore::ShareableBitmapConfiguration::calculateBitsPerComponent):
* Source/WebCore/platform/graphics/cg/ShareableBitmapCG.mm:
(WebCore::ShareableBitmapConfiguration::ShareableBitmapConfiguration):
(WebCore::ShareableBitmapConfiguration::calculateBitsPerComponent):
(WebCore::ShareableBitmap::createGraphicsContext):
(WebCore::ShareableBitmap::createCGImage const):
* Source/WebCore/platform/graphics/skia/ShareableBitmapSkia.cpp:
(WebCore::ShareableBitmapConfiguration::calculateBitsPerComponent):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/296119@main">https://commits.webkit.org/296119@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1bcff5b0ab7bb56041d413c5eb39179997c8612f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/107457 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27139 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/17546 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/112671 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/57993 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/109421 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/27823 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/35639 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/81569 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/110386 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22037 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/96842 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/61953 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/21476 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/14979 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/57437 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/91406 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15013 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/115772 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/34524 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/25439 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/90609 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/34899 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93097 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/90355 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23035 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35260 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13039 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/30267 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/34445 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/39986 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34191 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/37546 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/35852 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->