### PR TITLE
Add support for running a local DNS resolver for WPT

### DIFF
--- a/Source/WebCore/PAL/pal/spi/cocoa/NetworkSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/NetworkSPI.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -32,6 +32,11 @@ DECLARE_SYSTEM_HEADER
 #if USE(APPLE_INTERNAL_SDK)
 
 #import <nw/private.h>
+
+#if PLATFORM(MAC) && defined(__OBJC__)
+// Only needed for running tests.
+#import <NetworkExtension/NEPolicySession.h>
+#endif
 
 #else
 
@@ -75,5 +80,53 @@ const char* nw_webtransport_metadata_get_session_error_message(nw_protocol_metad
 void nw_webtransport_metadata_set_session_error_message(nw_protocol_metadata_t, const char*);
 
 WTF_EXTERN_C_END
+
+// ------------------------------------------------------------
+// The following declarations are only needed for running tests.
+
+WTF_EXTERN_C_BEGIN
+
+typedef enum {
+    nw_resolver_protocol_dns53 = 0,
+} nw_resolver_protocol_t;
+
+typedef enum {
+    nw_resolver_class_designated_direct = 2,
+} nw_resolver_class_t;
+
+nw_resolver_config_t nw_resolver_config_create(void);
+void nw_resolver_config_set_protocol(nw_resolver_config_t, nw_resolver_protocol_t);
+void nw_resolver_config_set_class(nw_resolver_config_t, nw_resolver_class_t);
+void nw_resolver_config_add_match_domain(nw_resolver_config_t, const char *);
+void nw_resolver_config_add_name_server(nw_resolver_config_t, const char *name_server);
+void nw_resolver_config_set_identifier(nw_resolver_config_t, const uuid_t identifier);
+bool nw_resolver_config_publish(nw_resolver_config_t);
+
+WTF_EXTERN_C_END
+
+#if defined(__OBJC__)
+typedef NS_ENUM(NSInteger, NEPolicySessionPriority) {
+    NEPolicySessionPriorityHigh = 300,
+};
+
+@interface NEPolicyCondition : NSObject
++ (NEPolicyCondition *)domain:(NSString *)domain;
+@end
+
+@interface NEPolicyResult : NSObject
++ (NEPolicyResult *)netAgentUUID:(NSUUID *)agentUUID;
+@end
+
+@interface NEPolicy : NSObject
+- (instancetype)initWithOrder:(uint32_t)order result:(NEPolicyResult *)result conditions:(NSArray<NEPolicyCondition *> *)conditions;
+@end
+
+@interface NEPolicySession : NSObject
+@property NEPolicySessionPriority priority;
+- (NSUInteger)addPolicy:(NEPolicy *)policy;
+- (BOOL)apply;
+@end
+#endif // defined(__OBJC__)
+// ------------------------------------------------------------
 
 #endif // USE(APPLE_INTERNAL_SDK)

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkProcessCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkProcessCocoa.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2014-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -59,6 +59,8 @@
 #import "WKProcessExtension.h"
 #endif
 
+#import <pal/spi/cocoa/NetworkSPI.h>
+
 namespace WebKit {
 
 static void initializeNetworkSettings()
@@ -116,6 +118,18 @@ void NetworkProcess::platformInitializeNetworkProcessCocoa(const NetworkProcessC
         [NEFilterSource setDelegation:&auditToken.value()];
 #endif
     m_enableModernDownloadProgress = parameters.enableModernDownloadProgress;
+
+#if PLATFORM(IOS_FAMILY)
+    // See TestController::cocoaPlatformInitialize for supporting a local DNS resolver on Mac.
+    if (!parameters.localhostAliasesForTesting.isEmpty()) {
+        nw_resolver_config_t resolverConfig = nw_resolver_config_create();
+        nw_resolver_config_set_protocol(resolverConfig, nw_resolver_protocol_dns53);
+        nw_resolver_config_set_class(resolverConfig, nw_resolver_class_designated_direct);
+        nw_resolver_config_add_name_server(resolverConfig, "127.0.0.1:8053");
+        nw_resolver_config_add_match_domain(resolverConfig, "test");
+        nw_privacy_context_require_encrypted_name_resolution(NW_DEFAULT_PRIVACY_CONTEXT, true, resolverConfig);
+    }
+#endif
 }
 
 RetainPtr<CFDataRef> NetworkProcess::sourceApplicationAuditData() const

--- a/Tools/Scripts/webkitpy/__init__.py
+++ b/Tools/Scripts/webkitpy/__init__.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2008-2020 Andrey Petrov and contributors.
-# Copyright (C) 2023 Apple Inc. All rights reserved.
+# Copyright (C) 2023-2025 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are
@@ -78,6 +78,7 @@ AutoInstall.register(Package('bs4', Version(4, 12, 0), pypi_name='beautifulsoup4
 AutoInstall.register(Package('configparser', Version(4, 0, 2), implicit_deps=['pyparsing'], aliases=['backports.configparser']))
 AutoInstall.register(Package('contextlib2', Version(0, 6, 0)))
 AutoInstall.register(Package('coverage', Version(7, 6, 1), wheel=True))
+AutoInstall.register(Package('dnslib', Version(0, 9, 26)))
 AutoInstall.register(Package('funcsigs', Version(1, 0, 2)))
 AutoInstall.register(Package('html5lib', Version(1, 1)))
 AutoInstall.register(Package('iniconfig', Version(1, 1, 1)))

--- a/Tools/Scripts/webkitpy/layout_tests/run_webkit_tests.py
+++ b/Tools/Scripts/webkitpy/layout_tests/run_webkit_tests.py
@@ -1,6 +1,6 @@
 # Copyright (C) 2010 Google Inc. All rights reserved.
 # Copyright (C) 2010 Gabor Rapcsanyi (rgabor@inf.u-szeged.hu), University of Szeged
-# Copyright (C) 2011, 2016, 2019 Apple Inc. All rights reserved.
+# Copyright (C) 2011-2025 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are
@@ -378,6 +378,7 @@ def parse_args(args):
     option_group_definitions.append(("Web Platform Test Server Options", [
         optparse.make_option("--disable-wpt-hostname-aliases", action="store_true", default=False, help="Disable running tests from WPT against the web-platform.test domain, if the port supports it."),
         optparse.make_option("--wptserver-doc-root", type="string", help=("Set web platform server document root, relative to LayoutTests directory")),
+        optparse.make_option("--local-dns-resolver", action="store_true", default=False, help="Run and use a local DNS resolver, if the port supports it.")
     ]))
 
     option_group_definitions.append(('Upload Options', upload_options()))

--- a/Tools/Scripts/webkitpy/layout_tests/servers/basic_dns_server.py
+++ b/Tools/Scripts/webkitpy/layout_tests/servers/basic_dns_server.py
@@ -1,0 +1,57 @@
+# Copyright (C) 2023-2025 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from dnslib import CLASS, QTYPE, RR, RCODE
+from dnslib.server import BaseResolver, DNSServer
+import logging
+from threading import Thread
+
+_log = logging.getLogger(__name__)
+
+
+class Resolver(BaseResolver):
+    def __init__(self, allowed_hosts=[]):
+        super().__init__()
+        self.hosts = list(map(lambda x: x if x.endswith(".") else x + ".", allowed_hosts))
+        _log.debug("Initializing Resolver with hosts: {}".format(self.hosts))
+
+    def resolve(self, request, handler):
+        question = request.q
+        reply = request.reply()
+        _log.debug("Received request for {}".format(question.qname))
+        if question.qtype == QTYPE.A and (question.qname in self.hosts or question.qname.matchSuffix("localhost")):
+            reply.add_answer(*RR.fromZone("{} 3600 A 127.0.0.1".format(question.qname)))
+        else:
+            reply.header.rcode = getattr(RCODE, "NXDOMAIN")
+        return reply
+
+
+if __name__ == "__main__":
+    # This script is not intended to be run on its own, and should only be used for testing purposes.
+    server = DNSServer(Resolver(["site.example"]), port=8053, address="127.0.0.1")
+    server.start_thread()
+    try:
+        Thread.join()
+    except Exception:
+        pass
+    finally:
+        server.stop()

--- a/Tools/Scripts/webkitpy/layout_tests/servers/web_platform_test_server.py
+++ b/Tools/Scripts/webkitpy/layout_tests/servers/web_platform_test_server.py
@@ -1,4 +1,4 @@
-#  Copyright (c) 2014, Canon Inc. All rights reserved.
+#  Copyright (c) 2014 Canon Inc. All rights reserved.
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions
 #  are met:
@@ -27,6 +27,7 @@ import sys
 import time
 
 from webkitpy.layout_tests.servers import http_server_base
+from webkitpy.layout_tests.servers.basic_dns_server import DNSServer, Resolver
 
 _log = logging.getLogger(__name__)
 
@@ -127,6 +128,11 @@ class WebPlatformTestServer(http_server_base.HttpServerBase):
         self._output_log_path = None
         self._wsout = None
         self._process = None
+        self._dns_server = None
+        if port_obj.supports_localhost_aliases and port_obj.get_option('local_dns_resolver') and not port_obj.get_option('disable_wpt_hostname_aliases'):
+            self._dns_server = DNSServer(Resolver(
+                allowed_hosts=port_obj.localhost_aliases()), port=8053, address="127.0.0.1")
+
         self._pid_file = pidfile
         if not self._pid_file:
             self._pid_file = self._filesystem.join(self._runtime_path, '%s.pid' % self._name)
@@ -178,6 +184,9 @@ class WebPlatformTestServer(http_server_base.HttpServerBase):
         self._process = self._executive.popen(self._start_cmd, cwd=self._doc_root_path, shell=False, stdin=self._executive.PIPE, stdout=self._wsout, stderr=self._wsout)
         self._filesystem.write_text_file(self._pid_file, str(self._process.pid))
 
+        if self._dns_server:
+            self._dns_server.start_thread()
+
         # Wait a second for the server to actually start so that tests do not start until server is running.
         time.sleep(1)
 
@@ -201,6 +210,9 @@ class WebPlatformTestServer(http_server_base.HttpServerBase):
         if self._wsout:
             self._wsout.close()
             self._wsout = None
+
+        if self._dns_server and hasattr(self._dns_server, "thread") and self._dns_server.isAlive():
+            self._dns_server.stop()
 
         if self._process is not None:
             self._process.poll()

--- a/Tools/Scripts/webkitpy/port/apple.py
+++ b/Tools/Scripts/webkitpy/port/apple.py
@@ -83,6 +83,7 @@ class ApplePort(Port):
 
         port_name = port_name.replace('-wk2', '')
         self._version = self._strip_port_name_prefix(port_name)
+        self.supports_localhost_aliases = False
 
     def setup_test_run(self, device_type=None):
         self._crash_logs_to_skip_for_host[self.host] = self.host.filesystem.files_under(self.path_to_crash_logs())

--- a/Tools/Scripts/webkitpy/port/driver.py
+++ b/Tools/Scripts/webkitpy/port/driver.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2011 Google Inc. All rights reserved.
-# Copyright (c) 2015-2019 Apple Inc. All rights reserved.
+# Copyright (c) 2015-2025 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are
@@ -582,6 +582,8 @@ class Driver(object):
             cmd.append('--show-window')
         if self._port.get_option('accessibility_isolated_tree'):
             cmd.append('--accessibility-isolated-tree')
+        if self._port.get_option('local_dns_resolver'):
+            cmd.append('--local-dns-resolver')
 
         for allowed_host in self._port.allowed_hosts():
             cmd.append('--allowed-host')

--- a/Tools/Scripts/webkitpy/port/test.py
+++ b/Tools/Scripts/webkitpy/port/test.py
@@ -30,7 +30,8 @@ import time
 
 from webkitcorepy import string_utils
 
-from webkitpy.port import Port, Driver, DriverOutput
+from webkitpy.port.base import Port
+from webkitpy.port.driver import Driver, DriverOutput
 from webkitpy.layout_tests.models.test_configuration import TestConfiguration
 from webkitpy.common.system.crashlogs import CrashLogs
 from webkitpy.common.version_name_map import PUBLIC_TABLE, VersionNameMap

--- a/Tools/WebKitTestRunner/Configurations/WebKitTestRunner-internal.entitlements
+++ b/Tools/WebKitTestRunner/Configurations/WebKitTestRunner-internal.entitlements
@@ -8,6 +8,12 @@
 	</array>
 	<key>com.apple.private.webkit.adattributiond.testing</key>
 	<true/>
+	<key>com.apple.private.nehelper.privileged</key>
+	<true/>
+	<key>com.apple.private.neagent</key>
+	<true/>
+	<key>com.apple.networkd.persistent_interface</key>
+	<true/>
 	<key>com.apple.security.temporary-exception.sbpl</key>
 	<array>
 		<string>(allow mach-issue-extension (require-all (extension-class &quot;com.apple.webkit.extension.mach&quot;)))</string>

--- a/Tools/WebKitTestRunner/Options.cpp
+++ b/Tools/WebKitTestRunner/Options.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2013 University of Szeged. All rights reserved.
  * Copyright (C) 2013 Samsung Electronics. All rights reserved.
- * Copyright (C) 2015-2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -192,6 +192,12 @@ static bool handleOptionWPELegacyAPI(Options& options, const char*, const char*)
 }
 #endif
 
+static bool handleOptionLocalDNSResolver(Options& options, const char*, const char*)
+{
+    options.useLocalDNSResolver = true;
+    return true;
+}
+
 static bool handleOptionUnmatched(Options& options, const char* option, const char*)
 {
     if (option[0] && option[1] && option[0] == '-' && option[1] == '-')
@@ -232,6 +238,7 @@ OptionsHandler::OptionsHandler(Options& o)
 #if PLATFORM(WPE)
     optionList.append(Option("--wpe-legacy-api", "Use the WPE legacy API (libwpe)", handleOptionWPELegacyAPI));
 #endif
+    optionList.append(Option("--local-dns-resolver", "Enable using a local DNS resolver, if the port supports it", handleOptionLocalDNSResolver));
 
     optionList.append(Option(0, 0, handleOptionUnmatched));
 }

--- a/Tools/WebKitTestRunner/Options.h
+++ b/Tools/WebKitTestRunner/Options.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2013 University of Szeged. All rights reserved.
  * Copyright (C) 2013 Samsung Electronics. All rights reserved.
- * Copyright (C) 2015-2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -54,6 +54,7 @@ struct Options {
 #if PLATFORM(WPE)
     bool useWPELegacyAPI { false };
 #endif
+    bool useLocalDNSResolver { false };
     std::vector<std::string> paths;
     std::set<std::string> allowedHosts;
     std::set<std::string> localhostAliases;

--- a/Tools/WebKitTestRunner/TestController.h
+++ b/Tools/WebKitTestRunner/TestController.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2010-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -495,6 +495,9 @@ private:
 
 #if PLATFORM(COCOA)
     void cocoaPlatformInitialize(const Options&);
+#if PLATFORM(MAC)
+    void cocoaDNSInitialize();
+#endif
     void cocoaResetStateToConsistentValues(const TestOptions&);
     void setApplicationBundleIdentifier(const std::string&);
     void clearApplicationBundleIdentifierTestingOverride();

--- a/Tools/WebKitTestRunner/WebKitTestRunner.xcodeproj/project.pbxproj
+++ b/Tools/WebKitTestRunner/WebKitTestRunner.xcodeproj/project.pbxproj
@@ -160,6 +160,9 @@
 		BCC997A411D3C8F60017BCA2 /* InjectedBundle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BCC997A011D3C8F60017BCA2 /* InjectedBundle.cpp */; };
 		BCC997A511D3C8F60017BCA2 /* InjectedBundlePage.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BCC997A211D3C8F60017BCA2 /* InjectedBundlePage.cpp */; };
 		C0CE720B1247C93300BC0EC4 /* TestRunnerMac.mm in Sources */ = {isa = PBXBuildFile; fileRef = C0CE720A1247C93300BC0EC4 /* TestRunnerMac.mm */; };
+		D2D99AEE2A9EF3F500000BBF /* Network.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D2D99AED2A9EF3F500000BBF /* Network.framework */; };
+		D2D99AF72AA21E6800000BBF /* NetworkExtension.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D2D99AF62AA21E6800000BBF /* NetworkExtension.framework */; platformFilters = (maccatalyst, macos, ); };
+		D2D99AFC2AA27BA800000BBF /* Network.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D2D99AED2A9EF3F500000BBF /* Network.framework */; };
 		DD4671AE2A6B136200E49DBD /* WebCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DD4671AD2A6B136200E49DBD /* WebCore.framework */; };
 		E132AA3A17CD5F1000611DF0 /* WebKitTestRunnerDraggingInfo.mm in Sources */ = {isa = PBXBuildFile; fileRef = E132AA3817CD5F1000611DF0 /* WebKitTestRunnerDraggingInfo.mm */; };
 		E132AA3D17CE776F00611DF0 /* WebKitTestRunnerEvent.mm in Sources */ = {isa = PBXBuildFile; fileRef = E132AA3B17CE776F00611DF0 /* WebKitTestRunnerEvent.mm */; };
