### PR TITLE
Reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in the codebase

### DIFF
--- a/Source/WTF/wtf/text/CString.cpp
+++ b/Source/WTF/wtf/text/CString.cpp
@@ -157,9 +157,7 @@ bool operator<(const CString& a, const CString& b)
         return !b.isNull();
     if (b.isNull())
         return false;
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-    return strcmp(a.data(), b.data()) < 0;
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+    return is_lt(compareSpans(a.span(), b.span()));
 }
 
 bool CStringHash::equal(const CString& a, const CString& b)

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUShaderModuleImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUShaderModuleImpl.cpp
@@ -79,12 +79,8 @@ void ShaderModuleImpl::compilationInfo(CompletionHandler<void(Ref<CompilationInf
             return;
         }
 
-        for (size_t i = 0; i < compilationInfo->messageCount; ++i) {
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-            auto& message = compilationInfo->messages[i];
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+        for (auto& message : messagesSpan(*compilationInfo))
             messages.append(CompilationMessage::create(message.message, convertFromBacking(message.type), message.lineNum, message.linePos + 1, message.offset, message.length));
-        }
 
         callback(CompilationInfo::create(WTFMove(messages)));
     });

--- a/Source/WebCore/PAL/pal/text/TextCodecICU.cpp
+++ b/Source/WebCore/PAL/pal/text/TextCodecICU.cpp
@@ -207,9 +207,7 @@ public:
             UConverterToUCallback oldAction;
             ucnv_setToUCallBack(&m_converter, m_savedAction, m_savedContext, &oldAction, &oldContext, &err);
             ASSERT(oldAction == UCNV_TO_U_CALLBACK_SUBSTITUTE);
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-            ASSERT(!strcmp(static_cast<const char*>(oldContext), UCNV_SUB_STOP_ON_ILLEGAL));
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+            ASSERT(equalSpans(unsafeSpan(static_cast<const char*>(oldContext)), UCNV_SUB_STOP_ON_ILLEGAL ""_span));
             ASSERT(U_SUCCESS(err));
         }
     }

--- a/Source/WebCore/dom/Position.cpp
+++ b/Source/WebCore/dom/Position.cpp
@@ -61,6 +61,7 @@
 #include "VisiblePosition.h"
 #include "VisibleUnits.h"
 #include <stdio.h>
+#include <wtf/StdLibExtras.h>
 #include <wtf/text/CString.h>
 #include <wtf/text/MakeString.h>
 #include <wtf/text/TextStream.h>
