### PR TITLE
Fix coreIPC fuzz blocker: NetworkStorageManager::didGenerateIndexKeyForRecord

### DIFF
--- a/LayoutTests/ipc/networkstoragemanager-didgenerateindexkeyforrecord-notransactionid-expected.txt
+++ b/LayoutTests/ipc/networkstoragemanager-didgenerateindexkeyforrecord-notransactionid-expected.txt
@@ -1,0 +1,3 @@
+This test passes if webkit does not crash
+
+PASS

--- a/LayoutTests/ipc/networkstoragemanager-didgenerateindexkeyforrecord-notransactionid.html
+++ b/LayoutTests/ipc/networkstoragemanager-didgenerateindexkeyforrecord-notransactionid.html
@@ -1,0 +1,82 @@
+<script>
+    window.testRunner?.waitUntilDone();
+    window.testRunner?.dumpAsText();
+
+    function test() {
+        var pass = document.getElementById('pass');
+        if (window.IPC) {
+            import('./coreipc.js').then(({
+                CoreIPC
+            }) => {
+                CoreIPC.Networking.NetworkStorageManager.DidGenerateIndexKeyForRecord(IPC.webPageProxyID, {
+                    transactionIdentifier: {
+                        m_idbConnectionIdentifier: {},
+                        m_resourceNumber: {}
+                    },
+                    requestIdentifier: {
+                        m_idbConnectionIdentifier: {},
+                        m_resourceNumber: {}
+                    },
+                    indexInfo: {
+                        identifier: 262145,
+                        objectStoreIdentifier: 17482,
+                        name: 'A',
+                        keyPath: {
+                            alias: {
+                                variantType: 'Vector<String>', variant: []
+                            }
+                        },
+                        unique: true,
+                        multiEntry: true
+                    },
+                    key: {
+                        isPlaceholder: true,
+                        value: {
+                            variantType: 'WebCore::ThreadSafeDataBuffer',
+                            variant: {
+                                m_impl: {
+                                    optionalValue: {
+                                        m_data: [180]
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    indexKey: {
+                        data: {
+                            variantType: 'Vector<WebCore::IDBKeyData>',
+                            variant: [
+                                {
+                                    isPlaceholder: false,
+                                    value: {
+                                        variantType: 'WebCore::IDBKeyData::Min',
+                                        variant: {}
+                                    }
+                                },
+                                {
+                                    isPlaceholder: true, value: { variantType: 'String', variant: 'A' }
+                                },
+                                {
+                                    isPlaceholder: false, value: { variantType: 'double', variant: 84 }
+                                },
+                                {
+                                    isPlaceholder: false, value: { variantType: 'std::nullptr_t', variant: null }
+                                }]
+                        }
+                    }, recordID: {}
+                })
+                pass.innerText = "PASS";
+                window.testRunner?.notifyDone();
+            });
+
+        } else {
+            pass.innerText = "PASS";
+            window.testRunner?.notifyDone();
+        }
+    }
+</script>
+
+<body onload="test()">
+    <p>This test passes if webkit does not crash</p>
+    <div id="pass"></div>
+</body>

--- a/Source/WebKit/NetworkProcess/storage/IDBStorageRegistry.cpp
+++ b/Source/WebKit/NetworkProcess/storage/IDBStorageRegistry.cpp
@@ -100,6 +100,8 @@ WebCore::IDBServer::UniqueIDBDatabaseConnection* IDBStorageRegistry::connection(
 
 WebCore::IDBServer::UniqueIDBDatabaseTransaction* IDBStorageRegistry::transaction(WebCore::IDBResourceIdentifier identifier)
 {
+    if (identifier.isEmpty())
+        return nullptr;
     return m_transactions.get(identifier).get();
 }
 


### PR DESCRIPTION
#### ab75ad576ed7e70d59e5a0751752c73cb2310e54
<pre>
Fix coreIPC fuzz blocker: NetworkStorageManager::didGenerateIndexKeyForRecord
<a href="https://bugs.webkit.org/show_bug.cgi?id=294375">https://bugs.webkit.org/show_bug.cgi?id=294375</a>
<a href="https://rdar.apple.com/152492569">rdar://152492569</a>

Reviewed by Sihui Liu.

Check whether key type of WebCore::IDBResourceIdentifier is empty before
attempting to use it to retrieve a value from a HashMap.

* LayoutTests/ipc/networkstoragemanager-didgenerateindexkeyforrecord-notransactionid-expected.txt: Added.
* LayoutTests/ipc/networkstoragemanager-didgenerateindexkeyforrecord-notransactionid.html: Added.
* Source/WebKit/NetworkProcess/storage/IDBStorageRegistry.cpp:
(WebKit::IDBStorageRegistry::transaction):

Canonical link: <a href="https://commits.webkit.org/296198@main">https://commits.webkit.org/296198@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0f8eb14ab939a4a9dfc4b27a34453ecd4c036db7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/107583 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27266 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/17677 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/112800 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/58125 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/27957 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/35768 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/81681 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/110512 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22157 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/96967 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62061 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/21594 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/15106 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/57564 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/91527 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15140 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/115901 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/34651 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/25607 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/90712 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/35027 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93217 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/90453 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23089 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35375 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13156 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/30414 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/34572 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/40128 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34318 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/37678 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/35981 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->