@@ -486,6 +489,8 @@
 		BCD7D2F711921278006DB7EE /* TestInvocation.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TestInvocation.cpp; sourceTree = "<group>"; };
 		BCDA2B991191051F00C3BC47 /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = JavaScriptCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C0CE720A1247C93300BC0EC4 /* TestRunnerMac.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = TestRunnerMac.mm; path = mac/TestRunnerMac.mm; sourceTree = "<group>"; };
+		D2D99AED2A9EF3F500000BBF /* Network.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Network.framework; path = System/Library/PrivateFrameworks/Network.framework; sourceTree = SDKROOT; };
+		D2D99AF62AA21E6800000BBF /* NetworkExtension.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = NetworkExtension.framework; path = System/Library/Frameworks/NetworkExtension.framework; sourceTree = SDKROOT; };
 		DD4671AD2A6B136200E49DBD /* WebCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = WebCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E132AA3817CD5F1000611DF0 /* WebKitTestRunnerDraggingInfo.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebKitTestRunnerDraggingInfo.mm; sourceTree = "<group>"; };
 		E132AA3917CD5F1000611DF0 /* WebKitTestRunnerDraggingInfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebKitTestRunnerDraggingInfo.h; sourceTree = "<group>"; };
@@ -524,6 +529,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D2D99AFC2AA27BA800000BBF /* Network.framework in Frameworks */,
 				57A0062F22976EF800AD08BD /* Security.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -533,6 +539,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				51058AD51D678820009A538C /* libWebCoreTestSupport.dylib in Frameworks */,
