### PR TITLE
[css-anchor-position-1] anchor-name mutation doesn't propagate to its anchor-positioned dependency

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-name-mutation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-name-mutation-expected.txt
@@ -1,0 +1,17 @@
+
+PASS Tests when an anchor-name is added later positioned-using-anchor-function-explicit-name
+PASS Tests when an anchor-name is removed later positioned-using-anchor-function-explicit-name
+PASS Tests when an anchor-name moves from one element to another positioned-using-anchor-function-explicit-name
+PASS Tests when a new anchor candidate is added (which wins out previous anchor) positioned-using-anchor-function-explicit-name
+PASS Tests when a new anchor candidate is added (which loses out previous anchor) positioned-using-anchor-function-explicit-name
+PASS Tests when an anchor-name is added later positioned-using-anchor-function-implicit-name
+PASS Tests when an anchor-name is removed later positioned-using-anchor-function-implicit-name
+PASS Tests when an anchor-name moves from one element to another positioned-using-anchor-function-implicit-name
+PASS Tests when a new anchor candidate is added (which wins out previous anchor) positioned-using-anchor-function-implicit-name
+PASS Tests when a new anchor candidate is added (which loses out previous anchor) positioned-using-anchor-function-implicit-name
+PASS Tests when an anchor-name is added later positioned-using-position-area
+PASS Tests when an anchor-name is removed later positioned-using-position-area
+PASS Tests when an anchor-name moves from one element to another positioned-using-position-area
+PASS Tests when a new anchor candidate is added (which wins out previous anchor) positioned-using-position-area
+PASS Tests when a new anchor candidate is added (which loses out previous anchor) positioned-using-position-area
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-name-mutation.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-name-mutation.html
@@ -1,0 +1,244 @@
+<!DOCTYPE html>
+
+<html>
+
+<title>Tests that when an anchor name is mutated, the anchor-positioned element adjusts to the new anchor</title>
+
+<link rel="author" href="mailto:kiet.ho@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-anchor-position-1/#name">
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/rendering-utils.js"></script>
+
+<style>
+    .containing-block {
+        position: relative;
+        width: 300px;
+        height: 300px;
+
+        border: 1px black solid;
+    }
+
+    .cell {
+        width: 100px;
+        height: 100px;
+    }
+
+    #anchor-1 {
+        position: absolute;
+        top: 0;
+        left: 0;
+
+        background: green;
+    }
+
+    #anchor-2 {
+        position: absolute;
+        top: 100px;
+        left: 0;
+
+        background: blue;
+    }
+
+    .anchor {
+        anchor-name: --anchor;
+    }
+
+    #anchor-positioned {
+        background: orange;
+
+        position: absolute;
+        top: 0;
+        left: 0;
+    }
+
+    .positioned-using-anchor-function-explicit-name {
+        position: absolute;
+        top: anchor(--anchor bottom) !important;
+        left: anchor(--anchor right) !important;
+    }
+
+    .positioned-using-anchor-function-implicit-name {
+        position: absolute;
+        position-anchor: --anchor;
+
+        top: anchor(bottom) !important;
+        left: anchor(right) !important;
+    }
+
+    .positioned-using-position-area {
+        position: absolute;
+        position-anchor: --anchor;
+
+        position-area: bottom right;
+    }
+</style>
+
+<body>
+    <main id="main">
+    </main>
+
+    <template id="test-template">
+        <div class="containing-block">
+            <div class="cell" id="anchor-1"></div>
+            <div class="cell" id="anchor-2"></div>
+            <div class="cell" id="anchor-positioned"></div>
+        </div>
+    </template>
+
+    <script>
+        function inflate(t, template_element) {
+            const main_element = document.getElementById("main");
+
+            t.add_cleanup(() => main_element.replaceChildren());
+            main_element.append(template_element.content.cloneNode(true));
+        }
+
+        const test_template = document.getElementById("test-template");
+
+        const positioning_methods = [
+            "positioned-using-anchor-function-explicit-name",
+            "positioned-using-anchor-function-implicit-name",
+            "positioned-using-position-area"
+        ]
+
+        for (let positioning_method of positioning_methods) {
+            promise_test(async (t) => {
+                inflate(t, test_template);
+
+                const anchor1 = document.getElementById("anchor-1");
+                const anchorPositioned = document.getElementById("anchor-positioned");
+
+                anchorPositioned.classList.add(positioning_method);
+
+                await waitForAtLeastOneFrame();
+
+                // Here, anchorPositioned should be at the default location (top-left of containing block)
+                // This is because the anchor elements don't have an anchor name yet.
+                assert_equals(anchorPositioned.offsetTop, 0);
+                assert_equals(anchorPositioned.offsetLeft, 0);
+
+                anchor1.classList.add("anchor");
+
+                await waitForAtLeastOneFrame();
+                await waitForAtLeastOneFrame();
+                await waitForAtLeastOneFrame();
+                await waitForAtLeastOneFrame();
+                await waitForAtLeastOneFrame();
+                await waitForAtLeastOneFrame();
+                await waitForAtLeastOneFrame();
+                await waitForAtLeastOneFrame();
+
+                // Here, anchorPositioned should be bottom-right of anchor1
+                assert_equals(anchorPositioned.offsetTop, 100);
+                assert_equals(anchorPositioned.offsetLeft, 100);
+            }, `Tests when an anchor-name is added later ${positioning_method}`);
+
+            promise_test(async (t) => {
+                inflate(t, test_template);
+
+                const anchor1 = document.getElementById("anchor-1");
+                const anchorPositioned = document.getElementById("anchor-positioned");
+
+                anchor1.classList.add("anchor");
+                anchorPositioned.classList.add(positioning_method);
+
+                await waitForAtLeastOneFrame();
+
+                // Here, anchorPositioned should be bottom-right of anchor1
+                assert_equals(anchorPositioned.offsetTop, 100);
+                assert_equals(anchorPositioned.offsetLeft, 100);
+
+                anchor1.classList.remove("anchor");
+
+                await waitForAtLeastOneFrame();
+
+                // Here, anchorPositioned should be at the default location (top-left of containing block)
+                // This is because the anchor elements don't have an anchor name.
+                assert_equals(anchorPositioned.offsetTop, 0);
+                assert_equals(anchorPositioned.offsetLeft, 0);
+            }, `Tests when an anchor-name is removed later ${positioning_method}`);
+
+            promise_test(async (t) => {
+                inflate(t, test_template);
+
+                const anchor1 = document.getElementById("anchor-1");
+                const anchor2 = document.getElementById("anchor-2");
+                const anchorPositioned = document.getElementById("anchor-positioned");
+
+                anchor1.classList.add("anchor");
+                anchorPositioned.classList.add(positioning_method);
+
+                await waitForAtLeastOneFrame();
+
+                // Here, anchorPositioned should be bottom-right of anchor1
+                assert_equals(anchorPositioned.offsetTop, 100);
+                assert_equals(anchorPositioned.offsetLeft, 100);
+
+                anchor1.classList.remove("anchor");
+                anchor2.classList.add("anchor");
+
+                await waitForAtLeastOneFrame();
+
+                // Here, anchorPositioned should be bottom-right of anchor2
+                assert_equals(anchorPositioned.offsetTop, 200);
+                assert_equals(anchorPositioned.offsetLeft, 100);
+            }, `Tests when an anchor-name moves from one element to another ${positioning_method}`);
+
+            promise_test(async (t) => {
+                inflate(t, test_template);
+
+                const anchor1 = document.getElementById("anchor-1");
+                const anchor2 = document.getElementById("anchor-2");
+                const anchorPositioned = document.getElementById("anchor-positioned");
+
+                anchor1.classList.add("anchor");
+                anchorPositioned.classList.add(positioning_method);
+
+                await waitForAtLeastOneFrame();
+
+                // Here, anchorPositioned should be bottom-right of anchor1
+                assert_equals(anchorPositioned.offsetTop, 100);
+                assert_equals(anchorPositioned.offsetLeft, 100);
+
+                anchor2.classList.add("anchor");
+
+                await waitForAtLeastOneFrame();
+
+                // Here, anchorPositioned should be bottom-right of anchor2
+                assert_equals(anchorPositioned.offsetTop, 200);
+                assert_equals(anchorPositioned.offsetLeft, 100);
+            }, `Tests when a new anchor candidate is added (which wins out previous anchor) ${positioning_method}`);
+
+
+            promise_test(async (t) => {
+                inflate(t, test_template);
+
+                const anchor1 = document.getElementById("anchor-1");
+                const anchor2 = document.getElementById("anchor-2");
+                const anchorPositioned = document.getElementById("anchor-positioned");
+
+                anchor2.classList.add("anchor");
+                anchorPositioned.classList.add(positioning_method);
+
+                await waitForAtLeastOneFrame();
+
+                // Here, anchorPositioned should be bottom-right of anchor2
+                assert_equals(anchorPositioned.offsetTop, 200);
+                assert_equals(anchorPositioned.offsetLeft, 100);
+
+                anchor1.classList.add("anchor");
+
+                await waitForAtLeastOneFrame();
+
+                // Here, anchorPositioned should be bottom-right of anchor2
+                assert_equals(anchorPositioned.offsetTop, 200);
+                assert_equals(anchorPositioned.offsetLeft, 100);
+            }, `Tests when a new anchor candidate is added (which loses out previous anchor) ${positioning_method}`);
+        }
+    </script>
+
+</body>
+
+</html>

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2733,6 +2733,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     storage/StorageUtilities.h
 
     style/AnchorPositionEvaluator.h
