### PR TITLE
[WPE] WPE Platform: add API to provide the VBlank monitor implementation

### DIFF
--- a/Source/WebKit/SourcesGTK.txt
+++ b/Source/WebKit/SourcesGTK.txt
@@ -251,6 +251,7 @@ UIProcess/glib/DRMDevice.cpp @no-unify
 UIProcess/glib/DisplayLinkGLib.cpp
 UIProcess/glib/DisplayVBlankMonitor.cpp
 UIProcess/glib/DisplayVBlankMonitorDRM.cpp
+UIProcess/glib/DisplayVBlankMonitorThreaded.cpp
 UIProcess/glib/DisplayVBlankMonitorTimer.cpp
 UIProcess/glib/FenceMonitor.cpp
 UIProcess/glib/ScreenManager.cpp

--- a/Source/WebKit/SourcesWPE.txt
+++ b/Source/WebKit/SourcesWPE.txt
@@ -223,6 +223,7 @@ UIProcess/glib/DRMDevice.cpp @no-unify
 UIProcess/glib/DisplayLinkGLib.cpp
 UIProcess/glib/DisplayVBlankMonitor.cpp
 UIProcess/glib/DisplayVBlankMonitorDRM.cpp
+UIProcess/glib/DisplayVBlankMonitorThreaded.cpp
 UIProcess/glib/DisplayVBlankMonitorTimer.cpp
 UIProcess/glib/FenceMonitor.cpp
 UIProcess/glib/ScreenManager.cpp
@@ -256,6 +257,7 @@ UIProcess/linux/MemoryPressureMonitor.cpp
 UIProcess/soup/WebProcessPoolSoup.cpp
 
 UIProcess/wpe/AcceleratedBackingStoreDMABuf.cpp
+UIProcess/wpe/DisplayVBlankMonitorWPE.cpp
 UIProcess/wpe/ScreenManagerWPE.cpp
 UIProcess/wpe/SystemSettingsManagerProxyWPE.cpp
 UIProcess/wpe/WPEUtilities.cpp

--- a/Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.cpp
@@ -67,6 +67,7 @@
 #if PLATFORM(WPE)
 #include "WPEUtilities.h"
 #if ENABLE(WPE_PLATFORM)
+#include "DisplayVBlankMonitorWPE.h"
 #include <wpe/wpe-platform.h>
 #endif
 #endif
@@ -294,6 +295,18 @@ static String renderBufferFormat(WebKitURISchemeRequest* request)
 #endif
 #endif
 