+				D2D99AEE2A9EF3F500000BBF /* Network.framework in Frameworks */,
+				D2D99AF72AA21E6800000BBF /* NetworkExtension.framework in Frameworks */,
 				57A0062E22976EEB00AD08BD /* Security.framework in Frameworks */,
 				DD4671AE2A6B136200E49DBD /* WebCore.framework in Frameworks */,
 				51058AD61D678825009A538C /* WebKit.framework in Frameworks */,
@@ -814,6 +822,8 @@
 				2EE52CE41890A9A80010ED21 /* CoreGraphics.framework */,
 				2EE52CE21890A9A80010ED21 /* Foundation.framework */,
 				0F73B5571BA7929E004B3EF4 /* JavaScriptCore.framework */,
+				D2D99AED2A9EF3F500000BBF /* Network.framework */,
+				D2D99AF62AA21E6800000BBF /* NetworkExtension.framework */,
 				570E75A42152DA2C00324B6E /* Security.framework */,
 				DD4671AD2A6B136200E49DBD /* WebCore.framework */,
 			);
@@ -1515,6 +1525,10 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = A18510381B9ADF2200744AEB /* WebKitTestRunner.xcconfig */;
 			buildSettings = {
+				SYSTEM_FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SDKROOT)$(SYSTEM_LIBRARY_DIR)/PrivateFrameworks",
+				);
 			};
 			name = Debug;
 		};
