### PR TITLE
REGRESSION(295171@main): [ iOS Debug ] fast/speechrecognition/ios/audio-capture.html is a constant crash

### DIFF
--- a/LayoutTests/fast/speechrecognition/ios/audio-capture-expected.txt
+++ b/LayoutTests/fast/speechrecognition/ios/audio-capture-expected.txt
@@ -7,7 +7,6 @@ PASS recognition = new webkitSpeechRecognition(); did not throw exception.
 PASS recognition.start() did not throw exception.
 Received start event
 Received audiostart event
-PASS internals.audioSessionCategory() is "PlayAndRecord"
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/speechrecognition/ios/audio-capture.html
+++ b/LayoutTests/fast/speechrecognition/ios/audio-capture.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ CaptureAudioInGPUProcessEnabled=false ] -->
+<!DOCTYPE html>
 <html>
 <body>
 <script src="../../../resources/js-test.js"></script>
@@ -17,7 +17,6 @@ recognition.onstart = (event) => {
 recognition.onaudiostart = (event) => {
     debug("Received audiostart event");
 
-    shouldBeEqualToString("internals.audioSessionCategory()", "PlayAndRecord");
     finishJSTest();
 }
 

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -7910,8 +7910,6 @@ webkit.org/b/294222 [ Debug ] compositing/cocoa/clip-sticky-element-with-overflo
 
 webkit.org/b/294229 http/tests/site-isolation/page-scale.html [ Pass ImageOnlyFailure ]
 
-webkit.org/b/294274 [ Debug ] fast/speechrecognition/ios/audio-capture.html [ Crash ]
-
 webkit.org/b/294276 [ Debug ] http/wpt/mediarecorder/MediaRecorder-first-frame.html [ Failure ]
 
 webkit.org/b/294277 [ Release ] imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-fixed-ancestor-iframe.html [ Pass ImageOnlyFailure ]


### PR DESCRIPTION
#### a453557b3315f7ba9e0d19264b0882bf05ccf174
<pre>
REGRESSION(295171@main): [ iOS Debug ] fast/speechrecognition/ios/audio-capture.html is a constant crash
<a href="https://bugs.webkit.org/show_bug.cgi?id=294274">https://bugs.webkit.org/show_bug.cgi?id=294274</a>
<a href="https://rdar.apple.com/152981168">rdar://152981168</a>

Reviewed by Youenn Fablet.

The test crashes for hitting an assertion that ensures audio capture only happens in GPU process. However, the test
explicitly disables audio capture in GPU process. The test was added when SpeechRecognition API did not work with audio
capture in GPU process, but now it has the support and we can just remove the flag in the test to fix the crash.

Also, the test checks audio session category with `internals.audioSessionCategory()`, but that function only returns
category for audio session in web process. Now that audio capture happens in GPU process, web process might not know
the categroy; so removing the check from test.

* LayoutTests/fast/speechrecognition/ios/audio-capture-expected.txt:
* LayoutTests/fast/speechrecognition/ios/audio-capture.html:
* LayoutTests/platform/ios/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/296150@main">https://commits.webkit.org/296150@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7dc7148b2162206c54caf29f12e53e64a407eafe

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/107437 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27119 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/17525 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/112651 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/57973 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/27802 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/35619 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/81558 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/110366 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22019 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/96824 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/61934 "Found 1 new API test failure: /WPE/TestSSL:/webkit/WebKitWebView/ephemeral-tls-errors (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/21459 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/14955 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/57417 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/91389 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/14989 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/115752 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/34504 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/25431 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/90596 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/34879 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93073 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/90335 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23055 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35252 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13026 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/30247 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/34425 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34171 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/37526 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/35832 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->