### PR TITLE
[css-anchor-position-1] anchor-name mutation doesn't propagate to its anchor-positioned dependency

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-name-mutation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-name-mutation-expected.txt
@@ -1,0 +1,17 @@
+
+PASS Tests when an anchor-name is added later positioned-using-anchor-function-explicit-name
+PASS Tests when an anchor-name is removed later positioned-using-anchor-function-explicit-name
+PASS Tests when an anchor-name moves from one element to another positioned-using-anchor-function-explicit-name
+PASS Tests when a new anchor candidate is added (which wins out previous anchor) positioned-using-anchor-function-explicit-name
+PASS Tests when a new anchor candidate is added (which loses out previous anchor) positioned-using-anchor-function-explicit-name
+PASS Tests when an anchor-name is added later positioned-using-anchor-function-implicit-name
+PASS Tests when an anchor-name is removed later positioned-using-anchor-function-implicit-name
+PASS Tests when an anchor-name moves from one element to another positioned-using-anchor-function-implicit-name
+PASS Tests when a new anchor candidate is added (which wins out previous anchor) positioned-using-anchor-function-implicit-name
+PASS Tests when a new anchor candidate is added (which loses out previous anchor) positioned-using-anchor-function-implicit-name
+PASS Tests when an anchor-name is added later positioned-using-position-area
+PASS Tests when an anchor-name is removed later positioned-using-position-area
+PASS Tests when an anchor-name moves from one element to another positioned-using-position-area
+PASS Tests when a new anchor candidate is added (which wins out previous anchor) positioned-using-position-area
+PASS Tests when a new anchor candidate is added (which loses out previous anchor) positioned-using-position-area
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-name-mutation.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-name-mutation.html
@@ -1,0 +1,217 @@
+<!DOCTYPE html>
+
+<html>
+
+<title>Tests that when an anchor name is mutated, the anchor-positioned element adjusts to the new anchor</title>
+
+<link rel="author" href="mailto:kiet.ho@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-anchor-position-1/#name">
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/rendering-utils.js"></script>
+
+<style>
+    .containing-block {
+        position: relative;
+        width: 300px;
+        height: 300px;
+
+        border: 1px black solid;
+    }
+
+    .cell {
+        width: 100px;
+        height: 100px;
+    }
+
+    #anchor-1 {
+        position: absolute;
+        top: 0;
+        left: 0;
+
+        background: green;
+    }
+
+    #anchor-2 {
+        position: absolute;
+        top: 100px;
+        left: 0;
+
+        background: blue;
+    }
+
+    .anchor {
+        anchor-name: --anchor;
+    }
+
+    #anchor-positioned {
+        background: orange;
+
+        position: absolute;
+        top: 0;
+        left: 0;
+    }
+
+    .positioned-using-anchor-function-explicit-name {
+        position: absolute;
+        top: anchor(--anchor bottom) !important;
+        left: anchor(--anchor right) !important;
+    }
+
+    .positioned-using-anchor-function-implicit-name {
+        position: absolute;
+        position-anchor: --anchor;
+
+        top: anchor(bottom) !important;
+        left: anchor(right) !important;
+    }
+
+    .positioned-using-position-area {
+        position: absolute;
+        position-anchor: --anchor;
+
+        position-area: bottom right;
+    }
+</style>
+
+<body>
+    <main id="main">
+    </main>
+
+    <template id="test-template">
+        <div class="containing-block">
+            <div class="cell" id="anchor-1"></div>
+            <div class="cell" id="anchor-2"></div>
+            <div class="cell" id="anchor-positioned"></div>
+        </div>
+    </template>
+
+    <script>
+        function inflate(t, template_element) {
+            const main_element = document.getElementById("main");
+
+            t.add_cleanup(() => main_element.replaceChildren());
+            main_element.append(template_element.content.cloneNode(true));
+        }
+
+        const test_template = document.getElementById("test-template");
+
+        const positioning_methods = [
+            "positioned-using-anchor-function-explicit-name",
+            "positioned-using-anchor-function-implicit-name",
+            "positioned-using-position-area"
+        ]
+
+        for (let positioning_method of positioning_methods) {
+            promise_test(async (t) => {
+                inflate(t, test_template);
+
+                const anchor1 = document.getElementById("anchor-1");
+                const anchorPositioned = document.getElementById("anchor-positioned");
+
+                anchorPositioned.classList.add(positioning_method);
+
+                // Here, anchorPositioned should be at the default location (top-left of containing block)
+                // This is because the anchor elements don't have an anchor name yet.
+                assert_equals(anchorPositioned.offsetTop, 0);
+                assert_equals(anchorPositioned.offsetLeft, 0);
+
+                anchor1.classList.add("anchor");
+
+                // Here, anchorPositioned should be bottom-right of anchor1
+                assert_equals(anchorPositioned.offsetTop, 100);
+                assert_equals(anchorPositioned.offsetLeft, 100);
+            }, `Tests when an anchor-name is added later ${positioning_method}`);
+
+            promise_test(async (t) => {
+                inflate(t, test_template);
+
+                const anchor1 = document.getElementById("anchor-1");
+                const anchorPositioned = document.getElementById("anchor-positioned");
+
+                anchor1.classList.add("anchor");
+                anchorPositioned.classList.add(positioning_method);
+
+                // Here, anchorPositioned should be bottom-right of anchor1
+                assert_equals(anchorPositioned.offsetTop, 100);
+                assert_equals(anchorPositioned.offsetLeft, 100);
+
+                anchor1.classList.remove("anchor");
+
+                // Here, anchorPositioned should be at the default location (top-left of containing block)
+                // This is because the anchor elements don't have an anchor name.
+                assert_equals(anchorPositioned.offsetTop, 0);
+                assert_equals(anchorPositioned.offsetLeft, 0);
+            }, `Tests when an anchor-name is removed later ${positioning_method}`);
+
+            promise_test(async (t) => {
+                inflate(t, test_template);
+
+                const anchor1 = document.getElementById("anchor-1");
+                const anchor2 = document.getElementById("anchor-2");
+                const anchorPositioned = document.getElementById("anchor-positioned");
+
+                anchor1.classList.add("anchor");
+                anchorPositioned.classList.add(positioning_method);
+
+                // Here, anchorPositioned should be bottom-right of anchor1
+                assert_equals(anchorPositioned.offsetTop, 100);
+                assert_equals(anchorPositioned.offsetLeft, 100);
+
+                anchor1.classList.remove("anchor");
+                anchor2.classList.add("anchor");
+
+                // Here, anchorPositioned should be bottom-right of anchor2
+                assert_equals(anchorPositioned.offsetTop, 200);
+                assert_equals(anchorPositioned.offsetLeft, 100);
+            }, `Tests when an anchor-name moves from one element to another ${positioning_method}`);
+
+            promise_test(async (t) => {
+                inflate(t, test_template);
+
+                const anchor1 = document.getElementById("anchor-1");
+                const anchor2 = document.getElementById("anchor-2");
+                const anchorPositioned = document.getElementById("anchor-positioned");
+
+                anchor1.classList.add("anchor");
+                anchorPositioned.classList.add(positioning_method);
+
+                // Here, anchorPositioned should be bottom-right of anchor1
+                assert_equals(anchorPositioned.offsetTop, 100);
+                assert_equals(anchorPositioned.offsetLeft, 100);
+
+                anchor2.classList.add("anchor");
+
+                // Here, anchorPositioned should be bottom-right of anchor2
+                assert_equals(anchorPositioned.offsetTop, 200);
+                assert_equals(anchorPositioned.offsetLeft, 100);
+            }, `Tests when a new anchor candidate is added (which wins out previous anchor) ${positioning_method}`);
+
+
+            promise_test(async (t) => {
+                inflate(t, test_template);
+
+                const anchor1 = document.getElementById("anchor-1");
+                const anchor2 = document.getElementById("anchor-2");
+                const anchorPositioned = document.getElementById("anchor-positioned");
+
+                anchor2.classList.add("anchor");
+                anchorPositioned.classList.add(positioning_method);
+
+                // Here, anchorPositioned should be bottom-right of anchor2
+                assert_equals(anchorPositioned.offsetTop, 200);
+                assert_equals(anchorPositioned.offsetLeft, 100);
+
+                anchor1.classList.add("anchor");
+
+                // Here, anchorPositioned should be bottom-right of anchor2
+                assert_equals(anchorPositioned.offsetTop, 200);
+                assert_equals(anchorPositioned.offsetLeft, 100);
+            }, `Tests when a new anchor candidate is added (which loses out previous anchor) ${positioning_method}`);
+        }
+    </script>
+
+</body>
+
+</html>