@@ -1522,6 +1536,10 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = A18510381B9ADF2200744AEB /* WebKitTestRunner.xcconfig */;
 			buildSettings = {
+				SYSTEM_FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SDKROOT)$(SYSTEM_LIBRARY_DIR)/PrivateFrameworks",
+				);
 			};
 			name = Release;
 		};
@@ -1548,6 +1566,10 @@
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				INFOPLIST_FILE = "WebKitTestRunnerApp/WebKitTestRunnerApp-Info.plist";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SYSTEM_FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SDKROOT)$(SYSTEM_LIBRARY_DIR)/PrivateFrameworks",
+				);
 				WRAPPER_EXTENSION = app;
 			};
 			name = Debug;
@@ -1559,6 +1581,10 @@
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
 				INFOPLIST_FILE = "WebKitTestRunnerApp/WebKitTestRunnerApp-Info.plist";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SYSTEM_FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SDKROOT)$(SYSTEM_LIBRARY_DIR)/PrivateFrameworks",
+				);
 				WRAPPER_EXTENSION = app;
 			};
 			name = Release;
@@ -1570,6 +1596,10 @@
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
 				INFOPLIST_FILE = "WebKitTestRunnerApp/WebKitTestRunnerApp-Info.plist";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SYSTEM_FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SDKROOT)$(SYSTEM_LIBRARY_DIR)/PrivateFrameworks",
