### PR TITLE
[Regression@293947@main] [WebGPU] Some external sites report missing geometry

### DIFF
--- a/LayoutTests/fast/webgpu/regression/repro_294360-expected.txt
+++ b/LayoutTests/fast/webgpu/regression/repro_294360-expected.txt
@@ -1,0 +1,3 @@
+CONSOLE MESSAGE: 0
+CONSOLE MESSAGE: no validation error
+

--- a/LayoutTests/fast/webgpu/regression/repro_294360.html
+++ b/LayoutTests/fast/webgpu/regression/repro_294360.html
@@ -1,0 +1,102 @@
+<script>
+  globalThis.testRunner?.waitUntilDone();
+  const log = console.debug;
+
+  const format = 'bgra8unorm';
+
+  onload = async () => {
+    let adapter = await navigator.gpu.requestAdapter({});
+    let device = await adapter.requestDevice({});
+    device.pushErrorScope('validation');
+    let module = device.createShaderModule({
+      code: `
+@group(0) @binding(0) var<storage, read_write> b: u32;
+
+struct VertexOutput {
+  @builtin(position) position : vec4f,
+  @location(0) something: f32,
+}
+
+@vertex
+fn v(@location(0) fromVertexBuffer: f32) -> VertexOutput {
+  var v = VertexOutput();
+    v.position = vec4(fromVertexBuffer);
+    v.something = fromVertexBuffer;
+  return v;
+}
+
+@fragment
+fn f(@location(0) @interpolate(flat) something: f32) -> @location(0) vec4f {
+  b = bitcast<u32>(something);
+  return vec4();
+}
+`,
+    });
+    let pipeline = device.createRenderPipeline({
+      layout: device.createPipelineLayout({bindGroupLayouts: []}),
+      vertex: {
+        module,
+        buffers: [{
+          arrayStride: 8,
+          attributes: [{format: 'float32', offset: 0, shaderLocation: 0}],
+        }],
+      },
+      fragment: {module, targets: [{format}]},
+      primitive: {topology: 'point-list'},
+    });
+    let texture = device.createTexture({format, size: [1, 1, 1], usage: GPUTextureUsage.RENDER_ATTACHMENT});
+    let renderPassDescriptor = {
+      colorAttachments: [
+        {
+          view: texture.createView(),
+          clearValue: [0, 0, 0, 0],
+          loadOp: 'clear',
+          storeOp: 'store',
+        },
+      ],
+    };
+    let commandEncoder = device.createCommandEncoder();
+    let renderPassEncoder = commandEncoder.beginRenderPass(renderPassDescriptor);
+    renderPassEncoder.setPipeline(pipeline);
+    let uniformBuffer = device.createBuffer({size: 32, usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC});
+    let bindGroup0 = device.createBindGroup({
+      layout: pipeline.getBindGroupLayout(0),
+      entries: [{binding: 0, resource: {buffer: uniformBuffer}}],
+    });
+
+    let vertexBuffer1 = device.createBuffer({size: 32, usage: GPUBufferUsage.VERTEX, mappedAtCreation: true});
+    let firstU32 = new Uint32Array(vertexBuffer1.getMappedRange());
+    firstU32.fill(123456789);
+    vertexBuffer1.unmap();
+
+    let vertexBuffer2 = device.createBuffer({size: 32, usage: GPUBufferUsage.VERTEX});
+
+    renderPassEncoder.setVertexBuffer(0, vertexBuffer1);
+    renderPassEncoder.setVertexBuffer(0, vertexBuffer2);
+    renderPassEncoder.setBindGroup(0, bindGroup0);
+
+    renderPassEncoder.draw(3);
+    renderPassEncoder.end();
+
+    let outputBuffer = device.createBuffer({size: 4, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+    commandEncoder.copyBufferToBuffer(uniformBuffer, 0, outputBuffer, 0, 4);
+
+    device.queue.submit([commandEncoder.finish()]);
+    await device.queue.onSubmittedWorkDone();
+    let error = await device.popErrorScope();
+
+    await outputBuffer.mapAsync(GPUMapMode.READ);
+    let outputU32 = new Uint32Array(outputBuffer.getMappedRange());
+    log(outputU32);
+
+    if (error) {
+      log(error.message);
+    } else {
+      log('no validation error');
+    }
+    globalThis.testRunner?.dumpAsText();
+    globalThis.testRunner?.notifyDone();
+  };
+
+</script>
+

--- a/Source/WebGPU/WebGPU/RenderPassEncoder.h
+++ b/Source/WebGPU/WebGPU/RenderPassEncoder.h
@@ -196,7 +196,6 @@ private:
     using ExistingBufferKey = std::pair<uint64_t, uint32_t>;
     std::array<ExistingBufferKey, maxBufferSlots> m_existingVertexBuffers;
     std::array<ExistingBufferKey, maxBufferSlots> m_existingFragmentBuffers;
-    std::array<uint64_t, maxBufferSlots> m_vertexBuffersValidatedForPipeline;
     HashMap<uint32_t, RefPtr<const BindGroup>, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>> m_bindGroups;
     std::array<uint32_t, 32> m_maxDynamicOffsetAtIndex;
     NSString* m_lastErrorString { nil };


### PR DESCRIPTION
#### 7c88a46d753b72ac9f2c0c1767b7e26d9566c0c2
<pre>
[Regression@293947@main] [WebGPU] Some external sites report missing geometry
<a href="https://bugs.webkit.org/show_bug.cgi?id=294360">https://bugs.webkit.org/show_bug.cgi?id=294360</a>
<a href="https://rdar.apple.com/153138317">rdar://153138317</a>

Reviewed by Tadeu Zagallo.

We were failing to update a cache resulting in
calls to setVertexBuffer: getting skipped.

But this cache was not really useful, since setVertexBuffer() already
maintains a cache itself. So better to remove the almost duplicate cache.

* Source/WebGPU/WebGPU/RenderPassEncoder.h:
* Source/WebGPU/WebGPU/RenderPassEncoder.mm:
(WebGPU::RenderPassEncoder::setVertexBuffer):
(WebGPU::RenderPassEncoder::setVertexBytes):
(WebGPU::RenderPassEncoder::errorValidatingAndBindingBuffers):
(WebGPU::RenderPassEncoder::executeBundles):
(WebGPU::RenderPassEncoder::setPipeline):

* LayoutTests/fast/webgpu/regression/repro_294360-expected.txt: Added.
* LayoutTests/fast/webgpu/regression/repro_294360.html: Added.
Add regression test.

Canonical link: <a href="https://commits.webkit.org/296192@main">https://commits.webkit.org/296192@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fef25fbb771ba8c9e17346f641a408cc622b3bb0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/107605 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27288 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/17699 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/112822 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/58147 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/27980 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/35790 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/81701 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/110534 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22174 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/96986 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62081 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/21610 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/15125 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/57586 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/91545 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15159 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/115923 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/34673 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/25570 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/90733 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/35049 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93236 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/90474 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23081 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35391 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13175 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/30436 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/34594 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/40150 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34340 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/37700 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/36003 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->