--- a/Source/WebCore/style/AnchorPositionEvaluator.cpp
+++ b/Source/WebCore/style/AnchorPositionEvaluator.cpp
@@ -939,8 +939,7 @@ AnchorElements AnchorPositionEvaluator::findAnchorsForAnchorPositionedElement(co
 
     for (auto& anchorName : anchorNames) {
         auto anchor = findLastAcceptableAnchorWithName(anchorName, anchorPositionedElement, anchorsForAnchorName);
-        if (anchor)
-            anchorElements.add(anchorName, anchor);
+        anchorElements.add(anchorName, anchor);
     }
 
     return anchorElements;
@@ -970,8 +969,9 @@ void AnchorPositionEvaluator::updateAnchorPositioningStatesAfterInterleavedLayou
 
                 Vector<ResolvedAnchor> anchors;
                 for (auto& anchorNameAndElement : state.anchorElements) {
+                    CheckedPtr anchorElement = anchorNameAndElement.value.get();
                     anchors.append(ResolvedAnchor {
-                        .renderer = dynamicDowncast<RenderBoxModelObject>(anchorNameAndElement.value->renderer()),
+                        .renderer = anchorElement ? dynamicDowncast<RenderBoxModelObject>(anchorElement->renderer()) : nullptr,
                         .name = anchorNameAndElement.key
                     });
                 }
@@ -987,7 +987,7 @@ void AnchorPositionEvaluator::updateAnchorPositioningStatesAfterInterleavedLayou
 
 void AnchorPositionEvaluator::updateAnchorPositionedStateForLayoutTimePositioned(Element& element, const RenderStyle& style, AnchorPositionedStates& states)
 {
-    if (!style.positionAnchor() && !isLayoutTimeAnchorPositioned(style))
+    if (!isLayoutTimeAnchorPositioned(style))
         return;
 
     auto* state = states.ensure({ &element, style.pseudoElementIdentifier() }, [&] {
@@ -1017,6 +1017,9 @@ void AnchorPositionEvaluator::updateSnapshottedScrollOffsets(Document& document)
                 return false;
 
             if (elementAndAnchors.value.size() != 1)
+                return false;
+
+            if (!elementAndAnchors.value[0].renderer)
                 return false;
 
             return true;

--- a/Source/WebCore/style/StyleTreeResolver.h
+++ b/Source/WebCore/style/StyleTreeResolver.h
@@ -166,7 +166,7 @@ private:
     const RenderStyle* parentBoxStyleForPseudoElement(const ElementUpdate&) const;
     const RenderStyle* documentElementStyle() const;
 
-    LayoutInterleavingAction updateAnchorPositioningState(Element&, const RenderStyle*, OptionSet<Change>);
+    LayoutInterleavingAction updateAnchorPositioningState(Element&, const RenderStyle*);
 
     void generatePositionOptionsIfNeeded(const ResolvedStyle&, const Styleable&, const ResolutionContext&);
     std::unique_ptr<RenderStyle> generatePositionOption(const PositionTryFallback&, const ResolvedStyle&, const Styleable&, const ResolutionContext&);
@@ -184,6 +184,8 @@ private:
     bool hasUnresolvedAnchorPosition(const Styleable&) const;
     bool hasResolvedAnchorPosition(const Styleable&) const;
 
+    void collectChangedAnchorNames(const RenderStyle&, const RenderStyle* currentStyle);
+
     const CheckedRef<Document> m_document;
     std::unique_ptr<RenderStyle> m_computedDocumentElementStyle;
 
@@ -199,6 +201,7 @@ private:
     };
     UncheckedKeyHashMap<Ref<Element>, DeferredDescendantResolutionState> m_deferredDescendantResolutionStates;
     bool m_needsInterleavedLayout { false };
+    bool m_didFirstInterleavedLayout { false };
 
     struct QueryContainerState {
         bool invalidated { false };
@@ -217,6 +220,9 @@ private:
         bool chosen { false };
     };
     HashMap<Ref<Element>, PositionOptions> m_positionOptions;
+
+    HashSet<AtomString> m_changedAnchorNames;
+    bool m_allAnchorNamesInvalid { false };
 
     std::unique_ptr<Update> m_update;
 };


### PR DESCRIPTION
#### 16977f92e64ac17ddc03794b2eb269636b659855
<pre>
[css-anchor-position-1] anchor-name mutation doesn&apos;t propagate to its anchor-positioned dependency
<a href="https://bugs.webkit.org/show_bug.cgi?id=294129">https://bugs.webkit.org/show_bug.cgi?id=294129</a>
<a href="https://rdar.apple.com/152727401">rdar://152727401</a>

Reviewed by Alan Baradlay.

We failed to invalidate the anchored elements in some cases when an anchor changed its name.

* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-name-mutation-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-name-mutation.html: Added.

Test by Kiet.

* Source/WebCore/style/AnchorPositionEvaluator.cpp:
(WebCore::Style::AnchorPositionEvaluator::findAnchorsForAnchorPositionedElement):
(WebCore::Style::AnchorPositionEvaluator::updateAnchorPositioningStatesAfterInterleavedLayout):

Include anchor references that we fail to resolve into anchorPositionedToAnchorMap. They may get resolved later.

(WebCore::Style::AnchorPositionEvaluator::updateAnchorPositionedStateForLayoutTimePositioned):

Remove a hack where we created anchor positioned state for anything with position-anchor here. It was hiding invalidation bugs.

(WebCore::Style::AnchorPositionEvaluator::updateSnapshottedScrollOffsets):

No resolved anchor -&gt; reset scroll offset.

* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::createAnimatedElementUpdate):

Collect any changed anchor names and scopes whens style changes.

(WebCore::Style::TreeResolver::resolveComposedTree):
(WebCore::Style::TreeResolver::resolve):

If there are changed anchor names use them to invalidate any existing anchor positioned elements for another round of interleaving.
Ensure we do at least one round of interleaving if there are any style changes and any anchor positioned elements as any style
change may cause anchors to move.

(WebCore::Style::TreeResolver::updateAnchorPositioningState):

Remove setting of m_needsInterleavedLayout on seeing any anchor names, it is no longer needed and was hiding bugs.

(WebCore::Style::TreeResolver::collectChangedAnchorNames):

Collect the changed names and names affected by changes in anchor scopes.

* Source/WebCore/style/StyleTreeResolver.h:

Canonical link: <a href="https://commits.webkit.org/296184@main">https://commits.webkit.org/296184@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6b1db59c46b7979b7bae8d596df6252c3563f499

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/107621 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27302 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/17715 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/112837 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/58162 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/109583 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/27994 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/35807 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/81716 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/110551 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22192 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/97004 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62096 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/21628 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/15143 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/57600 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/91564 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15177 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/115940 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/34689 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/25582 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/90750 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/35065 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93254 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/90491 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23074 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35407 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13193 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/30451 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/34608 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/40164 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34354 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/37715 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/36017 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->