+				);
 				WRAPPER_EXTENSION = app;
 			};
 			name = Production;
@@ -1668,6 +1698,10 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = A18510381B9ADF2200744AEB /* WebKitTestRunner.xcconfig */;
 			buildSettings = {
+				SYSTEM_FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SDKROOT)$(SYSTEM_LIBRARY_DIR)/PrivateFrameworks",
+				);
 			};
 			name = Production;
 		};

--- a/Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm
+++ b/Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm
@@ -36,6 +36,7 @@
 #import "TestWebsiteDataStoreDelegate.h"
 #import "WebCoreTestSupport.h"
 #import <Foundation/Foundation.h>
+#import <Network/Network.h>
 #import <Security/SecItem.h>
 #import <WebKit/WKContentRuleListStorePrivate.h>
 #import <WebKit/WKContextConfigurationRef.h>
@@ -59,6 +60,7 @@
 #import <WebKit/_WKApplicationManifest.h>
 #import <WebKit/_WKWebsiteDataStoreConfiguration.h>
 #import <pal/spi/cocoa/LaunchServicesSPI.h>
+#import <pal/spi/cocoa/NetworkSPI.h>
 #import <wtf/BlockPtr.h>
 #import <wtf/CompletionHandler.h>
 #import <wtf/MainThread.h>
