### PR TITLE
WIP fix grid-container-ignores-first-letter-001

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-model/grid-container-ignores-first-letter-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-model/grid-container-ignores-first-letter-001-expected.txt
@@ -3,43 +3,13 @@ PASS .container 1
 PASS .container 2
 PASS .container 3
 PASS .container 4
-FAIL .container 5 assert_equals:
-<div class="container container-first-letter">
-  <div class="grid grid-first-letter">
-    <div class="item" data-expected-height="20">The first item.</div>
-    <div class="item" data-expected-height="20">The second item.</div>
-  </div>
-  <div data-expected-height="20">Out of grid.</div>
-</div>
-height expected 20 but got 200
+PASS .container 5
 PASS .container 6
-FAIL .container 7 assert_equals:
-<div class="container container-first-letter">
-  <div class="grid grid-first-letter" data-expected-height="20">
-    Anonymous item.
-  </div>
-  <div data-expected-height="20">Out of grid.</div>
-</div>
-height expected 20 but got 200
+PASS .container 7
 PASS .container 8
-FAIL .container 9 assert_equals:
-<div class="container container-first-letter">
-  <div class="grid">
-    <div class="item" data-expected-height="20">The first item.</div>
-    <div class="item" data-expected-height="20">The second item.</div>
-  </div>
-  <div data-expected-height="20">Out of grid.</div>
-</div>
-height expected 20 but got 200
+PASS .container 9
 PASS .container 10
-FAIL .container 11 assert_equals:
-<div class="container container-first-letter">
-  <div class="grid" data-expected-height="20">
-    Anonymous item.
-  </div>
-  <div data-expected-height="20">Out of grid.</div>
-</div>
-height expected 20 but got 200
+PASS .container 11
 PASS .container 12
 The first item.
 The second item.

