### PR TITLE
[webkitpy] Move default CURRENT_VERSION variable definition to DarwinPort.

### DIFF
--- a/Tools/Scripts/webkitpy/common/version_name_map.py
+++ b/Tools/Scripts/webkitpy/common/version_name_map.py
@@ -48,6 +48,8 @@ class VersionNameMap(object):
             platform = SystemHost.get_default().platform
         self.mapping = {}
 
+        from webkitpy.port import darwin, ios, watch, visionos
+
         self.default_system_platform = platform.os_name
         self.mapping[PUBLIC_TABLE] = {
             'mac': {
@@ -69,10 +71,10 @@ class VersionNameMap(object):
                 'Sequoia': Version(15, 0),
                 'Tahoe': Version(26, 0)
             },
-            'ios': self._automap_to_major_version('iOS', minimum=Version(10), maximum=Version(26)),
-            'tvos': self._automap_to_major_version('tvOS', minimum=Version(10), maximum=Version(26)),
-            'watchos': self._automap_to_major_version('watchOS', minimum=Version(1), maximum=Version(26)),
-            'visionos': self._automap_to_major_version('visionOS', minimum=Version(1), maximum=Version(26)),
+            'ios': self._automap_to_major_version('iOS', minimum=Version(10), maximum=ios.IOSPort.CURRENT_VERSION),
+            'tvos': self._automap_to_major_version('tvOS', minimum=Version(10), maximum=darwin.DarwinPort.CURRENT_VERSION),
+            'watchos': self._automap_to_major_version('watchOS', minimum=Version(1), maximum=watch.WatchPort.CURRENT_VERSION),
+            'visionos': self._automap_to_major_version('visionOS', minimum=Version(1), maximum=visionos.VisionOSPort.CURRENT_VERSION),
             'win': {
                 'Win10': Version(10),
                 '8.1': Version(6, 3),

--- a/Tools/Scripts/webkitpy/port/darwin.py
+++ b/Tools/Scripts/webkitpy/port/darwin.py
@@ -31,7 +31,7 @@ from webkitpy.common.system.executive import ScriptError
 from webkitpy.port.apple import ApplePort
 from webkitpy.port.leakdetector import LeakDetector
 
-from webkitcorepy import decorators
+from webkitcorepy import decorators, Version
 
 
 _log = logging.getLogger(__name__)
@@ -39,7 +39,7 @@ _log = logging.getLogger(__name__)
 
 class DarwinPort(ApplePort):
 
-    CURRENT_VERSION = None
+    CURRENT_VERSION = Version(26)
     SDK = None
 
     API_TEST_BINARY_NAMES = ['TestWTF', 'TestWebKitAPI', 'TestIPC', 'TestWGSL']

--- a/Tools/Scripts/webkitpy/port/ios.py
+++ b/Tools/Scripts/webkitpy/port/ios.py
@@ -36,7 +36,6 @@ _log = logging.getLogger(__name__)
 class IOSPort(DevicePort):
     port_name = "ios"
 
-    CURRENT_VERSION = Version(26)
     DEVICE_TYPE = DeviceType(software_variant='iOS')
 
     def __init__(self, host, port_name, **kwargs):

--- a/Tools/Scripts/webkitpy/port/ios_device_unittest.py
+++ b/Tools/Scripts/webkitpy/port/ios_device_unittest.py
@@ -112,21 +112,23 @@ class IOSDeviceTest(ios_testcase.IOSTest):
 
     def test_layout_test_searchpath_with_apple_additions(self):
         with port_testcase.bind_mock_apple_additions():
-            search_path = self.make_port().default_baseline_search_path()
+            port = self.make_port()
+            major_os_version = port._options.version.split('.')[0]
+            search_path = port.default_baseline_search_path()
 
         self.assertEqual(search_path, [
-            '/additional_testing_path/ios-device-add-ios26-wk1',
-            '/mock-checkout/LayoutTests/platform/ios-device-26-wk1',
-            '/additional_testing_path/ios-device-add-ios26',
-            '/mock-checkout/LayoutTests/platform/ios-device-26',
+            f'/additional_testing_path/ios-device-add-ios{major_os_version}-wk1',
+            f'/mock-checkout/LayoutTests/platform/ios-device-{major_os_version}-wk1',
+            f'/additional_testing_path/ios-device-add-ios{major_os_version}',
+            f'/mock-checkout/LayoutTests/platform/ios-device-{major_os_version}',
             '/additional_testing_path/ios-device-wk1',
             '/mock-checkout/LayoutTests/platform/ios-device-wk1',
             '/additional_testing_path/ios-device',
             '/mock-checkout/LayoutTests/platform/ios-device',
-            '/additional_testing_path/ios-add-ios26-wk1',
-            '/mock-checkout/LayoutTests/platform/ios-26-wk1',
-            '/additional_testing_path/ios-add-ios26',
-            '/mock-checkout/LayoutTests/platform/ios-26',
+            f'/additional_testing_path/ios-add-ios{major_os_version}-wk1',
+            f'/mock-checkout/LayoutTests/platform/ios-{major_os_version}-wk1',
+            f'/additional_testing_path/ios-add-ios{major_os_version}',
+            f'/mock-checkout/LayoutTests/platform/ios-{major_os_version}',
             '/additional_testing_path/ios-wk1',
             '/mock-checkout/LayoutTests/platform/ios-wk1',
             '/additional_testing_path/ios',
@@ -134,46 +136,50 @@ class IOSDeviceTest(ios_testcase.IOSTest):
         ])
 
     def test_layout_test_searchpath_without_apple_additions(self):
-        search_path = self.make_port(port_name='ios-device-wk2', os_version=Version(26)).default_baseline_search_path()
+        port = self.make_port(port_name='ios-device-wk2')
+        major_os_version = port._options.version.split('.')[0]
+        search_path = port.default_baseline_search_path()
 
         self.assertEqual(search_path, [
-            '/mock-checkout/LayoutTests/platform/ios-device-26-wk2',
-            '/mock-checkout/LayoutTests/platform/ios-device-26',
+            f'/mock-checkout/LayoutTests/platform/ios-device-{major_os_version}-wk2',
+            f'/mock-checkout/LayoutTests/platform/ios-device-{major_os_version}',
             '/mock-checkout/LayoutTests/platform/ios-device-wk2',
             '/mock-checkout/LayoutTests/platform/ios-device',
-            '/mock-checkout/LayoutTests/platform/ios-26-wk2',
-            '/mock-checkout/LayoutTests/platform/ios-26',
+            f'/mock-checkout/LayoutTests/platform/ios-{major_os_version}-wk2',
+            f'/mock-checkout/LayoutTests/platform/ios-{major_os_version}',
             '/mock-checkout/LayoutTests/platform/ios-wk2',
             '/mock-checkout/LayoutTests/platform/ios',
             '/mock-checkout/LayoutTests/platform/wk2',
         ])
 
     def test_layout_searchpath_wih_device_type(self):
-        search_path = self.make_port(port_name='ios-device-wk2', os_version=Version(26)).default_baseline_search_path(DeviceType.from_string('iPhone SE'))
+        port = self.make_port(port_name='ios-device-wk2')
+        major_os_version = port._options.version.split('.')[0]
+        search_path = port.default_baseline_search_path(DeviceType.from_string('iPhone SE'))
 
         self.assertEqual(search_path, [
-            '/mock-checkout/LayoutTests/platform/iphone-se-device-26-wk2',
-            '/mock-checkout/LayoutTests/platform/iphone-se-device-26',
+            f'/mock-checkout/LayoutTests/platform/iphone-se-device-{major_os_version}-wk2',
+            f'/mock-checkout/LayoutTests/platform/iphone-se-device-{major_os_version}',
             '/mock-checkout/LayoutTests/platform/iphone-se-device-wk2',
             '/mock-checkout/LayoutTests/platform/iphone-se-device',
-            '/mock-checkout/LayoutTests/platform/iphone-device-26-wk2',
-            '/mock-checkout/LayoutTests/platform/iphone-device-26',
+            f'/mock-checkout/LayoutTests/platform/iphone-device-{major_os_version}-wk2',
+            f'/mock-checkout/LayoutTests/platform/iphone-device-{major_os_version}',
             '/mock-checkout/LayoutTests/platform/iphone-device-wk2',
             '/mock-checkout/LayoutTests/platform/iphone-device',
-            '/mock-checkout/LayoutTests/platform/ios-device-26-wk2',
-            '/mock-checkout/LayoutTests/platform/ios-device-26',
+            f'/mock-checkout/LayoutTests/platform/ios-device-{major_os_version}-wk2',
+            f'/mock-checkout/LayoutTests/platform/ios-device-{major_os_version}',
             '/mock-checkout/LayoutTests/platform/ios-device-wk2',
             '/mock-checkout/LayoutTests/platform/ios-device',
-            '/mock-checkout/LayoutTests/platform/iphone-se-26-wk2',
-            '/mock-checkout/LayoutTests/platform/iphone-se-26',
+            f'/mock-checkout/LayoutTests/platform/iphone-se-{major_os_version}-wk2',
+            f'/mock-checkout/LayoutTests/platform/iphone-se-{major_os_version}',
             '/mock-checkout/LayoutTests/platform/iphone-se-wk2',
             '/mock-checkout/LayoutTests/platform/iphone-se',
-            '/mock-checkout/LayoutTests/platform/iphone-26-wk2',
-            '/mock-checkout/LayoutTests/platform/iphone-26',
+            f'/mock-checkout/LayoutTests/platform/iphone-{major_os_version}-wk2',
+            f'/mock-checkout/LayoutTests/platform/iphone-{major_os_version}',
             '/mock-checkout/LayoutTests/platform/iphone-wk2',
             '/mock-checkout/LayoutTests/platform/iphone',
-            '/mock-checkout/LayoutTests/platform/ios-26-wk2',
-            '/mock-checkout/LayoutTests/platform/ios-26',
+            f'/mock-checkout/LayoutTests/platform/ios-{major_os_version}-wk2',
+            f'/mock-checkout/LayoutTests/platform/ios-{major_os_version}',
             '/mock-checkout/LayoutTests/platform/ios-wk2',
             '/mock-checkout/LayoutTests/platform/ios',
             '/mock-checkout/LayoutTests/platform/wk2',

--- a/Tools/Scripts/webkitpy/port/ios_simulator_unittest.py
+++ b/Tools/Scripts/webkitpy/port/ios_simulator_unittest.py
@@ -39,7 +39,7 @@ class IOSSimulatorTest(ios_testcase.IOSTest):
     port_name = 'ios-simulator'
     port_maker = IOSSimulatorPort
 
-    def make_port(self, host=None, port_name=None, options=None, os_name=None, os_version=Version(26), **kwargs):
+    def make_port(self, host=None, port_name=None, options=None, os_name=None, os_version=IOSSimulatorPort.CURRENT_VERSION, **kwargs):
         port = super(IOSSimulatorTest, self).make_port(host=host, port_name=port_name, options=options, os_name=os_name, os_version=os_version, kwargs=kwargs)
         port.set_option('child_processes', 1)
         return port
@@ -83,21 +83,23 @@ class IOSSimulatorTest(ios_testcase.IOSTest):
 
     def test_layout_test_searchpath_with_apple_additions(self):
         with port_testcase.bind_mock_apple_additions():
-            search_path = self.make_port().default_baseline_search_path()
+            port = self.make_port()
+            major_os_version = port._options.version.split('.')[0]
+            search_path = port.default_baseline_search_path()
 
         self.assertEqual(search_path, [
-            '/additional_testing_path/ios-simulator-add-ios26-wk1',
-            '/mock-checkout/LayoutTests/platform/ios-simulator-26-wk1',
-            '/additional_testing_path/ios-simulator-add-ios26',
-            '/mock-checkout/LayoutTests/platform/ios-simulator-26',
+            f'/additional_testing_path/ios-simulator-add-ios{major_os_version}-wk1',
+            f'/mock-checkout/LayoutTests/platform/ios-simulator-{major_os_version}-wk1',
+            f'/additional_testing_path/ios-simulator-add-ios{major_os_version}',
+            f'/mock-checkout/LayoutTests/platform/ios-simulator-{major_os_version}',
             '/additional_testing_path/ios-simulator-wk1',
             '/mock-checkout/LayoutTests/platform/ios-simulator-wk1',
             '/additional_testing_path/ios-simulator',
             '/mock-checkout/LayoutTests/platform/ios-simulator',
-            '/additional_testing_path/ios-add-ios26-wk1',
-            '/mock-checkout/LayoutTests/platform/ios-26-wk1',
-            '/additional_testing_path/ios-add-ios26',
-            '/mock-checkout/LayoutTests/platform/ios-26',
+            f'/additional_testing_path/ios-add-ios{major_os_version}-wk1',
+            f'/mock-checkout/LayoutTests/platform/ios-{major_os_version}-wk1',
+            f'/additional_testing_path/ios-add-ios{major_os_version}',
+            f'/mock-checkout/LayoutTests/platform/ios-{major_os_version}',
             '/additional_testing_path/ios-wk1',
             '/mock-checkout/LayoutTests/platform/ios-wk1',
             '/additional_testing_path/ios',
@@ -105,46 +107,50 @@ class IOSSimulatorTest(ios_testcase.IOSTest):
         ])
 
     def test_layout_test_searchpath_without_apple_additions(self):
-        search_path = self.make_port(port_name='ios-simulator-wk2', os_version=Version(26)).default_baseline_search_path()
+        port = self.make_port(port_name='ios-simulator-wk2')
+        major_os_version = port._options.version.split('.')[0]
+        search_path = port.default_baseline_search_path()
 
         self.assertEqual(search_path, [
-            '/mock-checkout/LayoutTests/platform/ios-simulator-26-wk2',
-            '/mock-checkout/LayoutTests/platform/ios-simulator-26',
+            f'/mock-checkout/LayoutTests/platform/ios-simulator-{major_os_version}-wk2',
+            f'/mock-checkout/LayoutTests/platform/ios-simulator-{major_os_version}',
             '/mock-checkout/LayoutTests/platform/ios-simulator-wk2',
             '/mock-checkout/LayoutTests/platform/ios-simulator',
-            '/mock-checkout/LayoutTests/platform/ios-26-wk2',
-            '/mock-checkout/LayoutTests/platform/ios-26',
+            f'/mock-checkout/LayoutTests/platform/ios-{major_os_version}-wk2',
+            f'/mock-checkout/LayoutTests/platform/ios-{major_os_version}',
             '/mock-checkout/LayoutTests/platform/ios-wk2',
             '/mock-checkout/LayoutTests/platform/ios',
             '/mock-checkout/LayoutTests/platform/wk2',
         ])
 
     def test_layout_searchpath_wih_device_type(self):
-        search_path = self.make_port(port_name='ios-simulator-wk2', os_version=Version(26)).default_baseline_search_path(DeviceType.from_string('iPhone SE'))
+        port = self.make_port(port_name='ios-simulator-wk2')
+        major_os_version = port._options.version.split('.')[0]
+        search_path = port.default_baseline_search_path(DeviceType.from_string('iPhone SE'))
 
         self.assertEqual(search_path, [
-            '/mock-checkout/LayoutTests/platform/iphone-se-simulator-26-wk2',
-            '/mock-checkout/LayoutTests/platform/iphone-se-simulator-26',
+            f'/mock-checkout/LayoutTests/platform/iphone-se-simulator-{major_os_version}-wk2',
+            f'/mock-checkout/LayoutTests/platform/iphone-se-simulator-{major_os_version}',
             '/mock-checkout/LayoutTests/platform/iphone-se-simulator-wk2',
             '/mock-checkout/LayoutTests/platform/iphone-se-simulator',
-            '/mock-checkout/LayoutTests/platform/iphone-simulator-26-wk2',
-            '/mock-checkout/LayoutTests/platform/iphone-simulator-26',
+            f'/mock-checkout/LayoutTests/platform/iphone-simulator-{major_os_version}-wk2',
+            f'/mock-checkout/LayoutTests/platform/iphone-simulator-{major_os_version}',
             '/mock-checkout/LayoutTests/platform/iphone-simulator-wk2',
             '/mock-checkout/LayoutTests/platform/iphone-simulator',
-            '/mock-checkout/LayoutTests/platform/ios-simulator-26-wk2',
-            '/mock-checkout/LayoutTests/platform/ios-simulator-26',
+            f'/mock-checkout/LayoutTests/platform/ios-simulator-{major_os_version}-wk2',
+            f'/mock-checkout/LayoutTests/platform/ios-simulator-{major_os_version}',
             '/mock-checkout/LayoutTests/platform/ios-simulator-wk2',
             '/mock-checkout/LayoutTests/platform/ios-simulator',
-            '/mock-checkout/LayoutTests/platform/iphone-se-26-wk2',
-            '/mock-checkout/LayoutTests/platform/iphone-se-26',
+            f'/mock-checkout/LayoutTests/platform/iphone-se-{major_os_version}-wk2',
+            f'/mock-checkout/LayoutTests/platform/iphone-se-{major_os_version}',
             '/mock-checkout/LayoutTests/platform/iphone-se-wk2',
             '/mock-checkout/LayoutTests/platform/iphone-se',
-            '/mock-checkout/LayoutTests/platform/iphone-26-wk2',
-            '/mock-checkout/LayoutTests/platform/iphone-26',
+            f'/mock-checkout/LayoutTests/platform/iphone-{major_os_version}-wk2',
+            f'/mock-checkout/LayoutTests/platform/iphone-{major_os_version}',
             '/mock-checkout/LayoutTests/platform/iphone-wk2',
             '/mock-checkout/LayoutTests/platform/iphone',
-            '/mock-checkout/LayoutTests/platform/ios-26-wk2',
-            '/mock-checkout/LayoutTests/platform/ios-26',
+            f'/mock-checkout/LayoutTests/platform/ios-{major_os_version}-wk2',
+            f'/mock-checkout/LayoutTests/platform/ios-{major_os_version}',
             '/mock-checkout/LayoutTests/platform/ios-wk2',
             '/mock-checkout/LayoutTests/platform/ios',
             '/mock-checkout/LayoutTests/platform/wk2',

--- a/Tools/Scripts/webkitpy/port/ios_testcase.py
+++ b/Tools/Scripts/webkitpy/port/ios_testcase.py
@@ -20,15 +20,14 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from webkitcorepy import Version
-
 from webkitpy.port import darwin_testcase
+from webkitpy.port.ios import IOSPort
 
 
 class IOSTest(darwin_testcase.DarwinTest):
     disable_setup = True
 
-    def make_port(self, host=None, port_name=None, options=None, os_name=None, os_version=Version(26), **kwargs):
+    def make_port(self, host=None, port_name=None, options=None, os_name=None, os_version=IOSPort.CURRENT_VERSION, **kwargs):
         port = super(IOSTest, self).make_port(host=host, port_name=port_name, options=options, os_name=os_name, os_version=None, kwargs=kwargs)
         port.set_option('version', str(os_version))
         return port

--- a/Tools/Scripts/webkitpy/port/mac.py
+++ b/Tools/Scripts/webkitpy/port/mac.py
@@ -48,7 +48,6 @@ _log = logging.getLogger(__name__)
 class MacPort(DarwinPort):
     port_name = "mac"
 
-    CURRENT_VERSION = Version(26, 0)
     LAST_MACOSX = Version(10, 15)
 
     SDK = 'macosx'

--- a/Tools/Scripts/webkitpy/port/visionos.py
+++ b/Tools/Scripts/webkitpy/port/visionos.py
@@ -36,7 +36,6 @@ _log = logging.getLogger(__name__)
 class VisionOSPort(DevicePort):
     port_name = 'visionos'
 
-    CURRENT_VERSION = Version(26)
     DEVICE_TYPE = DeviceType(software_variant='visionOS')
 
     def __init__(self, *args, **kwargs):

--- a/Tools/Scripts/webkitpy/port/visionos_testcase.py
+++ b/Tools/Scripts/webkitpy/port/visionos_testcase.py
@@ -20,16 +20,15 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from webkitcorepy import Version
-
 from webkitpy.port import darwin_testcase
+from webkitpy.port.visionos import VisionOSPort
 from webkitpy.tool.mocktool import MockOptions
 
 
 class VisionOSTest(darwin_testcase.DarwinTest):
     disable_setup = True
 
-    def make_port(self, host=None, port_name=None, options=None, os_name=None, os_version=Version(26), **kwargs):
+    def make_port(self, host=None, port_name=None, options=None, os_name=None, os_version=VisionOSPort.CURRENT_VERSION, **kwargs):
         if options:
             options.architecture = 'arm64'
             options.webkit_test_runner = True

--- a/Tools/Scripts/webkitpy/port/watch.py
+++ b/Tools/Scripts/webkitpy/port/watch.py
@@ -36,7 +36,6 @@ _log = logging.getLogger(__name__)
 class WatchPort(DevicePort):
     port_name = 'watchos'
 
-    CURRENT_VERSION = Version(26)
     DEVICE_TYPE = DeviceType(software_variant='watchOS')
 
     def __init__(self, *args, **kwargs):

--- a/Tools/Scripts/webkitpy/port/watch_simulator_unittest.py
+++ b/Tools/Scripts/webkitpy/port/watch_simulator_unittest.py
@@ -38,7 +38,7 @@ class WatchSimulatorTest(watch_testcase.WatchTest):
     port_name = 'watch-simulator'
     port_maker = WatchSimulatorPort
 
-    def make_port(self, host=None, port_name=None, options=None, os_name=None, os_version=Version(26), **kwargs):
+    def make_port(self, host=None, port_name=None, options=None, os_name=None, os_version=WatchSimulatorPort.CURRENT_VERSION, **kwargs):
         port = super(WatchSimulatorTest, self).make_port(host=host, port_name=port_name, options=options, os_name=os_name, os_version=os_version, kwargs=kwargs)
         port.set_option('child_processes', 1)
         return port

--- a/Tools/Scripts/webkitpy/port/watch_testcase.py
+++ b/Tools/Scripts/webkitpy/port/watch_testcase.py
@@ -23,13 +23,14 @@
 from webkitcorepy import Version
 
 from webkitpy.port import darwin_testcase
+from webkitpy.port.watch import WatchPort
 from webkitpy.tool.mocktool import MockOptions
 
 
 class WatchTest(darwin_testcase.DarwinTest):
     disable_setup = True
 
-    def make_port(self, host=None, port_name=None, options=None, os_name=None, os_version=Version(26), **kwargs):
+    def make_port(self, host=None, port_name=None, options=None, os_name=None, os_version=WatchPort.CURRENT_VERSION, **kwargs):
         if options:
             options.architecture = 'x86'
             options.webkit_test_runner = True


### PR DESCRIPTION
#### 71871b592a2fe399d0e1c041de1225a504ff66a6
<pre>
[webkitpy] Move default CURRENT_VERSION variable definition to DarwinPort.
<a href="https://bugs.webkit.org/show_bug.cgi?id=294287">https://bugs.webkit.org/show_bug.cgi?id=294287</a>
<a href="https://rdar.apple.com/153002661">rdar://153002661</a>

Reviewed by Jonathan Bedard.

Now that all Apple port versions are 26, we can synthesize all of the different
CURRENT_VERSION definitions by port into one definition in DarwinPort. If we
have different versioning for whatever reason (maybe differences in minor
version?), we can always override that in the subclasses.

This change also changes associated unit tests to use the current version
rather than manually defining it every time, requiring fewer changes each year.

* Tools/Scripts/webkitpy/common/version_name_map.py:
    (VersionNameMap)
        -&gt; (__init__): Pull CURRENT_VERSION from port objects for iOS, tvOS, watchOS, and visionOS.
                        (Not for macOS, as this requires a manual change to define new version names yearly anyway.)
* Tools/Scripts/webkitpy/port/darwin.py:
    (DarwinPort): Set default for CURRENT_VERSION to `Version(26)`.
* Tools/Scripts/webkitpy/port/ios.py:
    (IOSPort): Remove CURRENT_VERSION definition that overrides DarwinPort.
* Tools/Scripts/webkitpy/port/mac.py:
    (MacPort): Ditto.
* Tools/Scripts/webkitpy/port/visionos.py:
    (VisionOSPort): Ditto.
* Tools/Scripts/webkitpy/port/watch.py:
    (WatchPort): Ditto.
* Tools/Scripts/webkitpy/port/ios_device_unittest.py: Change unit tests to use CURRENT_VERSION from associated ports.
* Tools/Scripts/webkitpy/port/ios_simulator_unittest.py: Ditto.
* Tools/Scripts/webkitpy/port/ios_testcase.py: Ditto.
* Tools/Scripts/webkitpy/port/visionos_testcase.py: Ditto.
* Tools/Scripts/webkitpy/port/watch_simulator_unittest.py: Ditto.
* Tools/Scripts/webkitpy/port/watch_testcase.py: Ditto.

Canonical link: <a href="https://commits.webkit.org/296346@main">https://commits.webkit.org/296346@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/28c5ad3ddd3cb6182b78fcbcfefcb5cc8d6c9b31

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/107455 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27137 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/17544 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/112669 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/57991 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/109419 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/27821 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/35637 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/81568 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/110384 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22030 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/96844 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/61950 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/106860 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/21470 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/14988 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/57435 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/91399 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15015 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/115770 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/34522 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/25437 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/90606 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/34897 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93099 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/90352 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35258 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13041 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/30265 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17483 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/34443 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34189 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/37544 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/35850 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->