+static String vblankMonitorType(const DisplayVBlankMonitor& monitor)
+{
+#if ENABLE(WPE_PLATFORM)
+    if (monitor.type() == DisplayVBlankMonitor::Type::Wpe) {
+        const auto& wpeMonitor = *static_cast<const DisplayVBlankMonitorWPE*>(&monitor);
+        return makeString("WPE ("_s, String::fromUTF8(G_OBJECT_TYPE_NAME(wpeMonitor.observer())), ')');
+    }
+#endif
+
+    return monitor.type() == DisplayVBlankMonitor::Type::Timer ? "Timer"_s : "DRM"_s;
+}
+
 static String prettyPrintJSON(const String& jsonString)
 {
     StringBuilder result;
@@ -495,7 +508,7 @@ void WebKitProtocolHandler::handleGPU(WebKitURISchemeRequest* request)
     if (displayID) {
         if (auto* displayLink = page->configuration().processPool().displayLinks().existingDisplayLinkForDisplay(*displayID)) {
             auto& vblankMonitor = displayLink->vblankMonitor();
-            addTableRow(displayObject, "VBlank type"_s, vblankMonitor.type() == DisplayVBlankMonitor::Type::Timer ? "Timer"_s : "DRM"_s);
+            addTableRow(displayObject, "VBlank type"_s, vblankMonitorType(vblankMonitor));
             addTableRow(displayObject, "VBlank refresh rate"_s, makeString(vblankMonitor.refreshRate(), "Hz"_s));
         }
     }

--- a/Source/WebKit/UIProcess/glib/DisplayVBlankMonitor.cpp
+++ b/Source/WebKit/UIProcess/glib/DisplayVBlankMonitor.cpp
@@ -29,12 +29,15 @@
 #include "DisplayVBlankMonitorTimer.h"
 #include "Logging.h"
 #include <wtf/TZoneMallocInlines.h>
-#include <wtf/Threading.h>
 #include <wtf/Vector.h>
-#include <wtf/glib/RunLoopSourcePriority.h>
 
 #if USE(LIBDRM)
 #include "DisplayVBlankMonitorDRM.h"
+#endif
+
+#if ENABLE(WPE_PLATFORM)
+#include "DisplayVBlankMonitorWPE.h"
+#include "WPEUtilities.h"
 #endif
 
 namespace WebKit {
@@ -47,122 +50,37 @@ std::unique_ptr<DisplayVBlankMonitor> DisplayVBlankMonitor::create(PlatformDispl
     if (!displayID || (forceTimer && strcmp(forceTimer, "0")))
         return DisplayVBlankMonitorTimer::create();
 
+#if ENABLE(WPE_PLATFORM)
+    if (WKWPE::isUsingWPEPlatformAPI()) {
+        if (auto monitor = DisplayVBlankMonitorWPE::create(displayID))
+            return monitor;
+
+        RELEASE_LOG_FAULT(DisplayLink, "Failed to create WPE vblank monitor, falling back to timer");
+        return DisplayVBlankMonitorTimer::create();
+    }
+#endif
+
 #if USE(LIBDRM)
     if (auto monitor = DisplayVBlankMonitorDRM::create(displayID))
         return monitor;
     RELEASE_LOG_FAULT(DisplayLink, "Failed to create DRM vblank monitor, falling back to timer");
-#else
-    UNUSED_PARAM(displayID);
 #endif
+
     return DisplayVBlankMonitorTimer::create();
 }
 
 DisplayVBlankMonitor::DisplayVBlankMonitor(unsigned refreshRate)
     : m_refreshRate(refreshRate)
-    , m_destroyThreadTimer(RunLoop::main(), this, &DisplayVBlankMonitor::destroyThreadTimerFired)
 {
-    m_destroyThreadTimer.setPriority(RunLoopSourcePriority::ReleaseUnusedResourcesTimer);
 }
 
-DisplayVBlankMonitor::~DisplayVBlankMonitor()
-{
-    ASSERT(!m_thread);
-}
-
-bool DisplayVBlankMonitor::startThreadIfNeeded()
-{
-    if (m_thread)
-        return false;
-
-    m_thread = Thread::create("VBlankMonitor"_s, [this] {
-        while (true) {
-            {
-                Locker locker { m_lock };
-                m_condition.wait(m_lock, [this]() -> bool {
-                    return m_state != State::Stop;
-                });
-                if (m_state == State::Invalid || m_state == State::Failed)
-                    return;
-            }
-
-            if (!waitForVBlank()) {
-                WTFLogAlways("Failed to wait for vblank");
-                Locker locker { m_lock };
-                m_state = State::Failed;
-                return;
-            }
-
-            bool active;
-            {
-                Locker locker { m_lock };
-                active = m_state == State::Active;
-            }
-            if (active)
-                m_handler();
-        }
-    }, ThreadType::Graphics, Thread::QOS::Default);
-    return true;
-}
-
-void DisplayVBlankMonitor::start()
-{
-    Locker locker { m_lock };
-    if (m_state == State::Active)
-        return;
-
-    ASSERT(m_handler);
-    m_state = State::Active;
-    m_destroyThreadTimer.stop();
-    if (!startThreadIfNeeded())
-        m_condition.notifyAll();
-}
-
-void DisplayVBlankMonitor::stop()
-{
-    Locker locker { m_lock };
-    if (m_state != State::Active)
-        return;
-
-    m_state = State::Stop;
-    if (m_thread)
-        m_destroyThreadTimer.startOneShot(30_s);
-}
-
-void DisplayVBlankMonitor::invalidate()
-{
-    if (!m_thread) {
-        m_state = State::Invalid;
-        return;
-    }
-
-    {
-        Locker locker { m_lock };
-        m_state = State::Invalid;
-        m_condition.notifyAll();
-    }
-    m_thread->waitForCompletion();
-    m_thread = nullptr;
-}
-
-bool DisplayVBlankMonitor::isActive()
-{
-    Locker locker { m_lock };
-    return m_state == State::Active;
-}
+DisplayVBlankMonitor::~DisplayVBlankMonitor() = default;
 
 void DisplayVBlankMonitor::setHandler(Function<void()>&& handler)
 {
-    Locker locker { m_lock };
-    ASSERT(m_state != State::Active);
+    ASSERT(RunLoop::isMain());
+    ASSERT(!m_handler);
     m_handler = WTFMove(handler);
-}
-
-void DisplayVBlankMonitor::destroyThreadTimerFired()
-{
-    if (!m_thread)
-        return;
-
-    invalidate();
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/glib/DisplayVBlankMonitorDRM.h
+++ b/Source/WebKit/UIProcess/glib/DisplayVBlankMonitorDRM.h
@@ -27,12 +27,12 @@
 
 #if USE(LIBDRM)
 
-#include "DisplayVBlankMonitor.h"
+#include "DisplayVBlankMonitorThreaded.h"
 #include <wtf/unix/UnixFileDescriptor.h>
 
 namespace WebKit {
 
-class DisplayVBlankMonitorDRM final : public DisplayVBlankMonitor {
+class DisplayVBlankMonitorDRM final : public DisplayVBlankMonitorThreaded {
 public:
     static std::unique_ptr<DisplayVBlankMonitor> create(PlatformDisplayID);
     DisplayVBlankMonitorDRM(unsigned, WTF::UnixFileDescriptor&&, int);

--- a/Source/WebKit/UIProcess/glib/DisplayVBlankMonitorThreaded.cpp
+++ b/Source/WebKit/UIProcess/glib/DisplayVBlankMonitorThreaded.cpp
@@ -1,0 +1,144 @@
+/*
+ * Copyright (C) 2023 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "DisplayVBlankMonitorThreaded.h"
+
+#include "Logging.h"
+#include <wtf/Threading.h>
+#include <wtf/Vector.h>
+#include <wtf/glib/RunLoopSourcePriority.h>
+
+namespace WebKit {
+
+DisplayVBlankMonitorThreaded::DisplayVBlankMonitorThreaded(unsigned refreshRate)
+    : DisplayVBlankMonitor(refreshRate)
+    , m_destroyThreadTimer(RunLoop::main(), this, &DisplayVBlankMonitorThreaded::destroyThreadTimerFired)
+{
+    m_destroyThreadTimer.setPriority(RunLoopSourcePriority::ReleaseUnusedResourcesTimer);
+}
+
+DisplayVBlankMonitorThreaded::~DisplayVBlankMonitorThreaded()
+{
+    ASSERT(!m_thread);
+}
+
+bool DisplayVBlankMonitorThreaded::startThreadIfNeeded()
+{
+    if (m_thread)
+        return false;
+
+    m_thread = Thread::create("VBlankMonitor"_s, [this] {
+        while (true) {
+            {
+                Locker locker { m_lock };
+                m_condition.wait(m_lock, [this]() -> bool {
+                    return m_state != State::Stop;
+                });
+                if (m_state == State::Invalid || m_state == State::Failed)
+                    return;
+            }
+
+            if (!waitForVBlank()) {
+                RELEASE_LOG_FAULT(DisplayLink, "Failed to wait for vblank");
+                Locker locker { m_lock };
+                m_state = State::Failed;
+                return;
+            }
+
+            bool active;
+            {
+                Locker locker { m_lock };
+                active = m_state == State::Active;
+            }
+            if (active)
+                m_handler();
+        }
+    }, ThreadType::Graphics, Thread::QOS::Default);
+    return true;
+}
+
+void DisplayVBlankMonitorThreaded::start()
+{
+    Locker locker { m_lock };
+    if (m_state == State::Active)
+        return;
+
+    ASSERT(m_handler);
+    m_state = State::Active;
+    m_destroyThreadTimer.stop();
+    if (!startThreadIfNeeded())
+        m_condition.notifyAll();
+}
+
+void DisplayVBlankMonitorThreaded::stop()
+{
+    Locker locker { m_lock };
+    if (m_state != State::Active)
+        return;
+
+    m_state = State::Stop;
+    if (m_thread)
+        m_destroyThreadTimer.startOneShot(30_s);
+}
+
+void DisplayVBlankMonitorThreaded::invalidate()
+{
+    if (!m_thread) {
+        m_state = State::Invalid;
+        return;
+    }
+
+    {
+        Locker locker { m_lock };
+        m_state = State::Invalid;
+        m_condition.notifyAll();
+    }
+    m_thread->waitForCompletion();
+    m_thread = nullptr;
+}
+
+bool DisplayVBlankMonitorThreaded::isActive()
+{
+    Locker locker { m_lock };
+    return m_state == State::Active;
+}
+
+void DisplayVBlankMonitorThreaded::setHandler(Function<void()>&& handler)
+{
+    Locker locker { m_lock };
+    ASSERT(m_state == State::Stop);
+    DisplayVBlankMonitor::setHandler(WTFMove(handler));
+}
+
+void DisplayVBlankMonitorThreaded::destroyThreadTimerFired()
+{
+    if (!m_thread)
+        return;
+
+    invalidate();
+}
+
+} // namespace WebKit

--- a/Source/WebKit/UIProcess/glib/DisplayVBlankMonitorTimer.h
+++ b/Source/WebKit/UIProcess/glib/DisplayVBlankMonitorTimer.h
@@ -25,11 +25,11 @@
 
 #pragma once
 
-#include "DisplayVBlankMonitor.h"
+#include "DisplayVBlankMonitorThreaded.h"
 
 namespace WebKit {
 
-class DisplayVBlankMonitorTimer final : public DisplayVBlankMonitor {
+class DisplayVBlankMonitorTimer final : public DisplayVBlankMonitorThreaded {
 public:
     static std::unique_ptr<DisplayVBlankMonitor> create();
     explicit DisplayVBlankMonitorTimer();

--- a/Source/WebKit/UIProcess/wpe/DisplayVBlankMonitorWPE.cpp
+++ b/Source/WebKit/UIProcess/wpe/DisplayVBlankMonitorWPE.cpp
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2025 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "DisplayVBlankMonitorWPE.h"
+
+#if ENABLE(WPE_PLATFORM)
+#include "Logging.h"
+#include "ScreenManager.h"
+#include <wpe/wpe-platform.h>
+
+namespace WebKit {
+
+std::unique_ptr<DisplayVBlankMonitor> DisplayVBlankMonitorWPE::create(PlatformDisplayID displayID)
+{
+    auto* screen = ScreenManager::singleton().screen(displayID);
+    if (!screen) {
+        RELEASE_LOG_FAULT(DisplayLink, "Could not create a vblank monitor for display %u: no screen found", displayID);
+        return nullptr;
+    }
+
+    GRefPtr<WPEScreenSyncObserver> observer = adoptGRef(wpe_screen_get_sync_observer(screen));
+    if (!observer) {
+        RELEASE_LOG_FAULT(DisplayLink, "Could not create a vblank monitor for display %u: screen sync not supported by WPE platform", displayID);
+        return nullptr;
+    }
+
+    return makeUnique<DisplayVBlankMonitorWPE>(wpe_screen_get_refresh_rate(screen) / 1000, WTFMove(observer));
+}
+
+DisplayVBlankMonitorWPE::DisplayVBlankMonitorWPE(unsigned refreshRate, GRefPtr<WPEScreenSyncObserver>&& observer)
+    : DisplayVBlankMonitor(refreshRate)
+    , m_observer(WTFMove(observer))
+{
+    wpe_screen_sync_observer_set_callback(m_observer.get(), +[](WPEScreenSyncObserver* observer, gpointer userData) {
+        auto* monitor = static_cast<DisplayVBlankMonitorWPE*>(userData);
+        monitor->m_handler();
+    }, this, nullptr);
+}
+
+DisplayVBlankMonitorWPE::~DisplayVBlankMonitorWPE()
+{
+    ASSERT(!m_observer);
+}
+
+void DisplayVBlankMonitorWPE::start()
+{
+    if (!m_observer)
+        return;
+
+    wpe_screen_sync_observer_start(m_observer.get());
+}
+
+void DisplayVBlankMonitorWPE::stop()
+{
+    if (!m_observer)
+        return;
+
+    wpe_screen_sync_observer_stop(m_observer.get());
+}
+
+void DisplayVBlankMonitorWPE::invalidate()
+{
+    if (!m_observer)
+        return;
+
+    if (isActive())
+        stop();
+
+    m_observer = nullptr;
+}
+
+bool DisplayVBlankMonitorWPE::isActive()
+{
+    return m_observer && wpe_screen_sync_observer_is_active(m_observer.get());
+}
+
+} // namespace WebKit
+
+#endif // ENABLE(WPE_PLATFORM)

--- a/Source/WebKit/WPEPlatform/CMakeLists.txt
+++ b/Source/WebKit/WPEPlatform/CMakeLists.txt
@@ -34,6 +34,7 @@ set(WPEPlatform_SOURCES
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEGestureDetector.cpp
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPERectangle.cpp
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEScreen.cpp
+    ${WEBKIT_DIR}/WPEPlatform/wpe/WPEScreenSyncObserver.cpp
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPESettings.cpp
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEToplevel.cpp
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEVersion.cpp
@@ -63,6 +64,7 @@ set(WPEPlatform_INSTALLED_HEADERS
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEGestureController.h
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPERectangle.h
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEScreen.h
+    ${WEBKIT_DIR}/WPEPlatform/wpe/WPEScreenSyncObserver.h
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPESettings.h
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEToplevel.h
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEView.h
@@ -117,6 +119,12 @@ if (USE_GBM)
     list(APPEND WPEPlatform_LIBRARIES GBM::GBM)
 elseif (USE_LIBDRM)
     list(APPEND WPEPlatform_LIBRARIES LibDRM::LibDRM)
+endif ()
+
+if (USE_LIBDRM)
+    list(APPEND WPEPlatform_SOURCES
+        ${WEBKIT_DIR}/WPEPlatform/wpe/WPEScreenSyncObserverDRM.cpp
+    )
 endif ()
 
 if (USE_ATK)

--- a/Source/WebKit/WPEPlatform/wpe/WPEScreen.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEScreen.cpp
@@ -530,3 +530,22 @@ void wpe_screen_set_refresh_rate(WPEScreen* screen, int refreshRate)
     screen->priv->refreshRate = refreshRate;
     g_object_notify_by_pspec(G_OBJECT(screen), sObjProperties[PROP_REFRESH_RATE]);
 }
+
+/**
+ * wpe_screen_get_sync_observer:
+ * @screen: a #WPEScreen
+ *
+ * Get the #WPEScreenSyncObserver of @screen. If screen sync is not supported, %NULL is returned.
+ *
+ * Returns: (transfer none) (nullable): a #WPEScreenSyncObserver or %NULL
+ */
+WPEScreenSyncObserver* wpe_screen_get_sync_observer(WPEScreen* screen)
+{
+    g_return_val_if_fail(WPE_IS_SCREEN(screen), nullptr);
+
+    auto* screenClass = WPE_SCREEN_GET_CLASS(screen);
+    if (screenClass->get_sync_observer)
+        return screenClass->get_sync_observer(screen);
+
+    return nullptr;
+}

--- a/Source/WebKit/WPEPlatform/wpe/WPEScreen.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPEScreen.h
@@ -32,6 +32,7 @@
 
 #include <glib-object.h>
 #include <wpe/WPEDefines.h>
+#include <wpe/WPEScreenSyncObserver.h>
 
 G_BEGIN_DECLS
 
@@ -42,34 +43,36 @@ struct _WPEScreenClass
 {
     GObjectClass parent_class;
 
-    void (* invalidate) (WPEScreen *screen);
+    void                   (* invalidate)        (WPEScreen *screen);
+    WPEScreenSyncObserver *(* get_sync_observer) (WPEScreen *screen);
 
     gpointer padding[32];
 };
 
-WPE_API guint32 wpe_screen_get_id               (WPEScreen *screen);
-WPE_API void    wpe_screen_invalidate           (WPEScreen *screen);
-WPE_API int     wpe_screen_get_x                (WPEScreen *screen);
-WPE_API int     wpe_screen_get_y                (WPEScreen *screen);
-WPE_API void    wpe_screen_set_position         (WPEScreen *screen,
-                                                 int         x,
-                                                 int         y);
-WPE_API int     wpe_screen_get_width            (WPEScreen *screen);
-WPE_API int     wpe_screen_get_height           (WPEScreen *screen);
-WPE_API void    wpe_screen_set_size             (WPEScreen *screen,
-                                                 int         width,
-                                                 int         height);
-WPE_API int     wpe_screen_get_physical_width   (WPEScreen *screen);
-WPE_API int     wpe_screen_get_physical_height  (WPEScreen *screen);
-WPE_API void    wpe_screen_set_physical_size    (WPEScreen *screen,
-                                                 int         width,
-                                                 int         height);
-WPE_API gdouble wpe_screen_get_scale            (WPEScreen *screen);
-WPE_API void    wpe_screen_set_scale            (WPEScreen *screen,
-                                                 gdouble     scale);
-WPE_API int     wpe_screen_get_refresh_rate     (WPEScreen *screen);
-WPE_API void    wpe_screen_set_refresh_rate     (WPEScreen *screen,
-                                                 int         refresh_rate);
+WPE_API guint32                wpe_screen_get_id               (WPEScreen *screen);
+WPE_API void                   wpe_screen_invalidate           (WPEScreen *screen);
+WPE_API int                    wpe_screen_get_x                (WPEScreen *screen);
+WPE_API int                    wpe_screen_get_y                (WPEScreen *screen);
+WPE_API void                   wpe_screen_set_position         (WPEScreen *screen,
+                                                                int        x,
+                                                                int        y);
+WPE_API int                    wpe_screen_get_width            (WPEScreen *screen);
+WPE_API int                    wpe_screen_get_height           (WPEScreen *screen);
+WPE_API void                   wpe_screen_set_size             (WPEScreen *screen,
+                                                                int        width,
+                                                                int        height);
+WPE_API int                    wpe_screen_get_physical_width   (WPEScreen *screen);
+WPE_API int                    wpe_screen_get_physical_height  (WPEScreen *screen);
+WPE_API void                   wpe_screen_set_physical_size    (WPEScreen *screen,
+                                                                int        width,
+                                                                int        height);
+WPE_API gdouble                wpe_screen_get_scale            (WPEScreen *screen);
+WPE_API void                   wpe_screen_set_scale            (WPEScreen *screen,
+                                                                gdouble    scale);
+WPE_API int                    wpe_screen_get_refresh_rate     (WPEScreen *screen);
+WPE_API void                   wpe_screen_set_refresh_rate     (WPEScreen *screen,
+                                                                int        refresh_rate);
+WPE_API WPEScreenSyncObserver *wpe_screen_get_sync_observer    (WPEScreen *screen);
 
 G_END_DECLS
 

--- a/Source/WebKit/WPEPlatform/wpe/WPEScreenSyncObserver.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEScreenSyncObserver.cpp
@@ -1,0 +1,151 @@
+/*
+ * Copyright (C) 2025 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WPEScreenSyncObserver.h"
+
+#include <wtf/glib/WTFGType.h>
+
+/**
+ * WPEScreenSyncObserver:
+ *
+ * A screen sync observer.
+ */
+struct _WPEScreenSyncObserverPrivate {
+    gboolean isActive;
+    WPEScreenSyncObserverSyncFunc syncFunc;
+    gpointer userData;
+    GDestroyNotify destroyNotify;
+};
+
+WEBKIT_DEFINE_ABSTRACT_TYPE(WPEScreenSyncObserver, wpe_screen_sync_observer, G_TYPE_OBJECT)
+
+static void wpeScreenSyncObserverDispose(GObject* object)
+{
+    auto* priv = WPE_SCREEN_SYNC_OBSERVER(object)->priv;
+    if (priv->syncFunc) {
+        if (priv->destroyNotify) {
+            priv->destroyNotify(priv->userData);
+            priv->destroyNotify = nullptr;
+        }
+        priv->syncFunc = nullptr;
+        priv->userData = nullptr;
+    }
+
+    G_OBJECT_CLASS(wpe_screen_sync_observer_parent_class)->dispose(object);
+}
+
+static void wpeScreenSyncObserverSync(WPEScreenSyncObserver* observer)
+{
+    auto* priv = observer->priv;
+    priv->syncFunc(observer, priv->userData);
+}
+
+static void wpe_screen_sync_observer_class_init(WPEScreenSyncObserverClass* screenSyncObserverClass)
+{
+    auto* objectClass = G_OBJECT_CLASS(screenSyncObserverClass);
+    objectClass->dispose = wpeScreenSyncObserverDispose;
+
+    screenSyncObserverClass->sync = wpeScreenSyncObserverSync;
+}
+
+/**
+ * wpe_screen_sync_observer_set_callback:
+ * @observer: a #WPEScreenSyncObserver
+ * @sync_func: (scope notified): a #WPEScreenSyncObserverSyncFunc
+ * @user_data: data to pass to @sync_func
+ * @destroy_notify: (nullable): function for freeing @user_data or %NULL.
+ *
+ * Add a @sync_func to be called from a secondary thread when the screen sync is triggered.
+ * The callback must be set only once and before calling wpe_screen_sync_start().
+ */
+void wpe_screen_sync_observer_set_callback(WPEScreenSyncObserver* observer, WPEScreenSyncObserverSyncFunc syncFunc, gpointer userData, GDestroyNotify destroyNotify)
+{
+    g_return_if_fail(WPE_IS_SCREEN_SYNC_OBSERVER(observer));
+    g_return_if_fail(syncFunc);
+
+    auto* priv = observer->priv;
+    g_return_if_fail(!priv->isActive);
+    g_return_if_fail(!priv->syncFunc);
+
+    priv->syncFunc = syncFunc;
+    priv->userData = userData;
+    priv->destroyNotify = destroyNotify;
+}
+
+/**
+ * wpe_screen_sync_observer_start:
+ * @observer: a #WPEScreenSyncObserver
+ *
+ * Start the @observer.
+ */
+void wpe_screen_sync_observer_start(WPEScreenSyncObserver* observer)
+{
+    g_return_if_fail(WPE_IS_SCREEN_SYNC_OBSERVER(observer));
+
+    auto* priv = observer->priv;
+    g_return_if_fail(priv->syncFunc);
+
+    if (priv->isActive)
+        return;
+
+    auto* screenSyncObserverClass = WPE_SCREEN_SYNC_OBSERVER_GET_CLASS(observer);
+    screenSyncObserverClass->start(observer);
+    priv->isActive = TRUE;
+}
+
+/**
+ * wpe_screen_sync_observer_stop:
+ * @observer: a #WPEScreenSyncObserver
+ *
+ * Stop the @observer.
+ */
+void wpe_screen_sync_observer_stop(WPEScreenSyncObserver* observer)
+{
+    g_return_if_fail(WPE_IS_SCREEN_SYNC_OBSERVER(observer));
+
+    auto* priv = observer->priv;
+    if (!priv->isActive)
+        return;
+
+    auto* screenSyncObserverClass = WPE_SCREEN_SYNC_OBSERVER_GET_CLASS(observer);
+    screenSyncObserverClass->stop(observer);
+    priv->isActive = FALSE;
+}
+
+/**
+ * wpe_screen_sync_observer_is_active:
+ * @observer: a #WPEScreenSyncObserver
+ *
+ * Return whether @observer is active.
+ *
+ * Returns: %TRUE if @observer is active, or %FALSE otherwise
+ */
+gboolean wpe_screen_sync_observer_is_active(WPEScreenSyncObserver* observer)
+{
+    g_return_val_if_fail(WPE_IS_SCREEN_SYNC_OBSERVER(observer), FALSE);
+
+    return observer->priv->isActive;
+}

--- a/Source/WebKit/WPEPlatform/wpe/WPEScreenSyncObserver.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPEScreenSyncObserver.h
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2025 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef WPEScreenSyncObserver_h
+#define WPEScreenSyncObserver_h
+
+#if !defined(__WPE_PLATFORM_H_INSIDE__) && !defined(BUILDING_WEBKIT)
+#error "Only <wpe/wpe-platform.h> can be included directly."
+#endif
+
+#include <glib-object.h>
+#include <wpe/WPEDefines.h>
+
+G_BEGIN_DECLS
+
+#define WPE_TYPE_SCREEN_SYNC_OBSERVER (wpe_screen_sync_observer_get_type())
+WPE_API WPE_DECLARE_DERIVABLE_TYPE (WPEScreenSyncObserver, wpe_screen_sync_observer, WPE, SCREEN_SYNC_OBSERVER, GObject)
+
+/**
+ * WPEScreenSyncObserverSyncFunc:
+ * @observer: a #WPEScreenSyncObserver
+ * @user_data: user data
+ *
+ * Function passed to wpe_screen_sync_observer_add() to be called on
+ * every #WPEScreen sync.
+ */
+typedef void (* WPEScreenSyncObserverSyncFunc) (WPEScreenSyncObserver *observer,
+                                                gpointer               user_data);
+
+struct _WPEScreenSyncObserverClass
+{
+    GObjectClass parent_class;
+
+    void (* start) (WPEScreenSyncObserver *observer);
+    void (* stop)  (WPEScreenSyncObserver *observer);
+    void (* sync)  (WPEScreenSyncObserver *observer);
+
+    gpointer padding[32];
+};
+
+WPE_API void     wpe_screen_sync_observer_set_callback (WPEScreenSyncObserver        *observer,
+                                                        WPEScreenSyncObserverSyncFunc sync_func,
+                                                        gpointer                      user_data,
+                                                        GDestroyNotify                destroy_notify);
+WPE_API void     wpe_screen_sync_observer_start        (WPEScreenSyncObserver        *observer);
+WPE_API void     wpe_screen_sync_observer_stop         (WPEScreenSyncObserver        *observer);
+WPE_API gboolean wpe_screen_sync_observer_is_active    (WPEScreenSyncObserver        *observer);
+
+G_END_DECLS
+
+#endif /* WPEScreenSyncObserver_h */

--- a/Source/WebKit/WPEPlatform/wpe/WPEScreenSyncObserverDRM.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEScreenSyncObserverDRM.cpp
@@ -1,0 +1,195 @@
+/*
+ * Copyright (C) 2025 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WPEScreenSyncObserverDRM.h"
+
+#include <chrono>
+#include <errno.h>
+#include <fcntl.h>
+#include <thread>
+#include <wtf/Condition.h>
+#include <wtf/Function.h>
+#include <wtf/Lock.h>
+#include <wtf/RunLoop.h>
+#include <wtf/Threading.h>
+#include <wtf/Vector.h>
+#include <wtf/glib/RunLoopSourcePriority.h>
+#include <wtf/glib/WTFGType.h>
+#include <xf86drm.h>
+
+struct _WPEScreenSyncObserverDRMPrivate;
+
+namespace WTF {
+template<typename T> struct IsDeprecatedTimerSmartPointerException;
+template<> struct IsDeprecatedTimerSmartPointerException<_WPEScreenSyncObserverDRMPrivate> : std::true_type { };
+}
+
+enum class State {
+    Stop,
+    Active,
+    Failed,
+    Invalid
+};
+
+struct _WPEScreenSyncObserverDRMPrivate {
+    _WPEScreenSyncObserverDRMPrivate()
+        : destroyThreadTimer(RunLoop::main(), this, &_WPEScreenSyncObserverDRMPrivate::invalidate)
+    {
+        destroyThreadTimer.setPriority(RunLoopSourcePriority::ReleaseUnusedResourcesTimer);
+    }
+
+    void invalidate()
+    {
+        if (!thread) {
+            state = State::Invalid;
+            return;
+        }
+
+        destroyThreadTimer.stop();
+        {
+            Locker locker { lock };
+            state = State::Invalid;
+            condition.notifyAll();
+        }
+        thread->waitForCompletion();
+        thread = nullptr;
+    }
+
+    UnixFileDescriptor fd;
+    int crtcBitmask;
+
+    RefPtr<Thread> thread;
+    Lock lock;
+    Condition condition;
+    State state;
+    RunLoop::Timer destroyThreadTimer;
+};
+
+WEBKIT_DEFINE_FINAL_TYPE(WPEScreenSyncObserverDRM, wpe_screen_sync_observer_drm, WPE_TYPE_SCREEN_SYNC_OBSERVER, WPEScreenSyncObserver)
+
+static void wpeScreenSyncObserverDRMDispose(GObject* object)
+{
+    auto* priv = WPE_SCREEN_SYNC_OBSERVER_DRM(object)->priv;
+    priv->invalidate();
+
+    G_OBJECT_CLASS(wpe_screen_sync_observer_drm_parent_class)->dispose(object);
+}
+
+static void wpeScreenSyncObserverDRMStart(WPEScreenSyncObserver* observer)
+{
+    auto* priv = WPE_SCREEN_SYNC_OBSERVER_DRM(observer)->priv;
+    Locker locker { priv->lock };
+    if (priv->state != State::Active)
+        priv->state = State::Active;
+
+    priv->destroyThreadTimer.stop();
+    if (!priv->thread) {
+        priv->thread = Thread::create("WPEScreenSyncObserverDRM"_s, [observer] {
+            auto* priv = WPE_SCREEN_SYNC_OBSERVER_DRM(observer)->priv;
+            while (true) {
+                {
+                    Locker locker { priv->lock };
+                    priv->condition.wait(priv->lock, [priv]() -> bool {
+                        return priv->state != State::Stop;
+                    });
+                    if (priv->state == State::Invalid || priv->state == State::Failed)
+                        return;
+                }
+
+                drmVBlank vblank;
+                vblank.request.type = static_cast<drmVBlankSeqType>(DRM_VBLANK_RELATIVE | priv->crtcBitmask);
+                vblank.request.sequence = 1;
+                vblank.request.signal = 0;
+                auto ret = drmWaitVBlank(priv->fd.value(), &vblank);
+                if (!ret || ret == -EPERM) {
+                    if (ret == -EPERM) {
+                        // This can happen when the screen is suspended and the web view hasn't noticed it.
+                        // The display link should be stopped in those cases, but since it isn't, we can at
+                        // least sleep for a while pretending the screen is on.
+                        std::this_thread::sleep_for(std::chrono::milliseconds(500));
+                    }
+
+                    bool isActive;
+                    {
+                        Locker locker { priv->lock };
+                        isActive = priv->state == State::Active;
+                    }
+                    if (isActive)
+                        WPE_SCREEN_SYNC_OBSERVER_CLASS(wpe_screen_sync_observer_drm_parent_class)->sync(observer);
+                } else if (ret) {
+                    drmError(ret, "WPEScreenSyncObserverDRM");
+                    Locker locker { priv->lock };
+                    priv->state = State::Failed;
+                }
+            }
+        }, ThreadType::Graphics, Thread::QOS::Default);
+    } else
+        priv->condition.notifyAll();
+}
+
+static void wpeScreenSyncObserverDRMStop(WPEScreenSyncObserver* observer)
+{
+    auto* priv = WPE_SCREEN_SYNC_OBSERVER_DRM(observer)->priv;
+    Locker locker { priv->lock };
+    priv->state = State::Stop;
+    if (priv->thread)
+        priv->destroyThreadTimer.startOneShot(30_s);
+}
+
+static void wpe_screen_sync_observer_drm_class_init(WPEScreenSyncObserverDRMClass* screenSyncObserverDRMClass)
+{
+    auto* objectClass = G_OBJECT_CLASS(screenSyncObserverDRMClass);
+    objectClass->dispose = wpeScreenSyncObserverDRMDispose;
+
+    auto* screenSyncObserverClass = WPE_SCREEN_SYNC_OBSERVER_CLASS(screenSyncObserverDRMClass);
+    screenSyncObserverClass->start = wpeScreenSyncObserverDRMStart;
+    screenSyncObserverClass->stop = wpeScreenSyncObserverDRMStop;
+}
+
+static int crtcBitmaskForIndex(uint32_t crtcIndex)
+{
+    if (crtcIndex > 1)
+        return ((crtcIndex << DRM_VBLANK_HIGH_CRTC_SHIFT) & DRM_VBLANK_HIGH_CRTC_MASK);
+    if (crtcIndex > 0)
+        return DRM_VBLANK_SECONDARY;
+    return 0;
+}
+
+WPEScreenSyncObserver* wpeScreenSyncObserverDRMCreate(UnixFileDescriptor&& fd, int crtcIndex)
+{
+    auto crtcBitmask = crtcBitmaskForIndex(crtcIndex);
+    drmVBlank vblank;
+    vblank.request.type = static_cast<drmVBlankSeqType>(DRM_VBLANK_RELATIVE | crtcBitmask);
+    vblank.request.sequence = 0;
+    vblank.request.signal = 0;
+    if (drmWaitVBlank(fd.value(), &vblank))
+        return nullptr;
+
+    auto* observer = WPE_SCREEN_SYNC_OBSERVER_DRM(g_object_new(WPE_TYPE_SCREEN_SYNC_OBSERVER_DRM, nullptr));
+    observer->priv->fd = WTFMove(fd);
+    observer->priv->crtcBitmask = crtcBitmask;
+    return WPE_SCREEN_SYNC_OBSERVER(observer);
+}

--- a/Source/WebKit/WPEPlatform/wpe/WPEScreenSyncObserverDRM.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPEScreenSyncObserverDRM.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Igalia S.L.
+ * Copyright (C) 2025 Igalia S.L.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -22,40 +22,18 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-#ifndef __WPE_PLATFORM_H__
-#define __WPE_PLATFORM_H__
 
-#define __WPE_PLATFORM_H_INSIDE__
+#pragma once
 
-#include <wpe/WPEBuffer.h>
-#include <wpe/WPEBufferDMABuf.h>
-#include <wpe/WPEBufferDMABufFormats.h>
-#include <wpe/WPEBufferSHM.h>
-#include <wpe/WPEClipboard.h>
-#include <wpe/WPEColor.h>
-#include <wpe/WPEConfig.h>
-#include <wpe/WPEDefines.h>
-#include <wpe/WPEDisplay.h>
-#include <wpe/WPEEGLError.h>
-#include <wpe/WPEEnumTypes.h>
-#include <wpe/WPEEvent.h>
-#include <wpe/WPEGamepad.h>
-#include <wpe/WPEGamepadManager.h>
-#include <wpe/WPEGestureController.h>
-#include <wpe/WPEInputMethodContext.h>
-#include <wpe/WPEKeymap.h>
-#include <wpe/WPEKeyUnicode.h>
-#include <wpe/WPEKeymapXKB.h>
-#include <wpe/WPEKeysyms.h>
-#include <wpe/WPEKeysyms.h>
-#include <wpe/WPERectangle.h>
-#include <wpe/WPEScreen.h>
-#include <wpe/WPEScreenSyncObserver.h>
-#include <wpe/WPEToplevel.h>
-#include <wpe/WPEVersion.h>
-#include <wpe/WPEView.h>
-#include <wpe/WPEViewAccessible.h>
+#include <glib-object.h>
+#include <wpe/wpe-platform.h>
+#include <wtf/unix/UnixFileDescriptor.h>
 
-#undef __WPE_PLATFORM_H_INSIDE__
+G_BEGIN_DECLS
 
-#endif /* __WPE_PLATFORM_H__ */
+#define WPE_TYPE_SCREEN_SYNC_OBSERVER_DRM (wpe_screen_sync_observer_drm_get_type())
+G_DECLARE_FINAL_TYPE(WPEScreenSyncObserverDRM, wpe_screen_sync_observer_drm, WPE, SCREEN_SYNC_OBSERVER_DRM, WPEScreenSyncObserver)
+
+WPEScreenSyncObserver* wpeScreenSyncObserverDRMCreate(WTF::UnixFileDescriptor&&, int crtcIndex);
+
+G_END_DECLS

--- a/Source/WebKit/WPEPlatform/wpe/drm/WPEScreenDRM.h
+++ b/Source/WebKit/WPEPlatform/wpe/drm/WPEScreenDRM.h
@@ -38,8 +38,6 @@ G_BEGIN_DECLS
 #define WPE_TYPE_SCREEN_DRM (wpe_screen_drm_get_type())
 WPE_API G_DECLARE_FINAL_TYPE (WPEScreenDRM, wpe_screen_drm, WPE, SCREEN_DRM, WPEScreen)
 
-WPE_API guint wpe_screen_drm_get_crtc_index(WPEScreenDRM *screen);
-
 G_END_DECLS
 
 #endif /* WPEScreenDRM_h */

--- a/Source/WebKit/WPEPlatform/wpe/wayland/WPEScreenWayland.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/WPEScreenWayland.cpp
@@ -28,6 +28,16 @@
 
 #include <wtf/glib/WTFGType.h>
 
+#if USE(LIBDRM)
+#include "WPEScreenSyncObserverDRM.h"
+#include <errno.h>
+#include <fcntl.h>
+#include <optional>
+#include <wtf/glib/GRefPtr.h>
+#include <xf86drm.h>
+#include <xf86drmMode.h>
+#endif
+
 /**
  * WPEScreenWayland:
  *
@@ -41,12 +51,19 @@ struct _WPEScreenWaylandPrivate {
         int height;
         int scale;
     } pendingScreenUpdate;
+
+#if USE(LIBDRM)
+    GRefPtr<WPEScreenSyncObserver> syncObserver;
+#endif
 };
 WEBKIT_DEFINE_FINAL_TYPE(WPEScreenWayland, wpe_screen_wayland, WPE_TYPE_SCREEN, WPEScreen)
 
 static void wpeScreenWaylandInvalidate(WPEScreen* screen)
 {
     auto* priv = WPE_SCREEN_WAYLAND(screen)->priv;
+#if USE(LIBDRM)
+    priv->syncObserver = nullptr;
+#endif
     if (priv->wlOutput) {
         if (wl_output_get_version(priv->wlOutput) >= WL_OUTPUT_RELEASE_SINCE_VERSION)
             wl_output_release(priv->wlOutput);
@@ -55,6 +72,80 @@ static void wpeScreenWaylandInvalidate(WPEScreen* screen)
         priv->wlOutput = nullptr;
     }
 }
+
+#if USE(LIBDRM)
+static std::optional<uint32_t> findCrtc(WPEScreen* screen, int fd)
+{
+    drmModeRes* resources = drmModeGetResources(fd);
+    if (!resources)
+        return std::nullopt;
+
+    std::optional<uint32_t> crtcIndex;
+    uint32_t widthMM = wpe_screen_get_physical_width(screen);
+    uint32_t heightMM = wpe_screen_get_physical_height(screen);
+    for (int i = 0; i < resources->count_connectors && !crtcIndex; ++i) {
+        auto* connector = drmModeGetConnector(fd, resources->connectors[i]);
+        if (!connector)
+            continue;
+
+        if (connector->connection != DRM_MODE_CONNECTED || !connector->encoder_id || !connector->count_modes) {
+            drmModeFreeConnector(connector);
+            continue;
+        }
+
+        if (widthMM != connector->mmWidth || heightMM != connector->mmHeight) {
+            drmModeFreeConnector(connector);
+            continue;
+        }
+
+        // FIXME: if there are multiple connectors matching the size, check other properties.
+        if (drmModeEncoder* encoder = drmModeGetEncoder(fd, connector->encoder_id)) {
+            for (int i = 0; i < resources->count_crtcs; ++i) {
+                if (resources->crtcs[i] == encoder->crtc_id) {
+                    crtcIndex = i;
+                    break;
+                }
+            }
+            drmModeFreeEncoder(encoder);
+        }
+        drmModeFreeConnector(connector);
+    }
+    drmModeFreeResources(resources);
+
+    return crtcIndex;
+}
+
+static void wpeScreenWaylandTryEnsureSyncObserver(WPEScreenWayland* screen)
+{
+    drmDevicePtr devices[64];
+    const int devicesNum = drmGetDevices2(0, devices, std::size(devices));
+    if (devicesNum <= 0)
+        return;
+
+    for (int i = 0; i < devicesNum; i++) {
+        if (!(devices[i]->available_nodes & (1 << DRM_NODE_PRIMARY)))
+            continue;
+        auto fd = UnixFileDescriptor { open(devices[i]->nodes[DRM_NODE_PRIMARY], O_RDWR | O_CLOEXEC), UnixFileDescriptor::Adopt };
+        if (!fd)
+            continue;
+
+        if (auto crtcIndex = findCrtc(WPE_SCREEN(screen), fd.value())) {
+            screen->priv->syncObserver = adoptGRef(wpeScreenSyncObserverDRMCreate(WTFMove(fd), *crtcIndex));
+            break;
+        }
+    }
+    drmFreeDevices(devices, devicesNum);
+}
+
+static WPEScreenSyncObserver* wpeScreenWaylandGetSyncObserver(WPEScreen* screen)
+{
+    auto* screenWayland = WPE_SCREEN_WAYLAND(screen);
+    auto* priv = screenWayland->priv;
+    if (!priv->syncObserver)
+        wpeScreenWaylandTryEnsureSyncObserver(screenWayland);
+    return priv->syncObserver.get();
+}
+#endif
 
 static void wpeScreenWaylandDispose(GObject* object)
 {
@@ -70,6 +161,9 @@ static void wpe_screen_wayland_class_init(WPEScreenWaylandClass* screenWaylandCl
 
     WPEScreenClass* screenClass = WPE_SCREEN_CLASS(screenWaylandClass);
     screenClass->invalidate = wpeScreenWaylandInvalidate;
+#if USE(LIBDRM)
+    screenClass->get_sync_observer = wpeScreenWaylandGetSyncObserver;
+#endif
 }
 
 static const struct wl_output_listener outputListener = {


### PR DESCRIPTION
#### e5377cd747134bda1f7d744709dfa19aeec1c0f8
<pre>
[WPE] WPE Platform: add API to provide the VBlank monitor implementation
<a href="https://bugs.webkit.org/show_bug.cgi?id=294386">https://bugs.webkit.org/show_bug.cgi?id=294386</a>

Reviewed by Patrick Griffis.

Add WPEScreenSyncObserver abstract class and a default implementation
WPEScreenSyncObserverDRM when LIBDRM is available. WPEScreen now has
another virtual method to get its sync observer that is implemented by
Wayland and DRM platforms to return a WPEScreenSyncObserverDRM. In the
WebKit side, DisplayVBlankMonitorWPE has been added that uses the new
WPEScreenSyncObserver API. The threading implementation in
DisplayVBlankMonitor has been moved to a new class
DisplayVBlankMonitorThreaded used as parent of DisplayVBlankMonitorDRM
and DisplayVBlankMonitorTimer.

Canonical link: <a href="https://commits.webkit.org/296498@main">https://commits.webkit.org/296498@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/28dec80dad9b56aaf2c25740d94c292c3a95a045

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/107502 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27184 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/17593 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/112718 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/58038 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/27871 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/35685 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/81607 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/110431 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22077 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/96889 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/61991 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/21515 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/57482 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/91445 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15061 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/115818 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/34569 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/25471 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/90640 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/34944 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93144 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/90386 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35300 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13081 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/30324 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17553 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/34490 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/40036 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34236 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/37592 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/35897 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->