--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -2661,10 +2661,25 @@ void RenderBlock::getFirstLetter(RenderObject*& firstLetter, RenderElement*& fir
     
     // FIXME: We need to destroy the first-letter object if it is no longer the first child. Need to find
     // an efficient way to check for that situation though before implementing anything.
-    firstLetterContainer = findFirstLetterBlock(this);
-    if (!firstLetterContainer)
-        return;
+    auto initialContainer = [&] -> RenderElement* {
+        auto* currentBlockContainer = findFirstLetterBlock(this);
+        if (!currentBlockContainer)
+            return { };
+        while (!currentBlockContainer->childrenInline()) {
+            auto* firstInFlowBlockLevelChild = dynamicDowncast<RenderBlock>(currentBlockContainer->firstInFlowChild());
+            if (!firstInFlowBlockLevelChild || firstInFlowBlockLevelChild->isFlexibleBoxIncludingDeprecated()
+                || firstInFlowBlockLevelChild->isRenderGrid())
+                return { };
+            currentBlockContainer = firstInFlowBlockLevelChild;
+        }
+        return currentBlockContainer;
+    };
+
     
+
+    firstLetterContainer = initialContainer();
+    ASSERT(firstLetterContainer->childrenInline());
+
     // Drill into inlines looking for our first text descendant.
     firstLetter = firstLetterContainer->firstChild();
     while (firstLetter) {
@@ -2688,8 +2703,6 @@ void RenderBlock::getFirstLetter(RenderObject*& firstLetter, RenderElement*& fir
             firstLetter = current.nextSibling();
         } else if (current.isReplacedOrAtomicInline() || is<RenderButton>(current) || is<RenderMenuList>(current))
             break;
-        else if (current.isFlexibleBoxIncludingDeprecated() || current.isRenderGrid())
-            firstLetter = current.nextSibling();
         else if (current.style().hasPseudoStyle(PseudoId::FirstLetter) && current.canHaveGeneratedChildren())  {
             // We found a lower-level node with first-letter, which supersedes the higher-level style
             firstLetterContainer = &current;


### PR DESCRIPTION
#### 7ed077ec53892e5497db23a1e9f174393852b3f4
<pre>
WIP fix grid-container-ignores-first-letter-001
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7ed077ec53892e5497db23a1e9f174393852b3f4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/107433 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27115 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/17521 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/112647 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/57969 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/109397 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/27798 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/35615 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/81554 "Found 17 new test failures: css3/flexbox/flexbox-ignore-container-firstLetter.html fast/css-generated-content/after-with-first-letter-float-crash.html fast/css-generated-content/empty-first-letter-with-columns-crash.html fast/css-generated-content/first-letter-in-nested-before-table.html fast/css-generated-content/first-letter-in-nested-before.html fast/css-generated-content/first-letter-update-crash.html fast/css-grid-layout/grid-container-ignore-first-letter.html fast/css/first-letter-block-form-controls-crash.html fast/css/first-letter-removed-added.html fast/css/first-letter-skip-out-of-flow.html ... (failure)") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/110362 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22015 "Found 13 new test failures: css3/flexbox/flexbox-ignore-container-firstLetter.html fast/css-generated-content/empty-first-letter-with-columns-crash.html fast/css-generated-content/first-letter-in-nested-before-table.html fast/css-generated-content/first-letter-in-nested-before.html fast/css-generated-content/first-letter-update-crash.html fast/css-grid-layout/grid-container-ignore-first-letter.html fast/css/first-letter-block-form-controls-crash.html fast/css/first-letter-removed-added.html fast/css/first-letter-skip-out-of-flow.html fast/dom/set-outer-text-on-moved-element.html ... (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/96831 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/61930 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/21455 "Found 4 new test failures: imported/w3c/web-platform-tests/css/css-conditional/container-queries/pseudo-elements-002b.html imported/w3c/web-platform-tests/css/css-content/quotes-first-letter-003.html imported/w3c/web-platform-tests/css/css-pseudo/first-letter-and-sibling-display-change.html imported/w3c/web-platform-tests/css/css-pseudo/first-letter-exclude-block-child-marker.html (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/14962 "Found 19 new test failures: css3/flexbox/flexbox-ignore-container-firstLetter.html editing/inserting/insert-character-in-first-letter-crash.html fast/css-generated-content/empty-first-letter-with-columns-crash.html fast/css-generated-content/first-letter-in-nested-before-table.html fast/css-generated-content/first-letter-in-nested-before.html fast/css-generated-content/first-letter-update-crash.html fast/css-grid-layout/grid-container-ignore-first-letter.html fast/css/first-letter-removed-added.html fast/css/first-letter-skip-out-of-flow.html fast/dom/set-outer-text-on-moved-element.html ... (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/57413 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/91385 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/14997 "Found 16 new test failures: css3/flexbox/flexbox-ignore-container-firstLetter.html fast/css-generated-content/empty-first-letter-with-columns-crash.html fast/css-generated-content/first-letter-in-nested-before-table.html fast/css-generated-content/first-letter-in-nested-before.html fast/css-generated-content/first-letter-update-crash.html fast/css-grid-layout/grid-container-ignore-first-letter.html fast/css/first-letter-removed-added.html fast/css/first-letter-skip-out-of-flow.html fast/dom/set-outer-text-on-moved-element.html fast/forms/button-first-line-first-letter.html ... (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/115748 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/34500 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/25426 "Found 19 new test failures: css3/flexbox/flexbox-ignore-container-firstLetter.html fast/css-generated-content/after-with-first-letter-float-crash.html fast/css-generated-content/empty-first-letter-with-columns-crash.html fast/css-generated-content/first-letter-in-nested-before-table.html fast/css-generated-content/first-letter-in-nested-before.html fast/css-generated-content/first-letter-update-crash.html fast/css-grid-layout/grid-container-ignore-first-letter.html fast/css/first-letter-block-form-controls-crash.html fast/css/first-letter-removed-added.html fast/css/first-letter-skip-out-of-flow.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/90593 "Found 19 new test failures: css3/flexbox/flexbox-ignore-container-firstLetter.html fast/css-generated-content/after-with-first-letter-float-crash.html fast/css-generated-content/empty-first-letter-with-columns-crash.html fast/css-generated-content/first-letter-in-nested-before-table.html fast/css-generated-content/first-letter-in-nested-before.html fast/css-generated-content/first-letter-update-crash.html fast/css-grid-layout/grid-container-ignore-first-letter.html fast/css/first-letter-block-form-controls-crash.html fast/css/first-letter-removed-added.html fast/css/first-letter-skip-out-of-flow.html ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/34875 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93081 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/90331 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35242 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13032 "Found 15 new test failures: css3/flexbox/flexbox-ignore-container-firstLetter.html fast/css-generated-content/empty-first-letter-with-columns-crash.html fast/css-generated-content/first-letter-in-nested-before-table.html fast/css-generated-content/first-letter-in-nested-before.html fast/css-generated-content/first-letter-update-crash.html fast/css-grid-layout/grid-container-ignore-first-letter.html fast/css/first-letter-removed-added.html fast/css/first-letter-skip-out-of-flow.html fast/dom/set-outer-text-on-moved-element.html fast/forms/button-first-line-first-letter.html ... (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/30243 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/34421 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/39962 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34167 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/37522 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/35828 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->