+    style/AnchorTracker.h
     style/PseudoElementIdentifier.h
     style/ResolvedScopedName.h
     style/ScopedName.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -3103,6 +3103,7 @@ storage/StorageMap.cpp
 storage/StorageNamespaceProvider.cpp
 storage/StorageUtilities.cpp
 style/AnchorPositionEvaluator.cpp
+style/AnchorTracker.cpp
 style/AttributeChangeInvalidation.cpp
 style/ChildChangeInvalidation.cpp
 style/ClassChangeInvalidation.cpp

--- a/Source/WebCore/rendering/RenderBoxModelObject.cpp
+++ b/Source/WebCore/rendering/RenderBoxModelObject.cpp
@@ -142,7 +142,8 @@ void RenderBoxModelObject::styleWillChange(StyleDifference diff, const RenderSty
     const RenderStyle* oldStyle = hasInitializedStyle() ? &style() : nullptr;
 
     if (Style::AnchorPositionEvaluator::isAnchor(newStyle))
-        view().registerAnchor(*this);
+        // FIXME: could be implicit anchors!
+        view().registerAnchor(*this, newStyle.anchorNames());
     else if (oldStyle && Style::AnchorPositionEvaluator::isAnchor(*oldStyle))
         view().unregisterAnchor(*this);
 

--- a/Source/WebCore/rendering/RenderView.cpp
+++ b/Source/WebCore/rendering/RenderView.cpp
@@ -1102,14 +1102,14 @@ void RenderView::unregisterContainerQueryBox(const RenderBox& box)
     m_containerQueryBoxes.remove(box);
 }
 