@@ -232,7 +234,51 @@ void TestController::cocoaPlatformInitialize(const Options& options)
 #if ENABLE(DATA_DETECTION)
     m_appStoreURLSwizzler = makeUnique<InstanceMethodSwizzler>(NSURL.class, @selector(iTunesStoreURL), reinterpret_cast<IMP>(swizzledAppStoreURL));
 #endif
+
+#if PLATFORM(MAC)
+    // See NetworkProcess::platformInitializeNetworkProcessCocoa for supporting a local DNS resolver on iOS.
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{
+        if (!options.useLocalDNSResolver)
+            return;
+        cocoaDNSInitialize();
+    });
+#endif
 }
+
+#if PLATFORM(MAC)
+void TestController::cocoaDNSInitialize()
+{
+    auto agentUUID = adoptNS([[NSUUID alloc] init]);
+    uuid_t agentUUIDBytes;
+    [agentUUID.get() getUUIDBytes:agentUUIDBytes];
+    NSLog(@"useLocalDNSResolver: agent UUID: %@.", agentUUID.get());
+
+    static nw_resolver_config_t resolverConfig = nw_resolver_config_create();
+    nw_resolver_config_set_protocol(resolverConfig, nw_resolver_protocol_dns53);
+    nw_resolver_config_set_class(resolverConfig, nw_resolver_class_designated_direct);
+    nw_resolver_config_add_name_server(resolverConfig, "127.0.0.1:8053");
+    nw_resolver_config_add_match_domain(resolverConfig, "test");
+    nw_resolver_config_set_identifier(resolverConfig, agentUUIDBytes);
+    bool published = nw_resolver_config_publish(resolverConfig);
+    if (!published) {
+        NSLog(@"Failed to register DNS resolver agent UUID: %@. Using local DNS resolver failed.", agentUUID.get());
+        return;
+    }
+
+    // The following NetworkExtension policy is needed so we can run tests while a VPN is connected
+    RetainPtr policySession = adoptNS([[NEPolicySession alloc] init]);
+    RetainPtr domainPolicy = adoptNS([[NEPolicy alloc] initWithOrder:1 result:[NEPolicyResult netAgentUUID:agentUUID.get()] conditions:@[ [NEPolicyCondition domain:@"test"] ]]);
+    [policySession.get() addPolicy:domainPolicy.get()];
+
+    NSString *agentString = agentUUID.get().UUIDString;
+    RetainPtr agentPolicy = adoptNS([[NEPolicy alloc] initWithOrder:1 result:[NEPolicyResult netAgentUUID:agentUUID.get()] conditions:@[ [NEPolicyCondition domain:agentString] ]]);
+    [policySession.get() addPolicy:agentPolicy.get()];
+
+    policySession.get().priority = NEPolicySessionPriorityHigh;
+    [policySession.get() apply];
+}
+#endif
 
 #if ENABLE(IMAGE_ANALYSIS)
 


