### PR TITLE
Prevent JSC usage within the Model process.

### DIFF
--- a/Source/WebKit/GPUProcess/EntryPoint/Cocoa/XPCService/GPUServiceEntryPoint.mm
+++ b/Source/WebKit/GPUProcess/EntryPoint/Cocoa/XPCService/GPUServiceEntryPoint.mm
@@ -50,23 +50,9 @@ extern "C" WK_EXPORT void GPU_SERVICE_INITIALIZER(xpc_connection_t connection, x
 
 void GPU_SERVICE_INITIALIZER(xpc_connection_t connection, xpc_object_t initializerMessage)
 {
-    g_jscConfig.vmCreationDisallowed = true;
-    g_jscConfig.vmEntryDisallowed = true;
-    g_wtfConfig.useSpecialAbortForExtraSecurityImplications = true;
-
-    WTF::initializeMainThread();
-    {
-        JSC::Options::initialize();
-        JSC::Options::AllowUnfinalizedAccessScope scope;
-        JSC::ExecutableAllocator::disableJIT();
-        JSC::Options::useWasm() = false;
-        JSC::Options::notifyOptionsChanged();
-    }
-    WTF::compilerFence();
-
+    WebKit::disableJSC([&] {
 #if ENABLE(GPU_PROCESS)
-    WebKit::XPCServiceInitializer<WebKit::GPUProcess, WebKit::GPUServiceInitializerDelegate>(connection, initializerMessage);
+        WebKit::XPCServiceInitializer<WebKit::GPUProcess, WebKit::GPUServiceInitializerDelegate>(connection, initializerMessage);
 #endif // ENABLE(GPU_PROCESS)
-
-    JSC::Config::finalize();
+    });
 }

--- a/Source/WebKit/ModelProcess/EntryPoint/Cocoa/XPCService/ModelServiceEntryPoint.mm
+++ b/Source/WebKit/ModelProcess/EntryPoint/Cocoa/XPCService/ModelServiceEntryPoint.mm
@@ -56,9 +56,9 @@ extern "C" WK_EXPORT void MODEL_SERVICE_INITIALIZER(xpc_connection_t connection,
 
 void MODEL_SERVICE_INITIALIZER(xpc_connection_t connection, xpc_object_t initializerMessage)
 {
-    WTF::initializeMainThread();
-
+    WebKit::disableJSC([&] {
 #if ENABLE(MODEL_PROCESS)
-    WebKit::XPCServiceInitializer<WebKit::ModelProcess, WebKit::ModelServiceInitializerDelegate>(connection, initializerMessage);
+        WebKit::XPCServiceInitializer<WebKit::ModelProcess, WebKit::ModelServiceInitializerDelegate>(connection, initializerMessage);
 #endif // ENABLE(MODEL_PROCESS)
+    });
 }

--- a/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceEntryPoint.h
+++ b/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceEntryPoint.h
@@ -30,6 +30,7 @@
 #import "AuxiliaryProcess.h"
 #import "WebKit2Initialize.h"
 #import <JavaScriptCore/ExecutableAllocator.h>
+#import <wtf/CompletionHandler.h>
 #import <wtf/OSObjectPtr.h>
 #import <wtf/WTFProcess.h>
 #import <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
@@ -89,6 +90,7 @@ void setOSTransaction(OSObjectPtr<os_transaction_t>&&);
 enum class EnableLockdownMode: bool { No, Yes };
 
 void setJSCOptions(xpc_object_t initializerMessage, EnableLockdownMode, bool isWebContentProcess);
+void disableJSC(NOESCAPE WTF::CompletionHandler<void(void)>&& beforeFinalizeHandler);
 
 template<typename XPCServiceType, typename XPCServiceInitializerDelegateType, bool isWebContentProcess = false>
 void XPCServiceInitializer(OSObjectPtr<xpc_connection_t> connection, xpc_object_t initializerMessage)


### PR DESCRIPTION
#### ea9d557590116f1fbc374fd05f658d492802cfb5
<pre>
Prevent JSC usage within the Model process.
<a href="https://bugs.webkit.org/show_bug.cgi?id=294254">https://bugs.webkit.org/show_bug.cgi?id=294254</a>
<a href="https://rdar.apple.com/152938069">rdar://152938069</a>

Reviewed by Ada Chan.

Use the same prevention mechanism as the GPU process to prevent JSC usage within the Model process.
Due to repetititon of this pattern, refactored slightly to ease usage.

* Source/WebKit/GPUProcess/EntryPoint/Cocoa/XPCService/GPUServiceEntryPoint.mm:
(GPU_SERVICE_INITIALIZER):
* Source/WebKit/ModelProcess/EntryPoint/Cocoa/XPCService/ModelServiceEntryPoint.mm:
(MODEL_SERVICE_INITIALIZER):
* Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceEntryPoint.h:
* Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceEntryPoint.mm:
(WebKit::disableJSC):

Canonical link: <a href="https://commits.webkit.org/296152@main">https://commits.webkit.org/296152@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b348965ae10de53f4ac2409eddbb63ce6d5c04ba

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/107501 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27183 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/17592 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/112717 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/58037 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/27870 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/35684 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/81605 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/110430 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22074 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/96885 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/61989 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/21512 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/57481 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/91442 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15058 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/115817 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/34568 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/25472 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/90639 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/34943 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93141 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/90385 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23056 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35302 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13078 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/30322 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/34489 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/40035 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34235 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/37591 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/35896 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->