-void RenderView::registerAnchor(const RenderBoxModelObject& renderer)
+void RenderView::registerAnchor(const RenderBoxModelObject& renderer, const FixedVector<Style::ScopedName>& anchorNames)
 {
-    m_anchors.add(renderer);
+    m_anchorTracker.registerAnchor(renderer, anchorNames);
 }
 
 void RenderView::unregisterAnchor(const RenderBoxModelObject& renderer)
 {
-    m_anchors.remove(renderer);
+    m_anchorTracker.unregisterAnchor(renderer);
 }
 
 void RenderView::registerPositionTryBox(const RenderBox& box)

--- a/Source/WebCore/rendering/RenderView.h
+++ b/Source/WebCore/rendering/RenderView.h
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#include "AnchorPositionEvaluator.h"
 #include "LocalFrameView.h"
 #include "Region.h"
 #include "RenderBlockFlow.h"
@@ -208,9 +209,10 @@ public:
     void unregisterContainerQueryBox(const RenderBox&);
     const SingleThreadWeakHashSet<const RenderBox>& containerQueryBoxes() const { return m_containerQueryBoxes; }
 
-    void registerAnchor(const RenderBoxModelObject&);
+    void registerAnchor(const RenderBoxModelObject&, const FixedVector<Style::ScopedName>&);
     void unregisterAnchor(const RenderBoxModelObject&);
