### PR TITLE
REGRESSION(296061@main): [iOS] fast/events/ios/select-all-with-existing-selection.html is consistent crash

### DIFF
--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -7931,7 +7931,5 @@ webkit.org/b/294274 [ Debug ] platform/ios/mediastream/audio-muted-in-background
  webgl/1.0.x/conformance/textures/misc/gl-teximage.html [ Failure ]
  webgl/2.0.y/conformance/textures/misc/gl-teximage.html [ Failure ]
 
-webkit.org/b/294346 fast/events/ios/select-all-with-existing-selection.html [ Pass Crash ]
-
 fast/snapshot/nested-stacking-context.html [ Skip ]
 fast/snapshot/positioned-abs-relative-body.html [ Skip ]

--- a/Source/WebKit/UIProcess/PDF/WKPDFPageNumberIndicator.mm
+++ b/Source/WebKit/UIProcess/PDF/WKPDFPageNumberIndicator.mm
@@ -81,7 +81,7 @@ static constexpr Seconds indicatorMoveDuration { 0.3_s };
 
     RetainPtr<UIVisualEffect> visualEffect;
     if (shouldUseBlurEffectForBackdrop)
-        visualEffect = adoptNS([UIBlurEffect effectWithStyle:UIBlurEffectStyleLight]);
+        visualEffect = [UIBlurEffect effectWithStyle:UIBlurEffectStyleLight];
     else {
 #if HAVE(UI_GLASS_EFFECT)
         visualEffect = adoptNS([[UIGlassEffect alloc] init]);


### PR DESCRIPTION
#### 7a4483ecad755a7f57112eb3b87a4cefb20239b2
<pre>
REGRESSION(296061@main): [iOS] fast/events/ios/select-all-with-existing-selection.html is consistent crash
<a href="https://bugs.webkit.org/show_bug.cgi?id=294346">https://bugs.webkit.org/show_bug.cgi?id=294346</a>
<a href="https://rdar.apple.com/153123388">rdar://153123388</a>

Reviewed by Aditya Keerthi.

In 296061@main, we started storing the UIVisualEffect to configure the
backdrop view with in a RetainPtr. However, -effectWithStyle: on
UIBlurEffect is not a +1 method, and as such our `adoptNS()` call on its
return value meant that we were not retaining the blur effect. This lead
to an eventual overrelease when the UIVisualEffectView holding the blur
effect was destroyed.

Fix this crash by properly retaining the blur effect.

* LayoutTests/platform/ios/TestExpectations: Remove test gardening.
* Source/WebKit/UIProcess/PDF/WKPDFPageNumberIndicator.mm:
(-[WKPDFPageNumberIndicator initWithFrame:view:pageCount:]):

Canonical link: <a href="https://commits.webkit.org/296118@main">https://commits.webkit.org/296118@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d8ffdb3fe73c7be3c57e3647085611f8d33299b4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/107468 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27150 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/17558 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/112682 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/58004 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/27834 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/35650 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/81577 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/58004 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/110397 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/22047 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/96857 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/61962 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/21483 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/14998 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/57448 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/91413 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/15029 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/115783 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/34535 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/25445 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/90615 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/34910 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/93113 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/90361 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/35274 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/13050 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/30279 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17372 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/34456 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/39997 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34202 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/37557 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/35863 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->