### PR TITLE
Integrity-Policy - align about:blank behavior

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/subresource-integrity/integrity-policy/script.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/subresource-integrity/integrity-policy/script.https-expected.txt
@@ -10,4 +10,6 @@ PASS Ensure that a data URI script with no integrity runs
 PASS Ensure that a no-CORS data URI script with no integrity runs
 PASS Ensure that a blob URL script with no integrity runs
 PASS Ensure that a no-CORS blob URL script with no integrity runs
+PASS Ensure that an about:blank URL script with no integrity runs
+PASS Ensure that a no-CORS about:blank URL script with no integrity runs
 

--- a/LayoutTests/imported/w3c/web-platform-tests/subresource-integrity/integrity-policy/script.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/subresource-integrity/integrity-policy/script.https.html
@@ -38,9 +38,9 @@
       cross_origin: true,
       integrity: "",
       policy_violation: true,
-      block: true,
+      add_blocking_header: true,
       endpoints: true,
-      expected: {blocked: ORIGIN + "/content-security-policy/resources/ran.js", ran: false },
+      expected: {blocked: ORIGIN + "/content-security-policy/resources/ran.js", ran: false},
     },
     {
       description: "Ensure that a script with unknown integrity algorithm did not run",
@@ -48,9 +48,9 @@
       cross_origin: true,
       integrity: "foobar-AAAAAAAAAAAAAAAAAAAa",
       policy_violation: true,
-      block: true,
+      add_blocking_header: true,
       endpoints: true,
-      expected: {blocked: ORIGIN + "/content-security-policy/resources/ran.js", ran: false },
+      expected: {blocked: ORIGIN + "/content-security-policy/resources/ran.js", ran: false},
     },
     {
       description: "Ensure that a script without integrity algorithm runs and gets reported in report-only mode",
@@ -58,9 +58,9 @@
       cross_origin: true,
       integrity: "",
       policy_violation: true,
-      block: false,
+      add_blocking_header: false,
       endpoints: true,
-      expected: {blocked: ORIGIN + "/content-security-policy/resources/ran.js", ran: true },
+      expected: {blocked: ORIGIN + "/content-security-policy/resources/ran.js", ran: true},
     },
     {
       description: "Ensure that a no-cors script gets blocked",
@@ -68,9 +68,9 @@
       cross_origin: false,
       integrity: "sha384-tqyFpeo21WFM8HDeUtLqH20GUq/q3D1R6mqTzW3RtyTZ3dAYZJhC1wUcnkgOE2ak",
       policy_violation: true,
-      block: true,
+      add_blocking_header: true,
       endpoints: true,
-      expected: {blocked: ORIGIN + "/content-security-policy/resources/ran.js", ran: false },
+      expected: {blocked: ORIGIN + "/content-security-policy/resources/ran.js", ran: false},
     },
     {
       description: "Ensure that ReportingObserver gets called without endpoints",
@@ -78,9 +78,9 @@
       cross_origin: false,
       integrity: "sha384-tqyFpeo21WFM8HDeUtLqH20GUq/q3D1R6mqTzW3RtyTZ3dAYZJhC1wUcnkgOE2ak",
       policy_violation: true,
-      block: true,
+      add_blocking_header: true,
       endpoints: false,
-      expected: {blocked: ORIGIN + "/content-security-policy/resources/ran.js", ran: false },
+      expected: {blocked: ORIGIN + "/content-security-policy/resources/ran.js", ran: false},
     },
     {
       description: "Ensure that a script with integrity runs",
@@ -88,9 +88,9 @@
       cross_origin: true,
       integrity: "sha384-tqyFpeo21WFM8HDeUtLqH20GUq/q3D1R6mqTzW3RtyTZ3dAYZJhC1wUcnkgOE2ak",
       policy_violation: false,
-      block: true,
+      add_blocking_header: true,
       endpoints: true,
-      expected: {blocked: "", ran: true },
+      expected: {blocked: "", ran: true},
     },
     {
       description: "Ensure that a data URI script with no integrity runs",
@@ -98,9 +98,9 @@
       cross_origin: true,
       integrity: "",
       policy_violation: false,
-      block: true,
+      add_blocking_header: true,
       endpoints: true,
-      expected: {blocked: "", ran: true },
+      expected: {blocked: "", ran: true},
     },
     {
       description: "Ensure that a no-CORS data URI script with no integrity runs",
@@ -108,9 +108,9 @@
       cross_origin: false,
       integrity: "",
       policy_violation: false,
-      block: true,
+      add_blocking_header: true,
       endpoints: true,
-      expected: {blocked: "", ran: true },
+      expected: {blocked: "", ran: true},
     },
     {
       description: "Ensure that a blob URL script with no integrity runs",
@@ -118,9 +118,9 @@
       cross_origin: true,
       integrity: "",
       policy_violation: false,
-      block: true,
+      add_blocking_header: true,
       endpoints: true,
-      expected: {blocked: "", ran: true },
+      expected: {blocked: "", ran: true},
     },
     {
       description: "Ensure that a no-CORS blob URL script with no integrity runs",
@@ -128,9 +128,29 @@
       cross_origin: false,
       integrity: "",
       policy_violation: false,
-      block: true,
+      add_blocking_header: true,
       endpoints: true,
-      expected: {blocked: "", ran: true },
+      expected: {blocked: "", ran: true},
+    },
+    {
+      description: "Ensure that an about:blank URL script with no integrity runs",
+      url: "about:blank",
+      cross_origin: true,
+      integrity: "",
+      policy_violation: false,
+      add_blocking_header: true,
+      endpoints: false,
+      expected: {blocked: "", ran: false},
+    },
+    {
+      description: "Ensure that a no-CORS about:blank URL script with no integrity runs",
+      url: "about:blank",
+      cross_origin: false,
+      integrity: "",
+      policy_violation: false,
+      add_blocking_header: true,
+      endpoints: false,
+      expected: {blocked: "", ran: false},
     }
   ];
   test_cases.map(test_case => {
@@ -151,7 +171,7 @@
       const reporting_uuid_3 = token();
       const reporting_endpoint = `${ORIGIN}/reporting/resources/report.py`;
       let header = "";
-      if (test_case.block) {
+      if (test_case.add_blocking_header) {
         header +=
           `header(Integrity-Policy,blocked-destinations=\\(script\\)\\, endpoints=\\(integrity-endpoint-1 integrity-endpoint-2\\))`;
       }
@@ -173,19 +193,24 @@
       const ctx = new RemoteContext(iframe_uuid);
       const result = await ctx.execute_script(async (test_case) => {
         window.ran = false;
-        let report_observed_promise;
-        if (test_case.policy_violation) {
-           report_observed_promise = new Promise(r => {
-            (new ReportingObserver((reports, observer) => {
-              reports.forEach(report => {
-                if (report.body.blockedURL.endsWith(test_case.url)) {
-                  r(report.body);
-                  observer.disconnect();
-                }
-              });
-            })).observe('integrity-violation');
-          });
-        }
+
+        // Always set up report observer to catch any unexpected reports
+        const report_observed_promise = new Promise(r => {
+          (new ReportingObserver((reports, observer) => {
+            reports.forEach(report => {
+              // Match the tested URL against the stripped one:
+              // https://www.w3.org/TR/reporting-1/#strip-url-for-use-in-reports
+              // 1. If url’s scheme is not an HTTP(S) scheme, then return url’s scheme.
+              const test_url = test_case.url.startsWith("http") ?
+                test_case.url :
+                test_case.url.split(":")[0];
+              if (report.body.blockedURL.endsWith(test_url)) {
+                r(report.body);
+                observer.disconnect();
+              }
+            });
+          })).observe('integrity-violation');
+        });
 
         // Load the script
         await new Promise(resolve => {
@@ -201,20 +226,33 @@
           script.src = test_case.url;
           document.body.appendChild(script);
         });
-        const report_body = await report_observed_promise;
+
+        let report_body = null;
+        if (test_case.policy_violation) {
+          report_body = await report_observed_promise;
+        } else {
+          const timeout_promise = new Promise(r => setTimeout(() => r('timeout'), 100));
+          const race_result = await Promise.race([report_observed_promise, timeout_promise]);
+          if (race_result !== 'timeout') {
+            report_body = race_result;
+          }
+        }
         return { body: report_body, ran: window.ran };
       }, [test_case]);
-      assert_equals(result.ran, test_case.expected.ran);
+      assert_equals(result.ran, test_case.expected.ran, "Ran");
       if (test_case.policy_violation) {
+        assert_not_equals(result.body, null, "Expected a policy violation report");
         assert_equals(result.body.blockedURL, test_case.expected.blocked);
         assert_true(result.body.documentURL.endsWith(iframe_url));
         assert_equals(result.body.destination, "script");
-        assert_equals(result.body.reportOnly, !test_case.block);
+        assert_equals(result.body.reportOnly, !test_case.add_blocking_header);
+      } else {
+        assert_equals(result.body, null, "No policy violation report should be observed");
       }
       if (test_case.endpoints && test_case.policy_violation) {
-        if (test_case.block) {
-          await check_report(reporting_endpoint, reporting_uuid_1, iframe_url, test_case.url, !test_case.block);
-          await check_report(reporting_endpoint, reporting_uuid_2, iframe_url, test_case.url, !test_case.block);
+        if (test_case.add_blocking_header) {
+          await check_report(reporting_endpoint, reporting_uuid_1, iframe_url, test_case.url, !test_case.add_blocking_header);
+          await check_report(reporting_endpoint, reporting_uuid_2, iframe_url, test_case.url, !test_case.add_blocking_header);
         }
         await check_report(reporting_endpoint, reporting_uuid_3, iframe_url, test_case.url, true);
       }

--- a/Source/WebCore/loader/IntegrityPolicy.cpp
+++ b/Source/WebCore/loader/IntegrityPolicy.cpp
@@ -112,23 +112,24 @@ bool shouldRequestBeBlockedByIntegrityPolicy(ScriptExecutionContext& context, co
     // 2. Let parsedMetadata be the result of calling parse metadata with request’s integrity metadata.
     auto parsedMetadata = parseIntegrityMetadata(options.integrity);
     // 3. If parsedMetadata is not the empty set and request’s mode is either "cors" or "same-origin", return "Allowed".
-    if ((parsedMetadata && parsedMetadata->size() && options.mode != FetchOptions::Mode::NoCors) || url.protocolIsBlob() || url.protocolIsData())
+    // 4. If request’s url is local, return "Allowed".
+    if ((parsedMetadata && parsedMetadata->size() && options.mode != FetchOptions::Mode::NoCors) || url.hasLocalScheme())
         return false;
-    // 6. If both policy and reportPolicy are empty integrity policy structs, return "Allowed".
+    // 7. If both policy and reportPolicy are empty integrity policy structs, return "Allowed".
     if (!integrityPolicy && !integrityPolicyReportOnly)
         return false;
     // We don't currently support anything but script
     if (options.destination != FetchOptionsDestination::Script)
         return false;
 
-    // 9. Let block be a boolean, initially false.
+    // 10. Let block be a boolean, initially false.
     bool block = false;
-    // 10. Let reportBlock be a boolean, initially false.
+    // 11. Let reportBlock be a boolean, initially false.
     bool reportBlock = false;
-    // 11. If policy’s sources contains "inline" and policy’s blocked destinations contains request’s destination, set block to true.
+    // 12. If policy’s sources contains "inline" and policy’s blocked destinations contains request’s destination, set block to true.
     if (integrityPolicy && integrityPolicy->sources.contains("inline"_s) && integrityPolicy->blockedDestinations.contains("script"_s))
         block = true;
-    // 12. If reportPolicy’s sources contains "inline" and reportPolicy’s blocked destinations contains request’s destination, set reportBlock to true.
+    // 13. If reportPolicy’s sources contains "inline" and reportPolicy’s blocked destinations contains request’s destination, set reportBlock to true.
     if (integrityPolicyReportOnly && integrityPolicyReportOnly->sources.contains("inline"_s) && integrityPolicyReportOnly->blockedDestinations.contains("script"_s))
         reportBlock = true;
 


### PR DESCRIPTION
#### 13cc3923ebd9ec5d3394c385c7a3072dc5717ee5
<pre>
Integrity-Policy - align about:blank behavior
<a href="https://bugs.webkit.org/show_bug.cgi?id=294373">https://bugs.webkit.org/show_bug.cgi?id=294373</a>

Reviewed by Anne van Kesteren.

We recently added [1] about: URLs to the ones exempt from Integrity Policy.
This PR imports the relevant tests and aligns the implementation with that spec change.

[1] <a href="https://github.com/w3c/webappsec-subresource-integrity/pull/137#discussion_r2126331909">https://github.com/w3c/webappsec-subresource-integrity/pull/137#discussion_r2126331909</a>

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/d74262218de2e9419380ea4750e93e8993da81db">https://github.com/web-platform-tests/wpt/commit/d74262218de2e9419380ea4750e93e8993da81db</a>

* LayoutTests/imported/w3c/web-platform-tests/subresource-integrity/integrity-policy/script.https-expected.txt: Amend expectation
* LayoutTests/imported/w3c/web-platform-tests/subresource-integrity/integrity-policy/script.https.html: Test for the lack of a ReportingObserver and add about:blank test cases.
* Source/WebCore/loader/IntegrityPolicy.cpp:
(WebCore::shouldRequestBeBlockedByIntegrityPolicy): move to use hasLocalScheme

Canonical link: <a href="https://commits.webkit.org/296131@main">https://commits.webkit.org/296131@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/39120bfd4ce20a7e3a34dc0f1c54c3cc6635c8d9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/107479 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27161 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/17569 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/112693 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/58015 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/109443 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/27845 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/35662 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/81589 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/110408 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22052 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/96864 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/61970 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/21489 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/15005 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/57459 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/91418 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15036 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/115794 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/34546 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/25453 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/90623 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/34921 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93120 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/90369 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23040 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35280 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13057 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/30292 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/34467 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/40013 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34213 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/37568 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/35874 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->