### PR TITLE
Allow the model process to go idle (or exit if under memory pressure) if there are no more model players

### DIFF
--- a/Source/WebKit/ModelProcess/ModelConnectionToWebProcess.cpp
+++ b/Source/WebKit/ModelProcess/ModelConnectionToWebProcess.cpp
@@ -169,8 +169,7 @@ void ModelConnectionToWebProcess::didUnloadModelPlayer(WebCore::ModelPlayerIdent
 
 bool ModelConnectionToWebProcess::allowsExitUnderMemoryPressure() const
 {
-    // FIXME: Should allow exit if we have no models.
-    return false;
+    return !m_modelProcessModelPlayerManagerProxy->hasModelPlayers();
 }
 
 Logger& ModelConnectionToWebProcess::logger()

--- a/Source/WebKit/ModelProcess/ModelProcessModelPlayerManagerProxy.cpp
+++ b/Source/WebKit/ModelProcess/ModelProcessModelPlayerManagerProxy.cpp
@@ -92,6 +92,11 @@ void ModelProcessModelPlayerManagerProxy::unloadModelPlayer(WebCore::ModelPlayer
     m_modelConnectionToWebProcess->didUnloadModelPlayer(identifier);
 }
 
+bool ModelProcessModelPlayerManagerProxy::hasModelPlayers() const
+{
+    return m_proxies.size();
+}
+
 void ModelProcessModelPlayerManagerProxy::didReceivePlayerMessage(IPC::Connection& connection, IPC::Decoder& decoder)
 {
     ASSERT(RunLoop::isMain());

--- a/Source/WebKit/ModelProcess/ModelProcessModelPlayerManagerProxy.h
+++ b/Source/WebKit/ModelProcess/ModelProcessModelPlayerManagerProxy.h
@@ -63,6 +63,7 @@ public:
     void didReceivePlayerMessage(IPC::Connection&, IPC::Decoder&);
 
     void unloadModelPlayer(WebCore::ModelPlayerIdentifier);
+    bool hasModelPlayers() const;
 
 private:
     explicit ModelProcessModelPlayerManagerProxy(ModelConnectionToWebProcess&);

--- a/Source/WebKit/UIProcess/Model/ModelProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/Model/ModelProcessProxy.cpp
@@ -295,8 +295,8 @@ void ModelProcessProxy::updateProcessAssertion()
     bool hasAnyBackgroundWebProcesses = false;
 
     for (auto& processPool : WebProcessPool::allProcessPools()) {
-        hasAnyForegroundWebProcesses |= processPool->hasForegroundWebProcesses();
-        hasAnyBackgroundWebProcesses |= processPool->hasBackgroundWebProcesses();
+        hasAnyForegroundWebProcesses |= processPool->hasForegroundWebProcessesWithModels();
+        hasAnyBackgroundWebProcesses |= processPool->hasBackgroundWebProcessesWithModels();
     }
 
     if (hasAnyForegroundWebProcesses) {
@@ -309,6 +309,9 @@ void ModelProcessProxy::updateProcessAssertion()
             m_activityFromWebProcesses = protectedThrottler()->backgroundActivity("Model for background view(s)"_s);
         return;
     }
+
+    if (!!m_activityFromWebProcesses)
+        RELEASE_LOG(ModelElement, "Releasing all activities from model process");
 
     // Use std::exchange() instead of a simple nullptr assignment to avoid re-entering this
     // function during the destructor of the ProcessThrottler activity, before setting

--- a/Source/WebKit/UIProcess/WebProcessPool.h
+++ b/Source/WebKit/UIProcess/WebProcessPool.h
@@ -496,6 +496,11 @@ public:
     bool hasForegroundWebProcesses() const { return m_foregroundWebProcessCounter.value(); }
     bool hasBackgroundWebProcesses() const { return m_backgroundWebProcessCounter.value(); }
 
+#if ENABLE(MODEL_PROCESS)
+    bool hasForegroundWebProcessesWithModels() const;
+    bool hasBackgroundWebProcessesWithModels() const;
+#endif
+
     void processForNavigation(WebPageProxy&, WebFrameProxy&, const API::Navigation&, const URL& sourceURL, ProcessSwapRequestedByClient, WebProcessProxy::LockdownMode, LoadedWebArchive, const FrameInfoData&, Ref<WebsiteDataStore>&&, CompletionHandler<void(Ref<WebProcessProxy>&&, SuspendedPageProxy*, ASCIILiteral)>&&);
 
     void didReachGoodTimeToPrewarm();
@@ -752,6 +757,7 @@ private:
 
 #if ENABLE(MODEL_PROCESS)
     ModelProcessProxy& ensureModelProcess();
+    void updateModelProcessAssertion();
     void terminateAllWebContentProcessesWithModelPlayers();
 #endif
 

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -362,6 +362,9 @@ public:
     bool isPrewarmed() const { return m_isPrewarmed; }
     void markIsNoLongerInPrewarmedPool();
 
+    bool isForeground() const { return !!m_foregroundToken; }
+    bool isBackground() const { return !!m_backgroundToken; }
+
 #if PLATFORM(COCOA)
     Vector<String> mediaMIMETypes() const;
     void cacheMediaMIMETypes(const Vector<String>&);


### PR DESCRIPTION
#### 9830a21ee862d8286b9ccfa2c646f76f0f40695f
<pre>
Allow the model process to go idle (or exit if under memory pressure) if there are no more model players
<a href="https://bugs.webkit.org/show_bug.cgi?id=294365">https://bugs.webkit.org/show_bug.cgi?id=294365</a>
<a href="https://rdar.apple.com/153033560">rdar://153033560</a>

Reviewed by Chris Dumez.

To make sure the model process can exit if under memory pressure after the
last model player has been removed, implement ModelConnectionToWebProcess::allowsExitUnderMemoryPressure()
to return true if the number of model players is zero.

To allow the model process go idle, update ModelProcessProxy::updateProcessAssertion()
to count only the foreground and background web content processes that actually
have models loaded.

* Source/WebKit/ModelProcess/ModelConnectionToWebProcess.cpp:
(WebKit::ModelConnectionToWebProcess::allowsExitUnderMemoryPressure const):
Return whether there are no more model players for the web process.
* Source/WebKit/ModelProcess/ModelProcessModelPlayerManagerProxy.cpp:
(WebKit::ModelProcessModelPlayerManagerProxy::hasModelPlayers const):
* Source/WebKit/ModelProcess/ModelProcessModelPlayerManagerProxy.h:
* Source/WebKit/UIProcess/Model/ModelProcessProxy.cpp:
(WebKit::ModelProcessProxy::updateProcessAssertion):
Only take into account the web processes that have models.
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::startedPlayingModels):
Need to update the model process assertions after model player updates.
(WebKit::WebProcessPool::stoppedPlayingModels):
Ditto.
(WebKit::WebProcessPool::hasForegroundWebProcessesWithModels const):
We already track the web processes that have model players, so just go
through that set of model players to see if any is in foreground.
(WebKit::WebProcessPool::hasBackgroundWebProcessesWithModels const):
Ditto for background web processes with models.
(WebKit::WebProcessPool::updateModelProcessAssertion):
(WebKit::WebProcessPool::updateProcessAssertions):
* Source/WebKit/UIProcess/WebProcessPool.h:
* Source/WebKit/UIProcess/WebProcessProxy.h:

Canonical link: <a href="https://commits.webkit.org/296196@main">https://commits.webkit.org/296196@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/be8e70f2d7bc6cd227f4774353bd0c08f886c0d3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/107608 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27291 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/17702 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/112826 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/58150 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/27983 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/35793 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/81704 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/110537 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22180 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/96993 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62084 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/21617 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/57589 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/91552 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15166 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/115926 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/34676 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/25575 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/90738 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/35052 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93243 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/90479 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23087 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35396 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13182 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/30439 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/34597 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/40153 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34343 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/37703 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/36006 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->