### PR DESCRIPTION
#### 060bebfb1e6c057745cfc21a69433d5d9ea5c541
<pre>
Add support for running a local DNS resolver for WPT
<a href="https://bugs.webkit.org/show_bug.cgi?id=261038">https://bugs.webkit.org/show_bug.cgi?id=261038</a>
<a href="https://rdar.apple.com/82927182">rdar://82927182</a>

Reviewed by NOBODY (OOPS!).

Some ports don&apos;t have support for resolving arbitrary domains, but
web-platform-tests rely on this capability. Currently, the Apple ports only
use localhost, and 127.0.0.1 as a workaround where it&apos;s necessary, but this
affects our test coverage. This patch adds a very basic DNS resolver and
introduces a new command-line argument for run-webkit-tests; this is disabled
by default.

In 254273@main, glib ports gained support for resolving arbitrary domains,
and this moves Apple ports closer to supporting that. We expect to enable
this by default, along with rebaselining, in a later commit.

Previous attempts were made in <a href="https://bugs.webkit.org/show_bug.cgi?id=245294">https://bugs.webkit.org/show_bug.cgi?id=245294</a>,
and 264076@main introduced part of that behavior for a different reason. In
some situations, name resolutions falls back on that SPI, as well.

The basic DNS resolver only resolves A records for names ending with
&quot;localhost&quot; and for the host names defines by the port&apos;s localhost_aliases.
The server always returns 127.0.0.1 as the answer for those hosts. All other
queries return NXDomain. This resolver depends on the dnslib Python library.

On Apple ports, the iOS Simulator and Mac use different implementations. The
iOS simulator part is in the Network process because we need to define the
resolver in-process otherwise it won&apos;t be used. The way the resolver is
configured on Mac isn&apos;t supported on the simulator. On Mac, we use SPI and a
Network Extensions policy so this works when a VPN is enabled. We do this in
WebKitTestRunner so we don&apos;t need to add additional entitlements and weaken
the sandbox for the network process.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/060bebfb1e6c057745cfc21a69433d5d9ea5c541

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/108656 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/28317 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/18741 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/113867 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/59041 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/110619 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/29006 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/36873 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/82542 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/111604 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/23035 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97876 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62979 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/108088 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/22453 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/16013 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/58574 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/92405 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/16064 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/116988 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/35710 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/26341 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/91561 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/36083 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/94145 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/91365 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/36268 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/14028 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/31542 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/35611 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/41144 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/35321 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/38667 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/36998 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->