### PR TITLE
[GTK] Expose API to report theme color changes

### DIFF
--- a/Source/WebKit/UIProcess/API/glib/WebKitWebView.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebView.h.in
@@ -914,6 +914,12 @@ webkit_web_view_get_theme_color                      (WebKitWebView             
                                                       WebKitColor               *color);
 #endif
 
+#if PLATFORM(GTK)
+WEBKIT_API gboolean
+webkit_web_view_get_theme_color                      (WebKitWebView             *web_view,
+                                                      GdkRGBA                   *rgba);
+#endif
+
 #if USE(GI_FINISH_FUNC_ANNOTATION)
 /**
  * webkit_web_view_run_async_javascript_function_in_world: (finish-func webkit_web_view_run_javascript_in_world_finish)

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebViewPrivate.h
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebViewPrivate.h
@@ -104,6 +104,8 @@ void webkitWebViewPermissionStateQuery(WebKitWebView*, WebKitPermissionStateQuer
 bool webkitWebViewEmitRunColorChooser(WebKitWebView*, WebKitColorChooserRequest*);
 #endif
 
+void webkitWebViewEmitThemeColorChanged(WebKitWebView*);
+
 bool webkitWebViewShowOptionMenu(WebKitWebView*, const WebCore::IntRect&, WebKitOptionMenu*);
 
 gboolean webkitWebViewAuthenticate(WebKitWebView*, WebKitAuthenticationRequest*);

--- a/Source/WebKit/UIProcess/API/gtk/PageClientImpl.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/PageClientImpl.cpp
@@ -561,6 +561,12 @@ void PageClientImpl::didChangeBackgroundColor()
 {
 }
 
+void PageClientImpl::themeColorDidChange()
+{
+    if (WEBKIT_IS_WEB_VIEW(m_viewWidget))
+        webkitWebViewEmitThemeColorChanged(WEBKIT_WEB_VIEW(m_viewWidget));
+}
+
 void PageClientImpl::refView()
 {
     g_object_ref(m_viewWidget);

--- a/Source/WebKit/UIProcess/API/gtk/PageClientImpl.h
+++ b/Source/WebKit/UIProcess/API/gtk/PageClientImpl.h
@@ -154,6 +154,7 @@ private:
     void wheelEventWasNotHandledByWebCore(const NativeWebWheelEvent&) override;
 
     void didChangeBackgroundColor() override;
+    void themeColorDidChange() override;
 
     void refView() override;
     void derefView() override;

--- a/Source/WebKit/UIProcess/API/gtk/WebKitWebViewGtk.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitWebViewGtk.cpp
@@ -471,3 +471,32 @@ void webkit_web_view_get_background_color(WebKitWebView* webView, GdkRGBA* rgba)
     auto& page = *webkitWebViewBaseGetPage(reinterpret_cast<WebKitWebViewBase*>(webView));
     *rgba = page.backgroundColor().value_or(WebCore::Color::white);
 }
+
+/**
+ * webkit_web_view_get_theme_color:
+ * @web_view: a #WebKitWebView
+ * @rgba: (out): a #GdkRGBA to fill in with the theme color
+ *
+ * Gets the theme color that is specified by the content in the @web_view.
+ * If the @web_view doesn't have a theme color it will fill the @rgba
+ * with transparent black content.
+ *
+ * Returns: Whether the currently loaded page defines a theme color.
+ *
+ * Since: 2.50
+ */
+gboolean webkit_web_view_get_theme_color(WebKitWebView* webView, GdkRGBA* rgba)
+{
+    g_return_val_if_fail(WEBKIT_IS_WEB_VIEW(webView), FALSE);
+    g_return_val_if_fail(rgba, FALSE);
+
+    auto& page = webkitWebViewGetPage(webView);
+
+    if (!page.themeColor().isValid()) {
+        *rgba = static_cast<WebCore::Color>(WebCore::Color::transparentBlack);
+        return FALSE;
+    }
+
+    *rgba = page.themeColor();
+    return TRUE;
+}

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -87,7 +87,7 @@ messages -> WebPageProxy {
     DidChangeScrollbarsForMainFrame(bool hasHorizontalScrollbar, bool hasVerticalScrollbar)
     DidChangeScrollOffsetPinningForMainFrame(WebCore::RectEdges<bool> pinnedState)
     DidChangePageCount(unsigned pageCount)
-#if PLATFORM(MAC) || PLATFORM(WPE)
+#if PLATFORM(MAC) || PLATFORM(WPE) || PLATFORM(GTK)
     ThemeColorChanged(WebCore::Color themeColor)
 #endif
 #if ENABLE(WEB_PAGE_SPATIAL_BACKDROP)

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
@@ -186,7 +186,7 @@ void LayerTreeHost::flushLayers()
     page->updateRendering();
     page->flushPendingEditorStateUpdate();
 
-#if PLATFORM(WPE)
+#if PLATFORM(WPE) || PLATFORM(GTK)
     page->flushPendingThemeColorChange();
 #endif
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -8125,7 +8125,7 @@ void WebPage::getInformationFromImageData(const Vector<uint8_t>& data, Completio
 }
 #endif
 
-#if PLATFORM(MAC) || PLATFORM(WPE)
+#if PLATFORM(MAC) || PLATFORM(WPE) || PLATFORM(GTK)
 void WebPage::flushPendingThemeColorChange()
 {
     if (!m_pendingThemeColorChange)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1594,7 +1594,7 @@ public:
 #endif
 
     void themeColorChanged() { m_pendingThemeColorChange = true; }
-#if PLATFORM(MAC) || PLATFORM(WPE)
+#if PLATFORM(MAC) || PLATFORM(WPE) || PLATFORM(GTK)
     void flushPendingThemeColorChange();
 #endif
 

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitWebView.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitWebView.cpp
@@ -1636,7 +1636,6 @@ static void testWebViewBackgroundColor(WebViewTest* test, gconstpointer)
     // MiniBrowser --bg-color="<color-value>" for manually testing this API.
 }
 
-#if PLATFORM(WPE)
 class ThemeColorWebViewTest : public WebViewTest {
 public:
     MAKE_GLIB_TEST_FIXTURE(ThemeColorWebViewTest);
@@ -1649,7 +1648,7 @@ public:
 
     void testThemeColorResult()
     {
-        WebKitColor rgba;
+        ColorType rgba;
         g_assert_true(webkit_web_view_get_theme_color(m_webView.get(), &rgba));
         g_assert_cmpfloat(rgba.red, ==, targetColor.red);
         g_assert_cmpfloat(rgba.green, ==, targetColor.green);
@@ -1663,23 +1662,23 @@ public:
         g_main_loop_run(m_mainLoop);
     }
 
-    WebKitColor targetColor { 0.0, 0.0, 0.0, 0.0 };
+    ColorType targetColor { 0.0, 0.0, 0.0, 0.0 };
 };
 
 static void testWebViewThemeColor(ThemeColorWebViewTest* test, gconstpointer)
 {
-    WebKitColor rgba;
+    ColorType rgba;
 
     test->showInWindow();
 
     g_assert_false(webkit_web_view_get_theme_color(test->m_webView.get(), &rgba));
 
-    test->targetColor = WebKitColor(1.0, 0.0, 0.0, 1.0);
+    test->targetColor = ColorType(1.0, 0.0, 0.0, 1.0);
     test->loadHtml("<html style='width: 325px; height: 615px'><meta name='theme-color' content='#FF0000' /></html>", nullptr);
     test->waitUntilThemeColorChanged();
     test->testThemeColorResult();
 
-    test->targetColor = WebKitColor(0.0, 1.0, 0.0, 1.0);
+    test->targetColor = ColorType(0.0, 1.0, 0.0, 1.0);
     test->loadHtml("<html style='width: 325px; height: 615px'><meta name='theme-color' content='#00FF00' /></html>", nullptr);
     test->waitUntilThemeColorChanged();
     test->testThemeColorResult();
@@ -1688,7 +1687,6 @@ static void testWebViewThemeColor(ThemeColorWebViewTest* test, gconstpointer)
     test->waitUntilThemeColorChanged();
     g_assert_false(webkit_web_view_get_theme_color(test->m_webView.get(), &rgba));
 }
-#endif
 
 #if PLATFORM(GTK)
 static void testWebViewPreferredSize(WebViewTest* test, gconstpointer)
@@ -2178,9 +2176,7 @@ void beforeAll()
 #endif
     IsPlayingAudioWebViewTest::add("WebKitWebView", "is-playing-audio", testWebViewIsPlayingAudio);
     WebViewTest::add("WebKitWebView", "background-color", testWebViewBackgroundColor);
-#if PLATFORM(WPE)
     ThemeColorWebViewTest::add("WebKitWebView", "theme-color", testWebViewThemeColor);
-#endif
 #if PLATFORM(GTK)
     WebViewTest::add("WebKitWebView", "preferred-size", testWebViewPreferredSize);
 #if !USE(GTK4)


### PR DESCRIPTION
#### 4d7bd43827f50574456c8b329adabde9930411d6
<pre>
[GTK] Expose API to report theme color changes
<a href="https://bugs.webkit.org/show_bug.cgi?id=294389">https://bugs.webkit.org/show_bug.cgi?id=294389</a>

Reviewed by Carlos Garcia Campos.

Enable the WebKitWebView:theme-color property for the GTK port, based on
the implementation added for WPE in 296035@main. This mainly involved
removing PLATFORM(WPE) guards or adding PLATFORM(GTK) ones in code
common for both ports, and keeping some of the guards to use GdkRGBA
instead of WebKitColor to represent colors in the public API. The
existing test case is enabled for the GTK port, using the ColorType
alias type (which maps to GdkRGBA or WebKitColor depending on the port).
A small webkitWebViewEmitThemeColorChanged() private helper function was
also added, then changed the WPE port to make both ports use it.

Canonical link: <a href="https://commits.webkit.org/296160@main">https://commits.webkit.org/296160@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/41df1c86356a63577abf91bfa9072b451e3d6a0e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/107510 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27192 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/17601 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/112726 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/58046 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/109474 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/27880 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/35693 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/81615 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/110439 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22085 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/96896 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/61999 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/21523 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/15036 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/57490 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/91453 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15068 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/115826 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/34577 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/25501 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/90651 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/34952 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93151 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/90397 "Passed tests") | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23047 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/rotated-cat-off-top-edge.html (failure)") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35313 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13088 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/30334 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17395 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/34498 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/40063 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34245 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/37600 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/35905 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->