-    const SingleThreadWeakHashSet<const RenderBoxModelObject>& anchors() const { return m_anchors; }
+    Style::AnchorTracker& anchorTracker() { return m_anchorTracker; }
+    const Style::AnchorTracker& anchorTracker() const { return m_anchorTracker; }
 
     void registerPositionTryBox(const RenderBox&);
     void unregisterPositionTryBox(const RenderBox&);
@@ -290,7 +292,7 @@ private:
 
     SingleThreadWeakHashSet<const RenderBox> m_boxesWithScrollSnapPositions;
     SingleThreadWeakHashSet<const RenderBox> m_containerQueryBoxes;
-    SingleThreadWeakHashSet<const RenderBoxModelObject> m_anchors;
+    Style::AnchorTracker m_anchorTracker;
     SingleThreadWeakHashSet<const RenderBox> m_positionTryBoxes;
 
     SingleThreadWeakPtr<RenderBlockFlow> m_viewTransitionContainingBlock;

--- a/Source/WebCore/style/AnchorPositionEvaluator.h
+++ b/Source/WebCore/style/AnchorPositionEvaluator.h
@@ -24,6 +24,7 @@
 
 #pragma once
 
+#include "AnchorTracker.h"
 #include "CSSValueKeywords.h"
 #include "EventTarget.h"
 #include "LayoutUnit.h"