@@ -1387,8 +1388,6 @@ TextDirection Position::primaryDirection() const
 
 #if ENABLE(TREE_DEBUGGING)
 
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 void Position::debugPosition(ASCIILiteral msg) const
 {
     if (isNull())
@@ -1406,29 +1405,30 @@ String Position::debugDescription() const
 
 void Position::showAnchorTypeAndOffset() const
 {
+    ASCIILiteral legacy = ""_s;
     if (m_isLegacyEditingPosition)
-        fputs("legacy, ", stderr);
+        legacy = "legacy, "_s;
+
+    ASCIILiteral position;
     switch (anchorType()) {
     case PositionIsOffsetInAnchor:
-        fputs("offset", stderr);
+        position = "offset"_s;
         break;
     case PositionIsBeforeChildren:
-        fputs("beforeChildren", stderr);
+        position = "beforeChildren"_s;
         break;
     case PositionIsAfterChildren:
-        fputs("afterChildren", stderr);
+        position = "afterChildren"_s;
         break;
     case PositionIsBeforeAnchor:
-        fputs("before", stderr);
+        position = "before"_s;
         break;
     case PositionIsAfterAnchor:
-        fputs("after", stderr);
+        position = "after"_s;
         break;
     }
-    fprintf(stderr, ", offset:%d\n", m_offset);
+    SAFE_FPRINTF(stderr, "%s%s, offset:%d\n", legacy, position, m_offset);
 }
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 void Position::showTreeForThis() const
 {

--- a/Source/WebCore/html/HTMLAttachmentElement.cpp
+++ b/Source/WebCore/html/HTMLAttachmentElement.cpp
@@ -94,12 +94,8 @@ static CString compactStackTrace(StackTrace& stackTrace)
 {
     StringPrintStream stack;
     stackTrace.forEachFrame([&stack](int, void*, const char* fullName) {
-        constexpr size_t maxWorkLen = 1023;
-        constexpr bool is8Bit = true;
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-        StringView name { fullName ? fullName : "?", fullName ? unsigned(std::min(strlen(fullName), maxWorkLen)) : 1u, is8Bit };
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
-
+        constexpr size_t maxWorkLength = 1023;
+        auto name = StringView::fromLatin1(fullName ? fullName : "?").left(maxWorkLength);
         for (const auto& prefix : { "auto void "_s, "auto "_s }) {
             if (name.startsWith(prefix)) {
                 name = name.substring(prefix.length());

--- a/Source/WebGPU/WebGPU/WebGPU.h
+++ b/Source/WebGPU/WebGPU/WebGPU.h
@@ -1186,6 +1186,11 @@ typedef struct WGPUCompilationInfo {
     WGPUCompilationMessage const * messages;
 } WGPUCompilationInfo WGPU_STRUCTURE_ATTRIBUTE;
 
+inline std::span<const WGPUCompilationMessage> messagesSpan(const WGPUCompilationInfo& compilationInfo)
+{
+    return unsafeMakeSpan(compilationInfo.messages, compilationInfo.messageCount);
+}
+
 typedef struct WGPUComputePassDescriptor {
     WGPUChainedStruct const * nextInChain;
     WGPU_NULLABLE char const * label;

--- a/Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm
+++ b/Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm
@@ -415,9 +415,7 @@ static SandboxProfilePtr compileAndCacheSandboxProfile(const SandboxInfo& info)
         CachedSandboxVersionNumber,
         static_cast<uint32_t>(libsandboxVersion),
         safeCast<uint32_t>(info.header.length()),
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-        haveBuiltin ? safeCast<uint32_t>(strlen(sandboxProfile->builtin)) : std::numeric_limits<uint32_t>::max(),
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+        haveBuiltin ? safeCast<uint32_t>(unsafeSpan(sandboxProfile->builtin).size()) : std::numeric_limits<uint32_t>::max(),
         safeCast<uint32_t>(sandboxProfile->size),
         { 0 },
         { 0 }


### PR DESCRIPTION
#### 205a7fed6ac46767e1d9bb69900478f4321d88f2
<pre>
Reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in the codebase
<a href="https://bugs.webkit.org/show_bug.cgi?id=294369">https://bugs.webkit.org/show_bug.cgi?id=294369</a>

Reviewed by Mike Wyrzykowski.

* Source/WTF/wtf/cocoa/CrashReporter.cpp:
(WTF::setCrashLogMessage):
* Source/WTF/wtf/text/CString.cpp:
(WTF::operator&lt;):
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUShaderModuleImpl.cpp:
(WebCore::WebGPU::ShaderModuleImpl::compilationInfo):
* Source/WebCore/PAL/pal/text/TextCodecICU.cpp:
(PAL::ErrorCallbackSetter::~ErrorCallbackSetter):
* Source/WebCore/dom/Position.cpp:
(WebCore::Position::showAnchorTypeAndOffset const):
* Source/WebCore/html/HTMLAttachmentElement.cpp:
(WebCore::compactStackTrace):
* Source/WebGPU/WebGPU/WebGPU.h:
(messagesSpan):
* Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm:
(WebKit::compileAndCacheSandboxProfile):

Canonical link: <a href="https://commits.webkit.org/296162@main">https://commits.webkit.org/296162@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2f770836f2953050d8f4d647efc303e77943474b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/107471 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27153 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/17561 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/112685 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/58007 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/109435 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/27837 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/35653 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/81579 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/110400 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22044 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/96858 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/61964 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/21481 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/14999 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/57451 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/100060 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/91411 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15030 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/115786 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/106018 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/34538 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/25446 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/90617 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/34913 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93114 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/90363 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23062 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35272 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13051 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/30283 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/34459 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/40000 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/130334 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34205 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/35445 "Found 1 new JSC stress test failure: wasm.yaml/wasm/stress/jitless-wasm-to-js-should-follow-to-wasm-call-frame-convention.js.default (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/37560 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/35866 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->