@@ -75,8 +76,6 @@ struct AnchorPositionedState {
 using AnchorPositionedKey = std::pair<RefPtr<const Element>, std::optional<PseudoElementIdentifier>>;
 using AnchorPositionedStates = HashMap<AnchorPositionedKey, std::unique_ptr<AnchorPositionedState>>;
 
-using AnchorsForAnchorName = HashMap<ResolvedScopedName, Vector<SingleThreadWeakRef<const RenderBoxModelObject>>>;
-
 // https://drafts.csswg.org/css-anchor-position-1/#typedef-anchor-size
 enum class AnchorSizeDimension : uint8_t {
     Width,
@@ -93,7 +92,6 @@ struct ResolvedAnchor {
 };
 
 using AnchorPositionedToAnchorMap = WeakHashMap<Element, Vector<ResolvedAnchor>, WeakPtrImplWithEventTargetData>;
-using AnchorToAnchorPositionedMap = SingleThreadWeakHashMap<const RenderBoxModelObject, Vector<Ref<Element>>>;
 
 class AnchorPositionEvaluator {
 public:
@@ -115,8 +113,6 @@ public:
 
     static LayoutRect computeAnchorRectRelativeToContainingBlock(CheckedRef<const RenderBoxModelObject> anchorBox, const RenderBlock& containingBlock);
 
-    static AnchorToAnchorPositionedMap makeAnchorPositionedForAnchorMap(AnchorPositionedToAnchorMap&);
-
     static bool isLayoutTimeAnchorPositioned(const RenderStyle&);
     static CSSPropertyID resolvePositionTryFallbackProperty(CSSPropertyID, WritingMode, const BuilderPositionTryFallback&);
 
@@ -130,7 +126,7 @@ public:
     static CheckedPtr<RenderBoxModelObject> defaultAnchorForBox(const RenderBox&);
 
 private:
-    static AnchorElements findAnchorsForAnchorPositionedElement(const Element&, const UncheckedKeyHashSet<ResolvedScopedName>& anchorNames, const AnchorsForAnchorName&);
+    static AnchorElements findAnchorsForAnchorPositionedElement(const Element&, const UncheckedKeyHashSet<ResolvedScopedName>& anchorNames, const AnchorTracker&);
     static RefPtr<const Element> anchorPositionedElementOrPseudoElement(BuilderState&);
     static AnchorPositionedKey keyForElementOrPseudoElement(const Element&);
 };

--- a/Source/WebCore/style/AnchorTracker.cpp
+++ b/Source/WebCore/style/AnchorTracker.cpp
@@ -1,0 +1,112 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "AnchorTracker.h"
+
+#include "Element.h"
+#include "Node.h"
+#include "RenderBoxModelObject.h"
+#include "RenderElementInlines.h"
+
+namespace WebCore::Style {
+
+void AnchorSet::registerAnchor(const RenderBoxModelObject& renderer)
+{
+    bool isNewAnchor = m_anchors.add(renderer).isNewEntry;
+    m_isDirty |= isNewAnchor;
+}
+
+void AnchorSet::unregisterAnchor(const RenderBoxModelObject& renderer)
+{
+    bool isRemoved = m_anchors.remove(renderer);
+    m_isDirty |= isRemoved;
+}
+
+void AnchorTracker::registerAnchor(const RenderBoxModelObject& renderer, const FixedVector<ScopedName>& anchorNames)
+{
+    CheckedPtr element = renderer.element();
+    ASSERT(element);
+
+    HashSet<ResolvedScopedName> resolveNames;
+    for (const auto& name : anchorNames) {
+        auto resolvedName = ResolvedScopedName::createFromScopedName(*element, name);
+        m_anchors.ensure(resolvedName, [] () {
+            return AnchorSet { };
+        });
+        resolveNames.add(resolvedName);
+    }
+
+    // TODO: optimize this.
+    for (auto& [name, set] : m_anchors) {
+        if (resolveNames.contains(name))
+            set.registerAnchor(renderer);
+        else
+            set.unregisterAnchor(renderer);
+    }
+}
+
+void AnchorTracker::unregisterAnchor(const RenderBoxModelObject& renderer)
+{
+    for (auto& [name, set] : m_anchors)
+        set.unregisterAnchor(renderer);
+}
+
+void AnchorTracker::markAsClean()
+{
+    for (auto& [name, set] : m_anchors)
+        set.markAsClean();
+}
+
+Vector<SingleThreadWeakRef<const RenderBoxModelObject>> AnchorTracker::sortedAnchorsWithName(ResolvedScopedName anchorName) const
+{
+    auto maybeSetIter = m_anchors.find(anchorName);
+    if (maybeSetIter == m_anchors.end())
+        return { };
+
+    Vector<SingleThreadWeakRef<const RenderBoxModelObject>> sortedAnchors;
+    for (const auto& anchor : maybeSetIter->value.anchors())
+        sortedAnchors.append(anchor);
+
+    std::ranges::sort(sortedAnchors, [](auto& a, auto& b) {
+        // FIXME: Figure out anonymous pseudo-elements.
+        // FIXME: Since we already ensure renderer MUST have an associated element, maybe remove this?
+        if (!a->element() || !b->element())
+            return !!b->element();
+        return is_lt(treeOrder<ComposedTree>(*a->element(), *b->element()));
+    });
+
+    return sortedAnchors;
+}
+
+bool AnchorTracker::anchorNameIsDirty(ResolvedScopedName name) const
+{
+    auto maybeSetIter = m_anchors.find(name);
+    if (maybeSetIter == m_anchors.end())
+        return false;
+
+    return maybeSetIter->value.isDirty();
+}
+
+} // namespace WebCore::Style

--- a/Source/WebCore/style/AnchorTracker.h
+++ b/Source/WebCore/style/AnchorTracker.h
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "ResolvedScopedName.h"
+#include "ScopedName.h"
+#include <wtf/WeakHashSet.h>
+
+namespace WebCore {
+
+class RenderBoxModelObject;
+
+namespace Style {
+
+class AnchorSet {
+    WTF_MAKE_FAST_ALLOCATED;
+
+public:
+    AnchorSet() = default;
+
+    void registerAnchor(const RenderBoxModelObject& renderer);
+    void unregisterAnchor(const RenderBoxModelObject& renderer);
+
+    void markAsClean() { m_isDirty = false; }
+
+    const SingleThreadWeakHashSet<const RenderBoxModelObject>& anchors() const { return m_anchors; }
+    bool isDirty() const { return m_isDirty; }
+
+private:
+    SingleThreadWeakHashSet<const RenderBoxModelObject> m_anchors;
+    bool m_isDirty { false };
+};
+
+class AnchorTracker {
+    WTF_MAKE_FAST_ALLOCATED;
+
+public:
+    void registerAnchor(const RenderBoxModelObject& renderer, const FixedVector<ScopedName>&);
+    void unregisterAnchor(const RenderBoxModelObject& renderer);
+
+    void markAsClean();
+
+    Vector<SingleThreadWeakRef<const RenderBoxModelObject>> sortedAnchorsWithName(ResolvedScopedName anchorName) const;
+    bool anchorNameIsDirty(ResolvedScopedName anchorName) const;
+
+private:
+    HashMap<ResolvedScopedName, AnchorSet> m_anchors;
+};
+
+} // namespace Style
+
+} // namespace WebCore

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -1386,7 +1386,11 @@ auto TreeResolver::updateAnchorPositioningState(Element& element, const RenderSt
         AnchorPositionEvaluator::updateAnchorPositionedStateForLayoutTimePositioned(element, *style, m_treeResolutionState.anchorPositionedStates);
 
         if (changes && !style->anchorNames().isEmpty()) {
-            // Existing anchor positions may change due to a style change. We need a round of interleaving.
+            // FIXME: only set when the anchor name changes from old style to new style.
+            // Issue is, where to get old style?
+
+            // !style->anchorNames().isEmpty() doesn't work, because an element can go from having
+            // any names, to haing no names, and in that case, interleaved layout is required.
             m_needsInterleavedLayout = true;
         }
     };


### PR DESCRIPTION
#### c9212313656ea4c5b8a21a6adfa19cf65263c53f
<pre>
[css-anchor-position-1] anchor-name mutation doesn&apos;t propagate to its anchor-positioned dependency
<a href="https://rdar.apple.com/152727401">rdar://152727401</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=294129">https://bugs.webkit.org/show_bug.cgi?id=294129</a>

Reviewed by NOBODY (OOPS!).

The current code isn&apos;t reactive to changes in anchor names. More
specifically, if an anchorpos depends on an anchor name, and there
have been changes to the name (e.g: a new anchor with that name
appears, or an existing anchor with that name disappears), we
won&apos;t rerun anchor matching on the anchorpos. This manifests as
bugs where the anchorpos doesn&apos;t get updated when the anchor
name it uses changes.

Fixing this requires tracking which anchors are available, and which
anchor name are &quot;dirty&quot; (meaning it has been changed since the last
matching run). This logic is implemented in the new AnchorTracker
class, which replaces the old way of tracking anchors in a hash set.
Anchor (un)registration is now done through AnchorTracker.

* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-name-mutation-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-name-mutation.html: Added.
* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/rendering/RenderBoxModelObject.cpp:
(WebCore::RenderBoxModelObject::styleWillChange):
    - Explicitly specify the list of anchor names to register. This info
      is in the new style, which is not yet updated into the renderer.

* Source/WebCore/rendering/RenderView.cpp:
(WebCore::RenderView::registerAnchor):
    - Use AnchorTracker to register anchor.

(WebCore::RenderView::unregisterAnchor):
    - Use AnchorTracker to unregister anchor.

* Source/WebCore/rendering/RenderView.h:
    - Replace the hash set of anchors with AnchorTracker.

* Source/WebCore/style/AnchorPositionEvaluator.cpp:
(WebCore::Style::findLastAcceptableAnchorWithName):
    - Replace the anchor name =&gt; anchor map with AnchorTracker.

(WebCore::Style::AnchorPositionEvaluator::findAnchorsForAnchorPositionedElement):
    - Replace the anchor name =&gt; anchor map with AnchorTracker.
    - If an anchor couldn&apos;t be found for the given anchor name, still saves
      it into the returned map with a nullptr element. This allows tracking
      of all anchor names that the anchorpos depends on, not just the one
      that can be resolved.

(WebCore::Style::AnchorPositionEvaluator::updateAnchorPositioningStatesAfterInterleavedLayout):
    - Invalidate an anchorpos if it depends on a dirty anchor name.
      Also move it back to FindAnchor stage to force re-resolving anchors.

(WebCore::Style::AnchorPositionEvaluator::updateSnapshottedScrollOffsets):
    - Because anchorPositionedToAnchorMap can contain a mapping from an anchorpos
      to a nullptr anchor (see WebCore::Style::AnchorPositionEvaluator::findAnchorsForAnchorPositionedElement),
      filter out all nullptr anchor to find non-nullptr anchor for scroll adjustment.

(WebCore::Style::collectAnchorsForAnchorName): Deleted.
    - AnchorTracker supports querying which anchor has the anchor name,
      hence there&apos;s no need to generate this map anymore, as its clients
      can directly use AnchorTracker.

(WebCore::Style::AnchorPositionEvaluator::makeAnchorPositionedForAnchorMap): Deleted.
    - Not needed anymore, Scope::invalidateForAnchorDependencies now loops
      through anchorPositionedToAnchorMap instead.

* Source/WebCore/style/AnchorPositionEvaluator.h:
    - Remove AnchorsForAnchorName type, not needed anymore since
      WebCore::Style::collectAnchorsForAnchorName is removed.
    - Remove AnchorToAnchorPositionedMap type, not needed anymore
      since Scope::invalidateForAnchorDependencies now loops through
      anchorPositionedToAnchorMap instead.

* Source/WebCore/style/AnchorTracker.cpp: Added.
(WebCore::Style::AnchorSet::registerAnchor):
(WebCore::Style::AnchorSet::unregisterAnchor):
(WebCore::Style::AnchorTracker::registerAnchor):
(WebCore::Style::AnchorTracker::unregisterAnchor):
(WebCore::Style::AnchorTracker::markAsClean):
(WebCore::Style::AnchorTracker::sortedAnchorsWithName const):
(WebCore::Style::AnchorTracker::anchorNameIsDirty const):
* Source/WebCore/style/AnchorTracker.h: Added.
(WebCore::Style::AnchorSet::markAsClean):
(WebCore::Style::AnchorSet::anchors const):
(WebCore::Style::AnchorSet::isDirty const):
* Source/WebCore/style/StyleScope.cpp:
(WebCore::Style::Scope::invalidateForAnchorDependencies):
    - Loop through anchorPositionedToAnchorMap instead of the
      anchor =&gt; anchor positioned map.

* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::updateAnchorPositioningState):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c9212313656ea4c5b8a21a6adfa19cf65263c53f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/107489 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27171 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/17579 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/112710 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/58025 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/109453 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/27856 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/35672 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/81599 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-anchor-position/anchor-name-mutation.html (failure)") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/110418 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22063 "Exiting early after 10 failures. 10 tests run. 1 failures") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/96874 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/61983 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/21501 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-anchor-position/anchor-name-mutation.html (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/15015 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-anchor-position/anchor-name-mutation.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/57469 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/91429 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15046 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-anchor-position/anchor-name-mutation.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/115804 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/34556 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/25460 "Found 4 new test failures: imported/w3c/web-platform-tests/css/css-anchor-position/anchor-name-mutation.html inspector/model/remote-object-get-properties.html inspector/runtime/getDisplayableProperties.html inspector/runtime/getProperties.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/90631 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-anchor-position/anchor-name-mutation.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/34931 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93130 "Exiting early after 10 failures. 10 tests run. 1 failures") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/90377 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35290 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13067 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-anchor-position/anchor-name-mutation.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/30304 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/34477 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/40023 "Found 3 new failures in style/AnchorTracker.cpp, style/AnchorPositionEvaluator.cpp") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34223 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/37578 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/35884 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->